### PR TITLE
Feed Windows APIs with ICO icons of appropriate size

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -142,7 +142,8 @@ void Tray::PopUpContextMenu(mate::Arguments* args) {
   tray_icon_->PopUpContextMenu(pos, menu.IsEmpty() ? nullptr : menu->model());
 }
 
-void Tray::SetContextMenu(Menu* menu) {
+void Tray::SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu) {
+  menu_.Reset(isolate, menu.ToV8());
   tray_icon_->SetContextMenu(menu->model());
 }
 
@@ -168,7 +169,7 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setHighlightMode", &Tray::SetHighlightMode)
       .SetMethod("displayBalloon", &Tray::DisplayBalloon)
       .SetMethod("popUpContextMenu", &Tray::PopUpContextMenu)
-      .SetMethod("_setContextMenu", &Tray::SetContextMenu);
+      .SetMethod("setContextMenu", &Tray::SetContextMenu);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -97,7 +97,6 @@ void Tray::OnDragEnded() {
 }
 
 void Tray::SetImage(v8::Isolate* isolate, mate::Handle<NativeImage> image) {
-  image_.Reset(isolate, image.ToV8());
 #if defined(OS_WIN)
   tray_icon_->SetImage(image->GetHICON(GetSystemMetrics(SM_CXSMICON)));
 #else
@@ -107,7 +106,6 @@ void Tray::SetImage(v8::Isolate* isolate, mate::Handle<NativeImage> image) {
 
 void Tray::SetPressedImage(v8::Isolate* isolate,
                            mate::Handle<NativeImage> image) {
-  pressed_image_.Reset(isolate, image.ToV8());
 #if defined(OS_WIN)
   tray_icon_->SetPressedImage(image->GetHICON(GetSystemMetrics(SM_CXSMICON)));
 #else

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -24,13 +24,8 @@ namespace atom {
 namespace api {
 
 Tray::Tray(v8::Isolate* isolate, mate::Handle<NativeImage> image)
-    : image_(isolate, image.ToV8()),
-      tray_icon_(TrayIcon::Create()) {
-#if defined(OS_WIN)
-  tray_icon_->SetImage(image->GetHICON());
-#else
-  tray_icon_->SetImage(image->image());
-#endif
+    : tray_icon_(TrayIcon::Create()) {
+  SetImage(isolate, image);
   tray_icon_->AddObserver(this);
 }
 
@@ -104,7 +99,7 @@ void Tray::OnDragEnded() {
 void Tray::SetImage(v8::Isolate* isolate, mate::Handle<NativeImage> image) {
   image_.Reset(isolate, image.ToV8());
 #if defined(OS_WIN)
-  tray_icon_->SetImage(image->GetHICON());
+  tray_icon_->SetImage(image->GetHICON(GetSystemMetrics(SM_CXSMICON)));
 #else
   tray_icon_->SetImage(image->image());
 #endif
@@ -114,7 +109,7 @@ void Tray::SetPressedImage(v8::Isolate* isolate,
                            mate::Handle<NativeImage> image) {
   pressed_image_.Reset(isolate, image.ToV8());
 #if defined(OS_WIN)
-  tray_icon_->SetPressedImage(image->GetHICON());
+  tray_icon_->SetPressedImage(image->GetHICON(GetSystemMetrics(SM_CXSMICON)));
 #else
   tray_icon_->SetPressedImage(image->image());
 #endif
@@ -145,7 +140,8 @@ void Tray::DisplayBalloon(mate::Arguments* args,
 
 #if defined(OS_WIN)
   tray_icon_->DisplayBalloon(
-      icon.IsEmpty() ? NULL : icon->GetHICON(), title, content);
+      icon.IsEmpty() ? NULL : icon->GetHICON(GetSystemMetrics(SM_CXSMICON)),
+      title, content);
 #else
   tray_icon_->DisplayBalloon(
       icon.IsEmpty() ? gfx::Image() : icon->image(), title, content);

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -69,8 +69,6 @@ class Tray : public mate::TrackableObject<Tray>,
  private:
   v8::Local<v8::Object> ModifiersToObject(v8::Isolate* isolate, int modifiers);
 
-  v8::Global<v8::Object> image_;
-  v8::Global<v8::Object> pressed_image_;
   v8::Global<v8::Object> menu_;
   scoped_ptr<TrayIcon> tray_icon_;
 

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -64,13 +64,14 @@ class Tray : public mate::TrackableObject<Tray>,
   void SetHighlightMode(bool highlight);
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
   void PopUpContextMenu(mate::Arguments* args);
-  void SetContextMenu(Menu* menu);
+  void SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu);
 
  private:
   v8::Local<v8::Object> ModifiersToObject(v8::Isolate* isolate, int modifiers);
 
   v8::Global<v8::Object> image_;
   v8::Global<v8::Object> pressed_image_;
+  v8::Global<v8::Object> menu_;
   scoped_ptr<TrayIcon> tray_icon_;
 
   DISALLOW_COPY_AND_ASSIGN(Tray);

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -11,6 +11,7 @@
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/ui/tray_icon_observer.h"
 #include "base/memory/scoped_ptr.h"
+#include "native_mate/handle.h"
 
 namespace gfx {
 class Image;
@@ -28,18 +29,19 @@ class TrayIcon;
 namespace api {
 
 class Menu;
+class NativeImage;
 
 class Tray : public mate::TrackableObject<Tray>,
              public TrayIconObserver {
  public:
   static mate::WrappableBase* New(
-      v8::Isolate* isolate, const gfx::Image& image);
+      v8::Isolate* isolate, mate::Handle<NativeImage> image);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);
 
  protected:
-  Tray(v8::Isolate* isolate, const gfx::Image& image);
+  Tray(v8::Isolate* isolate, mate::Handle<NativeImage> image);
   ~Tray() override;
 
   // TrayIconObserver:
@@ -55,18 +57,20 @@ class Tray : public mate::TrackableObject<Tray>,
   void OnDragExited() override;
   void OnDragEnded() override;
 
-  void SetImage(mate::Arguments* args, const gfx::Image& image);
-  void SetPressedImage(mate::Arguments* args, const gfx::Image& image);
-  void SetToolTip(mate::Arguments* args, const std::string& tool_tip);
-  void SetTitle(mate::Arguments* args, const std::string& title);
-  void SetHighlightMode(mate::Arguments* args, bool highlight);
+  void SetImage(v8::Isolate* isolate, mate::Handle<NativeImage> image);
+  void SetPressedImage(v8::Isolate* isolate, mate::Handle<NativeImage> image);
+  void SetToolTip(const std::string& tool_tip);
+  void SetTitle(const std::string& title);
+  void SetHighlightMode(bool highlight);
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
   void PopUpContextMenu(mate::Arguments* args);
-  void SetContextMenu(mate::Arguments* args, Menu* menu);
+  void SetContextMenu(Menu* menu);
 
  private:
   v8::Local<v8::Object> ModifiersToObject(v8::Isolate* isolate, int modifiers);
 
+  v8::Global<v8::Object> image_;
+  v8::Global<v8::Object> pressed_image_;
   scoped_ptr<TrayIcon> tray_icon_;
 
   DISALLOW_COPY_AND_ASSIGN(Tray);

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -9,6 +9,7 @@
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window.h"
+#include "atom/common/api/atom_api_native_image.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
@@ -99,6 +100,15 @@ Window::Window(v8::Isolate* isolate, const mate::Dictionary& options) {
   window_->InitFromOptions(options);
   window_->AddObserver(this);
   AttachAsUserData(window_.get());
+
+#if defined(OS_WIN)
+  // Sets the window icon.
+  mate::Handle<NativeImage> icon;
+  if (options.Get(options::kIcon, &icon) && !icon.IsEmpty()) {
+    static_cast<NativeWindowViews*>(window_.get())->SetIcon(
+        icon->GetHICON(GetSystemMetrics(SM_CXSMICON)), icon->GetHICON(256));
+  }
+#endif
 }
 
 Window::~Window() {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -14,6 +14,7 @@
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/native_window_observer.h"
+#include "atom/common/api/atom_api_native_image.h"
 #include "native_mate/handle.h"
 
 class GURL;
@@ -170,6 +171,10 @@ class Window : public mate::TrackableObject<Window>,
 
 #if defined(OS_MACOSX)
   void ShowDefinitionForSelection();
+#endif
+
+#if defined(TOOLKIT_VIEWS)
+  void SetIcon(mate::Handle<NativeImage> icon);
 #endif
 
   void SetVisibleOnAllWorkspaces(bool visible);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -65,9 +65,6 @@ NativeWindow::NativeWindow(
   // mode.
   ui::GpuSwitchingManager::SetTransparent(transparent_);
 
-  // Read icon before window is created.
-  options.Get(options::kIcon, &icon_);
-
   WindowList::AddWindow(this);
 }
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -12,7 +12,6 @@
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/window_list.h"
 #include "atom/common/api/api_messages.h"
-#include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/options_switches.h"
 #include "base/files/file_util.h"

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -251,7 +251,6 @@ class NativeWindow : public base::SupportsUserData,
   bool transparent() const { return transparent_; }
   SkRegion* draggable_region() const { return draggable_region_.get(); }
   bool enable_larger_than_screen() const { return enable_larger_than_screen_; }
-  gfx::ImageSkia icon() const { return icon_; }
 
   void set_has_dialog_attached(bool has_dialog_attached) {
     has_dialog_attached_ = has_dialog_attached;
@@ -306,9 +305,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Whether window can be resized larger than screen.
   bool enable_larger_than_screen_;
-
-  // Window icon.
-  gfx::ImageSkia icon_;
 
   // The windows has been closed.
   bool is_closed_;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -221,6 +221,10 @@ NativeWindowViews::NativeWindowViews(
   std::string window_type;
   if (options.Get(options::kType, &window_type))
     SetWindowType(GetAcceleratedWidget(), window_type);
+
+  // Set window icon.
+  options.Get(options::kIcon, &icon_);
+  window_->UpdateWindowIcon();
 #endif
 
   // Add web view.
@@ -273,7 +277,6 @@ NativeWindowViews::NativeWindowViews(
       use_content_size_)
     size = ContentSizeToWindowSize(size);
 
-  window_->UpdateWindowIcon();
   window_->CenterWindow(size);
   Layout();
 }
@@ -842,13 +845,15 @@ bool NativeWindowViews::ShouldHandleSystemCommands() const {
   return true;
 }
 
+#if defined(USE_X11)
 gfx::ImageSkia NativeWindowViews::GetWindowAppIcon() {
-  return icon();
+  return icon_;
 }
 
 gfx::ImageSkia NativeWindowViews::GetWindowIcon() {
   return GetWindowAppIcon();
 }
+#endif
 
 views::Widget* NativeWindowViews::GetWidget() {
   return window_.get();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -11,6 +11,7 @@
 #include "atom/browser/ui/views/menu_layout.h"
 #include "atom/common/color_util.h"
 #include "atom/common/draggable_region.h"
+#include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/options_switches.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/inspectable_web_contents.h"
@@ -40,6 +41,7 @@
 #include "chrome/browser/ui/libgtk2ui/unity_service.h"
 #include "ui/base/x/x11_util.h"
 #include "ui/gfx/x/x11_types.h"
+#include "ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h"
 #include "ui/views/window/native_frame_view.h"
 #elif defined(OS_WIN)
 #include "atom/browser/ui/views/win_frame_view.h"
@@ -221,10 +223,6 @@ NativeWindowViews::NativeWindowViews(
   std::string window_type;
   if (options.Get(options::kType, &window_type))
     SetWindowType(GetAcceleratedWidget(), window_type);
-
-  // Set window icon.
-  options.Get(options::kIcon, &icon_);
-  window_->UpdateWindowIcon();
 #endif
 
   // Add web view.
@@ -781,6 +779,13 @@ gfx::AcceleratedWidget NativeWindowViews::GetAcceleratedWidget() {
   return GetNativeWindow()->GetHost()->GetAcceleratedWidget();
 }
 
+void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
+  views::DesktopWindowTreeHostX11* tree_host =
+      views::DesktopWindowTreeHostX11::GetHostForXID(GetAcceleratedWidget());
+  static_cast<views::DesktopWindowTreeHost*>(tree_host)->SetWindowIcons(
+      icon, icon);
+}
+
 void NativeWindowViews::OnWidgetActivationChanged(
     views::Widget* widget, bool active) {
   if (widget != window_.get())
@@ -844,16 +849,6 @@ base::string16 NativeWindowViews::GetWindowTitle() const {
 bool NativeWindowViews::ShouldHandleSystemCommands() const {
   return true;
 }
-
-#if defined(USE_X11)
-gfx::ImageSkia NativeWindowViews::GetWindowAppIcon() {
-  return icon_;
-}
-
-gfx::ImageSkia NativeWindowViews::GetWindowIcon() {
-  return GetWindowAppIcon();
-}
-#endif
 
 views::Widget* NativeWindowViews::GetWidget() {
   return window_.get();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -779,12 +779,22 @@ gfx::AcceleratedWidget NativeWindowViews::GetAcceleratedWidget() {
   return GetNativeWindow()->GetHost()->GetAcceleratedWidget();
 }
 
+#if defined(OS_WIN)
+void NativeWindowViews::SetIcon(HICON small_icon, HICON app_icon) {
+  HWND hwnd = GetAcceleratedWidget();
+  SendMessage(hwnd, WM_SETICON, ICON_SMALL,
+              reinterpret_cast<LPARAM>(small_icon));
+  SendMessage(hwnd, WM_SETICON, ICON_BIG,
+              reinterpret_cast<LPARAM>(app_icon));
+}
+#elif defined(USE_X11)
 void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
   views::DesktopWindowTreeHostX11* tree_host =
       views::DesktopWindowTreeHostX11::GetHostForXID(GetAcceleratedWidget());
   static_cast<views::DesktopWindowTreeHost*>(tree_host)->SetWindowIcons(
       icon, icon);
 }
+#endif
 
 void NativeWindowViews::OnWidgetActivationChanged(
     views::Widget* widget, bool active) {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -106,11 +106,15 @@ class NativeWindowViews : public NativeWindow,
 
 #if defined(OS_WIN)
   void SetIcon(HICON small_icon, HICON app_icon);
-
-  TaskbarHost& taskbar_host() { return taskbar_host_; }
+#elif defined(USE_X11)
+  void SetIcon(const gfx::ImageSkia& icon);
 #endif
 
   views::Widget* widget() const { return window_.get(); }
+
+#if defined(OS_WIN)
+  TaskbarHost& taskbar_host() { return taskbar_host_; }
+#endif
 
  private:
   // views::WidgetObserver:
@@ -127,10 +131,6 @@ class NativeWindowViews : public NativeWindow,
   bool CanMinimize() const override;
   base::string16 GetWindowTitle() const override;
   bool ShouldHandleSystemCommands() const override;
-#if defined(USE_X11)
-  gfx::ImageSkia GetWindowAppIcon() override;
-  gfx::ImageSkia GetWindowIcon() override;
-#endif
   views::Widget* GetWidget() override;
   const views::Widget* GetWidget() const override;
   views::View* GetContentsView() override;
@@ -188,9 +188,6 @@ class NativeWindowViews : public NativeWindow,
   // we need to make sure size constraints are restored when window becomes
   // resizable again.
   extensions::SizeConstraints old_size_constraints_;
-
-  // Window icon.
-  gfx::ImageSkia icon_;
 #elif defined(OS_WIN)
   // Weak ref.
   AtomDesktopWindowTreeHostWin* atom_desktop_window_tree_host_win_;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -104,11 +104,13 @@ class NativeWindowViews : public NativeWindow,
 
   gfx::AcceleratedWidget GetAcceleratedWidget() override;
 
-  views::Widget* widget() const { return window_.get(); }
-
 #if defined(OS_WIN)
+  void SetIcon(HICON small_icon, HICON app_icon);
+
   TaskbarHost& taskbar_host() { return taskbar_host_; }
 #endif
+
+  views::Widget* widget() const { return window_.get(); }
 
  private:
   // views::WidgetObserver:
@@ -125,8 +127,10 @@ class NativeWindowViews : public NativeWindow,
   bool CanMinimize() const override;
   base::string16 GetWindowTitle() const override;
   bool ShouldHandleSystemCommands() const override;
+#if defined(USE_X11)
   gfx::ImageSkia GetWindowAppIcon() override;
   gfx::ImageSkia GetWindowIcon() override;
+#endif
   views::Widget* GetWidget() override;
   const views::Widget* GetWidget() const override;
   views::View* GetContentsView() override;
@@ -145,7 +149,6 @@ class NativeWindowViews : public NativeWindow,
   // MessageHandlerDelegate:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
-
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
 #endif
 
@@ -185,6 +188,9 @@ class NativeWindowViews : public NativeWindow,
   // we need to make sure size constraints are restored when window becomes
   // resizable again.
   extensions::SizeConstraints old_size_constraints_;
+
+  // Window icon.
+  gfx::ImageSkia icon_;
 #elif defined(OS_WIN)
   // Weak ref.
   AtomDesktopWindowTreeHostWin* atom_desktop_window_tree_host_win_;
@@ -202,7 +208,6 @@ class NativeWindowViews : public NativeWindow,
 
   // If true we have enabled a11y
   bool enabled_a11y_support_;
-
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -73,6 +73,14 @@ const char* AppCommandToString(int command_id) {
 
 }  // namespace
 
+void NativeWindowViews::SetIcon(HICON small_icon, HICON app_icon) {
+  HWND hwnd = GetAcceleratedWidget();
+  SendMessage(hwnd, WM_SETICON, ICON_SMALL,
+              reinterpret_cast<LPARAM>(small_icon));
+  SendMessage(hwnd, WM_SETICON, ICON_BIG,
+              reinterpret_cast<LPARAM>(app_icon));
+}
+
 bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {
   std::string command = AppCommandToString(command_id);
   NotifyWindowExecuteWindowsCommand(command);

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -73,14 +73,6 @@ const char* AppCommandToString(int command_id) {
 
 }  // namespace
 
-void NativeWindowViews::SetIcon(HICON small_icon, HICON app_icon) {
-  HWND hwnd = GetAcceleratedWidget();
-  SendMessage(hwnd, WM_SETICON, ICON_SMALL,
-              reinterpret_cast<LPARAM>(small_icon));
-  SendMessage(hwnd, WM_SETICON, ICON_BIG,
-              reinterpret_cast<LPARAM>(app_icon));
-}
-
 bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {
   std::string command = AppCommandToString(command_id);
   NotifyWindowExecuteWindowsCommand(command);

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -12,7 +12,7 @@ TrayIcon::TrayIcon() {
 TrayIcon::~TrayIcon() {
 }
 
-void TrayIcon::SetPressedImage(const gfx::Image& image) {
+void TrayIcon::SetPressedImage(ImageType image) {
 }
 
 void TrayIcon::SetTitle(const std::string& title) {
@@ -21,7 +21,7 @@ void TrayIcon::SetTitle(const std::string& title) {
 void TrayIcon::SetHighlightMode(bool highlight) {
 }
 
-void TrayIcon::DisplayBalloon(const gfx::Image& icon,
+void TrayIcon::DisplayBalloon(ImageType icon,
                               const base::string16& title,
                               const base::string16& contents) {
 }

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -19,13 +19,19 @@ class TrayIcon {
  public:
   static TrayIcon* Create();
 
+#if defined(OS_WIN)
+  using ImageType = HICON;
+#else
+  using ImageType = const gfx::Image&;
+#endif
+
   virtual ~TrayIcon();
 
   // Sets the image associated with this status icon.
-  virtual void SetImage(const gfx::Image& image) = 0;
+  virtual void SetImage(ImageType image) = 0;
 
   // Sets the image associated with this status icon when pressed.
-  virtual void SetPressedImage(const gfx::Image& image);
+  virtual void SetPressedImage(ImageType image);
 
   // Sets the hover text for this status icon. This is also used as the label
   // for the menu item which is created as a replacement for the status icon
@@ -43,7 +49,7 @@ class TrayIcon {
 
   // Displays a notification balloon with the specified contents.
   // Depending on the platform it might not appear by the icon tray.
-  virtual void DisplayBalloon(const gfx::Image& icon,
+  virtual void DisplayBalloon(ImageType icon,
                               const base::string16& title,
                               const base::string16& contents);
 

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -9,7 +9,6 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/windows_version.h"
 #include "third_party/skia/include/core/SkBitmap.h"
-#include "ui/gfx/icon_util.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/geometry/point.h"
 #include "ui/gfx/geometry/rect.h"
@@ -26,6 +25,7 @@ NotifyIcon::NotifyIcon(NotifyIconHost* host,
       icon_id_(id),
       window_(window),
       message_id_(message),
+      icon_(NULL),
       menu_model_(NULL) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
@@ -80,7 +80,7 @@ void NotifyIcon::ResetIcon() {
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_MESSAGE;
   icon_data.uCallbackMessage = message_id_;
-  icon_data.hIcon = icon_.get();
+  icon_data.hIcon = icon_;
   // If we have an image, then set the NIF_ICON flag, which tells
   // Shell_NotifyIcon() to set the image for the status icon it creates.
   if (icon_data.hIcon)
@@ -91,19 +91,19 @@ void NotifyIcon::ResetIcon() {
     LOG(WARNING) << "Unable to re-create status tray icon.";
 }
 
-void NotifyIcon::SetImage(const gfx::Image& image) {
+void NotifyIcon::SetImage(HICON image) {
   // Create the icon.
+  icon_ = image;
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_ICON;
-  icon_ = IconUtil::CreateHICONFromSkBitmap(image.AsBitmap());
-  icon_data.hIcon = icon_.get();
+  icon_data.hIcon = image;
   BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);
   if (!result)
     LOG(WARNING) << "Error setting status tray icon image";
 }
 
-void NotifyIcon::SetPressedImage(const gfx::Image& image) {
+void NotifyIcon::SetPressedImage(HICON image) {
   // Ignore pressed images, since the standard on Windows is to not highlight
   // pressed status icons.
 }
@@ -119,7 +119,7 @@ void NotifyIcon::SetToolTip(const std::string& tool_tip) {
     LOG(WARNING) << "Unable to set tooltip for status tray icon";
 }
 
-void NotifyIcon::DisplayBalloon(const gfx::Image& icon,
+void NotifyIcon::DisplayBalloon(HICON icon,
                                 const base::string16& title,
                                 const base::string16& contents) {
   NOTIFYICONDATA icon_data;
@@ -129,13 +129,8 @@ void NotifyIcon::DisplayBalloon(const gfx::Image& icon,
   wcsncpy_s(icon_data.szInfoTitle, title.c_str(), _TRUNCATE);
   wcsncpy_s(icon_data.szInfo, contents.c_str(), _TRUNCATE);
   icon_data.uTimeout = 0;
-
-  base::win::Version win_version = base::win::GetVersion();
-  if (!icon.IsEmpty() && win_version != base::win::VERSION_PRE_XP) {
-    balloon_icon_ = IconUtil::CreateHICONFromSkBitmap(icon.AsBitmap());
-    icon_data.hBalloonIcon = balloon_icon_.get();
-    icon_data.dwInfoFlags = NIIF_USER | NIIF_LARGE_ICON;
-  }
+  icon_data.hBalloonIcon = icon;
+  icon_data.dwInfoFlags = NIIF_USER | NIIF_LARGE_ICON;
 
   BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);
   if (!result)

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -25,7 +25,6 @@ NotifyIcon::NotifyIcon(NotifyIconHost* host,
       icon_id_(id),
       window_(window),
       message_id_(message),
-      icon_(NULL),
       menu_model_(NULL) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
@@ -80,7 +79,7 @@ void NotifyIcon::ResetIcon() {
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_MESSAGE;
   icon_data.uCallbackMessage = message_id_;
-  icon_data.hIcon = icon_;
+  icon_data.hIcon = icon_.get();
   // If we have an image, then set the NIF_ICON flag, which tells
   // Shell_NotifyIcon() to set the image for the status icon it creates.
   if (icon_data.hIcon)
@@ -92,8 +91,9 @@ void NotifyIcon::ResetIcon() {
 }
 
 void NotifyIcon::SetImage(HICON image) {
+  icon_ = base::win::ScopedHICON(CopyIcon(image));
+
   // Create the icon.
-  icon_ = image;
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_ICON;

--- a/atom/browser/ui/win/notify_icon.h
+++ b/atom/browser/ui/win/notify_icon.h
@@ -14,6 +14,7 @@
 #include "base/macros.h"
 #include "base/compiler_specific.h"
 #include "base/memory/scoped_ptr.h"
+#include "base/win/scoped_gdi_object.h"
 
 namespace gfx {
 class Point;
@@ -70,7 +71,7 @@ class NotifyIcon : public TrayIcon {
   UINT message_id_;
 
   // The currently-displayed icon for the window.
-  HICON icon_;
+  base::win::ScopedHICON icon_;
 
   // The context menu.
   ui::SimpleMenuModel* menu_model_;

--- a/atom/browser/ui/win/notify_icon.h
+++ b/atom/browser/ui/win/notify_icon.h
@@ -14,7 +14,6 @@
 #include "base/macros.h"
 #include "base/compiler_specific.h"
 #include "base/memory/scoped_ptr.h"
-#include "base/win/scoped_gdi_object.h"
 
 namespace gfx {
 class Point;
@@ -45,10 +44,10 @@ class NotifyIcon : public TrayIcon {
   UINT message_id() const { return message_id_; }
 
   // Overridden from TrayIcon:
-  void SetImage(const gfx::Image& image) override;
-  void SetPressedImage(const gfx::Image& image) override;
+  void SetImage(HICON image) override;
+  void SetPressedImage(HICON image) override;
   void SetToolTip(const std::string& tool_tip) override;
-  void DisplayBalloon(const gfx::Image& icon,
+  void DisplayBalloon(HICON icon,
                       const base::string16& title,
                       const base::string16& contents) override;
   void PopUpContextMenu(const gfx::Point& pos,
@@ -71,10 +70,7 @@ class NotifyIcon : public TrayIcon {
   UINT message_id_;
 
   // The currently-displayed icon for the window.
-  base::win::ScopedHICON icon_;
-
-  // The currently-displayed icon for the notification balloon.
-  base::win::ScopedHICON balloon_icon_;
+  HICON icon_;
 
   // The context menu.
   ui::SimpleMenuModel* menu_model_;

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -341,6 +341,35 @@ void NativeImage::BuildPrototype(
 
 }  // namespace atom
 
+namespace mate {
+
+v8::Local<v8::Value> Converter<mate::Handle<atom::api::NativeImage>>::ToV8(
+    v8::Isolate* isolate,
+    const mate::Handle<atom::api::NativeImage>& val) {
+  return val.ToV8();
+}
+
+bool Converter<mate::Handle<atom::api::NativeImage>>::FromV8(
+    v8::Isolate* isolate, v8::Local<v8::Value> val,
+    mate::Handle<atom::api::NativeImage>* out) {
+  // Try converting from file path.
+  base::FilePath path;
+  if (ConvertFromV8(isolate, val, &path)) {
+    *out = atom::api::NativeImage::CreateFromPath(isolate, path);
+    // Should throw when failed to initialize from path.
+    return !(*out)->image().IsEmpty();
+  }
+
+  WrappableBase* wrapper = static_cast<WrappableBase*>(internal::FromV8Impl(
+      isolate, val));
+  if (!wrapper)
+    return false;
+
+  *out = CreateHandle(isolate, static_cast<atom::api::NativeImage*>(wrapper));
+  return true;
+}
+
+}  // namespace mate
 
 namespace {
 

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -4,6 +4,10 @@
 
 #include "atom/common/api/atom_api_native_image.h"
 
+#if defined(OS_WIN)
+#include <commctrl.h>
+#endif
+
 #include <string>
 #include <vector>
 
@@ -155,9 +159,9 @@ base::win::ScopedHICON ReadICOFromPath(const base::FilePath& path) {
   }
 
   // Load the icon from file.
-  return base::win::ScopedHICON(static_cast<HICON>(
-      LoadImage(NULL, image_path.value().c_str(), IMAGE_ICON, 0, 0,
-                LR_DEFAULTSIZE | LR_LOADFROMFILE)));
+  HICON icon = NULL;
+  LoadIconMetric(NULL, image_path.value().c_str(), LIM_SMALL, &icon);
+  return base::win::ScopedHICON(icon);
 }
 
 void ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon) {

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -295,22 +295,21 @@ mate::Handle<NativeImage> NativeImage::CreateFromJPEG(
 mate::Handle<NativeImage> NativeImage::CreateFromPath(
     v8::Isolate* isolate, const base::FilePath& path) {
   base::FilePath image_path = NormalizePath(path);
-  if (image_path.MatchesExtension(FILE_PATH_LITERAL(".ico"))) {
 #if defined(OS_WIN)
+  if (image_path.MatchesExtension(FILE_PATH_LITERAL(".ico"))) {
     return mate::CreateHandle(isolate,
                               new NativeImage(isolate, image_path));
-#endif
-  } else {
-    gfx::ImageSkia image_skia;
-    PopulateImageSkiaRepsFromPath(&image_skia, image_path);
-    gfx::Image image(image_skia);
-    mate::Handle<NativeImage> handle = Create(isolate, image);
-#if defined(OS_MACOSX)
-    if (IsTemplateFilename(image_path))
-      handle->SetTemplateImage(true);
-#endif
-    return handle;
   }
+#endif
+  gfx::ImageSkia image_skia;
+  PopulateImageSkiaRepsFromPath(&image_skia, image_path);
+  gfx::Image image(image_skia);
+  mate::Handle<NativeImage> handle = Create(isolate, image);
+#if defined(OS_MACOSX)
+  if (IsTemplateFilename(image_path))
+    handle->SetTemplateImage(true);
+#endif
+  return handle;
 }
 
 // static

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -11,6 +11,10 @@
 #include "native_mate/wrappable.h"
 #include "ui/gfx/image/image.h"
 
+#if defined(OS_WIN)
+#include "base/win/scoped_gdi_object.h"
+#endif
+
 class GURL;
 
 namespace base {
@@ -52,6 +56,9 @@ class NativeImage : public mate::Wrappable<NativeImage> {
 
  protected:
   NativeImage(v8::Isolate* isolate, const gfx::Image& image);
+#if defined(OS_WIN)
+  NativeImage(v8::Isolate* isolate, base::win::ScopedHICON&& hicon);
+#endif
   ~NativeImage() override;
 
  private:
@@ -68,6 +75,10 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   void SetTemplateImage(bool setAsTemplate);
   // Determine if the image is a template image.
   bool IsTemplateImage();
+
+#if defined(OS_WIN)
+  base::win::ScopedHICON hicon_;
+#endif
 
   gfx::Image image_;
 

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -53,6 +53,9 @@ class NativeImage : public mate::Wrappable<NativeImage> {
                              v8::Local<v8::ObjectTemplate> prototype);
 
   const gfx::Image& image() const { return image_; }
+#if defined(OS_WIN)
+  HICON hicon() const { return hicon_.get(); }
+#endif
 
  protected:
   NativeImage(v8::Isolate* isolate, const gfx::Image& image);
@@ -88,5 +91,20 @@ class NativeImage : public mate::Wrappable<NativeImage> {
 }  // namespace api
 
 }  // namespace atom
+
+namespace mate {
+
+// A custom converter that allows converting path to NativeImage.
+template<>
+struct Converter<mate::Handle<atom::api::NativeImage>> {
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      const mate::Handle<atom::api::NativeImage>& val);
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+                     mate::Handle<atom::api::NativeImage>* out);
+};
+
+}  // namespace mate
+
 
 #endif  // ATOM_COMMON_API_ATOM_API_NATIVE_IMAGE_H_

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_COMMON_API_ATOM_API_NATIVE_IMAGE_H_
 #define ATOM_COMMON_API_ATOM_API_NATIVE_IMAGE_H_
 
+#include <map>
 #include <string>
 
 #include "native_mate/handle.h"
@@ -12,6 +13,7 @@
 #include "ui/gfx/image/image.h"
 
 #if defined(OS_WIN)
+#include "base/files/file_path.h"
 #include "base/win/scoped_gdi_object.h"
 #endif
 
@@ -53,7 +55,7 @@ class NativeImage : public mate::Wrappable<NativeImage> {
                              v8::Local<v8::ObjectTemplate> prototype);
 
 #if defined(OS_WIN)
-  HICON GetHICON();
+  HICON GetHICON(int size);
 #endif
 
   const gfx::Image& image() const { return image_; }
@@ -61,7 +63,7 @@ class NativeImage : public mate::Wrappable<NativeImage> {
  protected:
   NativeImage(v8::Isolate* isolate, const gfx::Image& image);
 #if defined(OS_WIN)
-  NativeImage(v8::Isolate* isolate, base::win::ScopedHICON&& hicon);
+  NativeImage(v8::Isolate* isolate, const base::FilePath& hicon_path);
 #endif
   ~NativeImage() override;
 
@@ -81,7 +83,8 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   bool IsTemplateImage();
 
 #if defined(OS_WIN)
-  base::win::ScopedHICON hicon_;
+  base::FilePath hicon_path_;
+  std::map<int, base::win::ScopedHICON> hicons_;
 #endif
 
   gfx::Image image_;

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -52,10 +52,11 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);
 
-  const gfx::Image& image() const { return image_; }
 #if defined(OS_WIN)
-  HICON hicon() const { return hicon_.get(); }
+  HICON GetHICON();
 #endif
+
+  const gfx::Image& image() const { return image_; }
 
  protected:
   NativeImage(v8::Isolate* isolate, const gfx::Image& image);

--- a/atom/common/native_mate_converters/image_converter.cc
+++ b/atom/common/native_mate_converters/image_converter.cc
@@ -28,16 +28,8 @@ bool Converter<gfx::Image>::FromV8(v8::Isolate* isolate,
     return true;
 
   Handle<atom::api::NativeImage> native_image;
-  if (!ConvertFromV8(isolate, val, &native_image)) {
-    // Try converting from file path.
-    base::FilePath path;
-    if (!Converter<base::FilePath>::FromV8(isolate, val, &path))
-      return false;
-
-    native_image = atom::api::NativeImage::CreateFromPath(isolate, path);
-    if (native_image->image().IsEmpty())
-      return false;
-  }
+  if (!ConvertFromV8(isolate, val, &native_image))
+    return false;
 
   *out = native_image->image();
   return true;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -886,6 +886,12 @@ The `flags` is an array that can include following `String`s:
 
 Shows pop-up dictionary that searches the selected word on the page.
 
+### `win.setIcon(icon)` _Windows_ _Linux_
+
+* `icon` [NativeImage](native-image.md)
+
+Changes window icon.
+
 ### `win.setAutoHideMenuBar(hide)`
 
 * `hide` Boolean

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -65,8 +65,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     `false`.
   * `kiosk` Boolean - The kiosk mode. Default is `false`.
   * `title` String - Default window title. Default is `"Electron"`.
-  * `icon` [NativeImage](native-image.md) - The window icon, when omitted on
-    Windows the executable's icon would be used as window icon.
+  * `icon` [NativeImage](native-image.md) - The window icon. On Windows it is
+    recommended to use `ICO` icons to get best visual effects, you can also
+    leave it undefined so the executable's icon will be used.
   * `show` Boolean - Whether window should be shown when created. Default is
     `true`.
   * `frame` Boolean - Specify `false` to create a

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -25,7 +25,12 @@ const appIcon = new Tray(image);
 Currently `PNG` and `JPEG` image formats are supported. `PNG` is recommended
 because of its support for transparency and lossless compression.
 
-On Windows, you can also load an `ICO` icon from a file path.
+On Windows, you can also load `ICO` icons from file paths, to get best visual
+effects it is recommended to include at least followings sizes in the icon:
+
+* 16x16
+* 32x32
+* 256x256
 
 ## High Resolution Image
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -29,6 +29,7 @@ __Platform limitations:__
 * When app indicator is used on Linux, the `click` event is ignored.
 * On Linux in order for changes made to individual `MenuItem`s to take effect,
   you have to call `setContextMenu` again. For example:
+* On Windows it is recommended to use `ICO` icons to get best visual effects.
 
 ```javascript
 contextMenu.items[2].checked = false;

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -3,11 +3,4 @@ const {Tray} = process.atomBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
 
-Tray.prototype.setContextMenu = function (menu) {
-  this._setContextMenu(menu)
-
-  // Keep a strong reference of menu.
-  this.menu = menu
-}
-
 module.exports = Tray


### PR DESCRIPTION
This PR refactors the NativeImage code, so when a win32 API asks for icon, the raw HICON with appropriate size is passed.

Also adds `BrowserWindow.setIcon` API as extra benefit of the refactor.

Close #2248.
Close #3839.