### PR TITLE
fix link to how-to-share-data-between-web-pages

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -225,4 +225,4 @@ $ cd electron-quick-start
 $ npm install && npm start
 ```
 
-[share-data]: ../faq/electron-faq.md#how-to-share-data-between-web-pages
+[share-data]: ../faq/#how-to-share-data-between-web-pages


### PR DESCRIPTION
This link 404s on http://electron.atom.io/docs/tutorial/quick-start/