### PR TITLE
Update Guide for Windows Store Apps

### DIFF
--- a/docs/tutorial/windows-store-guide.md
+++ b/docs/tutorial/windows-store-guide.md
@@ -5,7 +5,7 @@ Windows Platform. The new `.appx` format does not only enable a number of new
 powerful APIs like Cortana or Push Notifications, but through the Windows Store,
 also simplifies installation and updating.
 
-Microsoft [developed a tool that compiles Electron apps as `.appx` packages](http://github.com/catalystcode/electron-windows-store),
+Microsoft [developed a tool that compiles Electron apps as `.appx` packages][electron-windows-store],
 enabling developers to use some of the goodies found in the new application
 model. This guide explains how to use it - and what the capabilities and
 limitations of an Electron AppX package are.
@@ -22,19 +22,17 @@ installation and uninstallation.
 
 In addition, the exe is launched inside the appx model - meaning that it can use
 many of the APIs available to the Universal Windows Platform. To gain even more
-capabilities, an Electron app can pair up with an invisible UWP app launched
-together with the `exe` - sort of launched as a sidekick to run tasks in the
-background, receive push notifications, or to communicate with other UWP
+capabilities, an Electron app can pair up with an invisible UWP background task
+launched together with the `exe` - sort of launched as a sidekick to run tasks
+in the background, receive push notifications, or to communicate with other UWP
 applications.
 
 To compile any existing Electron app, ensure that you have the following
 requirements:
 
-* Windows 10 Anniversary Update - Enterprise Edition (This is build 14316 and up
-  - as of May 2016, it's part of the Windows Insiders Preview)
-* A machine with 64 bit (x64) processor, Hardware-Assisted Virtualization, and
-  Second Level Address Translation (SLAT)
-* The Windows 10 SDK, [downloadable here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
+* Windows 10 Anniversary Update (until the update is released to the general public,
+developers can use the Windows Insider Preview)
+* The Windows 10 SDK, [downloadable here][windows-sdk]
 * At least Node 4 (to check, run `node -v`)
 
 Then, go and install the `electron-windows-store` CLI:
@@ -43,32 +41,11 @@ Then, go and install the `electron-windows-store` CLI:
 npm install -g electron-windows-store
 ```
 
-## Setup and Preparation
+## Step 1: Package Your Electron Application
 
-Before running the CLI for the first time, you will have to setup the "Windows
-Desktop App Converter". This will take a few minutes, but don't worry - you only
-have to do this once. Download and Desktop App Converter from
-[here](https://www.microsoft.com/en-us/download/details.aspx?id=51691). You will
-receive two files: `DesktopAppConverter.zip` and `BaseImage-14316.wim`.
-
-1. Unzip `DesktopAppConverter.zip`. From an elevated PowerShell (opened with
-  "run as Administrator", ensure that your systems execution policy allows us to
-  run everything we intend to run by calling `Set-ExecutionPolicy bypass`.
-2. Then, run the installation of the Desktop App Converter, passing in the
-  location of the Windows base Image (downloaded as `BaseImage-14316.wim`), by
-  calling `.\DesktopAppConverter.ps1 -Setup -BaseImage .\BaseImage-14316.wim`.
-3. If running the above command prompts you for a reboot, please restart your
-  machine and run the above command again after a successful restart.
-
-Once installation succeeded, you can move on to compiling your Electron app.
-
-## Package Your Electron Application
-
-Package the application using
-[electron-packager](https://github.com/electron-userland/electron-packager)
-(or a similar tool). Make sure to remove `node_modules` that you don't need in
-your final application, since any module you don't actually need will just
-increase your application's size.
+Package the application using [electron-packager][electron-packager] (or a similar tool).
+Make sure to remove `node_modules` that you don't need in your final application, since
+any module you don't actually need will just increase your application's size.
 
 The output should look roughly like this:
 
@@ -101,7 +78,7 @@ The output should look roughly like this:
 └── xinput1_3.dll
 ```
 
-## Running the Command Line Tool
+## Step 2: Running electron-windows-store
 
 From an elevated PowerShell (run it "as Administrator"), run
 `electron-windows-store` with the required parameters, passing both the input
@@ -130,13 +107,54 @@ Finally, the tool can be used to create a trusted certificate on your computer
 to sign the new AppX pacakge. With the signed AppX package, the CLI can also
 automatically install the package on your machine.
 
-## Using the AppX Package
+## Step 3: Using the AppX Package
 
 Since the Windows Anniversary Update (codenamed Windows Redstone) has not been
 released to consumers yet, you won't be able to release your app to the Windows
 Store until later this year - but you can already use the `Add-AppxPackage`
-[PowerShell Cmdlet to install it on machines](https://technet.microsoft.com/en-us/library/hh856048.aspx)
+[PowerShell Cmdlet to install it on machines][add-appxpackage]
 in developer or enterprise environments.
 
 Another important limitation is that the compiled AppX package still contains a
 win32 executable - and will therefore not run on Xbox, HoloLens, or Phones.
+
+## Optional: Add UWP Features using a BackgroundTask
+You can pair your Electron app up with an invisible UWP background task that
+gets to make full use of Windows 10 features - like push notifications,
+Cortana integration, or live tiles.
+
+To check out how an Electron app that uses a background task to send toast
+notifications and live tiles, [check out the Microsoft-provided sample][background-task].
+
+## Optional: Convert using Container Virtualiziation
+
+To generate the AppX package, the `electron-windows-store` CLI uses a template
+that should work for most Electron apps. However, if you are using a custom
+installer, or should you experience any trouble with the generated package, you
+can attempt to create a package using compilation with a Windows Container - in
+that mode, the CLI will install and run your application in blank Windows Container
+to determine what modifications your application is exactly doing to the operating
+system.
+
+Before running the CLI for the, you will have to setup the "Windows Desktop App
+Converter". This will take a few minutes, but don't worry - you only have to do
+this once. Download and Desktop App Converter from [here][app-converter].
+You will receive two files: `DesktopAppConverter.zip` and `BaseImage-14316.wim`.
+
+1. Unzip `DesktopAppConverter.zip`. From an elevated PowerShell (opened with
+  "run as Administrator", ensure that your systems execution policy allows us to
+  run everything we intend to run by calling `Set-ExecutionPolicy bypass`.
+2. Then, run the installation of the Desktop App Converter, passing in the
+  location of the Windows base Image (downloaded as `BaseImage-14316.wim`), by
+  calling `.\DesktopAppConverter.ps1 -Setup -BaseImage .\BaseImage-14316.wim`.
+3. If running the above command prompts you for a reboot, please restart your
+  machine and run the above command again after a successful restart.
+
+Once installation succeeded, you can move on to compiling your Electron app.
+
+[windows-sdk]: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
+[app-converter]: https://www.microsoft.com/en-us/download/details.aspx?id=51691
+[add-appxpackage]: https://technet.microsoft.com/en-us/library/hh856048.aspx
+[electron-packager]: https://github.com/electron-userland/electron-packager
+[electron-windows-store]: https://github.com/catalystcode/electron-windows-store
+[background-task]: https://github.com/felixrieseberg/electron-uwp-background


### PR DESCRIPTION
 - Updated the guide to reflect that electron-windows-store no longer
   requires container conversion prerequisites
 - Added a link and a note about using background tasks to include
   UWP features