### PR TITLE
Turn exception in protocol.registerStandardSchemes into warning warning

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -6,22 +6,21 @@ An example of implementing a protocol that has the same effect as the
 `file://` protocol:
 
 ```javascript
-const electron = require('electron');
-const { app, protocol } = electron;
-const path = require('path');
+const {app, protocol} = require('electron')
+const path = require('path')
 
-app.on('ready', function() {
-    protocol.registerFileProtocol('atom', function(request, callback) {
-      const url = request.url.substr(7);
-      callback({path: path.normalize(__dirname + '/' + url)});
-    }, function (error) {
-      if (error)
-        console.error('Failed to register protocol')
-    });
-});
+app.on('ready', function () {
+  protocol.registerFileProtocol('atom', function (request, callback) {
+    const url = request.url.substr(7)
+    callback({path: path.normalize(__dirname + '/' + url)})
+  }, function (error) {
+    if (error)
+      console.error('Failed to register protocol')
+  })
+})
 ```
-**Note:** All methods unless specified can only be used after the `ready`
-event in the `app` module is emitted.
+**Note:** All methods unless specified can only be used after the `ready` event
+of the `app` module gets emitted.
 
 ## Methods
 
@@ -31,13 +30,36 @@ The `protocol` module has the following methods:
 
 * `schemes` Array - Custom schemes to be registered as standard schemes.
 
-A standard `scheme` adheres to what RFC 3986 calls
-[generic URI syntax](https://tools.ietf.org/html/rfc3986#section-3). This
-includes `file:`, `filesystem:`, `http` etc. Registering a scheme as standard, will
-allow relative and absolute resources to be resolved correctly when served.
+A standard scheme adheres to what RFC 3986 calls [generic URI
+syntax](https://tools.ietf.org/html/rfc3986#section-3). For example `http` and
+`https` are standard schemes, while `file` is not.
 
-**Note:** This method can only be used before the `ready` event in the
-`app` module is emitted.
+Registering a scheme as standard, will allow relative and absolute resources to
+be resolved correctly when served. Otherwise the scheme will behave like the
+`file` protocol, but without the ability to resolve relative URLs.
+
+For example when you load following page with custom protocol without
+registering it as standard scheme, the image will not be loaded because
+non-standard schemes can not recognize relative URLs:
+
+```html
+<body>
+  <img src='test.png'>
+</body>
+```
+
+So if you want to register a custom protocol to replace the `http` protocol, you
+have to register it as standard scheme:
+
+```javascript
+protocol.registerStandardSchemes(['atom'])
+app.on('ready', function () {
+  protocol.registerHttpProtocol('atom', ...)
+})
+```
+
+**Note:** This method can only be used before the `ready` event of the `app`
+module gets emitted.
 
 ### `protocol.registerServiceWorkerSchemes(schemes)`
 

--- a/lib/browser/api/protocol.js
+++ b/lib/browser/api/protocol.js
@@ -1,9 +1,10 @@
-const app = require('electron').app
+const {app} = require('electron')
 const {createProtocolObject, registerStandardSchemes} = process.atomBinding('protocol')
 
 exports.registerStandardSchemes = function (schemes) {
   if (app.isReady()) {
-    throw new Error('protocol.registerStandardSchemes should be called before app is ready')
+    console.warn('protocol.registerStandardSchemes should be called before app is ready')
+    return
   }
   registerStandardSchemes(schemes)
 }

--- a/lib/browser/api/protocol.js
+++ b/lib/browser/api/protocol.js
@@ -1,16 +1,5 @@
 const app = require('electron').app
 const {createProtocolObject, registerStandardSchemes} = process.atomBinding('protocol')
-let protocol = null
-
-// Warn about removed APIs.
-var logAndThrow = function (callback, message) {
-  console.error(message)
-  if (callback) {
-    return callback(new Error(message))
-  } else {
-    throw new Error(message)
-  }
-}
 
 exports.registerStandardSchemes = function (schemes) {
   if (app.isReady()) {
@@ -20,20 +9,7 @@ exports.registerStandardSchemes = function (schemes) {
 }
 
 app.once('ready', function () {
-  protocol = createProtocolObject()
-  // Be compatible with old APIs.
-  protocol.registerProtocol = function (scheme, handler, callback) {
-    return logAndThrow(callback, 'registerProtocol API has been replaced by the register[File/Http/Buffer/String]Protocol API family, please switch to the new APIs.')
-  }
-
-  protocol.isHandledProtocol = function (scheme, callback) {
-    return logAndThrow(callback, 'isHandledProtocol API has been replaced by isProtocolHandled.')
-  }
-
-  protocol.interceptProtocol = function (scheme, handler, callback) {
-    return logAndThrow(callback, 'interceptProtocol API has been replaced by the intercept[File/Http/Buffer/String]Protocol API family, please switch to the new APIs.')
-  }
-
+  let protocol = createProtocolObject()
   for (let method in protocol) {
     exports[method] = protocol[method].bind(protocol)
   }

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -841,12 +841,6 @@ describe('protocol module', function () {
       })
     })
 
-    it('throws when called after ready event', function () {
-      assert.throws(function () {
-        protocol.registerStandardSchemes(['some-scheme'])
-      }, 'protocol.registerStandardSchemes should be called before app is ready')
-    })
-
     it('resolves relative resources', function (done) {
       var handler = function (request, callback) {
         if (request.url === imageURL) {


### PR DESCRIPTION
Current every usage of `protocol.registerStandardSchemes` is after the `ready` event of `app`, so all of they will throw after next release, which is probably not a good thing. This PR turns the the exception into warning, so things still keep broken like before if they don't care.

Also update the docs for protocol.registerStandardSchemes, close #5427.