### PR TITLE
Fix webview and preload script not working when there is no script tag in page

### DIFF
--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -27,6 +27,7 @@
 #include "third_party/WebKit/public/web/WebFrame.h"
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebKit.h"
+#include "third_party/WebKit/public/web/WebScriptSource.h"
 #include "third_party/WebKit/public/web/WebView.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "native_mate/dictionary.h"
@@ -87,6 +88,9 @@ AtomRenderViewObserver::~AtomRenderViewObserver() {
 void AtomRenderViewObserver::DidCreateDocumentElement(
     blink::WebLocalFrame* frame) {
   document_created_ = true;
+
+  // Make sure every page will get a script context created.
+  frame->executeScript(blink::WebScriptSource("void 0"));
 
   // Read --zoom-factor from command line.
   std::string zoom_factor_str = base::CommandLine::ForCurrentProcess()->

--- a/spec/fixtures/pages/ping.html
+++ b/spec/fixtures/pages/ping.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  require('electron').ipcRenderer.send('pong')
+</script>
+</body>
+</html>

--- a/spec/fixtures/pages/webview-no-script.html
+++ b/spec/fixtures/pages/webview-no-script.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<webview nodeintegration src="ping.html"/>
+</body>
+</html>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -155,6 +155,18 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/pages/e.html'
       document.body.appendChild(webview)
     })
+
+    it('works without script tag in page', function (done) {
+      var listener = function (e) {
+        assert.equal(e.message, 'function object object')
+        webview.removeEventListener('console-message', listener)
+        done()
+      }
+      webview.addEventListener('console-message', listener)
+      webview.setAttribute('preload', fixtures + '/module/preload.js')
+      webview.src = 'file://' + fixtures + '/pages/base-page.html'
+      document.body.appendChild(webview)
+    })
   })
 
   describe('httpreferrer attribute', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -2,7 +2,7 @@ const assert = require('assert')
 const path = require('path')
 const http = require('http')
 const url = require('url')
-const {app, session} = require('electron').remote
+const {app, session, ipcMain, BrowserWindow} = require('electron').remote
 
 describe('<webview> tag', function () {
   this.timeout(10000)
@@ -18,6 +18,15 @@ describe('<webview> tag', function () {
     if (document.body.contains(webview)) {
       document.body.removeChild(webview)
     }
+  })
+
+  it('works without script tag in page', function (done) {
+    let w = new BrowserWindow({show: false})
+    ipcMain.once('pong', function () {
+      w.destroy()
+      done()
+    })
+    w.loadURL('file://' + fixtures + '/pages/webview-no-script.html')
   })
 
   describe('src attribute', function () {


### PR DESCRIPTION
This PR solves it by force creating JavaScript context in every page, so our JavaScript bindings can be loaded.

Fix #1117.