### PR TITLE
Call loadExtension from addDevToolsExtension

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -352,6 +352,7 @@ app.once('ready', function () {
   BrowserWindow.addDevToolsExtension = function (srcDirectory) {
     const manifest = getManifestFromPath(srcDirectory)
     if (manifest) {
+      loadExtension(manifest)
       for (const webContents of getAllWebContents()) {
         if (isWindowOrWebView(webContents)) {
           loadDevToolsExtensions(webContents, [manifest])


### PR DESCRIPTION
Previously if `BrowserWindow.addDevToolsExtension` was called with no existing windows or webviews then `loadExtension` would not be called until the devtools were opened meaning background pages and content scripts wouldn't be created earlier than that.

This would cause the React dev tools to not show up on the initial call to `BrowserWindow.addDevToolsExtension`.

/cc @MarshallOfSound I believe this issue fixes what you saw your in reproduction example.

Closes #6101 