### PR TITLE
Keep copies of window icons

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -786,12 +786,16 @@ gfx::AcceleratedWidget NativeWindowViews::GetAcceleratedWidget() {
 }
 
 #if defined(OS_WIN)
-void NativeWindowViews::SetIcon(HICON small_icon, HICON app_icon) {
+void NativeWindowViews::SetIcon(HICON window_icon, HICON app_icon) {
+  // We are responsible for storing the images.
+  window_icon_ = base::win::ScopedHICON(CopyIcon(window_icon));
+  app_icon_ = base::win::ScopedHICON(CopyIcon(app_icon));
+
   HWND hwnd = GetAcceleratedWidget();
   SendMessage(hwnd, WM_SETICON, ICON_SMALL,
-              reinterpret_cast<LPARAM>(small_icon));
+              reinterpret_cast<LPARAM>(window_icon_.get()));
   SendMessage(hwnd, WM_SETICON, ICON_BIG,
-              reinterpret_cast<LPARAM>(app_icon));
+              reinterpret_cast<LPARAM>(app_icon_.get()));
 }
 #elif defined(USE_X11)
 void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -17,6 +17,7 @@
 #if defined(OS_WIN)
 #include "atom/browser/ui/win/message_handler_delegate.h"
 #include "atom/browser/ui/win/taskbar_host.h"
+#include "base/win/scoped_gdi_object.h"
 #endif
 
 namespace views {
@@ -205,6 +206,10 @@ class NativeWindowViews : public NativeWindow,
 
   // If true we have enabled a11y
   bool enabled_a11y_support_;
+
+  // The icons of window and taskbar.
+  base::win::ScopedHICON window_icon_;
+  base::win::ScopedHICON app_icon_;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.


### PR DESCRIPTION
Windows doesn't keep copies of the window icons, so after the NativeImage gets garbage collected, the window icon will revert to default when a redrawing happens.

Close #5754.