### PR TITLE
Add Session.setUserAgent(userAgent[, acceptLanguages]) API

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -463,10 +463,11 @@ void App::DisableHardwareAcceleration(mate::Arguments* args) {
 void App::ImportCertificate(
     const base::DictionaryValue& options,
     const net::CompletionCallback& callback) {
-  auto browser_context = AtomBrowserMainParts::Get()->browser_context();
+  auto browser_context = brightray::BrowserContext::From("", false);
   if (!certificate_manager_model_) {
     std::unique_ptr<base::DictionaryValue> copy = options.CreateDeepCopy();
-    CertificateManagerModel::Create(browser_context,
+    CertificateManagerModel::Create(
+        browser_context.get(),
         base::Bind(&App::OnCertificateManagerModelCreated,
                    base::Unretained(this),
                    base::Passed(&copy),

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -57,15 +57,7 @@ class Session: public mate::TrackableObject<Session>,
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);
 
- protected:
-  Session(v8::Isolate* isolate, AtomBrowserContext* browser_context);
-  ~Session();
-
-  // content::DownloadManager::Observer:
-  void OnDownloadCreated(content::DownloadManager* manager,
-                         content::DownloadItem* item) override;
-
- private:
+  // Methods.
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   template<CacheAction action>
   void DoCacheAction(const net::CompletionCallback& callback);
@@ -80,10 +72,21 @@ class Session: public mate::TrackableObject<Session>,
                                    mate::Arguments* args);
   void ClearHostResolverCache(mate::Arguments* args);
   void AllowNTLMCredentialsForDomains(const std::string& domains);
+  void SetUserAgent(const std::string& user_agent, mate::Arguments* args);
+  std::string GetUserAgent();
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
   v8::Local<v8::Value> Protocol(v8::Isolate* isolate);
   v8::Local<v8::Value> WebRequest(v8::Isolate* isolate);
 
+ protected:
+  Session(v8::Isolate* isolate, AtomBrowserContext* browser_context);
+  ~Session();
+
+  // content::DownloadManager::Observer:
+  void OnDownloadCreated(content::DownloadManager* manager,
+                         content::DownloadItem* item) override;
+
+ private:
   // Cached object.
   v8::Global<v8::Value> cookies_;
   v8::Global<v8::Value> protocol_;

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -81,7 +81,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void GoForward();
   void GoToOffset(int offset);
   bool IsCrashed() const;
-  void SetUserAgent(const std::string& user_agent);
+  void SetUserAgent(const std::string& user_agent, mate::Arguments* args);
   std::string GetUserAgent();
   void InsertCSS(const std::string& css);
   bool SavePage(const base::FilePath& full_file_path,

--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -7,8 +7,8 @@
 #include <utility>
 
 #include "atom/browser/atom_browser_context.h"
-#include "atom/browser/atom_browser_main_parts.h"
 #include "atom/common/google_api_key.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/geolocation_provider.h"
 
 namespace atom {
@@ -25,6 +25,7 @@ const char* kGeolocationProviderURL =
 }  // namespace
 
 AtomAccessTokenStore::AtomAccessTokenStore() {
+  LOG(ERROR) << "AtomAccessTokenStore";
   content::GeolocationProvider::GetInstance()->UserDidOptIntoLocationServices();
 }
 
@@ -33,21 +34,35 @@ AtomAccessTokenStore::~AtomAccessTokenStore() {
 
 void AtomAccessTokenStore::LoadAccessTokens(
     const LoadAccessTokensCallback& callback) {
-  AccessTokenMap access_token_map;
-
-  // Equivelent to access_token_map[kGeolocationProviderURL].
-  // Somehow base::string16 is causing compilation errors when used in a pair
-  // of std::map on Linux, this can work around it.
-  std::pair<GURL, base::string16> token_pair;
-  token_pair.first = GURL(kGeolocationProviderURL);
-  access_token_map.insert(token_pair);
-
-  auto browser_context = AtomBrowserMainParts::Get()->browser_context();
-  callback.Run(access_token_map, browser_context->url_request_context_getter());
+  content::BrowserThread::PostTaskAndReply(
+      content::BrowserThread::UI,
+      FROM_HERE,
+      base::Bind(&AtomAccessTokenStore::GetRequestContextOnUIThread, this),
+      base::Bind(&AtomAccessTokenStore::RespondOnOriginatingThread,
+                 this, callback));
 }
 
 void AtomAccessTokenStore::SaveAccessToken(const GURL& server_url,
                                            const base::string16& access_token) {
+}
+
+void AtomAccessTokenStore::GetRequestContextOnUIThread() {
+  auto browser_context = brightray::BrowserContext::From("", false);
+  request_context_getter_ = browser_context->GetRequestContext();
+}
+
+void AtomAccessTokenStore::RespondOnOriginatingThread(
+    const LoadAccessTokensCallback& callback) {
+  // Equivelent to access_token_map[kGeolocationProviderURL].
+  // Somehow base::string16 is causing compilation errors when used in a pair
+  // of std::map on Linux, this can work around it.
+  AccessTokenMap access_token_map;
+  std::pair<GURL, base::string16> token_pair;
+  token_pair.first = GURL(kGeolocationProviderURL);
+  access_token_map.insert(token_pair);
+
+  callback.Run(access_token_map, request_context_getter_.get());
+  request_context_getter_ = nullptr;
 }
 
 }  // namespace atom

--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -9,12 +9,10 @@
 
 namespace atom {
 
-class AtomBrowserContext;
-
 class AtomAccessTokenStore : public content::AccessTokenStore {
  public:
   AtomAccessTokenStore();
-  virtual ~AtomAccessTokenStore();
+  ~AtomAccessTokenStore();
 
   // content::AccessTokenStore:
   void LoadAccessTokens(
@@ -23,6 +21,11 @@ class AtomAccessTokenStore : public content::AccessTokenStore {
                        const base::string16& access_token) override;
 
  private:
+  void GetRequestContextOnUIThread();
+  void RespondOnOriginatingThread(const LoadAccessTokensCallback& callback);
+
+  scoped_refptr<net::URLRequestContextGetter> request_context_getter_;
+
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);
 };
 

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -88,12 +88,15 @@ AtomBrowserContext::AtomBrowserContext(const std::string& partition,
 AtomBrowserContext::~AtomBrowserContext() {
 }
 
+void AtomBrowserContext::SetUserAgent(const std::string& user_agent) {
+  user_agent_ = user_agent;
+}
+
 net::NetworkDelegate* AtomBrowserContext::CreateNetworkDelegate() {
   return network_delegate_;
 }
 
 std::string AtomBrowserContext::GetUserAgent() {
-  LOG(ERROR) << "GetUserAgent";
   return user_agent_;
 }
 

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -68,16 +68,7 @@ AtomBrowserContext::AtomBrowserContext(const std::string& partition,
     : brightray::BrowserContext(partition, in_memory),
       cert_verifier_(new AtomCertVerifier),
       network_delegate_(new AtomNetworkDelegate) {
-}
-
-AtomBrowserContext::~AtomBrowserContext() {
-}
-
-net::NetworkDelegate* AtomBrowserContext::CreateNetworkDelegate() {
-  return network_delegate_;
-}
-
-std::string AtomBrowserContext::GetUserAgent() {
+  // Construct user agent string.
   Browser* browser = Browser::Get();
   std::string name = RemoveWhitespace(browser->GetName());
   std::string user_agent;
@@ -91,7 +82,19 @@ std::string AtomBrowserContext::GetUserAgent() {
         browser->GetVersion().c_str(),
         CHROME_VERSION_STRING);
   }
-  return content::BuildUserAgentFromProduct(user_agent);
+  user_agent_ = content::BuildUserAgentFromProduct(user_agent);
+}
+
+AtomBrowserContext::~AtomBrowserContext() {
+}
+
+net::NetworkDelegate* AtomBrowserContext::CreateNetworkDelegate() {
+  return network_delegate_;
+}
+
+std::string AtomBrowserContext::GetUserAgent() {
+  LOG(ERROR) << "GetUserAgent";
+  return user_agent_;
 }
 
 std::unique_ptr<net::URLRequestJobFactory>

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -22,6 +22,8 @@ class AtomBrowserContext : public brightray::BrowserContext {
   AtomBrowserContext(const std::string& partition, bool in_memory);
   ~AtomBrowserContext() override;
 
+  void SetUserAgent(const std::string& user_agent);
+
   // brightray::URLRequestContextGetter::Delegate:
   net::NetworkDelegate* CreateNetworkDelegate() override;
   std::string GetUserAgent() override;

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -47,6 +47,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
   std::unique_ptr<AtomDownloadManagerDelegate> download_manager_delegate_;
   std::unique_ptr<WebViewManager> guest_manager_;
   std::unique_ptr<AtomPermissionManager> permission_manager_;
+  std::string user_agent_;
 
   // Managed by brightray::BrowserContext.
   AtomCertVerifier* cert_verifier_;

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -341,6 +341,23 @@ session.defaultSession.allowNTLMCredentialsForDomains('*example.com, *foobar.com
 session.defaultSession.allowNTLMCredentialsForDomains('*')
 ```
 
+#### `ses.setUserAgent(userAgent[, acceptLanguages])`
+
+* `userAgent` String
+* `acceptLanguages` String (optional)
+
+Overrides the `userAgent` and `acceptLanguages` for this session.
+
+The `acceptLanguages` must a comma separated ordered list of language codes, for
+example `"en-US,fr,de,ko,zh-CN,ja"`.
+
+This doesn't affect existing `WebContents`, and each `WebContents` can use
+`webContents.setUserAgent` to override the session-wide user agent.
+
+#### `ses.getUserAgent()`
+
+Returns a `String` representing the user agent for this session.
+
 #### `ses.webRequest`
 
 The `webRequest` API set allows to intercept and modify contents of a request at


### PR DESCRIPTION
* Close #3602.
* Close #5777.
* Refactor the code to avoid force creating default BrowserContext in C++,
* Make `webContents.setUserAgent` only work for current WebContents.