### PR TITLE
Document all Method Parameters

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -684,12 +684,17 @@ details.
 
 ### `app.commandLine.appendSwitch(switch[, value])`
 
+* `switch` String - A command-line switch
+* `value` String (optional) - A value for the given switch
+
 Append a switch (with optional `value`) to Chromium's command line.
 
 **Note:** This will not affect `process.argv`, and is mainly used by developers
 to control some low-level Chromium behaviors.
 
 ### `app.commandLine.appendArgument(value)`
+
+* `value` String - The argument to append to the command line
 
 Append an argument to Chromium's command line. The argument will be quoted
 correctly.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -944,9 +944,22 @@ Whether the window's document has been edited.
 
 #### `win.capturePage([rect, ]callback)`
 
+* `rect` Object (optional) - The area of the page to be captured
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+* `callback` Function
+
 Same as `webContents.capturePage([rect, ]callback)`.
 
 #### `win.loadURL(url[, options])`
+
+* `url` URL
+* `options` Object (optional)
+  * `httpReferrer` String - A HTTP Referrer url.
+  * `userAgent` String - A user agent originating the request.
+  * `extraHeaders` String - Extra headers separated by "\n"
 
 Same as `webContents.loadURL(url[, options])`.
 
@@ -1136,6 +1149,8 @@ this window, but if this window has focus, it will still receive keyboard
 events.
 
 #### `win.setContentProtection(enable)` _macOS_ _Windows_
+
+* `enable` Boolean
 
 Prevents the window contents from being captured by other apps.
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -119,6 +119,9 @@ will be passed via `callback(response)`.
 
 ### `dialog.showErrorBox(title, content)`
 
+* `title` String - The title to display in the error box
+* `content` String - The text content to display in the error box
+
 Displays a modal dialog that shows an error message.
 
 This API can be called safely before the `ready` event the `app` module emits,

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -152,9 +152,11 @@ Returns the [`WebContents`](web-contents.md) object of this web page.
 Returns the global variable of `name` (e.g. `global[name]`) in the main
 process.
 
+## Properties
+
 ### `remote.process`
 
-Returns the `process` object in the main process. This is the same as
+The `process` object in the main process. This is the same as
 `remote.getGlobal('process')` but is cached.
 
 [rmi]: http://en.wikipedia.org/wiki/Java_remote_method_invocation

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -62,10 +62,15 @@ Removes the subscriber with `id`.
 
 ### `systemPreferences.subscribeLocalNotification(event, callback)` _macOS_
 
+* `event` String
+* `callback` Function
+
 Same as `subscribeNotification`, but uses `NSNotificationCenter` for local defaults.
 This is necessary for events such as `NSUserDefaultsDidChangeNotification`
 
 ### `systemPreferences.unsubscribeLocalNotification(id)` _macOS_
+
+* `id` Integer
 
 Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificationCenter`.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -974,32 +974,31 @@ app.on('ready', () => {
 
 #### `contents.enableDeviceEmulation(parameters)`
 
-`parameters` Object, properties:
-
-* `screenPosition` String - Specify the screen type to emulate
-    (default: `desktop`)
-  * `desktop` - Desktop screen type
-  * `mobile` - Mobile screen type
-* `screenSize` Object - Set the emulated screen size (screenPosition == mobile)
-  * `width` Integer - Set the emulated screen width
-  * `height` Integer - Set the emulated screen height
-* `viewPosition` Object - Position the view on the screen
-    (screenPosition == mobile) (default: `{x: 0, y: 0}`)
-  * `x` Integer - Set the x axis offset from top left corner
-  * `y` Integer - Set the y axis offset from top left corner
-* `deviceScaleFactor` Float - Set the device scale factor (if zero defaults to
-    original device scale factor) (default: `0`)
-* `viewSize` Object - Set the emulated view size (empty means no override)
-  * `width` Integer - Set the emulated view width
-  * `height` Integer - Set the emulated view height
-* `fitToView` Boolean - Whether emulated view should be scaled down if
-    necessary to fit into available space (default: `false`)
-* `offset` Object - Offset of the emulated view inside available space (not in
-    fit to view mode) (default: `{x: 0, y: 0}`)
-  * `x` Float - Set the x axis offset from top left corner
-  * `y` Float - Set the y axis offset from top left corner
-* `scale` Float - Scale of emulated view inside available space (not in fit to
-    view mode) (default: `1`)
+* `parameters` Object
+  * `screenPosition` String - Specify the screen type to emulate
+      (default: `desktop`)
+    * `desktop` String - Desktop screen type
+    * `mobile` String - Mobile screen type
+  * `screenSize` Object - Set the emulated screen size (screenPosition == mobile)
+    * `width` Integer - Set the emulated screen width
+    * `height` Integer - Set the emulated screen height
+  * `viewPosition` Object - Position the view on the screen
+      (screenPosition == mobile) (default: `{x: 0, y: 0}`)
+    * `x` Integer - Set the x axis offset from top left corner
+    * `y` Integer - Set the y axis offset from top left corner
+  * `deviceScaleFactor` Integer - Set the device scale factor (if zero defaults to
+      original device scale factor) (default: `0`)
+  * `viewSize` Object - Set the emulated view size (empty means no override)
+    * `width` Integer - Set the emulated view width
+    * `height` Integer - Set the emulated view height
+  * `fitToView` Boolean - Whether emulated view should be scaled down if
+      necessary to fit into available space (default: `false`)
+  * `offset` Object - Offset of the emulated view inside available space (not in
+      fit to view mode) (default: `{x: 0, y: 0}`)
+    * `x` Float - Set the x axis offset from top left corner
+    * `y` Float - Set the y axis offset from top left corner
+  * `scale` Float - Scale of emulated view inside available space (not in fit to
+      view mode) (default: `1`)
 
 Enable device emulation with the given parameters.
 

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -53,10 +53,6 @@ Removes focus from the child window.
 
 Forcefully closes the child window without calling its unload event.
 
-#### `win.closed`
-
-Set to true after the child window gets closed.
-
 #### `win.eval(code)`
 
 * `code` String
@@ -81,3 +77,11 @@ origin preference.
 
 In addition to these methods, the child window implements `window.opener` object
 with no properties and a single method.
+
+### Instance Properties
+
+The `BrowserWindowProxy` object has the following instance properties:
+
+#### `win.closed`
+
+Set to true after the child window gets closed.


### PR DESCRIPTION
Replaces https://github.com/electron/electron/pull/6962, where I got into submodule hell 😱 

For every method of every API, I compared its signature (e.g. `(switch[, value])` with its `<ul>` of documented parameters. This PR:

- documents all module method parameters
- documents all class instance method parameters
- treats getters like `remote.process` and `win.closed` as properties instead of methods