### PR TITLE
Log a warning if an extension's manifest cannot be parsed

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -20,7 +20,15 @@ const generateExtensionIdFromName = function (name) {
 
 // Create or get manifest object from |srcDirectory|.
 const getManifestFromPath = function (srcDirectory) {
-  const manifest = JSON.parse(fs.readFileSync(path.join(srcDirectory, 'manifest.json')))
+  let manifest
+
+  try {
+    manifest = JSON.parse(fs.readFileSync(path.join(srcDirectory, 'manifest.json')))
+  } catch (err) {
+    console.warn(`Attempted to load extension from ${srcDirectory}, but parsing the manifest failed.`)
+    console.warn('Error encountered:', err)
+  }
+
   if (!manifestNameMap[manifest.name]) {
     const extensionId = generateExtensionIdFromName(manifest.name)
     console.log(extensionId)


### PR DESCRIPTION
Also logs a clean warning if an extension's manifest is incomplete,
missing, or can otherwise not be parsed.

I promised @mnquintana to make this a part of #5859, but Cheng was quicker with merging than I was with updating my PR :wink: