### PR TITLE
Send events as native macOS notifications

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -50,6 +50,10 @@ void SystemPreferences::BuildPrototype(
 #if defined(OS_WIN)
       .SetMethod("isAeroGlassEnabled", &SystemPreferences::IsAeroGlassEnabled)
 #elif defined(OS_MACOSX)
+      .SetMethod("postNotification",
+                 &SystemPreferences::PostNotification)
+      .SetMethod("postLocalNotification",
+                 &SystemPreferences::PostLocalNotification)
       .SetMethod("subscribeNotification",
                  &SystemPreferences::SubscribeNotification)
       .SetMethod("unsubscribeNotification",

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -9,6 +9,7 @@
 
 #include "atom/browser/api/event_emitter.h"
 #include "base/callback.h"
+#include "base/values.h"
 #include "native_mate/handle.h"
 
 namespace base {
@@ -32,6 +33,10 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
   using NotificationCallback = base::Callback<
     void(const std::string&, const base::DictionaryValue&)>;
 
+  void PostNotification(const std::string& name,
+                        const base::DictionaryValue& user_info);
+  void PostLocalNotification(const std::string& name,
+                             const base::DictionaryValue& user_info);
   int SubscribeNotification(const std::string& name,
                             const NotificationCallback& callback);
   void UnsubscribeNotification(int id);
@@ -49,6 +54,9 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
   ~SystemPreferences() override;
 
 #if defined(OS_MACOSX)
+  void DoPostNotification(const std::string& name,
+                          const base::DictionaryValue& user_info,
+                          bool is_local);
   int DoSubscribeNotification(const std::string& name,
                               const NotificationCallback& callback,
                               bool is_local);

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -45,8 +45,8 @@ void SystemPreferences::DoPostNotification(const std::string& name,
     [NSDistributedNotificationCenter defaultCenter];
   [center
      postNotificationName:base::SysUTF8ToNSString(name)
-     object:nil
-     userInfo:DictionaryValueToNSDictionary(user_info)
+                   object:nil
+                 userInfo:DictionaryValueToNSDictionary(user_info)
   ];
 }
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -28,6 +28,28 @@ std::map<int, id> g_id_map;
 
 }  // namespace
 
+void SystemPreferences::PostNotification(const std::string& name, 
+    const base::DictionaryValue& user_info) {
+  DoPostNotification(name, user_info, false);
+}
+
+void SystemPreferences::PostLocalNotification(const std::string& name, 
+    const base::DictionaryValue& user_info) {
+  DoPostNotification(name, user_info, true);
+}
+
+void SystemPreferences::DoPostNotification(const std::string& name, 
+    const base::DictionaryValue& user_info, bool is_local) {
+  NSNotificationCenter* center = is_local ?
+    [NSNotificationCenter defaultCenter] :
+    [NSDistributedNotificationCenter defaultCenter];
+  [center
+     postNotificationName:base::SysUTF8ToNSString(name)
+     object:nil
+     userInfo:DictionaryValueToNSDictionary(user_info)
+  ];
+}
+
 int SystemPreferences::SubscribeNotification(
     const std::string& name, const NotificationCallback& callback) {
   return DoSubscribeNotification(name, callback, false);

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -17,6 +17,22 @@ This method returns `true` if the system is in Dark Mode, and `false` otherwise.
 
 This method returns `true` if the Swipe between pages setting is on, and `false` otherwise.
 
+### `systemPreferences.postNotification(event, userInfo)` _macOS_
+
+* `event` String
+* `userInfo` Dictionary
+
+Posts `event` as native notifications of macOS. The `userInfo` is an Object
+that contains the user information dictionary sent along with the notification.
+
+### `systemPreferences.postLocalNotification(event, userInfo)` _macOS_
+
+* `event` String
+* `userInfo` Dictionary
+
+Posts `event` as native notifications of macOS. The `userInfo` is an Object
+that contains the user information dictionary sent along with the notification.
+
 ### `systemPreferences.subscribeNotification(event, callback)` _macOS_
 
 * `event` String


### PR DESCRIPTION
This PR is about making electron a good inter-process-communication citizen.
I'm working on an electron app, using a native helper/agent/daemon as a backend. 
I've been handling IPC using sockets. It works, but it's heavy, and not a great practice. 
Since electron supports receiving distributed notifications, it would be great to also make it able to send some of them.