### PR TITLE
Use previously set context menu when popup menu is null

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -263,7 +263,7 @@ const CGFloat kVerticalTitleMargin = 2;
   }
 
   if (menuController_ && ![menuController_ isMenuOpen]) {
-    // Redraw the dray icon to show highlight if it is enabled.
+    // Redraw the tray icon to show highlight if it is enabled.
     [self setNeedsDisplay:YES];
     [statusItem_ popUpStatusItemMenu:[menuController_ menu]];
     // The popUpStatusItemMenu returns only after the showing menu is closed.

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -134,7 +134,7 @@ void NotifyIcon::DisplayBalloon(HICON icon,
 void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
                                   ui::SimpleMenuModel* menu_model) {
   // Returns if context menu isn't set.
-  if (!menu_model && !menu_model_)
+  if (menu_model == nullptr && menu_model_ == nullptr)
     return;
 
   // Set our window as the foreground window, so the context menu closes when
@@ -148,7 +148,7 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
     rect.set_origin(gfx::Screen::GetScreen()->GetCursorScreenPoint());
 
   views::MenuRunner menu_runner(
-      menu_model ? menu_model : menu_model_,
+      menu_model != nullptr ? menu_model : menu_model_,
       views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS);
   ignore_result(menu_runner.RunMenuAt(
       NULL, NULL, rect, views::MENU_ANCHOR_TOPLEFT, ui::MENU_SOURCE_MOUSE));

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -134,8 +134,9 @@ void NotifyIcon::DisplayBalloon(HICON icon,
 void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
                                   ui::SimpleMenuModel* menu_model) {
   // Returns if context menu isn't set.
-  if (!menu_model)
+  if (!menu_model && !menu_model_)
     return;
+
   // Set our window as the foreground window, so the context menu closes when
   // we click away from it.
   if (!SetForegroundWindow(window_))
@@ -147,7 +148,7 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
     rect.set_origin(gfx::Screen::GetScreen()->GetCursorScreenPoint());
 
   views::MenuRunner menu_runner(
-      menu_model,
+      menu_model ? menu_model : menu_model_,
       views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS);
   ignore_result(menu_runner.RunMenuAt(
       NULL, NULL, rect, views::MENU_ANCHOR_TOPLEFT, ui::MENU_SOURCE_MOUSE));


### PR DESCRIPTION
Show menu previously set via `SetContextMenu` when no specified menu to `PopUpContextMenu`.

Closes #6276 