### PR TITLE
Fix typo in the web-view-tag.md

### DIFF
--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -491,7 +491,7 @@ examples.
 
 Sends an input `event` to the page.
 
-See [webContents.sendInputEvent](web-contents.md##webcontentssendinputeventevent)
+See [webContents.sendInputEvent](web-contents.md#webcontentssendinputeventevent)
 for detailed description of `event` object.
 
 ### `<webview>.showDefinitionForSelection()` _macOS_


### PR DESCRIPTION
:memo: Remove a redundant # from a href hash.

web-contents.md##webcontentssendinputeventevent ->
web-contents.md#webcontentssendinputeventevent
