### PR TITLE
Add test that loads a devtools extension

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -825,25 +825,29 @@ describe('browser-window module', function () {
 
   describe('dev tool extensions', function () {
     describe('BrowserWindow.addDevToolsExtension', function () {
+      this.timeout(10000)
+
       beforeEach(function () {
         BrowserWindow.removeDevToolsExtension('foo')
+
+        var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
+        BrowserWindow.addDevToolsExtension(extensionPath)
+
+        w.webContents.on('devtools-opened', () => {
+          var inputEventIntervalId = setInterval(function () {
+            if (w && w.devToolsWebContents) {
+              w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
+            } else {
+              clearInterval(inputEventIntervalId)
+            }
+          }, 200)
+        })
+
+        w.loadURL('about:blank')
       })
 
       describe('when the devtools is docked', function () {
         it('creates the extension', function (done) {
-          var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
-          BrowserWindow.addDevToolsExtension(extensionPath)
-
-          w.webContents.on('devtools-opened', () => {
-            var inputEventIntervalId = setInterval(function () {
-              if (w && w.devToolsWebContents) {
-                w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
-              } else {
-                clearInterval(inputEventIntervalId)
-              }
-            }, 250)
-          })
-          w.loadURL('about:blank')
           w.webContents.openDevTools({mode: 'bottom'})
 
           ipcMain.once('answer', function (event, message) {
@@ -855,19 +859,6 @@ describe('browser-window module', function () {
 
       describe('when the devtools is undocked', function () {
         it('creates the extension', function (done) {
-          var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
-          BrowserWindow.addDevToolsExtension(extensionPath)
-
-          w.webContents.on('devtools-opened', () => {
-            var inputEventIntervalId = setInterval(function () {
-              if (w && w.devToolsWebContents) {
-                w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
-              } else {
-                clearInterval(inputEventIntervalId)
-              }
-            }, 250)
-          })
-          w.loadURL('about:blank')
           w.webContents.openDevTools({mode: 'undocked'})
 
           ipcMain.once('answer', function (event, message) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -838,7 +838,7 @@ describe('browser-window module', function () {
             if (w && w.devToolsWebContents) {
               w.devToolsWebContents.executeJavaScript('(' + (function () {
                 var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
-                WebInspector.inspectorView.showPanel(lastPanelId);
+                WebInspector.inspectorView.showPanel(lastPanelId)
               }).toString() + ')()')
             } else {
               clearInterval(showPanelIntevalId)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -836,16 +836,14 @@ describe('browser-window module', function () {
         w.webContents.on('devtools-opened', function () {
           var inputEventIntervalId = setInterval(function () {
             if (w && w.devToolsWebContents) {
-              // Switch panels until the custom one is selected and loads
-              w.devToolsWebContents.sendInputEvent({
-                type: 'keyDown',
-                keyCode:'[',
-                modifiers: process.platform === 'darwin' ? ['meta'] : ['control']
-              })
+              w.devToolsWebContents.executeJavaScript('(' + (function () {
+                var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
+                WebInspector.inspectorView.showPanel(lastPanelId);
+              }).toString() + ')()')
             } else {
               clearInterval(inputEventIntervalId)
             }
-          }, 200)
+          }, 100)
         })
 
         w.loadURL('about:blank')

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -833,7 +833,7 @@ describe('browser-window module', function () {
         var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
         BrowserWindow.addDevToolsExtension(extensionPath)
 
-        w.webContents.on('devtools-opened', () => {
+        w.webContents.on('devtools-opened', function () {
           var inputEventIntervalId = setInterval(function () {
             if (w && w.devToolsWebContents) {
               w.devToolsWebContents.sendInputEvent({

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -825,25 +825,55 @@ describe('browser-window module', function () {
 
   describe('dev tool extensions', function () {
     describe('BrowserWindow.addDevToolsExtension', function () {
-      it('creates the extension', function (done) {
-        var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
-        BrowserWindow.addDevToolsExtension(extensionPath)
+      beforeEach(function () {
+        BrowserWindow.removeDevToolsExtension('foo')
+      })
 
-        w.webContents.on('devtools-opened', () => {
-          var inputEventIntervalId = setInterval(function () {
-            if (w && w.devToolsWebContents) {
-              w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
-            } else {
-              clearInterval(inputEventIntervalId)
-            }
-          }, 250)
+      describe('when the devtools is docked', function () {
+        it('creates the extension', function (done) {
+          var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
+          BrowserWindow.addDevToolsExtension(extensionPath)
+
+          w.webContents.on('devtools-opened', () => {
+            var inputEventIntervalId = setInterval(function () {
+              if (w && w.devToolsWebContents) {
+                w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
+              } else {
+                clearInterval(inputEventIntervalId)
+              }
+            }, 250)
+          })
+          w.loadURL('about:blank')
+          w.webContents.openDevTools({mode: 'bottom'})
+
+          ipcMain.once('answer', function (event, message) {
+            assert.equal(message, 'extension loaded')
+            done()
+          })
         })
-        w.loadURL('about:blank')
-        w.webContents.openDevTools({mode: 'bottom'})
+      })
 
-        ipcMain.once('answer', function (event, message) {
-          assert.equal(message, 'extension loaded')
-          done()
+      describe('when the devtools is undocked', function () {
+        it('creates the extension', function (done) {
+          var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
+          BrowserWindow.addDevToolsExtension(extensionPath)
+
+          w.webContents.on('devtools-opened', () => {
+            var inputEventIntervalId = setInterval(function () {
+              if (w && w.devToolsWebContents) {
+                w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
+              } else {
+                clearInterval(inputEventIntervalId)
+              }
+            }, 250)
+          })
+          w.loadURL('about:blank')
+          w.webContents.openDevTools({mode: 'undocked'})
+
+          ipcMain.once('answer', function (event, message) {
+            assert.equal(message, 'extension loaded')
+            done()
+          })
         })
       })
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -836,7 +836,11 @@ describe('browser-window module', function () {
         w.webContents.on('devtools-opened', () => {
           var inputEventIntervalId = setInterval(function () {
             if (w && w.devToolsWebContents) {
-              w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
+              w.devToolsWebContents.sendInputEvent({
+                type: 'keyDown',
+                keyCode:'[',
+                modifiers: process.platform === 'darwin' ? ['meta'] : ['control']
+              })
             } else {
               clearInterval(inputEventIntervalId)
             }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -834,14 +834,14 @@ describe('browser-window module', function () {
         BrowserWindow.addDevToolsExtension(extensionPath)
 
         w.webContents.on('devtools-opened', function () {
-          var inputEventIntervalId = setInterval(function () {
+          var showPanelIntevalId = setInterval(function () {
             if (w && w.devToolsWebContents) {
               w.devToolsWebContents.executeJavaScript('(' + (function () {
                 var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
                 WebInspector.inspectorView.showPanel(lastPanelId);
               }).toString() + ')()')
             } else {
-              clearInterval(inputEventIntervalId)
+              clearInterval(showPanelIntevalId)
             }
           }, 100)
         })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -824,6 +824,30 @@ describe('browser-window module', function () {
   })
 
   describe('dev tool extensions', function () {
+    describe('BrowserWindow.addDevToolsExtension', function () {
+      it('creates the extension', function (done) {
+        var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
+        BrowserWindow.addDevToolsExtension(extensionPath)
+
+        w.webContents.on('devtools-opened', () => {
+          var inputEventIntervalId = setInterval(function () {
+            if (w && w.devToolsWebContents) {
+              w.devToolsWebContents.sendInputEvent({type: 'keyDown', keyCode:'[', modifiers: ['meta']})
+            } else {
+              clearInterval(inputEventIntervalId)
+            }
+          }, 250)
+        })
+        w.loadURL('about:blank')
+        w.webContents.openDevTools({mode: 'bottom'})
+
+        ipcMain.once('answer', function (event, message) {
+          assert.equal(message, 'extension loaded')
+          done()
+        })
+      })
+    })
+
     it('serializes the registered extensions on quit', function () {
       var extensionName = 'foo'
       var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', extensionName)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -836,6 +836,7 @@ describe('browser-window module', function () {
         w.webContents.on('devtools-opened', function () {
           var inputEventIntervalId = setInterval(function () {
             if (w && w.devToolsWebContents) {
+              // Switch panels until the custom one is selected and loads
               w.devToolsWebContents.sendInputEvent({
                 type: 'keyDown',
                 keyCode:'[',

--- a/spec/fixtures/devtools-extensions/foo/foo.html
+++ b/spec/fixtures/devtools-extensions/foo/foo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>foo</title>
+    <script>
+      chrome.devtools.panels.create('Foo', 'foo.png', 'index.html')
+    </script>
+  </head>
+</html>

--- a/spec/fixtures/devtools-extensions/foo/index.html
+++ b/spec/fixtures/devtools-extensions/foo/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <script>
+      var sendMessage = `require('electron').ipcRenderer.send('answer', 'extension loaded')`
+      window.chrome.devtools.inspectedWindow.eval(sendMessage, function () {})
+    </script>
+  </head>
+  <body>
+    a custom devtools extension
+  </body>
+</html>

--- a/spec/fixtures/devtools-extensions/foo/manifest.json
+++ b/spec/fixtures/devtools-extensions/foo/manifest.json
@@ -1,3 +1,5 @@
 {
-  "name": "foo"
+  "name": "foo",
+  "version": "1.0",
+  "devtools_page": "foo.html"
 }


### PR DESCRIPTION
I introduced a regression in #5373 that was fixed in #5490 where custom extensions did not load upon opening the dev tools.

This pull request attempts to add additional test coverage where we actually load a custom devtools extension in the specs and verify it sends a message over ipc saying it was successfully created.
