### PR TITLE
Tweak default app error handling

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -239,8 +239,8 @@ function loadApplicationPackage (packagePath) {
       try {
         packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
       } catch (e) {
-        showErrorMessage('Unable to parse package.json.\n\n' +
-          `${e.toString()} in ${packageJsonPath}`)
+        showErrorMessage(`Unable to parse ${packageJsonPath}\n\n${e.message}`)
+        return
       }
       if (packageJson.version) app.setVersion(packageJson.version)
 

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -259,7 +259,7 @@ function loadApplicationPackage (packagePath) {
     try {
       Module._resolveFilename(packagePath, module, true)
     } catch (e) {
-      showErrorMessage(`Unable to find Electron app at ${packagePath}.\n\n${e.message}`)
+      showErrorMessage(`Unable to find Electron app at ${packagePath}\n\n${e.message}`)
       return
     }
 

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -242,8 +242,10 @@ function loadApplicationPackage (packagePath) {
         showErrorMessage(`Unable to parse ${packageJsonPath}\n\n${e.message}`)
         return
       }
-      if (packageJson.version) app.setVersion(packageJson.version)
 
+      if (packageJson.version) {
+        app.setVersion(packageJson.version)
+      }
       if (packageJson.productName) {
         app.setName(packageJson.productName)
       } else if (packageJson.name) {

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -257,9 +257,10 @@ function loadApplicationPackage (packagePath) {
     try {
       Module._resolveFilename(packagePath, module, true)
     } catch (e) {
-      showErrorMessage('Unable to find Electron app.\n\n' +
-        `See: ${packagePath}`)
+      showErrorMessage(`Unable to find Electron app at ${packagePath}.\n\n${e.message}`)
+      return
     }
+
     // Run the app.
     Module._load(packagePath, module, true)
   } catch (e) {

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -266,13 +266,9 @@ function loadApplicationPackage (packagePath) {
     // Run the app.
     Module._load(packagePath, module, true)
   } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
-      showErrorMessage('Unable to open Electron app.\n\n' +
-        `${e.toString()}`)
-    } else {
-      console.error('App threw an error when running', e)
-      throw e
-    }
+    console.error('App threw an error during load')
+    console.error(e)
+    throw e
   }
 }
 

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -275,15 +275,7 @@ function loadApplicationPackage (packagePath) {
 
 function showErrorMessage (message) {
   app.focus()
-  dialog.showMessageBox({
-    message: 'Error opening app',
-    detail: message,
-    buttons: ['OK', 'Learn More']
-  }, (response) => {
-    if (response === 1) {
-      shell.openExternal('http://electron.atom.io/docs')
-    }
-  })
+  dialog.showErrorBox('Error launching app', message)
   process.exit(1)
 }
 

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -309,7 +309,7 @@ if (option.file && !option.webdriver) {
   console.log('v' + process.versions.electron)
   process.exit(0)
 } else if (option.help) {
-  const helpMessage = `Electron v${process.versions.electron} - Cross Platform Desktop Application Shell
+  const helpMessage = `Electron ${process.versions.electron} - Build cross platform desktop apps with JavaScript, HTML, and CSS
 
   Usage: electron [options] [path]
 

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -1,6 +1,7 @@
 const {app, dialog, shell, Menu} = require('electron')
 
 const fs = require('fs')
+const Module = require('module')
 const path = require('path')
 const repl = require('repl')
 const url = require('url')
@@ -222,7 +223,7 @@ app.once('ready', () => {
 })
 
 if (option.modules.length > 0) {
-  require('module')._preloadModules(option.modules)
+  Module._preloadModules(option.modules)
 }
 
 function loadApplicationPackage (packagePath) {
@@ -252,7 +253,7 @@ function loadApplicationPackage (packagePath) {
       app.setPath('userCache', path.join(app.getPath('cache'), app.getName()))
       app.setAppPath(packagePath)
     }
-    const Module = require('module')
+
     try {
       Module._resolveFilename(packagePath, module, true)
     } catch (e) {

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -309,8 +309,7 @@ if (option.file && !option.webdriver) {
 
   Usage: electron [options] [path]
 
-  A path to an Electron application may be specified.
-  The path must be one of the following:
+  A path to an Electron app may be specified. The path must be one of the following:
 
     - index.js file.
     - Folder containing a package.json file.

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -267,7 +267,7 @@ function loadApplicationPackage (packagePath) {
     Module._load(packagePath, module, true)
   } catch (e) {
     console.error('App threw an error during load')
-    console.error(e)
+    console.error(e.stack || e)
     throw e
   }
 }


### PR DESCRIPTION
Follow up to #5610 

@bigtimebuddy I originally gave you bad advice in your pull request, `dialog.showMessageBox` can only be used after the app `ready` event fires. So `dialog.showErrorBox` needs to be used as documented in http://electron.atom.io/docs/api/dialog/#dialogshowerrorboxtitle-content

This pull request switches it back to that but keeps the additional error checks.

<img width="532" alt="screen shot 2016-05-24 at 9 37 07 am" src="https://cloud.githubusercontent.com/assets/671378/15512419/ad2a7baa-2194-11e6-8b8e-4861a96eadf3.png">
