### PR TITLE
Upper case initialisms in nativeImage API

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -344,14 +344,17 @@ mate::Handle<NativeImage> NativeImage::CreateFromDataURL(
 void NativeImage::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
   mate::ObjectTemplateBuilder(isolate, prototype)
-      .SetMethod("toPng", &NativeImage::ToPNG)
-      .SetMethod("toJpeg", &NativeImage::ToJPEG)
+      .SetMethod("toPNG", &NativeImage::ToPNG)
+      .SetMethod("toJPEG", &NativeImage::ToJPEG)
       .SetMethod("getNativeHandle", &NativeImage::GetNativeHandle)
       .SetMethod("toDataURL", &NativeImage::ToDataURL)
       .SetMethod("isEmpty", &NativeImage::IsEmpty)
       .SetMethod("getSize", &NativeImage::GetSize)
       .SetMethod("setTemplateImage", &NativeImage::SetTemplateImage)
-      .SetMethod("isTemplateImage", &NativeImage::IsTemplateImage);
+      .SetMethod("isTemplateImage", &NativeImage::IsTemplateImage)
+      // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
+      .SetMethod("toPng", &NativeImage::ToPNG)
+      .SetMethod("toJpeg", &NativeImage::ToJPEG);
 }
 
 }  // namespace api

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -127,11 +127,11 @@ Creates a new `nativeImage` instance from `dataURL`.
 
 The following methods are available on instances of `nativeImage`:
 
-### `image.toPng()`
+### `image.toPNG()`
 
 Returns a [Buffer][buffer] that contains the image's `PNG` encoded data.
 
-### `image.toJpeg(quality)`
+### `image.toJPEG(quality)`
 
 * `quality` Integer (**required**) - Between 0 - 100.
 


### PR DESCRIPTION
Noticed a few APIs that weren't using upper case initialisms:

- `nativeImage.toPng` -> `nativeImage.toPNG`
- `nativeImage.toJpeg` -> `nativeImage.toJPEG`

This pull request does not remove the old names but does update the docs so hopefully new apps will use the new APIs as documented.

Deprecation warnings will eventually be added for these once we are closer to a 2.0 API.