### PR TITLE
Support objects with no prototype over IPC

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -6,6 +6,8 @@ const {ipcMain, isPromise} = electron
 
 const objectsRegistry = require('./objects-registry')
 
+const hasProp = {}.hasOwnProperty
+
 // The internal properties of Function.
 const FUNCTION_PROPERTIES = [
   'length', 'name', 'arguments', 'caller', 'prototype'
@@ -67,7 +69,7 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
       meta.type = 'date'
     } else if (isPromise(value)) {
       meta.type = 'promise'
-    } else if (value.hasOwnProperty('callee') && value.length != null) {
+    } else if (hasProp.call(value, 'callee') && value.length != null) {
       // Treat the arguments object as array.
       meta.type = 'array'
     } else if (optimizeSimpleObject && v8Util.getHiddenValue(value, 'simple')) {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -32,6 +32,12 @@ describe('ipc module', function () {
       assert.equal(a.id, 1127)
     })
 
+    it('should work when object has no prototype', function () {
+      var a = remote.require(path.join(fixtures, 'module', 'no-prototype.js'))
+      assert.deepEqual(a.foo, {})
+      assert.equal(a.bar, 1234)
+    })
+
     it('should search module from the user app', function () {
       comparePaths(path.normalize(remote.process.mainModule.filename), path.resolve(__dirname, 'static', 'main.js'))
       comparePaths(path.normalize(remote.process.mainModule.paths[0]), path.resolve(__dirname, 'static', 'node_modules'))

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -32,9 +32,10 @@ describe('ipc module', function () {
       assert.equal(a.id, 1127)
     })
 
-    it('should work when object has no prototype', function () {
+    it.only('should work when object has no prototype', function () {
       var a = remote.require(path.join(fixtures, 'module', 'no-prototype.js'))
-      assert.deepEqual(a.foo, {})
+      assert.equal(a.foo.bar, 'baz')
+      assert.equal(a.foo.baz, false)
       assert.equal(a.bar, 1234)
     })
 

--- a/spec/fixtures/module/no-prototype.js
+++ b/spec/fixtures/module/no-prototype.js
@@ -1,4 +1,4 @@
-module.exports = {
-  foo: Object.create(null),
-  bar: 1234
-}
+const foo = Object.create(null)
+foo.bar = 'baz'
+foo.baz = false
+module.exports = {foo: foo, bar: 1234}

--- a/spec/fixtures/module/no-prototype.js
+++ b/spec/fixtures/module/no-prototype.js
@@ -1,0 +1,4 @@
+module.exports = {
+  foo: Object.create(null),
+  bar: 1234
+}


### PR DESCRIPTION
Objects created via `Object.create(null)` are currently failing to go through `rpc-server` since `hasOwnProperty` was being called and is `undefined` for objects created that way.

It looks like node changed its `EventEmitter` recently to have the `_events` property be an object with no prototype so this is pretty easy to reproduce in Electron with:

```js
require('electron').remote.getCurrentWindow()._events
```

https://github.com/nodejs/node/blob/0c294362502684b9273e7e7c7039ec7028471014/lib/events.js#L9

Closes https://github.com/electron/devtron/issues/73