### PR TITLE
Add javascript fence name to doc code blocks

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -41,7 +41,7 @@ otherwise it returns `undefined`.
 The `filters` specifies an array of file types that can be displayed or
 selected when you want to limit the user to a specific type. For example:
 
-```
+```javascript
 {
   filters: [
     {name: 'Images', extensions: ['jpg', 'png', 'gif']},

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -842,7 +842,7 @@ The `callback` will be called with `callback(error, data)` on completion. The
 
 By default, an empty `options` will be regarded as:
 
-```
+```javascript
 {
   marginsType: 0,
   printBackground: false,

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -133,7 +133,7 @@ This will generate:
   xslStyleSheets: { /* same with "images" */ },
   fonts: { /* same with "images" */ },
   other: { /* same with "images" */ }
-})
+}
 ```
 
 ### `webFrame.clearCache()`

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -119,7 +119,7 @@ console.log(webFrame.getResourceUsage())
 
 This will generate:
 
-```
+```javascript
 {
   images: {
     count: 22,


### PR DESCRIPTION
Noticed a few blocks on the docs website weren't fenced as JavaScript which causes them to highlight badly:

<img width="827" alt="screen shot 2016-08-05 at 12 00 20 pm" src="https://cloud.githubusercontent.com/assets/671378/17447611/41339612-5b04-11e6-886f-77a13b668065.png">
