### PR TITLE
Fix button order on Win32

### DIFF
--- a/browser/ui/message_box_win.cc
+++ b/browser/ui/message_box_win.cc
@@ -195,7 +195,10 @@ void MessageDialog::Layout() {
   int x = bounds.width();
   int height = buttons_[0]->GetPreferredSize().height() +
                views::kRelatedControlVerticalSpacing;
-  for (size_t i = 0; i < buttons_.size(); ++i) {
+
+  // NB: We iterate through the buttons backwards here because
+  // Mac and Windows buttons are laid out in opposite order.
+  for (int i = buttons_.size() - 1; i >= 0; --i) {
     gfx::Size size = buttons_[i]->GetPreferredSize();
     x -= size.width() + views::kRelatedButtonHSpacing;
 


### PR DESCRIPTION
On Windows, the button order is left to right, with the primary action on the left (i.e. "Ok" "Cancel"). On Mac, the button order is that the primary action is nearest to the corner.
