### PR TITLE
Only register code range in Windows crash reporter once

### DIFF
--- a/atom/common/crash_reporter/crash_reporter_win.cc
+++ b/atom/common/crash_reporter/crash_reporter_win.cc
@@ -192,6 +192,7 @@ void CrashReporterWin::InitBreakpad(const std::string& product_name,
 #ifdef _WIN64
   // Hook up V8 to breakpad.
   if (!code_range_registered_) {
+    code_range_registered_ = true;
     // gin::Debug::SetCodeRangeCreatedCallback only runs the callback when
     // Isolate is just created, so we have to manually run following code here.
     void* code_range = nullptr;
@@ -199,7 +200,6 @@ void CrashReporterWin::InitBreakpad(const std::string& product_name,
     v8::Isolate::GetCurrent()->GetCodeRange(&code_range, &size);
     if (code_range && size &&
         RegisterNonABICompliantCodeRange(code_range, size)) {
-      code_range_registered_ = true;
       gin::Debug::SetCodeRangeDeletedCallback(
           UnregisterNonABICompliantCodeRange);
     }

--- a/atom/common/crash_reporter/crash_reporter_win.h
+++ b/atom/common/crash_reporter/crash_reporter_win.h
@@ -62,6 +62,7 @@ class CrashReporterWin : public CrashReporter {
   google_breakpad::CustomClientInfo custom_info_;
 
   bool skip_system_crash_handler_;
+  bool code_range_registered_;
   std::unique_ptr<google_breakpad::ExceptionHandler> breakpad_;
 
   DISALLOW_COPY_AND_ASSIGN(CrashReporterWin);

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -88,5 +88,19 @@ describe('crash-reporter module', function () {
         })
       }, /companyName is a required option to crashReporter\.start/)
     })
+
+    it('can be called multiple times', function () {
+      assert.doesNotThrow(function () {
+        crashReporter.start({
+          companyName: 'Umbrella Corporation',
+          submitURL: 'http://127.0.0.1/crashes'
+        })
+
+        crashReporter.start({
+          companyName: 'Umbrella Corporation 2',
+          submitURL: 'http://127.0.0.1/more-crashes'
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Previously, calling `RegisterNonABICompliantCodeRange` multiple times via `crashReporter.start` would cause a crash.

This pull request updates it to only be called once instead.

Closes #6550 