### PR TITLE
Don't map command to ctrl

### DIFF
--- a/browser/ui/accelerator_util.cc
+++ b/browser/ui/accelerator_util.cc
@@ -108,13 +108,7 @@ bool StringToAccelerator(const std::string& description,
     } else if (tokens[i] == "ctrl") {
       modifiers |= ui::EF_CONTROL_DOWN;
     } else if (tokens[i] == "command") {
-      // The "Command" would be translated to "Ctrl" on platforms other than
-      // OS X.
-#if defined(OS_MACOSX)
       modifiers |= ui::EF_COMMAND_DOWN;
-#else
-      modifiers |= ui::EF_CONTROL_DOWN;
-#endif
     } else if (tokens[i] == "alt") {
       modifiers |= ui::EF_ALT_DOWN;
     } else if (tokens[i] == "shift") {


### PR DESCRIPTION
We no longer what this behavior because it's confusing unless you understand that atom-shell does this.

This looks like the only thing that needs to be changed, but I defer to @zcbenz here.
