### PR TITLE
Clean libchromiumcontent/src

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "bootstrap": "python ./script/bootstrap.py",
     "build": "python ./script/build.py -c D",
+    "clean": "python ./script/clean.py",
     "coverage": "npm run instrument-code-coverage && npm test -- --use-instrumented-asar",
     "instrument-code-coverage": "electabul instrument --input-path ./lib --output-path ./out/coverage/electron.asar",
     "lint": "npm run lint-js && npm run lint-cpp && npm run lint-docs",

--- a/script/clean.py
+++ b/script/clean.py
@@ -16,6 +16,7 @@ def main():
   rm_rf('out')
   rm_rf('spec/node_modules')
   rm_rf('vendor/brightray/vendor/download/libchromiumcontent')
+  rm_rf('vendor/brightray/vendor/libchromiumcontent/src')
   rm_rf(os.path.expanduser('~/.node-gyp'))
 
 


### PR DESCRIPTION
This pull request cleans out `libchromiumcontent/src` when running `script/clean.py` which will be present if Electron was bootstrapped with the `--build_libchromiumcontent` option.

Also adds a `npm run clean` helper.