### PR TITLE
Document 'zoom' role + add missing menu items (Delete / Paste and Match Style / Zoom)

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -81,6 +81,15 @@ app.once('ready', () => {
           role: 'paste'
         },
         {
+          label: 'Paste and Match Style',
+          accelerator: 'Shift+Command+V',
+          role: 'pasteandmatchstyle'
+        },
+        {
+          label: 'Delete',
+          role: 'delete'
+        },
+        {
           label: 'Select All',
           accelerator: 'CmdOrCtrl+A',
           role: 'selectall'
@@ -210,7 +219,21 @@ app.once('ready', () => {
         }
       ]
     })
-    template[3].submenu.push(
+    template[3].submenu = [
+      {
+        label: 'Close',
+        accelerator: 'CmdOrCtrl+W',
+        role: 'close'
+      },
+      {
+        label: 'Minimize',
+        accelerator: 'CmdOrCtrl+M',
+        role: 'minimize'
+      },
+      {
+        label: 'Zoom',
+        role: 'zoom'
+      },
       {
         type: 'separator'
       },
@@ -218,7 +241,7 @@ app.once('ready', () => {
         label: 'Bring All to Front',
         role: 'front'
       }
-    )
+    ]
   }
 
   const menu = Menu.buildFromTemplate(template)

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -59,6 +59,7 @@ On OS X `role` can also have following additional values:
 * `hideothers` - Map to the `hideOtherApplications` action
 * `unhide` - Map to the `unhideAllApplications` action
 * `front` - Map to the `arrangeInFront` action
+* `zoom` - Map to the `performZoom` action
 * `window` - The submenu is a "Window" menu
 * `help` - The submenu is a "Help" menu
 * `services` - The submenu is a "Services" menu

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -67,6 +67,15 @@ const template = [
         role: 'paste'
       },
       {
+        label: 'Paste and Match Style',
+        accelerator: 'Shift+Command+V',
+        role: 'pasteandmatchstyle'
+      },
+      {
+        label: 'Delete',
+        role: 'delete'
+      },
+      {
         label: 'Select All',
         accelerator: 'CmdOrCtrl+A',
         role: 'selectall'
@@ -174,7 +183,21 @@ if (process.platform === 'darwin') {
     ]
   });
   // Window menu.
-  template[3].submenu.push(
+  template[3].submenu = [
+    {
+      label: 'Close',
+      accelerator: 'CmdOrCtrl+W',
+      role: 'close'
+    },
+    {
+      label: 'Minimize',
+      accelerator: 'CmdOrCtrl+M',
+      role: 'minimize'
+    },
+    {
+      label: 'Zoom',
+      role: 'zoom'
+    },
     {
       type: 'separator'
     },
@@ -182,7 +205,7 @@ if (process.platform === 'darwin') {
       label: 'Bring All to Front',
       role: 'front'
     }
-  );
+  ];
 }
 
 const menu = Menu.buildFromTemplate(template);


### PR DESCRIPTION
Reason:
- Mac applications have Window -> Zoom menu item
- The order of Close / Minimize / Zoom is different on OS X