### PR TITLE
Added title to page-title-updated return args

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -298,6 +298,7 @@ labeled as such.
 Returns:
 
 * `event` Event
+* `title` String
 
 Emitted when the document changed its title, calling `event.preventDefault()`
 will prevent the native window's title from changing.


### PR DESCRIPTION
Adding an undocumented `title` argument to `page-title-updated` event.