### PR TITLE
Serialize ArrayBuffers as Buffers instead of Arrays over remote

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -91,7 +91,7 @@ let valueToMeta = function (sender, value, optimizeSimpleObject = false) {
     meta.members = getObjectMembers(value)
     meta.proto = getObjectPrototype(value)
   } else if (meta.type === 'buffer') {
-    meta.value = Array.prototype.slice.call(value, 0)
+    meta.value = Buffer.from(value)
   } else if (meta.type === 'promise') {
     // Add default handler to prevent unhandled rejections in main process
     // Instead they should appear in the renderer process

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -33,7 +33,7 @@ const wrapArgs = function (args, visited) {
     } else if (ArrayBuffer.isView(value)) {
       return {
         type: 'buffer',
-        value: Array.prototype.slice.call(value, 0)
+        value: Buffer.from(value)
       }
     } else if (value instanceof Date) {
       return {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -163,6 +163,17 @@ describe('ipc module', function () {
       assert.deepEqual(printName.echo(now), now)
     })
 
+    it('supports instanceof Buffer', function () {
+      const buffer = Buffer.from('test')
+      assert.ok(buffer.equals(printName.echo(buffer)))
+
+      const objectWithBuffer = {a: 'foo', b: Buffer.from('bar')}
+      assert.ok(objectWithBuffer.b.equals(printName.echo(objectWithBuffer).b))
+
+      const arrayWithBuffer = [1,2, Buffer.from('baz')]
+      assert.ok(arrayWithBuffer[2].equals(printName.echo(arrayWithBuffer)[2]))
+    })
+
     it('supports TypedArray', function () {
       const values = [1, 2, 3, 4]
       const typedArray = printName.typedArray(values)

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -286,13 +286,22 @@ describe('ipc module', function () {
       ipcRenderer.send('message', obj)
     })
 
-    it('can send instance of Date', function (done) {
+    it('can send instances of Date', function (done) {
       const currentDate = new Date()
       ipcRenderer.once('message', function (event, value) {
         assert.equal(value, currentDate.toISOString())
         done()
       })
       ipcRenderer.send('message', currentDate)
+    })
+
+    it('can send instances of Buffer', function (done) {
+      var buffer = Buffer.from('hello')
+      ipcRenderer.once('message', function (event, message) {
+        assert.ok(buffer.equals(message))
+        done()
+      })
+      ipcRenderer.send('message', buffer)
     })
 
     it('can send objects with DOM class prototypes', function (done) {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -170,7 +170,7 @@ describe('ipc module', function () {
       const objectWithBuffer = {a: 'foo', b: Buffer.from('bar')}
       assert.ok(objectWithBuffer.b.equals(printName.echo(objectWithBuffer).b))
 
-      const arrayWithBuffer = [1,2, Buffer.from('baz')]
+      const arrayWithBuffer = [1, 2, Buffer.from('baz')]
       assert.ok(arrayWithBuffer[2].equals(printName.echo(arrayWithBuffer)[2]))
     })
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -175,9 +175,11 @@ describe('ipc module', function () {
     })
 
     it('supports TypedArray', function () {
-      const values = [1, 2, 3, 4]
-      const typedArray = printName.typedArray(values)
-      assert.deepEqual(values, typedArray)
+      let values = [1, 2, 3, 4]
+      assert.deepEqual(printName.typedArray(values), values)
+
+      values = new Int16Array([1, 2, 3, 4])
+      assert.deepEqual(printName.typedArray(values), values)
     })
   })
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -175,11 +175,11 @@ describe('ipc module', function () {
     })
 
     it('supports TypedArray', function () {
-      let values = [1, 2, 3, 4]
+      const values = [1, 2, 3, 4]
       assert.deepEqual(printName.typedArray(values), values)
 
-      values = new Int16Array([1, 2, 3, 4])
-      assert.deepEqual(printName.typedArray(values), values)
+      const int16values = new Int16Array([1, 2, 3, 4])
+      assert.deepEqual(printName.typedArray(int16values), int16values)
     })
   })
 
@@ -309,7 +309,7 @@ describe('ipc module', function () {
     })
 
     it('can send instances of Buffer', function (done) {
-      var buffer = Buffer.from('hello')
+      const buffer = Buffer.from('hello')
       ipcRenderer.once('message', function (event, message) {
         assert.ok(buffer.equals(message))
         done()


### PR DESCRIPTION
This pull request switches to using `Buffer.from` instead of `Array.slice` when generating remote metadata to be sent over IPC.

This reduces the time taken to send a 10mb PDF `Buffer` as an argument to a remote function from ~10 seconds to ~100ms. This makes it equivalent in time to calling `ipcRenderer.sendSync` and sending the `Buffer` as an argument to that API.

Closes #6942 