### PR TITLE
Add `isLoadingMainFrame()` to WebContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -816,7 +816,7 @@ base::string16 WebContents::GetTitle() const {
 bool WebContents::IsLoading() const {
   return web_contents()->IsLoading();
 }
-    
+
 bool WebContents::IsLoadingMainFrame() const {
   return is_loading_main_frame_;
 }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -220,7 +220,8 @@ WebContents::WebContents(content::WebContents* web_contents)
       embedder_(nullptr),
       type_(REMOTE),
       request_id_(0),
-      background_throttling_(true) {
+      background_throttling_(true),
+      is_loading_main_frame_(false) {
   AttachAsUserData(web_contents);
   web_contents->SetUserAgentOverride(GetBrowserContext()->GetUserAgent());
 }
@@ -229,7 +230,8 @@ WebContents::WebContents(v8::Isolate* isolate,
                          const mate::Dictionary& options)
     : embedder_(nullptr),
       request_id_(0),
-      background_throttling_(true) {
+      background_throttling_(true),
+      is_loading_main_frame_(false) {
   // Read options.
   options.Get("backgroundThrottling", &background_throttling_);
 
@@ -543,10 +545,30 @@ void WebContents::DocumentLoadedInFrame(
 void WebContents::DidFinishLoad(content::RenderFrameHost* render_frame_host,
                                 const GURL& validated_url) {
   bool is_main_frame = !render_frame_host->GetParent();
+  if (is_main_frame)
+    is_loading_main_frame_ = false;
+
   Emit("did-frame-finish-load", is_main_frame);
 
   if (is_main_frame)
     Emit("did-finish-load");
+}
+
+void WebContents::DidStartProvisionalLoadForFrame(
+    content::RenderFrameHost* render_frame_host,
+    const GURL& url,
+    bool is_error_page,
+    bool is_iframe_srcdoc) {
+  if (!render_frame_host->GetParent())
+    is_loading_main_frame_ = true;
+}
+
+void WebContents::DidCommitProvisionalLoadForFrame(
+    content::RenderFrameHost* render_frame_host,
+    const GURL& url,
+    ui::PageTransition transition_type) {
+  if (!render_frame_host->GetParent())
+    is_loading_main_frame_ = true;
 }
 
 void WebContents::DidFailProvisionalLoad(
@@ -556,6 +578,8 @@ void WebContents::DidFailProvisionalLoad(
     const base::string16& description,
     bool was_ignored_by_handler) {
   bool is_main_frame = !render_frame_host->GetParent();
+  if (is_main_frame)
+    is_loading_main_frame_ = false;
   Emit("did-fail-provisional-load", code, description, url, is_main_frame);
   Emit("did-fail-load", code, description, url, is_main_frame);
 }
@@ -791,6 +815,10 @@ base::string16 WebContents::GetTitle() const {
 
 bool WebContents::IsLoading() const {
   return web_contents()->IsLoading();
+}
+    
+bool WebContents::IsLoadingMainFrame() const {
+  return is_loading_main_frame_;
 }
 
 bool WebContents::IsWaitingForResponse() const {
@@ -1189,6 +1217,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("_getURL", &WebContents::GetURL)
       .SetMethod("getTitle", &WebContents::GetTitle)
       .SetMethod("isLoading", &WebContents::IsLoading)
+      .SetMethod("isLoadingMainFrame", &WebContents::IsLoadingMainFrame)
       .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)
       .SetMethod("_stop", &WebContents::Stop)
       .SetMethod("_goBack", &WebContents::GoBack)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -224,18 +224,21 @@ class WebContents : public mate::TrackableObject<WebContents>,
                    int error_code,
                    const base::string16& error_description,
                    bool was_ignored_by_handler) override;
-  void DidFailProvisionalLoad(content::RenderFrameHost* render_frame_host,
-                              const GURL& validated_url,
-                              int error_code,
-                              const base::string16& error_description,
-                              bool was_ignored_by_handler) override;
-  void DidStartProvisionalLoadForFrame(content::RenderFrameHost* render_frame_host,
-                                       const GURL& validated_url,
-                                       bool is_error_page,
-                                       bool is_iframe_srcdoc) override;
-  void DidCommitProvisionalLoadForFrame(content::RenderFrameHost* render_frame_host,
-                                        const GURL& url,
-                                        ui::PageTransition transition_type) override;
+  void DidFailProvisionalLoad(
+      content::RenderFrameHost* render_frame_host,
+      const GURL& validated_url,
+      int error_code,
+      const base::string16& error_description,
+      bool was_ignored_by_handler) override;
+  void DidStartProvisionalLoadForFrame(
+      content::RenderFrameHost* render_frame_host,
+      const GURL& validated_url,
+      bool is_error_page,
+      bool is_iframe_srcdoc) override;
+  void DidCommitProvisionalLoadForFrame(
+      content::RenderFrameHost* render_frame_host,
+      const GURL& url,
+      ui::PageTransition transition_type) override;
   void DidStartLoading() override;
   void DidStopLoading() override;
   void DidGetResourceResponseStart(

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -224,21 +224,11 @@ class WebContents : public mate::TrackableObject<WebContents>,
                    int error_code,
                    const base::string16& error_description,
                    bool was_ignored_by_handler) override;
-  void DidFailProvisionalLoad(
-      content::RenderFrameHost* render_frame_host,
-      const GURL& validated_url,
-      int error_code,
-      const base::string16& error_description,
-      bool was_ignored_by_handler) override;
-  void DidStartProvisionalLoadForFrame(
-      content::RenderFrameHost* render_frame_host,
-      const GURL& validated_url,
-      bool is_error_page,
-      bool is_iframe_srcdoc) override;
-  void DidCommitProvisionalLoadForFrame(
-      content::RenderFrameHost* render_frame_host,
-      const GURL& url,
-      ui::PageTransition transition_type) override;
+  void DidFailProvisionalLoad(content::RenderFrameHost* render_frame_host,
+                              const GURL& validated_url,
+                              int error_code,
+                              const base::string16& error_description,
+                              bool was_ignored_by_handler) override;
   void DidStartLoading() override;
   void DidStopLoading() override;
   void DidGetResourceResponseStart(
@@ -312,9 +302,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether background throttling is disabled.
   bool background_throttling_;
-
-  // Whether the main frame (not just a sub-frame) is currently loading.
-  bool is_loading_main_frame_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -62,6 +62,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   GURL GetURL() const;
   base::string16 GetTitle() const;
   bool IsLoading() const;
+  bool IsLoadingMainFrame() const;
   bool IsWaitingForResponse() const;
   void Stop();
   void ReloadIgnoringCache();
@@ -228,6 +229,13 @@ class WebContents : public mate::TrackableObject<WebContents>,
                               int error_code,
                               const base::string16& error_description,
                               bool was_ignored_by_handler) override;
+  void DidStartProvisionalLoadForFrame(content::RenderFrameHost* render_frame_host,
+                                       const GURL& validated_url,
+                                       bool is_error_page,
+                                       bool is_iframe_srcdoc) override;
+  void DidCommitProvisionalLoadForFrame(content::RenderFrameHost* render_frame_host,
+                                        const GURL& url,
+                                        ui::PageTransition transition_type) override;
   void DidStartLoading() override;
   void DidStopLoading() override;
   void DidGetResourceResponseStart(
@@ -301,6 +309,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether background throttling is disabled.
   bool background_throttling_;
+
+  // Whether the main frame (not just a sub-frame) is currently loading.
+  bool is_loading_main_frame_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -353,6 +353,10 @@ Returns the title of the current web page.
 
 Returns whether web page is still loading resources.
 
+### `webContents.isLoadingMainFrame()`
+
+Returns whether the main frame (and not just iframes or frames within it) is still loading.
+
 ### `webContents.isWaitingForResponse()`
 
 Returns whether the web page is waiting for a first-response from the main

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -116,7 +116,7 @@ let wrapWebContents = function (webContents) {
       callback = hasUserGesture
       hasUserGesture = false
     }
-    if (this.getURL() && !this.isLoading()) {
+    if (this.getURL() && !this.isLoadingMainFrame()) {
       return asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
     } else {
       return this.once('did-finish-load', asyncWebFrameMethods.bind(this, requestId, 'executeJavaScript', callback, code, hasUserGesture))

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -335,6 +335,7 @@ var registerWebViewElement = function () {
     'loadURL',
     'getTitle',
     'isLoading',
+    'isLoadingMainFrame',
     'isWaitingForResponse',
     'stop',
     'reload',


### PR DESCRIPTION
This is meant to fix #5183.

@zcbenz it looks like I misunderstood what `WebContents::IsLoadingToDifferentDocument` does. I thought it was about the main frame specifically, but it appears to just be about whether the current thing loading is the actual document that is *any* frame in the WebContents, so it doesn’t get us anything better than `WebContents::IsLoading` did.

After some poking around, it seems like the only way you’re supposed to be able to get the state we are looking for is `WebContents::GetFrameTree()->root()->IsLoading()`, but `GetFrameTree` is not included in Chromium’s publicly exported headers.

Instead, I synthesized a similar bit of state based on `WebContentsObserver` callbacks. I don’t know that this approach is really all that great, but it’s the best I could think of. Feel free to throw it out or suggest a different approach if so. I’m also not 100% sure this handles all the possible loading situations, but I *think* it does.