### PR TITLE
Tweak doc headings

### DIFF
--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -1,4 +1,4 @@
-# Supported Chrome command line switches
+# Supported Chrome Command Line Switches
 
 > Command line switches supported by Electron.
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -1,4 +1,4 @@
-# Environment variables
+# Environment Variables
 
 > Control application configuration and behavior without changing code.
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -1,4 +1,4 @@
-# The `<webview>` tag
+# `<webview>` Tag
 
 > Display external web content in an isolated frame and process.
 

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -1,4 +1,4 @@
-# The `window.open` function
+# `window.open` Function
 
 > Open a new window and load a URL.
 

--- a/docs/development/debug-instructions-windows.md
+++ b/docs/development/debug-instructions-windows.md
@@ -1,4 +1,4 @@
-# Debugging Electron in Windows
+# Debugging on Windows
 
 If you experience crashes or issues in Electron that you believe are not caused
 by your JavaScript application, but instead by Electron itself, debugging can

--- a/docs/tutorial/testing-on-headless-ci.md
+++ b/docs/tutorial/testing-on-headless-ci.md
@@ -1,4 +1,4 @@
-# Testing with Headless CI Systems (Travis CI, Jenkins)
+# Testing on Headless CI Systems (Travis CI, Jenkins)
 
 Being based on Chromium, Electron requires a display driver to function.
 If Chromium can't find a display driver, Electron will simply fail to launch -

--- a/docs/tutorial/testing-on-headless-ci.md
+++ b/docs/tutorial/testing-on-headless-ci.md
@@ -1,4 +1,4 @@
-# Testing Electron with headless CI Systems (Travis CI, Jenkins)
+# Testing with Headless CI Systems (Travis CI, Jenkins)
 
 Being based on Chromium, Electron requires a display driver to function.
 If Chromium can't find a display driver, Electron will simply fail to launch -


### PR DESCRIPTION
This pull request makes a few minor tweaks to the doc headings to make them more consistent when shown in https://github.com/electron/electron.atom.io/pull/283

- Title-ize consistently
- Remove leading `The`
- Remove redundant `Electron` use