### PR TITLE
Check that window is an EventDispatchingWindow

### DIFF
--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -32,7 +32,8 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
       [[NSApp mainMenu] performKeyEquivalent:event.os_event])
     return;
 
-  if (event.os_event.window)
+  if (event.os_event.window &&
+      [event.os_event.window isKindOfClass:[EventDispatchingWindow class]])
     [event.os_event.window redispatchKeyEvent:event.os_event];
 }
 


### PR DESCRIPTION
It looks like sometimes the `event.os_event.window` property is an `NSToolbarFullScreenWindow` which will crash when redispatch of the key event is attempted.

This pull requests adds an explicit check for the window being an `EventDispatchingWindow`.

I  was unable to actually reproduce #6630 locally, I tried running keyboard commands for full screen windows, with and without frames, and with various title bar styles.

Closes #6630