### PR TITLE
Rename and move atom-shell-frameworks repo

### DIFF
--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -10,7 +10,7 @@ from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 VERSION = 'v1.0.0'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-FRAMEWORKS_URL = 'http://github.com/atom/atom-shell-frameworks/releases' \
+FRAMEWORKS_URL = 'http://github.com/electron/electron-frameworks/releases' \
                  '/download/' + VERSION
 
 


### PR DESCRIPTION
Missed this one while doing #4874

The repo has been moved and renamed and is now at https://github.com/electron/electron-frameworks

I ran `python script/update-external-binaries.py` directly with this new URL and everything seemed to download correctly.