### PR TITLE
The source_root was wrong computed

### DIFF
--- a/script/build.py
+++ b/script/build.py
@@ -7,7 +7,7 @@ import sys
 
 
 CONFIGURATIONS = ['Release', 'Debug']
-SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
+SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 
 def main():


### PR DESCRIPTION
Using 'SOURCE_ROOT = os.path.dirname(os.path.dirname(**file**))' leads to an empty string if the path is relative.
