### PR TITLE
remove strict mode

### DIFF
--- a/docs-translations/jp/tutorial/quick-start.md
+++ b/docs-translations/jp/tutorial/quick-start.md
@@ -52,8 +52,6 @@ __注記__： `package.json` に `main` が存在しない場合、Electron は 
 `main.js` ではウィンドウを作成してシステムイベントを管理します。典型的な例は次のようになります：
 
 ```javascript
-'use strict';
-
 const electron = require('electron');
 const app = electron.app;  // Module to control application life.
 const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.

--- a/docs-translations/ko-KR/tutorial/quick-start.md
+++ b/docs-translations/ko-KR/tutorial/quick-start.md
@@ -75,8 +75,6 @@ __알림__: 만약 `main` 필드가 `package.json`에 설정되어 있지 않으
 다음과 같이 작성할 수 있습니다:
 
 ```javascript
-'use strict';
-
 const electron = require('electron');
 const app = electron.app;  // 어플리케이션 기반을 조작 하는 모듈.
 const BrowserWindow = electron.BrowserWindow;  // 네이티브 브라우저 창을 만드는 모듈.

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -80,8 +80,6 @@ The `main.js` should create windows and handle system events, a typical
 example being:
 
 ```javascript
-'use strict';
-
 const electron = require('electron');
 const app = electron.app;  // Module to control application life.
 const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const deprecate = require('electron').deprecate
 const session = require('electron').session
 const Menu = require('electron').Menu

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const app = require('electron').app
 const EventEmitter = require('events').EventEmitter
 const squirrelUpdate = require('./squirrel-update-win')

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcMain = require('electron').ipcMain
 const deprecate = require('electron').deprecate
 const EventEmitter = require('events').EventEmitter

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const app = require('electron').app
 const BrowserWindow = require('electron').BrowserWindow
 const binding = process.atomBinding('dialog')

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -1,5 +1,3 @@
-'use strict'
-
 var MenuItem, methodInBrowserWindow, nextCommandId, rolesMap
 
 nextCommandId = 0

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const BrowserWindow = require('electron').BrowserWindow
 const MenuItem = require('electron').MenuItem
 const EventEmitter = require('events').EventEmitter

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcMain = require('electron').ipcMain
 
 // The history operation in renderer is redirected to browser.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const EventEmitter = require('events').EventEmitter
 const deprecate = require('electron').deprecate
 const ipcMain = require('electron').ipcMain

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcMain = require('electron').ipcMain
 const desktopCapturer = process.atomBinding('desktop_capturer').desktopCapturer
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcMain = require('electron').ipcMain
 const webContents = require('electron').webContents
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcMain = require('electron').ipcMain
 const BrowserWindow = require('electron').BrowserWindow
 

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const fs = require('fs')
 const path = require('path')
 const util = require('util')

--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const v8Util = process.atomBinding('v8_util')
 
 class ObjectsRegistry {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const electron = require('electron')
 const ipcMain = electron.ipcMain
 const objectsRegistry = require('./objects-registry')

--- a/lib/common/api/callbacks-registry.js
+++ b/lib/common/api/callbacks-registry.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const v8Util = process.atomBinding('v8_util')
 
 class CallbacksRegistry {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const os = require('os')
 const path = require('path')
 const spawn = require('child_process').spawn

--- a/lib/common/api/deprecations.js
+++ b/lib/common/api/deprecations.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const deprecate = require('electron').deprecate
 
 exports.setHandler = function (deprecationHandler) {

--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const binding = process.atomBinding('ipc')
 const v8Util = process.atomBinding('v8_util')
 

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcRenderer = require('electron').ipcRenderer
 const CallbacksRegistry = require('electron').CallbacksRegistry
 const v8Util = process.atomBinding('v8_util')

--- a/lib/renderer/api/web-frame.js
+++ b/lib/renderer/api/web-frame.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const deprecate = require('electron').deprecate
 const EventEmitter = require('events').EventEmitter
 

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const events = require('events')
 const path = require('path')
 const Module = require('module')

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcRenderer = require('electron').ipcRenderer
 const remote = require('electron').remote
 

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const ipcRenderer = require('electron').ipcRenderer
 const webFrame = require('electron').webFrame
 

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const WebViewImpl = require('./web-view')
 const guestViewInternal = require('./guest-view-internal')
 const webViewConstants = require('./web-view-constants')

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const deprecate = require('electron').deprecate
 const webFrame = require('electron').webFrame
 const remote = require('electron').remote

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const assert = require('assert')
 const fs = require('fs')
 const path = require('path')

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const assert = require('assert')
 const path = require('path')
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const assert = require('assert')
 const nativeImage = require('electron').nativeImage
 const path = require('path')

--- a/spec/fixtures/module/class.js
+++ b/spec/fixtures/module/class.js
@@ -1,5 +1,3 @@
-'use strict'
-
 let value = 'old'
 
 class BaseClass {


### PR DESCRIPTION
As of [Chromium 49](http://blog.chromium.org/2016/02/chrome-49-beta-css-custom-properties.html), `use strict` is no longer required for `const` and `let`.