### PR TITLE
Add API: app.dock.downloadFinished(filePath)

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -546,6 +546,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("dockBounce", &DockBounce);
   dict.SetMethod("dockCancelBounce",
                  base::Bind(&Browser::DockCancelBounce, browser));
+  dict.SetMethod("dockDownloadFinished",
+                 base::Bind(&Browser::DockDownloadFinished, browser));
   dict.SetMethod("dockSetBadgeText",
                  base::Bind(&Browser::DockSetBadgeText, browser));
   dict.SetMethod("dockGetBadgeText",

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -111,6 +111,9 @@ class Browser : public WindowListObserver {
   int DockBounce(BounceType type);
   void DockCancelBounce(int request_id);
 
+  // Bounce the Downloads stack.
+  void DockDownloadFinished(const std::string& filePath);
+
   // Set/Get dock's badge text.
   void DockSetBadgeText(const std::string& label);
   std::string DockGetBadgeText();

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -134,6 +134,12 @@ void Browser::DockSetBadgeText(const std::string& label) {
   [tile setBadgeLabel:base::SysUTF8ToNSString(label)];
 }
 
+void Browser::DockDownloadFinished(const std::string& filePath) {
+  [[NSDistributedNotificationCenter defaultCenter]
+      postNotificationName: @"com.apple.DownloadFileFinished"
+                    object: base::SysUTF8ToNSString(filePath)];
+}
+
 std::string Browser::DockGetBadgeText() {
   NSDockTile *tile = [[AtomApplication sharedApplication] dockTile];
   return base::SysNSStringToUTF8([tile badgeLabel]);

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -566,6 +566,12 @@ Returns an ID representing the request.
 
 Cancel the bounce of `id`.
 
+### `app.dock.downloadFinished(filePath)` _OS X_
+
+* `filePath` String
+
+Bounces the Downloads stack if the filePath is inside the Downloads folder.
+
 ### `app.dock.setBadge(text)` _OS X_
 
 * `text` String

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -32,6 +32,7 @@ if (process.platform === 'darwin') {
       return bindings.dockBounce(type)
     },
     cancelBounce: bindings.dockCancelBounce,
+    downloadFinished: bindings.dockDownloadFinished,
     setBadge: bindings.dockSetBadgeText,
     getBadge: bindings.dockGetBadgeText,
     hide: bindings.dockHide,


### PR DESCRIPTION
Implementation taken from [Chrome's Source] (https://code.google.com/p/chromium/codesearch#chromium/src/chrome/browser/download/download_status_updater_mac.mm&q=com.apple.DownloadFileFinished&sq=package:chromium&l=237)

Closes #5309 