### PR TITLE
Set the backgroundColor of RenderWidgetHostView

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -807,9 +807,14 @@ bool NativeWindowMac::IsKiosk() {
 }
 
 void NativeWindowMac::SetBackgroundColor(const std::string& color_name) {
-  base::ScopedCFTypeRef<CGColorRef> color =
-      skia::CGColorCreateFromSkColor(ParseHexColor(color_name));
-  [[[window_ contentView] layer] setBackgroundColor:color];
+  SkColor color = ParseHexColor(color_name);
+  base::ScopedCFTypeRef<CGColorRef> cgcolor =
+      skia::CGColorCreateFromSkColor(color);
+  [[[window_ contentView] layer] setBackgroundColor:cgcolor];
+
+  const auto view = web_contents()->GetRenderWidgetHostView();
+  if (view)
+    view->SetBackgroundColor(color);
 }
 
 void NativeWindowMac::SetHasShadow(bool has_shadow) {


### PR DESCRIPTION
On OS X the background color of RenderWidgetHostView can not be really transparent, even if we set it to SK_ColorTRANSPARENT a half-transparent mask would still show and change the background color of the native window.

This PR solves it by also setting the background color of RenderWidgetHostView to backgroundColor.

Close #5150.