### PR TITLE
docs: Update the code sample of screen module

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -9,44 +9,42 @@ emitted (by invoking or requiring it).
 
 **Note:** In the renderer / DevTools, `window.screen` is a reserved DOM
 property, so writing `let {screen} = require('electron')` will not work.
-In our examples below, we use `electronScreen` as the variable name instead.
+
 An example of creating a window that fills the whole screen:
 
 ```javascript
-const {app, BrowserWindow, screen: electronScreen} = require('electron');
+const electron = require('electron')
+const {app, BrowserWindow} = electron
 
-let win;
+let win
 
 app.on('ready', () => {
-  const {width, height} = electronScreen.getPrimaryDisplay().workAreaSize;
-  win = new BrowserWindow({width, height});
+  const {width, height} = electron.screen.getPrimaryDisplay().workAreaSize
+  win = new BrowserWindow({width, height})
 });
 ```
 
 Another example of creating a window in the external display:
 
 ```javascript
-const {app, BrowserWindow, screen: electronScreen} = require('electron');
+const electron = require('electron')
+const {app, BrowserWindow} = require('electron')
 
-let win;
+let win
 
 app.on('ready', () => {
-  let displays = electronScreen.getAllDisplays();
-  let externalDisplay = null;
-  for (let i in displays) {
-    if (displays[i].bounds.x !== 0 || displays[i].bounds.y !== 0) {
-      externalDisplay = displays[i];
-      break;
-    }
-  }
+  let displays = electron.screen.getAllDisplays()
+  let externalDisplay = displays.find((display) => {
+    return display.bounds.x !== 0 || display.bounds.y !== 0
+  })
 
   if (externalDisplay) {
     win = new BrowserWindow({
       x: externalDisplay.bounds.x + 50,
       y: externalDisplay.bounds.y + 50
-    });
+    })
   }
-});
+})
 ```
 
 ## The `Display` object


### PR DESCRIPTION
* We should not require it before the ready event;
* There is no need to use electronScreen as name in the main process.

