### PR TITLE
mac: Convert path to absolute path in ShowItemInFolder

### DIFF
--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -8,6 +8,7 @@
 #import <Cocoa/Cocoa.h>
 
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/mac/mac_logging.h"
 #include "base/mac/scoped_aedesc.h"
@@ -17,7 +18,11 @@
 
 namespace platform_util {
 
-void ShowItemInFolder(const base::FilePath& full_path) {
+void ShowItemInFolder(const base::FilePath& path) {
+  // The API only takes absolute path.
+  base::FilePath full_path =
+      path.IsAbsolute() ? path : base::MakeAbsoluteFilePath(path);
+
   DCHECK([NSThread isMainThread]);
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
   if (!path_string || ![[NSWorkspace sharedWorkspace] selectFile:path_string


### PR DESCRIPTION
This is to make the `shell.showItemInFolder` API have same behavior with `shell.openItem`.

Close #5739.