### PR TITLE
Fetch Process resource usage from WebContents

### DIFF
--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -389,14 +389,12 @@ v8::Local<v8::Value> Converter<blink::WebCache::ResourceTypeStat>::ToV8(
     v8::Isolate* isolate,
     const blink::WebCache::ResourceTypeStat& stat) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
-
-  dict.Set("count", (uint32_t)stat.count);
-  dict.Set("size", (double)stat.size);
-  dict.Set("liveSize", (double)stat.liveSize);
-  dict.Set("decodedSize", (double)stat.decodedSize);
-  dict.Set("purgedSize", (double)stat.purgedSize);
-  dict.Set("purgeableSize", (double)stat.purgeableSize);
-
+  dict.Set("count", static_cast<uint32_t>(stat.count));
+  dict.Set("size", static_cast<double>(stat.size));
+  dict.Set("liveSize", static_cast<double>(stat.liveSize));
+  dict.Set("decodedSize", static_cast<double>(stat.decodedSize));
+  dict.Set("purgedSize", static_cast<double>(stat.purgedSize));
+  dict.Set("purgeableSize", static_cast<double>(stat.purgeableSize));
   return dict.GetHandle();
 }
 
@@ -404,14 +402,12 @@ v8::Local<v8::Value> Converter<blink::WebCache::ResourceTypeStats>::ToV8(
     v8::Isolate* isolate,
     const blink::WebCache::ResourceTypeStats& stats) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
-
   dict.Set("images", mate::ConvertToV8(isolate, stats.images));
   dict.Set("scripts", mate::ConvertToV8(isolate, stats.scripts));
   dict.Set("cssStyleSheets", mate::ConvertToV8(isolate, stats.cssStyleSheets));
   dict.Set("xslStyleSheets", mate::ConvertToV8(isolate, stats.xslStyleSheets));
   dict.Set("fonts", mate::ConvertToV8(isolate, stats.fonts));
   dict.Set("other", mate::ConvertToV8(isolate, stats.other));
-
   return dict.GetHandle();
 }
 

--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -406,6 +406,7 @@ v8::Local<v8::Value> Converter<blink::WebCache::ResourceTypeStats>::ToV8(
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
 
   dict.Set("images", mate::ConvertToV8(isolate, stats.images));
+  dict.Set("scripts", mate::ConvertToV8(isolate, stats.scripts));
   dict.Set("cssStyleSheets", mate::ConvertToV8(isolate, stats.cssStyleSheets));
   dict.Set("xslStyleSheets", mate::ConvertToV8(isolate, stats.xslStyleSheets));
   dict.Set("fonts", mate::ConvertToV8(isolate, stats.fonts));

--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -12,6 +12,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "native_mate/dictionary.h"
+#include "third_party/WebKit/public/web/WebCache.h"
 #include "third_party/WebKit/public/web/WebDeviceEmulationParams.h"
 #include "third_party/WebKit/public/web/WebFindOptions.h"
 #include "third_party/WebKit/public/web/WebInputEvent.h"
@@ -382,6 +383,35 @@ v8::Local<v8::Value> MediaFlagsToV8(v8::Isolate* isolate, int mediaFlags) {
   dict.Set("canRotate",
       !!(mediaFlags & blink::WebContextMenuData::MediaCanRotate));
   return mate::ConvertToV8(isolate, dict);
+}
+
+v8::Local<v8::Value> Converter<blink::WebCache::ResourceTypeStat>::ToV8(
+    v8::Isolate* isolate,
+    const blink::WebCache::ResourceTypeStat& stat) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+
+  dict.Set("count", (uint32_t)stat.count);
+  dict.Set("size", (uint32_t)(stat.size >> 10));
+  dict.Set("liveSize", (uint32_t)(stat.liveSize >> 10));
+  dict.Set("decodedSize", (uint32_t)(stat.decodedSize >> 10));
+  dict.Set("purgedSize", (uint32_t)(stat.purgedSize >> 10));
+  dict.Set("purgeableSize", (uint32_t)(stat.purgeableSize >> 10));
+
+  return dict.GetHandle();
+}
+
+v8::Local<v8::Value> Converter<blink::WebCache::ResourceTypeStats>::ToV8(
+    v8::Isolate* isolate,
+    const blink::WebCache::ResourceTypeStats& stats) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+
+  dict.Set("images", mate::ConvertToV8(isolate, stats.images));
+  dict.Set("cssStyleSheets", mate::ConvertToV8(isolate, stats.cssStyleSheets));
+  dict.Set("xslStyleSheets", mate::ConvertToV8(isolate, stats.xslStyleSheets));
+  dict.Set("fonts", mate::ConvertToV8(isolate, stats.fonts));
+  dict.Set("other", mate::ConvertToV8(isolate, stats.other));
+
+  return dict.GetHandle();
 }
 
 }  // namespace mate

--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -402,12 +402,12 @@ v8::Local<v8::Value> Converter<blink::WebCache::ResourceTypeStats>::ToV8(
     v8::Isolate* isolate,
     const blink::WebCache::ResourceTypeStats& stats) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
-  dict.Set("images", mate::ConvertToV8(isolate, stats.images));
-  dict.Set("scripts", mate::ConvertToV8(isolate, stats.scripts));
-  dict.Set("cssStyleSheets", mate::ConvertToV8(isolate, stats.cssStyleSheets));
-  dict.Set("xslStyleSheets", mate::ConvertToV8(isolate, stats.xslStyleSheets));
-  dict.Set("fonts", mate::ConvertToV8(isolate, stats.fonts));
-  dict.Set("other", mate::ConvertToV8(isolate, stats.other));
+  dict.Set("images", stats.images);
+  dict.Set("scripts", stats.scripts);
+  dict.Set("cssStyleSheets", stats.cssStyleSheets);
+  dict.Set("xslStyleSheets", stats.xslStyleSheets);
+  dict.Set("fonts", stats.fonts);
+  dict.Set("other", stats.other);
   return dict.GetHandle();
 }
 

--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -391,11 +391,11 @@ v8::Local<v8::Value> Converter<blink::WebCache::ResourceTypeStat>::ToV8(
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
 
   dict.Set("count", (uint32_t)stat.count);
-  dict.Set("size", (uint32_t)(stat.size >> 10));
-  dict.Set("liveSize", (uint32_t)(stat.liveSize >> 10));
-  dict.Set("decodedSize", (uint32_t)(stat.decodedSize >> 10));
-  dict.Set("purgedSize", (uint32_t)(stat.purgedSize >> 10));
-  dict.Set("purgeableSize", (uint32_t)(stat.purgeableSize >> 10));
+  dict.Set("size", (double)stat.size);
+  dict.Set("liveSize", (double)stat.liveSize);
+  dict.Set("decodedSize", (double)stat.decodedSize);
+  dict.Set("purgedSize", (double)stat.purgedSize);
+  dict.Set("purgeableSize", (double)stat.purgeableSize);
 
   return dict.GetHandle();
 }

--- a/atom/common/native_mate_converters/blink_converter.h
+++ b/atom/common/native_mate_converters/blink_converter.h
@@ -101,21 +101,22 @@ struct Converter<blink::WebContextMenuData::InputFieldType> {
       const blink::WebContextMenuData::InputFieldType& in);
 };
 
-v8::Local<v8::Value> EditFlagsToV8(v8::Isolate* isolate, int editFlags);
-
-v8::Local<v8::Value> MediaFlagsToV8(v8::Isolate* isolate, int mediaFlags);
-
 template<>
 struct Converter<blink::WebCache::ResourceTypeStat> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const blink::WebCache::ResourceTypeStat& stat);
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      const blink::WebCache::ResourceTypeStat& stat);
 };
 
 template<>
 struct Converter<blink::WebCache::ResourceTypeStats> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const blink::WebCache::ResourceTypeStats& stats);
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      const blink::WebCache::ResourceTypeStats& stats);
 };
+
+v8::Local<v8::Value> EditFlagsToV8(v8::Isolate* isolate, int editFlags);
+v8::Local<v8::Value> MediaFlagsToV8(v8::Isolate* isolate, int mediaFlags);
 
 }  // namespace mate
 

--- a/atom/common/native_mate_converters/blink_converter.h
+++ b/atom/common/native_mate_converters/blink_converter.h
@@ -6,6 +6,7 @@
 #define ATOM_COMMON_NATIVE_MATE_CONVERTERS_BLINK_CONVERTER_H_
 
 #include "native_mate/converter.h"
+#include "third_party/WebKit/public/web/WebCache.h"
 #include "third_party/WebKit/public/web/WebContextMenuData.h"
 
 namespace blink {
@@ -103,6 +104,18 @@ struct Converter<blink::WebContextMenuData::InputFieldType> {
 v8::Local<v8::Value> EditFlagsToV8(v8::Isolate* isolate, int editFlags);
 
 v8::Local<v8::Value> MediaFlagsToV8(v8::Isolate* isolate, int mediaFlags);
+
+template<>
+struct Converter<blink::WebCache::ResourceTypeStat> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const blink::WebCache::ResourceTypeStat& stat);
+};
+
+template<>
+struct Converter<blink::WebCache::ResourceTypeStats> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const blink::WebCache::ResourceTypeStats& stats);
+};
 
 }  // namespace mate
 

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -10,6 +10,7 @@
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/renderer/api/atom_api_spell_check_client.h"
+#include "base/memory/memory_pressure_listener.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_view.h"
 #include "native_mate/dictionary.h"
@@ -177,6 +178,14 @@ v8::Local<v8::Value> WebFrame::GetResourceUsage(v8::Isolate* isolate) {
   return mate::Converter<blink::WebCache::ResourceTypeStats>::ToV8(isolate, stats);
 }
 
+void WebFrame::PurgeCaches(v8::Isolate* isolate) {
+  isolate->IdleNotificationDeadline(0.5);
+  blink::WebCache::clear();
+
+  base::MemoryPressureListener::NotifyMemoryPressure(
+    base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL);
+}
+
 // static
 void WebFrame::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
@@ -201,7 +210,8 @@ void WebFrame::BuildPrototype(
                  &WebFrame::RegisterURLSchemeAsPrivileged)
       .SetMethod("insertText", &WebFrame::InsertText)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
-      .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage);
+      .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
+      .SetMethod("purgeCaches", &WebFrame::PurgeCaches);
 }
 
 }  // namespace api

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -171,9 +171,9 @@ mate::Handle<WebFrame> WebFrame::Create(v8::Isolate* isolate) {
   return mate::CreateHandle(isolate, new WebFrame(isolate));
 }
 
-blink::WebCache::ResourceTypeStats WebFrame::GetResourceUsage(v8::Isolate* isolate) {
+blink::WebCache::ResourceTypeStats WebFrame::GetResourceUsage(
+    v8::Isolate* isolate) {
   blink::WebCache::ResourceTypeStats stats;
-
   blink::WebCache::getResourceTypeStats(&stats);
   return stats;
 }

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -171,11 +171,11 @@ mate::Handle<WebFrame> WebFrame::Create(v8::Isolate* isolate) {
   return mate::CreateHandle(isolate, new WebFrame(isolate));
 }
 
-v8::Local<v8::Value> WebFrame::GetResourceUsage(v8::Isolate* isolate) {
+blink::WebCache::ResourceTypeStats WebFrame::GetResourceUsage(v8::Isolate* isolate) {
   blink::WebCache::ResourceTypeStats stats;
 
   blink::WebCache::getResourceTypeStats(&stats);
-  return mate::Converter<blink::WebCache::ResourceTypeStats>::ToV8(isolate, stats);
+  return stats;
 }
 
 void WebFrame::PurgeCaches(v8::Isolate* isolate) {

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -5,6 +5,7 @@
 #include "atom/renderer/api/atom_api_web_frame.h"
 
 #include "atom/common/api/event_emitter_caller.h"
+#include "atom/common/native_mate_converters/blink_converter.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
@@ -13,6 +14,7 @@
 #include "content/public/renderer/render_view.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
+#include "third_party/WebKit/public/web/WebCache.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebScriptExecutionCallback.h"
@@ -168,6 +170,13 @@ mate::Handle<WebFrame> WebFrame::Create(v8::Isolate* isolate) {
   return mate::CreateHandle(isolate, new WebFrame(isolate));
 }
 
+v8::Local<v8::Value> WebFrame::GetResourceUsage(v8::Isolate* isolate) {
+  blink::WebCache::ResourceTypeStats stats;
+
+  blink::WebCache::getResourceTypeStats(&stats);
+  return mate::Converter<blink::WebCache::ResourceTypeStats>::ToV8(isolate, stats);
+}
+
 // static
 void WebFrame::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
@@ -191,7 +200,8 @@ void WebFrame::BuildPrototype(
       .SetMethod("registerURLSchemeAsPrivileged",
                  &WebFrame::RegisterURLSchemeAsPrivileged)
       .SetMethod("insertText", &WebFrame::InsertText)
-      .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript);
+      .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
+      .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage);
 }
 
 }  // namespace api

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -178,10 +178,9 @@ blink::WebCache::ResourceTypeStats WebFrame::GetResourceUsage(
   return stats;
 }
 
-void WebFrame::PurgeCaches(v8::Isolate* isolate) {
+void WebFrame::ClearCache(v8::Isolate* isolate) {
   isolate->IdleNotificationDeadline(0.5);
   blink::WebCache::clear();
-
   base::MemoryPressureListener::NotifyMemoryPressure(
     base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL);
 }
@@ -211,7 +210,7 @@ void WebFrame::BuildPrototype(
       .SetMethod("insertText", &WebFrame::InsertText)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
-      .SetMethod("purgeCaches", &WebFrame::PurgeCaches);
+      .SetMethod("clearCache", &WebFrame::ClearCache);
 }
 
 }  // namespace api

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -11,6 +11,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "native_mate/handle.h"
 #include "native_mate/wrappable.h"
+#include "third_party/WebKit/public/web/WebCache.h"
 
 namespace blink {
 class WebLocalFrame;
@@ -68,6 +69,9 @@ class WebFrame : public mate::Wrappable<WebFrame> {
 
   // Excecuting scripts.
   void ExecuteJavaScript(const base::string16& code, mate::Arguments* args);
+
+  // Resource related methods
+  v8::Local<v8::Value> GetResourceUsage(v8::Isolate* isolate);
 
   scoped_ptr<SpellCheckClient> spell_check_client_;
 

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -72,6 +72,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
 
   // Resource related methods
   v8::Local<v8::Value> GetResourceUsage(v8::Isolate* isolate);
+  void PurgeCaches(v8::Isolate* isolate);
 
   scoped_ptr<SpellCheckClient> spell_check_client_;
 

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -71,7 +71,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   void ExecuteJavaScript(const base::string16& code, mate::Arguments* args);
 
   // Resource related methods
-  v8::Local<v8::Value> GetResourceUsage(v8::Isolate* isolate);
+  blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);
   void PurgeCaches(v8::Isolate* isolate);
 
   scoped_ptr<SpellCheckClient> spell_check_client_;

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -72,7 +72,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
 
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);
-  void PurgeCaches(v8::Isolate* isolate);
+  void ClearCache(v8::Isolate* isolate);
 
   scoped_ptr<SpellCheckClient> spell_check_client_;
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -106,7 +106,6 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
-
 ### `webFrame.getResourceUsage()`
 
 Returns more detailed memory usage information in kilobytes of Blink's internal

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -106,4 +106,50 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
+
+### `webFrame.getResourceUsage()`
+
+Returns more detailed memory usage information in kilobytes of Blink's internal
+memory caches. Returns an Object of the following shape:
+
+```js
+{
+  "images": {
+    "count": 22,
+    "size": 2549,         // 2549kb
+    "liveSize": 2542,     // 2542kb, etc...
+    "decodedSize": 478,
+    "purgedSize": 0,
+    "purgeableSize": 0
+  },
+  "cssStyleSheets": {
+    "count": 7,
+    /* ... */
+  },
+  "xslStyleSheets": {
+    "count": 0,
+    /* ... */
+  },
+  "fonts": {
+    "count": 18,
+    /* ... */
+  },
+  "other": {
+    "count": 0,
+    /* ... */
+  }
+}
+```
+
+### `webFrame.purgeCaches()`
+
+Attempts to free memory that is no longer being used (i.e. images from a
+previous navigation, etc etc).
+
+Note that blindly calling this method probably makes Electron slower since it
+will have to refill these emptied caches, you should only call it if an event
+in your app has occured that makes you think your page is actually using less
+memory (i.e. you have navigated from a super heavy page to a mostly empty one,
+and intend to stay there)
+
 [spellchecker]: https://github.com/atom/node-spellchecker

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -108,47 +108,41 @@ this limitation.
 
 ### `webFrame.getResourceUsage()`
 
-Returns more detailed memory usage information in kilobytes of Blink's internal
-memory caches. Returns an Object of the following shape:
+Returns an object describing usage information of Blink's internal memory
+caches.
 
-```js
+```javascript
+console.log(webFrame.getResourceUsage())
+```
+
+This will generate:
+
+```javascript
 {
-  "images": {
-    "count": 22,
-    "size": 2549,         // 2549kb
-    "liveSize": 2542,     // 2542kb, etc...
-    "decodedSize": 478,
-    "purgedSize": 0,
-    "purgeableSize": 0
+  images: {
+    count: 22,
+    size: 2549,
+    liveSize: 2542,
+    decodedSize: 478,
+    purgedSize: 0,
+    purgeableSize: 0
   },
-  "cssStyleSheets": {
-    "count": 7,
-    /* ... */
-  },
-  "xslStyleSheets": {
-    "count": 0,
-    /* ... */
-  },
-  "fonts": {
-    "count": 18,
-    /* ... */
-  },
-  "other": {
-    "count": 0,
-    /* ... */
-  }
+  cssStyleSheets: { /* same with "images" */ },
+  xslStyleSheets: { /* same with "images" */ },
+  fonts: { /* same with "images" */ },
+  other: { /* same with "images" */ },
 }
 ```
 
-### `webFrame.purgeCaches()`
+### `webFrame.clearCache()`
 
-Attempts to free memory that is no longer being used (i.e. images from a
-previous navigation, etc etc).
+Attempts to free memory that is no longer being used (like images from a
+previous navigation).
 
 Note that blindly calling this method probably makes Electron slower since it
 will have to refill these emptied caches, you should only call it if an event
 in your app has occured that makes you think your page is actually using less
 memory (i.e. you have navigated from a super heavy page to a mostly empty one,
-and intend to stay there)
+and intend to stay there).
 
 [spellchecker]: https://github.com/atom/node-spellchecker

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -52,9 +52,6 @@ def main():
   if PLATFORM != 'win32':
     # Download prebuilt clang binaries.
     update_clang()
-    if not args.disable_clang and args.clang_dir == '':
-      # Build with prebuilt clang.
-      set_clang_env(os.environ)
 
   setup_python_libs()
   update_node_modules('.')
@@ -67,7 +64,7 @@ def main():
 
   create_chrome_version_h()
   touch_config_gypi()
-  run_update(defines)
+  run_update(defines, args.disable_clang, args.clang_dir)
   update_electron_modules('spec', args.target_arch)
 
 
@@ -250,9 +247,14 @@ def touch_config_gypi():
       f.write(content)
 
 
-def run_update(defines):
+def run_update(defines, disable_clang, clang_dir):
+  env = os.environ.copy()
+  if not disable_clang and clang_dir == '':
+    # Build with prebuilt clang.
+    set_clang_env(env)
+
   update = os.path.join(SOURCE_ROOT, 'script', 'update.py')
-  execute_stdout([sys.executable, update, '--defines', defines])
+  execute_stdout([sys.executable, update, '--defines', defines], env)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a new method to `WebFrame`, `getResourceUsage` - it returns more detailed memory usage information than `performance.memory` for a given renderer process:

```js
import {webFrame} from 'electron';
let usage = webFrame.getResourceUsage();
```

This PR also adds a `purgeCaches` method that attempts to free memory that is no longer being used (i.e. images from a previous navigation, etc etc):

```js
import {webFrame} from 'electron';
let usage1 = webFrame.getResourceUsage();

webFrame.purgeCaches();

let usage2 = webFrame.getResourceUsage();

console.log(`Before: ${JSON.stringify(usage1)}`);
console.log(`After: ${JSON.stringify(usage2)}`);
```

Note that blindly calling this method probably makes Electron slower since it will have to refill these emptied caches, you should only call it if an event in your app has occured that makes you think your page is actually using less memory (i.e. you have navigated from a super heavy page to a mostly empty one, and intend to stay there)