### PR TITLE
Example of creating local shortcuts

### DIFF
--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -37,19 +37,19 @@ app.on('will-quit', () => {
 ```
 
 To simulate local shortcuts, you can register the shortcut when the app obtains focus, 
-you can then then release the shortcut(s) when the app loses focus.
+then remove the shortcut(s) when the app loses focus.
 
 ```javascript
 const {app, globalShortcut} = require('electron')
 
 app.on('browser-window-focus', () => {
-    globalShortcut.register('F2', () => {
-        console.log('F2 is pressed')
-    })
+  globalShortcut.register('F2', () => {
+    console.log('F2 is pressed')
+  })
 })
 
 app.on('browser-window-blur', () => {
-    globalShortcut.unregisterAll()
+  globalShortcut.unregisterAll()
 })
 ```
 

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -36,6 +36,23 @@ app.on('will-quit', () => {
 })
 ```
 
+To simulate local shortcuts, you can register the shortcut when the app obtains focus, 
+you can then then release the shortcut(s) when the app loses focus.
+
+```javascript
+const {app, globalShortcut} = require('electron')
+
+app.on('browser-window-focus', () => {
+    globalShortcut.register('F2', () => {
+        console.log('F2 is pressed')
+    })
+})
+
+app.on('browser-window-blur', () => {
+    globalShortcut.unregisterAll()
+})
+```
+
 ## Methods
 
 The `globalShortcut` module has the following methods:


### PR DESCRIPTION
It is hard or nearly impossible to find any documentation or examples on how to create/simulate a local shortcut or a shortcut that doesn't override other applications shortcuts.

I have added an example to the global-shortcut.md to show how to simulate this.