### PR TITLE
mention electron-devtools-installer as an alternative

### DIFF
--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -5,6 +5,12 @@ be used to extend the ability of devtools for debugging popular web frameworks.
 
 ## How to load a DevTools Extension
 
+This document outlines the process for manually loading an extension.
+You may also try
+[electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer),
+a third-party tool the downloads the chrome extension directly from the
+Chrome WebStore.
+
 To load an extension in Electron, you need to download it in Chrome browser,
 locate its filesystem path, and then load it by calling the
 `BrowserWindow.addDevToolsExtension(extension)` API.

--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -8,8 +8,7 @@ be used to extend the ability of devtools for debugging popular web frameworks.
 This document outlines the process for manually loading an extension.
 You may also try
 [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer),
-a third-party tool the downloads the chrome extension directly from the
-Chrome WebStore.
+a third-party tool that downloads extensions directly from the Chrome WebStore.
 
 To load an extension in Electron, you need to download it in Chrome browser,
 locate its filesystem path, and then load it by calling the


### PR DESCRIPTION
This just landed in the awesome-electron repo: https://github.com/GPMDP/electron-devtools-installer

I know it's uncommon to mention third-party tools in the docs, but figured I'd open it up for discussion, as this package does provide a nice alternative to an otherwise very manual process.

cc @MarshallOfSound @jhen0409 @LestaD