### PR TITLE
[doc] Add support for titleBarStyle hidden on macOS 10.9

### DIFF
--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -21,7 +21,7 @@ win.show()
 
 ### Alternatives on macOS
 
-On macOS 10.10 Yosemite and newer, there's an alternative way to specify
+On macOS 10.9 Mavericks and newer, there's an alternative way to specify
 a chromeless window. Instead of setting `frame` to `false` which disables
 both the titlebar and window controls, you may want to have the title bar
 hidden and your content extend to the full window size, yet still preserve


### PR DESCRIPTION
I just saw a PR, "titleBarStyle: 'hidden'" supports macOS 10.9 now.

See https://github.com/electron/electron/pull/6848 and https://github.com/electron/electron/pull/6848/commits/ab8fd49c72e275fe8fb9697f466546c4bfb156aa for more info.

So I added that to the doc.