### PR TITLE
Enable mode indication for setProgressBar

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -584,8 +584,12 @@ void Window::SetFocusable(bool focusable) {
   return window_->SetFocusable(focusable);
 }
 
-void Window::SetProgressBar(double progress) {
-  window_->SetProgressBar(progress);
+void Window::SetProgressBar(double progress, mate::Arguments* args) {
+  mate::Dictionary options;
+  std::string mode;
+  args->GetNext(&options) && options.Get("mode", &mode);
+
+  window_->SetProgressBar(progress, mode);
 }
 
 void Window::SetOverlayIcon(const gfx::Image& overlay,

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -155,7 +155,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetIgnoreMouseEvents(bool ignore);
   void SetContentProtection(bool enable);
   void SetFocusable(bool focusable);
-  void SetProgressBar(double progress);
+  void SetProgressBar(double progress, mate::Arguments* args);
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);
   bool SetThumbarButtons(mate::Arguments* args);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -143,7 +143,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() = 0;
 
   // Taskbar/Dock APIs.
-  virtual void SetProgressBar(double progress) = 0;
+  virtual void SetProgressBar(double progress,
+                              const std::string& mode) = 0;
   virtual void SetOverlayIcon(const gfx::Image& overlay,
                               const std::string& description) = 0;
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -83,7 +83,7 @@ class NativeWindowMac : public NativeWindow {
   void SetParentWindow(NativeWindow* parent) override;
   gfx::NativeWindow GetNativeWindow() override;
   gfx::AcceleratedWidget GetAcceleratedWidget() override;
-  void SetProgressBar(double progress) override;
+  void SetProgressBar(double progress, const std::string& mode) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -973,7 +973,7 @@ gfx::AcceleratedWidget NativeWindowMac::GetAcceleratedWidget() {
   return inspectable_web_contents()->GetView()->GetNativeView();
 }
 
-void NativeWindowMac::SetProgressBar(double progress) {
+void NativeWindowMac::SetProgressBar(double progress, const std::string& mode) {
   NSDockTile* dock_tile = [NSApp dockTile];
 
   // For the first time API invoked, we need to create a ContentView in DockTile.

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -904,9 +904,10 @@ gfx::NativeWindow NativeWindowViews::GetNativeWindow() {
   return window_->GetNativeWindow();
 }
 
-void NativeWindowViews::SetProgressBar(double progress) {
+void NativeWindowViews::SetProgressBar(
+  double progress, const std::string& mode) {
 #if defined(OS_WIN)
-  taskbar_host_.SetProgressBar(GetAcceleratedWidget(), progress);
+  taskbar_host_.SetProgressBar(GetAcceleratedWidget(), progress, mode);
 #elif defined(USE_X11)
   if (unity::IsRunning()) {
     unity::SetProgressFraction(progress);

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -104,7 +104,7 @@ class NativeWindowViews : public NativeWindow,
   gfx::NativeWindow GetNativeWindow() override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
-  void SetProgressBar(double value) override;
+  void SetProgressBar(double value, const std::string& mode) override;
   void SetAutoHideMenuBar(bool auto_hide) override;
   bool IsMenuBarAutoHide() override;
   void SetMenuBarVisibility(bool visible) override;

--- a/atom/browser/ui/win/taskbar_host.h
+++ b/atom/browser/ui/win/taskbar_host.h
@@ -35,7 +35,7 @@ class TaskbarHost {
       HWND window, const std::vector<ThumbarButton>& buttons);
 
   // Set the progress state in taskbar.
-  bool SetProgressBar(HWND window, double value);
+  bool SetProgressBar(HWND window, double value, const std::string& mode);
 
   // Set the overlay icon in taskbar.
   bool SetOverlayIcon(

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -956,9 +956,11 @@ Same as `webContents.reload`.
 Sets the `menu` as the window's menu bar, setting it to `null` will remove the
 menu bar.
 
-#### `win.setProgressBar(progress)`
+#### `win.setProgressBar(progress[, options])`
 
 * `progress` Double
+* `options` Object (optional)
+  * `mode` String _Windows_ - Mode for the progres bar (`none`, `normal`, `indeterminate`, `error`, or `paused`)
 
 Sets progress value in progress bar. Valid range is [0, 1.0].
 
@@ -968,6 +970,10 @@ Change to indeterminate mode when progress > 1.
 On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
+
+On Windows, a mode can be passed. Accepted values are `none`, `normal`, 
+`indeterminate`, `error`, and `paused`. If you call `setProgressBar` without a
+mode set (but with a value within the valid range), `normal` will be assumed.
 
 #### `win.setOverlayIcon(overlay, description)` _Windows_
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -391,6 +391,24 @@ describe('browser-window module', function () {
         w.setProgressBar(-1)
       })
     })
+
+    it('sets the progress using "paused" mode', function () {
+      assert.doesNotThrow(function () {
+        w.setProgressBar(0.5, {mode: 'paused'})
+      })
+    })
+
+    it('sets the progress using "error" mode', function () {
+      assert.doesNotThrow(function () {
+        w.setProgressBar(0.5, {mode: 'error'})
+      })
+    })
+
+    it('sets the progress using "normal" mode', function () {
+      assert.doesNotThrow(function () {
+        w.setProgressBar(0.5, {mode: 'normal'})
+      })
+    })
   })
 
   describe('BrowserWindow.fromId(id)', function () {


### PR DESCRIPTION
This commit enables setting a mode for the setProgressBar method. Old behavior is kept intact, usage is entirely optional. Using the `options` parameter on OS X or Linux simply has no effect.

Usage: `win.setProgressBar(progress[, options])`
 
 * `progress` Double
* `options` Object (optional)
  * `mode` _Windows_ String - Mode for the progres bar (`none`, `normal`, `indeterminate`, `error`, or `paused`)

![image](https://cloud.githubusercontent.com/assets/1426799/17469915/ab51d6aa-5cec-11e6-9ef6-d84efca79bd6.png)

Closes #6672