### PR TITLE
Fixes the return value of executeJavaScript on non-primitive objects

### DIFF
--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -39,7 +39,7 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (eve
 
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
   const responseCallback = function (result) {
-    event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, result)
+    event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, typeof result === 'object' ? Object.assign({}, result) : result)
   }
   args.push(responseCallback)
   electron.webFrame[method].apply(electron.webFrame, args)

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -39,7 +39,11 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (eve
 
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
   const responseCallback = function (result) {
-    event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, typeof result === 'object' ? Object.assign({}, result) : result)
+    let resultToSend = result;
+    if (typeof result === 'object' && !Array.isArray(result)) {
+      resultToSend = Object.assign({}, result);
+    }
+    event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, resultToSend)
   }
   args.push(responseCallback)
   electron.webFrame[method].apply(electron.webFrame, args)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1183,6 +1183,15 @@ describe('browser-window module', function () {
       })
     })
 
+    it('returns result which contains getters', function (done) {
+      ipcRenderer.send('executeJavaScript', 'document.location', true)
+      ipcRenderer.once('executeJavaScript-response', function (event, result) {
+        assert.notDeepEqual(result, {})
+        assert.ok(result.href)
+        done()
+      })
+    })
+
     it('works after page load and during subframe load', function (done) {
       w.webContents.once('did-finish-load', function () {
         // initiate a sub-frame load, then try and execute script during it


### PR DESCRIPTION
Fixes #6407

Personally I am not aware of any side affects this may have (apart from a small performance hit), but this should allow `executeJavaScript` to return non-primitive objects (objects with getters and setters attached) such as `window` and `document.location` and pass the properties through correctly.