### PR TITLE
Handle the Page.reload command coming from devtools

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -635,6 +635,10 @@ void WebContents::DidUpdateFaviconURL(
   Emit("page-favicon-updated", unique_urls);
 }
 
+void WebContents::DevToolsReloadPage() {
+  Emit("devtools-reload-page");
+}
+
 void WebContents::DevToolsFocused() {
   Emit("devtools-focused");
 }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -251,6 +251,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void MediaStoppedPlaying(const MediaPlayerId& id) override;
   void DidChangeThemeColor(SkColor theme_color) override;
 
+  // brightray::InspectableWebContentsDelegate:
+  void DevToolsReloadPage() override;
+
   // brightray::InspectableWebContentsViewDelegate:
   void DevToolsFocused() override;
   void DevToolsOpened() override;

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -155,6 +155,11 @@ let wrapWebContents = function (webContents) {
     })
   })
 
+  // The devtools requests the webContents to reload.
+  webContents.on('devtools-reload-page', function () {
+    webContents.reload()
+  })
+
   // Delays the page-title-updated event to next tick.
   webContents.on('-page-title-updated', function (...args) {
     setImmediate(() => {
@@ -168,6 +173,7 @@ let wrapWebContents = function (webContents) {
   deprecate.event(webContents, 'page-title-set', 'page-title-updated', function (...args) {
     return this.emit.apply(this, ['page-title-set'].concat(args))
   })
+
   webContents.printToPDF = function (options, callback) {
     var printingSetting
     printingSetting = {


### PR DESCRIPTION
When users press CMD+R in devtools view, a `Page.reload` command would be sent to the main process to ask the page to reload. The default behavior of this command is to call `web_contents->GetNavigationController()->Reload()`, which bypasses Electron's hack that forces restarting renderer process for reloading.

This PR hijacks the `Page.reload` command to force using `webContents.reload` to reload pages.

Fix #4842.