### PR TITLE
Add BrowserWindow.getDevToolsExtensions API

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -396,11 +396,16 @@ Method will also not return if the extension's manifest is missing or incomplete
 
 Remove the DevTools extension whose name is `name`.
 
-### `BrowserWindow.isDevToolsExtensionInstalled(name)`
+### `BrowserWindow.getDevToolsExtensions()`
 
-* `name` String
+Returns an Object where the keys are the extension names and each value is
+an Object containing `name` and `version` properties.
 
-Returns `true` if the named DevTools extension is installed, `false` otherwise.
+To check if a DevTools extension is installed you can run the following:
+
+```javascript
+let installed = BrowserWindow.getDevToolsExtesion().hasOwnProperty('devtron')
+```
 
 ## Instance Properties
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -404,7 +404,7 @@ an Object containing `name` and `version` properties.
 To check if a DevTools extension is installed you can run the following:
 
 ```javascript
-let installed = BrowserWindow.getDevToolsExtesion().hasOwnProperty('devtron')
+let installed = BrowserWindow.getDevToolsExtensions().hasOwnProperty('devtron')
 ```
 
 ## Instance Properties

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -396,6 +396,12 @@ Method will also not return if the extension's manifest is missing or incomplete
 
 Remove the DevTools extension whose name is `name`.
 
+### `BrowserWindow.isDevToolsExtensionInstalled(name)`
+
+* `name` String
+
+Returns `true` if the named DevTools extension is installed, `false` otherwise.
+
 ## Instance Properties
 
 Objects created with `new BrowserWindow` have the following properties:

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -340,7 +340,12 @@ app.once('ready', function () {
     delete manifestNameMap[name]
   }
 
-  BrowserWindow.isDevToolsExtensionInstalled = function (name) {
-    return manifestNameMap.hasOwnProperty(name)
+  BrowserWindow.getDevToolsExtensions = function () {
+    const extensions = {}
+    Object.keys(manifestNameMap).forEach(function (name) {
+      const manifest = manifestNameMap[name]
+      extensions[name] = {name: manifest.name, version: manifest.version}
+    })
+    return extensions
   }
 })

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -339,4 +339,8 @@ app.once('ready', function () {
     delete manifestMap[manifest.extensionId]
     delete manifestNameMap[name]
   }
+
+  BrowserWindow.isDevToolsExtensionInstalled = function (name) {
+    return manifestNameMap.hasOwnProperty(name)
+  }
 })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -838,11 +838,11 @@ describe('browser-window module', function () {
 
       beforeEach(function () {
         BrowserWindow.removeDevToolsExtension('foo')
-        assert.equal(BrowserWindow.isDevToolsExtensionInstalled('foo'), false)
+        assert.equal(BrowserWindow.getDevToolsExtensions().hasOwnProperty('foo'), false)
 
         var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
         BrowserWindow.addDevToolsExtension(extensionPath)
-        assert.equal(BrowserWindow.isDevToolsExtensionInstalled('foo'), true)
+        assert.equal(BrowserWindow.getDevToolsExtensions().hasOwnProperty('foo'), true)
 
         w.webContents.on('devtools-opened', function () {
           var showPanelIntevalId = setInterval(function () {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -838,9 +838,11 @@ describe('browser-window module', function () {
 
       beforeEach(function () {
         BrowserWindow.removeDevToolsExtension('foo')
+        assert.equal(BrowserWindow.isDevToolsExtensionInstalled('foo'), false)
 
         var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
         BrowserWindow.addDevToolsExtension(extensionPath)
+        assert.equal(BrowserWindow.isDevToolsExtensionInstalled('foo'), true)
 
         w.webContents.on('devtools-opened', function () {
           var showPanelIntevalId = setInterval(function () {


### PR DESCRIPTION
Adds `BrowserWindow.getDevToolsExtensions()` that returns an object like so:

```json
{
  "devtron": {
    "name": "devtron",
    "version": "1.0.0"
  }
}
```

Closes #5960