### PR TITLE
Create user_data_dir before creating singleton lock

### DIFF
--- a/chromium_src/chrome/browser/process_singleton_posix.cc
+++ b/chromium_src/chrome/browser/process_singleton_posix.cc
@@ -717,6 +717,9 @@ ProcessSingleton::ProcessSingleton(
     const NotificationCallback& notification_callback)
     : notification_callback_(notification_callback),
       current_pid_(base::GetCurrentProcId()) {
+  // The user_data_dir may have not been created yet.
+  base::CreateDirectoryAndGetError(user_data_dir, nullptr);
+
   socket_path_ = user_data_dir.Append(kSingletonSocketFilename);
   lock_path_ = user_data_dir.Append(kSingletonLockFilename);
   cookie_path_ = user_data_dir.Append(kSingletonCookieFilename);

--- a/chromium_src/chrome/browser/process_singleton_win.cc
+++ b/chromium_src/chrome/browser/process_singleton_win.cc
@@ -10,6 +10,7 @@
 #include "base/bind.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/process/process.h"
 #include "base/process/process_info.h"
 #include "base/strings/string_number_conversions.h"
@@ -190,6 +191,8 @@ ProcessSingleton::ProcessSingleton(
       user_data_dir_(user_data_dir),
       should_kill_remote_process_callback_(
           base::Bind(&TerminateAppWithError)) {
+  // The user_data_dir may have not been created yet.
+  base::CreateDirectoryAndGetError(user_data_dir, nullptr);
 }
 
 ProcessSingleton::~ProcessSingleton() {


### PR DESCRIPTION
Because of #5237, there is no guarantee that the user_data_dir is always created, so we need to make sure it exists when calling `app.makeSingleInstance`.

Close #5277.