### PR TITLE
Documentation: Add more BrowserWindow methods

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -353,7 +353,9 @@ process.
 
 Same with `webContents.loadUrl(url)`.
 
-### BrowserWindow.restart()
+### BrowserWindow.reload()
+
+Reloads the current url.
 
 ### BrowserWindow.setMenu(menu)
 


### PR DESCRIPTION
I just added `restart` because it was missing.
Since I don't know _exactly_ what happens when this method is called I don't want to add any additional _wrong_ information.
Also I added `setMenu(menu)` with information.
