### PR TITLE
Opt into long path handling on Windows 10

### DIFF
--- a/atom/browser/resources/win/atom.manifest
+++ b/atom/browser/resources/win/atom.manifest
@@ -33,6 +33,7 @@
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
       <dpiAware>true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
       <disableWindowFiltering xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</disableWindowFiltering>
     </asmv3:windowsSettings>
   </asmv3:application>


### PR DESCRIPTION
Windows 10 (Anniversary Update) allows apps to receive paths with
more than 260 characters (yes, that was already possible with UNC,
but we're finally allowing it for non-UNC, too).

This commit opts Electron in for said feature.