### PR TITLE
Map roles by command id instead of index

### DIFF
--- a/atom/browser/ui/atom_menu_model.cc
+++ b/atom/browser/ui/atom_menu_model.cc
@@ -17,12 +17,14 @@ AtomMenuModel::~AtomMenuModel() {
 }
 
 void AtomMenuModel::SetRole(int index, const base::string16& role) {
-  roles_[index] = role;
+  int command_id = GetCommandIdAt(index);
+  roles_[command_id] = role;
 }
 
 base::string16 AtomMenuModel::GetRoleAt(int index) {
-  if (ContainsKey(roles_, index))
-    return roles_[index];
+  int command_id = GetCommandIdAt(index);
+  if (ContainsKey(roles_, command_id))
+    return roles_[command_id];
   else
     return base::string16();
 }

--- a/atom/browser/ui/atom_menu_model.h
+++ b/atom/browser/ui/atom_menu_model.h
@@ -42,7 +42,7 @@ class AtomMenuModel : public ui::SimpleMenuModel {
  private:
   Delegate* delegate_;  // weak ref.
 
-  std::map<int, base::string16> roles_;
+  std::map<int, base::string16> roles_;  // command id -> role
   base::ObserverList<Observer> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomMenuModel);


### PR DESCRIPTION
Use `GetCommandIdAt` to map/retrieve roles since menu indices might change if `Menu.insert` is used.

Closes #4479