### PR TITLE
Access native window through native view

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1004,7 +1004,8 @@ void WebContents::InspectElement(int x, int y) {
   if (type_ == REMOTE)
     return;
 
-  OpenDevTools(nullptr);
+  if (!managed_web_contents()->GetDevToolsWebContents())
+    OpenDevTools(nullptr);
   scoped_refptr<content::DevToolsAgentHost> agent(
     content::DevToolsAgentHost::GetOrCreateFor(web_contents()));
   agent->InspectElement(x, y);

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1175,7 +1175,7 @@ bool WebContents::IsFocused() const {
   if (!view) return false;
 
   if (GetType() != BACKGROUND_PAGE) {
-    auto window = web_contents()->GetNativeView()->GetTopLevelWindow();
+    auto window = web_contents()->GetNativeView()->GetToplevelWindow();
     if (window && !window->IsVisible())
       return false;
   }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1175,7 +1175,7 @@ bool WebContents::IsFocused() const {
   if (!view) return false;
 
   if (GetType() != BACKGROUND_PAGE) {
-    auto window = web_contents()->GetTopLevelNativeWindow();
+    auto window = web_contents()->GetNativeView()->GetTopLevelWindow();
     if (window && !window->IsVisible())
       return false;
   }

--- a/atom/browser/api/atom_api_web_contents_mac.mm
+++ b/atom/browser/api/atom_api_web_contents_mac.mm
@@ -4,9 +4,7 @@
 
 #include "atom/browser/api/atom_api_web_contents.h"
 
-@interface NSWindow
-- (BOOL)isKeyWindow;
-@end
+#import <Cocoa/Cocoa.h>
 
 namespace atom {
 
@@ -17,7 +15,7 @@ bool WebContents::IsFocused() const {
   if (!view) return false;
 
   if (GetType() != BACKGROUND_PAGE) {
-    auto window = web_contents()->GetTopLevelNativeWindow();
+    auto window = [web_contents()->GetNativeView() window];
     // On Mac the render widget host view does not lose focus when the window
     // loses focus so check if the top level window is the key window.
     if (window && ![window isKeyWindow])

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -49,11 +49,9 @@ describe('webContents module', function () {
   })
 
   describe('getFocusedWebContents() API', function () {
-    if (isCi) {
-      return
-    }
-
     it('returns the focused web contents', function (done) {
+      if (isCi) return done()
+
       const specWebContents = remote.getCurrentWebContents()
       assert.equal(specWebContents.getId(), webContents.getFocusedWebContents().getId())
 
@@ -68,6 +66,27 @@ describe('webContents module', function () {
       })
 
       specWebContents.openDevTools()
+    })
+
+    it('does not crash when called on a detached dev tools window', function (done) {
+      const specWebContents = w.webContents
+
+      specWebContents.once('devtools-opened', function () {
+        assert.doesNotThrow(function () {
+          webContents.getFocusedWebContents()
+        })
+        specWebContents.closeDevTools()
+      })
+
+      specWebContents.once('devtools-closed', function () {
+        assert.doesNotThrow(function () {
+          webContents.getFocusedWebContents()
+        })
+        done()
+      })
+
+      specWebContents.openDevTools({mode: 'detach'})
+      w.inspectElement(100, 100)
     })
   })
 


### PR DESCRIPTION
It looks like `WebContentsView::GetTopLevelNativeWindow` falls to back calling `WebContentsViewDelegate::GetNativeWindow` when the native view has no window and since the delegate isn't checked for being `null`, a crash will happen in certain scenarios.

This pull request switches the `WebContents::IsFocused` API to access the native window directly from the native view so this delegate fallback is never performed.

This looks to be a bug in Chrome since everywhere else in `WebContentsView` uses guards around `delegate()` to check that it is present before calling into it except in `GetTopLevelNativeWindow`.

https://cs.chromium.org/chromium/src/content/browser/web_contents/web_contents_view_mac.mm?l=150

https://cs.chromium.org/chromium/src/content/browser/web_contents/web_contents_view_aura.cc?l=626

Closes #6940