### PR TITLE
The fullscreen button should always be hidden for frameless window

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1098,6 +1098,9 @@ void NativeWindowMac::InstallView() {
     [view setFrame:[content_view_ bounds]];
     [content_view_ addSubview:view];
 
+    // The fullscreen button should always be hidden for frameless window.
+    [[window_ standardWindowButton:NSWindowFullScreenButton] setHidden:YES];
+
     if (title_bar_style_ != NORMAL)
       return;
 


### PR DESCRIPTION
The fullscreen button is a OS X 10.9 only thing, and we don't want to have it under frameless window. We actually had this patch at first, but it got removed some time later, probably when we introduced the titleBarStyle option.

Close #6227.