### PR TITLE
Add a getFeedURL API for the autoUpdater

### DIFF
--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -79,10 +79,6 @@ void AutoUpdater::OnWindowAllClosed() {
   QuitAndInstall();
 }
 
-std::string AutoUpdater::GetFeedURL() {
-  return "";
-}
-
 void AutoUpdater::SetFeedURL(const std::string& url, mate::Arguments* args) {
   auto_updater::AutoUpdater::HeaderMap headers;
   args->GetNext(&headers);

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -79,6 +79,10 @@ void AutoUpdater::OnWindowAllClosed() {
   QuitAndInstall();
 }
 
+std::string AutoUpdater::GetFeedURL() {
+  return "";
+}
+
 void AutoUpdater::SetFeedURL(const std::string& url, mate::Arguments* args) {
   auto_updater::AutoUpdater::HeaderMap headers;
   args->GetNext(&headers);
@@ -109,6 +113,7 @@ void AutoUpdater::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
   mate::ObjectTemplateBuilder(isolate, prototype)
       .SetMethod("checkForUpdates", &auto_updater::AutoUpdater::CheckForUpdates)
+      .SetMethod("getFeedURL", &auto_updater::AutoUpdater::GetFeedURL)
       .SetMethod("setFeedURL", &AutoUpdater::SetFeedURL)
       .SetMethod("quitAndInstall", &AutoUpdater::QuitAndInstall);
 }

--- a/atom/browser/api/atom_api_auto_updater.h
+++ b/atom/browser/api/atom_api_auto_updater.h
@@ -44,6 +44,7 @@ class AutoUpdater : public mate::EventEmitter<AutoUpdater>,
   void OnWindowAllClosed() override;
 
  private:
+  std::string GetFeedURL();
   void SetFeedURL(const std::string& url, mate::Arguments* args);
   void QuitAndInstall();
 

--- a/atom/browser/auto_updater.cc
+++ b/atom/browser/auto_updater.cc
@@ -17,6 +17,10 @@ void AutoUpdater::SetDelegate(Delegate* delegate) {
 }
 
 #if !defined(OS_MACOSX) || defined(MAS_BUILD)
+std::string AutoUpdater::GetFeedURL() {
+  return "";
+}
+
 void AutoUpdater::SetFeedURL(const std::string& url,
                              const HeaderMap& requestHeaders) {
 }

--- a/atom/browser/auto_updater.h
+++ b/atom/browser/auto_updater.h
@@ -49,6 +49,7 @@ class AutoUpdater {
   static Delegate* GetDelegate();
   static void SetDelegate(Delegate* delegate);
 
+  static std::string GetFeedURL();
   static void SetFeedURL(const std::string& url,
                          const HeaderMap& requestHeaders);
   static void CheckForUpdates();

--- a/atom/browser/auto_updater_mac.mm
+++ b/atom/browser/auto_updater_mac.mm
@@ -25,7 +25,12 @@ SQRLUpdater* g_updater = nil;
 namespace {
 
 bool g_update_available = false;
+std::string update_url_ = "";
 
+}
+
+std::string AutoUpdater::GetFeedURL() {
+  return update_url_;
 }
 
 // static
@@ -34,6 +39,8 @@ void AutoUpdater::SetFeedURL(const std::string& feed,
   Delegate* delegate = GetDelegate();
   if (!delegate)
     return;
+
+  update_url_ = feed;
 
   NSURL* url = [NSURL URLWithString:base::SysUTF8ToNSString(feed)];
   NSMutableURLRequest* urlRequest = [NSMutableURLRequest requestWithURL:url];

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -100,6 +100,10 @@ The `autoUpdater` object has the following methods:
 
 Sets the `url` and initialize the auto updater.
 
+### `autoUpdater.getFeedURL()`
+
+Returns the current update feed URL.
+
 ### `autoUpdater.checkForUpdates()`
 
 Asks the server whether there is an update. You must call `setFeedURL` before

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -19,7 +19,7 @@ AutoUpdater.prototype.quitAndInstall = function () {
   return app.quit()
 }
 
-AutoUpdater.prototype.GetFeedURL = function () {
+AutoUpdater.prototype.getFeedURL = function () {
   return this.updateURL
 }
 

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -20,7 +20,7 @@ AutoUpdater.prototype.quitAndInstall = function () {
 }
 
 AutoUpdater.prototype.GetFeedURL = function () {
-  return this.updateURL;
+  return this.updateURL
 }
 
 AutoUpdater.prototype.setFeedURL = function (updateURL, headers) {

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -19,6 +19,10 @@ AutoUpdater.prototype.quitAndInstall = function () {
   return app.quit()
 }
 
+AutoUpdater.prototype.GetFeedURL = function () {
+  return this.updateURL;
+}
+
 AutoUpdater.prototype.setFeedURL = function (updateURL, headers) {
   this.updateURL = updateURL
 }

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -33,5 +33,22 @@ if (!process.mas) {
         autoUpdater.setFeedURL('')
       })
     })
+
+    describe('getFeedURL', function () {
+      it('returns a falsey value by default', function () {
+        assert.ok(!autoUpdater.getFeedURL())
+      })
+
+      it('correctly fetches the previously set FeedURL', function (done) {
+        if (process.platform !== 'win32') {
+          return done()
+        }
+
+        const updateURL = 'https://fake-update.electron.io'
+        autoUpdater.setFeedURL(updateURL)
+        assert.equal(autoUpdater.getFeedURL(), updateURL)
+        done()
+      })
+    })
   })
 }


### PR DESCRIPTION
Implements the request `getFeedURL` API.

Closes #6454 