### PR TITLE
update all references to old atom-log bracket notation

### DIFF
--- a/docs-translations/es/api/process.md
+++ b/docs-translations/es/api/process.md
@@ -5,8 +5,8 @@ al node convencional:
 
 * `process.type` String - El tipo del proceso puede ser `browser` (ej. proceso
    principal) o `renderer`.
-* `process.versions['electron']` String - Versión de Electron.
-* `process.versions['chrome']` String - Versión de Chromium.
+* `process.versions.electron` String - Versión de Electron.
+* `process.versions.chrome` String - Versión de Chromium.
 * `process.resourcesPath` String - Ruta al código fuente JavaScript.
 
 ## Events

--- a/docs-translations/es/tutorial/quick-start.md
+++ b/docs-translations/es/tutorial/quick-start.md
@@ -115,7 +115,7 @@ Finalmente el `index.html` es la página web que mostraremos:
   <body>
     <h1>Hello World!</h1>
     We are using io.js <script>document.write(process.version)</script>
-    and Electron <script>document.write(process.versions['electron'])</script>.
+    and Electron <script>document.write(process.versions.electron)</script>.
   </body>
 </html>
 ```

--- a/docs-translations/jp/api/process.md
+++ b/docs-translations/jp/api/process.md
@@ -3,8 +3,8 @@
 Electronの`process`オブジェクトは上流nodeの1つから次のような違いがあります。
 
 * `process.type` String - プロセスの種類で、`browser` (例　メインプロセス)または `renderer`を設定できます。
-* `process.versions['electron']` String - Electronのバージョン
-* `process.versions['chrome']` String - Chromiumのバージョン
+* `process.versions.electron` String - Electronのバージョン
+* `process.versions.chrome` String - Chromiumのバージョン
 * `process.resourcesPath` String - JavaScriptのソースコードのパスを設定します。
 * `process.mas` Boolean - Mac app Store用のビルドで、値は`true`です。ほかのビルドの場合は`undefined`です。
 

--- a/docs-translations/ko-KR/api/process.md
+++ b/docs-translations/ko-KR/api/process.md
@@ -4,8 +4,8 @@ Electron의 `process` 객체는 기존의 node와는 달리 약간의 차이점�
 
 * `process.type` String - 프로세스의 타입, `browser` (메인 프로세스) 또는
   `renderer`가 됩니다.
-* `process.versions['electron']` String - Electron의 버전.
-* `process.versions['chrome']` String - Chromium의 버전.
+* `process.versions.electron` String - Electron의 버전.
+* `process.versions.chrome` String - Chromium의 버전.
 * `process.resourcesPath` String - JavaScript 소스 코드의 경로.
 * `process.mas` Boolean - Mac 앱 스토어용 빌드일 때 `true`로 지정됩니다. 다른
   빌드일 땐 `undefined`로 지정됩니다.

--- a/docs-translations/ko-KR/tutorial/quick-start.md
+++ b/docs-translations/ko-KR/tutorial/quick-start.md
@@ -129,7 +129,7 @@ app.on('ready', function() {
     <h1>헬로 월드!</h1>
     이 어플리케이션은 node <script>document.write(process.version)</script>,
     Chrome <script>document.write(process.versions.chrome)</script>,
-    Electron <script>document.write(process.versions['electron'])</script>을 사용합니다.
+    Electron <script>document.write(process.versions.electron)</script>을 사용합니다.
   </body>
 </html>
 ```

--- a/docs-translations/pt-BR/api/process.md
+++ b/docs-translations/pt-BR/api/process.md
@@ -3,8 +3,8 @@ O objeto `process` no Electron tem as seguintes diferenças do objeto no upstrea
 
 * `process.type` String - Tipo de processo, pode ser `browser` (processo principal) 
 ou `renderer`.
-* `process.versions['electron']` String - Versão do Electron.
-* `process.versions['chrome']` String - Versão do Chromium.
+* `process.versions.electron` String - Versão do Electron.
+* `process.versions.chrome` String - Versão do Chromium.
 * `process.resourcesPath` String - Caminho para o código fonte JavaScript.
 * `process.mas` Boolean - Para build da Mac App Store, este valor é `true`, para outros builds é `undefined`.
 

--- a/docs-translations/pt-BR/tutorial/quick-start.md
+++ b/docs-translations/pt-BR/tutorial/quick-start.md
@@ -130,7 +130,7 @@ Finalmente o `index.html` é a página web que você quer mostrar:
   <body>
     <h1>Hello World!</h1>
     Nós estamos usando io.js <script>document.write(process.version)</script>
-    e Electron <script>document.write(process.versions['electron'])</script>.
+    e Electron <script>document.write(process.versions.electron)</script>.
   </body>
 </html>
 ```

--- a/docs-translations/zh-CN/api/process.md
+++ b/docs-translations/zh-CN/api/process.md
@@ -4,8 +4,8 @@ Electron 中的 `process` 对象 与 upstream node 中的有以下的不同点:
 
 * `process.type` String - 进程类型, 可以是 `browser` (i.e. main process)
   或 `renderer`.
-* `process.versions['electron']` String - Electron的版本.
-* `process.versions['chrome']` String - Chromium的版本.
+* `process.versions.electron` String - Electron的版本.
+* `process.versions.chrome` String - Chromium的版本.
 * `process.resourcesPath` String - JavaScript源代码路径.
 * `process.mas` Boolean - 在Mac App Store 创建, 它的值为 `true`, 在其它的地方值为 `undefined`.
 

--- a/docs-translations/zh-CN/tutorial/quick-start.md
+++ b/docs-translations/zh-CN/tutorial/quick-start.md
@@ -89,7 +89,7 @@ app.on('ready', function() {
   <body>
     <h1>Hello World!</h1>
     We are using io.js <script>document.write(process.version)</script>
-    and Electron <script>document.write(process.versions['electron'])</script>.
+    and Electron <script>document.write(process.versions.electron)</script>.
   </body>
 </html>
 ```

--- a/docs-translations/zh-TW/api/process.md
+++ b/docs-translations/zh-TW/api/process.md
@@ -3,8 +3,8 @@
 在 Electron 裡的 `process` 物件具有以下幾個與 upstream node 的不同點:
 
 * `process.type` String - Process 的型態，可以是 `browser` (i.e. 主行程) 或 `renderer`.
-* `process.versions['electron']` String - Electron 的版本
-* `process.versions['chrome']` String - Chromium 的版本
+* `process.versions.electron` String - Electron 的版本
+* `process.versions.chrome` String - Chromium 的版本
 * `process.resourcesPath` String - JavaScript 源碼的路徑
 
 # 方法 (Methods)

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -7,8 +7,8 @@ upstream node:
 
 * `process.type` String - Process's type, can be `browser` (i.e. main process)
   or `renderer`.
-* `process.versions['electron']` String - Version of Electron.
-* `process.versions['chrome']` String - Version of Chromium.
+* `process.versions.electron` String - Version of Electron.
+* `process.versions.chrome` String - Version of Chromium.
 * `process.resourcesPath` String - Path to JavaScript source code.
 * `process.mas` Boolean - For Mac App Store build, this value is `true`, for
   other builds it is `undefined`.

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -44,7 +44,7 @@ describe('crash-reporter module', function () {
         if (called) return
         called = true
         assert.equal(fields['prod'], 'Electron')
-        assert.equal(fields['ver'], process.versions['electron'])
+        assert.equal(fields['ver'], process.versions.electron)
         assert.equal(fields['process_type'], 'renderer')
         assert.equal(fields['platform'], process.platform)
         assert.equal(fields['extra1'], 'extra1')


### PR DESCRIPTION
In https://github.com/electron/electron/pull/5351#issuecomment-215902650, @OlsonDev got me thinking about all the places this old syntax might be hanging out. This cleans the rest of them up!