### PR TITLE
Add 'delete' and 'pasteandmatchstyle' roles

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -33,7 +33,7 @@ Role kRolesMap[] = {
   { @selector(copy:), "copy" },
   { @selector(paste:), "paste" },
   { @selector(delete:), "delete" },
-  { @selector(pasteAndMatchStyle:), "paste-and-match-style" },
+  { @selector(pasteAndMatchStyle:), "pasteandmatchstyle" },
   { @selector(selectAll:), "selectall" },
   { @selector(performMiniaturize:), "minimize" },
   { @selector(performClose:), "close" },

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -46,7 +46,9 @@ The `role` property can have following values:
 * `cut`
 * `copy`
 * `paste`
+* `pasteandmatchstyle`
 * `selectall`
+* `delete`
 * `minimize` - Minimize current window
 * `close` - Close current window
 

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -11,6 +11,7 @@ rolesMap = {
   cut: 'cut',
   copy: 'copy',
   paste: 'paste',
+  pasteandmatchstyle: 'pasteAndMatchStyle',
   selectall: 'selectAll',
   minimize: 'minimize',
   close: 'close',


### PR DESCRIPTION
* `delete` was already implemented so we simply need to add to the docs.
* `paste-and-match-style` was already implemented on OS X side so we needed to map the corresponding action in `web-contents` for Linux and Windows.

---
Closes #5866 
Closes #5867 