### PR TITLE
Ignore invalid parameter error on Window

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -30,6 +30,13 @@ bool IsBrowserProcess(base::CommandLine* cmd) {
   return process_type.empty();
 }
 
+#if defined(OS_WIN)
+void InvalidParameterHandler(const wchar_t*, const wchar_t*, const wchar_t*,
+                             unsigned int, uintptr_t) {
+  // noop.
+}
+#endif
+
 }  // namespace
 
 AtomMainDelegate::AtomMainDelegate() {
@@ -85,6 +92,11 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 
 #if defined(OS_MACOSX)
   SetUpBundleOverrides();
+#endif
+
+#if defined(OS_WIN)
+  // Ignore invalid parameter errors.
+  _set_invalid_parameter_handler(InvalidParameterHandler);
 #endif
 
   return brightray::MainDelegate::BasicStartupComplete(exit_code);


### PR DESCRIPTION
Previously we were relying on `uv_init` to do the job, after we link with VC++ statically, `uv_init` only works for `node.dll`, so we have to also put a call of `_set_invalid_parameter_handler` in electron.exe to solve it.

Close #5632.