### PR TITLE
Default network conditions to 0.0

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -416,7 +416,9 @@ void Session::SetDownloadPath(const base::FilePath& path) {
 void Session::EnableNetworkEmulation(const mate::Dictionary& options) {
   std::unique_ptr<brightray::DevToolsNetworkConditions> conditions;
   bool offline = false;
-  double latency, download_throughput, upload_throughput;
+  double latency = 0.0;
+  double download_throughput = 0.0;
+  double upload_throughput = 0.0;
   if (options.Get("offline", &offline) && offline) {
     conditions.reset(new brightray::DevToolsNetworkConditions(offline));
   } else {

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -416,9 +416,7 @@ void Session::SetDownloadPath(const base::FilePath& path) {
 void Session::EnableNetworkEmulation(const mate::Dictionary& options) {
   std::unique_ptr<brightray::DevToolsNetworkConditions> conditions;
   bool offline = false;
-  double latency = 0.0;
-  double download_throughput = 0.0;
-  double upload_throughput = 0.0;
+  double latency = 0.0, download_throughput = 0.0, upload_throughput = 0.0;
   if (options.Get("offline", &offline) && offline) {
     conditions.reset(new brightray::DevToolsNetworkConditions(offline));
   } else {

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -212,10 +212,14 @@ Sets download saving directory. By default, the download directory will be the
 #### `ses.enableNetworkEmulation(options)`
 
 * `options` Object
-  * `offline` Boolean - Whether to emulate network outage.
-  * `latency` Double - RTT in ms
-  * `downloadThroughput` Double - Download rate in Bps
-  * `uploadThroughput` Double - Upload rate in Bps
+  * `offline` Boolean (optional) - Whether to emulate network outage. Defaults
+    to false.
+  * `latency` Double (optional) - RTT in ms. Defaults to 0 which will disable
+    latency throttling.
+  * `downloadThroughput` Double (optional) - Download rate in Bps. Defaults to 0
+    which will disable download throttling.
+  * `uploadThroughput` Double (optional) - Upload rate in Bps. Defaults to 0
+    which will disable upload throttling.
 
 Emulates network with the given configuration for the `session`.
 


### PR DESCRIPTION
Default throttling values to `0.0` so [DevToolsNetworkConditions::IsThrottling](https://github.com/electron/brightray/blob/242feb1c817565de6592e9e672c136635bfff453/browser/net/devtools_network_conditions.cc) will return the expected value when they are unspecified.

Closes #6928 