### PR TITLE
webFrame: enable privileged schemes to send CORS requests

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -146,6 +146,7 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme) {
       privileged_scheme);
   blink::WebSecurityPolicy::registerURLSchemeAsSupportingFetchAPI(
       privileged_scheme);
+  blink::WebSecurityPolicy::registerURLSchemeAsCORSEnabled(privileged_scheme);
 }
 
 void WebFrame::InsertText(const std::string& text) {


### PR DESCRIPTION
Ref https://github.com/electron/electron/issues/6749#issuecomment-238177677