### PR TITLE
Mention signing is required on OS X for automatic updates

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -19,6 +19,9 @@ On OS X, the `autoUpdater` module is built upon [Squirrel.Mac][squirrel-mac],
 meaning you don't need any special setup to make it work. For server-side
 requirements, you can read [Server Support][server-support].
 
+**Note:** Your application must be signed for automatic updates on Mac OS X.
+This is a requirement of `Squirrel.Mac`.
+
 ### Windows
 
 On Windows, you have to install your app into a user's machine before you can


### PR DESCRIPTION
Small note about signing being required for `Squirrel.Mac` updates.

Refs #5008