### PR TITLE
Handle rejection of remote promises

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -91,7 +91,9 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
   } else if (meta.type === 'buffer') {
     meta.value = Array.prototype.slice.call(value, 0)
   } else if (meta.type === 'promise') {
-    meta.then = valueToMeta(sender, function (v) { value.then(v) })
+    meta.then = valueToMeta(sender, function (onFulfilled, onRejected) {
+      value.then(onFulfilled, onRejected)
+    })
   } else if (meta.type === 'error') {
     meta.members = plainObjectToMeta(value)
 

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -47,7 +47,9 @@ var wrapArgs = function (args, visited) {
       if (value.constructor != null && value.constructor.name === 'Promise') {
         return {
           type: 'promise',
-          then: valueToMeta(function (v) { value.then(v) })
+          then: valueToMeta(function (onFulfilled, onRejected) {
+            value.then(onFulfilled, onRejected)
+          })
         }
       } else if (v8Util.getHiddenValue(value, 'atomId')) {
         return {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -106,6 +106,22 @@ describe('ipc module', function () {
         done()
       })
     })
+
+    it('handles rejections via catch(onRejected)', function (done) {
+      var promise = remote.require(path.join(fixtures, 'module', 'rejected-promise.js'))
+      promise.reject(Promise.resolve(1234)).catch(function (error) {
+        assert.equal(error.message, 'rejected')
+        done()
+      })
+    })
+
+    it('handles rejections via then(onFulfilled, onRejected)', function (done) {
+      var promise = remote.require(path.join(fixtures, 'module', 'rejected-promise.js'))
+      promise.reject(Promise.resolve(1234)).then(function () {}, function (error) {
+        assert.equal(error.message, 'rejected')
+        done()
+      })
+    })
   })
 
   describe('remote webContents', function () {

--- a/spec/fixtures/module/rejected-promise.js
+++ b/spec/fixtures/module/rejected-promise.js
@@ -1,0 +1,5 @@
+exports.reject = function (promise) {
+  return promise.then(function () {
+    throw Error('rejected')
+  })
+}


### PR DESCRIPTION
I think https://github.com/electron/electron/commit/6de9c4332fdf85a1e7645b996be0c9534fcf0f4c introduced a regression where the `onRejected` handler was ignored in the RPC handler for promises since only the first argument, `v`, was used. Previously it passed a bound version of `then` which would have caused all arguments to be passed through.

This pull request adds an explicit second argument that will be passed to the proxied `Promise.then` calls.

Closes #5111