### PR TITLE
Make MenuItem.commandId read only

### DIFF
--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -72,7 +72,7 @@ const MenuItem = function (options) {
     throw new Error(`Unknown menu item type: ${this.type}`)
   }
 
-  this.commandId = ++nextCommandId
+  this.overrideReadOnlyProperty('commandId', ++nextCommandId)
 
   const click = options.click
   this.click = (event, focusedWindow) => {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -357,10 +357,23 @@ describe('menu module', function () {
     })
   })
 
+  describe('MenuItem command id', function () {
+    it('cannot be overwritten', function () {
+      var item = new MenuItem({
+        label: 'item'
+      })
+
+      var commandId = item.commandId
+      assert(commandId != null)
+      item.commandId = '' + commandId + '-modified'
+      assert.equal(item.commandId, commandId)
+    })
+  })
+
   describe('MenuItem with invalid type', function () {
     it('throws an exception', function () {
       assert.throws(function () {
-        var menu = Menu.buildFromTemplate([
+        Menu.buildFromTemplate([
           {
             label: 'text',
             type: 'not-a-type'
@@ -373,7 +386,7 @@ describe('menu module', function () {
   describe('MenuItem with submenu type and missing submenu', function () {
     it('throws an exception', function () {
       assert.throws(function () {
-        var menu = Menu.buildFromTemplate([
+        Menu.buildFromTemplate([
           {
             label: 'text',
             type: 'submenu'


### PR DESCRIPTION
This property is used to map items to their role so this shouldn't be modifiable since weird things could happen if it is. 👻 

