### PR TITLE
webContents: custom pageSize for printToPDF

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -655,7 +655,7 @@ size.
   * `marginsType` Integer - Specifies the type of margins to use. Uses 0 for
     default margin, 1 for no margin, and 2 for minimum margin.
   * `pageSize` String - Specify page size of the generated PDF. Can be `A3`,
-    `A4`, `A5`, `Legal`, `Letter` and `Tabloid`.
+    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height` & `width` in Microns.
   * `printBackground` Boolean - Whether to print CSS backgrounds.
   * `printSelectionOnly` Boolean - Whether to print selection only.
   * `landscape` Boolean - `true` for landscape, `false` for portrait.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -197,11 +197,31 @@ let wrapWebContents = function (webContents) {
     if (options.printBackground) {
       printingSetting.shouldPrintBackgrounds = options.printBackground
     }
-    if (options.pageSize && PDFPageSize[options.pageSize]) {
-      printingSetting.mediaSize = PDFPageSize[options.pageSize]
-    } else {
-      printingSetting.mediaSize = PDFPageSize['A4']
+
+    if (options.pageSize) {
+      let height = 0
+      let width = 0
+      if (typeof options.pageSize === 'object') {
+        // Dimensions in Microns
+        // 1 meter = 10^6 microns
+        height = options.pageSize.height ? options.pageSize.height : 0
+        width = options.pageSize.width ? options.pageSize.width : 0
+      }
+
+      if (height > 0 && width > 0) {
+        printingSetting.mediaSize = {
+          height_microns: height,
+          name: 'CUSTOM',
+          width_microns: width,
+          custom_display_name: 'Custom'
+        }
+      } else if (PDFPageSize[options.pageSize]) {
+        printingSetting.mediaSize = PDFPageSize[options.pageSize]
+      } else {
+        printingSetting.mediaSize = PDFPageSize['A4']
+      }
     }
+
     return this._printToPDF(printingSetting, callback)
   }
 }


### PR DESCRIPTION
Fixes #5747 

It was printing irrespective of `custom_display_name` and `name` so I just set them up to `custom`.

Few examples:

[3in x 5in PDF](https://github.com/vasumahesh1/electron-test-playground/blob/master/pdf/PDF3inx5in.pdf)

[10cm x 10cm PDF](https://github.com/vasumahesh1/electron-test-playground/blob/master/pdf/PDF10cmx10cm.pdf)