### PR TITLE
Rename remaining Atom Shell references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 
 The Electron framework lets you write cross-platform desktop applications
 using JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and
-[Chromium](http://www.chromium.org) and is used in the [Atom
-editor](https://github.com/atom/atom).
+[Chromium](http://www.chromium.org) and is used by the [Atom
+editor](https://github.com/atom/atom) and many other [apps](http://electron.atom.io/apps).
 
 Follow [@ElectronJS](https://twitter.com/electronjs) on Twitter for important
 announcements.
 
 This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable
-behavior to atom@github.com.
+behavior to electron@github.com.
 
 ## Downloads
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![devDependency Status](https://david-dm.org/electron/electron/dev-status.svg)](https://david-dm.org/electron/electron#info=devDependencies)
 [![Join the Electron Community on Slack](http://atom-slack.herokuapp.com/badge.svg)](http://atom-slack.herokuapp.com/)
 
-:zap: *Formerly known as Atom Shell* :zap:
-
 The Electron framework lets you write cross-platform desktop applications
 using JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and
 [Chromium](http://www.chromium.org) and is used in the [Atom

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -105,7 +105,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     base::AtExitManager atexit_manager;
     base::i18n::InitializeICU();
     return atom::NodeMain(argc, argv);
-  } else if (IsEnvSet("ATOM_SHELL_INTERNAL_CRASH_SERVICE")) {
+  } else if (IsEnvSet("ELECTRON_INTERNAL_CRASH_SERVICE")) {
     return crash_service::Main(cmd);
   }
 

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -55,7 +55,7 @@ var CrashReporter = (function () {
     if (process.platform === 'win32') {
       args = ['--reporter-url=' + submitURL, '--application-name=' + this.productName, '--v=1']
       env = {
-        ATOM_SHELL_INTERNAL_CRASH_SERVICE: 1
+        ELECTRON_INTERNAL_CRASH_SERVICE: 1
       }
       spawn(process.execPath, args, {
         env: env,

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -7,7 +7,7 @@ import sys
 
 from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
                        enable_verbose_mode, is_verbose_mode, get_target_arch
-from lib.util import execute_stdout, get_atom_shell_version, scoped_cwd
+from lib.util import execute_stdout, get_electron_version, scoped_cwd
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -184,7 +184,7 @@ def update_node_modules(dirname, env=None):
 def update_electron_modules(dirname, target_arch):
   env = os.environ.copy()
   env['npm_config_arch']    = target_arch
-  env['npm_config_target']  = get_atom_shell_version()
+  env['npm_config_target']  = get_electron_version()
   env['npm_config_disturl'] = 'https://atom.io/download/atom-shell'
   update_node_modules(dirname, env)
 

--- a/script/build.py
+++ b/script/build.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 from lib.config import get_target_arch
-from lib.util import atom_gyp, import_vs_env
+from lib.util import electron_gyp, import_vs_env
 
 
 CONFIGURATIONS = ['Release', 'Debug']
@@ -40,7 +40,7 @@ def parse_args():
                       required=False)
   parser.add_argument('-t', '--target',
                       help='Build specified target',
-                      default=atom_gyp()['project_name%'],
+                      default=electron_gyp()['project_name%'],
                       required=False)
   return parser.parse_args()
 

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 
-from lib.util import execute, get_atom_shell_version, parse_version, scoped_cwd
+from lib.util import execute, get_electron_version, parse_version, scoped_cwd
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -18,7 +18,7 @@ def main():
   option = sys.argv[1]
   increments = ['major', 'minor', 'patch', 'build']
   if option in increments:
-    version = get_atom_shell_version()
+    version = get_electron_version()
     versions = parse_version(version.split('-')[0])
     versions = increase_version(versions, increments.index(option))
   else:

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -27,7 +27,7 @@ def main():
   version = '.'.join(versions[:3])
 
   with scoped_cwd(SOURCE_ROOT):
-    update_atom_gyp(version)
+    update_electron_gyp(version)
     update_win_rc(version, versions)
     update_version_h(versions)
     update_info_plist(version)
@@ -42,7 +42,7 @@ def increase_version(versions, index):
   return versions
 
 
-def update_atom_gyp(version):
+def update_electron_gyp(version):
   pattern = re.compile(" *'version%' *: *'[0-9.]+'")
   with open('electron.gyp', 'r') as f:
     lines = f.readlines()

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -11,11 +11,11 @@ import stat
 from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
                        get_target_arch, get_chromedriver_version, \
                        get_platform_key
-from lib.util import scoped_cwd, rm_rf, get_atom_shell_version, make_zip, \
+from lib.util import scoped_cwd, rm_rf, get_electron_version, make_zip, \
                      execute, atom_gyp
 
 
-ATOM_SHELL_VERSION = get_atom_shell_version()
+ELECTRON_VERSION = get_electron_version()
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 DIST_DIR = os.path.join(SOURCE_ROOT, 'dist')
@@ -86,7 +86,7 @@ def main():
   create_version()
   create_dist_zip()
   create_chrome_binary_zip('chromedriver', get_chromedriver_version())
-  create_chrome_binary_zip('mksnapshot', ATOM_SHELL_VERSION)
+  create_chrome_binary_zip('mksnapshot', ELECTRON_VERSION)
   create_ffmpeg_zip()
   create_symbols_zip()
 
@@ -140,7 +140,7 @@ def strip_binary(binary_path):
 def create_version():
   version_path = os.path.join(SOURCE_ROOT, 'dist', 'version')
   with open(version_path, 'w') as version_file:
-    version_file.write(ATOM_SHELL_VERSION)
+    version_file.write(ELECTRON_VERSION)
 
 
 def create_symbols():
@@ -155,7 +155,7 @@ def create_symbols():
 
 
 def create_dist_zip():
-  dist_name = '{0}-{1}-{2}-{3}.zip'.format(PROJECT_NAME, ATOM_SHELL_VERSION,
+  dist_name = '{0}-{1}-{2}-{3}.zip'.format(PROJECT_NAME, ELECTRON_VERSION,
                                            get_platform_key(),
                                            get_target_arch())
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
@@ -183,7 +183,7 @@ def create_chrome_binary_zip(binary, version):
 
 def create_ffmpeg_zip():
   dist_name = 'ffmpeg-{0}-{1}-{2}.zip'.format(
-      ATOM_SHELL_VERSION, get_platform_key(), get_target_arch())
+      ELECTRON_VERSION, get_platform_key(), get_target_arch())
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
 
   if PLATFORM == 'darwin':
@@ -205,7 +205,7 @@ def create_ffmpeg_zip():
 
 def create_symbols_zip():
   dist_name = '{0}-{1}-{2}-{3}-symbols.zip'.format(PROJECT_NAME,
-                                                   ATOM_SHELL_VERSION,
+                                                   ELECTRON_VERSION,
                                                    get_platform_key(),
                                                    get_target_arch())
   zip_file = os.path.join(DIST_DIR, dist_name)
@@ -217,7 +217,7 @@ def create_symbols_zip():
 
   if PLATFORM == 'darwin':
     dsym_name = '{0}-{1}-{2}-{3}-dsym.zip'.format(PROJECT_NAME,
-                                                  ATOM_SHELL_VERSION,
+                                                  ELECTRON_VERSION,
                                                   get_platform_key(),
                                                   get_target_arch())
     with scoped_cwd(DIST_DIR):

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -12,7 +12,7 @@ from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
                        get_target_arch, get_chromedriver_version, \
                        get_platform_key
 from lib.util import scoped_cwd, rm_rf, get_electron_version, make_zip, \
-                     execute, atom_gyp
+                     execute, electron_gyp
 
 
 ELECTRON_VERSION = get_electron_version()
@@ -23,8 +23,8 @@ OUT_DIR = os.path.join(SOURCE_ROOT, 'out', 'R')
 CHROMIUM_DIR = os.path.join(SOURCE_ROOT, 'vendor', 'brightray', 'vendor',
                             'download', 'libchromiumcontent', 'static_library')
 
-PROJECT_NAME = atom_gyp()['project_name%']
-PRODUCT_NAME = atom_gyp()['product_name%']
+PROJECT_NAME = electron_gyp()['project_name%']
+PRODUCT_NAME = electron_gyp()['product_name%']
 
 TARGET_BINARIES = {
   'darwin': [

--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from lib.config import PLATFORM
-from lib.util import atom_gyp, execute, rm_rf
+from lib.util import electron_gyp, execute, rm_rf
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -56,7 +56,7 @@ def register_required_dll():
 
 
 def get_names_from_gyp():
-  variables = atom_gyp()
+  variables = electron_gyp()
   return (variables['project_name%'], variables['product_name%'])
 
 

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -46,9 +46,10 @@ def get_chromedriver_version():
 
 
 def s3_config():
-  config = (os.environ.get('ELECTRON_S3_BUCKET', ''),
-            os.environ.get('ELECTRON_S3_ACCESS_KEY', ''),
-            os.environ.get('ELECTRON_S3_SECRET_KEY', ''))
+  # TODO Remove ATOM_SHELL_* fallback values
+  config = (os.environ.get('ELECTRON_S3_BUCKET', os.environ.get('ATOM_SHELL_S3_BUCKET', '')),
+            os.environ.get('ELECTRON_S3_ACCESS_KEY',  os.environ.get('ATOM_SHELL_S3_ACCESS_KEY', '')),
+            os.environ.get('ELECTRON_S3_SECRET_KEY', os.environ.get('ATOM_SHELL_S3_SECRET_KEY', '')))
   message = ('Error: Please set the $ELECTRON_S3_BUCKET, '
              '$ELECTRON_S3_ACCESS_KEY, and '
              '$ELECTRON_S3_SECRET_KEY environment variables')

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -44,12 +44,20 @@ def get_target_arch():
 def get_chromedriver_version():
   return 'v2.21'
 
+def get_env_var(name):
+  value = os.environ.get('ELECTRON_' + name, '')
+  if not value:
+    # TODO Remove ATOM_SHELL_* fallback values
+    value = os.environ.get('ATOM_SHELL_' + name, '')
+    if value:
+      print 'Warning: Use $ELECTRON_' + name + ' instead of $ATOM_SHELL_' + name
+  return value
+
 
 def s3_config():
-  # TODO Remove ATOM_SHELL_* fallback values
-  config = (os.environ.get('ELECTRON_S3_BUCKET', os.environ.get('ATOM_SHELL_S3_BUCKET', '')),
-            os.environ.get('ELECTRON_S3_ACCESS_KEY',  os.environ.get('ATOM_SHELL_S3_ACCESS_KEY', '')),
-            os.environ.get('ELECTRON_S3_SECRET_KEY', os.environ.get('ATOM_SHELL_S3_SECRET_KEY', '')))
+  config = (get_env_var('S3_BUCKET'),
+            get_env_var('S3_ACCESS_KEY'),
+            get_env_var('S3_SECRET_KEY'))
   message = ('Error: Please set the $ELECTRON_S3_BUCKET, '
              '$ELECTRON_S3_ACCESS_KEY, and '
              '$ELECTRON_S3_SECRET_KEY environment variables')

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -46,12 +46,12 @@ def get_chromedriver_version():
 
 
 def s3_config():
-  config = (os.environ.get('ATOM_SHELL_S3_BUCKET', ''),
-            os.environ.get('ATOM_SHELL_S3_ACCESS_KEY', ''),
-            os.environ.get('ATOM_SHELL_S3_SECRET_KEY', ''))
-  message = ('Error: Please set the $ATOM_SHELL_S3_BUCKET, '
-             '$ATOM_SHELL_S3_ACCESS_KEY, and '
-             '$ATOM_SHELL_S3_SECRET_KEY environment variables')
+  config = (os.environ.get('ELECTRON_S3_BUCKET', ''),
+            os.environ.get('ELECTRON_S3_ACCESS_KEY', ''),
+            os.environ.get('ELECTRON_S3_SECRET_KEY', ''))
+  message = ('Error: Please set the $ELECTRON_S3_BUCKET, '
+             '$ELECTRON_S3_ACCESS_KEY, and '
+             '$ELECTRON_S3_SECRET_KEY environment variables')
   assert all(len(c) for c in config), message
   return config
 

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -179,7 +179,7 @@ def execute_stdout(argv, env=os.environ):
     execute(argv, env)
 
 
-def atom_gyp():
+def electron_gyp():
   SOURCE_ROOT = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
   gyp = os.path.join(SOURCE_ROOT, 'electron.gyp')
   with open(gyp) as f:
@@ -188,7 +188,7 @@ def atom_gyp():
 
 
 def get_electron_version():
-  return 'v' + atom_gyp()['version%']
+  return 'v' + electron_gyp()['version%']
 
 
 def parse_version(version):

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -187,7 +187,7 @@ def atom_gyp():
     return obj['variables']
 
 
-def get_atom_shell_version():
+def get_electron_version():
   return 'v' + atom_gyp()['version%']
 
 

--- a/script/start.py
+++ b/script/start.py
@@ -4,13 +4,13 @@ import os
 import subprocess
 import sys
 
-from lib.util import atom_gyp
+from lib.util import electron_gyp
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
-PROJECT_NAME = atom_gyp()['project_name%']
-PRODUCT_NAME = atom_gyp()['product_name%']
+PROJECT_NAME = electron_gyp()['project_name%']
+PRODUCT_NAME = electron_gyp()['product_name%']
 
 
 def main():

--- a/script/test.py
+++ b/script/test.py
@@ -4,13 +4,13 @@ import os
 import subprocess
 import sys
 
-from lib.util import atom_gyp, rm_rf
+from lib.util import electron_gyp, rm_rf
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
-PROJECT_NAME = atom_gyp()['project_name%']
-PRODUCT_NAME = atom_gyp()['product_name%']
+PROJECT_NAME = electron_gyp()['project_name%']
+PRODUCT_NAME = electron_gyp()['product_name%']
 
 
 def main():

--- a/script/test.py
+++ b/script/test.py
@@ -21,18 +21,18 @@ def main():
     config = 'R'
 
   if sys.platform == 'darwin':
-    atom_shell = os.path.join(SOURCE_ROOT, 'out', config,
+    electron = os.path.join(SOURCE_ROOT, 'out', config,
                               '{0}.app'.format(PRODUCT_NAME), 'Contents',
                               'MacOS', PRODUCT_NAME)
   elif sys.platform == 'win32':
-    atom_shell = os.path.join(SOURCE_ROOT, 'out', config,
+    electron = os.path.join(SOURCE_ROOT, 'out', config,
                               '{0}.exe'.format(PROJECT_NAME))
   else:
-    atom_shell = os.path.join(SOURCE_ROOT, 'out', config, PROJECT_NAME)
+    electron = os.path.join(SOURCE_ROOT, 'out', config, PROJECT_NAME)
 
   returncode = 0
   try:
-    subprocess.check_call([atom_shell, 'spec'] + sys.argv[1:])
+    subprocess.check_call([electron, 'spec'] + sys.argv[1:])
   except subprocess.CalledProcessError as e:
     returncode = e.returncode
 

--- a/script/upload-index-json.py
+++ b/script/upload-index-json.py
@@ -4,14 +4,14 @@ import os
 import sys
 
 from lib.config import PLATFORM, s3_config
-from lib.util import atom_gyp, execute, s3put, scoped_cwd
+from lib.util import electron_gyp, execute, s3put, scoped_cwd
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 OUT_DIR     = os.path.join(SOURCE_ROOT, 'out', 'D')
 
-PROJECT_NAME = atom_gyp()['project_name%']
-PRODUCT_NAME = atom_gyp()['product_name%']
+PROJECT_NAME = electron_gyp()['project_name%']
+PRODUCT_NAME = electron_gyp()['product_name%']
 
 
 def main():

--- a/script/upload-index-json.py
+++ b/script/upload-index-json.py
@@ -18,14 +18,14 @@ def main():
   # Upload the index.json.
   with scoped_cwd(SOURCE_ROOT):
     if sys.platform == 'darwin':
-      atom_shell = os.path.join(OUT_DIR, '{0}.app'.format(PRODUCT_NAME),
+      electron = os.path.join(OUT_DIR, '{0}.app'.format(PRODUCT_NAME),
                                 'Contents', 'MacOS', PRODUCT_NAME)
     elif sys.platform == 'win32':
-      atom_shell = os.path.join(OUT_DIR, '{0}.exe'.format(PROJECT_NAME))
+      electron = os.path.join(OUT_DIR, '{0}.exe'.format(PROJECT_NAME))
     else:
-      atom_shell = os.path.join(OUT_DIR, PROJECT_NAME)
+      electron = os.path.join(OUT_DIR, PROJECT_NAME)
     index_json = os.path.relpath(os.path.join(OUT_DIR, 'index.json'))
-    execute([atom_shell,
+    execute([electron,
              os.path.join('tools', 'dump-version-info.js'),
              index_json])
 

--- a/script/upload-windows-pdb.py
+++ b/script/upload-windows-pdb.py
@@ -5,15 +5,15 @@ import glob
 import sys
 
 from lib.config import s3_config
-from lib.util import atom_gyp, execute, rm_rf, safe_mkdir, s3put
+from lib.util import electron_gyp, execute, rm_rf, safe_mkdir, s3put
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 SYMBOLS_DIR = 'dist\\symbols'
 DOWNLOAD_DIR = 'vendor\\brightray\\vendor\\download\\libchromiumcontent'
 
-PROJECT_NAME = atom_gyp()['project_name%']
-PRODUCT_NAME = atom_gyp()['product_name%']
+PROJECT_NAME = electron_gyp()['project_name%']
+PRODUCT_NAME = electron_gyp()['product_name%']
 
 PDB_LIST = [
   'out\\R\\{0}.exe.pdb'.format(PROJECT_NAME),

--- a/script/upload.py
+++ b/script/upload.py
@@ -9,7 +9,7 @@ import tempfile
 
 from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
                        get_platform_key, get_env_var
-from lib.util import atom_gyp, execute, get_electron_version, parse_version, \
+from lib.util import electron_gyp, execute, get_electron_version, parse_version, \
                      scoped_cwd
 from lib.github import GitHub
 
@@ -17,8 +17,8 @@ from lib.github import GitHub
 ELECTRON_REPO = 'electron/electron'
 ELECTRON_VERSION = get_electron_version()
 
-PROJECT_NAME = atom_gyp()['project_name%']
-PRODUCT_NAME = atom_gyp()['product_name%']
+PROJECT_NAME = electron_gyp()['project_name%']
+PRODUCT_NAME = electron_gyp()['product_name%']
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 OUT_DIR = os.path.join(SOURCE_ROOT, 'out', 'R')
@@ -80,7 +80,7 @@ def main():
     # Do not upload other files when passed "-p".
     return
 
-  # Upload atom-shell with GitHub Releases API.
+  # Upload Electron with GitHub Releases API.
   upload_electron(github, release, os.path.join(DIST_DIR, DIST_NAME))
   upload_electron(github, release, os.path.join(DIST_DIR, SYMBOLS_NAME))
   if PLATFORM == 'darwin':

--- a/script/upload.py
+++ b/script/upload.py
@@ -9,8 +9,8 @@ import tempfile
 
 from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
                        get_platform_key, get_env_var
-from lib.util import electron_gyp, execute, get_electron_version, parse_version, \
-                     scoped_cwd
+from lib.util import electron_gyp, execute, get_electron_version, \
+                     parse_version, scoped_cwd
 from lib.github import GitHub
 
 

--- a/script/upload.py
+++ b/script/upload.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 
 from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
-                       get_platform_key
+                       get_platform_key, get_env_var
 from lib.util import atom_gyp, execute, get_electron_version, parse_version, \
                      scoped_cwd
 from lib.github import GitHub
@@ -221,7 +221,7 @@ def publish_release(github, release_id):
 
 
 def auth_token():
-  token = os.environ.get('ELECTRON_GITHUB_TOKEN')
+  token = get_env_var('GITHUB_TOKEN')
   message = ('Error: Please set the $ELECTRON_GITHUB_TOKEN '
              'environment variable, which is your personal token')
   assert token, message

--- a/script/upload.py
+++ b/script/upload.py
@@ -9,13 +9,13 @@ import tempfile
 
 from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
                        get_platform_key
-from lib.util import atom_gyp, execute, get_atom_shell_version, parse_version, \
+from lib.util import atom_gyp, execute, get_electron_version, parse_version, \
                      scoped_cwd
 from lib.github import GitHub
 
 
-ATOM_SHELL_REPO = 'electron/electron'
-ATOM_SHELL_VERSION = get_atom_shell_version()
+ELECTRON_REPO = 'electron/electron'
+ELECTRON_VERSION = get_electron_version()
 
 PROJECT_NAME = atom_gyp()['project_name%']
 PRODUCT_NAME = atom_gyp()['product_name%']
@@ -24,15 +24,15 @@ SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 OUT_DIR = os.path.join(SOURCE_ROOT, 'out', 'R')
 DIST_DIR = os.path.join(SOURCE_ROOT, 'dist')
 DIST_NAME = '{0}-{1}-{2}-{3}.zip'.format(PROJECT_NAME,
-                                         ATOM_SHELL_VERSION,
+                                         ELECTRON_VERSION,
                                          get_platform_key(),
                                          get_target_arch())
 SYMBOLS_NAME = '{0}-{1}-{2}-{3}-symbols.zip'.format(PROJECT_NAME,
-                                                    ATOM_SHELL_VERSION,
+                                                    ELECTRON_VERSION,
                                                     get_platform_key(),
                                                     get_target_arch())
 DSYM_NAME = '{0}-{1}-{2}-{3}-dsym.zip'.format(PROJECT_NAME,
-                                              ATOM_SHELL_VERSION,
+                                              ELECTRON_VERSION,
                                               get_platform_key(),
                                               get_target_arch())
 
@@ -45,16 +45,16 @@ def main():
       create_dist = os.path.join(SOURCE_ROOT, 'script', 'create-dist.py')
       execute([sys.executable, create_dist])
 
-    build_version = get_atom_shell_build_version()
-    if not ATOM_SHELL_VERSION.startswith(build_version):
+    build_version = get_electron_build_version()
+    if not ELECTRON_VERSION.startswith(build_version):
       error = 'Tag name ({0}) should match build version ({1})\n'.format(
-          ATOM_SHELL_VERSION, build_version)
+          ELECTRON_VERSION, build_version)
       sys.stderr.write(error)
       sys.stderr.flush()
       return 1
 
   github = GitHub(auth_token())
-  releases = github.repos(ATOM_SHELL_REPO).releases.get()
+  releases = github.repos(ELECTRON_REPO).releases.get()
   tag_exists = False
   for release in releases:
     if not release['draft'] and release['tag_name'] == args.version:
@@ -68,7 +68,7 @@ def main():
     # Upload the SHASUMS.txt.
     execute([sys.executable,
              os.path.join(SOURCE_ROOT, 'script', 'upload-checksums.py'),
-             '-v', ATOM_SHELL_VERSION])
+             '-v', ELECTRON_VERSION])
 
     # Upload the index.json.
     execute([sys.executable,
@@ -81,24 +81,24 @@ def main():
     return
 
   # Upload atom-shell with GitHub Releases API.
-  upload_atom_shell(github, release, os.path.join(DIST_DIR, DIST_NAME))
-  upload_atom_shell(github, release, os.path.join(DIST_DIR, SYMBOLS_NAME))
+  upload_electron(github, release, os.path.join(DIST_DIR, DIST_NAME))
+  upload_electron(github, release, os.path.join(DIST_DIR, SYMBOLS_NAME))
   if PLATFORM == 'darwin':
-    upload_atom_shell(github, release, os.path.join(DIST_DIR, DSYM_NAME))
+    upload_electron(github, release, os.path.join(DIST_DIR, DSYM_NAME))
 
   # Upload free version of ffmpeg.
   ffmpeg = 'ffmpeg-{0}-{1}-{2}.zip'.format(
-      ATOM_SHELL_VERSION, get_platform_key(), get_target_arch())
-  upload_atom_shell(github, release, os.path.join(DIST_DIR, ffmpeg))
+      ELECTRON_VERSION, get_platform_key(), get_target_arch())
+  upload_electron(github, release, os.path.join(DIST_DIR, ffmpeg))
 
   # Upload chromedriver and mksnapshot for minor version update.
   if parse_version(args.version)[2] == '0':
     chromedriver = 'chromedriver-{0}-{1}-{2}.zip'.format(
         get_chromedriver_version(), get_platform_key(), get_target_arch())
-    upload_atom_shell(github, release, os.path.join(DIST_DIR, chromedriver))
+    upload_electron(github, release, os.path.join(DIST_DIR, chromedriver))
     mksnapshot = 'mksnapshot-{0}-{1}-{2}.zip'.format(
-        ATOM_SHELL_VERSION, get_platform_key(), get_target_arch())
-    upload_atom_shell(github, release, os.path.join(DIST_DIR, mksnapshot))
+        ELECTRON_VERSION, get_platform_key(), get_target_arch())
+    upload_electron(github, release, os.path.join(DIST_DIR, mksnapshot))
 
   if PLATFORM == 'win32' and not tag_exists:
     # Upload PDBs to Windows symbol server.
@@ -114,28 +114,28 @@ def main():
 def parse_args():
   parser = argparse.ArgumentParser(description='upload distribution file')
   parser.add_argument('-v', '--version', help='Specify the version',
-                      default=ATOM_SHELL_VERSION)
+                      default=ELECTRON_VERSION)
   parser.add_argument('-p', '--publish-release',
                       help='Publish the release',
                       action='store_true')
   return parser.parse_args()
 
 
-def get_atom_shell_build_version():
+def get_electron_build_version():
   if get_target_arch() == 'arm' or os.environ.has_key('CI'):
     # In CI we just build as told.
-    return ATOM_SHELL_VERSION
+    return ELECTRON_VERSION
   if PLATFORM == 'darwin':
-    atom_shell = os.path.join(SOURCE_ROOT, 'out', 'R',
+    electron = os.path.join(SOURCE_ROOT, 'out', 'R',
                               '{0}.app'.format(PRODUCT_NAME), 'Contents',
                               'MacOS', PRODUCT_NAME)
   elif PLATFORM == 'win32':
-    atom_shell = os.path.join(SOURCE_ROOT, 'out', 'R',
+    electron = os.path.join(SOURCE_ROOT, 'out', 'R',
                               '{0}.exe'.format(PROJECT_NAME))
   else:
-    atom_shell = os.path.join(SOURCE_ROOT, 'out', 'R', PROJECT_NAME)
+    electron = os.path.join(SOURCE_ROOT, 'out', 'R', PROJECT_NAME)
 
-  return subprocess.check_output([atom_shell, '--version']).strip()
+  return subprocess.check_output([electron, '--version']).strip()
 
 
 def dist_newer_than_head():
@@ -192,17 +192,17 @@ def create_release_draft(github, tag):
     sys.exit(0)
 
   data = dict(tag_name=tag, name=name, body=body, draft=True)
-  r = github.repos(ATOM_SHELL_REPO).releases.post(data=data)
+  r = github.repos(ELECTRON_REPO).releases.post(data=data)
   return r
 
 
-def upload_atom_shell(github, release, file_path):
+def upload_electron(github, release, file_path):
   # Delete the original file before uploading in CI.
   if os.environ.has_key('CI'):
     try:
       for asset in release['assets']:
         if asset['name'] == os.path.basename(file_path):
-          github.repos(ATOM_SHELL_REPO).releases.assets(asset['id']).delete()
+          github.repos(ELECTRON_REPO).releases.assets(asset['id']).delete()
           break
     except Exception:
       pass
@@ -211,18 +211,18 @@ def upload_atom_shell(github, release, file_path):
   params = {'name': os.path.basename(file_path)}
   headers = {'Content-Type': 'application/zip'}
   with open(file_path, 'rb') as f:
-    github.repos(ATOM_SHELL_REPO).releases(release['id']).assets.post(
+    github.repos(ELECTRON_REPO).releases(release['id']).assets.post(
         params=params, headers=headers, data=f, verify=False)
 
 
 def publish_release(github, release_id):
   data = dict(draft=False)
-  github.repos(ATOM_SHELL_REPO).releases(release_id).patch(data=data)
+  github.repos(ELECTRON_REPO).releases(release_id).patch(data=data)
 
 
 def auth_token():
-  token = os.environ.get('ATOM_SHELL_GITHUB_TOKEN')
-  message = ('Error: Please set the $ATOM_SHELL_GITHUB_TOKEN '
+  token = os.environ.get('ELECTRON_GITHUB_TOKEN')
+  message = ('Error: Please set the $ELECTRON_GITHUB_TOKEN '
              'environment variable, which is your personal token')
   assert token, message
   return token


### PR DESCRIPTION
This pull request removes all references to the old Atom Shell name from the repo.

After seeing #5670 it seems worth changing the remaining helper functions and environment variables to say Electron instead of Atom Shell to prevent confusion.

/cc @electron/maintainers 