### PR TITLE
Do not create the folder passed to app.setPath

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -351,10 +351,15 @@ base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
 void App::SetPath(mate::Arguments* args,
                   const std::string& name,
                   const base::FilePath& path) {
+  if (!path.IsAbsolute()) {
+    args->ThrowError("path must be absolute");
+    return;
+  }
+
   bool succeed = false;
   int key = GetPathConstant(name);
   if (key >= 0)
-    succeed = PathService::Override(key, path);
+    succeed = PathService::OverrideAndCreateIfNeeded(key, path, true, false);
   if (!succeed)
     args->ThrowError("Failed to set path");
 }


### PR DESCRIPTION
When calling app.setPath, if the path passed to it doesn't exist, a folder would be created at that path. This causes problem when users want to change the default userData, since Electron always creates a folder at the default userData location.

This PR makes sure `app.setPath` has no side effect on filesystem, fixes #2668.