### PR TITLE
Small cleanup of the code determining value's type 

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -50,50 +50,37 @@ let getObjectPrototype = function (object) {
 }
 
 // Convert a real value into meta data.
-var valueToMeta = function (sender, value, optimizeSimpleObject) {
-  var el, i, len, meta
-  if (optimizeSimpleObject == null) {
-    optimizeSimpleObject = false
-  }
-  meta = {
-    type: typeof value
-  }
+let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
+  // Determine the type of value.
+  let meta = { type: typeof value }
   if (Buffer.isBuffer(value)) {
     meta.type = 'buffer'
-  }
-  if (value === null) {
+  } else if (value === null) {
     meta.type = 'value'
-  }
-  if (Array.isArray(value)) {
+  } else if (Array.isArray(value)) {
     meta.type = 'array'
-  }
-  if (value instanceof Error) {
+  } else if (value instanceof Error) {
     meta.type = 'error'
-  }
-  if (value instanceof Date) {
+  } else if (value instanceof Date) {
     meta.type = 'date'
-  }
-  if ((value != null ? value.constructor.name : void 0) === 'Promise') {
-    meta.type = 'promise'
-  }
-
-  // Treat simple objects as value.
-  if (optimizeSimpleObject && meta.type === 'object' && v8Util.getHiddenValue(value, 'simple')) {
-    meta.type = 'value'
-  }
-
-  // Treat the arguments object as array.
-  if (meta.type === 'object' && (value.hasOwnProperty('callee')) && (value.length != null)) {
-    meta.type = 'array'
-  }
-  if (meta.type === 'array') {
-    meta.members = []
-    for (i = 0, len = value.length; i < len; i++) {
-      el = value[i]
-      meta.members.push(valueToMeta(sender, el))
+  } else if (meta.type === 'object') {
+    // Recognize certain types of objects.
+    if (value.constructor != null && value.constructor.name === 'Promise') {
+      meta.type = 'promise'
+    } else if (value.hasOwnProperty('callee') && value.length != null) {
+      // Treat the arguments object as array.
+      meta.type = 'array'
+    } else if (optimizeSimpleObject && v8Util.getHiddenValue(value, 'simple')) {
+      // Treat simple objects as value.
+      meta.type = 'value'
     }
+  }
+
+  // Fill the meta object according to value's type.
+  if (meta.type === 'array') {
+    meta.members = value.map((el) => valueToMeta(sender, el))
   } else if (meta.type === 'object' || meta.type === 'function') {
-    meta.name = value.constructor.name
+    meta.name = value.constructor ? value.constructor.name : ''
 
     // Reference the original value if it's an object, because when it's
     // passed to renderer we would assume the renderer keeps a reference of

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -53,19 +53,19 @@ let getObjectPrototype = function (object) {
 let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
   // Determine the type of value.
   let meta = { type: typeof value }
-  if (Buffer.isBuffer(value)) {
-    meta.type = 'buffer'
-  } else if (value === null) {
-    meta.type = 'value'
-  } else if (Array.isArray(value)) {
-    meta.type = 'array'
-  } else if (value instanceof Error) {
-    meta.type = 'error'
-  } else if (value instanceof Date) {
-    meta.type = 'date'
-  } else if (meta.type === 'object') {
+  if (meta.type === 'object') {
     // Recognize certain types of objects.
-    if (value.constructor != null && value.constructor.name === 'Promise') {
+    if (value === null) {
+      meta.type = 'value'
+    } else if (Buffer.isBuffer(value)) {
+      meta.type = 'buffer'
+    } else if (Array.isArray(value)) {
+      meta.type = 'array'
+    } else if (value instanceof Error) {
+      meta.type = 'error'
+    } else if (value instanceof Date) {
+      meta.type = 'date'
+    } else if (value.constructor != null && value.constructor.name === 'Promise') {
       meta.type = 'promise'
     } else if (value.hasOwnProperty('callee') && value.length != null) {
       // Treat the arguments object as array.

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -45,17 +45,19 @@ var wrapArgs = function (args, visited) {
         type: 'date',
         value: value.getTime()
       }
-    } else if ((value != null ? value.constructor.name : void 0) === 'Promise') {
-      return {
-        type: 'promise',
-        then: valueToMeta(function (v) { value.then(v) })
-      }
-    } else if ((value != null) && typeof value === 'object' && v8Util.getHiddenValue(value, 'atomId')) {
-      return {
-        type: 'remote-object',
-        id: v8Util.getHiddenValue(value, 'atomId')
-      }
     } else if ((value != null) && typeof value === 'object') {
+      if (value.constructor != null && value.constructor.name === 'Promise') {
+        return {
+          type: 'promise',
+          then: valueToMeta(function (v) { value.then(v) })
+        }
+      } else if (v8Util.getHiddenValue(value, 'atomId')) {
+        return {
+          type: 'remote-object',
+          id: v8Util.getHiddenValue(value, 'atomId')
+        }
+      }
+
       ret = {
         type: 'object',
         name: value.constructor.name,


### PR DESCRIPTION
It also adds a check for `value.constructor` before using `value.constructor.name`, fix #5215.