### PR TITLE
Add a flag indicating app is started from default app

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -230,6 +230,9 @@ if (option.modules.length > 0) {
 }
 
 function loadApplicationPackage (packagePath) {
+  // Add a flag indicating app is started from default app.
+  process.defaultApp = true
+
   try {
     // Override app name and version.
     packagePath = path.resolve(packagePath)

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -14,6 +14,9 @@ upstream node:
   other builds it is `undefined`.
 * `process.windowsStore` Boolean - If the app is running as a Windows Store app
   (appx), this value is `true`, for other builds it is `undefined`.
+* `process.defaultApp` Boolean - When app is started by being passed as parameter
+  to the default app, this value is `true` in the main process, otherwise it is
+  `undefined`.
 
 ## Events
 


### PR DESCRIPTION
When app is started by being passed as parameter to the default app, the `process.defaultApp` will be set to `true` in the main process.

Close #4690.