### PR TITLE
Add a Windows script to just invoke cibuild

### DIFF
--- a/script/cibuild.ps1
+++ b/script/cibuild.ps1
@@ -1,0 +1,2 @@
+$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+& python "$scriptPath/cibuild"


### PR DESCRIPTION
This PR adds a cibuild script that just punts to the python one, so that we can build Electron with the latest version of [Surf](https://github.com/surf-build/surf)