### PR TITLE
Fix chrome.runtime.sendMessage

### DIFF
--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -119,7 +119,13 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
       if (args.length === 1) {
         message = args[0]
       } else if (args.length === 2) {
-        [targetExtensionId, message] = args
+        // A case of not provide extension-id: (message, responseCallback)
+        if (typeof args[1] === 'function') {
+          console.error('responseCallback is not supported')
+          message = args[0]
+        } else {
+          [targetExtensionId, message] = args
+        }
       } else {
         console.error('options and responseCallback are not supported')
       }


### PR DESCRIPTION
Add a case of not provide extension-id: (message, responseCallback)

It will be fix wrong log `Connect to unknown extension [object Object]`.
([redux-devtools-extension/src/browser/extension/options/syncOptions.js#L52](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/src/browser/extension/options/syncOptions.js#L52) can be reproduced)