### PR TITLE
Move autoUpdater to ES6

### DIFF
--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -1,71 +1,66 @@
 'use strict'
 
-const app = require('electron').app
-const EventEmitter = require('events').EventEmitter
+const {app} = require('electron')
+const {EventEmitter} = require('events')
 const squirrelUpdate = require('./squirrel-update-win')
-const util = require('util')
 
-function AutoUpdater () {
-  EventEmitter.call(this)
-}
-
-util.inherits(AutoUpdater, EventEmitter)
-
-AutoUpdater.prototype.quitAndInstall = function () {
-  if (!this.updateAvailable) {
-    return this.emitError('No update available, can\'t quit and install')
-  }
-  squirrelUpdate.processStart()
-  return app.quit()
-}
-
-AutoUpdater.prototype.getFeedURL = function () {
-  return this.updateURL
-}
-
-AutoUpdater.prototype.setFeedURL = function (updateURL, headers) {
-  this.updateURL = updateURL
-}
-
-AutoUpdater.prototype.checkForUpdates = function () {
-  if (!this.updateURL) {
-    return this.emitError('Update URL is not set')
-  }
-  if (!squirrelUpdate.supported()) {
-    return this.emitError('Can not find Squirrel')
-  }
-  this.emit('checking-for-update')
-  squirrelUpdate.download(this.updateURL, (error, update) => {
-    if (error != null) {
-      return this.emitError(error)
+class AutoUpdater extends EventEmitter {
+  quitAndInstall () {
+    if (!this.updateAvailable) {
+      return this.emitError('No update available, can\'t quit and install')
     }
-    if (update == null) {
-      this.updateAvailable = false
-      return this.emit('update-not-available')
+    squirrelUpdate.processStart()
+    return app.quit()
+  }
+
+  getFeedURL () {
+    return this.updateURL
+  }
+
+  setFeedURL (updateURL, headers) {
+    this.updateURL = updateURL
+  }
+
+  checkForUpdates () {
+    if (!this.updateURL) {
+      return this.emitError('Update URL is not set')
     }
-    this.updateAvailable = true
-    this.emit('update-available')
-    squirrelUpdate.update(this.updateURL, (error) => {
-      var date, releaseNotes, version
+    if (!squirrelUpdate.supported()) {
+      return this.emitError('Can not find Squirrel')
+    }
+    this.emit('checking-for-update')
+    squirrelUpdate.download(this.updateURL, (error, update) => {
       if (error != null) {
         return this.emitError(error)
       }
-      releaseNotes = update.releaseNotes
-      version = update.version
+      if (update == null) {
+        this.updateAvailable = false
+        return this.emit('update-not-available')
+      }
+      this.updateAvailable = true
+      this.emit('update-available')
+      squirrelUpdate.update(this.updateURL, (error) => {
+        var date, releaseNotes, version
+        if (error != null) {
+          return this.emitError(error)
+        }
+        releaseNotes = update.releaseNotes
+        version = update.version
 
-      // Following information is not available on Windows, so fake them.
-      date = new Date()
-      this.emit('update-downloaded', {}, releaseNotes, version, date, this.updateURL, () => {
-        this.quitAndInstall()
+        // Following information is not available on Windows, so fake them.
+        date = new Date()
+        this.emit('update-downloaded', {}, releaseNotes, version, date, this.updateURL, () => {
+          this.quitAndInstall()
+        })
       })
     })
-  })
-}
+  }
 
-// Private: Emit both error object and message, this is to keep compatibility
-// with Old APIs.
-AutoUpdater.prototype.emitError = function (message) {
-  return this.emit('error', new Error(message), message)
+  // Private: Emit both error object and message, this is to keep compatibility
+  // with Old APIs.
+  emitError (message) {
+    return this.emit('error', new Error(message), message)
+  }
 }
 
 module.exports = new AutoUpdater()


### PR DESCRIPTION
This adds a method that will allow consumers to easily set the appUserModelId of Electron to be the ID that Squirrel sets on the Desktop Shortcuts and Start menu Shortcuts it creates.  This reduces the knowledge barrier to getting Notifications working on Windows 8 (which is still a nightmare).

ID format was found here https://github.com/electron/electron/issues/4381#issuecomment-180534842

I went with a method instead of doing it automatically for backwards compatability reasons (setting the ID without consumers realizing might be interesting).