### PR TITLE
Remove returns from event listeners

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -45,7 +45,7 @@ if (process.platform === 'darwin') {
 const events = ['login', 'certificate-error', 'select-client-certificate']
 for (let name of events) {
   app.on(name, (event, webContents, ...args) => {
-    return webContents.emit.apply(webContents, [name, event].concat(args))
+    webContents.emit.apply(webContents, [name, event].concat(args))
   })
 }
 

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -55,7 +55,7 @@ var spawnUpdate = function (args, detached, callback) {
   errorEmitted = false
   spawnedProcess.on('error', function (error) {
     errorEmitted = true
-    return callback(error)
+    callback(error)
   })
   return spawnedProcess.on('exit', function (code, signal) {
     spawnedProcess = undefined
@@ -72,7 +72,7 @@ var spawnUpdate = function (args, detached, callback) {
     }
 
     // Success.
-    return callback(null, stdout)
+    callback(null, stdout)
   })
 }
 

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -23,7 +23,7 @@ BrowserWindow.prototype._init = function () {
       width: 800,
       height: 600
     }
-    return ipcMain.emit('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', event, url, frameName, disposition, options)
+    ipcMain.emit('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', event, url, frameName, disposition, options)
   })
 
   // window.resizeTo(...)

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -125,7 +125,7 @@ let wrapWebContents = function (webContents) {
 
   // Dispatch IPC messages to the ipc module.
   webContents.on('ipc-message', function (event, [channel, ...args]) {
-    return ipcMain.emit.apply(ipcMain, [channel, event].concat(args))
+    ipcMain.emit.apply(ipcMain, [channel, event].concat(args))
   })
   webContents.on('ipc-message-sync', function (event, [channel, ...args]) {
     Object.defineProperty(event, 'returnValue', {
@@ -141,9 +141,8 @@ let wrapWebContents = function (webContents) {
 
   // Handle context menu action request from pepper plugin.
   webContents.on('pepper-context-menu', function (event, params) {
-    var menu
-    menu = Menu.buildFromTemplate(params.menu)
-    return menu.popup(params.x, params.y)
+    const menu = Menu.buildFromTemplate(params.menu)
+    menu.popup(params.x, params.y)
   })
 
   // The devtools requests the webContents to reload.

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -28,7 +28,7 @@ ipcMain.on('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function (event, cap
 
   // If the WebContents is destroyed before receiving result, just remove the
   // reference from requestsQueue to make the module not send the result to it.
-  return event.sender.once('destroyed', function () {
+  event.sender.once('destroyed', function () {
     request.webContents = null
   })
 })

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -137,7 +137,7 @@ var createGuest = function (embedder, params) {
   // Dispatch events to embedder.
   fn = function (event) {
     return guest.on(event, function (_, ...args) {
-      return embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + guest.viewInstanceId, event].concat(args))
+      embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + guest.viewInstanceId, event].concat(args))
     })
   }
   for (j = 0, len1 = supportedWebViewEvents.length; j < len1; j++) {
@@ -147,12 +147,12 @@ var createGuest = function (embedder, params) {
 
   // Dispatch guest's IPC messages to embedder.
   guest.on('ipc-message-host', function (_, [channel, ...args]) {
-    return embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + guest.viewInstanceId, channel].concat(args))
+    embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + guest.viewInstanceId, channel].concat(args))
   })
 
   // Autosize.
   guest.on('size-changed', function (_, ...args) {
-    return embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + guest.viewInstanceId].concat(args))
+    embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + guest.viewInstanceId].concat(args))
   })
   return id
 }
@@ -206,15 +206,15 @@ var destroyGuest = function (embedder, id) {
 }
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params, requestId) {
-  return event.sender.send('ELECTRON_RESPONSE_' + requestId, createGuest(event.sender, params))
+  event.sender.send('ELECTRON_RESPONSE_' + requestId, createGuest(event.sender, params))
 })
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, elementInstanceId, guestInstanceId, params) {
-  return attachGuest(event.sender, elementInstanceId, guestInstanceId, params)
+  attachGuest(event.sender, elementInstanceId, guestInstanceId, params)
 })
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_DESTROY_GUEST', function (event, id) {
-  return destroyGuest(event.sender, id)
+  destroyGuest(event.sender, id)
 })
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_SET_SIZE', function (event, id, params) {

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -79,7 +79,7 @@ var createGuest = function (embedder, url, frameName, options) {
     frameToGuest[frameName] = guest
     guest.frameName = frameName
     guest.once('closed', function () {
-      return delete frameToGuest[frameName]
+      delete frameToGuest[frameName]
     })
   }
   return guest.id
@@ -98,7 +98,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, fr
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function (event, guestId) {
   var ref1
-  return (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1.destroy() : void 0
+  (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1.destroy() : void 0
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guestId, method, ...args) {
@@ -114,11 +114,11 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, 
   }
   guestContents = (ref2 = BrowserWindow.fromId(guestId)) != null ? ref2.webContents : void 0
   if ((guestContents != null ? guestContents.getURL().indexOf(targetOrigin) : void 0) === 0 || targetOrigin === '*') {
-    return guestContents != null ? guestContents.send('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin) : void 0
+    guestContents != null ? guestContents.send('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin) : void 0
   }
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event, guestId, method, ...args) {
   var ref1, ref2
-  return (ref1 = BrowserWindow.fromId(guestId)) != null ? (ref2 = ref1.webContents) != null ? ref2[method].apply(ref2, args) : void 0 : void 0
+  (ref1 = BrowserWindow.fromId(guestId)) != null ? (ref2 = ref1.webContents) != null ? ref2[method].apply(ref2, args) : void 0 : void 0
 })

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -61,14 +61,14 @@ process.on('uncaughtException', function (error) {
   dialog = require('electron').dialog
   stack = (ref = error.stack) != null ? ref : error.name + ': ' + error.message
   message = 'Uncaught Exception:\n' + stack
-  return dialog.showErrorBox('A JavaScript error occurred in the main process', message)
+  dialog.showErrorBox('A JavaScript error occurred in the main process', message)
 })
 
 // Emit 'exit' event on quit.
 var app = require('electron').app
 
 app.on('quit', function (event, exitCode) {
-  return process.emit('exit', exitCode)
+  process.emit('exit', exitCode)
 })
 
 if (process.platform === 'win32') {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -273,7 +273,7 @@ ipcMain.on('ELECTRON_BROWSER_FUNCTION_CALL', function (event, id, args) {
   try {
     args = unwrapArgs(event.sender, args)
     let func = objectsRegistry.get(id)
-    return callFunction(event, func, global, args)
+    callFunction(event, func, global, args)
   } catch (error) {
     event.returnValue = exceptionToMeta(error)
   }
@@ -296,7 +296,7 @@ ipcMain.on('ELECTRON_BROWSER_MEMBER_CALL', function (event, id, method, args) {
   try {
     args = unwrapArgs(event.sender, args)
     let obj = objectsRegistry.get(id)
-    return callFunction(event, obj[method], obj, args)
+    callFunction(event, obj[method], obj, args)
   } catch (error) {
     event.returnValue = exceptionToMeta(error)
   }
@@ -322,7 +322,7 @@ ipcMain.on('ELECTRON_BROWSER_MEMBER_GET', function (event, id, name) {
 })
 
 ipcMain.on('ELECTRON_BROWSER_DEREFERENCE', function (event, id) {
-  return objectsRegistry.remove(event.sender.getId(), id)
+  objectsRegistry.remove(event.sender.getId(), id)
 })
 
 ipcMain.on('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, guestInstanceId) {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -59,8 +59,7 @@ deprecate.property = function (object, property, method) {
 
 // Deprecate an event.
 deprecate.event = function (emitter, oldName, newName, fn) {
-  var warned
-  warned = false
+  var warned = false
   return emitter.on(newName, function (...args) {
     // there is listeners for old API.
     if (this.listenerCount(oldName) > 0) {
@@ -69,9 +68,9 @@ deprecate.event = function (emitter, oldName, newName, fn) {
         deprecate.warn("'" + oldName + "' event", "'" + newName + "' event")
       }
       if (fn != null) {
-        return fn.apply(this, arguments)
+        fn.apply(this, arguments)
       } else {
-        return this.emit.apply(this, [oldName].concat(args))
+        this.emit.apply(this, [oldName].concat(args))
       }
     }
   })

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -30,7 +30,7 @@ exports.getSources = function (options, callback) {
   ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, id)
   return ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function (event, sources) {
     var source
-    return callback(null, (function () {
+    callback(null, (function () {
       var i, len, results
       results = []
       for (i = 0, len = sources.length; i < len; i++) {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -238,12 +238,12 @@ var metaToPlainObject = function (meta) {
 
 // Browser calls a callback in renderer.
 ipcRenderer.on('ELECTRON_RENDERER_CALLBACK', function (event, id, args) {
-  return callbacksRegistry.apply(id, metaToValue(args))
+  callbacksRegistry.apply(id, metaToValue(args))
 })
 
 // A callback in browser is released.
 ipcRenderer.on('ELECTRON_RENDERER_RELEASE_CALLBACK', function (event, id) {
-  return callbacksRegistry.remove(id)
+  callbacksRegistry.remove(id)
 })
 
 // List all built-in modules in browser process.

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -3,7 +3,7 @@ window.onload = function () {
   window.InspectorFrontendHost.showContextMenuAtPoint = createMenu
 
   // Use dialog API to override file chooser dialog.
-  return (window.WebInspector.createFileSelectorElement = createFileSelectorElement)
+  window.WebInspector.createFileSelectorElement = createFileSelectorElement
 }
 
 var convertToMenuTemplate = function (items) {

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -193,7 +193,7 @@ ipcRenderer.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId, m
   event.data = message
   event.origin = sourceOrigin
   event.source = BrowserWindowProxy.getOrCreate(sourceId)
-  return window.dispatchEvent(event)
+  window.dispatchEvent(event)
 })
 
 // Forward history operations to browser.

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -62,14 +62,14 @@ var dispatchEvent = function (webView, eventName, eventKey, ...args) {
 module.exports = {
   registerEvents: function (webView, viewInstanceId) {
     ipcRenderer.on('ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + viewInstanceId, function (event, eventName, ...args) {
-      return dispatchEvent.apply(null, [webView, eventName, eventName].concat(args))
+      dispatchEvent.apply(null, [webView, eventName, eventName].concat(args))
     })
 
     ipcRenderer.on('ELECTRON_GUEST_VIEW_INTERNAL_IPC_MESSAGE-' + viewInstanceId, function (event, channel, ...args) {
       var domEvent = new Event('ipc-message')
       domEvent.channel = channel
       domEvent.args = args
-      return webView.dispatchEvent(domEvent)
+      webView.dispatchEvent(domEvent)
     })
 
     return ipcRenderer.on('ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + viewInstanceId, function (event, ...args) {
@@ -80,7 +80,7 @@ module.exports = {
         f = ref1[i]
         domEvent[f] = args[i]
       }
-      return webView.onSizeChanged(domEvent)
+      webView.onSizeChanged(domEvent)
     })
   },
   deregisterEvents: function (viewInstanceId) {


### PR DESCRIPTION
Clean up the old CoffeeScript auto-generated `return` statements in functions registered via `on` or `once`.

These functions are never expected to return anything so it should be possible to remove them without any side-effects or backwards compatibility issues.