### PR TITLE
Guard against destroyed background pages

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -64,6 +64,14 @@ const getManifestFromPath = function (srcDirectory) {
 // Manage the background pages.
 const backgroundPages = {}
 
+const getBackgroundPages = function () {
+  return objectValues(backgroundPages).filter(function (page) {
+    const destroyed = page.webContents.isDestroyed()
+    if (destroyed) delete backgroundPages[page.id]
+    return !destroyed
+  })
+}
+
 const startBackgroundPages = function (manifest) {
   if (backgroundPages[manifest.extensionId] || !manifest.background) return
 
@@ -75,7 +83,11 @@ const startBackgroundPages = function (manifest) {
   const contents = webContents.create({
     commandLineSwitches: ['--background-page']
   })
-  backgroundPages[manifest.extensionId] = { html: html, webContents: contents }
+  backgroundPages[manifest.extensionId] = {
+    id: manifest.extensionId,
+    html: html,
+    webContents: contents
+  }
   contents.loadURL(url.format({
     protocol: 'chrome-extension',
     slashes: true,
@@ -94,12 +106,12 @@ const removeBackgroundPages = function (manifest) {
 // Dispatch tabs events.
 const hookWebContentsForTabEvents = function (webContents) {
   const tabId = webContents.id
-  for (const page of objectValues(backgroundPages)) {
+  for (const page of getBackgroundPages()) {
     page.webContents.sendToAll('CHROME_TABS_ONCREATED', tabId)
   }
 
   webContents.once('destroyed', () => {
-    for (const page of objectValues(backgroundPages)) {
+    for (const page of getBackgroundPages()) {
       page.webContents.sendToAll('CHROME_TABS_ONREMOVED', tabId)
     }
   })


### PR DESCRIPTION
Noticed while running the react dev tools on master that an error is thrown on shutdown because a destroyed background page is being accessed. Seems to be related to the changes in #5913 which changed to use the `destroyed` event on `webContents` instead of `closed` on `BrowserWindow`.

This adds a helper `getBackgroundPages` method that filters and removes any background pages that have been destroyed to prevent this error on shutdown.

<img width="532" alt="screen shot 2016-06-13 at 3 57 14 pm" src="https://cloud.githubusercontent.com/assets/671378/16025956/a3215372-317f-11e6-849b-255728090c40.png">