### PR TITLE
Log a warning if an extension has already been loaded

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -380,7 +380,11 @@ Find a window according to its ID.
 Adds DevTools extension located at `path`, and returns extension's name.
 
 The extension will be remembered so you only need to call this API once, this
-API is not for programming use.
+API is not for programming use. If you try to add an extension that has already
+been loaded, this method will not return and instead log a warning to the
+console.
+
+Method will also not return if the extension's manifest is missing or incomplete.
 
 ### `BrowserWindow.removeDevToolsExtension(name)`
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -38,6 +38,8 @@ const getManifestFromPath = function (srcDirectory) {
       })
     })
     return manifest
+  } else if (manifest && manifest.name) {
+    console.warn(`Attempted to load extension "${manifest.name}", but extension was already loaded!`)
   }
 }
 


### PR DESCRIPTION
If an extension has already been loaded (for instance because it’s
persisted), `addDevToolsExtension` will return nothing, which is
confusing. This adds a little `console.warn` to educate people about
what’s happening.

Closes #5854