### PR TITLE
Replace gtk_widget_hide_all with gtk_widget_hide

### DIFF
--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -151,7 +151,7 @@ class FileChooserDialog {
 };
 
 void FileChooserDialog::OnFileDialogResponse(GtkWidget* widget, int response) {
-  gtk_widget_hide_all(dialog_);
+  gtk_widget_hide(dialog_);
 
   if (!save_callback_.is_null()) {
     if (response == GTK_RESPONSE_ACCEPT)

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -149,7 +149,7 @@ class GtkMessageBox {
 };
 
 void GtkMessageBox::OnResponseDialog(GtkWidget* widget, int response) {
-  gtk_widget_hide_all(dialog_);
+  gtk_widget_hide(dialog_);
 
   if (response < 0)
     callback_.Run(cancel_id_);


### PR DESCRIPTION
gtk_widget_hide_all was deprecated in gtk+ 2.24 and was removed
entirely in recent versions. This is a pretty straight forward
replacement.