### PR TITLE
clear the storage for the webContentsId when the render view is deleted

### DIFF
--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -27,8 +27,8 @@ class ObjectsRegistry {
     if (!owner) {
       owner = this.owners[webContentsId] = new Set()
       // Clear the storage when webContents is reloaded/navigated.
-      webContents.once('render-view-deleted', (event, id) => {
-        this.clear(id)
+      webContents.once('render-view-deleted', () => {
+        this.clear(webContentsId)
       })
     }
     if (!owner.has(id)) {


### PR DESCRIPTION
related #6832
