### PR TITLE
Enable WebGL

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -65,7 +65,7 @@ void AtomBrowserClient::OverrideWebkitPrefs(
   prefs->application_cache_enabled = true;
   prefs->allow_universal_access_from_file_urls = true;
   prefs->allow_file_access_from_file_urls = true;
-  prefs->experimental_webgl_enabled = false;
+  prefs->experimental_webgl_enabled = true;
   prefs->allow_displaying_insecure_content = true;
   prefs->allow_running_insecure_content = true;
 


### PR DESCRIPTION
Enabling the `experimental_webgl_enabled` preference allows you to create a WebGL context from within atom-shell.

While not necessarily important for the Atom editor, for others to use atom-shell in substitution for node-webkit this is a potentially useful feature, e.g. for packaged HTML5 games.

Unless there's a reason to have this disabled, it would be nice to have it made available :)

Thanks!
