### PR TITLE
Add `resourceType` to `did-get-response-details` event on WebContents/WebView

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -14,6 +14,7 @@
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/native_window.h"
+#include "atom/browser/net/atom_network_delegate.h"
 #include "atom/browser/web_contents_permission_helper.h"
 #include "atom/browser/web_contents_preferences.h"
 #include "atom/browser/web_view_guest_delegate.h"
@@ -587,7 +588,8 @@ void WebContents::DidGetResourceResponseStart(
        details.http_response_code,
        details.method,
        details.referrer,
-       details.headers.get());
+       details.headers.get(),
+       ResourceTypeToString(details.resource_type));
 }
 
 void WebContents::DidGetRedirectForResourceRequest(

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -36,7 +36,7 @@ const char* ResourceTypeToString(content::ResourceType type) {
       return "other";
   }
 }
-    
+
 namespace {
 
 void RunSimpleListener(const AtomNetworkDelegate::SimpleListener& listener,

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -10,14 +10,11 @@
 #include "base/stl_util.h"
 #include "base/strings/string_util.h"
 #include "content/public/browser/browser_thread.h"
-#include "content/public/browser/resource_request_info.h"
 #include "net/url_request/url_request.h"
 
 using content::BrowserThread;
 
 namespace atom {
-
-namespace {
 
 const char* ResourceTypeToString(content::ResourceType type) {
   switch (type) {
@@ -39,6 +36,8 @@ const char* ResourceTypeToString(content::ResourceType type) {
       return "other";
   }
 }
+    
+namespace {
 
 void RunSimpleListener(const AtomNetworkDelegate::SimpleListener& listener,
                        scoped_ptr<base::DictionaryValue> details) {

--- a/atom/browser/net/atom_network_delegate.h
+++ b/atom/browser/net/atom_network_delegate.h
@@ -15,6 +15,7 @@
 #include "net/base/net_errors.h"
 #include "net/http/http_request_headers.h"
 #include "net/http/http_response_headers.h"
+#include "content/public/browser/resource_request_info.h"
 
 namespace extensions {
 class URLPattern;
@@ -23,6 +24,8 @@ class URLPattern;
 namespace atom {
 
 using URLPatterns = std::set<extensions::URLPattern>;
+
+const char* ResourceTypeToString(content::ResourceType type);
 
 class AtomNetworkDelegate : public brightray::NetworkDelegate {
  public:

--- a/docs-translations/ko-KR/api/web-contents.md
+++ b/docs-translations/ko-KR/api/web-contents.md
@@ -67,6 +67,7 @@ Returns:
 * `requestMethod` String
 * `referrer` String
 * `headers` Object
+* `resourceType` String
 
 요청한 리소스에 관련된 자세한 정보를 사용할 수 있을 때 발생하는 이벤트입니다.
 `status`는 리소스를 다운로드하기 위한 소켓 연결을 나타냅니다.

--- a/docs-translations/ko-KR/api/web-view-tag.md
+++ b/docs-translations/ko-KR/api/web-view-tag.md
@@ -495,6 +495,7 @@ Returns:
 * `requestMethod` String
 * `referrer` String
 * `headers` Object
+* `resourceType` String
 
 요청한 리소스에 관해 자세한 내용을 알 수 있을 때 발생하는 이벤트입니다.
 `status`는 리소스를 다운로드할 소켓 커낵션을 나타냅니다.

--- a/docs-translations/zh-CN/api/web-contents.md
+++ b/docs-translations/zh-CN/api/web-contents.md
@@ -63,6 +63,7 @@ var webContents = win.webContents;
 * `requestMethod` String
 * `referrer` String
 * `headers` Object
+* `resourceType` String
 
 当有关请求资源的详细信息可用的时候发出事件.
 `status` 标识了 socket链接来下载资源.

--- a/docs-translations/zh-CN/api/web-view-tag.md
+++ b/docs-translations/zh-CN/api/web-view-tag.md
@@ -457,6 +457,7 @@ Returns:
 * `requestMethod` String
 * `referrer` String
 * `headers` Object
+* `resourceType` String
 
 当获得返回详情的时候触发.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -68,6 +68,7 @@ Returns:
 * `requestMethod` String
 * `referrer` String
 * `headers` Object
+* `resourceType` String
 
 Emitted when details regarding a requested resource are available.
 `status` indicates the socket connection to download the resource.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -510,6 +510,7 @@ Returns:
 * `requestMethod` String
 * `referrer` String
 * `headers` Object
+* `resourceType` String
 
 Fired when details regarding a requested resource is available.
 `status` indicates socket connection to download the resource.

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -12,7 +12,7 @@ var WEB_VIEW_EVENTS = {
   'did-frame-finish-load': ['isMainFrame'],
   'did-start-loading': [],
   'did-stop-loading': [],
-  'did-get-response-details': ['status', 'newURL', 'originalURL', 'httpResponseCode', 'requestMethod', 'referrer', 'headers'],
+  'did-get-response-details': ['status', 'newURL', 'originalURL', 'httpResponseCode', 'requestMethod', 'referrer', 'headers', 'resourceType'],
   'did-get-redirect-request': ['oldURL', 'newURL', 'isMainFrame'],
   'dom-ready': [],
   'console-message': ['level', 'message', 'line', 'sourceId'],

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -101,6 +101,32 @@ describe('browser-window module', function () {
       w.loadURL('about:blank')
     })
 
+    it('should emit did-get-response-details event', function (done) {
+      // expected {fileName: resourceType} pairs
+      var expectedResources = {
+        'did-get-response-details.html': 'mainFrame',
+        'logo.png': 'image'
+      }
+      var responses = 0;
+      w.webContents.on('did-get-response-details', function (event, status, newUrl, oldUrl, responseCode, method, referrer, headers, resourceType) {
+        responses++
+        var fileName = newUrl.slice(newUrl.lastIndexOf('/') + 1)
+        var expectedType = expectedResources[fileName]
+        assert(!!expectedType, `Unexpected response details for ${newUrl}`)
+        assert(typeof status === 'boolean', 'status should be boolean')
+        assert.equal(responseCode, 200)
+        assert.equal(method, 'GET')
+        assert(typeof referrer === 'string', 'referrer should be string')
+        assert(!!headers, 'headers should be present')
+        assert(typeof headers === 'object', 'headers should be object')
+        assert.equal(resourceType, expectedType, 'Incorrect resourceType')
+        if (responses === Object.keys(expectedResources).length) {
+          done()
+        }
+      })
+      w.loadURL('file://' + path.join(fixtures, 'pages', 'did-get-response-details.html'))
+    })
+
     it('should emit did-fail-load event for files that do not exist', function (done) {
       w.webContents.on('did-fail-load', function (event, code, desc, url, isMainFrame) {
         assert.equal(code, -6)

--- a/spec/fixtures/pages/did-get-response-details.html
+++ b/spec/fixtures/pages/did-get-response-details.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+  <img src="../assets/logo.png" />
+</body>
+</html>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -763,4 +763,33 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
   })
+
+  describe('did-get-response-details event', function () {
+    it('emits for the page and its resources', function (done) {
+      // expected {fileName: resourceType} pairs
+      var expectedResources = {
+        'did-get-response-details.html': 'mainFrame',
+        'logo.png': 'image'
+      }
+      var responses = 0;
+      webview.addEventListener('did-get-response-details', function (event) {
+        responses++
+        var fileName = event.newURL.slice(event.newURL.lastIndexOf('/') + 1)
+        var expectedType = expectedResources[fileName]
+        assert(!!expectedType, `Unexpected response details for ${event.newURL}`)
+        assert(typeof event.status === 'boolean', 'status should be boolean')
+        assert.equal(event.httpResponseCode, 200)
+        assert.equal(event.requestMethod, 'GET')
+        assert(typeof event.referrer === 'string', 'referrer should be string')
+        assert(!!event.headers, 'headers should be present')
+        assert(typeof event.headers === 'object', 'headers should be object')
+        assert.equal(event.resourceType, expectedType, 'Incorrect resourceType')
+        if (responses === Object.keys(expectedResources).length) {
+          done()
+        }
+      })
+      webview.src = 'file://' + path.join(fixtures, 'pages', 'did-get-response-details.html')
+      document.body.appendChild(webview)
+    })
+  })
 })


### PR DESCRIPTION
This resolves #5074 by adding `resourceType` as the last argument for WebContents’s `did-get-response-details` event.

In order to do this without duplicating the string conversion logic from `atom_network_delegate`, the `ResourceTypeToString()` function is moved to the `atom` namespace and is exposed publicly (per @zcbenz’s recommendation). In hindsight, that seems less than wonderful, so I wonder whether putting it under another namespace (maybe `atom::net`?) would be better. I don’t know enough about Electron to know where is best or if it just being under the `atom` namespace is ok.

(Also note the tests here cover more than just `resourceType` because there were no pre-existing tests for the `did-get-response-details` event at all.)