### PR TITLE
Mention setting cookie in failure message

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -30,7 +30,7 @@ struct Converter<atom::api::Cookies::Error> {
     if (val == atom::api::Cookies::SUCCESS)
       return v8::Null(isolate);
     else
-      return v8::Exception::Error(StringToV8(isolate, "failed"));
+      return v8::Exception::Error(StringToV8(isolate, "Setting cookie failed"));
   }
 };
 

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -69,6 +69,17 @@ describe('session module', function () {
       })
     })
 
+    it('calls back with an error when setting a cookie with missing required fields', function (done) {
+      session.defaultSession.cookies.set({
+        url: '',
+        name: '1',
+        value: '1'
+      }, function (error) {
+        assert.equal(error.message, 'Setting cookie failed')
+        done()
+      })
+    })
+
     it('should over-write the existent cookie', function (done) {
       session.defaultSession.cookies.set({
         url: url,


### PR DESCRIPTION
Changes the `cookies.set` error message to be "Setting cookie failed" instead of "failed".

Refs #6209