### PR TITLE
Redispatch events to handle native OSX shortcuts

### DIFF
--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -25,8 +25,7 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
 
   NSWindow* window = event.os_event.window;
   if (window && [window isKindOfClass:[AtomNSWindow class]]) {
-    AtomNSWindow* native_window = static_cast<AtomNSWindow*>(window);
-    [native_window redispatchKeyEvent:event.os_event];
+    [((AtomNSWindow*)window) redispatchKeyEvent:event.os_event];
   }
 }
 

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -23,8 +23,9 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
   if (event.windowsKeyCode == ui::VKEY_ESCAPE && is_html_fullscreen())
     ExitFullscreenModeForTab(source);
 
-  if (event.os_event.window) {
-    AtomNSWindow* native_window = static_cast<AtomNSWindow*>(event.os_event.window);
+  NSWindow* window = event.os_event.window;
+  if (window && [window isKindOfClass:[AtomNSWindow class]]) {
+    AtomNSWindow* native_window = static_cast<AtomNSWindow*>(window);
     [native_window redispatchKeyEvent:event.os_event];
   }
 }

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -23,11 +23,8 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
   if (event.windowsKeyCode == ui::VKEY_ESCAPE && is_html_fullscreen())
     ExitFullscreenModeForTab(source);
 
-  NSWindow* window = event.os_event.window;
-  if (window && [window isKindOfClass:[EventDispatchingWindow class]]) {
-    EventDispatchingWindow* native_window = static_cast<EventDispatchingWindow*>(window);
-    [native_window redispatchKeyEvent:event.os_event];
-  }
+  EventDispatchingWindow* native_window = static_cast<EventDispatchingWindow*>(event.os_event.window);
+  [native_window redispatchKeyEvent:event.os_event];
 }
 
 }  // namespace atom

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -10,6 +10,10 @@
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
+@interface NSWindow (EventDispatchingWindow)
+- (void)redispatchKeyEvent:(NSEvent*)event;
+@end
+
 namespace atom {
 
 void CommonWebContentsDelegate::HandleKeyboardEvent(
@@ -24,7 +28,7 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
     ExitFullscreenModeForTab(source);
 
   if (event.os_event.window)
-    [(EventDispatchingWindow*)event.os_event.window redispatchKeyEvent:event.os_event];
+    [event.os_event.window redispatchKeyEvent:event.os_event];
 }
 
 }  // namespace atom

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -23,8 +23,7 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
   if (event.windowsKeyCode == ui::VKEY_ESCAPE && is_html_fullscreen())
     ExitFullscreenModeForTab(source);
 
-  EventDispatchingWindow* native_window = static_cast<EventDispatchingWindow*>(event.os_event.window);
-  [native_window redispatchKeyEvent:event.os_event];
+  [(EventDispatchingWindow*)event.os_event.window redispatchKeyEvent:event.os_event];
 }
 
 }  // namespace atom

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -24,8 +24,8 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
     ExitFullscreenModeForTab(source);
 
   NSWindow* window = event.os_event.window;
-  if (window && [window isKindOfClass:[AtomNSWindow class]]) {
-    [((AtomNSWindow*)window) redispatchKeyEvent:event.os_event];
+  if ([window respondsToSelector:@selector(redispatchKeyEvent:)]) {
+    [(id)window redispatchKeyEvent:event.os_event];
   }
 }
 

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -6,6 +6,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include "atom/browser/native_window_mac.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
@@ -22,17 +23,9 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
   if (event.windowsKeyCode == ui::VKEY_ESCAPE && is_html_fullscreen())
     ExitFullscreenModeForTab(source);
 
-  BOOL handled = [[NSApp mainMenu] performKeyEquivalent:event.os_event];
-  if (!handled && event.os_event.window) {
-    // Handle the cmd+~ shortcut.
-    if ((event.os_event.modifierFlags & NSCommandKeyMask) /* cmd */ &&
-        (event.os_event.keyCode == 50  /* ~ */)) {
-      if (event.os_event.modifierFlags & NSShiftKeyMask) {
-        [NSApp sendAction:@selector(_cycleWindowsReversed:) to:nil from:nil];
-      } else {
-        [NSApp sendAction:@selector(_cycleWindows:) to:nil from:nil];
-      }
-    }
+  if (event.os_event.window) {
+    AtomNSWindow* native_window = static_cast<AtomNSWindow*>(event.os_event.window);
+    [native_window redispatchKeyEvent:event.os_event];
   }
 }
 

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -6,7 +6,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-#include "atom/browser/native_window_mac.h"
+#include "brightray/browser/mac/event_dispatching_window.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
@@ -24,8 +24,9 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
     ExitFullscreenModeForTab(source);
 
   NSWindow* window = event.os_event.window;
-  if ([window respondsToSelector:@selector(redispatchKeyEvent:)]) {
-    [(id)window redispatchKeyEvent:event.os_event];
+  if (window && [window isKindOfClass:[EventDispatchingWindow class]]) {
+    EventDispatchingWindow* native_window = static_cast<EventDispatchingWindow*>(window);
+    [native_window redispatchKeyEvent:event.os_event];
   }
 }
 

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -23,7 +23,8 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
   if (event.windowsKeyCode == ui::VKEY_ESCAPE && is_html_fullscreen())
     ExitFullscreenModeForTab(source);
 
-  [(EventDispatchingWindow*)event.os_event.window redispatchKeyEvent:event.os_event];
+  if (event.os_event.window)
+    [(EventDispatchingWindow*)event.os_event.window redispatchKeyEvent:event.os_event];
 }
 
 }  // namespace atom

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -152,19 +152,4 @@ class NativeWindowMac : public NativeWindow {
 
 }  // namespace atom
 
-@interface AtomNSWindow : NSWindow {
- @private
-  atom::NativeWindowMac* shell_;
-  bool enable_larger_than_screen_;
-  BOOL redispatchingEvent_;
-}
-@property BOOL acceptsFirstMouse;
-@property BOOL disableAutoHideCursor;
-@property BOOL disableKeyOrMainWindow;
-
-- (void)setShell:(atom::NativeWindowMac*)shell;
-- (void)setEnableLargerThanScreen:(bool)enable;
-- (void)redispatchKeyEvent:(NSEvent*)event;
-@end
-
 #endif  // ATOM_BROWSER_NATIVE_WINDOW_MAC_H_

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -157,7 +157,6 @@ class NativeWindowMac : public NativeWindow {
   atom::NativeWindowMac* shell_;
   bool enable_larger_than_screen_;
   BOOL redispatchingEvent_;
-  BOOL eventHandled_;
 }
 @property BOOL acceptsFirstMouse;
 @property BOOL disableAutoHideCursor;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -152,4 +152,21 @@ class NativeWindowMac : public NativeWindow {
 
 }  // namespace atom
 
+@interface AtomNSWindow : NSWindow {
+ @private
+  atom::NativeWindowMac* shell_;
+  bool enable_larger_than_screen_;
+  BOOL redispatchingEvent_;
+  BOOL eventHandled_;
+}
+@property BOOL acceptsFirstMouse;
+@property BOOL disableAutoHideCursor;
+@property BOOL disableKeyOrMainWindow;
+
+- (void)setShell:(atom::NativeWindowMac*)shell;
+- (void)setEnableLargerThanScreen:(bool)enable;
+- (BOOL)redispatchKeyEvent:(NSEvent*)event;
+- (BOOL)performKeyEquivalent:(NSEvent*)theEvent;
+@end
+
 #endif  // ATOM_BROWSER_NATIVE_WINDOW_MAC_H_

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -165,7 +165,7 @@ class NativeWindowMac : public NativeWindow {
 
 - (void)setShell:(atom::NativeWindowMac*)shell;
 - (void)setEnableLargerThanScreen:(bool)enable;
-- (BOOL)redispatchKeyEvent:(NSEvent*)event;
+- (void)redispatchKeyEvent:(NSEvent*)event;
 - (BOOL)performKeyEquivalent:(NSEvent*)theEvent;
 @end
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -165,7 +165,6 @@ class NativeWindowMac : public NativeWindow {
 - (void)setShell:(atom::NativeWindowMac*)shell;
 - (void)setEnableLargerThanScreen:(bool)enable;
 - (void)redispatchKeyEvent:(NSEvent*)event;
-- (BOOL)performKeyEquivalent:(NSEvent*)theEvent;
 @end
 
 #endif  // ATOM_BROWSER_NATIVE_WINDOW_MAC_H_

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -337,34 +337,26 @@ bool ScopedDisableResize::disable_resize_ = false;
 - (void)sendEvent:(NSEvent*)event {
   if (!redispatchingEvent_)
     [super sendEvent:event];
-  else
-    eventHandled_ = NO;
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent*)event {
   if (redispatchingEvent_)
     return NO;
-
-  if ([super performKeyEquivalent:event])
-    return YES;
-
-  return NO;
+  else
+    return [super performKeyEquivalent:event];
  }
 
-- (BOOL)redispatchKeyEvent:(NSEvent*)event {
+- (void)redispatchKeyEvent:(NSEvent*)event {
   NSEventType eventType = [event type];
   if (eventType != NSKeyDown && eventType != NSKeyUp &&
       eventType != NSFlagsChanged) {
-    return YES;
+    return;
   }
 
   // Redispatch the event.
-  eventHandled_ = YES;
   redispatchingEvent_ = YES;
   [NSApp sendEvent:event];
   redispatchingEvent_ = NO;
-
-  return eventHandled_;
 }
 @end
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -15,6 +15,7 @@
 #include "base/strings/sys_string_conversions.h"
 #include "brightray/browser/inspectable_web_contents.h"
 #include "brightray/browser/inspectable_web_contents_view.h"
+#include "brightray/browser/mac/event_dispatching_window.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/render_view_host.h"
@@ -270,6 +271,19 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 @end
 
+@interface AtomNSWindow : EventDispatchingWindow {
+ @private
+  atom::NativeWindowMac* shell_;
+  bool enable_larger_than_screen_;
+}
+@property BOOL acceptsFirstMouse;
+@property BOOL disableAutoHideCursor;
+@property BOOL disableKeyOrMainWindow;
+
+- (void)setShell:(atom::NativeWindowMac*)shell;
+- (void)setEnableLargerThanScreen:(bool)enable;
+@end
+
 @implementation AtomNSWindow
 
 - (void)setShell:(atom::NativeWindowMac*)shell {
@@ -334,30 +348,6 @@ bool ScopedDisableResize::disable_resize_ = false;
   return !self.disableKeyOrMainWindow;
 }
 
-- (void)sendEvent:(NSEvent*)event {
-  if (!redispatchingEvent_)
-    [super sendEvent:event];
-}
-
-- (BOOL)performKeyEquivalent:(NSEvent*)event {
-  if (redispatchingEvent_)
-    return NO;
-  else
-    return [super performKeyEquivalent:event];
- }
-
-- (void)redispatchKeyEvent:(NSEvent*)event {
-  NSEventType eventType = [event type];
-  if (eventType != NSKeyDown && eventType != NSKeyUp &&
-      eventType != NSFlagsChanged) {
-    return;
-  }
-
-  // Redispatch the event.
-  redispatchingEvent_ = YES;
-  [NSApp sendEvent:event];
-  redispatchingEvent_ = NO;
-}
 @end
 
 @interface ControlRegionView : NSView


### PR DESCRIPTION
This pull request pulls in code from [command_dispatcher.mm](https://cs.chromium.org/codesearch/f/chromium/src/ui/base/cocoa/command_dispatcher.mm) that redispatches events in an attempt to correctly handle native keyboard shortcuts like `Ctrl+F2` and `Cmd-~` on Mac OS X.

### Tested Scenarios

- [x] Menu-based shortcuts like `Cmd-R`, `Cmd-A`, `Cmd-Alt-I`.
- [x] Native shortcuts like `Cmd-~` and `Ctrl-F2`
- [x] Calling `preventDefault()` on a `keydown` event to disable something native like `Cmd-A` to select all
- [x] Typing and keybindings in `<input>` elements 
- [x] Docked devtools window
- [x] Undocked devtools window
- [ ] Others?

If anyone is able to test this branch for their app and verify menus and shortcuts still work as expected, that would be really helpful. /cc @electron/maintainers 

Closes #5246 
Closes #6016 
Depends on https://github.com/electron/brightray/issues/227

Related reading:

https://www.chromium.org/developers/os-x-keyboard-handling
https://github.com/nwjs/nw.js/commit/6658fbb839a9623f373b51fee37370f5bf500a6d