### PR TITLE
Add isVisible() to app.dock

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -656,6 +656,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                  base::Bind(&Browser::DockGetBadgeText, browser));
   dict.SetMethod("dockHide", base::Bind(&Browser::DockHide, browser));
   dict.SetMethod("dockShow", base::Bind(&Browser::DockShow, browser));
+  dict.SetMethod("dockIsVisible", base::Bind(&Browser::DockIsVisible, browser));
   dict.SetMethod("dockSetMenu", &DockSetMenu);
   dict.SetMethod("dockSetIcon", base::Bind(&Browser::DockSetIcon, browser));
 #endif

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -136,6 +136,7 @@ class Browser : public WindowListObserver {
   // Hide/Show dock.
   void DockHide();
   void DockShow();
+  bool DockIsVisible();
 
   // Set docks' menu.
   void DockSetMenu(AtomMenuModel* model);

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -208,6 +208,12 @@ void Browser::DockHide() {
   TransformProcessType(&psn, kProcessTransformToUIElementApplication);
 }
 
+bool Browser::DockIsVisible() {
+  // Because DockShow has a slight delay this may not be true immediately
+  // after that call.
+  return ([[NSRunningApplication currentApplication] activationPolicy] == NSApplicationActivationPolicyRegular);
+}
+
 void Browser::DockShow() {
   BOOL active = [[NSRunningApplication currentApplication] isActive];
   ProcessSerialNumber psn = { 0, kCurrentProcess };

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -725,6 +725,12 @@ Hides the dock icon.
 
 Shows the dock icon.
 
+### `app.dock.isVisible()` _macOS_
+
+Returns whether the dock icon is visible.
+The `app.dock.show()` call is asynchronous so this method might not
+return true immediately after that call.
+
 ### `app.dock.setMenu(menu)` _macOS_
 
 * `menu` [Menu](menu.md)

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -40,6 +40,7 @@ if (process.platform === 'darwin') {
     getBadge: bindings.dockGetBadgeText,
     hide: bindings.dockHide,
     show: bindings.dockShow,
+    isVisible: bindings.dockIsVisible,
     setMenu: bindings.dockSetMenu,
     setIcon: bindings.dockSetIcon
   }


### PR DESCRIPTION
It would be nice to be able to know if the dock is visible or not. The dock is a little quirky though and since `app.dock.show` isn't synchronous, the `isVisible` may not be true immediately after `show`. But I think if we mention that in the docs, people would be wary of that?

Or we could add an instance var to track whether the dock is in the process of showing?

I tested this in the electron-quick-start app with:

```js
setInterval(function(){
  console.log('dock visible:', app.dock.isVisible())
  if (app.dock.isVisible()) {
    app.dock.hide()
    console.log('after hide:', app.dock.isVisible())
    console.log('-')
  } else {
    app.dock.show()
    console.log('after show:', app.dock.isVisible())
    setTimeout(function(){
      console.log('after show (with delay):', app.dock.isVisible())
      console.log('-')
    }, 10);
  }
}, 1000)
```

The output of this looks like:

```
dock visible: true
after hide: false
-
dock visible: false
after show: false
after show (with delay): true
-
dock visible: true
after hide: false
-
dock visible: false
after show: false
after show (with delay): true
...
```

I wasn't sure if there was a test suite to add to or if this type of testing was manual. I can push my test app branch if you would like to try it out.