### PR TITLE
Fix 'setAspectRatio(0)' not resetting the default behaviour.

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -718,14 +718,11 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
                                      const gfx::Size& extra_size) {
     NativeWindow::SetAspectRatio(aspect_ratio, extra_size);
 
-    // We can't just pass the aspect ratio to Cocoa, since our API receives
-    // it as a float, and Cocoa expects an NSRect with explicit width & height
-    // arguments. Instead we derive those args ourselves from the given aspect
-    // ratio.
-    double width = roundf([window_ frame].size.height * aspect_ratio);
-    double height = roundf(width / aspect_ratio);
-
-    [window_ setAspectRatio:NSMakeSize(width, height)];
+    // Reset the behaviour to default if aspect_ratio is set to 0 or less.
+    if (aspect_ratio > 0.0)
+      [window_ setAspectRatio:NSMakeSize(aspect_ratio, 1.0)];
+    else
+      [window_ setResizeIncrements:NSMakeSize(1.0, 1.0)];
 }
 
 void NativeWindowMac::SetMovable(bool movable) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -284,6 +284,21 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.setAspectRatio(ratio)', function () {
+    it('resets the behaviour when passing in 0', function (done) {
+      var size = [300, 400]
+      w.setAspectRatio(1/2)
+      w.setAspectRatio(0)
+      w.once('resize', function () {
+        var newSize = w.getSize()
+        assert.equal(newSize[0], size[0])
+        assert.equal(newSize[1], size[1])
+        done()
+      })
+      w.setSize(size[0], size[1])
+    })
+  })
+
   describe('BrowserWindow.setPosition(x, y)', function () {
     it('sets the window position', function (done) {
       var pos = [10, 10]


### PR DESCRIPTION
There were 2 things going wrong:
* We were doing a division by a 0 and it passed on invalid values.
* There was no way to remove the aspect ratio enforcement once set.

This addresses both of those points.

---
Closes #5728 
