### PR TITLE
Lookup node in PATHs

### DIFF
--- a/script/compile-coffee.py
+++ b/script/compile-coffee.py
@@ -7,8 +7,8 @@ import sys
 
 SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
 WINDOWS_NODE_PATHs = [
-  'C:/Program Files/nodejs',
   'C:/Program Files (x86)/nodejs',
+  'C:/Program Files/nodejs',
 ] + os.environ['PATH'].split(os.pathsep)
 
 


### PR DESCRIPTION
I installed to `c:\nodejs` to avoid spaces in path (old habits die hard). So i had an obstacle you see.
