### PR TITLE
Move item to trash without confirming on Windows

### DIFF
--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -175,7 +175,7 @@ void MoveItemToTrash(const base::FilePath& path) {
   SHFILEOPSTRUCT file_operation = {0};
   file_operation.wFunc = FO_DELETE;
   file_operation.pFrom = double_terminated_path;
-  file_operation.fFlags = FOF_ALLOWUNDO;
+  file_operation.fFlags = FOF_ALLOWUNDO | FOF_SILENT | FOF_NOCONFIRMATION;
   SHFileOperation(&file_operation);
 }
 


### PR DESCRIPTION
This will skip the "Are you sure you want to move this file to the Recycle Bin?" dialog on Windows.

I was testing Atom on Windows, and the editor froze when I tried to move a file to trash. After debugging this issue, I noticed that it was stuck on shell.moveItemToTrash and that a Windows confirm dialog had appeared behind the Atom window. Since Atom already asks the user to confirm the action I assume it should be fine to have MoveItemToTrash silently move the file to trash without additional confirmations.
