### PR TITLE
Add support for reading/writing bookmarks from the clipboard

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -122,6 +122,23 @@ void WriteHtml(const base::string16& html, mate::Arguments* args) {
   writer.WriteHTML(html, std::string());
 }
 
+v8::Local<v8::Value> ReadBookmark(mate::Arguments* args) {
+  base::string16 title;
+  std::string url;
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(args->isolate());
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  clipboard->ReadBookmark(&title, &url);
+  dict.Set("title", title);
+  dict.Set("url", url);
+  return dict.GetHandle();
+}
+
+void WriteBookmark(const base::string16& title, const std::string& url,
+                   mate::Arguments* args) {
+  ui::ScopedClipboardWriter writer(GetClipboardType(args));
+  writer.WriteBookmark(title, url);
+}
+
 gfx::Image ReadImage(mate::Arguments* args) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   SkBitmap bitmap = clipboard->ReadImage(GetClipboardType(args));
@@ -150,6 +167,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("writeRTF", &WriteRtf);
   dict.SetMethod("readHTML", &ReadHtml);
   dict.SetMethod("writeHTML", &WriteHtml);
+  dict.SetMethod("readBookmark", &ReadBookmark);
+  dict.SetMethod("writeBookmark", &WriteBookmark);
   dict.SetMethod("readImage", &ReadImage);
   dict.SetMethod("writeImage", &WriteImage);
   dict.SetMethod("clear", &Clear);

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -54,11 +54,15 @@ std::string Read(const std::string& format_string,
 void Write(const mate::Dictionary& data,
            mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
-  base::string16 text, html;
+  base::string16 text, html, bookmark;
   gfx::Image image;
 
-  if (data.Get("text", &text))
+  if (data.Get("text", &text)) {
     writer.WriteText(text);
+
+    if (data.Get("bookmark", &bookmark))
+      writer.WriteBookmark(bookmark, base::UTF16ToUTF8(text));
+  }
 
   if (data.Get("rtf", &text)) {
     std::string rtf = base::UTF16ToUTF8(text);

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -75,9 +75,7 @@ Returns the content in the clipboard as RTF.
 
 Writes the `text` into the clipboard in RTF.
 
-### `clipboard.readBookmark([type])`
-
-* `type` String (optional)
+### `clipboard.readBookmark()`
 
 Returns an Object containing `title` and `url` string keys representing the
 bookmark in clipboard.

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -77,9 +77,9 @@ Writes the `text` into the clipboard in RTF.
 
 ### `clipboard.readBookmark()`
 
-Returns an Object containing `title` and `url` string keys representing the
-bookmark in the clipboard. The `title` and `url` values will be empty strings
-when the bookmark is unavailable.
+Returns an Object containing `title` and `url` keys representing the bookmark in
+the clipboard. The `title` and `url` values will be empty strings when the
+bookmark is unavailable.
 
 ### `clipboard.writeBookmark(title, url[, type])`
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -111,6 +111,7 @@ Reads `data` from the clipboard.
   * `text` String
   * `html` String
   * `image` [NativeImage](native-image.md)
+  * `rtf` String
 * `type` String (optional)
 
 ```javascript

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -75,13 +75,13 @@ Returns the content in the clipboard as RTF.
 
 Writes the `text` into the clipboard in RTF.
 
-### `clipboard.readBookmark()`
+### `clipboard.readBookmark()` _macOS_ _Windows_
 
 Returns an Object containing `title` and `url` keys representing the bookmark in
 the clipboard. The `title` and `url` values will be empty strings when the
 bookmark is unavailable.
 
-### `clipboard.writeBookmark(title, url[, type])`
+### `clipboard.writeBookmark(title, url[, type])` _macOS_ _Windows_
 
 * `title` String
 * `url` String

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -78,7 +78,8 @@ Writes the `text` into the clipboard in RTF.
 ### `clipboard.readBookmark()`
 
 Returns an Object containing `title` and `url` string keys representing the
-bookmark in clipboard.
+bookmark in the clipboard. The `title` and `url` values will be empty strings
+when the bookmark is unavailable.
 
 ### `clipboard.writeBookmark(title, url[, type])`
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -75,6 +75,21 @@ Returns the content in the clipboard as RTF.
 
 Writes the `text` into the clipboard in RTF.
 
+### `clipboard.readBookmark([type])`
+
+* `type` String (optional)
+
+Returns an Object containing `title` and `url` string keys representing the
+bookmark in clipboard.
+
+### `clipboard.writeBookmark(title, url[, type])`
+
+* `title` String
+* `url` String
+* `type` String (optional)
+
+Writes the `title` and `url` into the clipboard as a bookmark.
+
 ### `clipboard.clear([type])`
 
 * `type` String (optional)
@@ -112,6 +127,7 @@ Reads `data` from the clipboard.
   * `html` String
   * `image` [NativeImage](native-image.md)
   * `rtf` String
+  * `bookmark` String - The title of the url at `text`.
 * `type` String (optional)
 
 ```javascript

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -41,6 +41,16 @@ describe('clipboard module', function () {
     })
   })
 
+  describe('clipboard.readBookmark', function () {
+    it('returns title and url', function () {
+      clipboard.writeBookmark('a title', 'http://electron.atom.io')
+      assert.deepEqual(clipboard.readBookmark(), {
+        title: 'a title',
+        url: 'https://electron.atom.io'
+      })
+    })
+  })
+
   describe('clipboard.write()', function () {
     it('returns data correctly', function () {
       var text = 'test'

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -46,7 +46,13 @@ describe('clipboard module', function () {
       clipboard.writeBookmark('a title', 'http://electron.atom.io')
       assert.deepEqual(clipboard.readBookmark(), {
         title: 'a title',
-        url: 'https://electron.atom.io'
+        url: 'http://electron.atom.io'
+      })
+
+      clipboard.writeText('no bookmark')
+      assert.deepEqual(clipboard.readBookmark(), {
+        title: '',
+        url: ''
       })
     })
   })

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -43,6 +43,8 @@ describe('clipboard module', function () {
 
   describe('clipboard.readBookmark', function () {
     it('returns title and url', function () {
+      if (process.platform === 'linux') return
+
       clipboard.writeBookmark('a title', 'http://electron.atom.io')
       assert.deepEqual(clipboard.readBookmark(), {
         title: 'a title',
@@ -76,7 +78,10 @@ describe('clipboard module', function () {
       assert.equal(clipboard.readHTML(), markup)
       assert.equal(clipboard.readRTF(), rtf)
       assert.equal(clipboard.readImage().toDataURL(), i.toDataURL())
-      assert.deepEqual(clipboard.readBookmark(), bookmark)
+
+      if (process.platform !== 'linux') {
+        assert.deepEqual(clipboard.readBookmark(), bookmark)
+      }
     })
   })
 })

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -58,16 +58,19 @@ describe('clipboard module', function () {
       var p = path.join(fixtures, 'assets', 'logo.png')
       var i = nativeImage.createFromPath(p)
       var markup = process.platform === 'darwin' ? "<meta charset='utf-8'><b>Hi</b>" : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><b>Hi</b>' : '<b>Hi</b>'
+      var bookmark = {title: 'a title', url: 'test'}
       clipboard.write({
         text: 'test',
         html: '<b>Hi</b>',
         rtf: '{\\rtf1\\utf8 text}',
+        bookmark: 'a title',
         image: p
       })
       assert.equal(clipboard.readText(), text)
       assert.equal(clipboard.readHTML(), markup)
       assert.equal(clipboard.readRTF(), rtf)
       assert.equal(clipboard.readImage().toDataURL(), i.toDataURL())
+      assert.deepEqual(clipboard.readBookmark(), bookmark)
     })
   })
 })


### PR DESCRIPTION
This adds two new APIs to `clipboard`:

- `clipboard.readBookmark()` that returns an object with `title` and `url` keys
- `clipboard.writeBookmark(title, url)` that writes a bookmark to the clipboard

This allows you to write combined url/titles to the clipboard and apps supporting that (like `TextEdit`) will paste them as hyperlinks. Apps default to using the `url` if pasting bookmarks isn't supported.

![clipboard-bookmark](https://cloud.githubusercontent.com/assets/671378/16352115/e76d01ea-3a1f-11e6-8ad7-16e8bae4a6d2.gif)

Closes #5861