### PR TITLE
Fix Atom Shell from always using the discrete GPU

### DIFF
--- a/atom/common/resources/mac/Info.plist
+++ b/atom/common/resources/mac/Info.plist
@@ -10,5 +10,7 @@
 	<string>Atom Framework</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>

--- a/atom/renderer/resources/mac/Info.plist
+++ b/atom/renderer/resources/mac/Info.plist
@@ -10,5 +10,7 @@
 	<string>APPL</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
While the `NSSupportsAutomaticGraphicsSwitching` attribute was added to [atom/browser/resources/mac/Info.plist](https://github.com/atom/atom-shell/blob/05216630765a52b8f3115cf288530b6729ba5323/atom/browser/resources/mac/Info.plist#L19-20), it was missing from Info.plist files in `renderer/` and `common/`. This was causing Atom Helper.app to not have this attribute, which in turn causes the discrete GPU to become active.
