### PR TITLE
Disable node in webviews when disabled in parent window

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -182,6 +182,11 @@ var attachGuest = function (embedder, elementInstanceId, guestInstanceId, params
     webSecurity: !params.disablewebsecurity,
     blinkFeatures: params.blinkfeatures
   }
+
+  if (embedder.getWebPreferences().nodeIntegration === false) {
+    webPreferences.nodeIntegration = false
+  }
+
   if (params.preload) {
     webPreferences.preloadURL = params.preload
   }

--- a/spec/fixtures/module/answer.js
+++ b/spec/fixtures/module/answer.js
@@ -1,0 +1,4 @@
+var ipcRenderer = require('electron').ipcRenderer
+window.answer = function (answer) {
+  ipcRenderer.send('answer', answer)
+}

--- a/spec/fixtures/pages/web-view-log-process.html
+++ b/spec/fixtures/pages/web-view-log-process.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>test</title>
+    <script>
+      console.log(typeof process)
+    </script>
+  </head>
+  <body>
+    test?
+  </body>
+</html>

--- a/spec/fixtures/pages/webview-no-node-integration-on-window.html
+++ b/spec/fixtures/pages/webview-no-node-integration-on-window.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        var windowUrl = decodeURIComponent(window.location.search.substring(3))
+
+        var wv = new WebView()
+        wv.setAttribute('nodeintegration', 'yes')
+        wv.setAttribute('src', windowUrl)
+        wv.setAttribute('style', 'display:inline-block; width:200px; height:200px')
+
+        wv.addEventListener('console-message', function(e) {
+          window.answer(e.message)
+        })
+
+        document.body.appendChild(wv)
+      })
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -84,6 +84,39 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
+    it('disables node integration when disabled on the parent BrowserWindow', function (done) {
+      var b = undefined
+
+      ipcMain.once('answer', function (event, typeofProcess) {
+        try {
+          assert.equal(typeofProcess, 'undefined')
+          done()
+        } finally {
+          b.close()
+        }
+      })
+
+      var windowUrl = require('url').format({
+        pathname: `${fixtures}/pages/webview-no-node-integration-on-window.html`,
+        protocol: 'file',
+        query: {
+          p: `${fixtures}/pages/web-view-log-process.html`
+        },
+        slashes: true
+      })
+      var preload = path.join(fixtures, 'module', 'answer.js')
+
+      b = new BrowserWindow({
+        height: 400,
+        width: 400,
+        show: false,
+        webPreferences: {
+          preload: preload,
+          nodeIntegration: false,
+        }
+      })
+      b.loadURL(windowUrl)
+    })
 
     it('disables node integration on child windows when it is disabled on the webview', function (done) {
       app.once('browser-window-created', function (event, window) {


### PR DESCRIPTION
This pull request always disabled node integration on `<webview>` if it is disabled on the parent `BrowserWindow`.

Previously node integration on a `<webview>` could be enabled even when the parent did not have it.

This is a follow on to #4897 which disabled node integration on windows opened via `window.open` when it was disabled on the parent window.

Now `nodeIntegration` inheritance will behave consistently across `<webview>` tags and `window.open` windows.

Refs #3943

/cc @zcbenz @laramies