### PR TITLE
Use the setTitleVisibility to control tittlebar's visibility

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -96,9 +96,12 @@ class NativeWindowMac : public NativeWindow {
   void SetStyleMask(bool on, NSUInteger flag);
   void SetCollectionBehavior(bool on, NSUInteger flag);
 
-  bool should_hide_native_toolbar_in_fullscreen() const {
-    return should_hide_native_toolbar_in_fullscreen_;
-  }
+  enum TitleBarStyle {
+    NORMAL,
+    HIDDEN,
+    HIDDEN_INSET,
+  };
+  TitleBarStyle title_bar_style() const { return title_bar_style_; }
 
  protected:
   // Return a vector of non-draggable regions that fill a window of size
@@ -138,11 +141,8 @@ class NativeWindowMac : public NativeWindow {
   // The presentation options before entering kiosk mode.
   NSApplicationPresentationOptions kiosk_options_;
 
-  // The window title, for frameless windows we only set title when fullscreen.
-  std::string title_;
-
-  // Force showing the buttons for frameless window.
-  bool force_show_buttons_;
+  // The "titleBarStyle" option.
+  TitleBarStyle title_bar_style_;
 
   // Whether to hide the native toolbar under fullscreen mode.
   bool should_hide_native_toolbar_in_fullscreen_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -197,7 +197,7 @@ bool ScopedDisableResize::disable_resize_ = false;
   // titlebar is expected to be empty, but after entering fullscreen mode we
   // have to set one, because title bar is visible here.
   NSWindow* window = shell_->GetNativeWindow();
-  if (!shell_->has_frame() &&
+  if ((shell_->transparent() || !shell_->has_frame()) &&
       // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
       // fullscreen mode.
       shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET) {
@@ -221,7 +221,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 - (void)windowWillExitFullScreen:(NSNotification*)notification {
   // Restore the titlebar visibility.
   NSWindow* window = shell_->GetNativeWindow();
-  if (!shell_->has_frame() &&
+  if ((shell_->transparent() || !shell_->has_frame()) &&
       shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET) {
     [window setTitleVisibility:NSWindowTitleHidden];
   }
@@ -501,8 +501,6 @@ NativeWindowMac::NativeWindowMac(
   [window_ setDelegate:window_delegate_];
 
   if (transparent()) {
-    // Make window has transparent background.
-    [window_ setOpaque:NO];
     // Setting the background color to clear will also hide the shadow.
     [window_ setBackgroundColor:[NSColor clearColor]];
   }
@@ -520,7 +518,7 @@ NativeWindowMac::NativeWindowMac(
   if (options.Get(options::kFocusable, &focusable) && !focusable)
     [window_ setDisableKeyOrMainWindow:YES];
 
-  if (!has_frame()) {
+  if (transparent() || !has_frame()) {
     // Don't show title bar.
     [window_ setTitleVisibility:NSWindowTitleHidden];
     // Remove non-transparent corners, see http://git.io/vfonD.


### PR DESCRIPTION
This continues #6089's work:

* Fix `titleBarStyle: 'hidden'` showing title.
* Make normal frameless window also show in Window menu.