### PR TITLE
Enable sandboxing without using temporary-exception

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -83,6 +83,10 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 
   chrome::RegisterPathProvider();
 
+#if defined(OS_MACOSX)
+  SetUpBundleOverrides();
+#endif
+
   return brightray::MainDelegate::BasicStartupComplete(exit_code);
 }
 

--- a/atom/app/atom_main_delegate.h
+++ b/atom/app/atom_main_delegate.h
@@ -31,6 +31,10 @@ class AtomMainDelegate : public brightray::MainDelegate {
 #endif
 
  private:
+#if defined(OS_MACOSX)
+  void SetUpBundleOverrides();
+#endif
+
   brightray::ContentClient content_client_;
   scoped_ptr<content::ContentBrowserClient> browser_client_;
   scoped_ptr<content::ContentRendererClient> renderer_client_;

--- a/atom/app/atom_main_delegate_mac.mm
+++ b/atom/app/atom_main_delegate_mac.mm
@@ -7,6 +7,8 @@
 #include "base/mac/bundle_locations.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/mac/foundation_util.h"
+#include "base/mac/scoped_nsautorelease_pool.h"
 #include "base/path_service.h"
 #include "brightray/common/application_info.h"
 #include "brightray/common/mac/main_application_bundle.h"
@@ -46,6 +48,12 @@ void AtomMainDelegate::OverrideChildProcessPath() {
   if (!base::PathExists(helper_path))
     LOG(FATAL) << "Unable to find helper app";
   PathService::Override(content::CHILD_PROCESS_EXE, helper_path);
+}
+
+void AtomMainDelegate::SetUpBundleOverrides() {
+  base::mac::ScopedNSAutoreleasePool pool;
+  NSBundle* base_bundle = brightray::MainApplicationBundle();
+  base::mac::SetBaseBundleID([[base_bundle bundleIdentifier] UTF8String]);
 }
 
 }  // namespace atom

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -52,11 +52,16 @@ First, you need to prepare two entitlements files.
   <dict>
     <key>com.apple.security.app-sandbox</key>
     <true/>
-    <key>com.apple.security.temporary-exception.sbpl</key>
-    <string>(allow mach-lookup (global-name-regex #"^org.chromium.Chromium.rohitfork.[0-9]+$"))</string>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>your.bundle.id</string>
+    </array>
   </dict>
 </plist>
 ```
+
+_You have to replace `your.bundle.id` with the Bundle ID specified in your app's
+`Info.plist`._
 
 And then sign your app with the following script:
 
@@ -100,23 +105,6 @@ add keys for the permissions needed by your app to the entitlements files.
 After signing your app, you can use Application Loader to upload it to iTunes
 Connect for processing, making sure you have [created a record][create-record]
 before uploading.
-
-### Explain the Usages of `temporary-exception`
-
-When sandboxing your app there was a `temporary-exception` entry added to the
-entitlements, according to the [App Sandbox Temporary Exception
-Entitlements][temporary-exception] documentation, you have to explain why this
-entry is needed:
-
-> Note: If you request a temporary-exception entitlement, be sure to follow the
-guidance regarding entitlements provided on the iTunes Connect website. In
-particular, identify the entitlement and corresponding issue number in the App
-Sandbox Entitlement Usage Information section in iTunes Connect and explain why
-your app needs the exception.
-
-You may explain that your app is built upon Chromium browser, which uses Mach
-port for its multi-process architecture. But there is still probability that
-your app failed the review because of this.
 
 ### Submit Your App for Review
 


### PR DESCRIPTION
According to [App Sandbox in Depth](https://developer.apple.com/library/mac/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html), if we use application groups then it will be possible to use mach IPC without acquiring `temporary-exception`.

This should be able to make apps much easier to get approved.

Close #5350.