### PR TITLE
Remove ATOM_SHELL_INTERNAL_RUN_AS_NODE support

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -34,7 +34,6 @@
 namespace {
 
 const char* kRunAsNode = "ELECTRON_RUN_AS_NODE";
-const char* kOldRunAsNode = "ATOM_SHELL_INTERNAL_RUN_AS_NODE";
 
 bool IsEnvSet(const char* name) {
 #if defined(OS_WIN)
@@ -48,7 +47,7 @@ bool IsEnvSet(const char* name) {
 }
 
 bool IsRunAsNode() {
-  return IsEnvSet(kRunAsNode) || IsEnvSet(kOldRunAsNode);
+  return IsEnvSet(kRunAsNode);
 }
 
 }  // namespace


### PR DESCRIPTION
Should have been removed in #5373 but wasn't.

I think this is fine to remove now since the 1.0 [env var docs](http://electron.atom.io/docs/api/environment-variables/) went out with only mentioning [ELECTRON_RUN_AS_NODE](http://electron.atom.io/docs/api/environment-variables/#electronrunasnode)

Depends on https://github.com/electron/node/pull/15