### PR TITLE
Add webContents.copyImageAt(x, y)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1146,6 +1146,12 @@ void WebContents::ShowDefinitionForSelection() {
 #endif
 }
 
+void WebContents::CopyImageAt(int x, int y) {
+  const auto host = web_contents()->GetRenderViewHost();
+  if (host)
+    host->CopyImageAt(x, y);
+}
+
 void WebContents::Focus() {
   web_contents()->Focus();
 }
@@ -1425,6 +1431,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("removeWorkSpace", &WebContents::RemoveWorkSpace)
       .SetMethod("showDefinitionForSelection",
                  &WebContents::ShowDefinitionForSelection)
+      .SetMethod("copyImageAt", &WebContents::CopyImageAt)
       .SetMethod("capturePage", &WebContents::CapturePage)
       .SetMethod("isFocused", &WebContents::IsFocused)
       .SetProperty("id", &WebContents::ID)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -126,6 +126,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   uint32_t FindInPage(mate::Arguments* args);
   void StopFindInPage(content::StopFindAction action);
   void ShowDefinitionForSelection();
+  void CopyImageAt(int x, int y);
 
   // Focus.
   void Focus();

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -620,6 +620,13 @@ Executes the editing command `cut` in web page.
 
 Executes the editing command `copy` in web page.
 
+### `contents.copyImageAt(x, y)`
+
+* `x` Integer
+* `y` Integer
+
+Copy the image at the given position to the clipboard.
+
 #### `contents.paste()`
 
 Executes the editing command `paste` in web page.


### PR DESCRIPTION
Adds a new `copyImageAt` API to `webContents` that copies the image at the given position to the clipboard.

Allows you to easily implement the behavior of the `Copy Image` context menu in Chrome.

Closes #6553