### PR TITLE
:memo: Rename `electron-prebuilt` to `electron` when install [ci skip]

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -31,10 +31,10 @@ Linux, Windows, macOS 용으로 미리 빌드된 Electron 바이너리와 디버
 
 ```sh
 # $PATH에 `electron` 커맨드를 등록하고 전역에 설치합니다.
-npm install electron-prebuilt -g
+npm install electron -g
 
 # 개발 의존성 모듈 형태로 설치합니다.
-npm install electron-prebuilt --save-dev
+npm install electron --save-dev
 ```
 
 ### 미러

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ binaries:
 
 ```sh
 # Install the `electron` command globally in your $PATH
-npm install electron-prebuilt -g
+npm install electron -g
 
 # Install as a development dependency
-npm install electron-prebuilt --save-dev
+npm install electron --save-dev
 ```
 
 ### Mirrors


### PR DESCRIPTION
ref electron-userland/electron-prebuilt#160