### PR TITLE
linux: GlobalMenu: only if UBUNTU_MENUPROXY is set

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -67,9 +67,12 @@ int kWindowsCreated = 0;
 bool ShouldUseGlobalMenuBar() {
   // Some DE would pretend to be Unity but don't have global application menu,
   // so we can not trust unity::IsRunning().
+  // When Unity's GlobalMenu is running $UBUNTU_MENUPROXY should be set to
+  // something like "libappmenu.so".
   scoped_ptr<base::Environment> env(base::Environment::Create());
-  return unity::IsRunning() && (base::nix::GetDesktopEnvironment(env.get()) ==
-      base::nix::DESKTOP_ENVIRONMENT_UNITY);
+  std::string name;
+  return env && env->GetVar("UBUNTU_MENUPROXY", &name) &&
+         !name.empty() && name != "0";
 }
 #endif
 


### PR DESCRIPTION
Hello,

When checking if we should react differently when GlobalMenu bar is used, we should check if `UBUNTU_MENUPROXY` env var is (correctly) set instead of checking if we're using Unity on a Unity session.

It's maybe better to do that because we can use Compiz on a Unity session without Unity. Or we can also use Unity in a different session.

Note that I was not able to test this new code (sorry for that) but when I'm using Atom on Ubuntu with a Cairo-Dock session and Unity is not running, Atom window doesn't have any menu.

A few details about my system:

```
$ echo $DESKTOP_SESSION    
cairo-dock
$ ps aux | grep "[l]ibappmenu"
$ echo $UBUNTU_MENUPROXY   

$ echo $XDG_CURRENT_DESKTOP
Unity
```

![Atom on a Cairo-Dock session](http://ibin.co/1dVcy2QOY4Vi)

On an Ubuntu session, we have something like that:

```
$ echo $DESKTOP_SESSION    
ubuntu
$ ps aux | grep "[l]ibappmenu"
(...)
$ echo $UBUNTU_MENUPROXY   
libappmenu.so
$ echo $XDG_CURRENT_DESKTOP
Unity
```

Regards,

Matt
