### PR TITLE
Add login item API

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -527,8 +527,6 @@ void App::BuildPrototype(
       .SetMethod("show", base::Bind(&Browser::Show, browser))
       .SetMethod("setUserActivity",
                  base::Bind(&Browser::SetUserActivity, browser))
-      .SetMethod("getLoginItemLaunchStatus",
-                 base::Bind(&Browser::GetLoginItemLaunchStatus, browser))
       .SetMethod("getLoginItemStatus",
                  base::Bind(&Browser::GetLoginItemStatus, browser))
       .SetMethod("setAsLoginItem",

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -71,6 +71,33 @@ struct Converter<Browser::UserTask> {
 };
 #endif
 
+#if defined(OS_MACOSX)
+template<>
+struct Converter<Browser::LoginItemSettings> {
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+                     Browser::LoginItemSettings* out) {
+    mate::Dictionary dict;
+    if (!ConvertFromV8(isolate, val, &dict))
+      return false;
+
+    dict.Get("openAtLogin", &(out->open_at_login));
+    dict.Get("openAsHidden", &(out->open_as_hidden));
+    return true;
+  }
+
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   Browser::LoginItemSettings val) {
+    mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+    dict.Set("openAtLogin", val.open_at_login);
+    dict.Set("openAsHidden", val.open_as_hidden);
+    dict.Set("restoreState", val.restore_state);
+    dict.Set("openedAtLogin", val.opened_at_login);
+    dict.Set("openedAsHidden", val.opened_as_hidden);
+    return dict.GetHandle();
+  }
+};
+#endif
+
 }  // namespace mate
 
 
@@ -529,12 +556,10 @@ void App::BuildPrototype(
                  base::Bind(&Browser::SetUserActivity, browser))
       .SetMethod("getCurrentActivityType",
                  base::Bind(&Browser::GetCurrentActivityType, browser))
-      .SetMethod("getLoginItemStatus",
-                 base::Bind(&Browser::GetLoginItemStatus, browser))
-      .SetMethod("setAsLoginItem",
-                 base::Bind(&Browser::SetAsLoginItem, browser))
-      .SetMethod("removeAsLoginItem",
-                 base::Bind(&Browser::RemoveAsLoginItem, browser))
+      .SetMethod("getLoginItemSettings",
+                 base::Bind(&Browser::GetLoginItemSettings, browser))
+      .SetMethod("setLoginItemSettings",
+                 base::Bind(&Browser::SetLoginItemSettings, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -531,6 +531,10 @@ void App::BuildPrototype(
                  base::Bind(&Browser::GetLoginItemLaunchStatus, browser))
       .SetMethod("getLoginItemStatus",
                  base::Bind(&Browser::GetLoginItemStatus, browser))
+      .SetMethod("setAsLoginItem",
+                 base::Bind(&Browser::SetAsLoginItem, browser))
+      .SetMethod("removeAsLoginItem",
+                 base::Bind(&Browser::RemoveAsLoginItem, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -91,8 +91,8 @@ struct Converter<Browser::LoginItemSettings> {
     dict.Set("openAtLogin", val.open_at_login);
     dict.Set("openAsHidden", val.open_as_hidden);
     dict.Set("restoreState", val.restore_state);
-    dict.Set("openedAtLogin", val.opened_at_login);
-    dict.Set("openedAsHidden", val.opened_as_hidden);
+    dict.Set("wasOpenedAtLogin", val.opened_at_login);
+    dict.Set("wasOpenedAsHidden", val.opened_as_hidden);
     return dict.GetHandle();
   }
 };

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -527,6 +527,8 @@ void App::BuildPrototype(
       .SetMethod("show", base::Bind(&Browser::Show, browser))
       .SetMethod("setUserActivity",
                  base::Bind(&Browser::SetUserActivity, browser))
+      .SetMethod("getCurrentActivityType",
+                 base::Bind(&Browser::GetCurrentActivityType, browser))
       .SetMethod("getLoginItemStatus",
                  base::Bind(&Browser::GetLoginItemStatus, browser))
       .SetMethod("setAsLoginItem",

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -529,6 +529,8 @@ void App::BuildPrototype(
                  base::Bind(&Browser::SetUserActivity, browser))
       .SetMethod("getLoginItemLaunchStatus",
                  base::Bind(&Browser::GetLoginItemLaunchStatus, browser))
+      .SetMethod("getLoginItemStatus",
+                 base::Bind(&Browser::GetLoginItemStatus, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -527,8 +527,8 @@ void App::BuildPrototype(
       .SetMethod("show", base::Bind(&Browser::Show, browser))
       .SetMethod("setUserActivity",
                  base::Bind(&Browser::SetUserActivity, browser))
-      .SetMethod("getCurrentActivityType",
-                 base::Bind(&Browser::GetCurrentActivityType, browser))
+      .SetMethod("getLoginItemLaunchStatus",
+                 base::Bind(&Browser::GetLoginItemLaunchStatus, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -135,9 +135,6 @@ class Browser : public WindowListObserver {
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
 
-  // Get login item status of current app launch
-  v8::Local<v8::Value> GetLoginItemLaunchStatus(mate::Arguments* args);
-
   // Get login item status of app
   v8::Local<v8::Value> GetLoginItemStatus(mate::Arguments* args);
 

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -134,6 +134,8 @@ class Browser : public WindowListObserver {
 
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
+
+  v8::Local<v8::Value> GetLoginItemLaunchStatus(mate::Arguments* args);
 #endif  // defined(OS_MACOSX)
 
 #if defined(OS_WIN)

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -140,6 +140,12 @@ class Browser : public WindowListObserver {
 
   // Get login item status of app
   v8::Local<v8::Value> GetLoginItemStatus(mate::Arguments* args);
+
+  // Set app as a login item
+  void SetAsLoginItem(mate::Arguments* args);
+
+  // Remove app as a login item
+  void RemoveAsLoginItem();
 #endif  // defined(OS_MACOSX)
 
 #if defined(OS_WIN)

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -92,6 +92,14 @@ class Browser : public WindowListObserver {
   int GetBadgeCount();
 
 #if defined(OS_MACOSX)
+  struct LoginItemSettings {
+    bool open_at_login = false;
+    bool open_as_hidden = false;
+    bool restore_state = false;
+    bool opened_at_login = false;
+    bool opened_as_hidden = false;
+  };
+
   // Hide the application.
   void Hide();
 
@@ -135,14 +143,11 @@ class Browser : public WindowListObserver {
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
 
-  // Get login item status of app
-  v8::Local<v8::Value> GetLoginItemStatus(mate::Arguments* args);
+  // Get login item settings of app
+  LoginItemSettings GetLoginItemSettings();
 
-  // Set app as a login item
-  void SetAsLoginItem(mate::Arguments* args);
-
-  // Remove app as a login item
-  void RemoveAsLoginItem();
+  // Set login item settings of app
+  void SetLoginItemSettings(LoginItemSettings settings);
 #endif  // defined(OS_MACOSX)
 
 #if defined(OS_WIN)

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -135,7 +135,11 @@ class Browser : public WindowListObserver {
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
 
+  // Get login item status of current app launch
   v8::Local<v8::Value> GetLoginItemLaunchStatus(mate::Arguments* args);
+
+  // Get login item status of app
+  v8::Local<v8::Value> GetLoginItemStatus(mate::Arguments* args);
 #endif  // defined(OS_MACOSX)
 
 #if defined(OS_WIN)

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -11,9 +11,11 @@
 #include "atom/browser/window_list.h"
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
+#include "base/mac/mac_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brightray/common/application_info.h"
+#include "native_mate/dictionary.h"
 #include "net/base/mac/url_conversions.h"
 #include "url/gurl.h"
 
@@ -146,6 +148,14 @@ bool Browser::ContinueUserActivity(const std::string& type,
                     observers_,
                     OnContinueUserActivity(&prevent_default, type, user_info));
   return prevent_default;
+}
+
+v8::Local<v8::Value> Browser::GetLoginItemLaunchStatus(mate::Arguments* args) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(args->isolate());
+  dict.Set("loginItem", base::mac::WasLaunchedAsLoginOrResumeItem());
+  dict.Set("hidden", base::mac::WasLaunchedAsHiddenLoginItem());
+  dict.Set("restoreState", base::mac::WasLaunchedAsLoginItemRestoreState());
+  return dict.GetHandle();
 }
 
 std::string Browser::GetExecutableFileVersion() const {

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -160,11 +160,10 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings() {
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
-  if (settings.open_at_login) {
+  if (settings.open_at_login)
     base::mac::AddToLoginItems(settings.open_as_hidden);
-  } else {
+  else
     base::mac::RemoveFromLoginItems();
-  }
 }
 
 std::string Browser::GetExecutableFileVersion() const {

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -158,6 +158,14 @@ v8::Local<v8::Value> Browser::GetLoginItemLaunchStatus(mate::Arguments* args) {
   return dict.GetHandle();
 }
 
+v8::Local<v8::Value> Browser::GetLoginItemStatus(mate::Arguments* args) {
+  bool hidden = false;
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(args->isolate());
+  dict.Set("loginItem", base::mac::CheckLoginItemStatus(&hidden));
+  dict.Set("hidden", hidden);
+  return dict.GetHandle();
+}
+
 std::string Browser::GetExecutableFileVersion() const {
   return brightray::GetApplicationVersion();
 }

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -150,19 +150,15 @@ bool Browser::ContinueUserActivity(const std::string& type,
   return prevent_default;
 }
 
-v8::Local<v8::Value> Browser::GetLoginItemLaunchStatus(mate::Arguments* args) {
-  mate::Dictionary dict = mate::Dictionary::CreateEmpty(args->isolate());
-  dict.Set("loginItem", base::mac::WasLaunchedAsLoginOrResumeItem());
-  dict.Set("hidden", base::mac::WasLaunchedAsHiddenLoginItem());
-  dict.Set("restoreState", base::mac::WasLaunchedAsLoginItemRestoreState());
-  return dict.GetHandle();
-}
-
 v8::Local<v8::Value> Browser::GetLoginItemStatus(mate::Arguments* args) {
   bool hidden = false;
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(args->isolate());
-  dict.Set("loginItem", base::mac::CheckLoginItemStatus(&hidden));
-  dict.Set("hidden", hidden);
+  dict.Set("openAtLogin", base::mac::CheckLoginItemStatus(&hidden));
+  dict.Set("openAsHidden", hidden);
+  dict.Set("restoreState", base::mac::WasLaunchedAsLoginItemRestoreState());
+  dict.Set("openedAtLogin", base::mac::WasLaunchedAsLoginOrResumeItem());
+  dict.Set("openedAsHidden", base::mac::WasLaunchedAsHiddenLoginItem());
+
   return dict.GetHandle();
 }
 

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -166,6 +166,16 @@ v8::Local<v8::Value> Browser::GetLoginItemStatus(mate::Arguments* args) {
   return dict.GetHandle();
 }
 
+void Browser::SetAsLoginItem(mate::Arguments* args) {
+  bool hidden = false;
+  args->GetNext(&hidden);
+  base::mac::AddToLoginItems(hidden);
+}
+
+void Browser::RemoveAsLoginItem() {
+  base::mac::RemoveFromLoginItems();
+}
+
 std::string Browser::GetExecutableFileVersion() const {
   return brightray::GetApplicationVersion();
 }

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -598,6 +598,33 @@ Returns the current value displayed in the counter badge.
 
 Returns whether current desktop environment is Unity launcher.
 
+### `app.getLoginItemStatus()` _macOS_
+
+Return an Object with the login item status the app.
+
+* `openAtLogin` Boolean - `true` if the app is set to open at login.
+* `openAsHidden` Boolean - `true` if the app is set to open as hidden at login.
+* `openedAtLogin` Boolean - `true` if the app was opened at login automatically.
+* `openedAsHidden` Boolean - `true` if the app was opened as a hidden login
+  item. This indicates that the app should not open any windows at startup.
+* `restoreState` Boolean - `true` if the app was opened as a login item that
+  should restore the state from the previous session. This indicates that the
+  app should restore the windows that were open the last time the app was
+  closed.
+
+### `app.setAsLoginItem([openAsHidden])` _macOS_
+
+Set the app as a login item. This will cause the app to be opened automatically
+on login.
+
+* `openAsHidden` Boolean - `true` to hide the app when opened. Defaults to
+  `false`.
+
+### `app.removeAsLoginItem()` _macOS_
+
+Removes the app as a login item. The app will no longer be opened automatically
+on login.
+
 ### `app.commandLine.appendSwitch(switch[, value])`
 
 Append a switch (with optional `value`) to Chromium's command line.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -600,7 +600,7 @@ Returns whether current desktop environment is Unity launcher.
 
 ### `app.getLoginItemStatus()` _macOS_
 
-Return an Object with the login item status the app.
+Return an Object with the login item status of the app.
 
 * `openAtLogin` Boolean - `true` if the app is set to open at login.
 * `openAsHidden` Boolean - `true` if the app is set to open as hidden at login.
@@ -615,15 +615,17 @@ Return an Object with the login item status the app.
 ### `app.setAsLoginItem([openAsHidden])` _macOS_
 
 Set the app as a login item. This will cause the app to be opened automatically
-on login.
+at login.
 
-* `openAsHidden` Boolean - `true` to hide the app when opened. Defaults to
-  `false`.
+* `openAsHidden` Boolean - `true` to open the app as hidden. Defaults to
+  `false`. The user can edit this setting from the System Preferences so
+  `app.getLoginItemStatus().openedAsHidden` should be checked when the app
+  is opened to know the current value.
 
 ### `app.removeAsLoginItem()` _macOS_
 
 Removes the app as a login item. The app will no longer be opened automatically
-on login.
+at login.
 
 ### `app.commandLine.appendSwitch(switch[, value])`
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -598,29 +598,32 @@ Returns the current value displayed in the counter badge.
 
 Returns whether current desktop environment is Unity launcher.
 
-### `app.getLoginItemStatus()` _macOS_
+### `app.getLoginItemSettings()` _macOS_
 
 Return an Object with the login item status of the app.
 
 * `openAtLogin` Boolean - `true` if the app is set to open at login.
 * `openAsHidden` Boolean - `true` if the app is set to open as hidden at login.
-* `openedAtLogin` Boolean - `true` if the app was opened at login automatically.
-* `openedAsHidden` Boolean - `true` if the app was opened as a hidden login
+* `wasOpenedAtLogin` Boolean - `true` if the app was opened at login
+  automatically.
+* `wasOpenedAsHidden` Boolean - `true` if the app was opened as a hidden login
   item. This indicates that the app should not open any windows at startup.
 * `restoreState` Boolean - `true` if the app was opened as a login item that
   should restore the state from the previous session. This indicates that the
   app should restore the windows that were open the last time the app was
   closed.
 
-### `app.setAsLoginItem([openAsHidden])` _macOS_
+### `app.setLoginItemSettings(settings)` _macOS_
 
-Set the app as a login item. This will cause the app to be opened automatically
-at login.
+* `settings` Object
+  * `openAtLogin` Boolean - `true` to open the app at login, `false` to remove
+    the app as a login item. Defaults to `false`.
+  * `openAsHidden` Boolean - `true` to open the app as hidden. Defaults to
+    `false`. The user can edit this setting from the System Preferences so
+    `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
+    is opened to know the current value.
 
-* `openAsHidden` Boolean - `true` to open the app as hidden. Defaults to
-  `false`. The user can edit this setting from the System Preferences so
-  `app.getLoginItemStatus().openedAsHidden` should be checked when the app
-  is opened to know the current value.
+Set the app's as a login item settings.
 
 ### `app.removeAsLoginItem()` _macOS_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -600,7 +600,7 @@ Returns whether current desktop environment is Unity launcher.
 
 ### `app.getLoginItemSettings()` _macOS_
 
-Return an Object with the login item status of the app.
+Return an Object with the login item settings of the app.
 
 * `openAtLogin` Boolean - `true` if the app is set to open at login.
 * `openAsHidden` Boolean - `true` if the app is set to open as hidden at login.
@@ -623,12 +623,7 @@ Return an Object with the login item status of the app.
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value.
 
-Set the app's as a login item settings.
-
-### `app.removeAsLoginItem()` _macOS_
-
-Removes the app as a login item. The app will no longer be opened automatically
-at login.
+Set the app's login item settings.
 
 ### `app.commandLine.appendSwitch(switch[, value])`
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -315,8 +315,8 @@ describe('app module', function () {
       assert.deepEqual(app.getLoginItemSettings(), {
         openAtLogin: true,
         openAsHidden: false,
-        openedAtLogin: false,
-        openedAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
         restoreState: false
       })
 
@@ -324,8 +324,8 @@ describe('app module', function () {
       assert.deepEqual(app.getLoginItemSettings(), {
         openAtLogin: true,
         openAsHidden: true,
-        openedAtLogin: false,
-        openedAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
         restoreState: false
       })
 
@@ -333,8 +333,8 @@ describe('app module', function () {
       assert.deepEqual(app.getLoginItemSettings(), {
         openAtLogin: false,
         openAsHidden: false,
-        openedAtLogin: false,
-        openedAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
         restoreState: false
       })
     })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -302,29 +302,25 @@ describe('app module', function () {
   describe('app.getLoginItemStatus API', function () {
     if (process.platform !== 'darwin') return
 
+    beforeEach(function () {
+      assert.equal(app.getLoginItemStatus().openedAtLogin, false)
+      assert.equal(app.getLoginItemStatus().openedAsHidden, false)
+      assert.equal(app.getLoginItemStatus().restoreState, false)
+    })
+
     afterEach(function () {
       app.removeAsLoginItem()
-      assert.equal(app.getLoginItemStatus().loginItem, false)
+      assert.equal(app.getLoginItemStatus().openAtLogin, false)
     })
 
     it('returns the login item status of the app', function () {
       app.setAsLoginItem(true)
-      assert.equal(app.getLoginItemStatus().loginItem, true)
-      assert.equal(app.getLoginItemStatus().hidden, true)
+      assert.equal(app.getLoginItemStatus().openAtLogin, true)
+      assert.equal(app.getLoginItemStatus().openAsHidden, true)
 
       app.setAsLoginItem(false)
-      assert.equal(app.getLoginItemStatus().loginItem, true)
-      assert.equal(app.getLoginItemStatus().hidden, false)
-    })
-  })
-
-  describe('app.getLoginItemLaunchStatus API', function () {
-    if (process.platform !== 'darwin') return
-
-    it('returns the login item status launch of the app', function () {
-      assert.equal(app.getLoginItemLaunchStatus().loginItem, false)
-      assert.equal(app.getLoginItemLaunchStatus().hidden, false)
-      assert.equal(app.getLoginItemLaunchStatus().restoreState, false)
+      assert.equal(app.getLoginItemStatus().openAtLogin, true)
+      assert.equal(app.getLoginItemStatus().openAsHidden, false)
     })
   })
 })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -298,4 +298,33 @@ describe('app module', function () {
       assert.equal(app.getBadgeCount(), shouldFail ? 0 : 42)
     })
   })
+
+  describe('app.getLoginItemStatus API', function () {
+    if (process.platform !== 'darwin') return
+
+    afterEach(function () {
+      app.removeAsLoginItem()
+      assert.equal(app.getLoginItemStatus().loginItem, false)
+    })
+
+    it('returns the login item status of the app', function () {
+      app.setAsLoginItem(true)
+      assert.equal(app.getLoginItemStatus().loginItem, true)
+      assert.equal(app.getLoginItemStatus().hidden, true)
+
+      app.setAsLoginItem(false)
+      assert.equal(app.getLoginItemStatus().loginItem, true)
+      assert.equal(app.getLoginItemStatus().hidden, false)
+    })
+  })
+
+  describe('app.getLoginItemLaunchStatus API', function () {
+    if (process.platform !== 'darwin') return
+
+    it('returns the login item status launch of the app', function () {
+      assert.equal(app.getLoginItemLaunchStatus().loginItem, false)
+      assert.equal(app.getLoginItemLaunchStatus().hidden, false)
+      assert.equal(app.getLoginItemLaunchStatus().restoreState, false)
+    })
+  })
 })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -299,28 +299,44 @@ describe('app module', function () {
     })
   })
 
-  describe('app.getLoginItemStatus API', function () {
+  describe('app.get/setLoginItemSettings API', function () {
     if (process.platform !== 'darwin') return
 
     beforeEach(function () {
-      assert.equal(app.getLoginItemStatus().openedAtLogin, false)
-      assert.equal(app.getLoginItemStatus().openedAsHidden, false)
-      assert.equal(app.getLoginItemStatus().restoreState, false)
+      app.setLoginItemSettings({openAtLogin: false})
     })
 
     afterEach(function () {
-      app.removeAsLoginItem()
-      assert.equal(app.getLoginItemStatus().openAtLogin, false)
+      app.setLoginItemSettings({openAtLogin: false})
     })
 
     it('returns the login item status of the app', function () {
-      app.setAsLoginItem(true)
-      assert.equal(app.getLoginItemStatus().openAtLogin, true)
-      assert.equal(app.getLoginItemStatus().openAsHidden, true)
+      app.setLoginItemSettings({openAtLogin: true})
+      assert.deepEqual(app.getLoginItemSettings(), {
+        openAtLogin: true,
+        openAsHidden: false,
+        openedAtLogin: false,
+        openedAsHidden: false,
+        restoreState: false
+      })
 
-      app.setAsLoginItem(false)
-      assert.equal(app.getLoginItemStatus().openAtLogin, true)
-      assert.equal(app.getLoginItemStatus().openAsHidden, false)
+      app.setLoginItemSettings({openAtLogin: true, openAsHidden: true})
+      assert.deepEqual(app.getLoginItemSettings(), {
+        openAtLogin: true,
+        openAsHidden: true,
+        openedAtLogin: false,
+        openedAsHidden: false,
+        restoreState: false
+      })
+
+      app.setLoginItemSettings({})
+      assert.deepEqual(app.getLoginItemSettings(), {
+        openAtLogin: false,
+        openAsHidden: false,
+        openedAtLogin: false,
+        openedAsHidden: false,
+        restoreState: false
+      })
     })
   })
 })


### PR DESCRIPTION
Adds ~~3~~ 2 new APIs to `app` on macOS 🍎 that allows apps to add and remove themselves as a login item that will open at login.

### Original API

~~Also adds a `getLoginItemStatus` API that reports back if the app is currently set as a login item and if it was currently opened automatically at login.~~

- ~~`app.setAsLoginItem([openAsHidden])`~~
- ~~`app.removeAsLoginItem()`~~
- ~~`app.getLoginItemStatus()`~~

### Updated API

- `app.getLoginItemSettings()` - returns an object with the app's current settings
- `app.setLoginItemSettings(settings)` - sets the app's login item settings, can be used to both add and remove the app as a login item.

/cc @electron/maintainers any naming feedback on these APIs would be appreciated

Closes #6202