### PR TITLE
Use require to load package.json in default app

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -229,7 +229,7 @@ function loadApplicationPackage (packagePath) {
     if (fs.existsSync(packageJsonPath)) {
       let packageJson
       try {
-        packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
+        packageJson = require(packageJsonPath)
       } catch (e) {
         showErrorMessage(`Unable to parse ${packageJsonPath}\n\n${e.message}`)
         return


### PR DESCRIPTION
Follow on to #6354, missed this other case of using `JSON.parse` + `fs.readFileSync` instead of `require` for loading `package.json` which does not handle a BOM in the file.

Closes #6353