### PR TITLE
Support non-native promises

### DIFF
--- a/filenames.gypi
+++ b/filenames.gypi
@@ -42,6 +42,7 @@
       'lib/common/api/crash-reporter.js',
       'lib/common/api/deprecate.js',
       'lib/common/api/deprecations.js',
+      'lib/common/api/is-promise.js',
       'lib/common/api/exports/electron.js',
       'lib/common/api/native-image.js',
       'lib/common/api/shell.js',

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -2,7 +2,7 @@
 
 const electron = require('electron')
 const v8Util = process.atomBinding('v8_util')
-const {ipcMain} = electron
+const {ipcMain, isPromise} = electron
 
 const objectsRegistry = require('./objects-registry')
 
@@ -65,7 +65,7 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
       meta.type = 'error'
     } else if (value instanceof Date) {
       meta.type = 'date'
-    } else if (value.constructor != null && value.constructor.name === 'Promise') {
+    } else if (isPromise(value)) {
       meta.type = 'promise'
     } else if (value.hasOwnProperty('callee') && value.length != null) {
       // Treat the arguments object as array.

--- a/lib/common/api/exports/electron.js
+++ b/lib/common/api/exports/electron.js
@@ -43,6 +43,11 @@ exports.defineProperties = function (exports) {
       get: function () {
         return require('../deprecations')
       }
+    },
+    isPromise: {
+      get: function () {
+        return require('../is-promise')
+      }
     }
   })
 }

--- a/lib/common/api/is-promise.js
+++ b/lib/common/api/is-promise.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = function isPromise (val) {
+  return (
+    val &&
+    val.then &&
+    val.then instanceof Function &&
+    val.constructor &&
+    val.constructor.reject &&
+    val.constructor.reject instanceof Function &&
+    val.constructor.resolve &&
+    val.constructor.resolve instanceof Function
+  )
+}

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const v8Util = process.atomBinding('v8_util')
-const {ipcRenderer, CallbacksRegistry} = require('electron')
+const {ipcRenderer, isPromise, CallbacksRegistry} = require('electron')
 
 const callbacksRegistry = new CallbacksRegistry()
 
@@ -44,7 +44,7 @@ var wrapArgs = function (args, visited) {
         value: value.getTime()
       }
     } else if ((value != null) && typeof value === 'object') {
-      if (value.constructor != null && value.constructor.name === 'Promise') {
+      if (isPromise(value)) {
         return {
           type: 'promise',
           then: valueToMeta(function (onFulfilled, onRejected) {


### PR DESCRIPTION
#### problem statement

- non-native promises are not supported

#### solution

- support non-native promises

#### discussion

there is a lot of talk on how-to-detect if something is a promise or not.  many people respond to the question with something like "don't try to detect a promise, just `Promise.resolve` it if you need promise behavior."  it's a strange response that doesn't address the intent of question--how to do proper type detection on Promises.  it's tricky because a Promise describes both a formal type as well as a behavioral expectation.  due to this complication, detecting a promise is not so simple. @zcbenz already denoted that a simple `.then` check is out of the question, and right fully so.  hence, the strategy taken should cover ~99.9% of promise implementations, with the downside that it takes many type checks to reach a conclusion.

closes #5633