### PR TITLE
renderer: generate net error strings when requested

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -18,6 +18,7 @@
 #include "atom/renderer/guest_view_container.h"
 #include "atom/renderer/node_array_buffer_bridge.h"
 #include "base/command_line.h"
+#include "base/strings/utf_string_conversions.h"
 #include "chrome/renderer/media/chrome_key_systems.h"
 #include "chrome/renderer/pepper/pepper_helper.h"
 #include "chrome/renderer/printing/print_web_view_helper.h"
@@ -28,6 +29,7 @@
 #include "content/public/renderer/render_thread.h"
 #include "content/public/renderer/render_view.h"
 #include "ipc/ipc_message_macros.h"
+#include "net/base/net_errors.h"
 #include "third_party/WebKit/public/web/WebCustomElement.h"
 #include "third_party/WebKit/public/web/WebFrameWidget.h"
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
@@ -250,6 +252,18 @@ content::BrowserPluginDelegate* AtomRendererClient::CreateBrowserPluginDelegate(
 void AtomRendererClient::AddKeySystems(
     std::vector<media::KeySystemInfo>* key_systems) {
   AddChromeKeySystems(key_systems);
+}
+
+void AtomRendererClient::GetNavigationErrorStrings(
+    content::RenderFrame* render_frame,
+    const blink::WebURLRequest& failed_request,
+    const blink::WebURLError& error,
+    std::string* error_html,
+    base::string16* error_description) {
+  if (!error_description)
+    return;
+
+  *error_description = base::UTF8ToUTF16(net::ErrorToShortString(error.reason));
 }
 
 }  // namespace atom

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -58,6 +58,11 @@ class AtomRendererClient : public content::ContentRendererClient,
       const std::string& mime_type,
       const GURL& original_url) override;
   void AddKeySystems(std::vector<media::KeySystemInfo>* key_systems) override;
+  void GetNavigationErrorStrings(content::RenderFrame* render_frame,
+                                 const blink::WebURLRequest& failed_request,
+                                 const blink::WebURLError& error,
+                                 std::string* error_html,
+                                 base::string16* error_description) override;
 
   scoped_ptr<NodeBindings> node_bindings_;
   scoped_ptr<AtomBindings> atom_bindings_;

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -148,6 +148,7 @@ describe('browser-window module', function () {
     it('should emit did-fail-load event for files that do not exist', function (done) {
       w.webContents.on('did-fail-load', function (event, code, desc, url, isMainFrame) {
         assert.equal(code, -6)
+        assert.equal(desc, 'ERR_FILE_NOT_FOUND')
         assert.equal(isMainFrame, true)
         done()
       })


### PR DESCRIPTION
Fixes #5619 