### PR TITLE
Fix crash setting progress after setting dock icon

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -907,7 +907,9 @@ void NativeWindowMac::SetProgressBar(double progress) {
     NSImageView* image_view = [[NSImageView alloc] init];
     [image_view setImage:[NSApp applicationIconImage]];
     [dock_tile setContentView:image_view];
+  }
 
+  if ([[dock_tile.contentView subviews] count] == 0) {
     NSProgressIndicator* progress_indicator = [[AtomProgressBar alloc]
         initWithFrame:NSMakeRect(0.0f, 0.0f, dock_tile.size.width, 15.0)];
     [progress_indicator setStyle:NSProgressIndicatorBarStyle];
@@ -916,7 +918,7 @@ void NativeWindowMac::SetProgressBar(double progress) {
     [progress_indicator setMinValue:0];
     [progress_indicator setMaxValue:1];
     [progress_indicator setHidden:NO];
-    [image_view addSubview:progress_indicator];
+    [dock_tile.contentView addSubview:progress_indicator];
   }
 
   NSProgressIndicator* progress_indicator =

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -337,6 +337,17 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.setProgressBar(progress)', function () {
+    it('sets the progress', function () {
+      assert.doesNotThrow(function () {
+        if (process.platform === 'darwin') {
+          app.dock.setIcon(path.join(fixtures, 'assets', 'logo.png'))
+        }
+        w.setProgressBar(.5)
+      })
+    })
+  })
+
   describe('BrowserWindow.fromId(id)', function () {
     it('returns the window with id', function () {
       assert.equal(w.id, BrowserWindow.fromId(w.id).id)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -344,6 +344,11 @@ describe('browser-window module', function () {
           app.dock.setIcon(path.join(fixtures, 'assets', 'logo.png'))
         }
         w.setProgressBar(.5)
+
+        if (process.platform === 'darwin') {
+          app.dock.setIcon(null)
+        }
+        w.setProgressBar(-1)
       })
     })
   })


### PR DESCRIPTION
Add progress indicator whenever the dock tile's content view is empty.

Previously calling `setProgressBar` after `app.dock.setIcon` would crash because the subviews array was empty.

This also adds a simple spec to verify the `setProgressBar` API does not throw which will give some coverage to these APIs for crashes or parameter conversion errors.

Thanks @fasterthanlime for the great investigation.

Closes #6056