### PR TITLE
Fix BrowserWindow.maximize/unmaximize on Mac

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -602,10 +602,16 @@ bool NativeWindowMac::IsVisible() {
 }
 
 void NativeWindowMac::Maximize() {
+  if (IsMaximized())
+    return;
+
   [window_ zoom:nil];
 }
 
 void NativeWindowMac::Unmaximize() {
+  if (!IsMaximized())
+    return;
+
   [window_ zoom:nil];
 }
 


### PR DESCRIPTION
BrowserWindow's **maximize / unmaximize** methods currently behave differently between Mac and Windows:
- Mac: both **maximize** and **unmaximize** toggle between normal / maximized states.
- Windows: **maximize** does not do anything when the window is already maximized, **unmaximize** does not do anything if the window is no longer maximized.