### PR TITLE
Set window icon before showing window

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -106,9 +106,6 @@ Window::Window(v8::Isolate* isolate, const mate::Dictionary& options) {
       options,
       parent.IsEmpty() ? nullptr : parent->window_.get()));
   web_contents->SetOwnerWindow(window_.get());
-  window_->InitFromOptions(options);
-  window_->AddObserver(this);
-  AttachAsUserData(window_.get());
 
 #if defined(TOOLKIT_VIEWS)
   // Sets the window icon.
@@ -116,6 +113,10 @@ Window::Window(v8::Isolate* isolate, const mate::Dictionary& options) {
   if (options.Get(options::kIcon, &icon))
     SetIcon(icon);
 #endif
+
+  window_->InitFromOptions(options);
+  window_->AddObserver(this);
+  AttachAsUserData(window_.get());
 }
 
 Window::~Window() {


### PR DESCRIPTION
On Linux if we set icon after window shows, weird things will happen.

Close #6205.