### PR TITLE
Apply resolveURL when set a location of a window opened by window.open()

### DIFF
--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -60,6 +60,7 @@ var BrowserWindowProxy = (function () {
       return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'getURL')
     },
     set: function (url) {
+      url = resolveURL(url)
       return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'loadURL', url)
     }
   })


### PR DESCRIPTION
Now the following code is not working because it requires an absolute url:
```js
const wnd = window.open('about:blank', 'new-window');
wnd.location = '/some-relative-url';
```