### PR TITLE
docs: Move "Sign Native Modules" to MAS Guide

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -120,6 +120,24 @@ If you are new to app sandboxing under OS X, you should also read through
 Apple's [Enabling App Sandbox][enable-app-sandbox] to have a basic idea, then
 add keys for the permissions needed by your app to the entitlements files.
 
+Apart from manually signing your app, you can also choose to use the
+[electron-osx-sign][electron-osx-sign] module to do the job.
+
+#### Sign Native Modules
+
+Native modules used in your app also need to be signed. If using
+electron-osx-sign, be sure to include the path to the built binaries in the
+argument list:
+
+```bash
+electron-osx-sign YourApp.app YourApp.app/Contents/Resources/app/node_modules/nativemodule/build/release/nativemodule
+```
+
+Also note that native modules may have intermediate files produced which should
+not be included (as they would also need to be signed). If you use
+[electron-packager][electron-packager], add `--ignore=.+\.o$` to build step to
+ignore these files.
+
 ### Upload Your App
 
 After signing your app, you can use Application Loader to upload it to iTunes
@@ -189,6 +207,8 @@ ERN)][ern-tutorial].
 [nwjs-guide]: https://github.com/nwjs/nw.js/wiki/Mac-App-Store-%28MAS%29-Submission-Guideline#first-steps
 [enable-app-sandbox]: https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html
 [create-record]: https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/CreatingiTunesConnectRecord.html
+[electron-osx-sign]: https://github.com/electron-userland/electron-osx-sign
+[electron-packager]: https://github.com/electron-userland/electron-packager
 [submit-for-review]: https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html
 [app-sandboxing]: https://developer.apple.com/app-sandboxing/
 [ern-tutorial]: https://carouselapps.com/2015/12/15/legally-submit-app-apples-app-store-uses-encryption-obtain-ern/

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -65,8 +65,3 @@ The `HOME=~/.electron-gyp` changes where to find development headers. The
 `--target=0.29.1` is version of Electron. The `--dist-url=...` specifies
 where to download the headers. The `--arch=x64` says the module is built for
 64bit system.
-
-### Packaging and signing apps with native modules
-
-Native modules need to be signed. If using electron-osx-sign, be sure to include the path to the built binaries in the argument list (eg electron-osx-sign yourapp/YourApp.app yourapp/YourApp.app/Contents/Resources/app/node_modules/nativemodule/build/release/nativemodule). Also note that native modules may have intermediate files produced which should not be included (as they would also need to be signed). Add --ignore=.+\.o$ to your electron-packager build step to ignore these files (their unsigned inclusion will result in the ITMS-90135 error).
-


### PR DESCRIPTION
Only people signing an OS X app would need this information.