### PR TITLE
Remove HasRealNamedCallbackProperty check when converting objects

### DIFF
--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -352,10 +352,6 @@ base::Value* V8ValueConverter::FromV8Object(
       continue;
     }
 
-    // Skip all callbacks: crbug.com/139933
-    if (val->HasRealNamedCallbackProperty(key->ToString()))
-      continue;
-
     v8::String::Utf8Value name_utf8(key->ToString());
 
     v8::TryCatch try_catch;

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1206,6 +1206,15 @@ describe('browser-window module', function () {
       })
       w.loadURL(server.url)
     })
+
+    it('works with result objects that have DOM class prototypes', function (done) {
+      w.webContents.executeJavaScript('document.location', function (result) {
+        assert.equal(result.origin, server.url)
+        assert.equal(result.protocol, 'http:')
+        done()
+      })
+      w.loadURL(server.url)
+    })
   })
 
   describe('offscreen rendering', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -294,6 +294,15 @@ describe('ipc module', function () {
       })
       ipcRenderer.send('message', currentDate)
     })
+
+    it('can send objects with DOM class prototypes', function (done) {
+      ipcRenderer.once('message', function (event, value) {
+        assert.equal(value.protocol, 'file:')
+        assert.equal(value.hostname, '')
+        done()
+      })
+      ipcRenderer.send('message', document.location)
+    })
   })
 
   describe('ipc.sendSync', function () {


### PR DESCRIPTION
This pull request removes the `HasRealNamedCallbackProperty` check from `V8ValueConverter::FromV8Object`.

It looks like Chrome removed this check in https://codereview.chromium.org/16511004 so it seems safe to remove in Electron.

Original issue was https://bugs.chromium.org/p/chromium/issues/detail?id=139933 which was fixed and tweaked a couple times.

This allows objects like `document.location` to have their properties send over IPC.

Closes #6407 