### PR TITLE
Use select to query the uv kqueue

### DIFF
--- a/atom/common/node_bindings_mac.cc
+++ b/atom/common/node_bindings_mac.cc
@@ -5,6 +5,7 @@
 #include "atom/common/node_bindings_mac.h"
 
 #include <errno.h>
+#include <sys/select.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -14,13 +15,7 @@
 namespace atom {
 
 NodeBindingsMac::NodeBindingsMac(bool is_browser)
-    : NodeBindings(is_browser),
-      kqueue_(kqueue()) {
-  // Add uv's backend fd to kqueue.
-  struct kevent ev;
-  EV_SET(&ev, uv_backend_fd(uv_loop_), EVFILT_READ, EV_ADD | EV_ENABLE,
-         0, 0, 0);
-  kevent(kqueue_, &ev, 1, NULL, 0, NULL);
+    : NodeBindings(is_browser) {
 }
 
 NodeBindingsMac::~NodeBindingsMac() {
@@ -44,19 +39,22 @@ void NodeBindingsMac::OnWatcherQueueChanged(uv_loop_t* loop) {
 }
 
 void NodeBindingsMac::PollEvents() {
-  struct timespec spec;
+  struct timeval tv;
   int timeout = uv_backend_timeout(uv_loop_);
   if (timeout != -1) {
-    spec.tv_sec = timeout / 1000;
-    spec.tv_nsec = (timeout % 1000) * 1000000;
+    tv.tv_sec = timeout / 1000;
+    tv.tv_usec = (timeout % 1000) * 1000;
   }
+
+  fd_set readset;
+  int fd = uv_backend_fd(uv_loop_);
+  FD_ZERO(&readset);
+  FD_SET(fd, &readset);
 
   // Wait for new libuv events.
   int r;
   do {
-    struct kevent ev;
-    r = ::kevent(kqueue_, NULL, 0, &ev, 1,
-                 timeout == -1 ? NULL : &spec);
+    r = select(fd + 1, &readset, NULL, NULL, timeout == -1 ? NULL : &tv);
   } while (r == -1 && errno == EINTR);
 }
 

--- a/atom/common/node_bindings_mac.h
+++ b/atom/common/node_bindings_mac.h
@@ -23,9 +23,6 @@ class NodeBindingsMac : public NodeBindings {
 
   void PollEvents() override;
 
-  // Kqueue to poll for uv's backend fd.
-  int kqueue_;
-
   DISALLOW_COPY_AND_ASSIGN(NodeBindingsMac);
 };
 


### PR DESCRIPTION
This resolves #38. Read the issue for context, but after debugging the problem looks like this:

When a pty is in the uv kqueue, the poll kqueue does not properly clear the event after receiving it. The obvious fix would be to add `EV_CLEAR` to the event flags so that it is definitely cleared after receiving any event, however this causes a race condition in Darwin. The poll kqueue is signaled before the uv kqueue, resulting in the uv thread running once, seeing no events, and going back to sleep, while simultaneously the poll thread clears its kqueue out. This results in events being delayed until the next event comes in. You can verify that this is a race condition by adding `EV_CLEAR` to the original kevent call and then adding a sleep at the end of `PollEvents`

The code is simply waiting for data to be available for reading on the uv kqueue file descriptor, which `select` also does. I have migrated the Darwin-specific uv polling code to use `select` instead of kqueue.

I've verified that events still get processed like they should on El Capitan 10.11.3 (15D21).

Note: `poll` doesn't work on kqueues, otherwise I would have used that instead.