### PR TITLE
Implement titleBarStyle without using NSFullSizeContentViewWindowMask

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -49,7 +49,6 @@ NativeWindow::NativeWindow(
     const mate::Dictionary& options)
     : content::WebContentsObserver(inspectable_web_contents->GetWebContents()),
       has_frame_(true),
-      force_using_draggable_region_(false),
       transparent_(false),
       enable_larger_than_screen_(false),
       is_closed_(false),
@@ -573,7 +572,7 @@ bool NativeWindow::OnMessageReceived(const IPC::Message& message) {
 void NativeWindow::UpdateDraggableRegions(
     const std::vector<DraggableRegion>& regions) {
   // Draggable region is not supported for non-frameless window.
-  if (has_frame_ && !force_using_draggable_region_)
+  if (has_frame_)
     return;
   draggable_region_ = DraggableRegionsToSkRegion(regions);
 }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -246,17 +246,12 @@ class NativeWindow : public base::SupportsUserData,
   }
 
   bool has_frame() const { return has_frame_; }
+  void set_has_frame(bool has_frame) { has_frame_ = has_frame; }
+
   bool transparent() const { return transparent_; }
   SkRegion* draggable_region() const { return draggable_region_.get(); }
   bool enable_larger_than_screen() const { return enable_larger_than_screen_; }
   gfx::ImageSkia icon() const { return icon_; }
-
-  bool force_using_draggable_region() const {
-    return force_using_draggable_region_;
-  }
-  void set_force_using_draggable_region(bool force) {
-    force_using_draggable_region_ = true;
-  }
 
   void set_has_dialog_attached(bool has_dialog_attached) {
     has_dialog_attached_ = has_dialog_attached;
@@ -298,9 +293,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Whether window has standard frame.
   bool has_frame_;
-
-  // Force the window to be aware of draggable regions.
-  bool force_using_draggable_region_;
 
   // Whether window is transparent.
   bool transparent_;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -91,6 +91,10 @@ class NativeWindowMac : public NativeWindow {
     UpdateDraggableRegionViews(draggable_regions_);
   }
 
+  // Set the attribute of NSWindow while work around a bug of zoom button.
+  void SetStyleMask(bool on, NSUInteger flag);
+  void SetCollectionBehavior(bool on, NSUInteger flag);
+
   bool should_hide_native_toolbar_in_fullscreen() const {
     return should_hide_native_toolbar_in_fullscreen_;
   }
@@ -119,10 +123,6 @@ class NativeWindowMac : public NativeWindow {
   // Install the drag view, which will cover the whole window and decides
   // whehter we can drag.
   void UpdateDraggableRegionViews(const std::vector<DraggableRegion>& regions);
-
-  // Set the attribute of NSWindow while work around a bug of zo0m button.
-  void SetStyleMask(bool on, NSUInteger flag);
-  void SetCollectionBehavior(bool on, NSUInteger flag);
 
   base::scoped_nsobject<AtomNSWindow> window_;
   base::scoped_nsobject<AtomNSWindowDelegate> window_delegate_;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -142,6 +142,10 @@ class NativeWindowMac : public NativeWindow {
   // The presentation options before entering kiosk mode.
   NSApplicationPresentationOptions kiosk_options_;
 
+  // Force showing the buttons for frameless window.
+  bool force_show_buttons_;
+
+  // Whether to hide the native toolbar under fullscreen mode.
   bool should_hide_native_toolbar_in_fullscreen_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -391,6 +391,7 @@ NativeWindowMac::NativeWindowMac(
     : NativeWindow(web_contents, options),
       is_kiosk_(false),
       attention_request_id_(0),
+      force_show_buttons_(false),
       should_hide_native_toolbar_in_fullscreen_(false) {
   int width = 800, height = 600;
   options.Get(options::kWidth, &width);
@@ -438,21 +439,16 @@ NativeWindowMac::NativeWindowMac(
   if (closable) {
     styleMask |= NSClosableWindowMask;
   }
+  if ((titleBarStyle == "hidden") || (titleBarStyle == "hidden-inset")) {
+    // The window without titlebar is treated the same with frameless window.
+    set_has_frame(false);
+    force_show_buttons_ = true;
+  }
   if (!useStandardWindow || transparent() || !has_frame()) {
     styleMask |= NSTexturedBackgroundWindowMask;
   }
   if (resizable) {
     styleMask |= NSResizableWindowMask;
-  }
-  if ((titleBarStyle == "hidden") || (titleBarStyle == "hidden-inset")) {
-    styleMask |= NSFullSizeContentViewWindowMask;
-    styleMask |= NSUnifiedTitleAndToolbarWindowMask;
-  }
-  // We capture this because we need to access the option later when
-  // entering/exiting fullscreen and since the options dict is only passed to
-  // the constructor but not stored, let’s store this option this way.
-  if (titleBarStyle == "hidden-inset") {
-    should_hide_native_toolbar_in_fullscreen_ = true;
   }
 
   window_.reset([[AtomNSWindow alloc]
@@ -498,9 +494,8 @@ NativeWindowMac::NativeWindowMac(
           [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
       [toolbar setShowsBaselineSeparator:NO];
       [window_ setToolbar:toolbar];
+      should_hide_native_toolbar_in_fullscreen_ = true;
     }
-    // We should be aware of draggable regions when using hidden titlebar.
-    set_force_using_draggable_region(true);
   }
 
   // On OS X the initial window size doesn't include window frame.
@@ -1013,6 +1008,10 @@ void NativeWindowMac::InstallView() {
     [view setFrame:[content_view_ bounds]];
     [content_view_ addSubview:view];
 
+    if (force_show_buttons_)
+      return;
+
+    // Hide the window buttons.
     [[window_ standardWindowButton:NSWindowZoomButton] setHidden:YES];
     [[window_ standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
     [[window_ standardWindowButton:NSWindowCloseButton] setHidden:YES];
@@ -1031,7 +1030,7 @@ void NativeWindowMac::UninstallView() {
 
 void NativeWindowMac::UpdateDraggableRegionViews(
     const std::vector<DraggableRegion>& regions) {
-  if (has_frame() && !force_using_draggable_region())
+  if (has_frame())
     return;
 
   // All ControlRegionViews should be added as children of the WebContentsView,


### PR DESCRIPTION
This is inspired from https://github.com/brave/electron/commit/7fa16afa67c7cf539a0708d1ea10b158eb94ee66.

Instead of using the `NSFullSizeContentViewWindowMask` style to hide the titlebar, this PR treats window with `titleBarStyle` as normal frameless window but shows the window buttons instead. 

Close https://github.com/electron/electron/issues/3009.