### PR TITLE
Use ### for env var headings

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -19,36 +19,36 @@ on Windows console:
 > electron
 ```
 
-## `ELECTRON_RUN_AS_NODE`
+### `ELECTRON_RUN_AS_NODE`
 
 Starts the process as a normal Node.js process.
 
-## `ELECTRON_ENABLE_LOGGING`
+### `ELECTRON_ENABLE_LOGGING`
 
 Prints Chrome's internal logging to console.
 
-## `ELECTRON_LOG_ASAR_READS`
+### `ELECTRON_LOG_ASAR_READS`
 
 When Electron reads from an ASAR file, log the read offset and file path to
 the system `tmpdir`. The resulting file can be provided to the ASAR module
 to optimize file ordering.
 
-## `ELECTRON_ENABLE_STACK_DUMPING`
+### `ELECTRON_ENABLE_STACK_DUMPING`
 
 When Electron crashed, prints the stack trace to console.
 
 This environment variable will not work if `crashReporter` is started.
 
-## `ELECTRON_DEFAULT_ERROR_MODE` _Windows_
+### `ELECTRON_DEFAULT_ERROR_MODE` _Windows_
 
 Shows Windows's crash dialog when Electron crashed.
 
 This environment variable will not work if `crashReporter` is started.
 
-## `ELECTRON_NO_ATTACH_CONSOLE` _Windows_
+### `ELECTRON_NO_ATTACH_CONSOLE` _Windows_
 
 Don't attach to current console session.
 
-## `ELECTRON_FORCE_WINDOW_MENU_BAR` _Linux_
+### `ELECTRON_FORCE_WINDOW_MENU_BAR` _Linux_
 
 Don't use global menu bar on Linux.

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -35,7 +35,7 @@ to optimize file ordering.
 
 ### `ELECTRON_ENABLE_STACK_DUMPING`
 
-When Electron crashes, prints the stack trace to the console.
+Prints the stack trace to the console when Electron crashes.
 
 This environment variable will not work if the `crashReporter` is started.
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -25,7 +25,7 @@ Starts the process as a normal Node.js process.
 
 ### `ELECTRON_ENABLE_LOGGING`
 
-Prints Chrome's internal logging to console.
+Prints Chrome's internal logging to the console.
 
 ### `ELECTRON_LOG_ASAR_READS`
 
@@ -35,20 +35,20 @@ to optimize file ordering.
 
 ### `ELECTRON_ENABLE_STACK_DUMPING`
 
-When Electron crashed, prints the stack trace to console.
+When Electron crashes, prints the stack trace to the console.
 
-This environment variable will not work if `crashReporter` is started.
+This environment variable will not work if the `crashReporter` is started.
 
 ### `ELECTRON_DEFAULT_ERROR_MODE` _Windows_
 
-Shows Windows's crash dialog when Electron crashed.
+Shows the Windows's crash dialog when Electron crashes.
 
-This environment variable will not work if `crashReporter` is started.
+This environment variable will not work if the `crashReporter` is started.
 
 ### `ELECTRON_NO_ATTACH_CONSOLE` _Windows_
 
-Don't attach to current console session.
+Don't attach to the current console session.
 
 ### `ELECTRON_FORCE_WINDOW_MENU_BAR` _Linux_
 
-Don't use global menu bar on Linux.
+Don't use the global menu bar on Linux.

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -2,8 +2,8 @@
 
 > Control application configuration and behavior without changing code.
 
-Some behaviors of Electron are controlled by environment variables, because they
-are initialized earlier than command line and the app's code.
+Certain Electron behaviors are controlled by environment variables because they
+are initialized earlier than the command line flags and the app's code.
 
 Examples on POSIX shells:
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -5,14 +5,14 @@
 Certain Electron behaviors are controlled by environment variables because they
 are initialized earlier than the command line flags and the app's code.
 
-Examples on POSIX shells:
+POSIX shell example:
 
 ```bash
 $ export ELECTRON_ENABLE_LOGGING=true
 $ electron
 ```
 
-on Windows console:
+Windows console example:
 
 ```powershell
 > set ELECTRON_ENABLE_LOGGING=true


### PR DESCRIPTION
Makes them consistency with other docs and will be styled consistently on http://electron.atom.io/docs/

Also some minor wording updates.