### PR TITLE
Mark update available until restart

### DIFF
--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -10,7 +10,7 @@ class AutoUpdater extends EventEmitter {
       return this.emitError('No update available, can\'t quit and install')
     }
     squirrelUpdate.processStart()
-    return app.quit()
+    app.quit()
   }
 
   getFeedURL () {
@@ -39,15 +39,12 @@ class AutoUpdater extends EventEmitter {
       this.updateAvailable = true
       this.emit('update-available')
       squirrelUpdate.update(this.updateURL, (error) => {
-        var date, releaseNotes, version
         if (error != null) {
           return this.emitError(error)
         }
-        releaseNotes = update.releaseNotes
-        version = update.version
-
-        // Following information is not available on Windows, so fake them.
-        date = new Date()
+        const {releaseNotes, version} = update
+        // Date is not available on Windows, so fake it.
+        const date = new Date()
         this.emit('update-downloaded', {}, releaseNotes, version, date, this.updateURL, () => {
           this.quitAndInstall()
         })
@@ -58,7 +55,7 @@ class AutoUpdater extends EventEmitter {
   // Private: Emit both error object and message, this is to keep compatibility
   // with Old APIs.
   emitError (message) {
-    return this.emit('error', new Error(message), message)
+    this.emit('error', new Error(message), message)
   }
 }
 

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -34,7 +34,6 @@ class AutoUpdater extends EventEmitter {
         return this.emitError(error)
       }
       if (update == null) {
-        this.updateAvailable = false
         return this.emit('update-not-available')
       }
       this.updateAvailable = true

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -50,5 +50,19 @@ if (!process.mas) {
         done()
       })
     })
+
+    describe('quitAndInstall', function () {
+      it('emits an error on Windows when no update is available', function (done) {
+        if (process.platform !== 'win32') {
+          return done()
+        }
+
+        ipcRenderer.once('auto-updater-error', function (event, message) {
+          assert.equal(message, 'No update available, can\'t quit and install')
+          done()
+        })
+        autoUpdater.quitAndInstall()
+      })
+    })
   })
 }


### PR DESCRIPTION
Previously calling `autoUpdate.checkForUpdates()` twice with a successful update followed by a call to `quitAndInstall` would emit an error since `updateAvailable` would be set back to `false` the second time it was called when the first time successfully downloaded and installed an update.

This pull request removes the clearing of the flag so that `updateAvailable` is `true` until restart.

Closes #6647 