### PR TITLE
Highlight the whole eval() override

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -57,7 +57,7 @@ This is not bulletproof, but at the least, you should attempt the following:
 * Do not disable `webSecurity`. Disabling it will disable the same-origin policy.
 * Define a [`Content-Security-Policy`](http://www.html5rocks.com/en/tutorials/security/content-security-policy/)
 , and use restrictive rules (i.e. `script-src 'self'`)
-* [Override and disable `eval`](https://github.com/nylas/N1/blob/0abc5d5defcdb057120d726b271933425b75b415/static/index.js#L6)
+* [Override and disable `eval`](https://github.com/nylas/N1/blob/0abc5d5defcdb057120d726b271933425b75b415/static/index.js#L6-L8)
 , which allows strings to be executed as code.
 * Do not set `allowDisplayingInsecureContent` to true.
 * Do not set `allowRunningInsecureContent` to true.


### PR DESCRIPTION
I updated the link to hightlight not only the first line but the whole `window.eval()` override.