### PR TITLE
Update docs re: electron module update

### DIFF
--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -16,6 +16,6 @@ Version numbers are bumped using the following rules:
 * Patch: For new features and bug fixes - if you upgrade from `1.0.0` to
   `1.0.1`, your app will continue to work as-is.
 
-If you are using `electron-prebuilt`, we recommend that you set a fixed version
+If you are using `electron` or `electron-prebuilt`, we recommend that you set a fixed version
 number (`1.1.0` instead of `^1.1.0`) to ensure that all upgrades of Electron are
 a manual operation made by you, the developer.

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -155,9 +155,9 @@ Once you've created your initial `main.js`, `index.html`, and `package.json` fil
 you'll probably want to try running your app locally to test it and make sure it's
 working as expected.
 
-### electron-prebuilt
+### `electron`
 
-[`electron-prebuilt`](https://github.com/electron-userland/electron-prebuilt) is
+[`electron`](https://github.com/electron-userland/electron-prebuilt) is
 an `npm` module that contains pre-compiled versions of Electron.
 
 If you've installed it globally with `npm`, then you will only need to run the


### PR DESCRIPTION
This updates the docs 📖 in two places where we were using the `electron-prebuilt` module name. The module name has been updated to just `electron`. 

- I mention both `electron` and `electron-prebuilt` in `electron-versioning.md` as users to this doc may still be on the older module.
- I just mention `electron` in `quick-start.md` because it seems best to point people starting off to the new module.

[Blog post on the module name update](http://electron.atom.io/blog/2016/08/16/npm-install-electron) 📝 

cc @zeke 
