### PR TITLE
Add webNavigation APIs to background pages

### DIFF
--- a/filenames.gypi
+++ b/filenames.gypi
@@ -65,6 +65,7 @@
       'lib/renderer/api/web-frame.js',
       'lib/renderer/extensions/i18n.js',
       'lib/renderer/extensions/storage.js',
+      'lib/renderer/extensions/web-navigation.js',
     ],
     'js2c_sources': [
       'lib/common/asar.js',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -63,6 +63,7 @@
       'lib/renderer/api/remote.js',
       'lib/renderer/api/screen.js',
       'lib/renderer/api/web-frame.js',
+      'lib/renderer/extensions/event.js',
       'lib/renderer/extensions/i18n.js',
       'lib/renderer/extensions/storage.js',
       'lib/renderer/extensions/web-navigation.js',

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -97,17 +97,42 @@ const removeBackgroundPages = function (manifest) {
   delete backgroundPages[manifest.extensionId]
 }
 
-// Dispatch tabs events.
-const hookWebContentsForTabEvents = function (webContents) {
-  const tabId = webContents.id
+const sendToBackgroundPages = function (...args) {
   for (const page of objectValues(backgroundPages)) {
-    page.webContents.sendToAll('CHROME_TABS_ONCREATED', tabId)
+    page.webContents.sendToAll(...args)
   }
+}
+
+// Dispatch web contents events to Chrome APIs
+const hookWebContentsEvents = function (webContents) {
+  const tabId = webContents.id
+
+  sendToBackgroundPages('CHROME_TABS_ONCREATED')
+
+  webContents.on('will-navigate', (event, url) => {
+    sendToBackgroundPages('CHROME_WEBNAVIGATION_ONBEFORENAVIGATE', {
+      frameId: 0,
+      parentFrameId: -1,
+      processId: webContents.getId(),
+      tabId: tabId,
+      timeStamp: Date.now(),
+      url: url
+    })
+  })
+
+  webContents.on('did-navigate', (event, url) => {
+    sendToBackgroundPages('CHROME_WEBNAVIGATION_ONCOMPLETED', {
+      frameId: 0,
+      parentFrameId: -1,
+      processId: webContents.getId(),
+      tabId: tabId,
+      timeStamp: Date.now(),
+      url: url
+    })
+  })
 
   webContents.once('destroyed', () => {
-    for (const page of objectValues(backgroundPages)) {
-      page.webContents.sendToAll('CHROME_TABS_ONREMOVED', tabId)
-    }
+    sendToBackgroundPages('CHROME_TABS_ONREMOVED', tabId)
   })
 }
 
@@ -245,7 +270,7 @@ const loadDevToolsExtensions = function (win, manifests) {
 app.on('web-contents-created', function (event, webContents) {
   if (!isWindowOrWebView(webContents)) return
 
-  hookWebContentsForTabEvents(webContents)
+  hookWebContentsEvents(webContents)
   webContents.on('devtools-opened', function () {
     loadDevToolsExtensions(webContents, objectValues(manifestMap))
   })

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -1,30 +1,8 @@
 const {ipcRenderer} = require('electron')
+const Event = require('./extensions/event')
 const url = require('url')
 
 let nextId = 0
-
-class Event {
-  constructor () {
-    this.listeners = []
-  }
-
-  addListener (callback) {
-    this.listeners.push(callback)
-  }
-
-  removeListener (callback) {
-    const index = this.listeners.indexOf(callback)
-    if (index !== -1) {
-      this.listeners.splice(index, 1)
-    }
-  }
-
-  emit (...args) {
-    for (const listener of this.listeners) {
-      listener(...args)
-    }
-  }
-}
 
 class Tab {
   constructor (tabId) {

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -174,5 +174,5 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
   }
 
   chrome.i18n = require('./extensions/i18n').setup(extensionId)
-  chrome.webNavigation = require('./extensions/web-navigation')
+  chrome.webNavigation = require('./extensions/web-navigation').setup()
 }

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -196,4 +196,5 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
   }
 
   chrome.i18n = require('./extensions/i18n.js').setup(extensionId)
+  chrome.webNavigation = require('./extensions/web-navigation.js')
 }

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -161,7 +161,7 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
     onMessage: chrome.runtime.onMessage
   }
 
-  chrome.storage = require('./extensions/storage.js')
+  chrome.storage = require('./extensions/storage')
 
   chrome.pageAction = {
     show () {},
@@ -173,6 +173,6 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
     getPopup () {}
   }
 
-  chrome.i18n = require('./extensions/i18n.js').setup(extensionId)
-  chrome.webNavigation = require('./extensions/web-navigation.js')
+  chrome.i18n = require('./extensions/i18n').setup(extensionId)
+  chrome.webNavigation = require('./extensions/web-navigation')
 }

--- a/lib/renderer/extensions/event.js
+++ b/lib/renderer/extensions/event.js
@@ -1,0 +1,24 @@
+class Event {
+  constructor () {
+    this.listeners = []
+  }
+
+  addListener (callback) {
+    this.listeners.push(callback)
+  }
+
+  removeListener (callback) {
+    const index = this.listeners.indexOf(callback)
+    if (index !== -1) {
+      this.listeners.splice(index, 1)
+    }
+  }
+
+  emit (...args) {
+    for (const listener of this.listeners) {
+      listener(...args)
+    }
+  }
+}
+
+module.exports = Event

--- a/lib/renderer/extensions/web-navigation.js
+++ b/lib/renderer/extensions/web-navigation.js
@@ -1,19 +1,5 @@
-exports.onBeforeNavigate = {
-  addListener () {
+const Event = require('./event')
 
-  },
+exports.onBeforeNavigate = new Event()
 
-  removeListener () {
-
-  }
-}
-
-exports.onCompleted = {
-  addListener () {
-
-  },
-
-  removeListener () {
-
-  }
-}
+exports.onCompleted = new Event()

--- a/lib/renderer/extensions/web-navigation.js
+++ b/lib/renderer/extensions/web-navigation.js
@@ -1,0 +1,19 @@
+exports.onBeforeNavigate = {
+  addListener () {
+
+  },
+
+  removeListener () {
+
+  }
+}
+
+exports.onCompleted = {
+  addListener () {
+
+  },
+
+  removeListener () {
+
+  }
+}

--- a/lib/renderer/extensions/web-navigation.js
+++ b/lib/renderer/extensions/web-navigation.js
@@ -1,5 +1,21 @@
 const Event = require('./event')
+const {ipcRenderer} = require('electron')
 
-exports.onBeforeNavigate = new Event()
+class WebNavigation {
+  constructor () {
+    this.onBeforeNavigate = new Event()
+    this.onCompleted = new Event()
 
-exports.onCompleted = new Event()
+    ipcRenderer.on('CHROME_WEBNAVIGATION_ONBEFORENAVIGATE', (event, details) => {
+      this.onBeforeNavigate.emit(details)
+    })
+
+    ipcRenderer.on('CHROME_WEBNAVIGATION_ONCOMPLETED', (event, details) => {
+      this.onCompleted.emit(details)
+    })
+  }
+}
+
+exports.setup = () => {
+  return new WebNavigation()
+}


### PR DESCRIPTION
Adds the following API to devtools extension background pages:

- `chrome.webNavigation.onBeforeNavigate.addListener`
- `chrome.webNavigation.onBeforeNavigate.removeListener`
- `chrome.webNavigation.onCompleted.addListener`
- `chrome.webNavigation.onCompleted.removeListener`

These are implemented via the `webContents` `will-navigate` and `did-navigate` APIs.

Refs #5842