### PR TITLE
Make guestId on BrowserWindowProxy non-writeable

### DIFF
--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -25,7 +25,13 @@ var BrowserWindowProxy = (function () {
   }
 
   function BrowserWindowProxy (guestId1) {
-    this.guestId = guestId1
+    Object.defineProperty(this, 'guestId', {
+      configurable: false,
+      enumerable: true,
+      writeable: false,
+      value: guestId1
+    })
+
     this.closed = false
     ipcRenderer.once('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + this.guestId, () => {
       BrowserWindowProxy.remove(this.guestId)

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -165,6 +165,12 @@ describe('chromium feature', function () {
       var b = window.open('about:blank', '', 'show=no')
       assert.equal(b.closed, false)
       assert.equal(b.constructor.name, 'BrowserWindowProxy')
+
+      // Check that guestId is not writeable
+      assert(b.guestId)
+      b.guestId = 'anotherValue'
+      assert.notEqual(b.guestId, 'anoterValue')
+
       b.close()
     })
 


### PR DESCRIPTION
This pull request make the `BrowserWindowProxy` `guestId` property non-writeable.

Since `guestId` is used internally to route IPC messages to the proper parent/child window, it shouldn't be writeable when accessed via `window.opener` or the value returned from `window.open()`.