### PR TITLE
Link to electron-winstaller

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -30,8 +30,9 @@ This is a requirement of `Squirrel.Mac`.
 ### Windows
 
 On Windows, you have to install your app into a user's machine before you can
-use the auto-updater, so it is recommended to use
-[grunt-electron-installer][installer] module to generate a Windows installer.
+use the `autoUpdater`, so it is recommended that you use the
+[electron-winstaller][installer-lib] module or the [grunt-electron-installer][installer]
+package to generate a Windows installer.
 
 The installer generated with Squirrel will create a shortcut icon with an
 [Application User Model ID][app-user-model-id] in the format of
@@ -111,7 +112,8 @@ should only be called after `update-downloaded` has been emitted.
 [squirrel-mac]: https://github.com/Squirrel/Squirrel.Mac
 [server-support]: https://github.com/Squirrel/Squirrel.Mac#server-support
 [squirrel-windows]: https://github.com/Squirrel/Squirrel.Windows
-[installer]: https://github.com/atom/grunt-electron-installer
+[installer]: https://github.com/electron/grunt-electron-installer
+[installer-lib]: https://github.com/electron/windows-installer
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [electron-release-server]: https://github.com/ArekSredzki/electron-release-server
 [squirrel-updates-server]: https://github.com/Aluxian/squirrel-updates-server


### PR DESCRIPTION
Adds a link to https://github.com/electron/windows-installer in the docs about auto updates on Windows.