### PR TITLE
Support build variable setting during bootstrap

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -103,11 +103,13 @@ def parse_args():
                       help='The shared library path of libchromiumcontent.')
   parser.add_argument('--libcc_static_library_path', required=False,
                       help='The static library path of libchromiumcontent.')
+  parser.add_argument('--defines', default='',
+                      help='The build variables passed to gyp')
   return parser.parse_args()
 
 
 def args_to_defines(args):
-  defines = ''
+  defines = args.defines
   if args.disable_clang:
     defines += ' clang=0'
   if args.clang_dir:

--- a/script/update.py
+++ b/script/update.py
@@ -27,7 +27,7 @@ def main():
 def parse_args():
   parser = argparse.ArgumentParser(description='Update build configurations')
   parser.add_argument('--defines', default='',
-                      help='The definetions passed to gyp')
+                      help='The build variables passed to gyp')
   parser.add_argument('--msvs', action='store_true',
                       help='Generate Visual Studio project')
   return parser.parse_args()


### PR DESCRIPTION
This pull request adds support to `script/bootstrap.py` to specify `--defines` variables.

Allowing you to do things like `npm run bootstrap -- --defines=arm_float_abi=hard`.

Refs #5706