### PR TITLE
Override the Notification API constructor to create silent notificatons when the webContents is muted

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -303,6 +303,13 @@ void AtomBrowserClient::WebNotificationAllowed(
   permission_helper->RequestWebNotificationPermission(callback);
 }
 
+bool AtomBrowserClient::WebContentsAudioMuted(
+  int render_process_id) {
+    content::WebContents* web_contents =
+        WebContentsPreferences::GetWebContentsFromProcessID(render_process_id);
+    return web_contents->IsAudioMuted();
+  }
+
 void AtomBrowserClient::RenderProcessHostDestroyed(
     content::RenderProcessHost* host) {
   int process_id = host->GetID();

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -101,6 +101,8 @@ class AtomBrowserClient : public brightray::BrowserClient,
   void WebNotificationAllowed(
       int render_process_id,
       const base::Callback<void(bool)>& callback) override;
+  bool WebContentsAudioMuted(
+    int render_process_id) override;
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -248,14 +248,3 @@ Object.defineProperty(document, 'visibilityState', {
     return cachedVisibilityState
   }
 })
-
-// Make notifications silent if the the current webContents is muted
-const NativeNotification = window.Notification
-class Notification extends NativeNotification {
-  constructor (title, opts) {
-    super(title, Object.assign({
-      silent: remote.getCurrentWebContents().isAudioMuted()
-    }, opts))
-  }
-}
-window.Notification = Notification

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -248,3 +248,14 @@ Object.defineProperty(document, 'visibilityState', {
     return cachedVisibilityState
   }
 })
+
+// Make notifications silent if the the current webContents is muted
+const NativeNotification = window.Notification
+class Notification extends NativeNotification {
+  constructor (title, opts) {
+    super(title, Object.assign({
+      silent: remote.getCurrentWebContents().isAudioMuted()
+    }, opts))
+  }
+}
+window.Notification = Notification


### PR DESCRIPTION
Wraps the native Notification class provided by Brightway and ensures that (unless specified in the constructor) that muted webcontents make silent notifications

Fixes #5983