### PR TITLE
Remove unused results collection

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -82,7 +82,7 @@ var createGuest = function (embedder, params) {
   for (const event of destroyEvents) {
     embedder.once(event, destroy)
 
-    // Users might also listen to the crashed event, so We must ensure the guest
+    // Users might also listen to the crashed event, so we must ensure the guest
     // is destroyed before users' listener gets called. It is done by moving our
     // listener to the first one in queue.
     const listeners = embedder._events[event]

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -57,12 +57,12 @@ var getNextInstanceId = function () {
 
 // Create a new guest instance.
 var createGuest = function (embedder, params) {
-  var destroy, destroyEvents, event, fn, guest, i, id, j, len, len1, listeners
   if (webViewManager == null) {
     webViewManager = process.atomBinding('web_view_manager')
   }
-  id = getNextInstanceId(embedder)
-  guest = webContents.create({
+
+  const id = getNextInstanceId(embedder)
+  const guest = webContents.create({
     isGuest: true,
     partition: params.partition,
     embedder: embedder
@@ -73,20 +73,19 @@ var createGuest = function (embedder, params) {
   }
 
   // Destroy guest when the embedder is gone or navigated.
-  destroyEvents = ['will-destroy', 'crashed', 'did-navigate']
-  destroy = function () {
+  const destroyEvents = ['will-destroy', 'crashed', 'did-navigate']
+  const destroy = function () {
     if (guestInstances[id] != null) {
-      return destroyGuest(embedder, id)
+      destroyGuest(embedder, id)
     }
   }
-  for (i = 0, len = destroyEvents.length; i < len; i++) {
-    event = destroyEvents[i]
+  for (const event of destroyEvents) {
     embedder.once(event, destroy)
 
     // Users might also listen to the crashed event, so We must ensure the guest
     // is destroyed before users' listener gets called. It is done by moving our
     // listener to the first one in queue.
-    listeners = embedder._events[event]
+    const listeners = embedder._events[event]
     if (Array.isArray(listeners)) {
       moveLastToFirst(listeners)
     }
@@ -132,13 +131,12 @@ var createGuest = function (embedder, params) {
   })
 
   // Dispatch events to embedder.
-  fn = function (event) {
-    return guest.on(event, function (_, ...args) {
+  const fn = function (event) {
+    guest.on(event, function (_, ...args) {
       embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + guest.viewInstanceId, event].concat(args))
     })
   }
-  for (j = 0, len1 = supportedWebViewEvents.length; j < len1; j++) {
-    event = supportedWebViewEvents[j]
+  for (const event of supportedWebViewEvents) {
     fn(event)
   }
 
@@ -151,6 +149,7 @@ var createGuest = function (embedder, params) {
   guest.on('size-changed', function (_, ...args) {
     embedder.send.apply(embedder, ['ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED-' + guest.viewInstanceId].concat(args))
   })
+
   return id
 }
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -92,13 +92,9 @@ var createGuest = function (embedder, params) {
     }
   }
   guest.once('destroyed', function () {
-    var j, len1, results
-    results = []
-    for (j = 0, len1 = destroyEvents.length; j < len1; j++) {
-      event = destroyEvents[j]
-      results.push(embedder.removeListener(event, destroy))
+    for (const event of destroyEvents) {
+      embedder.removeListener(event, destroy)
     }
-    return results
   })
 
   // Init guest web view after attached.

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -4,9 +4,9 @@ const ipcMain = require('electron').ipcMain
 const webContents = require('electron').webContents
 
 // Doesn't exist in early initialization.
-var webViewManager = null
+let webViewManager = null
 
-var supportedWebViewEvents = [
+const supportedWebViewEvents = [
   'load-commit',
   'did-finish-load',
   'did-fail-load',
@@ -40,23 +40,23 @@ var supportedWebViewEvents = [
   'update-target-url'
 ]
 
-var nextInstanceId = 0
-var guestInstances = {}
-var embedderElementsMap = {}
-var reverseEmbedderElementsMap = {}
+let nextInstanceId = 0
+const guestInstances = {}
+const embedderElementsMap = {}
+const reverseEmbedderElementsMap = {}
 
 // Moves the last element of array to the first one.
-var moveLastToFirst = function (list) {
+const moveLastToFirst = function (list) {
   return list.unshift(list.pop())
 }
 
 // Generate guestInstanceId.
-var getNextInstanceId = function () {
+const getNextInstanceId = function () {
   return ++nextInstanceId
 }
 
 // Create a new guest instance.
-var createGuest = function (embedder, params) {
+const createGuest = function (embedder, params) {
   if (webViewManager == null) {
     webViewManager = process.atomBinding('web_view_manager')
   }
@@ -98,7 +98,7 @@ var createGuest = function (embedder, params) {
 
   // Init guest web view after attached.
   guest.once('did-attach', function () {
-    var opts
+    let opts
     params = this.attachParams
     delete this.attachParams
     this.viewInstanceId = params.instanceId
@@ -154,8 +154,8 @@ var createGuest = function (embedder, params) {
 }
 
 // Attach the guest to an element of embedder.
-var attachGuest = function (embedder, elementInstanceId, guestInstanceId, params) {
-  var guest, key, oldGuestInstanceId, ref1, webPreferences
+const attachGuest = function (embedder, elementInstanceId, guestInstanceId, params) {
+  let guest, key, oldGuestInstanceId, ref1, webPreferences
   guest = guestInstances[guestInstanceId].guest
 
   // Destroy the old guest when attaching.
@@ -190,12 +190,12 @@ var attachGuest = function (embedder, elementInstanceId, guestInstanceId, params
 }
 
 // Destroy an existing guest instance.
-var destroyGuest = function (embedder, id) {
-  var key
+const destroyGuest = function (embedder, id) {
   webViewManager.removeGuest(embedder, id)
   guestInstances[id].guest.destroy()
   delete guestInstances[id]
-  key = reverseEmbedderElementsMap[id]
+
+  const key = reverseEmbedderElementsMap[id]
   if (key != null) {
     delete reverseEmbedderElementsMap[id]
     return delete embedderElementsMap[key]
@@ -215,18 +215,18 @@ ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_DESTROY_GUEST', function (event, id) {
 })
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_SET_SIZE', function (event, id, params) {
-  var ref1
-  return (ref1 = guestInstances[id]) != null ? ref1.guest.setSize(params) : void 0
+  const guestInstance = guestInstances[id]
+  return guestInstance != null ? guestInstance.guest.setSize(params) : void 0
 })
 
 // Returns WebContents from its guest id.
 exports.getGuest = function (id) {
-  var ref1
-  return (ref1 = guestInstances[id]) != null ? ref1.guest : void 0
+  const guestInstance = guestInstances[id]
+  return guestInstance != null ? guestInstance.guest : void 0
 }
 
 // Returns the embedder of the guest.
 exports.getEmbedder = function (id) {
-  var ref1
-  return (ref1 = guestInstances[id]) != null ? ref1.embedder : void 0
+  const guestInstance = guestInstances[id]
+  return guestInstance != null ? guestInstance.embedder : void 0
 }


### PR DESCRIPTION
Noticed a place in `guest-view-manager` where the CoffeeScript auto-array collection when a method ended with a for loop was still happening.

This pull request removes it since it was unused and also uses `const`, `let` and `for`/`of` loops inside this file 🎨