### PR TITLE
Reformat MenuItem class

### DIFF
--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -75,7 +75,7 @@ const MenuItem = function (options) {
   this.commandId = ++nextCommandId
 
   const click = options.click
-  this.click = (focusedWindow) => {
+  this.click = (event, focusedWindow) => {
     // Manually flip the checked flags when clicked.
     if (this.type === 'checkbox' || this.type === 'radio') {
       this.checked = !this.checked
@@ -94,7 +94,7 @@ const MenuItem = function (options) {
         return webContents != null ? webContents[methodName]() : void 0
       }
     } else if (typeof click === 'function') {
-      return click(this, focusedWindow)
+      return click(this, focusedWindow, event)
     } else if (typeof this.selector === 'string' && process.platform === 'darwin') {
       return Menu.sendActionToFirstResponder(this.selector)
     }

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -34,7 +34,6 @@ const methodInApp = {
 const MenuItem = function (options) {
   const {app, Menu} = require('electron')
 
-  const click = options.click
   this.selector = options.selector
   this.type = options.type
   this.role = options.role
@@ -75,6 +74,7 @@ const MenuItem = function (options) {
 
   this.commandId = ++nextCommandId
 
+  const click = options.click
   this.click = (focusedWindow) => {
     // Manually flip the checked flags when clicked.
     if (this.type === 'checkbox' || this.type === 'radio') {

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -70,7 +70,7 @@ const MenuItem = function (options) {
   this.overrideProperty('checked', false)
 
   if (!MenuItem.types.includes(this.type)) {
-    throw new Error(`Unknown menu type ${this.type}`)
+    throw new Error(`Unknown menu item type: ${this.type}`)
   }
 
   this.commandId = ++nextCommandId

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -31,97 +31,94 @@ const methodInApp = {
   quit: true
 }
 
-const MenuItem = (function () {
-  MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio']
+const MenuItem = function (options) {
+  const {app, Menu} = require('electron')
 
-  function MenuItem (options) {
-    const {app, Menu} = require('electron')
+  const click = options.click
+  this.selector = options.selector
+  this.type = options.type
+  this.role = options.role
+  this.label = options.label
+  this.sublabel = options.sublabel
+  this.accelerator = options.accelerator
+  this.icon = options.icon
+  this.enabled = options.enabled
+  this.visible = options.visible
+  this.checked = options.checked
 
-    const click = options.click
-    this.selector = options.selector
-    this.type = options.type
-    this.role = options.role
-    this.label = options.label
-    this.sublabel = options.sublabel
-    this.accelerator = options.accelerator
-    this.icon = options.icon
-    this.enabled = options.enabled
-    this.visible = options.visible
-    this.checked = options.checked
-    this.submenu = options.submenu
-    if ((this.submenu != null) && this.submenu.constructor !== Menu) {
-      this.submenu = Menu.buildFromTemplate(this.submenu)
+  this.submenu = options.submenu
+  if (this.submenu != null && this.submenu.constructor !== Menu) {
+    this.submenu = Menu.buildFromTemplate(this.submenu)
+  }
+  if (this.type == null && this.submenu != null) {
+    this.type = 'submenu'
+  }
+  if (this.type === 'submenu' && (this.submenu == null || this.submenu.constructor !== Menu)) {
+    throw new Error('Invalid submenu')
+  }
+
+  this.overrideReadOnlyProperty('type', 'normal')
+  this.overrideReadOnlyProperty('role')
+  this.overrideReadOnlyProperty('accelerator')
+  this.overrideReadOnlyProperty('icon')
+  this.overrideReadOnlyProperty('submenu')
+
+  this.overrideProperty('label', '')
+  this.overrideProperty('sublabel', '')
+  this.overrideProperty('enabled', true)
+  this.overrideProperty('visible', true)
+  this.overrideProperty('checked', false)
+
+  if (!MenuItem.types.includes(this.type)) {
+    throw new Error(`Unknown menu type ${this.type}`)
+  }
+
+  this.commandId = ++nextCommandId
+
+  this.click = (focusedWindow) => {
+    // Manually flip the checked flags when clicked.
+    if (this.type === 'checkbox' || this.type === 'radio') {
+      this.checked = !this.checked
     }
-    if ((this.type == null) && (this.submenu != null)) {
-      this.type = 'submenu'
-    }
-    if (this.type === 'submenu' && (this.submenu != null ? this.submenu.constructor : void 0) !== Menu) {
-      throw new Error('Invalid submenu')
-    }
-    this.overrideReadOnlyProperty('type', 'normal')
-    this.overrideReadOnlyProperty('role')
-    this.overrideReadOnlyProperty('accelerator')
-    this.overrideReadOnlyProperty('icon')
-    this.overrideReadOnlyProperty('submenu')
-    this.overrideProperty('label', '')
-    this.overrideProperty('sublabel', '')
-    this.overrideProperty('enabled', true)
-    this.overrideProperty('visible', true)
-    this.overrideProperty('checked', false)
-    if (MenuItem.types.indexOf(this.type) === -1) {
-      throw new Error('Unknown menu type ' + this.type)
-    }
-    this.commandId = ++nextCommandId
-    this.click = (event, focusedWindow) => {
-      // Manually flip the checked flags when clicked.
-      if (this.type === 'checkbox' || this.type === 'radio') {
-        this.checked = !this.checked
+
+    if (this.role && rolesMap[this.role] && process.platform !== 'darwin' && focusedWindow != null) {
+      const methodName = rolesMap[this.role]
+      if (methodInApp[methodName]) {
+        return app[methodName]()
+      } else if (typeof methodInBrowserWindow[methodName] === 'function') {
+        return methodInBrowserWindow[methodName](focusedWindow)
+      } else if (methodInBrowserWindow[methodName]) {
+        return focusedWindow[methodName]()
+      } else {
+        const {webContents} = focusedWindow
+        return webContents != null ? webContents[methodName]() : void 0
       }
-
-      if (this.role && rolesMap[this.role] && process.platform !== 'darwin' && (focusedWindow != null)) {
-        const methodName = rolesMap[this.role]
-        if (methodInApp[methodName]) {
-          return app[methodName]()
-        } else if (typeof methodInBrowserWindow[methodName] === 'function') {
-          return methodInBrowserWindow[methodName](focusedWindow)
-        } else if (methodInBrowserWindow[methodName]) {
-          return focusedWindow[methodName]()
-        } else {
-          const {webContents} = focusedWindow
-          return webContents != null ? webContents[methodName]() : void 0
-        }
-      } else if (typeof click === 'function') {
-        return click(this, focusedWindow, event)
-      } else if (typeof this.selector === 'string' && process.platform === 'darwin') {
-        return Menu.sendActionToFirstResponder(this.selector)
-      }
+    } else if (typeof click === 'function') {
+      return click(this, focusedWindow)
+    } else if (typeof this.selector === 'string' && process.platform === 'darwin') {
+      return Menu.sendActionToFirstResponder(this.selector)
     }
   }
+}
 
-  MenuItem.prototype.overrideProperty = function (name, defaultValue) {
-    if (defaultValue == null) {
-      defaultValue = null
-    }
-    this[name] != null ? this[name] : this[name] = defaultValue
+MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio']
 
-    return this[name]
+MenuItem.prototype.overrideProperty = function (name, defaultValue) {
+  if (defaultValue == null) {
+    defaultValue = null
   }
-
-  MenuItem.prototype.overrideReadOnlyProperty = function (name, defaultValue) {
-    if (defaultValue == null) {
-      defaultValue = null
-    }
-    if (this[name] == null) {
-      this[name] = defaultValue
-    }
-    return Object.defineProperty(this, name, {
-      enumerable: true,
-      writable: false,
-      value: this[name]
-    })
+  if (this[name] == null) {
+    this[name] = defaultValue
   }
+}
 
-  return MenuItem
-})()
+MenuItem.prototype.overrideReadOnlyProperty = function (name, defaultValue) {
+  this.overrideProperty(name, defaultValue)
+  Object.defineProperty(this, name, {
+    enumerable: true,
+    writable: false,
+    value: this[name]
+  })
+}
 
 module.exports = MenuItem

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -372,4 +372,17 @@ describe('menu module', function () {
       }, /Unknown menu item type: not-a-type/)
     })
   })
+
+  describe('MenuItem with submenu type and missing submenu', function () {
+    it('throws an exception', function () {
+      assert.throws(function () {
+        var menu = Menu.buildFromTemplate([
+          {
+            label: 'text',
+            type: 'submenu'
+          }
+        ])
+      }, /Invalid submenu/)
+    })
+  })
 })

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -1,10 +1,7 @@
 const assert = require('assert')
 
-const remote = require('electron').remote
-const ipcRenderer = require('electron').ipcRenderer
-
-const Menu = remote.require('electron').Menu
-const MenuItem = remote.require('electron').MenuItem
+const {ipcRenderer, remote} = require('electron')
+const {Menu, MenuItem} = remote
 
 describe('menu module', function () {
   describe('Menu.buildFromTemplate', function () {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -359,4 +359,17 @@ describe('menu module', function () {
       }
     })
   })
+
+  describe('MenuItem with invalid type', function () {
+    it('throws an exception', function () {
+      assert.throws(function () {
+        var menu = Menu.buildFromTemplate([
+          {
+            label: 'text',
+            type: 'not-a-type'
+          }
+        ])
+      }, /Unknown menu item type: not-a-type/)
+    })
+  })
 })


### PR DESCRIPTION
`menu-item.js` was still using the old CoffeeScript generated class wrapper.

This pull request reformats it a bit to make it blend in with the new code style.

Also adds a few more specs for the error cases of creating an invalid `MenuItem`.