### PR TITLE
Fs stat fixes #672

### DIFF
--- a/atom/common/lib/asar.coffee
+++ b/atom/common/lib/asar.coffee
@@ -38,11 +38,11 @@ asarStatsToFsStats = (stats) ->
     uid: uid,
     gid: gid,
     rdev: 0,
-    atime: stats.atime,
-    birthtime: stats.birthtime,
-    mtime: stats.mtime,
-    ctime: stats.ctime,
-    size: stats.size
+    atime: stats.atime || new Date(),
+    birthtime: stats.birthtime || new Date(),
+    mtime: stats.mtime || new Date(),
+    ctime: stats.ctime || new Date(),
+    size: stats.size,
     isFile: -> stats.isFile
     isDirectory: -> stats.isDirectory
     isSymbolicLink: -> stats.isLink


### PR DESCRIPTION
Adds shim for `stat.atime`, `stat.mtime`, `stat.ctime` and `stat.birthtime`
