### PR TITLE
linux: GlobalMenu: UBUNTU_MENUPROXY with >1 char

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -68,11 +68,10 @@ bool ShouldUseGlobalMenuBar() {
   // Some DE would pretend to be Unity but don't have global application menu,
   // so we can not trust unity::IsRunning().
   // When Unity's GlobalMenu is running $UBUNTU_MENUPROXY should be set to
-  // something like "libappmenu.so".
+  // something like "libappmenu.so" (not 0 or 1)
   scoped_ptr<base::Environment> env(base::Environment::Create());
   std::string name;
-  return env && env->GetVar("UBUNTU_MENUPROXY", &name) &&
-         !name.empty() && name != "0";
+  return env && env->GetVar("UBUNTU_MENUPROXY", &name) && name.length() > 1;
 }
 #endif
 


### PR DESCRIPTION
Hello,

When testing if `$UBUNTU_MENUPROXY` is set, we should also check if it contains more than one character.

It should avoid cases when this environment variable is set to `1` (problem reported by @jbt in #699 )

Best Regards,

Matt
