### PR TITLE
Listen for devtools-opened on webContents

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -136,7 +136,7 @@ app.once('ready', function () {
   init = BrowserWindow.prototype._init
   BrowserWindow.prototype._init = function () {
     init.call(this)
-    return this.webContents.on('devtools-opened', function () {
+    return this.webContents.on('devtools-opened', () => {
       return this._loadDevToolsExtensions(Object.keys(extensionInfoMap).map(function (key) {
         return extensionInfoMap[key]
       }))

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -136,7 +136,7 @@ app.once('ready', function () {
   init = BrowserWindow.prototype._init
   BrowserWindow.prototype._init = function () {
     init.call(this)
-    return this.on('devtools-opened', function () {
+    return this.webContents.on('devtools-opened', function () {
       return this._loadDevToolsExtensions(Object.keys(extensionInfoMap).map(function (key) {
         return extensionInfoMap[key]
       }))


### PR DESCRIPTION
It is no longer emitted on `BrowserWindow`.

/cc @zcbenz 

Regression from #5373 
Fixes https://github.com/electron/devtron/issues/59