### PR TITLE
Remove deprecated APIs from the docs

### DIFF
--- a/docs-translations/ko-KR/api/browser-window.md
+++ b/docs-translations/ko-KR/api/browser-window.md
@@ -778,14 +778,6 @@ Windows 메시지 훅을 등록합니다. `callback`은 WndProc에서 메시지�
 `callback(image)` 형식으로 호출됩니다. `image`는 [NativeImage](native-image.md)의
 인스턴스이며 스크린샷 데이터를 담고있습니다. `rect`를 생략하면 페이지 전체를 캡처합니다.
 
-### `win.print([options])`
-
-`webContents.print([options])` API와 같습니다.
-
-### `win.printToPDF(options, callback)`
-
-`webContents.printToPDF(options, callback)` API와 같습니다.
-
 ### `win.loadURL(url[, options])`
 
 `webContents.loadURL(url[, options])` API와 같습니다.

--- a/docs-translations/pt-BR/api/browser-window.md
+++ b/docs-translations/pt-BR/api/browser-window.md
@@ -112,10 +112,10 @@ Normalmente você utiliza o manipulador de eventos do `beforeunload` para decidi
 window.onbeforeunload = function(e) {
   console.log('Não quero ser fechada');
 
-  // Diferente de navegadores comuns, nos quais uma string deve ser retornada e 
+  // Diferente de navegadores comuns, nos quais uma string deve ser retornada e
   // o usuário deve confirmar se a janela será fechada, o Electron dá mais opções
   // aos desenvolvedores. Retornar uma string vazia ou false cancela o fechamento.
-  // Você também pode usar a API de diálogo para deixar que o usuário confirme o 
+  // Você também pode usar a API de diálogo para deixar que o usuário confirme o
   // fechamento do aplicativo.
   e.returnValue = false;
 };
@@ -528,14 +528,6 @@ Retorna um boolean indicando se o documento da janela foi editado.
 
 Captura uma imagem da página dentro do `rect`. Após completar, `callback` será chamada com `callback(imagem)`. `imagem` é uma instância de [NativeImage](../../../docs/api/native-image.md) que guarda dados sobre a imagem. Omitir `rect` captura toda a página visível.
 
-### `win.print([options])`
-
-Igual a `webContents.print([options])`
-
-### `win.printToPDF(options, callback)`
-
-Igual a `webContents.printToPDF(options, callback)`
-
 ### `win.loadURL(url[, options])`
 
 Igual a `webContents.loadURL(url[, options])`.
@@ -628,5 +620,3 @@ Define se a janela deve estar visível em todos os *workspaces*.
 Retorna um boolean indicando se a janela está visível em todos os *workspaces*.
 
 **Nota:** Esta API sempre retorna `false` no Windows.
-
-

--- a/docs-translations/zh-CN/api/browser-window.md
+++ b/docs-translations/zh-CN/api/browser-window.md
@@ -636,14 +636,6 @@ windows上句柄类型为 `HWND` ，OS X `NSView*` ， Linux `Window`.
 
 捕获 `rect` 中的page 的快照.完成后将调用回调函数 `callback` 并返回 `image` . `image` 是存储了快照信息的[NativeImage](native-image.md)实例.如果不设置 `rect` 则将捕获所有可见page.
 
-### `win.print([options])`
-
-类似 `webContents.print([options])`
-
-### `win.printToPDF(options, callback)`
-
-类似 `webContents.printToPDF(options, callback)`
-
 ### `win.loadURL(url[, options])`
 
 类似 `webContents.loadURL(url[, options])`.
@@ -671,7 +663,7 @@ windows上句柄类型为 `HWND` ，OS X `NSView*` ， Linux `Window`.
 
 ### `win.setOverlayIcon(overlay, description)` _Windows 7+_
 
-* `overlay` [NativeImage](native-image.md) - 在底部任务栏右边显示图标. 
+* `overlay` [NativeImage](native-image.md) - 在底部任务栏右边显示图标.
 * `description` String - 描述.
 
 向当前任务栏添加一个 16 x 16 像素的图标，通常用来覆盖一些应用的状态，或者直接来提示用户.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -787,14 +787,6 @@ be called with `callback(image)`. The `image` is an instance of
 [NativeImage](native-image.md) that stores data of the snapshot. Omitting
 `rect` will capture the whole visible page.
 
-### `win.print([options])`
-
-Same as `webContents.print([options])`
-
-### `win.printToPDF(options, callback)`
-
-Same as `webContents.printToPDF(options, callback)`
-
 ### `win.loadURL(url[, options])`
 
 Same as `webContents.loadURL(url[, options])`.


### PR DESCRIPTION
There were a few `BrowserWindow` APIs removed in 1.0 that were still mentioned in the docs 😨 

This pull request removes them.

Refs https://github.com/electron/electron/pull/5373