### PR TITLE
Link to open-file event in File object docs

### DIFF
--- a/docs/api/file-object.md
+++ b/docs/api/file-object.md
@@ -30,3 +30,5 @@ Example on getting a real path from a dragged-onto-the-app file:
   };
 </script>
 ```
+
+On OS X [the `open-file` event](app.md#event-open-file-os-x) will additionally be emitted when a file is opened.


### PR DESCRIPTION
Since we're on the subject of files it makes sense to include a link to info on the `open-file` event. Otherwise, it can only be found by reading about the `app` module for the main process which a user may not think to look at when trying to find documentation on interacting with files.