### PR TITLE
change heading level for MenuItem instance properties

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -72,21 +72,21 @@ On macOS `role` can also have following additional values:
 When specifying `role` on macOS, `label` and `accelerator` are the only options
 that will affect the MenuItem. All other options will be ignored.
 
-### Instance Properties
+## Instance Properties
 
 The following properties are available on instances of `MenuItem`:
 
-#### `menuItem.enabled`
+### `menuItem.enabled`
 
 A Boolean indicating whether the item is enabled, this property can be
 dynamically changed.
 
-#### `menuItem.visible`
+### `menuItem.visible`
 
 A Boolean indicating whether the item is visible, this property can be
 dynamically changed.
 
-#### `menuItem.checked`
+### `menuItem.checked`
 
 A Boolean indicating whether the item is checked, this property can be
 dynamically changed.


### PR DESCRIPTION
@zcbenz I think these headings were too deep. Is that correct?