### PR TITLE
Include team ID in the base bundle ID

### DIFF
--- a/atom/app/atom_main_delegate_mac.mm
+++ b/atom/app/atom_main_delegate_mac.mm
@@ -10,6 +10,7 @@
 #include "base/mac/foundation_util.h"
 #include "base/mac/scoped_nsautorelease_pool.h"
 #include "base/path_service.h"
+#include "base/strings/sys_string_conversions.h"
 #include "brightray/common/application_info.h"
 #include "brightray/common/mac/main_application_bundle.h"
 #include "content/public/common/content_paths.h"
@@ -52,8 +53,13 @@ void AtomMainDelegate::OverrideChildProcessPath() {
 
 void AtomMainDelegate::SetUpBundleOverrides() {
   base::mac::ScopedNSAutoreleasePool pool;
-  NSBundle* base_bundle = brightray::MainApplicationBundle();
-  base::mac::SetBaseBundleID([[base_bundle bundleIdentifier] UTF8String]);
+  NSBundle* bundle = brightray::MainApplicationBundle();
+  std::string base_bundle_id =
+      base::SysNSStringToUTF8([bundle bundleIdentifier]);
+  NSString* team_id = [bundle objectForInfoDictionaryKey:@"ElectronTeamID"];
+  if (team_id)
+    base_bundle_id = base::SysNSStringToUTF8(team_id) + "." + base_bundle_id;
+  base::mac::SetBaseBundleID(base_bundle_id.c_str());
 }
 
 }  // namespace atom

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -19,14 +19,33 @@ how to meet the Mac App Store requirements.
 To submit your app to the Mac App Store, you first must get a certificate from
 Apple. You can follow these [existing guides][nwjs-guide] on web.
 
+### Get Team ID
+
+Before signing your app, you need to know the Team ID of your account. To locate
+your Team ID, Sign in to https://developer.apple.com/account/, and click
+Membership in the sidebar. Your Team ID appears in the Membership Information
+section under the team name.
+
 ### Sign Your App
 
-After getting the certificate from Apple, you can package your app by following
+After finishing the preparation work, you can package your app by following
 [Application Distribution](application-distribution.md), and then proceed to
-signing your app. This step is basically the same with other programs, but the
-key is to sign every dependency of Electron one by one.
+signing your app.
 
-First, you need to prepare two entitlements files.
+First, you have to add a `ElectronTeamID` key to your app's `Info.plist`, which
+has your Team ID as key:
+
+```xml
+<plist version="1.0">
+<dict>
+  ...
+  <key>ElectronTeamID</key>
+  <string>TEAM_ID</string>
+</dict>
+</plist>
+```
+
+Then, you need to prepare two entitlements files.
 
 `child.plist`:
 
@@ -53,15 +72,13 @@ First, you need to prepare two entitlements files.
     <key>com.apple.security.app-sandbox</key>
     <true/>
     <key>com.apple.security.application-groups</key>
-    <array>
-      <string>your.bundle.id</string>
-    </array>
+    <string>TEAM_ID.your.bundle.id</string>
   </dict>
 </plist>
 ```
 
-_You have to replace `your.bundle.id` with the Bundle ID specified in your app's
-`Info.plist`._
+You have to replace `TEAM_ID` with your Team ID, and replace `your.bundle.id`
+with the Bundle ID of your app.
 
 And then sign your app with the following script:
 


### PR DESCRIPTION
This PR adds an `ElectronTeamID` key in `Info.plist` which can be used to specify the Team ID of user's developer account. Also updates the MAS submission guide on Team ID.

Refs https://github.com/electron/electron/pull/5584#issuecomment-220011556.