### PR TITLE
docs: Small document fixes

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -197,7 +197,7 @@ supported values are:
     (`kCGDesktopWindowLevel - 1`). Note that desktop window will not receive
     focus, keyboard or mouse events, but you can use `globalShortcut` to receive
     input sparingly.
-* On Windows, possible types are `toolbar`.
+* On Windows, possible type is `toolbar`.
 
 The `titleBarStyle` option is only supported on macOS 10.10 Yosemite and newer.
 Possible values are:

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -197,7 +197,7 @@ supported values are:
     (`kCGDesktopWindowLevel - 1`). Note that desktop window will not receive
     focus, keyboard or mouse events, but you can use `globalShortcut` to receive
     input sparingly.
-* On Windows, possible types are `toolbar`,
+* On Windows, possible types are `toolbar`.
 
 The `titleBarStyle` option is only supported on macOS 10.10 Yosemite and newer.
 Possible values are:

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -47,7 +47,7 @@ In Electron, we have several ways to communicate between the main process and
 renderer processes. Like [`ipcRenderer`](../api/ipc-renderer.md) and
 [`ipcMain`](../api/ipc-main.md) modules for sending messages, and the
 [remote](../api/remote.md) module for RPC style communication. There is also
-an FAQ entry on [how to share data between web pages](../faq.md/#how-to-share-data-between-web-pages).
+an FAQ entry on [how to share data between web pages][share-data].
 
 ## Write your First Electron App
 
@@ -225,4 +225,4 @@ $ cd electron-quick-start
 $ npm install && npm start
 ```
 
-[share-data]: ../faq/electron-faq.md#how-to-share-data-between-web-pages
+[share-data]: ../faq.md#how-to-share-data-between-web-pages


### PR DESCRIPTION
:memo: :sparkles: 

* Fix isolated link in `quick-start.md`.
* Fix typo in `browser-window.md`.