### PR TITLE
browser: flags to control iwa enabled server whitelist

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -375,12 +375,6 @@ void App::SetDesktopName(const std::string& desktop_name) {
 #endif
 }
 
-void App::AllowNTLMCredentialsForAllDomains(bool should_allow) {
-  auto browser_context = static_cast<AtomBrowserContext*>(
-        AtomBrowserMainParts::Get()->browser_context());
-  browser_context->AllowNTLMCredentialsForAllDomains(should_allow);
-}
-
 std::string App::GetLocale() {
   return l10n_util::GetApplicationLocale("");
 }
@@ -482,8 +476,6 @@ void App::BuildPrototype(
       .SetMethod("setPath", &App::SetPath)
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("setDesktopName", &App::SetDesktopName)
-      .SetMethod("allowNTLMCredentialsForAllDomains",
-                 &App::AllowNTLMCredentialsForAllDomains)
       .SetMethod("getLocale", &App::GetLocale)
 #if defined(USE_NSS_CERTS)
       .SetMethod("importCertificate", &App::ImportCertificate)

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -106,7 +106,6 @@ class App : public AtomBrowserClient::Delegate,
                const base::FilePath& path);
 
   void SetDesktopName(const std::string& desktop_name);
-  void AllowNTLMCredentialsForAllDomains(bool should_allow);
   bool MakeSingleInstance(
       const ProcessSingleton::NotificationCallback& callback);
   std::string GetLocale();

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -79,6 +79,7 @@ class Session: public mate::TrackableObject<Session>,
   void SetPermissionRequestHandler(v8::Local<v8::Value> val,
                                    mate::Arguments* args);
   void ClearHostResolverCache(mate::Arguments* args);
+  void AllowNTLMCredentialsForDomains(const std::string& domains);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
   v8::Local<v8::Value> WebRequest(v8::Isolate* isolate);
 

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -67,8 +67,7 @@ AtomBrowserContext::AtomBrowserContext(const std::string& partition,
     : brightray::BrowserContext(partition, in_memory),
       cert_verifier_(new AtomCertVerifier),
       job_factory_(new AtomURLRequestJobFactory),
-      network_delegate_(new AtomNetworkDelegate),
-      allow_ntlm_everywhere_(false) {
+      network_delegate_(new AtomNetworkDelegate) {
 }
 
 AtomBrowserContext::~AtomBrowserContext() {
@@ -193,16 +192,6 @@ void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
   pref_registry->RegisterFilePathPref(prefs::kDownloadDefaultDirectory,
                                       download_dir);
   pref_registry->RegisterDictionaryPref(prefs::kDevToolsFileSystemPaths);
-}
-
-bool AtomBrowserContext::AllowNTLMCredentialsForDomain(const GURL& origin) {
-  if (allow_ntlm_everywhere_)
-    return true;
-  return Delegate::AllowNTLMCredentialsForDomain(origin);
-}
-
-void AtomBrowserContext::AllowNTLMCredentialsForAllDomains(bool should_allow) {
-  allow_ntlm_everywhere_ = should_allow;
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -33,7 +33,6 @@ class AtomBrowserContext : public brightray::BrowserContext {
       const base::FilePath& base_path) override;
   scoped_ptr<net::CertVerifier> CreateCertVerifier() override;
   net::SSLConfigService* CreateSSLConfigService() override;
-  bool AllowNTLMCredentialsForDomain(const GURL& auth_origin) override;
 
   // content::BrowserContext:
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;
@@ -42,8 +41,6 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // brightray::BrowserContext:
   void RegisterPrefs(PrefRegistrySimple* pref_registry) override;
-
-  void AllowNTLMCredentialsForAllDomains(bool should_allow);
 
   AtomCertVerifier* cert_verifier() const { return cert_verifier_; }
 
@@ -60,8 +57,6 @@ class AtomBrowserContext : public brightray::BrowserContext {
   AtomCertVerifier* cert_verifier_;
   AtomURLRequestJobFactory* job_factory_;
   AtomNetworkDelegate* network_delegate_;
-
-  bool allow_ntlm_everywhere_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserContext);
 };

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -443,16 +443,6 @@ Adds `tasks` to the [Tasks][tasks] category of the JumpList on Windows.
   consists of two or more icons, set this value to identify the icon. If an
   icon file consists of one icon, this value is 0.
 
-### `app.allowNTLMCredentialsForAllDomains()`
-
-Dynamically sets whether to always send credentials for HTTP NTLM or Negotiate
-authentication - normally, Electron will only send NTLM/Kerberos credentials for
-URLs that fall under "Local Intranet" sites (i.e. are in the same domain as you).
-However, this detection often fails when corporate networks are badly configured,
-so this lets you co-opt this behavior and enable it for all URLs.
-
-**Note:** This method should be called before the `ready` event gets emitted.
-
 ### `app.makeSingleInstance(callback)`
 
 * `callback` Function

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -443,15 +443,15 @@ Adds `tasks` to the [Tasks][tasks] category of the JumpList on Windows.
   consists of two or more icons, set this value to identify the icon. If an
   icon file consists of one icon, this value is 0.
 
-### `app.allowNTLMCredentialsForAllDomains(allow)`
-
-* `allow` Boolean
+### `app.allowNTLMCredentialsForAllDomains()`
 
 Dynamically sets whether to always send credentials for HTTP NTLM or Negotiate
 authentication - normally, Electron will only send NTLM/Kerberos credentials for
 URLs that fall under "Local Intranet" sites (i.e. are in the same domain as you).
 However, this detection often fails when corporate networks are badly configured,
 so this lets you co-opt this behavior and enable it for all URLs.
+
+**Note:** This method should be called before the `ready` event gets emitted.
 
 ### `app.makeSingleInstance(callback)`
 

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -95,6 +95,24 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
+## --auth-server-whitelist=`url`
+
+A comma-separated list of servers for which integrated authentication is enabled.
+
+For example:
+
+```
+--auth-server-whitelist='*example.com, *foobar.com, *baz'
+```
+
+then any `url` ending with `example.com`, `foobar.com`, `baz` will be considered
+for integrated authentication. Without `*` prefix the url has to match exactly.
+
+## --auth-negotiate-delegate-whitelist=`url`
+
+A comma-separated list of servers for which delegation of user credentials is required.
+Without `*` prefix the url has to match exactly.
+
 ## --ignore-certificate-errors
 
 Ignores certificate related errors.

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -323,6 +323,23 @@ session.fromPartition(partition).setPermissionRequestHandler((webContents, permi
 
 Clears the host resolver cache.
 
+#### `ses.allowNTLMCredentialsForDomains(domains)`
+
+* `domains` String - A comma-seperated list of servers for which
+  integrated authentication is enabled.
+
+Dynamically sets whether to always send credentials for HTTP NTLM or Negotiate
+authentication.
+
+```javascript
+// consider any url ending with `example.com`, `foobar.com`, `baz`
+// for integrated authentication.
+session.defaultSession.allowNTLMCredentialsForDomains('*example.com, *foobar.com, *baz')
+
+// consider all urls for integrated authentication.
+session.defaultSession.allowNTLMCredentialsForDomains('*')
+```
+
 #### `ses.webRequest`
 
 The `webRequest` API set allows to intercept and modify contents of a request at

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {Menu} = require('electron')
+const {deprecate, Menu, session} = require('electron')
 const {EventEmitter} = require('events')
 
 const bindings = process.atomBinding('app')
@@ -22,9 +22,6 @@ Object.assign(app, {
   commandLine: {
     appendSwitch: bindings.appendSwitch,
     appendArgument: bindings.appendArgument
-  },
-  allowNTLMCredentialsForAllDomains () {
-    this.commandLine.appendSwitch('auth-server-whitelist', '*')
   }
 })
 
@@ -41,6 +38,18 @@ if (process.platform === 'darwin') {
     show: bindings.dockShow,
     setMenu: bindings.dockSetMenu,
     setIcon: bindings.dockSetIcon
+  }
+}
+
+app.allowNTLMCredentialsForAllDomains = function (allow) {
+  if (!process.noDeprecations) {
+    deprecate.warn('app.allowNTLMCredentialsForAllDomains', 'session.allowNTLMCredentialsForDomains')
+  }
+  let domains = allow ? '*' : ''
+  if (!this.isReady()) {
+    this.commandLine.appendSwitch('auth-server-whitelist', domains)
+  } else {
+    session.defaultSession.allowNTLMCredentialsForDomains(domains)
   }
 }
 

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -22,6 +22,9 @@ Object.assign(app, {
   commandLine: {
     appendSwitch: bindings.appendSwitch,
     appendArgument: bindings.appendArgument
+  },
+  allowNTLMCredentialsForAllDomains () {
+    this.commandLine.appendSwitch('auth-server-whitelist', '*')
   }
 })
 


### PR DESCRIPTION
Since v0.37 there is no `URLSecurityManager` directly configured by brightray, instead we need to set the whitelist with `HttpAuthPreferences`. This makes `app.allowNTLMCredentialsForAllDomains` obsolete, have introduced flags which mimic chromes' behavior. This will be a breaking change. Also should `DisableAuthNegotiateCnameLookup` and `EnableAuthNegotiatePort` be added ? 

Ref https://www.chromium.org/developers/design-documents/http-authentication

Fixes https://github.com/electron/electron/issues/4825

Depends on https://github.com/electron/brightray/pull/223

/cc @paulcbetts 