### PR TITLE
add missing require to win.loadURL doc

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -961,7 +961,7 @@ method:
 let url = require('url').format({
   protocol: 'file',
   slashes: true,
-  pathname: path.join(__dirname, 'index.html')
+  pathname: require('path').join(__dirname, 'index.html')
 })
 
 win.loadURL(url)


### PR DESCRIPTION
Fixes https://github.com/electron/electron/commit/1985432e8e0ebfeb6cc720c0fb889c6c472cbcb5#commitcomment-18732039

Hat tip to @nikola and @sbruchmann