### PR TITLE
fix intermittent crash in RemoteObjectFreer

### DIFF
--- a/atom/common/api/remote_object_freer.cc
+++ b/atom/common/api/remote_object_freer.cc
@@ -53,7 +53,8 @@ RemoteObjectFreer::~RemoteObjectFreer() {
 }
 
 void RemoteObjectFreer::RunDestructor() {
-  content::RenderView* render_view = content::RenderView::FromRoutingID(routing_id_);
+  content::RenderView* render_view =
+      content::RenderView::FromRoutingID(routing_id_);
   if (!render_view)
     return;
 

--- a/atom/common/api/remote_object_freer.cc
+++ b/atom/common/api/remote_object_freer.cc
@@ -41,14 +41,19 @@ void RemoteObjectFreer::BindTo(
 RemoteObjectFreer::RemoteObjectFreer(
     v8::Isolate* isolate, v8::Local<v8::Object> target, int object_id)
     : ObjectLifeMonitor(isolate, target),
-      object_id_(object_id) {
+      object_id_(object_id),
+      routing_id_(0) {
+  content::RenderView* render_view = GetCurrentRenderView();
+  if (render_view) {
+    routing_id_ = render_view->GetRoutingID();
+  }
 }
 
 RemoteObjectFreer::~RemoteObjectFreer() {
 }
 
 void RemoteObjectFreer::RunDestructor() {
-  content::RenderView* render_view = GetCurrentRenderView();
+  content::RenderView* render_view = content::RenderView::FromRoutingID(routing_id_);
   if (!render_view)
     return;
 

--- a/atom/common/api/remote_object_freer.cc
+++ b/atom/common/api/remote_object_freer.cc
@@ -42,7 +42,7 @@ RemoteObjectFreer::RemoteObjectFreer(
     v8::Isolate* isolate, v8::Local<v8::Object> target, int object_id)
     : ObjectLifeMonitor(isolate, target),
       object_id_(object_id),
-      routing_id_(0) {
+      routing_id_(MSG_ROUTING_NONE) {
   content::RenderView* render_view = GetCurrentRenderView();
   if (render_view) {
     routing_id_ = render_view->GetRoutingID();

--- a/atom/common/api/remote_object_freer.h
+++ b/atom/common/api/remote_object_freer.h
@@ -23,6 +23,7 @@ class RemoteObjectFreer : public ObjectLifeMonitor {
 
  private:
   int object_id_;
+  int routing_id_;
 
   DISALLOW_COPY_AND_ASSIGN(RemoteObjectFreer);
 };


### PR DESCRIPTION
this caches the render view's `routing_id` in the `RemoteObjectFreer` constructor so we can look it up later in `RunDestructor` with no v8 calls. this is a speculative fix for #6813 -- we can't reproduce it in-house and i don't have enough data yet to know if it's fixed in the wild but i wanted to open it up to discussion.

@zcbenz 