### PR TITLE
win: Fix total value in SetProgressBar API.

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -499,7 +499,7 @@ void NativeWindowViews::SetProgressBar(double progress) {
   } else if (progress >= 0) {
     taskbar->SetProgressValue(frame,
                               static_cast<int>(progress * 100),
-                              progress);
+                              100);
   }
 #elif defined(USE_X11)
   if (unity::IsRunning()) {


### PR DESCRIPTION
The third parameter of [SetProgressValue](http://msdn.microsoft.com/library/windows/desktop/dd391698) should be 100 as it is the maximum progress value.
