### PR TITLE
Use FunctionTemplate instead of ObjectTemplate for native classes

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -639,6 +639,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   auto command_line = base::CommandLine::ForCurrentProcess();
 
   mate::Dictionary dict(isolate, exports);
+  dict.Set("App", atom::api::App::GetConstructor(isolate)->GetFunction());
   dict.Set("app", atom::api::App::Create(isolate));
   dict.SetMethod("appendSwitch", &AppendSwitch);
   dict.SetMethod("appendArgument",

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -531,9 +531,9 @@ mate::Handle<App> App::Create(v8::Isolate* isolate) {
 
 // static
 void App::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
   auto browser = base::Unretained(Browser::Get());
-  mate::ObjectTemplateBuilder(isolate, prototype)
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("quit", base::Bind(&Browser::Quit, browser))
       .SetMethod("exit", base::Bind(&Browser::Exit, browser))
       .SetMethod("focus", base::Bind(&Browser::Focus, browser))

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -532,6 +532,7 @@ mate::Handle<App> App::Create(v8::Isolate* isolate) {
 // static
 void App::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "App"));
   auto browser = base::Unretained(Browser::Get());
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("quit", base::Bind(&Browser::Quit, browser))

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -40,7 +40,7 @@ class App : public AtomBrowserClient::Delegate,
   static mate::Handle<App> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   // Called when window with disposition needs to be created.
   void OnCreateWindow(const GURL& target_url,

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -106,8 +106,8 @@ mate::Handle<AutoUpdater> AutoUpdater::Create(v8::Isolate* isolate) {
 
 // static
 void AutoUpdater::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("checkForUpdates", &auto_updater::AutoUpdater::CheckForUpdates)
       .SetMethod("getFeedURL", &auto_updater::AutoUpdater::GetFeedURL)
       .SetMethod("setFeedURL", &AutoUpdater::SetFeedURL)

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -107,6 +107,7 @@ mate::Handle<AutoUpdater> AutoUpdater::Create(v8::Isolate* isolate) {
 // static
 void AutoUpdater::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "AutoUpdater"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("checkForUpdates", &auto_updater::AutoUpdater::CheckForUpdates)
       .SetMethod("getFeedURL", &auto_updater::AutoUpdater::GetFeedURL)

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -122,11 +122,14 @@ void AutoUpdater::BuildPrototype(
 
 namespace {
 
+using atom::api::AutoUpdater;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("autoUpdater", atom::api::AutoUpdater::Create(isolate));
+  dict.Set("autoUpdater", AutoUpdater::Create(isolate));
+  dict.Set("AutoUpdater", AutoUpdater::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_auto_updater.h
+++ b/atom/browser/api/atom_api_auto_updater.h
@@ -24,7 +24,7 @@ class AutoUpdater : public mate::EventEmitter<AutoUpdater>,
   static mate::Handle<AutoUpdater> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   explicit AutoUpdater(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -249,6 +249,7 @@ mate::Handle<Cookies> Cookies::Create(
 // static
 void Cookies::BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Cookies"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("get", &Cookies::Get)
       .SetMethod("remove", &Cookies::Remove)

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -248,8 +248,8 @@ mate::Handle<Cookies> Cookies::Create(
 
 // static
 void Cookies::BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                             v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("get", &Cookies::Get)
       .SetMethod("remove", &Cookies::Remove)
       .SetMethod("set", &Cookies::Set);

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -41,7 +41,7 @@ class Cookies : public mate::TrackableObject<Cookies> {
 
   // mate::TrackableObject:
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context);

--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -23,14 +23,6 @@ namespace atom {
 
 namespace api {
 
-namespace {
-
-// The wrapDebugger funtion which is implemented in JavaScript.
-using WrapDebuggerCallback = base::Callback<void(v8::Local<v8::Value>)>;
-WrapDebuggerCallback g_wrap_debugger;
-
-}  // namespace
-
 Debugger::Debugger(v8::Isolate* isolate, content::WebContents* web_contents)
     : web_contents_(web_contents),
       previous_request_id_(0) {
@@ -151,10 +143,7 @@ void Debugger::SendCommand(mate::Arguments* args) {
 mate::Handle<Debugger> Debugger::Create(
     v8::Isolate* isolate,
     content::WebContents* web_contents) {
-  auto handle = mate::CreateHandle(
-      isolate, new Debugger(isolate, web_contents));
-  g_wrap_debugger.Run(handle.ToV8());
-  return handle;
+  return mate::CreateHandle(isolate, new Debugger(isolate, web_contents));
 }
 
 // static
@@ -168,21 +157,19 @@ void Debugger::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("sendCommand", &Debugger::SendCommand);
 }
 
-void SetWrapDebugger(const WrapDebuggerCallback& callback) {
-  g_wrap_debugger = callback;
-}
-
 }  // namespace api
 
 }  // namespace atom
 
 namespace {
 
+using atom::api::Debugger;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  mate::Dictionary dict(isolate, exports);
-  dict.SetMethod("_setWrapDebugger", &atom::api::SetWrapDebugger);
+  mate::Dictionary(isolate, exports)
+      .Set("Debugger", Debugger::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -160,6 +160,7 @@ mate::Handle<Debugger> Debugger::Create(
 // static
 void Debugger::BuildPrototype(v8::Isolate* isolate,
                               v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Debugger"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("attach", &Debugger::Attach)
       .SetMethod("isAttached", &Debugger::IsAttached)

--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -159,8 +159,8 @@ mate::Handle<Debugger> Debugger::Create(
 
 // static
 void Debugger::BuildPrototype(v8::Isolate* isolate,
-                              v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                              v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("attach", &Debugger::Attach)
       .SetMethod("isAttached", &Debugger::IsAttached)
       .SetMethod("detach", &Debugger::Detach)

--- a/atom/browser/api/atom_api_debugger.h
+++ b/atom/browser/api/atom_api_debugger.h
@@ -39,7 +39,7 @@ class Debugger: public mate::TrackableObject<Debugger>,
 
   // mate::TrackableObject:
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   Debugger(v8::Isolate* isolate, content::WebContents* web_contents);

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -99,8 +99,8 @@ mate::Handle<DesktopCapturer> DesktopCapturer::Create(v8::Isolate* isolate) {
 
 // static
 void DesktopCapturer::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("startHandling", &DesktopCapturer::StartHandling);
 }
 

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -100,6 +100,7 @@ mate::Handle<DesktopCapturer> DesktopCapturer::Create(v8::Isolate* isolate) {
 // static
 void DesktopCapturer::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "DesktopCapturer"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("startHandling", &DesktopCapturer::StartHandling);
 }

--- a/atom/browser/api/atom_api_desktop_capturer.h
+++ b/atom/browser/api/atom_api_desktop_capturer.h
@@ -20,7 +20,7 @@ class DesktopCapturer: public mate::EventEmitter<DesktopCapturer>,
   static mate::Handle<DesktopCapturer> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   void StartHandling(bool capture_window,
                      bool capture_screen,

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -167,8 +167,8 @@ base::FilePath DownloadItem::GetSavePath() const {
 
 // static
 void DownloadItem::BuildPrototype(v8::Isolate* isolate,
-                                  v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                                  v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("pause", &DownloadItem::Pause)
       .SetMethod("isPaused", &DownloadItem::IsPaused)

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -51,10 +51,6 @@ namespace api {
 
 namespace {
 
-// The wrapDownloadItem funtion which is implemented in JavaScript
-using WrapDownloadItemCallback = base::Callback<void(v8::Local<v8::Value>)>;
-WrapDownloadItemCallback g_wrap_download_item;
-
 std::map<uint32_t, v8::Global<v8::Object>> g_download_item_objects;
 
 }  // namespace
@@ -197,16 +193,11 @@ mate::Handle<DownloadItem> DownloadItem::Create(
     return mate::CreateHandle(isolate, static_cast<DownloadItem*>(existing));
 
   auto handle = mate::CreateHandle(isolate, new DownloadItem(isolate, item));
-  g_wrap_download_item.Run(handle.ToV8());
 
   // Reference this object in case it got garbage collected.
   g_download_item_objects[handle->weak_map_id()] =
       v8::Global<v8::Object>(isolate, handle.ToV8());
   return handle;
-}
-
-void SetWrapDownloadItem(const WrapDownloadItemCallback& callback) {
-  g_wrap_download_item = callback;
 }
 
 }  // namespace api
@@ -218,8 +209,9 @@ namespace {
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  mate::Dictionary dict(isolate, exports);
-  dict.SetMethod("_setWrapDownloadItem", &atom::api::SetWrapDownloadItem);
+  mate::Dictionary(isolate, exports)
+      .Set("DownloadItem",
+           atom::api::DownloadItem::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -168,6 +168,7 @@ base::FilePath DownloadItem::GetSavePath() const {
 // static
 void DownloadItem::BuildPrototype(v8::Isolate* isolate,
                                   v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "DownloadItem"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("pause", &DownloadItem::Pause)

--- a/atom/browser/api/atom_api_download_item.h
+++ b/atom/browser/api/atom_api_download_item.h
@@ -24,7 +24,7 @@ class DownloadItem : public mate::TrackableObject<DownloadItem>,
                                            content::DownloadItem* item);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   void Pause();
   bool IsPaused() const;

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -74,8 +74,8 @@ mate::Handle<GlobalShortcut> GlobalShortcut::Create(v8::Isolate* isolate) {
 
 // static
 void GlobalShortcut::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("register", &GlobalShortcut::Register)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)
       .SetMethod("unregister", &GlobalShortcut::Unregister)

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -75,6 +75,7 @@ mate::Handle<GlobalShortcut> GlobalShortcut::Create(v8::Isolate* isolate) {
 // static
 void GlobalShortcut::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "GlobalShortcut"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("register", &GlobalShortcut::Register)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)

--- a/atom/browser/api/atom_api_global_shortcut.h
+++ b/atom/browser/api/atom_api_global_shortcut.h
@@ -24,7 +24,7 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
   static mate::Handle<GlobalShortcut> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   explicit GlobalShortcut(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -19,9 +19,10 @@ namespace atom {
 
 namespace api {
 
-Menu::Menu(v8::Isolate* isolate)
+Menu::Menu(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
     : model_(new AtomMenuModel(this)),
       parent_(nullptr) {
+  InitWith(isolate, wrapper);
 }
 
 Menu::~Menu() {
@@ -189,7 +190,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   using atom::api::Menu;
   v8::Isolate* isolate = context->GetIsolate();
   v8::Local<v8::Function> constructor = mate::CreateConstructor<Menu>(
-      isolate, "Menu", base::Bind(&Menu::Create));
+      isolate, "Menu", base::Bind(&Menu::New));
   mate::Dictionary dict(isolate, exports);
   dict.Set("Menu", static_cast<v8::Local<v8::Value>>(constructor));
 #if defined(OS_MACOSX)

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -156,6 +156,7 @@ bool Menu::IsVisibleAt(int index) const {
 // static
 void Menu::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Menu"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("insertItem", &Menu::InsertItemAt)
@@ -190,7 +191,7 @@ using atom::api::Menu;
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Menu::SetConstructor(isolate, "Menu", base::Bind(&Menu::New));
+  Menu::SetConstructor(isolate, base::Bind(&Menu::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("Menu", Menu::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -193,7 +193,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   Menu::SetConstructor(isolate, "Menu", base::Bind(&Menu::New));
 
   mate::Dictionary dict(isolate, exports);
-  dict.Set("Menu", Menu::GetConstructor(isolate));
+  dict.Set("Menu", Menu::GetConstructor(isolate)->GetFunction());
 #if defined(OS_MACOSX)
   dict.SetMethod("setApplicationMenu", &Menu::SetApplicationMenu);
   dict.SetMethod("sendActionToFirstResponder",

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -185,14 +185,15 @@ void Menu::BuildPrototype(v8::Isolate* isolate,
 
 namespace {
 
+using atom::api::Menu;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
-  using atom::api::Menu;
   v8::Isolate* isolate = context->GetIsolate();
-  v8::Local<v8::Function> constructor = mate::CreateConstructor<Menu>(
-      isolate, "Menu", base::Bind(&Menu::New));
+  Menu::SetConstructor(isolate, "Menu", base::Bind(&Menu::New));
+
   mate::Dictionary dict(isolate, exports);
-  dict.Set("Menu", static_cast<v8::Local<v8::Value>>(constructor));
+  dict.Set("Menu", Menu::GetConstructor(isolate));
 #if defined(OS_MACOSX)
   dict.SetMethod("setApplicationMenu", &Menu::SetApplicationMenu);
   dict.SetMethod("sendActionToFirstResponder",

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -155,8 +155,8 @@ bool Menu::IsVisibleAt(int index) const {
 
 // static
 void Menu::BuildPrototype(v8::Isolate* isolate,
-                          v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                          v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("insertItem", &Menu::InsertItemAt)
       .SetMethod("insertCheckItem", &Menu::InsertCheckItemAt)

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -20,7 +20,7 @@ namespace api {
 class Menu : public mate::TrackableObject<Menu>,
              public AtomMenuModel::Delegate {
  public:
-  static mate::WrappableBase* Create(v8::Isolate* isolate);
+  static mate::WrappableBase* New(mate::Arguments* args);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);
@@ -36,7 +36,7 @@ class Menu : public mate::TrackableObject<Menu>,
   AtomMenuModel* model() const { return model_.get(); }
 
  protected:
-  explicit Menu(v8::Isolate* isolate);
+  Menu(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
   ~Menu() override;
 
   // mate::Wrappable:

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -23,7 +23,7 @@ class Menu : public mate::TrackableObject<Menu>,
   static mate::WrappableBase* New(mate::Arguments* args);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
 #if defined(OS_MACOSX)
   // Set the global menubar.

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -17,7 +17,7 @@ namespace api {
 
 class MenuMac : public Menu {
  protected:
-  explicit MenuMac(v8::Isolate* isolate);
+  MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
 
   void PopupAt(Window* window, int x, int y, int positioning_item) override;
 

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -18,7 +18,8 @@ namespace atom {
 
 namespace api {
 
-MenuMac::MenuMac(v8::Isolate* isolate) : Menu(isolate) {
+MenuMac::MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
+    : Menu(isolate, wrapper) {
 }
 
 void MenuMac::PopupAt(Window* window, int x, int y, int positioning_item) {
@@ -94,8 +95,8 @@ void Menu::SendActionToFirstResponder(const std::string& action) {
 }
 
 // static
-mate::WrappableBase* Menu::Create(v8::Isolate* isolate) {
-  return new MenuMac(isolate);
+mate::WrappableBase* Menu::New(mate::Arguments* args) {
+  return new MenuMac(args->isolate(), args->GetThis());
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -14,7 +14,8 @@ namespace atom {
 
 namespace api {
 
-MenuViews::MenuViews(v8::Isolate* isolate) : Menu(isolate) {
+MenuViews::MenuViews(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
+    : Menu(isolate, wrapper) {
 }
 
 void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
@@ -53,8 +54,8 @@ void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
 }
 
 // static
-mate::WrappableBase* Menu::Create(v8::Isolate* isolate) {
-  return new MenuViews(isolate);
+mate::WrappableBase* Menu::New(mate::Arguments* args) {
+  return new MenuViews(args->isolate(), args->GetThis());
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -14,7 +14,7 @@ namespace api {
 
 class MenuViews : public Menu {
  public:
-  explicit MenuViews(v8::Isolate* isolate);
+  MenuViews(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
 
  protected:
   void PopupAt(Window* window, int x, int y, int positioning_item) override;

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -53,7 +53,7 @@ v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
 // static
 void PowerMonitor::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate());
+  prototype->SetClassName(mate::StringToV8(isolate, "PowerMonitor"));
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -52,8 +52,8 @@ v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
 
 // static
 void PowerMonitor::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype);
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate());
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -63,16 +63,19 @@ void PowerMonitor::BuildPrototype(
 
 namespace {
 
+using atom::api::PowerMonitor;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
 #if defined(OS_MACOSX)
   base::PowerMonitorDeviceSource::AllocateSystemIOPorts();
 #endif
 
-  using atom::api::PowerMonitor;
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("powerMonitor", PowerMonitor::Create(isolate));
+  dict.Set("PowerMonitor",
+           PowerMonitor::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -20,7 +20,7 @@ class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   explicit PowerMonitor(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_power_save_blocker.cc
+++ b/atom/browser/api/atom_api_power_save_blocker.cc
@@ -105,8 +105,8 @@ mate::Handle<PowerSaveBlocker> PowerSaveBlocker::Create(v8::Isolate* isolate) {
 
 // static
 void PowerSaveBlocker::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("start", &PowerSaveBlocker::Start)
       .SetMethod("stop", &PowerSaveBlocker::Stop)
       .SetMethod("isStarted", &PowerSaveBlocker::IsStarted);

--- a/atom/browser/api/atom_api_power_save_blocker.cc
+++ b/atom/browser/api/atom_api_power_save_blocker.cc
@@ -106,6 +106,7 @@ mate::Handle<PowerSaveBlocker> PowerSaveBlocker::Create(v8::Isolate* isolate) {
 // static
 void PowerSaveBlocker::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "PowerSaveBlocker"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("start", &PowerSaveBlocker::Start)
       .SetMethod("stop", &PowerSaveBlocker::Stop)

--- a/atom/browser/api/atom_api_power_save_blocker.h
+++ b/atom/browser/api/atom_api_power_save_blocker.h
@@ -25,7 +25,7 @@ class PowerSaveBlocker : public mate::TrackableObject<PowerSaveBlocker> {
   static mate::Handle<PowerSaveBlocker> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   explicit PowerSaveBlocker(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -161,6 +161,7 @@ mate::Handle<Protocol> Protocol::Create(
 // static
 void Protocol::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Protocol"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("registerServiceWorkerSchemes",
                  &Protocol::RegisterServiceWorkerSchemes)

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -160,8 +160,8 @@ mate::Handle<Protocol> Protocol::Create(
 
 // static
 void Protocol::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("registerServiceWorkerSchemes",
                  &Protocol::RegisterServiceWorkerSchemes)
       .SetMethod("registerStringProtocol",

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -39,7 +39,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
       v8::Isolate* isolate, AtomBrowserContext* browser_context);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   Protocol(v8::Isolate* isolate, AtomBrowserContext* browser_context);

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -54,6 +54,8 @@ void RenderProcessPreferences::RemoveEntry(int id) {
 // static
 void RenderProcessPreferences::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(
+      mate::StringToV8(isolate, "RenderProcessPreferences"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("addEntry", &RenderProcessPreferences::AddEntry)
       .SetMethod("removeEntry", &RenderProcessPreferences::RemoveEntry);

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -53,8 +53,8 @@ void RenderProcessPreferences::RemoveEntry(int id) {
 
 // static
 void RenderProcessPreferences::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("addEntry", &RenderProcessPreferences::AddEntry)
       .SetMethod("removeEntry", &RenderProcessPreferences::RemoveEntry);
 }

--- a/atom/browser/api/atom_api_render_process_preferences.h
+++ b/atom/browser/api/atom_api_render_process_preferences.h
@@ -20,7 +20,7 @@ class RenderProcessPreferences
       ForAllWebContents(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   int AddEntry(const base::DictionaryValue& entry);
   void RemoveEntry(int id);

--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -129,10 +129,14 @@ void Screen::BuildPrototype(
 
 namespace {
 
+using atom::api::Screen;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
-  mate::Dictionary dict(context->GetIsolate(), exports);
-  dict.Set("screen", atom::api::Screen::Create(context->GetIsolate()));
+  v8::Isolate* isolate = context->GetIsolate();
+  mate::Dictionary dict(isolate, exports);
+  dict.Set("screen", Screen::Create(isolate));
+  dict.Set("Screen", Screen::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -114,6 +114,7 @@ v8::Local<v8::Value> Screen::Create(v8::Isolate* isolate) {
 // static
 void Screen::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Screen"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("getCursorScreenPoint", &Screen::GetCursorScreenPoint)
       .SetMethod("getPrimaryDisplay", &Screen::GetPrimaryDisplay)

--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -113,8 +113,8 @@ v8::Local<v8::Value> Screen::Create(v8::Isolate* isolate) {
 
 // static
 void Screen::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("getCursorScreenPoint", &Screen::GetCursorScreenPoint)
       .SetMethod("getPrimaryDisplay", &Screen::GetPrimaryDisplay)
       .SetMethod("getAllDisplays", &Screen::GetAllDisplays)

--- a/atom/browser/api/atom_api_screen.h
+++ b/atom/browser/api/atom_api_screen.h
@@ -28,7 +28,7 @@ class Screen : public mate::EventEmitter<Screen>,
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   Screen(v8::Isolate* isolate, display::Screen* screen);

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -570,8 +570,8 @@ mate::Handle<Session> Session::FromPartition(
 
 // static
 void Session::BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                             v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("resolveProxy", &Session::ResolveProxy)
       .SetMethod("getCacheSize", &Session::DoCacheAction<CacheAction::STATS>)

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -571,6 +571,7 @@ mate::Handle<Session> Session::FromPartition(
 // static
 void Session::BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Session"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("resolveProxy", &Session::ResolveProxy)

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -170,10 +170,6 @@ namespace {
 
 const char kPersistPrefix[] = "persist:";
 
-// The wrapSession funtion which is implemented in JavaScript
-using WrapSessionCallback = base::Callback<void(v8::Local<v8::Value>)>;
-WrapSessionCallback g_wrap_session;
-
 // Referenced session objects.
 std::map<uint32_t, v8::Global<v8::Object>> g_sessions;
 
@@ -541,7 +537,6 @@ mate::Handle<Session> Session::CreateFrom(
 
   auto handle = mate::CreateHandle(
       isolate, new Session(isolate, browser_context));
-  g_wrap_session.Run(handle.ToV8());
 
   // The Sessions should never be garbage collected, since the common pattern is
   // to use partition strings, instead of using the Session object directly.
@@ -596,15 +591,13 @@ void Session::BuildPrototype(v8::Isolate* isolate,
       .SetProperty("webRequest", &Session::WebRequest);
 }
 
-void SetWrapSession(const WrapSessionCallback& callback) {
-  g_wrap_session = callback;
-}
-
 }  // namespace api
 
 }  // namespace atom
 
 namespace {
+
+using atom::api::Session;
 
 v8::Local<v8::Value> FromPartition(
     const std::string& partition, mate::Arguments* args) {
@@ -614,16 +607,15 @@ v8::Local<v8::Value> FromPartition(
   }
   base::DictionaryValue options;
   args->GetNext(&options);
-  return atom::api::Session::FromPartition(
-      args->isolate(), partition, options).ToV8();
+  return Session::FromPartition(args->isolate(), partition, options).ToV8();
 }
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
+  dict.Set("Session", Session::GetConstructor(isolate)->GetFunction());
   dict.SetMethod("fromPartition", &FromPartition);
-  dict.SetMethod("_setWrapSession", &atom::api::SetWrapSession);
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -57,7 +57,7 @@ class Session: public mate::TrackableObject<Session>,
 
   // mate::TrackableObject:
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   // Methods.
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -69,11 +69,15 @@ void SystemPreferences::BuildPrototype(
 
 namespace {
 
+using atom::api::SystemPreferences;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("systemPreferences", atom::api::SystemPreferences::Create(isolate));
+  dict.Set("systemPreferences", SystemPreferences::Create(isolate));
+  dict.Set("SystemPreferences",
+           SystemPreferences::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -45,6 +45,7 @@ mate::Handle<SystemPreferences> SystemPreferences::Create(
 // static
 void SystemPreferences::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "SystemPreferences"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
 #if defined(OS_WIN)
       .SetMethod("isAeroGlassEnabled", &SystemPreferences::IsAeroGlassEnabled)

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -44,8 +44,8 @@ mate::Handle<SystemPreferences> SystemPreferences::Create(
 
 // static
 void SystemPreferences::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
 #if defined(OS_WIN)
       .SetMethod("isAeroGlassEnabled", &SystemPreferences::IsAeroGlassEnabled)
 #elif defined(OS_MACOSX)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -24,7 +24,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
   static mate::Handle<SystemPreferences> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
 #if defined(OS_WIN)
   bool IsAeroGlassEnabled();

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -202,6 +202,7 @@ gfx::Rect Tray::GetBounds() {
 // static
 void Tray::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Tray"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("setImage", &Tray::SetImage)
@@ -227,7 +228,7 @@ using atom::api::Tray;
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Tray::SetConstructor(isolate, "Tray", base::Bind(&Tray::New));
+  Tray::SetConstructor(isolate, base::Bind(&Tray::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("Tray", Tray::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -222,14 +222,15 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
 
 namespace {
 
+using atom::api::Tray;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
-  using atom::api::Tray;
   v8::Isolate* isolate = context->GetIsolate();
-  v8::Local<v8::Function> constructor = mate::CreateConstructor<Tray>(
-      isolate, "Tray", base::Bind(&Tray::New));
+  Tray::SetConstructor(isolate, "Tray", base::Bind(&Tray::New));
+
   mate::Dictionary dict(isolate, exports);
-  dict.Set("Tray", static_cast<v8::Local<v8::Value>>(constructor));
+  dict.Set("Tray", Tray::GetConstructor(isolate));
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -230,7 +230,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   Tray::SetConstructor(isolate, "Tray", base::Bind(&Tray::New));
 
   mate::Dictionary dict(isolate, exports);
-  dict.Set("Tray", Tray::GetConstructor(isolate));
+  dict.Set("Tray", Tray::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -60,10 +60,13 @@ namespace atom {
 
 namespace api {
 
-Tray::Tray(v8::Isolate* isolate, mate::Handle<NativeImage> image)
+Tray::Tray(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,
+           mate::Handle<NativeImage> image)
     : tray_icon_(TrayIcon::Create()) {
   SetImage(isolate, image);
   tray_icon_->AddObserver(this);
+
+  InitWith(isolate, wrapper);
 }
 
 Tray::~Tray() {
@@ -72,14 +75,13 @@ Tray::~Tray() {
 }
 
 // static
-mate::WrappableBase* Tray::New(v8::Isolate* isolate,
-                               mate::Handle<NativeImage> image) {
+mate::WrappableBase* Tray::New(mate::Handle<NativeImage> image,
+                               mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    isolate->ThrowException(v8::Exception::Error(mate::StringToV8(
-        isolate, "Cannot create Tray before app is ready")));
+    args->ThrowError("Cannot create Tray before app is ready");
     return nullptr;
   }
-  return new Tray(isolate, image);
+  return new Tray(args->isolate(), args->GetThis(), image);
 }
 
 void Tray::OnClicked(const gfx::Rect& bounds, int modifiers) {

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -201,8 +201,8 @@ gfx::Rect Tray::GetBounds() {
 
 // static
 void Tray::BuildPrototype(v8::Isolate* isolate,
-                          v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                          v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("setImage", &Tray::SetImage)
       .SetMethod("setPressedImage", &Tray::SetPressedImage)

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -35,14 +35,15 @@ class NativeImage;
 class Tray : public mate::TrackableObject<Tray>,
              public TrayIconObserver {
  public:
-  static mate::WrappableBase* New(
-      v8::Isolate* isolate, mate::Handle<NativeImage> image);
+  static mate::WrappableBase* New(mate::Handle<NativeImage> image,
+                                  mate::Arguments* args);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);
 
  protected:
-  Tray(v8::Isolate* isolate, mate::Handle<NativeImage> image);
+  Tray(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,
+       mate::Handle<NativeImage> image);
   ~Tray() override;
 
   // TrayIconObserver:

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -39,7 +39,7 @@ class Tray : public mate::TrackableObject<Tray>,
                                   mate::Arguments* args);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   Tray(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -221,10 +221,6 @@ namespace api {
 
 namespace {
 
-// The wrapWebContents function which is implemented in JavaScript
-using WrapWebContentsCallback = base::Callback<void(v8::Local<v8::Value>)>;
-WrapWebContentsCallback g_wrap_web_contents;
-
 content::ServiceWorkerContext* GetServiceWorkerContext(
     const content::WebContents* web_contents) {
   auto context = web_contents->GetBrowserContext();
@@ -1470,41 +1466,32 @@ mate::Handle<WebContents> WebContents::CreateFrom(
     return mate::CreateHandle(isolate, static_cast<WebContents*>(existing));
 
   // Otherwise create a new WebContents wrapper object.
-  auto handle = mate::CreateHandle(
-      isolate, new WebContents(isolate, web_contents));
-  g_wrap_web_contents.Run(handle.ToV8());
-  return handle;
+  return mate::CreateHandle(isolate, new WebContents(isolate, web_contents));
 }
 
 // static
 mate::Handle<WebContents> WebContents::Create(
     v8::Isolate* isolate, const mate::Dictionary& options) {
-  auto handle = mate::CreateHandle(isolate, new WebContents(isolate, options));
-  g_wrap_web_contents.Run(handle.ToV8());
-  return handle;
-}
-
-void SetWrapWebContents(const WrapWebContentsCallback& callback) {
-  g_wrap_web_contents = callback;
+  return mate::CreateHandle(isolate, new WebContents(isolate, options));
 }
 
 }  // namespace api
 
 }  // namespace atom
 
-
 namespace {
+
+using atom::api::WebContents;
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.SetMethod("create", &atom::api::WebContents::Create);
-  dict.SetMethod("_setWrapWebContents", &atom::api::SetWrapWebContents);
-  dict.SetMethod("fromId",
-                 &mate::TrackableObject<atom::api::WebContents>::FromWeakMapID);
+  dict.Set("WebContents", WebContents::GetConstructor(isolate)->GetFunction());
+  dict.SetMethod("create", &WebContents::Create);
+  dict.SetMethod("fromId", &mate::TrackableObject<WebContents>::FromWeakMapID);
   dict.SetMethod("getAllWebContents",
-                 &mate::TrackableObject<atom::api::WebContents>::GetAll);
+                 &mate::TrackableObject<WebContents>::GetAll);
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1364,8 +1364,8 @@ v8::Local<v8::Value> WebContents::Debugger(v8::Isolate* isolate) {
 
 // static
 void WebContents::BuildPrototype(v8::Isolate* isolate,
-                                 v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                                 v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("getId", &WebContents::GetID)
       .SetMethod("equal", &WebContents::Equal)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1365,6 +1365,7 @@ v8::Local<v8::Value> WebContents::Debugger(v8::Isolate* isolate) {
 // static
 void WebContents::BuildPrototype(v8::Isolate* isolate,
                                  v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "WebContents"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("getId", &WebContents::GetID)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -63,7 +63,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
       v8::Isolate* isolate, const mate::Dictionary& options);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   int GetID() const;
   Type GetType() const;

--- a/atom/browser/api/atom_api_web_request.cc
+++ b/atom/browser/api/atom_api_web_request.cc
@@ -89,6 +89,7 @@ mate::Handle<WebRequest> WebRequest::Create(
 // static
 void WebRequest::BuildPrototype(v8::Isolate* isolate,
                                 v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "WebRequest"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("onBeforeRequest",
                  &WebRequest::SetResponseListener<

--- a/atom/browser/api/atom_api_web_request.cc
+++ b/atom/browser/api/atom_api_web_request.cc
@@ -88,8 +88,8 @@ mate::Handle<WebRequest> WebRequest::Create(
 
 // static
 void WebRequest::BuildPrototype(v8::Isolate* isolate,
-                                v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                                v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("onBeforeRequest",
                  &WebRequest::SetResponseListener<
                     AtomNetworkDelegate::kOnBeforeRequest>)

--- a/atom/browser/api/atom_api_web_request.h
+++ b/atom/browser/api/atom_api_web_request.h
@@ -22,7 +22,7 @@ class WebRequest : public mate::TrackableObject<WebRequest> {
                                          AtomBrowserContext* browser_context);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
   WebRequest(v8::Isolate* isolate, AtomBrowserContext* browser_context);

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -871,7 +871,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   v8::Isolate* isolate = context->GetIsolate();
   Window::SetConstructor(isolate, "BrowserWindow", base::Bind(&Window::New));
 
-  mate::Dictionary browser_window(isolate, Window::GetConstructor(isolate));
+  mate::Dictionary browser_window(
+      isolate, Window::GetConstructor(isolate)->GetFunction());
   browser_window.SetMethod("fromId",
                            &mate::TrackableObject<Window>::FromWeakMapID);
   browser_window.SetMethod("getAllWindows",

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -746,8 +746,8 @@ void Window::RemoveFromParentChildWindows() {
 
 // static
 void Window::BuildPrototype(v8::Isolate* isolate,
-                            v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+                            v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("close", &Window::Close)
       .SetMethod("focus", &Window::Focus)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -869,9 +869,9 @@ using atom::api::Window;
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  v8::Local<v8::Function> constructor = mate::CreateConstructor<Window>(
-      isolate, "BrowserWindow", base::Bind(&Window::New));
-  mate::Dictionary browser_window(isolate, constructor);
+  Window::SetConstructor(isolate, "BrowserWindow", base::Bind(&Window::New));
+
+  mate::Dictionary browser_window(isolate, Window::GetConstructor(isolate));
   browser_window.SetMethod("fromId",
                            &mate::TrackableObject<Window>::FromWeakMapID);
   browser_window.SetMethod("getAllWindows",

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -747,6 +747,7 @@ void Window::RemoveFromParentChildWindows() {
 // static
 void Window::BuildPrototype(v8::Isolate* isolate,
                             v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "BrowserWindow"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("close", &Window::Close)
@@ -869,7 +870,7 @@ using atom::api::Window;
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Window::SetConstructor(isolate, "BrowserWindow", base::Bind(&Window::New));
+  Window::SetConstructor(isolate, base::Bind(&Window::New));
 
   mate::Dictionary browser_window(
       isolate, Window::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -43,7 +43,7 @@ class Window : public mate::TrackableObject<Window>,
   static mate::WrappableBase* New(mate::Arguments* args);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   // Returns the BrowserWindow object from |native_window|.
   static v8::Local<v8::Value> From(v8::Isolate* isolate,

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -40,7 +40,7 @@ class WebContents;
 class Window : public mate::TrackableObject<Window>,
                public NativeWindowObserver {
  public:
-  static mate::WrappableBase* New(v8::Isolate* isolate, mate::Arguments* args);
+  static mate::WrappableBase* New(mate::Arguments* args);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);
@@ -52,11 +52,9 @@ class Window : public mate::TrackableObject<Window>,
   NativeWindow* window() const { return window_.get(); }
 
  protected:
-  Window(v8::Isolate* isolate, const mate::Dictionary& options);
+  Window(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,
+         const mate::Dictionary& options);
   ~Window() override;
-
-  // TrackableObject:
-  void AfterInit(v8::Isolate* isolate) override;
 
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;

--- a/atom/browser/api/event.cc
+++ b/atom/browser/api/event.cc
@@ -58,8 +58,8 @@ Handle<Event> Event::Create(v8::Isolate* isolate) {
 
 // static
 void Event::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("preventDefault", &Event::PreventDefault)
       .SetMethod("sendReply", &Event::SendReply);
 }

--- a/atom/browser/api/event.cc
+++ b/atom/browser/api/event.cc
@@ -59,6 +59,7 @@ Handle<Event> Event::Create(v8::Isolate* isolate) {
 // static
 void Event::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "Event"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("preventDefault", &Event::PreventDefault)
       .SetMethod("sendReply", &Event::SendReply);

--- a/atom/browser/api/event.h
+++ b/atom/browser/api/event.h
@@ -21,7 +21,7 @@ class Event : public Wrappable<Event>,
   static Handle<Event> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
   // Pass the sender and message to be replied.
   void SetSenderAndMessage(content::WebContents* sender, IPC::Message* message);

--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -16,9 +16,6 @@ namespace mate {
 
 namespace {
 
-// The prototype of Node's EventEmitter.
-v8::Persistent<v8::Object> g_event_emitter_prototype;
-
 v8::Persistent<v8::ObjectTemplate> event_template;
 
 void PreventDefault(mate::Arguments* args) {
@@ -80,29 +77,6 @@ v8::Local<v8::Object> CreateEventFromFlags(v8::Isolate* isolate, int flags) {
   return obj.GetHandle();
 }
 
-void InheritFromEventEmitter(v8::Isolate* isolate,
-                             v8::Local<v8::FunctionTemplate> constructor) {
-}
-
-void SetEventEmitterPrototype(v8::Isolate* isolate,
-                              v8::Local<v8::Object> prototype) {
-  g_event_emitter_prototype.Reset(isolate, prototype);
-}
-
 }  // namespace internal
 
 }  // namespace mate
-
-
-namespace {
-
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
-  mate::Dictionary(context->GetIsolate(), exports)
-      .SetMethod("setEventEmitterPrototype",
-                 &mate::internal::SetEventEmitterPrototype);
-}
-
-}  // namespace
-
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(atom_browser_event_emitter, Initialize)

--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -10,9 +10,14 @@
 #include "native_mate/object_template_builder.h"
 #include "ui/events/event_constants.h"
 
+#include "atom/common/node_includes.h"
+
 namespace mate {
 
 namespace {
+
+// The prototype of Node's EventEmitter.
+v8::Persistent<v8::Object> g_event_emitter_prototype;
 
 v8::Persistent<v8::ObjectTemplate> event_template;
 
@@ -75,6 +80,29 @@ v8::Local<v8::Object> CreateEventFromFlags(v8::Isolate* isolate, int flags) {
   return obj.GetHandle();
 }
 
+void InheritFromEventEmitter(v8::Isolate* isolate,
+                             v8::Local<v8::FunctionTemplate> constructor) {
+}
+
+void SetEventEmitterPrototype(v8::Isolate* isolate,
+                              v8::Local<v8::Object> prototype) {
+  g_event_emitter_prototype.Reset(isolate, prototype);
+}
+
 }  // namespace internal
 
 }  // namespace mate
+
+
+namespace {
+
+void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context, void* priv) {
+  mate::Dictionary(context->GetIsolate(), exports)
+      .SetMethod("setEventEmitterPrototype",
+                 &mate::internal::SetEventEmitterPrototype);
+}
+
+}  // namespace
+
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(atom_browser_event_emitter, Initialize)

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -32,9 +32,6 @@ v8::Local<v8::Object> CreateCustomEvent(
     v8::Local<v8::Object> event);
 v8::Local<v8::Object> CreateEventFromFlags(v8::Isolate* isolate, int flags);
 
-void InheritFromEventEmitter(v8::Isolate* isolate,
-                             v8::Local<v8::FunctionTemplate> constructor);
-
 }  // namespace internal
 
 // Provide helperers to emit event in JavaScript.
@@ -89,11 +86,6 @@ class EventEmitter : public Wrappable<T> {
 
  protected:
   EventEmitter() {}
-
-  static void InheritFromEventEmitter(
-      v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> constructor) {
-    internal::InheritFromEventEmitter(isolate, constructor);
-  }
 
  private:
   // this.emit(name, event, args...);

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -32,6 +32,9 @@ v8::Local<v8::Object> CreateCustomEvent(
     v8::Local<v8::Object> event);
 v8::Local<v8::Object> CreateEventFromFlags(v8::Isolate* isolate, int flags);
 
+void InheritFromEventEmitter(v8::Isolate* isolate,
+                             v8::Local<v8::FunctionTemplate> constructor);
+
 }  // namespace internal
 
 // Provide helperers to emit event in JavaScript.
@@ -86,6 +89,11 @@ class EventEmitter : public Wrappable<T> {
 
  protected:
   EventEmitter() {}
+
+  static void InheritFromEventEmitter(
+      v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> constructor) {
+    internal::InheritFromEventEmitter(isolate, constructor);
+  }
 
  private:
   // this.emit(name, event, args...);

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -29,7 +29,7 @@ class IDUserData : public base::SupportsUserData::Data {
 }  // namespace
 
 TrackableObjectBase::TrackableObjectBase()
-    : weak_map_id_(0), wrapped_(nullptr), weak_factory_(this) {
+    : weak_map_id_(0), weak_factory_(this) {
   cleanup_ = RegisterDestructionCallback(GetDestroyClosure());
 }
 
@@ -46,14 +46,7 @@ void TrackableObjectBase::Destroy() {
 }
 
 void TrackableObjectBase::AttachAsUserData(base::SupportsUserData* wrapped) {
-  if (weak_map_id_ != 0) {
-    wrapped->SetUserData(kTrackedObjectKey, new IDUserData(weak_map_id_));
-    wrapped_ = nullptr;
-  } else {
-    // If the TrackableObjectBase is not ready yet then delay SetUserData until
-    // AfterInit is called.
-    wrapped_ = wrapped;
-  }
+  wrapped->SetUserData(kTrackedObjectKey, new IDUserData(weak_map_id_));
 }
 
 // static

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -44,7 +44,6 @@ class TrackableObjectBase {
   static base::Closure RegisterDestructionCallback(const base::Closure& c);
 
   int32_t weak_map_id_;
-  base::SupportsUserData* wrapped_;
 
  private:
   void Destroy();
@@ -110,14 +109,13 @@ class TrackableObject : public TrackableObjectBase,
     RemoveFromWeakMap();
   }
 
-  void AfterInit(v8::Isolate* isolate) override {
+  void InitWith(v8::Isolate* isolate, v8::Local<v8::Object> wrapper) override {
+    WrappableBase::InitWith(isolate, wrapper);
     if (!weak_map_) {
       weak_map_ = new atom::KeyWeakMap<int32_t>;
     }
     weak_map_id_ = ++next_id_;
-    weak_map_->Set(isolate, weak_map_id_, Wrappable<T>::GetWrapper());
-    if (wrapped_)
-      AttachAsUserData(wrapped_);
+    weak_map_->Set(isolate, weak_map_id_, wrapper);
   }
 
  private:

--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -29,8 +29,8 @@ class Archive : public mate::Wrappable<Archive> {
   }
 
   static void BuildPrototype(
-      v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-    mate::ObjectTemplateBuilder(isolate, prototype)
+      v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+    mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
         .SetProperty("path", &Archive::GetPath)
         .SetMethod("getFileInfo", &Archive::GetFileInfo)
         .SetMethod("stat", &Archive::Stat)

--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -30,6 +30,7 @@ class Archive : public mate::Wrappable<Archive> {
 
   static void BuildPrototype(
       v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+    prototype->SetClassName(mate::StringToV8(isolate, "Archive"));
     mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
         .SetProperty("path", &Archive::GetPath)
         .SetMethod("getFileInfo", &Archive::GetFileInfo)

--- a/atom/common/api/atom_api_key_weak_map.h
+++ b/atom/common/api/atom_api_key_weak_map.h
@@ -23,6 +23,7 @@ class KeyWeakMap : public mate::Wrappable<KeyWeakMap<K>> {
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype) {
+    prototype->SetClassName(mate::StringToV8(isolate, "KeyWeakMap"));
     mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
         .SetMethod("set", &KeyWeakMap<K>::Set)
         .SetMethod("get", &KeyWeakMap<K>::Get)

--- a/atom/common/api/atom_api_key_weak_map.h
+++ b/atom/common/api/atom_api_key_weak_map.h
@@ -8,6 +8,7 @@
 #include "atom/common/key_weak_map.h"
 #include "native_mate/object_template_builder.h"
 #include "native_mate/handle.h"
+#include "native_mate/wrappable.h"
 
 namespace atom {
 

--- a/atom/common/api/atom_api_key_weak_map.h
+++ b/atom/common/api/atom_api_key_weak_map.h
@@ -22,8 +22,8 @@ class KeyWeakMap : public mate::Wrappable<KeyWeakMap<K>> {
   }
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype) {
-    mate::ObjectTemplateBuilder(isolate, prototype)
+                             v8::Local<v8::FunctionTemplate> prototype) {
+    mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
         .SetMethod("set", &KeyWeakMap<K>::Set)
         .SetMethod("get", &KeyWeakMap<K>::Get)
         .SetMethod("has", &KeyWeakMap<K>::Has)

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -356,6 +356,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromDataURL(
 // static
 void NativeImage::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "NativeImage"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("toPNG", &NativeImage::ToPNG)
       .SetMethod("toJPEG", &NativeImage::ToJPEG)

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -355,8 +355,8 @@ mate::Handle<NativeImage> NativeImage::CreateFromDataURL(
 
 // static
 void NativeImage::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("toPNG", &NativeImage::ToPNG)
       .SetMethod("toJPEG", &NativeImage::ToJPEG)
       .SetMethod("toBitmap", &NativeImage::ToBitmap)

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -52,7 +52,7 @@ class NativeImage : public mate::Wrappable<NativeImage> {
       v8::Isolate* isolate, const GURL& url);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
 #if defined(OS_WIN)
   HICON GetHICON(int size);

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -188,6 +188,7 @@ void WebFrame::ClearCache(v8::Isolate* isolate) {
 // static
 void WebFrame::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "WebFrame"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("setName", &WebFrame::SetName)
       .SetMethod("setZoomLevel", &WebFrame::SetZoomLevel)

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -187,8 +187,8 @@ void WebFrame::ClearCache(v8::Isolate* isolate) {
 
 // static
 void WebFrame::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> prototype) {
-  mate::ObjectTemplateBuilder(isolate, prototype)
+    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("setName", &WebFrame::SetName)
       .SetMethod("setZoomLevel", &WebFrame::SetZoomLevel)
       .SetMethod("getZoomLevel", &WebFrame::GetZoomLevel)

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -220,11 +220,14 @@ void WebFrame::BuildPrototype(
 
 namespace {
 
+using atom::api::WebFrame;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("webFrame", atom::api::WebFrame::Create(isolate));
+  dict.Set("webFrame", WebFrame::Create(isolate));
+  dict.Set("WebFrame", WebFrame::GetConstructor(isolate)->GetFunction());
 }
 
 }  // namespace

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -32,7 +32,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   static mate::Handle<WebFrame> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::ObjectTemplate> prototype);
+                             v8::Local<v8::FunctionTemplate> prototype);
 
  private:
   explicit WebFrame(v8::Isolate* isolate);

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const bindings = process.atomBinding('app')
-const {app} = bindings
+const {app, App} = bindings
 
 // Only one app object permitted.
 module.exports = app
@@ -10,7 +10,7 @@ const electron = require('electron')
 const {deprecate, Menu} = electron
 const {EventEmitter} = require('events')
 
-Object.setPrototypeOf(app.__proto__, EventEmitter.prototype)
+Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 
 let appPath = null
 
@@ -76,7 +76,5 @@ for (let name of events) {
 }
 
 // Wrappers for native classes.
-process.atomBinding('download_item')._setWrapDownloadItem((downloadItem) => {
-  // downloadItem is an EventEmitter.
-  Object.setPrototypeOf(downloadItem.__proto__, EventEmitter.prototype)
-})
+const {DownloadItem} = process.atomBinding('download_item')
+Object.setPrototypeOf(DownloadItem.prototype, EventEmitter.prototype)

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -10,7 +10,7 @@ const electron = require('electron')
 const {deprecate, Menu} = electron
 const {EventEmitter} = require('events')
 
-Object.setPrototypeOf(app, EventEmitter.prototype)
+Object.setPrototypeOf(app.__proto__, EventEmitter.prototype)
 
 let appPath = null
 
@@ -78,5 +78,5 @@ for (let name of events) {
 // Wrappers for native classes.
 process.atomBinding('download_item')._setWrapDownloadItem((downloadItem) => {
   // downloadItem is an EventEmitter.
-  Object.setPrototypeOf(downloadItem, EventEmitter.prototype)
+  Object.setPrototypeOf(downloadItem.__proto__, EventEmitter.prototype)
 })

--- a/lib/browser/api/auto-updater/auto-updater-native.js
+++ b/lib/browser/api/auto-updater/auto-updater-native.js
@@ -1,6 +1,6 @@
 const EventEmitter = require('events').EventEmitter
 const autoUpdater = process.atomBinding('auto_updater').autoUpdater
 
-Object.setPrototypeOf(autoUpdater, EventEmitter.prototype)
+Object.setPrototypeOf(autoUpdater.__proto__, EventEmitter.prototype)
 
 module.exports = autoUpdater

--- a/lib/browser/api/auto-updater/auto-updater-native.js
+++ b/lib/browser/api/auto-updater/auto-updater-native.js
@@ -1,6 +1,6 @@
 const EventEmitter = require('events').EventEmitter
-const autoUpdater = process.atomBinding('auto_updater').autoUpdater
+const {autoUpdater, AutoUpdater} = process.atomBinding('auto_updater')
 
-Object.setPrototypeOf(autoUpdater.__proto__, EventEmitter.prototype)
+Object.setPrototypeOf(AutoUpdater.prototype, EventEmitter.prototype)
 
 module.exports = autoUpdater

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
-const {powerMonitor} = process.atomBinding('power_monitor')
+const {powerMonitor, PowerMonitor} = process.atomBinding('power_monitor')
 
-Object.setPrototypeOf(powerMonitor.__proto__, EventEmitter.prototype)
+Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
 
 module.exports = powerMonitor

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
 const {powerMonitor} = process.atomBinding('power_monitor')
 
-Object.setPrototypeOf(powerMonitor, EventEmitter.prototype)
+Object.setPrototypeOf(powerMonitor.__proto__, EventEmitter.prototype)
 
 module.exports = powerMonitor

--- a/lib/browser/api/protocol.js
+++ b/lib/browser/api/protocol.js
@@ -9,7 +9,7 @@ Object.setPrototypeOf(module.exports, new Proxy({}, {
     if (!app.isReady()) return
 
     const protocol = session.defaultSession.protocol
-    if (!protocol.hasOwnProperty(property)) return
+    if (!protocol.__proto__.hasOwnProperty(property)) return
 
     // Returning a native function directly would throw error.
     return (...args) => protocol[property](...args)
@@ -18,7 +18,7 @@ Object.setPrototypeOf(module.exports, new Proxy({}, {
   ownKeys () {
     if (!app.isReady()) return []
 
-    return Object.getOwnPropertyNames(session.defaultSession.protocol)
+    return Object.getOwnPropertyNames(session.defaultSession.protocol.__proto__)
   },
 
   getOwnPropertyDescriptor (target) {

--- a/lib/browser/api/protocol.js
+++ b/lib/browser/api/protocol.js
@@ -9,7 +9,7 @@ Object.setPrototypeOf(module.exports, new Proxy({}, {
     if (!app.isReady()) return
 
     const protocol = session.defaultSession.protocol
-    if (!protocol.__proto__.hasOwnProperty(property)) return
+    if (!Object.getPrototypeOf(protocol).hasOwnProperty(property)) return
 
     // Returning a native function directly would throw error.
     return (...args) => protocol[property](...args)
@@ -18,7 +18,7 @@ Object.setPrototypeOf(module.exports, new Proxy({}, {
   ownKeys () {
     if (!app.isReady()) return []
 
-    return Object.getOwnPropertyNames(session.defaultSession.protocol.__proto__)
+    return Object.getOwnPropertyNames(Object.getPrototypeOf(session.defaultSession.protocol))
   },
 
   getOwnPropertyDescriptor (target) {

--- a/lib/browser/api/screen.js
+++ b/lib/browser/api/screen.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
 const {screen} = process.atomBinding('screen')
 
-Object.setPrototypeOf(screen, EventEmitter.prototype)
+Object.setPrototypeOf(screen.__proto__, EventEmitter.prototype)
 
 module.exports = screen

--- a/lib/browser/api/screen.js
+++ b/lib/browser/api/screen.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
-const {screen} = process.atomBinding('screen')
+const {screen, Screen} = process.atomBinding('screen')
 
-Object.setPrototypeOf(screen.__proto__, EventEmitter.prototype)
+Object.setPrototypeOf(Screen.prototype, EventEmitter.prototype)
 
 module.exports = screen

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
 const {app} = require('electron')
-const {fromPartition, _setWrapSession} = process.atomBinding('session')
+const {fromPartition, Session} = process.atomBinding('session')
 
 // Public API.
 Object.defineProperties(exports, {
@@ -14,9 +14,8 @@ Object.defineProperties(exports, {
   }
 })
 
-// Wraps native Session class.
-_setWrapSession(function (session) {
-  // Session is an EventEmitter.
-  Object.setPrototypeOf(session.__proto__, EventEmitter.prototype)
-  app.emit('session-created', session)
-})
+Object.setPrototypeOf(Session.prototype, EventEmitter.prototype)
+
+Session.prototype._init = function () {
+  app.emit('session-created', this)
+}

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -17,6 +17,6 @@ Object.defineProperties(exports, {
 // Wraps native Session class.
 _setWrapSession(function (session) {
   // Session is an EventEmitter.
-  Object.setPrototypeOf(session, EventEmitter.prototype)
+  Object.setPrototypeOf(session.__proto__, EventEmitter.prototype)
   app.emit('session-created', session)
 })

--- a/lib/browser/api/system-preferences.js
+++ b/lib/browser/api/system-preferences.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
-const {systemPreferences} = process.atomBinding('system_preferences')
+const {systemPreferences, SystemPreferences} = process.atomBinding('system_preferences')
 
-Object.setPrototypeOf(systemPreferences.__proto__, EventEmitter.prototype)
+Object.setPrototypeOf(SystemPreferences.prototype, EventEmitter.prototype)
 
 module.exports = systemPreferences

--- a/lib/browser/api/system-preferences.js
+++ b/lib/browser/api/system-preferences.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
 const {systemPreferences} = process.atomBinding('system_preferences')
 
-Object.setPrototypeOf(systemPreferences, EventEmitter.prototype)
+Object.setPrototypeOf(systemPreferences.__proto__, EventEmitter.prototype)
 
 module.exports = systemPreferences

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -97,7 +97,7 @@ const webFrameMethodsWithResult = [
 // Add JavaScript wrappers for WebContents class.
 const wrapWebContents = function (webContents) {
   // webContents is an EventEmitter.
-  Object.setPrototypeOf(webContents, EventEmitter.prototype)
+  Object.setPrototypeOf(webContents.__proto__, EventEmitter.prototype)
 
   // Every remote callback from renderer process would add a listenter to the
   // render-view-deleted event, so ignore the listenters warning.
@@ -252,7 +252,7 @@ binding._setWrapWebContents(wrapWebContents)
 // Add JavaScript wrappers for Debugger class.
 const wrapDebugger = function (webContentsDebugger) {
   // debugger is an EventEmitter.
-  Object.setPrototypeOf(webContentsDebugger, EventEmitter.prototype)
+  Object.setPrototypeOf(webContentsDebugger.__proto__, EventEmitter.prototype)
 }
 
 debuggerBinding._setWrapDebugger(wrapDebugger)

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -82,7 +82,8 @@ const defaultPrintingSetting = {
 const binding = process.atomBinding('web_contents')
 const {WebContents} = binding
 
-Object.setPrototypeOf(WebContents.prototype, EventEmitter.prototype)
+Object.setPrototypeOf(NavigationController.prototype, EventEmitter.prototype)
+Object.setPrototypeOf(WebContents.prototype, NavigationController.prototype)
 
 // WebContents::send(channel, args..)
 // WebContents::sendToAll(channel, args..)
@@ -196,20 +197,12 @@ WebContents.prototype.printToPDF = function (options, callback) {
 
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
+  // The navigation controller.
+  NavigationController.call(this, this)
+
   // Every remote callback from renderer process would add a listenter to the
   // render-view-deleted event, so ignore the listenters warning.
   this.setMaxListeners(0)
-
-  // The navigation controller.
-  const controller = new NavigationController(this)
-  for (const name in NavigationController.prototype) {
-    const method = NavigationController.prototype[name]
-    if (method instanceof Function) {
-      this[name] = function () {
-        return method.apply(controller, arguments)
-      }
-    }
-  }
 
   // Dispatch IPC messages to the ipc module.
   this.on('ipc-message', function (event, [channel, ...args]) {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -78,10 +78,22 @@ const defaultPrintingSetting = {
   shouldPrintSelectionOnly: false
 }
 
+// JavaScript implementations of WebContents.
 const binding = process.atomBinding('web_contents')
 const {WebContents} = binding
 
 Object.setPrototypeOf(WebContents.prototype, EventEmitter.prototype)
+
+// WebContents::send(channel, args..)
+// WebContents::sendToAll(channel, args..)
+WebContents.prototype.send = function (channel, ...args) {
+  if (channel == null) throw new Error('Missing required channel argument')
+  return this._send(false, channel, args)
+}
+WebContents.prototype.sendToAll = function (channel, ...args) {
+  if (channel == null) throw new Error('Missing required channel argument')
+  return this._send(true, channel, args)
+}
 
 // Following methods are mapped to webFrame.
 const webFrameMethods = [
@@ -90,28 +102,103 @@ const webFrameMethods = [
   'setZoomLevel',
   'setZoomLevelLimits'
 ]
-
 const webFrameMethodsWithResult = [
   'getZoomFactor',
   'getZoomLevel'
 ]
+
+const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
+  this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
+  ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
+    if (callback) callback(result)
+  })
+}
+
+const syncWebFrameMethods = function (requestId, method, callback, ...args) {
+  this.send('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', requestId, method, args)
+  ipcMain.once(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
+    if (callback) callback(result)
+  })
+}
+
+for (const method of webFrameMethods) {
+  WebContents.prototype[method] = function (...args) {
+    this.send('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, args)
+  }
+}
+
+for (const method of webFrameMethodsWithResult) {
+  WebContents.prototype[method] = function (...args) {
+    const callback = args[args.length - 1]
+    const actualArgs = args.slice(0, args.length - 2)
+    syncWebFrameMethods.call(this, getNextId(), method, callback, ...actualArgs)
+  }
+}
+
+// Make sure WebContents::executeJavaScript would run the code only when the
+// WebContents has been loaded.
+WebContents.prototype.executeJavaScript = function (code, hasUserGesture, callback) {
+  const requestId = getNextId()
+  if (typeof hasUserGesture === 'function') {
+    callback = hasUserGesture
+    hasUserGesture = false
+  }
+  if (this.getURL() && !this.isLoadingMainFrame()) {
+    asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
+  } else {
+    this.once('did-finish-load', () => {
+      asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
+    })
+  }
+}
+
+// Translate the options of printToPDF.
+WebContents.prototype.printToPDF = function (options, callback) {
+  const printingSetting = Object.assign({}, defaultPrintingSetting)
+  if (options.landscape) {
+    printingSetting.landscape = options.landscape
+  }
+  if (options.marginsType) {
+    printingSetting.marginsType = options.marginsType
+  }
+  if (options.printSelectionOnly) {
+    printingSetting.shouldPrintSelectionOnly = options.printSelectionOnly
+  }
+  if (options.printBackground) {
+    printingSetting.shouldPrintBackgrounds = options.printBackground
+  }
+
+  if (options.pageSize) {
+    const pageSize = options.pageSize
+    if (typeof pageSize === 'object') {
+      if (!pageSize.height || !pageSize.width) {
+        return callback(new Error('Must define height and width for pageSize'))
+      }
+      // Dimensions in Microns
+      // 1 meter = 10^6 microns
+      printingSetting.mediaSize = {
+        name: 'CUSTOM',
+        custom_display_name: 'Custom',
+        height_microns: pageSize.height,
+        width_microns: pageSize.width
+      }
+    } else if (PDFPageSizes[pageSize]) {
+      printingSetting.mediaSize = PDFPageSizes[pageSize]
+    } else {
+      return callback(new Error(`Does not support pageSize with ${pageSize}`))
+    }
+  } else {
+    printingSetting.mediaSize = PDFPageSizes['A4']
+  }
+
+  this._printToPDF(printingSetting, callback)
+}
 
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // Every remote callback from renderer process would add a listenter to the
   // render-view-deleted event, so ignore the listenters warning.
   this.setMaxListeners(0)
-
-  // WebContents::send(channel, args..)
-  // WebContents::sendToAll(channel, args..)
-  const sendWrapper = (allFrames, channel, ...args) => {
-    if (channel == null) {
-      throw new Error('Missing required channel argument')
-    }
-    return this._send(allFrames, channel, args)
-  }
-  this.send = sendWrapper.bind(null, false)
-  this.sendToAll = sendWrapper.bind(null, true)
 
   // The navigation controller.
   const controller = new NavigationController(this)
@@ -121,52 +208,6 @@ WebContents.prototype._init = function () {
       this[name] = function () {
         return method.apply(controller, arguments)
       }
-    }
-  }
-
-  const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
-    this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
-    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
-      if (callback) callback(result)
-    })
-  }
-
-  const syncWebFrameMethods = function (requestId, method, callback, ...args) {
-    this.send('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', requestId, method, args)
-    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
-      if (callback) callback(result)
-    })
-  }
-
-  // Mapping webFrame methods.
-  for (const method of webFrameMethods) {
-    this[method] = function (...args) {
-      this.send('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, args)
-    }
-  }
-
-  for (const method of webFrameMethodsWithResult) {
-    this[method] = function (...args) {
-      const callback = args[args.length - 1]
-      const actualArgs = args.slice(0, args.length - 2)
-      syncWebFrameMethods.call(this, getNextId(), method, callback, ...actualArgs)
-    }
-  }
-
-  // Make sure webContents.executeJavaScript would run the code only when the
-  // webContents has been loaded.
-  this.executeJavaScript = function (code, hasUserGesture, callback) {
-    const requestId = getNextId()
-    if (typeof hasUserGesture === 'function') {
-      callback = hasUserGesture
-      hasUserGesture = false
-    }
-    if (this.getURL() && !this.isLoadingMainFrame()) {
-      asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
-    } else {
-      this.once('did-finish-load', () => {
-        asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
-      })
     }
   }
 
@@ -202,50 +243,10 @@ WebContents.prototype._init = function () {
     })
   })
 
-  this.printToPDF = function (options, callback) {
-    const printingSetting = Object.assign({}, defaultPrintingSetting)
-    if (options.landscape) {
-      printingSetting.landscape = options.landscape
-    }
-    if (options.marginsType) {
-      printingSetting.marginsType = options.marginsType
-    }
-    if (options.printSelectionOnly) {
-      printingSetting.shouldPrintSelectionOnly = options.printSelectionOnly
-    }
-    if (options.printBackground) {
-      printingSetting.shouldPrintBackgrounds = options.printBackground
-    }
-
-    if (options.pageSize) {
-      const pageSize = options.pageSize
-      if (typeof pageSize === 'object') {
-        if (!pageSize.height || !pageSize.width) {
-          return callback(new Error('Must define height and width for pageSize'))
-        }
-        // Dimensions in Microns
-        // 1 meter = 10^6 microns
-        printingSetting.mediaSize = {
-          name: 'CUSTOM',
-          custom_display_name: 'Custom',
-          height_microns: pageSize.height,
-          width_microns: pageSize.width
-        }
-      } else if (PDFPageSizes[pageSize]) {
-        printingSetting.mediaSize = PDFPageSizes[pageSize]
-      } else {
-        return callback(new Error(`Does not support pageSize with ${pageSize}`))
-      }
-    } else {
-      printingSetting.mediaSize = PDFPageSizes['A4']
-    }
-
-    this._printToPDF(printingSetting, callback)
-  }
-
   app.emit('web-contents-created', {}, this)
 }
 
+// JavaScript wrapper of Debugger.
 const {Debugger} = process.atomBinding('debugger')
 
 Object.setPrototypeOf(Debugger.prototype, EventEmitter.prototype)

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -7,9 +7,6 @@ const {app, ipcMain, session, Menu, NavigationController} = require('electron')
 // before the webContents module.
 session
 
-const binding = process.atomBinding('web_contents')
-const debuggerBinding = process.atomBinding('debugger')
-
 let nextId = 0
 const getNextId = function () {
   return ++nextId
@@ -81,6 +78,11 @@ const defaultPrintingSetting = {
   shouldPrintSelectionOnly: false
 }
 
+const binding = process.atomBinding('web_contents')
+const {WebContents} = binding
+
+Object.setPrototypeOf(WebContents.prototype, EventEmitter.prototype)
+
 // Following methods are mapped to webFrame.
 const webFrameMethods = [
   'insertText',
@@ -95,13 +97,10 @@ const webFrameMethodsWithResult = [
 ]
 
 // Add JavaScript wrappers for WebContents class.
-const wrapWebContents = function (webContents) {
-  // webContents is an EventEmitter.
-  Object.setPrototypeOf(webContents.__proto__, EventEmitter.prototype)
-
+WebContents.prototype._init = function () {
   // Every remote callback from renderer process would add a listenter to the
   // render-view-deleted event, so ignore the listenters warning.
-  webContents.setMaxListeners(0)
+  this.setMaxListeners(0)
 
   // WebContents::send(channel, args..)
   // WebContents::sendToAll(channel, args..)
@@ -109,17 +108,17 @@ const wrapWebContents = function (webContents) {
     if (channel == null) {
       throw new Error('Missing required channel argument')
     }
-    return webContents._send(allFrames, channel, args)
+    return this._send(allFrames, channel, args)
   }
-  webContents.send = sendWrapper.bind(null, false)
-  webContents.sendToAll = sendWrapper.bind(null, true)
+  this.send = sendWrapper.bind(null, false)
+  this.sendToAll = sendWrapper.bind(null, true)
 
   // The navigation controller.
-  const controller = new NavigationController(webContents)
+  const controller = new NavigationController(this)
   for (const name in NavigationController.prototype) {
     const method = NavigationController.prototype[name]
     if (method instanceof Function) {
-      webContents[name] = function () {
+      this[name] = function () {
         return method.apply(controller, arguments)
       }
     }
@@ -141,13 +140,13 @@ const wrapWebContents = function (webContents) {
 
   // Mapping webFrame methods.
   for (const method of webFrameMethods) {
-    webContents[method] = function (...args) {
+    this[method] = function (...args) {
       this.send('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, args)
     }
   }
 
   for (const method of webFrameMethodsWithResult) {
-    webContents[method] = function (...args) {
+    this[method] = function (...args) {
       const callback = args[args.length - 1]
       const actualArgs = args.slice(0, args.length - 2)
       syncWebFrameMethods.call(this, getNextId(), method, callback, ...actualArgs)
@@ -156,7 +155,7 @@ const wrapWebContents = function (webContents) {
 
   // Make sure webContents.executeJavaScript would run the code only when the
   // webContents has been loaded.
-  webContents.executeJavaScript = function (code, hasUserGesture, callback) {
+  this.executeJavaScript = function (code, hasUserGesture, callback) {
     const requestId = getNextId()
     if (typeof hasUserGesture === 'function') {
       callback = hasUserGesture
@@ -172,10 +171,10 @@ const wrapWebContents = function (webContents) {
   }
 
   // Dispatch IPC messages to the ipc module.
-  webContents.on('ipc-message', function (event, [channel, ...args]) {
+  this.on('ipc-message', function (event, [channel, ...args]) {
     ipcMain.emit(channel, event, ...args)
   })
-  webContents.on('ipc-message-sync', function (event, [channel, ...args]) {
+  this.on('ipc-message-sync', function (event, [channel, ...args]) {
     Object.defineProperty(event, 'returnValue', {
       set: function (value) {
         return event.sendReply(JSON.stringify(value))
@@ -186,24 +185,24 @@ const wrapWebContents = function (webContents) {
   })
 
   // Handle context menu action request from pepper plugin.
-  webContents.on('pepper-context-menu', function (event, params) {
+  this.on('pepper-context-menu', function (event, params) {
     const menu = Menu.buildFromTemplate(params.menu)
     menu.popup(params.x, params.y)
   })
 
   // The devtools requests the webContents to reload.
-  webContents.on('devtools-reload-page', function () {
-    webContents.reload()
+  this.on('devtools-reload-page', function () {
+    this.reload()
   })
 
   // Delays the page-title-updated event to next tick.
-  webContents.on('-page-title-updated', function (...args) {
+  this.on('-page-title-updated', function (...args) {
     setImmediate(() => {
       this.emit.apply(this, ['page-title-updated'].concat(args))
     })
   })
 
-  webContents.printToPDF = function (options, callback) {
+  this.printToPDF = function (options, callback) {
     const printingSetting = Object.assign({}, defaultPrintingSetting)
     if (options.landscape) {
       printingSetting.landscape = options.landscape
@@ -244,19 +243,14 @@ const wrapWebContents = function (webContents) {
     this._printToPDF(printingSetting, callback)
   }
 
-  app.emit('web-contents-created', {}, webContents)
+  app.emit('web-contents-created', {}, this)
 }
 
-binding._setWrapWebContents(wrapWebContents)
+const {Debugger} = process.atomBinding('debugger')
 
-// Add JavaScript wrappers for Debugger class.
-const wrapDebugger = function (webContentsDebugger) {
-  // debugger is an EventEmitter.
-  Object.setPrototypeOf(webContentsDebugger.__proto__, EventEmitter.prototype)
-}
+Object.setPrototypeOf(Debugger.prototype, EventEmitter.prototype)
 
-debuggerBinding._setWrapDebugger(wrapDebugger)
-
+// Public APIs.
 module.exports = {
   create (options = {}) {
     return binding.create(options)

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -65,7 +65,7 @@ process.on('uncaughtException', function (error) {
 })
 
 // Emit 'exit' event on quit.
-var app = require('electron').app
+const {app} = require('electron')
 
 app.on('quit', function (event, exitCode) {
   process.emit('exit', exitCode)
@@ -86,15 +86,12 @@ if (process.platform === 'win32') {
   // form `com.squirrel.PACKAGE-NAME.OUREXE`. We need to call
   // app.setAppUserModelId with a matching identifier so that renderer processes
   // will inherit this value.
-  var updateDotExe = path.join(
-    path.dirname(process.execPath),
-    '..',
-    'update.exe')
+  const updateDotExe = path.join(path.dirname(process.execPath), '..', 'update.exe')
 
-  if (fs.statSyncNoException(updateDotExe)) {
-    var packageDir = path.dirname(path.resolve(updateDotExe))
-    var packageName = path.basename(packageDir).replace(/\s/g, '')
-    var exeName = path.basename(process.execPath).replace(/\.exe$/i, '').replace(/\s/g, '')
+  if (fs.existsSync(updateDotExe)) {
+    const packageDir = path.dirname(path.resolve(updateDotExe))
+    const packageName = path.basename(packageDir).replace(/\s/g, '')
+    const exeName = path.basename(process.execPath).replace(/\.exe$/i, '').replace(/\s/g, '')
 
     app.setAppUserModelId(`com.squirrel.${packageName}.${exeName}`)
   }
@@ -108,15 +105,13 @@ require('./rpc-server')
 
 // Load the guest view manager.
 require('./guest-view-manager')
-
 require('./guest-window-manager')
 
 // Now we try to load app's package.json.
-var packageJson = null
-var searchPaths = ['app', 'app.asar', 'default_app.asar']
-var i, len, packagePath
-for (i = 0, len = searchPaths.length; i < len; i++) {
-  packagePath = searchPaths[i]
+let packagePath = null
+let packageJson = null
+const searchPaths = ['app', 'app.asar', 'default_app.asar']
+for (packagePath of searchPaths) {
   try {
     packagePath = path.join(process.resourcesPath, packagePath)
     packageJson = require(path.join(packagePath, 'package.json'))
@@ -157,14 +152,9 @@ if (packageJson.v8Flags != null) {
   v8.setFlagsFromString(packageJson.v8Flags)
 }
 
-// Chrome 42 disables NPAPI plugins by default, reenable them here
-app.commandLine.appendSwitch('enable-npapi')
-
 // Set the user path according to application's name.
 app.setPath('userData', path.join(app.getPath('appData'), app.getName()))
-
 app.setPath('userCache', path.join(app.getPath('cache'), app.getName()))
-
 app.setAppPath(packagePath)
 
 // Load the chrome extension support.
@@ -177,7 +167,7 @@ require('./desktop-capturer')
 require('./api/protocol')
 
 // Set main startup script of the app.
-var mainStartupScript = packageJson.main || 'index.js'
+const mainStartupScript = packageJson.main || 'index.js'
 
 // Finally load app's main.js and transfer control to C++.
 Module._load(path.join(packagePath, mainStartupScript), Module, true)

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -6,10 +6,6 @@ const util = require('util')
 const Module = require('module')
 const v8 = require('v8')
 
-// Save the prototype of EventEmitter, must be called before using native API.
-const {setEventEmitterPrototype} = process.binding('atom_browser_event_emitter')
-setEventEmitterPrototype(require('events').EventEmitter)
-
 // We modified the original process.argv to let node.js load the atom.js,
 // we need to restore it here.
 process.argv.splice(1, 1)

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -6,6 +6,10 @@ const util = require('util')
 const Module = require('module')
 const v8 = require('v8')
 
+// Save the prototype of EventEmitter, must be called before using native API.
+const {setEventEmitterPrototype} = process.binding('atom_browser_event_emitter')
+setEventEmitterPrototype(require('events').EventEmitter)
+
 // We modified the original process.argv to let node.js load the atom.js,
 // we need to restore it here.
 process.argv.splice(1, 1)

--- a/lib/renderer/api/web-frame.js
+++ b/lib/renderer/api/web-frame.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events').EventEmitter
 const webFrame = process.atomBinding('web_frame').webFrame
 
 // webFrame is an EventEmitter.
-Object.setPrototypeOf(webFrame, EventEmitter.prototype)
+Object.setPrototypeOf(webFrame.__proto__, EventEmitter.prototype)
 
 // Lots of webview would subscribe to webFrame's events.
 webFrame.setMaxListeners(0)

--- a/lib/renderer/api/web-frame.js
+++ b/lib/renderer/api/web-frame.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const EventEmitter = require('events').EventEmitter
+const {EventEmitter} = require('events')
+const {webFrame, WebFrame} = process.atomBinding('web_frame')
 
-const webFrame = process.atomBinding('web_frame').webFrame
-
-// webFrame is an EventEmitter.
-Object.setPrototypeOf(webFrame.__proto__, EventEmitter.prototype)
+// WebFrame is an EventEmitter.
+Object.setPrototypeOf(WebFrame.prototype, EventEmitter.prototype)
 
 // Lots of webview would subscribe to webFrame's events.
 webFrame.setMaxListeners(0)


### PR DESCRIPTION
This means every native class now gets a constructor, so it is possible for us to manipulate the prototype of native classes directly instead of running hooks for creations of every native object.