### PR TITLE
Fix setFullscreen() on Windows

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -146,6 +146,11 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   bool fullscreen = false;
   if (options.Get(options::kFullscreen, &fullscreen) && !fullscreen)
     fullscreenable = false;
+  // On Windows, we can only enter fullscreen via API
+  // Ensure that setFullscreen(true) is usable by default
+  #if defined(OS_WIN)
+    fullscreenable = true;
+  #endif
   // Overriden by 'fullscreenable'.
   options.Get(options::kFullScreenable, &fullscreenable);
   SetFullScreenable(fullscreenable);

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -59,8 +59,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `fullscreen` Boolean - Whether the window should show in fullscreen. When
     explicity set to `false` the fullscreen button will be hidden or disabled
     on OS X. Default is `false`.
-  * `fullscreenable` Boolean - Whether the maximize/zoom button on OS X should
-    toggle full screen mode or maximize window. Default is `true`.
+  * `fullscreenable` Boolean - Whether the window can be put into fullscreen 
+    mode. On OS X, also whether the maximize/zoom button should toggle full 
+    screen mode or maximize window. Default is `true`.
   * `skipTaskbar` Boolean - Whether to show the window in taskbar. Default is
     `false`.
   * `kiosk` Boolean - The kiosk mode. Default is `false`.


### PR DESCRIPTION
This ensures that a BrowserWindow responds to `setFullscreen(true)` if `full screenable` was not defined during creation.

This bug was on Windows only. Previously, if you created a new BrowserWindow *without* specifying `fullscreenable: true`, `setFullscreen(true)` wouldn't do anything.

Closes #5699 