### PR TITLE
Upgrade asar to remove graceful-fs warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electron",
   "version": "0.37.5",
   "devDependencies": {
-    "asar": "^0.10.0",
+    "asar": "^0.11.0",
     "request": "*",
     "standard": "^6.0.8"
   },


### PR DESCRIPTION
This upgrades to the latest version of `asar` which removes this warning from being logged during `npm install`.

```
npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
```