### PR TITLE
Add v7l to ARM release assets

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -10,7 +10,7 @@ import stat
 
 from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
                        get_target_arch, get_chromedriver_version, \
-                       get_platform_key, get_zip_name
+                       get_zip_name
 from lib.util import scoped_cwd, rm_rf, get_electron_version, make_zip, \
                      execute, electron_gyp
 

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -10,7 +10,7 @@ import stat
 
 from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
                        get_target_arch, get_chromedriver_version, \
-                       get_platform_key
+                       get_platform_key, get_zip_name
 from lib.util import scoped_cwd, rm_rf, get_electron_version, make_zip, \
                      execute, electron_gyp
 
@@ -165,9 +165,7 @@ def create_symbols():
 
 
 def create_dist_zip():
-  dist_name = '{0}-{1}-{2}-{3}.zip'.format(PROJECT_NAME, ELECTRON_VERSION,
-                                           get_platform_key(),
-                                           get_target_arch())
+  dist_name = get_zip_name(PROJECT_NAME, ELECTRON_VERSION)
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
 
   with scoped_cwd(DIST_DIR):
@@ -178,8 +176,7 @@ def create_dist_zip():
 
 
 def create_chrome_binary_zip(binary, version):
-  dist_name = '{0}-{1}-{2}-{3}.zip'.format(binary, version, get_platform_key(),
-                                           get_target_arch())
+  dist_name = get_zip_name(binary, version)
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
 
   with scoped_cwd(DIST_DIR):
@@ -192,8 +189,7 @@ def create_chrome_binary_zip(binary, version):
 
 
 def create_ffmpeg_zip():
-  dist_name = 'ffmpeg-{0}-{1}-{2}.zip'.format(
-      ELECTRON_VERSION, get_platform_key(), get_target_arch())
+  dist_name = get_zip_name('ffmpeg', ELECTRON_VERSION)
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
 
   if PLATFORM == 'darwin':
@@ -214,10 +210,7 @@ def create_ffmpeg_zip():
 
 
 def create_symbols_zip():
-  dist_name = '{0}-{1}-{2}-{3}-symbols.zip'.format(PROJECT_NAME,
-                                                   ELECTRON_VERSION,
-                                                   get_platform_key(),
-                                                   get_target_arch())
+  dist_name = get_zip_name(PROJECT_NAME, ELECTRON_VERSION)
   zip_file = os.path.join(DIST_DIR, dist_name)
   licenses = ['LICENSE', 'LICENSES.chromium.html', 'version']
 
@@ -226,18 +219,12 @@ def create_symbols_zip():
     make_zip(zip_file, licenses, dirs)
 
   if PLATFORM == 'darwin':
-    dsym_name = '{0}-{1}-{2}-{3}-dsym.zip'.format(PROJECT_NAME,
-                                                  ELECTRON_VERSION,
-                                                  get_platform_key(),
-                                                  get_target_arch())
+    dsym_name = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'dsym')
     with scoped_cwd(DIST_DIR):
       dsyms = glob.glob('*.dSYM')
       make_zip(os.path.join(DIST_DIR, dsym_name), licenses, dsyms)
   elif PLATFORM == 'win32':
-    pdb_name = '{0}-{1}-{2}-{3}-pdb.zip'.format(PROJECT_NAME,
-                                                ELECTRON_VERSION,
-                                                get_platform_key(),
-                                                get_target_arch())
+    pdb_name = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'pdb')
     with scoped_cwd(DIST_DIR):
       pdbs = glob.glob('*.pdb')
       make_zip(os.path.join(DIST_DIR, pdb_name), pdbs + licenses, [])

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -76,10 +76,10 @@ def is_verbose_mode():
 
 
 def get_zip_name(name, version, suffix=''):
-  zip_name = '{0}-{1}-{2}-{3}'.format(name,
-                                      version,
-                                      get_platform_key(),
-                                      get_target_arch())
+  arch = get_target_arch()
+  if arch is 'arm':
+    arch += 'v7l'
+  zip_name = '{0}-{1}-{2}-{3}'.format(name, version, get_platform_key(), arch)
   if suffix:
     zip_name += '-' + suffix
   return zip_name + '.zip'

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -73,3 +73,13 @@ def enable_verbose_mode():
 
 def is_verbose_mode():
   return verbose_mode
+
+
+def get_zip_name(name, version, suffix=''):
+  zip_name = '{0}-{1}-{2}-{3}'.format(name,
+                                      version,
+                                      get_platform_key(),
+                                      get_target_arch())
+  if suffix:
+    zip_name += '-' + suffix
+  return zip_name + '.zip'

--- a/script/upload.py
+++ b/script/upload.py
@@ -10,7 +10,7 @@ import tempfile
 
 from io import StringIO
 from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
-                       get_platform_key, get_env_var, s3_config, get_zip_name
+                       get_env_var, s3_config, get_zip_name
 from lib.util import electron_gyp, execute, get_electron_version, \
                      parse_version, scoped_cwd, s3put
 from lib.github import GitHub

--- a/script/upload.py
+++ b/script/upload.py
@@ -10,7 +10,7 @@ import tempfile
 
 from io import StringIO
 from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
-                       get_platform_key, get_env_var, s3_config
+                       get_platform_key, get_env_var, s3_config, get_zip_name
 from lib.util import electron_gyp, execute, get_electron_version, \
                      parse_version, scoped_cwd, s3put
 from lib.github import GitHub
@@ -25,22 +25,11 @@ PRODUCT_NAME = electron_gyp()['product_name%']
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 OUT_DIR = os.path.join(SOURCE_ROOT, 'out', 'R')
 DIST_DIR = os.path.join(SOURCE_ROOT, 'dist')
-DIST_NAME = '{0}-{1}-{2}-{3}.zip'.format(PROJECT_NAME,
-                                         ELECTRON_VERSION,
-                                         get_platform_key(),
-                                         get_target_arch())
-SYMBOLS_NAME = '{0}-{1}-{2}-{3}-symbols.zip'.format(PROJECT_NAME,
-                                                    ELECTRON_VERSION,
-                                                    get_platform_key(),
-                                                    get_target_arch())
-DSYM_NAME = '{0}-{1}-{2}-{3}-dsym.zip'.format(PROJECT_NAME,
-                                              ELECTRON_VERSION,
-                                              get_platform_key(),
-                                              get_target_arch())
-PDB_NAME = '{0}-{1}-{2}-{3}-pdb.zip'.format(PROJECT_NAME,
-                                            ELECTRON_VERSION,
-                                            get_platform_key(),
-                                            get_target_arch())
+
+DIST_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION)
+SYMBOLS_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'symbols')
+DSYM_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'dsym')
+PDB_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'pdb')
 
 
 def main():
@@ -94,17 +83,14 @@ def main():
     upload_electron(github, release, os.path.join(DIST_DIR, PDB_NAME))
 
   # Upload free version of ffmpeg.
-  ffmpeg = 'ffmpeg-{0}-{1}-{2}.zip'.format(
-      ELECTRON_VERSION, get_platform_key(), get_target_arch())
+  ffmpeg = get_zip_name('ffmpeg', ELECTRON_VERSION)
   upload_electron(github, release, os.path.join(DIST_DIR, ffmpeg))
 
   # Upload chromedriver and mksnapshot for minor version update.
   if parse_version(args.version)[2] == '0':
-    chromedriver = 'chromedriver-{0}-{1}-{2}.zip'.format(
-        get_chromedriver_version(), get_platform_key(), get_target_arch())
+    chromedriver = get_zip_name('chromedriver', get_chromedriver_version())
     upload_electron(github, release, os.path.join(DIST_DIR, chromedriver))
-    mksnapshot = 'mksnapshot-{0}-{1}-{2}.zip'.format(
-        ELECTRON_VERSION, get_platform_key(), get_target_arch())
+    mksnapshot = get_zip_name('mksnapshot', ELECTRON_VERSION)
     upload_electron(github, release, os.path.join(DIST_DIR, mksnapshot))
 
   if PLATFORM == 'win32' and not tag_exists:


### PR DESCRIPTION
This pull requests adds the `v7l` suffix to ARM build release assets so they can eventually be disambiguated from future `armv6l` and `arm64` assets that may be produced.

This mirrors the ARM build names that node uses: https://nodejs.org/dist/v4.5.0/

### Example

* Old name: `electron-v1.3.4-linux-arm.zip`
* New name: `electron-v1.3.4-linux-armv7l.zip`

This will be backported to all 1.0+ releases but no old assets will be deleted.

Closes #2343 
Refs #5706