### PR TITLE
Initialize new size constraints to current constraints

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -209,7 +209,7 @@ gfx::Size NativeWindow::GetContentSize() {
 
 void NativeWindow::SetSizeConstraints(
     const extensions::SizeConstraints& window_constraints) {
-  extensions::SizeConstraints content_constraints;
+  extensions::SizeConstraints content_constraints(GetContentSizeConstraints());
   if (window_constraints.HasMaximumSize())
     content_constraints.set_maximum_size(
         WindowSizeToContentSize(window_constraints.GetMaximumSize()));

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -287,6 +287,21 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.setMinimum/MaximumSize(width, height)', function () {
+    it('sets the maximum and minimum size of the window', function () {
+      assert.deepEqual(w.getMinimumSize(), [0, 0])
+      assert.deepEqual(w.getMaximumSize(), [0, 0])
+
+      w.setMinimumSize(100, 100)
+      assert.deepEqual(w.getMinimumSize(), [100, 100])
+      assert.deepEqual(w.getMaximumSize(), [0, 0])
+
+      w.setMaximumSize(900, 600)
+      assert.deepEqual(w.getMinimumSize(), [100, 100])
+      assert.deepEqual(w.getMaximumSize(), [900, 600])
+    })
+  })
+
   describe('BrowserWindow.setAspectRatio(ratio)', function () {
     it('resets the behaviour when passing in 0', function (done) {
       var size = [300, 400]


### PR DESCRIPTION
The specified constraints may only contain minimum **or** maximum constraints so reuse the existing constraints so they aren't lost if only one is set.

Closes #6122