### PR TITLE
Always return internal module when requiring electron

### DIFF
--- a/lib/common/asar_init.js
+++ b/lib/common/asar_init.js
@@ -1,6 +1,6 @@
 ;(function () {
   return function (process, require, asarSource) {
-    // Make asar.coffee accessible via "require".
+    // Make asar.js accessible via "require".
     process.binding('natives').ELECTRON_ASAR = asarSource
 
     // Monkey-patch the fs module.

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -4,7 +4,7 @@ const Module = require('module')
 // Clear Node's global search paths.
 Module.globalPaths.length = 0
 
-// Clear current and parent(init.coffee)'s search paths.
+// Clear current and parent(init.js)'s search paths.
 module.paths = []
 
 module.parent.paths = []

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -20,7 +20,9 @@ Module._nodeModulePaths = function (from) {
   const paths = []
   const parts = from.split(splitRe)
 
-  for (let tip = i = parts.length - 1; i >= 0; tip = i += -1) {
+  let tip
+  let i
+  for (tip = i = parts.length - 1; i >= 0; tip = i += -1) {
     const part = parts[tip]
     if (part === 'node_modules') {
       continue

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -17,7 +17,7 @@ Module._nodeModulePaths = function (from) {
   // If "from" is outside the app then we do nothing.
   skipOutsidePaths = from.startsWith(process.resourcesPath)
 
-  // Following logoic is copied from module.js.
+  // Following logic is copied from module.js.
   splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//
   paths = []
   parts = from.split(splitRe)
@@ -33,4 +33,14 @@ Module._nodeModulePaths = function (from) {
     paths.push(path.join(dir, 'node_modules'))
   }
   return paths
+}
+
+const electronPath = path.join(__dirname, '..', process.type, 'api', 'exports', 'electron.js')
+const originalResolveFilename = Module._resolveFilename
+Module._resolveFilename = function (request, parent, isMain) {
+  if (request === 'electron') {
+    return electronPath
+  } else {
+    return originalResolveFilename(request, parent, isMain)
+  }
 }

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -36,6 +36,8 @@ Module._nodeModulePaths = function (from) {
   return paths
 }
 
+// Patch Module._resolveFilename to always require the Electron API when
+// require('electron') is done.
 const electronPath = path.join(__dirname, '..', process.type, 'api', 'exports', 'electron.js')
 const originalResolveFilename = Module._resolveFilename
 Module._resolveFilename = function (request, parent, isMain) {

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -6,27 +6,26 @@ Module.globalPaths.length = 0
 
 // Clear current and parent(init.js)'s search paths.
 module.paths = []
-
 module.parent.paths = []
 
 // Prevent Node from adding paths outside this app to search paths.
 Module._nodeModulePaths = function (from) {
-  var dir, i, part, parts, paths, skipOutsidePaths, splitRe, tip
   from = path.resolve(from)
 
   // If "from" is outside the app then we do nothing.
-  skipOutsidePaths = from.startsWith(process.resourcesPath)
+  const skipOutsidePaths = from.startsWith(process.resourcesPath)
 
   // Following logic is copied from module.js.
-  splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//
-  paths = []
-  parts = from.split(splitRe)
-  for (tip = i = parts.length - 1; i >= 0; tip = i += -1) {
-    part = parts[tip]
+  const splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//
+  const paths = []
+  const parts = from.split(splitRe)
+
+  for (let tip = i = parts.length - 1; i >= 0; tip = i += -1) {
+    const part = parts[tip]
     if (part === 'node_modules') {
       continue
     }
-    dir = parts.slice(0, tip + 1).join(path.sep)
+    const dir = parts.slice(0, tip + 1).join(path.sep)
     if (skipOutsidePaths && !dir.startsWith(process.resourcesPath)) {
       break
     }

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -3,10 +3,9 @@ const ChildProcess = require('child_process')
 const https = require('https')
 const fs = require('fs')
 const path = require('path')
-const remote = require('electron').remote
+const {remote} = require('electron')
 
-const app = remote.require('electron').app
-const BrowserWindow = remote.require('electron').BrowserWindow
+const {app, BrowserWindow, ipcMain} = remote
 const isCI = remote.getGlobal('isCi')
 
 describe('electron module', function () {
@@ -15,6 +14,36 @@ describe('electron module', function () {
       require('clipboard')
     }, /Cannot find module 'clipboard'/)
   })
+
+  describe('require("electron")', function () {
+    let window = null
+
+    beforeEach(function () {
+      if (window != null) {
+        window.destroy()
+      }
+      window = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400
+      })
+    })
+
+    afterEach(function () {
+      if (window != null) {
+        window.destroy()
+      }
+      window = null
+    })
+
+    it('always returns the internal electron module', function (done) {
+      ipcMain.once('answer', function () {
+        done()
+      })
+      window.loadURL('file://' + path.join(__dirname, 'fixtures', 'api', 'electron-module-app', 'index.html'))
+    })
+  })
+
 })
 
 describe('app module', function () {

--- a/spec/fixtures/api/electron-module-app/index.html
+++ b/spec/fixtures/api/electron-module-app/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title></title>
     <script>
+      require('foo').bar()
       require('electron').ipcRenderer.send('answer')
     </script>
   </head>

--- a/spec/fixtures/api/electron-module-app/index.html
+++ b/spec/fixtures/api/electron-module-app/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <script>
+      require('electron').ipcRenderer.send('answer')
+    </script>
+  </head>
+  <body>
+
+  </body>
+</html>

--- a/spec/fixtures/api/electron-module-app/node_modules/electron/package.json
+++ b/spec/fixtures/api/electron-module-app/node_modules/electron/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron",
+  "main": "index.js"
+}

--- a/spec/fixtures/api/electron-module-app/node_modules/foo/index.js
+++ b/spec/fixtures/api/electron-module-app/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+exports.bar = function () {}

--- a/spec/fixtures/api/electron-module-app/node_modules/foo/package.json
+++ b/spec/fixtures/api/electron-module-app/node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foo",
+  "main": "index.js"
+}

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -4,7 +4,6 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 const {remote} = require('electron')
-const {BrowserWindow, ipcMain} = remote
 
 describe('node feature', function () {
   var fixtures = path.join(__dirname, 'fixtures')
@@ -227,35 +226,6 @@ describe('node feature', function () {
   describe('vm.createContext', function () {
     it('should not crash', function () {
       require('vm').runInNewContext('')
-    })
-  })
-
-  describe('require("electron")', function () {
-    let window = null
-
-    beforeEach(function () {
-      if (window != null) {
-        window.destroy()
-      }
-      window = new BrowserWindow({
-        show: false,
-        width: 400,
-        height: 400
-      })
-    })
-
-    afterEach(function () {
-      if (window != null) {
-        window.destroy()
-      }
-      window = null
-    })
-
-    it('always returns the internal electron module', function (done) {
-      ipcMain.once('answer', function () {
-        done()
-      })
-      window.loadURL('file://' + path.join(__dirname, 'fixtures', 'api', 'electron-module-app', 'index.html'))
     })
   })
 })

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -230,7 +230,7 @@ describe('node feature', function () {
     })
   })
 
-  describe.only('require("electron")', function () {
+  describe('require("electron")', function () {
     let window = null
 
     beforeEach(function () {

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -3,7 +3,8 @@ const child_process = require('child_process')
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
-const remote = require('electron').remote
+const {remote} = require('electron')
+const {BrowserWindow, ipcMain} = remote
 
 describe('node feature', function () {
   var fixtures = path.join(__dirname, 'fixtures')
@@ -226,6 +227,35 @@ describe('node feature', function () {
   describe('vm.createContext', function () {
     it('should not crash', function () {
       require('vm').runInNewContext('')
+    })
+  })
+
+  describe.only('require("electron")', function () {
+    let window = null
+
+    beforeEach(function () {
+      if (window != null) {
+        window.destroy()
+      }
+      window = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400
+      })
+    })
+
+    afterEach(function () {
+      if (window != null) {
+        window.destroy()
+      }
+      window = null
+    })
+
+    it('always returns the internal electron module', function (done) {
+      ipcMain.once('answer', function () {
+        done()
+      })
+      window.loadURL('file://' + path.join(__dirname, 'fixtures', 'api', 'electron-module-app', 'index.html'))
     })
   })
 })


### PR DESCRIPTION
We are seeing several reports of errors like `TypeError: Cannot read property 'on' of undefined` on the object returned from `require('electron').app`.

This appears to be because people are accidentally (or on purpose) running `npm install electron` inside their apps which then makes `require('electron')` return the [electron npm module](https://www.npmjs.com/package/electron) instead of the internal Electron module with all the expected properties.

Then things like the quick start app and other examples will not work since none of the properties are present and the stack trace appears confusing when they open issues.

This pull request patches `Module._resolveFilename` to always return the internal Electron module when running `require('electron')`. This seems to be consistent with node's other built-ins like `fs`, `path`, etc. that can't be overridden and always return the internal versions when required even when their is a local module by that name in the app's `node_modules/` folder.

Here is an example issue: https://github.com/electron/electron-quick-start/issues/53

/cc @electron/maintainers

Closes #3708