### PR TITLE
Link to vendor folder on GitHub

### DIFF
--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -66,7 +66,7 @@ Electron
 ## Keeping Git Submodules Up to Date
 
 The Electron repository has a few vendored dependencies, found in the
-[/vendor](/vendor) directory. Occasionally you might see a message like this
+[/vendor][vendor] directory. Occasionally you might see a message like this
 when running `git status`:
 
 ```sh
@@ -89,3 +89,5 @@ in your `~/.gitconfig` file:
 [alias]
 	su = submodule update --init --recursive
 ```
+
+[vendor]: https://github.com/electron/electron/tree/master/vendor


### PR DESCRIPTION
Small docs fix after noticing this link was broken on http://electron.atom.io/docs/v0.37.8/development/source-code-directory-structure/#keeping-git-submodules-up-to-date

Just changes it to be an absolute link instead.

/cc @jlord 