### PR TITLE
add process.purgeMemory()

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -12,6 +12,7 @@
 #include "atom/common/chrome_version.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/logging.h"
+#include "base/memory/memory_pressure_listener.h"
 #include "base/process/process_metrics.h"
 #include "native_mate/dictionary.h"
 
@@ -84,6 +85,11 @@ void Log(const base::string16& message) {
   std::cout << message << std::flush;
 }
 
+void PurgeMemory() {
+  base::MemoryPressureListener::NotifyMemoryPressure(
+      base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL);
+}
+
 }  // namespace
 
 
@@ -110,6 +116,7 @@ void AtomBindings::BindTo(v8::Isolate* isolate,
 #endif
   dict.SetMethod("activateUvLoop",
       base::Bind(&AtomBindings::ActivateUVLoop, base::Unretained(this)));
+  dict.SetMethod("purgeMemory", &PurgeMemory);
 
 #if defined(MAS_BUILD)
   dict.Set("mas", true);

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -111,3 +111,8 @@ On Windows / Linux:
   system.
 * `swapFree` - The free amount of swap memory in Kilobytes available to the
   system.
+
+### `process.purgeMemory()`
+
+Issues a `CRITICAL` memory pressure warning as a hint to chromium to release
+discardable memory


### PR DESCRIPTION
this is something we've been using for a while in our fork and i figured it might be desirable upstream. we tend to use this when minimizing to tray to shrink our footprint as much as possible.