### PR TITLE
Guard against unexist owner when removing ref to remote object

### DIFF
--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -50,7 +50,10 @@ class ObjectsRegistry {
     this.dereference(id)
 
     // Also remove the reference in owner.
-    this.owners[webContentsId].delete(id)
+    let owner = this.owners[webContentsId]
+    if (owner) {
+      owner.delete(id)
+    }
   }
 
   // Clear all references to objects refrenced by the WebContents.


### PR DESCRIPTION
In Electron we have two ways to remove the reference to remote objects:
1) call `remove` when the remote object gets garbage collected in renderer process;
2) erase all references to remote objects of a page when the page gets reloaded or closed;

So it is possible that when a page gets reloaded/closed, before the JavaScript context gets destroyed, a remote object gets garbage collected, and since all references added by the page have been erased, the `remove` call will try to remove an unexist reference.

This PR fixes it by simply checking whether the page is still there.

Close #4733.