### PR TITLE
Add setThumbnailClip API on Windows

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -649,6 +649,12 @@ bool Window::IsWindowMessageHooked(UINT message) {
 void Window::UnhookAllWindowMessages() {
   messages_callback_map_.clear();
 }
+
+bool Window::SetThumbnailClip(const gfx::Rect& region) {
+  auto window = static_cast<NativeWindowViews*>(window_.get());
+  return window->taskbar_host().SetThumbnailClip(
+      window_->GetAcceleratedWidget(), region);
+}
 #endif
 
 #if defined(TOOLKIT_VIEWS)
@@ -836,6 +842,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isWindowMessageHooked", &Window::IsWindowMessageHooked)
       .SetMethod("unhookWindowMessage", &Window::UnhookWindowMessage)
       .SetMethod("unhookAllWindowMessages", &Window::UnhookAllWindowMessages)
+      .SetMethod("setThumbnailClip", &Window::SetThumbnailClip)
 #endif
 #if defined(TOOLKIT_VIEWS)
       .SetMethod("setIcon", &Window::SetIcon)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -179,6 +179,7 @@ class Window : public mate::TrackableObject<Window>,
   bool IsWindowMessageHooked(UINT message);
   void UnhookWindowMessage(UINT message);
   void UnhookAllWindowMessages();
+  bool SetThumbnailClip(const gfx::Rect& window_region);
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -179,7 +179,7 @@ class Window : public mate::TrackableObject<Window>,
   bool IsWindowMessageHooked(UINT message);
   void UnhookWindowMessage(UINT message);
   void UnhookAllWindowMessages();
-  bool SetThumbnailClip(const gfx::Rect& window_region);
+  bool SetThumbnailClip(const gfx::Rect& region);
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/atom/browser/ui/win/taskbar_host.cc
+++ b/atom/browser/ui/win/taskbar_host.cc
@@ -142,6 +142,22 @@ bool TaskbarHost::SetOverlayIcon(
       window, icon.get(), base::UTF8ToUTF16(text).c_str()));
 }
 
+bool TaskbarHost::SetThumbnailClip(HWND window, const gfx::Rect& region) {
+  if (!InitializeTaskbar())
+    return false;
+
+  if (region.IsEmpty()) {
+    return SUCCEEDED(taskbar_->SetThumbnailClip(window, NULL));
+  } else {
+    RECT rect;
+    rect.left = region.x();
+    rect.right = region.right();
+    rect.top = region.y();
+    rect.bottom = region.bottom();
+    return SUCCEEDED(taskbar_->SetThumbnailClip(window, &rect));
+  }
+}
+
 bool TaskbarHost::HandleThumbarButtonEvent(int button_id) {
   if (ContainsKey(callback_map_, button_id)) {
     auto callback = callback_map_[button_id];

--- a/atom/browser/ui/win/taskbar_host.h
+++ b/atom/browser/ui/win/taskbar_host.h
@@ -13,6 +13,7 @@
 
 #include "base/callback.h"
 #include "base/win/scoped_comptr.h"
+#include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/image/image.h"
 
 namespace atom {
@@ -39,6 +40,9 @@ class TaskbarHost {
   // Set the overlay icon in taskbar.
   bool SetOverlayIcon(
       HWND window, const gfx::Image& overlay, const std::string& text);
+
+  // Set the region of the window to show as a thumbnail in taskbar.
+  bool TaskbarHost::SetThumbnailClip(HWND window, const gfx::Rect& region);
 
   // Called by the window that there is a button in thumbar clicked.
   bool HandleThumbarButtonEvent(int button_id);

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -987,7 +987,11 @@ The `flags` is an array that can include following `String`s:
 
 #### `win.setThumbnailClip(region)` _Windows_
 
-* `region` - Object with `x`, `y`, `width`, and `height` properties.
+* `region` - Object
+  * `x` Integer - x-position of region
+  * `y` Integer - y-position of region
+  * `width` Integer - width of region
+  * `height` Integer - height of region
 
 Sets the region of the window to show as the thumbnail image displayed when
 hovering over the window in the taskbar.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -985,6 +985,13 @@ The `flags` is an array that can include following `String`s:
   button state is drawn. This value is intended for instances where the button
   is used in a notification.
 
+#### `win.setThumbnailClip(region)` _Windows_
+
+* `region` - Object with `x`, `y`, `width`, and `height` properties.
+
+Sets the region of the window to show as the thumbnail image displayed when
+hovering over the window in the taskbar.
+
 #### `win.showDefinitionForSelection()` _macOS_
 
 Same as `webContents.showDefinitionForSelection()`.


### PR DESCRIPTION
This pull requests adds a ` setThumbnailClip(region)` API to `BrowserWindow` instances on Windows that can be used to control which region of the window is used to generate the thumbnail image displayed in the taskbar when the window is hoverered over.

For the sample Electron app if you called it as:

```js
require('electron').remote.getCurrentWindow().setThumbnailClip({x:0, y:0, width:500, height:100})
```

It would change the taskbar thumbnail from:

| Default | Set via `setThumbnailClip` |
| --- | --- |
| <img width="145" alt="screen shot 2016-07-14 at 3 52 22 pm" src="https://cloud.githubusercontent.com/assets/671378/16858426/8f5f0202-49db-11e6-9bdc-159e698a0e01.png"> | <img width="174" alt="screen shot 2016-07-14 at 3 51 55 pm" src="https://cloud.githubusercontent.com/assets/671378/16858445/bf6dd8ce-49db-11e6-8237-e7beeed4900f.png"> |

This can be useful for media-related apps that want the thumbnail to be the specific content such as an image, video element, etc.

Closes https://github.com/electron/electron/issues/2623
