### PR TITLE
Revert Node's call of SetAutorunMicrotasks(false)

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -173,6 +173,11 @@ node::Environment* NodeBindings::CreateEnvironment(
       context->GetIsolate(), uv_default_loop(), context,
       args.size(), c_argv.get(), 0, nullptr);
 
+  // Node turns off AutorunMicrotasks, but we need it in web pages to match the
+  // behavior of Chrome.
+  if (!is_browser_)
+    context->GetIsolate()->SetAutorunMicrotasks(true);
+
   mate::Dictionary process(context->GetIsolate(), env->process_object());
   process.Set("type", process_type);
   process.Set("resourcesPath", resources_path);


### PR DESCRIPTION
Close #6605.

The remote devtools of Chrome initializes itself in two steps: 1. Inject runtime bindings; 2. start the application when window is loaded. The step 1 is a chain of `Promise`s, and Chrome assumes all the `Promise`s will get resolved before the `window.onload`.

However Node turns off the `AutorunMicrotasks` of V8, making the resolution of `Promise`s to be delayed. So the app of devtools is started before its runtime bindings get ready.

This PR fixes it by reverting Node's call of `SetAutorunMicrotasks(false)`.