### PR TITLE
Add initial specs for untested modules

### DIFF
--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -10,7 +10,7 @@ const app = remote.require('electron').app
 const crashReporter = remote.require('electron').crashReporter
 const BrowserWindow = remote.require('electron').BrowserWindow
 
-describe('crash-reporter module', function () {
+describe('crashReporter module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
   var w = null
 
@@ -53,8 +53,13 @@ describe('crash-reporter module', function () {
         assert.equal(fields['_productName'], 'Zombies')
         assert.equal(fields['_companyName'], 'Umbrella Corporation')
         assert.equal(fields['_version'], app.getVersion())
-        res.end('abc-123-def')
-        done()
+
+        res.end('abc-123-def', () => {
+          assert.equal(crashReporter.getLastCrashReport().id, 'abc-123-def')
+          assert.notEqual(crashReporter.getUploadedReports().length, 0)
+          assert.equal(crashReporter.getUploadedReports()[0].id, 'abc-123-def')
+          done()
+        })
       })
     })
     var port = remote.process.port

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -18,6 +18,13 @@ describe('desktopCapturer', function () {
     })
   })
 
+  it('throws an error for invalid options', function (done) {
+    desktopCapturer.getSources(['window', 'screen'], function (error) {
+      assert.equal(error.message, 'Invalid options')
+      done()
+    })
+  })
+
   it('does not throw an error when called more than once (regression)', function (done) {
     var callCount = 0
     var callback = function (error, sources) {

--- a/spec/api-global-shortcut-spec.js
+++ b/spec/api-global-shortcut-spec.js
@@ -1,0 +1,24 @@
+const {globalShortcut} = require('electron').remote
+const assert = require('assert')
+
+describe('globalShortcut module', () => {
+  beforeEach(() => {
+    globalShortcut.unregisterAll()
+  })
+
+  it('can register and unregister accelerators', () => {
+    const accelerator = 'CommandOrControl+A+B+C'
+
+    assert.equal(globalShortcut.isRegistered(accelerator), false)
+    globalShortcut.register(accelerator, () => {})
+    assert.equal(globalShortcut.isRegistered(accelerator), true)
+    globalShortcut.unregister(accelerator)
+    assert.equal(globalShortcut.isRegistered(accelerator), false)
+
+    assert.equal(globalShortcut.isRegistered(accelerator), false)
+    globalShortcut.register(accelerator, () => {})
+    assert.equal(globalShortcut.isRegistered(accelerator), true)
+    globalShortcut.unregisterAll()
+    assert.equal(globalShortcut.isRegistered(accelerator), false)
+  })
+})

--- a/spec/api-power-save-blocker-spec.js
+++ b/spec/api-power-save-blocker-spec.js
@@ -1,0 +1,13 @@
+const {powerSaveBlocker} = require('electron').remote
+const assert = require('assert')
+
+describe('powerSaveBlocker module', () => {
+  it('can be started and stopped', () => {
+    assert.equal(powerSaveBlocker.isStarted(-1), false)
+    const id = powerSaveBlocker.start('prevent-app-suspension')
+    assert.ok(id != null)
+    assert.equal(powerSaveBlocker.isStarted(id), true)
+    powerSaveBlocker.stop(id)
+    assert.equal(powerSaveBlocker.isStarted(id), false)
+  })
+})


### PR DESCRIPTION
This pull requests adds an initial spec for a couple modules, `powerSaveBlocker` and `globalShortcut`.

Noticed this by running `npm run coverage` and looking at the generated report.