### PR TITLE
Use enum to declare ProgressState

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -587,9 +587,21 @@ void Window::SetFocusable(bool focusable) {
 void Window::SetProgressBar(double progress, mate::Arguments* args) {
   mate::Dictionary options;
   std::string mode;
+  NativeWindow::ProgressState state = NativeWindow::PROGRESS_NORMAL;
+
   args->GetNext(&options) && options.Get("mode", &mode);
 
-  window_->SetProgressBar(progress, mode);
+  if (mode == "error") {
+    state = NativeWindow::PROGRESS_ERROR;
+  } else if (mode == "paused") {
+    state = NativeWindow::PROGRESS_PAUSED;
+  } else if (mode == "indeterminate") {
+    state = NativeWindow::PROGRESS_INDETERMINATE;
+  } else if (mode == "none") {
+    state = NativeWindow::PROGRESS_NONE;
+  }
+
+  window_->SetProgressBar(progress, state);
 }
 
 void Window::SetOverlayIcon(const gfx::Image& overlay,

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -143,8 +143,16 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() = 0;
 
   // Taskbar/Dock APIs.
+  enum ProgressState {
+    PROGRESS_NONE,               // no progress, no marking
+    PROGRESS_INDETERMINATE,      // progress, indeterminate
+    PROGRESS_ERROR,              // progress, errored (red)
+    PROGRESS_PAUSED,             // progress, paused (yellow)
+    PROGRESS_NORMAL,             // progress, not marked (green)
+  };
+
   virtual void SetProgressBar(double progress,
-                              const std::string& mode) = 0;
+                              const ProgressState state) = 0;
   virtual void SetOverlayIcon(const gfx::Image& overlay,
                               const std::string& description) = 0;
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -85,7 +85,7 @@ class NativeWindowMac : public NativeWindow,
   void SetParentWindow(NativeWindow* parent) override;
   gfx::NativeWindow GetNativeWindow() override;
   gfx::AcceleratedWidget GetAcceleratedWidget() override;
-  void SetProgressBar(double progress, const std::string& mode) override;
+  void SetProgressBar(double progress, const ProgressState state) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
   void SetVisibleOnAllWorkspaces(bool visible) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -979,7 +979,7 @@ gfx::AcceleratedWidget NativeWindowMac::GetAcceleratedWidget() {
   return inspectable_web_contents()->GetView()->GetNativeView();
 }
 
-void NativeWindowMac::SetProgressBar(double progress, const std::string& mode) {
+void NativeWindowMac::SetProgressBar(double progress, const NativeWindow::ProgressState state) {
   NSDockTile* dock_tile = [NSApp dockTile];
 
   // For the first time API invoked, we need to create a ContentView in DockTile.

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -905,9 +905,9 @@ gfx::NativeWindow NativeWindowViews::GetNativeWindow() {
 }
 
 void NativeWindowViews::SetProgressBar(
-    double progress, const std::string& mode) {
+    double progress, NativeWindow::ProgressState state) {
 #if defined(OS_WIN)
-  taskbar_host_.SetProgressBar(GetAcceleratedWidget(), progress, mode);
+  taskbar_host_.SetProgressBar(GetAcceleratedWidget(), progress, state);
 #elif defined(USE_X11)
   if (unity::IsRunning()) {
     unity::SetProgressFraction(progress);

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -104,7 +104,7 @@ class NativeWindowViews : public NativeWindow,
   gfx::NativeWindow GetNativeWindow() override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
-  void SetProgressBar(double value, const std::string& mode) override;
+  void SetProgressBar(double progress, const ProgressState state) override;
   void SetAutoHideMenuBar(bool auto_hide) override;
   bool IsMenuBarAutoHide() override;
   void SetMenuBarVisibility(bool visible) override;

--- a/atom/browser/ui/win/taskbar_host.cc
+++ b/atom/browser/ui/win/taskbar_host.cc
@@ -12,6 +12,7 @@
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/display/win/screen_win.h"
 #include "ui/gfx/icon_util.h"
+#include "atom/browser/native_window.h"
 
 namespace atom {
 
@@ -119,23 +120,23 @@ bool TaskbarHost::SetThumbarButtons(
 }
 
 bool TaskbarHost::SetProgressBar(
-    HWND window, double value, const std::string& mode) {
+    HWND window, double value, const NativeWindow::ProgressState state) {
   if (!InitializeTaskbar())
     return false;
 
   bool success;
-  if (value > 1.0 || mode == "indeterminate") {
+  if (value > 1.0 || state == NativeWindow::PROGRESS_INDETERMINATE) {
     success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_INDETERMINATE));
-  } else if (value < 0 || mode == "none") {
+  } else if (value < 0 || state == NativeWindow::PROGRESS_NONE) {
     success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_NOPROGRESS));
   } else {
     // Unless SetProgressState set a blocking state (TBPF_ERROR, TBPF_PAUSED)
     // for the window, a call to SetProgressValue assumes the TBPF_NORMAL
     // state even if it is not explicitly set.
     // SetProgressValue overrides and clears the TBPF_INDETERMINATE state.
-    if (mode == "error") {
+    if (state == NativeWindow::PROGRESS_ERROR) {
       success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_ERROR));
-    } else if (mode == "paused") {
+    } else if (state == NativeWindow::PROGRESS_PAUSED) {
       success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_PAUSED));
     } else {
       success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_NORMAL));

--- a/atom/browser/ui/win/taskbar_host.h
+++ b/atom/browser/ui/win/taskbar_host.h
@@ -15,6 +15,7 @@
 #include "base/win/scoped_comptr.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/image/image.h"
+#include "atom/browser/native_window.h"
 
 namespace atom {
 
@@ -35,7 +36,8 @@ class TaskbarHost {
       HWND window, const std::vector<ThumbarButton>& buttons);
 
   // Set the progress state in taskbar.
-  bool SetProgressBar(HWND window, double value, const std::string& mode);
+  bool SetProgressBar(
+      HWND window, double value, const NativeWindow::ProgressState state);
 
   // Set the overlay icon in taskbar.
   bool SetOverlayIcon(


### PR DESCRIPTION
As recommended in #6768, this commit adds an enum for progress states for windows.