### PR TITLE
Add API for Chrome's accessibility support state

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -32,6 +32,7 @@
 #include "base/strings/string_util.h"
 #include "brightray/browser/brightray_paths.h"
 #include "chrome/common/chrome_paths.h"
+#include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/browser/client_certificate_delegate.h"
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/render_frame_host.h"
@@ -281,6 +282,10 @@ void App::OnFinishLaunching() {
   Emit("ready");
 }
 
+void App::OnAccessibilityChanged() {
+  Emit("accessibility-changed", IsAccessible());
+}
+
 #if defined(OS_MACOSX)
 void App::OnContinueUserActivity(
     bool* prevent_default,
@@ -486,6 +491,11 @@ void App::DisableHardwareAcceleration(mate::Arguments* args) {
   content::GpuDataManager::GetInstance()->DisableHardwareAcceleration();
 }
 
+bool App::IsAccessible() {
+  auto ax_state = content::BrowserAccessibilityState::GetInstance();
+  return ax_state->IsAccessibleBrowser();
+}
+
 #if defined(USE_NSS_CERTS)
 void App::ImportCertificate(
     const base::DictionaryValue& options,
@@ -578,6 +588,7 @@ void App::BuildPrototype(
       .SetMethod("makeSingleInstance", &App::MakeSingleInstance)
       .SetMethod("releaseSingleInstance", &App::ReleaseSingleInstance)
       .SetMethod("relaunch", &App::Relaunch)
+      .SetMethod("isAccessible", &App::IsAccessible)
       .SetMethod("disableHardwareAcceleration",
                  &App::DisableHardwareAcceleration);
 }

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -588,7 +588,7 @@ void App::BuildPrototype(
       .SetMethod("makeSingleInstance", &App::MakeSingleInstance)
       .SetMethod("releaseSingleInstance", &App::ReleaseSingleInstance)
       .SetMethod("relaunch", &App::Relaunch)
-      .SetMethod("IsAccessibilitySupportEnabled",
+      .SetMethod("isAccessibilitySupportEnabled",
                  &App::IsAccessibilitySupportEnabled)
       .SetMethod("disableHardwareAcceleration",
                  &App::DisableHardwareAcceleration);

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -282,8 +282,8 @@ void App::OnFinishLaunching() {
   Emit("ready");
 }
 
-void App::OnAccessibilityChanged() {
-  Emit("accessibility-changed", IsAccessible());
+void App::OnAccessibilitySupportChanged() {
+  Emit("accessibility-support-changed", IsAccessibilitySupportEnabled());
 }
 
 #if defined(OS_MACOSX)
@@ -491,7 +491,7 @@ void App::DisableHardwareAcceleration(mate::Arguments* args) {
   content::GpuDataManager::GetInstance()->DisableHardwareAcceleration();
 }
 
-bool App::IsAccessible() {
+bool App::IsAccessibilitySupportEnabled() {
   auto ax_state = content::BrowserAccessibilityState::GetInstance();
   return ax_state->IsAccessibleBrowser();
 }
@@ -588,7 +588,8 @@ void App::BuildPrototype(
       .SetMethod("makeSingleInstance", &App::MakeSingleInstance)
       .SetMethod("releaseSingleInstance", &App::ReleaseSingleInstance)
       .SetMethod("relaunch", &App::Relaunch)
-      .SetMethod("isAccessible", &App::IsAccessible)
+      .SetMethod("IsAccessibilitySupportEnabled",
+                 &App::IsAccessibilitySupportEnabled)
       .SetMethod("disableHardwareAcceleration",
                  &App::DisableHardwareAcceleration);
 }

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -72,7 +72,7 @@ class App : public AtomBrowserClient::Delegate,
   void OnFinishLaunching() override;
   void OnLogin(LoginHandler* login_handler,
                const base::DictionaryValue& request_details) override;
-  void OnAccessibilityChanged() override;
+  void OnAccessibilitySupportChanged() override;
 #if defined(OS_MACOSX)
   void OnContinueUserActivity(
       bool* prevent_default,
@@ -114,7 +114,7 @@ class App : public AtomBrowserClient::Delegate,
   void ReleaseSingleInstance();
   bool Relaunch(mate::Arguments* args);
   void DisableHardwareAcceleration(mate::Arguments* args);
-  bool IsAccessible();
+  bool IsAccessibilitySupportEnabled();
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -72,6 +72,7 @@ class App : public AtomBrowserClient::Delegate,
   void OnFinishLaunching() override;
   void OnLogin(LoginHandler* login_handler,
                const base::DictionaryValue& request_details) override;
+  void OnAccessibilityChanged() override;
 #if defined(OS_MACOSX)
   void OnContinueUserActivity(
       bool* prevent_default,
@@ -113,6 +114,7 @@ class App : public AtomBrowserClient::Delegate,
   void ReleaseSingleInstance();
   bool Relaunch(mate::Arguments* args);
   void DisableHardwareAcceleration(mate::Arguments* args);
+  bool IsAccessible();
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -155,6 +155,10 @@ void Browser::DidFinishLaunching() {
   FOR_EACH_OBSERVER(BrowserObserver, observers_, OnFinishLaunching());
 }
 
+void Browser::OnAccessibilityChanged() {
+  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnAccessibilityChanged());
+}
+
 void Browser::RequestLogin(
     LoginHandler* login_handler,
     std::unique_ptr<base::DictionaryValue> request_details) {

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -155,8 +155,10 @@ void Browser::DidFinishLaunching() {
   FOR_EACH_OBSERVER(BrowserObserver, observers_, OnFinishLaunching());
 }
 
-void Browser::OnAccessibilityChanged() {
-  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnAccessibilityChanged());
+void Browser::OnAccessibilitySupportChanged() {
+  FOR_EACH_OBSERVER(BrowserObserver,
+                    observers_,
+                    OnAccessibilitySupportChanged());
 }
 
 void Browser::RequestLogin(

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -185,6 +185,8 @@ class Browser : public WindowListObserver {
   void WillFinishLaunching();
   void DidFinishLaunching();
 
+  void OnAccessibilityChanged();
+
   // Request basic auth login.
   void RequestLogin(LoginHandler* login_handler,
                     std::unique_ptr<base::DictionaryValue> request_details);

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -185,7 +185,7 @@ class Browser : public WindowListObserver {
   void WillFinishLaunching();
   void DidFinishLaunching();
 
-  void OnAccessibilityChanged();
+  void OnAccessibilitySupportChanged();
 
   // Request basic auth login.
   void RequestLogin(LoginHandler* login_handler,

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -52,8 +52,8 @@ class BrowserObserver {
   virtual void OnLogin(LoginHandler* login_handler,
                        const base::DictionaryValue& request_details) {}
 
-  // The browser's accessibility state has changed.
-  virtual void OnAccessibilityChanged() {};
+  // The browser's accessibility suppport has changed.
+  virtual void OnAccessibilitySupportChanged() {};
 
 #if defined(OS_MACOSX)
   // The browser wants to resume a user activity via handoff. (macOS only)

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -52,6 +52,9 @@ class BrowserObserver {
   virtual void OnLogin(LoginHandler* login_handler,
                        const base::DictionaryValue& request_details) {}
 
+  // The browser's accessibility state has changed.
+  virtual void OnAccessibilityChanged() {};
+
 #if defined(OS_MACOSX)
   // The browser wants to resume a user activity via handoff. (macOS only)
   virtual void OnContinueUserActivity(

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -53,7 +53,7 @@ class BrowserObserver {
                        const base::DictionaryValue& request_details) {}
 
   // The browser's accessibility suppport has changed.
-  virtual void OnAccessibilitySupportChanged() {};
+  virtual void OnAccessibilitySupportChanged() {}
 
 #if defined(OS_MACOSX)
   // The browser wants to resume a user activity via handoff. (macOS only)

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -84,7 +84,7 @@
     ax_state->DisableAccessibility();
   }
 
-  atom::Browser::Get()->OnAccessibilityChanged();
+  atom::Browser::Get()->OnAccessibilitySupportChanged();
 }
 
 @end

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -83,6 +83,8 @@
   } else {
     ax_state->DisableAccessibility();
   }
+
+  atom::Browser::Get()->OnAccessibilityChanged();
 }
 
 @end

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "atom/browser/browser.h"
 #include "atom/browser/native_window_views.h"
 #include "content/public/browser/browser_accessibility_state.h"
 
@@ -98,6 +99,7 @@ bool NativeWindowViews::PreHandleMSG(
         if (axState && !axState->IsAccessibleBrowser()) {
           axState->OnScreenReaderDetected();
           enabled_a11y_support_ = true;
+          Browser::Get()->OnAccessibilityChanged();
         }
       }
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -99,7 +99,7 @@ bool NativeWindowViews::PreHandleMSG(
         if (axState && !axState->IsAccessibleBrowser()) {
           axState->OnScreenReaderDetected();
           enabled_a11y_support_ = true;
-          Browser::Get()->OnAccessibilityChanged();
+          Browser::Get()->OnAccessibilitySupportChanged();
         }
       }
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -259,6 +259,19 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
 
 Emitted when the gpu process crashes.
 
+### Event: 'accessibility-support-changed' _macOS_ _Windows_
+
+Returns:
+
+* `event` Event
+* `accessibilitySupportEnabled` Boolean - `true` when Chrome's accessibility
+  support is enabled, `false` otherwise.
+
+Emitted when Chrome's accessibility support changes. This event fires when
+assistive technologies, such as screen readers, are enabled or disabled.
+See https://www.chromium.org/developers/design-documents/accessibility for more
+details.
+
 ## Methods
 
 The `app` object has the following methods:
@@ -624,6 +637,14 @@ Return an Object with the login item settings of the app.
     is opened to know the current value.
 
 Set the app's login item settings.
+
+### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
+
+Returns a `Boolean`, `true` if Chrome's accessibility support is enabled,
+`false` otherwise. This API will return `true` if the use of assistive
+technologies, such as screen readers, has been detected. See
+https://www.chromium.org/developers/design-documents/accessibility for more
+details.
 
 ### `app.commandLine.appendSwitch(switch[, value])`
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -342,7 +342,7 @@ describe('app module', function () {
 
   describe('isAccessibilitySupportEnabled API', function () {
     it('returns whether the Chrome has accessibility APIs enabled', function () {
-      assert.equal(app.isAccessibilitySupportEnabled(), 'boolean')
+      assert.equal(typeof app.isAccessibilitySupportEnabled(), 'boolean')
     })
   })
 })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -339,4 +339,10 @@ describe('app module', function () {
       })
     })
   })
+
+  describe('isAccessibilitySupportEnabled API', function () {
+    it('returns whether the Chrome has accessibility APIs enabled', function () {
+      assert.equal(app.isAccessibilitySupportEnabled(), 'boolean')
+    })
+  })
 })


### PR DESCRIPTION
This pull request adds a new `app.isAccessibilitySupportEnabled()` that can be used to detect if a screen reader or other assistive technologies are enabled for the application.

It also adds an `app` `accessibility-support-changed` event for when this value changes, such as turning VoiceOver on/off (`Cmd+F5`) on macOS.

Closes #5709