### PR TITLE
docs: electron-userland package tools links

### DIFF
--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -107,8 +107,8 @@ You can rename the `electron` executable to any name you like.
 Apart from packaging your app manually, you can also choose to use third party
 packaging tools to do the work for you:
 
-* [electron-packager](https://github.com/maxogden/electron-packager)
-* [electron-builder](https://github.com/loopline-systems/electron-builder)
+* [electron-builder](https://github.com/electron-userland/electron-builder)
+* [electron-packager](https://github.com/electron-userland/electron-packager)
 
 ## Rebranding by Rebuilding Electron from Source
 


### PR DESCRIPTION
`electron-packager` and `electron-builder` now in the `electron-userland` github org — links fixed.

Link to `electron-packager` placed after `electron-builder` because 
* user often needs to pack into distributable format
* by alphabet.