### PR TITLE
Update docs-translations

### DIFF
--- a/docs-translations/es/README.md
+++ b/docs-translations/es/README.md
@@ -65,7 +65,7 @@
 * [Estructura de los directorios del Código Fuente](development/source-code-directory-structure.md)
 * [Diferencias Técnicas con NW.js (anteriormente conocido como node-webkit)](development/atom-shell-vs-node-webkit.md)
 * [Repaso del Sistema de Compilación](development/build-system-overview.md)
-* [Instrucciones de Compilación (Mac)](development/build-instructions-osx.md)
+* [Instrucciones de Compilación (macOS)](development/build-instructions-osx.md)
 * [Instrucciones de Compilación (Windows)](development/build-instructions-windows.md)
 * [Instrucciones de Compilación (Linux)](development/build-instructions-linux.md)
 * [Configurando un Servidor de Símbolos en el depurador](development/setting-up-symbol-server.md)

--- a/docs-translations/es/tutorial/application-distribution.md
+++ b/docs-translations/es/tutorial/application-distribution.md
@@ -2,7 +2,7 @@
 
 Para distribuir tu aplicación con Electron, el directorio que contiene la
 aplicación deberá llamarse `app`, y ser colocado debajo del directorio de
-recursos de Electron (en OSX es `Electron.app/Contents/Resources/`, en Linux y
+recursos de Electron (en macOS es `Electron.app/Contents/Resources/`, en Linux y
 Windows es `resources/`), de esta forma:
 
 En macOS:
@@ -63,7 +63,7 @@ de distribuirlo a los usuarios.
 Puedes renombrar `electron.exe` a cualquier nombre que desees, y editar su ícono
 y otra información con herramientas como [rcedit](https://github.com/atom/rcedit).
 
-### OSX
+### macOS
 
 Puedes renombrar `Electron.app` a cualquier nombre que desees, y tendrás que
 renombrar los campos `CFBundleDisplayName`, `CFBundleIdentifier` y `CFBundleName`

--- a/docs-translations/es/tutorial/desktop-environment-integration.md
+++ b/docs-translations/es/tutorial/desktop-environment-integration.md
@@ -57,7 +57,7 @@ __Menú dock de Terminal.app:__
 
 <img src="https://cloud.githubusercontent.com/assets/639601/5069962/6032658a-6e9c-11e4-9953-aa84006bdfff.png" height="354" width="341" >
 
-Para establecer tu menú dock, puedes utilizar la API `app.dock.setMenu`, la cual sólo está disponible para OSX:
+Para establecer tu menú dock, puedes utilizar la API `app.dock.setMenu`, la cual sólo está disponible para macOS:
 
 ```javascript
 var app = require('app');

--- a/docs-translations/es/tutorial/quick-start.md
+++ b/docs-translations/es/tutorial/quick-start.md
@@ -35,8 +35,8 @@ porque la gestión de los recursos GUI nativos es peligrosa, y tiende a que ocur
 Si deseas realizar operaciones GUI en una página web, el proceso renderer de la página web debe comunicarse
 con el proceso principal, y solicitar a este que realice esas operaciones.
 
-En Electron, hemos proveído el módulo [ipc](../api/ipc-renderer.md) para la comunicación
-entre el proceso principal y el proceso renderer. Y también hay un módulo [remote](../api/remote.md)
+En Electron, hemos proveído el módulo [ipc](../../../docs/api/ipc-renderer.md) para la comunicación
+entre el proceso principal y el proceso renderer. Y también hay un módulo [remote](../../../docs/api/remote.md)
 para comunicación al estilo RPC.
 
 ## Escribe tu primera aplicación Electron

--- a/docs-translations/es/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/es/tutorial/using-pepper-flash-plugin.md
@@ -4,7 +4,7 @@ El plugin Pepper Flash es soportado ahora. Para utilizar pepper flash en Electro
 
 ## Preparar una copia del plugin Flash
 
-En OSX y Linux, el detalle del plugin puede encontrarse accediendo a `chrome://plugins` en el navegador. Su ubicación y versión son útiles para el soporte. También puedes copiarlo a otro lugar.
+En macOS y Linux, el detalle del plugin puede encontrarse accediendo a `chrome://plugins` en el navegador. Su ubicación y versión son útiles para el soporte. También puedes copiarlo a otro lugar.
 
 ## Agrega la opción a Electron
 

--- a/docs-translations/pt-BR/tutorial/application-distribution.md
+++ b/docs-translations/pt-BR/tutorial/application-distribution.md
@@ -1,11 +1,11 @@
 # Distribuição de aplicações
 
 Para distribuir sua aplicação com o Electron, você deve nomear o diretório que contém sua aplicação como
-`app` e dentro deste diretório colocar os recursos que você está utilizando (no OSX
+`app` e dentro deste diretório colocar os recursos que você está utilizando (no macOS
 `Electron.app/Contents/Resources/`,
 no Linux e no Windows é em `resources/`):
 
-No OSX:
+No macOS:
 
 ```text
 electron/Electron.app/Contents/Resources/app/
@@ -37,7 +37,7 @@ Para usar um arquivo `asar` ao invés da pasta `app` você precisa mudar o nome 
 arquivo para `app.asar` e colocá-lo sob o diretório de recursos do Electron como
 mostrado abaixo, então o Electron vai ler o arquivo e iniciar a aplicação a partir dele.
 
-No OSX:
+No macOS:
 
 ```text
 electron/Electron.app/Contents/Resources/

--- a/docs-translations/pt-BR/tutorial/using-native-node-modules.md
+++ b/docs-translations/pt-BR/tutorial/using-native-node-modules.md
@@ -8,12 +8,12 @@ módulos nativos.
 ## Compatibilidade de Módulos Nativos do Node
 
 Módulos nativos podem quebrar quando utilizar a nova versão do Node, V8.
-Para ter certeza que o módulo que você está interessado em trabalhar com o 
+Para ter certeza que o módulo que você está interessado em trabalhar com o
 Electron, você deve checar se a versão do Node utilizada é compatível com a
 usada pelo Electron.
 Você pode verificar qual versão do Node foi utilizada no Electron olhando na
 página [releases](https://github.com/electron/electron/releases) ou usando
-`process.version` (veja [Quick Start](https://github.com/electron/electron/blob/master/docs/tutorial/quick-start.md)
+`process.version` (veja em [Introdução](quick-start.md)
 por exemplo).
 
 Considere usar [NAN](https://github.com/nodejs/nan/) para seus próprios


### PR DESCRIPTION
- Replace OSX to macOS
- Update references in:

> - docs-translations/es/tutorial/quick-start.md
>> Not exist: docs-translations/es/api/ipc-renderer.md - Update to docs/api/ipc-renderer.md
>> Not exist: docs-translations/es/api/remote.md -  Update to docs/api/remote.md

> - docs-translations/pt-BR/tutorial/using-native-node-modules.md
>> Update to "Quick Start" in PT-BR