### PR TITLE
A little confused by docs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -34,7 +34,7 @@ Emitted when Electron has finished initialization.
 
 Emitted when all windows have been closed.
 
-This event is only emitted when the application is not going to quit. If the
+If you do not subscribe to this event and all windows are closed, the default behavior is to quit the app; however, if you subscribe, you control whether the app quits or not. If the
 user pressed `Cmd + Q`, or the developer called `app.quit()`, Electron will
 first try to close all the windows and then emit the `will-quit` event, and in
 this case the `window-all-closed` event would not be emitted.


### PR DESCRIPTION
It wasn't entirely clear to me that 'window-all-closed' was used for this purpose. I was originally looking for an event that would fire if all windows were closed and the reason was NOT because the intent was to quit; however, this differs in that it is called regardless of whether the app was quitting.
![gnome-quit](https://cloud.githubusercontent.com/assets/7494573/15266145/da0e39be-1969-11e6-9ff3-de4a55f2ec7a.png)