### PR TITLE
Small typo fix in fatal JS error message

### DIFF
--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -47,7 +47,7 @@ setImmediate ->
     message = error.stack ? "#{error.name}: #{error.message}"
     require('dialog').showMessageBox
       type: 'warning'
-      title: 'An javascript error occured in the browser'
+      title: 'A javascript error occured in the browser'
       message: 'uncaughtException'
       detail: message
       buttons: ['OK']


### PR DESCRIPTION
An javascript error -> A javascript error
