### PR TITLE
improve the `webContents.openDevTools` docs

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -655,8 +655,9 @@ Removes the specified path from DevTools workspace.
 ### `webContents.openDevTools([options])`
 
 * `options` Object (optional)
-  * `mode` String - Opens the devtools with specified dock state, can be one of
-    "right", "bottom", "undocked", "detach". Defaults to last used dock state.
+  * `mode` String - Opens the devtools with specified dock state, can be
+  `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
+  In `undocked` mode it's possible to dock back. In `detach` mode it's not.
 
 Opens the devtools.
 


### PR DESCRIPTION
consistent value notation and explain the difference between `undocked` and `detach` mode.

Ref: https://github.com/electron/electron/pull/5208#discussion_r60907205