### PR TITLE
Log and exit when calling only in specs on CI

### DIFF
--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -54,7 +54,7 @@
   if (isCi) {
     mocha.grep = function () {
       try {
-        throw new Error('it.only or describe.only was called')
+        throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
       } catch (error) {
         console.error(error.stack || error)
       }

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -50,6 +50,18 @@
   var Mocha = require('mocha');
 
   var mocha = new Mocha();
+
+  if (isCi) {
+    mocha.grep = function () {
+      try {
+        throw new Error('it.only or describe.only was called')
+      } catch (error) {
+        console.error(error.stack || error)
+      }
+      ipcRenderer.send('process.exit', 1)
+    }
+  }
+
   mocha.ui('bdd').reporter(isCi ? 'tap' : 'html');
 
   var query = Mocha.utils.parseQuery(window.location.search || '');


### PR DESCRIPTION
This pull request fails CI if `it.only` or `describe.only` is called meaning only a subset of specs are run and so any pull requests containing these calls should go 🔴 until those calls are removed and all the specs are running again 🍏 .

Sometimes these are accidentally checked in and merged and this pull request guards against this happening in the future.

The following message will be logged when this happens and will contain the offending spec:

```
Error: A spec contains a call to it.only or describe.only and should be reverted.
    at Mocha.mocha.grep (file:///Users/kevin/github/electron/spec/static/index.html?grep=&invert=:57:15)
    at Function.context.it.only (/Users/kevin/github/electron/spec/node_modules/mocha/lib/interfaces/bdd.js:125:13)
    at Suite.<anonymous> (/Users/kevin/github/electron/spec/api-browser-window-spec.js:59:8)
    at context.describe.context.context (/Users/kevin/github/electron/spec/node_modules/mocha/lib/interfaces/bdd.js:74:10)
    at Suite.<anonymous> (/Users/kevin/github/electron/spec/api-browser-window-spec.js:58:3)
    at context.describe.context.context (/Users/kevin/github/electron/spec/node_modules/mocha/lib/interfaces/bdd.js:74:10)
    at Object.<anonymous> (/Users/kevin/github/electron/spec/api-browser-window-spec.js:19:1)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
```
