### PR TITLE
Make sure the userData directory is created before ready event

### DIFF
--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -9,7 +9,10 @@
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/window_list.h"
+#include "base/files/file_util.h"
 #include "base/message_loop/message_loop.h"
+#include "base/path_service.h"
+#include "brightray/browser/brightray_paths.h"
 
 namespace atom {
 
@@ -139,6 +142,11 @@ void Browser::WillFinishLaunching() {
 }
 
 void Browser::DidFinishLaunching() {
+  // Make sure the userData directory is created.
+  base::FilePath user_data;
+  if (PathService::Get(brightray::DIR_USER_DATA, &user_data))
+    base::CreateDirectoryAndGetError(user_data, nullptr);
+
   is_ready_ = true;
   FOR_EACH_OBSERVER(BrowserObserver, observers_, OnFinishLaunching());
 }


### PR DESCRIPTION
Because of #5237, the userData dir is not created unless the first window is loaded, usually it is fine but we should at least guarantee it is created in the `ready` event.

Close #5336.