### PR TITLE
Move framework downloads to GitHub release

### DIFF
--- a/script/update-frameworks.py
+++ b/script/update-frameworks.py
@@ -8,7 +8,8 @@ from lib.util import safe_mkdir, extract_zip, tempdir, download
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'https://github.com/atom/atom-shell-frameworks/releases' \
-                 '/download/v0.0.1'
+                 '/download/v0.0.2'
+
 
 def main():
   os.chdir(SOURCE_ROOT)


### PR DESCRIPTION
I've moved the framework files to https://github.com/atom/atom-shell/releases/tag/v0.11.10. It's a little weird, but I think it is a nice public place for them.
