### PR TITLE
Use "--processStartAndWait" when launching Update.exe

### DIFF
--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -78,7 +78,7 @@ var spawnUpdate = function (args, detached, callback) {
 
 // Start an instance of the installed app.
 exports.processStart = function () {
-  return spawnUpdate(['--processStart', exeName], true, function () {})
+  return spawnUpdate(['--processStartAndWait', exeName], true, function () {})
 }
 
 // Download the releases specified by the URL and write new results to stdout.


### PR DESCRIPTION
This makes Squirrel wait for current app to quit before launching the newly downloaded app.

Close #5163. 