### PR TITLE
Don't hard-code the atom.lib file

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -902,7 +902,7 @@
             {
               'action_name': 'Create node.lib',
               'inputs': [
-                '<(PRODUCT_DIR)/atom.lib',
+                '<(PRODUCT_DIR)/<(project_name).lib',
                 '<(libchromiumcontent_library_dir)/chromiumcontent.dll.lib',
               ],
               'outputs': [


### PR DESCRIPTION
Use the `project_name` instead, which by default will be the same thing. This helps to work around #713, so the generated `node.lib` will reference the correct EXE name.
