### PR TITLE
Do not emit did-fail-load for canceled requests

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -607,7 +607,10 @@ void WebContents::DidFailProvisionalLoad(
     bool was_ignored_by_handler) {
   bool is_main_frame = !render_frame_host->GetParent();
   Emit("did-fail-provisional-load", code, description, url, is_main_frame);
-  Emit("did-fail-load", code, description, url, is_main_frame);
+
+  // Do not emit "did-fail-load" for canceled requests.
+  if (code != net::ERR_ABORTED)
+    Emit("did-fail-load", code, description, url, is_main_frame);
 }
 
 void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,


### PR DESCRIPTION
For all `ERR_ABORTED ` errors happened in `DidFailProvisionalLoad`, the requests are actually canceled, like:

* page redirects
* page starts a download
* have two calls of `loadURL` together

Which do not satisfy the use cases of `did-fail-load` event, and causes surprises to users.

So this PR suppresses `ERR_ABORTED` for `DidFailProvisionalLoad`, closes #4396.