### PR TITLE
Support window.opener from windows opened from a <webview>

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const ipcMain = require('electron').ipcMain
-const BrowserWindow = require('electron').BrowserWindow
+const {BrowserWindow, ipcMain, webContents} = require('electron')
 
 const hasProp = {}.hasOwnProperty
 const frameToGuest = {}
@@ -56,15 +55,14 @@ const createGuest = function (embedder, url, frameName, options) {
   if (options.webPreferences == null) {
     options.webPreferences = {}
   }
-  const embedderWindow = BrowserWindow.fromWebContents(embedder)
-  options.webPreferences.openerId = embedderWindow != null ? embedderWindow.id : void 0
+  options.webPreferences.openerId = embedder.id
   guest = new BrowserWindow(options)
   guest.loadURL(url)
 
   // When |embedder| is destroyed we should also destroy attached guest, and if
   // guest is closed by user then we should prevent |embedder| from double
   // closing guest.
-  const guestId = guest.id
+  const guestId = guest.webContents.id
 
   const closedByEmbedder = function () {
     guest.removeListener('closed', closedByUser)
@@ -85,7 +83,18 @@ const createGuest = function (embedder, url, frameName, options) {
     })
   }
 
-  return guest.id
+  return guestId
+}
+
+const getGuestWindow = function (guestId) {
+  const guestContents = webContents.fromId(guestId)
+  if (guestContents == null) return
+
+  let guestWindow = BrowserWindow.fromWebContents(guestContents)
+  if (guestWindow == null && guestContents.hostWebContents != null) {
+    guestWindow = BrowserWindow.fromWebContents(guestContents.hostWebContents)
+  }
+  return guestWindow
 }
 
 // Routed window.open messages.
@@ -100,35 +109,26 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, fr
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function (event, guestId) {
-  const guestWindow = BrowserWindow.fromId(guestId)
+  const guestWindow = getGuestWindow(guestId)
   if (guestWindow != null) guestWindow.destroy()
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guestId, method, ...args) {
-  const guestWindow = BrowserWindow.fromId(guestId)
-  event.returnValue = guestWindow != null ? guestWindow[method].apply(guestWindow, args) : void 0
+  const guestWindow = getGuestWindow(guestId)
+  event.returnValue = guestWindow != null ? guestWindow[method].apply(guestWindow, args) : null
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, guestId, message, targetOrigin, sourceOrigin) {
-  const sourceContents = BrowserWindow.fromWebContents(event.sender)
-  const sourceId = sourceContents != null ? sourceContents.id : void 0
-  if (sourceId == null) {
-    return
-  }
+  const guestContents = webContents.fromId(guestId)
+  if (guestContents == null) return
 
-  const guestWindow = BrowserWindow.fromId(guestId)
-  const guestContents = guestWindow != null ? guestWindow.webContents : void 0
-  if ((guestContents != null ? guestContents.getURL().indexOf(targetOrigin) : void 0) === 0 || targetOrigin === '*') {
-    guestContents != null ? guestContents.send('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin) : void 0
+  if (guestContents.getURL().indexOf(targetOrigin) === 0 || targetOrigin === '*') {
+    const sourceId = event.sender.id
+    guestContents.send('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin)
   }
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event, guestId, method, ...args) {
-  const guestWindow = BrowserWindow.fromId(guestId)
-  if (guestWindow != null) {
-    const guestContents = guestWindow.webContents
-    if (guestContents != null) {
-      guestContents[method].apply(guestContents, args)
-    }
-  }
+  const guestContents = webContents.fromId(guestId)
+  if (guestContents != null) guestContents[method].apply(guestContents, args)
 })

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -3,12 +3,12 @@
 const ipcMain = require('electron').ipcMain
 const BrowserWindow = require('electron').BrowserWindow
 
-var hasProp = {}.hasOwnProperty
-var frameToGuest = {}
+const hasProp = {}.hasOwnProperty
+const frameToGuest = {}
 
 // Copy attribute of |parent| to |child| if it is not defined in |child|.
-var mergeOptions = function (child, parent) {
-  var key, value
+const mergeOptions = function (child, parent) {
+  let key, value
   for (key in parent) {
     if (!hasProp.call(parent, key)) continue
     value = parent[key]
@@ -24,7 +24,7 @@ var mergeOptions = function (child, parent) {
 }
 
 // Merge |options| with the |embedder|'s window's options.
-var mergeBrowserWindowOptions = function (embedder, options) {
+const mergeBrowserWindowOptions = function (embedder, options) {
   if (embedder.browserWindowOptions != null) {
     // Inherit the original options if it is a BrowserWindow.
     mergeOptions(options, embedder.browserWindowOptions)
@@ -45,9 +45,8 @@ var mergeBrowserWindowOptions = function (embedder, options) {
 }
 
 // Create a new guest created by |embedder| with |options|.
-var createGuest = function (embedder, url, frameName, options) {
-  var closedByEmbedder, closedByUser, guest, guestId, ref1
-  guest = frameToGuest[frameName]
+const createGuest = function (embedder, url, frameName, options) {
+  let guest = frameToGuest[frameName]
   if (frameName && (guest != null)) {
     guest.loadURL(url)
     return guest.id
@@ -57,24 +56,27 @@ var createGuest = function (embedder, url, frameName, options) {
   if (options.webPreferences == null) {
     options.webPreferences = {}
   }
-  options.webPreferences.openerId = (ref1 = BrowserWindow.fromWebContents(embedder)) != null ? ref1.id : void 0
+  const embedderWindow = BrowserWindow.fromWebContents(embedder)
+  options.webPreferences.openerId = embedderWindow != null ? embedderWindow.id : void 0
   guest = new BrowserWindow(options)
   guest.loadURL(url)
 
   // When |embedder| is destroyed we should also destroy attached guest, and if
   // guest is closed by user then we should prevent |embedder| from double
   // closing guest.
-  guestId = guest.id
-  closedByEmbedder = function () {
+  const guestId = guest.id
+
+  const closedByEmbedder = function () {
     guest.removeListener('closed', closedByUser)
-    return guest.destroy()
+    guest.destroy()
   }
-  closedByUser = function () {
+  const closedByUser = function () {
     embedder.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + guestId)
-    return embedder.removeListener('render-view-deleted', closedByEmbedder)
+    embedder.removeListener('render-view-deleted', closedByEmbedder)
   }
   embedder.once('render-view-deleted', closedByEmbedder)
   guest.once('closed', closedByUser)
+
   if (frameName) {
     frameToGuest[frameName] = guest
     guest.frameName = frameName
@@ -82,6 +84,7 @@ var createGuest = function (embedder, url, frameName, options) {
       delete frameToGuest[frameName]
     })
   }
+
   return guest.id
 }
 
@@ -97,28 +100,35 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, fr
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function (event, guestId) {
-  var ref1
-  (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1.destroy() : void 0
+  const guestWindow = BrowserWindow.fromId(guestId)
+  if (guestWindow != null) guestWindow.destroy()
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guestId, method, ...args) {
-  var ref1
-  event.returnValue = (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1[method].apply(ref1, args) : void 0
+  const guestWindow = BrowserWindow.fromId(guestId)
+  event.returnValue = guestWindow != null ? guestWindow[method].apply(guestWindow, args) : void 0
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, guestId, message, targetOrigin, sourceOrigin) {
-  var guestContents, ref1, ref2, sourceId
-  sourceId = (ref1 = BrowserWindow.fromWebContents(event.sender)) != null ? ref1.id : void 0
+  const sourceContents = BrowserWindow.fromWebContents(event.sender)
+  const sourceId = sourceContents != null ? sourceContents.id : void 0
   if (sourceId == null) {
     return
   }
-  guestContents = (ref2 = BrowserWindow.fromId(guestId)) != null ? ref2.webContents : void 0
+
+  const guestWindow = BrowserWindow.fromId(guestId)
+  const guestContents = guestWindow != null ? guestWindow.webContents : void 0
   if ((guestContents != null ? guestContents.getURL().indexOf(targetOrigin) : void 0) === 0 || targetOrigin === '*') {
     guestContents != null ? guestContents.send('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin) : void 0
   }
 })
 
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event, guestId, method, ...args) {
-  var ref1, ref2
-  (ref1 = BrowserWindow.fromId(guestId)) != null ? (ref2 = ref1.webContents) != null ? ref2[method].apply(ref2, args) : void 0 : void 0
+  const guestWindow = BrowserWindow.fromId(guestId)
+  if (guestWindow != null) {
+    const guestContents = guestWindow.webContents
+    if (guestContents != null) {
+      guestContents[method].apply(guestContents, args)
+    }
+  }
 })

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -91,8 +91,11 @@ const getGuestWindow = function (guestId) {
   if (guestContents == null) return
 
   let guestWindow = BrowserWindow.fromWebContents(guestContents)
-  if (guestWindow == null && guestContents.hostWebContents != null) {
-    guestWindow = BrowserWindow.fromWebContents(guestContents.hostWebContents)
+  if (guestWindow == null) {
+    const hostContents = guestContents.hostWebContents
+    if (hostContents != null) {
+      guestWindow = BrowserWindow.fromWebContents(hostContents)
+    }
   }
   return guestWindow
 }

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -328,7 +328,7 @@ describe('chromium feature', function () {
       b = window.open('file://' + fixtures + '/pages/window-opener-postMessage.html', '', 'show=no')
     })
 
-    it('works for windows opened from a <webview>', function (done) {
+    it('supports windows opened from a <webview>', function (done) {
       const webview = new WebView()
       webview.addEventListener('console-message', function (e) {
         webview.remove()

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1,8 +1,8 @@
-
 const assert = require('assert')
 const http = require('http')
 const path = require('path')
 const ws = require('ws')
+const url = require('url')
 const remote = require('electron').remote
 
 const BrowserWindow = remote.require('electron').BrowserWindow
@@ -326,6 +326,25 @@ describe('chromium feature', function () {
       }
       window.addEventListener('message', listener)
       b = window.open('file://' + fixtures + '/pages/window-opener-postMessage.html', '', 'show=no')
+    })
+
+    it('works for windows opened from a <webview>', function (done) {
+      const webview = new WebView()
+      webview.addEventListener('console-message', function (e) {
+        webview.remove()
+        assert.equal(e.message, 'message')
+        done()
+      })
+      webview.allowpopups = true
+      webview.src = url.format({
+        pathname: `${fixtures}/pages/webview-opener-postMessage.html`,
+        protocol: 'file',
+        query: {
+          p: `${fixtures}/pages/window-opener-postMessage.html`
+        },
+        slashes: true
+      })
+      document.body.appendChild(webview)
     })
   })
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -5,8 +5,7 @@ const ws = require('ws')
 const url = require('url')
 const remote = require('electron').remote
 
-const BrowserWindow = remote.require('electron').BrowserWindow
-const session = remote.require('electron').session
+const {BrowserWindow, session, webContents} = remote
 
 const isCI = remote.getGlobal('isCi')
 
@@ -235,7 +234,7 @@ describe('chromium feature', function () {
       else
         targetURL = 'file://' + fixtures + '/pages/base-page.html'
       b = window.open(targetURL)
-      BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function () {
+      webContents.fromId(b.guestId).once('did-finish-load', function () {
         assert.equal(b.location, targetURL)
         b.close()
         done()
@@ -246,10 +245,10 @@ describe('chromium feature', function () {
       // Load a page that definitely won't redirect
       var b
       b = window.open('about:blank')
-      BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function () {
+      webContents.fromId(b.guestId).once('did-finish-load', function () {
         // When it loads, redirect
         b.location = 'file://' + fixtures + '/pages/base-page.html'
-        BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function () {
+        webContents.fromId(b.guestId).once('did-finish-load', function () {
           // After our second redirect, cleanup and callback
           b.close()
           done()
@@ -308,7 +307,7 @@ describe('chromium feature', function () {
       }
       window.addEventListener('message', listener)
       b = window.open('file://' + fixtures + '/pages/window-open-postMessage.html', '', 'show=no')
-      BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function () {
+      webContents.fromId(b.guestId).once('did-finish-load', function () {
         b.postMessage('testing', '*')
       })
     })

--- a/spec/fixtures/pages/webview-opener-postMessage.html
+++ b/spec/fixtures/pages/webview-opener-postMessage.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script>
+      var windowUrl = decodeURIComponent(window.location.search.substring(3))
+      var opened = window.open(windowUrl, '', 'show=no')
+      window.addEventListener('message', function (event) {
+        try {
+          opened.close()
+        } finally {
+          console.log(event.data)
+        }
+      })
+    </script>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
This pull request adds support for `window.opener` from windows opened via `window.open()` from within a `<webview>` tag.

This reworks the guest window manager a bit to track guests using the `id` from the `webContents` instead of `id` from the `BrowserWindow` so the `BrowserWindowProxy` can be used in windows opened from a `<webview>` tag.

It also uses `webContents.hostWebContents` to lookup the window for a `<webview>`'s webContents so things like `window.opener.close()` will close the window containing the `<webview>`.

Closes #5953