### PR TITLE
Only call setCanSelectHiddenExtension on save dialogs

### DIFF
--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -71,7 +71,6 @@ void SetupDialog(NSSavePanel* dialog,
   if (default_filename)
     [dialog setNameFieldStringValue:default_filename];
 
-  [dialog setCanSelectHiddenExtension:YES];
   if (filters.empty())
     [dialog setAllowsOtherFileTypes:YES];
   else
@@ -196,6 +195,7 @@ void ShowSaveDialog(atom::NativeWindow* parent_window,
   NSSavePanel* dialog = [NSSavePanel savePanel];
 
   SetupDialog(dialog, title, button_label, default_path, filters);
+  [dialog setCanSelectHiddenExtension:YES];
 
   __block SaveDialogCallback callback = c;
 


### PR DESCRIPTION
The Hide Extension button only appears to be application to save dialogs and has no effect on open dialogs when toggled, so only show it on save dialogs.

Showing this button for open dialogs was previously causing the New Folder button to overlay on top of the Hide Extension button.

Closes #6866 