### PR TITLE
protocol: allow standard schemes to support filesystem api

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -23,8 +23,9 @@
 #include "base/command_line.h"
 #include "base/files/file_util.h"
 #include "base/stl_util.h"
-#include "base/strings/string_util.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "chrome/browser/printing/printing_message_filter.h"
 #include "chrome/browser/renderer_host/pepper/chrome_browser_pepper_host_factory.h"
 #include "chrome/browser/renderer_host/pepper/widevine_cdm_message_filter.h"
@@ -277,6 +278,21 @@ bool AtomBrowserClient::CanCreateWindow(
   }
 
   return false;
+}
+
+void AtomBrowserClient::GetAdditionalAllowedSchemesForFileSystem(
+    std::vector<std::string>* additional_schemes) {
+  // Parse --standard-schemes=scheme1,scheme2
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  std::string custom_schemes = command_line->GetSwitchValueASCII(
+      switches::kStandardSchemes);
+  if (!custom_schemes.empty()) {
+    std::vector<std::string> schemes_list = base::SplitString(
+        custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    additional_schemes->insert(additional_schemes->end(),
+                               schemes_list.begin(),
+                               schemes_list.end());
+  }
 }
 
 brightray::BrowserMainParts* AtomBrowserClient::OverrideCreateBrowserMainParts(

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -9,6 +9,7 @@
 #endif
 
 #include "atom/browser/api/atom_api_app.h"
+#include "atom/browser/api/atom_api_protocol.h"
 #include "atom/browser/atom_access_token_store.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
@@ -24,7 +25,6 @@
 #include "base/files/file_util.h"
 #include "base/stl_util.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "chrome/browser/printing/printing_message_filter.h"
 #include "chrome/browser/renderer_host/pepper/chrome_browser_pepper_host_factory.h"
@@ -282,17 +282,11 @@ bool AtomBrowserClient::CanCreateWindow(
 
 void AtomBrowserClient::GetAdditionalAllowedSchemesForFileSystem(
     std::vector<std::string>* additional_schemes) {
-  // Parse --standard-schemes=scheme1,scheme2
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  std::string custom_schemes = command_line->GetSwitchValueASCII(
-      switches::kStandardSchemes);
-  if (!custom_schemes.empty()) {
-    std::vector<std::string> schemes_list = base::SplitString(
-        custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  auto schemes_list = api::GetStandardSchemes();
+  if (!schemes_list.empty())
     additional_schemes->insert(additional_schemes->end(),
                                schemes_list.begin(),
                                schemes_list.end());
-  }
 }
 
 brightray::BrowserMainParts* AtomBrowserClient::OverrideCreateBrowserMainParts(

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -94,6 +94,8 @@ class AtomBrowserClient : public brightray::BrowserClient,
                        int opener_render_view_id,
                        int opener_render_frame_id,
                        bool* no_javascript_access) override;
+  void GetAdditionalAllowedSchemesForFileSystem(
+      std::vector<std::string>* schemes) override;
 
   // brightray::BrowserClient:
   brightray::BrowserMainParts* OverrideCreateBrowserMainParts(

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -47,10 +47,11 @@ non-standard schemes can not recognize relative URLs:
   <img src='test.png'>
 </body>
 ```
-Registering a scheme as standard, will allow access of files through
-the FileSystem API. Otherwise the renderer will throw a security error for the
-scheme. So in general if you want to register a custom protocol to replace the
-`http` protocol, you have to register it as standard scheme:
+
+Registering a scheme as standard will allow access to files through the
+[FileSystem API][file-system-api]. Otherwise the renderer will throw a security
+error for the scheme. So in general if you want to register a custom protocol to
+replace the `http` protocol, you have to register it as a standard scheme:
 
 ```javascript
 const {app, protocol} = require('electron')
@@ -229,3 +230,4 @@ which sends a new HTTP request as a response.
 Remove the interceptor installed for `scheme` and restore its original handler.
 
 [net-error]: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
+[file-system-api]: https://developer.mozilla.org/en-US/docs/Web/API/LocalFileSystem

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -47,9 +47,10 @@ non-standard schemes can not recognize relative URLs:
   <img src='test.png'>
 </body>
 ```
-
-So if you want to register a custom protocol to replace the `http` protocol, you
-have to register it as standard scheme:
+Registering a scheme as standard, will allow access of files through
+the FileSystem API. Otherwise the renderer will throw a security error for the
+scheme. So in general if you want to register a custom protocol to replace the
+`http` protocol, you have to register it as standard scheme:
 
 ```javascript
 const {app, protocol} = require('electron')

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -4,7 +4,7 @@ const path = require('path')
 const qs = require('querystring')
 const {closeWindow} = require('./window-helpers')
 const remote = require('electron').remote
-const {BrowserWindow, protocol, webContents} = remote
+const {BrowserWindow, ipcMain, protocol, webContents} = remote
 
 describe('protocol module', function () {
   var protocolName = 'sp'
@@ -964,6 +964,19 @@ describe('protocol module', function () {
         })
         w.loadURL(origin)
       })
+    })
+
+    it('can access files through FileSystem API', function (done) {
+      let filePath = path.join(__dirname, 'fixtures', 'pages', 'filesystem.html')
+      const handler = function (request, callback) {
+        callback({path: filePath})
+      }
+      protocol.registerFileProtocol(standardScheme, handler, function (error) {
+        if (error) return done(error)
+        w.loadURL(origin)
+      })
+      ipcMain.once('file-system-error', (event, err) => done(err))
+      ipcMain.once('file-system-write-end', () => done())
     })
   })
 })

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -966,7 +966,7 @@ describe('protocol module', function () {
       })
     })
 
-    it('can access files through FileSystem API', function (done) {
+    it('can access files through the FileSystem API', function (done) {
       let filePath = path.join(__dirname, 'fixtures', 'pages', 'filesystem.html')
       const handler = function (request, callback) {
         callback({path: filePath})

--- a/spec/fixtures/pages/filesystem.html
+++ b/spec/fixtures/pages/filesystem.html
@@ -1,0 +1,24 @@
+<script>
+const {ipcRenderer} = require('electron')
+function onInitFs (fs) {
+  fs.root.getFile('log.txt', {create: true}, function (fileEntry) {
+    fileEntry.createWriter(function (fileWriter) {
+      var blob = new Blob(['Lorem Ipsum'], {type: 'text/plain'});
+      fileWriter.onwriteend = function() {
+        ipcRenderer.send('file-system-write-end')
+      };
+      fileWriter.onerror = errorHandler
+      fileWriter.write(blob);
+    }, errorHandler);
+  }, errorHandler);
+
+}
+
+navigator.webkitPersistentStorage.requestQuota(5 * 1024 * 1024, function (granted) {
+  webkitRequestFileSystem(TEMPORARY, granted, onInitFs, errorHandler);
+}, errorHandler)
+
+function errorHandler(e) {
+  ipcRenderer.send('file-system-error', e)
+}
+</script>


### PR DESCRIPTION
It isn't necessary for the scheme to be standard for accessing filesystem api, but the registeration has to happen during context creation which means to add another api to protocol for use before `ready` event. Would it be better to have an api like

```
protocol.registerCustomSchemes({
  'scheme1': 'filesystem, standard',
  'scheme2': 'serviceworker'
})
```

instead of a strict `registerStandardSchemes` api, thoughts ?

Fixes #6949 