### PR TITLE
Implement login item API on Windows

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -72,7 +72,6 @@ struct Converter<Browser::UserTask> {
 };
 #endif
 
-#if defined(OS_MACOSX)
 template<>
 struct Converter<Browser::LoginItemSettings> {
   static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
@@ -97,8 +96,6 @@ struct Converter<Browser::LoginItemSettings> {
     return dict.GetHandle();
   }
 };
-#endif
-
 }  // namespace mate
 
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -559,6 +559,10 @@ void App::BuildPrototype(
                  base::Bind(&Browser::RemoveAsDefaultProtocolClient, browser))
       .SetMethod("setBadgeCount", base::Bind(&Browser::SetBadgeCount, browser))
       .SetMethod("getBadgeCount", base::Bind(&Browser::GetBadgeCount, browser))
+      .SetMethod("getLoginItemSettings",
+                 base::Bind(&Browser::GetLoginItemSettings, browser))
+      .SetMethod("setLoginItemSettings",
+                 base::Bind(&Browser::SetLoginItemSettings, browser))
 #if defined(OS_MACOSX)
       .SetMethod("hide", base::Bind(&Browser::Hide, browser))
       .SetMethod("show", base::Bind(&Browser::Show, browser))
@@ -566,10 +570,6 @@ void App::BuildPrototype(
                  base::Bind(&Browser::SetUserActivity, browser))
       .SetMethod("getCurrentActivityType",
                  base::Bind(&Browser::GetCurrentActivityType, browser))
-      .SetMethod("getLoginItemSettings",
-                 base::Bind(&Browser::GetLoginItemSettings, browser))
-      .SetMethod("setLoginItemSettings",
-                 base::Bind(&Browser::SetLoginItemSettings, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -88,7 +88,7 @@ class Browser : public WindowListObserver {
   bool SetBadgeCount(int count);
   int GetBadgeCount();
 
-#if defined(OS_MACOSX)
+  // Set/Get the login item settings of the app
   struct LoginItemSettings {
     bool open_at_login = false;
     bool open_as_hidden = false;
@@ -96,7 +96,10 @@ class Browser : public WindowListObserver {
     bool opened_at_login = false;
     bool opened_as_hidden = false;
   };
+  void SetLoginItemSettings(LoginItemSettings settings);
+  LoginItemSettings GetLoginItemSettings();
 
+#if defined(OS_MACOSX)
   // Hide the application.
   void Hide();
 
@@ -139,12 +142,6 @@ class Browser : public WindowListObserver {
 
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
-
-  // Get login item settings of app
-  LoginItemSettings GetLoginItemSettings();
-
-  // Set login item settings of app
-  void SetLoginItemSettings(LoginItemSettings settings);
 #endif  // defined(OS_MACOSX)
 
 #if defined(OS_WIN)

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -57,6 +57,13 @@ bool Browser::SetBadgeCount(int count) {
   }
 }
 
+void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+}
+
+LoginItemSettings Browser::GetLoginItemSettings() {
+  return LoginItemSettings();
+}
+
 std::string Browser::GetExecutableFileVersion() const {
   return brightray::GetApplicationVersion();
 }

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -60,7 +60,7 @@ bool Browser::SetBadgeCount(int count) {
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 }
 
-LoginItemSettings Browser::GetLoginItemSettings() {
+Browser::LoginItemSettings Browser::GetLoginItemSettings() {
   return LoginItemSettings();
 }
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -274,10 +274,47 @@ bool Browser::SetBadgeCount(int count) {
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+  base::FilePath path;
+  if (!PathService::Get(base::FILE_EXE, &path)) {
+    LOG(ERROR) << "Error getting app exe path";
+    return;
+  }
+
+  // Main Registry Key
+  HKEY root = HKEY_CURRENT_USER;
+  std::string keyPathStr = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  std::wstring keyPath = std::wstring(keyPathStr.begin(), keyPathStr.end());
+
+  // Executable Path
+  std::wstring exePath(path.value());
+  base::win::RegKey key(root, keyPath.c_str(), KEY_ALL_ACCESS);
+
+  if (settings.open_at_login)
+    key.WriteValue(GetAppUserModelID(), exePath.c_str());
+  else {
+    key.DeleteValue(GetAppUserModelID())
+  }
 }
 
 LoginItemSettings Browser::GetLoginItemSettings() {
-  return LoginItemSettings();
+  LoginItemSettings settings;
+
+  base::FilePath path;
+  if (!PathService::Get(base::FILE_EXE, &path)) {
+    LOG(ERROR) << "Error getting app exe path";
+    return;
+  }
+
+  // Main Registry Key
+  HKEY root = HKEY_CURRENT_USER;
+  std::string keyPathStr = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  std::wstring keyPath = std::wstring(keyPathStr.begin(), keyPathStr.end());
+
+  // Executable Path
+  std::wstring exePath(path.value());
+  base::win::RegKey key(root, keyPath.c_str(), KEY_ALL_ACCESS);
+
+  settings.open_at_login = key.HasValue(GetAppUserModelID());
 }
 
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -273,6 +273,14 @@ bool Browser::SetBadgeCount(int count) {
   return false;
 }
 
+void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+}
+
+LoginItemSettings Browser::GetLoginItemSettings() {
+  return LoginItemSettings();
+}
+
+
 PCWSTR Browser::GetAppUserModelID() {
   if (app_user_model_id_.empty()) {
     SetAppUserModelID(base::ReplaceStringPlaceholders(

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -274,47 +274,35 @@ bool Browser::SetBadgeCount(int count) {
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
-  base::FilePath path;
-  if (!PathService::Get(base::FILE_EXE, &path)) {
-    LOG(ERROR) << "Error getting app exe path";
-    return;
-  }
+  std::wstring keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
 
-  // Main Registry Key
-  HKEY root = HKEY_CURRENT_USER;
-  std::string keyPathStr = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
-  std::wstring keyPath = std::wstring(keyPathStr.begin(), keyPathStr.end());
-
-  // Executable Path
-  std::wstring exePath(path.value());
-  base::win::RegKey key(root, keyPath.c_str(), KEY_ALL_ACCESS);
-
-  if (settings.open_at_login)
-    key.WriteValue(GetAppUserModelID(), exePath.c_str());
-  else {
-    key.DeleteValue(GetAppUserModelID())
+  if (settings.open_at_login) {
+    base::FilePath path;
+    if (PathService::Get(base::FILE_EXE, &path)) {
+      std::wstring exePath(path.value());
+      key.WriteValue(GetAppUserModelID(), exePath.c_str());
+    }
+  } else {
+    key.DeleteValue(GetAppUserModelID());
   }
 }
 
-LoginItemSettings Browser::GetLoginItemSettings() {
+Browser::LoginItemSettings Browser::GetLoginItemSettings() {
   LoginItemSettings settings;
+  std::wstring keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
+  std::wstring keyVal;
 
-  base::FilePath path;
-  if (!PathService::Get(base::FILE_EXE, &path)) {
-    LOG(ERROR) << "Error getting app exe path";
-    return;
+  if (!FAILED(key.ReadValue(GetAppUserModelID(), &keyVal))) {
+    base::FilePath path;
+    if (PathService::Get(base::FILE_EXE, &path)) {
+      std::wstring exePath(path.value());
+      settings.open_at_login = keyVal == exePath;
+    }
   }
 
-  // Main Registry Key
-  HKEY root = HKEY_CURRENT_USER;
-  std::string keyPathStr = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
-  std::wstring keyPath = std::wstring(keyPathStr.begin(), keyPathStr.end());
-
-  // Executable Path
-  std::wstring exePath(path.value());
-  base::win::RegKey key(root, keyPath.c_str(), KEY_ALL_ACCESS);
-
-  settings.open_at_login = key.HasValue(GetAppUserModelID());
+  return settings;
 }
 
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -611,22 +611,24 @@ Returns the current value displayed in the counter badge.
 
 Returns whether current desktop environment is Unity launcher.
 
-### `app.getLoginItemSettings()` _macOS_
+### `app.getLoginItemSettings()` _macOS_ _Windows_
 
 Return an Object with the login item settings of the app.
 
 * `openAtLogin` Boolean - `true` if the app is set to open at login.
 * `openAsHidden` Boolean - `true` if the app is set to open as hidden at login.
+  This setting is only supported on macOS.
 * `wasOpenedAtLogin` Boolean - `true` if the app was opened at login
-  automatically.
+  automatically. This setting is only supported on macOS.
 * `wasOpenedAsHidden` Boolean - `true` if the app was opened as a hidden login
   item. This indicates that the app should not open any windows at startup.
+  This setting is only supported on macOS.
 * `restoreState` Boolean - `true` if the app was opened as a login item that
   should restore the state from the previous session. This indicates that the
   app should restore the windows that were open the last time the app was
-  closed.
+  closed. This setting is only supported on macOS.
 
-### `app.setLoginItemSettings(settings)` _macOS_
+### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
 
 * `settings` Object
   * `openAtLogin` Boolean - `true` to open the app at login, `false` to remove
@@ -634,7 +636,8 @@ Return an Object with the login item settings of the app.
   * `openAsHidden` Boolean - `true` to open the app as hidden. Defaults to
     `false`. The user can edit this setting from the System Preferences so
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
-    is opened to know the current value.
+    is opened to know the current value. This setting is only supported on
+    macOS.
 
 Set the app's login item settings.
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -300,7 +300,7 @@ describe('app module', function () {
   })
 
   describe('app.get/setLoginItemSettings API', function () {
-    if (process.platform !== 'darwin') return
+    if (process.platform === 'linux') return
 
     beforeEach(function () {
       app.setLoginItemSettings({openAtLogin: false})
@@ -323,7 +323,7 @@ describe('app module', function () {
       app.setLoginItemSettings({openAtLogin: true, openAsHidden: true})
       assert.deepEqual(app.getLoginItemSettings(), {
         openAtLogin: true,
-        openAsHidden: true,
+        openAsHidden: process.platform === 'darwin', // Only available on macOS
         wasOpenedAtLogin: false,
         wasOpenedAsHidden: false,
         restoreState: false


### PR DESCRIPTION
Implements #6375 on Windows by reading/writing registry keys following https://msdn.microsoft.com/en-us/library/windows/desktop/aa376977(v=vs.85).aspx

This pull request uses the app user model id as the key name, not sure if `app.getName()` would be a "better" name. /cc @felixrieseberg