### PR TITLE
Add thickFrame option for BrowserWindow

### DIFF
--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -220,6 +220,9 @@ class NativeWindowViews : public NativeWindow,
   // If true we have enabled a11y
   bool enabled_a11y_support_;
 
+  // Whether to show the WS_THICKFRAME style.
+  bool thick_frame_;
+
   // The icons of window and taskbar.
   base::win::ScopedHICON window_icon_;
   base::win::ScopedHICON app_icon_;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -174,6 +174,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     this below.
   * `titleBarStyle` String - The style of window title bar. See more about this
     below.
+  * `thickFrame` Boolean - Use `WS_THICKFRAME` style for frameless windows on
+    Windows, which adds standard window frame. Setting it to `false` will remove
+    window shadow and window animations. Default is `true`.
   * `webPreferences` Object - Settings of web page's features. See more about
     this below.
 


### PR DESCRIPTION
This options provides a way to remove the `WS_THICKFRAME` style for frameless window, which can achieve some special effects.

Close #4573.
Close #5060.