### PR TITLE
Fixed broken FAQ link in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ select the tag that matches your version.
 There are questions that are asked quite often, check this out before creating
 an issue:
 
-* [Electron FAQ](faq/electron-faq.md)
+* [Electron FAQ](faq.md)
 
 ## Guides
 


### PR DESCRIPTION
The FAQ link in the docs pointed to a non existent faq directory.