### PR TITLE
isSwipeTrackingFromScrollEventsEnabled cleanup

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -40,9 +40,6 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
   void UnsubscribeLocalNotification(int request_id);
   v8::Local<v8::Value> GetUserDefault(const std::string& name,
                                       const std::string& type);
-  // On 10.7+, back and forward swipe gestures can be triggered using a scroll
-  // gesture, if enabled in System Preferences. This function returns true if
-  // the feature is supported and enabled, and false otherwise.
   bool IsSwipeTrackingFromScrollEventsEnabled();
 #endif
   bool IsDarkMode();

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -123,9 +123,7 @@ bool SystemPreferences::IsDarkMode() {
 }
 
 bool SystemPreferences::IsSwipeTrackingFromScrollEventsEnabled() {
-  SEL selector = @selector(isSwipeTrackingFromScrollEventsEnabled);
-  return [NSEvent respondsToSelector:selector] &&
-         [NSEvent performSelector:selector];
+  return [NSEvent isSwipeTrackingFromScrollEventsEnabled];
 }
 
 }  // namespace api


### PR DESCRIPTION
It does not make sense to do a `respondsToSelector:` check as the API is available in all the supported versions of macOS (https://developer.apple.com/reference/appkit/nsevent/1533987-isswipetrackingfromscrolleventse)