### PR TITLE
Always call chrome.storage.*.get callback

### DIFF
--- a/lib/renderer/extensions/storage.js
+++ b/lib/renderer/extensions/storage.js
@@ -12,11 +12,17 @@ const setStorage = (storageType, storage) => {
   window.localStorage.setItem(`__chrome.storage.${storageType}__`, json)
 }
 
+const scheduleCallback = (items, callback) => {
+  setTimeout(function () {
+    callback(items)
+  })
+}
+
 const getStorageManager = (storageType) => {
   return {
     get (keys, callback) {
       const storage = getStorage(storageType)
-      if (keys == null) return storage
+      if (keys == null) return scheduleCallback(storage, callback)
 
       let defaults = {}
       switch (typeof keys) {
@@ -30,7 +36,7 @@ const getStorageManager = (storageType) => {
           }
           break
       }
-      if (keys.length === 0) return {}
+      if (keys.length === 0) return scheduleCallback({}, callback)
 
       let items = {}
       keys.forEach(function (key) {
@@ -38,10 +44,7 @@ const getStorageManager = (storageType) => {
         if (value == null) value = defaults[key]
         items[key] = value
       })
-
-      setTimeout(function () {
-        callback(items)
-      })
+      scheduleCallback(items, callback)
     },
 
     set (items, callback) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1025,7 +1025,7 @@ describe('browser-window module', function () {
         }, /Unexpected token }/)
       })
 
-      describe('when the devtools is docked', function () {
+      describe.only('when the devtools is docked', function () {
         it('creates the extension', function (done) {
           w.webContents.openDevTools({mode: 'bottom'})
 
@@ -1033,7 +1033,10 @@ describe('browser-window module', function () {
             assert.equal(message.runtimeId, 'foo')
             assert.equal(message.tabId, w.webContents.id)
             assert.equal(message.i18nString, 'foo - bar (baz)')
-            assert.deepEqual(message.storageItems, {foo: 'bar'})
+            assert.deepEqual(message.storageItems, {
+              local: {hello: 'world'},
+              sync: {foo: 'bar'}
+            })
             done()
           })
         })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1025,7 +1025,7 @@ describe('browser-window module', function () {
         }, /Unexpected token }/)
       })
 
-      describe.only('when the devtools is docked', function () {
+      describe('when the devtools is docked', function () {
         it('creates the extension', function (done) {
           w.webContents.openDevTools({mode: 'bottom'})
 

--- a/spec/fixtures/devtools-extensions/foo/index.html
+++ b/spec/fixtures/devtools-extensions/foo/index.html
@@ -6,16 +6,25 @@
     <script>
       function testStorage (callback) {
         chrome.storage.sync.set({foo: 'bar'}, function () {
-          chrome.storage.sync.get({foo: 'baz'}, callback)
+          chrome.storage.sync.get({foo: 'baz'}, function (syncItems) {
+            chrome.storage.local.set({hello: 'world'}, function () {
+              chrome.storage.local.get(null, function(localItems) {
+                callback(syncItems, localItems)
+              })
+            })
+          })
         })
       }
 
-      testStorage(function (items) {
+      testStorage(function (syncItems, localItems) {
         var message = JSON.stringify({
           runtimeId: chrome.runtime.id,
           tabId: chrome.devtools.inspectedWindow.tabId,
           i18nString: chrome.i18n.getMessage('foo', ['bar', 'baz']),
-          storageItems: items
+          storageItems: {
+            local: localItems,
+            sync: syncItems
+          }
         })
         var sendMessage = `require('electron').ipcRenderer.send('answer', ${message})`
         window.chrome.devtools.inspectedWindow.eval(sendMessage, function () {})


### PR DESCRIPTION
While writing a spec for #6269 I found an issue where the callback to `chrome.storage.*.get` was not being called when no keys were specified.

This was because it was returning the values instead of calling the callback with them.

/cc @jlord