### PR TITLE
webContents: fix executejavascript when called before page load

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -117,9 +117,11 @@ let wrapWebContents = function (webContents) {
       hasUserGesture = false
     }
     if (this.getURL() && !this.isLoadingMainFrame()) {
-      return asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
+      asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
     } else {
-      return this.once('did-finish-load', asyncWebFrameMethods.bind(this, requestId, 'executeJavaScript', callback, code, hasUserGesture))
+      this.once('did-finish-load', () => {
+        asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
+      })
     }
   }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -870,6 +870,14 @@ describe('browser-window module', function () {
       })
       w.loadURL(server.url)
     })
+
+    it('executes after page load', function (done) {
+      w.webContents.executeJavaScript(code, function(result) {
+        assert.equal(result, expected)
+        done()
+      })
+      w.loadURL(server.url)
+    })
   })
 
   describe('deprecated options', function () {


### PR DESCRIPTION
The `event` parameter from `did-finish-load` was messing up the argument list.

Ref https://github.com/electron/electron/pull/5291