### PR TITLE
Use a more permissive version of standard-markdown

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -41,7 +41,7 @@ otherwise it returns `undefined`.
 The `filters` specifies an array of file types that can be displayed or
 selected when you want to limit the user to a specific type. For example:
 
-```js
+```javascript
 {
   filters: [
     {name: 'Images', extensions: ['jpg', 'png', 'gif']},

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -41,7 +41,7 @@ otherwise it returns `undefined`.
 The `filters` specifies an array of file types that can be displayed or
 selected when you want to limit the user to a specific type. For example:
 
-```
+```js
 {
   filters: [
     {name: 'Images', extensions: ['jpg', 'png', 'gif']},

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -359,7 +359,7 @@ the first item.
 
 Template:
 
-```js
+```javascript
 [
   {label: '4', id: '4'},
   {label: '5', id: '5'},
@@ -381,7 +381,7 @@ Menu:
 
 Template:
 
-```js
+```javascript
 [
   {label: 'a', position: 'endof=letters'},
   {label: '1', position: 'endof=numbers'},

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -359,7 +359,7 @@ the first item.
 
 Template:
 
-```
+```js
 [
   {label: '4', id: '4'},
   {label: '5', id: '5'},
@@ -381,7 +381,7 @@ Menu:
 
 Template:
 
-```
+```js
 [
   {label: 'a', position: 'endof=letters'},
   {label: '1', position: 'endof=numbers'},

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -197,7 +197,7 @@ Sets when the tray's icon background becomes highlighted (in blue).
 by toggling between `'never'` and `'always'` modes when the window visibility
 changes.
 
-```js
+```javascript
 const {BrowserWindow, Tray} = require('electron')
 
 const win = new BrowserWindow({width: 800, height: 600})

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -22,7 +22,7 @@ console.log(contents)
 
 These methods can be accessed from the `webContents` module:
 
-```js
+```javascript
 const {webContents} = require('electron')
 console.log(webContents)
 ```
@@ -843,7 +843,7 @@ The `callback` will be called with `callback(error, data)` on completion. The
 
 By default, an empty `options` will be regarded as:
 
-```js
+```javascript
 {
   marginsType: 0,
   printBackground: false,

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -843,7 +843,7 @@ The `callback` will be called with `callback(error, data)` on completion. The
 
 By default, an empty `options` will be regarded as:
 
-```
+```js
 {
   marginsType: 0,
   printBackground: false,

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -119,7 +119,7 @@ console.log(webFrame.getResourceUsage())
 
 This will generate:
 
-```
+```js
 {
   images: {
     count: 22,
@@ -133,7 +133,7 @@ This will generate:
   xslStyleSheets: { /* same with "images" */ },
   fonts: { /* same with "images" */ },
   other: { /* same with "images" */ }
-})
+}
 ```
 
 ### `webFrame.clearCache()`

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -119,7 +119,7 @@ console.log(webFrame.getResourceUsage())
 
 This will generate:
 
-```js
+```javascript
 {
   images: {
     count: 22,

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -47,6 +47,8 @@ For API references, there are exceptions to this rule.
 * Use `bash` instead of `cmd` in code blocks (due to the syntax highlighter).
 * Lines should be wrapped at 80 columns.
 * No nesting lists more than 2 levels (due to the markdown renderer).
+* All `js` and `javascript` code blocks are linted with
+[standard-markdown](http://npm.im/standard-markdown).
 
 ## Picking words
 

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -18,7 +18,7 @@ has helpers to access Electron APIs in your tests and bundles ChromeDriver.
 $ npm install --save-dev spectron
 ```
 
-```js
+```javascript
 // A simple test to verify a visible window is opened with a title
 var Application = require('spectron').Application
 var assert = require('assert')

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "electabul": "~0.0.4",
     "request": "*",
     "standard": "^7.1.2",
-    "standard-markdown": "^1.2.0"
+    "standard-markdown": "^1.2.1"
   },
   "optionalDependencies": {
     "runas": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "electabul": "~0.0.4",
     "request": "*",
     "standard": "^7.1.2",
-    "standard-markdown": "^1.1.1"
+    "standard-markdown": "^1.2.0"
   },
   "optionalDependencies": {
     "runas": "^3.0.0"


### PR DESCRIPTION
This updates `standard-markdown` to version 1.2.1, which allows a few exceptions to the `standard` rules. See https://github.com/zeke/standard-markdown/issues/2 for more info.

undeclared variable:

```js
win.close()
```

unused variable:

```js
const {BrowserWindow} = require('electron')
```

orphan object: 

```js
{
  marginsType: 0,
  printBackground: false
}
```

orphan array:

```js
['this', 'array', 'is', 'okay', 'too']
```

This PR also revives the `javascript` language label that I removed from some code blocks a while back, and renames all `js` blocks `javascript` for consistency.

Closes https://github.com/electron/electron/pull/6748