### PR TITLE
mac: Do not change window size when in fullscreen

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -737,6 +737,10 @@ bool NativeWindowMac::IsFullscreen() const {
 }
 
 void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
+  // Do nothing if in fullscreen mode.
+  if (IsFullscreen())
+    return;
+
   // Check size constraints since setFrame does not check it.
   gfx::Size size = bounds.size();
   size.SetToMax(GetMinimumSize());


### PR DESCRIPTION
This is to match the behavior on Windows and Linux.

Close #6267.