### PR TITLE
Support disabling Blink features

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -166,6 +166,13 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
     command_line->AppendSwitchASCII(::switches::kEnableBlinkFeatures,
                                     blink_features);
 
+  // Disable blink features.
+  std::string disable_blink_features;
+  if (web_preferences.GetString(options::kDisableBlinkFeatures,
+                                &disable_blink_features))
+    command_line->AppendSwitchASCII(::switches::kDisableBlinkFeatures,
+                                    disable_blink_features);
+
   // The initial visibility state.
   NativeWindow* window = NativeWindow::FromWebContents(web_contents);
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -109,6 +109,9 @@ const char kScrollBounce[] = "scrollBounce";
 // Enable blink features.
 const char kBlinkFeatures[] = "blinkFeatures";
 
+// Disable blink features.
+const char kDisableBlinkFeatures[] = "disableBlinkFeatures";
+
 }  // namespace options
 
 namespace switches {

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -107,6 +107,7 @@ const char kOpenerID[] = "openerId";
 const char kScrollBounce[] = "scrollBounce";
 
 // Enable blink features.
+// TODO(kevinsawicki) Rename to enableBlinkFeatures in 2.0
 const char kBlinkFeatures[] = "blinkFeatures";
 
 // Disable blink features.

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -58,6 +58,7 @@ extern const char kExperimentalCanvasFeatures[];
 extern const char kOpenerID[];
 extern const char kScrollBounce[];
 extern const char kBlinkFeatures[];
+extern const char kDisableBlinkFeatures[];
 
 }   // namespace options
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -176,8 +176,7 @@ The `webPreferences` option is an object that can have following properties:
   OS X. Default is `false`.
 * `blinkFeatures` String - A list of feature strings separated by `,`, like
   `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
-  can be found in the [setFeatureEnabledFromString][blink-feature-string]
-  function.
+  can be found in the [RuntimeEnabledFeatures.in][blink-feature-string] file.
 * `defaultFontFamily` Object - Sets the default font for the font-family.
   * `standard` String - Defaults to `Times New Roman`.
   * `serif` String - Defaults to `Times New Roman`.
@@ -938,4 +937,4 @@ All mouse events happened in this window will be passed to the window bellow
 this window, but if this window has focus, it will still receive keyboard
 events.
 
-[blink-feature-string]: https://code.google.com/p/chromium/codesearch#chromium/src/out/Debug/gen/blink/platform/RuntimeEnabledFeatures.cpp&sq=package:chromium&type=cs&l=576
+[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.in

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -175,12 +175,13 @@ The `webPreferences` option is an object that can have following properties:
 * `scrollBounce` Boolean - Enables scroll bounce (rubber banding) effect on
   OS X. Default is `false`.
 * `blinkFeatures` String - A list of feature strings separated by `,`, like
-  `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
-  can be found in the [RuntimeEnabledFeatures.in][blink-feature-string] file.
-* `disableBlinkFeatures` String - A list of feature strings separated by `,`,
-  like `CSSVariables,KeyboardEventKey`. The full list of supported feature
+  `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
   strings can be found in the [RuntimeEnabledFeatures.in][blink-feature-string]
   file.
+* `disableBlinkFeatures` String - A list of feature strings separated by `,`,
+  like `CSSVariables,KeyboardEventKey` to disable. The full list of supported
+  feature strings can be found in the
+  [RuntimeEnabledFeatures.in][blink-feature-string] file.
 * `defaultFontFamily` Object - Sets the default font for the font-family.
   * `standard` String - Defaults to `Times New Roman`.
   * `serif` String - Defaults to `Times New Roman`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -177,6 +177,10 @@ The `webPreferences` option is an object that can have following properties:
 * `blinkFeatures` String - A list of feature strings separated by `,`, like
   `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
   can be found in the [RuntimeEnabledFeatures.in][blink-feature-string] file.
+* `disableBlinkFeatures` String - A list of feature strings separated by `,`,
+  like `CSSVariables,KeyboardEventKey`. The full list of supported feature
+  strings can be found in the [RuntimeEnabledFeatures.in][blink-feature-string]
+  file.
 * `defaultFontFamily` Object - Sets the default font for the font-family.
   * `standard` String - Defaults to `Times New Roman`.
   * `serif` String - Defaults to `Times New Roman`.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -205,7 +205,17 @@ If "on", the guest page will be allowed to open new windows.
 
 A list of strings which specifies the blink features to be enabled separated by `,`.
 The full list of supported feature strings can be found in the
-[setFeatureEnabledFromString][blink-feature-string] function.
+[RuntimeEnabledFeatures.in][blink-feature-string] file.
+
+### `disableblinkfeatures`
+
+```html
+<webview src="https://www.github.com/" disableblinkfeatures="PreciseMemoryInfo, CSSVariables"></webview>
+```
+
+A list of strings which specifies the blink features to be disabled separated by `,`.
+The full list of supported feature strings can be found in the
+[RuntimeEnabledFeatures.in][blink-feature-string] file.
 
 ## Methods
 
@@ -802,4 +812,4 @@ Emitted when DevTools is closed.
 
 Emitted when DevTools is focused / opened.
 
-[blink-feature-string]: https://code.google.com/p/chromium/codesearch#chromium/src/out/Debug/gen/blink/platform/RuntimeEnabledFeatures.cpp&sq=package:chromium&type=cs&l=527
+[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.in

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -183,7 +183,7 @@ var attachGuest = function (embedder, elementInstanceId, guestInstanceId, params
     zoomFactor: params.zoomFactor,
     webSecurity: !params.disablewebsecurity,
     blinkFeatures: params.blinkfeatures,
-    disableBlinkFeatures: params.disableBlinkFeatures,
+    disableBlinkFeatures: params.disableBlinkFeatures
   }
 
   if (params.preload) {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -183,7 +183,7 @@ var attachGuest = function (embedder, elementInstanceId, guestInstanceId, params
     zoomFactor: params.zoomFactor,
     webSecurity: !params.disablewebsecurity,
     blinkFeatures: params.blinkfeatures,
-    disableBlinkFeatures: params.disableBlinkFeatures
+    disableBlinkFeatures: params.disableblinkfeatures
   }
 
   if (params.preload) {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -182,7 +182,8 @@ var attachGuest = function (embedder, elementInstanceId, guestInstanceId, params
     plugins: params.plugins,
     zoomFactor: params.zoomFactor,
     webSecurity: !params.disablewebsecurity,
-    blinkFeatures: params.blinkfeatures
+    blinkFeatures: params.blinkfeatures,
+    disableBlinkFeatures: params.disableBlinkFeatures,
   }
 
   if (params.preload) {

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -267,7 +267,7 @@ class BlinkFeaturesAttribute extends WebViewAttribute {
 // Attribute that specifies the blink features to be disabled.
 class DisableBlinkFeaturesAttribute extends WebViewAttribute {
   constructor (webViewImpl) {
-    super(webViewConstants.ATTRIBUTE_DISBLEBLINKFEATURES, webViewImpl)
+    super(webViewConstants.ATTRIBUTE_DISABLEBLINKFEATURES, webViewImpl)
   }
 }
 
@@ -285,7 +285,7 @@ WebViewImpl.prototype.setupWebViewAttributes = function () {
   this.attributes[webViewConstants.ATTRIBUTE_ALLOWPOPUPS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_ALLOWPOPUPS, this)
   this.attributes[webViewConstants.ATTRIBUTE_PRELOAD] = new PreloadAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_BLINKFEATURES] = new BlinkFeaturesAttribute(this)
-  this.attributes[webViewConstants.ATTRIBUTE_DISBLEBLINKFEATURES] = new DisableBlinkFeaturesAttribute(this)
+  this.attributes[webViewConstants.ATTRIBUTE_DISABLEBLINKFEATURES] = new DisableBlinkFeaturesAttribute(this)
 
   const autosizeAttributes = [webViewConstants.ATTRIBUTE_MAXHEIGHT, webViewConstants.ATTRIBUTE_MAXWIDTH, webViewConstants.ATTRIBUTE_MINHEIGHT, webViewConstants.ATTRIBUTE_MINWIDTH]
   autosizeAttributes.forEach((attribute) => {

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -264,6 +264,13 @@ class BlinkFeaturesAttribute extends WebViewAttribute {
   }
 }
 
+// Attribute that specifies the blink features to be disabled.
+class DisableBlinkFeaturesAttribute extends WebViewAttribute {
+  constructor (webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_DISBLEBLINKFEATURES, webViewImpl)
+  }
+}
+
 // Sets up all of the webview attributes.
 WebViewImpl.prototype.setupWebViewAttributes = function () {
   this.attributes = {}
@@ -278,6 +285,7 @@ WebViewImpl.prototype.setupWebViewAttributes = function () {
   this.attributes[webViewConstants.ATTRIBUTE_ALLOWPOPUPS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_ALLOWPOPUPS, this)
   this.attributes[webViewConstants.ATTRIBUTE_PRELOAD] = new PreloadAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_BLINKFEATURES] = new BlinkFeaturesAttribute(this)
+  this.attributes[webViewConstants.ATTRIBUTE_DISBLEBLINKFEATURES] = new DisableBlinkFeaturesAttribute(this)
 
   const autosizeAttributes = [webViewConstants.ATTRIBUTE_MAXHEIGHT, webViewConstants.ATTRIBUTE_MAXWIDTH, webViewConstants.ATTRIBUTE_MINHEIGHT, webViewConstants.ATTRIBUTE_MINWIDTH]
   autosizeAttributes.forEach((attribute) => {

--- a/lib/renderer/web-view/web-view-constants.js
+++ b/lib/renderer/web-view/web-view-constants.js
@@ -16,7 +16,7 @@ module.exports = {
   ATTRIBUTE_PRELOAD: 'preload',
   ATTRIBUTE_USERAGENT: 'useragent',
   ATTRIBUTE_BLINKFEATURES: 'blinkfeatures',
-  ATTRIBUTE_DISBLEBLINKFEATURES: 'disableblinkfeatures',
+  ATTRIBUTE_DISABLEBLINKFEATURES: 'disableblinkfeatures',
 
   // Internal attribute.
   ATTRIBUTE_INTERNALINSTANCEID: 'internalinstanceid',

--- a/lib/renderer/web-view/web-view-constants.js
+++ b/lib/renderer/web-view/web-view-constants.js
@@ -16,6 +16,7 @@ module.exports = {
   ATTRIBUTE_PRELOAD: 'preload',
   ATTRIBUTE_USERAGENT: 'useragent',
   ATTRIBUTE_BLINKFEATURES: 'blinkfeatures',
+  ATTRIBUTE_DISBLEBLINKFEATURES: 'disableblinkfeatures',
 
   // Internal attribute.
   ATTRIBUTE_INTERNALINSTANCEID: 'internalinstanceid',


### PR DESCRIPTION
This pull request adds support for a `disableBlinkFeatures` option to the `BrowserWindow` constructor that does the inverse of what the current `blinkFeatures` option does.

It also adds support for it in `<webview>` tags using the `disableblinkfeatures` attribute.

Closes #5460 