### PR TITLE
Add showDefinitionForSelection to webContents/webview

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1299,7 +1299,8 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("_printToPDF", &WebContents::PrintToPDF)
       .SetMethod("addWorkSpace", &WebContents::AddWorkSpace)
       .SetMethod("removeWorkSpace", &WebContents::RemoveWorkSpace)
-      .SetMethod("showDefinitionForSelection", &WebContents::ShowDefinitionForSelection)
+      .SetMethod("showDefinitionForSelection",
+                 &WebContents::ShowDefinitionForSelection)
       .SetProperty("id", &WebContents::ID)
       .SetProperty("session", &WebContents::Session)
       .SetProperty("hostWebContents", &WebContents::HostWebContents)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1095,7 +1095,7 @@ void WebContents::StopFindInPage(content::StopFindAction action) {
 }
 
 void WebContents::ShowDefinitionForSelection() {
-#if defined(OS_WIN)
+#if defined(OS_MACOSX)
   const auto view = web_contents()->GetRenderWidgetHostView();
   if (view)
     view->ShowDefinitionForSelection();

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1099,8 +1099,6 @@ void WebContents::ShowDefinitionForSelection() {
   const auto view = web_contents()->GetRenderWidgetHostView();
   if (view)
     view->ShowDefinitionForSelection();
-#else
-  NOTIMPLEMENTED();
 #endif
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1094,6 +1094,16 @@ void WebContents::StopFindInPage(content::StopFindAction action) {
   web_contents()->StopFinding(action);
 }
 
+void WebContents::ShowDefinitionForSelection() {
+#if defined(OS_WIN)
+  const auto view = web_contents()->GetRenderWidgetHostView();
+  if (view)
+    view->ShowDefinitionForSelection();
+#else
+  NOTIMPLEMENTED();
+#endif
+}
+
 void WebContents::Focus() {
   web_contents()->Focus();
 }
@@ -1289,6 +1299,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("_printToPDF", &WebContents::PrintToPDF)
       .SetMethod("addWorkSpace", &WebContents::AddWorkSpace)
       .SetMethod("removeWorkSpace", &WebContents::RemoveWorkSpace)
+      .SetMethod("showDefinitionForSelection", &WebContents::ShowDefinitionForSelection)
       .SetProperty("id", &WebContents::ID)
       .SetProperty("session", &WebContents::Session)
       .SetProperty("hostWebContents", &WebContents::HostWebContents)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -116,6 +116,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void ReplaceMisspelling(const base::string16& word);
   uint32_t FindInPage(mate::Arguments* args);
   void StopFindInPage(content::StopFindAction action);
+  void ShowDefinitionForSelection();
 
   // Focus.
   void Focus();

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -623,12 +623,6 @@ void Window::UnhookAllWindowMessages() {
 }
 #endif
 
-#if defined(OS_MACOSX)
-void Window::ShowDefinitionForSelection() {
-  window_->ShowDefinitionForSelection();
-}
-#endif
-
 #if defined(TOOLKIT_VIEWS)
 void Window::SetIcon(mate::Handle<NativeImage> icon) {
 #if defined(OS_WIN)
@@ -759,10 +753,6 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isWindowMessageHooked", &Window::IsWindowMessageHooked)
       .SetMethod("unhookWindowMessage", &Window::UnhookWindowMessage)
       .SetMethod("unhookAllWindowMessages", &Window::UnhookAllWindowMessages)
-#endif
-#if defined(OS_MACOSX)
-      .SetMethod("showDefinitionForSelection",
-                 &Window::ShowDefinitionForSelection)
 #endif
 #if defined(TOOLKIT_VIEWS)
       .SetMethod("setIcon", &Window::SetIcon)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -169,10 +169,6 @@ class Window : public mate::TrackableObject<Window>,
   void UnhookAllWindowMessages();
 #endif
 
-#if defined(OS_MACOSX)
-  void ShowDefinitionForSelection();
-#endif
-
 #if defined(TOOLKIT_VIEWS)
   void SetIcon(mate::Handle<NativeImage> icon);
 #endif

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -334,10 +334,6 @@ void NativeWindow::CapturePage(const gfx::Rect& rect,
       kBGRA_8888_SkColorType);
 }
 
-void NativeWindow::ShowDefinitionForSelection() {
-  NOTIMPLEMENTED();
-}
-
 void NativeWindow::SetAutoHideMenuBar(bool auto_hide) {
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -179,9 +179,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual void CapturePage(const gfx::Rect& rect,
                            const CapturePageCallback& callback);
 
-  // Show popup dictionary.
-  virtual void ShowDefinitionForSelection();
-
   // Toggle the menu bar.
   virtual void SetAutoHideMenuBar(bool auto_hide);
   virtual bool IsMenuBarAutoHide();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -83,7 +83,6 @@ class NativeWindowMac : public NativeWindow {
   void SetProgressBar(double progress) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
-  void ShowDefinitionForSelection() override;
 
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -933,17 +933,6 @@ void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
                                      const std::string& description) {
 }
 
-void NativeWindowMac::ShowDefinitionForSelection() {
-  // TODO(kevinsawicki): Deprecate and remove this method in 2.0 in favor of
-  // calling it directly on webContents.
-  if (!web_contents())
-    return;
-  auto rwhv = web_contents()->GetRenderWidgetHostView();
-  if (!rwhv)
-    return;
-  rwhv->ShowDefinitionForSelection();
-}
-
 void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible) {
   SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -934,6 +934,8 @@ void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
 }
 
 void NativeWindowMac::ShowDefinitionForSelection() {
+  // TODO(kevinsawicki): Deprecate and remove this method in 2.0 in favor of
+  // calling it directly on webContents.
   if (!web_contents())
     return;
   auto rwhv = web_contents()->GetRenderWidgetHostView();

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -885,7 +885,7 @@ The `flags` is an array that can include following `String`s:
 
 ### `win.showDefinitionForSelection()` _OS X_
 
-Shows pop-up dictionary that searches the selected word on the page.
+Same as `webContents.showDefinitionForSelection()`.
 
 ### `win.setIcon(icon)` _Windows_ _Linux_
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -957,6 +957,10 @@ win.webContents.on('did-finish-load', () => {
 });
 ```
 
+### `webContents.showDefinitionForSelection()` _OS X_
+
+Shows pop-up dictionary that searches the selected word on the page.
+
 ## Instance Properties
 
 `WebContents` objects also have the following properties:

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -490,6 +490,10 @@ Sends an input `event` to the page.
 See [webContents.sendInputEvent](web-contents.md##webcontentssendinputeventevent)
 for detailed description of `event` object.
 
+### `<webview>.showDefinitionForSelection()` _OS X_
+
+Shows pop-up dictionary that searches the selected word on the page.
+
 ### `<webview>.getWebContents()`
 
 Returns the [WebContents](web-contents.md) associated with this `webview`.

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -151,6 +151,9 @@ Object.assign(BrowserWindow.prototype, {
   },
   inspectServiceWorker () {
     return this.webContents.inspectServiceWorker()
+  },
+  showDefinitionForSelection () {
+    return this.webContents.showDefinitionForSelection()
   }
 })
 

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -379,7 +379,8 @@ var registerWebViewElement = function () {
     'downloadURL',
     'inspectServiceWorker',
     'print',
-    'printToPDF'
+    'printToPDF',
+    'showDefinitionForSelection'
   ]
   nonblockMethods = [
     'insertCSS',


### PR DESCRIPTION
Adds the Mac OS X only `showDefinitionForSelection` API to `webContents` and `<webview>` that is currently only on the `BrowserWindow` API.

~~Also adds a `TODO` to deprecate `BrowserWindow.showDefinitionForSelection` in 2.0 since it seems consistent with the other `webContents` APIs like `findInPage`, `replaceMisspelling`, etc.~~

Closes #5275 