### PR TITLE
Upper case initialisms in clipboard API

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -154,7 +154,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("writeImage", &WriteImage);
   dict.SetMethod("clear", &Clear);
 
-  // TODO Remove in 2.0, deprecate before then with warnings
+  // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
   dict.SetMethod("readRtf", &ReadRtf);
   dict.SetMethod("writeRtf", &WriteRtf);
   dict.SetMethod("readHtml", &ReadHtml);

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -146,13 +146,19 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("write", &Write);
   dict.SetMethod("readText", &ReadText);
   dict.SetMethod("writeText", &WriteText);
+  dict.SetMethod("readRTF", &ReadRtf);
+  dict.SetMethod("writeRTF", &WriteRtf);
+  dict.SetMethod("readHTML", &ReadHtml);
+  dict.SetMethod("writeHTML", &WriteHtml);
+  dict.SetMethod("readImage", &ReadImage);
+  dict.SetMethod("writeImage", &WriteImage);
+  dict.SetMethod("clear", &Clear);
+
+  // TODO Remove in 2.0, deprecate before then with warnings
   dict.SetMethod("readRtf", &ReadRtf);
   dict.SetMethod("writeRtf", &WriteRtf);
   dict.SetMethod("readHtml", &ReadHtml);
   dict.SetMethod("writeHtml", &WriteHtml);
-  dict.SetMethod("readImage", &ReadImage);
-  dict.SetMethod("writeImage", &WriteImage);
-  dict.SetMethod("clear", &Clear);
 }
 
 }  // namespace

--- a/docs-translations/jp/api/clipboard.md
+++ b/docs-translations/jp/api/clipboard.md
@@ -33,13 +33,13 @@ console.log(clipboard.readText('selection'));
 
 プレーンテキストとしてクリップボードに`text`を書き込みます。
 
-### `clipboard.readHtml([type])`
+### `clipboard.readHTML([type])`
 
 * `type` String (optional)
 
 HTMLマークアップとして、クリップボードの内容を返します。
 
-### `clipboard.writeHtml(markup[, type])`
+### `clipboard.writeHTML(markup[, type])`
 
 * `markup` String
 * `type` String (optional)

--- a/docs-translations/ko-KR/api/clipboard.md
+++ b/docs-translations/ko-KR/api/clipboard.md
@@ -37,13 +37,13 @@ console.log(clipboard.readText('selection'));
 
 클립보드에 `plain text`로 문자열을 씁니다.
 
-### `clipboard.readHtml([type])`
+### `clipboard.readHTML([type])`
 
 * `type` String (optional)
 
 클립보드 콘텐츠를 `markup`으로 반환합니다.
 
-### `clipboard.writeHtml(markup[, type])`
+### `clipboard.writeHTML(markup[, type])`
 
 * `markup` String
 * `type` String (optional)
@@ -63,13 +63,13 @@ console.log(clipboard.readText('selection'));
 
 클립보드에 `image`를 씁니다.
 
-### `clipboard.readRtf([type])`
+### `clipboard.readRTF([type])`
 
 * `type` String (optional)
 
 클립보드로부터 RTF 형식으로 콘텐츠를 읽어옵니다.
 
-### `clipboard.writeRtf(text[, type])`
+### `clipboard.writeRTF(text[, type])`
 
 * `text` String
 * `type` String (optional)

--- a/docs-translations/zh-CN/api/clipboard.md
+++ b/docs-translations/zh-CN/api/clipboard.md
@@ -34,13 +34,13 @@ console.log(clipboard.readText('selection'));
 
 以纯文本形式向 clipboard 添加内容 .
 
-### `clipboard.readHtml([type])`
+### `clipboard.readHTML([type])`
 
 * `type` String (可选)
 
 返回 clipboard 中的标记内容.
 
-### `clipboard.writeHtml(markup[, type])`
+### `clipboard.writeHTML(markup[, type])`
 
 * `markup` String
 * `type` String (可选)
@@ -60,13 +60,13 @@ console.log(clipboard.readText('selection'));
 
 向 clipboard 中写入 `image` .
 
-### `clipboard.readRtf([type])`
+### `clipboard.readRTF([type])`
 
 * `type` String (可选)
 
 从 clipboard 中返回 RTF 内容. 
 
-### `clipboard.writeRtf(text[, type])`
+### `clipboard.writeRTF(text[, type])`
 
 * `text` String
 * `type` String (可选)

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -36,13 +36,13 @@ Returns the content in the clipboard as plain text.
 
 Writes the `text` into the clipboard as plain text.
 
-### `clipboard.readHtml([type])`
+### `clipboard.readHTML([type])`
 
 * `type` String (optional)
 
 Returns the content in the clipboard as markup.
 
-### `clipboard.writeHtml(markup[, type])`
+### `clipboard.writeHTML(markup[, type])`
 
 * `markup` String
 * `type` String (optional)
@@ -62,13 +62,13 @@ Returns the content in the clipboard as a [NativeImage](native-image.md).
 
 Writes `image` to the clipboard.
 
-### `clipboard.readRtf([type])`
+### `clipboard.readRTF([type])`
 
 * `type` String (optional)
 
 Returns the content in the clipboard as RTF.
 
-### `clipboard.writeRtf(text[, type])`
+### `clipboard.writeRTF(text[, type])`
 
 * `text` String
 * `type` String (optional)

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -24,20 +24,20 @@ describe('clipboard module', function () {
     })
   })
 
-  describe('clipboard.readHtml()', function () {
+  describe('clipboard.readHTML()', function () {
     it('returns markup correctly', function () {
       var text = '<string>Hi</string>'
       var markup = process.platform === 'darwin' ? "<meta charset='utf-8'><string>Hi</string>" : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><string>Hi</string>' : '<string>Hi</string>'
-      clipboard.writeHtml(text)
-      assert.equal(clipboard.readHtml(), markup)
+      clipboard.writeHTML(text)
+      assert.equal(clipboard.readHTML(), markup)
     })
   })
 
-  describe('clipboard.readRtf', function () {
+  describe('clipboard.readRTF', function () {
     it('returns rtf text correctly', function () {
       var rtf = '{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}'
-      clipboard.writeRtf(rtf)
-      assert.equal(clipboard.readRtf(), rtf)
+      clipboard.writeRTF(rtf)
+      assert.equal(clipboard.readRTF(), rtf)
     })
   })
 
@@ -55,8 +55,8 @@ describe('clipboard module', function () {
         image: p
       })
       assert.equal(clipboard.readText(), text)
-      assert.equal(clipboard.readHtml(), markup)
-      assert.equal(clipboard.readRtf(), rtf)
+      assert.equal(clipboard.readHTML(), markup)
+      assert.equal(clipboard.readRTF(), rtf)
       assert.equal(clipboard.readImage().toDataURL(), i.toDataURL())
     })
   })


### PR DESCRIPTION
In https://github.com/electron/electron/issues/2544 we decided to go with an API naming scheme like `printToPDF`/`setFeedURL` instead of `printToPdf`/`setFeedUrl`.

There were 4 `clipboard` module APIs that didn't get updated for 1.0:

- `clipboard.readHtml`
- `clipboard.writeHtml`
- `clipboard.readRtf`
- `clipboard.writeRtf`

This pull request tweaks them to:
- `clipboard.readHTML`
- `clipboard.writeHTML`
- `clipboard.readRTF`
- `clipboard.writeRTF`

This pull request does not remove the old names and they shouldn't be removed before 2.0. But the docs are updated so hopefully new apps will use the new APIs as documented.

This pull request does not add deprecation warnings either for the old versions. Since 1.0 just came out it seems a bit premature to start spamming the log with deprecation warnings.

Deprecation warnings should eventually be added for these but only when the 2.0 API picture is clearer while still giving people months to adjust before they get removed (like the 1.0 plan).

This was originally brought up at the Electron meetup yesterday at SF where someone asked why these APIs were inconsistent.

/cc @electron/maintainers 
