### PR TITLE
fix typo in variable name

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -19,7 +19,7 @@ namespace {
 
 struct PrintSettings {
   bool silent;
-  bool print_backgournd;
+  bool print_background;
 };
 
 }  // namespace
@@ -34,7 +34,7 @@ struct Converter<PrintSettings> {
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
     dict.Get("silent", &(out->silent));
-    dict.Get("printBackground", &(out->print_backgournd));
+    dict.Get("printBackground", &(out->print_background));
     return true;
   }
 };
@@ -395,7 +395,7 @@ void Window::Print(mate::Arguments* args) {
     return;
   }
 
-  window_->Print(settings.silent, settings.print_backgournd);
+  window_->Print(settings.silent, settings.print_background);
 }
 
 void Window::SetProgressBar(double progress) {


### PR DESCRIPTION
This is just for the looks. No errors where thrown, because the name was misspelled everywhere it occurred.

**edit:** I called it variable name, but it's a field name. (Or what is it called? It's in a struct.)
