### PR TITLE
Fix typo in `atom::TaskbarHost::InitializeTaskbar()`

### DIFF
--- a/atom/browser/ui/win/taskbar_host.cc
+++ b/atom/browser/ui/win/taskbar_host.cc
@@ -54,7 +54,7 @@ TaskbarHost::~TaskbarHost() {
 
 bool TaskbarHost::SetThumbarButtons(
     HWND window, const std::vector<ThumbarButton>& buttons) {
-  if (buttons.size() > kMaxButtonsCount || !InitailizeTaskbar())
+  if (buttons.size() > kMaxButtonsCount || !InitializeTaskbar())
     return false;
 
   callback_map_.clear();
@@ -118,7 +118,7 @@ bool TaskbarHost::SetThumbarButtons(
 }
 
 bool TaskbarHost::SetProgressBar(HWND window, double value) {
-  if (!InitailizeTaskbar())
+  if (!InitializeTaskbar())
     return false;
 
   HRESULT r;
@@ -133,7 +133,7 @@ bool TaskbarHost::SetProgressBar(HWND window, double value) {
 
 bool TaskbarHost::SetOverlayIcon(
     HWND window, const gfx::Image& overlay, const std::string& text) {
-  if (!InitailizeTaskbar())
+  if (!InitializeTaskbar())
     return false;
 
   base::win::ScopedHICON icon(
@@ -152,7 +152,7 @@ bool TaskbarHost::HandleThumbarButtonEvent(int button_id) {
   return false;
 }
 
-bool TaskbarHost::InitailizeTaskbar() {
+bool TaskbarHost::InitializeTaskbar() {
   if (FAILED(taskbar_.CreateInstance(CLSID_TaskbarList,
                                      nullptr,
                                      CLSCTX_INPROC_SERVER)) ||

--- a/atom/browser/ui/win/taskbar_host.h
+++ b/atom/browser/ui/win/taskbar_host.h
@@ -44,8 +44,8 @@ class TaskbarHost {
   bool HandleThumbarButtonEvent(int button_id);
 
  private:
-  // Initailize the taskbar object.
-  bool InitailizeTaskbar();
+  // Initialize the taskbar object.
+  bool InitializeTaskbar();
 
   using CallbackMap = std::map<int, base::Closure>;
   CallbackMap callback_map_;


### PR DESCRIPTION
`InitailizeTaskbar` -> `InitializeTaskbar`