### PR TITLE
Fix nullref crash in WebViewManager::RemoveGuest

### DIFF
--- a/atom/browser/web_view/web_view_manager.cc
+++ b/atom/browser/web_view/web_view_manager.cc
@@ -80,16 +80,18 @@ void WebViewManager::AddGuest(int guest_instance_id,
 }
 
 void WebViewManager::RemoveGuest(int guest_instance_id) {
+  if (!ContainsKey(web_contents_map_, guest_instance_id)) {
+    return;
+  }
+
   auto web_contents = web_contents_map_[guest_instance_id].web_contents;
 
-  if (web_contents) {
-    content::BrowserThread::PostTask(
-        content::BrowserThread::IO, FROM_HERE,
-        base::Bind(
-            &WebViewRendererState::RemoveGuest,
-            base::Unretained(WebViewRendererState::GetInstance()),
-            web_contents->GetRenderProcessHost()->GetID()));
-  }
+  content::BrowserThread::PostTask(
+      content::BrowserThread::IO, FROM_HERE,
+      base::Bind(
+          &WebViewRendererState::RemoveGuest,
+          base::Unretained(WebViewRendererState::GetInstance()),
+          web_contents->GetRenderProcessHost()->GetID()));
 
   web_contents_map_.erase(guest_instance_id);
 


### PR DESCRIPTION
This fix might not be The Right Fix, here's what we're seeing during running our test suite that quickly creates and trashes WebView objects:

```
(lldb) bt
* thread #1: tid = 0x1ed1ee, 0x0000000100039afe Slack Framework`atom::WebViewManager::RemoveGuest(this=0x000000010624ed20, guest_instance_id=6) + 94 at web_view_manager.cc:89, name = 'CrBrowserMain', queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x0000000100039afe Slack Framework`atom::WebViewManager::RemoveGuest(this=0x000000010624ed20, guest_instance_id=6) + 94 at web_view_manager.cc:89
    frame #1: 0x000000010003abf1 Slack Framework`mate::internal::Dispatcher<void (int)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) [inlined] base::Callback<void (a1=0x045dbc2000000006)>::Run(int const&) const + 14 at callback.h:441
    frame #2: 0x000000010003abe3 Slack Framework`mate::internal::Dispatcher<void (int)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) [inlined] mate::internal::Invoker<void, int, void, void, void, void, void, void>::Go(args=0x000000010509de00, a1=0x045dbc2000000006)> const&, int const&) at function_template.h:271
    frame #3: 0x000000010003abe3 Slack Framework`mate::internal::Dispatcher<void (info=<unavailable>)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 167 at function_template.h:366
    frame #4: 0x0000000101e5b74f libchromiumcontent.dylib`___lldb_unnamed_function45102$$libchromiumcontent.dylib + 159
    frame #5: 0x0000000101e7dc1f libchromiumcontent.dylib`___lldb_unnamed_function45852$$libchromiumcontent.dylib + 511

(lldb) frame variable
(atom::WebViewManager *) this = 0x000000010624ed20
(int) guest_instance_id = 6
(content::WebContents *) web_contents = 0x0000000000000000
(logging::LogSeverity) LOG_FATAL = <empty constant data>
(const int) kApiPointerSize = <empty constant data>
```

This is because the last element in `web_element_map_` is garbage:

```
(lldb) po web_contents_map_
size=5
 {
   {
    1
     {
      0x0000000106865c00
      0x0000000107007000
    }
  }
   {
    2
     {
      0x0000000105138200
      0x0000000107007000
    }
  }
   {
    3
     {
      0x0000000105159000
      0x0000000107007000
    }
  }
   {
    <object returned empty description>
     {
      0x000000010b1ea000
      0x0000000107356a00
    }
  }
   {
    6
     {
      <nil>
      <nil>
    }
  }
```
