### PR TITLE
Allow settings of launch args when using defaultProtocol

### DIFF
--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -76,13 +76,13 @@ class Browser : public WindowListObserver {
   void SetAppUserModelID(const base::string16& name);
 
   // Remove the default protocol handler registry key
-  bool RemoveAsDefaultProtocolClient(const std::string& protocol);
+  bool RemoveAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args);
 
   // Set as default handler for a protocol.
-  bool SetAsDefaultProtocolClient(const std::string& protocol);
+  bool SetAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args);
 
   // Query the current state of default handler for a protocol.
-  bool IsDefaultProtocolClient(const std::string& protocol);
+  bool IsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args);
 
   // Set/Get the badge count.
   bool SetBadgeCount(int count);

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -76,13 +76,16 @@ class Browser : public WindowListObserver {
   void SetAppUserModelID(const base::string16& name);
 
   // Remove the default protocol handler registry key
-  bool RemoveAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args);
+  bool RemoveAsDefaultProtocolClient(const std::string& protocol,
+                                    mate::Arguments* args);
 
   // Set as default handler for a protocol.
-  bool SetAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args);
+  bool SetAsDefaultProtocolClient(const std::string& protocol,
+                                  mate::Arguments* args);
 
   // Query the current state of default handler for a protocol.
-  bool IsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args);
+  bool IsDefaultProtocolClient(const std::string& protocol,
+                              mate::Arguments* args);
 
   // Set/Get the badge count.
   bool SetBadgeCount(int count);

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -35,15 +35,15 @@ void Browser::ClearRecentDocuments() {
 void Browser::SetAppUserModelID(const base::string16& name) {
 }
 
-bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol) {
+bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
   return false;
 }
 
-bool Browser::SetAsDefaultProtocolClient(const std::string& protocol) {
+bool Browser::SetAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
   return false;
 }
 
-bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
+bool Browser::IsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
   return false;
 }
 

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -35,15 +35,18 @@ void Browser::ClearRecentDocuments() {
 void Browser::SetAppUserModelID(const base::string16& name) {
 }
 
-bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
+                                            mate::Arguments* args) {
   return false;
 }
 
-bool Browser::SetAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
+                                        mate::Arguments* args) {
   return false;
 }
 
-bool Browser::IsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::IsDefaultProtocolClient(const std::string& protocol,
+                                      mate::Arguments* args) {
   return false;
 }
 

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -52,7 +52,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
   if (!identifier)
     return false;
 
-  if (!Browser::IsDefaultProtocolClient(protocol))
+  if (!Browser::IsDefaultProtocolClient(protocol, args))
     return false;
 
   NSString* protocol_ns = [NSString stringWithUTF8String:protocol.c_str()];

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -46,7 +46,7 @@ void Browser::ClearRecentDocuments() {
   [[NSDocumentController sharedDocumentController] clearRecentDocuments:nil];
 }
 
-bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol) {
+bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
   NSString* identifier = [base::mac::MainBundle() bundleIdentifier];
   if (!identifier)
     return false;
@@ -74,7 +74,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol) {
   return return_code == noErr;
 }
 
-bool Browser::SetAsDefaultProtocolClient(const std::string& protocol) {
+bool Browser::SetAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
   if (protocol.empty())
     return false;
 
@@ -89,7 +89,7 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol) {
   return return_code == noErr;
 }
 
-bool Browser::IsDefaultProtocolClient(const std::string& protocol) {
+bool Browser::IsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
   if (protocol.empty())
     return false;
 

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -46,7 +46,8 @@ void Browser::ClearRecentDocuments() {
   [[NSDocumentController sharedDocumentController] clearRecentDocuments:nil];
 }
 
-bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
+                                            mate::Arguments* args) {
   NSString* identifier = [base::mac::MainBundle() bundleIdentifier];
   if (!identifier)
     return false;
@@ -74,7 +75,8 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol, mate::A
   return return_code == noErr;
 }
 
-bool Browser::SetAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
+                                        mate::Arguments* args) {
   if (protocol.empty())
     return false;
 
@@ -89,7 +91,8 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol, mate::Argu
   return return_code == noErr;
 }
 
-bool Browser::IsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::IsDefaultProtocolClient(const std::string& protocol,
+                                      mate::Arguments* args) {
   if (protocol.empty())
     return false;
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -162,7 +162,8 @@ std::wstring protocolLaunchPath(std::string protocol, mate::Arguments* args) {
   return exe + L"\"%1\"";
 }
 
-bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
+                                            mate::Arguments* args) {
   if (protocol.empty())
     return false;
 
@@ -204,7 +205,8 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol, mate::A
   }
 }
 
-bool Browser::SetAsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
+                                        mate::Arguments* args) {
   // HKEY_CLASSES_ROOT
   //    $PROTOCOL
   //       (Default) = "URL:$NAME"
@@ -251,7 +253,8 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol, mate::Argu
   return true;
 }
 
-bool Browser::IsDefaultProtocolClient(const std::string& protocol, mate::Arguments* args) {
+bool Browser::IsDefaultProtocolClient(const std::string& protocol,
+                                      mate::Arguments* args) {
   if (protocol.empty())
     return false;
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -150,7 +150,8 @@ bool GetProtocolLaunchPath(mate::Arguments* args, base::string16* exe) {
   if (launchArgs.size() != 0) {
     launchArgString = base::JoinString(launchArgs, L" ");
   }
-  *exe = base::StringPrintf(L"\"%s\" %s \"%%1\"", exePath.c_str(), launchArgString.c_str());
+  *exe = base::StringPrintf(L"\"%s\" %s \"%%1\"",
+                            exePath.c_str(), launchArgString.c_str());
   return true;
 }
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -453,8 +453,8 @@ Clears the recent documents list.
 * `protocol` String - The name of your protocol, without `://`. If you want your
   app to handle `electron://` links, call this method with `electron` as the
   parameter.
-* `path` String (optional) _Windows_
-* `args` Array (options) _Windows_
+* `path` String (optional) _Windows_ - Defaults to `process.execPath`
+* `args` Array (options) _Windows_ - Defaults to an empty array
 
 This method sets the current executable as the default handler for a protocol
 (aka URI scheme). It allows you to integrate your app deeper into the operating

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -448,17 +448,22 @@ bar, and on macOS you can visit it from dock menu.
 
 Clears the recent documents list.
 
-### `app.setAsDefaultProtocolClient(protocol)` _macOS_ _Windows_
+### `app.setAsDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
 
 * `protocol` String - The name of your protocol, without `://`. If you want your
   app to handle `electron://` links, call this method with `electron` as the
   parameter.
+* `path` String (optional) _Windows_
+* `args` Array (options) _Windows_
 
 This method sets the current executable as the default handler for a protocol
 (aka URI scheme). It allows you to integrate your app deeper into the operating
 system. Once registered, all links with `your-protocol://` will be opened with
 the current executable. The whole link, including protocol, will be passed to
 your application as a parameter.
+
+On windows you can provide optional parameters path, the path to your executable,
+and args, an array of arguments to be passed to your executable when it launches.
 
 Returns `true` when the call succeeded, otherwise returns `false`.
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -454,7 +454,7 @@ Clears the recent documents list.
   app to handle `electron://` links, call this method with `electron` as the
   parameter.
 * `path` String (optional) _Windows_ - Defaults to `process.execPath`
-* `args` Array (options) _Windows_ - Defaults to an empty array
+* `args` Array (optional) _Windows_ - Defaults to an empty array
 
 This method sets the current executable as the default handler for a protocol
 (aka URI scheme). It allows you to integrate your app deeper into the operating
@@ -462,7 +462,7 @@ system. Once registered, all links with `your-protocol://` will be opened with
 the current executable. The whole link, including protocol, will be passed to
 your application as a parameter.
 
-On windows you can provide optional parameters path, the path to your executable,
+On Windows you can provide optional parameters path, the path to your executable,
 and args, an array of arguments to be passed to your executable when it launches.
 
 Returns `true` when the call succeeded, otherwise returns `false`.
@@ -474,18 +474,22 @@ Please refer to [Apple's documentation][CFBundleURLTypes] for details.
 
 The API uses the Windows Registry and LSSetDefaultHandlerForURLScheme internally.
 
-### `app.removeAsDefaultProtocolClient(protocol)` _macOS_ _Windows_
+### `app.removeAsDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
 
 * `protocol` String - The name of your protocol, without `://`.
+* `path` String (optional) _Windows_ - Defaults to `process.execPath`
+* `args` Array (optional) _Windows_ - Defaults to an empty array
 
 This method checks if the current executable as the default handler for a
 protocol (aka URI scheme). If so, it will remove the app as the default handler.
 
 Returns `true` when the call succeeded, otherwise returns `false`.
 
-### `app.isDefaultProtocolClient(protocol)` _macOS_ _Windows_
+### `app.isDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
 
 * `protocol` String - The name of your protocol, without `://`.
+* `path` String (optional) _Windows_ - Defaults to `process.execPath`
+* `args` Array (optional) _Windows_ - Defaults to an empty array
 
 This method checks if the current executable is the default handler for a protocol
 (aka URI scheme). If so, it will return true. Otherwise, it will return false.


### PR DESCRIPTION
Currently this is windows only as I don't know how to do the equivalent on macOS (I don't think it is actually needed).

Basically most people use Squirrel.Windows to install Electron applications on Windows.  When a user updates the app the stored default path is now wrong and instead of having to update the path during the update process it would be great if we could use the Squirrel `--processStart` syntax as our launcher.

If someone can point me at the direction to do this on `macOS` would be much appreciated 👍 