### PR TITLE
Load content scripts in webview devtools

### DIFF
--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -26,7 +26,9 @@ bool IsWebContents(v8::Isolate* isolate, content::RenderProcessHost* process) {
     return false;
 
   auto api_web_contents = WebContents::CreateFrom(isolate, web_contents);
-  return api_web_contents->GetType() != WebContents::Type::REMOTE;
+  auto type = api_web_contents->GetType();
+  return type == WebContents::Type::BROWSER_WINDOW ||
+         type == WebContents::Type::WEB_VIEW;
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -26,7 +26,7 @@ bool IsWebContents(v8::Isolate* isolate, content::RenderProcessHost* process) {
     return false;
 
   auto api_web_contents = WebContents::CreateFrom(isolate, web_contents);
-  return !api_web_contents->IsRemote();
+  return api_web_contents->GetType() != WebContents::Type::REMOTE;
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -6,8 +6,6 @@
 
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/atom_browser_client.h"
-#include "atom/browser/native_window.h"
-#include "atom/browser/window_list.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
 #include "content/public/browser/render_process_host.h"

--- a/atom/browser/api/atom_api_render_process_preferences.h
+++ b/atom/browser/api/atom_api_render_process_preferences.h
@@ -17,7 +17,7 @@ class RenderProcessPreferences
     : public mate::Wrappable<RenderProcessPreferences> {
  public:
   static mate::Handle<RenderProcessPreferences>
-      ForAllBrowserWindow(v8::Isolate* isolate);
+      ForAllWebContents(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1197,6 +1197,10 @@ bool WebContents::IsGuest() const {
   return type_ == WEB_VIEW;
 }
 
+bool WebContents::IsRemote() const {
+  return type_ == REMOTE;
+}
+
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
   WebContentsPreferences* web_preferences =
       WebContentsPreferences::FromWebContents(web_contents());

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -193,10 +193,20 @@ struct Converter<atom::api::WebContents::Type> {
                                    atom::api::WebContents::Type val) {
     std::string type = "";
     switch (val) {
-      case atom::api::WebContents::Type::BROWSER_WINDOW: type = "window"; break;
-      case atom::api::WebContents::Type::WEB_VIEW: type = "webview"; break;
-      case atom::api::WebContents::Type::REMOTE: type =  "remote"; break;
-      default: break;
+      case atom::api::WebContents::Type::BACKGROUND_PAGE:
+        type = "backgroundPage";
+        break;
+      case atom::api::WebContents::Type::BROWSER_WINDOW:
+        type = "window";
+        break;
+      case atom::api::WebContents::Type::REMOTE:
+        type =  "remote";
+        break;
+      case atom::api::WebContents::Type::WEB_VIEW:
+        type = "webview";
+        break;
+      default:
+        break;
     }
     return mate::ConvertToV8(isolate, type);
   }
@@ -208,6 +218,8 @@ struct Converter<atom::api::WebContents::Type> {
       return false;
     if (type == "webview") {
       *out = atom::api::WebContents::Type::WEB_VIEW;
+    } else if (type == "backgroundPage") {
+      *out = atom::api::WebContents::Type::BACKGROUND_PAGE;
     } else {
       return false;
     }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -191,35 +191,28 @@ template<>
 struct Converter<atom::api::WebContents::Type> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    atom::api::WebContents::Type val) {
+    using Type = atom::api::WebContents::Type;
     std::string type = "";
     switch (val) {
-      case atom::api::WebContents::Type::BACKGROUND_PAGE:
-        type = "backgroundPage";
-        break;
-      case atom::api::WebContents::Type::BROWSER_WINDOW:
-        type = "window";
-        break;
-      case atom::api::WebContents::Type::REMOTE:
-        type =  "remote";
-        break;
-      case atom::api::WebContents::Type::WEB_VIEW:
-        type = "webview";
-        break;
-      default:
-        break;
+      case Type::BACKGROUND_PAGE: type = "backgroundPage"; break;
+      case Type::BROWSER_WINDOW: type = "window"; break;
+      case Type::REMOTE: type = "remote"; break;
+      case Type::WEB_VIEW: type = "webview"; break;
+      default: break;
     }
     return mate::ConvertToV8(isolate, type);
   }
 
   static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
                      atom::api::WebContents::Type* out) {
+    using Type = atom::api::WebContents::Type;
     std::string type;
     if (!ConvertFromV8(isolate, val, &type))
       return false;
     if (type == "webview") {
-      *out = atom::api::WebContents::Type::WEB_VIEW;
+      *out = Type::WEB_VIEW;
     } else if (type == "backgroundPage") {
-      *out = atom::api::WebContents::Type::BACKGROUND_PAGE;
+      *out = Type::BACKGROUND_PAGE;
     } else {
       return false;
     }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -187,6 +187,22 @@ struct Converter<content::SavePageType> {
   }
 };
 
+template<>
+struct Converter<atom::api::WebContents::Type> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   atom::api::WebContents::Type val) {
+    std::string type = "";
+    switch (val) {
+      case atom::api::WebContents::Type::BROWSER_WINDOW: type = "window"; break;
+      case atom::api::WebContents::Type::WEB_VIEW: type = "webview"; break;
+      case atom::api::WebContents::Type::REMOTE: type =  "remote"; break;
+      default: break;
+    }
+    return mate::ConvertToV8(isolate, type);
+  }
+};
+
+
 }  // namespace mate
 
 
@@ -744,13 +760,8 @@ int WebContents::GetID() const {
   return web_contents()->GetRenderProcessHost()->GetID();
 }
 
-std::string WebContents::GetType() const {
-  switch (type_) {
-    case BROWSER_WINDOW: return "window";
-    case WEB_VIEW: return "webview";
-    case REMOTE: return "remote";
-    default: return "";
-  }
+WebContents::Type WebContents::GetType() const {
+  return type_;
 }
 
 bool WebContents::Equal(const WebContents* web_contents) const {
@@ -1195,10 +1206,6 @@ void WebContents::SetSize(const SetSizeParams& params) {
 
 bool WebContents::IsGuest() const {
   return type_ == WEB_VIEW;
-}
-
-bool WebContents::IsRemote() const {
-  return type_ == REMOTE;
 }
 
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -44,7 +44,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
                     public content::WebContentsObserver {
  public:
   enum Type {
-    BACKGROUND_PAGE, // A DevTools extension background page.
+    BACKGROUND_PAGE,  // A DevTools extension background page.
     BROWSER_WINDOW,  // Used by BrowserWindow.
     REMOTE,  // Thin wrap around an existing WebContents.
     WEB_VIEW,  // Used by <webview>.

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -44,9 +44,10 @@ class WebContents : public mate::TrackableObject<WebContents>,
                     public content::WebContentsObserver {
  public:
   enum Type {
+    BACKGROUND_PAGE, // A DevTools extension background page.
     BROWSER_WINDOW,  // Used by BrowserWindow.
-    WEB_VIEW,  // Used by <webview>.
     REMOTE,  // Thin wrap around an existing WebContents.
+    WEB_VIEW,  // Used by <webview>.
   };
 
   // For node.js callback function type: function(error, buffer)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -139,6 +139,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // Methods for creating <webview>.
   void SetSize(const SetSizeParams& params);
   bool IsGuest() const;
+  bool IsRemote() const;
 
   // Callback triggered on permission response.
   void OnEnterFullscreenModeForTab(content::WebContents* source,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -43,6 +43,12 @@ class WebContents : public mate::TrackableObject<WebContents>,
                     public CommonWebContentsDelegate,
                     public content::WebContentsObserver {
  public:
+  enum Type {
+    BROWSER_WINDOW,  // Used by BrowserWindow.
+    WEB_VIEW,  // Used by <webview>.
+    REMOTE,  // Thin wrap around an existing WebContents.
+  };
+
   // For node.js callback function type: function(error, buffer)
   using PrintToPDFCallback =
       base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>)>;
@@ -59,7 +65,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
                              v8::Local<v8::ObjectTemplate> prototype);
 
   int GetID() const;
-  std::string GetType() const;
+  Type GetType() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);
   void DownloadURL(const GURL& url);
@@ -139,7 +145,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // Methods for creating <webview>.
   void SetSize(const SetSizeParams& params);
   bool IsGuest() const;
-  bool IsRemote() const;
 
   // Callback triggered on permission response.
   void OnEnterFullscreenModeForTab(content::WebContents* source,
@@ -269,12 +274,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DevToolsClosed() override;
 
  private:
-  enum Type {
-    BROWSER_WINDOW,  // Used by BrowserWindow.
-    WEB_VIEW,  // Used by <webview>.
-    REMOTE,  // Thin wrap around an existing WebContents.
-  };
-
   AtomBrowserContext* GetBrowserContext() const;
 
   uint32_t GetNextRequestId() {

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -73,6 +73,7 @@ const startBackgroundPages = function (manifest) {
   const html = new Buffer(`<html><body>${scripts}</body></html>`)
 
   const contents = webContents.create({
+    type: 'backgroundPage',
     commandLineSwitches: ['--background-page']
   })
   backgroundPages[manifest.extensionId] = { html: html, webContents: contents }

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -117,7 +117,7 @@ let nextId = 0
 ipcMain.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, connectInfo) {
   const page = backgroundPages[extensionId]
   if (!page) {
-    console.error(`Connect to unkown extension ${extensionId}`)
+    console.error(`Connect to unknown extension ${extensionId}`)
     return
   }
 
@@ -138,7 +138,7 @@ ipcMain.on('CHROME_I18N_MANIFEST', function (event, extensionId) {
 ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message) {
   const page = backgroundPages[extensionId]
   if (!page) {
-    console.error(`Connect to unkown extension ${extensionId}`)
+    console.error(`Connect to unknown extension ${extensionId}`)
     return
   }
 
@@ -148,7 +148,7 @@ ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message) 
 ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBackgroundPage, message) {
   const contents = webContents.fromId(tabId)
   if (!contents) {
-    console.error(`Sending message to unkown tab ${tabId}`)
+    console.error(`Sending message to unknown tab ${tabId}`)
     return
   }
 
@@ -160,7 +160,7 @@ ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBa
 ipcMain.on('CHROME_TABS_EXECUTESCRIPT', function (event, requestId, tabId, extensionId, details) {
   const contents = webContents.fromId(tabId)
   if (!contents) {
-    console.error(`Sending message to unkown tab ${tabId}`)
+    console.error(`Sending message to unknown tab ${tabId}`)
     return
   }
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -1,6 +1,6 @@
 const {app, ipcMain, session, webContents, BrowserWindow} = require('electron')
 const {getAllWebContents} = process.atomBinding('web_contents')
-const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllBrowserWindow()
+const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllWebContents()
 
 const fs = require('fs')
 const path = require('path')

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -19,6 +19,11 @@ const generateExtensionIdFromName = function (name) {
   return name.replace(/[\W_]+/g, '-').toLowerCase()
 }
 
+const isWindowOrWebView = function (webContents) {
+  const type = webContents.getType()
+  return type === 'window' || type === 'webview'
+}
+
 // Create or get manifest object from |srcDirectory|.
 const getManifestFromPath = function (srcDirectory) {
   let manifest
@@ -238,7 +243,7 @@ const loadDevToolsExtensions = function (win, manifests) {
 }
 
 app.on('web-contents-created', function (event, webContents) {
-  if (webContents.getType() === 'remote') return
+  if (!isWindowOrWebView(webContents)) return
 
   hookWebContentsForTabEvents(webContents)
   webContents.on('devtools-opened', function () {
@@ -323,7 +328,7 @@ app.once('ready', function () {
     const manifest = getManifestFromPath(srcDirectory)
     if (manifest) {
       for (const webContents of getAllWebContents()) {
-        if (webContents.getType() !== 'remote') {
+        if (isWindowOrWebView(webContents)) {
           loadDevToolsExtensions(webContents, [manifest])
         }
       }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -63,7 +63,7 @@ const createGuest = function (embedder, params) {
 
   const id = getNextInstanceId(embedder)
   const guest = webContents.create({
-    isGuest: true,
+    type: 'webview',
     partition: params.partition,
     embedder: embedder
   })


### PR DESCRIPTION
This pull request switches `RenderProcessPreferences` to consider non-remote web contents instead of window-based web contents when supporting the `content_scripts` of a devtools extension so that they will work for the webview devtools.

This was the result of trying to get the react devtools working for a webview. With this branch I could get it successfully showing for a webview loading http://todomvc.com/examples/react

<img width="1280" alt="screen shot 2016-06-13 at 5 06 24 pm" src="https://cloud.githubusercontent.com/assets/671378/16027230/352e8fb0-3189-11e6-9bdf-3ea5890ac4b1.png">

Refs #5913 