### PR TITLE
protocol: custom standard schemes should support cookies

### DIFF
--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -17,6 +17,7 @@
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
 #include "base/strings/string_util.h"
+#include "brightray/common/switches.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "native_mate/dictionary.h"
 #include "url/url_util.h"
@@ -208,6 +209,8 @@ void RegisterStandardSchemes(
 
   auto command_line = base::CommandLine::ForCurrentProcess();
   command_line->AppendSwitchASCII(atom::switches::kStandardSchemes,
+                                  base::JoinString(schemes, ","));
+  command_line->AppendSwitchASCII(brightray::switches::kCookieableSchemes,
                                   base::JoinString(schemes, ","));
 }
 

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -17,7 +17,6 @@
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
 #include "base/strings/string_util.h"
-#include "brightray/common/switches.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "native_mate/dictionary.h"
 #include "url/url_util.h"
@@ -29,6 +28,9 @@ namespace atom {
 namespace api {
 
 namespace {
+
+// List of registered custom standard schemes.
+std::vector<std::string> g_standard_schemes;
 
 // Clear protocol handlers in IO thread.
 void ClearJobFactoryInIO(
@@ -43,6 +45,7 @@ void ClearJobFactoryInIO(
 Protocol::Protocol(v8::Isolate* isolate, AtomBrowserContext* browser_context)
     : request_context_getter_(browser_context->GetRequestContext()),
       weak_factory_(this) {
+  browser_context->SetCookieableSchemes(g_standard_schemes);
   Init(isolate);
 }
 
@@ -210,8 +213,8 @@ void RegisterStandardSchemes(
   auto command_line = base::CommandLine::ForCurrentProcess();
   command_line->AppendSwitchASCII(atom::switches::kStandardSchemes,
                                   base::JoinString(schemes, ","));
-  command_line->AppendSwitchASCII(brightray::switches::kCookieableSchemes,
-                                  base::JoinString(schemes, ","));
+
+  atom::api::g_standard_schemes = schemes;
 }
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -88,6 +88,9 @@ AtomBrowserContext::AtomBrowserContext(
   use_cache_ = true;
   options.GetBoolean("cache", &use_cache_);
 
+  // Default schemes that should support cookies.
+  cookieable_schemes_ = {"http", "https", "ws", "wss"};
+
   // Initialize Pref Registry in brightray.
   InitPrefs();
 }
@@ -97,6 +100,13 @@ AtomBrowserContext::~AtomBrowserContext() {
 
 void AtomBrowserContext::SetUserAgent(const std::string& user_agent) {
   user_agent_ = user_agent;
+}
+
+void AtomBrowserContext::SetCookieableSchemes(
+    const std::vector<std::string>& schemes) {
+  if (!schemes.empty())
+    cookieable_schemes_.insert(cookieable_schemes_.end(),
+                               schemes.begin(), schemes.end());
 }
 
 net::NetworkDelegate* AtomBrowserContext::CreateNetworkDelegate() {
@@ -186,6 +196,10 @@ std::unique_ptr<net::CertVerifier> AtomBrowserContext::CreateCertVerifier() {
 
 net::SSLConfigService* AtomBrowserContext::CreateSSLConfigService() {
   return new AtomSSLConfigService;
+}
+
+std::vector<std::string> AtomBrowserContext::GetCookieableSchemes() {
+  return cookieable_schemes_;
 }
 
 void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_ATOM_BROWSER_CONTEXT_H_
 
 #include <string>
+#include <vector>
 
 #include "brightray/browser/browser_context.h"
 
@@ -26,6 +27,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
       const base::DictionaryValue& options = base::DictionaryValue());
 
   void SetUserAgent(const std::string& user_agent);
+  void SetCookieableSchemes(const std::vector<std::string>& schemes);
 
   // brightray::URLRequestContextGetter::Delegate:
   net::NetworkDelegate* CreateNetworkDelegate() override;
@@ -36,6 +38,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
       const base::FilePath& base_path) override;
   std::unique_ptr<net::CertVerifier> CreateCertVerifier() override;
   net::SSLConfigService* CreateSSLConfigService() override;
+  std::vector<std::string> GetCookieableSchemes() override;
 
   // content::BrowserContext:
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;
@@ -56,6 +59,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
   std::unique_ptr<AtomDownloadManagerDelegate> download_manager_delegate_;
   std::unique_ptr<WebViewManager> guest_manager_;
   std::unique_ptr<AtomPermissionManager> permission_manager_;
+  std::vector<std::string> cookieable_schemes_;
   std::string user_agent_;
   bool use_cache_;
 

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -153,6 +153,32 @@ describe('session module', function () {
         })
       })
     })
+
+    it('should set cookie for standard scheme', function (done) {
+      const standardScheme = remote.getGlobal('standardScheme')
+      const origin = standardScheme + '://fake-host'
+      session.defaultSession.cookies.set({
+        url: origin,
+        name: 'custom',
+        value: '1'
+      }, function (error) {
+        if (error) {
+          return done(error)
+        }
+        session.defaultSession.cookies.get({
+          url: origin
+        }, function (error, list) {
+          if (error) {
+            return done(error)
+          }
+          assert.equal(list.length, 1)
+          assert.equal(list[0].name, 'custom')
+          assert.equal(list[0].value, '1')
+          assert.equal(list[0].domain, 'fake-host')
+          done()
+        })
+      })
+    })
   })
 
   describe('ses.clearStorageData(options)', function () {


### PR DESCRIPTION
Fixes #6659 

Depends on https://github.com/electron/brightray/pull/244