### PR TITLE
Ubuntu Unity launcher counter badge

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -614,6 +614,16 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("dockSetMenu", &DockSetMenu);
   dict.SetMethod("dockSetIcon", base::Bind(&Browser::DockSetIcon, browser));
 #endif
+
+#if defined(OS_LINUX)
+  auto browser = base::Unretained(Browser::Get());
+  dict.SetMethod("unityLauncherAvailable",
+                  base::Bind(&Browser::UnityLauncherAvailable, browser));
+  dict.SetMethod("unityLauncherSetBadgeCount",
+                  base::Bind(&Browser::UnityLauncherSetBadgeCount, browser));
+  dict.SetMethod("unityLauncherGetBadgeCount",
+                  base::Bind(&Browser::UnityLauncherGetBadgeCount, browser));
+#endif
 }
 
 }  // namespace

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -149,14 +149,14 @@ class Browser : public WindowListObserver {
   // one from app's name.
   // The returned string managed by Browser, and should not be modified.
   PCWSTR GetAppUserModelID();
-#endif // defined(OS_WIN)
+#endif  // defined(OS_WIN)
 
 #if defined(OS_LINUX)
   // Set/Get unity dock's badge counter.
   bool UnityLauncherAvailable();
   void UnityLauncherSetBadgeCount(int count);
   int UnityLauncherGetBadgeCount();
-#endif // defined(OS_LINUX)
+#endif  // defined(OS_LINUX)
 
   // Tell the application to open a file.
   bool OpenFile(const std::string& file_path);

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -149,7 +149,14 @@ class Browser : public WindowListObserver {
   // one from app's name.
   // The returned string managed by Browser, and should not be modified.
   PCWSTR GetAppUserModelID();
-#endif
+#endif // defined(OS_WIN)
+
+#if defined(OS_LINUX)
+  // Set/Get unity dock's badge counter.
+  bool UnityLauncherAvailable();
+  void UnityLauncherSetBadgeCount(int count);
+  int UnityLauncherGetBadgeCount();
+#endif // defined(OS_LINUX)
 
   // Tell the application to open a file.
   bool OpenFile(const std::string& file_path);
@@ -215,6 +222,8 @@ class Browser : public WindowListObserver {
 
   std::string version_override_;
   std::string name_override_;
+
+  int current_badge_count_ = 0;
 
 #if defined(OS_WIN)
   base::string16 app_user_model_id_;

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -223,7 +223,9 @@ class Browser : public WindowListObserver {
   std::string version_override_;
   std::string name_override_;
 
+#if defined(OS_LINUX)
   int current_badge_count_ = 0;
+#endif
 
 #if defined(OS_WIN)
   base::string16 app_user_model_id_;

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -60,8 +60,10 @@ bool Browser::UnityLauncherAvailable() {
 }
 
 void Browser::UnityLauncherSetBadgeCount(int count) {
-  current_badge_count_ = count;
-  unity::SetDownloadCount(count);
+  if (UnityLauncherAvailable()) {
+    current_badge_count_ = count;
+    unity::SetDownloadCount(count);
+  }
 }
 
 int Browser::UnityLauncherGetBadgeCount() {

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -10,6 +10,7 @@
 #include "atom/browser/window_list.h"
 #include "atom/common/atom_version.h"
 #include "brightray/common/application_info.h"
+#include "chrome/browser/ui/libgtk2ui/unity_service.h"
 
 namespace atom {
 
@@ -52,6 +53,19 @@ std::string Browser::GetExecutableFileVersion() const {
 
 std::string Browser::GetExecutableFileProductName() const {
   return brightray::GetApplicationName();
+}
+
+bool Browser::UnityLauncherAvailable() {
+  return unity::IsRunning();
+}
+
+void Browser::UnityLauncherSetBadgeCount(int count) {
+  current_badge_count_ = count;
+  unity::SetDownloadCount(count);
+}
+
+int Browser::UnityLauncherGetBadgeCount() {
+  return current_badge_count_;
 }
 
 }  // namespace atom

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -647,15 +647,25 @@ Sets the application's [dock menu][dock-menu].
 
 Sets the `image` associated with this dock icon.
 
-### `app.unityLauncher.setBadgeCount(count)` _Ubuntu Unity_
+### `app.launcher.setBadgeCount(count)` _Linux_
 * `count` Integer
 
 Sets the number to be displayed next to the app icon in the unity launcher.
 Setting count to `0` will hide the badge.
 
-### `app.unityLauncher.getBadgeCount(count)` _Ubuntu Unity_
+**Note:** This feature is currently only supported on Ubuntu Unity. Calling this function has no effect, when the application is running in a different environment.
+
+**Note:** you need to specify the .desktop file name to the desktopName field in package.json. By default, it will assume app.getName().desktop in packaged apps.
+
+### `app.launcher.getBadgeCount(count)` _Linux_
 
 Returns the current value displayed in the counter badge next to the launcher icon.
+
+**Note:** As `setBadgeCount` only supports Ubuntu Unity, the value will be 0 when the application is running in a different environment.
+
+### `app.launcher.isCounterBadgeAvailable()` _Linux_
+
+This method checks if the current desktop environment supports an app icon counter badge and returns `true` in this case.
 
 
 [dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -647,6 +647,17 @@ Sets the application's [dock menu][dock-menu].
 
 Sets the `image` associated with this dock icon.
 
+### `app.unityLauncher.setBadgeCount(count)` _Ubuntu Unity_
+* `count` Integer
+
+Sets the number to be displayed next to the app icon in the unity launcher.
+Setting count to `0` will hide the badge.
+
+### `app.unityLauncher.getBadgeCount(count)` _Ubuntu Unity_
+
+Returns the current value displayed in the counter badge next to the launcher icon.
+
+
 [dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103
 [tasks]:http://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -650,18 +650,22 @@ Sets the `image` associated with this dock icon.
 ### `app.launcher.setBadgeCount(count)` _Linux_
 * `count` Integer
 
-Sets the number to be displayed next to the app icon in the unity launcher.
-Setting count to `0` will hide the badge.
+Sets the number to be displayed next to the app icon in the Unity launcher.
+Setting the count to `0` will hide the badge.
 
-**Note:** This feature is currently only supported on Ubuntu Unity. Calling this function has no effect, when the application is running in a different environment.
+**Note:** This feature is currently only supported on Ubuntu Unity. Calling this function has no effect when the application is running in a different environment.
 
-**Note:** you need to specify the .desktop file name to the desktopName field in package.json. By default, it will assume app.getName().desktop in packaged apps.
+**Note:** You need to specify the .desktop file name to the `desktopName` field in package.json. By default, it will assume `app.getName().desktop` in packaged apps.
 
-### `app.launcher.getBadgeCount(count)` _Linux_
+### `app.launcher.getBadgeCount()` _Linux_
 
 Returns the current value displayed in the counter badge next to the launcher icon.
 
 **Note:** As `setBadgeCount` only supports Ubuntu Unity, the value will be 0 when the application is running in a different environment.
+
+### `app.launcher.isUnityRunning()` _Linux_
+
+This method checks if the current desktop environment is Unity and returns `true` in this case.
 
 ### `app.launcher.isCounterBadgeAvailable()` _Linux_
 

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -49,7 +49,8 @@ if (process.platform === 'linux') {
   app.launcher = {
     setBadgeCount: bindings.unityLauncherSetBadgeCount,
     getBadgeCount: bindings.unityLauncherGetBadgeCount,
-    isCounterBadgeAvailable: bindings.unityLauncherAvailable
+    isCounterBadgeAvailable: bindings.unityLauncherAvailable,
+    isUnityRunning: bindings.unityLauncherAvailable
   }
 }
 

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -49,7 +49,7 @@ if (process.platform === 'linux' && bindings.unityLauncherAvailable()) {
   app.unityLauncher = {
     setBadgeCount: bindings.unityLauncherSetBadgeCount,
     getBadgeCount: bindings.unityLauncherGetBadgeCount
-  };
+  }
 }
 
 app.allowNTLMCredentialsForAllDomains = function (allow) {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -45,6 +45,13 @@ if (process.platform === 'darwin') {
   }
 }
 
+if (process.platform === 'linux' && bindings.unityLauncherAvailable()) {
+  app.unityLauncher = {
+    setBadgeCount: bindings.unityLauncherSetBadgeCount,
+    getBadgeCount: bindings.unityLauncherGetBadgeCount
+  };
+}
+
 app.allowNTLMCredentialsForAllDomains = function (allow) {
   if (!process.noDeprecations) {
     deprecate.warn('app.allowNTLMCredentialsForAllDomains', 'session.allowNTLMCredentialsForDomains')

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -45,10 +45,11 @@ if (process.platform === 'darwin') {
   }
 }
 
-if (process.platform === 'linux' && bindings.unityLauncherAvailable()) {
-  app.unityLauncher = {
+if (process.platform === 'linux') {
+  app.launcher = {
     setBadgeCount: bindings.unityLauncherSetBadgeCount,
-    getBadgeCount: bindings.unityLauncherGetBadgeCount
+    getBadgeCount: bindings.unityLauncherGetBadgeCount,
+    isCounterBadgeAvailable: bindings.unityLauncherAvailable
   }
 }
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -284,4 +284,37 @@ describe('app module', function () {
       })
     })
   })
+
+  describe('app.launcher API', function () {
+    it('should be available on linux', function () {
+      if (process.platform !== 'linux') {
+        assert.equal(app.launcher, undefined)
+      } else {
+        assert.notEqual(app.launcher, undefined)
+      }
+    })
+
+    it('should be possible to set a badge count on supported environments', function () {
+      if (process.platform === 'linux' &&
+          app.launcher.isCounterBadgeAvailable()) {
+        app.launcher.setBadgeCount(42)
+        assert.equal(app.launcher.getBadgeCount(), 42)
+      }
+    })
+
+    it('should be possible to set a badge count on unity', function () {
+      if (process.platform === 'linux' &&
+          app.launcher.isUnityRunning()) {
+        assert.equal(app.launcher.isCounterBadgeAvailable(), true)
+      }
+    })
+
+    it('should not be possible to set a badge counter on unsupported environments', function () {
+      if (process.platform === 'linux' &&
+          !app.launcher.isCounterBadgeAvailable()) {
+        app.launcher.setBadgeCount(42)
+        assert.equal(app.launcher.getBadgeCount(), 0)
+      }
+    })
+  })
 })


### PR DESCRIPTION
Hi,
I implemented a way to change the unity launcher counter badge from within electron:
![Screenshot](https://jnugh.de/index.php/s/8nzeiJSUT3WtjUe/download)

For this to work the app needs to be started with `env CHROME_DESKTOP=[name of desktop file]` or (which I found out about while writing this: set desktopName in package.json the way you would do for making the progressbar work).

Please let me know what you think. When there is something to improve, just let me know. :construction_worker: 