### PR TITLE
Do not garbage collect sessions

### DIFF
--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -2,7 +2,7 @@ const {EventEmitter} = require('events')
 const {app} = require('electron')
 const {fromPartition, _setWrapSession} = process.atomBinding('session')
 
-// Returns the default session.
+// Public API.
 Object.defineProperties(exports, {
   defaultSession: {
     enumerable: true,
@@ -14,9 +14,15 @@ Object.defineProperties(exports, {
   }
 })
 
+const sessions = []
+
 // Wraps native Session class.
 _setWrapSession(function (session) {
   // Session is an EventEmitter.
   Object.setPrototypeOf(session, EventEmitter.prototype)
   app.emit('session-created', session)
+
+  // The Sessions should never be garbage collected, since the common pattern is
+  // to use partition strings, instead of using the Session object directly.
+  sessions.push(session)
 })

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -14,15 +14,9 @@ Object.defineProperties(exports, {
   }
 })
 
-const sessions = []
-
 // Wraps native Session class.
 _setWrapSession(function (session) {
   // Session is an EventEmitter.
   Object.setPrototypeOf(session, EventEmitter.prototype)
   app.emit('session-created', session)
-
-  // The Sessions should never be garbage collected, since the common pattern is
-  // to use partition strings, instead of using the Session object directly.
-  sessions.push(session)
 })


### PR DESCRIPTION
Since users can use partition strings to refer to `Session` objects, it is not usual for users to save a reference to `Session`s. So we have to prevent `Session` from being garbaged collected, otherwise the same `Session` object might be deleted between uses of partition strings.

Close #6258.