### PR TITLE
Add scrollBounce option and disable it by default

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -141,6 +141,14 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
     command_line->AppendSwitchASCII(switches::kOpenerID,
                                     base::IntToString(opener_id));
 
+#if defined(OS_MACOSX)
+  // Enable scroll bounce.
+  bool scroll_bounce;
+  if (web_preferences.GetBoolean(options::kScrollBounce, &scroll_bounce) &&
+      scroll_bounce)
+    command_line->AppendSwitch(switches::kScrollBounce);
+#endif
+
   // Enable blink features.
   std::string blink_features;
   if (web_preferences.GetString(options::kBlinkFeatures, &blink_features))

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -103,6 +103,9 @@ const char kExperimentalCanvasFeatures[] = "experimentalCanvasFeatures";
 // Opener window's ID.
 const char kOpenerID[] = "openerId";
 
+// Enable the rubber banding effect.
+const char kScrollBounce[] = "scrollBounce";
+
 // Enable blink features.
 const char kBlinkFeatures[] = "blinkFeatures";
 
@@ -146,6 +149,7 @@ const char kPreloadURL[]      = "preload-url";
 const char kNodeIntegration[] = "node-integration";
 const char kGuestInstanceID[] = "guest-instance-id";
 const char kOpenerID[]        = "opener-id";
+const char kScrollBounce[]    = "scroll-bounce";
 
 // Widevine options
 // Path to Widevine CDM binaries.

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -56,6 +56,7 @@ extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];
 extern const char kOpenerID[];
+extern const char kScrollBounce[];
 extern const char kBlinkFeatures[];
 
 }   // namespace options
@@ -82,6 +83,7 @@ extern const char kPreloadURL[];
 extern const char kNodeIntegration[];
 extern const char kGuestInstanceID[];
 extern const char kOpenerID[];
+extern const char kScrollBounce[];
 
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -170,6 +170,8 @@ The `webPreferences` option is an object that can have following properties:
   canvas features. Default is `false`.
 * `directWrite` Boolean - Enables DirectWrite font rendering system on
   Windows. Default is `true`.
+* `scrollBounce` Boolean - Enables scroll bounce (rubber banding) effect on
+  OS X. Default is `false`.
 * `blinkFeatures` String - A list of feature strings separated by `,`, like
   `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
   can be found in the [setFeatureEnabledFromString][blink-feature-string]


### PR DESCRIPTION
This PR disables the scroll bounce (rubber banding) effect on OS X by default, and add a `scrollBounce` option to enable it.

We used to disable scroll bounce effect completely by patching Webkit, but in recent versions of Chrome the way scroll bounce is implemented had changed and the scroll bounce effect was back.

Close #5397.