### PR TITLE
Implement RemoveAsDefaultProtocolClient on OS X

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -43,7 +43,28 @@ void Browser::ClearRecentDocuments() {
 }
 
 bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol) {
-  return false;
+  NSString* identifier = [base::mac::MainBundle() bundleIdentifier];
+  if (!identifier)
+    return false;
+
+  NSString* protocol_ns = [NSString stringWithUTF8String:protocol.c_str()];
+  CFStringRef protocol_cf = base::mac::NSToCFCast(protocol_ns);
+  CFArrayRef bundleList = LSCopyAllHandlersForURLScheme(protocol_cf);
+  if (!bundleList) {
+    return false;
+  }
+  // On Mac OS X, we can't query the default, but the handlers list seems to put
+  // Apple's defaults first, so we'll use the first option that isn't our bundle
+  CFStringRef other = nil;
+  for (CFIndex i = 0; i < CFArrayGetCount(bundleList); i++) {
+    other = (CFStringRef)CFArrayGetValueAtIndex(bundleList, i);
+    if (![identifier isEqualToString: (__bridge NSString *)other]) {
+      break;
+    }
+  }
+
+  OSStatus return_code = LSSetDefaultHandlerForURLScheme(protocol_cf, other);
+  return return_code == noErr;
 }
 
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol) {

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -47,6 +47,9 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol) {
   if (!identifier)
     return false;
 
+  if (!Browser::IsDefaultProtocolClient(protocol))
+    return false;
+
   NSString* protocol_ns = [NSString stringWithUTF8String:protocol.c_str()];
   CFStringRef protocol_cf = base::mac::NSToCFCast(protocol_ns);
   CFArrayRef bundleList = LSCopyAllHandlersForURLScheme(protocol_cf);

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -393,15 +393,12 @@ Please refer to [Apple's documentation][CFBundleURLTypes] for details.
 
 The API uses the Windows Registry and LSSetDefaultHandlerForURLScheme internally.
 
-### `app.removeAsDefaultProtocolClient(protocol)` _Windows_
+### `app.removeAsDefaultProtocolClient(protocol)` _OS X_ _Windows_
 
 * `protocol` String - The name of your protocol, without `://`.
 
 This method checks if the current executable as the default handler for a protocol
 (aka URI scheme). If so, it will remove the app as the default handler.
-
-**Note:** On OS X, removing the app will automatically remove the app as the
-default protocol handler.
 
 ### `app.isDefaultProtocolClient(protocol)` _OS X_ _Windows_
 


### PR DESCRIPTION
Follow up from #5385 - it looks like there's no way to truly reset the default protocol handler on Mac OS X. This patch basically just chooses the first available handler which is not the user's app and sets it to the default. In my (pretty limited) testing with `mailto`, it seems like the first handler returned is Apple's, so   I think this will do the trick...