### PR TITLE
Improve error message

### DIFF
--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -121,11 +121,7 @@ if (preloadScript) {
   try {
     require(preloadScript)
   } catch (error) {
-    if (error.code === 'MODULE_NOT_FOUND' && error.message.indexOf(preloadScript) > -1) {
-      console.error('Unable to load preload script ' + preloadScript)
-    } else {
-      console.error(error)
-      console.error(error.stack)
-    }
+    console.error('Unable to load preload script: ' + preloadScript)
+    console.error(error.stack || error.message)
   }
 }

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -121,7 +121,7 @@ if (preloadScript) {
   try {
     require(preloadScript)
   } catch (error) {
-    if (error.code === 'MODULE_NOT_FOUND') {
+    if (error.code === 'MODULE_NOT_FOUND' && error.message.indexOf(preloadScript) > -1) {
       console.error('Unable to load preload script ' + preloadScript)
     } else {
       console.error(error)


### PR DESCRIPTION
Currently if the preloaded file throw an exception the error message isn't the real stack trace.

**browser.js**
```
const path = require('wrong-module-name');
```

**main.js**
```
const win = new BrowserWindow({
    'width': 500,
    'height': 500,
    'webPreferences': {
      'nodeIntegration': true,
      'preload': path.join(__dirname, 'wrong-file.js')
    }
  });
```
In this case the browser will throw the console.error with the following message `Unable to load preload script wrong-file.js`


But if the main.js finds the preload file and this file throws an exception, the app will continue showing the same message `Unable to load preload script browser.js` and not the real exception `Error: Cannot find module 'wrong-module-name'`

With this change the browser will throw the real stack trace.

**Stack trace**
```
Error: Cannot find module 'wrong-module-name'
    at Function.Module._resolveFilename (module.js:438)
    at Function.Module._load (module.js:386)
    at Module.require (module.js:466)
    at require (internal/module.js:20)
    at Object.<anonymous> (/home/bruno/dev/test-app/browser.js:1)
    at Module._compile (module.js:541)
    at Object.Module._extensions..js (module.js:550)
    at Module.load (module.js:456)
    at tryModuleLoad (module.js:415)
    at Function.Module._load (module.js:407)
```