### PR TITLE
Document entitlements needed for dialog APIs

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -169,8 +169,8 @@ more information.
 ### Additional Entitlements
 
 Depending on which Electron APIs your app uses, you may need to add additional
-entitlements to your `parent.plist` file to be able to use these certain APIs
-from your app's Mac App Store build.
+entitlements to your `parent.plist` file to be able to use these APIs from your
+app's Mac App Store build.
 
 #### dialog.showOpenDialog
 

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -166,6 +166,30 @@ Also, due to the usage of app sandboxing, the resources which can be accessed by
 the app are strictly limited; you can read [App Sandboxing][app-sandboxing] for
 more information.
 
+### Additional Entitlements
+
+Depending on which Electron APIs your app uses, you may need to add additional
+entitlements to your `parent.plist` file to be able to use these certain APIs
+from your app's Mac App Store build.
+
+#### dialog.showOpenDialog
+
+```xml
+<key>com.apple.security.files.user-selected.read-only</key>
+<true/>
+```
+
+See [Apple documentation](https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6).
+
+#### dialog.showSaveDialog
+
+```xml
+<key>com.apple.security.files.user-selected.read-write</key>
+<true/>
+```
+
+See [Apple documentation](https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6).
+
 ## Cryptographic Algorithms Used by Electron
 
 Depending on the country and region you are located, Mac App Store may require

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -179,7 +179,8 @@ app's Mac App Store build.
 <true/>
 ```
 
-See [Apple documentation](https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6).
+See the [Enabling User-Selected File Access documentation][user-selected] for
+more details.
 
 #### dialog.showSaveDialog
 
@@ -188,7 +189,8 @@ See [Apple documentation](https://developer.apple.com/library/mac/documentation/
 <true/>
 ```
 
-See [Apple documentation](https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6).
+See the [Enabling User-Selected File Access documentation][user-selected] for
+more details.
 
 ## Cryptographic Algorithms Used by Electron
 
@@ -237,3 +239,4 @@ ERN)][ern-tutorial].
 [app-sandboxing]: https://developer.apple.com/app-sandboxing/
 [ern-tutorial]: https://carouselapps.com/2015/12/15/legally-submit-app-apples-app-store-uses-encryption-obtain-ern/
 [temporary-exception]: https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/AppSandboxTemporaryExceptionEntitlements.html
+[user-selected]: https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6


### PR DESCRIPTION
Calling `dialog.showOpenDialog` and/or `dialog.showSaveDialog` requires additional entitlements in your `parent.plist` file.

This pull request documents and links to the apple docs for these. 🍎 📖 

/cc @zeke @jlord 