### PR TITLE
Add --build_libchromiumcontent command line switch

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -4,6 +4,7 @@ Follow the guidelines below for building Electron on Linux.
 
 ## Prerequisites
 
+* At least 25GB disk space and 8GB RAM.
 * Python 2.7.x. Some distributions like CentOS still use Python 2.6.x
   so you may need to check your Python version with `python -V`.
 * Node.js v0.12.x. There are various ways to install Node. You can download
@@ -32,11 +33,6 @@ $ sudo yum install clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-
 
 Other distributions may offer similar packages for installation via package
 managers such as pacman. Or one can compile from source code.
-
-## If You Use Virtual Machines For Building
-
-If you plan to build Electron on a virtual machine you will need a fixed-size
-device container of at least 25 gigabytes in size.
 
 ## Getting the Code
 
@@ -112,8 +108,6 @@ $ ./script/clean.py
 
 ## Troubleshooting
 
-Make sure you have installed all of the build dependencies.
-
 ### Error While Loading Shared Libraries: libtinfo.so.5
 
 Prebulit `clang` will try to link to `libtinfo.so.5`. Depending on the host
@@ -128,7 +122,7 @@ $ sudo ln -s /usr/lib/libncurses.so.5 /usr/lib/libtinfo.so.5
 Test your changes conform to the project coding style using:
 
 ```bash
-$ ./script/cpplint.py
+$ npm run lint
 ```
 
 Test functionality using:

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -130,3 +130,25 @@ Test functionality using:
 ```bash
 $ ./script/test.py
 ```
+
+## Advanced topics
+
+The default building configuration is targeted for major desktop Linux
+distributions, to build for a specific distribution or device, following
+information may help you.
+
+### Build libchromiumcontent locally
+
+To avoid using the prebuilt binaries of libchromiumcontent, you can pass the
+`--build_libchromiumcontent` switch to `bootstrap.py` script:
+
+```bash
+$ ./script/bootstrap.py -v --build_libchromiumcontent
+```
+
+Note that by default the `shared_library` configuration is not built, so you can
+only build `Release` version of Electron if you use this mode:
+
+```bash
+$ ./script/build.py -c D
+```

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -33,6 +33,8 @@ def main():
   if sys.platform == 'cygwin':
     update_win32_python()
 
+  update_submodules()
+
   libcc_source_path = args.libcc_source_path
   libcc_shared_library_path = args.libcc_shared_library_path
   libcc_static_library_path = args.libcc_static_library_path
@@ -49,7 +51,6 @@ def main():
   if PLATFORM != 'win32':
     update_clang()
 
-  update_submodules()
   setup_python_libs()
   update_node_modules('.')
   bootstrap_brightray(args.dev, args.url, args.target_arch,

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -174,9 +174,9 @@ def update_win32_python():
       execute_stdout(['git', 'clone', PYTHON_26_URL])
 
 
-def build_libchromiumcontent(is_verbose_mode, target_arch):
+def build_libchromiumcontent(verbose, target_arch):
   args = [os.path.join(SOURCE_ROOT, 'script', 'build-libchromiumcontent.py')]
-  if is_verbose_mode:
+  if verbose:
     args += ['-v']
   execute_stdout(args + ['--target_arch', target_arch])
 

--- a/script/build-libchromiumcontent.py
+++ b/script/build-libchromiumcontent.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+
+from lib.config import enable_verbose_mode, get_target_arch
+from lib.util import execute_stdout
+
+
+SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+
+def main():
+  os.chdir(SOURCE_ROOT)
+
+  args = parse_args()
+  if args.verbose:
+    enable_verbose_mode()
+
+  # ./script/bootstrap
+  # ./script/update -t x64
+  # ./script/build --no_shared_library -t x64
+  # ./script/create-dist -c static_library -t x64 --no_zip
+  script_dir = os.path.join(SOURCE_ROOT, 'vendor', 'brightray', 'vendor',
+                            'libchromiumcontent', 'script')
+  bootstrap = os.path.join(script_dir, 'bootstrap')
+  update = os.path.join(script_dir, 'update')
+  build = os.path.join(script_dir, 'build')
+  create_dist = os.path.join(script_dir, 'create-dist')
+  execute_stdout([sys.executable, bootstrap])
+  execute_stdout([sys.executable, update, '-t', args.target_arch])
+  execute_stdout([sys.executable, build, '-R', '-t', args.target_arch])
+  execute_stdout([sys.executable, create_dist, '-c', 'static_library',
+                  '--no_zip', '-t', args.target_arch])
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Build libchromiumcontent')
+  parser.add_argument('--target_arch',
+                      help='Specify the arch to build for')
+  parser.add_argument('-v', '--verbose', action='store_true',
+                      help='Prints the output of the subprocesses')
+  return parser.parse_args()
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
Making it possible to build libchromiumcontent locally instead of downloading prebuilt binaries from internet.

Close #3310.
Refs #259.