### PR TITLE
Allow accessing remote function properties

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -51,18 +51,6 @@ let getObjectPrototype = function (object) {
   }
 }
 
-// Include properties on member methods
-const addFunctionProperties = (sender, value, members) => {
-  members.forEach((member) => {
-    if (member.type !== 'method') return
-    const method = value[member.name]
-    member.members = getObjectMembers(method)
-    if (member.members.length > 0) {
-      member.id = objectsRegistry.add(sender, method)
-    }
-  })
-}
-
 // Convert a real value into meta data.
 let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
   // Determine the type of value.
@@ -102,7 +90,6 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
     meta.id = objectsRegistry.add(sender, value)
     meta.members = getObjectMembers(value)
     meta.proto = getObjectPrototype(value)
-    addFunctionProperties(sender, value, meta.members)
   } else if (meta.type === 'buffer') {
     meta.value = Array.prototype.slice.call(value, 0)
   } else if (meta.type === 'promise') {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -95,8 +95,10 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
     meta.members.forEach((member) => {
       if (member.type === 'method') {
         const method = value[member.name]
-        member.id = objectsRegistry.add(sender, method)
         member.members = getObjectMembers(method)
+        if (member.members.length > 0) {
+          member.id = objectsRegistry.add(sender, method)
+        }
       }
     })
   } else if (meta.type === 'buffer') {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -51,6 +51,18 @@ let getObjectPrototype = function (object) {
   }
 }
 
+// Include properties on member methods
+const addFunctionProperties = (sender, value, members) => {
+  members.forEach((member) => {
+    if (member.type !== 'method') return
+    const method = value[member.name]
+    member.members = getObjectMembers(method)
+    if (member.members.length > 0) {
+      member.id = objectsRegistry.add(sender, method)
+    }
+  })
+}
+
 // Convert a real value into meta data.
 let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
   // Determine the type of value.
@@ -90,17 +102,7 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
     meta.id = objectsRegistry.add(sender, value)
     meta.members = getObjectMembers(value)
     meta.proto = getObjectPrototype(value)
-
-    // Include properties on member methods
-    meta.members.forEach((member) => {
-      if (member.type === 'method') {
-        const method = value[member.name]
-        member.members = getObjectMembers(method)
-        if (member.members.length > 0) {
-          member.id = objectsRegistry.add(sender, method)
-        }
-      }
-    })
+    addFunctionProperties(sender, value, meta.members)
   } else if (meta.type === 'buffer') {
     meta.value = Array.prototype.slice.call(value, 0)
   } else if (meta.type === 'promise') {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -90,6 +90,15 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
     meta.id = objectsRegistry.add(sender, value)
     meta.members = getObjectMembers(value)
     meta.proto = getObjectPrototype(value)
+
+    // Include properties on member methods
+    meta.members.forEach((member) => {
+      if (member.type === 'method') {
+        const method = value[member.name]
+        member.id = objectsRegistry.add(sender, method)
+        member.members = getObjectMembers(method)
+      }
+    })
   } else if (meta.type === 'buffer') {
     meta.value = Array.prototype.slice.call(value, 0)
   } else if (meta.type === 'promise') {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -99,7 +99,7 @@ const setObjectMembers = function (ref, object, metaId, members) {
 
     let descriptor = { enumerable: member.enumerable }
     if (member.type === 'method') {
-      let remoteMemberFunction = function () {
+      const remoteMemberFunction = function () {
         if (this && this.constructor === remoteMemberFunction) {
           // Constructor call.
           let ret = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', metaId, member.name, wrapArgs(arguments))
@@ -110,13 +110,22 @@ const setObjectMembers = function (ref, object, metaId, members) {
           return metaToValue(ret)
         }
       }
+
+      // Wrap function in proxy for accessing remote properties
+      let descriptorFunction = new Proxy(remoteMemberFunction, {
+        get: (target, property, receiver) => {
+          if (target.hasOwnProperty(property)) return target[property]
+          return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_GET', metaId, member.name))[property]
+        }
+      })
+
       descriptor.get = function () {
-        remoteMemberFunction.ref = ref  // The member should reference its object.
-        return remoteMemberFunction
+        descriptorFunction.ref = ref  // The member should reference its object.
+        return descriptorFunction
       }
       // Enable monkey-patch the method
       descriptor.set = function (value) {
-        remoteMemberFunction = value
+        descriptorFunction = value
         return value
       }
       descriptor.configurable = true
@@ -135,16 +144,7 @@ const setObjectMembers = function (ref, object, metaId, members) {
     }
 
     Object.defineProperty(object, member.name, descriptor)
-    addFunctionProperties(object, member)
   }
-}
-
-// Include properties on member methods
-const addFunctionProperties = (object, member) => {
-  if (member.type !== 'method') return
-  if (member.members == null || member.members.length === 0) return
-  const method = object[member.name]
-  setObjectMembers(method, method, member.id, member.members)
 }
 
 // Populate object's prototype from descriptor.

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -135,6 +135,12 @@ const setObjectMembers = function (ref, object, metaId, members) {
     }
 
     Object.defineProperty(object, member.name, descriptor)
+
+    // Include properties on member methods
+    if (member.type === 'method' && member.members != null && member.members.length > 0) {
+      const method = object[member.name]
+      setObjectMembers(method, method, member.id, member.members)
+    }
   }
 }
 

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -135,13 +135,16 @@ const setObjectMembers = function (ref, object, metaId, members) {
     }
 
     Object.defineProperty(object, member.name, descriptor)
-
-    // Include properties on member methods
-    if (member.type === 'method' && member.members != null && member.members.length > 0) {
-      const method = object[member.name]
-      setObjectMembers(method, method, member.id, member.members)
-    }
+    addFunctionProperties(object, member)
   }
+}
+
+// Include properties on member methods
+const addFunctionProperties = (object, member) => {
+  if (member.type !== 'method') return
+  if (member.members == null || member.members.length === 0) return
+  const method = object[member.name]
+  setObjectMembers(method, method, member.id, member.members)
 }
 
 // Populate object's prototype from descriptor.

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -154,6 +154,8 @@ const setObjectPrototype = function (ref, object, metaId, descriptor) {
 // Wrap function in Proxy for accessing remote properties
 const proxyFunctionProperties = function (remoteMemberFunction, metaId, name) {
   let loaded = false
+
+  // Lazily load function properties
   const loadRemoteProperties = () => {
     if (loaded) return
     loaded = true

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -111,13 +111,7 @@ const setObjectMembers = function (ref, object, metaId, members) {
         }
       }
 
-      // Wrap function in proxy for accessing remote properties
-      let descriptorFunction = new Proxy(remoteMemberFunction, {
-        get: (target, property, receiver) => {
-          if (target.hasOwnProperty(property)) return target[property]
-          return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_GET', metaId, member.name))[property]
-        }
-      })
+      let descriptorFunction = proxyFunctionProperties(remoteMemberFunction, metaId, member.name)
 
       descriptor.get = function () {
         descriptorFunction.ref = ref  // The member should reference its object.
@@ -155,6 +149,34 @@ const setObjectPrototype = function (ref, object, metaId, descriptor) {
   setObjectMembers(ref, proto, metaId, descriptor.members)
   setObjectPrototype(ref, proto, metaId, descriptor.proto)
   Object.setPrototypeOf(object, proto)
+}
+
+// Wrap function in Proxy for accessing remote properties
+const proxyFunctionProperties = function (remoteMemberFunction, metaId, name) {
+  let loaded = false
+  const loadRemoteProperties = () => {
+    if (loaded) return
+    loaded = true
+    const meta = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_GET', metaId, name)
+    setObjectMembers(remoteMemberFunction, remoteMemberFunction, meta.id, meta.members)
+  }
+
+  return new Proxy(remoteMemberFunction, {
+    get: (target, property, receiver) => {
+      if (!target.hasOwnProperty(property)) loadRemoteProperties()
+      return target[property]
+    },
+    ownKeys: (target) => {
+      loadRemoteProperties()
+      return Object.getOwnPropertyNames(target)
+    },
+    getOwnPropertyDescriptor: (target, property) => {
+      let descriptor = Object.getOwnPropertyDescriptor(target, property)
+      if (descriptor != null) return descriptor
+      loadRemoteProperties()
+      return Object.getOwnPropertyDescriptor(target, property)
+    }
+  })
 }
 
 // Convert meta data from browser into real value.

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -64,6 +64,10 @@ describe('ipc module', function () {
       assert.equal(a.foo.nested.prop, 'yes')
       assert.equal(a.foo.method1(), 'world')
       assert.equal(a.foo.method1.prop1(), 123)
+
+      assert.ok(Object.keys(a.foo).includes('bar'))
+      assert.ok(Object.keys(a.foo).includes('nested'))
+      assert.ok(Object.keys(a.foo).includes('method1'))
     })
 
     it('should work with static class members', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -52,6 +52,17 @@ describe('ipc module', function () {
       comparePaths(path.normalize(remote.process.mainModule.paths[0]), path.resolve(__dirname, 'static', 'node_modules'))
     })
 
+    it('should work with function properties', function () {
+      var a = remote.require(path.join(fixtures, 'module', 'export-function-with-properties.js'))
+      assert.equal(typeof a, 'function')
+      assert.equal(a.bar, 'baz')
+
+      a = remote.require(path.join(fixtures, 'module', 'function-with-properties.js'))
+      assert.equal(typeof a, 'object')
+      assert.equal(typeof a.foo, 'function')
+      assert.equal(a.foo.bar, 'baz')
+    })
+
     it('handles circular references in arrays and objects', function () {
       var a = remote.require(path.join(fixtures, 'module', 'circular.js'))
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -63,6 +63,16 @@ describe('ipc module', function () {
       assert.equal(a.foo.bar, 'baz')
     })
 
+    it('should work with static class members', function () {
+      var a = remote.require(path.join(fixtures, 'module', 'remote-static.js'))
+      assert.equal(typeof a.Foo, 'function')
+      assert.equal(a.Foo.foo(), 3)
+      assert.equal(a.Foo.bar, 'baz')
+
+      var foo = new a.Foo()
+      assert.equal(foo.baz(), 123)
+    })
+
     it('handles circular references in arrays and objects', function () {
       var a = remote.require(path.join(fixtures, 'module', 'circular.js'))
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -59,9 +59,11 @@ describe('ipc module', function () {
 
       a = remote.require(path.join(fixtures, 'module', 'function-with-properties.js'))
       assert.equal(typeof a, 'object')
-      assert.equal(typeof a.foo, 'function')
+      assert.equal(a.foo(), 'hello')
       assert.equal(a.foo.bar, 'baz')
       assert.equal(a.foo.nested.prop, 'yes')
+      assert.equal(a.foo.method1(), 'world')
+      assert.equal(a.foo.method1.prop1(), 123)
     })
 
     it('should work with static class members', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -148,6 +148,10 @@ describe('ipc module', function () {
       assert.equal(property.property, 1127)
       property.property = 1007
       assert.equal(property.property, 1007)
+      assert.equal(property.getFunctionProperty(), 'foo-browser')
+      property.func.property = 'bar'
+      assert.equal(property.getFunctionProperty(), 'bar-browser')
+
       var property2 = remote.require(path.join(fixtures, 'module', 'property.js'))
       assert.equal(property2.property, 1007)
       property.property = 1127

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -61,6 +61,7 @@ describe('ipc module', function () {
       assert.equal(typeof a, 'object')
       assert.equal(typeof a.foo, 'function')
       assert.equal(a.foo.bar, 'baz')
+      assert.equal(a.foo.nested.prop, 'yes')
     })
 
     it('should work with static class members', function () {

--- a/spec/fixtures/module/export-function-with-properties.js
+++ b/spec/fixtures/module/export-function-with-properties.js
@@ -1,0 +1,4 @@
+function foo() {}
+foo.bar = 'baz'
+
+module.exports = foo

--- a/spec/fixtures/module/export-function-with-properties.js
+++ b/spec/fixtures/module/export-function-with-properties.js
@@ -1,4 +1,4 @@
-function foo() {}
+function foo () {}
 foo.bar = 'baz'
 
 module.exports = foo

--- a/spec/fixtures/module/function-with-properties.js
+++ b/spec/fixtures/module/function-with-properties.js
@@ -1,4 +1,4 @@
-function foo() {}
+function foo () {}
 foo.bar = 'baz'
 foo.nested = {
   prop: 'yes'

--- a/spec/fixtures/module/function-with-properties.js
+++ b/spec/fixtures/module/function-with-properties.js
@@ -1,5 +1,8 @@
 function foo() {}
 foo.bar = 'baz'
+foo.nested = {
+  prop: 'yes'
+}
 
 module.exports = {
   foo: foo

--- a/spec/fixtures/module/function-with-properties.js
+++ b/spec/fixtures/module/function-with-properties.js
@@ -1,0 +1,6 @@
+function foo() {}
+foo.bar = 'baz'
+
+module.exports = {
+  foo: foo
+}

--- a/spec/fixtures/module/function-with-properties.js
+++ b/spec/fixtures/module/function-with-properties.js
@@ -1,7 +1,15 @@
-function foo () {}
+function foo () {
+  return 'hello'
+}
 foo.bar = 'baz'
 foo.nested = {
   prop: 'yes'
+}
+foo.method1 = function () {
+  return 'world'
+}
+foo.method1.prop1 = function () {
+  return 123
 }
 
 module.exports = {

--- a/spec/fixtures/module/property.js
+++ b/spec/fixtures/module/property.js
@@ -1,1 +1,11 @@
 exports.property = 1127
+
+function func () {
+
+}
+func.property = 'foo'
+exports.func = func
+
+exports.getFunctionProperty = () => {
+  return `${func.property}-${process.type}`
+}

--- a/spec/fixtures/module/remote-static.js
+++ b/spec/fixtures/module/remote-static.js
@@ -1,9 +1,9 @@
 class Foo {
-  static foo() {
+  static foo () {
     return 3
   }
 
-  baz() {
+  baz () {
     return 123
   }
 }

--- a/spec/fixtures/module/remote-static.js
+++ b/spec/fixtures/module/remote-static.js
@@ -1,0 +1,15 @@
+class Foo {
+  static foo() {
+    return 3
+  }
+
+  baz() {
+    return 123
+  }
+}
+
+Foo.bar = 'baz'
+
+module.exports = {
+  Foo: Foo
+}


### PR DESCRIPTION
This pull request adds support for accessing the properties on a remote function when using `remote.require`.

It wraps remote functions in a [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) object so properties on those functions are accessed over IPC and lazily loaded.

Closes #6863
Refs #4957