### PR TITLE
Revert #3643

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -547,28 +547,21 @@ void WebContents::DidFinishLoad(content::RenderFrameHost* render_frame_host,
 void WebContents::DidFailProvisionalLoad(
     content::RenderFrameHost* render_frame_host,
     const GURL& url,
-    int error_code,
-    const base::string16& error_description,
+    int code,
+    const base::string16& description,
     bool was_ignored_by_handler) {
   bool is_main_frame = !render_frame_host->GetParent();
-  Emit("did-fail-provisional-load",
-       error_code,
-       error_description,
-       url,
-       is_main_frame);
+  Emit("did-fail-provisional-load", code, description, url, is_main_frame);
+  Emit("did-fail-load", code, description, url, is_main_frame);
 }
 
 void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
-                              const GURL& validated_url,
+                              const GURL& url,
                               int error_code,
                               const base::string16& error_description,
                               bool was_ignored_by_handler) {
   bool is_main_frame = !render_frame_host->GetParent();
-  Emit("did-fail-load",
-       error_code,
-       error_description,
-       validated_url,
-       is_main_frame);
+  Emit("did-fail-load", error_code, error_description, url, is_main_frame);
 }
 
 void WebContents::DidStartLoading() {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -146,15 +146,6 @@ let wrapWebContents = function (webContents) {
     return menu.popup(params.x, params.y)
   })
 
-  // This error occurs when host could not be found.
-  webContents.on('did-fail-provisional-load', function (...args) {
-    // Calling loadURL during this event might cause crash, so delay the event
-    // until next tick.
-    setImmediate(() => {
-      this.emit.apply(this, ['did-fail-load'].concat(args))
-    })
-  })
-
   // The devtools requests the webContents to reload.
   webContents.on('devtools-reload-page', function () {
     webContents.reload()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -156,10 +156,10 @@ describe('browser-window module', function () {
 
     it('does not crash in did-fail-provisional-load handler', function (done) {
       w.webContents.once('did-fail-provisional-load', function () {
-        w.loadURL('http://somewhere-that-does-not.exist/')
+        w.loadURL('http://localhost:11111')
         done()
       })
-      w.loadURL('http://somewhere-that-does-not.exist/')
+      w.loadURL('http://localhost:11111')
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -153,6 +153,14 @@ describe('browser-window module', function () {
       })
       w.loadURL('file://' + path.join(fixtures, 'api', 'did-fail-load-iframe.html'))
     })
+
+    it('does not crash in did-fail-provisional-load handler', function (done) {
+      w.webContents.once('did-fail-provisional-load', function () {
+        w.loadURL('http://somewhere-that-does-not.exist/')
+        done()
+      })
+      w.loadURL('http://somewhere-that-does-not.exist/')
+    })
   })
 
   describe('BrowserWindow.show()', function () {


### PR DESCRIPTION
The #3185 is no longer a problem after the upgrade to Chrome 49, so we are safe to revert #3643.

Close #5128.