### PR TITLE
dialog: resize icon on linux before showing

### DIFF
--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -53,9 +53,16 @@ class GtkMessageBox {
     // Set dialog's icon.
     if (!icon.isNull()) {
       GdkPixbuf* pixbuf = libgtk2ui::GdkPixbufFromSkBitmap(*icon.bitmap());
-      GtkWidget* image = gtk_image_new_from_pixbuf(pixbuf);
+      GtkIconSource* iconsource = gtk_icon_source_new();
+      GtkIconSet* iconset = gtk_icon_set_new();
+      gtk_icon_source_set_pixbuf(iconsource, pixbuf);
+      gtk_icon_set_add_source(iconset, iconsource);
+      GtkWidget* image = gtk_image_new_from_icon_set(iconset,
+                                                     GTK_ICON_SIZE_DIALOG);
       gtk_message_dialog_set_image(GTK_MESSAGE_DIALOG(dialog_), image);
       gtk_widget_show(image);
+      gtk_icon_source_free(iconsource);
+      gtk_icon_set_unref(iconset);
       g_object_unref(pixbuf);
     }
 


### PR DESCRIPTION
Fixes #5465 