### PR TITLE
browser: create cert verifier when browser context is created

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -65,7 +65,7 @@ std::string RemoveWhitespace(const std::string& str) {
 AtomBrowserContext::AtomBrowserContext(const std::string& partition,
                                        bool in_memory)
     : brightray::BrowserContext(partition, in_memory),
-      cert_verifier_(nullptr),
+      cert_verifier_(new AtomCertVerifier),
       job_factory_(new AtomURLRequestJobFactory),
       network_delegate_(new AtomNetworkDelegate),
       allow_ntlm_everywhere_(false) {
@@ -178,8 +178,6 @@ content::PermissionManager* AtomBrowserContext::GetPermissionManager() {
 }
 
 scoped_ptr<net::CertVerifier> AtomBrowserContext::CreateCertVerifier() {
-  DCHECK(!cert_verifier_);
-  cert_verifier_ = new AtomCertVerifier;
   return make_scoped_ptr(cert_verifier_);
 }
 


### PR DESCRIPTION
currently it crashes when trying to set a verifier. tested only on linux.

```
WARNING: ThreadSanitizer: data race (pid=21932)
  Write of size 8 at 0x7d3800017e38 by thread T12:
    #0 atom::AtomBrowserContext::CreateCertVerifier() <null> (electron+0x000000abe74b)
    #1 non-virtual thunk to atom::AtomBrowserContext::CreateCertVerifier() <null> (electron+0x000000abe81e)
    #2 brightray::URLRequestContextGetter::GetURLRequestContext() <null> (electron+0x000000ca6b4e)
    #3 content::ChromeAppCacheService::InitializeOnIOThread(base::FilePath const&, content::ResourceContext*, net::URLRequestContextGetter*, scoped_refptr<storage::SpecialStoragePolicy>) <null> (libcontent.so+0x0000005690bb)

  Previous read of size 8 at 0x7d3800017e38 by main thread (mutexes: write M3058):
    #0 atom::AtomBrowserContext::cert_verifier() const <null> (electron+0x000000a17349)
    #1 atom::api::Session::SetCertVerifyProc(v8::Local<v8::Value>, mate::Arguments*) <null> (electron+0x000000a12272)
    #2 base::internal::RunnableAdapter<void (atom::api::Session::*)(v8::Local<v8::Value>, mate::Arguments*)>::Run(atom::api::Session*, v8::Local<v8::Value> const&, mate::Arguments* const&) <null> (electron+0x000000a2e12b)
    #3 base::internal::InvokeHelper<false, void, base::internal::RunnableAdapter<void (atom::api::Session::*)(v8::Local<v8::Value>, mate::Arguments*)>, base::internal::TypeList<atom::api::Session* const&, v8::Local<v8::Value> const&, mate::Arguments* const&> >::MakeItSo(base::internal::RunnableAdapter<void (atom::api::Session::*)(v8::Local<v8::Value>, mate::Arguments*)>, atom::api::Session* const&, v8::Local<v8::Value> const&, mate::Arguments* const&) <null> (electron+0x000000a2dfec)
    #4 base::internal::Invoker<base::IndexSequence<>, base::internal::BindState<base::internal::RunnableAdapter<void (atom::api::Session::*)(v8::Local<v8::Value>, mate::Arguments*)>, void (atom::api::Session*, v8::Local<v8::Value>, mate::Arguments*)>, base::internal::TypeList<>, base::internal::InvokeHelper<false, void, base::internal::RunnableAdapter<void (atom::api::Session::*)(v8::Local<v8::Value>, mate::Arguments*)>, base::internal::TypeList<atom::api::Session* const&, v8::Local<v8::Value> const&, mate::Arguments* const&> >, void (atom::api::Session* const&, v8::Local<v8::Value> const&, mate::Arguments* const&)>::Run(base::internal::BindStateBase*, atom::api::Session* const&, v8::Local<v8::Value> const&, mate::Arguments* const&) <null> (electron+0x000000a2df3a)
    #5 base::Callback<void (atom::api::Session*, v8::Local<v8::Value>, mate::Arguments*)>::Run(atom::api::Session* const&, v8::Local<v8::Value> const&, mate::Arguments* const&) const <null> (electron+0x000000a2dc02)
    #6 mate::internal::Invoker<mate::internal::IndicesHolder<0ul, 1ul, 2ul>, atom::api::Session*, v8::Local<v8::Value>, mate::Arguments*>::DispatchToCallback(base::Callback<void (atom::api::Session*, v8::Local<v8::Value>, mate::Arguments*)>) <null> (electron+0x000000a2d5c7)
    #7 mate::internal::Dispatcher<void (atom::api::Session*, v8::Local<v8::Value>, mate::Arguments*)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) <null> (electron+0x000000a2d25b)
    #8 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) <null> (libv8.so+0x0000003a7863)
    #9 node::MakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::String>, int, v8::Local<v8::Value>*) <null> (libnode.so+0x0000000dc36e)
    #10 node::MakeCallback(node::Environment*, v8::Local<v8::Object>, char const*, int, v8::Local<v8::Value>*) <null> (libnode.so+0x0000000dc460)
    #11 node::MakeCallback(v8::Isolate*, v8::Local<v8::Object>, char const*, int, v8::Local<v8::Value>*) <null> (libnode.so+0x0000000dc608)
    #12 mate::internal::CallEmitWithArgs(v8::Isolate*, v8::Local<v8::Object>, std::vector<v8::Local<v8::Value>, std::allocator<v8::Local<v8::Value> > >*) <null> (electron+0x000000b84382)
    #13 v8::Local<v8::Value> mate::EmitEvent<base::BasicStringPiece<std::string>, v8::Local<v8::Object> >(v8::Isolate*, v8::Local<v8::Object>, base::BasicStringPiece<std::string> const&, v8::Local<v8::Object> const&) <null> (electron+0x000000971395)
    #14 bool mate::EventEmitter::EmitWithEvent<>(base::BasicStringPiece<std::string> const&, v8::Local<v8::Object>) <null> (electron+0x000000971124)
    #15 bool mate::EventEmitter::EmitWithSender<>(base::BasicStringPiece<std::string> const&, content::WebContents*, IPC::Message*) <null> (electron+0x000000970f9f)
    #16 bool mate::EventEmitter::Emit<>(base::BasicStringPiece<std::string> const&) <null> (electron+0x0000009689f2)
    #17 atom::api::App::OnFinishLaunching() <null> (electron+0x000000964bfb)
    #18 non-virtual thunk to atom::api::App::OnFinishLaunching() <null> (electron+0x000000964c3c)
    #19 atom::Browser::DidFinishLaunching() <null> (electron+0x0000008a8d6b)
    #20 atom::AtomBrowserMainParts::PreMainMessageLoopRun() <null> (electron+0x00000089d730)
    #21 content::BrowserMainLoop::PreMainMessageLoopRun() <null> (libcontent.so+0x00000058d780)
    #22 __libc_start_main <null> (libc.so.6+0x00000002070f)

  Location is heap block of size 216 at 0x7d3800017d80 allocated by main thread:
    #0 operator new(unsigned long) <null> (electron+0x00000088a57e)
    #1 brightray::BrowserContext::Create(std::string const&, bool) <null> (electron+0x000000abed03)
    #2 brightray::BrowserContext::From(std::string const&, bool) <null> (electron+0x000000c6d074)
    #3 brightray::BrowserMainParts::PreMainMessageLoopRun() <null> (electron+0x000000c740a7)
    #4 atom::AtomBrowserMainParts::PreMainMessageLoopRun() <null> (electron+0x00000089d6d3)
    #5 content::BrowserMainLoop::PreMainMessageLoopRun() <null> (libcontent.so+0x00000058d780)
    #6 __libc_start_main <null> (libc.so.6+0x00000002070f)

  Mutex M3058 (0x7d1400016210) created at:
    #0 pthread_mutex_init <null> (electron+0x000000823ec0)
    #1 v8::internal::ThreadManager::ThreadManager() <null> (libv8.so+0x00000083e63c)
    #2 atom::AtomBrowserMainParts::PostEarlyInitialization() <null> (electron+0x00000089d1b7)
    #3 content::BrowserMainLoop::EarlyInitialization() <null> (libcontent.so+0x000000589b22)
    #4 __libc_start_main <null> (libc.so.6+0x00000002070f)

  Thread T12 'Chrome_IOThread' (tid=21950, running) created by main thread at:
    #0 pthread_create <null> (electron+0x000000822861)
    #1 <null> <null> (libbase.so+0x0000000d2d33)
    #2 __libc_start_main <null> (libc.so.6+0x00000002070f)
```