### PR TITLE
Fix converting from windows virtual keycode back to mac keycode

### DIFF
--- a/atom/browser/ui/accelerator_util_mac.mm
+++ b/atom/browser/ui/accelerator_util_mac.mm
@@ -13,18 +13,24 @@ namespace accelerator_util {
 void SetPlatformAccelerator(ui::Accelerator* accelerator) {
   unichar character;
   unichar characterIgnoringModifiers;
-  ui::MacKeyCodeForWindowsKeyCode(accelerator->key_code(),
-                                  0,
-                                  &character,
-                                  &characterIgnoringModifiers);
-  NSString* characters =
-      [[[NSString alloc] initWithCharacters:&character length:1] autorelease];
 
   NSUInteger modifiers =
       (accelerator->IsCtrlDown() ? NSControlKeyMask : 0) |
       (accelerator->IsCmdDown() ? NSCommandKeyMask : 0) |
       (accelerator->IsAltDown() ? NSAlternateKeyMask : 0) |
       (accelerator->IsShiftDown() ? NSShiftKeyMask : 0);
+
+  ui::MacKeyCodeForWindowsKeyCode(accelerator->key_code(),
+                                  modifiers,
+                                  &character,
+                                  &characterIgnoringModifiers);
+
+  if (character != characterIgnoringModifiers) {
+    modifiers ^= NSShiftKeyMask;
+  }
+
+  NSString* characters =
+      [[[NSString alloc] initWithCharacters:&character length:1] autorelease];
 
   scoped_ptr<ui::PlatformAccelerator> platform_accelerator(
       new ui::PlatformAcceleratorCocoa(characters, modifiers));


### PR DESCRIPTION
Accelerators keys no longer use the virtual keys for symbols with are reached via 'Shift'
For example, `Plus` now correctly uses `+` instead of the virtual key `Shift+=` 

Don't have Windows, so I didn't look into that part of the issue.
Ref #1507