### PR TITLE
Allow bootstrap to be invoked via python2

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -15,7 +15,7 @@
     'openssl_fips': '',
     'openssl_no_asm': 1,
     'node_release_urlbase': 'https://atom.io/download/atom-shell',
-    'node_byteorder': '<!(python -c "import sys; print sys.byteorder")',
+    'node_byteorder': '<!(node <(DEPTH)/tools/get-endianness.js)',
     'node_target_type': 'shared_library',
     'node_install_npm': 'false',
     'node_prefix': '',

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -164,12 +164,12 @@ def update_clang():
 
 
 def download_sysroot(target_arch):
-  python = sys.executable;
   if target_arch == 'ia32':
     target_arch = 'i386'
   if target_arch == 'x64':
     target_arch = 'amd64'
-  execute_stdout([python, os.path.join(SOURCE_ROOT, 'script', 'install-sysroot.py'),
+  execute_stdout([sys.executable,
+                  os.path.join(SOURCE_ROOT, 'script', 'install-sysroot.py'),
                   '--arch', target_arch])
 
 def create_chrome_version_h():

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -164,11 +164,12 @@ def update_clang():
 
 
 def download_sysroot(target_arch):
+  python = sys.executable;
   if target_arch == 'ia32':
     target_arch = 'i386'
   if target_arch == 'x64':
     target_arch = 'amd64'
-  execute_stdout([os.path.join(SOURCE_ROOT, 'script', 'install-sysroot.py'),
+  execute_stdout([python, os.path.join(SOURCE_ROOT, 'script', 'install-sysroot.py'),
                   '--arch', target_arch])
 
 def create_chrome_version_h():

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -16,7 +16,7 @@
       'arm_neon%': 1,
 
       # Abosulte path to source root.
-      'source_root%': '<!(python <(DEPTH)/tools/atom_source_root.py)',
+      'source_root%': '<!(node <(DEPTH)/tools/atom_source_root.js)',
     },
 
     # Copy conditionally-set variables out one scope.

--- a/tools/atom_source_root.js
+++ b/tools/atom_source_root.js
@@ -1,0 +1,3 @@
+var path = require('path')
+
+console.log(path.resolve(path.dirname(__dirname)))

--- a/tools/atom_source_root.py
+++ b/tools/atom_source_root.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-
-import os
-
-"""Prints the absolute path of the root of atom-shell's source tree.
-"""
-
-
-print os.path.abspath(os.path.dirname(os.path.dirname(__file__)))

--- a/tools/get-endianness.js
+++ b/tools/get-endianness.js
@@ -1,0 +1,1 @@
+console.log(require('os').endianness() === 'BE' ? 'big' : 'little')

--- a/tools/get-endianness.js
+++ b/tools/get-endianness.js
@@ -1,1 +1,6 @@
-console.log(require('os').endianness() === 'BE' ? 'big' : 'little')
+var os = require('os')
+if (os.endianness) {
+  console.log(require('os').endianness() === 'BE' ? 'big' : 'little')
+} else {  // Your Node is rather old, but I don't care.
+  console.log('little')
+}

--- a/tools/linux/pkg-config-wrapper
+++ b/tools/linux/pkg-config-wrapper
@@ -31,6 +31,11 @@ then
   exit 1
 fi
 
+python2=$(which python2)
+if [ ! -x "$python2" ] ; then
+	python2=python
+fi 
+
 rewrite=`dirname $0`/rewrite_dirs.py
 package=${!#}
 
@@ -46,4 +51,4 @@ set -e
 # pkg-config's |prefix| variable.
 prefix=`PKG_CONFIG_LIBDIR=$libdir pkg-config --variable=prefix "$package" | sed -e 's|/usr$||'`
 result=`PKG_CONFIG_LIBDIR=$libdir pkg-config "$@"`
-echo "$result"| $rewrite --sysroot "$root" --strip-prefix "$prefix"
+echo "$result"| $python2 $rewrite --sysroot "$root" --strip-prefix "$prefix"

--- a/tools/linux/pkg-config-wrapper
+++ b/tools/linux/pkg-config-wrapper
@@ -33,8 +33,8 @@ fi
 
 python2=$(which python2)
 if [ ! -x "$python2" ] ; then
-	python2=python
-fi 
+  python2=python
+fi
 
 rewrite=`dirname $0`/rewrite_dirs.py
 package=${!#}


### PR DESCRIPTION
This means that on most Linux distributions where python3 is the default, we can invoke `python2 script/bootstrap.py` and have it work, instead of having to stomp the name `python` back to Python 2.x