### PR TITLE
Document API naming conventions

### DIFF
--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -44,7 +44,7 @@ etc.
 Electron APIs uses the same capitalization scheme as Node.js:
 
 - When the module itself is a class like `BrowserWindow`, use CamelCase.
-- When the module is a set of APIs, like `clipboard`, use mixedCase.
+- When the module is a set of APIs, like `globalShortcut`, use mixedCase.
 - When the API is a property of object, and it is complex enough to be in a separate chapter like `win.webContents`, use mixedCase.
 - For other non-module APIs, use natural titles, like `<webview> Tag` or `Process Object`.
 

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -39,9 +39,16 @@ etc.
   * [Template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
     instead of string concatenation using `+`
 
-## API Names
+## Naming Things
 
-When creating a new API, we should prefer getters and setters instead of
+Electron APIs uses the same capitalization scheme as Node.js:
+
+- When the module itself is a class like `BrowserWindow`, use CamelCase.
+- When the module is a set of APIs, like `clipboard`, use mixedCase.
+- When the API is a property of object, and it is complex enough to be in a separate chapter like `win.webContents`, use mixedCase.
+- For other non-module APIs, use natural titles, like `<webview> Tag` or `Process Object`.
+
+When creating a new API, it is preferred to use getters and setters instead of
 jQuery's one-function style. For example, `.getText()` and `.setText(text)`
 are preferred to `.text([text])`. There is a
 [discussion](https://github.com/electron/electron/issues/46) on this.

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -43,9 +43,9 @@ etc.
 
 Electron APIs uses the same capitalization scheme as Node.js:
 
-- When the module itself is a class like `BrowserWindow`, use CamelCase.
-- When the module is a set of APIs, like `globalShortcut`, use mixedCase.
-- When the API is a property of object, and it is complex enough to be in a separate chapter like `win.webContents`, use mixedCase.
+- When the module itself is a class like `BrowserWindow`, use `CamelCase`.
+- When the module is a set of APIs, like `globalShortcut`, use `mixedCase`.
+- When the API is a property of object, and it is complex enough to be in a separate chapter like `win.webContents`, use `mixedCase`.
 - For other non-module APIs, use natural titles, like `<webview> Tag` or `Process Object`.
 
 When creating a new API, it is preferred to use getters and setters instead of


### PR DESCRIPTION
This is a followup to https://github.com/electron/electron/issues/5010 that adds API naming conventions to the dev docs.

Thanks for clarifying, @yishn and @zcbenz.