### PR TITLE
The checksum file needs to indicate that the files should be opened in binary mode

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -247,7 +247,7 @@ def upload_sha256_checksum(version, file_path):
 
   filename = os.path.basename(file_path)
   with open(checksum_path, 'w') as checksum:
-    checksum.write('{}  {}'.format(sha256.hexdigest(), filename))
+    checksum.write('{} *{}'.format(sha256.hexdigest(), filename))
   s3put(bucket, access_key, secret_key, os.path.dirname(checksum_path),
         'atom-shell/tmp/{0}'.format(version), [checksum_path])
 


### PR DESCRIPTION
For context, please see https://github.com/electron/electron/pull/6676#discussion_r75332120.