### PR TITLE
Setup protocol after ready has already fired

### DIFF
--- a/lib/browser/api/protocol.js
+++ b/lib/browser/api/protocol.js
@@ -9,9 +9,15 @@ exports.registerStandardSchemes = function (schemes) {
   registerStandardSchemes(schemes)
 }
 
-app.once('ready', function () {
+const setupProtocol = function () {
   let protocol = session.defaultSession.protocol
   for (let method in protocol) {
     exports[method] = protocol[method].bind(protocol)
   }
-})
+}
+
+if (app.isReady()) {
+  setupProtocol()
+} else {
+  app.once('ready', setupProtocol)
+}


### PR DESCRIPTION
Looks like in `1.2.3` `browser/api/protocol.js` is no longer eagerly required so the properties/methods are missing on it since the `ready` event on `app` has already been fired when required later on and so the properties from `session.defaultSession.protocol` were never copied over to the exports object.

This pull request adds a check `app.isReady()` to handle this case.

I *think* it might have been introduced by this line, https://github.com/electron/electron/pull/5904/files#diff-8d85c651cb0fb8feef2c4694d52da2e3L1

Closes #6094 