### PR TITLE
Add backgroundThrottling option to webPreferences	

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -296,6 +296,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // Request id used for findInPage request.
   uint32_t request_id_;
 
+  // Whether background throttling is disabled.
+  bool background_throttling_;
+
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -179,6 +179,8 @@ The `webPreferences` option is an object that can have following properties:
 * `defaultMonospaceFontSize` Integer - Defaults to `13`.
 * `minimumFontSize` Integer - Defaults to `0`.
 * `defaultEncoding` String - Defaults to `ISO-8859-1`.
+* `backgroundThrottling` Boolean - Whether to throttle animations and timers
+  when the page becomes background. Defaults to `true`.
 
 ## Events
 

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -8,7 +8,7 @@ import sys
 
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = '9229f39b44ca1dde25db9c648547861286b61935'
+LIBCHROMIUMCONTENT_COMMIT = '4e506867ad95907e0a9cbec4ab3ee0f84214de94'
 
 PLATFORM = {
   'cygwin': 'win32',

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -83,7 +83,7 @@ app.on('ready', function () {
     width: 800,
     height: 600,
     webPreferences: {
-      javascript: true // Test whether web preferences crashes.
+      backgroundThrottling: false,
     }
   })
   window.loadURL(url.format({


### PR DESCRIPTION
Setting `backgroundThrottling` will disable all throttling for background pages, close #4925.