### PR TITLE
Correct typo in code block name

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -391,7 +391,7 @@ first available device will be selected. `callback` should be called with
 `deviceId` to be selected, passing empty string to `callback` will
 cancel the request.
 
-```javacript
+```javascript
 app.commandLine.appendSwitch('enable-web-bluetooth')
 
 app.on('ready', () => {


### PR DESCRIPTION
Add missing `s`, `javascript` -> `javascript`

Noticed it wasn't highlighted on http://electron.atom.io/docs/api/web-contents/#event-select-bluetooth-device