### PR TITLE
docs: Add recommended sizes for Windows ICO icons

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -35,6 +35,8 @@ quality it is recommended to include at least the following sizes in the icon:
 
 * 16x16
 * 32x32
+* 40x40
+* 48x48
 * 64x64
 * 256x256
 


### PR DESCRIPTION
For #6396
Please refer to "For high dpi" section of https://msdn.microsoft.com/en-us/library/windows/desktop/dn742485(v=vs.85).aspx

And `atom/browser/resources/win/atom.ico` should include 40x40 icon for 125% scaling.