### PR TITLE
Update links to electron org in docs

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -20,7 +20,7 @@ For setting up a server to accept and process crash reports, you can use
 following projects:
 
 * [socorro](https://github.com/mozilla/socorro)
-* [mini-breakpad-server](https://github.com/atom/mini-breakpad-server)
+* [mini-breakpad-server](https://github.com/electron/mini-breakpad-server)
 
 ## Methods
 

--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -30,7 +30,7 @@ your distribution to deliver to final users.
 ## Packaging Your App into a File
 
 Apart from shipping your app by copying all of its source files, you can also
-package your app into an [asar](https://github.com/atom/asar) archive to avoid
+package your app into an [asar](https://github.com/electron/asar) archive to avoid
 exposing your app's source code to users.
 
 To use an `asar` archive to replace the `app` folder, you need to rename the

--- a/docs/tutorial/application-packaging.md
+++ b/docs/tutorial/application-packaging.md
@@ -181,4 +181,4 @@ After running the command, apart from the `app.asar`, there is also an
 `app.asar.unpacked` folder generated which contains the unpacked files, you
 should copy it together with `app.asar` when shipping it to users.
 
-[asar]: https://github.com/atom/asar
+[asar]: https://github.com/electron/asar


### PR DESCRIPTION
Found a few remaining spots where the link were to the Atom GitHub org instead of the Electron one where the repos now live.