### PR TITLE
`subprocess.Popen` fails when Python is in "App Paths"

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -352,7 +352,7 @@
       'sk', 'sl', 'sr', 'sv', 'sw', 'ta', 'te', 'th', 'tr', 'uk',
       'vi', 'zh-CN', 'zh-TW',
     ],
-    'atom_source_root': '<!(python tools/atom_source_root.py)',
+    'atom_source_root': '<!(["python", "tools/atom_source_root.py"])',
     'conditions': [
       ['OS=="win"', {
         'app_sources': [


### PR DESCRIPTION
Win32. Python is not added to PATHs by default. Instead it is added to `App Paths` registry key ( http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx ). In any case Python binary is found when i enter `python` command. But `subprocess.Popen` seems to fail when BOTH (1) runs a string `python tools/atom_source_root.py` AND (2) python is not in PATHs, only in App Paths. I suggest using list in `<!(` and hope this does not break linux/macos builds.
