### PR TITLE
browser: fix some edge cases with download manager

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -315,7 +315,7 @@ void Session::OnDownloadCreated(content::DownloadManager* manager,
   bool prevent_default = Emit(
       "will-download",
       DownloadItem::Create(isolate(), item),
-      api::WebContents::CreateFrom(isolate(), web_contents));
+      web_contents);
   if (prevent_default) {
     item->Cancel(true);
     item->Remove();

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -9,9 +9,7 @@
 
 #include "atom/browser/api/atom_api_cookies.h"
 #include "atom/browser/api/atom_api_download_item.h"
-#include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/api/atom_api_web_request.h"
-#include "atom/browser/api/save_page_handler.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/atom_permission_manager.h"
@@ -306,8 +304,7 @@ Session::~Session() {
 
 void Session::OnDownloadCreated(content::DownloadManager* manager,
                                 content::DownloadItem* item) {
-  auto web_contents = item->GetWebContents();
-  if (SavePageHandler::IsSavePageTypes(item->GetMimeType()))
+  if (item->IsSavePackageDownload())
     return;
 
   v8::Locker locker(isolate());
@@ -315,7 +312,7 @@ void Session::OnDownloadCreated(content::DownloadManager* manager,
   bool prevent_default = Emit(
       "will-download",
       DownloadItem::Create(isolate(), item),
-      web_contents);
+      item->GetWebContents());
   if (prevent_default) {
     item->Cancel(true);
     item->Remove();

--- a/atom/browser/api/save_page_handler.cc
+++ b/atom/browser/api/save_page_handler.cc
@@ -73,11 +73,6 @@ void SavePageHandler::Destroy(content::DownloadItem* item) {
   delete this;
 }
 
-// static
-bool SavePageHandler::IsSavePageTypes(const std::string& type) {
-  return type == "multipart/related" || type == "text/html";
-}
-
 }  // namespace api
 
 }  // namespace atom

--- a/atom/browser/api/save_page_handler.h
+++ b/atom/browser/api/save_page_handler.h
@@ -37,8 +37,6 @@ class SavePageHandler : public content::DownloadManager::Observer,
   bool Handle(const base::FilePath& full_path,
               const content::SavePageType& save_type);
 
-  static bool IsSavePageTypes(const std::string& type);
-
  private:
   void Destroy(content::DownloadItem* item);
 

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -70,7 +70,9 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
     return;
 
   NativeWindow* window = nullptr;
-  auto relay = NativeWindowRelay::FromWebContents(item->GetWebContents());
+  content::WebContents* web_contents = item->GetWebContents();
+  auto relay = web_contents ? NativeWindowRelay::FromWebContents(web_contents)
+                            : nullptr;
   if (relay)
     window = relay->window.get();
 


### PR DESCRIPTION
* Dont attach download dialog to destroyed webcontents window
* Use `DownloadItem::IsSavePackageDownload` to prevent `will-download` event for savePage method instead of relying on mimetype.

Fixes https://github.com/electron/electron/issues/5228
Fixes https://github.com/electron/electron/issues/5278