### PR TITLE
Print stack traces when starting app failed in addition to a dialog

### DIFF
--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -34,6 +34,7 @@ if (argv._.length > 0) {
   } catch(e) {
     if (e.code == 'MODULE_NOT_FOUND') {
       app.focus();
+      console.error(e.stack);
       dialog.showMessageBox({
         type: 'warning',
         buttons: ['OK'],


### PR DESCRIPTION
Error logs were surpressed while booting up.
