### PR TITLE
Correct WebContents send example.

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -468,7 +468,7 @@ var window = null;
 app.on('ready', function() {
   window = new BrowserWindow({width: 800, height: 600});
   window.loadUrl('file://' + __dirname + '/index.html');
-  window.on('did-finish-load', function() {
+  window.webContents.on('did-finish-load', function() {
     window.webContents.send('ping', 'whoooooooh!');
   });
 });


### PR DESCRIPTION
After spending some time trying to figure out why `did-finish-load` wasn't getting emitted, I figured out that `window.on` should have been `window.webContents.on` in the `WebContents` send example.
