### PR TITLE
Check DownloadItem save path before prompting

### DIFF
--- a/atom/browser/atom_download_manager_delegate.h
+++ b/atom/browser/atom_download_manager_delegate.h
@@ -46,6 +46,9 @@ class AtomDownloadManagerDelegate : public content::DownloadManagerDelegate {
   void GetNextId(const content::DownloadIdCallback& callback) override;
 
  private:
+  // Get the save path set on the associated api::DownloadItem object
+  void GetItemSavePath(content::DownloadItem* item, base::FilePath* path);
+
   content::DownloadManager* download_manager_;
   base::WeakPtrFactory<AtomDownloadManagerDelegate> weak_ptr_factory_;
 

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -319,6 +319,17 @@ describe('session module', function () {
         })
       })
     })
+
+    describe('when a save path is specified and the URL is unavailable', function () {
+      it('does not display a save dialog and reports the done state as interrupted', function (done) {
+        ipcRenderer.sendSync('set-download-option', false, false)
+        ipcRenderer.once('download-done', (event, state) => {
+          assert.equal(state, 'interrupted')
+          done()
+        })
+        w.webContents.downloadURL('file://' + __dirname)
+      })
+    })
   })
 
   describe('ses.protocol', function () {

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -327,7 +327,7 @@ describe('session module', function () {
           assert.equal(state, 'interrupted')
           done()
         })
-        w.webContents.downloadURL('file://' + __dirname)
+        w.webContents.downloadURL('file://' + path.join(__dirname, 'does-not-exist.txt'))
       })
     })
   })


### PR DESCRIPTION
For failing URLs (such as 404s), it looks like `AtomDownloadManagerDelegate::DetermineDownloadTarget` is called before the `will-download` event fires so the wrapped `api::DownloadItem` class has not been created yet and so `AtomDownloadManagerDelegate::OnDownloadPathGenerated` is called to prompt for the path even when it was explicitly set on the download item.

This pull requests adds a check to `AtomDownloadManagerDelegate::OnDownloadPathGenerated` to see if the specified item has a save path and only prompt when that path is empty.

Closes #6784 