### PR TITLE
Refactor the URLRequestFetchJob code

### DIFF
--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -511,7 +511,7 @@ describe('protocol module', function () {
       })
     })
 
-    it('loads resource for webContents', function (done) {
+    it('works when target URL redirects', function (done) {
       var contents = null
       var server = http.createServer(function (req, res) {
         if (req.url == '/serverRedirect') {


### PR DESCRIPTION
This makes the read end and write end of the pipe have same logic, so it is more easy to maintain.