### PR TITLE
Update screen.md

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -1,8 +1,8 @@
 # screen
 
 The `screen` module retrieves information about screen size, displays, cursor
-position, etc. You should not use this module until the `ready` event of the
-`app` module is emitted.
+position, etc. You cannot not use this module until the `ready` event of the
+`app` module is emitted (by invoking or requiring it).
 
 `screen` is an [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
 


### PR DESCRIPTION
If a consumer does:

```
var screen = require('electron').screen;
```
before appReady, an Error is thrown.