### PR TITLE
Add option to always highlight the tray icon

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -8,7 +8,6 @@
 
 #include "atom/browser/api/atom_api_menu.h"
 #include "atom/browser/browser.h"
-#include "atom/browser/ui/tray_icon.h"
 #include "atom/common/api/atom_api_native_image.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/image_converter.h"
@@ -17,6 +16,44 @@
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
 #include "ui/gfx/image/image.h"
+
+namespace mate {
+
+template<>
+struct Converter<atom::TrayIcon::HighlightMode> {
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+                     atom::TrayIcon::HighlightMode* out) {
+    std::string mode;
+    if (ConvertFromV8(isolate, val, &mode)) {
+      if (mode == "always") {
+        *out = atom::TrayIcon::HighlightMode::ALWAYS;
+        return true;
+      }
+      if (mode == "selection") {
+        *out = atom::TrayIcon::HighlightMode::SELECTION;
+        return true;
+      }
+      if (mode == "never") {
+        *out = atom::TrayIcon::HighlightMode::NEVER;
+        return true;
+      }
+    }
+
+    // Support old boolean parameter
+    bool hightlight;
+    if (ConvertFromV8(isolate, val, &hightlight)) {
+      if (hightlight)
+        *out = atom::TrayIcon::HighlightMode::SELECTION;
+      else
+        *out = atom::TrayIcon::HighlightMode::NEVER;
+      return true;
+    }
+
+    return false;
+  }
+};
+}  // namespace mate
+
 
 namespace atom {
 
@@ -117,8 +154,8 @@ void Tray::SetTitle(const std::string& title) {
   tray_icon_->SetTitle(title);
 }
 
-void Tray::SetHighlightMode(bool highlight) {
-  tray_icon_->SetHighlightMode(highlight);
+void Tray::SetHighlightMode(TrayIcon::HighlightMode mode) {
+  tray_icon_->SetHighlightMode(mode);
 }
 
 void Tray::DisplayBalloon(mate::Arguments* args,

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -40,6 +40,7 @@ struct Converter<atom::TrayIcon::HighlightMode> {
     }
 
     // Support old boolean parameter
+    // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
     bool highlight;
     if (ConvertFromV8(isolate, val, &highlight)) {
       if (highlight)

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -40,9 +40,9 @@ struct Converter<atom::TrayIcon::HighlightMode> {
     }
 
     // Support old boolean parameter
-    bool hightlight;
-    if (ConvertFromV8(isolate, val, &hightlight)) {
-      if (hightlight)
+    bool highlight;
+    if (ConvertFromV8(isolate, val, &highlight)) {
+      if (highlight)
         *out = atom::TrayIcon::HighlightMode::SELECTION;
       else
         *out = atom::TrayIcon::HighlightMode::NEVER;

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "atom/browser/api/trackable_object.h"
+#include "atom/browser/ui/tray_icon.h"
 #include "atom/browser/ui/tray_icon_observer.h"
 #include "native_mate/handle.h"
 
@@ -62,7 +63,7 @@ class Tray : public mate::TrackableObject<Tray>,
   void SetPressedImage(v8::Isolate* isolate, mate::Handle<NativeImage> image);
   void SetToolTip(const std::string& tool_tip);
   void SetTitle(const std::string& title);
-  void SetHighlightMode(bool highlight);
+  void SetHighlightMode(TrayIcon::HighlightMode mode);
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
   void PopUpContextMenu(mate::Arguments* args);
   void SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu);

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -18,7 +18,7 @@ void TrayIcon::SetPressedImage(ImageType image) {
 void TrayIcon::SetTitle(const std::string& title) {
 }
 
-void TrayIcon::SetHighlightMode(bool highlight) {
+void TrayIcon::SetHighlightMode(TrayIcon::HighlightMode mode) {
 }
 
 void TrayIcon::DisplayBalloon(ImageType icon,

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -43,9 +43,13 @@ class TrayIcon {
   // only works on macOS.
   virtual void SetTitle(const std::string& title);
 
-  // Sets whether the status icon is highlighted when it is clicked. This only
-  // works on macOS.
-  virtual void SetHighlightMode(bool highlight);
+  // Sets the status icon highlight mode. This only works on macOS.
+  enum HighlightMode {
+    ALWAYS,  // Always highlight the tray icon
+    NEVER,  // Never highlight the tray icon
+    SELECTION  // Highlight the tray icon when clicked or the menu is opened
+  };
+  virtual void SetHighlightMode(HighlightMode mode);
 
   // Displays a notification balloon with the specified contents.
   // Depending on the platform it might not appear by the icon tray.

--- a/atom/browser/ui/tray_icon_cocoa.h
+++ b/atom/browser/ui/tray_icon_cocoa.h
@@ -27,7 +27,7 @@ class TrayIconCocoa : public TrayIcon,
   void SetPressedImage(const gfx::Image& image) override;
   void SetToolTip(const std::string& tool_tip) override;
   void SetTitle(const std::string& title) override;
-  void SetHighlightMode(bool highlight) override;
+  void SetHighlightMode(TrayIcon::HighlightMode mode) override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -173,12 +173,15 @@ Sets the hover text for this tray icon.
 
 Sets the title displayed aside of the tray icon in the status bar.
 
-#### `tray.setHighlightMode(highlight)` _macOS_
+#### `tray.setHighlightMode(mode)` _macOS_
 
-* `highlight` Boolean
+* `mode` String highlight mode with one of the following values:
+  * `'selection'` - Highlight the tray icon when it is clicked and also when
+    its context menu is open. This is the default.
+  * `'always'` - Always highlight the tray icon.
+  * `'never'` - Never highlight the tray icon.
 
-Sets whether the tray icon's background becomes highlighted (in blue)
-when the tray icon is clicked. Defaults to true.
+Sets when the tray's icon background becomes highlighted (in blue).
 
 #### `tray.displayBalloon(options)` _Windows_
 


### PR DESCRIPTION
For applications showing "popover" style windows when the tray icon is clicked, it is nice to highlight the tray icon background for the entirety of when the window is open (like screenhero, dropbox, 1password, etc. do).

Previously the icon would highlight only when clicked but the highlight would go away on mouse up.

Now you can control when the highlight goes away explicitly so you can maintain the highlighted background until your window is closed.

Since there was already a `tray.setHighlightMode(mode)` API, I expanded that API to take a string enum instead of a boolean.

The possible values are:

- `'always'` - Always highlight the tray icon
- `'never'` - Never highlight the tray icon, previously equivalent to`tray.setHighlightMode(false)`.
- `'selection'` - Highlight the icon when clicked and when the context menu is open (the default), previously equivalent to calling `tray.setHighlightMode(true)`.

It still handles a `boolean` param so it should be backwards compatible with the previous behavior.

| Before | After |
| --- | --- |
| <img width="389" alt="screen shot 2016-07-26 at 2 06 31 pm" src="https://cloud.githubusercontent.com/assets/671378/17155499/32fed8bc-533a-11e6-9d7d-32224231feff.png"> | <img width="383" alt="screen shot 2016-07-26 at 2 06 02 pm" src="https://cloud.githubusercontent.com/assets/671378/17155597/955fb8c8-533a-11e6-9bce-61d4374114ab.png"> | 

Closes #6528