### PR TITLE
Bound the target width and height of window when calling SetSize

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -46,7 +46,6 @@ class NativeWindowMac : public NativeWindow {
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
   gfx::Rect GetBounds() override;
-  void SetSize(const gfx::Size& size, bool animate = false) override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -46,6 +46,7 @@ class NativeWindowMac : public NativeWindow {
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
   gfx::Rect GetBounds() override;
+  void SetSize(const gfx::Size& size, bool animate = false) override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -737,13 +737,21 @@ bool NativeWindowMac::IsFullscreen() const {
 }
 
 void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
+  gfx::Size bSize = gfx::Size(bounds.width(), bounds.height());
+  bSize.SetToMax(GetMinimumSize());
+
+  gfx::Size maxSize = GetMaximumSize();
+  maxSize = gfx::Size(maxSize.width() == 0 ? bSize.width() : maxSize.width(),
+    maxSize.height() == 0 ? bSize.height() : maxSize.height());
+  bSize.SetToMin(maxSize);
+
   NSRect cocoa_bounds = NSMakeRect(bounds.x(), 0,
-                                   bounds.width(),
-                                   bounds.height());
+                                   bSize.width(),
+                                   bSize.height());
   // Flip coordinates based on the primary screen.
   NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
   cocoa_bounds.origin.y =
-      NSHeight([screen frame]) - bounds.height() - bounds.y();
+      NSHeight([screen frame]) - bSize.height() - bounds.y();
 
   [window_ setFrame:cocoa_bounds display:YES animate:animate];
 }
@@ -754,17 +762,6 @@ gfx::Rect NativeWindowMac::GetBounds() {
   NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
   bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
   return bounds;
-}
-
-void NativeWindowMac::SetSize(const gfx::Size& size, bool animate) {
-  gfx::Size minSize = GetMinimumSize();
-  gfx::Size maxSize = GetMaximumSize();
-  // Bound the supplied width and height values with max and min sizes
-  int bWidth = fmax(minSize.width(), size.width());
-  bWidth = maxSize.width() == 0 ? bWidth : fmin(maxSize.width(), bWidth);
-  int bHeight = fmax(minSize.height(), size.height());
-  bHeight = maxSize.height() == 0 ? bHeight : fmin(maxSize.height(), bHeight);
-  SetBounds(gfx::Rect(GetPosition(), gfx::Size(bWidth, bHeight)), animate);
 }
 
 void NativeWindowMac::SetContentSizeConstraints(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -756,6 +756,17 @@ gfx::Rect NativeWindowMac::GetBounds() {
   return bounds;
 }
 
+void NativeWindowMac::SetSize(const gfx::Size& size, bool animate) {
+  gfx::Size minSize = GetMinimumSize();
+  gfx::Size maxSize = GetMaximumSize();
+  // Bound the supplied width and height values with max and min sizes
+  int bWidth = fmax(minSize.width(), size.width());
+  bWidth = maxSize.width() == 0 ? bWidth : fmin(maxSize.width(), bWidth);
+  int bHeight = fmax(minSize.height(), size.height());
+  bHeight = maxSize.height() == 0 ? bHeight : fmin(maxSize.height(), bHeight);
+  SetBounds(gfx::Rect(GetPosition(), gfx::Size(bWidth, bHeight)), animate);
+}
+
 void NativeWindowMac::SetContentSizeConstraints(
     const extensions::SizeConstraints& size_constraints) {
   auto convertSize = [this](const gfx::Size& size) {


### PR DESCRIPTION
This fixes #6347 by bounding the width and height values by the MinimumSize and MaximumSize bounds of the window.