### PR TITLE
renderer: fix desktop capture api not responding different subsequest calls

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -89,7 +89,6 @@ void DesktopCapturer::OnSourceThumbnailChanged(int index) {
 
 bool DesktopCapturer::OnRefreshFinished() {
   Emit("finished", media_list_->GetSources());
-  media_list_.reset();
   return false;
 }
 

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -24,4 +24,16 @@ describe('desktopCapturer', function () {
     desktopCapturer.getSources({types: ['window', 'screen']}, callback)
     desktopCapturer.getSources({types: ['window', 'screen']}, callback)
   })
+
+  it('responds to subsequest calls of different options', function (done) {
+    var callCount = 0
+    var callback = function (error, sources) {
+      callCount++
+      assert.equal(error, null)
+      if (callCount === 2) done()
+    }
+
+    desktopCapturer.getSources({types: ['window']}, callback)
+    desktopCapturer.getSources({types: ['screen']}, callback)
+  })
 })


### PR DESCRIPTION
Race condition between media_list reset on `DesktopCapturer::StartHandling` and `DesktopCapturer::OnRefreshFinished`

Fixes https://github.com/electron/electron/issues/5269