### PR TITLE
Only change window state when fullscreen is true

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -506,7 +506,7 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
 #else
   if (IsVisible())
     window_->SetFullscreen(fullscreen);
-  else
+  else if (fullscreen)
     window_->native_widget_private()->ShowWithWindowState(
         ui::SHOW_STATE_FULLSCREEN);
 


### PR DESCRIPTION
Previously calling `setFullScreen(false)` on an invisible window on Linux would show it and move it to fullscreen mode.

Closes #6954 