### PR TITLE
Work around a compiler bug that crashes on Windows

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -266,13 +266,22 @@ WebContents::WebContents(v8::Isolate* isolate,
 WebContents::WebContents(v8::Isolate* isolate,
                          const mate::Dictionary& options)
     : embedder_(nullptr),
+      type_(BROWSER_WINDOW),
       request_id_(0),
       background_throttling_(true) {
   // Read options.
   options.Get("backgroundThrottling", &background_throttling_);
 
-  type_ = BROWSER_WINDOW;
-  options.Get("type", &type_);
+  // FIXME(zcbenz): We should read "type" parameter for better design, but
+  // on Windows we have encountered a compiler bug that if we read "type"
+  // from |options| and then set |type_|, a memory corruption will happen
+  // and Electron will soon crash.
+  // Remvoe this after we upgraded to use VS 2015 Update 3.
+  bool b = false;
+  if (options.Get("isGuest", &b) && b)
+    type_ = WEB_VIEW;
+  else if (options.Get("isBackgroundPage", &b) && b)
+    type_ = BACKGROUND_PAGE;
 
   // Obtain the session.
   std::string partition;

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -78,7 +78,7 @@ const startBackgroundPages = function (manifest) {
   const html = new Buffer(`<html><body>${scripts}</body></html>`)
 
   const contents = webContents.create({
-    type: 'backgroundPage',
+    isBackgroundPage: true,
     commandLineSwitches: ['--background-page']
   })
   backgroundPages[manifest.extensionId] = { html: html, webContents: contents }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -63,7 +63,7 @@ const createGuest = function (embedder, params) {
 
   const id = getNextInstanceId(embedder)
   const guest = webContents.create({
-    type: 'webview',
+    isGuest: true,
     partition: params.partition,
     embedder: embedder
   })


### PR DESCRIPTION
Usually I wouldn't blame compiler for crashes, but this time I do.

This should bring the Windows CI to green.