### PR TITLE
Osx horizontal sheet offset

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -371,8 +371,12 @@ std::vector<int> Window::GetMaximumSize() {
   return result;
 }
 
-void Window::SetSheetOffset(double offset) {
-  window_->SetSheetOffset(offset);
+void Window::SetSheetOffset(double offsetY) {
+  window_->SetSheetOffset(offsetY);
+}
+
+void Window::SetSheetOffsets(double offsetX, double offsetY) {
+  window_->SetSheetOffsets(offsetX, offsetY);
 }
 
 void Window::SetResizable(bool resizable) {
@@ -682,6 +686,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setMaximumSize", &Window::SetMaximumSize)
       .SetMethod("getMaximumSize", &Window::GetMaximumSize)
       .SetMethod("setSheetOffset", &Window::SetSheetOffset)
+      .SetMethod("setSheetOffsets", &Window::SetSheetOffsets)
       .SetMethod("setResizable", &Window::SetResizable)
       .SetMethod("isResizable", &Window::IsResizable)
       .SetMethod("setMovable", &Window::SetMovable)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -371,12 +371,10 @@ std::vector<int> Window::GetMaximumSize() {
   return result;
 }
 
-void Window::SetSheetOffset(double offsetY) {
-  window_->SetSheetOffset(offsetY);
-}
-
-void Window::SetSheetOffsets(double offsetX, double offsetY) {
-  window_->SetSheetOffsets(offsetX, offsetY);
+void Window::SetSheetOffset(double offsetY, mate::Arguments* args) {
+  double offsetX = 0.0;
+  args->GetNext(&offsetX);
+  window_->SetSheetOffset(offsetX, offsetY);
 }
 
 void Window::SetResizable(bool resizable) {
@@ -686,7 +684,6 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setMaximumSize", &Window::SetMaximumSize)
       .SetMethod("getMaximumSize", &Window::GetMaximumSize)
       .SetMethod("setSheetOffset", &Window::SetSheetOffset)
-      .SetMethod("setSheetOffsets", &Window::SetSheetOffsets)
       .SetMethod("setResizable", &Window::SetResizable)
       .SetMethod("isResizable", &Window::IsResizable)
       .SetMethod("setMovable", &Window::SetMovable)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -110,7 +110,8 @@ class Window : public mate::TrackableObject<Window>,
   std::vector<int> GetMinimumSize();
   void SetMaximumSize(int width, int height);
   std::vector<int> GetMaximumSize();
-  void SetSheetOffset(double offset);
+  void SetSheetOffset(double offsetY);
+  void SetSheetOffsets(double offsetX, double offsetY);
   void SetResizable(bool resizable);
   bool IsResizable();
   void SetMovable(bool movable);

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -110,8 +110,7 @@ class Window : public mate::TrackableObject<Window>,
   std::vector<int> GetMinimumSize();
   void SetMaximumSize(int width, int height);
   std::vector<int> GetMaximumSize();
-  void SetSheetOffset(double offsetY);
-  void SetSheetOffsets(double offsetX, double offsetY);
+  void SetSheetOffset(double offsetY, mate::Arguments* args);
   void SetResizable(bool resizable);
   bool IsResizable();
   void SetMovable(bool movable);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -255,11 +255,7 @@ gfx::Size NativeWindow::GetMaximumSize() {
   return GetSizeConstraints().GetMaximumSize();
 }
 
-void NativeWindow::SetSheetOffset(const double offsetY) {
-  sheet_offset_y_ = offsetY;
-}
-
-void NativeWindow::SetSheetOffsets(const double offsetX, const double offsetY) {
+void NativeWindow::SetSheetOffset(const double offsetX, const double offsetY) {
   sheet_offset_x_ = offsetX;
   sheet_offset_y_ = offsetY;
 }

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -53,7 +53,8 @@ NativeWindow::NativeWindow(
       enable_larger_than_screen_(false),
       is_closed_(false),
       has_dialog_attached_(false),
-      sheet_offset_(0.0),
+      sheet_offset_x_(0.0),
+      sheet_offset_y_(0.0),
       aspect_ratio_(0.0),
       inspectable_web_contents_(inspectable_web_contents),
       weak_factory_(this) {
@@ -254,12 +255,21 @@ gfx::Size NativeWindow::GetMaximumSize() {
   return GetSizeConstraints().GetMaximumSize();
 }
 
-void NativeWindow::SetSheetOffset(const double offset) {
-  sheet_offset_ = offset;
+void NativeWindow::SetSheetOffset(const double offsetY) {
+  sheet_offset_y_ = offsetY;
 }
 
-double NativeWindow::GetSheetOffset() {
-  return sheet_offset_;
+void NativeWindow::SetSheetOffsets(const double offsetX, const double offsetY) {
+  sheet_offset_x_ = offsetX;
+  sheet_offset_y_ = offsetY;
+}
+
+double NativeWindow::GetSheetOffsetX() {
+  return sheet_offset_x_;
+}
+
+double NativeWindow::GetSheetOffsetY() {
+  return sheet_offset_y_;
 }
 
 void NativeWindow::SetRepresentedFilename(const std::string& filename) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -123,8 +123,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Size GetMinimumSize();
   virtual void SetMaximumSize(const gfx::Size& size);
   virtual gfx::Size GetMaximumSize();
-  virtual void SetSheetOffset(const double offsetY);
-  virtual void SetSheetOffsets(const double offsetX, const double offsetY);
+  virtual void SetSheetOffset(const double offsetX, const double offsetY);
   virtual double GetSheetOffsetX();
   virtual double GetSheetOffsetY();
   virtual void SetResizable(bool resizable) = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -123,8 +123,10 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Size GetMinimumSize();
   virtual void SetMaximumSize(const gfx::Size& size);
   virtual gfx::Size GetMaximumSize();
-  virtual void SetSheetOffset(const double offset);
-  virtual double GetSheetOffset();
+  virtual void SetSheetOffset(const double offsetY);
+  virtual void SetSheetOffsets(const double offsetX, const double offsetY);
+  virtual double GetSheetOffsetX();
+  virtual double GetSheetOffsetY();
   virtual void SetResizable(bool resizable) = 0;
   virtual bool IsResizable() = 0;
   virtual void SetMovable(bool movable) = 0;
@@ -320,8 +322,10 @@ class NativeWindow : public base::SupportsUserData,
   // it should be cancelled when we can prove that the window is responsive.
   base::CancelableClosure window_unresposive_closure_;
 
-  // Used to display sheets at the appropriate vertical offset
-  double sheet_offset_;
+  // Used to display sheets at the appropriate horizontal and vertical offsets
+  // on OS X.
+  double sheet_offset_x_;
+  double sheet_offset_y_;
 
   // Used to maintain the aspect ratio of a view which is inside of the
   // content view.

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -257,7 +257,9 @@ bool ScopedDisableResize::disable_resize_ = false;
 - (NSRect)window:(NSWindow*)window
     willPositionSheet:(NSWindow*)sheet usingRect:(NSRect)rect {
   NSView* view = window.contentView;
-  rect.origin.y = view.frame.size.height - shell_->GetSheetOffset();
+
+  rect.origin.x = shell_->GetSheetOffsetX();
+  rect.origin.y = view.frame.size.height - shell_->GetSheetOffsetY();
   return rect;
 }
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -682,7 +682,7 @@ Returns the title of the native window.
 **Note:** The title of web page can be different from the title of the native
 window.
 
-### `win.setSheetOffset(offset)` _OS X_
+### `win.setSheetOffset(offsetY)` _OS X_
 
 Changes the attachment point for sheets on Mac OS X. By default, sheets are
 attached just below the window frame, but you may want to display them beneath
@@ -691,6 +691,16 @@ a HTML-rendered toolbar. For example:
 ```javascript
 let toolbarRect = document.getElementById('toolbar').getBoundingClientRect();
 win.setSheetOffset(toolbarRect.height);
+```
+
+### `win.setSheetOffsets(offsetX, offsetY)` _OS X_
+
+Like `win.setSheetOffset` but allows for an offset along the x-axis to be set
+in addition to the y-axis.
+
+```javascript
+let toolbarRect = document.getElementById('toolbar').getBoundingClientRect();
+win.setSheetOffset(toolbarRect.left, toolbarRect.height);
 ```
 
 ### `win.flashFrame(flag)`

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -682,7 +682,7 @@ Returns the title of the native window.
 **Note:** The title of web page can be different from the title of the native
 window.
 
-### `win.setSheetOffset(offsetY)` _OS X_
+### `win.setSheetOffset(offsetY[, offsetX])` _OS X_
 
 Changes the attachment point for sheets on Mac OS X. By default, sheets are
 attached just below the window frame, but you may want to display them beneath
@@ -691,16 +691,6 @@ a HTML-rendered toolbar. For example:
 ```javascript
 let toolbarRect = document.getElementById('toolbar').getBoundingClientRect();
 win.setSheetOffset(toolbarRect.height);
-```
-
-### `win.setSheetOffsets(offsetX, offsetY)` _OS X_
-
-Like `win.setSheetOffset` but allows for an offset along the x-axis to be set
-in addition to the y-axis.
-
-```javascript
-let toolbarRect = document.getElementById('toolbar').getBoundingClientRect();
-win.setSheetOffset(toolbarRect.left, toolbarRect.height);
 ```
 
 ### `win.flashFrame(flag)`


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/5447. Though I was trying to maintain backwards compatibility, I'm not sure if this is the best way to do it. I don't want to bloat the API but this works for now.

`win.setSheetOffsets(100, -100);`

<img width="800" alt="screen shot 2016-05-19 at 12 09 37 am" src="https://cloud.githubusercontent.com/assets/5622404/15385368/0575dfd6-1d56-11e6-9585-ac03fa8640ba.png">


The old `win.setSheetOffset(100)` still works as expected, setting only the Y offset.

<img width="801" alt="screen shot 2016-05-19 at 12 23 08 am" src="https://cloud.githubusercontent.com/assets/5622404/15385659/e412c762-1d57-11e6-8fa6-4369cad701c1.png">
