### PR TITLE
Remove implicit references to Vista in docs

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -926,7 +926,7 @@ On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
 
-#### `win.setOverlayIcon(overlay, description)` _Windows 7+_
+#### `win.setOverlayIcon(overlay, description)` _Windows_
 
 * `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
 right corner of the taskbar icon. If this parameter is `null`, the overlay is
@@ -949,7 +949,7 @@ nothing.
 Returns whether the window has a shadow. On Windows and Linux always returns
 `true`.
 
-#### `win.setThumbarButtons(buttons)` _Windows 7+_
+#### `win.setThumbarButtons(buttons)` _Windows_
 
 * `buttons` Array
 

--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -36,7 +36,7 @@ are fine differences.
 * On Windows 8.1 and Windows 8, a shortcut to your app, with a [Application User
 Model ID][app-user-model-id], must be installed to the Start screen. Note,
 however, that it does not need to be pinned to the Start screen.
-* On Windows 7 and below, notifications are not supported. You can however send
+* On Windows 7, notifications are not supported. You can however send
 "balloon notifications" using the [Tray API][tray-balloon].
 
 Furthermore, the maximum length for the notification body is 250 characters,


### PR DESCRIPTION
- Remove Windows 7+ API labels since Windows 7 is the minimum version supported
- Remove reference to below Windows 7 since it isn't supported