### PR TITLE
Add BrowserWindow.prototype.setProgressState

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -48,6 +48,26 @@ struct Converter<atom::TaskbarHost::ThumbarButton> {
   }
 };
 
+template<>
+struct Converter<atom::TaskbarHost::ProgressState> {
+  static bool FromV8(v8::Isolate* isolate, v8::Handle<v8::Value> val,
+                     atom::TaskbarHost::ProgressState* out) {
+    std::string progress_state;
+    if (!ConvertFromV8(isolate, val, &progress_state))
+      return false;
+    if (progress_state == "normal") {
+      *out = atom::TaskbarHost::PROGRESS_STATE_NORMAL;
+    } else if (progress_state == "error") {
+      *out = atom::TaskbarHost::PROGRESS_STATE_ERROR;
+    } else if (progress_state == "paused") {
+      *out = atom::TaskbarHost::PROGRESS_STATE_PAUSED;
+    } else {
+      return false;
+    }
+    return true;
+  }
+};
+
 }  // namespace mate
 #endif
 
@@ -588,6 +608,19 @@ void Window::SetProgressBar(double progress) {
   window_->SetProgressBar(progress);
 }
 
+#if defined(OS_WIN)
+bool Window::SetProgressState(mate::Arguments* args) {
+  TaskbarHost::ProgressState state;
+  if (!args->GetNext(&state)) {
+    args->ThrowError();
+    return false;
+  }
+  auto window = static_cast<NativeWindowViews*>(window_.get());
+  return window->taskbar_host().SetProgressState(
+      window_->GetAcceleratedWidget(), state);
+}
+#endif
+
 void Window::SetOverlayIcon(const gfx::Image& overlay,
                             const std::string& description) {
   window_->SetOverlayIcon(overlay, description);
@@ -841,6 +874,9 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("blurWebView", &Window::BlurWebView)
       .SetMethod("isWebViewFocused", &Window::IsWebViewFocused)
       .SetMethod("setProgressBar", &Window::SetProgressBar)
+#if defined(OS_WIN)
+      .SetMethod("setProgressState", &Window::SetProgressState)
+#endif
       .SetMethod("setOverlayIcon", &Window::SetOverlayIcon)
       .SetMethod("setThumbarButtons", &Window::SetThumbarButtons)
       .SetMethod("setMenu", &Window::SetMenu)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -156,6 +156,9 @@ class Window : public mate::TrackableObject<Window>,
   void SetContentProtection(bool enable);
   void SetFocusable(bool focusable);
   void SetProgressBar(double progress);
+#if defined(OS_WIN)
+  bool SetProgressState(mate::Arguments* args);
+#endif
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);
   bool SetThumbarButtons(mate::Arguments* args);

--- a/atom/browser/ui/win/taskbar_host.cc
+++ b/atom/browser/ui/win/taskbar_host.cc
@@ -44,6 +44,19 @@ bool GetThumbarButtonFlags(const std::vector<std::string>& flags,
   return true;
 }
 
+TBPFLAG GetProgressStateFlags(TaskbarHost::ProgressState state) {
+  switch (state) {
+    case TaskbarHost::PROGRESS_STATE_NORMAL:
+      return TBPF_NORMAL;
+    case TaskbarHost::PROGRESS_STATE_ERROR:
+      return TBPF_ERROR;
+    case TaskbarHost::PROGRESS_STATE_PAUSED:
+      return TBPF_PAUSED;
+    default:
+      return TBPF_NOPROGRESS;
+  }
+}
+
 }  // namespace
 
 TaskbarHost::TaskbarHost() : thumbar_buttons_added_(false) {
@@ -129,6 +142,14 @@ bool TaskbarHost::SetProgressBar(HWND window, double value) {
   else
     r = taskbar_->SetProgressValue(window, static_cast<int>(value * 100), 100);
   return SUCCEEDED(r);
+}
+
+bool TaskbarHost::SetProgressState(HWND window, ProgressState state) {
+  if (!InitializeTaskbar())
+    return false;
+
+  return SUCCEEDED(taskbar_->SetProgressState(
+      window, GetProgressStateFlags(state)));
 }
 
 bool TaskbarHost::SetOverlayIcon(

--- a/atom/browser/ui/win/taskbar_host.h
+++ b/atom/browser/ui/win/taskbar_host.h
@@ -27,6 +27,12 @@ class TaskbarHost {
     base::Closure clicked_callback;
   };
 
+  enum ProgressState {
+    PROGRESS_STATE_NORMAL,
+    PROGRESS_STATE_ERROR,
+    PROGRESS_STATE_PAUSED,
+  };
+
   TaskbarHost();
   virtual ~TaskbarHost();
 
@@ -36,6 +42,9 @@ class TaskbarHost {
 
   // Set the progress state in taskbar.
   bool SetProgressBar(HWND window, double value);
+
+  // Set the progress state in taskbar.
+  bool SetProgressState(HWND window, ProgressState state);
 
   // Set the overlay icon in taskbar.
   bool SetOverlayIcon(

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -969,6 +969,14 @@ On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
 
+#### `win.setProgressState(state)` _Windows_
+
+* `state` Possible states are `normal`, `error`, `paused`.
+
+Check the [ITaskbarList3::SetProgressState][SetProgressState] documentation for details.
+
+[SetProgressState]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd391697(v=vs.85).aspx
+
 #### `win.setOverlayIcon(overlay, description)` _Windows_
 
 * `overlay` [NativeImage](native-image.md) - the icon to display on the bottom


### PR DESCRIPTION
The other option would be to add a second optional argument to `setProgressBar`. If you think that's a better approach, I'll redo the change.