### PR TITLE
Properly notify observers when window prevents close

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "atom/browser/window_list.h"
 #include "atom/common/color_util.h"
 #include "atom/common/draggable_region.h"
 #include "atom/common/options_switches.h"
@@ -553,6 +554,11 @@ NativeWindowMac::~NativeWindowMac() {
 }
 
 void NativeWindowMac::Close() {
+  if (!IsClosable()) {
+    WindowList::WindowCloseCancelled(this);
+    return;
+  }
+
   [window_ performClose:nil];
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -9,6 +9,7 @@
 
 #include "atom/browser/ui/views/menu_bar.h"
 #include "atom/browser/ui/views/menu_layout.h"
+#include "atom/browser/window_list.h"
 #include "atom/common/color_util.h"
 #include "atom/common/draggable_region.h"
 #include "atom/common/native_mate_converters/image_converter.h"
@@ -284,6 +285,11 @@ NativeWindowViews::~NativeWindowViews() {
 }
 
 void NativeWindowViews::Close() {
+  if (!IsClosable()) {
+    WindowList::WindowCloseCancelled(this);
+    return;
+  }
+
   window_->Close();
 }
 


### PR DESCRIPTION
It used to somewhat work on OS X since we were just letting the system block the close. But the action was never passed back to relevant observers.
I don't know how to write the tests for this behaviour so I stopped here...

Closes #5680