### PR TITLE
Suppress the window.open tests on travis CI's mac machine

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -155,6 +155,10 @@ describe('chromium feature', function () {
   })
 
   describe('window.open', function () {
+    if (process.env.TRAVIS === 'true' && process.platform === 'darwin') {
+      return
+    }
+
     this.timeout(20000)
 
     it('returns a BrowserWindowProxy object', function () {


### PR DESCRIPTION
The mac machine of travis CI is getting more and more slower, those test cases now become quite flaky on it.