### PR TITLE
Update dialog.md

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -15,7 +15,7 @@ The Dialog is opened from Electron's main thread. If you want to use the dialog
 object from a renderer process, remember to access it using the remote:
 
 ```javascript
-const {dialog} = require('electron').remote;
+const {dialog} = require('electron').remote.dialog;
 ```
 
 ## Methods


### PR DESCRIPTION
require('electron').remote returns the remote object, not a dialog object. So when you call a function of the dialog object given the above example an error is thrown.