### PR TITLE
MenuItem: Use 'Close Window' for 'close' role label

### DIFF
--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -7,7 +7,7 @@ const roles = {
     }
   },
   close: {
-    label: 'Close',
+    label: process.platform === 'darwin' ? 'Close Window' : 'Close',
     accelerator: 'CommandOrControl+W',
     windowMethod: 'close'
   },


### PR DESCRIPTION
On OS X, the standard label that's used for the 'close' role is 'Close
Window'. You can see this in the default macOS apps from Apple.

iTunes:
<img width="239" alt="screen shot 2016-07-25 at 3 14 05 pm" src="https://cloud.githubusercontent.com/assets/121766/17119404/8392c51a-527a-11e6-9332-64a73f6817c0.png">

Finder:
<img width="290" alt="screen shot 2016-07-25 at 3 14 13 pm" src="https://cloud.githubusercontent.com/assets/121766/17119408/85316b9c-527a-11e6-882e-6af94ca7f32c.png">

Terminal:
<img width="295" alt="screen shot 2016-07-25 at 3 14 26 pm" src="https://cloud.githubusercontent.com/assets/121766/17119413/87d940e0-527a-11e6-8cf8-e6cda4dbffbc.png">

etc.