### PR TITLE
Reuse node's implementation of Module._nodeModulePaths

### DIFF
--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -12,10 +12,11 @@ module.parent.paths = []
 const originalNodeModulePaths = Module._nodeModulePaths
 Module._nodeModulePaths = function (from) {
   const paths = originalNodeModulePaths(from)
-  const rootPath = process.resourcesPath
 
   // If "from" is outside the app then we do nothing.
-  const skipOutsidePaths = path.resolve(from).startsWith(rootPath)
+  const rootPath = process.resourcesPath + path.sep
+  const fromPath = path.resolve(from) + path.sep
+  const skipOutsidePaths = fromPath.startsWith(rootPath)
   if (skipOutsidePaths) {
     return paths.filter(function (candidate) {
       return candidate.startsWith(rootPath)

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -9,21 +9,19 @@ module.paths = []
 module.parent.paths = []
 
 // Prevent Node from adding paths outside this app to search paths.
+const resourcesPathWithTrailingSlash = process.resourcesPath + path.sep
 const originalNodeModulePaths = Module._nodeModulePaths
 Module._nodeModulePaths = function (from) {
   const paths = originalNodeModulePaths(from)
-
-  // If "from" is outside the app then we do nothing.
-  const rootPath = process.resourcesPath + path.sep
   const fromPath = path.resolve(from) + path.sep
-  const skipOutsidePaths = fromPath.startsWith(rootPath)
-  if (skipOutsidePaths) {
+  // If "from" is outside the app then we do nothing.
+  if (fromPath.startsWith(resourcesPathWithTrailingSlash)) {
     return paths.filter(function (candidate) {
-      return candidate.startsWith(rootPath)
+      return candidate.startsWith(resourcesPathWithTrailingSlash)
     })
+  } else {
+    return paths
   }
-
-  return paths
 }
 
 // Patch Module._resolveFilename to always require the Electron API when

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -9,30 +9,19 @@ module.paths = []
 module.parent.paths = []
 
 // Prevent Node from adding paths outside this app to search paths.
+const originalNodeModulePaths = Module._nodeModulePaths
 Module._nodeModulePaths = function (from) {
-  from = path.resolve(from)
+  const paths = originalNodeModulePaths(from)
+  const rootPath = process.resourcesPath
 
   // If "from" is outside the app then we do nothing.
-  const skipOutsidePaths = from.startsWith(process.resourcesPath)
-
-  // Following logic is copied from module.js.
-  const splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//
-  const paths = []
-  const parts = from.split(splitRe)
-
-  let tip
-  let i
-  for (tip = i = parts.length - 1; i >= 0; tip = i += -1) {
-    const part = parts[tip]
-    if (part === 'node_modules') {
-      continue
-    }
-    const dir = parts.slice(0, tip + 1).join(path.sep)
-    if (skipOutsidePaths && !dir.startsWith(process.resourcesPath)) {
-      break
-    }
-    paths.push(path.join(dir, 'node_modules'))
+  const skipOutsidePaths = path.resolve(from).startsWith(rootPath)
+  if (skipOutsidePaths) {
+    return paths.filter(function (candidate) {
+      return candidate.startsWith(rootPath)
+    })
   }
+
   return paths
 }
 

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const Module = require('module')
 const path = require('path')
 const temp = require('temp')
 
@@ -44,6 +45,53 @@ describe('third-party module', function () {
           done()
         })
       })
+    })
+  })
+})
+
+describe('Module._nodeModulePaths', function () {
+  describe('when the path is inside the resources path', function () {
+    it('does not include paths outside of the resources path', function () {
+      let modulePath = process.resourcesPath
+      assert.deepEqual(Module._nodeModulePaths(modulePath), [
+        path.join(process.resourcesPath, 'node_modules')
+      ])
+
+      modulePath = path.join(process.resourcesPath, 'foo')
+      assert.deepEqual(Module._nodeModulePaths(modulePath), [
+        path.join(process.resourcesPath, 'foo', 'node_modules'),
+        path.join(process.resourcesPath, 'node_modules')
+      ])
+
+      modulePath = path.join(process.resourcesPath, 'node_modules', 'foo')
+      assert.deepEqual(Module._nodeModulePaths(modulePath), [
+        path.join(process.resourcesPath, 'node_modules', 'foo', 'node_modules'),
+        path.join(process.resourcesPath, 'node_modules')
+      ])
+
+      modulePath = path.join(process.resourcesPath, 'node_modules', 'foo', 'bar')
+      assert.deepEqual(Module._nodeModulePaths(modulePath), [
+        path.join(process.resourcesPath, 'node_modules', 'foo', 'bar', 'node_modules'),
+        path.join(process.resourcesPath, 'node_modules', 'foo', 'node_modules'),
+        path.join(process.resourcesPath, 'node_modules')
+      ])
+
+      modulePath = path.join(process.resourcesPath, 'node_modules', 'foo', 'node_modules', 'bar')
+      assert.deepEqual(Module._nodeModulePaths(modulePath), [
+        path.join(process.resourcesPath, 'node_modules', 'foo', 'node_modules', 'bar', 'node_modules'),
+        path.join(process.resourcesPath, 'node_modules', 'foo', 'node_modules'),
+        path.join(process.resourcesPath, 'node_modules')
+      ])
+    })
+  })
+
+  describe('when the path is outside the resources path', function () {
+    it('includes paths outside of the resources path', function () {
+      let modulePath = path.resolve('/foo')
+      assert.deepEqual(Module._nodeModulePaths(modulePath), [
+        path.join(modulePath, 'node_modules'),
+        path.join('node_modules')
+      ])
     })
   })
 })

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -89,8 +89,7 @@ describe('Module._nodeModulePaths', function () {
     it('includes paths outside of the resources path', function () {
       let modulePath = path.resolve('/foo')
       assert.deepEqual(Module._nodeModulePaths(modulePath), [
-        path.join(modulePath, 'node_modules'),
-        path.join('node_modules')
+        path.join(modulePath, 'node_modules')
       ])
     })
   })

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -57,6 +57,11 @@ describe('Module._nodeModulePaths', function () {
         path.join(process.resourcesPath, 'node_modules')
       ])
 
+      modulePath = process.resourcesPath + '-foo'
+      let nodeModulePaths = Module._nodeModulePaths(modulePath)
+      assert(nodeModulePaths.includes(path.join(modulePath, 'node_modules')))
+      assert(nodeModulePaths.includes(path.join(modulePath, '..', 'node_modules')))
+
       modulePath = path.join(process.resourcesPath, 'foo')
       assert.deepEqual(Module._nodeModulePaths(modulePath), [
         path.join(process.resourcesPath, 'foo', 'node_modules'),


### PR DESCRIPTION
Pull request https://github.com/electron/electron/pull/2976 added support for `require` not looking outside of the current application when loading modules by patching `Module._nodeModulePaths` and pulling in some code from node's own `module.js` implementation.

Node's implementation got some great improvements via https://github.com/nodejs/node/pull/5172 and this pull request seeks to use those improvements via post-processing the results of the default implementation instead of reimplementing the method fully.

- [x] Add specs for previous behavior
- [x] Use default `Module._nodeModulePaths` implementations and filter results in patched version
- [x] Profile it 🏇

This was profiled by calling `Module._nodeModulePaths` using 1,000 paths that were all inside the app's resources path so the filtering is happening on every call.

It looks to be a 50-75% speed improvement, results below.

```js
var path = require('path')
var Module = require('module')
var paths = require('./paths')

module.exports = function () {
  var start = Date.now()
  var count = 0
  var total = 0
  for (var i = 0; i < paths.length; i++) {
    count++
    total += Module._nodeModulePaths(paths[i]).length
  }

  var time = Date.now() - start
  console.log(`${paths.length} paths resolved to ${total} search paths in ${time}ms`)

}
```

### Before

<img width="403" alt="screen shot 2016-06-23 at 3 47 37 pm" src="https://cloud.githubusercontent.com/assets/671378/16322997/343c044a-395c-11e6-8691-c9ebdff5a639.png">

### After

<img width="419" alt="screen shot 2016-06-23 at 3 48 23 pm" src="https://cloud.githubusercontent.com/assets/671378/16322999/38fe2698-395c-11e6-8e2f-1233d0a08f5f.png">