### PR TITLE
Adding custom jumplist categories for windows

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -571,6 +571,8 @@ void App::BuildPrototype(
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))
+      .SetMethod("setCategoryUserTasks",
+                 base::Bind(&Browser::SetCategoryUserTasks, browser))
 #endif
 #if defined(OS_LINUX)
       .SetMethod("isUnityRunning",

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -158,6 +158,10 @@ class Browser : public WindowListObserver {
   // Add a custom task to jump list.
   void SetUserTasks(const std::vector<UserTask>& tasks);
 
+  // Add a custom category (and it's corressponding tasks) to a jump list.
+  void SetCategoryUserTasks(const std::string& categoryName,
+                            const std::vector<UserTask>& tasks);
+
   // Returns the application user model ID, if there isn't one, then create
   // one from app's name.
   // The returned string managed by Browser, and should not be modified.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -512,6 +512,30 @@ Adds `tasks` to the [Tasks][tasks] category of the JumpList on Windows.
   consists of two or more icons, set this value to identify the icon. If an
   icon file consists of one icon, this value is 0.
 
+### `app.setCategoryUserTasks(name, tasks)` _Windows_
+
+* `name` String - Name of the Tasks cateory
+* `tasks` Array - Array of `Task` objects
+
+Adds `tasks` to a custom category under the heading identified by `name`.
+
+`tasks` is an array of `Task` objects in the following format:
+
+`Task` Object:
+
+* `program` String - Path of the program to execute, usually you should
+  specify `process.execPath` which opens the current program.
+* `arguments` String - The command line arguments when `program` is
+  executed.
+* `title` String - The string to be displayed in a JumpList.
+* `description` String - Description of this task.
+* `iconPath` String - The absolute path to an icon to be displayed in a
+  JumpList, which can be an arbitrary resource file that contains an icon. You
+  can usually specify `process.execPath` to show the icon of the program.
+* `iconIndex` Integer - The icon index in the icon file. If an icon file
+  consists of two or more icons, set this value to identify the icon. If an
+  icon file consists of one icon, this value is 0.
+
 ### `app.makeSingleInstance(callback)`
 
 * `callback` Function


### PR DESCRIPTION
Fixes #4852

![custom_jump_list_categories](https://cloud.githubusercontent.com/assets/87996/17424859/b6754f8e-5a7c-11e6-8cd4-b66a18ec3b7f.PNG)

I'm not *that* familiar with C++, and most of the code I added in `browser_win.cpp` was based on the example set by the existing `SetUserTasks` method. Attempts to refactor shared functionality (the entirety of the for-loop that creates and populates `IShellLink` objects) didn't seem to work, so I would appreciate a second pair of eyes to give me feedback on how that can be done.
