### PR TITLE
Add test for header with . characters

### DIFF
--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -164,10 +164,14 @@ describe('webRequest module', function () {
     it('receives details object', function (done) {
       ses.webRequest.onBeforeSendHeaders(function (details, callback) {
         assert.equal(typeof details.requestHeaders, 'object')
+        assert.equal(details.requestHeaders['Foo.Bar'], 'baz')
         callback({})
       })
       $.ajax({
         url: defaultURL,
+        headers: {
+          'Foo.Bar': 'baz'
+        },
         success: function (data) {
           assert.equal(data, '/')
           done()


### PR DESCRIPTION
Adds a test for headers with `.` characters in them for verify behavior of #6856 

Refs #6855

/cc @bridiver 