### PR TITLE
Fix spacing on lines and url

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -386,12 +386,12 @@ default protocol handler.
 
 ### `app.isDefaultProtocolClient(protocol)` _OS X_ _Windows_
 
-* `protocol` String - The name of your protocol, without `://`. 
+* `protocol` String - The name of your protocol, without `://`.
 
 This method checks if the current executable is the default handler for a protocol
-(aka URI scheme). If so, it will return true. Otherwise, it will return false. 
+(aka URI scheme). If so, it will return true. Otherwise, it will return false.
 
-**Note:** On OS X, you can use this method to check if the app has been registered as the default protocol handler for a protocol. You can also verify this by checking `~/Library/Preferences/com.apple.LaunchServices.plist` on the OS X machine. 
+**Note:** On OS X, you can use this method to check if the app has been registered as the default protocol handler for a protocol. You can also verify this by checking `~/Library/Preferences/com.apple.LaunchServices.plist` on the OS X machine.
 Please refer to [Apple's documentation][LSCopyDefaultHandlerForURLScheme] for details.
 
 The API uses the Windows Registry and LSCopyDefaultHandlerForURLScheme internally.
@@ -568,5 +568,4 @@ Sets the `image` associated with this dock icon.
 [tasks]:http://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [CFBundleURLTypes]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102207-TPXREF115
-[LSCopyDefaultHandlerForURLScheme]: 
-https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/#//apple_ref/c/func/LSCopyDefaultHandlerForURLScheme
+[LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/#//apple_ref/c/func/LSCopyDefaultHandlerForURLScheme


### PR DESCRIPTION
This PR takes care of some spaces that Atom auto cleaned up but also removes an extra space in a link that was causing the link to not get recognized properly.

This is already fixed in `master` but would be nice to have on this branch so that website looks ✨ 

cc @kevinsawicki 