### PR TITLE
Initialize script context in DidClearWindowObject

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -68,6 +68,10 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
         renderer_client_(renderer_client) {}
 
   // content::RenderFrameObserver:
+  void DidClearWindowObject() override {
+    renderer_client_->DidClearWindowObject(render_frame_);
+  }
+
   void DidCreateScriptContext(v8::Handle<v8::Context> context,
                               int extension_group,
                               int world_id) override {
@@ -185,12 +189,14 @@ void AtomRendererClient::RenderViewCreated(content::RenderView* render_view) {
   }
 }
 
-void AtomRendererClient::RunScriptsAtDocumentStart(
+void AtomRendererClient::DidClearWindowObject(
     content::RenderFrame* render_frame) {
   // Make sure every page will get a script context created.
-  render_frame->GetWebFrame()->executeScript(
-      blink::WebScriptSource("void 0"));
+  render_frame->GetWebFrame()->executeScript(blink::WebScriptSource("void 0"));
+}
 
+void AtomRendererClient::RunScriptsAtDocumentStart(
+    content::RenderFrame* render_frame) {
   // Inform the document start pharse.
   node::Environment* env = node_bindings_->uv_env();
   if (env) {

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -21,6 +21,7 @@ class AtomRendererClient : public content::ContentRendererClient {
   AtomRendererClient();
   virtual ~AtomRendererClient();
 
+  void DidClearWindowObject(content::RenderFrame* render_frame);
   void DidCreateScriptContext(
       v8::Handle<v8::Context> context, content::RenderFrame* render_frame);
   void WillReleaseScriptContext(

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -29,7 +29,7 @@ describe('ipc module', function () {
       assert.equal(a.id, 1127)
     })
 
-    it.only('should work when object has no prototype', function () {
+    it('should work when object has no prototype', function () {
       var a = remote.require(path.join(fixtures, 'module', 'no-prototype.js'))
       assert.equal(a.foo.bar, 'baz')
       assert.equal(a.foo.baz, false)

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -259,6 +259,30 @@ describe('<webview> tag', function () {
       webview.src = 'data:text/html;base64,' + encoded
       document.body.appendChild(webview)
     })
+
+    it('does not break node integration', function (done) {
+      webview.addEventListener('console-message', function (e) {
+        assert.equal(e.message, 'function object object')
+        done()
+      })
+      webview.setAttribute('nodeintegration', 'on')
+      webview.setAttribute('disablewebsecurity', '')
+      webview.src = 'file://' + fixtures + '/pages/d.html'
+      document.body.appendChild(webview)
+    })
+
+    it('does not break preload script', function (done) {
+      var listener = function (e) {
+        assert.equal(e.message, 'function object object')
+        webview.removeEventListener('console-message', listener)
+        done()
+      }
+      webview.addEventListener('console-message', listener)
+      webview.setAttribute('disablewebsecurity', '')
+      webview.setAttribute('preload', fixtures + '/module/preload.js')
+      webview.src = 'file://' + fixtures + '/pages/e.html'
+      document.body.appendChild(webview)
+    })
   })
 
   describe('partition attribute', function () {


### PR DESCRIPTION
Doing it in RunScriptsAtDocumentStart would somehow result in weird results when webSecurity is off.

Close #5712.
Close #5721.
Close #5727.