### PR TITLE
Escape accelerator

### DIFF
--- a/atom/browser/ui/accelerator_util.cc
+++ b/atom/browser/ui/accelerator_util.cc
@@ -149,7 +149,7 @@ bool StringToAccelerator(const std::string& description,
       key = ui::VKEY_PRIOR;
     } else if (tokens[i] == "pageup") {
       key = ui::VKEY_NEXT;
-    } else if (tokens[i] == "esc") {
+    } else if (tokens[i] == "esc" || tokens[i] == "escape") {
       key = ui::VKEY_ESCAPE;
     } else if (tokens[i] == "volumemute") {
       key = ui::VKEY_VOLUME_MUTE;


### PR DESCRIPTION
Not sure if/when this might have changed, but Atom's keymap module generates `escape` as the keystroke, not `esc`, as atom-shell was expecting.

Seemed reasonable to support both `esc` and `escape`.
