### PR TITLE
docs: Correct debugging chapter.

### DIFF
--- a/docs/tutorial/debugging-browser-process.md
+++ b/docs/tutorial/debugging-browser-process.md
@@ -33,13 +33,13 @@ $ node-inspector
 You can either start atom-shell with a debug flag like:
 
 ```bash
-$ atom-shell --debug your/app
+$ atom-shell --debug=5858 your/app
 ```
 
 or, to pause your script on the first line:
 
 ```bash
-$ atom-shell --debug-brk your/app
+$ atom-shell --debug-brk=5858 your/app
 ```
 
 ### 3. Load the debugger UI


### PR DESCRIPTION
@zcbenz, 

the default app can not process `--debug your/app/` correctly. We need to specify the port explicitly. The `optimist` module doesn't support this usage, it will set `your/app/` as the debug port which leads to `default_app/main.js` run in [wrong branch](https://github.com/atom/atom-shell/blob/master/atom/browser/default_app/main.js#L55). 
