### PR TITLE
Fixes buffer size in offscreen mode

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1345,11 +1345,19 @@ bool WebContents::IsOffScreen() const {
 
 void WebContents::OnPaint(const gfx::Rect& dirty_rect,
                           const gfx::Size& bitmap_size,
+                          const int pixel_size,
                           void* bitmap_pixels) {
   v8::MaybeLocal<v8::Object> buffer = node::Buffer::New(
-      isolate(), reinterpret_cast<char*>(bitmap_pixels), sizeof(bitmap_pixels));
+      isolate(), reinterpret_cast<char*>(bitmap_pixels),
+      pixel_size * dirty_rect.width() * dirty_rect.height());
+
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate());
+  dict.Set("width", bitmap_size.width());
+  dict.Set("height", bitmap_size.height());
+  dict.Set("pixel", pixel_size);
+
   if (!buffer.IsEmpty())
-    Emit("paint", dirty_rect, buffer.ToLocalChecked(), bitmap_size);
+    Emit("paint", dirty_rect, buffer.ToLocalChecked(), dict);
 }
 
 void WebContents::StartPainting() {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1345,16 +1345,15 @@ bool WebContents::IsOffScreen() const {
 
 void WebContents::OnPaint(const gfx::Rect& dirty_rect,
                           const gfx::Size& bitmap_size,
-                          const int pixel_size,
+                          int pixel_size,
                           void* bitmap_pixels) {
-  v8::MaybeLocal<v8::Object> buffer = node::Buffer::New(
+  v8::MaybeLocal<v8::Object> buffer = node::Buffer::Copy(
       isolate(), reinterpret_cast<char*>(bitmap_pixels),
-      pixel_size * dirty_rect.width() * dirty_rect.height());
+      pixel_size * bitmap_size.width() * bitmap_size.height());
 
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate());
   dict.Set("width", bitmap_size.width());
   dict.Set("height", bitmap_size.height());
-  dict.Set("bytesPerPixel", pixel_size);
 
   if (!buffer.IsEmpty())
     Emit("paint", dirty_rect, buffer.ToLocalChecked(), dict);
@@ -1367,8 +1366,8 @@ void WebContents::StartPainting() {
   auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
       web_contents()->GetRenderWidgetHostView());
   if (osr_rwhv) {
-    osr_rwhv->SetPainting(true);
     osr_rwhv->Show();
+    osr_rwhv->SetPainting(true);
   }
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1354,7 +1354,7 @@ void WebContents::OnPaint(const gfx::Rect& dirty_rect,
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate());
   dict.Set("width", bitmap_size.width());
   dict.Set("height", bitmap_size.height());
-  dict.Set("pixel", pixel_size);
+  dict.Set("bytesPerPixel", pixel_size);
 
   if (!buffer.IsEmpty())
     Emit("paint", dirty_rect, buffer.ToLocalChecked(), dict);

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -160,6 +160,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   bool IsOffScreen() const;
   void OnPaint(const gfx::Rect& dirty_rect,
                const gfx::Size& bitmap_size,
+               const int pixel_size,
                void* bitmap_pixels);
   void StartPainting();
   void StopPainting();

--- a/atom/browser/osr/osr_output_device.cc
+++ b/atom/browser/osr/osr_output_device.cc
@@ -87,7 +87,7 @@ void OffScreenOutputDevice::OnPaint(const gfx::Rect& damage_rect) {
 
   SkAutoLockPixels bitmap_pixels_lock(*bitmap_);
   callback_.Run(rect, gfx::Size(bitmap_->width(), bitmap_->height()),
-                bitmap_->getPixels());
+                bitmap_->bytesPerPixel(), bitmap_->getPixels());
 }
 
 }  // namespace atom

--- a/atom/browser/osr/osr_output_device.h
+++ b/atom/browser/osr/osr_output_device.h
@@ -12,8 +12,8 @@
 
 namespace atom {
 
-typedef base::Callback<void(const gfx::Rect&,
-                            const gfx::Size&, void*)> OnPaintCallback;
+typedef base::Callback<void(const gfx::Rect&, const gfx::Size&,
+                            const int, void*)> OnPaintCallback;
 
 class OffScreenOutputDevice : public cc::SoftwareOutputDevice {
  public:

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -262,7 +262,7 @@ class AtomCopyFrameGenerator {
       std::unique_ptr<SkAutoLockPixels> bitmap_pixels_lock) {
     view_->OnPaint(damage_rect,
                    gfx::Size(bitmap.width(), bitmap.height()),
-                   bitmap.getPixels());
+                   bitmap.bytesPerPixel(), bitmap.getPixels());
 
     if (frame_retry_count_ > 0)
       frame_retry_count_ = 0;
@@ -791,11 +791,12 @@ void OffScreenRenderWidgetHostView::SetPaintCallback(
 void OffScreenRenderWidgetHostView::OnPaint(
     const gfx::Rect& damage_rect,
     const gfx::Size& bitmap_size,
+    const int pixel_size,
     void* bitmap_pixels) {
   TRACE_EVENT0("electron", "OffScreenRenderWidgetHostView::OnPaint");
 
   if (!callback_.is_null())
-    callback_.Run(damage_rect, bitmap_size, bitmap_pixels);
+    callback_.Run(damage_rect, bitmap_size, pixel_size, bitmap_pixels);
 }
 
 void OffScreenRenderWidgetHostView::SetPainting(bool painting) {

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -379,13 +379,6 @@ OffScreenRenderWidgetHostView::~OffScreenRenderWidgetHostView() {
 #if defined(OS_MACOSX)
   DestroyPlatformWidget();
 #endif
-
-  if (copy_frame_generator_.get())
-    copy_frame_generator_.reset(nullptr);
-
-  delegated_frame_host_.reset(nullptr);
-  compositor_.reset(nullptr);
-  root_layer_.reset(nullptr);
 }
 
 void OffScreenRenderWidgetHostView::OnBeginFrameTimerTick() {

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -381,11 +381,11 @@ OffScreenRenderWidgetHostView::~OffScreenRenderWidgetHostView() {
 #endif
 
   if (copy_frame_generator_.get())
-    copy_frame_generator_.reset(NULL);
+    copy_frame_generator_.reset(nullptr);
 
-  delegated_frame_host_.reset(NULL);
-  compositor_.reset(NULL);
-  root_layer_.reset(NULL);
+  delegated_frame_host_.reset(nullptr);
+  compositor_.reset(nullptr);
+  root_layer_.reset(nullptr);
 }
 
 void OffScreenRenderWidgetHostView::OnBeginFrameTimerTick() {

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -379,6 +379,13 @@ OffScreenRenderWidgetHostView::~OffScreenRenderWidgetHostView() {
 #if defined(OS_MACOSX)
   DestroyPlatformWidget();
 #endif
+
+  if (copy_frame_generator_.get())
+    copy_frame_generator_.reset(NULL);
+
+  delegated_frame_host_.reset(NULL);
+  compositor_.reset(NULL);
+  root_layer_.reset(NULL);
 }
 
 void OffScreenRenderWidgetHostView::OnBeginFrameTimerTick() {

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -192,6 +192,7 @@ class OffScreenRenderWidgetHostView
   void SetPaintCallback(const OnPaintCallback& callback);
   void OnPaint(const gfx::Rect& damage_rect,
                const gfx::Size& bitmap_size,
+               const int pixel_size,
                void* bitmap_pixels);
 
   void SetPainting(bool painting);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -352,7 +352,7 @@ Emitted when the cursor's type changes. The `type` parameter can be `default`,
 `not-allowed`, `zoom-in`, `zoom-out`, `grab`, `grabbing`, `custom`.
 
 If the `type` parameter is `custom`, the `image` parameter will hold the custom
-cursor image in a `NativeImage`, and `scale`, `size` and `hotspot` will hold 
+cursor image in a `NativeImage`, and `scale`, `size` and `hotspot` will hold
 additional information about the custom cursor.
 
 #### Event: 'context-menu'
@@ -471,6 +471,7 @@ Returns:
 * `bitmapSize` Object
   * `width` Number - the width of the whole bitmap
   * `height` Number - the height of the whole bitmap
+  * `pixel` Number - The number of bytes per pixel
 
 Emitted when a new frame is generated. Only the dirty area is passed in the
 buffer.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -471,7 +471,7 @@ Returns:
 * `bitmapSize` Object
   * `width` Number - the width of the whole bitmap
   * `height` Number - the height of the whole bitmap
-  * `pixel` Number - The number of bytes per pixel
+  * `bytesPerPixel` Number - The number of bytes per pixel in the bitmap
 
 Emitted when a new frame is generated. Only the dirty area is passed in the
 buffer.


### PR DESCRIPTION
This PR fixes the buffer size issue in the `'paint'` event in offscreen mode. #6704 

Also resets some properties in `OffScreenRenderWidgetHostView`'s destructor.