### PR TITLE
Do not throw exception when channel name is "error"

### DIFF
--- a/lib/browser/api/ipc-main.js
+++ b/lib/browser/api/ipc-main.js
@@ -1,3 +1,6 @@
 const EventEmitter = require('events').EventEmitter
 
 module.exports = new EventEmitter()
+
+// Do not throw exception when channel name is "error".
+module.exports.on('error', () => {})


### PR DESCRIPTION
This fixes the hang of CI when a test was sending "error" as channel name through IPC. As happened in http://54.249.141.255:1128/job/electron-osx-x64/1976/.