### PR TITLE
WIP Pass notification metadata to callback when using systemPreferences.subscribeNotification

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -9,6 +9,7 @@
 #import <Cocoa/Cocoa.h>
 
 #include "atom/common/native_mate_converters/gurl_converter.h"
+#include "atom/browser/mac/dict_util.h"
 #include "base/strings/sys_string_conversions.h"
 #include "net/base/mac/url_conversions.h"
 
@@ -34,7 +35,7 @@ int SystemPreferences::SubscribeNotification(const std::string& name,
       object:nil
       queue:nil
       usingBlock:^(NSNotification* notification) {
-        copied_callback.Run();
+        copied_callback.Run(NSDictionaryToDictionaryValue([notification userInfo]));
       }
   ];
   return request_id;


### PR DESCRIPTION
Making an attempt at https://github.com/electron/electron/issues/5543

I haven't been able to get tests running locally yet, so just opening a PR to get a build status.