### PR TITLE
Give menu a chance to handle keydown event before window

### DIFF
--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -27,6 +27,11 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
   if (event.windowsKeyCode == ui::VKEY_ESCAPE && is_html_fullscreen())
     ExitFullscreenModeForTab(source);
 
+  // Send the event to the menu before sending it to the window
+  if (event.os_event.type == NSKeyDown &&
+      [[NSApp mainMenu] performKeyEquivalent:event.os_event])
+    return;
+
   if (event.os_event.window)
     [event.os_event.window redispatchKeyEvent:event.os_event];
 }


### PR DESCRIPTION
Pull request #6068 introduced a regression where menu shortcuts with no modifiers would no longer fire.

This pull request adds back the key forwarding to the main menu before it gets re-dispatched to the window, it was previously done as https://github.com/electron/electron/pull/6068/files#diff-00f46b45a76b7daf5efc593cfbbba7c9L25

This seems like the needed behavior after reading https://cs.chromium.org/chromium/src/chrome/browser/ui/cocoa/browser_window_utils.mm?l=63

Closes #6362