### PR TITLE
💄 Use ES6; clean up CoffeeScript conversion in BrowserWindow module

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -50,13 +50,13 @@ BrowserWindow.prototype._init = function () {
     if (!event.defaultPrevented) this.setTitle(title)
   })
 
-  // Sometimes the webContents doesn't get focus when window is shown, so we 
-  // have to force focusing on webContents in this case. The safest way is to 
-  // focus it when we first start to load URL, if we do it earlier it won't 
+  // Sometimes the webContents doesn't get focus when window is shown, so we
+  // have to force focusing on webContents in this case. The safest way is to
+  // focus it when we first start to load URL, if we do it earlier it won't
   // have effect, if we do it later we might move focus in the page.
   //
   // Though this hack is only needed on OS X when the app is launched from
-  // Finder, we still do it on all platforms in case of other bugs we don't 
+  // Finder, we still do it on all platforms in case of other bugs we don't
   // know.
   this.webContents.once('load-url', function () {
     this.focus()
@@ -79,7 +79,7 @@ BrowserWindow.prototype._init = function () {
       this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', isVisible ? 'visible' : 'hidden')
     }
   }
-  
+
   const visibilityEvents = ['show', 'hide', 'minimize', 'maximize', 'restore']
   for (let event of visibilityEvents) {
     this.on(event, visibilityChanged)
@@ -101,6 +101,7 @@ BrowserWindow.getFocusedWindow = () => {
   for (let window of BrowserWindow.getAllWindows()) {
     if (window.isFocused()) return window
   }
+  return null
 }
 
 BrowserWindow.fromWebContents = (webContents) => {
@@ -118,20 +119,20 @@ BrowserWindow.fromDevToolsWebContents = (webContents) => {
 // Helpers.
 
 Object.assign(BrowserWindow.prototype, {
-  loadURL () {
-    return this.webContents.loadURL.apply(this.webContents, arguments)
+  loadURL (...args) {
+    return this.webContents.loadURL.apply(this.webContents, args)
   },
-  getURL () {
+  getURL (...args) {
     return this.webContents.getURL()
   },
-  reload () {
-    return this.webContents.reload.apply(this.webContents, arguments)
+  reload (...args) {
+    return this.webContents.reload.apply(this.webContents, args)
   },
-  send () {
-    return this.webContents.send.apply(this.webContents, arguments)
+  send (...args) {
+    return this.webContents.send.apply(this.webContents, args)
   },
-  openDevTools () {
-    return this.webContents.openDevTools.apply(this.webContents, arguments)
+  openDevTools (...args) {
+    return this.webContents.openDevTools.apply(this.webContents, args)
   },
   closeDevTools () {
     return this.webContents.closeDevTools()
@@ -145,8 +146,8 @@ Object.assign(BrowserWindow.prototype, {
   toggleDevTools () {
     return this.webContents.toggleDevTools()
   },
-  inspectElement () {
-    return this.webContents.inspectElement.apply(this.webContents, arguments)
+  inspectElement (...args) {
+    return this.webContents.inspectElement.apply(this.webContents, args)
   },
   inspectServiceWorker () {
     return this.webContents.inspectServiceWorker()

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -1,28 +1,24 @@
 'use strict'
 
-const ipcMain = require('electron').ipcMain
-const EventEmitter = require('events').EventEmitter
+const {ipcMain} = require('electron')
+const {EventEmitter} = require('events')
 const {BrowserWindow} = process.atomBinding('window')
 
 Object.setPrototypeOf(BrowserWindow.prototype, EventEmitter.prototype)
 
 BrowserWindow.prototype._init = function () {
-  // avoid recursive require.
-  var app, menu
-  app = require('electron').app
+  // Avoid recursive require.
+  const {app} = require('electron')
 
   // Simulate the application menu on platforms other than OS X.
   if (process.platform !== 'darwin') {
-    menu = app.getApplicationMenu()
-    if (menu != null) {
-      this.setMenu(menu)
-    }
+    const menu = app.getApplicationMenu()
+    if (menu) this.setMenu(menu)
   }
 
   // Make new windows requested by links behave like "window.open"
   this.webContents.on('-new-window', (event, url, frameName, disposition) => {
-    var options
-    options = {
+    const options = {
       show: true,
       width: 800,
       height: 600
@@ -54,12 +50,14 @@ BrowserWindow.prototype._init = function () {
     if (!event.defaultPrevented) this.setTitle(title)
   })
 
-  // Sometimes the webContents doesn't get focus when window is shown, so we have
-  // to force focusing on webContents in this case. The safest way is to focus it
-  // when we first start to load URL, if we do it earlier it won't have effect,
-  // if we do it later we might move focus in the page.
+  // Sometimes the webContents doesn't get focus when window is shown, so we 
+  // have to force focusing on webContents in this case. The safest way is to 
+  // focus it when we first start to load URL, if we do it earlier it won't 
+  // have effect, if we do it later we might move focus in the page.
+  //
   // Though this hack is only needed on OS X when the app is launched from
-  // Finder, we still do it on all platforms in case of other bugs we don't know.
+  // Finder, we still do it on all platforms in case of other bugs we don't 
+  // know.
   this.webContents.once('load-url', function () {
     this.focus()
   })
@@ -74,18 +72,18 @@ BrowserWindow.prototype._init = function () {
 
   // Subscribe to visibilityState changes and pass to renderer process.
   let isVisible = this.isVisible() && !this.isMinimized()
-  let visibilityChanged = () => {
-    let newState = this.isVisible() && !this.isMinimized()
+  const visibilityChanged = () => {
+    const newState = this.isVisible() && !this.isMinimized()
     if (isVisible !== newState) {
       isVisible = newState
       this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', isVisible ? 'visible' : 'hidden')
     }
   }
-  this.on('show', visibilityChanged)
-  this.on('hide', visibilityChanged)
-  this.on('minimize', visibilityChanged)
-  this.on('restore', visibilityChanged)
-  this.on('maximize', visibilityChanged)
+  
+  const visibilityEvents = ['show', 'hide', 'minimize', 'maximize', 'restore']
+  for (let event of visibilityEvents) {
+    this.on(event, visibilityChanged)
+  }
 
   // Notify the creation of the window.
   app.emit('browser-window-created', {}, this)
@@ -93,90 +91,66 @@ BrowserWindow.prototype._init = function () {
   Object.defineProperty(this, 'devToolsWebContents', {
     enumerable: true,
     configurable: false,
-    get: function () {
+    get () {
       return this.webContents.devToolsWebContents
     }
   })
 }
 
-BrowserWindow.getFocusedWindow = function () {
-  var i, len, window, windows
-  windows = BrowserWindow.getAllWindows()
-  for (i = 0, len = windows.length; i < len; i++) {
-    window = windows[i]
-    if (window.isFocused()) {
-      return window
-    }
-  }
-  return null
-}
-
-BrowserWindow.fromWebContents = function (webContents) {
-  var i, len, ref1, window, windows
-  windows = BrowserWindow.getAllWindows()
-  for (i = 0, len = windows.length; i < len; i++) {
-    window = windows[i]
-    if ((ref1 = window.webContents) != null ? ref1.equal(webContents) : void 0) {
-      return window
-    }
+BrowserWindow.getFocusedWindow = () => {
+  for (let window of BrowserWindow.getAllWindows()) {
+    if (window.isFocused()) return window
   }
 }
 
-BrowserWindow.fromDevToolsWebContents = function (webContents) {
-  var i, len, ref1, window, windows
-  windows = BrowserWindow.getAllWindows()
-  for (i = 0, len = windows.length; i < len; i++) {
-    window = windows[i]
-    if ((ref1 = window.devToolsWebContents) != null ? ref1.equal(webContents) : void 0) {
-      return window
-    }
+BrowserWindow.fromWebContents = (webContents) => {
+  for (let window of BrowserWindow.getAllWindows()) {
+    if (window.webContents.equal(webContents)) return window
+  }
+}
+
+BrowserWindow.fromDevToolsWebContents = (webContents) => {
+  for (let window of BrowserWindow.getAllWindows()) {
+    if (window.devToolsWebContents.equal(webContents)) return window
   }
 }
 
 // Helpers.
 
-BrowserWindow.prototype.loadURL = function () {
-  return this.webContents.loadURL.apply(this.webContents, arguments)
-}
-
-BrowserWindow.prototype.getURL = function () {
-  return this.webContents.getURL()
-}
-
-BrowserWindow.prototype.reload = function () {
-  return this.webContents.reload.apply(this.webContents, arguments)
-}
-
-BrowserWindow.prototype.send = function () {
-  return this.webContents.send.apply(this.webContents, arguments)
-}
-
-BrowserWindow.prototype.openDevTools = function () {
-  return this.webContents.openDevTools.apply(this.webContents, arguments)
-}
-
-BrowserWindow.prototype.closeDevTools = function () {
-  return this.webContents.closeDevTools()
-}
-
-BrowserWindow.prototype.isDevToolsOpened = function () {
-  return this.webContents.isDevToolsOpened()
-}
-
-BrowserWindow.prototype.isDevToolsFocused = function () {
-  return this.webContents.isDevToolsFocused()
-}
-
-BrowserWindow.prototype.toggleDevTools = function () {
-  return this.webContents.toggleDevTools()
-}
-
-BrowserWindow.prototype.inspectElement = function () {
-  return this.webContents.inspectElement.apply(this.webContents, arguments)
-}
-
-BrowserWindow.prototype.inspectServiceWorker = function () {
-  return this.webContents.inspectServiceWorker()
-}
+Object.assign(BrowserWindow.prototype, {
+  loadURL () {
+    return this.webContents.loadURL.apply(this.webContents, arguments)
+  },
+  getURL () {
+    return this.webContents.getURL()
+  },
+  reload () {
+    return this.webContents.reload.apply(this.webContents, arguments)
+  },
+  send () {
+    return this.webContents.send.apply(this.webContents, arguments)
+  },
+  openDevTools () {
+    return this.webContents.openDevTools.apply(this.webContents, arguments)
+  },
+  closeDevTools () {
+    return this.webContents.closeDevTools()
+  },
+  isDevToolsOpened () {
+    return this.webContents.isDevToolsOpened()
+  },
+  isDevToolsFocused () {
+    return this.webContents.isDevToolsFocused()
+  },
+  toggleDevTools () {
+    return this.webContents.toggleDevTools()
+  },
+  inspectElement () {
+    return this.webContents.inspectElement.apply(this.webContents, arguments)
+  },
+  inspectServiceWorker () {
+    return this.webContents.inspectServiceWorker()
+  }
+})
 
 module.exports = BrowserWindow


### PR DESCRIPTION
Another quick clean up to remove some of the extra cruft that came from converting from CoffeeScript to JavaScript.