### PR TITLE
Add process labels to API docs

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -1,4 +1,4 @@
-# Accelerator
+# Accelerator _Main Process_
 
 > Define keyboard shortcuts.
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,4 +1,4 @@
-# app
+# app _Main Process_
 
 > Control your application's event lifecycle.
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -1,4 +1,4 @@
-# autoUpdater
+# autoUpdater _Main Process_
 
 > Enable apps to automatically update themselves.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1,4 +1,4 @@
-# BrowserWindow
+# BrowserWindow _Main Process_
 
 > Create and control browser windows.
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -1,4 +1,4 @@
-# clipboard
+# clipboard _Both Processes_
 
 > Perform copy and paste operations on the system clipboard.
 

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -1,4 +1,4 @@
-# contentTracing
+# contentTracing _Main Process_
 
 > Collect tracing data from Chromium's content module for finding performance
 bottlenecks and slow operations.

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -1,4 +1,4 @@
-# crashReporter
+# crashReporter _Both Processes_
 
 > Submit crash reports to a remote server.
 

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -1,4 +1,4 @@
-# desktopCapturer
+# desktopCapturer _Renderer Process_
 
 > List `getUserMedia` sources for capturing audio, video, and images from a
 microphone, camera, or screen.

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -1,4 +1,4 @@
-# dialog
+# dialog _Main Process_
 
 > Display native system dialogs for opening and saving files, alerting, etc.
 

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -1,4 +1,4 @@
-# DownloadItem
+# DownloadItem _Main Process_
 
 > Control file downloads from remote sources.
 

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -1,4 +1,4 @@
-# Frameless Window
+# Frameless Window _Main Process_
 
 > Open a window without toolbars, borders, or other graphical "chrome".
 

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -1,4 +1,4 @@
-# globalShortcut
+# globalShortcut _Main Process_
 
 > Detect keyboard events when the application does not have keyboard focus.
 

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -1,4 +1,4 @@
-# ipcMain
+# ipcMain _Main Process_
 
 > Communicate asynchronously from the main process to renderer processes.
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -1,4 +1,4 @@
-# ipcRenderer
+# ipcRenderer _Renderer Process_
 
 > Communicate asynchronously from a renderer process to the main process.
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -1,4 +1,4 @@
-# MenuItem
+# MenuItem _Main Process_
 
 > Add items to native application menus and context menus.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -1,4 +1,4 @@
-# Menu
+# Menu _Main Process_
 
 > Create native application menus and context menus.
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -1,4 +1,4 @@
-# nativeImage
+# nativeImage _Both Processes_
 
 > Create tray, dock, and application icons using PNG or JPG files.
 

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -1,4 +1,4 @@
-# powerMonitor
+# powerMonitor _Main Process_
 
 > Monitor power state changes.
 

--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -1,4 +1,4 @@
-# powerSaveBlocker
+# powerSaveBlocker _Main Process_
 
 > Block the system from entering low-power (sleep) mode.
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -1,4 +1,4 @@
-# protocol
+# protocol _Main Process_
 
 > Register a custom protocol and intercept existing protocol requests.
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -1,4 +1,4 @@
-# remote
+# remote _Renderer Processes_
 
 > Use main process modules from the renderer process.
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -1,4 +1,4 @@
-# remote _Renderer Processes_
+# remote _Renderer Process_
 
 > Use main process modules from the renderer process.
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -1,4 +1,4 @@
-# screen
+# screen _Both Processes_
 
 > Retrieve information about screen size, displays, cursor position, etc.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1,4 +1,4 @@
-# session
+# session _Main Process_
 
 > Manage browser sessions, cookies, cache, proxy settings, etc.
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -1,4 +1,4 @@
-# shell
+# shell _Both Processes_
 
 > Manage files and URLs using their default applications.
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -1,4 +1,4 @@
-# systemPreferences
+# systemPreferences _Main Process_
 
 > Get system preferences.
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -1,4 +1,4 @@
-# Tray
+# Tray _Main Process_
 
 > Add icons and context menus to the system's notification area.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1,4 +1,4 @@
-# webContents
+# webContents _Main Process_
 
 > Render and control web pages.
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -1,4 +1,4 @@
-# webFrame
+# webFrame _Renderer Process_
 
 > Customize the rendering of the current web page.
 


### PR DESCRIPTION
This PR adds the process each API belongs to next to the header of the doc. It will be styled on the website much like the platform labels that follow methods:

<img width="424" alt="screen shot 2016-05-10 at 2 00 51 pm" src="https://cloud.githubusercontent.com/assets/1305617/15145731/a3abb090-16b7-11e6-8a62-1024e5a3798f.png">

cc @kevinsawicki 