### PR TITLE
Execute click handlers for top level menu items

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -145,8 +145,10 @@ void MenuBar::OnMenuButtonClicked(views::MenuButton* source,
 
   int id = source->tag();
   ui::MenuModel::ItemType type = menu_model_->GetTypeAt(id);
-  if (type != ui::MenuModel::TYPE_SUBMENU)
+  if (type != ui::MenuModel::TYPE_SUBMENU) {
+    menu_model_->ActivatedAt(id, 0);
     return;
+  }
 
   MenuDelegate menu_delegate(this);
   menu_delegate.RunMenu(menu_model_->GetSubmenuModelAt(id), source);


### PR DESCRIPTION
:bug: Fixes top level menu items not executing click handlers for at least Windows.

Note : For X11 with DBus we will probably have to report an issue because it looks like there is not any callback available or working. I will have a look at it.

Related to #3049 