### PR TITLE
Fix console STDIO

### DIFF
--- a/app/atom_main.cc
+++ b/app/atom_main.cc
@@ -24,47 +24,18 @@ int Start(int argc, char *argv[]);
 #include "content/public/app/startup_helper_win.h"
 #include "sandbox/win/src/sandbox_types.h"
 
-/*
- * An alternate way to skin the same cat
-
-void ConnectStdioToConsole()
-{
-  int hCrt;
-  AllocConsole();
-
-  HANDLE handle_out = GetStdHandle(STD_OUTPUT_HANDLE);
-  hCrt = _open_osfhandle((long) handle_out, _O_TEXT);
-  FILE* hf_out = _fdopen(hCrt, "w");
-  setvbuf(hf_out, NULL, _IONBF, 1);
-  *stdout = *hf_out;
-
-  HANDLE handle_err = GetStdHandle(STD_ERROR_HANDLE);
-  hCrt = _open_osfhandle((long) handle_err, _O_TEXT);
-  FILE* hf_err = _fdopen(hCrt, "w");
-  setvbuf(hf_err, NULL, _IONBF, 1);
-  *stderr = *hf_err;
-
-
-  HANDLE handle_in = GetStdHandle(STD_INPUT_HANDLE);
-  hCrt = _open_osfhandle((long) handle_in, _O_TEXT);
-  FILE* hf_in = _fdopen(hCrt, "r");
-  setvbuf(hf_in, NULL, _IONBF, 128);
-  *stdin = *hf_in;
-}
-*/
 
 int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   int argc = 0;
   wchar_t** wargv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
 
   // Attach to the parent console if we've got one so that stdio works
-  if (GetConsoleWindow()) {
-    AllocConsole() ;
-    AttachConsole(GetCurrentProcessId());
-    freopen("CON", "w", stdout);
-    freopen("CON", "w", stderr);
-    freopen("CON", "r", stdin);
-  }
+  AttachConsole(ATTACH_PARENT_PROCESS);
+
+  FILE* dontcare;
+  freopen_s(&dontcare, "CON", "w", stdout);
+  freopen_s(&dontcare, "CON", "w", stderr);
+  freopen_s(&dontcare, "CON", "r", stdin);
 
   scoped_ptr<base::Environment> env(base::Environment::Create());
   std::string node_indicator;


### PR DESCRIPTION
This connects atom.exe to the console STDIO so that we can see the output of the app. It appears that we'll need another fix to get the optparse stuff working though (perhaps it was just removed in Windows? /cc @zcbenz)
