### PR TITLE
Show spec window initially when not on CI

### DIFF
--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -101,7 +101,7 @@ app.on('ready', function () {
 
   window = new BrowserWindow({
     title: 'Electron Tests',
-    show: false,
+    show: !global.isCi,
     width: 800,
     height: 600,
     webPreferences: {


### PR DESCRIPTION
When testing locally, errors in render process code can cause the spec runner to not display if the error occurs when requiring `'electron'`.

This pull request sets the window to show by default when not in CI mode so these errors can be inspected from the dev tools.