### PR TITLE
Mark isDestroyed as public on BrowserWindow/WebContents

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -572,6 +572,10 @@ Removes focus from the window.
 
 Returns a boolean, whether the window is focused.
 
+#### `win.isDestroyed()`
+
+Returns a boolean, whether the window is destroyed.
+
 #### `win.show()`
 
 Shows and gives focus to the window.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -352,7 +352,7 @@ Emitted when the cursor's type changes. The `type` parameter can be `default`,
 `not-allowed`, `zoom-in`, `zoom-out`, `grab`, `grabbing`, `custom`.
 
 If the `type` parameter is `custom`, the `image` parameter will hold the custom
-cursor image in a `NativeImage`, and `scale`, `size` and `hotspot` will hold 
+cursor image in a `NativeImage`, and `scale`, `size` and `hotspot` will hold
 additional information about the custom cursor.
 
 #### Event: 'context-menu'
@@ -535,6 +535,10 @@ console.log(currentURL)
 #### `contents.getTitle()`
 
 Returns the title of the current web page.
+
+#### `contents.isDestroyed()`
+
+Returns a Boolean, whether the web page is destroyed.
 
 #### `contents.isFocused()`
 


### PR DESCRIPTION
This pull request documents the `isDestroyed()` as API as public for browser windows and web contents.