### PR TITLE
Check view before checking top level native window

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -743,7 +743,7 @@ bool WebContents::OnMessageReceived(const IPC::Message& message) {
 }
 
 // There are three ways of destroying a webContents:
-// 1. call webContents.destory();
+// 1. call webContents.destroy();
 // 2. garbage collection;
 // 3. user closes the window of webContents;
 // For webview only #1 will happen, for BrowserWindow both #1 and #3 may

--- a/atom/browser/api/atom_api_web_contents_mac.mm
+++ b/atom/browser/api/atom_api_web_contents_mac.mm
@@ -13,6 +13,9 @@ namespace atom {
 namespace api {
 
 bool WebContents::IsFocused() const {
+  auto view = web_contents()->GetRenderWidgetHostView();
+  if (!view) return false;
+
   if (GetType() != BACKGROUND_PAGE) {
     auto window = web_contents()->GetTopLevelNativeWindow();
     // On Mac the render widget host view does not lose focus when the window
@@ -21,8 +24,7 @@ bool WebContents::IsFocused() const {
       return false;
   }
 
-  auto view = web_contents()->GetRenderWidgetHostView();
-  return view && view->HasFocus();
+  return view->HasFocus();
 }
 
 }  // namespace api


### PR DESCRIPTION
Calling `web_contents()->GetTopLevelNativeWindow()` appears to crash if called when no `web_contents()->GetRenderWidgetHostView()` is available.

This pull requests tweaks the `WebContents::IsFocused` method to not check the window's focus state when no render widget host view is present.

Closes #6642