### PR TITLE
Add a `focus` event to BrowserWindow

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -95,6 +95,10 @@ void Window::OnWindowBlur() {
   Emit("blur");
 }
 
+void Window::OnWindowFocus() {
+  Emit("focus");
+}
+
 void Window::OnRendererUnresponsive() {
   Emit("unresponsive");
 }

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -53,6 +53,7 @@ class Window : public mate::EventEmitter,
   virtual void WillCloseWindow(bool* prevent_default) OVERRIDE;
   virtual void OnWindowClosed() OVERRIDE;
   virtual void OnWindowBlur() OVERRIDE;
+  virtual void OnWindowFocus() OVERRIDE;
   virtual void OnRendererUnresponsive() OVERRIDE;
   virtual void OnRendererResponsive() OVERRIDE;
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -368,6 +368,10 @@ void NativeWindow::NotifyWindowBlur() {
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_, OnWindowBlur());
 }
 
+void NativeWindow::NotifyWindowFocus() {
+  FOR_EACH_OBSERVER(NativeWindowObserver, observers_, OnWindowFocus());
+}
+
 // In atom-shell all reloads and navigations started by renderer process would
 // be redirected to this method, so we can have precise control of how we
 // would open the url (in our case, is to restart the renderer process). See

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -177,6 +177,7 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   // related notifications.
   void NotifyWindowClosed();
   void NotifyWindowBlur();
+  void NotifyWindowFocus();
 
   void AddObserver(NativeWindowObserver* obs) {
     observers_.AddObserver(obs);

--- a/atom/browser/native_window_gtk.cc
+++ b/atom/browser/native_window_gtk.cc
@@ -492,6 +492,11 @@ gboolean NativeWindowGtk::OnWindowDeleteEvent(GtkWidget* widget,
   return TRUE;
 }
 
+gboolean NativeWindowGtk::OnFocusIn(GtkWidget* window, GdkEventFocus*) {
+  NotifyWindowFocus();
+  return FALSE;
+}
+
 gboolean NativeWindowGtk::OnFocusOut(GtkWidget* window, GdkEventFocus*) {
   NotifyWindowBlur();
   return FALSE;

--- a/atom/browser/native_window_gtk.h
+++ b/atom/browser/native_window_gtk.h
@@ -101,6 +101,7 @@ class NativeWindowGtk : public NativeWindow,
 
   CHROMEGTK_CALLBACK_1(NativeWindowGtk, gboolean, OnWindowDeleteEvent,
                        GdkEvent*);
+  CHROMEGTK_CALLBACK_1(NativeWindowGtk, gboolean, OnFocusIn, GdkEventFocus*);
   CHROMEGTK_CALLBACK_1(NativeWindowGtk, gboolean, OnFocusOut, GdkEventFocus*);
   CHROMEGTK_CALLBACK_1(NativeWindowGtk, gboolean, OnWindowState,
                        GdkEventWindowState*);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -48,6 +48,10 @@ static const CGFloat kAtomWindowCornerRadius = 4.0;
   acceptsFirstMouse_ = accept;
 }
 
+- (void)windowDidBecomeMain:(NSNotification*)notification {
+  shell_->NotifyWindowFocus();
+}
+
 - (void)windowDidResignMain:(NSNotification*)notification {
   shell_->NotifyWindowBlur();
 }

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -26,6 +26,9 @@ class NativeWindowObserver {
   // Called when window loses focus.
   virtual void OnWindowBlur() {}
 
+  // Called when window gains focus.
+  virtual void OnWindowFocus() {}
+
   // Called when renderer is hung.
   virtual void OnRendererUnresponsive() {}
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -134,6 +134,10 @@ Emitted when the unresponsive web page becomes responsive again.
 
 Emitted when window loses focus.
 
+### Event: 'focus'
+
+Emitted when window gains focus.
+
 ### Class Method: BrowserWindow.getAllWindows()
 
 Returns an array of all opened browser windows.


### PR DESCRIPTION
- Tested in OSX
- Untested in GTK, but I expect it should work
- Did not see any similar constructs for notifications in Windows
