### PR TITLE
Refactor parseArgs function in dialog module

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -23,15 +23,12 @@ var messageBoxOptions = {
 var parseArgs = function (window, options, callback, ...args) {
   if (!(window === null || (window != null ? window.constructor : void 0) === BrowserWindow)) {
     // Shift.
-    callback = options
-    options = window
-    window = null
+    [callback, options, window] = [options, window, null]
   }
 
   if ((callback == null) && typeof options === 'function') {
     // Shift.
-    callback = options
-    options = null
+    [callback, options] = [options, null]
   }
 
   // Fallback to using very last argument as the callback function

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -35,8 +35,9 @@ var parseArgs = function (window, options, callback, ...args) {
   }
 
   // Fallback to using very last argument as the callback function
-  if ((callback == null) && typeof args[args.length - 1] === 'function') {
-    callback = args[args.length - 1]
+  var lastArgument = args[args.length - 1]
+  if ((callback == null) && typeof lastArgument === 'function') {
+    callback = lastArgument
   }
 
   return [window, options, callback]

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -21,7 +21,7 @@ var messageBoxOptions = {
 }
 
 var parseArgs = function (window, options, callback, ...args) {
-  if (!(window === null || (window != null ? window.constructor : void 0) === BrowserWindow)) {
+  if (window !== null && window.constructor !== BrowserWindow) {
     // Shift.
     [callback, options, window] = [options, window, null]
   }


### PR DESCRIPTION
I did a little bit of refactoring on the `parseArgs` helper function in the dialog module.

- When checking the last argument to see if it's a function, we access the array twice. I cached the argument into the variable in order to prevent that additional array access.
- I added destructuring for the argument shifting.
- In the conditional check to see if the first argument was a `BrowserWindow`, we were checking to see if `window` was `null` and then immediately checking it again in the ternary. We were also flipping the entire conditional after the fact. My thinking is that we could short-circuit using `&&` and save the extra conditional check and then just check the constructor if it wasn't `null`. (I wonder if one call to `Object.getPrototypeOf(window)` would be a better approach?)

I wrote up some tests to verify that this all worked as I was going along, but `parseArgs` is a private helper and I didn't want to expose it as a public method, but I'm happy to figure out a way to include them if that's helpful.