### PR TITLE
Add .focus to the quick-start docs.

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -96,6 +96,9 @@ app.on('ready', function() {
   // and load the index.html of the app.
   mainWindow.loadUrl('file://' + __dirname + '/index.html');
 
+  // by default the window would open in the background
+  mainWindow.focus();
+
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {
     // Dereference the window object, usually you would store windows


### PR DESCRIPTION
This makes the example app behave more in line with what users expect from a normal app.
