### PR TITLE
fix windows command prompt error

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -170,7 +170,7 @@ electron .
 If you've installed it locally, then run:
 
 ```bash
-./node_modules/.bin/electron .
+"./node_modules/.bin/electron" .
 ```
 
 ### Manually Downloaded Electron Binary

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -169,8 +169,16 @@ electron .
 
 If you've installed it locally, then run:
 
+#### macOS / Linux
+
 ```bash
-"./node_modules/.bin/electron" .
+$ ./node_modules/.bin/electron .
+```
+
+#### Windows
+
+```bash
+$ .\node_modules\.bin\electron .
 ```
 
 ### Manually Downloaded Electron Binary


### PR DESCRIPTION
path to electron needs to be wrapped in quotes or else windows command prompt will error out