### PR TITLE
devtools: initialise extensions only on devtools load

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -671,6 +671,10 @@ void WebContents::DevToolsClosed() {
   Emit("devtools-closed");
 }
 
+void WebContents::DevToolsLoaded() {
+  Emit("-devtools-loaded");
+}
+
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(WebContents, message)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -258,6 +258,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DevToolsFocused() override;
   void DevToolsOpened() override;
   void DevToolsClosed() override;
+  void DevToolsLoaded() override;
 
  private:
   enum Type {

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -133,8 +133,8 @@ app.once('ready', function () {
   init = BrowserWindow.prototype._init
   BrowserWindow.prototype._init = function () {
     init.call(this)
-    return this.webContents.on('devtools-opened', () => {
-      return this._loadDevToolsExtensions(Object.keys(extensionInfoMap).map(function (key) {
+    this.webContents.on('-devtools-loaded', () => {
+      this._loadDevToolsExtensions(Object.keys(extensionInfoMap).map(function (key) {
         return extensionInfoMap[key]
       }))
     })


### PR DESCRIPTION
Ref https://github.com/electron/devtron/issues/60#issuecomment-218499197

Steps to reproduce:
* install any devtools extension
* change dock state
* duplicate panels created on every dock state change

Currently we close and reopen devtools whenever dock state is changed, this causes extensions to be loaded multiple times. A more appropriate fix would be to emit `devtools-opened` and `devtools-closed` once per lifetime of devtools.

Depends on https://github.com/electron/brightray/pull/218