### PR TITLE
Add web-contents-created event to app

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -160,6 +160,15 @@ Returns:
 
 Emitted when a new [browserWindow](browser-window.md) is created.
 
+### Event: 'web-contents-created'
+
+Returns:
+
+* `event` Event
+* `webContents` WebContents
+
+Emitted when a new [webContents](web-contents.md) is created.
+
 ### Event: 'certificate-error'
 
 Returns:

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const {EventEmitter} = require('events')
-const {ipcMain, session, Menu, NavigationController} = require('electron')
+const {app, ipcMain, session, Menu, NavigationController} = require('electron')
 
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
@@ -9,14 +9,6 @@ session
 
 const binding = process.atomBinding('web_contents')
 const debuggerBinding = process.atomBinding('debugger')
-
-const WebContents = new EventEmitter()
-WebContents.create = (options = {}) => {
-  return binding.create(options)
-}
-WebContents.fromId = (id) => {
-  return binding.fromId(id)
-}
 
 let nextId = 0
 const getNextId = function () {
@@ -232,7 +224,7 @@ const wrapWebContents = function (webContents) {
     this._printToPDF(printingSetting, callback)
   }
 
-  WebContents.emit('web-contents-created', webContents)
+  app.emit('web-contents-created', {}, webContents)
 }
 
 binding._setWrapWebContents(wrapWebContents)
@@ -245,4 +237,12 @@ const wrapDebugger = function (webContentsDebugger) {
 
 debuggerBinding._setWrapDebugger(wrapDebugger)
 
-module.exports = WebContents
+module.exports = {
+  create () {
+    return binding.create(options)
+  },
+
+  fromId (id) {
+    return binding.fromId(id)
+  }
+}

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -238,7 +238,7 @@ const wrapDebugger = function (webContentsDebugger) {
 debuggerBinding._setWrapDebugger(wrapDebugger)
 
 module.exports = {
-  create () {
+  create (options = {}) {
     return binding.create(options)
   },
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -236,7 +236,7 @@ const loadDevToolsExtensions = function (win, manifests) {
   win.devToolsWebContents.executeJavaScript(`DevToolsAPI.addExtensions(${JSON.stringify(extensionInfoArray)})`)
 }
 
-webContents.on('web-contents-created', function (webContents) {
+app.on('web-contents-created', function (event, webContents) {
   if (webContents.getType() === 'remote') return
 
   hookWebContentsForTabEvents(webContents)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -275,7 +275,18 @@ describe('app module', function () {
       w = new BrowserWindow({
         show: false
       })
-      w.emit('blur')
+    })
+
+    it('should emit web-contents-created event when a webContents is created', function (done) {
+      app.once('web-contents-created', function (e, webContents) {
+        setImmediate(function () {
+          assert.equal(w.webContents.id, webContents.id)
+          done()
+        })
+      })
+      w = new BrowserWindow({
+        show: false
+      })
     })
   })
 })


### PR DESCRIPTION
#5913 added a `web-contents-created` event to `webContents`.

This pull request moves the event to `app` to be consistent with `browser-window-created` and documents it as a public API.