### PR TITLE
win: Fix default path for native dialogs

### DIFF
--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -105,7 +105,7 @@ class FileDialog {
                                              NULL,
                                              IID_PPV_ARGS(&folder_item));
     if (SUCCEEDED(hr))
-      GetPtr()->SetDefaultFolder(folder_item);
+      GetPtr()->SetFolder(folder_item);
   }
 
   scoped_ptr<T> dialog_;


### PR DESCRIPTION
- Call SetFolder instead of SetDefaultFolder on the dialog to set the default path. 

MSDN documentation states that SetDefaultFolder "Sets the folder used as a default if there is not a recently used folder value available."

http://msdn.microsoft.com/en-us/library/windows/desktop/bb775972(v=vs.85).aspx

MSDN documentation states that SetFolder "Sets a folder that is always selected when the dialog is opened, regardless of previous user action."

http://msdn.microsoft.com/en-us/library/windows/desktop/bb761828(v=vs.85).aspx
