### PR TITLE
Add quit menu item role

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -38,6 +38,7 @@ Role kRolesMap[] = {
   { @selector(performMiniaturize:), "minimize" },
   { @selector(performClose:), "close" },
   { @selector(performZoom:), "zoom" },
+  { @selector(terminate:), "quit" },
 };
 
 }  // namespace

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -243,6 +243,18 @@ app.once('ready', () => {
     ]
   }
 
+  if (process.platform === 'win32') {
+    template.unshift({
+      label: 'File',
+      submenu: [
+        {
+          label: 'Exit',
+          role: 'quit'
+        }
+      ]
+    })
+  }
+
   const menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
 })

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -214,7 +214,7 @@ app.once('ready', () => {
         {
           label: 'Quit ' + app.getName(),
           accelerator: 'Command+Q',
-          click () { app.quit() }
+          role: 'quit'
         }
       ]
     })

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -51,6 +51,7 @@ The `role` property can have following values:
 * `delete`
 * `minimize` - Minimize current window
 * `close` - Close current window
+* `quit`- Quit the application
 
 On macOS `role` can also have following additional values:
 

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -1,11 +1,9 @@
 'use strict'
 
-var MenuItem, methodInBrowserWindow, nextCommandId, rolesMap
-
-nextCommandId = 0
+let nextCommandId = 0
 
 // Maps role to methods of webContents
-rolesMap = {
+const rolesMap = {
   undo: 'undo',
   redo: 'redo',
   cut: 'cut',
@@ -20,7 +18,7 @@ rolesMap = {
 }
 
 // Maps methods that should be called directly on the BrowserWindow instance
-methodInBrowserWindow = {
+const methodInBrowserWindow = {
   minimize: true,
   close: true
 }
@@ -29,11 +27,11 @@ const methodInApp = {
   quit: true
 }
 
-MenuItem = (function () {
+const MenuItem = (function () {
   MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio']
 
   function MenuItem (options) {
-    var click, ref
+    let click, ref
     const {app, Menu} = require('electron')
     click = options.click
     this.selector = options.selector
@@ -72,7 +70,7 @@ MenuItem = (function () {
     this.commandId = ++nextCommandId
     this.click = (focusedWindow) => {
       // Manually flip the checked flags when clicked.
-      var methodName, ref1, ref2
+      let methodName, ref1, ref2
       if ((ref1 = this.type) === 'checkbox' || ref1 === 'radio') {
         this.checked = !this.checked
       }

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -31,9 +31,9 @@ const MenuItem = (function () {
   MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio']
 
   function MenuItem (options) {
-    let click, ref
     const {app, Menu} = require('electron')
-    click = options.click
+
+    const click = options.click
     this.selector = options.selector
     this.type = options.type
     this.role = options.role
@@ -51,7 +51,7 @@ const MenuItem = (function () {
     if ((this.type == null) && (this.submenu != null)) {
       this.type = 'submenu'
     }
-    if (this.type === 'submenu' && ((ref = this.submenu) != null ? ref.constructor : void 0) !== Menu) {
+    if (this.type === 'submenu' && (this.submenu != null ? this.submenu.constructor : void 0) !== Menu) {
       throw new Error('Invalid submenu')
     }
     this.overrideReadOnlyProperty('type', 'normal')
@@ -70,18 +70,19 @@ const MenuItem = (function () {
     this.commandId = ++nextCommandId
     this.click = (focusedWindow) => {
       // Manually flip the checked flags when clicked.
-      let methodName, ref1, ref2
-      if ((ref1 = this.type) === 'checkbox' || ref1 === 'radio') {
+      if (this.type === 'checkbox' || this.type === 'radio') {
         this.checked = !this.checked
       }
+
       if (this.role && rolesMap[this.role] && process.platform !== 'darwin' && (focusedWindow != null)) {
-        methodName = rolesMap[this.role]
+        const methodName = rolesMap[this.role]
         if(methodInApp[methodName]) {
           return app[methodName]()
         } else if (methodInBrowserWindow[methodName]) {
           return focusedWindow[methodName]()
         } else {
-          return (ref2 = focusedWindow.webContents) != null ? ref2[methodName]() : void 0
+          const {webContents} = focusedWindow
+          return webContents != null ? webContents[methodName]() : void 0
         }
       } else if (typeof click === 'function') {
         return click(this, focusedWindow)

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -15,7 +15,8 @@ rolesMap = {
   selectall: 'selectAll',
   minimize: 'minimize',
   close: 'close',
-  delete: 'delete'
+  delete: 'delete',
+  quit: 'quit'
 }
 
 // Maps methods that should be called directly on the BrowserWindow instance
@@ -24,12 +25,16 @@ methodInBrowserWindow = {
   close: true
 }
 
+const methodInApp = {
+  quit: true
+}
+
 MenuItem = (function () {
   MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio']
 
   function MenuItem (options) {
     var click, ref
-    const Menu = require('electron').Menu
+    const {app, Menu} = require('electron')
     click = options.click
     this.selector = options.selector
     this.type = options.type
@@ -73,7 +78,9 @@ MenuItem = (function () {
       }
       if (this.role && rolesMap[this.role] && process.platform !== 'darwin' && (focusedWindow != null)) {
         methodName = rolesMap[this.role]
-        if (methodInBrowserWindow[methodName]) {
+        if(methodInApp[methodName]) {
+          return app[methodName]()
+        } else if (methodInBrowserWindow[methodName]) {
           return focusedWindow[methodName]()
         } else {
           return (ref2 = focusedWindow.webContents) != null ? ref2[methodName]() : void 0

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -76,7 +76,7 @@ const MenuItem = (function () {
 
       if (this.role && rolesMap[this.role] && process.platform !== 'darwin' && (focusedWindow != null)) {
         const methodName = rolesMap[this.role]
-        if(methodInApp[methodName]) {
+        if (methodInApp[methodName]) {
           return app[methodName]()
         } else if (methodInBrowserWindow[methodName]) {
           return focusedWindow[methodName]()


### PR DESCRIPTION
Adds `role: 'quit'` support to menu items that maps to the `terminate` selector on OS X and `app.quit()` on Linux and Windows.

Also does a little `var`, `const`, `let` cleanup and removes CoffeeScript `ref` variables.

Closes #2813