### PR TITLE
Fix location of code snippet in nativeImage docs

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -103,6 +103,12 @@ Creates an empty `nativeImage` instance.
 
 Creates a new `nativeImage` instance from a file located at `path`.
 
+```javascript
+const nativeImage = require('electron').nativeImage;
+
+let image = nativeImage.createFromPath('/Users/somebody/images/icon.png');
+```
+
 ### `nativeImage.createFromBuffer(buffer[, scaleFactor])`
 
 * `buffer` [Buffer][buffer]
@@ -120,12 +126,6 @@ Creates a new `nativeImage` instance from `dataURL`.
 ## Instance Methods
 
 The following methods are available on instances of `nativeImage`:
-
-```javascript
-const nativeImage = require('electron').nativeImage;
-
-let image = nativeImage.createFromPath('/Users/somebody/images/icon.png');
-```
 
 ### `image.toPng()`
 


### PR DESCRIPTION
The code snippet for `nativeImage.createFromPath` somehow ended up in the wrong section of the document, this PR moves it back where it belongs.