### PR TITLE
Add BrowserWindow.showDefinitionForSelection()

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -422,6 +422,12 @@ bool Window::IsMenuBarVisible() {
   return window_->IsMenuBarVisible();
 }
 
+#if defined(OS_MACOSX)
+void Window::ShowDefinitionForSelection() {
+  window_->ShowDefinitionForSelection();
+}
+#endif
+
 mate::Handle<WebContents> Window::GetWebContents(v8::Isolate* isolate) const {
   return WebContents::CreateFrom(isolate, window_->GetWebContents());
 }
@@ -491,6 +497,10 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isMenuBarAutoHide", &Window::IsMenuBarAutoHide)
       .SetMethod("setMenuBarVisibility", &Window::SetMenuBarVisibility)
       .SetMethod("isMenuBarVisible", &Window::IsMenuBarVisible)
+#if defined(OS_MACOSX)
+      .SetMethod(
+        "showDefinitionForSelection", &Window::ShowDefinitionForSelection)
+#endif
       .SetMethod("_getWebContents", &Window::GetWebContents)
       .SetMethod("_getDevToolsWebContents", &Window::GetDevToolsWebContents);
 }

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -123,6 +123,10 @@ class Window : public mate::EventEmitter,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
 
+#if defined(OS_MACOSX)
+  void ShowDefinitionForSelection();
+#endif
+
   // APIs for WebContents.
   mate::Handle<WebContents> GetWebContents(v8::Isolate* isolate) const;
   mate::Handle<WebContents> GetDevToolsWebContents(v8::Isolate* isolate) const;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -247,6 +247,10 @@ void NativeWindow::Print(bool silent, bool print_background) {
       PrintNow(silent, print_background);
 }
 
+void NativeWindow::ShowDefinitionForSelection() {
+  NOTIMPLEMENTED();
+}
+
 void NativeWindow::SetAutoHideMenuBar(bool auto_hide) {
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -161,6 +161,9 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   // Print current page.
   virtual void Print(bool silent, bool print_background);
 
+  // Show popup dictionary.
+  virtual void ShowDefinitionForSelection();
+
   // Toggle the menu bar.
   virtual void SetAutoHideMenuBar(bool auto_hide);
   virtual bool IsMenuBarAutoHide();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -7,6 +7,9 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include <string>
+#include <vector>
+
 #include "base/mac/scoped_nsobject.h"
 #include "base/memory/scoped_ptr.h"
 #include "atom/browser/native_window.h"
@@ -68,6 +71,7 @@ class NativeWindowMac : public NativeWindow {
   virtual bool HasModalDialog() OVERRIDE;
   virtual gfx::NativeWindow GetNativeWindow() OVERRIDE;
   virtual void SetProgressBar(double progress) OVERRIDE;
+  virtual void ShowDefinitionForSelection() OVERRIDE;
 
   // Returns true if |point| in local Cocoa coordinate system falls within
   // the draggable region.

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -642,6 +642,14 @@ void NativeWindowMac::SetProgressBar(double progress) {
   [dock_tile display];
 }
 
+void NativeWindowMac::ShowDefinitionForSelection() {
+  content::WebContents* web_contents = GetWebContents();
+  content::RenderWidgetHostView* rwhv = web_contents->GetRenderWidgetHostView();
+  if (!rwhv)
+    return;
+  rwhv->ShowDefinitionForSelection();
+}
+
 bool NativeWindowMac::IsWithinDraggableRegion(NSPoint point) const {
   if (!draggable_region_)
     return false;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -530,6 +530,11 @@ On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
 
+### BrowserWindow.showDefinitionForSelection()
+
+Show pop-up dictionary that searches the selected word on the page.
+This API is available only on Mac OS.
+
 ### BrowserWindow.setAutoHideMenuBar(hide)
 
 * `hide` Boolean


### PR DESCRIPTION
This API shows the system-provided pop-up dictionary.
Some Mac apps including Chrome have "Look Up in in Dictionary" context
menu item. This API can be used to implement it.
