### PR TITLE
10.8+, preexisting node required.

### DIFF
--- a/docs/development/build-instructions-mac.md
+++ b/docs/development/build-instructions-mac.md
@@ -2,9 +2,9 @@
 
 ## Prerequisites
 
-* Mac OS X >= 10.7
+* Mac OS X >= 10.8
 * [Xcode](https://developer.apple.com/technologies/tools/) >= 5.1
-* [node.js](http://nodejs.org)
+* [node.js](http://nodejs.org) (external).
 
 If you are using the python downloaded by Homebrew, you also need to install
 following python modules:


### PR DESCRIPTION
I'm presently giving [10.7 support](https://github.com/atom/atom/issues/1967) the old college try (building against the 10.7 SDK with Xcode 5.1, not necessarily supporting the Xcode 4.6 toolchain) — but I thought this should be updated in the meantime. 

It also seems possible to me that the pre-installed node requirement is somewhat accidental.

Since we have the source checked out already, it should be rather trivial to build an intermediate "bootstrap" node if there isn't one found in the path.

Do it?
