### PR TITLE
Update app manifest

### DIFF
--- a/atom/browser/resources/win/atom.manifest
+++ b/atom/browser/resources/win/atom.manifest
@@ -30,4 +30,10 @@
     </security>
   </trustInfo>
 
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <disableWindowFiltering xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</disableWindowFiltering>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+
 </assembly>

--- a/atom/browser/resources/win/atom.manifest
+++ b/atom/browser/resources/win/atom.manifest
@@ -32,6 +32,7 @@
 
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
       <disableWindowFiltering xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</disableWindowFiltering>
     </asmv3:windowsSettings>
   </asmv3:application>


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/aa374191(v=vs.85).aspx#disableWindowFiltering
https://msdn.microsoft.com/en-us/library/aa374191(v=vs.85).aspx#dpiAware

According to https://msdn.microsoft.com/en-us/library/windows/desktop/dn302122(v=vs.85).aspx:
It is strongly recommended to not use SetProcessDpiAwareness to set the DPI awareness for your application. Instead, you should declare the DPI awareness for your application in the application manifest. See PROCESS_DPI_AWARENESS for more information about the DPI awareness values and how to set them in the manifest.

https://msdn.microsoft.com/en-us/library/windows/desktop/dn280512(v=vs.85).aspx