### PR TITLE
Update remote.md to mention enumerable property limitation

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -37,7 +37,8 @@ process. Instead, it created a `BrowserWindow` object in the main process and
 returned the corresponding remote object in the renderer process, namely the
 `win` object.
 
-Please note that only [enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) are accessible via remote.
+Please note that only [enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) which are present when the remote object is first referenced are
+accessible via remote.
 
 ## Lifetime of Remote Objects
 


### PR DESCRIPTION
Based on our conversation in #5599 I think it'd be good to explicitly mention the fact that remote objects do not support enumerable properties added after they are first used.