### PR TITLE
Use require to load package.json

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -119,7 +119,7 @@ for (i = 0, len = searchPaths.length; i < len; i++) {
   packagePath = searchPaths[i]
   try {
     packagePath = path.join(process.resourcesPath, packagePath)
-    packageJson = JSON.parse(fs.readFileSync(path.join(packagePath, 'package.json')))
+    packageJson = require(path.join(packagePath, 'package.json'))
     break
   } catch (error) {
     continue


### PR DESCRIPTION
This pull request uses `require` instead of `JSON.parse` + `fs.readFileSync` to load the app's package.json so that a `BOM`, if included, is stripped.

Closes #6353