### PR TITLE
Correctly handle maximize/fullscreen in window without thickFrame

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -421,7 +421,7 @@ void NativeWindowViews::Maximize() {
 #if defined(OS_WIN)
   // For window without WS_THICKFRAME style, we can not call Maximize().
   if (!thick_frame_) {
-    last_normal_bounds_ = GetBounds();
+    restore_bounds_ = GetBounds();
     auto display =
         gfx::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
     SetBounds(display.work_area(), false);
@@ -439,7 +439,7 @@ void NativeWindowViews::Maximize() {
 void NativeWindowViews::Unmaximize() {
 #if defined(OS_WIN)
   if (!thick_frame_) {
-    SetBounds(last_normal_bounds_, false);
+    SetBounds(restore_bounds_, false);
     return;
   }
 #endif
@@ -484,12 +484,12 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
   // For window without WS_THICKFRAME style, we can not call SetFullscreen().
   if (!thick_frame_) {
     if (fullscreen) {
-      last_normal_bounds_ = GetBounds();
+      restore_bounds_ = GetBounds();
       auto display =
           gfx::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
       SetBounds(display.bounds(), false);
     } else {
-      SetBounds(last_normal_bounds_, false);
+      SetBounds(restore_bounds_, false);
     }
     return;
   }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -279,13 +279,6 @@ NativeWindowViews::NativeWindowViews(
   AddChildView(web_view_);
 
 #if defined(OS_WIN)
-  // Save initial window state.
-  if (fullscreen)
-    last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
-  else
-    last_window_state_ = ui::SHOW_STATE_NORMAL;
-  last_normal_size_ = widget_size_;
-
   if (!has_frame()) {
     // Set Window style so that we get a minimize and maximize animation when
     // frameless.
@@ -325,6 +318,15 @@ NativeWindowViews::NativeWindowViews(
 
   window_->CenterWindow(size);
   Layout();
+
+#if defined(OS_WIN)
+  // Save initial window state.
+  if (fullscreen)
+    last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
+  else
+    last_window_state_ = ui::SHOW_STATE_NORMAL;
+  last_normal_bounds_ = GetBounds();
+#endif
 }
 
 NativeWindowViews::~NativeWindowViews() {
@@ -419,7 +421,7 @@ void NativeWindowViews::Maximize() {
 #if defined(OS_WIN)
   // For window without WS_THICKFRAME style, we can not call Maximize().
   if (!thick_frame_) {
-    last_normal_size_ = GetSize();
+    last_normal_bounds_ = GetBounds();
     auto display =
         gfx::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
     SetBounds(display.work_area(), false);
@@ -437,7 +439,7 @@ void NativeWindowViews::Maximize() {
 void NativeWindowViews::Unmaximize() {
 #if defined(OS_WIN)
   if (!thick_frame_) {
-    NativeWindow::SetSize(last_normal_size_);
+    SetBounds(last_normal_bounds_, false);
     return;
   }
 #endif
@@ -482,12 +484,12 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
   // For window without WS_THICKFRAME style, we can not call SetFullscreen().
   if (!thick_frame_) {
     if (fullscreen) {
-      last_normal_size_ = GetSize();
+      last_normal_bounds_ = GetBounds();
       auto display =
           gfx::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
       SetBounds(display.bounds(), false);
     } else {
-      NativeWindow::SetSize(last_normal_size_);
+      SetBounds(last_normal_bounds_, false);
     }
     return;
   }

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -223,6 +223,9 @@ class NativeWindowViews : public NativeWindow,
   // Whether to show the WS_THICKFRAME style.
   bool thick_frame_;
 
+  // The bounds of window before maximize/fullscreen.
+  gfx::Rect restore_bounds_;
+
   // The icons of window and taskbar.
   base::win::ScopedHICON window_icon_;
   base::win::ScopedHICON app_icon_;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -212,7 +212,7 @@ class NativeWindowViews : public NativeWindow,
   // to receive the wrong size (#2498). To circumvent that, we keep tabs on the
   // size of the window while in the normal state (not maximized, minimized or
   // fullscreen), so we restore it correctly.
-  gfx::Size last_normal_size_;
+  gfx::Rect last_normal_bounds_;
 
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -140,7 +140,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
     case SIZE_RESTORED:
       if (last_window_state_ == ui::SHOW_STATE_NORMAL) {
         // Window was resized so we save it's new size.
-        last_normal_size_ = GetSize();
+        last_normal_bounds_ = GetBounds();
       } else {
         switch (last_window_state_) {
           case ui::SHOW_STATE_MAXIMIZED:
@@ -148,7 +148,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 
             // When the window is restored we resize it to the previous known
             // normal size.
-            NativeWindow::SetSize(last_normal_size_);
+            SetBounds(last_normal_bounds_, false);
 
             NotifyWindowUnmaximize();
             break;
@@ -161,7 +161,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 
               // When the window is restored we resize it to the previous known
               // normal size.
-              NativeWindow::SetSize(last_normal_size_);
+              SetBounds(last_normal_bounds_, false);
 
               NotifyWindowRestore();
             }


### PR DESCRIPTION
For window without thickFrame, we have to keep them always in normal window state, otherwise weird things will happen.

Close #1690.