### PR TITLE
Fix NVDA/JAWS support in Electron

### DIFF
--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -199,6 +199,10 @@ class NativeWindowViews : public NativeWindow,
 
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;
+
+  // If true we have enabled a11y
+  bool enabled_a11y_support_;
+
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -91,11 +91,16 @@ bool NativeWindowViews::PreHandleMSG(
     // accessibility object.
     case WM_GETOBJECT: {
       const DWORD obj_id = static_cast<DWORD>(l_param);
+      if (enabled_a11y_support_) return false;
+
       if (obj_id == OBJID_CLIENT) {
         const auto axState = content::BrowserAccessibilityState::GetInstance();
-        if (axState && !axState->IsAccessibleBrowser())
+        if (axState && !axState->IsAccessibleBrowser()) {
           axState->OnScreenReaderDetected();
+          enabled_a11y_support_ = true;
+        }
       }
+
       return false;
     }
     case WM_COMMAND:

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -84,6 +84,20 @@ bool NativeWindowViews::PreHandleMSG(
   NotifyWindowMessage(message, w_param, l_param);
 
   switch (message) {
+    // Screen readers send WM_GETOBJECT in order to get the accessibility
+    // object, so take this opportunity to push Chromium into accessible
+    // mode if it isn't already, always say we didn't handle the message
+    // because we still want Chromium to handle returning the actual
+    // accessibility object.
+    case WM_GETOBJECT: {
+      const DWORD obj_id = static_cast<DWORD>(l_param);
+      if (obj_id == OBJID_CLIENT) {
+        const auto axState = content::BrowserAccessibilityState::GetInstance();
+        if (axState && !axState->IsAccessibleBrowser())
+          axState->OnScreenReaderDetected();
+      }
+      return false;
+    }
     case WM_COMMAND:
       // Handle thumbar button click message.
       if (HIWORD(w_param) == THBN_CLICKED)


### PR DESCRIPTION
It appears that whatever was causing the performance issues in #4001 doesn't happen in Chromium 49, and users are reporting that the fix in #4009 does indeed cause degradation of functionality in NVDA / JAWS (though it's hard to see via NVDA's reader panel - both settings report what I would consider to be junk). 