### PR TITLE
Update key to be httpOnly instead of session

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -377,8 +377,8 @@ with `callback(error, cookies)` on complete.
   * `path` String - The path of the cookie. Empty by default if omitted.
   * `secure` Boolean - Whether the cookie should be marked as Secure. Defaults to
     false.
-  * `session` Boolean - Whether the cookie should be marked as HTTP only. Defaults
-    to false.
+  * `httpOnly` Boolean - Whether the cookie should be marked as HTTP only.
+    Defaults to false.
   * `expirationDate` Double -	The expiration date of the cookie as the number of
     seconds since the UNIX epoch. If omitted then the cookie becomes a session
     cookie and will not be retained between sessions.


### PR DESCRIPTION
This previously had `session` as a property to `cookies.set` but the comment mentioned `HTTP only` and it looks like internally it was meant to be `httpOnly` instead: https://github.com/electron/electron/blob/8155e7192569c3a30ca3cb5f25a306d0dc5d3d44/atom/browser/api/atom_api_cookies.cc#L174