### PR TITLE
Implement and Document the zoom methods that are mapped to the webContents object

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -616,6 +616,28 @@ Mute the audio on the current web page.
 
 Returns whether this page has been muted.
 
+#### `contents.setZoomFactor(factor)`
+
+* `factor` Number - Zoom factor.
+
+Changes the zoom factor to the specified factor. Zoom factor is
+zoom percent divided by 100, so 300% = 3.0.
+
+#### `contents.setZoomLevel(level)`
+
+* `level` Number - Zoom level
+
+Changes the zoom level to the specified level. The original size is 0 and each
+increment above or below represents zooming 20% larger or smaller to default
+limits of 300% and 50% of original size, respectively.
+
+#### `contents.setZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum zoom level.`
+
 #### `contents.undo()`
 
 Executes the editing command `undo` in web page.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -623,6 +623,10 @@ Returns whether this page has been muted.
 Changes the zoom factor to the specified factor. Zoom factor is
 zoom percent divided by 100, so 300% = 3.0.
 
+#### `contents.getZoomFactor(callback)`
+
+`callback` is called with the current zoom factor
+
 #### `contents.setZoomLevel(level)`
 
 * `level` Number - Zoom level
@@ -630,6 +634,10 @@ zoom percent divided by 100, so 300% = 3.0.
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
 limits of 300% and 50% of original size, respectively.
+
+#### `contents.getZoomLevel(callback)`
+
+`callback` is called with the current zoom level
 
 #### `contents.setZoomLevelLimits(minimumLevel, maximumLevel)`
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -128,7 +128,6 @@ const wrapWebContents = function (webContents) {
   const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
     this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
     ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
-      console.info(callback);
       if (callback) callback(result)
     })
   }

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -89,6 +89,11 @@ const webFrameMethods = [
   'setZoomLevelLimits'
 ]
 
+const webFrameMethodsWithResult = [
+  'getZoomFactor',
+  'getZoomLevel'
+]
+
 // Add JavaScript wrappers for WebContents class.
 const wrapWebContents = function (webContents) {
   // webContents is an EventEmitter.
@@ -120,6 +125,21 @@ const wrapWebContents = function (webContents) {
     }
   }
 
+  const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
+    this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
+    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
+      console.info(callback);
+      if (callback) callback(result)
+    })
+  }
+
+  const syncWebFrameMethods = function (requestId, method, callback, ...args) {
+    this.send('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', requestId, method, args)
+    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
+      if (callback) callback(result)
+    })
+  }
+
   // Mapping webFrame methods.
   for (const method of webFrameMethods) {
     webContents[method] = function (...args) {
@@ -127,11 +147,12 @@ const wrapWebContents = function (webContents) {
     }
   }
 
-  const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
-    this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
-    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
-      if (callback) callback(result)
-    })
+  for (const method of webFrameMethodsWithResult) {
+    webContents[method] = function (...args) {
+      const callback = args[args.length - 1]
+      const actualArgs = args.slice(0, args.length - 2)
+      syncWebFrameMethods.call(this, getNextId(), method, callback, ...actualArgs)
+    }
   }
 
   // Make sure webContents.executeJavaScript would run the code only when the

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -32,6 +32,11 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, m
   electron.webFrame[method].apply(electron.webFrame, args)
 })
 
+electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
+  const result = electron.webFrame[method].apply(electron.webFrame, args)
+  event.sender.send(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, result)
+})
+
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
   const responseCallback = function (result) {
     event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, result)


### PR DESCRIPTION
RE: https://github.com/electron/electron/pull/6677#discussion_r73013337

This also implements asyncronous versions of `getZoomFactor` and `getZoomLevel`