### PR TITLE
Use node 0.10 instead of 0.8 on internal CI machines

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -98,7 +98,8 @@ def log_versions():
 
   sys.stderr.write('\nnpm --version\n')
   sys.stderr.flush()
-  subprocess.call(["npm", "--version"])
+  npm = 'npm.cmd' if PLATFORM == 'win32' else 'npm'
+  subprocess.call([npm, "--version"])
 
 
 def setup_nodenv():

--- a/script/cibuild
+++ b/script/cibuild
@@ -94,6 +94,7 @@ def setup_nodenv():
     os.environ['NODENV_ROOT'] = '/usr/local/share/nodenv'
     os.environ['PATH'] += '/usr/local/share/nodenv/bin:/usr/local/share/nodenv/shims:' + os.environ['PATH']
     os.environ['NODENV_VERSION'] = 'v0.10.21'
+  subprocess.call(["node", "--version"])
 
 
 if __name__ == '__main__':

--- a/script/cibuild
+++ b/script/cibuild
@@ -92,7 +92,7 @@ def run_script(script, args=[]):
 def setup_nodenv():
   if os.path.isdir('/usr/local/share/nodenv'):
     os.environ['NODENV_ROOT'] = '/usr/local/share/nodenv'
-    os.environ['PATH'] += '/usr/local/share/nodenv/bin:/usr/local/share/nodenv/shims:' + os.environ['PATH']
+    os.environ['PATH'] = '/usr/local/share/nodenv/bin:/usr/local/share/nodenv/shims:' + os.environ['PATH']
     os.environ['NODENV_VERSION'] = 'v0.10.21'
     print('configured nodenv')
   subprocess.call(["node", "--version"])

--- a/script/cibuild
+++ b/script/cibuild
@@ -94,6 +94,7 @@ def setup_nodenv():
     os.environ['NODENV_ROOT'] = '/usr/local/share/nodenv'
     os.environ['PATH'] += '/usr/local/share/nodenv/bin:/usr/local/share/nodenv/shims:' + os.environ['PATH']
     os.environ['NODENV_VERSION'] = 'v0.10.21'
+    print('configured nodenv')
   subprocess.call(["node", "--version"])
 
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -32,6 +32,9 @@ LINUX_DEPS_ARM = [
 def main():
   os.environ['CI'] = '1'
 
+  if os.environ.has_key('JANKY_SHA1'):
+    setup_nodenv()
+
   target_arch = 'x64'
   if os.environ.has_key('TARGET_ARCH'):
     target_arch = os.environ['TARGET_ARCH']
@@ -84,6 +87,13 @@ def run_script(script, args=[]):
   sys.stderr.flush()
   script = os.path.join(SOURCE_ROOT, 'script', script)
   subprocess.check_call([sys.executable, script] + args)
+
+
+def setup_nodenv():
+  if os.isdir('/usr/local/share/nodenv'):
+    os.environ['NODENV_ROOT'] = '/usr/local/share/nodenv'
+    os.environ['PATH'] += '/usr/local/share/nodenv/bin:/usr/local/share/nodenv/shims:' + os.environ['PATH']
+    os.environ['NODENV_VERSION'] = 'v0.10.21'
 
 
 if __name__ == '__main__':

--- a/script/cibuild
+++ b/script/cibuild
@@ -90,7 +90,7 @@ def run_script(script, args=[]):
 
 
 def setup_nodenv():
-  if os.isdir('/usr/local/share/nodenv'):
+  if os.path.isdir('/usr/local/share/nodenv'):
     os.environ['NODENV_ROOT'] = '/usr/local/share/nodenv'
     os.environ['PATH'] += '/usr/local/share/nodenv/bin:/usr/local/share/nodenv/shims:' + os.environ['PATH']
     os.environ['NODENV_VERSION'] = 'v0.10.21'

--- a/script/cibuild
+++ b/script/cibuild
@@ -59,6 +59,8 @@ def main():
   npm = 'npm.cmd' if PLATFORM == 'win32' else 'npm'
   execute([npm, 'install', 'npm@2.12.1'])
 
+  log_versions()
+
   is_release = os.environ.has_key('ELECTRON_RELEASE')
   args = ['--target_arch=' + target_arch]
   if not is_release:
@@ -89,13 +91,21 @@ def run_script(script, args=[]):
   subprocess.check_call([sys.executable, script] + args)
 
 
+def log_versions():
+  sys.stderr.write('\nnode --version\n')
+  sys.stderr.flush()
+  subprocess.call(["node", "--version"])
+
+  sys.stderr.write('\nnpm --version\n')
+  sys.stderr.flush()
+  subprocess.call(["npm", "--version"])
+
+
 def setup_nodenv():
   if os.path.isdir('/usr/local/share/nodenv'):
     os.environ['NODENV_ROOT'] = '/usr/local/share/nodenv'
     os.environ['PATH'] = '/usr/local/share/nodenv/bin:/usr/local/share/nodenv/shims:' + os.environ['PATH']
     os.environ['NODENV_VERSION'] = 'v0.10.21'
-    print('configured nodenv')
-  subprocess.call(["node", "--version"])
 
 
 if __name__ == '__main__':

--- a/script/cibuild
+++ b/script/cibuild
@@ -94,12 +94,12 @@ def run_script(script, args=[]):
 def log_versions():
   sys.stderr.write('\nnode --version\n')
   sys.stderr.flush()
-  subprocess.call(["node", "--version"])
+  subprocess.call(['node', '--version'])
 
   sys.stderr.write('\nnpm --version\n')
   sys.stderr.flush()
   npm = 'npm.cmd' if PLATFORM == 'win32' else 'npm'
-  subprocess.call([npm, "--version"])
+  subprocess.call([npm, '--version'])
 
 
 def setup_nodenv():


### PR DESCRIPTION
Previously `0.8.1` was used which was blocking module upgrades in #5064 since that version does not the new stream APIs.

Now `0.10.21` is used (still pretty old) is used.

I'm working on getting `v4.2.2` on these machines but until then this should unblock #5064 