### PR TITLE
browser: flag to disable HTTP/2 and SPDY/3.1 protocols

### DIFF
--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -24,6 +24,10 @@ Ignore the connections limit for `domains` list separated by `,`.
 
 Disables the disk cache for HTTP requests.
 
+## --disable-http2
+
+Disable HTTP/2 and SPDY/3.1 protocols.
+
 ## --remote-debugging-port=`port`
 
 Enables remote debugging over HTTP on the specified `port`.


### PR DESCRIPTION
Fixes #5555 

Depends on https://github.com/electron/brightray/pull/222