### PR TITLE
💄 Add ES6; Clean up from CoffeeScript conversion in app module

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -51,12 +51,10 @@ for (let name of events) {
 }
 
 // Wrappers for native classes.
-const wrapDownloadItem = (downloadItem) => {
+downloadItemBindings._setWrapDownloadItem((downloadItem) => {
   // downloadItem is an EventEmitter.
   Object.setPrototypeOf(downloadItem, EventEmitter.prototype)
-}
-
-downloadItemBindings._setWrapDownloadItem(wrapDownloadItem)
+})
 
 // Only one App object pemitted.
 module.exports = app

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -4,7 +4,6 @@ const {Menu} = require('electron')
 const {EventEmitter} = require('events')
 
 const bindings = process.atomBinding('app')
-const downloadItemBindings = process.atomBinding('download_item')
 const {app} = bindings
 
 Object.setPrototypeOf(app, EventEmitter.prototype)
@@ -51,7 +50,7 @@ for (let name of events) {
 }
 
 // Wrappers for native classes.
-downloadItemBindings._setWrapDownloadItem((downloadItem) => {
+process.atomBinding('download_item')._setWrapDownloadItem((downloadItem) => {
   // downloadItem is an EventEmitter.
   Object.setPrototypeOf(downloadItem, EventEmitter.prototype)
 })

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -1,33 +1,34 @@
 'use strict'
 
 const {Menu} = require('electron')
-const EventEmitter = require('events').EventEmitter
+const {EventEmitter} = require('events')
 
 const bindings = process.atomBinding('app')
 const downloadItemBindings = process.atomBinding('download_item')
-const app = bindings.app
+const {app} = bindings
 
 Object.setPrototypeOf(app, EventEmitter.prototype)
 
-app.setApplicationMenu = function (menu) {
-  return Menu.setApplicationMenu(menu)
-}
+let appPath = null
 
-app.getApplicationMenu = function () {
-  return Menu.getApplicationMenu()
-}
-
-app.commandLine = {
-  appendSwitch: bindings.appendSwitch,
-  appendArgument: bindings.appendArgument
-}
+Object.assign(app, {
+  getAppPath() { return appPath },
+  setAppPath(path) { appPath = path },
+  setApplicationMenu(menu) {
+    return Menu.setApplicationMenu(menu)
+  },
+  getApplicationMenu() {
+    return Menu.getApplicationMenu()
+  },
+  commandLine: {
+    appendSwitch: bindings.appendSwitch,
+    appendArgument: bindings.appendArgument
+  }
+})
 
 if (process.platform === 'darwin') {
   app.dock = {
-    bounce: function (type) {
-      if (type == null) {
-        type = 'informational'
-      }
+    bounce (type = 'informational') {
       return bindings.dockBounce(type)
     },
     cancelBounce: bindings.dockCancelBounce,
@@ -41,30 +42,16 @@ if (process.platform === 'darwin') {
   }
 }
 
-var appPath = null
-
-app.setAppPath = function (path) {
-  appPath = path
-}
-
-app.getAppPath = function () {
-  return appPath
-}
-
 // Routes the events to webContents.
-var ref1 = ['login', 'certificate-error', 'select-client-certificate']
-var fn = function (name) {
-  return app.on(name, function (event, webContents, ...args) {
+const events = ['login', 'certificate-error', 'select-client-certificate']
+for (let name of events) {
+  app.on(name, (event, webContents, ...args) => {
     return webContents.emit.apply(webContents, [name, event].concat(args))
   })
 }
-var i, len
-for (i = 0, len = ref1.length; i < len; i++) {
-  fn(ref1[i])
-}
 
 // Wrappers for native classes.
-var wrapDownloadItem = function (downloadItem) {
+const wrapDownloadItem = (downloadItem) => {
   // downloadItem is an EventEmitter.
   Object.setPrototypeOf(downloadItem, EventEmitter.prototype)
 }

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -12,12 +12,12 @@ Object.setPrototypeOf(app, EventEmitter.prototype)
 let appPath = null
 
 Object.assign(app, {
-  getAppPath() { return appPath },
-  setAppPath(path) { appPath = path },
-  setApplicationMenu(menu) {
+  getAppPath () { return appPath },
+  setAppPath (path) { appPath = path },
+  setApplicationMenu (menu) {
     return Menu.setApplicationMenu(menu)
   },
-  getApplicationMenu() {
+  getApplicationMenu () {
     return Menu.getApplicationMenu()
   },
   commandLine: {


### PR DESCRIPTION
This pull request aims to achieve the following:

- Clean up some of the artifacts left over from the conversion from CoffeeScript
- Use natively-supported JavaScript features when appropriate
- Slightly reduce the number of functions created by using a `for-of` loop when binding event listeners.