### PR TITLE
Inherit zoomFactor in webview

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -179,6 +179,7 @@ var attachGuest = function (embedder, elementInstanceId, guestInstanceId, params
     guestInstanceId: guestInstanceId,
     nodeIntegration: (ref1 = params.nodeintegration) != null ? ref1 : false,
     plugins: params.plugins,
+    zoomFactor: params.zoomFactor,
     webSecurity: !params.disablewebsecurity,
     blinkFeatures: params.blinkfeatures
   }

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -47,8 +47,7 @@ var WebViewImpl = (function () {
   WebViewImpl.prototype.createBrowserPluginNode = function () {
     // We create BrowserPlugin as a custom element in order to observe changes
     // to attributes synchronously.
-    var browserPluginNode
-    browserPluginNode = new WebViewImpl.BrowserPlugin()
+    var browserPluginNode = new WebViewImpl.BrowserPlugin()
     v8Util.setHiddenValue(browserPluginNode, 'internal', this)
     return browserPluginNode
   }
@@ -259,8 +258,7 @@ var WebViewImpl = (function () {
 
 // Registers browser plugin <object> custom element.
 var registerBrowserPluginElement = function () {
-  var proto
-  proto = Object.create(HTMLObjectElement.prototype)
+  var proto = Object.create(HTMLObjectElement.prototype)
   proto.createdCallback = function () {
     this.setAttribute('type', 'application/browser-plugin')
     this.setAttribute('id', 'browser-plugin-' + getNextId())

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -223,7 +223,8 @@ var WebViewImpl = (function () {
     var attribute, attributeName, css, elementRect, params, ref1
     params = {
       instanceId: this.viewInstanceId,
-      userAgentOverride: this.userAgentOverride
+      userAgentOverride: this.userAgentOverride,
+      zoomFactor: webFrame.getZoomFactor()
     }
     ref1 = this.attributes
     for (attributeName in ref1) {

--- a/spec/fixtures/pages/webview-zoom-factor.html
+++ b/spec/fixtures/pages/webview-zoom-factor.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<webview nodeintegration src="zoom-factor.html"/>
+</body>
+</html>

--- a/spec/fixtures/pages/zoom-factor.html
+++ b/spec/fixtures/pages/zoom-factor.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const {ipcRenderer, webFrame} = require('electron')
+  ipcRenderer.send('pong', webFrame.getZoomFactor(), webFrame.getZoomLevel())
+</script>
+</body>
+</html>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -852,4 +852,19 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
   })
+
+  it('inherits the zoomFactor of the parent window', function (done) {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        zoomFactor: 1.2
+      }
+    })
+    ipcMain.once('pong', function (event, zoomFactor, zoomLevel) {
+      assert.equal(zoomFactor, 1.2)
+      assert.equal(zoomLevel, 1)
+      done()
+    })
+    w.loadURL('file://' + fixtures + '/pages/webview-zoom-factor.html')
+  })
 })


### PR DESCRIPTION
Set the initial `zoomFactor` of `<webview>` elements to be the current value of the parent `BrowserWindow`.

Closes #5312