### PR TITLE
Fixes transformed webview size

### DIFF
--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -166,6 +166,12 @@ var WebViewImpl = (function () {
     resizeEvent = new Event('resize', {
       bubbles: true
     })
+
+    // Using client size values, because when a webview is transformed `newSize`
+    // is incorrect
+    newSize.width = this.webviewNode.clientWidth
+    newSize.height = this.webviewNode.clientHeight
+
     resizeEvent.newWidth = newSize.width
     resizeEvent.newHeight = newSize.height
     this.dispatchEvent(resizeEvent)


### PR DESCRIPTION
This PR solves the resizing issue of a transformed `webview` tag, as mentioned in #5968 and #2168.