### PR TITLE
Add BrowserWindow.get/setContentBounds()

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -366,6 +366,10 @@ gfx::Rect Window::GetBounds() {
   return window_->GetBounds();
 }
 
+gfx::Rect Window::GetContentBounds() {
+  return window_->GetContentBounds();
+}
+
 void Window::SetSize(int width, int height, mate::Arguments* args) {
   bool animate = false;
   args->GetNext(&animate);
@@ -785,6 +789,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setBounds", &Window::SetBounds)
       .SetMethod("getSize", &Window::GetSize)
       .SetMethod("setSize", &Window::SetSize)
+      .SetMethod("getContentBounds", &Window::GetContentBounds)
       .SetMethod("getContentSize", &Window::GetContentSize)
       .SetMethod("setContentSize", &Window::SetContentSize)
       .SetMethod("setMinimumSize", &Window::SetMinimumSize)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -366,6 +366,12 @@ gfx::Rect Window::GetBounds() {
   return window_->GetBounds();
 }
 
+void Window::SetContentBounds(const gfx::Rect& bounds, mate::Arguments* args) {
+  bool animate = false;
+  args->GetNext(&animate);
+  window_->SetContentBounds(bounds, animate);
+}
+
 gfx::Rect Window::GetContentBounds() {
   return window_->GetContentBounds();
 }
@@ -790,6 +796,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getSize", &Window::GetSize)
       .SetMethod("setSize", &Window::SetSize)
       .SetMethod("getContentBounds", &Window::GetContentBounds)
+      .SetMethod("setContentBounds", &Window::SetContentBounds)
       .SetMethod("getContentSize", &Window::GetContentSize)
       .SetMethod("setContentSize", &Window::SetContentSize)
       .SetMethod("setMinimumSize", &Window::SetMinimumSize)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -112,6 +112,7 @@ class Window : public mate::TrackableObject<Window>,
   std::vector<int> GetSize();
   void SetContentSize(int width, int height, mate::Arguments* args);
   std::vector<int> GetContentSize();
+  gfx::Rect GetContentBounds();
   void SetMinimumSize(int width, int height);
   std::vector<int> GetMinimumSize();
   void SetMaximumSize(int width, int height);

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -112,6 +112,7 @@ class Window : public mate::TrackableObject<Window>,
   std::vector<int> GetSize();
   void SetContentSize(int width, int height, mate::Arguments* args);
   std::vector<int> GetContentSize();
+  void SetContentBounds(const gfx::Rect& bounds, mate::Arguments* args);
   gfx::Rect GetContentBounds();
   void SetMinimumSize(int width, int height);
   std::vector<int> GetMinimumSize();

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -219,9 +219,7 @@ gfx::Point NativeWindow::GetPosition() {
 }
 
 void NativeWindow::SetContentSize(const gfx::Size& size, bool animate) {
-  gfx::Rect bounds = GetContentBounds();
-  bounds.set_size(size);
-  SetSize(ContentBoundsToWindowBounds(bounds).size(), animate);
+  SetSize(ContentBoundsToWindowBounds(gfx::Rect(size)).size(), animate);
 }
 
 gfx::Size NativeWindow::GetContentSize() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -228,6 +228,10 @@ gfx::Size NativeWindow::GetContentSize() {
   return GetContentBounds().size();
 }
 
+void NativeWindow::SetContentBounds(const gfx::Rect& bounds, bool animate) {
+  SetBounds(ContentBoundsToWindowBounds(bounds), animate);
+}
+
 gfx::Rect NativeWindow::GetContentBounds() {
   return WindowBoundsToContentBounds(GetBounds());
 }

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -256,7 +256,7 @@ extensions::SizeConstraints NativeWindow::GetSizeConstraints() {
   if (content_constraints.HasMaximumSize()) {
     gfx::Rect max_bounds = ContentBoundsToWindowBounds(
         gfx::Rect(content_constraints.GetMaximumSize()));
-    content_constraints.set_maximum_size(max_bounds.size());
+    window_constraints.set_maximum_size(max_bounds.size());
   }
   if (content_constraints.HasMinimumSize()) {
     gfx::Rect min_bounds = ContentBoundsToWindowBounds(

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -219,34 +219,46 @@ gfx::Point NativeWindow::GetPosition() {
 }
 
 void NativeWindow::SetContentSize(const gfx::Size& size, bool animate) {
-  SetSize(ContentSizeToWindowSize(size), animate);
+  SetSize(ContentBoundsToWindowBounds(gfx::Rect(size)).size(), animate);
 }
 
 gfx::Size NativeWindow::GetContentSize() {
-  return WindowSizeToContentSize(GetSize());
+  return GetContentBounds().size();
+}
+
+gfx::Rect NativeWindow::GetContentBounds() {
+  return WindowBoundsToContentBounds(GetBounds());
 }
 
 void NativeWindow::SetSizeConstraints(
     const extensions::SizeConstraints& window_constraints) {
   extensions::SizeConstraints content_constraints(GetContentSizeConstraints());
-  if (window_constraints.HasMaximumSize())
-    content_constraints.set_maximum_size(
-        WindowSizeToContentSize(window_constraints.GetMaximumSize()));
-  if (window_constraints.HasMinimumSize())
-    content_constraints.set_minimum_size(
-        WindowSizeToContentSize(window_constraints.GetMinimumSize()));
+  if (window_constraints.HasMaximumSize()) {
+    gfx::Rect max_bounds = WindowBoundsToContentBounds(
+        gfx::Rect(window_constraints.GetMaximumSize()));
+    content_constraints.set_maximum_size(max_bounds.size());
+  }
+  if (window_constraints.HasMinimumSize()) {
+    gfx::Rect min_bounds = WindowBoundsToContentBounds(
+        gfx::Rect(window_constraints.GetMinimumSize()));
+    content_constraints.set_minimum_size(min_bounds.size());
+  }
   SetContentSizeConstraints(content_constraints);
 }
 
 extensions::SizeConstraints NativeWindow::GetSizeConstraints() {
   extensions::SizeConstraints content_constraints = GetContentSizeConstraints();
   extensions::SizeConstraints window_constraints;
-  if (content_constraints.HasMaximumSize())
-    window_constraints.set_maximum_size(
-        ContentSizeToWindowSize(content_constraints.GetMaximumSize()));
-  if (content_constraints.HasMinimumSize())
-    window_constraints.set_minimum_size(
-        ContentSizeToWindowSize(content_constraints.GetMinimumSize()));
+  if (content_constraints.HasMaximumSize()) {
+    gfx::Rect max_bounds = ContentBoundsToWindowBounds(
+        gfx::Rect(content_constraints.GetMaximumSize()));
+    content_constraints.set_maximum_size(max_bounds.size());
+  }
+  if (content_constraints.HasMinimumSize()) {
+    gfx::Rect min_bounds = ContentBoundsToWindowBounds(
+        gfx::Rect(content_constraints.GetMinimumSize()));
+    window_constraints.set_minimum_size(min_bounds.size());
+  }
   return window_constraints;
 }
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -219,7 +219,9 @@ gfx::Point NativeWindow::GetPosition() {
 }
 
 void NativeWindow::SetContentSize(const gfx::Size& size, bool animate) {
-  SetSize(ContentBoundsToWindowBounds(gfx::Rect(size)).size(), animate);
+  gfx::Rect bounds = GetContentBounds();
+  bounds.set_size(size);
+  SetSize(ContentBoundsToWindowBounds(bounds).size(), animate);
 }
 
 gfx::Size NativeWindow::GetContentSize() {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -91,6 +91,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Point GetPosition();
   virtual void SetContentSize(const gfx::Size& size, bool animate = false);
   virtual gfx::Size GetContentSize();
+  virtual void SetContentBounds(const gfx::Rect& bounds, bool animate = false);
   virtual gfx::Rect GetContentBounds();
   virtual void SetSizeConstraints(
       const extensions::SizeConstraints& size_constraints);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -91,6 +91,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Point GetPosition();
   virtual void SetContentSize(const gfx::Size& size, bool animate = false);
   virtual gfx::Size GetContentSize();
+  virtual gfx::Rect GetContentBounds() = 0;
   virtual void SetSizeConstraints(
       const extensions::SizeConstraints& size_constraints);
   virtual extensions::SizeConstraints GetSizeConstraints();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -91,7 +91,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Point GetPosition();
   virtual void SetContentSize(const gfx::Size& size, bool animate = false);
   virtual gfx::Size GetContentSize();
-  virtual gfx::Rect GetContentBounds() = 0;
+  virtual gfx::Rect GetContentBounds();
   virtual void SetSizeConstraints(
       const extensions::SizeConstraints& size_constraints);
   virtual extensions::SizeConstraints GetSizeConstraints();
@@ -239,9 +239,9 @@ class NativeWindow : public base::SupportsUserData,
   std::unique_ptr<SkRegion> DraggableRegionsToSkRegion(
       const std::vector<DraggableRegion>& regions);
 
-  // Converts between content size to window size.
-  virtual gfx::Size ContentSizeToWindowSize(const gfx::Size& size) = 0;
-  virtual gfx::Size WindowSizeToContentSize(const gfx::Size& size) = 0;
+  // Converts between content bounds and window bounds.
+  virtual gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) = 0;
+  virtual gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) = 0;
 
   // Called when the window needs to update its draggable region.
   virtual void UpdateDraggableRegions(

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -46,6 +46,7 @@ class NativeWindowMac : public NativeWindow {
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
   gfx::Rect GetBounds() override;
+  gfx::Rect GetContentBounds() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -46,7 +46,6 @@ class NativeWindowMac : public NativeWindow {
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
   gfx::Rect GetBounds() override;
-  gfx::Rect GetContentBounds() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
@@ -115,8 +114,8 @@ class NativeWindowMac : public NativeWindow {
 
  private:
   // NativeWindow:
-  gfx::Size ContentSizeToWindowSize(const gfx::Size& size) override;
-  gfx::Size WindowSizeToContentSize(const gfx::Size& size) override;
+  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds);
+  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds);
   void UpdateDraggableRegions(
       const std::vector<DraggableRegion>& regions) override;
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1045,10 +1045,15 @@ std::vector<gfx::Rect> NativeWindowMac::CalculateNonDraggableRegions(
 
 gfx::Rect NativeWindowMac::ContentBoundsToWindowBounds(
     const gfx::Rect& bounds) {
-  if (has_frame())
-    return gfx::Rect([window_ frameRectForContentRect:bounds.ToCGRect()]);
-  else
+  if (has_frame()) {
+    gfx::Rect window_bounds(
+        [window_ frameRectForContentRect:bounds.ToCGRect()]);
+    int frame_height = window_bounds.height() - bounds.height();
+    window_bounds.set_y(window_bounds.y() - frame_height);
+    return window_bounds;
+  } else {
     return bounds;
+  }
 }
 
 gfx::Rect NativeWindowMac::WindowBoundsToContentBounds(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -753,6 +753,14 @@ gfx::Rect NativeWindowMac::GetBounds() {
   return bounds;
 }
 
+gfx::Rect NativeWindowMac::GetContentBounds() {
+  NSRect frame = [window_ convertRectToScreen:[[window_ contentView] frame]];
+  gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
+  NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
+  bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
+  return bounds;
+}
+
 void NativeWindowMac::SetContentSizeConstraints(
     const extensions::SizeConstraints& size_constraints) {
   auto convertSize = [this](const gfx::Size& size) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -545,9 +545,7 @@ gfx::Rect NativeWindowViews::GetBounds() {
 }
 
 gfx::Rect NativeWindowViews::GetContentBounds() {
-  gfx::Rect bounds = window_->GetClientAreaBoundsInScreen();
-  bounds.set_size(GetContentSize());
-  return bounds;
+  return web_view_->GetBoundsInScreen();
 }
 
 gfx::Size NativeWindowViews::GetContentSize() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1164,8 +1164,10 @@ gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
       window_->non_client_view()->GetWindowBoundsForClientBounds(dpi_bounds));
 #endif
 
-  if (menu_bar_ && menu_bar_visible_)
+  if (menu_bar_ && menu_bar_visible_) {
+    window_bounds.set_y(window_bounds.y() - kMenuBarHeight);
     window_bounds.set_height(window_bounds.height() + kMenuBarHeight);
+  }
   return window_bounds;
 }
 
@@ -1190,8 +1192,10 @@ gfx::Rect NativeWindowViews::WindowBoundsToContentBounds(
       display::win::ScreenWin::ScreenToDIPSize(hwnd, content_bounds.size()));
 #endif
 
-  if (menu_bar_ && menu_bar_visible_)
+  if (menu_bar_ && menu_bar_visible_) {
+    content_bounds.set_y(content_bounds.y() + kMenuBarHeight);
     content_bounds.set_height(content_bounds.height() - kMenuBarHeight);
+  }
   return content_bounds;
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -545,7 +545,9 @@ gfx::Rect NativeWindowViews::GetBounds() {
 }
 
 gfx::Rect NativeWindowViews::GetContentBounds() {
-  return window_->GetClientAreaBoundsInScreen();
+  gfx::Rect bounds = window_->GetClientAreaBoundsInScreen();
+  bounds.set_size(GetContentSize());
+  return bounds;
 }
 
 gfx::Size NativeWindowViews::GetContentSize() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -316,7 +316,7 @@ NativeWindowViews::NativeWindowViews(
   if (has_frame() &&
       options.Get(options::kUseContentSize, &use_content_size_) &&
       use_content_size_)
-    size = ContentSizeToWindowSize(size);
+    size = ContentBoundsToWindowBounds(gfx::Rect(size)).size();
 
   window_->CenterWindow(size);
   Layout();
@@ -1150,47 +1150,49 @@ void NativeWindowViews::OnWidgetMove() {
   NotifyWindowMove();
 }
 
-gfx::Size NativeWindowViews::ContentSizeToWindowSize(const gfx::Size& size) {
+gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
+    const gfx::Rect& bounds) {
   if (!has_frame())
-    return size;
+    return bounds;
 
-  gfx::Size window_size(size);
+  gfx::Rect window_bounds(bounds);
 #if defined(OS_WIN)
   HWND hwnd = GetAcceleratedWidget();
-  gfx::Rect dpi_bounds = gfx::Rect(
-      gfx::Point(), display::win::ScreenWin::DIPToScreenSize(hwnd, size));
-  gfx::Rect window_bounds = display::win::ScreenWin::ScreenToDIPRect(
+  gfx::Rect dpi_bounds = display::win::ScreenWin::DIPToScreenRect(hwnd, bounds);
+  window_bounds = display::win::ScreenWin::ScreenToDIPRect(
       hwnd,
       window_->non_client_view()->GetWindowBoundsForClientBounds(dpi_bounds));
-  window_size = window_bounds.size();
 #endif
 
   if (menu_bar_ && menu_bar_visible_)
-    window_size.set_height(window_size.height() + kMenuBarHeight);
-  return window_size;
+    window_bounds.set_height(window_bounds.height() + kMenuBarHeight);
+  return window_bounds;
 }
 
-gfx::Size NativeWindowViews::WindowSizeToContentSize(const gfx::Size& size) {
+gfx::Rect NativeWindowViews::WindowBoundsToContentBounds(
+    const gfx::Rect& bounds) {
   if (!has_frame())
-    return size;
+    return bounds;
 
-  gfx::Size content_size(size);
+  gfx::Rect content_bounds(bounds);
 #if defined(OS_WIN)
   HWND hwnd = GetAcceleratedWidget();
-  content_size = display::win::ScreenWin::DIPToScreenSize(hwnd, content_size);
+  content_bounds.set_size(
+      display::win::ScreenWin::DIPToScreenSize(hwnd, content_bounds.size()));
   RECT rect;
   SetRectEmpty(&rect);
   DWORD style = ::GetWindowLong(hwnd, GWL_STYLE);
   DWORD ex_style = ::GetWindowLong(hwnd, GWL_EXSTYLE);
   AdjustWindowRectEx(&rect, style, FALSE, ex_style);
-  content_size.set_width(content_size.width() - (rect.right - rect.left));
-  content_size.set_height(content_size.height() - (rect.bottom - rect.top));
-  content_size = display::win::ScreenWin::ScreenToDIPSize(hwnd, content_size);
+  content_bounds.set_width(content_bounds.width() - (rect.right - rect.left));
+  content_bounds.set_height(content_bounds.height() - (rect.bottom - rect.top));
+  content_bounds.set_size(
+      display::win::ScreenWin::ScreenToDIPSize(hwnd, content_bounds.size()));
 #endif
 
   if (menu_bar_ && menu_bar_visible_)
-    content_size.set_height(content_size.height() - kMenuBarHeight);
-  return content_size;
+    content_bounds.set_height(content_bounds.height() - kMenuBarHeight);
+  return content_bounds;
 }
 
 void NativeWindowViews::HandleKeyboardEvent(

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -544,6 +544,10 @@ gfx::Rect NativeWindowViews::GetBounds() {
   return window_->GetWindowBoundsInScreen();
 }
 
+gfx::Rect NativeWindowViews::GetContentBounds() {
+  return window_->GetClientAreaBoundsInScreen();
+}
+
 gfx::Size NativeWindowViews::GetContentSize() {
 #if defined(OS_WIN)
   if (IsMinimized())

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -68,6 +68,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds, bool animate) override;
   gfx::Rect GetBounds() override;
+  gfx::Rect GetContentBounds() override;
   gfx::Size GetContentSize() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -165,8 +165,8 @@ class NativeWindowViews : public NativeWindow,
 #endif
 
   // NativeWindow:
-  gfx::Size ContentSizeToWindowSize(const gfx::Size& size) override;
-  gfx::Size WindowSizeToContentSize(const gfx::Size& size) override;
+  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) override;
+  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) override;
   void HandleKeyboardEvent(
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -669,6 +669,11 @@ Resizes and moves the window to `width`, `height`, `x`, `y`.
 
 Returns an object that contains window's width, height, x and y values.
 
+#### `win.getContentBounds()`
+
+Returns an object that contains the window's client area (e.g. the web page)
+width, height, x and y values.
+
 #### `win.setSize(width, height[, animate])`
 
 * `width` Integer

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -669,6 +669,18 @@ Resizes and moves the window to `width`, `height`, `x`, `y`.
 
 Returns an object that contains window's width, height, x and y values.
 
+#### `win.setContentBounds(options[, animate])`
+
+* `options` Object
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+* `animate` Boolean (optional) _macOS_
+
+Resizes and moves the window's client area (e.g. the web page) to
+`width`, `height`, `x`, `y`.
+
 #### `win.getContentBounds()`
 
 Returns an object that contains the window's client area (e.g. the web page)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -352,7 +352,7 @@ describe('browser-window module', function () {
 
   describe('BrowserWindow.setContentBounds(bounds)', function () {
     it('sets the content size and position', function (done) {
-      var bounds = {x: 60, y: 60, width: 250, height: 250}
+      var bounds = {x: 10, y: 10, width: 250, height: 250}
       w.once('resize', function () {
         assert.deepEqual(w.getContentBounds(), bounds)
         done()
@@ -368,7 +368,7 @@ describe('browser-window module', function () {
         width: 300,
         height: 300
       })
-      var bounds = {x: 60, y: 60, width: 250, height: 250}
+      var bounds = {x: 10, y: 10, width: 250, height: 250}
       w.once('resize', function () {
         assert.deepEqual(w.getContentBounds(), bounds)
         done()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -332,25 +332,42 @@ describe('browser-window module', function () {
       var after = w.getContentSize()
       assert.equal(after[0], size[0])
       assert.equal(after[1], size[1])
-      assert.equal(w.getContentBounds().width, size[0])
-      assert.equal(w.getContentBounds().height, size[1])
     })
 
-    it('works for framless window', function () {
+    it('works for a frameless window', function () {
       w.destroy()
       w = new BrowserWindow({
         show: false,
         frame: false,
-        width: 400,
-        height: 400
+        width: 300,
+        height: 300
       })
       var size = [400, 400]
       w.setContentSize(size[0], size[1])
       var after = w.getContentSize()
       assert.equal(after[0], size[0])
       assert.equal(after[1], size[1])
-      assert.equal(w.getContentBounds().width, size[0])
-      assert.equal(w.getContentBounds().height, size[1])
+    })
+  })
+
+  describe('BrowserWindow.setContentBounds(bounds)', function () {
+    it('sets the content size and position', function () {
+      var bounds = {x: 100, y: 100, width: 400, height: 400}
+      w.setContentBounds(bounds)
+      assert.deepEqual(w.getContentBounds(), bounds)
+    })
+
+    it('works for a frameless window', function () {
+      w.destroy()
+      w = new BrowserWindow({
+        show: false,
+        frame: false,
+        width: 300,
+        height: 300
+      })
+      var bounds = {x: 100, y: 100, width: 400, height: 400}
+      w.setContentBounds(bounds)
+      assert.deepEqual(w.getContentBounds(), bounds)
     })
   })
 
@@ -396,7 +413,7 @@ describe('browser-window module', function () {
       assert.equal(size[1], 400)
     })
 
-    it('works for framless window', function () {
+    it('works for a frameless window', function () {
       w.destroy()
       w = new BrowserWindow({
         show: false,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -332,6 +332,8 @@ describe('browser-window module', function () {
       var after = w.getContentSize()
       assert.equal(after[0], size[0])
       assert.equal(after[1], size[1])
+      assert.equal(w.getContentBounds().width, size[0])
+      assert.equal(w.getContentBounds().height, size[1])
     })
 
     it('works for framless window', function () {
@@ -347,6 +349,8 @@ describe('browser-window module', function () {
       var after = w.getContentSize()
       assert.equal(after[0], size[0])
       assert.equal(after[1], size[1])
+      assert.equal(w.getContentBounds().width, size[0])
+      assert.equal(w.getContentBounds().height, size[1])
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -339,8 +339,8 @@ describe('browser-window module', function () {
       w = new BrowserWindow({
         show: false,
         frame: false,
-        width: 300,
-        height: 300
+        width: 400,
+        height: 400
       })
       var size = [400, 400]
       w.setContentSize(size[0], size[1])
@@ -351,13 +351,16 @@ describe('browser-window module', function () {
   })
 
   describe('BrowserWindow.setContentBounds(bounds)', function () {
-    it('sets the content size and position', function () {
-      var bounds = {x: 100, y: 100, width: 400, height: 400}
+    it('sets the content size and position', function (done) {
+      var bounds = {x: 60, y: 60, width: 250, height: 250}
+      w.once('resize', function () {
+        assert.deepEqual(w.getContentBounds(), bounds)
+        done()
+      })
       w.setContentBounds(bounds)
-      assert.deepEqual(w.getContentBounds(), bounds)
     })
 
-    it('works for a frameless window', function () {
+    it('works for a frameless window', function (done) {
       w.destroy()
       w = new BrowserWindow({
         show: false,
@@ -365,9 +368,12 @@ describe('browser-window module', function () {
         width: 300,
         height: 300
       })
-      var bounds = {x: 100, y: 100, width: 400, height: 400}
+      var bounds = {x: 60, y: 60, width: 250, height: 250}
+      w.once('resize', function () {
+        assert.deepEqual(w.getContentBounds(), bounds)
+        done()
+      })
       w.setContentBounds(bounds)
-      assert.deepEqual(w.getContentBounds(), bounds)
     })
   })
 


### PR DESCRIPTION
This pull request adds a new `getContentBounds()` API to `BrowserWindow` that returns the x, y, width, and height of the content area.

This will allow apps to know the size of the window chrome by comparing the content bounds to the window bounds.

Closes #6536