### PR TITLE
Fix `expirationDate` not showing for persistent cookies

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -47,7 +47,7 @@ struct Converter<net::CanonicalCookie> {
     dict.Set("secure", val.IsSecure());
     dict.Set("httpOnly", val.IsHttpOnly());
     dict.Set("session", !val.IsPersistent());
-    if (!val.IsPersistent())
+    if (val.IsPersistent())
       dict.Set("expirationDate", val.ExpiryDate().ToDoubleT());
     return dict.GetHandle();
   }


### PR DESCRIPTION
Close  #5438.