### PR TITLE
Emit NativeImage objects in paint event

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1337,15 +1337,10 @@ bool WebContents::IsOffScreen() const {
   return type_ == OFF_SCREEN;
 }
 
-void WebContents::OnPaint(const gfx::Rect& dirty_rect,
-                          const SkBitmap& bitmap) {
-  v8::MaybeLocal<v8::Object> buffer = node::Buffer::Copy(
-      isolate(),
-      reinterpret_cast<char*>(bitmap.getPixels()), bitmap.getSize());
-  if (!buffer.IsEmpty()) {
-    Emit("paint", dirty_rect, buffer.ToLocalChecked(),
-         gfx::Size(bitmap.width(), bitmap.height()));
-  }
+void WebContents::OnPaint(const gfx::Rect& dirty_rect, const SkBitmap& bitmap) {
+  mate::Handle<NativeImage> image =
+      NativeImage::Create(isolate(), gfx::Image::CreateFrom1xBitmap(bitmap));
+  Emit("paint", dirty_rect, image);
 }
 
 void WebContents::StartPainting() {

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -172,6 +172,9 @@ bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon) {
 }
 #endif
 
+void Noop(char*, void*) {
+}
+
 }  // namespace
 
 NativeImage::NativeImage(v8::Isolate* isolate, const gfx::Image& image)
@@ -228,18 +231,6 @@ v8::Local<v8::Value> NativeImage::ToBitmap(v8::Isolate* isolate) {
                             bitmap->getSafeSize()).ToLocalChecked();
 }
 
-void noop(char*, void*) {}
-
-v8::Local<v8::Value> NativeImage::GetBitmap(v8::Isolate* isolate) {
-  const SkBitmap* bitmap = image_.ToSkBitmap();
-  SkPixelRef* ref = bitmap->pixelRef();
-  return node::Buffer::New(isolate,
-                            reinterpret_cast<char*>(ref->pixels()),
-                            bitmap->getSafeSize(),
-                            &noop,
-                            nullptr).ToLocalChecked();
-}
-
 v8::Local<v8::Value> NativeImage::ToJPEG(v8::Isolate* isolate, int quality) {
   std::vector<unsigned char> output;
   gfx::JPEG1xEncodedDataFromImage(image_, quality, &output);
@@ -256,6 +247,16 @@ std::string NativeImage::ToDataURL() {
   base::Base64Encode(data_url, &data_url);
   data_url.insert(0, "data:image/png;base64,");
   return data_url;
+}
+
+v8::Local<v8::Value> NativeImage::GetBitmap(v8::Isolate* isolate) {
+  const SkBitmap* bitmap = image_.ToSkBitmap();
+  SkPixelRef* ref = bitmap->pixelRef();
+  return node::Buffer::New(isolate,
+                           reinterpret_cast<char*>(ref->pixels()),
+                           bitmap->getSafeSize(),
+                           &Noop,
+                           nullptr).ToLocalChecked();
 }
 
 v8::Local<v8::Value> NativeImage::GetNativeHandle(v8::Isolate* isolate,

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -228,6 +228,18 @@ v8::Local<v8::Value> NativeImage::ToBitmap(v8::Isolate* isolate) {
                             bitmap->getSafeSize()).ToLocalChecked();
 }
 
+void noop(char*, void*) {}
+
+v8::Local<v8::Value> NativeImage::GetBitmap(v8::Isolate* isolate) {
+  const SkBitmap* bitmap = image_.ToSkBitmap();
+  SkPixelRef* ref = bitmap->pixelRef();
+  return node::Buffer::New(isolate,
+                            reinterpret_cast<char*>(ref->pixels()),
+                            bitmap->getSafeSize(),
+                            &noop,
+                            nullptr).ToLocalChecked();
+}
+
 v8::Local<v8::Value> NativeImage::ToJPEG(v8::Isolate* isolate, int quality) {
   std::vector<unsigned char> output;
   gfx::JPEG1xEncodedDataFromImage(image_, quality, &output);
@@ -361,6 +373,7 @@ void NativeImage::BuildPrototype(
       .SetMethod("toPNG", &NativeImage::ToPNG)
       .SetMethod("toJPEG", &NativeImage::ToJPEG)
       .SetMethod("toBitmap", &NativeImage::ToBitmap)
+      .SetMethod("getBitmap", &NativeImage::GetBitmap)
       .SetMethod("getNativeHandle", &NativeImage::GetNativeHandle)
       .SetMethod("toDataURL", &NativeImage::ToDataURL)
       .SetMethod("isEmpty", &NativeImage::IsEmpty)

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -71,6 +71,7 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   v8::Local<v8::Value> ToPNG(v8::Isolate* isolate);
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
   v8::Local<v8::Value> ToBitmap(v8::Isolate* isolate);
+  v8::Local<v8::Value> GetBitmap(v8::Isolate* isolate);
   v8::Local<v8::Value> GetNativeHandle(
     v8::Isolate* isolate,
     mate::Arguments* args);

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -163,11 +163,16 @@ Returns a [Buffer][buffer] that contains the image's `JPEG` encoded data.
 
 #### `image.toBitmap()`
 
-Returns a [Buffer][buffer] that contains the image's raw pixel data.
+Returns a [Buffer][buffer] that contains a copy of the image's raw pixel data.
 
 #### `image.toDataURL()`
 
 Returns the data URL of the image.
+
+#### `image.getBitmap()`
+
+Returns a [Buffer][buffer] that contains the image's raw pixel data. The pixel 
+data is not owned by the `Buffer` object.
 
 #### `image.getNativeHandle()` _macOS_
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -163,7 +163,8 @@ Returns a [Buffer][buffer] that contains the image's `JPEG` encoded data.
 
 #### `image.toBitmap()`
 
-Returns a [Buffer][buffer] that contains a copy of the image's raw pixel data.
+Returns a [Buffer][buffer] that contains a copy of the image's raw bitmap pixel
+data.
 
 #### `image.toDataURL()`
 
@@ -171,8 +172,11 @@ Returns the data URL of the image.
 
 #### `image.getBitmap()`
 
-Returns a [Buffer][buffer] that contains the image's raw pixel data. The pixel 
-data is not owned by the `Buffer` object.
+Returns a [Buffer][buffer] that contains the image's raw bitmap pixel data.
+
+The difference between `getBitmap()` and `toBitmap()` is, `getBitmap()` does not
+copy the bitmap data, so you have to use the returned Buffer immediately in
+current event loop tick, otherwise the data might be changed or destroyed.
 
 #### `image.getNativeHandle()` _macOS_
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -463,33 +463,21 @@ Returns:
 
 * `event` Event
 * `dirtyRect` Object
-  * `x` Number - the x coordinate on the bitmap
-  * `y` Number - the y coordinate on the bitmap
-  * `width` Number - the width of the dirty area
-  * `height` Number - the height of the dirty area
-* `data` Buffer - the bitmap data of the dirty rect
-* `bitmapSize` Object
-  * `width` Number - the width of the whole bitmap
-  * `height` Number - the height of the whole bitmap
+  * `x` Integer - The x coordinate on the image.
+  * `y` Integer - The y coordinate on the image.
+  * `width` Integer - The width of the dirty area.
+  * `height` Integer - The height of the dirty area.
+* `image` [NativeImage](native-image.md) - The image data of the dirty rect
 
 Emitted when a new frame is generated. Only the dirty area is passed in the
 buffer.
 
 ```javascript
-const {BrowserWindow} = require('electron')
-
-let win = new BrowserWindow({
-  width: 800,
-  height: 1500,
-  webPreferences: {
-    offscreen: true
-  }
+let win = new BrowserWindow({webPreferences: {offscreen: true}})
+win.webContents.on('paint', (event, dirty, image) => {
+  fs.writeSync('frame.png', image.toPNG())
 })
 win.loadURL('http://github.com')
-
-win.webContents.on('paint', (event, dirty, data) => {
-  // updateBitmap(dirty, data)
-})
 ```
 
 ### Instance Methods

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -473,9 +473,11 @@ Emitted when a new frame is generated. Only the dirty area is passed in the
 buffer.
 
 ```javascript
+const {BrowserWindow} = require('electron')
+
 let win = new BrowserWindow({webPreferences: {offscreen: true}})
 win.webContents.on('paint', (event, dirty, image) => {
-  fs.writeSync('frame.png', image.toPNG())
+  // updateBitmap(dirty, image.toBitmap())
 })
 win.loadURL('http://github.com')
 ```

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -467,7 +467,7 @@ Returns:
   * `y` Integer - The y coordinate on the image.
   * `width` Integer - The width of the dirty area.
   * `height` Integer - The height of the dirty area.
-* `image` [NativeImage](native-image.md) - The image data of the dirty rect
+* `image` [NativeImage](native-image.md) - The image data of the whole frame.
 
 Emitted when a new frame is generated. Only the dirty area is passed in the
 buffer.
@@ -477,7 +477,7 @@ const {BrowserWindow} = require('electron')
 
 let win = new BrowserWindow({webPreferences: {offscreen: true}})
 win.webContents.on('paint', (event, dirty, image) => {
-  // updateBitmap(dirty, image.toBitmap())
+  // updateBitmap(dirty, image.getBitmap())
 })
 win.loadURL('http://github.com')
 ```

--- a/docs/tutorial/offscreen-rendering.md
+++ b/docs/tutorial/offscreen-rendering.md
@@ -37,19 +37,18 @@ const {app, BrowserWindow} = require('electron')
 
 app.disableHardwareAcceleration()
 
-let win = new BrowserWindow({
-  width: 800,
-  height: 1500,
-  webPreferences: {
-    offscreen: true
-  }
-})
-win.loadURL('http://github.com')
-
-win.webContents.setFrameRate(30)
-
-win.webContents.on('paint', (event, dirty, data) => {
-  // updateBitmap(dirty, data)
+let win
+app.once('ready', () => {
+  win = new BrowserWindow({
+    webPreferences: {
+      offscreen: true
+    }
+  })
+  win.loadURL('http://github.com')
+  win.webContents.on('paint', (event, dirty, image) => {
+    fs.writeSync('frame.png', image.toPNG())
+  })
+  win.webContents.setFrameRate(30)
 })
 ```
 

--- a/docs/tutorial/offscreen-rendering.md
+++ b/docs/tutorial/offscreen-rendering.md
@@ -46,7 +46,7 @@ app.once('ready', () => {
   })
   win.loadURL('http://github.com')
   win.webContents.on('paint', (event, dirty, image) => {
-    fs.writeSync('frame.png', image.toPNG())
+    // updateBitmap(dirty, image.toBitmap())
   })
   win.webContents.setFrameRate(30)
 })

--- a/docs/tutorial/offscreen-rendering.md
+++ b/docs/tutorial/offscreen-rendering.md
@@ -46,7 +46,7 @@ app.once('ready', () => {
   })
   win.loadURL('http://github.com')
   win.webContents.on('paint', (event, dirty, image) => {
-    // updateBitmap(dirty, image.toBitmap())
+    // updateBitmap(dirty, image.getBitmap())
   })
   win.webContents.setFrameRate(30)
 })


### PR DESCRIPTION
Instead of passing `data` as `Buffer` directly in the `paint` event, this PR changes to emit `NativeImage` objects. So the API would be easier to use and test.

Regarding the performance, `NativeImage` stores the bitmap by simply ref-counting its underlying data, so no copying and encoding are involved, and for users wanting to access the bitmap data, calling `toBitmap()` is as efficient as before.

@gerhardberger @brenca Please let me know if you have concerns about this.