### PR TITLE
Add BrowserWindow.prototype.setContentProtection(enable)

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -572,6 +572,10 @@ void Window::SetIgnoreMouseEvents(bool ignore) {
   return window_->SetIgnoreMouseEvents(ignore);
 }
 
+void Window::SetContentProtection(bool enable) {
+  return window_->SetContentProtection(enable);
+}
+
 void Window::SetFocusable(bool focusable) {
   return window_->SetFocusable(focusable);
 }
@@ -833,6 +837,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setDocumentEdited", &Window::SetDocumentEdited)
       .SetMethod("isDocumentEdited", &Window::IsDocumentEdited)
       .SetMethod("setIgnoreMouseEvents", &Window::SetIgnoreMouseEvents)
+      .SetMethod("setContentProtection", &Window::SetContentProtection)
       .SetMethod("setFocusable", &Window::SetFocusable)
       .SetMethod("focusOnWebView", &Window::FocusOnWebView)
       .SetMethod("blurWebView", &Window::BlurWebView)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -153,6 +153,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetDocumentEdited(bool edited);
   bool IsDocumentEdited();
   void SetIgnoreMouseEvents(bool ignore);
+  void SetContentProtection(bool enable);
   void SetFocusable(bool focusable);
   void CapturePage(mate::Arguments* args);
   void SetProgressBar(double progress);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -157,6 +157,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetDocumentEdited(bool edited);
   virtual bool IsDocumentEdited();
   virtual void SetIgnoreMouseEvents(bool ignore) = 0;
+  virtual void SetContentProtection(bool enable) = 0;
   virtual void SetFocusable(bool focusable);
   virtual void SetMenu(ui::MenuModel* menu);
   virtual bool HasModalDialog();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -79,6 +79,7 @@ class NativeWindowMac : public NativeWindow {
   void SetDocumentEdited(bool edited) override;
   bool IsDocumentEdited() override;
   void SetIgnoreMouseEvents(bool ignore) override;
+  void SetContentProtection(bool enable) override;
   bool HasModalDialog() override;
   void SetParentWindow(NativeWindow* parent) override;
   gfx::NativeWindow GetNativeWindow() override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -941,6 +941,11 @@ void NativeWindowMac::SetIgnoreMouseEvents(bool ignore) {
   [window_ setIgnoresMouseEvents:ignore];
 }
 
+void NativeWindowMac::SetContentProtection(bool enable) {
+  [window_ setSharingType:enable ? NSWindowSharingNone
+                                 : NSWindowSharingReadOnly];
+}
+
 bool NativeWindowMac::HasModalDialog() {
   return [window_ attachedSheet] != nil;
 }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -728,6 +728,13 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore) {
 #endif
 }
 
+void NativeWindowViews::SetContentProtection(bool enable) {
+#if defined(OS_WIN)
+  DWORD affinity = enable ? WDA_MONITOR : WDA_NONE;
+  ::SetWindowDisplayAffinity(GetAcceleratedWidget(), affinity);
+#endif
+}
+
 void NativeWindowViews::SetFocusable(bool focusable) {
 #if defined(OS_WIN)
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -96,6 +96,7 @@ class NativeWindowViews : public NativeWindow,
   void SetHasShadow(bool has_shadow) override;
   bool HasShadow() override;
   void SetIgnoreMouseEvents(bool ignore) override;
+  void SetContentProtection(bool enable) override;
   void SetFocusable(bool focusable) override;
   void SetMenu(ui::MenuModel* menu_model) override;
   void SetParentWindow(NativeWindow* parent) override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1050,6 +1050,13 @@ All mouse events happened in this window will be passed to the window below
 this window, but if this window has focus, it will still receive keyboard
 events.
 
+### `win.setContentProtection(enable)` _macOS_ _Windows_
+
+Prevents the window contents from being captured by other apps.
+
+On macOS it sets the NSWindow's sharingType to NSWindowSharingNone.
+On Windows it calls SetWindowDisplayAffinity with WDA_MONITOR.
+
 ### `win.setFocusable(focusable)` _Windows_
 
 * `focusable` Boolean


### PR DESCRIPTION
This allows the app to prevent other apps from capturing it's window contents.