### PR TITLE
Log error when repling on Windows

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -309,6 +309,12 @@ function loadApplicationByUrl (appUrl) {
 }
 
 function startRepl () {
+  if (process.platform === 'win32') {
+    console.error('Electron REPL not currently supported on Windows')
+    process.exit(1)
+    return
+  }
+
   repl.start('> ').on('exit', () => {
     process.exit(0)
   })


### PR DESCRIPTION
This is not currently supported to log a message about it when it is run.

I think this approach might be better than just removing it from `electron -h` since it might be confusing to have different options supported on different platforms.

Refs #6025