### PR TITLE
Do not overwrite CC and CXX in bootstrap

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -65,7 +65,7 @@ def main():
 
   create_chrome_version_h()
   touch_config_gypi()
-  run_update(defines, args.msvs, args.disable_clang, args.clang_dir)
+  run_update(defines, args.msvs)
   update_electron_modules('spec', args.target_arch)
 
 
@@ -251,19 +251,14 @@ def touch_config_gypi():
       f.write(content)
 
 
-def run_update(defines, msvs, disable_clang, clang_dir):
-  env = os.environ.copy()
-  if not disable_clang and clang_dir == '':
-    # Build with prebuilt clang.
-    set_clang_env(env)
-
+def run_update(defines, msvs):
   args = [sys.executable, os.path.join(SOURCE_ROOT, 'script', 'update.py')]
   if defines:
     args += ['--defines', defines]
   if msvs:
     args += ['--msvs']
 
-  execute_stdout(args, env)
+  execute_stdout(args)
 
 
 if __name__ == '__main__':

--- a/script/cibuild
+++ b/script/cibuild
@@ -35,6 +35,13 @@ def main():
   if os.environ.has_key('JANKY_SHA1'):
     setup_nodenv()
 
+  # Ignore the CXX and CC env in CI.
+  try:
+    del os.environ['CC']
+    del os.environ['CXX']
+  except KeyError:
+    pass
+
   target_arch = 'x64'
   if os.environ.has_key('TARGET_ARCH'):
     target_arch = os.environ['TARGET_ARCH']


### PR DESCRIPTION
It was to fix the problem with CI machine setting CC and CXX to its own compilers, but as a result running `bootstrap.py` and `update.py` separately would cause the entire project to rebuild.

This PR just ignores CC and CXX in CI machine so we don't have to overwrite them in `bootstrap.py`.