### PR TITLE
don't convert a string to an array buffer

### DIFF
--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -42,10 +42,7 @@ v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
   std::string encoded_data;
   net::X509Certificate::GetPEMEncoded(
       val->os_cert_handle(), &encoded_data);
-  auto buffer = node::Buffer::Copy(isolate,
-                                   encoded_data.data(),
-                                   encoded_data.size()).ToLocalChecked();
-  dict.Set("data", buffer);
+  dict.Set("data", encoded_data);
   dict.Set("issuerName", val->issuer().GetDisplayName());
   dict.Set("subjectName", val->subject().GetDisplayName());
   dict.Set("serialNumber", base::HexEncode(val->serial_number().data(),

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -178,7 +178,7 @@ Returns:
 * `url` URL
 * `error` String - The error code
 * `certificate` Object
-  * `data` Buffer - PEM encoded data
+  * `data` String - PEM encoded data
   * `issuerName` String - Issuer's Common Name
   * `subjectName` String - Subject's Common Name
   * `serialNumber` String - Hex value represented string
@@ -213,7 +213,7 @@ Returns:
 * `webContents` [WebContents](web-contents.md)
 * `url` URL
 * `certificateList` [Objects]
-  * `data` Buffer - PEM encoded data
+  * `data` String - PEM encoded data
   * `issuerName` String - Issuer's Common Name
   * `subjectName` String - Subject's Common Name
   * `serialNumber` String - Hex value represented string

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -230,7 +230,7 @@ Returns:
 * `url` URL
 * `error` String - The error code
 * `certificate` Object
-  * `data` Buffer - PEM encoded data
+  * `data` String - PEM encoded data
   * `issuerName` String - Issuer's Common Name
   * `subjectName` String - Subject's Common Name
   * `serialNumber` String - Hex value represented string
@@ -251,7 +251,7 @@ Returns:
 * `event` Event
 * `url` URL
 * `certificateList` [Objects]
-  * `data` Buffer - PEM encoded data
+  * `data` String - PEM encoded data
   * `issuerName` String - Issuer's Common Name
   * `subjectName` String - Subject's Common Name
   * `serialNumber` String - Hex value represented string


### PR DESCRIPTION
see https://github.com/brave/electron/commit/d072e612823bdf342b519c866e09c55269b0cadf#diff-7452c2b1cabfbce577fef50b254bd08dL33
encoded_data is a base64 string so there is no reason to convert it anyway
cc @deepak1556 
