### PR TITLE
Remove unused using decls.

### DIFF
--- a/chromium_src/chrome/browser/renderer_host/pepper/pepper_broker_message_filter.cc
+++ b/chromium_src/chrome/browser/renderer_host/pepper/pepper_broker_message_filter.cc
@@ -17,7 +17,6 @@
 
 using content::BrowserPpapiHost;
 using content::BrowserThread;
-using content::RenderProcessHost;
 
 namespace chrome {
 

--- a/chromium_src/chrome/browser/renderer_host/pepper/pepper_flash_browser_host.cc
+++ b/chromium_src/chrome/browser/renderer_host/pepper/pepper_flash_browser_host.cc
@@ -26,7 +26,6 @@
 
 using content::BrowserPpapiHost;
 using content::BrowserThread;
-using content::RenderProcessHost;
 
 namespace chrome {
 


### PR DESCRIPTION
These unused using decls are found and fixed automatically by running `misc-unused-using-decls` check in [clang-tidy](http://clang.llvm.org/extra/clang-tidy/). Tested with local build on macOS.