### PR TITLE
Always restore maximizable state after changing window behavior/style

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -591,11 +591,9 @@ NativeWindowMac::NativeWindowMac(
 
   InstallView();
 
-  // Disable zoom button if window is not resizable.
   // Set maximizable state last to ensure zoom button does not get reset
   // by calls to other APIs.
-  if (!maximizable)
-    SetMaximizable(false);
+  SetMaximizable(maximizable);
 }
 
 NativeWindowMac::~NativeWindowMac() {
@@ -1170,27 +1168,25 @@ void NativeWindowMac::UpdateDraggableRegionViews(
 }
 
 void NativeWindowMac::SetStyleMask(bool on, NSUInteger flag) {
-  bool zoom_button_enabled = IsMaximizable();
+  bool was_maximizable = IsMaximizable();
   if (on)
     [window_ setStyleMask:[window_ styleMask] | flag];
   else
     [window_ setStyleMask:[window_ styleMask] & (~flag)];
   // Change style mask will make the zoom button revert to default, probably
   // a bug of Cocoa or macOS.
-  if (!zoom_button_enabled)
-    SetMaximizable(false);
+  SetMaximizable(was_maximizable);
 }
 
 void NativeWindowMac::SetCollectionBehavior(bool on, NSUInteger flag) {
-  bool zoom_button_enabled = IsMaximizable();
+  bool was_maximizable = IsMaximizable();
   if (on)
     [window_ setCollectionBehavior:[window_ collectionBehavior] | flag];
   else
     [window_ setCollectionBehavior:[window_ collectionBehavior] & (~flag)];
   // Change collectionBehavior will make the zoom button revert to default,
   // probably a bug of Cocoa or macOS.
-  if (!zoom_button_enabled)
-    SetMaximizable(false);
+  SetMaximizable(was_maximizable);
 }
 
 // static

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -711,6 +711,7 @@ describe('browser-window module', function () {
         w.destroy()
         w = new BrowserWindow({show: false, resizable: false})
         assert.equal(w.isResizable(), false)
+        assert.equal(w.isMaximizable(), true)
       })
 
       it('can be changed with setResizable method', function () {
@@ -819,6 +820,15 @@ describe('browser-window module', function () {
         assert.equal(w.isMaximizable(), false)
         w.setClosable(false)
         assert.equal(w.isMaximizable(), false)
+
+        w.setMaximizable(true)
+        assert.equal(w.isMaximizable(), true)
+        w.setClosable(true)
+        assert.equal(w.isMaximizable(), true)
+        w.setFullScreenable(false)
+        assert.equal(w.isMaximizable(), true)
+        w.setResizable(false)
+        assert.equal(w.isMaximizable(), true)
       })
     })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -711,7 +711,10 @@ describe('browser-window module', function () {
         w.destroy()
         w = new BrowserWindow({show: false, resizable: false})
         assert.equal(w.isResizable(), false)
-        assert.equal(w.isMaximizable(), true)
+
+        if (process.platform === 'darwin') {
+          assert.equal(w.isMaximizable(), true)
+        }
       })
 
       it('can be changed with setResizable method', function () {


### PR DESCRIPTION
Previously, to work around a zoom button but on macOS, the zoom button was disabled if previously disabled in certain places.

#6664 showed a case where it wasn't properly enabled when it should have been.

This pull request adjusts the workaround to always set the state of the zoom button to the state it was in before `setStyleMask` or `setCollectionBehavior`.

Closes #6664