### PR TITLE
Add more options for building on Linux

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -179,3 +179,25 @@ For example building with GCC toolchain:
 $ env CC=gcc CXX=g++ ./script/bootstrap.py -v --build_libchromiumcontent --disable_clang
 $ ./script/build.py -c R
 ```
+
+### Environment variables
+
+Apart from `CC` and `CXX`, you can also set following environment variables to
+custom the building configurations:
+
+* `CPPFLAGS`
+* `CPPFLAGS_host`
+* `CFLAGS`
+* `CFLAGS_host`
+* `CXXFLAGS`
+* `CXXFLAGS_host`
+* `AR`
+* `AR_host`
+* `CC`
+* `CC_host`
+* `CXX`
+* `CXX_host`
+* `LDFLAGS`
+
+The environment variables have to be set when executing the `bootstrap.py`
+script, it won't work in the `build.py` script.

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -137,9 +137,9 @@ The default building configuration is targeted for major desktop Linux
 distributions, to build for a specific distribution or device, following
 information may help you.
 
-### Build libchromiumcontent locally
+### Building `libchromiumcontent` locally
 
-To avoid using the prebuilt binaries of libchromiumcontent, you can pass the
+To avoid using the prebuilt binaries of `libchromiumcontent`, you can pass the
 `--build_libchromiumcontent` switch to `bootstrap.py` script:
 
 ```bash
@@ -150,5 +150,32 @@ Note that by default the `shared_library` configuration is not built, so you can
 only build `Release` version of Electron if you use this mode:
 
 ```bash
-$ ./script/build.py -c D
+$ ./script/build.py -c R
+```
+
+### Using system `clang` instead of downloaded `clang` binaries
+
+By default Electron is built with prebuilt `clang` binaries provided by Chromium
+project. If for some reason you want to build with the `clang` installed in your
+system, you can call `bootstrap.py` with `--clang_dir=<path>` switch. By passing
+it the build script will assume the clang binaries reside in `<path>/bin/`.
+
+For example if you installed `clang` under `/user/local/bin/clang`:
+
+```bash
+$ ./script/bootstrap.py -v --build_libchromiumcontent --clang_dir /usr/local
+$ ./script/build.py -c R
+```
+
+### Using other compilers other than `clang`
+
+To build Electron with compilers like `g++`, you first need to disable `clang`
+with `--disable_clang` switch first, and then set `CC` and `CXX` environment
+variables to the ones you want.
+
+For example building with GCC toolchain:
+
+```bash
+$ env CC=gcc CXX=g++ ./script/bootstrap.py -v --build_libchromiumcontent --disable_clang
+$ ./script/build.py -c R
 ```

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -49,11 +49,12 @@ def main():
     libcc_shared_library_path = os.path.join(dist_dir, 'shared_library')
     libcc_static_library_path = os.path.join(dist_dir, 'static_library')
 
-  update_clang()
-
-  if PLATFORM != 'win32' and not args.disable_clang and args.clang_dir == '':
-    # Build with prebuilt clang.
-    set_clang_env(os.environ)
+  if PLATFORM != 'win32':
+    # Download prebuilt clang binaries.
+    update_clang()
+    if not args.disable_clang and args.clang_dir == '':
+      # Build with prebuilt clang.
+      set_clang_env(os.environ)
 
   setup_python_libs()
   update_node_modules('.')

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -42,15 +42,14 @@ def main():
 
   # Redirect to use local libchromiumcontent build.
   if args.build_libchromiumcontent:
-    build_libchromiumcontent(args.verbose, args.target_arch, args.disable_clang,
-                             args.clang_dir)
+    build_libchromiumcontent(args.verbose, args.target_arch, defines)
     dist_dir = os.path.join(SOURCE_ROOT, 'vendor', 'brightray', 'vendor',
                             'libchromiumcontent', 'dist', 'main')
     libcc_source_path = os.path.join(dist_dir, 'src')
     libcc_shared_library_path = os.path.join(dist_dir, 'shared_library')
     libcc_static_library_path = os.path.join(dist_dir, 'static_library')
 
-  if PLATFORM != 'win32' and not args.disable_clang and args.clang_dir != '':
+  if PLATFORM != 'win32' and not args.disable_clang and args.clang_dir == '':
     update_clang()
 
   setup_python_libs()

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -153,7 +153,7 @@ def bootstrap_brightray(is_dev, url, target_arch, libcc_source_path,
 
 def update_node_modules(dirname, env=None):
   if env is None:
-    env = os.environ
+    env = os.environ.copy()
   if PLATFORM == 'linux':
     # Use prebuilt clang for building native modules.
     llvm_dir = os.path.join(SOURCE_ROOT, 'vendor', 'llvm-build',

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -41,14 +41,15 @@ def main():
 
   # Redirect to use local libchromiumcontent build.
   if args.build_libchromiumcontent:
-    build_libchromiumcontent(args.verbose, args.target_arch)
+    build_libchromiumcontent(args.verbose, args.target_arch, args.disable_clang,
+                             args.clang_dir)
     dist_dir = os.path.join(SOURCE_ROOT, 'vendor', 'brightray', 'vendor',
                             'libchromiumcontent', 'dist', 'main')
     libcc_source_path = os.path.join(dist_dir, 'src')
     libcc_shared_library_path = os.path.join(dist_dir, 'shared_library')
     libcc_static_library_path = os.path.join(dist_dir, 'static_library')
 
-  if PLATFORM != 'win32':
+  if PLATFORM != 'win32' and not args.disable_clang and args.clang_dir != '':
     update_clang()
 
   setup_python_libs()
@@ -85,6 +86,9 @@ def parse_args():
                            'prompts.')
   parser.add_argument('--target_arch', default=get_target_arch(),
                       help='Manually specify the arch to build for')
+  parser.add_argument('--clang_dir', default='', help='Path to clang binaries')
+  parser.add_argument('--disable_clang', action='store_true',
+                      help='Use compilers other than clang for building')
   parser.add_argument('--build_libchromiumcontent', action='store_true',
                       help='Build local version of libchromiumcontent')
   parser.add_argument('--libcc_source_path', required=False,
@@ -175,10 +179,14 @@ def update_win32_python():
       execute_stdout(['git', 'clone', PYTHON_26_URL])
 
 
-def build_libchromiumcontent(verbose, target_arch):
+def build_libchromiumcontent(verbose, target_arch, disable_clang, clang_dir):
   args = [os.path.join(SOURCE_ROOT, 'script', 'build-libchromiumcontent.py')]
   if verbose:
     args += ['-v']
+  if disable_clang:
+    args += ['--disable_clang']
+  if clang_dir:
+    args += ['--clang_dir', clang_dir]
   execute_stdout(args + ['--target_arch', target_arch])
 
 

--- a/script/build-libchromiumcontent.py
+++ b/script/build-libchromiumcontent.py
@@ -18,6 +18,12 @@ def main():
   if args.verbose:
     enable_verbose_mode()
 
+  extra_update_args = []
+  if args.disable_clang:
+    extra_update_args += ['--disable_clang']
+  if args.clang_dir:
+    extra_update_args += ['--clang_dir', args.clang_dir]
+
   # ./script/bootstrap
   # ./script/update -t x64
   # ./script/build --no_shared_library -t x64
@@ -29,7 +35,8 @@ def main():
   build = os.path.join(script_dir, 'build')
   create_dist = os.path.join(script_dir, 'create-dist')
   execute_stdout([sys.executable, bootstrap])
-  execute_stdout([sys.executable, update, '-t', args.target_arch])
+  execute_stdout([sys.executable, update, '-t', args.target_arch] +
+                 extra_update_args)
   execute_stdout([sys.executable, build, '-R', '-t', args.target_arch])
   execute_stdout([sys.executable, create_dist, '-c', 'static_library',
                   '--no_zip', '-t', args.target_arch])
@@ -39,6 +46,9 @@ def parse_args():
   parser = argparse.ArgumentParser(description='Build libchromiumcontent')
   parser.add_argument('--target_arch',
                       help='Specify the arch to build for')
+  parser.add_argument('--clang_dir', default='', help='Path to clang binaries')
+  parser.add_argument('--disable_clang', action='store_true',
+                      help='Use compilers other than clang for building')
   parser.add_argument('-v', '--verbose', action='store_true',
                       help='Prints the output of the subprocesses')
   return parser.parse_args()

--- a/script/build-libchromiumcontent.py
+++ b/script/build-libchromiumcontent.py
@@ -18,14 +18,8 @@ def main():
   if args.verbose:
     enable_verbose_mode()
 
-  extra_update_args = []
-  if args.disable_clang:
-    extra_update_args += ['--disable_clang']
-  if args.clang_dir:
-    extra_update_args += ['--clang_dir', args.clang_dir]
-
   # ./script/bootstrap
-  # ./script/update -t x64
+  # ./script/update -t x64 --defines=''
   # ./script/build --no_shared_library -t x64
   # ./script/create-dist -c static_library -t x64 --no_zip
   script_dir = os.path.join(SOURCE_ROOT, 'vendor', 'brightray', 'vendor',
@@ -35,8 +29,8 @@ def main():
   build = os.path.join(script_dir, 'build')
   create_dist = os.path.join(script_dir, 'create-dist')
   execute_stdout([sys.executable, bootstrap])
-  execute_stdout([sys.executable, update, '-t', args.target_arch] +
-                 extra_update_args)
+  execute_stdout([sys.executable, update, '-t', args.target_arch,
+                  '--defines', args.defines])
   execute_stdout([sys.executable, build, '-R', '-t', args.target_arch])
   execute_stdout([sys.executable, create_dist, '-c', 'static_library',
                   '--no_zip', '-t', args.target_arch])
@@ -46,9 +40,8 @@ def parse_args():
   parser = argparse.ArgumentParser(description='Build libchromiumcontent')
   parser.add_argument('--target_arch',
                       help='Specify the arch to build for')
-  parser.add_argument('--clang_dir', default='', help='Path to clang binaries')
-  parser.add_argument('--disable_clang', action='store_true',
-                      help='Use compilers other than clang for building')
+  parser.add_argument('--defines', default='',
+                      help='The definetions passed to gyp')
   parser.add_argument('-v', '--verbose', action='store_true',
                       help='Prints the output of the subprocesses')
   return parser.parse_args()

--- a/script/update.py
+++ b/script/update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import platform
 import subprocess
@@ -21,6 +22,13 @@ def main():
 
   update_external_binaries()
   return update_gyp()
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Update build configurations')
+  parser.add_argument('--defines', default='',
+                      help='The definetions passed to gyp')
+  return parser.parse_args()
 
 
 def update_external_binaries():
@@ -60,6 +68,7 @@ def run_gyp(target_arch, component):
     mas_build = 1
   else:
     mas_build = 0
+
   defines = [
     '-Dlibchromiumcontent_component={0}'.format(component),
     '-Dtarget_arch={0}'.format(target_arch),
@@ -67,6 +76,13 @@ def run_gyp(target_arch, component):
     '-Dlibrary=static_library',
     '-Dmas_build={0}'.format(mas_build),
   ]
+
+  # Add the defines passed from command line.
+  args = parse_args()
+  for define in [d.strip() for d in args.defines.split(' ')]:
+    if define:
+      defines += ['-D' + define]
+
   return subprocess.call([python, gyp, '-f', 'ninja', '--depth', '.',
                           'electron.gyp', '-Icommon.gypi'] + defines, env=env)
 


### PR DESCRIPTION
`bootstrap.py`:
  * `--disable_clang` - Use compilers other than clang for building
  * `--clang_dir` - Path to clang binaries

Also updated the documents on how to build with custom build configurations.

Refs #259.