### PR TITLE
Support forward delete menu item accelerator

### DIFF
--- a/atom/browser/ui/accelerator_util_mac.mm
+++ b/atom/browser/ui/accelerator_util_mac.mm
@@ -29,6 +29,10 @@ void SetPlatformAccelerator(ui::Accelerator* accelerator) {
     modifiers ^= NSShiftKeyMask;
   }
 
+  if (character == NSDeleteFunctionKey) {
+    character = NSDeleteCharacter;
+  }
+
   NSString* characters =
       [[[NSString alloc] initWithCharacters:&character length:1] autorelease];
 

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -86,6 +86,7 @@ app.once('ready', () => {
         },
         {
           label: 'Delete',
+          accelerator: 'Delete',
           role: 'delete'
         },
         {


### PR DESCRIPTION
Not sure if/when/how this might have regressed, but using an `accelerator` of `Delete` no longer works as reported in #5419.

This looks to be because `ui::MacKeyCodeForWindowsKeyCode` from Chrome is returning [`NSDeleteFunctionKey`](https://developer.apple.com/reference/appkit/1535851-function_key_unicodes/nsdeletefunctionkey?language=objc) as the character instead of [`NSDeleteCharacter`](https://developer.apple.com/reference/appkit/1540619-anonymous/nsdeletecharacter?language=objc).

From the [NSMenuItem keyEquivalent docs](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSMenuItem_Class/#//apple_ref/occ/instp/NSMenuItem/keyEquivalent):

> If you want to specify the Backspace key as the key equivalent for a menu item, use a single character string with NSBackspaceCharacter (defined in NSText.h as 0x08) and for the Forward Delete key, use NSDeleteCharacter (defined in NSText.h as 0x7F). Note that these are not the same characters you get from an NSEvent key-down event when pressing those keys.

https://cs.chromium.org/chromium/src/ui/events/keycodes/keyboard_code_conversion_mac.mm?l=75

This pull request adds a check and mapping for this case which gets `Delete` working again as an accelerator for a menu like:

```js
{
  label: 'Backspace',
  accelerator: 'Backspace'
},
{
  label: 'Delete',
  accelerator: 'Delete'
}
```

### Before

<img width="223" alt="screen shot 2016-06-21 at 12 31 35 pm" src="https://cloud.githubusercontent.com/assets/671378/16243547/a708dd9c-37ac-11e6-800d-d25306e880b1.png">

### After

<img width="217" alt="screen shot 2016-06-21 at 12 32 13 pm" src="https://cloud.githubusercontent.com/assets/671378/16243552/ab5fa1fa-37ac-11e6-80c5-95f26a4fcd9a.png">


Closes #5419