### PR TITLE
Do not add extra space when args is empty

### DIFF
--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -77,7 +77,7 @@ class Browser : public WindowListObserver {
 
   // Remove the default protocol handler registry key
   bool RemoveAsDefaultProtocolClient(const std::string& protocol,
-                                    mate::Arguments* args);
+                                     mate::Arguments* args);
 
   // Set as default handler for a protocol.
   bool SetAsDefaultProtocolClient(const std::string& protocol,
@@ -85,7 +85,7 @@ class Browser : public WindowListObserver {
 
   // Query the current state of default handler for a protocol.
   bool IsDefaultProtocolClient(const std::string& protocol,
-                              mate::Arguments* args);
+                               mate::Arguments* args);
 
   // Set/Get the badge count.
   bool SetBadgeCount(int count);

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -41,7 +41,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 }
 
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
-                                        mate::Arguments* args) {
+                                         mate::Arguments* args) {
   return false;
 }
 

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -76,7 +76,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 }
 
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
-                                        mate::Arguments* args) {
+                                         mate::Arguments* args) {
   if (protocol.empty())
     return false;
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -61,8 +61,6 @@ bool GetProtocolLaunchPath(mate::Arguments* args, base::string16* exe) {
                               base::JoinString(launch_args, L" ").c_str());
   else
     *exe = base::StringPrintf(L"\"%s\" \"%%1\"", exe->c_str());
-  LOG(ERROR) << *exe;
-  return false;
   return true;
 }
 
@@ -157,12 +155,10 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 
   // Main Registry Key
   HKEY root = HKEY_CURRENT_USER;
-  std::string keyPathStr = "Software\\Classes\\" + protocol;
-  std::wstring keyPath = std::wstring(keyPathStr.begin(), keyPathStr.end());
+  base::string16 keyPath = base::UTF8ToUTF16("Software\\Classes\\" + protocol);
 
   // Command Key
-  std::string cmdPathStr = keyPathStr + "\\shell\\open\\command";
-  std::wstring cmdPath = std::wstring(cmdPathStr.begin(), cmdPathStr.end());
+  base::string16 cmdPath = keyPath + L"\\shell\\open\\command";
 
   base::win::RegKey key;
   base::win::RegKey commandKey;
@@ -174,12 +170,12 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
     // Key doesn't even exist, we can confirm that it is not set
     return true;
 
-  std::wstring keyVal;
+  base::string16 keyVal;
   if (FAILED(commandKey.ReadValue(L"", &keyVal)))
     // Default value not set, we can confirm that it is not set
     return true;
 
-  std::wstring exe;
+  base::string16 exe;
   if (!GetProtocolLaunchPath(args, &exe))
     return false;
 
@@ -213,20 +209,17 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
   if (protocol.empty())
     return false;
 
-  std::wstring exe;
+  base::string16 exe;
   if (!GetProtocolLaunchPath(args, &exe))
     return false;
 
   // Main Registry Key
   HKEY root = HKEY_CURRENT_USER;
-  std::string keyPathStr = "Software\\Classes\\" + protocol;
-  std::wstring keyPath = std::wstring(keyPathStr.begin(), keyPathStr.end());
-  std::string urlDeclStr = "URL:" + protocol;
-  std::wstring urlDecl = std::wstring(urlDeclStr.begin(), urlDeclStr.end());
+  base::string16 keyPath = base::UTF8ToUTF16("Software\\Classes\\" + protocol);
+  base::string16 urlDecl = base::UTF8ToUTF16("URL:" + protocol);
 
   // Command Key
-  std::string cmdPathStr = keyPathStr + "\\shell\\open\\command";
-  std::wstring cmdPath = std::wstring(cmdPathStr.begin(), cmdPathStr.end());
+  base::string16 cmdPath = keyPath + L"\\shell\\open\\command";
 
   // Write information to registry
   base::win::RegKey key(root, keyPath.c_str(), KEY_ALL_ACCESS);
@@ -246,18 +239,16 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
   if (protocol.empty())
     return false;
 
-  std::wstring exe;
+  base::string16 exe;
   if (!GetProtocolLaunchPath(args, &exe))
     return false;
 
   // Main Registry Key
   HKEY root = HKEY_CURRENT_USER;
-  std::string keyPathStr = "Software\\Classes\\" + protocol;
-  std::wstring keyPath = std::wstring(keyPathStr.begin(), keyPathStr.end());
+  base::string16 keyPath = base::UTF8ToUTF16("Software\\Classes\\" + protocol);
 
   // Command Key
-  std::string cmdPathStr = keyPathStr + "\\shell\\open\\command";
-  std::wstring cmdPath = std::wstring(cmdPathStr.begin(), cmdPathStr.end());
+  base::string16 cmdPath = keyPath + L"\\shell\\open\\command";
 
   base::win::RegKey key;
   base::win::RegKey commandKey;
@@ -269,17 +260,13 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
     // Key doesn't exist, we can confirm that it is not set
     return false;
 
-  std::wstring keyVal;
+  base::string16 keyVal;
   if (FAILED(commandKey.ReadValue(L"", &keyVal)))
     // Default value not set, we can confirm that it is not set
     return false;
 
-  if (keyVal == exe) {
-    // Default value is the same as current file path
-    return true;
-  } else {
-    return false;
-  }
+  // Default value is the same as current file path
+  return keyVal == exe;
 }
 
 bool Browser::SetBadgeCount(int count) {
@@ -287,13 +274,13 @@ bool Browser::SetBadgeCount(int count) {
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
-  std::wstring keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  base::string16 keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
   base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
 
   if (settings.open_at_login) {
     base::FilePath path;
     if (PathService::Get(base::FILE_EXE, &path)) {
-      std::wstring exePath(path.value());
+      base::string16 exePath(path.value());
       key.WriteValue(GetAppUserModelID(), exePath.c_str());
     }
   } else {
@@ -303,14 +290,14 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings() {
   LoginItemSettings settings;
-  std::wstring keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  base::string16 keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
   base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
-  std::wstring keyVal;
+  base::string16 keyVal;
 
   if (!FAILED(key.ReadValue(GetAppUserModelID(), &keyVal))) {
     base::FilePath path;
     if (PathService::Get(base::FILE_EXE, &path)) {
-      std::wstring exePath(path.value());
+      base::string16 exePath(path.value());
       settings.open_at_login = keyVal == exePath;
     }
   }


### PR DESCRIPTION
When the args of `setAsDefaultProtocolClient` is empty, the generated path should be `"/path/to/exe" "%1"`(one space) instead of `"/path/to/exe"  "%1"` (two spaces), the extra space there would break compatibility with previous API.

Also cleans up all the usages of `std::wstring` and UTF conversions in `browser_win.cc`.