### PR TITLE
Need PathService on Win32

### DIFF
--- a/app/atom_main_delegate.cc
+++ b/app/atom_main_delegate.cc
@@ -10,6 +10,7 @@
 #include "content/public/common/content_switches.h"
 #include "renderer/atom_renderer_client.h"
 #include "ui/base/resource/resource_bundle.h"
+#include "base/path_service.h"
 
 namespace atom {
 


### PR DESCRIPTION
This was accidentally left out of 8708d061, the PR fixes the build on Windows
