### PR TITLE
linux: Rename window's class to Atom

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -155,8 +155,8 @@ NativeWindowViews::NativeWindowViews(content::WebContents* web_contents,
       "%s/%s/%d", "Atom Shell", Browser::Get()->GetName().c_str(),
       ++kWindowsCreated);
   // Set WM_CLASS.
-  params.wm_class_name = "atom-shell";
-  params.wm_class_class = "Atom Shell";
+  params.wm_class_name = "atom";
+  params.wm_class_class = "Atom";
 #endif
 
   window_->Init(params);


### PR DESCRIPTION
Hello,

Thank you for developing and maintaining Atom!
I'm using Atom on GNU/Linux Ubuntu and it seems that the launcher is named `Atom.desktop` but the window's class is `Atom Shell` (we can get it via this command: `xprop | grep CLASS`).

The window's class should be `Atom` instead of `Atom Shell` because the launcher and the binary to launch Atom are called 'atom' and not 'atom shell'. This is why currently all Atom's windows will not be linked to their launcher in a dock (e.g. with Cairo-Dock).

Note that it's not advised to add white-spaces in a window's class ('Atom Shell').

I'm going to add a new pull request in `atom` project in order to remove the capital letter in the name of the `.desktop` file (a `.desktop` file should not contain any capital letters in its name).

Regards,

Matt
