### PR TITLE
Rename internal IPC events to start with ELECTRON_

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -28,7 +28,7 @@ BrowserWindow.prototype._init = function () {
       width: 800,
       height: 600
     }
-    return ipcMain.emit('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', event, url, frameName, disposition, options)
+    return ipcMain.emit('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', event, url, frameName, disposition, options)
   })
 
   // window.resizeTo(...)
@@ -80,16 +80,16 @@ BrowserWindow.prototype._init = function () {
 
   // Evented visibilityState changes
   this.on('show', () => {
-    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
+    this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
   })
   this.on('hide', () => {
-    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
+    this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
   })
   this.on('minimize', () => {
-    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
+    this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
   })
   this.on('restore', () => {
-    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
+    this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized())
   })
 
   // Notify the creation of the window.

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -3,12 +3,12 @@
 const ipcMain = require('electron').ipcMain
 
 // The history operation in renderer is redirected to browser.
-ipcMain.on('ATOM_SHELL_NAVIGATION_CONTROLLER', function (event, method, ...args) {
+ipcMain.on('ELECTRON_NAVIGATION_CONTROLLER', function (event, method, ...args) {
   var ref
   (ref = event.sender)[method].apply(ref, args)
 })
 
-ipcMain.on('ATOM_SHELL_SYNC_NAVIGATION_CONTROLLER', function (event, method, ...args) {
+ipcMain.on('ELECTRON_SYNC_NAVIGATION_CONTROLLER', function (event, method, ...args) {
   var ref
   event.returnValue = (ref = event.sender)[method].apply(ref, args)
 })

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -10,7 +10,7 @@ var deepEqual = function (opt1, opt2) {
 // A queue for holding all requests from renderer process.
 var requestsQueue = []
 
-ipcMain.on('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function (event, captureWindow, captureScreen, thumbnailSize, id) {
+ipcMain.on('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function (event, captureWindow, captureScreen, thumbnailSize, id) {
   var request
   request = {
     id: id,
@@ -51,7 +51,7 @@ desktopCapturer.emit = function (event, name, sources) {
     return results
   })()
   if ((ref = handledRequest.webContents) != null) {
-    ref.send('ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_' + handledRequest.id, result)
+    ref.send('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + handledRequest.id, result)
   }
 
   // Check the queue to see whether there is other same request. If has, handle
@@ -61,7 +61,7 @@ desktopCapturer.emit = function (event, name, sources) {
     request = requestsQueue[i]
     if (deepEqual(handledRequest.options, request.options)) {
       if ((ref1 = request.webContents) != null) {
-        ref1.send('ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_' + request.id, result)
+        ref1.send('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + request.id, result)
       }
     } else {
       unhandledRequestsQueue.push(request)

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -137,7 +137,7 @@ var createGuest = function (embedder, params) {
   // Dispatch events to embedder.
   fn = function (event) {
     return guest.on(event, function (_, ...args) {
-      return embedder.send.apply(embedder, ['ATOM_SHELL_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + guest.viewInstanceId, event].concat(args))
+      return embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + guest.viewInstanceId, event].concat(args))
     })
   }
   for (j = 0, len1 = supportedWebViewEvents.length; j < len1; j++) {
@@ -147,12 +147,12 @@ var createGuest = function (embedder, params) {
 
   // Dispatch guest's IPC messages to embedder.
   guest.on('ipc-message-host', function (_, [channel, ...args]) {
-    return embedder.send.apply(embedder, ['ATOM_SHELL_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + guest.viewInstanceId, channel].concat(args))
+    return embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + guest.viewInstanceId, channel].concat(args))
   })
 
   // Autosize.
   guest.on('size-changed', function (_, ...args) {
-    return embedder.send.apply(embedder, ['ATOM_SHELL_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + guest.viewInstanceId].concat(args))
+    return embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + guest.viewInstanceId].concat(args))
   })
   return id
 }
@@ -204,19 +204,19 @@ var destroyGuest = function (embedder, id) {
   }
 }
 
-ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params, requestId) {
-  return event.sender.send('ATOM_SHELL_RESPONSE_' + requestId, createGuest(event.sender, params))
+ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params, requestId) {
+  return event.sender.send('ELECTRON_RESPONSE_' + requestId, createGuest(event.sender, params))
 })
 
-ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, elementInstanceId, guestInstanceId, params) {
+ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, elementInstanceId, guestInstanceId, params) {
   return attachGuest(event.sender, elementInstanceId, guestInstanceId, params)
 })
 
-ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_DESTROY_GUEST', function (event, id) {
+ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_DESTROY_GUEST', function (event, id) {
   return destroyGuest(event.sender, id)
 })
 
-ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_SIZE', function (event, id, params) {
+ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_SET_SIZE', function (event, id, params) {
   var ref1
   return (ref1 = guestInstances[id]) != null ? ref1.guest.setSize(params) : void 0
 })

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -70,7 +70,7 @@ var createGuest = function (embedder, url, frameName, options) {
     return guest.destroy()
   }
   closedByUser = function () {
-    embedder.send('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + guestId)
+    embedder.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + guestId)
     return embedder.removeListener('render-view-deleted', closedByEmbedder)
   }
   embedder.once('render-view-deleted', closedByEmbedder)
@@ -86,7 +86,7 @@ var createGuest = function (embedder, url, frameName, options) {
 }
 
 // Routed window.open messages.
-ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, frameName, disposition, options) {
+ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, frameName, disposition, options) {
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options)
   if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {
@@ -96,17 +96,17 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, 
   }
 })
 
-ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function (event, guestId) {
+ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function (event, guestId) {
   var ref1
   return (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1.destroy() : void 0
 })
 
-ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guestId, method, ...args) {
+ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guestId, method, ...args) {
   var ref1
   event.returnValue = (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1[method].apply(ref1, args) : void 0
 })
 
-ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, guestId, message, targetOrigin, sourceOrigin) {
+ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, guestId, message, targetOrigin, sourceOrigin) {
   var guestContents, ref1, ref2, sourceId
   sourceId = (ref1 = BrowserWindow.fromWebContents(event.sender)) != null ? ref1.id : void 0
   if (sourceId == null) {
@@ -114,11 +114,11 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event
   }
   guestContents = (ref2 = BrowserWindow.fromId(guestId)) != null ? ref2.webContents : void 0
   if ((guestContents != null ? guestContents.getURL().indexOf(targetOrigin) : void 0) === 0 || targetOrigin === '*') {
-    return guestContents != null ? guestContents.send('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin) : void 0
+    return guestContents != null ? guestContents.send('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin) : void 0
   }
 })
 
-ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event, guestId, method, ...args) {
+ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event, guestId, method, ...args) {
   var ref1, ref2
   return (ref1 = BrowserWindow.fromId(guestId)) != null ? (ref2 = ref1.webContents) != null ? ref2[method].apply(ref2, args) : void 0 : void 0
 })

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -193,14 +193,14 @@ var unwrapArgs = function (sender, args) {
 
         let callIntoRenderer = function (...args) {
           if ((webContentsId in rendererFunctions) && !sender.isDestroyed()) {
-            sender.send('ATOM_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
+            sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
             throw new Error(`Attempting to call a function in a renderer window that has been closed or released. Function provided here: ${meta.location}.`)
           }
         }
         v8Util.setDestructor(callIntoRenderer, function () {
           if ((webContentsId in rendererFunctions) && !sender.isDestroyed()) {
-            sender.send('ATOM_RENDERER_RELEASE_CALLBACK', meta.id)
+            sender.send('ELECTRON_RENDERER_RELEASE_CALLBACK', meta.id)
           }
         })
         callbacks.set(meta.id, callIntoRenderer)
@@ -238,7 +238,7 @@ var callFunction = function (event, func, caller, args) {
   }
 }
 
-ipcMain.on('ATOM_BROWSER_REQUIRE', function (event, module) {
+ipcMain.on('ELECTRON_BROWSER_REQUIRE', function (event, module) {
   try {
     event.returnValue = valueToMeta(event.sender, process.mainModule.require(module))
   } catch (error) {
@@ -246,7 +246,7 @@ ipcMain.on('ATOM_BROWSER_REQUIRE', function (event, module) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_GET_BUILTIN', function (event, module) {
+ipcMain.on('ELECTRON_BROWSER_GET_BUILTIN', function (event, module) {
   try {
     event.returnValue = valueToMeta(event.sender, electron[module])
   } catch (error) {
@@ -254,7 +254,7 @@ ipcMain.on('ATOM_BROWSER_GET_BUILTIN', function (event, module) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_GLOBAL', function (event, name) {
+ipcMain.on('ELECTRON_BROWSER_GLOBAL', function (event, name) {
   try {
     event.returnValue = valueToMeta(event.sender, global[name])
   } catch (error) {
@@ -262,7 +262,7 @@ ipcMain.on('ATOM_BROWSER_GLOBAL', function (event, name) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_CURRENT_WINDOW', function (event) {
+ipcMain.on('ELECTRON_BROWSER_CURRENT_WINDOW', function (event) {
   try {
     event.returnValue = valueToMeta(event.sender, event.sender.getOwnerBrowserWindow())
   } catch (error) {
@@ -270,11 +270,11 @@ ipcMain.on('ATOM_BROWSER_CURRENT_WINDOW', function (event) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_CURRENT_WEB_CONTENTS', function (event) {
+ipcMain.on('ELECTRON_BROWSER_CURRENT_WEB_CONTENTS', function (event) {
   event.returnValue = valueToMeta(event.sender, event.sender)
 })
 
-ipcMain.on('ATOM_BROWSER_CONSTRUCTOR', function (event, id, args) {
+ipcMain.on('ELECTRON_BROWSER_CONSTRUCTOR', function (event, id, args) {
   try {
     args = unwrapArgs(event.sender, args)
     let constructor = objectsRegistry.get(id)
@@ -288,7 +288,7 @@ ipcMain.on('ATOM_BROWSER_CONSTRUCTOR', function (event, id, args) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_FUNCTION_CALL', function (event, id, args) {
+ipcMain.on('ELECTRON_BROWSER_FUNCTION_CALL', function (event, id, args) {
   try {
     args = unwrapArgs(event.sender, args)
     let func = objectsRegistry.get(id)
@@ -298,7 +298,7 @@ ipcMain.on('ATOM_BROWSER_FUNCTION_CALL', function (event, id, args) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_MEMBER_CONSTRUCTOR', function (event, id, method, args) {
+ipcMain.on('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', function (event, id, method, args) {
   try {
     args = unwrapArgs(event.sender, args)
     let constructor = objectsRegistry.get(id)[method]
@@ -311,7 +311,7 @@ ipcMain.on('ATOM_BROWSER_MEMBER_CONSTRUCTOR', function (event, id, method, args)
   }
 })
 
-ipcMain.on('ATOM_BROWSER_MEMBER_CALL', function (event, id, method, args) {
+ipcMain.on('ELECTRON_BROWSER_MEMBER_CALL', function (event, id, method, args) {
   try {
     args = unwrapArgs(event.sender, args)
     let obj = objectsRegistry.get(id)
@@ -321,7 +321,7 @@ ipcMain.on('ATOM_BROWSER_MEMBER_CALL', function (event, id, method, args) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_MEMBER_SET', function (event, id, name, value) {
+ipcMain.on('ELECTRON_BROWSER_MEMBER_SET', function (event, id, name, value) {
   try {
     let obj = objectsRegistry.get(id)
     obj[name] = value
@@ -331,7 +331,7 @@ ipcMain.on('ATOM_BROWSER_MEMBER_SET', function (event, id, name, value) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_MEMBER_GET', function (event, id, name) {
+ipcMain.on('ELECTRON_BROWSER_MEMBER_GET', function (event, id, name) {
   try {
     let obj = objectsRegistry.get(id)
     event.returnValue = valueToMeta(event.sender, obj[name])
@@ -340,11 +340,11 @@ ipcMain.on('ATOM_BROWSER_MEMBER_GET', function (event, id, name) {
   }
 })
 
-ipcMain.on('ATOM_BROWSER_DEREFERENCE', function (event, id) {
+ipcMain.on('ELECTRON_BROWSER_DEREFERENCE', function (event, id) {
   return objectsRegistry.remove(event.sender.getId(), id)
 })
 
-ipcMain.on('ATOM_BROWSER_GUEST_WEB_CONTENTS', function (event, guestInstanceId) {
+ipcMain.on('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, guestInstanceId) {
   try {
     let guestViewManager = require('./guest-view-manager')
     event.returnValue = valueToMeta(event.sender, guestViewManager.getGuest(guestInstanceId))
@@ -353,13 +353,13 @@ ipcMain.on('ATOM_BROWSER_GUEST_WEB_CONTENTS', function (event, guestInstanceId) 
   }
 })
 
-ipcMain.on('ATOM_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', function (event, requestId, guestInstanceId, method, ...args) {
+ipcMain.on('ELECTRON_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', function (event, requestId, guestInstanceId, method, ...args) {
   try {
     let guestViewManager = require('./guest-view-manager')
     let guest = guestViewManager.getGuest(guestInstanceId)
     if (requestId) {
       const responseCallback = function (result) {
-        event.sender.send(`ATOM_RENDERER_ASYNC_CALL_TO_GUEST_VIEW_RESPONSE_${requestId}`, result)
+        event.sender.send(`ELECTRON_RENDERER_ASYNC_CALL_TO_GUEST_VIEW_RESPONSE_${requestId}`, result)
       }
       args.push(responseCallback)
     }

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -27,8 +27,8 @@ exports.getSources = function (options, callback) {
     }
   }
   id = getNextId()
-  ipcRenderer.send('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, id)
-  return ipcRenderer.once('ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function (event, sources) {
+  ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, id)
+  return ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function (event, sources) {
     var source
     return callback(null, (function () {
       var i, len, results

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -102,11 +102,11 @@ let setObjectMembers = function (ref, object, metaId, members) {
       let remoteMemberFunction = function () {
         if (this && this.constructor === remoteMemberFunction) {
           // Constructor call.
-          let ret = ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_CONSTRUCTOR', metaId, member.name, wrapArgs(arguments))
+          let ret = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', metaId, member.name, wrapArgs(arguments))
           return metaToValue(ret)
         } else {
           // Call member function.
-          let ret = ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_CALL', metaId, member.name, wrapArgs(arguments))
+          let ret = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_CALL', metaId, member.name, wrapArgs(arguments))
           return metaToValue(ret)
         }
       }
@@ -122,13 +122,13 @@ let setObjectMembers = function (ref, object, metaId, members) {
       descriptor.configurable = true
     } else if (member.type === 'get') {
       descriptor.get = function () {
-        return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_GET', metaId, member.name))
+        return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_GET', metaId, member.name))
       }
 
       // Only set setter when it is writable.
       if (member.writable) {
         descriptor.set = function (value) {
-          ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_SET', metaId, member.name, value)
+          ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_SET', metaId, member.name, value)
           return value
         }
       }
@@ -182,14 +182,14 @@ let metaToValue = function (meta) {
         let remoteFunction = function () {
           if (this && this.constructor === remoteFunction) {
             // Constructor call.
-            let obj = ipcRenderer.sendSync('ATOM_BROWSER_CONSTRUCTOR', meta.id, wrapArgs(arguments))
+            let obj = ipcRenderer.sendSync('ELECTRON_BROWSER_CONSTRUCTOR', meta.id, wrapArgs(arguments))
             // Returning object in constructor will replace constructed object
             // with the returned object.
             // http://stackoverflow.com/questions/1978049/what-values-can-a-constructor-return-to-avoid-returning-this
             return metaToValue(obj)
           } else {
             // Function call.
-            let obj = ipcRenderer.sendSync('ATOM_BROWSER_FUNCTION_CALL', meta.id, wrapArgs(arguments))
+            let obj = ipcRenderer.sendSync('ELECTRON_BROWSER_FUNCTION_CALL', meta.id, wrapArgs(arguments))
             return metaToValue(obj)
           }
         }
@@ -209,7 +209,7 @@ let metaToValue = function (meta) {
       // Track delegate object's life time, and tell the browser to clean up
       // when the object is GCed.
       v8Util.setDestructor(ret, function () {
-        ipcRenderer.send('ATOM_BROWSER_DEREFERENCE', meta.id)
+        ipcRenderer.send('ELECTRON_BROWSER_DEREFERENCE', meta.id)
       })
 
       // Remember object's id.
@@ -239,12 +239,12 @@ var metaToPlainObject = function (meta) {
 }
 
 // Browser calls a callback in renderer.
-ipcRenderer.on('ATOM_RENDERER_CALLBACK', function (event, id, args) {
+ipcRenderer.on('ELECTRON_RENDERER_CALLBACK', function (event, id, args) {
   return callbacksRegistry.apply(id, metaToValue(args))
 })
 
 // A callback in browser is released.
-ipcRenderer.on('ATOM_RENDERER_RELEASE_CALLBACK', function (event, id) {
+ipcRenderer.on('ELECTRON_RENDERER_RELEASE_CALLBACK', function (event, id) {
   return callbacksRegistry.remove(id)
 })
 
@@ -265,27 +265,27 @@ for (var name in browserModules) {
 
 // Get remote module.
 exports.require = function (module) {
-  return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_REQUIRE', module))
+  return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_REQUIRE', module))
 }
 
 // Alias to remote.require('electron').xxx.
 exports.getBuiltin = function (module) {
-  return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_GET_BUILTIN', module))
+  return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_GET_BUILTIN', module))
 }
 
 // Get current BrowserWindow.
 exports.getCurrentWindow = function () {
-  return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_CURRENT_WINDOW'))
+  return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_CURRENT_WINDOW'))
 }
 
 // Get current WebContents object.
 exports.getCurrentWebContents = function () {
-  return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_CURRENT_WEB_CONTENTS'))
+  return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_CURRENT_WEB_CONTENTS'))
 }
 
 // Get a global object in browser.
 exports.getGlobal = function (name) {
-  return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_GLOBAL', name))
+  return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_GLOBAL', name))
 }
 
 // Get the process object in browser.
@@ -306,6 +306,6 @@ exports.createFunctionWithReturnValue = function (returnValue) {
 // Get the guest WebContents from guestInstanceId.
 exports.getGuestWebContents = function (guestInstanceId) {
   var meta
-  meta = ipcRenderer.sendSync('ATOM_BROWSER_GUEST_WEB_CONTENTS', guestInstanceId)
+  meta = ipcRenderer.sendSync('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', guestInstanceId)
   return metaToValue(meta)
 }

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -38,30 +38,30 @@ var BrowserWindowProxy = (function () {
   function BrowserWindowProxy (guestId1) {
     this.guestId = guestId1
     this.closed = false
-    ipcRenderer.once('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + this.guestId, () => {
+    ipcRenderer.once('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + this.guestId, () => {
       BrowserWindowProxy.remove(this.guestId)
       this.closed = true
     })
   }
 
   BrowserWindowProxy.prototype.close = function () {
-    return ipcRenderer.send('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', this.guestId)
+    return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', this.guestId)
   }
 
   BrowserWindowProxy.prototype.focus = function () {
-    return ipcRenderer.send('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'focus')
+    return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'focus')
   }
 
   BrowserWindowProxy.prototype.blur = function () {
-    return ipcRenderer.send('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'blur')
+    return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'blur')
   }
 
   Object.defineProperty(BrowserWindowProxy.prototype, 'location', {
     get: function () {
-      return ipcRenderer.sendSync('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'getURL')
+      return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'getURL')
     },
     set: function (url) {
-      return ipcRenderer.sendSync('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'loadURL', url)
+      return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'loadURL', url)
     }
   })
 
@@ -69,11 +69,11 @@ var BrowserWindowProxy = (function () {
     if (targetOrigin == null) {
       targetOrigin = '*'
     }
-    return ipcRenderer.send('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', this.guestId, message, targetOrigin, window.location.origin)
+    return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', this.guestId, message, targetOrigin, window.location.origin)
   }
 
   BrowserWindowProxy.prototype['eval'] = function (...args) {
-    return ipcRenderer.send.apply(ipcRenderer, ['ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, 'executeJavaScript'].concat(args))
+    return ipcRenderer.send.apply(ipcRenderer, ['ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, 'executeJavaScript'].concat(args))
   }
 
   return BrowserWindowProxy
@@ -147,7 +147,7 @@ window.open = function (url, frameName, features) {
       options[name] = parseInt(options[name], 10)
     }
   }
-  guestId = ipcRenderer.sendSync('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, frameName, disposition, options)
+  guestId = ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, frameName, disposition, options)
   if (guestId) {
     return BrowserWindowProxy.getOrCreate(guestId)
   } else {
@@ -200,7 +200,7 @@ if (process.openerId != null) {
   window.opener = BrowserWindowProxy.getOrCreate(process.openerId)
 }
 
-ipcRenderer.on('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', function (event, isVisible, isMinimized) {
+ipcRenderer.on('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', function (event, isVisible, isMinimized) {
   var hasChanged = _isVisible !== isVisible || _isMinimized !== isMinimized
 
   if (hasChanged) {
@@ -211,7 +211,7 @@ ipcRenderer.on('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', function (event, isVisi
   }
 })
 
-ipcRenderer.on('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId, message, sourceOrigin) {
+ipcRenderer.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId, message, sourceOrigin) {
   // Manually dispatch event instead of using postMessage because we also need to
   // set event.source.
   event = document.createEvent('Event')
@@ -224,11 +224,11 @@ ipcRenderer.on('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId,
 
 // Forward history operations to browser.
 var sendHistoryOperation = function (...args) {
-  return ipcRenderer.send.apply(ipcRenderer, ['ATOM_SHELL_NAVIGATION_CONTROLLER'].concat(args))
+  return ipcRenderer.send.apply(ipcRenderer, ['ELECTRON_NAVIGATION_CONTROLLER'].concat(args))
 }
 
 var getHistoryOperation = function (...args) {
-  return ipcRenderer.sendSync.apply(ipcRenderer, ['ATOM_SHELL_SYNC_NAVIGATION_CONTROLLER'].concat(args))
+  return ipcRenderer.sendSync.apply(ipcRenderer, ['ELECTRON_SYNC_NAVIGATION_CONTROLLER'].concat(args))
 }
 
 window.history.back = function () {

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -61,18 +61,18 @@ var dispatchEvent = function (webView, eventName, eventKey, ...args) {
 
 module.exports = {
   registerEvents: function (webView, viewInstanceId) {
-    ipcRenderer.on('ATOM_SHELL_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + viewInstanceId, function (event, eventName, ...args) {
+    ipcRenderer.on('ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + viewInstanceId, function (event, eventName, ...args) {
       return dispatchEvent.apply(null, [webView, eventName, eventName].concat(args))
     })
 
-    ipcRenderer.on('ATOM_SHELL_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + viewInstanceId, function (event, channel, ...args) {
+    ipcRenderer.on('ELECTRON_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + viewInstanceId, function (event, channel, ...args) {
       var domEvent = new Event('ipc-message')
       domEvent.channel = channel
       domEvent.args = args
       return webView.dispatchEvent(domEvent)
     })
 
-    return ipcRenderer.on('ATOM_SHELL_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + viewInstanceId, function (event, ...args) {
+    return ipcRenderer.on('ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + viewInstanceId, function (event, ...args) {
       var domEvent, f, i, j, len, ref1
       domEvent = new Event('size-changed')
       ref1 = ['oldWidth', 'oldHeight', 'newWidth', 'newHeight']
@@ -84,23 +84,23 @@ module.exports = {
     })
   },
   deregisterEvents: function (viewInstanceId) {
-    ipcRenderer.removeAllListeners('ATOM_SHELL_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + viewInstanceId)
-    ipcRenderer.removeAllListeners('ATOM_SHELL_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + viewInstanceId)
-    return ipcRenderer.removeAllListeners('ATOM_SHELL_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + viewInstanceId)
+    ipcRenderer.removeAllListeners('ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + viewInstanceId)
+    ipcRenderer.removeAllListeners('ELECTRON_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + viewInstanceId)
+    return ipcRenderer.removeAllListeners('ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + viewInstanceId)
   },
   createGuest: function (params, callback) {
     requestId++
-    ipcRenderer.send('ATOM_SHELL_GUEST_VIEW_MANAGER_CREATE_GUEST', params, requestId)
-    return ipcRenderer.once('ATOM_SHELL_RESPONSE_' + requestId, callback)
+    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', params, requestId)
+    return ipcRenderer.once('ELECTRON_RESPONSE_' + requestId, callback)
   },
   attachGuest: function (elementInstanceId, guestInstanceId, params) {
-    ipcRenderer.send('ATOM_SHELL_GUEST_VIEW_MANAGER_ATTACH_GUEST', elementInstanceId, guestInstanceId, params)
+    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', elementInstanceId, guestInstanceId, params)
     return webFrame.attachGuest(elementInstanceId)
   },
   destroyGuest: function (guestInstanceId) {
-    return ipcRenderer.send('ATOM_SHELL_GUEST_VIEW_MANAGER_DESTROY_GUEST', guestInstanceId)
+    return ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_DESTROY_GUEST', guestInstanceId)
   },
   setSize: function (guestInstanceId, params) {
-    return ipcRenderer.send('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_SIZE', guestInstanceId, params)
+    return ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_SET_SIZE', guestInstanceId, params)
   }
 }

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -404,7 +404,7 @@ var registerWebViewElement = function () {
   createNonBlockHandler = function (m) {
     return function (...args) {
       const internal = v8Util.getHiddenValue(this, 'internal')
-      return ipcRenderer.send.apply(ipcRenderer, ['ATOM_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', null, internal.guestInstanceId, m].concat(args))
+      return ipcRenderer.send.apply(ipcRenderer, ['ELECTRON_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', null, internal.guestInstanceId, m].concat(args))
     }
   }
   for (j = 0, len1 = nonblockMethods.length; j < len1; j++) {
@@ -419,8 +419,8 @@ var registerWebViewElement = function () {
       hasUserGesture = false
     }
     let requestId = getNextId()
-    ipcRenderer.send('ATOM_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', requestId, internal.guestInstanceId, 'executeJavaScript', code, hasUserGesture)
-    ipcRenderer.once(`ATOM_RENDERER_ASYNC_CALL_TO_GUEST_VIEW_RESPONSE_${requestId}`, function (event, result) {
+    ipcRenderer.send('ELECTRON_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', requestId, internal.guestInstanceId, 'executeJavaScript', code, hasUserGesture)
+    ipcRenderer.once(`ELECTRON_RENDERER_ASYNC_CALL_TO_GUEST_VIEW_RESPONSE_${requestId}`, function (event, result) {
       if (callback) callback(result)
     })
   }


### PR DESCRIPTION
This is a minor cleanup to rename the internal IPC events starting with `ATOM_` and `ATOM_SHELL_` to be `ELECTRON_` instead.

Although these are internal, doing debugging and logging you might across them so I figured they should have the updated name.