### PR TITLE
Rename ATOM_SHELL_ASAR to ELECTRON_ASAR

### DIFF
--- a/lib/common/asar_init.js
+++ b/lib/common/asar_init.js
@@ -1,10 +1,10 @@
 ;(function () {
   return function (process, require, asarSource) {
     // Make asar.coffee accessible via "require".
-    process.binding('natives').ATOM_SHELL_ASAR = asarSource
+    process.binding('natives').ELECTRON_ASAR = asarSource
 
     // Monkey-patch the fs module.
-    require('ATOM_SHELL_ASAR').wrapFsWithAsar(require('fs'))
+    require('ELECTRON_ASAR').wrapFsWithAsar(require('fs'))
 
     // Make graceful-fs work with asar.
     var source = process.binding('natives')
@@ -13,7 +13,7 @@
 var nativeModule = new process.NativeModule('original-fs')
 nativeModule.cache()
 nativeModule.compile()
-var asar = require('ATOM_SHELL_ASAR')
+var asar = require('ELECTRON_ASAR')
 asar.wrapFsWithAsar(nativeModule.exports)
 module.exports = nativeModule.exports`
   }


### PR DESCRIPTION
Minor rename but figured this was worth doing since they show up in stack traces and might confuse people who don't know what `ATOM_SHELL` is.

This shows up in stack traces when requiring a native module fails.

### Before

```
Error: Module version mismatch. Expected 47, got 46.
    at Error (native)
    at process.module.(anonymous function) [as dlopen] (ATOM_SHELL_ASAR.js:158:20)
    at Object.Module._extensions..node (module.js:440:18)
    at Object.module.(anonymous function) [as .node] (ATOM_SHELL_ASAR.js:158:20)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at <anonymous>:2:6
    at Object.InjectedScript._evaluateOn (<anonymous>:878:140)
```
### After

```
Error: Module version mismatch. Expected 47, got 46.
    at Error (native)
    at process.module.(anonymous function) [as dlopen] (ELECTRON_ASAR.js:158:20)
    at Object.Module._extensions..node (module.js:440:18)
    at Object.module.(anonymous function) [as .node] (ELECTRON_ASAR.js:158:20)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at <anonymous>:2:6
    at Object.InjectedScript._evaluateOn (<anonymous>:878:140)
```