### PR TITLE
Force native window

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -237,7 +237,7 @@ NativeWindowViews::NativeWindowViews(content::WebContents* web_contents,
   }
 #endif
 
-  if(has_frame_) {
+  if (has_frame_) {
     window_->set_frame_type(views::Widget::FrameType::FRAME_TYPE_FORCE_NATIVE);
     window_->FrameTypeChanged();
   }


### PR DESCRIPTION
- Force native frame for all OSes and suppress the Chrome provided blue frame. This also resolves an issue on Windows where systems cannot enable Aero Glass and were getting a Chrome provided blue frame even when the BrowserWindow option for frame was set to false.
