### PR TITLE
Set maximizable state after installing view

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -524,10 +524,6 @@ NativeWindowMac::NativeWindowMac(
   options.Get(options::kDisableAutoHideCursor, &disableAutoHideCursor);
   [window_ setDisableAutoHideCursor:disableAutoHideCursor];
 
-  // Disable zoom button if window is not resizable.
-  if (!maximizable)
-    SetMaximizable(false);
-
   NSView* view = inspectable_web_contents()->GetView()->GetNativeView();
   [view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
 
@@ -555,6 +551,12 @@ NativeWindowMac::NativeWindowMac(
   }];
 
   InstallView();
+
+  // Disable zoom button if window is not resizable.
+  // Set maximizable state last to ensure zoom button does not get reset
+  // by calls to other APIs.
+  if (!maximizable)
+    SetMaximizable(false);
 }
 
 NativeWindowMac::~NativeWindowMac() {


### PR DESCRIPTION
Looks like the call to `setWantsLayer` on a transparent window with a frame in `InstallView` was causing the zoom button state to get reset so the previous call to `SetMaximizable` was getting undone.

This sets the maximizable state after `InstallView()` is called which appears to resolve this issue.

```js
window = new BrowserWindow({
    show: true,
    width: 800,
    height: 800,
    transparent: true,
    maximizable: false,
    backgroundColor: '#fff',
})
```

### Before

<img width="820" alt="screen shot 2016-06-08 at 2 02 33 pm" src="https://cloud.githubusercontent.com/assets/671378/15910832/a0a0b630-2d81-11e6-83b3-13b4227df332.png">

### After

<img width="809" alt="screen shot 2016-06-08 at 2 01 14 pm" src="https://cloud.githubusercontent.com/assets/671378/15910951/514ee876-2d82-11e6-8e5a-d1f9abc62981.png">

@zcbenz you mentioned in https://github.com/electron/electron/issues/5745#issuecomment-222398412 that transparent windows with frames weren't really supported but it might be okay to address if the fix was small and it does seem pretty small, but I'm also fine closing this out if this issue isn't worth addressing.

Closes #5745