### PR TITLE
Add <webview>.capturePage([rect,] callback)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1276,11 +1276,10 @@ void WebContents::CapturePage(mate::Arguments* args) {
   if (scale > 1.0f)
     bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
 
-  host->CopyFromBackingStore(
-      gfx::Rect(rect.origin(), view_size),
-      bitmap_size,
-      base::Bind(&OnCapturePageDone, callback),
-      kBGRA_8888_SkColorType);
+  host->CopyFromBackingStore(gfx::Rect(rect.origin(), view_size),
+                             bitmap_size,
+                             base::Bind(&OnCapturePageDone, callback),
+                             kBGRA_8888_SkColorType);
 }
 
 void WebContents::OnCursorChange(const content::WebCursor& cursor) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1272,7 +1272,9 @@ void WebContents::CapturePage(mate::Arguments* args) {
   host->CopyFromBackingStore(
       gfx::Rect(rect.origin(), view_size),
       bitmap_size,
-      base::Bind(&WebContents::OnCapturePageDone, base::Unretained(this), callback),
+      base::Bind(&WebContents::OnCapturePageDone,
+                base::Unretained(this),
+                callback),
       kBGRA_8888_SkColorType);
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -239,6 +239,13 @@ content::ServiceWorkerContext* GetServiceWorkerContext(
   return storage_partition->GetServiceWorkerContext();
 }
 
+// Called when CapturePage is done.
+void OnCapturePageDone(base::Callback<void(const gfx::Image&)> callback,
+                       const SkBitmap& bitmap,
+                       content::ReadbackResponse response) {
+  callback.Run(gfx::Image::CreateFrom1xBitmap(bitmap));
+}
+
 }  // namespace
 
 WebContents::WebContents(v8::Isolate* isolate,
@@ -1272,19 +1279,8 @@ void WebContents::CapturePage(mate::Arguments* args) {
   host->CopyFromBackingStore(
       gfx::Rect(rect.origin(), view_size),
       bitmap_size,
-      base::Bind(&WebContents::OnCapturePageDone,
-                base::Unretained(this),
-                callback),
+      base::Bind(&OnCapturePageDone, callback),
       kBGRA_8888_SkColorType);
-}
-
-void WebContents::OnCapturePageDone(
-    base::Callback<void(const gfx::Image&)> callback,
-    const SkBitmap& bitmap,
-    content::ReadbackResponse response) {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
-  callback.Run(gfx::Image::CreateFrom1xBitmap(bitmap));
 }
 
 void WebContents::OnCursorChange(const content::WebCursor& cursor) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -65,6 +65,7 @@
 #include "net/url_request/url_request_context.h"
 #include "third_party/WebKit/public/web/WebInputEvent.h"
 #include "third_party/WebKit/public/web/WebFindOptions.h"
+#include "ui/gfx/screen.h"
 
 #include "atom/common/node_includes.h"
 
@@ -1235,6 +1236,55 @@ void WebContents::StartDrag(const mate::Dictionary& item,
   }
 }
 
+void WebContents::CapturePage(mate::Arguments* args) {
+  gfx::Rect rect;
+  base::Callback<void(const gfx::Image&)> callback;
+
+  if (!(args->Length() == 1 && args->GetNext(&callback)) &&
+      !(args->Length() == 2 && args->GetNext(&rect)
+                            && args->GetNext(&callback))) {
+    args->ThrowError();
+    return;
+  }
+
+  const auto view = web_contents()->GetRenderWidgetHostView();
+  const auto host = view ? view->GetRenderWidgetHost() : nullptr;
+  if (!view || !host) {
+    callback.Run(gfx::Image());
+    return;
+  }
+
+  // Capture full page if user doesn't specify a |rect|.
+  const gfx::Size view_size = rect.IsEmpty() ? view->GetViewBounds().size() :
+                                               rect.size();
+
+  // By default, the requested bitmap size is the view size in screen
+  // coordinates.  However, if there's more pixel detail available on the
+  // current system, increase the requested bitmap size to capture it all.
+  gfx::Size bitmap_size = view_size;
+  const gfx::NativeView native_view = view->GetNativeView();
+  const float scale =
+      gfx::Screen::GetScreen()->GetDisplayNearestWindow(native_view)
+      .device_scale_factor();
+  if (scale > 1.0f)
+    bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
+
+  host->CopyFromBackingStore(
+      gfx::Rect(rect.origin(), view_size),
+      bitmap_size,
+      base::Bind(&WebContents::OnCapturePageDone, base::Unretained(this), callback),
+      kBGRA_8888_SkColorType);
+}
+
+void WebContents::OnCapturePageDone(
+    base::Callback<void(const gfx::Image&)> callback,
+    const SkBitmap& bitmap,
+    content::ReadbackResponse response) {
+  v8::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+  callback.Run(gfx::Image::CreateFrom1xBitmap(bitmap));
+}
+
 void WebContents::OnCursorChange(const content::WebCursor& cursor) {
   content::WebCursor::CursorInfo info;
   cursor.GetCursorInfo(&info);
@@ -1370,6 +1420,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("removeWorkSpace", &WebContents::RemoveWorkSpace)
       .SetMethod("showDefinitionForSelection",
                  &WebContents::ShowDefinitionForSelection)
+      .SetMethod("capturePage", &WebContents::CapturePage)
       .SetProperty("id", &WebContents::ID)
       .SetProperty("session", &WebContents::Session)
       .SetProperty("hostWebContents", &WebContents::HostWebContents)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -54,6 +54,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   using PrintToPDFCallback =
       base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>)>;
 
+  using CapturePageCallback = base::Callback<void(const SkBitmap& bitmap)>;
+
   // Create from an existing WebContents.
   static mate::Handle<WebContents> CreateFrom(
       v8::Isolate* isolate, content::WebContents* web_contents);
@@ -145,6 +147,10 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // Dragging native items.
   void StartDrag(const mate::Dictionary& item, mate::Arguments* args);
 
+  // Captures the page with |rect|, |callback| would be called when capturing is
+  // done.
+  void CapturePage(mate::Arguments* args);
+
   // Methods for creating <webview>.
   void SetSize(const SetSizeParams& params);
   bool IsGuest() const;
@@ -158,6 +164,11 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void OnCreateWindow(const GURL& target_url,
                       const std::string& frame_name,
                       WindowOpenDisposition disposition);
+
+  // Called when CapturePage is done.
+  void OnCapturePageDone(base::Callback<void(const gfx::Image&)>,
+                         const SkBitmap& bitmap,
+                         content::ReadbackResponse response);
 
   // Returns the web preferences of current WebContents.
   v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -163,11 +163,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
                       const std::string& frame_name,
                       WindowOpenDisposition disposition);
 
-  // Called when CapturePage is done.
-  void OnCapturePageDone(base::Callback<void(const gfx::Image&)>,
-                         const SkBitmap& bitmap,
-                         content::ReadbackResponse response);
-
   // Returns the web preferences of current WebContents.
   v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate);
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -54,8 +54,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   using PrintToPDFCallback =
       base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>)>;
 
-  using CapturePageCallback = base::Callback<void(const SkBitmap& bitmap)>;
-
   // Create from an existing WebContents.
   static mate::Handle<WebContents> CreateFrom(
       v8::Isolate* isolate, content::WebContents* web_contents);

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -55,15 +55,6 @@ namespace api {
 
 namespace {
 
-void OnCapturePageDone(
-    v8::Isolate* isolate,
-    const base::Callback<void(const gfx::Image&)>& callback,
-    const SkBitmap& bitmap) {
-  v8::Locker locker(isolate);
-  v8::HandleScope handle_scope(isolate);
-  callback.Run(gfx::Image::CreateFrom1xBitmap(bitmap));
-}
-
 // Converts binary data to Buffer.
 v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
   auto buffer = node::Buffer::Copy(isolate, static_cast<char*>(val), size);
@@ -581,21 +572,6 @@ void Window::SetFocusable(bool focusable) {
   return window_->SetFocusable(focusable);
 }
 
-void Window::CapturePage(mate::Arguments* args) {
-  gfx::Rect rect;
-  base::Callback<void(const gfx::Image&)> callback;
-
-  if (!(args->Length() == 1 && args->GetNext(&callback)) &&
-      !(args->Length() == 2 && args->GetNext(&rect)
-                            && args->GetNext(&callback))) {
-    args->ThrowError();
-    return;
-  }
-
-  window_->CapturePage(
-      rect, base::Bind(&OnCapturePageDone, args->isolate(), callback));
-}
-
 void Window::SetProgressBar(double progress) {
   window_->SetProgressBar(progress);
 }
@@ -843,7 +819,6 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("focusOnWebView", &Window::FocusOnWebView)
       .SetMethod("blurWebView", &Window::BlurWebView)
       .SetMethod("isWebViewFocused", &Window::IsWebViewFocused)
-      .SetMethod("capturePage", &Window::CapturePage)
       .SetMethod("setProgressBar", &Window::SetProgressBar)
       .SetMethod("setOverlayIcon", &Window::SetOverlayIcon)
       .SetMethod("setThumbarButtons", &Window::SetThumbarButtons)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -155,7 +155,6 @@ class Window : public mate::TrackableObject<Window>,
   void SetIgnoreMouseEvents(bool ignore);
   void SetContentProtection(bool enable);
   void SetFocusable(bool focusable);
-  void CapturePage(mate::Arguments* args);
   void SetProgressBar(double progress);
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -54,8 +54,6 @@ struct DraggableRegion;
 class NativeWindow : public base::SupportsUserData,
                      public content::WebContentsObserver {
  public:
-  using CapturePageCallback = base::Callback<void(const SkBitmap& bitmap)>;
-
   class DialogScope {
    public:
     explicit DialogScope(NativeWindow* window)
@@ -179,11 +177,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual void BlurWebView();
   virtual bool IsWebViewFocused();
 
-  // Captures the page with |rect|, |callback| would be called when capturing is
-  // done.
-  virtual void CapturePage(const gfx::Rect& rect,
-                           const CapturePageCallback& callback);
-
   // Toggle the menu bar.
   virtual void SetAutoHideMenuBar(bool auto_hide);
   virtual bool IsMenuBarAutoHide();
@@ -295,11 +288,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Dispatch ReadyToShow event to observers.
   void NotifyReadyToShow();
-
-  // Called when CapturePage has done.
-  void OnCapturePageDone(const CapturePageCallback& callback,
-                         const SkBitmap& bitmap,
-                         content::ReadbackResponse response);
 
   // Whether window has standard frame.
   bool has_frame_;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -892,17 +892,7 @@ Whether the window's document has been edited.
 
 ### `win.capturePage([rect, ]callback)`
 
-* `rect` Object (optional) - The area of page to be captured
-  * `x` Integer
-  * `y` Integer
-  * `width` Integer
-  * `height` Integer
-* `callback` Function
-
-Captures a snapshot of the page within `rect`. Upon completion `callback` will
-be called with `callback(image)`. The `image` is an instance of
-[NativeImage](native-image.md) that stores data of the snapshot. Omitting
-`rect` will capture the whole visible page.
+Same as `webContents.capturePage([rect, ]callback)`.
 
 ### `win.loadURL(url[, options])`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -664,6 +664,20 @@ webContents.on('found-in-page', (event, result) => {
 const requestId = webContents.findInPage('api');
 ```
 
+### `webContents.capturePage([rect, ]callback)`
+
+* `rect` Object (optional) - The area of the page to be captured
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+* `callback` Function
+
+Captures a snapshot of the page within `rect`. Upon completion `callback` will
+be called with `callback(image)`. The `image` is an instance of
+[NativeImage](native-image.md) that stores data of the snapshot. Omitting
+`rect` will capture the whole visible page.
+
 ### `webContents.hasServiceWorker(callback)`
 
 * `callback` Function

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -469,6 +469,20 @@ Prints `webview`'s web page. Same with `webContents.print([options])`.
 
 Prints `webview`'s web page as PDF, Same with `webContents.printToPDF(options, callback)`
 
+### `<webview>.capturePage([rect, ]callback)`
+
+* `rect` Object (optional) - The area of the page to be captured
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+* `callback` Function
+
+Captures a snapshot of the page within `rect`. Upon completion `callback` will
+be called with `callback(image)`. The `image` is an instance of
+[NativeImage](native-image.md) that stores data of the snapshot. Omitting
+`rect` will capture the whole visible page.
+
 ### `<webview>.send(channel[, arg1][, arg2][, ...])`
 
 * `channel` String

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -463,25 +463,15 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
 
 ### `<webview>.print([options])`
 
-Prints `webview`'s web page. Same with `webContents.print([options])`.
+Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 ### `<webview>.printToPDF(options, callback)`
 
-Prints `webview`'s web page as PDF, Same with `webContents.printToPDF(options, callback)`
+Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
 
 ### `<webview>.capturePage([rect, ]callback)`
 
-* `rect` Object (optional) - The area of the page to be captured
-  * `x` Integer
-  * `y` Integer
-  * `width` Integer
-  * `height` Integer
-* `callback` Function
-
-Captures a snapshot of the page within `rect`. Upon completion `callback` will
-be called with `callback(image)`. The `image` is an instance of
-[NativeImage](native-image.md) that stores data of the snapshot. Omitting
-`rect` will capture the whole visible page.
+Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([rect, ]callback)`.
 
 ### `<webview>.send(channel[, arg1][, arg2][, ...])`
 

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -153,6 +153,9 @@ Object.assign(BrowserWindow.prototype, {
   },
   showDefinitionForSelection () {
     return this.webContents.showDefinitionForSelection()
+  },
+  capturePage (...args) {
+    return this.webContents.capturePage.apply(this.webContents, args)
   }
 })
 

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -386,7 +386,8 @@ var registerWebViewElement = function () {
     'inspectServiceWorker',
     'print',
     'printToPDF',
-    'showDefinitionForSelection'
+    'showDefinitionForSelection',
+    'capturePage'
   ]
   nonblockMethods = [
     'insertCSS',


### PR DESCRIPTION
This pull request moves the `capturePage` implementation from the window to the web contents so it can be used on a `<webview>` tag.

Closes #3687 