### PR TITLE
Enforce the BrowserWindow's min/max dimensions.

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -405,9 +405,26 @@ bool Window::IsFullscreen() {
 }
 
 void Window::SetBounds(const gfx::Rect& bounds, mate::Arguments* args) {
+  // Copy the bounds so we can change them.
+  gfx::Rect params = bounds;
+
+  // Honour the max sizes
+  gfx::Size maxSize = window_->GetMaximumSize();
+  if (maxSize.width() && params.width() > maxSize.width())
+    params.set_width(maxSize.width());
+  if (maxSize.height() && params.height() > maxSize.height())
+    params.set_height(maxSize.height());
+
+  // Honour the min sizes.
+  gfx::Size minSize = window_->GetMinimumSize();
+  if (minSize.width() && params.width() < minSize.width())
+    params.set_width(minSize.width());
+  if (minSize.height() && params.height() < minSize.height())
+    params.set_height(minSize.height());
+
   bool animate = false;
   args->GetNext(&animate);
-  window_->SetBounds(bounds, animate);
+  window_->SetBounds(params, animate);
 }
 
 gfx::Rect Window::GetBounds() {
@@ -415,6 +432,20 @@ gfx::Rect Window::GetBounds() {
 }
 
 void Window::SetSize(int width, int height, mate::Arguments* args) {
+  // Honour the max sizes
+  gfx::Size maxSize = window_->GetMaximumSize();
+  if (maxSize.width() && width > maxSize.width())
+    width = maxSize.width();
+  if (maxSize.height() && height > maxSize.height())
+    height = maxSize.height();
+
+  // Honour the min sizes.
+  gfx::Size minSize = window_->GetMinimumSize();
+  if (minSize.width() && width < minSize.width())
+    width = minSize.width();
+  if (minSize.height() && height < minSize.height())
+    height = minSize.height();
+
   bool animate = false;
   args->GetNext(&animate);
   window_->SetSize(gfx::Size(width, height), animate);

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -270,6 +270,62 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.setBounds({x, y, width, height})', function () {
+    it('sets the window bounds', function (done) {
+      var bounds = {x: 10, y: 10, width: 300, height: 350}
+      w.once('resize', function () {
+        var newSize = w.getSize()
+        var newPosition = w.getPosition()
+        assert.equal(newSize[0], bounds.width)
+        assert.equal(newSize[1], bounds.height)
+        assert.equal(newPosition[0], bounds.x)
+        assert.equal(newPosition[1], bounds.y)
+        done()
+      })
+      w.setBounds(bounds)
+    })
+
+    it('respects the minWidth and minHeight settings', function (done) {
+      w.destroy()
+      var bounds = {x: 10, y: 10, width: 200, height: 200}
+      var size = [300, 350]
+      w = new BrowserWindow({
+        minWidth: size[0],
+        minHeight: size[1],
+        width: 400,
+        height: 400
+      })
+      w.once('resize', function () {
+        var newSize = w.getSize()
+        var newPosition = w.getPosition()
+        assert.equal(newSize[0], size[0])
+        assert.equal(newSize[1], size[1])
+        done()
+      })
+      w.setBounds(bounds)
+    })
+
+    it('respects the maxWidth and maxHeight settings', function (done) {
+      w.destroy()
+      var size = [500, 550]
+      var bounds = {x: 10, y: 10, width: 600, height: 650}
+      w = new BrowserWindow({
+        maxWidth: size[0],
+        maxHeight: size[1],
+        width: 400,
+        height: 400
+      })
+      w.once('resize', function () {
+        var newSize = w.getSize()
+        var newPosition = w.getPosition()
+        assert.equal(newSize[0], size[0])
+        assert.equal(newSize[1], size[1])
+        done()
+      })
+      w.setBounds(bounds)
+    })
+  })
+
   describe('BrowserWindow.setSize(width, height)', function () {
     it('sets the window size', function (done) {
       var size = [300, 400]
@@ -282,34 +338,40 @@ describe('browser-window module', function () {
       w.setSize(size[0], size[1])
     })
 
-    it('respects the minWidth and minHeight settings', function () {
+    it('respects the minWidth and minHeight settings', function (done) {
       w.destroy()
-      var size = [300, 300]
+      var size = [300, 350]
       w = new BrowserWindow({
         minWidth: size[0],
         minHeight: size[1],
         width: 400,
         height: 400
       })
+      w.once('resize', function () {
+        var newSize = w.getSize()
+        assert.equal(newSize[0], size[0])
+        assert.equal(newSize[1], size[1])
+        done()
+      })
       w.setSize(100, 100)
-      var after = w.getSize()
-      assert.equal(after[0], size[0])
-      assert.equal(after[1], size[1])
     })
 
-    it('respects the maxWidth and maxHeight settings', function () {
+    it('respects the maxWidth and maxHeight settings', function (done) {
       w.destroy()
-      var size = [500, 500]
+      var size = [500, 550]
       w = new BrowserWindow({
         maxWidth: size[0],
         maxHeight: size[1],
         width: 400,
         height: 400
       })
+      w.once('resize', function () {
+        var newSize = w.getSize()
+        assert.equal(newSize[0], size[0])
+        assert.equal(newSize[1], size[1])
+        done()
+      })
       w.setSize(600, 600)
-      var after = w.getSize()
-      assert.equal(after[0], size[0])
-      assert.equal(after[1], size[1])
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -281,6 +281,36 @@ describe('browser-window module', function () {
       })
       w.setSize(size[0], size[1])
     })
+
+    it('respects the minWidth and minHeight settings', function () {
+      w.destroy()
+      var size = [300, 300]
+      w = new BrowserWindow({
+        minWidth: size[0],
+        minHeight: size[1],
+        width: 400,
+        height: 400
+      })
+      w.setSize(100, 100)
+      var after = w.getSize()
+      assert.equal(after[0], size[0])
+      assert.equal(after[1], size[1])
+    })
+
+    it('respects the maxWidth and maxHeight settings', function () {
+      w.destroy()
+      var size = [500, 500]
+      w = new BrowserWindow({
+        maxWidth: size[0],
+        maxHeight: size[1],
+        width: 400,
+        height: 400
+      })
+      w.setSize(600, 600)
+      var after = w.getSize()
+      assert.equal(after[0], size[0])
+      assert.equal(after[1], size[1])
+    })
   })
 
   describe('BrowserWindow.setPosition(x, y)', function () {


### PR DESCRIPTION
If the user tries to set the bounds of the window such that a value falls outside of the min/max of width or height, the app will default to the corresponding min or max.

Closes #4586