### PR TITLE
Update Clang only if needed

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -50,8 +50,9 @@ def main():
     libcc_static_library_path = os.path.join(dist_dir, 'static_library')
 
   if PLATFORM != 'win32':
-    # Download prebuilt clang binaries.
-    update_clang()
+    if not args.disable_clang and args.clang_dir == '':
+      # Download prebuilt clang binaries.
+      update_clang()
 
   setup_python_libs()
   update_node_modules('.')


### PR DESCRIPTION
Don't run `update_clang()` if using system clang or another compiler.