### PR TITLE
Do not use require('app') in dump-version-info.js

### DIFF
--- a/tools/dump-version-info.js
+++ b/tools/dump-version-info.js
@@ -1,4 +1,4 @@
-var app = require('app')
+var app = require('electron').app
 var fs = require('fs')
 var request = require('request')
 


### PR DESCRIPTION
It has been removed.