### PR TITLE
AutoUpdate Windows: Don't spawn if running

### DIFF
--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -7,17 +7,34 @@ const appFolder = path.dirname(process.execPath)
 
 // i.e. my-app/Update.exe
 const updateExe = path.resolve(appFolder, '..', 'Update.exe')
-
 const exeName = path.basename(process.execPath)
+var spawnedArgs = []
+var spawnedProcess
+
+var isSameArgs = function (args) {
+  return (args.length === spawnedArgs.length) && args.every(function (e, i) {
+    return e === spawnedArgs[i]
+  })
+}
 
 // Spawn a command and invoke the callback when it completes with an error
 // and the output from standard out.
 var spawnUpdate = function (args, detached, callback) {
-  var error, errorEmitted, spawnedProcess, stderr, stdout
+  var error, errorEmitted, stderr, stdout
+
   try {
-    spawnedProcess = spawn(updateExe, args, {
-      detached: detached
-    })
+    // Ensure we don't spawn multiple squirrel processes
+    // Process spawned, same args:        Attach events to alread running process
+    // Process spawned, different args:   Return with error
+    // No process spawned:                Spawn new process
+    if (spawnedProcess && !isSameArgs(args)) {
+      return callback('AutoUpdater process with arugments ' + args + ' is already running')
+    } else if (!spawnedProcess) {
+      spawnedProcess = spawn(updateExe, args, {
+        detached: detached
+      })
+      spawnedArgs = args || []
+    }
   } catch (error1) {
     error = error1
 
@@ -41,6 +58,9 @@ var spawnUpdate = function (args, detached, callback) {
     return callback(error)
   })
   return spawnedProcess.on('exit', function (code, signal) {
+    spawnedProcess = undefined
+    spawnedArgs = []
+
     // We may have already emitted an error.
     if (errorEmitted) {
       return


### PR DESCRIPTION
Previously, the auto updater would run as many squirrel processes
as told. This introduces a little change where instead of spawning
a second process, we attach to the already running process - or, if
different arguments are passed, return and emit an error.

This is not failsafe, but it ensures that we don't run into simple
race condition crashes.

@paulcbetts: I liked your Promise idea frankly better, but I didn't
want to introduce a breaking API change - but this achieves the
same result (existing process w/ same args => get same events).

Closes #5097