### PR TITLE
fix node to build with target_arch=x64 on linux

### DIFF
--- a/script/update.py
+++ b/script/update.py
@@ -24,9 +24,11 @@ def update_gyp():
   gyp = os.path.join('vendor', 'brightray', 'vendor', 'gyp', 'gyp_main.py')
   python = sys.executable
   arch = 'ia32'
-  if sys.platform.startswith('linux') and sys.maxsize > 2**32 or sys.platform == 'darwin':
+  if sys.platform.startswith('linux') and sys.maxsize > 2**32:
     arch = 'x64'
-  if sys.platform in ['cygwin', 'win32']:
+  elif sys.platform == 'darwin':
+    arch = 'x64'
+  elif sys.platform in ['cygwin', 'win32']:
     python = os.path.join('vendor', 'python_26', 'python.exe')
   subprocess.call([python, gyp,
                    '-f', 'ninja', '--depth', '.', 'atom.gyp',


### PR DESCRIPTION
atom-shell on linux is incorrectly reporting `ia32` for `process.arch`.

This is happening because `-Dtarget_arch=ia32` is passed to ninja on linux inside `script/update.py` which leads to '-DARCH="ia32"' being set in the compile flags. I see that the current intention is to target 64 bit builds on linux (37275c64cd07) and the binaries are in fact compiled as 64 bit despite this bug.  I guess ninja is somehow smartly ignoring the incorrect setting of the `-m32` flags at https://github.com/atom/node/blob/6d772c3cda0bb8270857397e128ea1e36c361125/common.gypi#L175-L178.

Until this is fixed it breaks usage of any node-pre-gyp packaged node addons because node-pre-gyp depends on process.arch being correct in order to require the right binary arch.
