### PR TITLE
session: api to provide security style for the webcontents.

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -21,6 +21,7 @@
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/net_converter.h"
+#include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
 #include "base/files/file_path.h"
 #include "base/prefs/pref_service.h"
@@ -435,6 +436,17 @@ void Session::ClearHostResolverCache(mate::Arguments* args) {
                  callback));
 }
 
+void Session::SetSecurityStateHandler(v8::Local<v8::Value> val,
+                                      mate::Arguments* args) {
+  AtomBrowserContext::SecurityStateHandler handler;
+  if (!(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &handler))) {
+    args->ThrowError("Must pass null or function");
+    return;
+  }
+
+  browser_context_->set_security_state_handler(handler);
+}
+
 v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   if (cookies_.IsEmpty()) {
     auto handle = atom::api::Cookies::Create(isolate, browser_context());
@@ -489,6 +501,7 @@ void Session::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setPermissionRequestHandler",
                  &Session::SetPermissionRequestHandler)
       .SetMethod("clearHostResolverCache", &Session::ClearHostResolverCache)
+      .SetMethod("setSecurityStateHandler", &Session::SetSecurityStateHandler)
       .SetProperty("cookies", &Session::Cookies)
       .SetProperty("webRequest", &Session::WebRequest);
 }

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -79,6 +79,8 @@ class Session: public mate::TrackableObject<Session>,
   void SetPermissionRequestHandler(v8::Local<v8::Value> val,
                                    mate::Arguments* args);
   void ClearHostResolverCache(mate::Arguments* args);
+  void SetSecurityStateHandler(v8::Local<v8::Value> val,
+                               mate::Arguments* args);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
   v8::Local<v8::Value> WebRequest(v8::Isolate* isolate);
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -36,6 +36,7 @@
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "chrome/browser/printing/print_preview_message_handler.h"
 #include "content/common/view_messages.h"
+#include "content/public/browser/cert_store.h"
 #include "content/public/browser/favicon_status.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/navigation_details.h"
@@ -481,6 +482,40 @@ void WebContents::RequestToLockMouse(
   auto permission_helper =
       WebContentsPermissionHelper::FromWebContents(web_contents);
   permission_helper->RequestPointerLockPermission(user_gesture);
+}
+
+content::SecurityStyle WebContents::GetSecurityStyle(
+    content::WebContents* web_contents,
+    content::SecurityStyleExplanations* explanations) {
+  content::NavigationEntry* entry =
+      web_contents->GetController().GetVisibleEntry();
+  if (!entry)
+    return content::SECURITY_STYLE_UNKNOWN;
+  const content::SSLStatus& ssl_status = entry->GetSSL();
+  scoped_refptr<net::X509Certificate> cert = nullptr;
+  content::CertStore::GetInstance()->RetrieveCert(ssl_status.cert_id, &cert);
+  auto callback =
+      base::Bind(&WebContents::OnSecurityStateResponse, base::Unretained(this));
+  auto handler = GetBrowserContext()->security_state_handler();
+  if (!handler.is_null()) {
+    // Run in next tick to avoid race condition with default result dispatched to
+    // devtools.
+    base::MessageLoop::current()->PostTask(FROM_HERE,
+                                           base::Bind(handler,
+                                                      web_contents,
+                                                      ssl_status,
+                                                      cert,
+                                                      callback));
+  }
+  return ssl_status.security_style;
+}
+
+void WebContents::OnSecurityStateResponse(
+    const base::DictionaryValue& state) {
+  base::DictionaryValue notification;
+  notification.SetString("method", "Security.securityStateChanged");
+  notification.Set("params", make_scoped_ptr(state.DeepCopy()));
+  SendMessageToDevTools(notification);
 }
 
 void WebContents::BeforeUnloadFired(const base::TimeTicks& proceed_time) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -143,6 +143,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
                       const std::string& frame_name,
                       WindowOpenDisposition disposition);
 
+  // Callback triggered to set security state.
+  void OnSecurityStateResponse(const base::DictionaryValue& state);
+
   // Returns the web preferences of current WebContents.
   v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate);
 
@@ -209,6 +212,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
       content::WebContents* web_contents,
       bool user_gesture,
       bool last_unlocked_by_target) override;
+  content::SecurityStyle GetSecurityStyle(
+      content::WebContents* web_contents,
+      content::SecurityStyleExplanations* explanations) override;
 
   // content::WebContentsObserver:
   void BeforeUnloadFired(const base::TimeTicks& proceed_time) override;

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -9,6 +9,10 @@
 
 #include "brightray/browser/browser_context.h"
 
+namespace content {
+struct SSLStatus;
+}
+
 namespace atom {
 
 class AtomDownloadManagerDelegate;
@@ -20,6 +24,12 @@ class WebViewManager;
 
 class AtomBrowserContext : public brightray::BrowserContext {
  public:
+  using SecurityStateHandler =
+      base::Callback<void(content::WebContents*,
+                          const content::SSLStatus&,
+                          scoped_refptr<net::X509Certificate>,
+                          base::Callback<void(const base::DictionaryValue&)>)>;
+
   AtomBrowserContext(const std::string& partition, bool in_memory);
   ~AtomBrowserContext() override;
 
@@ -51,6 +61,13 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   AtomNetworkDelegate* network_delegate() const { return network_delegate_; }
 
+  void set_security_state_handler(const SecurityStateHandler& handler) {
+    security_state_handler_ = handler;
+  }
+  SecurityStateHandler security_state_handler() const {
+      return security_state_handler_;
+  }
+
  private:
   scoped_ptr<AtomDownloadManagerDelegate> download_manager_delegate_;
   scoped_ptr<WebViewManager> guest_manager_;
@@ -60,6 +77,8 @@ class AtomBrowserContext : public brightray::BrowserContext {
   AtomCertVerifier* cert_verifier_;
   AtomURLRequestJobFactory* job_factory_;
   AtomNetworkDelegate* network_delegate_;
+
+  SecurityStateHandler security_state_handler_;
 
   bool allow_ntlm_everywhere_;
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -14,6 +14,7 @@
 #include "atom/browser/ui/file_dialog.h"
 #include "atom/browser/web_dialog_helper.h"
 #include "base/files/file_util.h"
+#include "base/json/json_writer.h"
 #include "base/prefs/pref_service.h"
 #include "base/prefs/scoped_user_pref_update.h"
 #include "chrome/browser/printing/print_preview_message_handler.h"
@@ -175,6 +176,13 @@ void CommonWebContentsDelegate::SetOwnerWindow(
 
 void CommonWebContentsDelegate::DestroyWebContents() {
   web_contents_.reset();
+}
+
+void CommonWebContentsDelegate::SendMessageToDevTools(
+    const base::DictionaryValue& notification) {
+  std::string json_message;
+  base::JSONWriter::Write(notification, &json_message);
+  web_contents_->SendProtocolMessage(json_message);
 }
 
 content::WebContents* CommonWebContentsDelegate::GetWebContents() const {

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -40,6 +40,8 @@ class CommonWebContentsDelegate
   // Destroy the managed InspectableWebContents object.
   void DestroyWebContents();
 
+  void SendMessageToDevTools(const base::DictionaryValue& params);
+
   // Returns the WebContents managed by this delegate.
   content::WebContents* GetWebContents() const;
 

--- a/atom/common/native_mate_converters/content_converter.h
+++ b/atom/common/native_mate_converters/content_converter.h
@@ -15,6 +15,7 @@
 
 namespace content {
 struct ContextMenuParams;
+struct SSLStatus;
 class WebContents;
 }
 
@@ -51,6 +52,12 @@ template<>
 struct Converter<content::StopFindAction> {
   static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
                      content::StopFindAction* out);
+};
+
+template<>
+struct Converter<content::SSLStatus> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const content::SSLStatus& val);
 };
 
 template<>

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -54,6 +54,8 @@ v8::Local<v8::Value> Converter<const net::AuthChallengeInfo*>::ToV8(
 v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
     v8::Isolate* isolate, const scoped_refptr<net::X509Certificate>& val) {
   mate::Dictionary dict(isolate, v8::Object::New(isolate));
+  if (!val.get())
+     return v8::Null(isolate);
   std::string encoded_data;
   net::X509Certificate::GetPEMEncoded(
       val->os_cert_handle(), &encoded_data);
@@ -62,6 +64,8 @@ v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
                                    encoded_data.size()).ToLocalChecked();
   dict.Set("data", buffer);
   dict.Set("issuerName", val->issuer().GetDisplayName());
+  dict.Set("validStart", val->valid_start().ToDoubleT());
+  dict.Set("validExpiry", val->valid_expiry().ToDoubleT());
   return dict.GetHandle();
 }
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -320,6 +320,119 @@ session.fromPartition(partition).setPermissionRequestHandler(function(webContent
 
 Clears the host resolver cache.
 
+#### `ses.setSecurityStateHandler(handler)`
+
+* `handler` Function
+  * `webContents` Object - [WebContents](web-contents.md) requesting the security state.
+  * `sslStatus` Object
+    * `certStatus` String (optional) - Certificate error status as described
+      in [cert_status_flags.h](cert-status-flags).
+    * `sslVersion` String (optional)
+    * `ciphersuite` Object (optional)
+      * `keyExchange` String
+      * `cipher` String
+    * `ranMixedContent` Boolean
+    * `displayedMixedContent` Boolean
+  * `certificate` Object
+    * `data` Buffer - PEM encoded data
+    * `issuerName` String - Issuer's Common Name
+    * `vaildStart` Double - The valid start date of the certificate as
+       the number of seconds since the UNIX epoch.
+    * `validExpiry` Double - The expiration date of the certificate as
+       the number of seconds since the UNIX epoch.
+  * `callback` Function
+
+The `callback` has to be called with a `securityState` object
+
+* `securityState` Object
+  * `securityState` String - The security level of the page resource, can be
+    'unknown', 'neutral', 'insecure', 'warning', 'secure', 'info'.
+  * `explanations` Array (optional) - An array of `securityStateExplanation`.
+  * `mixedContentStatus` Object (optional)
+    * `ranInsecureContent` Boolean - Whether the page ran insecure content such as scripts.
+    * `displayedInsecureContent` Boolean - Whether the page displayed insecure content such as images.
+    * `ranInsecureContentStyle` String - `securityState` representing a page that ran insecure content.
+    * `displayedInsecureContentStyle` String - `securityState` representing a page that displayed insecure content.
+  * `schemeIsCryptographic` Boolean (optional) - Whether the page was loaded over a cryptographic transport.
+
+* `securityStateExplanation` Object
+  * `securityState` String - Represents the severity of the factor being explained, can be
+    'unknown', 'neutral', 'insecure', 'warning', 'secure', 'info'.
+  * `summary` String - Short phrase descirbing the type of factor.
+  * `description` String - Full text explanation of the factor.
+
+Sets the `handler` which can be used to respond security state requests for the `session`.
+
+```javascript
+session.fromPartition(partition).setSecurityStateHandler(function(webContents, sslStatus, certificate, callback) {
+  let explanations = []
+  let certExplanation, cipherExplanation, securityState = "neutral"
+  let isSecureScheme = (url.parse(webContents.getURL()).protocol == "https:")
+  if (isSecureScheme) {
+    securityState = "secure"
+    if (sslStatus.certStatus) {
+      securityState = "insecure"
+      certExplanation = {
+        securityState: "insecure",
+        summary: "Certificate Error",
+        description: "There are issues with site's certificate chain " + sslStatus.certStatus,
+      }
+    } else {
+      certExplanation = {
+        securityState: "secure",
+        summary: "Valid Certificate",
+        description: "The connection to this site is using a valid, trusted server certificate.",
+      }
+    }
+    explanations.push(certExplanation)
+
+    if (sslStatus.sslVersion && sslStatus.ciphersuite) {
+      let isSecureProtocol = (sslStatus.sslVersion == "TLS 1.2")
+      let isSecureCiphersuite = true
+      let ciphersuite = sslStatus.ciphersuite
+      switch (ciphersuite.keyExchange) {
+        case "ECDHE_RSA":
+        case "ECDHE_ECDSA":
+          break
+        default:
+          isSecureCiphersuite = false
+      }
+
+      switch (ciphersuite.cipher) {
+        case "AES_128_GCM":
+        case "AES_256_GCM":
+          break
+        default:
+          isSecureCiphersuite = false
+      }
+
+      if (isSecureProtocol && isSecureCiphersuite) {
+        cipherExplanation = {
+          securityState: "secure",
+          summary: "Secure TLS connection",
+          description: "The connection to this site is using strong protocol and cipher suite."
+        }
+        explanations.push(cipherExplanation)
+      }
+    }
+  }
+
+  let state = {
+    securityState: securityState,
+    explanations: explanations,
+    mixedContentStatus: {
+      ranInsecureContent: sslStatus.ranInsecureContent,
+      displayedInsecureContent: sslStatus.displayedInsecureContent,
+      ranInsecureContentStyle: "insecure",
+      displayedInsecureContentStyle: "neutral",
+    },
+    schemeIsCryptograhic: isSecureScheme,
+  }
+
+  callback(state);
+});
+```
+
 #### `ses.webRequest`
 
 The `webRequest` API set allows to intercept and modify contents of a request at
@@ -523,3 +636,5 @@ The `listener` will be called with `listener(details)` when an error occurs.
   * `timestamp` Double
   * `fromCache` Boolean
   * `error` String - The error description.
+
+[cert-status-flags]: https://code.google.com/p/chromium/codesearch#chromium/src/net/cert/cert_status_flags_list.h


### PR DESCRIPTION
Instead of electron describing the security style of the webcontents, we allow users to decide custom security style when requested by devtools security panel.


Depends on https://github.com/electron/brightray/pull/206

Fixes #5022 