### PR TITLE
Omits setMouseDownCanMoveWindow call for OffScreenView

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1128,7 +1128,9 @@ void NativeWindowMac::UpdateDraggableRegionViews(
   NSInteger webViewWidth = NSWidth([webView bounds]);
   NSInteger webViewHeight = NSHeight([webView bounds]);
 
-  [webView setMouseDownCanMoveWindow:YES];
+  if ([webView respondsToSelector:@selector(setMouseDownCanMoveWindow:)]) {
+    [webView setMouseDownCanMoveWindow:YES];
+  }
 
   // Remove all ControlRegionViews that are added last time.
   // Note that [webView subviews] returns the view's mutable internal array and


### PR DESCRIPTION
This PR omits the `setMouseDownCanMoveWindow` call for `OffScreenView`, because `OffScreenView` doesn't have this method, beause it a plain `NSView` and it causes an error when running browser windows in offscreen mode.