### PR TITLE
Clear protocol handlers on exit

### DIFF
--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -43,6 +43,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
 
  protected:
   Protocol(v8::Isolate* isolate, AtomBrowserContext* browser_context);
+  ~Protocol();
 
  private:
   // Possible errors.

--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -25,7 +25,6 @@ const char* kGeolocationProviderURL =
 }  // namespace
 
 AtomAccessTokenStore::AtomAccessTokenStore() {
-  LOG(ERROR) << "AtomAccessTokenStore";
   content::GeolocationProvider::GetInstance()->UserDidOptIntoLocationServices();
 }
 

--- a/atom/browser/net/atom_url_request_job_factory.cc
+++ b/atom/browser/net/atom_url_request_job_factory.cc
@@ -20,7 +20,7 @@ typedef net::URLRequestJobFactory::ProtocolHandler ProtocolHandler;
 AtomURLRequestJobFactory::AtomURLRequestJobFactory() {}
 
 AtomURLRequestJobFactory::~AtomURLRequestJobFactory() {
-  STLDeleteValues(&protocol_handler_map_);
+  Clear();
 }
 
 bool AtomURLRequestJobFactory::SetProtocolHandler(
@@ -75,6 +75,10 @@ ProtocolHandler* AtomURLRequestJobFactory::GetProtocolHandler(
 bool AtomURLRequestJobFactory::HasProtocolHandler(
     const std::string& scheme) const {
   return ContainsKey(protocol_handler_map_, scheme);
+}
+
+void AtomURLRequestJobFactory::Clear() {
+  STLDeleteValues(&protocol_handler_map_);
 }
 
 net::URLRequestJob* AtomURLRequestJobFactory::MaybeCreateJobWithProtocolHandler(

--- a/atom/browser/net/atom_url_request_job_factory.h
+++ b/atom/browser/net/atom_url_request_job_factory.h
@@ -39,6 +39,9 @@ class AtomURLRequestJobFactory : public net::URLRequestJobFactory {
   // Whether the protocol handler is registered by the job factory.
   bool HasProtocolHandler(const std::string& scheme) const;
 
+  // Clear all protocol handlers.
+  void Clear();
+
   // URLRequestJobFactory implementation
   net::URLRequestJob* MaybeCreateJobWithProtocolHandler(
       const std::string& scheme,


### PR DESCRIPTION
Close #6388.

This fixes a circular reference problem, the `URLRequestContextGetter` is referenced by protocol handlers, which are store in `AtomURLRequestJobFactory`, which the factory is managed by `URLRequestContextGetter`. So if we do not clear the protocol handlers, the `URLRequestContextGetter` will never get cleared.