### PR TITLE
Emit an error if `quitAndInstall` is called without an update being available

### DIFF
--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -12,6 +12,9 @@ function AutoUpdater () {
 util.inherits(AutoUpdater, EventEmitter)
 
 AutoUpdater.prototype.quitAndInstall = function () {
+  if (!this.updateAvailable) {
+    return this.emitError('No update available, can\'t quit and install')
+  }
   squirrelUpdate.processStart()
   return app.quit()
 }
@@ -33,8 +36,10 @@ AutoUpdater.prototype.checkForUpdates = function () {
       return this.emitError(error)
     }
     if (update == null) {
+      this.updateAvailable = false
       return this.emit('update-not-available')
     }
+    this.updateAvailable = true
     this.emit('update-available')
     squirrelUpdate.update(this.updateURL, (error) => {
       var date, releaseNotes, version


### PR DESCRIPTION
Emit an error if `quitAndInstall` is called without an update being available.

Fixes #3840