### PR TITLE
Update "app" to "your-app" to avoid module collision with require('app')

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -43,10 +43,10 @@ use the easy [remote](../api/remote.md) module.
 
 ## Write your first atom-shell app
 
-Generally, an atom-shell app would be like this:
+Generally, an atom-shell app would be like this (see this repo for reference [hello-atom](https://github.com/dougnukem/hello-atom)):
 
 ```text
-app/
+your-app/
 ├── package.json
 ├── main.js
 └── index.html
@@ -130,17 +130,17 @@ binary to execute your app directly.
 On Windows:
 
 ```cmd
-$ .\atom-shell\atom.exe path-to-app\
+$ .\atom-shell\atom.exe your-app\
 ```
 
 On Linux:
 
 ```bash
-$ ./atom-shell/atom path-to-app/
+$ ./atom-shell/atom your-app/
 ```
 
 On Mac OS X:
 
 ```bash
-$ ./Atom.app/Contents/MacOS/Atom path-to-app/
+$ ./Atom.app/Contents/MacOS/Atom your-app/
 ```


### PR DESCRIPTION
If you name your app's folder `app/` and if you run the atom-shell from the directory above that, it will result in an error, which I believe is caused by resolving `require('app')` to your `app/` folder.

So just to avoid confusion where someone might create an app with that folder and run the atom-shell from that directory.

I wrote up some details getting atom-shell working using the grunt plugin.
- https://github.com/atom/atom-shell/issues/256#issuecomment-42464026
