### PR TITLE
docs: mention app ready event for DevTools Extension tutorial

### DIFF
--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -29,7 +29,10 @@ Using the [React Developer Tools][react-devtools] as example:
    * on macOS it is `~/Library/Application Support/Google/Chrome/Default/Extensions`.
 1. Pass the location of the extension to `BrowserWindow.addDevToolsExtension`
    API, for the React Developer Tools, it is something like:
-   `~/Library/Application Support/Google/Chrome/Default/Extensions/fmkadmapgofadopljbjfkapdkoienihi/0.14.10_0`
+   `~/Library/Application Support/Google/Chrome/Default/Extensions/fmkadmapgofadopljbjfkapdkoienihi/0.15.0_0`
+
+**Note:** The `BrowserWindow.addDevToolsExtension` API cannot be called before the
+ready event of the app module is emitted.
 
 The name of the extension is returned by `BrowserWindow.addDevToolsExtension`,
 and you can pass the name of the extension to the `BrowserWindow.removeDevToolsExtension`


### PR DESCRIPTION
Just attempted to install the React DevTools following this tutorial and kept getting `TypeError: BrowserWindow.addDevToolsExtension is not a function` error message when attempting to load the extension. Had to dig into the API docs before I found that this particular API is not available before the app ready event has been called. Would be nice to newcomers to have that information right on the tutorial.

On an other note, I did not get the relative `~` path working on macOS 10.11.6 and Electron 1.3.0 and had to use the full path `/Users/me/Library/...` before the extension loaded successfully. Might be worth mentioning?