### PR TITLE
Standardize requires

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const app = require('electron').app
-const BrowserWindow = require('electron').BrowserWindow
+const {app, BrowserWindow} = require('electron')
 const binding = process.atomBinding('dialog')
 const v8Util = process.atomBinding('v8_util')
 

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ipcMain = require('electron').ipcMain
+const {ipcMain} = require('electron')
 
 // The history operation in renderer is redirected to browser.
 ipcMain.on('ELECTRON_NAVIGATION_CONTROLLER', function (event, method, ...args) {

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -1,5 +1,5 @@
-const EventEmitter = require('events').EventEmitter
-const powerMonitor = process.atomBinding('power_monitor').powerMonitor
+const {EventEmitter} = require('events')
+const {powerMonitor} = process.atomBinding('power_monitor')
 
 Object.setPrototypeOf(powerMonitor, EventEmitter.prototype)
 

--- a/lib/browser/api/power-save-blocker.js
+++ b/lib/browser/api/power-save-blocker.js
@@ -1,5 +1,1 @@
-var powerSaveBlocker
-
-powerSaveBlocker = process.atomBinding('power_save_blocker').powerSaveBlocker
-
-module.exports = powerSaveBlocker
+module.exports = process.atomBinding('power_save_blocker').powerSaveBlocker

--- a/lib/browser/api/screen.js
+++ b/lib/browser/api/screen.js
@@ -1,5 +1,5 @@
-const EventEmitter = require('events').EventEmitter
-const screen = process.atomBinding('screen').screen
+const {EventEmitter} = require('events')
+const {screen} = process.atomBinding('screen')
 
 Object.setPrototypeOf(screen, EventEmitter.prototype)
 

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -1,5 +1,5 @@
-const EventEmitter = require('events').EventEmitter
-const Tray = process.atomBinding('tray').Tray
+const {EventEmitter} = require('events')
+const {Tray} = process.atomBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const EventEmitter = require('events').EventEmitter
-const ipcMain = require('electron').ipcMain
-const NavigationController = require('electron').NavigationController
-const Menu = require('electron').Menu
+const {EventEmitter} = require('events')
+const {ipcMain, Menu, NavigationController} = require('electron')
 
 const binding = process.atomBinding('web_contents')
 const debuggerBinding = process.atomBinding('debugger')


### PR DESCRIPTION
A small update to make all of the different API modules a little bit more consistent. I omitted `Menu` and `MenuItem` as I plan on refactoring them in the very near future.