### PR TITLE
Fix for transparent frames when offscreen window restarted painting

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1354,10 +1354,8 @@ void WebContents::StartPainting() {
 
   auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
       web_contents()->GetRenderWidgetHostView());
-  if (osr_rwhv) {
-    osr_rwhv->Show();
+  if (osr_rwhv)
     osr_rwhv->SetPainting(true);
-  }
 }
 
 void WebContents::StopPainting() {
@@ -1366,10 +1364,8 @@ void WebContents::StopPainting() {
 
   auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
       web_contents()->GetRenderWidgetHostView());
-  if (osr_rwhv) {
+  if (osr_rwhv)
     osr_rwhv->SetPainting(false);
-    osr_rwhv->Hide();
-  }
 }
 
 bool WebContents::IsPainting() const {

--- a/atom/browser/osr/osr_output_device.cc
+++ b/atom/browser/osr/osr_output_device.cc
@@ -76,10 +76,6 @@ void OffScreenOutputDevice::SetActive(bool active) {
 
 void OffScreenOutputDevice::OnPaint(const gfx::Rect& damage_rect) {
   gfx::Rect rect = damage_rect;
-  if (!pending_damage_rect_.IsEmpty()) {
-    rect.Union(pending_damage_rect_);
-    pending_damage_rect_.SetRect(0, 0, 0, 0);
-  }
 
   rect.Intersect(gfx::Rect(viewport_pixel_size_));
   if (rect.IsEmpty())

--- a/atom/browser/osr/osr_output_device.h
+++ b/atom/browser/osr/osr_output_device.h
@@ -35,7 +35,6 @@ class OffScreenOutputDevice : public cc::SoftwareOutputDevice {
 
   std::unique_ptr<SkCanvas> canvas_;
   std::unique_ptr<SkBitmap> bitmap_;
-  gfx::Rect pending_damage_rect_;
 
   DISALLOW_COPY_AND_ASSIGN(OffScreenOutputDevice);
 };

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -476,7 +476,6 @@ void OffScreenRenderWidgetHostView::Show() {
     render_widget_host_->WasShown(ui::LatencyInfo());
   delegated_frame_host_->SetCompositor(compositor_.get());
   delegated_frame_host_->WasShown(ui::LatencyInfo());
-  compositor_->ScheduleFullRedraw();
 }
 
 void OffScreenRenderWidgetHostView::Hide() {
@@ -540,7 +539,7 @@ void OffScreenRenderWidgetHostView::OnSwapCompositorFrame(
   if (frame->delegated_frame_data) {
     if (software_output_device_) {
       if (!begin_frame_timer_.get()) {
-        software_output_device_->SetActive(true);
+        software_output_device_->SetActive(painting_);
       }
 
       delegated_frame_host_->SwapDelegatedFrame(output_surface_id,
@@ -780,7 +779,7 @@ void OffScreenRenderWidgetHostView::OnSetNeedsBeginFrames(bool enabled) {
   begin_frame_timer_->SetActive(enabled);
 
   if (software_output_device_) {
-    software_output_device_->SetActive(enabled);
+    software_output_device_->SetActive(enabled && painting_);
   }
 }
 
@@ -794,7 +793,7 @@ void OffScreenRenderWidgetHostView::SetPainting(bool painting) {
   painting_ = painting;
 
   if (software_output_device_) {
-    software_output_device_->SetActive(painting);
+    software_output_device_->SetActive(painting_);
   }
 }
 


### PR DESCRIPTION
We used to call `Show` and `Hide` when starting/stopping the flow of painting events - this caused a bug where upon restarting the first frame that was generated was completely transparent in some cases (mostly when pushing the limits of the machine's memory).
Related to #6704.