### PR TITLE
One alphabetical reordering in the docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,8 +66,8 @@ an issue:
 * [protocol](api/protocol.md)
 * [session](api/session.md)
 * [systemPreferences](api/system-preferences.md)
-* [webContents](api/web-contents.md)
 * [Tray](api/tray.md)
+* [webContents](api/web-contents.md)
 
 ### Modules for the Renderer Process (Web Page):
 


### PR DESCRIPTION
:memo: webContents, Tray -> Tray, webContents

If I get it right, only API TOCs should be ordered alphabetically, so I've left other ones (Guides, Tutorials, Development) untouched. I'm not so sure about API TOC Intro (three links below the "Synopsis"), tell me if they should be sorted alphabetically too.
