### PR TITLE
Add support for child windows

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -77,8 +77,7 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
 
 
 Window::Window(v8::Isolate* isolate, const mate::Dictionary& options)
-    : disable_count_(0),
-      is_modal_(false) {
+    : is_modal_(false) {
   // Use options.webPreferences to create WebContents.
   mate::Dictionary web_preferences = mate::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
@@ -325,15 +324,11 @@ bool Window::IsVisible() {
 }
 
 void Window::Disable() {
-  ++disable_count_;
-  if (disable_count_ == 1)
-    window_->Disable();
+  window_->Disable();
 }
 
 void Window::Enable() {
-  --disable_count_;
-  if (disable_count_ == 0)
-    window_->Enable();
+  window_->Enable();
 }
 
 bool Window::IsEnabled() {

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -723,6 +723,18 @@ bool Window::IsModal() const {
   return is_modal_;
 }
 
+void Window::BeginSheet(mate::Handle<Window> sheet, mate::Arguments* args) {
+  if (sheet->IsVisible()) {
+    args->ThrowError("Sheet window must not be visible");
+    return;
+  }
+  window_->BeginSheet(sheet->window_.get());
+}
+
+void Window::EndSheet(mate::Handle<Window> sheet) {
+  window_->EndSheet(sheet->window_.get());
+}
+
 v8::Local<v8::Value> Window::GetNativeWindowHandle() {
   gfx::AcceleratedWidget handle = window_->GetAcceleratedWidget();
   return ToBuffer(
@@ -793,6 +805,8 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getChildWindows", &Window::GetChildWindows)
       .SetMethod("setModal", &Window::SetModal)
       .SetMethod("isModal", &Window::IsModal)
+      .SetMethod("beginSheet", &Window::BeginSheet)
+      .SetMethod("endSheet", &Window::EndSheet)
       .SetMethod("getNativeWindowHandle", &Window::GetNativeWindowHandle)
       .SetMethod("getBounds", &Window::GetBounds)
       .SetMethod("setBounds", &Window::SetBounds)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -326,14 +326,6 @@ bool Window::IsVisible() {
   return window_->IsVisible();
 }
 
-void Window::Disable() {
-  window_->Disable();
-}
-
-void Window::Enable() {
-  window_->Enable();
-}
-
 bool Window::IsEnabled() {
   return window_->IsEnabled();
 }
@@ -767,8 +759,6 @@ void Window::RemoveFromParentChildWindows() {
     return;
 
   parent->child_windows_.Remove(ID());
-  if (IsModal())
-    parent->Enable();
 }
 
 // static
@@ -784,8 +774,6 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("showInactive", &Window::ShowInactive)
       .SetMethod("hide", &Window::Hide)
       .SetMethod("isVisible", &Window::IsVisible)
-      .SetMethod("enable", &Window::Enable)
-      .SetMethod("disable", &Window::Disable)
       .SetMethod("isEnabled", &Window::IsEnabled)
       .SetMethod("maximize", &Window::Maximize)
       .SetMethod("unmaximize", &Window::Unmaximize)
@@ -796,7 +784,9 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setFullScreen", &Window::SetFullScreen)
       .SetMethod("isFullScreen", &Window::IsFullscreen)
       .SetMethod("setAspectRatio", &Window::SetAspectRatio)
+#if !defined(OS_WIN)
       .SetMethod("setParentWindow", &Window::SetParentWindow)
+#endif
       .SetMethod("getParentWindow", &Window::GetParentWindow)
       .SetMethod("getChildWindows", &Window::GetChildWindows)
       .SetMethod("isModal", &Window::IsModal)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -650,6 +650,10 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
+void Window::SetParentWindow(NativeWindow* parent) {
+  window_->SetParentWindow(parent);
+}
+
 v8::Local<v8::Value> Window::GetNativeWindowHandle() {
   gfx::AcceleratedWidget handle = window_->GetAcceleratedWidget();
   return ToBuffer(
@@ -697,6 +701,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setFullScreen", &Window::SetFullScreen)
       .SetMethod("isFullScreen", &Window::IsFullscreen)
       .SetMethod("setAspectRatio", &Window::SetAspectRatio)
+      .SetMethod("setParentWindow", &Window::SetParentWindow)
       .SetMethod("getNativeWindowHandle", &Window::GetNativeWindowHandle)
       .SetMethod("getBounds", &Window::GetBounds)
       .SetMethod("setBounds", &Window::SetBounds)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -293,6 +293,18 @@ bool Window::IsVisible() {
   return window_->IsVisible();
 }
 
+void Window::Disable() {
+  window_->Disable();
+}
+
+void Window::Enable() {
+  window_->Enable();
+}
+
+bool Window::IsEnabled() {
+  return window_->IsEnabled();
+}
+
 void Window::Maximize() {
   window_->Maximize();
 }
@@ -726,6 +738,9 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("showInactive", &Window::ShowInactive)
       .SetMethod("hide", &Window::Hide)
       .SetMethod("isVisible", &Window::IsVisible)
+      .SetMethod("enable", &Window::Enable)
+      .SetMethod("disable", &Window::Disable)
+      .SetMethod("isEnabled", &Window::IsEnabled)
       .SetMethod("maximize", &Window::Maximize)
       .SetMethod("unmaximize", &Window::Unmaximize)
       .SetMethod("isMaximized", &Window::IsMaximized)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -650,8 +650,23 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
-void Window::SetParentWindow(NativeWindow* parent) {
-  window_->SetParentWindow(parent);
+void Window::SetParentWindow(mate::Arguments* args) {
+  v8::Local<v8::Value> value;
+  NativeWindow* parent;
+  if (args->GetNext(&value) &&
+      mate::ConvertFromV8(isolate(), value, &parent)) {
+    parent_window_.Reset(isolate(), value);
+    window_->SetParentWindow(parent);
+  } else {
+    args->ThrowError("Must pass BrowserWindow instance or null");
+  }
+}
+
+v8::Local<v8::Value> Window::GetParentWindow() {
+  if (parent_window_.IsEmpty())
+    return v8::Null(isolate());
+  else
+    return v8::Local<v8::Value>::New(isolate(), parent_window_);
 }
 
 v8::Local<v8::Value> Window::GetNativeWindowHandle() {
@@ -702,6 +717,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isFullScreen", &Window::IsFullscreen)
       .SetMethod("setAspectRatio", &Window::SetAspectRatio)
       .SetMethod("setParentWindow", &Window::SetParentWindow)
+      .SetMethod("getParentWindow", &Window::GetParentWindow)
       .SetMethod("getNativeWindowHandle", &Window::GetNativeWindowHandle)
       .SetMethod("getBounds", &Window::GetBounds)
       .SetMethod("setBounds", &Window::SetBounds)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -76,8 +76,7 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
 }  // namespace
 
 
-Window::Window(v8::Isolate* isolate, const mate::Dictionary& options)
-    : is_modal_(false) {
+Window::Window(v8::Isolate* isolate, const mate::Dictionary& options) {
   // Use options.webPreferences to create WebContents.
   mate::Dictionary web_preferences = mate::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
@@ -312,6 +311,10 @@ void Window::Show() {
 }
 
 void Window::ShowInactive() {
+  // This method doesn't make sense for modal window..
+  if (IsModal())
+    return;
+
   window_->ShowInactive();
 }
 
@@ -696,6 +699,11 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
 
 void Window::SetParentWindow(v8::Local<v8::Value> value,
                              mate::Arguments* args) {
+  if (IsModal()) {
+    args->ThrowError("Can not be called for modal window");
+    return;
+  }
+
   mate::Handle<Window> parent;
   if (value->IsNull()) {
     RemoveFromParentChildWindows();
@@ -721,43 +729,8 @@ std::vector<v8::Local<v8::Object>> Window::GetChildWindows() const {
   return child_windows_.Values(isolate());
 }
 
-void Window::SetModal(bool modal, mate::Arguments* args) {
-  if (parent_window_.IsEmpty()) {
-    args->ThrowError("setModal can only be called for child window");
-    return;
-  }
-
-  mate::Handle<Window> parent;
-  if (!mate::ConvertFromV8(isolate(), GetParentWindow(), &parent)) {
-    args->ThrowError("Invalid parent window");  // should never happen
-    return;
-  }
-
-  if (modal == is_modal_)
-    return;
-
-  if (modal)
-    parent->Disable();
-  else
-    parent->Enable();
-  window_->SetModal(modal);
-  is_modal_ = modal;
-}
-
 bool Window::IsModal() const {
-  return is_modal_;
-}
-
-void Window::BeginSheet(mate::Handle<Window> sheet, mate::Arguments* args) {
-  if (sheet->IsVisible()) {
-    args->ThrowError("Sheet window must not be visible");
-    return;
-  }
-  window_->BeginSheet(sheet->window_.get());
-}
-
-void Window::EndSheet(mate::Handle<Window> sheet) {
-  window_->EndSheet(sheet->window_.get());
+  return window_->is_modal();
 }
 
 v8::Local<v8::Value> Window::GetNativeWindowHandle() {
@@ -794,10 +767,8 @@ void Window::RemoveFromParentChildWindows() {
     return;
 
   parent->child_windows_.Remove(ID());
-  if (IsModal()) {
+  if (IsModal())
     parent->Enable();
-    is_modal_ = false;
-  }
 }
 
 // static
@@ -828,10 +799,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setParentWindow", &Window::SetParentWindow)
       .SetMethod("getParentWindow", &Window::GetParentWindow)
       .SetMethod("getChildWindows", &Window::GetChildWindows)
-      .SetMethod("setModal", &Window::SetModal)
       .SetMethod("isModal", &Window::IsModal)
-      .SetMethod("beginSheet", &Window::BeginSheet)
-      .SetMethod("endSheet", &Window::EndSheet)
       .SetMethod("getNativeWindowHandle", &Window::GetNativeWindowHandle)
       .SetMethod("getBounds", &Window::GetBounds)
       .SetMethod("setBounds", &Window::SetBounds)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -159,7 +159,8 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
-  void SetParentWindow(NativeWindow* parent);
+  void SetParentWindow(mate::Arguments* args);
+  v8::Local<v8::Value> GetParentWindow();
   v8::Local<v8::Value> GetNativeWindowHandle();
 
 #if defined(OS_WIN)
@@ -189,6 +190,7 @@ class Window : public mate::TrackableObject<Window>,
 
   v8::Global<v8::Value> web_contents_;
   v8::Global<v8::Value> menu_;
+  v8::Global<v8::Value> parent_window_;
 
   api::WebContents* api_web_contents_;
 

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -95,6 +95,9 @@ class Window : public mate::TrackableObject<Window>,
   void ShowInactive();
   void Hide();
   bool IsVisible();
+  void Disable();
+  void Enable();
+  bool IsEnabled();
   void Maximize();
   void Unmaximize();
   bool IsMaximized();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -170,10 +170,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   v8::Local<v8::Value> GetParentWindow() const;
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;
-  void SetModal(bool modal, mate::Arguments* args);
   bool IsModal() const;
-  void BeginSheet(mate::Handle<Window> sheet, mate::Arguments* args);
-  void EndSheet(mate::Handle<Window> sheet);
   v8::Local<v8::Value> GetNativeWindowHandle();
 
 #if defined(OS_WIN)
@@ -208,9 +205,6 @@ class Window : public mate::TrackableObject<Window>,
   v8::Global<v8::Value> menu_;
   v8::Global<v8::Value> parent_window_;
   KeyWeakMap<int> child_windows_;
-
-  // Is current window modal.
-  bool is_modal_;
 
   api::WebContents* api_web_contents_;
 

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -6,15 +6,16 @@
 #define ATOM_BROWSER_API_ATOM_API_WINDOW_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
-#include "base/memory/scoped_ptr.h"
 #include "ui/gfx/image/image.h"
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/native_window_observer.h"
 #include "atom/common/api/atom_api_native_image.h"
+#include "atom/common/key_weak_map.h"
 #include "native_mate/handle.h"
 
 class GURL;
@@ -159,8 +160,9 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
-  void SetParentWindow(mate::Arguments* args);
+  void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   v8::Local<v8::Value> GetParentWindow();
+  std::vector<v8::Local<v8::Object>> GetChildWindows();
   v8::Local<v8::Value> GetNativeWindowHandle();
 
 #if defined(OS_WIN)
@@ -183,6 +185,9 @@ class Window : public mate::TrackableObject<Window>,
   int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);
 
+  // Helpers.
+  void RemoveFromParentChildWindows();
+
 #if defined(OS_WIN)
   typedef std::map<UINT, MessageCallback> MessageCallbackMap;
   MessageCallbackMap messages_callback_map_;
@@ -191,6 +196,7 @@ class Window : public mate::TrackableObject<Window>,
   v8::Global<v8::Value> web_contents_;
   v8::Global<v8::Value> menu_;
   v8::Global<v8::Value> parent_window_;
+  KeyWeakMap<int> child_windows_;
 
   api::WebContents* api_web_contents_;
 

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -55,6 +55,9 @@ class Window : public mate::TrackableObject<Window>,
   Window(v8::Isolate* isolate, const mate::Dictionary& options);
   ~Window() override;
 
+  // TrackableObject:
+  void AfterInit(v8::Isolate* isolate) override;
+
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
   void OnWindowClosed() override;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -99,8 +99,6 @@ class Window : public mate::TrackableObject<Window>,
   void ShowInactive();
   void Hide();
   bool IsVisible();
-  void Disable();
-  void Enable();
   bool IsEnabled();
   void Maximize();
   void Unmaximize();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -168,6 +168,8 @@ class Window : public mate::TrackableObject<Window>,
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;
   void SetModal(bool modal, mate::Arguments* args);
   bool IsModal() const;
+  void BeginSheet(mate::Handle<Window> sheet, mate::Arguments* args);
+  void EndSheet(mate::Handle<Window> sheet);
   v8::Local<v8::Value> GetNativeWindowHandle();
 
 #if defined(OS_WIN)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -159,6 +159,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
+  void SetParentWindow(NativeWindow* parent);
   v8::Local<v8::Value> GetNativeWindowHandle();
 
 #if defined(OS_WIN)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -164,8 +164,10 @@ class Window : public mate::TrackableObject<Window>,
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
-  v8::Local<v8::Value> GetParentWindow();
-  std::vector<v8::Local<v8::Object>> GetChildWindows();
+  v8::Local<v8::Value> GetParentWindow() const;
+  std::vector<v8::Local<v8::Object>> GetChildWindows() const;
+  void SetModal(bool modal, mate::Arguments* args);
+  bool IsModal() const;
   v8::Local<v8::Value> GetNativeWindowHandle();
 
 #if defined(OS_WIN)
@@ -188,7 +190,7 @@ class Window : public mate::TrackableObject<Window>,
   int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);
 
-  // Helpers.
+  // Remove this window from parent window's |child_windows_|.
   void RemoveFromParentChildWindows();
 
 #if defined(OS_WIN)
@@ -200,6 +202,12 @@ class Window : public mate::TrackableObject<Window>,
   v8::Global<v8::Value> menu_;
   v8::Global<v8::Value> parent_window_;
   KeyWeakMap<int> child_windows_;
+
+  // How many times the Disable has been called.
+  int disable_count_;
+
+  // Is current window modal.
+  bool is_modal_;
 
   api::WebContents* api_web_contents_;
 

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -60,6 +60,7 @@ class Window : public mate::TrackableObject<Window>,
 
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
+  void WillDestoryNativeObject() override;
   void OnWindowClosed() override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -209,9 +209,6 @@ class Window : public mate::TrackableObject<Window>,
   v8::Global<v8::Value> parent_window_;
   KeyWeakMap<int> child_windows_;
 
-  // How many times the Disable has been called.
-  int disable_count_;
-
   // Is current window modal.
   bool is_modal_;
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -56,6 +56,7 @@ NativeWindow::NativeWindow(
       sheet_offset_x_(0.0),
       sheet_offset_y_(0.0),
       aspect_ratio_(0.0),
+      disable_count_(0),
       inspectable_web_contents_(inspectable_web_contents),
       weak_factory_(this) {
   options.Get(options::kFrame, &has_frame_);
@@ -176,6 +177,18 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   options.Get(options::kShow, &show);
   if (show)
     Show();
+}
+
+void NativeWindow::Disable() {
+  ++disable_count_;
+  if (disable_count_ == 1)
+    SetEnabled(false);
+}
+
+void NativeWindow::Enable() {
+  --disable_count_;
+  if (disable_count_ == 0)
+    SetEnabled(true);
 }
 
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -620,7 +620,7 @@ void NativeWindow::ScheduleUnresponsiveEvent(int ms) {
 void NativeWindow::NotifyWindowUnresponsive() {
   window_unresposive_closure_.Cancel();
 
-  if (!is_closed_ && !HasModalDialog())
+  if (!is_closed_ && !HasModalDialog() && IsEnabled())
     FOR_EACH_OBSERVER(NativeWindowObserver,
                       observers_,
                       OnRendererUnresponsive());

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -46,7 +46,8 @@ namespace atom {
 
 NativeWindow::NativeWindow(
     brightray::InspectableWebContents* inspectable_web_contents,
-    const mate::Dictionary& options)
+    const mate::Dictionary& options,
+    NativeWindow* parent)
     : content::WebContentsObserver(inspectable_web_contents->GetWebContents()),
       has_frame_(true),
       transparent_(false),
@@ -57,11 +58,16 @@ NativeWindow::NativeWindow(
       sheet_offset_y_(0.0),
       aspect_ratio_(0.0),
       disable_count_(0),
+      parent_(parent),
+      is_modal_(false),
       inspectable_web_contents_(inspectable_web_contents),
       weak_factory_(this) {
   options.Get(options::kFrame, &has_frame_);
   options.Get(options::kTransparent, &transparent_);
   options.Get(options::kEnableLargerThanScreen, &enable_larger_than_screen_);
+
+  if (parent)
+    options.Get("modal", &is_modal_);
 
   // Tell the content module to initialize renderer widget with transparent
   // mode.
@@ -305,10 +311,8 @@ bool NativeWindow::HasModalDialog() {
   return has_dialog_attached_;
 }
 
-void NativeWindow::BeginSheet(NativeWindow* sheet) {
-}
-
-void NativeWindow::EndSheet(NativeWindow* sheet) {
+void NativeWindow::SetParentWindow(NativeWindow* parent) {
+  parent_ = parent;
 }
 
 void NativeWindow::FocusOnWebView() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -57,7 +57,6 @@ NativeWindow::NativeWindow(
       sheet_offset_x_(0.0),
       sheet_offset_y_(0.0),
       aspect_ratio_(0.0),
-      disable_count_(0),
       parent_(parent),
       is_modal_(false),
       inspectable_web_contents_(inspectable_web_contents),
@@ -183,18 +182,6 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   options.Get(options::kShow, &show);
   if (show)
     Show();
-}
-
-void NativeWindow::Disable() {
-  ++disable_count_;
-  if (disable_count_ == 1)
-    SetEnabled(false);
-}
-
-void NativeWindow::Enable() {
-  --disable_count_;
-  if (disable_count_ == 0)
-    SetEnabled(true);
 }
 
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -403,6 +403,9 @@ void NativeWindow::CloseContents(content::WebContents* source) {
   inspectable_web_contents_ = nullptr;
   Observe(nullptr);
 
+  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
+                    WillDestoryNativeObject());
+
   // When the web contents is gone, close the window immediately, but the
   // memory will not be freed until you call delete.
   // In this way, it would be safe to manage windows via smart pointers. If you

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -292,6 +292,12 @@ bool NativeWindow::HasModalDialog() {
   return has_dialog_attached_;
 }
 
+void NativeWindow::BeginSheet(NativeWindow* sheet) {
+}
+
+void NativeWindow::EndSheet(NativeWindow* sheet) {
+}
+
 void NativeWindow::FocusOnWebView() {
   web_contents()->GetRenderViewHost()->GetWidget()->Focus();
 }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -162,6 +162,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetMenu(ui::MenuModel* menu);
   virtual bool HasModalDialog();
   virtual void SetParentWindow(NativeWindow* parent) = 0;
+  virtual void BeginSheet(NativeWindow* sheet);
+  virtual void EndSheet(NativeWindow* sheet);
   virtual gfx::NativeWindow GetNativeWindow() = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() = 0;
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -158,6 +158,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetFocusable(bool focusable);
   virtual void SetMenu(ui::MenuModel* menu);
   virtual bool HasModalDialog();
+  virtual void SetParentWindow(NativeWindow* parent) = 0;
   virtual gfx::NativeWindow GetNativeWindow() = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() = 0;
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -100,7 +100,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsVisible() = 0;
   virtual void Disable();
   virtual void Enable();
-  virtual void SetEnabled(bool enable) = 0;  // should not be used
+  virtual void SetEnabled(bool enable) = 0;  // internal API, should not be used
   virtual bool IsEnabled() = 0;
   virtual void Maximize() = 0;
   virtual void Unmaximize() = 0;
@@ -163,10 +163,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetFocusable(bool focusable);
   virtual void SetMenu(ui::MenuModel* menu);
   virtual bool HasModalDialog();
-  virtual void SetParentWindow(NativeWindow* parent) = 0;
-  virtual void BeginSheet(NativeWindow* sheet);
-  virtual void EndSheet(NativeWindow* sheet);
-  virtual void SetModal(bool modal) = 0;
+  virtual void SetParentWindow(NativeWindow* parent);
   virtual gfx::NativeWindow GetNativeWindow() = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() = 0;
 
@@ -264,9 +261,13 @@ class NativeWindow : public base::SupportsUserData,
     has_dialog_attached_ = has_dialog_attached;
   }
 
+  NativeWindow* parent() const { return parent_; }
+  bool is_modal() const { return is_modal_; }
+
  protected:
   NativeWindow(brightray::InspectableWebContents* inspectable_web_contents,
-               const mate::Dictionary& options);
+               const mate::Dictionary& options,
+               NativeWindow* parent);
 
   // Convert draggable regions in raw format to SkRegion format. Caller is
   // responsible for deleting the returned SkRegion instance.
@@ -340,6 +341,12 @@ class NativeWindow : public base::SupportsUserData,
 
   // How many times the Disable has been called.
   int disable_count_;
+
+  // The parent window, it is guaranteed to be valid during this window's life.
+  NativeWindow* parent_;
+
+  // Is this a modal window.
+  bool is_modal_;
 
   // The page this window is viewing.
   brightray::InspectableWebContents* inspectable_web_contents_;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -165,6 +165,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetParentWindow(NativeWindow* parent) = 0;
   virtual void BeginSheet(NativeWindow* sheet);
   virtual void EndSheet(NativeWindow* sheet);
+  virtual void SetModal(bool modal) = 0;
   virtual gfx::NativeWindow GetNativeWindow() = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() = 0;
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -81,7 +81,8 @@ class NativeWindow : public base::SupportsUserData,
   // managing the window's live.
   static NativeWindow* Create(
       brightray::InspectableWebContents* inspectable_web_contents,
-      const mate::Dictionary& options);
+      const mate::Dictionary& options,
+      NativeWindow* parent = nullptr);
 
   // Find a window from its WebContents
   static NativeWindow* FromWebContents(content::WebContents* web_contents);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -98,9 +98,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual void ShowInactive() = 0;
   virtual void Hide() = 0;
   virtual bool IsVisible() = 0;
-  virtual void Disable();
-  virtual void Enable();
-  virtual void SetEnabled(bool enable) = 0;  // internal API, should not be used
   virtual bool IsEnabled() = 0;
   virtual void Maximize() = 0;
   virtual void Unmaximize() = 0;
@@ -338,9 +335,6 @@ class NativeWindow : public base::SupportsUserData,
   // content view.
   double aspect_ratio_;
   gfx::Size aspect_ratio_extraSize_;
-
-  // How many times the Disable has been called.
-  int disable_count_;
 
   // The parent window, it is guaranteed to be valid during this window's life.
   NativeWindow* parent_;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -97,6 +97,9 @@ class NativeWindow : public base::SupportsUserData,
   virtual void ShowInactive() = 0;
   virtual void Hide() = 0;
   virtual bool IsVisible() = 0;
+  virtual void Disable() = 0;
+  virtual void Enable() = 0;
+  virtual bool IsEnabled() = 0;
   virtual void Maximize() = 0;
   virtual void Unmaximize() = 0;
   virtual bool IsMaximized() = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -98,8 +98,9 @@ class NativeWindow : public base::SupportsUserData,
   virtual void ShowInactive() = 0;
   virtual void Hide() = 0;
   virtual bool IsVisible() = 0;
-  virtual void Disable() = 0;
-  virtual void Enable() = 0;
+  virtual void Disable();
+  virtual void Enable();
+  virtual void SetEnabled(bool enable) = 0;  // should not be used
   virtual bool IsEnabled() = 0;
   virtual void Maximize() = 0;
   virtual void Unmaximize() = 0;
@@ -336,6 +337,9 @@ class NativeWindow : public base::SupportsUserData,
   // content view.
   double aspect_ratio_;
   gfx::Size aspect_ratio_extraSize_;
+
+  // How many times the Disable has been called.
+  int disable_count_;
 
   // The page this window is viewing.
   brightray::InspectableWebContents* inspectable_web_contents_;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -82,6 +82,8 @@ class NativeWindowMac : public NativeWindow {
   void SetIgnoreMouseEvents(bool ignore) override;
   bool HasModalDialog() override;
   void SetParentWindow(NativeWindow* parent) override;
+  void BeginSheet(NativeWindow* sheet) override;
+  void EndSheet(NativeWindow* sheet) override;
   gfx::NativeWindow GetNativeWindow() override;
   gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void SetProgressBar(double progress) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -78,6 +78,7 @@ class NativeWindowMac : public NativeWindow {
   bool IsDocumentEdited() override;
   void SetIgnoreMouseEvents(bool ignore) override;
   bool HasModalDialog() override;
+  void SetParentWindow(NativeWindow* parent) override;
   gfx::NativeWindow GetNativeWindow() override;
   gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void SetProgressBar(double progress) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -35,7 +35,6 @@ class NativeWindowMac : public NativeWindow {
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() override;
-  void SetEnabled(bool enable) override;
   bool IsEnabled() override;
   void Maximize() override;
   void Unmaximize() override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -85,6 +85,7 @@ class NativeWindowMac : public NativeWindow {
   void SetParentWindow(NativeWindow* parent) override;
   void BeginSheet(NativeWindow* sheet) override;
   void EndSheet(NativeWindow* sheet) override;
+  void SetModal(bool modal) override;
   gfx::NativeWindow GetNativeWindow() override;
   gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void SetProgressBar(double progress) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -22,7 +22,8 @@ namespace atom {
 class NativeWindowMac : public NativeWindow {
  public:
   NativeWindowMac(brightray::InspectableWebContents* inspectable_web_contents,
-                  const mate::Dictionary& options);
+                  const mate::Dictionary& options,
+                  NativeWindow* parent);
   ~NativeWindowMac() override;
 
   // NativeWindow:

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -82,9 +82,6 @@ class NativeWindowMac : public NativeWindow {
   void SetIgnoreMouseEvents(bool ignore) override;
   bool HasModalDialog() override;
   void SetParentWindow(NativeWindow* parent) override;
-  void BeginSheet(NativeWindow* sheet) override;
-  void EndSheet(NativeWindow* sheet) override;
-  void SetModal(bool modal) override;
   gfx::NativeWindow GetNativeWindow() override;
   gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void SetProgressBar(double progress) override;
@@ -150,9 +147,6 @@ class NativeWindowMac : public NativeWindow {
 
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_;
-
-  // Whether to hide the native toolbar under fullscreen mode.
-  bool should_hide_native_toolbar_in_fullscreen_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -35,8 +35,7 @@ class NativeWindowMac : public NativeWindow {
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() override;
-  void Disable() override;
-  void Enable() override;
+  void SetEnabled(bool enable) override;
   bool IsEnabled() override;
   void Maximize() override;
   void Unmaximize() override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -34,6 +34,9 @@ class NativeWindowMac : public NativeWindow {
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() override;
+  void Disable() override;
+  void Enable() override;
+  bool IsEnabled() override;
   void Maximize() override;
   void Unmaximize() override;
   bool IsMaximized() override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -604,6 +604,10 @@ void NativeWindowMac::Close() {
 }
 
 void NativeWindowMac::CloseImmediately() {
+  // Close all child windows before closing this window.
+  for (NSWindow* child in [window_ childWindows])
+    [child close];
+
   [window_ close];
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -673,14 +673,9 @@ bool NativeWindowMac::IsVisible() {
   return [window_ isVisible];
 }
 
-void NativeWindowMac::Disable() {
-  [window_ setDisableKeyOrMainWindow:YES];
-  [window_ setDisableMouseEvents:YES];
-}
-
-void NativeWindowMac::Enable() {
-  [window_ setDisableKeyOrMainWindow:NO];
-  [window_ setDisableMouseEvents:NO];
+void NativeWindowMac::SetEnabled(bool enable) {
+  [window_ setDisableKeyOrMainWindow:!enable];
+  [window_ setDisableMouseEvents:!enable];
 }
 
 bool NativeWindowMac::IsEnabled() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -634,10 +634,6 @@ void NativeWindowMac::Close() {
 }
 
 void NativeWindowMac::CloseImmediately() {
-  // Close all child windows before closing this window.
-  for (NSWindow* child in [window_ childWindows])
-    [child close];
-
   [window_ close];
 }
 
@@ -979,6 +975,9 @@ void NativeWindowMac::EndSheet(NativeWindow* sheet) {
   sheet->Hide();
   [window_ endSheet:sheet->GetNativeWindow()];
   sheet->CloseImmediately();
+}
+
+void NativeWindowMac::SetModal(bool modal) {
 }
 
 gfx::NativeWindow NativeWindowMac::GetNativeWindow() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -911,6 +911,16 @@ bool NativeWindowMac::HasModalDialog() {
   return [window_ attachedSheet] != nil;
 }
 
+void NativeWindowMac::SetParentWindow(NativeWindow* parent) {
+  // Remove current parent window.
+  if ([window_ parentWindow])
+    [[window_ parentWindow] removeChildWindow:window_];
+
+  // Set new current window.
+  if (parent)
+    [parent->GetNativeWindow() addChildWindow:window_ ordered:NSWindowAbove];
+}
+
 gfx::NativeWindow NativeWindowMac::GetNativeWindow() {
   return window_;
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -453,7 +453,8 @@ namespace atom {
 
 NativeWindowMac::NativeWindowMac(
     brightray::InspectableWebContents* web_contents,
-    const mate::Dictionary& options)
+    const mate::Dictionary& options,
+    NativeWindow* parent)
     : NativeWindow(web_contents, options),
       is_kiosk_(false),
       attention_request_id_(0),
@@ -525,6 +526,10 @@ NativeWindowMac::NativeWindowMac(
 
   window_delegate_.reset([[AtomNSWindowDelegate alloc] initWithShell:this]);
   [window_ setDelegate:window_delegate_];
+
+  if (parent) {
+    SetParentWindow(parent);
+  }
 
   if (transparent()) {
     // Setting the background color to clear will also hide the shadow.
@@ -1197,8 +1202,9 @@ void NativeWindowMac::SetCollectionBehavior(bool on, NSUInteger flag) {
 // static
 NativeWindow* NativeWindow::Create(
     brightray::InspectableWebContents* inspectable_web_contents,
-    const mate::Dictionary& options) {
-  return new NativeWindowMac(inspectable_web_contents, options);
+    const mate::Dictionary& options,
+    NativeWindow* parent) {
+  return new NativeWindowMac(inspectable_web_contents, options, parent);
 }
 
 }  // namespace atom

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -964,6 +964,18 @@ void NativeWindowMac::SetParentWindow(NativeWindow* parent) {
     [parent->GetNativeWindow() addChildWindow:window_ ordered:NSWindowAbove];
 }
 
+void NativeWindowMac::BeginSheet(NativeWindow* sheet) {
+  [window_ beginSheet:sheet->GetNativeWindow()
+    completionHandler:^(NSModalResponse) {
+  }];
+}
+
+void NativeWindowMac::EndSheet(NativeWindow* sheet) {
+  sheet->Hide();
+  [window_ endSheet:sheet->GetNativeWindow()];
+  sheet->CloseImmediately();
+}
+
 gfx::NativeWindow NativeWindowMac::GetNativeWindow() {
   return window_;
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -279,6 +279,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 @property BOOL acceptsFirstMouse;
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
+@property BOOL disableMouseEvents;
 
 - (void)setShell:(atom::NativeWindowMac*)shell;
 - (void)setEnableLargerThanScreen:(bool)enable;
@@ -346,6 +347,29 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (BOOL)canBecomeKeyWindow {
   return !self.disableKeyOrMainWindow;
+}
+
+- (void)sendEvent:(NSEvent*)event {
+  // Drop all mouse events.
+  if (self.disableMouseEvents) {
+    switch([event type]) {
+      case NSLeftMouseUp:
+      case NSLeftMouseDown:
+      case NSRightMouseDown:
+      case NSRightMouseUp:
+      case NSOtherMouseUp:
+      case NSLeftMouseDragged:
+      case NSRightMouseDragged:
+      case NSOtherMouseDragged:
+      case NSMouseMoved:
+      case NSScrollWheel:
+        return;
+      default:
+        break;
+    }
+  }
+
+  [super sendEvent:event];
 }
 
 @end
@@ -496,6 +520,7 @@ NativeWindowMac::NativeWindowMac(
                   backing:NSBackingStoreBuffered
                     defer:YES]);
   [window_ setShell:this];
+  [window_ setDisableMouseEvents:NO];
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
 
   window_delegate_.reset([[AtomNSWindowDelegate alloc] initWithShell:this]);
@@ -645,6 +670,20 @@ void NativeWindowMac::Hide() {
 
 bool NativeWindowMac::IsVisible() {
   return [window_ isVisible];
+}
+
+void NativeWindowMac::Disable() {
+  [window_ setDisableKeyOrMainWindow:YES];
+  [window_ setDisableMouseEvents:YES];
+}
+
+void NativeWindowMac::Enable() {
+  [window_ setDisableKeyOrMainWindow:NO];
+  [window_ setDisableMouseEvents:NO];
+}
+
+bool NativeWindowMac::IsEnabled() {
+  return ![window_ disableMouseEvents];
 }
 
 void NativeWindowMac::Maximize() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -279,7 +279,6 @@ bool ScopedDisableResize::disable_resize_ = false;
 @property BOOL acceptsFirstMouse;
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
-@property BOOL disableMouseEvents;
 
 - (void)setShell:(atom::NativeWindowMac*)shell;
 - (void)setEnableLargerThanScreen:(bool)enable;
@@ -347,29 +346,6 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (BOOL)canBecomeKeyWindow {
   return !self.disableKeyOrMainWindow;
-}
-
-- (void)sendEvent:(NSEvent*)event {
-  // Drop all mouse events.
-  if (self.disableMouseEvents) {
-    switch([event type]) {
-      case NSLeftMouseUp:
-      case NSLeftMouseDown:
-      case NSRightMouseDown:
-      case NSRightMouseUp:
-      case NSOtherMouseUp:
-      case NSLeftMouseDragged:
-      case NSRightMouseDragged:
-      case NSOtherMouseDragged:
-      case NSMouseMoved:
-      case NSScrollWheel:
-        return;
-      default:
-        break;
-    }
-  }
-
-  [super sendEvent:event];
 }
 
 @end
@@ -521,7 +497,6 @@ NativeWindowMac::NativeWindowMac(
                   backing:NSBackingStoreBuffered
                     defer:YES]);
   [window_ setShell:this];
-  [window_ setDisableMouseEvents:NO];
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
 
   window_delegate_.reset([[AtomNSWindowDelegate alloc] initWithShell:this]);
@@ -690,11 +665,6 @@ void NativeWindowMac::Hide() {
 
 bool NativeWindowMac::IsVisible() {
   return [window_ isVisible];
-}
-
-void NativeWindowMac::SetEnabled(bool enable) {
-  [window_ setDisableKeyOrMainWindow:!enable];
-  [window_ setDisableMouseEvents:!enable];
 }
 
 bool NativeWindowMac::IsEnabled() {

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -33,6 +33,9 @@ class NativeWindowObserver {
   // Called when the window is gonna closed.
   virtual void WillCloseWindow(bool* prevent_default) {}
 
+  // Called before the native window object is going to be destroyed.
+  virtual void WillDestoryNativeObject() {}
+
   // Called when the window is closed.
   virtual void OnWindowClosed() {}
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -126,7 +126,8 @@ class NativeWindowClientView : public views::ClientView {
 
 NativeWindowViews::NativeWindowViews(
     brightray::InspectableWebContents* web_contents,
-    const mate::Dictionary& options)
+    const mate::Dictionary& options,
+    NativeWindow* parent)
     : NativeWindow(web_contents, options),
       window_(new views::Widget),
       web_view_(inspectable_web_contents()->GetView()->GetView()),
@@ -1139,8 +1140,9 @@ ui::WindowShowState NativeWindowViews::GetRestoredState() {
 // static
 NativeWindow* NativeWindow::Create(
     brightray::InspectableWebContents* inspectable_web_contents,
-    const mate::Dictionary& options) {
-  return new NativeWindowViews(inspectable_web_contents, options);
+    const mate::Dictionary& options,
+    NativeWindow* parent) {
+  return new NativeWindowViews(inspectable_web_contents, options, parent);
 }
 
 }  // namespace atom

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -837,9 +837,10 @@ void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
 
 void NativeWindowViews::SetModal(bool modal) {
 #if defined(USE_X11)
+  SetWindowType(GetAcceleratedWidget(), modal ? "dialog" : "normal");
+  Show();
   SetWMSpecState(GetAcceleratedWidget(), modal,
                  GetAtom("_NET_WM_STATE_MODAL"));
-  SetWindowType(GetAcceleratedWidget(), modal ? "dialog" : "normal");
 #endif
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -373,6 +373,16 @@ bool NativeWindowViews::IsVisible() {
   return window_->IsVisible();
 }
 
+void NativeWindowViews::Disable() {
+}
+
+void NativeWindowViews::Enable() {
+}
+
+bool NativeWindowViews::IsEnabled() {
+  return true;
+}
+
 void NativeWindowViews::Maximize() {
   if (IsVisible())
     window_->Maximize();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -382,25 +382,19 @@ bool NativeWindowViews::IsVisible() {
   return window_->IsVisible();
 }
 
-void NativeWindowViews::Disable() {
+void NativeWindowViews::SetEnabled(bool enable) {
 #if defined(OS_WIN)
-  ::EnableWindow(GetAcceleratedWidget(), FALSE);
-#elif defined(USE_X11)
-  event_disabler_.reset(new EventDisabler);
-  views::DesktopWindowTreeHostX11* tree_host =
-      views::DesktopWindowTreeHostX11::GetHostForXID(GetAcceleratedWidget());
-  tree_host->AddEventRewriter(event_disabler_.get());
-#endif
-}
-
-void NativeWindowViews::Enable() {
-#if defined(OS_WIN)
-  ::EnableWindow(GetAcceleratedWidget(), TRUE);
+  ::EnableWindow(GetAcceleratedWidget(), enable);
 #elif defined(USE_X11)
   views::DesktopWindowTreeHostX11* tree_host =
       views::DesktopWindowTreeHostX11::GetHostForXID(GetAcceleratedWidget());
-  tree_host->RemoveEventRewriter(event_disabler_.get());
-  event_disabler_.reset();
+  if (enable) {
+    tree_host->RemoveEventRewriter(event_disabler_.get());
+    event_disabler_.reset();
+  } else {
+    event_disabler_.reset(new EventDisabler);
+    tree_host->AddEventRewriter(event_disabler_.get());
+  }
 #endif
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -772,6 +772,9 @@ void NativeWindowViews::SetMenu(ui::MenuModel* menu_model) {
   Layout();
 }
 
+void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
+}
+
 gfx::NativeWindow NativeWindowViews::GetNativeWindow() {
   return window_->GetNativeWindow();
 }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -806,6 +806,8 @@ void NativeWindowViews::SetMenu(ui::MenuModel* menu_model) {
 }
 
 void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
+  NativeWindow::SetParentWindow(parent);
+
 #if defined(USE_X11)
   XDisplay* xdisplay = gfx::GetXDisplay();
   XSetTransientForHint(
@@ -830,6 +832,7 @@ void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
 }
 
 void NativeWindowViews::SetModal(bool modal) {
+  NativeWindow::SetModal(modal);
 #if defined(USE_X11)
   SetWindowType(GetAcceleratedWidget(), modal ? "dialog" : "normal");
   Show();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -29,6 +29,7 @@
 #include "ui/views/window/client_view.h"
 #include "ui/views/widget/native_widget_private.h"
 #include "ui/views/widget/widget.h"
+#include "ui/wm/core/window_util.h"
 #include "ui/wm/core/shadow_types.h"
 
 #if defined(USE_X11)
@@ -783,6 +784,21 @@ void NativeWindowViews::SetMenu(ui::MenuModel* menu_model) {
 }
 
 void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
+  // Should work, but does not, it seems that the views toolkit doesn't support
+  // reparenting on desktop.
+#if defined(DEBUG)
+  if (parent) {
+    ::SetParent(GetAcceleratedWidget(), parent->GetAcceleratedWidget());
+    views::Widget::ReparentNativeView(GetNativeWindow(),
+                                      parent->GetNativeWindow());
+    wm::AddTransientChild(parent->GetNativeWindow(), GetNativeWindow());
+  } else {
+    if (!GetNativeWindow()->parent())
+      return;
+    views::Widget::ReparentNativeView(GetNativeWindow(), nullptr);
+    wm::RemoveTransientChild(GetNativeWindow()->parent(), GetNativeWindow());
+  }
+#endif
 }
 
 gfx::NativeWindow NativeWindowViews::GetNativeWindow() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -187,6 +187,9 @@ NativeWindowViews::NativeWindowViews(
   if (options.Get(options::kFocusable, &focusable) && !focusable)
     params.activatable = views::Widget::InitParams::ACTIVATABLE_NO;
 
+  if (parent)
+    params.parent = parent->GetNativeWindow();
+
 #if defined(OS_WIN)
   params.native_widget =
       new views::DesktopNativeWidgetAura(window_.get());
@@ -376,13 +379,15 @@ bool NativeWindowViews::IsVisible() {
 }
 
 void NativeWindowViews::Disable() {
+  ::EnableWindow(GetAcceleratedWidget(), FALSE);
 }
 
 void NativeWindowViews::Enable() {
+  ::EnableWindow(GetAcceleratedWidget(), TRUE);
 }
 
 bool NativeWindowViews::IsEnabled() {
-  return true;
+  return ::IsWindowEnabled(GetAcceleratedWidget());
 }
 
 void NativeWindowViews::Maximize() {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -94,6 +94,7 @@ class NativeWindowViews : public NativeWindow,
   void SetIgnoreMouseEvents(bool ignore) override;
   void SetFocusable(bool focusable) override;
   void SetMenu(ui::MenuModel* menu_model) override;
+  void SetParentWindow(NativeWindow* parent) override;
   gfx::NativeWindow GetNativeWindow() override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -57,7 +57,6 @@ class NativeWindowViews : public NativeWindow,
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() override;
-  void SetEnabled(bool enable) override;
   bool IsEnabled() override;
   void Maximize() override;
   void Unmaximize() override;
@@ -100,7 +99,6 @@ class NativeWindowViews : public NativeWindow,
   void SetFocusable(bool focusable) override;
   void SetMenu(ui::MenuModel* menu_model) override;
   void SetParentWindow(NativeWindow* parent) override;
-  void SetModal(bool modal) override;
   gfx::NativeWindow GetNativeWindow() override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
@@ -119,6 +117,8 @@ class NativeWindowViews : public NativeWindow,
 #elif defined(USE_X11)
   void SetIcon(const gfx::ImageSkia& icon);
 #endif
+
+  void SetEnabled(bool enable);
 
   views::Widget* widget() const { return window_.get(); }
 
@@ -229,6 +229,9 @@ class NativeWindowViews : public NativeWindow,
 
   // Map from accelerator to menu item's command id.
   accelerator_util::AcceleratorTable accelerator_table_;
+
+  // How many times the Disable has been called.
+  int disable_count_;
 
   bool use_content_size_;
   bool movable_;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -54,6 +54,9 @@ class NativeWindowViews : public NativeWindow,
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() override;
+  void Disable() override;
+  void Enable() override;
+  bool IsEnabled() override;
   void Maximize() override;
   void Unmaximize() override;
   bool IsMaximized() override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -99,6 +99,7 @@ class NativeWindowViews : public NativeWindow,
   void SetFocusable(bool focusable) override;
   void SetMenu(ui::MenuModel* menu_model) override;
   void SetParentWindow(NativeWindow* parent) override;
+  void SetModal(bool modal) override;
   gfx::NativeWindow GetNativeWindow() override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -32,6 +32,8 @@ class WindowStateWatcher;
 
 #if defined(OS_WIN)
 class AtomDesktopWindowTreeHostWin;
+#elif defined(USE_X11)
+class EventDisabler;
 #endif
 
 class NativeWindowViews : public NativeWindow,
@@ -192,6 +194,9 @@ class NativeWindowViews : public NativeWindow,
 
   // Handles window state events.
   std::unique_ptr<WindowStateWatcher> window_state_watcher_;
+
+  // To disable the mouse events.
+  std::unique_ptr<EventDisabler> event_disabler_;
 
   // The "resizable" flag on Linux is implemented by setting size constraints,
   // we need to make sure size constraints are restored when window becomes

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -42,7 +42,8 @@ class NativeWindowViews : public NativeWindow,
                           public views::WidgetObserver {
  public:
   NativeWindowViews(brightray::InspectableWebContents* inspectable_web_contents,
-                    const mate::Dictionary& options);
+                    const mate::Dictionary& options,
+                    NativeWindow* parent);
   ~NativeWindowViews() override;
 
   // NativeWindow:

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -57,8 +57,7 @@ class NativeWindowViews : public NativeWindow,
   void ShowInactive() override;
   void Hide() override;
   bool IsVisible() override;
-  void Disable() override;
-  void Enable() override;
+  void SetEnabled(bool enable) override;
   bool IsEnabled() override;
   void Maximize() override;
   void Unmaximize() override;

--- a/atom/browser/ui/x/event_disabler.cc
+++ b/atom/browser/ui/x/event_disabler.cc
@@ -1,0 +1,27 @@
+// Copyright (c) 2016 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/ui/x/event_disabler.h"
+
+namespace atom {
+
+EventDisabler::EventDisabler() {
+}
+
+EventDisabler::~EventDisabler() {
+}
+
+ui::EventRewriteStatus EventDisabler::RewriteEvent(
+    const ui::Event& event,
+    std::unique_ptr<ui::Event>* rewritten_event) {
+  return ui::EVENT_REWRITE_DISCARD;
+}
+
+ui::EventRewriteStatus EventDisabler::NextDispatchEvent(
+    const ui::Event& last_event,
+    std::unique_ptr<ui::Event>* new_event) {
+  return ui::EVENT_REWRITE_CONTINUE;
+}
+
+}  // namespace atom

--- a/atom/browser/ui/x/event_disabler.h
+++ b/atom/browser/ui/x/event_disabler.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2016 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_UI_X_EVENT_DISABLER_H_
+#define ATOM_BROWSER_UI_X_EVENT_DISABLER_H_
+
+#include "base/macros.h"
+#include "ui/events/event_rewriter.h"
+
+namespace atom {
+
+class EventDisabler : public ui::EventRewriter {
+ public:
+  EventDisabler();
+  ~EventDisabler() override;
+
+  // ui::EventRewriter:
+  ui::EventRewriteStatus RewriteEvent(
+      const ui::Event& event,
+      std::unique_ptr<ui::Event>* rewritten_event) override;
+  ui::EventRewriteStatus NextDispatchEvent(
+      const ui::Event& last_event,
+      std::unique_ptr<ui::Event>* new_event) override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(EventDisabler);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_UI_X_EVENT_DISABLER_H_

--- a/atom/common/key_weak_map.h
+++ b/atom/common/key_weak_map.h
@@ -14,10 +14,6 @@
 
 namespace atom {
 
-namespace internal {
-
-}  // namespace internal
-
 // Like ES6's WeakMap, but the key is Integer and the value is Weak Pointer.
 template<typename K>
 class KeyWeakMap {

--- a/atom/common/key_weak_map.h
+++ b/atom/common/key_weak_map.h
@@ -53,7 +53,7 @@ class KeyWeakMap {
   }
 
   // Returns all objects.
-  std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) {
+  std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) const {
     std::vector<v8::Local<v8::Object>> keys;
     keys.reserve(map_.size());
     for (const auto& iter : map_) {

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -72,39 +72,25 @@ The `child` window will always show on top of the `top` window.
 
 ### Modal windows
 
-A modal window is a child window that disables parent window, to turn a child
-window into modal window, you need to call `win.setModal(true)`:
+A modal window is a child window that disables parent window, to create a modal
+window, you have to set both `parent` and `modal` options:
 
 ```javascript
-let child = new BrowserWindow({parent: top, show: false})
+let child = new BrowserWindow({parent: top, modal: true, show: false})
 child.loadURL('https://github.com')
-child.setModal(true)
 child.once('ready-to-show', () => {
   child.show()
 })
 ```
 
-### Sheets
-
-On macOS it is uncommon to use modal windows for tasks, a more native way is to
-show window as sheet by calling `win.beginSheet(sheet)` API:
-
-```javascript
-let child = new BrowserWindow({show: false})
-child.loadURL('https://github.com')
-child.once('ready-to-show', () => {
-  top.beginSheet(child)
-})
-```
-
 ### Platform notices
 
-* On macOS the child window will keep the relative position to parent window
+* On macOS the child windows will keep the relative position to parent window
   when parent window moves, while on Windows and Linux child windows will not
   move.
-* On macOS the `setModal` has to be called before the child window shows.
 * On Windows it is not supported to change parent window dynamically.
 * On Linux the type of modal windows will be changed to `dialog`.
+* On Linux many desktop environments do not support hiding a modal window.
 
 ## Class: BrowserWindow
 
@@ -163,7 +149,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     `true`.
   * `frame` Boolean - Specify `false` to create a
     [Frameless Window](frameless-window.md). Default is `true`.
-  * `parent` BrowserWindow - Parent window.
+  * `parent` BrowserWindow - Specify parent window. Default is `null`.
+  * `modal` Boolean - Whether this is a modal window. This only works when the
+    window is a child window. Default is `false`.
   * `acceptFirstMouse` Boolean - Whether the web view accepts a single
     mouse-down event that simultaneously activates the window. Default is
     `false`.
@@ -580,32 +568,9 @@ Hides the window.
 
 Returns a boolean, whether the window is visible to the user.
 
-### `win.setModal(modal)`
-
-* `modal` Boolean
-
-Sets current window as modal window.
-
-It can only be called for child windows.
-
 ### `win.isModal()`
 
 Returns whether current window is a modal window.
-
-### `win.beginSheet(sheet)` _macOS_
-
-* `sheet` BrowserWindow
-
-Shows `sheet` as a sheet for current window, when there is already a sheet
-showing, this call will be queued.
-
-It can only be called for top-level windows.
-
-### `win.endSheet(sheet)` _macOS_
-
-* `sheet` BrowserWindow
-
-Dismisses the `sheet`.
 
 ### `win.maximize()`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -59,6 +59,53 @@ win.loadURL('https://github.com')
 Note that even for apps that use `ready-to-show` event, it is still recommended
 to set `backgroundColor` to make app feel more native.
 
+## Parent and child windows
+
+By using `parent` option, you can create child windows:
+
+```javascript
+let top = new BrowserWindow()
+let child = new BrowserWindow({parent: top})
+```
+
+The `child` window will always show on top of the `top` window.
+
+### Modal windows
+
+A modal window is a child window that disables parent window, to turn a child
+window into modal window, you need to call `win.setModal(true)`:
+
+```javascript
+let child = new BrowserWindow({parent: top, show: false})
+child.loadURL('https://github.com')
+child.setModal(true)
+child.once('ready-to-show', () => {
+  child.show()
+})
+```
+
+### Sheets
+
+On macOS it is uncommon to use modal windows for tasks, a more native way is to
+show window as sheet by calling `win.beginSheet(sheet)` API:
+
+```javascript
+let child = new BrowserWindow({show: false})
+child.loadURL('https://github.com')
+child.once('ready-to-show', () => {
+  top.beginSheet(child)
+})
+```
+
+### Platform notices
+
+* On macOS the child window will keep the relative position to parent window
+  when parent window moves, while on Windows and Linux child windows will not
+  move.
+* On macOS the `setModal` has to be called before the child window shows.
+* On Windows it is not supported to change parent window dynamically.
+* On Linux the type of modal windows will be changed to `dialog`.
+
 ## Class: BrowserWindow
 
 `BrowserWindow` is an
@@ -116,6 +163,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     `true`.
   * `frame` Boolean - Specify `false` to create a
     [Frameless Window](frameless-window.md). Default is `true`.
+  * `parent` BrowserWindow - Parent window.
   * `acceptFirstMouse` Boolean - Whether the web view accepts a single
     mouse-down event that simultaneously activates the window. Default is
     `false`.
@@ -531,6 +579,33 @@ Hides the window.
 ### `win.isVisible()`
 
 Returns a boolean, whether the window is visible to the user.
+
+### `win.setModal(modal)`
+
+* `modal` Boolean
+
+Sets current window as modal window.
+
+It can only be called for child windows.
+
+### `win.isModal()`
+
+Returns whether current window is a modal window.
+
+### `win.beginSheet(sheet)` _macOS_
+
+* `sheet` BrowserWindow
+
+Shows `sheet` as a sheet for current window, when there is already a sheet
+showing, this call will be queued.
+
+It can only be called for top-level windows.
+
+### `win.endSheet(sheet)` _macOS_
+
+* `sheet` BrowserWindow
+
+Dismisses the `sheet`.
 
 ### `win.maximize()`
 
@@ -1017,3 +1092,18 @@ events.
 Changes whether the window can be focused.
 
 [blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.in
+
+### `win.setParentWindow(parent)` _Linux_ _macOS_
+
+* `parent` BrowserWindow
+
+Sets `parent` as current window's parent window, passing `null` will turn
+current window into a top-level window.
+
+### `win.getParentWindow()`
+
+Returns the parent window.
+
+### `win.getChildWindows()`
+
+Returns all child windows.

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -286,6 +286,8 @@
       'atom/browser/ui/win/notify_icon.h',
       'atom/browser/ui/win/taskbar_host.cc',
       'atom/browser/ui/win/taskbar_host.h',
+      'atom/browser/ui/x/event_disabler.cc',
+      'atom/browser/ui/x/event_disabler.h',
       'atom/browser/ui/x/window_state_watcher.cc',
       'atom/browser/ui/x/window_state_watcher.h',
       'atom/browser/ui/x/x_window_utils.cc',

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -97,23 +97,6 @@ BrowserWindow.prototype._init = function () {
   })
 }
 
-BrowserWindow.prototype.setModal = function (modal) {
-  const parent = this.getParentWindow()
-  if (!parent) {
-    throw new Error('setModal can only be called for child window')
-  }
-
-  let closeListener = () => parent.enable()
-  if (modal) {
-    parent.disable()
-    this.once('closed', closeListener)
-    this.show()
-  } else {
-    parent.enable()
-    this.removeListener('closed', closeListener)
-  }
-}
-
 BrowserWindow.getFocusedWindow = () => {
   for (let window of BrowserWindow.getAllWindows()) {
     if (window.isFocused()) return window

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -97,6 +97,23 @@ BrowserWindow.prototype._init = function () {
   })
 }
 
+BrowserWindow.prototype.setModal = function (modal) {
+  const parent = this.getParentWindow()
+  if (!parent) {
+    throw new Error('setModal can only be called for child window')
+  }
+
+  let closeListener = () => parent.enable()
+  if (modal) {
+    parent.disable()
+    this.once('closed', closeListener)
+    this.show()
+  } else {
+    parent.enable()
+    this.removeListener('closed', closeListener)
+  }
+}
+
 BrowserWindow.getFocusedWindow = () => {
   for (let window of BrowserWindow.getAllWindows()) {
     if (window.isFocused()) return window
@@ -117,7 +134,6 @@ BrowserWindow.fromDevToolsWebContents = (webContents) => {
 }
 
 // Helpers.
-
 Object.assign(BrowserWindow.prototype, {
   loadURL (...args) {
     return this.webContents.loadURL.apply(this.webContents, args)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -902,10 +902,18 @@ describe('browser-window module', function () {
       })
     })
 
-    describe('win.setModal(modal)', function () {
+    describe('modal option', function () {
+      // The isEnabled API is not reliable on macOS.
+      if (process.platform === 'darwin') return
+
+      beforeEach(function () {
+        if (c != null) c.destroy()
+        c = new BrowserWindow({show: false, parent: w, modal: true})
+      })
+
       it('disables parent window', function () {
         assert.equal(w.isEnabled(), true)
-        c.setModal(true)
+        c.show()
         assert.equal(w.isEnabled(), false)
       })
 
@@ -914,38 +922,20 @@ describe('browser-window module', function () {
           assert.equal(w.isEnabled(), true)
           done()
         })
-        c.setModal(true)
+        c.show()
         c.close()
       })
 
-      it('enables parent window when setting not modal', function () {
-        assert.equal(w.isEnabled(), true)
-        c.setModal(true)
-        assert.equal(w.isEnabled(), false)
-        c.setModal(false)
-        assert.equal(w.isEnabled(), true)
-      })
-
-      it('enables parent window when removing parent', function () {
-        if (process.platform !== 'darwin') return
-
-        assert.equal(w.isEnabled(), true)
-        c.setModal(true)
-        assert.equal(w.isEnabled(), false)
-        c.setParentWindow(null)
-        assert.equal(w.isEnabled(), true)
-      })
-
       it('disables parent window recursively', function () {
-        let c2 = new BrowserWindow({show: false, parent: w})
-        c.setModal(true)
-        c2.setModal(true)
+        let c2 = new BrowserWindow({show: false, parent: w, modal: true})
+        c.show()
         assert.equal(w.isEnabled(), false)
-        c.setModal(false)
+        c2.show()
         assert.equal(w.isEnabled(), false)
-        c2.setModal(false)
-        assert.equal(w.isEnabled(), true)
+        c.destroy()
+        assert.equal(w.isEnabled(), false)
         c2.destroy()
+        assert.equal(w.isEnabled(), true)
       })
     })
   })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -841,7 +841,7 @@ describe('browser-window module', function () {
 
     beforeEach(function () {
       if (c != null) c.destroy()
-      c = new BrowserWindow({show: false})
+      c = new BrowserWindow({show: false, parent: w})
     })
 
     afterEach(function () {
@@ -850,11 +850,6 @@ describe('browser-window module', function () {
     })
 
     describe('parent option', function () {
-      beforeEach(function () {
-        if (c != null) c.destroy()
-        c = new BrowserWindow({show: false, parent: w})
-      })
-
       it('sets parent window', function () {
         assert.equal(c.getParentWindow(), w)
       })
@@ -874,6 +869,11 @@ describe('browser-window module', function () {
 
     describe('win.setParentWindow(parent)', function () {
       if (process.platform !== 'darwin') return
+
+      beforeEach(function () {
+        if (c != null) c.destroy()
+        c = new BrowserWindow({show: false})
+      })
 
       it('sets parent window', function () {
         assert.equal(w.getParentWindow(), null)
@@ -905,7 +905,6 @@ describe('browser-window module', function () {
     describe('win.setModal(modal)', function () {
       it('disables parent window', function () {
         assert.equal(w.isEnabled(), true)
-        c.setParentWindow(w)
         c.setModal(true)
         assert.equal(w.isEnabled(), false)
       })
@@ -915,14 +914,12 @@ describe('browser-window module', function () {
           assert.equal(w.isEnabled(), true)
           done()
         })
-        c.setParentWindow(w)
         c.setModal(true)
         c.close()
       })
 
       it('enables parent window when setting not modal', function () {
         assert.equal(w.isEnabled(), true)
-        c.setParentWindow(w)
         c.setModal(true)
         assert.equal(w.isEnabled(), false)
         c.setModal(false)
@@ -930,8 +927,9 @@ describe('browser-window module', function () {
       })
 
       it('enables parent window when removing parent', function () {
+        if (process.platform !== 'darwin') return
+
         assert.equal(w.isEnabled(), true)
-        c.setParentWindow(w)
         c.setModal(true)
         assert.equal(w.isEnabled(), false)
         c.setParentWindow(null)
@@ -939,10 +937,8 @@ describe('browser-window module', function () {
       })
 
       it('disables parent window recursively', function () {
-        let c2 = new BrowserWindow({show: false})
-        c.setParentWindow(w)
+        let c2 = new BrowserWindow({show: false, parent: w})
         c.setModal(true)
-        c2.setParentWindow(w)
         c2.setModal(true)
         assert.equal(w.isEnabled(), false)
         c.setModal(false)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -876,6 +876,57 @@ describe('browser-window module', function () {
         c.close()
       })
     })
+
+    describe('win.setModal(modal)', function () {
+      it('disables parent window', function () {
+        assert.equal(w.isEnabled(), true)
+        c.setParentWindow(w)
+        c.setModal(true)
+        assert.equal(w.isEnabled(), false)
+      })
+
+      it('enables parent window when closed', function (done) {
+        c.once('closed', () => {
+          assert.equal(w.isEnabled(), true)
+          done()
+        })
+        c.setParentWindow(w)
+        c.setModal(true)
+        c.close()
+      })
+
+      it('enables parent window when setting not modal', function () {
+        assert.equal(w.isEnabled(), true)
+        c.setParentWindow(w)
+        c.setModal(true)
+        assert.equal(w.isEnabled(), false)
+        c.setModal(false)
+        assert.equal(w.isEnabled(), true)
+      })
+
+      it('enables parent window when removing parent', function () {
+        assert.equal(w.isEnabled(), true)
+        c.setParentWindow(w)
+        c.setModal(true)
+        assert.equal(w.isEnabled(), false)
+        c.setParentWindow(null)
+        assert.equal(w.isEnabled(), true)
+      })
+
+      it('disables parent window recursively', function () {
+        let c2 = new BrowserWindow({show: false})
+        c.setParentWindow(w)
+        c.setModal(true)
+        c2.setParentWindow(w)
+        c2.setModal(true)
+        assert.equal(w.isEnabled(), false)
+        c.setModal(false)
+        assert.equal(w.isEnabled(), false)
+        c2.setModal(false)
+        assert.equal(w.isEnabled(), true)
+        c2.destroy()
+      })
+    })
   })
 
   describe('window.webContents.send(channel, args...)', function () {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -849,7 +849,32 @@ describe('browser-window module', function () {
       c = null
     })
 
+    describe('parent option', function () {
+      beforeEach(function () {
+        if (c != null) c.destroy()
+        c = new BrowserWindow({show: false, parent: w})
+      })
+
+      it('sets parent window', function () {
+        assert.equal(c.getParentWindow(), w)
+      })
+
+      it('adds window to child windows of parent', function () {
+        assert.deepEqual(w.getChildWindows(), [c])
+      })
+
+      it('removes from child windows of parent when window is closed', function (done) {
+        c.once('closed', () => {
+          assert.deepEqual(w.getChildWindows(), [])
+          done()
+        })
+        c.close()
+      })
+    })
+
     describe('win.setParentWindow(parent)', function () {
+      if (process.platform !== 'darwin') return
+
       it('sets parent window', function () {
         assert.equal(w.getParentWindow(), null)
         assert.equal(c.getParentWindow(), null)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -868,7 +868,7 @@ describe('browser-window module', function () {
     })
 
     describe('win.setParentWindow(parent)', function () {
-      if (process.platform !== 'darwin') return
+      if (process.platform === 'win32') return
 
       beforeEach(function () {
         if (c != null) c.destroy()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -836,6 +836,48 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('parent window', function () {
+    let c = null
+
+    beforeEach(function () {
+      if (c != null) c.destroy()
+      c = new BrowserWindow({show: false})
+    })
+
+    afterEach(function () {
+      if (c != null) c.destroy()
+      c = null
+    })
+
+    describe('win.setParentWindow(parent)', function () {
+      it('sets parent window', function () {
+        assert.equal(w.getParentWindow(), null)
+        assert.equal(c.getParentWindow(), null)
+        c.setParentWindow(w)
+        assert.equal(c.getParentWindow(), w)
+        c.setParentWindow(null)
+        assert.equal(c.getParentWindow(), null)
+      })
+
+      it('adds window to child windows of parent', function () {
+        assert.deepEqual(w.getChildWindows(), [])
+        c.setParentWindow(w)
+        assert.deepEqual(w.getChildWindows(), [c])
+        c.setParentWindow(null)
+        assert.deepEqual(w.getChildWindows(), [])
+      })
+
+      it('removes from child windows of parent when window is closed', function (done) {
+        c.once('closed', () => {
+          assert.deepEqual(w.getChildWindows(), [])
+          done()
+        })
+        c.setParentWindow(w)
+        c.close()
+      })
+    })
+  })
+
   describe('window.webContents.send(channel, args...)', function () {
     it('throws an error when the channel is missing', function () {
       assert.throws(function () {


### PR DESCRIPTION
# WIP

This is still under testing, each platform has huge differences on how the child windows should work, I'm trying to figure out a way to make the API work consistently on all platforms without platform-dependent code.

Close #323.

# Docs 

## Parent and child windows

By using `parent` option, you can create child windows:

```javascript
let top = new BrowserWindow()
let child = new BrowserWindow({parent: top})
```

The `child` window will always show on top of the `top` window.

### Modal windows

A modal window is a child window that disables parent window, to create a modal
window, you have to set both `parent` and `modal` options:

```javascript
let child = new BrowserWindow({parent: top, modal: true, show: false})
child.loadURL('https://github.com')
child.once('ready-to-show', () => {
  child.show()
})
```

### Platform notices

* On macOS the child windows will keep the relative position to parent window
  when parent window moves, while on Windows and Linux child windows will not
  move.
* On Windows it is not supported to change parent window dynamically.
* On Linux the type of modal windows will be changed to `dialog`.
* On Linux many desktop environments do not support hiding a modal window.
