### PR TITLE
Upgrade clang

### DIFF
--- a/atom/browser/atom_browser_main_parts_mac.mm
+++ b/atom/browser/atom_browser_main_parts_mac.mm
@@ -18,7 +18,7 @@ void AtomBrowserMainParts::PreMainMessageLoopStart() {
 
   // Set our own application delegate.
   AtomApplicationDelegate* delegate = [[AtomApplicationDelegate alloc] init];
-  [NSApp setDelegate:(id<NSFileManagerDelegate>)delegate];
+  [NSApp setDelegate:delegate];
 
   brightray::BrowserMainParts::PreMainMessageLoopStart();
 

--- a/common.gypi
+++ b/common.gypi
@@ -102,6 +102,7 @@
             '-Wno-return-type',
             '-Wno-gnu-folding-constant',
             '-Wno-shift-negative-value',
+            '-Wno-varargs', # https://git.io/v6Olj
           ],
         },
         'conditions': [
@@ -117,6 +118,7 @@
               '-Wno-deprecated-declarations',
               '-Wno-return-type',
               '-Wno-shift-negative-value',
+              '-Wno-varargs', # https://git.io/v6Olj
               # Required when building as shared library.
               '-fPIC',
             ],

--- a/script/update-clang.sh
+++ b/script/update-clang.sh
@@ -8,7 +8,7 @@
 # Do NOT CHANGE this if you don't know what you're doing -- see
 # https://code.google.com/p/chromium/wiki/UpdatingClang
 # Reverting problematic clang rolls is safe, though.
-CLANG_REVISION=261368
+CLANG_REVISION=269902
 
 # This is incremented when pushing a new build of Clang at the same revision.
 CLANG_SUB_REVISION=1

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -5,11 +5,6 @@
     # Set this to true when building with Clang.
     'clang%': 1,
 
-    'clang_warning_flags': [
-      '-Wno-undefined-var-template', # https://crbug.com/604888
-      '-Wno-varargs', # https://git.io/v6Olj
-    ],
-
     'variables': {
       # The minimum macOS SDK version to use.
       'mac_sdk_min%': '10.10',
@@ -109,7 +104,6 @@
         'cflags_cc': [
           '-std=c++11',
         ],
-        'cflags': [ '<@(clang_warning_flags)' ],
         'xcode_settings': {
           'CC': '<(make_clang_dir)/bin/clang',
           'LDPLUSPLUS': '<(make_clang_dir)/bin/clang++',
@@ -117,7 +111,6 @@
             '-fcolor-diagnostics',
           ],
 
-          'WARNING_CFLAGS': ['<@(clang_warning_flags)'],
           'GCC_C_LANGUAGE_STANDARD': 'c99',  # -std=c99
           'CLANG_CXX_LIBRARY': 'libc++',  # -stdlib=libc++
           'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',  # -std=c++11

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -7,6 +7,7 @@
 
     'clang_warning_flags': [
       '-Wno-undefined-var-template', # https://crbug.com/604888
+      '-Wno-varargs', # https://git.io/v6Olj
     ],
 
     'variables': {

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -5,6 +5,10 @@
     # Set this to true when building with Clang.
     'clang%': 1,
 
+    'clang_warning_flags': [
+      '-Wno-undefined-var-template', # https://crbug.com/604888
+    ],
+
     'variables': {
       # The minimum macOS SDK version to use.
       'mac_sdk_min%': '10.10',
@@ -104,6 +108,7 @@
         'cflags_cc': [
           '-std=c++11',
         ],
+        'cflags': [ '<@(clang_warning_flags)' ],
         'xcode_settings': {
           'CC': '<(make_clang_dir)/bin/clang',
           'LDPLUSPLUS': '<(make_clang_dir)/bin/clang++',
@@ -111,6 +116,7 @@
             '-fcolor-diagnostics',
           ],
 
+          'WARNING_CFLAGS': ['<@(clang_warning_flags)'],
           'GCC_C_LANGUAGE_STANDARD': 'c99',  # -std=c99
           'CLANG_CXX_LIBRARY': 'libc++',  # -stdlib=libc++
           'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',  # -std=c++11


### PR DESCRIPTION
Upgrade to clang r269902, which is used in Chrome stable v52. Tested on macOS & Linux.