### PR TITLE
Correct misspelling of destroy in method name

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -137,7 +137,7 @@ void Window::WillCloseWindow(bool* prevent_default) {
   *prevent_default = Emit("close");
 }
 
-void Window::WillDestoryNativeObject() {
+void Window::WillDestroyNativeObject() {
   // Close all child windows before closing current window.
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -58,7 +58,7 @@ class Window : public mate::TrackableObject<Window>,
 
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
-  void WillDestoryNativeObject() override;
+  void WillDestroyNativeObject() override;
   void OnWindowClosed() override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -405,7 +405,7 @@ void NativeWindow::CloseContents(content::WebContents* source) {
   Observe(nullptr);
 
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
-                    WillDestoryNativeObject());
+                    WillDestroyNativeObject());
 
   // When the web contents is gone, close the window immediately, but the
   // memory will not be freed until you call delete.

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -34,7 +34,7 @@ class NativeWindowObserver {
   virtual void WillCloseWindow(bool* prevent_default) {}
 
   // Called before the native window object is going to be destroyed.
-  virtual void WillDestoryNativeObject() {}
+  virtual void WillDestroyNativeObject() {}
 
   // Called when the window is closed.
   virtual void OnWindowClosed() {}


### PR DESCRIPTION
`Window::WillDestoryNativeObject` ➡️ `Window::WillDestroyNativeObject` 