### PR TITLE
:memo: Indicate directories in the Structure of Source Code section

### DIFF
--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -11,38 +11,38 @@ to understand the source code better.
 
 ```
 Electron
-├── atom - C++ source code.
-|   ├── app - System entry code.
-|   ├── browser - The frontend including the main window, UI, and all of the
+├── atom/ - C++ source code.
+|   ├── app/ - System entry code.
+|   ├── browser/ - The frontend including the main window, UI, and all of the
 |   |   main process things. This talks to the renderer to manage web pages.
-|   |   ├── ui - Implementation of UI stuff for different platforms.
-|   |   |   ├── cocoa - Cocoa specific source code.
-|   |   |   ├── gtk - GTK+ specific source code.
-|   |   |   └── win - Windows GUI specific source code.
-|   |   ├── api - The implementation of the main process APIs.
-|   |   ├── net - Network related code.
-|   |   ├── mac - Mac specific Objective-C source code.
-|   |   └── resources - Icons, platform-dependent files, etc.
-|   ├── renderer - Code that runs in renderer process.
-|   |   └── api - The implementation of renderer process APIs.
-|   └── common - Code that used by both the main and renderer processes,
+|   |   ├── ui/ - Implementation of UI stuff for different platforms.
+|   |   |   ├── cocoa/ - Cocoa specific source code.
+|   |   |   ├── win/ - Windows GUI specific source code.
+|   |   |   └── x/ - X11 specific source code.
+|   |   ├── api/ - The implementation of the main process APIs.
+|   |   ├── net/ - Network related code.
+|   |   ├── mac/ - Mac specific Objective-C source code.
+|   |   └── resources/ - Icons, platform-dependent files, etc.
+|   ├── renderer/ - Code that runs in renderer process.
+|   |   └── api/ - The implementation of renderer process APIs.
+|   └── common/ - Code that used by both the main and renderer processes,
 |       including some utility functions and code to integrate node's message
 |       loop into Chromium's message loop.
-|       └── api - The implementation of common APIs, and foundations of
+|       └── api/ - The implementation of common APIs, and foundations of
 |           Electron's built-in modules.
-├── chromium_src - Source code that copied from Chromium.
-├── default_app - The default page to show when Electron is started without
+├── chromium_src/ - Source code that copied from Chromium.
+├── default_app/ - The default page to show when Electron is started without
 |   providing an app.
-├── docs - Documentations.
-├── lib - JavaScript source code.
-|   ├── browser - Javascript main process initialization code.
-|   |   └── api - Javascript API implementation.
-|   ├── common - JavaScript used by both the main and renderer processes
-|   |   └── api - Javascript API implementation.
-|   └── renderer - Javascript renderer process initialization code.
-|       └── api - Javascript API implementation.
-├── spec - Automatic tests.
-├── atom.gyp - Building rules of Electron.
+├── docs/ - Documentations.
+├── lib/ - JavaScript source code.
+|   ├── browser/ - Javascript main process initialization code.
+|   |   └── api/ - Javascript API implementation.
+|   ├── common/ - JavaScript used by both the main and renderer processes
+|   |   └── api/ - Javascript API implementation.
+|   └── renderer/ - Javascript renderer process initialization code.
+|       └── api/ - Javascript API implementation.
+├── spec/ - Automatic tests.
+├── electron.gyp - Building rules of Electron.
 └── common.gypi - Compiler specific settings and building rules for other
     components like `node` and `breakpad`.
 ```


### PR DESCRIPTION
I would like to start working on Electron and therefore I started reading the documentation. Something I felt that could improve is the section *Structure of Source Code*, which does not indicate directories with slashes. Therefore, in this patch I have added slashes to files when they are of type directory. 

For example, C++ source code is stored in the `atom/` directory, which is indicated as `atom` in the structure. However, in my opinion it would be more clear if a slash is added at the end to indicate that it is a directory: `atom/`. 

In addition, I have added an additional directories in the structure: `atom/browser/ui/x/`. Please correct me if you disagree with the description that I used to describe it. 

Also, I changed `atom.gyp` to `electron.gyp`.

I am really looking forward to contributing to this awesome project! :grin: 

