### PR TITLE
Add details to docs/styleguide.md

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -170,6 +170,7 @@ of argument is notated by either the common types:
 - [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
 - [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 - [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+- [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
 - Or a custom type like Electron's [`WebContent`](api/web-content.md)
 
 If an argument or a method is unique to certain platforms, those platforms are

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,66 +1,169 @@
 # Electron Documentation Styleguide
 
-Find the appropriate section for your task: [reading Electron documentation](#reading-electron-documentation)
-or [writing Electron documentation](#writing-electron-documentation).
-
-## Writing Electron Documentation
-
 These are the ways that we construct the Electron documentation.
 
-- Maximum one `h1` title per page.
-- Use `bash` instead of `cmd` in code blocks (because of syntax highlighter).
-- Doc `h1` titles should match object name (i.e. `browser-window` →
-  `BrowserWindow`).
-  - Hyphen separated filenames, however, are fine.
-- No headers following headers, add at least a one-sentence description.
-- Methods headers are wrapped in `code` ticks.
-- Event headers are wrapped in single 'quotation' marks.
-- No nesting lists more than 2 levels (unfortunately because of markdown
+## Titles
+
+Each page has only one `#`-level title on the top, following chapters in the
+same page must have `##`-level titles, and sub-chapters need to increase the
+number of `#` in title according to its nesting depth.
+
+For the page's title, all words must be capitalized, for other chapters, only
+the first word has to be capitalized.
+
+Using `Quick Start` as example:
+
+```markdown
+# Quick Start
+
+...
+
+## Main process
+
+...
+
+## Renderer process
+
+...
+
+## Run your app
+
+...
+
+### Run as a distribution
+
+...
+
+### Manually downloaded Electron binary
+
+...
+```
+
+For API references, there are exceptions to this rule.
+
+## Markdown rules
+
+* Use `bash` instead of `cmd` in code blocks (because of syntax highlighter).
+* Line length is 80-column wrapped.
+* No nesting lists more than 2 levels (unfortunately because of markdown
   renderer).
-- Add section titles: Events, Class Methods and Instance Methods.
-- Use 'will' over 'would' when describing outcomes.
-- Events and methods are `h3` headers.
-- Optional arguments written as `function (required[, optional])`.
-- Optional arguments are denoted when called out in list.
-- Line length is 80-column wrapped.
-- Platform specific methods are noted in italics following method header.
- - ```### `method(foo, bar)` _macOS_```
-- Prefer 'in the ___ process' over 'on'
 
-### Documentation Translations
+## Picking words
 
-Translations of the Electron docs are located within the `docs-translations`
-directory.
+* Use "will" over "would" when describing outcomes.
+* Prefer "in the ___ process" over "on".
 
-To add another set (or partial set):
+## API references
 
-- Create a subdirectory named by language abbreviation.
-- Within that subdirectory, duplicate the `docs` directory, keeping the
-  names of directories and files same.
-- Translate the files.
-- Update the `README.md` within your language directory to link to the files
-  you have translated.
-- Add a link to your translation directory on the main Electron [README](https://github.com/electron/electron#documentation-translations).
+Following rules only apply to documentations of APIs.
 
-## Reading Electron Documentation
+### Page title
 
-Here are some tips for understanding Electron documentation syntax.
+Each page must use the actual object name returned by `require('electron')`
+as name, like `BrowserWindow`, `autoUpdater`, `session`.
+
+Under the page tile must be a one-line description starting with `>`.
+
+Using `session` as example:
+
+```markdown
+# session
+
+> Manage browser sessions, cookies, cache, proxy settings, etc.
+
+```
+
+### Module methods and events
+
+For modules that are not classes, their methods and events must be listed under
+`## Methods` and `## Events` chapters.
+
+Using `autoUpdater` as example:
+
+```markdown
+# autoUpdater
+
+## Events
+
+### Event: 'error'
+
+## Methods
+
+### `autoUpdater.setFeedURL(url[, requestHeaders])`
+```
+
+### Classes
+
+For APIs that exists as classes, or for classes that are parts of modules, they
+must listed under `## Class: TheClassName` chapter. One page can have multiple
+classes.
+
+If the class has constructors, they must be listed with `###`-level titles.
+
+The methods, events and properties of a class must be listed under
+`### Instance Methods`, `### Instance Events` and `Instance Properties`
+chapters.
+
+Using `Session`, `Cookies` classes as example:
+
+```markdown
+# session
+
+## Methods
+
+### session.fromPartition(partition)
+
+## Properties
+
+### session.defaultSession
+
+## Class: Session
+
+### Instance Events
+
+#### Event: 'will-download'
+
+### Instance Methods
+
+#### `ses.getCacheSize(callback)`
+
+### Instance Properties
+
+#### `ses.cookies`
+
+## Class: Cookies
+
+### Instance Methods
+
+#### `cookies.get(filter, callback)`
+```
 
 ### Methods
 
-An example of [method](https://developer.mozilla.org/en-US/docs/Glossary/Method)
-documentation:
+The chapter of method must be in the following form:
+
+```markdown
+### `objectName.methodName(required[, optional]))`
+
+* `required` String
+* `optional` Integer (optional)
+
+...
 
 ```
-`methodName(required[, optional]))`
 
-* `required` String (**required**)
-* `optional` Integer
-```
+The title can be `###` or `####`-levels depending on whether it is a method of
+module or class.
 
-The method name is followed by the arguments it takes. Optional arguments are
-notated by brackets surrounding the optional argument as well as the comma
-required if this optional argument follows another argument.
+For modules, the `objectName` is the module's name, for classes, it must be the
+name of instance of the class, and must not be same with the module's name.
+
+For example, the methods of `Session` class under `session` module must use
+`ses` as `objectName`.
+
+The optional arguments are notated by brackets surrounding the optional argument
+as well as the comma required if this optional argument follows another
+argument.
 
 Below the method is more detailed information on each of the arguments. The type
 of argument is notated by either the common types:
@@ -68,35 +171,69 @@ of argument is notated by either the common types:
 [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number),
 [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object),
 [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-or a custom type like Electron's [`webContent`](api/web-content.md).
+or a custom type like Electron's [`WebContent`](api/web-content.md).
 
-If an argument is unique to certain platforms, those platforms are denoted
-using a space-delimited italicized list following the datatype. Values can be
-`macOS`, `Windows`, or `Linux`.
+If an argument or a method is unique to certain platforms, those platforms are
+denoted using a space-delimited italicized list following the datatype. Values
+can be `macOS`, `Windows`, or `Linux`.
 
-```
+``` markdown
 * `animate` Boolean (optional) _macOS_ _Windows_
 ```
 
+For argument with `Array` type, it must be classified what elements the array
+may include in the description below.
+
+For argument with `Function` type, the description should make it clear how it
+may be called and list the types of the arguments that passed to it.
+
 ### Events
 
-An example of [event](https://developer.mozilla.org/en-US/docs/Web/API/Event)
-documentation:
+The chapter of event must be in following form:
 
-```
-Event: 'wake-up'
+```markdown
+### Event: 'wake-up'
 
 Returns:
 
 * `time` String
+
+...
+
 ```
 
-The event is a string that is used after a `.on` listener method. If it returns
-a value it and its type is noted below. If you were to listen and respond to
-this event it might look something like this:
+The title can be `###` or `####`-levels depending on whether it is an event of
+module or class.
 
-```javascript
-Alarm.on('wake-up', (time) => {
-  console.log(time)
-})
+The arguments of an event have the same rules with methods.
+
+### Properties
+
+The chapter of property must be in following form:
+
+```markdown
+### session.defaultSession
+
+...
+
 ```
+
+The title can be `###` or `####`-levels depending on whether it is a property of
+module or class.
+
+## Documentation Translations
+
+Translations of the Electron docs are located within the `docs-translations`
+directory.
+
+To add another set (or partial set):
+
+* Create a subdirectory named by language abbreviation.
+* Translate the files.
+* Update the `README.md` within your language directory to link to the files
+  you have translated.
+* Add a link to your translation directory on the main Electron
+  [README](https://github.com/electron/electron#documentation-translations).
+
+Note that the files under `docs-translations` must only include the translated
+ones, the original English files should not be copied there.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -4,12 +4,12 @@ These are the guidelines for writing Electron documentation.
 
 ## Titles
 
-Each page has only one `#`-level title on the top, following chapters in the
-same page must have `##`-level titles, and sub-chapters need to increase the
-number of `#` in the title according to its nesting depth.
-
-For the page's title, all words must be capitalized, for other chapters, only
-the first word has to be capitalized.
+* Each page must have a single `#`-level title at the top.
+* Chapters in the same page must have `##`-level titles.
+* Sub-chapters need to increase the number of `#` in the title according to its
+  nesting depth.
+* All words in the page's title must be capitalized.
+* Only the first word of a chapter title must be capitalized.
 
 Using `Quick Start` as example:
 
@@ -59,7 +59,7 @@ The following rules only apply to the documentation of APIs.
 ### Page title
 
 Each page must use the actual object name returned by `require('electron')`
-as the title, such as `BrowserWindow`, `autoUpdater`, `session`, etc.
+as the title, such as `BrowserWindow`, `autoUpdater`, and `session`.
 
 Under the page tile must be a one-line description starting with `>`.
 
@@ -75,7 +75,7 @@ Using `session` as example:
 ### Module methods and events
 
 For modules that are not classes, their methods and events must be listed under
-`## Methods` and `## Events` chapters.
+the `## Methods` and `## Events` chapters.
 
 Using `autoUpdater` as an example:
 
@@ -93,17 +93,15 @@ Using `autoUpdater` as an example:
 
 ### Classes
 
-For APIs that exists as classes, or for classes that are part of modules, they
-must listed under a `## Class: TheClassName` chapter. One page can have multiple
-classes.
+- API classes or classes that are part of modules must be listed under a
+  `## Class: TheClassName` chapter.
+- One page can have multiple classes.
+- The constructors must be listed with `###`-level titles.
+- The methods must be listed under a `### Instance Methods` chapter.
+- The events must be listed under a `### Instance Events` chapter.
+- The properties must be listed under a `Instance Properties` chapter.
 
-If the class has constructors, they must be listed with `###`-level titles.
-
-The methods, events and properties of a class must be listed under
-`### Instance Methods`, `### Instance Events`, and `Instance Properties`
-chapters.
-
-Using `Session`, `Cookies` classes as an example:
+Using the `Session` and `Cookies` classes as an example:
 
 ```markdown
 # session
@@ -182,11 +180,11 @@ can be `macOS`, `Windows`, or `Linux`.
 * `animate` Boolean (optional) _macOS_ _Windows_
 ```
 
-For any argument with `Array` type, it must be classified what elements the
-array may include in the description below.
+`Array` type arguments must be classified what elements the array may include in
+the description below.
 
-For any argument with `Function` type, the description should make it clear how
-it may be called and list the types of the arguments that will be passed to it.
+The description for `Function` type arguments should make it clear how it may be
+called and list the types of the parameters that will be passed to it.
 
 ### Events
 
@@ -206,7 +204,7 @@ Returns:
 The title can be `###` or `####`-levels depending on whether it is an event of
 a module or a class.
 
-The arguments of an event have the same rules as methods.
+The arguments of an event follow the same rules as methods.
 
 ### Properties
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -6,7 +6,7 @@ These are the guidelines for writing Electron documentation.
 
 * Each page must have a single `#`-level title at the top.
 * Chapters in the same page must have `##`-level titles.
-* Sub-chapters need to increase the number of `#` in the title according to its
+* Sub-chapters need to increase the number of `#` in the title according to their
   nesting depth.
 * All words in the page's title must be capitalized.
 * Only the first word of a chapter title must be capitalized.
@@ -69,7 +69,6 @@ Using `session` as example:
 # session
 
 > Manage browser sessions, cookies, cache, proxy settings, etc.
-
 ```
 
 ### Module methods and events
@@ -97,9 +96,9 @@ Using `autoUpdater` as an example:
   `## Class: TheClassName` chapter.
 - One page can have multiple classes.
 - The constructors must be listed with `###`-level titles.
-- The methods must be listed under a `### Instance Methods` chapter.
-- The events must be listed under a `### Instance Events` chapter.
-- The properties must be listed under a `Instance Properties` chapter.
+- The methods must be listed under an `### Instance Methods` chapter.
+- The events must be listed under an `### Instance Events` chapter.
+- The properties must be listed under an `### Instance Properties` chapter.
 
 Using the `Session` and `Cookies` classes as an example:
 
@@ -146,22 +145,25 @@ The methods chapter must be in the following form:
 * `optional` Integer (optional)
 
 ...
-
 ```
 
 The title can be `###` or `####`-levels depending on whether it is a method of
 a module or a class.
 
-For modules, the `objectName` is the module's name, for classes, it must be the
+For modules, the `objectName` is the module's name. For classes, it must be the
 name of the instance of the class, and must not be the same as the module's
 name.
 
 For example, the methods of the `Session` class under the `session` module must
 use `ses` as the `objectName`.
 
-The optional arguments are notated by brackets surrounding the optional argument
+The optional arguments are notated by square brackets `[]` surrounding the optional argument
 as well as the comma required if this optional argument follows another
-argument.
+argument:
+
+```
+required[, optional]
+```
 
 Below the method is more detailed information on each of the arguments. The type
 of argument is notated by either the common types:
@@ -181,7 +183,7 @@ can be `macOS`, `Windows`, or `Linux`.
 * `animate` Boolean (optional) _macOS_ _Windows_
 ```
 
-`Array` type arguments must be classified what elements the array may include in
+`Array` type arguments must specify what elements the array may include in
 the description below.
 
 The description for `Function` type arguments should make it clear how it may be
@@ -199,7 +201,6 @@ Returns:
 * `time` String
 
 ...
-
 ```
 
 The title can be `###` or `####`-levels depending on whether it is an event of
@@ -215,7 +216,6 @@ The properties chapter must be in following form:
 ### session.defaultSession
 
 ...
-
 ```
 
 The title can be `###` or `####`-levels depending on whether it is a property of

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,12 +1,12 @@
 # Electron Documentation Styleguide
 
-These are the ways that we construct the Electron documentation.
+These are the guidelines for writing Electron documentation.
 
 ## Titles
 
 Each page has only one `#`-level title on the top, following chapters in the
 same page must have `##`-level titles, and sub-chapters need to increase the
-number of `#` in title according to its nesting depth.
+number of `#` in the title according to its nesting depth.
 
 For the page's title, all words must be capitalized, for other chapters, only
 the first word has to be capitalized.
@@ -43,10 +43,9 @@ For API references, there are exceptions to this rule.
 
 ## Markdown rules
 
-* Use `bash` instead of `cmd` in code blocks (because of syntax highlighter).
-* Line length is 80-column wrapped.
-* No nesting lists more than 2 levels (unfortunately because of markdown
-  renderer).
+* Use `bash` instead of `cmd` in code blocks (due to the syntax highlighter).
+* Lines should be wrapped at 80 columns.
+* No nesting lists more than 2 levels (due to the markdown renderer).
 
 ## Picking words
 
@@ -55,12 +54,12 @@ For API references, there are exceptions to this rule.
 
 ## API references
 
-Following rules only apply to documentations of APIs.
+The following rules only apply to the documentation of APIs.
 
 ### Page title
 
 Each page must use the actual object name returned by `require('electron')`
-as name, like `BrowserWindow`, `autoUpdater`, `session`.
+as the title, such as `BrowserWindow`, `autoUpdater`, `session`, etc.
 
 Under the page tile must be a one-line description starting with `>`.
 
@@ -78,7 +77,7 @@ Using `session` as example:
 For modules that are not classes, their methods and events must be listed under
 `## Methods` and `## Events` chapters.
 
-Using `autoUpdater` as example:
+Using `autoUpdater` as an example:
 
 ```markdown
 # autoUpdater
@@ -94,17 +93,17 @@ Using `autoUpdater` as example:
 
 ### Classes
 
-For APIs that exists as classes, or for classes that are parts of modules, they
-must listed under `## Class: TheClassName` chapter. One page can have multiple
+For APIs that exists as classes, or for classes that are part of modules, they
+must listed under a `## Class: TheClassName` chapter. One page can have multiple
 classes.
 
 If the class has constructors, they must be listed with `###`-level titles.
 
 The methods, events and properties of a class must be listed under
-`### Instance Methods`, `### Instance Events` and `Instance Properties`
+`### Instance Methods`, `### Instance Events`, and `Instance Properties`
 chapters.
 
-Using `Session`, `Cookies` classes as example:
+Using `Session`, `Cookies` classes as an example:
 
 ```markdown
 # session
@@ -140,7 +139,7 @@ Using `Session`, `Cookies` classes as example:
 
 ### Methods
 
-The chapter of method must be in the following form:
+The methods chapter must be in the following form:
 
 ```markdown
 ### `objectName.methodName(required[, optional]))`
@@ -153,13 +152,14 @@ The chapter of method must be in the following form:
 ```
 
 The title can be `###` or `####`-levels depending on whether it is a method of
-module or class.
+a module or a class.
 
 For modules, the `objectName` is the module's name, for classes, it must be the
-name of instance of the class, and must not be same with the module's name.
+name of the instance of the class, and must not be the same as the module's
+name.
 
-For example, the methods of `Session` class under `session` module must use
-`ses` as `objectName`.
+For example, the methods of the `Session` class under the `session` module must
+use `ses` as the `objectName`.
 
 The optional arguments are notated by brackets surrounding the optional argument
 as well as the comma required if this optional argument follows another
@@ -167,29 +167,30 @@ argument.
 
 Below the method is more detailed information on each of the arguments. The type
 of argument is notated by either the common types:
-[`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String),
-[`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number),
-[`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object),
-[`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-or a custom type like Electron's [`WebContent`](api/web-content.md).
+
+- [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
+- [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+- [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+- [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+- Or a custom type like Electron's [`WebContent`](api/web-content.md)
 
 If an argument or a method is unique to certain platforms, those platforms are
 denoted using a space-delimited italicized list following the datatype. Values
 can be `macOS`, `Windows`, or `Linux`.
 
-``` markdown
+```markdown
 * `animate` Boolean (optional) _macOS_ _Windows_
 ```
 
-For argument with `Array` type, it must be classified what elements the array
-may include in the description below.
+For any argument with `Array` type, it must be classified what elements the
+array may include in the description below.
 
-For argument with `Function` type, the description should make it clear how it
-may be called and list the types of the arguments that passed to it.
+For any argument with `Function` type, the description should make it clear how
+it may be called and list the types of the arguments that will be passed to it.
 
 ### Events
 
-The chapter of event must be in following form:
+The events chapter must be in following form:
 
 ```markdown
 ### Event: 'wake-up'
@@ -203,13 +204,13 @@ Returns:
 ```
 
 The title can be `###` or `####`-levels depending on whether it is an event of
-module or class.
+a module or a class.
 
-The arguments of an event have the same rules with methods.
+The arguments of an event have the same rules as methods.
 
 ### Properties
 
-The chapter of property must be in following form:
+The properties chapter must be in following form:
 
 ```markdown
 ### session.defaultSession
@@ -219,7 +220,7 @@ The chapter of property must be in following form:
 ```
 
 The title can be `###` or `####`-levels depending on whether it is a property of
-module or class.
+a module or a class.
 
 ## Documentation Translations
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -6,9 +6,10 @@ These are the guidelines for writing Electron documentation.
 
 * Each page must have a single `#`-level title at the top.
 * Chapters in the same page must have `##`-level titles.
-* Sub-chapters need to increase the number of `#` in the title according to their
-  nesting depth.
-* All words in the page's title must be capitalized.
+* Sub-chapters need to increase the number of `#` in the title according to
+  their nesting depth.
+* All words in the page's title must be capitalized, except for conjunctions
+  like "of" and "and" .
 * Only the first word of a chapter title must be capitalized.
 
 Using `Quick Start` as example:

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -92,13 +92,13 @@ Using `autoUpdater` as an example:
 
 ### Classes
 
-- API classes or classes that are part of modules must be listed under a
+* API classes or classes that are part of modules must be listed under a
   `## Class: TheClassName` chapter.
-- One page can have multiple classes.
-- The constructors must be listed with `###`-level titles.
-- The methods must be listed under an `### Instance Methods` chapter.
-- The events must be listed under an `### Instance Events` chapter.
-- The properties must be listed under an `### Instance Properties` chapter.
+* One page can have multiple classes.
+* The constructors must be listed with `###`-level titles.
+* The methods must be listed under an `### Instance Methods` chapter.
+* The events must be listed under an `### Instance Events` chapter.
+* The properties must be listed under an `### Instance Properties` chapter.
 
 Using the `Session` and `Cookies` classes as an example:
 
@@ -168,12 +168,12 @@ required[, optional]
 Below the method is more detailed information on each of the arguments. The type
 of argument is notated by either the common types:
 
-- [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
-- [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
-- [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-- [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-- [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
-- Or a custom type like Electron's [`WebContent`](api/web-content.md)
+* [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
+* [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+* [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+* [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+* [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
+* Or a custom type like Electron's [`WebContent`](api/web-content.md)
 
 If an argument or a method is unique to certain platforms, those platforms are
 denoted using a space-delimited italicized list following the datatype. Values


### PR DESCRIPTION
[__Renderer page__](https://github.com/electron/electron/blob/class-docs/docs/styleguide.md)

This PR adds details to styleguide.md on how should pages and API references be formatted. Currently we have many files using different styles, and eventually we should format them to use only one style.

Some decisions in this PR may still need to be discussed.

/cc @electron/core 