### PR TITLE
Update using-pepper-flash-plugin.md

### DIFF
--- a/docs/tutorial/using-pepper-flash-plugin.md
+++ b/docs/tutorial/using-pepper-flash-plugin.md
@@ -11,6 +11,9 @@ navigating to `chrome://plugins` in the Chrome browser. Its location and version
 are useful for Electron's Pepper Flash support. You can also copy it to another
 location.
 
+_**Attention:** On windows, Pepper Flash plugin is win32 and it won't work with Electron x64 version. 
+<br>Get win32 version from [Electron Releases](https://github.com/electron/electron/releases)_
+
 ## Add Electron Switch
 
 You can directly add `--ppapi-flash-path` and `ppapi-flash-version` to the
@@ -20,19 +23,20 @@ For example:
 
 ```javascript
 // Specify flash path.
-// On Windows, it might be /path/to/pepflashplayer.dll
+// On Windows, it might be /path/to/pepflashplayer.dll or just pepflashplayer.dll if it resides main.js
 // On OS X, /path/to/PepperFlashPlayer.plugin
 // On Linux, /path/to/libpepflashplayer.so
 app.commandLine.appendSwitch('ppapi-flash-path', '/path/to/libpepflashplayer.so');
 
-// Specify flash version, for example, v17.0.0.169
+// Optional: Specify flash version, for example, v17.0.0.169
 app.commandLine.appendSwitch('ppapi-flash-version', '17.0.0.169');
 
 app.on('ready', function() {
   mainWindow = new BrowserWindow({
     'width': 800,
     'height': 600,
-    'web-preferences': {
+    // web-preferences is deprecated. Use webPreferences instead.
+    'webPreferences': {
       'plugins': true
     }
   });
@@ -40,6 +44,8 @@ app.on('ready', function() {
   // Something else
 });
 ```
+
+_**Attention:** You can check if Flash dll was loaded by running `navigator.plugins` on the Console (although you can't know if the plugin's path is correct)_
 
 ## Enable Flash Plugin in a `<webview>` Tag
 


### PR DESCRIPTION
After spending few hours of trying to make Flash work on [electron-quick-start](https://github.com/electron/electron-quick-start)
This [discussion](https://discuss.atom.io/t/does-flash-really-work-now/21887) "saved my ass".

I thought it is worth mentioning this in the tutorial (it might save time for someone in the future)

*As for the Electron Releases
I kind of guessed which windows version to download (i took electron-v0.37.7-win32-ia32.zip) - is there an explanation of the different windows versions that exists? It might be mentioned here or in the release notes

*As for `navigator.plugins`
I saw that when the path isn't correct or I didn't add
```
'webPreferences': {
      'plugins': true
    }
```
It's hard to tell what is wrong because navigator.plugins does display the Shockwave Flash 
* do you have some tools to check this?
* it seems that no matter if the path is ok or not - it always displays the same version... 
```
description: "Shockwave Flash 11.2 r999"
filename: "123.dll"
``` 
```
description: "Shockwave Flash 11.2 r999"
filename: "pepflashplayer32_21_0_0_197.dll"
``` 
Hope you would see me additions relevant
Waiting for your response

Thanks,
Michal