### PR TITLE
Clarify the default arguments for Menu popup

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -227,16 +227,14 @@ The `menu` object has the following instance methods:
 
 #### `menu.popup([browserWindow, x, y, positioningItem])`
 
-* `browserWindow` BrowserWindow (optional) - Default is `null`.
-* `x` Number (optional) - Default is -1.
-* `y` Number (**required** if `x` is used) - Default is -1.
+* `browserWindow` BrowserWindow (optional) - Default is `BrowserWindow.getFocusedWindow()`.
+* `x` Number (optional) - Default is the current mouse cursor position.
+* `y` Number (**required** if `x` is used) - Default is the current mouse cursor position.
 * `positioningItem` Number (optional) _macOS_ - The index of the menu item to
   be positioned under the mouse cursor at the specified coordinates. Default is
   -1.
 
-Pops up this menu as a context menu in the `browserWindow`. You can optionally
-provide a `x, y` coordinate to place the menu at, otherwise it will be placed
-at the current mouse cursor position.
+Pops up this menu as a context menu in the `browserWindow`.
 
 #### `menu.append(menuItem)`
 


### PR DESCRIPTION
The null / -1 defaults weren't very helpful, so changed to follow other documentation and write the behaviour if that param is missing.