### PR TITLE
Convert DIP to screen rect for thumbnail clip

### DIFF
--- a/atom/browser/ui/win/taskbar_host.cc
+++ b/atom/browser/ui/win/taskbar_host.cc
@@ -10,6 +10,7 @@
 #include "base/win/scoped_gdi_object.h"
 #include "base/strings/utf_string_conversions.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/display/win/screen_win.h"
 #include "ui/gfx/icon_util.h"
 
 namespace atom {
@@ -167,11 +168,13 @@ bool TaskbarHost::SetThumbnailClip(HWND window, const gfx::Rect& region) {
   if (region.IsEmpty()) {
     return SUCCEEDED(taskbar_->SetThumbnailClip(window, NULL));
   } else {
+    gfx::Rect screen_rect = display::win::ScreenWin::DIPToScreenRect(window,
+                                                                     region);
     RECT rect;
-    rect.left = region.x();
-    rect.right = region.right();
-    rect.top = region.y();
-    rect.bottom = region.bottom();
+    rect.left = screen_rect.x();
+    rect.right = screen_rect.right();
+    rect.top = screen_rect.y();
+    rect.bottom = screen_rect.bottom();
     return SUCCEEDED(taskbar_->SetThumbnailClip(window, &rect));
   }
 }

--- a/atom/browser/ui/win/taskbar_host.cc
+++ b/atom/browser/ui/win/taskbar_host.cc
@@ -168,13 +168,8 @@ bool TaskbarHost::SetThumbnailClip(HWND window, const gfx::Rect& region) {
   if (region.IsEmpty()) {
     return SUCCEEDED(taskbar_->SetThumbnailClip(window, NULL));
   } else {
-    gfx::Rect screen_rect = display::win::ScreenWin::DIPToScreenRect(window,
-                                                                     region);
-    RECT rect;
-    rect.left = screen_rect.x();
-    rect.right = screen_rect.right();
-    rect.top = screen_rect.y();
-    rect.bottom = screen_rect.bottom();
+    RECT rect = display::win::ScreenWin::DIPToScreenRect(window, region)
+        .ToRECT();
     return SUCCEEDED(taskbar_->SetThumbnailClip(window, &rect));
   }
 }


### PR DESCRIPTION
Use `DIPToScreenRect` to convert specified region to screen coordinates.

The following app and screenshots show it previously broken but not correctly positioning the thumbnail region.

```html
<html>
  <head>
    <style>
      div {
        position: absolute;
        left: 30px;
        top: 30px;
        width: 45px;
        height: 45px;
        background-color: yellow;
        border: 5px solid green;
      }

      body {
        background-color: #f00;
      }
    </style>
  </head>
  <body>
    <div></div>
  </body>
</html>
```

```js
require('electron').remote.getCurrentWindow().setThumbnailClip({x: 30, y: 30, width: 55, height: 55})
```

| Before | After |
| --- | --- |
| <img width="132" alt="screen shot 2016-08-08 at 2 04 47 pm" src="https://cloud.githubusercontent.com/assets/671378/17496272/5b35874a-5d71-11e6-8188-75b6d2169a70.png"> | <img width="195" alt="screen shot 2016-08-08 at 2 04 00 pm" src="https://cloud.githubusercontent.com/assets/671378/17496273/5b38a998-5d71-11e6-9048-72d63f5c483b.png"> |

Big thanks for @paulcbetts for bringing this up over on https://github.com/electron/electron/pull/6497#issuecomment-238111148