### PR TITLE
Fix context menus selecting first item by default.

### DIFF
--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -19,7 +19,7 @@ class MenuMac : public Menu {
  protected:
   explicit MenuMac(v8::Isolate* isolate);
 
-  void PopupAt(Window* window, int x, int y, int positioning_item = 0) override;
+  void PopupAt(Window* window, int x, int y, int positioning_item) override;
 
   base::scoped_nsobject<AtomMenuController> menu_controller_;
 

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -17,7 +17,7 @@ class MenuViews : public Menu {
   explicit MenuViews(v8::Isolate* isolate);
 
  protected:
-  void PopupAt(Window* window, int x, int y, int positioning_item = 0) override;
+  void PopupAt(Window* window, int x, int y, int positioning_item) override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(MenuViews);

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -150,10 +150,12 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     window = BrowserWindow.getFocusedWindow()
   }
 
-  // Default parameters.
+  // Default to showing under mouse location.
   if (typeof x !== 'number') x = -1
   if (typeof y !== 'number') y = -1
-  if (typeof positioningItem !== 'number') positioningItem = 0
+
+  // Default to not highlighting any item.
+  if (typeof positioningItem !== 'number') positioningItem = -1
 
   this.popupAt(window, x, y, positioningItem)
 }


### PR DESCRIPTION
This sets the default value for `positioningItem` to -1 (an invalid value) so that no item is selected.
The proper checks are performed by https://github.com/electron/electron/blob/79cb648b6b15ae0cc25e1bf528f3f4fbd1fed710/atom/browser/api/atom_api_menu_mac.mm#L39

Closes #6109