### PR TITLE
Add Windows Store Detection

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -10,6 +10,8 @@ upstream node:
 * `process.resourcesPath` String - Path to JavaScript source code.
 * `process.mas` Boolean - For Mac App Store build, this value is `true`, for
   other builds it is `undefined`.
+* `process.windowsstore` Boolean - If the app is running as a Windows Store app (appx), this value is `true`, for
+  other builds it is `undefined`.
 
 ## Events
 

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -44,3 +44,12 @@ if (process.type === 'browser') {
   global.setTimeout = wrapWithActivateUvLoop(timers.setTimeout)
   global.setInterval = wrapWithActivateUvLoop(timers.setInterval)
 }
+
+// If we're running as a Windows Store app, __dirname will be set
+// to C:/Program Files/WindowsApps.
+//
+// Nobody else get's to install there, changing the path is forbidden
+// We can therefore say that we're running as appx
+if (process.platform === 'win32' && __dirname.indexOf('\\Program Files\\WindowsApps\\') === 2) {
+  process.windowsstore = true
+}


### PR DESCRIPTION
If we're running as a Windows Store appx package,
`process.windowsstore` will be `true`, otherwise
`undefined`.