### PR TITLE
Remove standard linter warnings from specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bootstrap": "python ./script/bootstrap.py",
     "build": "python ./script/build.py -c D",
     "lint": "npm run lint-js && npm run lint-cpp",
-    "lint-js": "standard && standard spec",
+    "lint-js": "standard && cd spec && standard",
     "lint-cpp": "python ./script/cpplint.py",
     "preinstall": "node -e 'process.exit(0)'",
     "repl": "python ./script/start.py --interactive",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "asar": "^0.11.0",
     "request": "*",
-    "standard": "^7.1.0"
+    "standard": "^7.1.2"
   },
   "optionalDependencies": {
     "runas": "^3.0.0"

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -7,7 +7,6 @@ const path = require('path')
 const {remote} = require('electron')
 
 const {app, BrowserWindow, ipcMain} = remote
-const isCI = remote.getGlobal('isCi')
 
 describe('electron module', function () {
   it('does not expose internal modules to require', function () {
@@ -44,7 +43,6 @@ describe('electron module', function () {
       window.loadURL('file://' + path.join(__dirname, 'fixtures', 'api', 'electron-module-app', 'index.html'))
     })
   })
-
 })
 
 describe('app module', function () {
@@ -111,12 +109,10 @@ describe('app module', function () {
 
   describe('app.relaunch', function () {
     let server = null
-    const socketPath = process.platform === 'win32' ?
-      '\\\\.\\pipe\\electron-app-relaunch' :
-      '/tmp/electron-app-relaunch'
+    const socketPath = process.platform === 'win32' ? '\\\\.\\pipe\\electron-app-relaunch' : '/tmp/electron-app-relaunch'
 
     beforeEach(function (done) {
-      fs.unlink(socketPath, (error) => {
+      fs.unlink(socketPath, () => {
         server = net.createServer()
         server.listen(socketPath)
         done()
@@ -128,7 +124,7 @@ describe('app module', function () {
         if (process.platform === 'win32') {
           done()
         } else {
-          fs.unlink(socketPath, (error) => {
+          fs.unlink(socketPath, () => {
             done()
           })
         }
@@ -164,14 +160,13 @@ describe('app module', function () {
     }
 
     it('sets the current activity', function () {
-      app.setUserActivity('com.electron.testActivity', {testData: '123'});
-      assert.equal(app.getCurrentActivityType(), 'com.electron.testActivity');
+      app.setUserActivity('com.electron.testActivity', {testData: '123'})
+      assert.equal(app.getCurrentActivityType(), 'com.electron.testActivity')
     })
   })
 
   describe('app.importCertificate', function () {
-    if (process.platform !== 'linux')
-      return
+    if (process.platform !== 'linux') return
 
     this.timeout(5000)
 
@@ -190,8 +185,8 @@ describe('app module', function () {
 
     var server = https.createServer(options, function (req, res) {
       if (req.client.authorized) {
-        res.writeHead(200);
-        res.end('authorized');
+        res.writeHead(200)
+        res.end('authorized')
       }
     })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1004,7 +1004,7 @@ describe('browser-window module', function () {
                 var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
                 WebInspector.inspectorView.showPanel(lastPanelId)
               }
-              w.devToolsWebContents.executeJavaScript('(' + showLastPanel.toString() + ')()')
+              w.devToolsWebContents.executeJavaScript(`(${showLastPanel})()`)
             } else {
               clearInterval(showPanelIntevalId)
             }
@@ -1080,7 +1080,7 @@ describe('browser-window module', function () {
               var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
               WebInspector.inspectorView.showPanel(lastPanelId)
             }
-            w.devToolsWebContents.executeJavaScript('(' + showLastPanel.toString() + ')()')
+            w.devToolsWebContents.executeJavaScript(`(${showLastPanel})()`)
           } else {
             clearInterval(showPanelIntevalId)
           }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -23,9 +23,9 @@ describe('browser-window module', function () {
 
   before(function (done) {
     server = http.createServer(function (req, res) {
-      function respond() { res.end(''); }
+      function respond () { res.end('') }
       setTimeout(respond, req.url.includes('slow') ? 200 : 0)
-    });
+    })
     server.listen(0, '127.0.0.1', function () {
       server.url = 'http://127.0.0.1:' + server.address().port
       done()
@@ -128,7 +128,7 @@ describe('browser-window module', function () {
         'did-get-response-details.html': 'mainFrame',
         'logo.png': 'image'
       }
-      var responses = 0;
+      var responses = 0
       w.webContents.on('did-get-response-details', function (event, status, newUrl, oldUrl, responseCode, method, referrer, headers, resourceType) {
         responses++
         var fileName = newUrl.slice(newUrl.lastIndexOf('/') + 1)
@@ -290,7 +290,7 @@ describe('browser-window module', function () {
   describe('BrowserWindow.setAspectRatio(ratio)', function () {
     it('resets the behaviour when passing in 0', function (done) {
       var size = [300, 400]
-      w.setAspectRatio(1/2)
+      w.setAspectRatio(1 / 2)
       w.setAspectRatio(0)
       w.once('resize', function () {
         var newSize = w.getSize()
@@ -346,7 +346,7 @@ describe('browser-window module', function () {
         if (process.platform === 'darwin') {
           app.dock.setIcon(path.join(fixtures, 'assets', 'logo.png'))
         }
-        w.setProgressBar(.5)
+        w.setProgressBar(0.5)
 
         if (process.platform === 'darwin') {
           app.dock.setIcon(null)
@@ -433,7 +433,7 @@ describe('browser-window module', function () {
     })
   })
 
-  describe('"enableLargerThanScreen" option', function () {
+  describe('enableLargerThanScreen" option', function () {
     if (process.platform === 'linux') {
       return
     }
@@ -647,7 +647,7 @@ describe('browser-window module', function () {
       w.loadURL('file://' + fixtures + '/api/frame-subscriber.html')
       try {
         w.webContents.beginFrameSubscription(true, true)
-      } catch(e) {
+      } catch (e) {
         done()
       }
     })
@@ -714,7 +714,7 @@ describe('browser-window module', function () {
 
     describe('loading main frame state', function () {
       it('is true when the main frame is loading', function (done) {
-        w.webContents.on('did-start-loading', function() {
+        w.webContents.on('did-start-loading', function () {
           assert.equal(w.webContents.isLoadingMainFrame(), true)
           done()
         })
@@ -722,9 +722,9 @@ describe('browser-window module', function () {
       })
 
       it('is false when only a subframe is loading', function (done) {
-        w.webContents.once('did-finish-load', function() {
+        w.webContents.once('did-finish-load', function () {
           assert.equal(w.webContents.isLoadingMainFrame(), false)
-          w.webContents.on('did-start-loading', function() {
+          w.webContents.on('did-start-loading', function () {
             assert.equal(w.webContents.isLoadingMainFrame(), false)
             done()
           })
@@ -738,9 +738,9 @@ describe('browser-window module', function () {
       })
 
       it('is true when navigating to pages from the same origin', function (done) {
-        w.webContents.once('did-finish-load', function() {
+        w.webContents.once('did-finish-load', function () {
           assert.equal(w.webContents.isLoadingMainFrame(), false)
-          w.webContents.on('did-start-loading', function() {
+          w.webContents.on('did-start-loading', function () {
             assert.equal(w.webContents.isLoadingMainFrame(), true)
             done()
           })
@@ -1000,10 +1000,11 @@ describe('browser-window module', function () {
         w.webContents.on('devtools-opened', function () {
           var showPanelIntevalId = setInterval(function () {
             if (w && w.devToolsWebContents) {
-              w.devToolsWebContents.executeJavaScript('(' + (function () {
+              var showLastPanel = function () {
                 var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
                 WebInspector.inspectorView.showPanel(lastPanelId)
-              }).toString() + ')()')
+              }
+              w.devToolsWebContents.executeJavaScript('(' + showLastPanel.toString() + ')()')
             } else {
               clearInterval(showPanelIntevalId)
             }
@@ -1075,10 +1076,11 @@ describe('browser-window module', function () {
       w.webContents.on('devtools-opened', function () {
         var showPanelIntevalId = setInterval(function () {
           if (w && w.devToolsWebContents) {
-            w.devToolsWebContents.executeJavaScript('(' + (function () {
+            var showLastPanel = function () {
               var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
               WebInspector.inspectorView.showPanel(lastPanelId)
-            }).toString() + ')()')
+            }
+            w.devToolsWebContents.executeJavaScript('(' + showLastPanel.toString() + ')()')
           } else {
             clearInterval(showPanelIntevalId)
           }
@@ -1127,14 +1129,14 @@ describe('browser-window module', function () {
     })
 
     it('works after page load and during subframe load', function (done) {
-      w.webContents.once('did-finish-load', function() {
+      w.webContents.once('did-finish-load', function () {
         // initiate a sub-frame load, then try and execute script during it
         w.webContents.executeJavaScript(`
           var iframe = document.createElement('iframe')
           iframe.src = '${server.url}/slow'
           document.body.appendChild(iframe)
-        `, function() {
-          w.webContents.executeJavaScript(`console.log('hello')`, function() {
+        `, function () {
+          w.webContents.executeJavaScript('console.log(\'hello\')', function () {
             done()
           })
         })
@@ -1143,7 +1145,7 @@ describe('browser-window module', function () {
     })
 
     it('executes after page load', function (done) {
-      w.webContents.executeJavaScript(code, function(result) {
+      w.webContents.executeJavaScript(code, function (result) {
         assert.equal(result, expected)
         done()
       })

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -80,9 +80,9 @@ describe('ipc module', function () {
 
     it('is referenced by its members', function () {
       let stringify = remote.getGlobal('JSON').stringify
-      gc();
+      global.gc()
       stringify({})
-    });
+    })
   })
 
   describe('remote value in browser', function () {
@@ -90,15 +90,15 @@ describe('ipc module', function () {
 
     it('keeps its constructor name for objects', function () {
       var buf = new Buffer('test')
-      var print_name = remote.require(print)
-      assert.equal(print_name.print(buf), 'Buffer')
+      var printName = remote.require(print)
+      assert.equal(printName.print(buf), 'Buffer')
     })
 
     it('supports instanceof Date', function () {
       var now = new Date()
-      var print_name = remote.require(print)
-      assert.equal(print_name.print(now), 'Date')
-      assert.deepEqual(print_name.echo(now), now)
+      var printName = remote.require(print)
+      assert.equal(printName.print(now), 'Date')
+      assert.deepEqual(printName.echo(now), now)
     })
   })
 
@@ -200,9 +200,9 @@ describe('ipc module', function () {
     it('is referenced by methods in prototype chain', function () {
       let method = derived.method
       derived = null
-      gc()
+      global.gc()
       assert.equal(method(), 'method')
-    });
+    })
   })
 
   describe('ipc.sender.send', function () {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -402,23 +402,23 @@ describe('menu module', function () {
       assert.equal(item.label, 'Close')
       assert.equal(item.accelerator, 'CommandOrControl+W')
 
-      var item = new MenuItem({role: 'close', label: 'Other'})
+      item = new MenuItem({role: 'close', label: 'Other'})
       assert.equal(item.label, 'Other')
       assert.equal(item.accelerator, 'CommandOrControl+W')
 
-      var item = new MenuItem({role: 'close', accelerator: 'D'})
+      item = new MenuItem({role: 'close', accelerator: 'D'})
       assert.equal(item.label, 'Close')
       assert.equal(item.accelerator, 'D')
 
-      var item = new MenuItem({role: 'close', label: 'C', accelerator: 'D'})
+      item = new MenuItem({role: 'close', label: 'C', accelerator: 'D'})
       assert.equal(item.label, 'C')
       assert.equal(item.accelerator, 'D')
 
-      var item = new MenuItem({role: 'help'})
+      item = new MenuItem({role: 'help'})
       assert.equal(item.label, 'Help')
       assert.equal(item.accelerator, undefined)
 
-      var item = new MenuItem({role: 'hide'})
+      item = new MenuItem({role: 'hide'})
       assert.equal(item.label, 'Hide Electron Test')
       assert.equal(item.accelerator, 'Command+H')
     })

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -514,7 +514,7 @@ describe('protocol module', function () {
     it('works when target URL redirects', function (done) {
       var contents = null
       var server = http.createServer(function (req, res) {
-        if (req.url == '/serverRedirect') {
+        if (req.url === '/serverRedirect') {
           res.statusCode = 301
           res.setHeader('Location', 'http://' + req.rawHeaders[1])
           res.end()
@@ -919,7 +919,7 @@ describe('protocol module', function () {
         })
         w.loadURL(origin)
       })
-    }),
+    })
 
     it('can have fetch working in it', function (done) {
       const content = '<html><script>fetch("http://github.com")</script></html>'

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -285,7 +285,7 @@ describe('session module', function () {
     const protocolName = 'sp'
     const partitionProtocol = session.fromPartition(partitionName).protocol
     const protocol = session.defaultSession.protocol
-    const handler = function (_, callback) {
+    const handler = function (ignoredError, callback) {
       callback({data: 'test', mimeType: 'text/html'})
     }
 

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -285,7 +285,7 @@ describe('session module', function () {
     const protocolName = 'sp'
     const partitionProtocol = session.fromPartition(partitionName).protocol
     const protocol = session.defaultSession.protocol
-    const handler = function (error, callback) {
+    const handler = function (_, callback) {
       callback({data: 'test', mimeType: 'text/html'})
     }
 
@@ -298,7 +298,7 @@ describe('session module', function () {
         }
       })
       partitionProtocol.registerStringProtocol(protocolName, handler, function (error) {
-        done(error ? error : undefined)
+        done(error != null ? error : undefined)
       })
     })
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -18,5 +18,4 @@ describe('systemPreferences module', function () {
       assert(languages.length > 0)
     })
   })
-
 })

--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -7,7 +7,7 @@ const session = remote.session
 describe('webRequest module', function () {
   var ses = session.defaultSession
   var server = http.createServer(function (req, res) {
-    if (req.url == '/serverRedirect') {
+    if (req.url === '/serverRedirect') {
       res.statusCode = 301
       res.setHeader('Location', 'http://' + req.rawHeaders[1])
       res.end()
@@ -308,7 +308,7 @@ describe('webRequest module', function () {
       ses.webRequest.onHeadersReceived(function (details, callback) {
         var responseHeaders = details.responseHeaders
         callback({
-          responseHeaders: responseHeaders,
+          responseHeaders: responseHeaders
         })
       })
       $.ajax({
@@ -328,7 +328,7 @@ describe('webRequest module', function () {
         var responseHeaders = details.responseHeaders
         callback({
           responseHeaders: responseHeaders,
-          statusLine: "HTTP/1.1 404 Not Found"
+          statusLine: 'HTTP/1.1 404 Not Found'
         })
       })
       $.ajax({

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const child_process = require('child_process')
+const ChildProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
 
@@ -536,7 +536,7 @@ describe('asar package', function () {
 
     describe('child_process.fork', function () {
       it('opens a normal js file', function (done) {
-        var child = child_process.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'))
+        var child = ChildProcess.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'))
         child.on('message', function (msg) {
           assert.equal(msg, 'message')
           done()
@@ -546,7 +546,7 @@ describe('asar package', function () {
 
       it('supports asar in the forked js', function (done) {
         var file = path.join(fixtures, 'asar', 'a.asar', 'file1')
-        var child = child_process.fork(path.join(fixtures, 'module', 'asar.js'))
+        var child = ChildProcess.fork(path.join(fixtures, 'module', 'asar.js'))
         child.on('message', function (content) {
           assert.equal(content, fs.readFileSync(file).toString())
           done()
@@ -556,11 +556,10 @@ describe('asar package', function () {
     })
 
     describe('child_process.exec', function () {
-      var child_process = require('child_process');
       var echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
       it('should not try to extract the command if there is a reference to a file inside an .asar', function (done) {
-        child_process.exec('echo ' + echo + ' foo bar', function (error, stdout) {
+        ChildProcess.exec('echo ' + echo + ' foo bar', function (error, stdout) {
           assert.equal(error, null)
           assert.equal(stdout.toString().replace(/\r/g, ''), echo + ' foo bar\n')
           done()
@@ -569,24 +568,22 @@ describe('asar package', function () {
     })
 
     describe('child_process.execSync', function () {
-      var child_process = require('child_process');
       var echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
       it('should not try to extract the command if there is a reference to a file inside an .asar', function (done) {
-        var stdout = child_process.execSync('echo ' + echo + ' foo bar')
+        var stdout = ChildProcess.execSync('echo ' + echo + ' foo bar')
         assert.equal(stdout.toString().replace(/\r/g, ''), echo + ' foo bar\n')
         done()
       })
     })
 
     describe('child_process.execFile', function () {
-      var echo, execFile, execFileSync, ref2
+      var echo, execFile, execFileSync
       if (process.platform !== 'darwin') {
         return
       }
-      ref2 = require('child_process')
-      execFile = ref2.execFile
-      execFileSync = ref2.execFileSync
+      execFile = ChildProcess.execFile
+      execFileSync = ChildProcess.execFileSync
       echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
       it('executes binaries', function (done) {
@@ -785,7 +782,7 @@ describe('asar package', function () {
     })
 
     it('is available in forked scripts', function (done) {
-      var child = child_process.fork(path.join(fixtures, 'module', 'original-fs.js'))
+      var child = ChildProcess.fork(path.join(fixtures, 'module', 'original-fs.js'))
       child.on('message', function (msg) {
         assert.equal(msg, 'object')
         done()

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -235,10 +235,11 @@ describe('chromium feature', function () {
 
     it('defines a window.location getter', function (done) {
       var b, targetURL
-      if (process.platform == 'win32')
+      if (process.platform === 'win32') {
         targetURL = 'file:///' + fixtures.replace(/\\/g, '/') + '/pages/base-page.html'
-      else
+      } else {
         targetURL = 'file://' + fixtures + '/pages/base-page.html'
+      }
       b = window.open(targetURL)
       webContents.fromId(b.guestId).once('did-finish-load', function () {
         assert.equal(b.location, targetURL)

--- a/spec/fixtures/api/relaunch/main.js
+++ b/spec/fixtures/api/relaunch/main.js
@@ -1,9 +1,7 @@
-const {app, dialog} = require('electron')
+const {app} = require('electron')
 const net = require('net')
 
-const socketPath = process.platform === 'win32' ?
-  '\\\\.\\pipe\\electron-app-relaunch' :
-  '/tmp/electron-app-relaunch'
+const socketPath = process.platform === 'win32' ? '\\\\.\\pipe\\electron-app-relaunch' : '/tmp/electron-app-relaunch'
 
 process.on('uncaughtException', () => {
   app.exit(1)

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -214,9 +214,9 @@ describe('node feature', function () {
 
     it('does not crash when creating large Buffers', function () {
       var buffer = new Buffer(new Array(4096).join(' '))
-      assert.equal(buffer.length, 4096)
+      assert.equal(buffer.length, 4095)
       buffer = new Buffer(new Array(4097).join(' '))
-      assert.equal(buffer.length, 4097)
+      assert.equal(buffer.length, 4096)
     })
   })
 

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const child_process = require('child_process')
+const ChildProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
@@ -13,7 +13,7 @@ describe('node feature', function () {
   describe('child_process', function () {
     describe('child_process.fork', function () {
       it('works in current process', function (done) {
-        var child = child_process.fork(path.join(fixtures, 'module', 'ping.js'))
+        var child = ChildProcess.fork(path.join(fixtures, 'module', 'ping.js'))
         child.on('message', function (msg) {
           assert.equal(msg, 'message')
           done()
@@ -23,7 +23,7 @@ describe('node feature', function () {
 
       it('preserves args', function (done) {
         var args = ['--expose_gc', '-test', '1']
-        var child = child_process.fork(path.join(fixtures, 'module', 'process_args.js'), args)
+        var child = ChildProcess.fork(path.join(fixtures, 'module', 'process_args.js'), args)
         child.on('message', function (msg) {
           assert.deepEqual(args, msg.slice(2))
           done()
@@ -32,7 +32,7 @@ describe('node feature', function () {
       })
 
       it('works in forked process', function (done) {
-        var child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'))
+        var child = ChildProcess.fork(path.join(fixtures, 'module', 'fork_ping.js'))
         child.on('message', function (msg) {
           assert.equal(msg, 'message')
           done()
@@ -41,7 +41,7 @@ describe('node feature', function () {
       })
 
       it('works in forked process when options.env is specifed', function (done) {
-        var child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'), [], {
+        var child = ChildProcess.fork(path.join(fixtures, 'module', 'fork_ping.js'), [], {
           path: process.env['PATH']
         })
         child.on('message', function (msg) {
@@ -62,7 +62,7 @@ describe('node feature', function () {
       })
 
       it('has String::localeCompare working in script', function (done) {
-        var child = child_process.fork(path.join(fixtures, 'module', 'locale-compare.js'))
+        var child = ChildProcess.fork(path.join(fixtures, 'module', 'locale-compare.js'))
         child.on('message', function (msg) {
           assert.deepEqual(msg, [0, -1, 1])
           done()
@@ -71,7 +71,7 @@ describe('node feature', function () {
       })
 
       it('has setImmediate working in script', function (done) {
-        var child = child_process.fork(path.join(fixtures, 'module', 'set-immediate.js'))
+        var child = ChildProcess.fork(path.join(fixtures, 'module', 'set-immediate.js'))
         child.on('message', function (msg) {
           assert.equal(msg, 'ok')
           done()
@@ -80,7 +80,7 @@ describe('node feature', function () {
       })
 
       it('pipes stdio', function (done) {
-        let child = child_process.fork(path.join(fixtures, 'module', 'process-stdout.js'), {silent: true})
+        let child = ChildProcess.fork(path.join(fixtures, 'module', 'process-stdout.js'), {silent: true})
         let data = ''
         child.stdout.on('data', (chunk) => {
           data += String(chunk)
@@ -183,7 +183,7 @@ describe('node feature', function () {
     it('emit error when connect to a socket path without listeners', function (done) {
       var socketPath = path.join(os.tmpdir(), 'atom-shell-test.sock')
       var script = path.join(fixtures, 'module', 'create_socket.js')
-      var child = child_process.fork(script, [socketPath])
+      var child = ChildProcess.fork(script, [socketPath])
       child.on('exit', function (code) {
         assert.equal(code, 0)
         var client = require('net').connect(socketPath)
@@ -213,8 +213,10 @@ describe('node feature', function () {
     })
 
     it('does not crash when creating large Buffers', function () {
-      new Buffer(new Array(4096).join(' '));
-      new Buffer(new Array(4097).join(' '));
+      var buffer = new Buffer(new Array(4096).join(' '))
+      assert.equal(buffer.length, 4096)
+      buffer = new Buffer(new Array(4097).join(' '))
+      assert.equal(buffer.length, 4097)
     })
   })
 

--- a/spec/package.json
+++ b/spec/package.json
@@ -27,7 +27,8 @@
       "serviceworker": true
     },
     "globals": [
-      "WebView"
+      "WebView",
+      "WebInspector"
     ]
   }
 }

--- a/spec/package.json
+++ b/spec/package.json
@@ -21,6 +21,7 @@
   },
   "standard": {
     "env": {
+      "browser": true,
       "mocha": true,
       "jquery": true,
       "serviceworker": true

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -95,7 +95,7 @@ app.on('ready', function () {
     width: 800,
     height: 600,
     webPreferences: {
-      backgroundThrottling: false,
+      backgroundThrottling: false
     }
   })
   window.loadURL(url.format({
@@ -119,9 +119,9 @@ app.on('ready', function () {
   // For session's download test, listen 'will-download' event in browser, and
   // reply the result to renderer for verifying
   var downloadFilePath = path.join(__dirname, '..', 'fixtures', 'mock.pdf')
-  ipcMain.on('set-download-option', function (event, need_cancel, prevent_default) {
+  ipcMain.on('set-download-option', function (event, needCancel, preventDefault) {
     window.webContents.session.once('will-download', function (e, item) {
-      if (prevent_default) {
+      if (preventDefault) {
         e.preventDefault()
         const url = item.getURL()
         const filename = item.getFilename()
@@ -144,7 +144,7 @@ app.on('ready', function () {
             item.getContentDisposition(),
             item.getFilename())
         })
-        if (need_cancel) item.cancel()
+        if (needCancel) item.cancel()
       }
     })
     event.returnValue = 'done'

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -40,7 +40,7 @@ describe('<webview> tag', function () {
       webPreferences: {
         nodeIntegration: false,
         preload: path.join(fixtures, 'module', 'preload-webview.js')
-      },
+      }
     })
     ipcMain.once('webview', function (event, type) {
       if (type === 'undefined') {
@@ -776,13 +776,12 @@ describe('<webview> tag', function () {
   })
 
   describe('permission-request event', function () {
-    function setUpRequestHandler (webview, requested_permission, completed) {
+    function setUpRequestHandler (webview, requestedPermission, completed) {
       var listener = function (webContents, permission, callback) {
         if (webContents.getId() === webview.getId()) {
-          assert.equal(permission, requested_permission)
+          assert.equal(permission, requestedPermission)
           callback(false)
-          if (completed)
-            completed()
+          if (completed) completed()
         }
       }
       session.fromPartition(webview.partition).setPermissionRequestHandler(listener)
@@ -855,7 +854,7 @@ describe('<webview> tag', function () {
         'did-get-response-details.html': 'mainFrame',
         'logo.png': 'image'
       }
-      var responses = 0;
+      var responses = 0
       webview.addEventListener('did-get-response-details', function (event) {
         responses++
         var fileName = event.newURL.slice(event.newURL.lastIndexOf('/') + 1)


### PR DESCRIPTION
At some point the `spec/` directory stopped being linted when running `npm run lint`.

This looks to be because `/spec` is ignored in the root `package.json` so running `standard spec` from the root of the repo was ignoring all the files instead of linting them.

This pull request switches it to `cd spec && standard` so that the standard linter picks up the config from `spec/package.json` instead of the root one.

/cc @zeke 