### PR TITLE
Enable DevTools extensions in webviews

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -749,6 +749,7 @@ std::string WebContents::GetType() const {
     case BROWSER_WINDOW: return "window";
     case WEB_VIEW: return "webview";
     case REMOTE: return "remote";
+    default: return "";
   }
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -744,6 +744,14 @@ int WebContents::GetID() const {
   return web_contents()->GetRenderProcessHost()->GetID();
 }
 
+std::string WebContents::GetType() const {
+  switch (type_) {
+    case BROWSER_WINDOW: return "window";
+    case WEB_VIEW: return "webview";
+    case REMOTE: return "remote";
+  }
+}
+
 bool WebContents::Equal(const WebContents* web_contents) const {
   return GetID() == web_contents->GetID();
 }
@@ -1287,6 +1295,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("endFrameSubscription", &WebContents::EndFrameSubscription)
       .SetMethod("setSize", &WebContents::SetSize)
       .SetMethod("isGuest", &WebContents::IsGuest)
+      .SetMethod("getType", &WebContents::GetType)
       .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)
       .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
       .SetMethod("hasServiceWorker", &WebContents::HasServiceWorker)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1365,6 +1365,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("_setWrapWebContents", &atom::api::SetWrapWebContents);
   dict.SetMethod("fromId",
                  &mate::TrackableObject<atom::api::WebContents>::FromWeakMapID);
+  dict.SetMethod("getAllWebContents",
+                 &mate::TrackableObject<atom::api::WebContents>::GetAll);
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -59,6 +59,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
                              v8::Local<v8::ObjectTemplate> prototype);
 
   int GetID() const;
+  std::string GetType() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);
   void DownloadURL(const GURL& url);

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -10,6 +10,14 @@ session
 const binding = process.atomBinding('web_contents')
 const debuggerBinding = process.atomBinding('debugger')
 
+const WebContents = new EventEmitter()
+WebContents.create = (options = {}) => {
+  return binding.create(options)
+}
+WebContents.fromId = (id) => {
+  return binding.fromId(id)
+}
+
 let nextId = 0
 const getNextId = function () {
   return ++nextId
@@ -223,6 +231,8 @@ const wrapWebContents = function (webContents) {
 
     this._printToPDF(printingSetting, callback)
   }
+
+  WebContents.emit('web-contents-created', webContents)
 }
 
 binding._setWrapWebContents(wrapWebContents)
@@ -235,12 +245,4 @@ const wrapDebugger = function (webContentsDebugger) {
 
 debuggerBinding._setWrapDebugger(wrapDebugger)
 
-module.exports = {
-  create (options = {}) {
-    return binding.create(options)
-  },
-
-  fromId (id) {
-    return binding.fromId(id)
-  }
-}
+module.exports = WebContents

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -1,4 +1,5 @@
 const {app, ipcMain, protocol, webContents, BrowserWindow} = require('electron')
+const WebContents = process.atomBinding('web_contents')
 const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllBrowserWindow()
 
 const fs = require('fs')
@@ -295,8 +296,8 @@ app.once('ready', function () {
   BrowserWindow.addDevToolsExtension = function (srcDirectory) {
     const manifest = getManifestFromPath(srcDirectory)
     if (manifest) {
-      for (const win of BrowserWindow.getAllWindows()) {
-        loadDevToolsExtensions(win, [manifest])
+      for (const webContents of WebContents.getAllWebContents()) {
+        loadDevToolsExtensions(webContents, [manifest])
       }
       return manifest.name
     }

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -222,6 +222,13 @@ const loadDevToolsExtensions = function (win, manifests) {
   win.devToolsWebContents.executeJavaScript(`DevToolsAPI.addExtensions(${JSON.stringify(extensionInfoArray)})`)
 }
 
+webContents.on('web-contents-created', function (webContents) {
+  hookWindowForTabEvents(webContents)
+  webContents.on('devtools-opened', function () {
+    loadDevToolsExtensions(webContents, objectValues(manifestMap))
+  })
+})
+
 // The persistent path of "DevTools Extensions" preference file.
 let loadedExtensionsPath = null
 
@@ -312,18 +319,4 @@ app.once('ready', function () {
     delete manifestMap[manifest.extensionId]
     delete manifestNameMap[name]
   }
-
-  // Load extensions automatically when devtools is opened.
-  const init = BrowserWindow.prototype._init
-  BrowserWindow.prototype._init = function () {
-    init.call(this)
-    exports.loadDevToolsExtensions(this.webContents)
-  }
 })
-
-exports.loadDevToolsExtensions = function (webContents) {
-  hookWindowForTabEvents(webContents)
-  webContents.on('devtools-opened', function () {
-    loadDevToolsExtensions(webContents, objectValues(manifestMap))
-  })
-}

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -81,8 +81,8 @@ const removeBackgroundPages = function (manifest) {
 }
 
 // Dispatch tabs events.
-const hookWindowForTabEvents = function (win) {
-  const tabId = win.webContents.id
+const hookWindowForTabEvents = function (win, webContents) {
+  const tabId = webContents.id
   for (const page of objectValues(backgroundPages)) {
     page.webContents.sendToAll('CHROME_TABS_ONCREATED', tabId)
   }
@@ -301,6 +301,7 @@ app.once('ready', function () {
       return manifest.name
     }
   }
+
   BrowserWindow.removeDevToolsExtension = function (name) {
     const manifest = manifestNameMap[name]
     if (!manifest) return
@@ -315,9 +316,13 @@ app.once('ready', function () {
   const init = BrowserWindow.prototype._init
   BrowserWindow.prototype._init = function () {
     init.call(this)
-    hookWindowForTabEvents(this)
-    this.webContents.on('devtools-opened', () => {
-      loadDevToolsExtensions(this, objectValues(manifestMap))
+    this._loadDevToolsExtensions(this.webContents)
+  }
+
+  BrowserWindow.prototype._loadDevToolsExtensions = function (webContents) {
+    hookWindowForTabEvents(this, webContents)
+    webContents.on('devtools-opened', function () {
+      loadDevToolsExtensions(webContents, objectValues(manifestMap))
     })
   }
 })

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -317,13 +317,13 @@ app.once('ready', function () {
   const init = BrowserWindow.prototype._init
   BrowserWindow.prototype._init = function () {
     init.call(this)
-    this._loadDevToolsExtensions(this.webContents)
-  }
-
-  BrowserWindow.prototype._loadDevToolsExtensions = function (webContents) {
-    hookWindowForTabEvents(webContents)
-    webContents.on('devtools-opened', function () {
-      loadDevToolsExtensions(webContents, objectValues(manifestMap))
-    })
+    exports.loadDevToolsExtensions(this.webContents)
   }
 })
+
+exports.loadDevToolsExtensions = function (webContents) {
+  hookWindowForTabEvents(webContents)
+  webContents.on('devtools-opened', function () {
+    loadDevToolsExtensions(webContents, objectValues(manifestMap))
+  })
+}

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -1,5 +1,5 @@
 const {app, ipcMain, protocol, webContents, BrowserWindow} = require('electron')
-const WebContents = process.atomBinding('web_contents')
+const {getAllWebContents} = process.atomBinding('web_contents')
 const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllBrowserWindow()
 
 const fs = require('fs')
@@ -296,7 +296,7 @@ app.once('ready', function () {
   BrowserWindow.addDevToolsExtension = function (srcDirectory) {
     const manifest = getManifestFromPath(srcDirectory)
     if (manifest) {
-      for (const webContents of WebContents.getAllWebContents()) {
+      for (const webContents of getAllWebContents()) {
         loadDevToolsExtensions(webContents, [manifest])
       }
       return manifest.name

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -82,7 +82,7 @@ const removeBackgroundPages = function (manifest) {
 }
 
 // Dispatch tabs events.
-const hookWindowForTabEvents = function (webContents) {
+const hookWebContentsForTabEvents = function (webContents) {
   const tabId = webContents.id
   for (const page of objectValues(backgroundPages)) {
     page.webContents.sendToAll('CHROME_TABS_ONCREATED', tabId)
@@ -225,7 +225,7 @@ const loadDevToolsExtensions = function (win, manifests) {
 webContents.on('web-contents-created', function (webContents) {
   if (webContents.getType() === 'remote') return
 
-  hookWindowForTabEvents(webContents)
+  hookWebContentsForTabEvents(webContents)
   webContents.on('devtools-opened', function () {
     loadDevToolsExtensions(webContents, objectValues(manifestMap))
   })

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -81,13 +81,13 @@ const removeBackgroundPages = function (manifest) {
 }
 
 // Dispatch tabs events.
-const hookWindowForTabEvents = function (win, webContents) {
+const hookWindowForTabEvents = function (webContents) {
   const tabId = webContents.id
   for (const page of objectValues(backgroundPages)) {
     page.webContents.sendToAll('CHROME_TABS_ONCREATED', tabId)
   }
 
-  win.once('closed', () => {
+  webContents.once('destroyed', () => {
     for (const page of objectValues(backgroundPages)) {
       page.webContents.sendToAll('CHROME_TABS_ONREMOVED', tabId)
     }
@@ -320,7 +320,7 @@ app.once('ready', function () {
   }
 
   BrowserWindow.prototype._loadDevToolsExtensions = function (webContents) {
-    hookWindowForTabEvents(this, webContents)
+    hookWindowForTabEvents(webContents)
     webContents.on('devtools-opened', function () {
       loadDevToolsExtensions(webContents, objectValues(manifestMap))
     })

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -223,6 +223,8 @@ const loadDevToolsExtensions = function (win, manifests) {
 }
 
 webContents.on('web-contents-created', function (webContents) {
+  if (webContents.getType() === 'remote') return
+
   hookWindowForTabEvents(webContents)
   webContents.on('devtools-opened', function () {
     loadDevToolsExtensions(webContents, objectValues(manifestMap))
@@ -304,7 +306,9 @@ app.once('ready', function () {
     const manifest = getManifestFromPath(srcDirectory)
     if (manifest) {
       for (const webContents of getAllWebContents()) {
-        loadDevToolsExtensions(webContents, [manifest])
+        if (webContents.getType() !== 'remote') {
+          loadDevToolsExtensions(webContents, [manifest])
+        }
       }
       return manifest.name
     }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const ChromeExtension = require('./chrome-extension')
 const ipcMain = require('electron').ipcMain
 const webContents = require('electron').webContents
 
@@ -150,9 +149,6 @@ const createGuest = function (embedder, params) {
   guest.on('size-changed', function (_, ...args) {
     embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + guest.viewInstanceId].concat(args))
   })
-
-  // Enable DevTools extensions in guest view
-  ChromeExtension.loadDevToolsExtensions(guest)
 
   return id
 }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const {BrowserWindow, ipcMain, webContents} = require('electron')
+const ChromeExtension = require('./chrome-extension')
+const ipcMain = require('electron').ipcMain
+const webContents = require('electron').webContents
 
 // Doesn't exist in early initialization.
 let webViewManager = null
@@ -150,8 +152,7 @@ const createGuest = function (embedder, params) {
   })
 
   // Enable DevTools extensions in guest view
-  const window = BrowserWindow.fromWebContents(embedder)
-  if (window) window._loadDevToolsExtensions(guest)
+  ChromeExtension.loadDevToolsExtensions(guest)
 
   return id
 }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const BrowserWindow = require('electron').BrowserWindow
-const ipcMain = require('electron').ipcMain
-const webContents = require('electron').webContents
+const {BrowserWindow, ipcMain, webContents} = require('electron')
 
 // Doesn't exist in early initialization.
 let webViewManager = null

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const BrowserWindow = require('electron').BrowserWindow
 const ipcMain = require('electron').ipcMain
 const webContents = require('electron').webContents
 
@@ -149,6 +150,10 @@ const createGuest = function (embedder, params) {
   guest.on('size-changed', function (_, ...args) {
     embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + guest.viewInstanceId].concat(args))
   })
+
+  // Enable DevTools extensions in guest view
+  const window = BrowserWindow.fromWebContents(embedder)
+  if (window) window._loadDevToolsExtensions(guest)
 
   return id
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -864,6 +864,7 @@ describe('browser-window module', function () {
 
           ipcMain.once('answer', function (event, message) {
             assert.equal(message.runtimeId, 'foo')
+            assert.equal(message.tabId, w.webContents.id)
             done()
           })
         })
@@ -875,6 +876,7 @@ describe('browser-window module', function () {
 
           ipcMain.once('answer', function (event, message, extensionId) {
             assert.equal(message.runtimeId, 'foo')
+            assert.equal(message.tabId, w.webContents.id)
             done()
           })
         })

--- a/spec/fixtures/devtools-extensions/foo/index.html
+++ b/spec/fixtures/devtools-extensions/foo/index.html
@@ -5,7 +5,8 @@
     <title></title>
     <script>
       var message = JSON.stringify({
-        runtimeId: chrome.runtime.id
+        runtimeId: chrome.runtime.id,
+        tabId: chrome.devtools.inspectedWindow.tabId
       })
       var sendMessage = `require('electron').ipcRenderer.send('answer', ${message})`
       window.chrome.devtools.inspectedWindow.eval(sendMessage, function () {})

--- a/spec/fixtures/pages/webview-devtools.html
+++ b/spec/fixtures/pages/webview-devtools.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <webview nodeintegration src="./a.html"></webview>
+    <script>
+        var wv = document.querySelector('webview')
+        wv.addEventListener('dom-ready', () => {
+          const webContents = wv.getWebContents()
+          webContents.on('devtools-opened', function () {
+            var showPanelIntevalId = setInterval(function () {
+              if (webContents.devToolsWebContents) {
+                webContents.devToolsWebContents.executeJavaScript('(' + (function () {
+                  var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
+                  WebInspector.inspectorView.showPanel(lastPanelId)
+                }).toString() + ')()')
+              } else {
+                clearInterval(showPanelIntevalId)
+              }
+            }, 100)
+          })
+
+          wv.openDevTools()
+        })
+      </script>
+    </script>
+  </body>
+</html>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -912,4 +912,24 @@ describe('<webview> tag', function () {
 
     w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
   })
+
+  it('loads devtools extension registered on the parent window', function (done) {
+    this.timeout(10000)
+
+    w = new BrowserWindow({
+      show: false
+    })
+
+    BrowserWindow.removeDevToolsExtension('foo')
+
+    var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
+    BrowserWindow.addDevToolsExtension(extensionPath)
+
+    w.loadURL('file://' + fixtures + '/pages/webview-devtools.html')
+
+    ipcMain.once('answer', function (event, message) {
+      assert.equal(message.runtimeId, 'foo')
+      done()
+    })
+  })
 })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -929,6 +929,7 @@ describe('<webview> tag', function () {
 
     ipcMain.once('answer', function (event, message) {
       assert.equal(message.runtimeId, 'foo')
+      assert.notEqual(message.tabId, w.webContents.id)
       done()
     })
   })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -913,7 +913,7 @@ describe('<webview> tag', function () {
     w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
   })
 
-  it('loads devtools extension registered on the parent window', function (done) {
+  it('loads devtools extensions registered on the parent window', function (done) {
     this.timeout(10000)
 
     w = new BrowserWindow({


### PR DESCRIPTION
Load registered extensions in the devtools for a `<webview>` when opened.

Closes #896