### PR TITLE
Add recovery suggestion to auto update failure string

### DIFF
--- a/atom/browser/auto_updater_mac.mm
+++ b/atom/browser/auto_updater_mac.mm
@@ -104,11 +104,18 @@ void AutoUpdater::CheckForUpdates() {
           delegate->OnUpdateNotAvailable();
         }
       } error:^(NSError *error) {
-        NSString* failureString = error.localizedFailureReason ?
-            [NSString stringWithFormat:@"%@: %@",
-                                       error.localizedDescription,
-                                       error.localizedFailureReason] :
-            [NSString stringWithString:error.localizedDescription];
+        NSMutableString* failureString =
+          [NSMutableString stringWithString:error.localizedDescription];
+        if (error.localizedFailureReason) {
+          [failureString appendString:@": "];
+          [failureString appendString:error.localizedFailureReason];
+        }
+        if (error.localizedRecoverySuggestion) {
+          if (![failureString hasSuffix:@"."])
+            [failureString appendString:@"."];
+          [failureString appendString:@" "];
+          [failureString appendString:error.localizedRecoverySuggestion];
+        }
         delegate->OnError(base::SysNSStringToUTF8(failureString));
       }];
 }


### PR DESCRIPTION
This pull requests adds the auto update error's `localizedRecoverySuggestion` value to the error message when available.

The message on a non-200 response will now be:

> Update check failed. The server sent an invalid response. Try again later.

The message on a JSON response missing the update data will now be:

> Update check failed. The server sent an invalid JSON response. Try again later.

Closes #6695 