### PR TITLE
Fixed code snippet in read me

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -15,7 +15,8 @@ the user right clicks the page:
 ```html
 <!-- index.html -->
 <script>
-const { Menu, MenuItem } = require('electron').remote;
+const { remote } = require('electron');
+const { Menu, MenuItem } = remote;
 
 const menu = new Menu();
 menu.append(new MenuItem({ label: 'MenuItem1', click: () => { console.log('item 1 clicked'); } }));


### PR DESCRIPTION
This is a minor fix in the api docs. The change to the code snippet is so that the context menu works if someone copies this code from the menu documentation. Fixes #5470