### PR TITLE
Don't wait for xdg-open to exit when OpenExternal is called (Linux)

### DIFF
--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -32,8 +32,10 @@ bool XDGUtil(const std::string& util,
   if (!process.IsValid())
     return false;
 
-  if (!wait_for_exit)
+  if (!wait_for_exit) {
+    base::EnsureProcessGetsReaped(process.Pid());
     return true;
+  }
 
   int exit_code = -1;
   if (!process.WaitForExit(&exit_code))

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -13,7 +13,9 @@
 
 namespace {
 
-bool XDGUtil(const std::string& util, const std::string& arg) {
+bool XDGUtil(const std::string& util,
+             const std::string& arg,
+             bool wait_for_exit) {
   std::vector<std::string> argv;
   argv.push_back(util);
   argv.push_back(arg);
@@ -30,6 +32,9 @@ bool XDGUtil(const std::string& util, const std::string& arg) {
   if (!process.IsValid())
     return false;
 
+  if (!wait_for_exit)
+    return true;
+
   int exit_code = -1;
   if (!process.WaitForExit(&exit_code))
     return false;
@@ -37,12 +42,12 @@ bool XDGUtil(const std::string& util, const std::string& arg) {
   return (exit_code == 0);
 }
 
-bool XDGOpen(const std::string& path) {
-  return XDGUtil("xdg-open", path);
+bool XDGOpen(const std::string& path, bool wait_for_exit) {
+  return XDGUtil("xdg-open", path, wait_for_exit);
 }
 
-bool XDGEmail(const std::string& email) {
-  return XDGUtil("xdg-email", email);
+bool XDGEmail(const std::string& email, bool wait_for_exit) {
+  return XDGUtil("xdg-email", email, wait_for_exit);
 }
 
 }  // namespace
@@ -57,22 +62,24 @@ void ShowItemInFolder(const base::FilePath& full_path) {
   if (!base::DirectoryExists(dir))
     return;
 
-  XDGOpen(dir.value());
+  XDGOpen(dir.value(), true);
 }
 
 void OpenItem(const base::FilePath& full_path) {
-  XDGOpen(full_path.value());
+  XDGOpen(full_path.value(), true);
 }
 
 bool OpenExternal(const GURL& url, bool activate) {
+  // Don't wait for exit, since we don't want to wait for the browser/email
+  // client window to close before returning
   if (url.SchemeIs("mailto"))
-    return XDGEmail(url.spec());
+    return XDGEmail(url.spec(), false);
   else
-    return XDGOpen(url.spec());
+    return XDGOpen(url.spec(), false);
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path) {
-  return XDGUtil("gvfs-trash", full_path.value());
+  return XDGUtil("gvfs-trash", full_path.value(), true);
 }
 
 void Beep() {

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -15,7 +15,7 @@ namespace {
 
 bool XDGUtil(const std::string& util,
              const std::string& arg,
-             bool wait_for_exit) {
+             const bool wait_for_exit) {
   std::vector<std::string> argv;
   argv.push_back(util);
   argv.push_back(arg);
@@ -42,11 +42,11 @@ bool XDGUtil(const std::string& util,
   return (exit_code == 0);
 }
 
-bool XDGOpen(const std::string& path, bool wait_for_exit) {
+bool XDGOpen(const std::string& path, const bool wait_for_exit) {
   return XDGUtil("xdg-open", path, wait_for_exit);
 }
 
-bool XDGEmail(const std::string& email, bool wait_for_exit) {
+bool XDGEmail(const std::string& email, const bool wait_for_exit) {
   return XDGUtil("xdg-email", email, wait_for_exit);
 }
 


### PR DESCRIPTION
Some browsers (eg. Firefox) may not return until the browser window is closed. This causes the Electron application to lock up while the browser window is open.

Fixes https://github.com/atom/atom/issues/6320

I'm struggling to properly test this fix, as I can't work out how to use a custom build of Electron when building Atom. Any help with this would be appreciated.