### PR TITLE
Correctly redirect output to console on Windows

### DIFF
--- a/spec/fixtures/module/process-stdout.js
+++ b/spec/fixtures/module/process-stdout.js
@@ -1,0 +1,1 @@
+process.stdout.write('pipes stdio')

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -76,6 +76,19 @@ describe('node feature', function () {
         })
         child.send('message')
       })
+
+      it('pipes stdio', function (done) {
+        let child = child_process.fork(path.join(fixtures, 'module', 'process-stdout.js'), {silent: true})
+        let data = ''
+        child.stdout.on('data', (chunk) => {
+          data += String(chunk)
+        })
+        child.on('exit', (code) => {
+          assert.equal(code, 0)
+          assert.equal(data, 'pipes stdio')
+          done()
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Since the upgrade to VS 2015, the implementation of stdio seems to have changed. This PR fixes routing stdio to Console by using `base::RouteStdioToConsole`.

However it is impossible to make stdin work, we have to attach to parent Console, but because Electron is a GUI program, Windows is not willing to pipe stdin to us. One workaround is to alloc a new Console window for Electron, which would cause troubles since it makes every Electron process being attached with an extra Console window. 

This should be totally fine for all apps though, the only downside is we are not able to run REPL in Electron on Windows.

Close #5713.
Close #5715.
