### PR TITLE
Handle remote arguments with no constructor

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -60,7 +60,7 @@ var wrapArgs = function (args, visited) {
 
       ret = {
         type: 'object',
-        name: value.constructor.name,
+        name: (value.constructor && value.constructor.name) ? value.constructor.name : 'Object',
         members: []
       }
       for (prop in value) {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -60,7 +60,7 @@ var wrapArgs = function (args, visited) {
 
       ret = {
         type: 'object',
-        name: value.constructor != null ? value.constructor.name : 'Object',
+        name: value.constructor != null ? value.constructor.name : '',
         members: []
       }
       for (prop in value) {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -60,7 +60,7 @@ var wrapArgs = function (args, visited) {
 
       ret = {
         type: 'object',
-        name: (value.constructor && value.constructor.name) ? value.constructor.name : 'Object',
+        name: value.constructor != null ? value.constructor.name : 'Object',
         members: []
       }
       for (prop in value) {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -37,7 +37,7 @@ describe('ipc module', function () {
       assert.equal(a.bar, 1234)
       assert.equal(a.anonymous.constructor.name, '')
       assert.equal(a.getConstructorName(Object.create(null)), '')
-      assert.equal(a.getConstructorName(new class {}), '')
+      assert.equal(a.getConstructorName(new (class {})), '')
     })
 
     it('should search module from the user app', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -34,6 +34,7 @@ describe('ipc module', function () {
       assert.equal(a.foo.bar, 'baz')
       assert.equal(a.foo.baz, false)
       assert.equal(a.bar, 1234)
+      assert.equal(a.baz(Object.create(null)), 'hello')
     })
 
     it('should search module from the user app', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -35,8 +35,9 @@ describe('ipc module', function () {
       assert.equal(a.foo.bar, 'baz')
       assert.equal(a.foo.baz, false)
       assert.equal(a.bar, 1234)
+      assert.equal(a.anonymous.constructor.name, '')
       assert.equal(a.getConstructorName(Object.create(null)), '')
-      assert.equal(a.getConstructorName(new (class {})), '')
+      assert.equal(a.getConstructorName(new class {}), '')
     })
 
     it('should search module from the user app', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -34,7 +34,8 @@ describe('ipc module', function () {
       assert.equal(a.foo.bar, 'baz')
       assert.equal(a.foo.baz, false)
       assert.equal(a.bar, 1234)
-      assert.equal(a.baz(Object.create(null)), 'hello')
+      assert.equal(a.getConstructorName(Object.create(null)), 'Object')
+      assert.equal(a.getConstructorName(new (class {})), '')
     })
 
     it('should search module from the user app', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -31,10 +31,11 @@ describe('ipc module', function () {
 
     it('should work when object has no prototype', function () {
       var a = remote.require(path.join(fixtures, 'module', 'no-prototype.js'))
+      assert.equal(a.foo.constructor.name, '')
       assert.equal(a.foo.bar, 'baz')
       assert.equal(a.foo.baz, false)
       assert.equal(a.bar, 1234)
-      assert.equal(a.getConstructorName(Object.create(null)), 'Object')
+      assert.equal(a.getConstructorName(Object.create(null)), '')
       assert.equal(a.getConstructorName(new (class {})), '')
     })
 

--- a/spec/fixtures/module/no-prototype.js
+++ b/spec/fixtures/module/no-prototype.js
@@ -1,4 +1,10 @@
 const foo = Object.create(null)
 foo.bar = 'baz'
 foo.baz = false
-module.exports = {foo: foo, bar: 1234}
+module.exports = {
+  foo: foo,
+  bar: 1234,
+  baz: function () {
+    return 'hello'
+  }
+}

--- a/spec/fixtures/module/no-prototype.js
+++ b/spec/fixtures/module/no-prototype.js
@@ -4,7 +4,7 @@ foo.baz = false
 module.exports = {
   foo: foo,
   bar: 1234,
-  anonymous: new class {},
+  anonymous: new (class {}),
   getConstructorName: function (value) {
     return value.constructor.name
   }

--- a/spec/fixtures/module/no-prototype.js
+++ b/spec/fixtures/module/no-prototype.js
@@ -4,6 +4,7 @@ foo.baz = false
 module.exports = {
   foo: foo,
   bar: 1234,
+  anonymous: new class {},
   getConstructorName: function (value) {
     return value.constructor.name
   }

--- a/spec/fixtures/module/no-prototype.js
+++ b/spec/fixtures/module/no-prototype.js
@@ -4,7 +4,7 @@ foo.baz = false
 module.exports = {
   foo: foo,
   bar: 1234,
-  baz: function () {
-    return 'hello'
+  getConstructorName: function (value) {
+    return value.constructor.name
   }
 }


### PR DESCRIPTION
Continuation of #6360 with an added spec.

Use `''` as the `name` when the object argument has no constructor. This makes the behavior for arguments the same as the behavior of return values.

Refs #5736
Closes #6360 