### PR TITLE
🐛 Don't load 'repl' unless needed

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -3,7 +3,6 @@ const {app, dialog, shell, Menu} = require('electron')
 const fs = require('fs')
 const Module = require('module')
 const path = require('path')
-const repl = require('repl')
 const url = require('url')
 
 // Parse command line options.
@@ -315,6 +314,7 @@ function startRepl () {
     return
   }
 
+  const repl = require('repl')
   repl.start('> ').on('exit', () => {
     process.exit(0)
   })

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -225,7 +225,7 @@ describe('node feature', function () {
       process.stdout.write('test')
     })
 
-    xit('should have isTTY defined', function () {
+    it('should have isTTY defined', function () {
       assert.equal(typeof process.stdout.isTTY, 'boolean')
     })
   })


### PR DESCRIPTION
Ever since v0.37.3, process.stdout in the renderer has not worked at all. It turns out that electron's fork of node sets stdout to [a stream that does nothing](https://github.com/electron/node/blob/4f9e177f4c729f5f6d1001843f42cef35c1becab/lib/internal/process/stdio.js#L168) if an error is thrown while creating the stream. I haven't found the root cause of the error, but [`guessHandleType(fd)`](https://github.com/electron/node/blob/4f9e177f4c729f5f6d1001843f42cef35c1becab/lib/internal/process/stdio.js#L137) returns `'TCP'` for fd1 in v0.37.3. It used to return `'TTY'` in v0.37.2.

I did a git bisect and found the [first commit](https://github.com/electron/electron/commit/0066833887aba619fd2f91e6462a9b001c54fa47) that had this issue. Seems like just loading the `repl` module is enough to cause the issue described above. This commit moves `require('repl')` so that it is only loaded when the --interactive flag is present.

I don't know why loading `repl` breaks stdout.

I'm not entirely sure how to write a test to verify that stdout is indeed writing to the correct place. It seems like the pending test checking `process.stdout.isTTY` is working now, though.

Fixes #5051