### PR TITLE
Do not run clean in cibuild

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -53,8 +53,6 @@ def main():
   if PLATFORM == 'linux':
     os.environ['DISPLAY'] = ':99.0'
 
-  run_script('clean.py')
-
   # CI's npm is not reliable.
   npm = 'npm.cmd' if PLATFORM == 'win32' else 'npm'
   execute([npm, 'install', 'npm@2.12.1'])
@@ -80,8 +78,6 @@ def main():
     run_script('build.py', ['-c', 'D'])
     if PLATFORM != 'win32' and target_arch == 'x64':
       run_script('test.py', ['--ci'])
-
-  run_script('clean.py')
 
 
 def run_script(script, args=[]):


### PR DESCRIPTION
It was added to save disk space on CI machine, we no longer need to do it now.