### PR TITLE
Add print() to BrowserWindowProxy

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -63,6 +63,10 @@ Evaluates the code in the child window.
 
 Focuses the child window (brings the window to front).
 
+### `BrowserWindowProxy.print()`
+
+Invokes the print dialog on the child window.
+
 ### `BrowserWindowProxy.postMessage(message, targetOrigin)`
 
 * `message` String

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -45,6 +45,10 @@ var BrowserWindowProxy = (function () {
     return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'blur')
   }
 
+  BrowserWindowProxy.prototype.print = function () {
+    return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'print')
+  }
+
   Object.defineProperty(BrowserWindowProxy.prototype, 'location', {
     get: function () {
       return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'getURL')

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -46,7 +46,7 @@ var BrowserWindowProxy = (function () {
   }
 
   BrowserWindowProxy.prototype.print = function () {
-    return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'print')
+    return ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, 'print')
   }
 
   Object.defineProperty(BrowserWindowProxy.prototype, 'location', {


### PR DESCRIPTION
Continuation of #5717, adds `print` support to the `BrowserWindowProxy` returned from `window.open` and also available via `window.opener` in the child window.

/cc @felixrieseberg I made a small tweak to your original PR which was calling print on the `BrowserWindow` when it needs to instead call it on the `webContents`.

Closes #5717
Closes https://github.com/electron/electron/issues/5685