### PR TITLE
Adjust default app styles for accessibility

### DIFF
--- a/default_app/index.html
+++ b/default_app/index.html
@@ -3,7 +3,7 @@
   <title>Electron</title>
   <style>
     body {
-      color: #205161;
+      color: #3a585f;
       font-family: Roboto, -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", sans-serif;
       margin: 0;
       display: flex;
@@ -67,7 +67,7 @@
 
     a,
     a:hover {
-      color: #2ab0cb;
+      color: #5667bd;
       text-decoration: none;
     }
 

--- a/default_app/index.html
+++ b/default_app/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
   <title>Electron</title>
   <style>


### PR DESCRIPTION
I ran https://github.com/GoogleChrome/accessibility-developer-tools against the default app and there were a few failures.

- Missing `lang` attribute on `<html>` https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_01
- Low contrast ratio on link and text colors https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_color_01

The updated colors are directly from http://electron.atom.io since those had already been adjusted for contrast awhile back.

| 🔅  | 🔆  |
| --- | --- | 
| ![screen shot 2016-07-08 at 11 34 44 am](https://cloud.githubusercontent.com/assets/671378/16697757/0b419bea-4500-11e6-8547-2975855047f7.png) | ![screen shot 2016-07-08 at 11 34 30 am](https://cloud.githubusercontent.com/assets/671378/16697760/0d0b4ebc-4500-11e6-9540-ae48a1c9df2b.png) |

/cc @jlord @zeke 