### PR TITLE
Add copy/pasta example for system preferences.

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -2,6 +2,11 @@
 
 > Get system preferences.
 
+```javascript
+const {systemPreferences} = require('electron');
+console.log(systemPreferences.isDarkMode());
+```
+
 ## Methods
 
 ### `systemPreferences.isDarkMode()` _macOS_


### PR DESCRIPTION
Most of the other api docs have one example of where to find the module in a copy/paste format. This pull request adds one for the system preferences.