### PR TITLE
Add chrome.storage.local

### DIFF
--- a/lib/renderer/extensions/storage.js
+++ b/lib/renderer/extensions/storage.js
@@ -1,5 +1,5 @@
-const getStorage = () => {
-  const data = window.localStorage.getItem('__chrome.storage.sync__')
+const getStorage = (storageType) => {
+  const data = window.localStorage.getItem(`__chrome.storage.${storageType}__`)
   if (data != null) {
     return JSON.parse(data)
   } else {
@@ -7,15 +7,15 @@ const getStorage = () => {
   }
 }
 
-const setStorage = (storage) => {
+const setStorage = (storageType, storage) => {
   const json = JSON.stringify(storage)
-  window.localStorage.setItem('__chrome.storage.sync__', json)
+  window.localStorage.setItem(`__chrome.storage.${storageType}__`, json)
 }
 
-module.exports = {
-  sync: {
+const getStorageManager = (storageType) => {
+  return {
     get (keys, callback) {
-      const storage = getStorage()
+      const storage = getStorage(storageType)
       if (keys == null) return storage
 
       let defaults = {}
@@ -45,15 +45,20 @@ module.exports = {
     },
 
     set (items, callback) {
-      const storage = getStorage()
+      const storage = getStorage(storageType)
 
       Object.keys(items).forEach(function (name) {
         storage[name] = items[name]
       })
 
-      setStorage(storage)
+      setStorage(storageType, storage)
 
       setTimeout(callback)
     }
   }
+}
+
+module.exports = {
+  sync: getStorageManager('sync'),
+  local: getStorageManager('local')
 }


### PR DESCRIPTION
Some chrome extensions use `chrome.storage.local` instead of `chrome.storage.sync`, this pull request generalizes the storage code to work with multiple namespaces.

One example is redux devtools latest version, as I said here: https://github.com/electron/electron/issues/6148.