### PR TITLE
Add support for TypedArrays in IPC.

### DIFF
--- a/filenames.gypi
+++ b/filenames.gypi
@@ -44,6 +44,7 @@
       'lib/common/api/deprecate.js',
       'lib/common/api/deprecations.js',
       'lib/common/api/is-promise.js',
+      'lib/common/api/is-typed-array.js',
       'lib/common/api/exports/electron.js',
       'lib/common/api/native-image.js',
       'lib/common/api/shell.js',

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -63,7 +63,7 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
       meta.type = 'buffer'
     } else if (Array.isArray(value)) {
       meta.type = 'array'
-    } else if (isTypedArray(value.buffer)) {
+    } else if (isTypedArray(value)) {
       meta.type = 'typed-array'
     } else if (value instanceof Error) {
       meta.type = 'error'

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -2,7 +2,7 @@
 
 const electron = require('electron')
 const v8Util = process.atomBinding('v8_util')
-const {ipcMain, isPromise, webContents} = electron
+const {ipcMain, isPromise, isTypedArray, webContents} = electron
 
 const objectsRegistry = require('./objects-registry')
 
@@ -63,6 +63,8 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
       meta.type = 'buffer'
     } else if (Array.isArray(value)) {
       meta.type = 'array'
+    } else if (isTypedArray(value.buffer)) {
+      meta.type = 'typed-array'
     } else if (value instanceof Error) {
       meta.type = 'error'
     } else if (value instanceof Date) {
@@ -149,6 +151,8 @@ const unwrapArgs = function (sender, args) {
         return unwrapArgs(sender, meta.value)
       case 'buffer':
         return new Buffer(meta.value)
+      case 'typed-array':
+        return Buffer.from(meta.value)
       case 'date':
         return new Date(meta.value)
       case 'promise':

--- a/lib/common/api/exports/electron.js
+++ b/lib/common/api/exports/electron.js
@@ -48,6 +48,11 @@ exports.defineProperties = function (exports) {
       get: function () {
         return require('../is-promise')
       }
+    },
+    isTypedArray: {
+      get: function () {
+        return require('../is-typed-array')
+      }
     }
   })
 }

--- a/lib/common/api/is-typed-array.js
+++ b/lib/common/api/is-typed-array.js
@@ -1,16 +1,16 @@
 'use strict'
 
-module.exports = function isTypedArray(val) {
+module.exports = function isTypedArray (val) {
   return (
     val &&
-    (val instanceof Int8Array
-    || val instanceof Int16Array
-    || val instanceof Int32Array
-    || val instanceof Uint8Array
-    || val instanceof Uint8ClampedArray
-    || val instanceof Uint16Array
-    || val instanceof Uint32Array
-    || val instanceof Float32Array
-    || val instanceof Float64Array)
+    (val instanceof Int8Array ||
+     val instanceof Int16Array ||
+     val instanceof Int32Array ||
+     val instanceof Uint8Array ||
+     val instanceof Uint8ClampedArray ||
+     val instanceof Uint16Array ||
+     val instanceof Uint32Array ||
+     val instanceof Float32Array ||
+     val instanceof Float64Array)
   )
 }

--- a/lib/common/api/is-typed-array.js
+++ b/lib/common/api/is-typed-array.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = function isTypedArray(val) {
+  return (
+    val &&
+    (val instanceof Int8Array
+    || val instanceof Int16Array
+    || val instanceof Int32Array
+    || val instanceof Uint8Array
+    || val instanceof Uint8ClampedArray
+    || val instanceof Uint16Array
+    || val instanceof Uint32Array
+    || val instanceof Float32Array
+    || val instanceof Float64Array)
+  )
+}

--- a/lib/common/api/is-typed-array.js
+++ b/lib/common/api/is-typed-array.js
@@ -11,6 +11,7 @@ module.exports = function isTypedArray (val) {
      val instanceof Uint16Array ||
      val instanceof Uint32Array ||
      val instanceof Float32Array ||
-     val instanceof Float64Array)
+     val instanceof Float64Array) ||
+    (Object.prototype.toString.call(val).substr(-6, 5) === 'Array')
   )
 }

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -35,7 +35,7 @@ const wrapArgs = function (args, visited) {
         type: 'buffer',
         value: Array.prototype.slice.call(value, 0)
       }
-    } else if (isTypedArray(value.buffer)) {
+    } else if (isTypedArray(value)) {
       return {
         type: 'typed-array',
         value: Array.prototype.slice.call(value)

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const v8Util = process.atomBinding('v8_util')
-const {ipcRenderer, isPromise, CallbacksRegistry} = require('electron')
+const {ipcRenderer, isPromise, isTypedArray, CallbacksRegistry} = require('electron')
 
 const callbacksRegistry = new CallbacksRegistry()
 
@@ -34,6 +34,11 @@ const wrapArgs = function (args, visited) {
       return {
         type: 'buffer',
         value: Array.prototype.slice.call(value, 0)
+      }
+    } else if (isTypedArray(value.buffer)) {
+      return {
+        type: 'typed-array',
+        value: Array.prototype.slice.call(value)
       }
     } else if (value instanceof Date) {
       return {
@@ -164,6 +169,8 @@ const metaToValue = function (meta) {
       return results
     case 'buffer':
       return new Buffer(meta.value)
+    case 'typed-array':
+      return Buffer.from(meta.value)
     case 'promise':
       return Promise.resolve({
         then: metaToValue(meta.then)


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/2104.

When using Buffer shims in your application, such as https://www.npmjs.com/package/buffer, the IPC via remote currently handles TypedArrays (eg. UInt8Array) as objects and fails to transport the values as function params or return values.

This PR will add support for transporting TypedArrays between the renderer and main process. TypedArrays get converted to regular Arrays on the sending side (remote) and to Node.js Buffers on the receiving side (rpc-server).

Read the spec but wasn't sure if I should add a test and where to put it, so there's no test for this change. If you want to test this, I'd be happy to add one if you can advice where to put it.