### PR TITLE
Documentation fixes

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -44,6 +44,10 @@ built-in modules.
 
 The `process` object has the following method:
 
+### `process.crash()`
+
+Causes the main thread of the current process crash.
+
 ### `process.hang()`
 
 Causes the main thread of the current process hang.

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -62,8 +62,8 @@ a remote, virtual display.
 
 * `display` object
   * `id` Integer - Unique identifier associated with the display.
-  * `rotation` Integer - Can be 0, 1, 2, 3, each represents screen rotation in
-    clock-wise degrees of 0, 90, 180, 270.
+  * `rotation` Integer - Can be 0, 90, 180, 270, represents screen rotation in
+    clock-wise degrees.
   * `scaleFactor` Number - Output device's pixel scale factor.
   * `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
   * `bounds` Object


### PR DESCRIPTION
The actual code says:
```
  dict.Set("rotation", val.RotationAsDegree());
```