### PR TITLE
Don't use MatchesExtension for matching filters

### DIFF
--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -211,7 +211,9 @@ base::FilePath FileChooserDialog::AddExtensionForFilename(
 
   const auto& extensions = filters_[i].second;
   for (const auto& extension : extensions) {
-    if (extension == "*" || path.MatchesExtension("." + extension))
+    if (extension == "*" ||
+        base::EndsWith(path.value(), "." + extension,
+                       base::CompareCase::INSENSITIVE_ASCII))
       return path;
   }
 


### PR DESCRIPTION
MatchesExtension compares double extensions like .tar.gz, which does not match the filters.

Close #6305.