### PR TITLE
Publish Windows PDBs to allow debugging without Symbol server

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -152,6 +152,10 @@ def create_symbols():
     dsyms = glob.glob(os.path.join(OUT_DIR, '*.dSYM'))
     for dsym in dsyms:
       shutil.copytree(dsym, os.path.join(DIST_DIR, os.path.basename(dsym)))
+  elif PLATFORM == 'win32':
+    pdbs = glob.glob(os.path.join(OUT_DIR, '*.pdb'))
+    for pdb in pdbs:
+      shutil.copy2(pdb, DIST_DIR)
 
 
 def create_dist_zip():
@@ -223,6 +227,14 @@ def create_symbols_zip():
     with scoped_cwd(DIST_DIR):
       dsyms = glob.glob('*.dSYM')
       make_zip(os.path.join(DIST_DIR, dsym_name), licenses, dsyms)
+  elif PLATFORM == 'win32':
+    pdb_name = '{0}-{1}-{2}-{3}-pdb.zip'.format(PROJECT_NAME,
+                                                ELECTRON_VERSION,
+                                                get_platform_key(),
+                                                get_target_arch())
+    with scoped_cwd(DIST_DIR):
+      pdbs = glob.glob('*.pdb')
+      make_zip(os.path.join(DIST_DIR, pdb_name), pdbs + licenses, [])
 
 
 if __name__ == '__main__':

--- a/script/upload.py
+++ b/script/upload.py
@@ -35,6 +35,10 @@ DSYM_NAME = '{0}-{1}-{2}-{3}-dsym.zip'.format(PROJECT_NAME,
                                               ELECTRON_VERSION,
                                               get_platform_key(),
                                               get_target_arch())
+PDB_NAME = '{0}-{1}-{2}-{3}-pdb.zip'.format(PROJECT_NAME,
+                                            ELECTRON_VERSION,
+                                            get_platform_key(),
+                                            get_target_arch())
 
 
 def main():
@@ -85,6 +89,8 @@ def main():
   upload_electron(github, release, os.path.join(DIST_DIR, SYMBOLS_NAME))
   if PLATFORM == 'darwin':
     upload_electron(github, release, os.path.join(DIST_DIR, DSYM_NAME))
+  elif PLATFORM == 'win32':
+    upload_electron(github, release, os.path.join(DIST_DIR, PDB_NAME))
 
   # Upload free version of ffmpeg.
   ffmpeg = 'ffmpeg-{0}-{1}-{2}.zip'.format(


### PR DESCRIPTION
I know that you are publishing the electron.exe.pdb and node.dll.pdb to your private symbol server, but when I have a crash dump from an actual rebranded app, then main executable has a different name and cannot be found on the symbol server. I would need to get the electron.exe.pdb and load it manually.