### PR TITLE
Don't log devtools extension id

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -31,7 +31,6 @@ const getManifestFromPath = function (srcDirectory) {
 
   if (!manifestNameMap[manifest.name]) {
     const extensionId = generateExtensionIdFromName(manifest.name)
-    console.log(extensionId)
     manifestMap[extensionId] = manifestNameMap[manifest.name] = manifest
     Object.assign(manifest, {
       srcDirectory: srcDirectory,


### PR DESCRIPTION
This removes the logging of the devtools extension id that was added in #5711

The extension name is returned `BrowserWindow.addDevToolsExtension` from the API to indicate success so I'm not sure this logging is needed and gets kind of noisy since it will get logged every time you open the dev tools for each extension you have installed. 