### PR TITLE
Add `isMainFrame` param to WebContents `did-fail-load` event

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -541,7 +541,12 @@ void WebContents::DidFailProvisionalLoad(
     int error_code,
     const base::string16& error_description,
     bool was_ignored_by_handler) {
-  Emit("did-fail-provisional-load", error_code, error_description, url);
+  bool is_main_frame = !render_frame_host->GetParent();
+  Emit("did-fail-provisional-load",
+       error_code,
+       error_description,
+       url,
+       is_main_frame);
 }
 
 void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
@@ -549,7 +554,12 @@ void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
                               int error_code,
                               const base::string16& error_description,
                               bool was_ignored_by_handler) {
-  Emit("did-fail-load", error_code, error_description, validated_url);
+  bool is_main_frame = !render_frame_host->GetParent();
+  Emit("did-fail-load",
+       error_code,
+       error_description,
+       validated_url,
+       is_main_frame);
 }
 
 void WebContents::DidStartLoading() {
@@ -705,7 +715,8 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
     Emit("did-fail-load",
          static_cast<int>(net::ERR_INVALID_URL),
          net::ErrorToShortString(net::ERR_INVALID_URL),
-         url.possibly_invalid_spec());
+         url.possibly_invalid_spec(),
+         true);
     return;
   }
 

--- a/docs-translations/ko-KR/api/web-contents.md
+++ b/docs-translations/ko-KR/api/web-contents.md
@@ -31,6 +31,7 @@ Returns:
 * `errorCode` Integer
 * `errorDescription` String
 * `validatedURL` String
+* `isMainFrame` Boolean
 
 이 이벤트는 `did-finish-load`와 비슷하나, 로드가 실패했거나 취소되었을 때 발생합니다.
 예를 들면 `window.stop()`이 실행되었을 때 발생합니다. 발생할 수 있는 전체 에러 코드의

--- a/docs-translations/zh-CN/api/web-contents.md
+++ b/docs-translations/zh-CN/api/web-contents.md
@@ -30,6 +30,7 @@ var webContents = win.webContents;
 * `errorCode` Integer
 * `errorDescription` String
 * `validatedURL` String
+* `isMainFrame` Boolean
 
 这个事件类似 `did-finish-load` ，但是是在加载失败或取消加载时发出, 例如， `window.stop()` 请求结束.错误代码的完整列表和它们的含义都可以在 [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h) 找到.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -33,6 +33,7 @@ Returns:
 * `errorCode` Integer
 * `errorDescription` String
 * `validatedURL` String
+* `isMainFrame` Boolean
 
 This event is like `did-finish-load` but emitted when the load failed or was
 cancelled, e.g. `window.stop()` is invoked.

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -8,7 +8,7 @@ var requestId = 0
 var WEB_VIEW_EVENTS = {
   'load-commit': ['url', 'isMainFrame'],
   'did-finish-load': [],
-  'did-fail-load': ['errorCode', 'errorDescription', 'validatedURL'],
+  'did-fail-load': ['errorCode', 'errorDescription', 'validatedURL', 'isMainFrame'],
   'did-frame-finish-load': ['isMainFrame'],
   'did-start-loading': [],
   'did-stop-loading': [],

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -102,20 +102,30 @@ describe('browser-window module', function () {
     })
 
     it('should emit did-fail-load event for files that do not exist', function (done) {
-      w.webContents.on('did-fail-load', function (event, code) {
+      w.webContents.on('did-fail-load', function (event, code, desc, url, isMainFrame) {
         assert.equal(code, -6)
+        assert.equal(isMainFrame, true)
         done()
       })
       w.loadURL('file://a.txt')
     })
 
     it('should emit did-fail-load event for invalid URL', function (done) {
-      w.webContents.on('did-fail-load', function (event, code, desc) {
+      w.webContents.on('did-fail-load', function (event, code, desc, url, isMainFrame) {
         assert.equal(desc, 'ERR_INVALID_URL')
         assert.equal(code, -300)
+        assert.equal(isMainFrame, true)
         done()
       })
       w.loadURL('http://example:port')
+    })
+
+    it('should set `mainFrame = false` on did-fail-load events in iframes', function (done) {
+      w.webContents.on('did-fail-load', function (event, code, desc, url, isMainFrame) {
+        assert.equal(isMainFrame, false)
+        done()
+      })
+      w.loadURL('file://' + path.join(fixtures, 'api', 'did-fail-load-iframe.html'))
     })
   })
 

--- a/spec/fixtures/api/did-fail-load-iframe.html
+++ b/spec/fixtures/api/did-fail-load-iframe.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<iframe src="file://a.txt"></iframe>
+</body>
+</html>


### PR DESCRIPTION
This is a fairly simple patch to add a `isMainFrame` boolean param for the `did-fail-load` event on WebContents, indicating whether the failed load came from the main frame or from a child frame.

Fixes #5013.