### PR TITLE
Use scoped policy for micro tasks

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -169,10 +169,11 @@ node::Environment* NodeBindings::CreateEnvironment(
       context->GetIsolate(), uv_default_loop(), context,
       args.size(), c_argv.get(), 0, nullptr);
 
-  // Node turns off AutorunMicrotasks, but we need it in web pages to match the
-  // behavior of Chrome.
-  if (!is_browser_)
-    context->GetIsolate()->SetAutorunMicrotasks(true);
+  // Node uses the deprecated SetAutorunMicrotasks(false) mode, we should switch
+  // to use the scoped policy to match blink's behavior.
+  if (!is_browser_) {
+    context->GetIsolate()->SetMicrotasksPolicy(v8::MicrotasksPolicy::kScoped);
+  }
 
   mate::Dictionary process(context->GetIsolate(), env->process_object());
   process.Set("type", process_type);

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -496,4 +496,25 @@ describe('chromium feature', function () {
       })
     })
   })
+
+  describe('fetch', function () {
+    it('does not crash', function (done) {
+      const server = http.createServer(function (req, res) {
+        res.end('test')
+        server.close()
+      })
+      server.listen(0, '127.0.0.1', function () {
+        const port = server.address().port
+        fetch(`http://127.0.0.1:${port}`).then((res) => {
+          return res.body.getReader()
+        }).then((reader) => {
+          reader.read().then((r) => {
+            reader.cancel()
+          })
+        }).catch(function (e) {
+          done()
+        })
+      })
+    })
+  })
 })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -510,9 +510,10 @@ describe('chromium feature', function () {
         }).then((reader) => {
           reader.read().then((r) => {
             reader.cancel()
+            done()
           })
         }).catch(function (e) {
-          done()
+          done(e)
         })
       })
     })


### PR DESCRIPTION
This fixes #6830 which was introduced by #6707.

V8 5.2 has some compatibility mode for `SetAutorunMicrotasks`, so either calling it with `true` or `false` would make V8 use a different mode from blink. This PR makes V8 use `SetMicrotasksPolicy(v8::MicrotasksPolicy::kScoped)` in renderer process, so it is not crashing and does not revert the previous bug.