### PR TITLE
Rebase on the correct Node commit

### DIFF
--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -196,6 +196,11 @@ describe('node feature', function () {
       assert.equal(b.toString(), 'Jøhänñéß')
       assert.equal(Buffer.byteLength(p.innerText), 13)
     })
+
+    it('does not crash when creating large Buffers', function () {
+      new Buffer(new Array(4096).join(' '));
+      new Buffer(new Array(4097).join(' '));
+    })
   })
 
   describe('process.stdout', function () {

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -217,6 +217,12 @@ describe('node feature', function () {
     })
   })
 
+  describe('process.version', function () {
+    it('should not have -pre', function () {
+      assert(!process.version.endsWith('-pre'))
+    })
+  })
+
   describe('vm.createContext', function () {
     it('should not crash', function () {
       require('vm').runInNewContext('')


### PR DESCRIPTION
Previously our Node fork was based on https://github.com/nodejs/node/commit/64c87e2cf4bdac6cdea302d5a5ead36c56f81c65, which is actually v6.0.0-pre, this commit fixes it by rebasing on https://github.com/nodejs/node/commit/79ea8c333c0ff7960d5f5da41c6b6cce9dc95776.

Close #5003.
Close #5019.