### PR TITLE
Eagerly require protocol

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -173,6 +173,9 @@ require('./chrome-extension')
 // Load internal desktop-capturer module.
 require('./desktop-capturer')
 
+// Load protocol module to ensure it is populated on app ready
+require('./api/protocol')
+
 // Set main startup script of the app.
 var mainStartupScript = packageJson.main || 'index.js'
 


### PR DESCRIPTION
This is a secondary fix for #6094 and pull request #6095

Previously it was still possible to access `protocol` without the properties after `ready has fired:

```js
let protocol

app.on('ready', function () {
  // will be undefined
  console.log(protocol.interceptFileProtocol) 
})

// later on but before app ready
protocol = require('electron').protocol
```

This pull request eagerly requires `protocol` so that it is an earlier `ready` listener than anything loaded from the app's main script.

`protocol` was previously required eagerly by `chrome-extension.js` so this shouldn't impact performance.

Closes #6094 