### PR TITLE
Implement app.setBadgeCount on Mac

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -520,6 +520,8 @@ void App::BuildPrototype(
                  base::Bind(&Browser::SetAsDefaultProtocolClient, browser))
       .SetMethod("removeAsDefaultProtocolClient",
                  base::Bind(&Browser::RemoveAsDefaultProtocolClient, browser))
+      .SetMethod("setBadgeCount", base::Bind(&Browser::SetBadgeCount, browser))
+      .SetMethod("getBadgeCount", base::Bind(&Browser::GetBadgeCount, browser))
 #if defined(OS_MACOSX)
       .SetMethod("hide", base::Bind(&Browser::Hide, browser))
       .SetMethod("show", base::Bind(&Browser::Show, browser))
@@ -529,8 +531,11 @@ void App::BuildPrototype(
                  base::Bind(&Browser::GetCurrentActivityType, browser))
 #endif
 #if defined(OS_WIN)
-      .SetMethod("setUserTasks",
-                 base::Bind(&Browser::SetUserTasks, browser))
+      .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))
+#endif
+#if defined(OS_LINUX)
+      .SetMethod("isUnityRunning",
+                 base::Bind(&Browser::IsUnityRunning, browser))
 #endif
       .SetMethod("setPath", &App::SetPath)
       .SetMethod("getPath", &App::GetPath)
@@ -613,16 +618,6 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("dockShow", base::Bind(&Browser::DockShow, browser));
   dict.SetMethod("dockSetMenu", &DockSetMenu);
   dict.SetMethod("dockSetIcon", base::Bind(&Browser::DockSetIcon, browser));
-#endif
-
-#if defined(OS_LINUX)
-  auto browser = base::Unretained(Browser::Get());
-  dict.SetMethod("unityLauncherAvailable",
-                  base::Bind(&Browser::UnityLauncherAvailable, browser));
-  dict.SetMethod("unityLauncherSetBadgeCount",
-                  base::Bind(&Browser::UnityLauncherSetBadgeCount, browser));
-  dict.SetMethod("unityLauncherGetBadgeCount",
-                  base::Bind(&Browser::UnityLauncherGetBadgeCount, browser));
 #endif
 }
 

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -118,6 +118,10 @@ void Browser::SetName(const std::string& name) {
   name_override_ = name;
 }
 
+int Browser::GetBadgeCount() {
+  return current_badge_count_;
+}
+
 bool Browser::OpenFile(const std::string& file_path) {
   bool prevent_default = false;
   FOR_EACH_OBSERVER(BrowserObserver,

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -119,7 +119,7 @@ void Browser::SetName(const std::string& name) {
 }
 
 int Browser::GetBadgeCount() {
-  return current_badge_count_;
+  return badge_count_;
 }
 
 bool Browser::OpenFile(const std::string& file_path) {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -88,7 +88,7 @@ class Browser : public WindowListObserver {
   bool IsDefaultProtocolClient(const std::string& protocol);
 
   // Set/Get the badge count.
-  void SetBadgeCount(int count);
+  bool SetBadgeCount(int count);
   int GetBadgeCount();
 
 #if defined(OS_MACOSX)

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -87,6 +87,10 @@ class Browser : public WindowListObserver {
   // Query the current state of default handler for a protocol.
   bool IsDefaultProtocolClient(const std::string& protocol);
 
+  // Set/Get the badge count.
+  void SetBadgeCount(int count);
+  int GetBadgeCount();
+
 #if defined(OS_MACOSX)
   // Hide the application.
   void Hide();
@@ -152,10 +156,8 @@ class Browser : public WindowListObserver {
 #endif  // defined(OS_WIN)
 
 #if defined(OS_LINUX)
-  // Set/Get unity dock's badge counter.
-  bool UnityLauncherAvailable();
-  void UnityLauncherSetBadgeCount(int count);
-  int UnityLauncherGetBadgeCount();
+  // Whether Unity launcher is running.
+  bool IsUnityRunning();
 #endif  // defined(OS_LINUX)
 
   // Tell the application to open a file.
@@ -223,9 +225,7 @@ class Browser : public WindowListObserver {
   std::string version_override_;
   std::string name_override_;
 
-#if defined(OS_LINUX)
   int current_badge_count_ = 0;
-#endif
 
 #if defined(OS_WIN)
   base::string16 app_user_model_id_;

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -225,7 +225,7 @@ class Browser : public WindowListObserver {
   std::string version_override_;
   std::string name_override_;
 
-  int current_badge_count_ = 0;
+  int badge_count_ = 0;
 
 #if defined(OS_WIN)
   base::string16 app_user_model_id_;

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -47,6 +47,11 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
   return false;
 }
 
+void Browser::SetBadgeCount(int count) {
+  current_badge_count_ = count;
+  unity::SetDownloadCount(count);
+}
+
 std::string Browser::GetExecutableFileVersion() const {
   return brightray::GetApplicationVersion();
 }
@@ -55,19 +60,8 @@ std::string Browser::GetExecutableFileProductName() const {
   return brightray::GetApplicationName();
 }
 
-bool Browser::UnityLauncherAvailable() {
+bool Browser::IsUnityRunning() {
   return unity::IsRunning();
-}
-
-void Browser::UnityLauncherSetBadgeCount(int count) {
-  if (UnityLauncherAvailable()) {
-    current_badge_count_ = count;
-    unity::SetDownloadCount(count);
-  }
-}
-
-int Browser::UnityLauncherGetBadgeCount() {
-  return current_badge_count_;
 }
 
 }  // namespace atom

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -47,9 +47,14 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
   return false;
 }
 
-void Browser::SetBadgeCount(int count) {
-  current_badge_count_ = count;
-  unity::SetDownloadCount(count);
+bool Browser::SetBadgeCount(int count) {
+  if (IsUnityRunning()) {
+    unity::SetDownloadCount(count);
+    current_badge_count_ = count;
+    return true;
+  } else {
+    return false;
+  }
 }
 
 std::string Browser::GetExecutableFileVersion() const {

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -50,7 +50,7 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
 bool Browser::SetBadgeCount(int count) {
   if (IsUnityRunning()) {
     unity::SetDownloadCount(count);
-    current_badge_count_ = count;
+    badge_count_ = count;
     return true;
   } else {
     return false;

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -11,8 +11,8 @@
 #include "atom/browser/window_list.h"
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
-#include "base/strings/sys_string_conversions.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/sys_string_conversions.h"
 #include "brightray/common/application_info.h"
 #include "net/base/mac/url_conversions.h"
 #include "url/gurl.h"
@@ -117,7 +117,7 @@ void Browser::SetAppUserModelID(const base::string16& name) {
 
 bool Browser::SetBadgeCount(int count) {
   DockSetBadgeText(count != 0 ? base::IntToString(count) : "");
-  current_badge_count_ = count;
+  badge_count_ = count;
   return true;
 }
 

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -115,9 +115,10 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
 void Browser::SetAppUserModelID(const base::string16& name) {
 }
 
-void Browser::SetBadgeCount(int count) {
+bool Browser::SetBadgeCount(int count) {
+  DockSetBadgeText(count != 0 ? base::IntToString(count) : "");
   current_badge_count_ = count;
-  DockSetBadgeText(count == 0 ? base::IntToString(count) : "");
+  return true;
 }
 
 void Browser::SetUserActivity(const std::string& type,

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -12,6 +12,7 @@
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
 #include "base/strings/sys_string_conversions.h"
+#include "base/strings/string_number_conversions.h"
 #include "brightray/common/application_info.h"
 #include "net/base/mac/url_conversions.h"
 #include "url/gurl.h"
@@ -112,6 +113,11 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
 }
 
 void Browser::SetAppUserModelID(const base::string16& name) {
+}
+
+void Browser::SetBadgeCount(int count) {
+  current_badge_count_ = count;
+  DockSetBadgeText(count == 0 ? base::IntToString(count) : "");
 }
 
 void Browser::SetUserActivity(const std::string& type,

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -269,6 +269,10 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
   }
 }
 
+void Browser::SetBadgeCount(int count) {
+  current_badge_count_ = count;
+}
+
 PCWSTR Browser::GetAppUserModelID() {
   if (app_user_model_id_.empty()) {
     SetAppUserModelID(base::ReplaceStringPlaceholders(

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -269,8 +269,8 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
   }
 }
 
-void Browser::SetBadgeCount(int count) {
-  current_badge_count_ = count;
+bool Browser::SetBadgeCount(int count) {
+  return false;
 }
 
 PCWSTR Browser::GetAppUserModelID() {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -582,7 +582,7 @@ This method can only be called before app is ready.
 * `count` Integer
 
 Sets the counter badge for current app. Setting the count to `0` will hide the
-badge.
+badge. Returns `true` when the call succeeded, otherwise returns `false`.
 
 On macOS it shows on the dock icon. On Linux it only works for Unity launcher,
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -577,6 +577,26 @@ Disables hardware acceleration for current app.
 
 This method can only be called before app is ready.
 
+### `app.setBadgeCount(count)` _Linux_ _macOS_
+
+* `count` Integer
+
+Sets the counter badge for current app. Setting the count to `0` will hide the
+badge.
+
+On macOS it shows on the dock icon. On Linux it only works for Unity launcher,
+
+**Note:** Unity launcher requires the exsistence of `.desktop` file to work, for
+more please read [Desktop Environment Integration][unity-requiremnt]
+
+### `app.getBadgeCount()` _Linux_ _macOS_
+
+Returns the current value displayed in the counter badge.
+
+### `app.isUnityRunning()` _Linux_
+
+Returns whether current desktop environment is Unity launcher.
+
 ### `app.commandLine.appendSwitch(switch[, value])`
 
 Append a switch (with optional `value`) to Chromium's command line.
@@ -647,31 +667,6 @@ Sets the application's [dock menu][dock-menu].
 
 Sets the `image` associated with this dock icon.
 
-### `app.launcher.setBadgeCount(count)` _Linux_
-* `count` Integer
-
-Sets the number to be displayed next to the app icon in the Unity launcher.
-Setting the count to `0` will hide the badge.
-
-**Note:** This feature is currently only supported on Ubuntu Unity. Calling this function has no effect when the application is running in a different environment.
-
-**Note:** You need to specify the .desktop file name to the `desktopName` field in package.json. By default, it will assume `app.getName().desktop` in packaged apps.
-
-### `app.launcher.getBadgeCount()` _Linux_
-
-Returns the current value displayed in the counter badge next to the launcher icon.
-
-**Note:** As `setBadgeCount` only supports Ubuntu Unity, the value will be 0 when the application is running in a different environment.
-
-### `app.launcher.isUnityRunning()` _Linux_
-
-This method checks if the current desktop environment is Unity and returns `true` in this case.
-
-### `app.launcher.isCounterBadgeAvailable()` _Linux_
-
-This method checks if the current desktop environment supports an app icon counter badge and returns `true` in this case.
-
-
 [dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103
 [tasks]:http://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
@@ -679,3 +674,4 @@ This method checks if the current desktop environment supports an app icon count
 [LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/#//apple_ref/c/func/LSCopyDefaultHandlerForURLScheme
 [handoff]: https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/HandoffFundamentals/HandoffFundamentals.html
 [activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
+[unity-requiremnt]: ../tutorial/desktop-environment-integration.md#unity-launcher-shortcuts-linux

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -586,8 +586,8 @@ badge. Returns `true` when the call succeeded, otherwise returns `false`.
 
 On macOS it shows on the dock icon. On Linux it only works for Unity launcher,
 
-**Note:** Unity launcher requires the exsistence of `.desktop` file to work, for
-more please read [Desktop Environment Integration][unity-requiremnt]
+**Note:** Unity launcher requires the exsistence of a `.desktop` file to work,
+for more information please read [Desktop Environment Integration][unity-requiremnt].
 
 ### `app.getBadgeCount()` _Linux_ _macOS_
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -287,7 +287,7 @@ describe('app module', function () {
 
   describe('app.setBadgeCount API', function () {
     const shouldFail = process.platform === 'win32' ||
-                       (process.platform === 'linux' && app.isUnityRunning())
+                       (process.platform === 'linux' && !app.isUnityRunning())
 
     it('returns false when failed', function () {
       assert.equal(app.setBadgeCount(42), !shouldFail)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -285,36 +285,10 @@ describe('app module', function () {
     })
   })
 
-  describe('app.launcher API', function () {
-    it('should be available on linux', function () {
-      if (process.platform !== 'linux') {
-        assert.equal(app.launcher, undefined)
-      } else {
-        assert.notEqual(app.launcher, undefined)
-      }
-    })
-
-    it('should be possible to set a badge count on supported environments', function () {
-      if (process.platform === 'linux' &&
-          app.launcher.isCounterBadgeAvailable()) {
-        app.launcher.setBadgeCount(42)
-        assert.equal(app.launcher.getBadgeCount(), 42)
-      }
-    })
-
-    it('should be possible to set a badge count on unity', function () {
-      if (process.platform === 'linux' &&
-          app.launcher.isUnityRunning()) {
-        assert.equal(app.launcher.isCounterBadgeAvailable(), true)
-      }
-    })
-
-    it('should not be possible to set a badge counter on unsupported environments', function () {
-      if (process.platform === 'linux' &&
-          !app.launcher.isCounterBadgeAvailable()) {
-        app.launcher.setBadgeCount(42)
-        assert.equal(app.launcher.getBadgeCount(), 0)
-      }
+  describe('app.getBadgeCount API', function () {
+    it('should set a badge count', function () {
+      app.setBadgeCount(42)
+      assert.equal(app.getBadgeCount(), 42)
     })
   })
 })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -285,10 +285,17 @@ describe('app module', function () {
     })
   })
 
-  describe('app.getBadgeCount API', function () {
+  describe('app.setBadgeCount API', function () {
+    const shouldFail = process.platform === 'win32' ||
+                       (process.platform === 'linux' && app.isUnityRunning())
+
+    it('returns false when failed', function () {
+      assert.equal(app.setBadgeCount(42), !shouldFail)
+    })
+
     it('should set a badge count', function () {
       app.setBadgeCount(42)
-      assert.equal(app.getBadgeCount(), 42)
+      assert.equal(app.getBadgeCount(), shouldFail ? 0 : 42)
     })
   })
 })


### PR DESCRIPTION
This PR implements `app.setBadgeCount` on Mac and moves APIs under `app.launcher` to `app`.

`app.launcher` is probably not a good name because `launcher` also means a popular type of programs, and since we are making `setBadgeCount` work on other platforms, there is no meaning to keep the `app.launcher` set of APIs.

Also for the `isCounterBadgeAvailable` API, generally for cross-platform APIs they should usually silently fail on platforms that do not support them, so users don't have to worry about platform differences. In the case of `app.setBadgeCount`, there is no case that users would care whether the call succeed, so I'm removing it.