### PR TITLE
Set download item save path to selected path from dialog

### DIFF
--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -85,6 +85,14 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
         download_manager_->GetBrowserContext());
     browser_context->prefs()->SetFilePath(prefs::kDownloadDefaultDirectory,
                                           path.DirName());
+
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::Locker locker(isolate);
+    v8::HandleScope handle_scope(isolate);
+    api::DownloadItem* download_item = api::DownloadItem::FromWrappedClass(
+        isolate, item);
+    if (download_item)
+      download_item->SetSavePath(path);
   }
 
   // Running the DownloadTargetCallback with an empty FilePath signals that the

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -80,6 +80,12 @@ The API is only available in session's `will-download` callback function.
 If user doesn't set the save path via the API, Electron will use the original
 routine to determine the save path(Usually prompts a save dialog).
 
+### `downloadItem.getSavePath()`
+
+Returns the save path of the download item. This will be either the path
+set via `downloadItem.setSavePath(path)` or the path selected from the shown
+save dialog.
+
 ### `downloadItem.pause()`
 
 Pauses the download.

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -239,9 +239,10 @@ describe('session module', function () {
       res.end(mockPDF)
       downloadServer.close()
     })
-    var assertDownload = function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port) {
+    var assertDownload = function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port, savePath) {
       assert.equal(state, 'completed')
       assert.equal(filename, 'mock.pdf')
+      assert.equal(savePath, path.join(__dirname, 'fixtures', 'mock.pdf'))
       assert.equal(url, 'http://127.0.0.1:' + port + '/')
       assert.equal(mimeType, 'application/pdf')
       assert.equal(receivedBytes, mockPDF.length)
@@ -256,8 +257,8 @@ describe('session module', function () {
         var port = downloadServer.address().port
         ipcRenderer.sendSync('set-download-option', false, false)
         w.loadURL(url + ':' + port)
-        ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
-          assertDownload(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port)
+        ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, savePath) {
+          assertDownload(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port, savePath)
           done()
         })
       })
@@ -272,8 +273,8 @@ describe('session module', function () {
         webview.addEventListener('did-finish-load', function () {
           webview.downloadURL(url + ':' + port + '/')
         })
-        ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
-          assertDownload(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port)
+        ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, savePath) {
+          assertDownload(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port, savePath)
           document.body.removeChild(webview)
           done()
         })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -142,7 +142,8 @@ app.on('ready', function () {
             item.getReceivedBytes(),
             item.getTotalBytes(),
             item.getContentDisposition(),
-            item.getFilename())
+            item.getFilename(),
+            item.getSavePath())
         })
         if (needCancel) item.cancel()
       }


### PR DESCRIPTION
Set the save path of the download item to the path selected from the save dialog so it is accessible once set.

This pull requests also makes the `downloadItem.getSavePath()` API public.

Closes #5877