### PR TITLE
Fix autoUpdater error on OS X

### DIFF
--- a/atom/browser/auto_updater_mac.mm
+++ b/atom/browser/auto_updater_mac.mm
@@ -90,9 +90,14 @@ void AutoUpdater::CheckForUpdates() {
           delegate->OnUpdateNotAvailable();
         }
       } error:^(NSError *error) {
-        delegate->OnError(base::SysNSStringToUTF8(
-            [NSString stringWithFormat:@"%@: %@",
-                error.localizedDescription, error.localizedFailureReason]));
+        NSString *failureString;
+        if(error.localizedFailureReason) {
+          failureString = [NSString stringWithFormat:@"%@: %@",
+            error.localizedDescription, error.localizedFailureReason];
+        } else {
+          failureString = [NSString stringWithString: error.localizedDescription];
+        }
+        delegate->OnError(base::SysNSStringToUTF8(failureString));
       }];
 }
 


### PR DESCRIPTION
Addresses #5343 

If there is no localizedFailureReason, then then this will no longer be
added to the error string (which would result previously in it printing
'(null)' as part of the string)

Since testing this requires MAS certificates for codesigning (a requirement of Squirrel.Mac), I have no idea how to unit test this. Any ideas greatly appreciated.