### PR TITLE
docs: Update nodeintegration of web-view-tag.md

### DIFF
--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -121,9 +121,6 @@ than the minimum values or greater than the maximum.
 If "on", the guest page in `webview` will have node integration and can use node
 APIs like `require` and `process` to access low level system resources.
 
-**Note:** Node integration will always be disabled in the `webview` if it is
-disabled on the parent window.
-
 ### `plugins`
 
 ```html


### PR DESCRIPTION
webview is now disabled when nodeIntegration is off.

Close #6538.