### PR TITLE
Use Ctrl+Q as default accelerator for quit role on Linux

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -197,9 +197,7 @@ app.once('ready', () => {
         role: 'front'
       }
     ]
-  }
-
-  if (process.platform === 'win32') {
+  } else {
     template.unshift({
       label: 'File',
       submenu: [

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -64,7 +64,7 @@ const roles = {
         default: return 'Quit'
       }
     },
-    accelerator: process.platform === 'win32' ? null : 'Command+Q',
+    accelerator: process.platform === 'win32' ? null : 'CommandOrControl+Q',
     appMethod: 'quit'
   },
   redo: {


### PR DESCRIPTION
Previously it was setting the accelerator to `Command+Q` for the `quit` menu item role on Linux when it should have been `CommandOrControl+Q`.

Also adds a `File > Quit` menu item to the default app on Linux to be consistent with Windows.