### PR TITLE
Implement chrome.runtime.id

### DIFF
--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -99,6 +99,8 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
   })
 
   chrome.runtime = {
+    id: extensionId,
+
     getURL: function (path) {
       return url.format({
         protocol: 'chrome-extension',

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -863,7 +863,7 @@ describe('browser-window module', function () {
           w.webContents.openDevTools({mode: 'bottom'})
 
           ipcMain.once('answer', function (event, message) {
-            assert.equal(message, 'extension loaded')
+            assert.equal(message.runtimeId, 'foo')
             done()
           })
         })
@@ -873,8 +873,8 @@ describe('browser-window module', function () {
         it('creates the extension', function (done) {
           w.webContents.openDevTools({mode: 'undocked'})
 
-          ipcMain.once('answer', function (event, message) {
-            assert.equal(message, 'extension loaded')
+          ipcMain.once('answer', function (event, message, extensionId) {
+            assert.equal(message.runtimeId, 'foo')
             done()
           })
         })

--- a/spec/fixtures/devtools-extensions/foo/index.html
+++ b/spec/fixtures/devtools-extensions/foo/index.html
@@ -4,7 +4,10 @@
     <meta charset="utf-8">
     <title></title>
     <script>
-      var sendMessage = `require('electron').ipcRenderer.send('answer', 'extension loaded')`
+      var message = JSON.stringify({
+        runtimeId: chrome.runtime.id
+      })
+      var sendMessage = `require('electron').ipcRenderer.send('answer', ${message})`
       window.chrome.devtools.inspectedWindow.eval(sendMessage, function () {})
     </script>
   </head>


### PR DESCRIPTION
Implements the [`chrome.runtime.id`](https://developer.chrome.com/extensions/runtime#property-id) with the extension id.

Refs #5842