### PR TITLE
Don't serialize external values over IPC

### DIFF
--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -393,19 +393,6 @@ base::Value* V8ValueConverter::FromV8Object(
   std::unique_ptr<base::DictionaryValue> result(new base::DictionaryValue());
   v8::Local<v8::Array> property_names(val->GetOwnPropertyNames());
 
-  // Don't consider DOM objects. This check matches isHostObject() in Blink's
-  // bindings/v8/V8Binding.h used in structured cloning. It reads:
-  //
-  // If the object has any internal fields, then we won't be able to serialize
-  // or deserialize them; conveniently, this is also a quick way to detect DOM
-  // wrapper objects, because the mechanism for these relies on data stored in
-  // these fields.
-  //
-  // ANOTHER NOTE: returning an empty dictionary here to minimise surprise.
-  // See also http://crbug.com/330559.
-  if (val->InternalFieldCount())
-    return result.release();
-
   for (uint32_t i = 0; i < property_names->Length(); ++i) {
     v8::Local<v8::Value> key(property_names->Get(i));
 
@@ -427,6 +414,11 @@ base::Value* V8ValueConverter::FromV8Object(
                  << " threw an exception.";
       child_v8 = v8::Null(isolate);
     }
+
+    // Ignore external values since calling CreationContext() on them can
+    // crash
+    if (child_v8->IsExternal())
+      continue;
 
     std::unique_ptr<base::Value> child(
         FromV8ValueImpl(state, child_v8, isolate));

--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -262,6 +262,9 @@ base::Value* V8ValueConverter::FromV8ValueImpl(
   if (state->HasReachedMaxRecursionDepth())
     return nullptr;
 
+  if (val->IsExternal())
+    return base::Value::CreateNullValue().release();
+
   if (val->IsNull())
     return base::Value::CreateNullValue().release();
 
@@ -414,11 +417,6 @@ base::Value* V8ValueConverter::FromV8Object(
                  << " threw an exception.";
       child_v8 = v8::Null(isolate);
     }
-
-    // Ignore external values since calling CreationContext() on them can
-    // crash
-    if (child_v8->IsExternal())
-      continue;
 
     std::unique_ptr<base::Value> child(
         FromV8ValueImpl(state, child_v8, isolate));

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1256,7 +1256,7 @@ describe('browser-window module', function () {
     })
 
     it('works with result objects that have DOM class prototypes', function (done) {
-       w.webContents.executeJavaScript('document.location', function (result) {
+      w.webContents.executeJavaScript('document.location', function (result) {
         assert.equal(result.origin, server.url)
         assert.equal(result.protocol, 'http:')
         done()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1255,9 +1255,10 @@ describe('browser-window module', function () {
       w.loadURL(server.url)
     })
 
-    it('converts DOM objects to empty objects', function (done) {
-      w.webContents.executeJavaScript('document.location', function (result) {
-        assert.deepEqual(result, {})
+    it('works with result objects that have DOM class prototypes', function (done) {
+       w.webContents.executeJavaScript('document.location', function (result) {
+        assert.equal(result.origin, server.url)
+        assert.equal(result.protocol, 'http:')
         done()
       })
       w.loadURL(server.url)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1255,10 +1255,9 @@ describe('browser-window module', function () {
       w.loadURL(server.url)
     })
 
-    it('works with result objects that have DOM class prototypes', function (done) {
+    it('converts DOM objects to empty objects', function (done) {
       w.webContents.executeJavaScript('document.location', function (result) {
-        assert.equal(result.origin, server.url)
-        assert.equal(result.protocol, 'http:')
+        assert.deepEqual(result, {})
         done()
       })
       w.loadURL(server.url)

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -338,13 +338,16 @@ describe('ipc module', function () {
 
     it('does not crash on external objects (regression)', function (done) {
       const request = http.request({port: 5000, hostname: '127.0.0.1', method: 'GET', path: '/'})
+      const stream = request.agent.sockets['127.0.0.1:5000:'][0]._handle._externalStream
       request.on('error', function () {})
-      ipcRenderer.once('message', function (event, value) {
-        assert.equal(value.method, 'GET')
-        assert.equal(value.path, '/')
+      ipcRenderer.once('message', function (event, requestValue, externalStreamValue) {
+        assert.equal(requestValue.method, 'GET')
+        assert.equal(requestValue.path, '/')
+        assert.equal(externalStreamValue, null)
         done()
       })
-      ipcRenderer.send('message', request)
+
+      ipcRenderer.send('message', request, stream)
     })
 
     it('can send objects that both reference the same object', function (done) {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -327,6 +327,15 @@ describe('ipc module', function () {
       ipcRenderer.send('message', document.location)
     })
 
+    it('can send Electron API objects', function (done) {
+      const webContents = remote.getCurrentWebContents()
+      ipcRenderer.once('message', function (event, value) {
+        assert.deepEqual(value.browserWindowOptions, webContents.browserWindowOptions)
+        done()
+       })
+      ipcRenderer.send('message', webContents)
+    })
+
     it('does not crash on HTTP request objects (regression)', function (done) {
       const request = http.request({port: 5000, hostname: '127.0.0.1', method: 'GET', path: '/'})
       request.on('error', function () {})

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -328,6 +328,7 @@ describe('ipc module', function () {
 
     it('does not crash on HTTP request objects (regression)', function (done) {
       const request = http.request({port: 5000, hostname: '127.0.0.1', method: 'GET', path: '/'})
+      request.on('error', function () {})
       ipcRenderer.once('message', function (event, value) {
         assert.equal(value.method, 'GET')
         assert.equal(value.path, '/')

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -317,10 +317,9 @@ describe('ipc module', function () {
       ipcRenderer.send('message', buffer)
     })
 
-    it('can send objects with DOM class prototypes', function (done) {
+    it('converts DOM objects to empty objects', function (done) {
       ipcRenderer.once('message', function (event, value) {
-        assert.equal(value.protocol, 'file:')
-        assert.equal(value.hostname, '')
+        assert.deepEqual(value, {})
         done()
       })
       ipcRenderer.send('message', document.location)

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -362,6 +362,25 @@ describe('ipc module', function () {
       })
       ipcRenderer.send('message', array, foo, bar, child)
     })
+
+    it('inserts null for cyclic references', function (done) {
+      const array = [5]
+      array.push(array)
+
+      const child = {hello: 'world'}
+      child.child = child
+
+      ipcRenderer.once('message', function (event, arrayValue, childValue) {
+        assert.equal(arrayValue[0], 5)
+        assert.equal(arrayValue[1], null)
+
+        assert.equal(childValue.hello, 'world')
+        assert.equal(childValue.child, null)
+
+        done()
+      })
+      ipcRenderer.send('message', array, child)
+    })
   })
 
   describe('ipc.sendSync', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -332,11 +332,11 @@ describe('ipc module', function () {
       ipcRenderer.once('message', function (event, value) {
         assert.deepEqual(value.browserWindowOptions, webContents.browserWindowOptions)
         done()
-       })
+      })
       ipcRenderer.send('message', webContents)
     })
 
-    it('does not crash on HTTP request objects (regression)', function (done) {
+    it('does not crash on external objects (regression)', function (done) {
       const request = http.request({port: 5000, hostname: '127.0.0.1', method: 'GET', path: '/'})
       request.on('error', function () {})
       ipcRenderer.once('message', function (event, value) {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const http = require('http')
 const path = require('path')
 const {closeWindow} = require('./window-helpers')
 
@@ -323,6 +324,16 @@ describe('ipc module', function () {
         done()
       })
       ipcRenderer.send('message', document.location)
+    })
+
+    it('does not crash on HTTP request objects (regression)', function (done) {
+      const request = http.request({port: 5000, hostname: '127.0.0.1', method: 'GET', path: '/'})
+      ipcRenderer.once('message', function (event, value) {
+        assert.equal(value.method, 'GET')
+        assert.equal(value.path, '/')
+        done()
+      })
+      ipcRenderer.send('message', request)
     })
 
     it('can send objects that both reference the same object', function (done) {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -323,7 +323,7 @@ describe('ipc module', function () {
         assert.equal(value.protocol, 'file:')
         assert.equal(value.hostname, '')
         done()
-       })
+      })
       ipcRenderer.send('message', document.location)
     })
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -318,11 +318,12 @@ describe('ipc module', function () {
       ipcRenderer.send('message', buffer)
     })
 
-    it('converts DOM objects to empty objects', function (done) {
+    it('can send objects with DOM class prototypes', function (done) {
       ipcRenderer.once('message', function (event, value) {
-        assert.deepEqual(value, {})
+        assert.equal(value.protocol, 'file:')
+        assert.equal(value.hostname, '')
         done()
-      })
+       })
       ipcRenderer.send('message', document.location)
     })
 


### PR DESCRIPTION
While looking into the crash in #6992 introduced via #6776, I came across https://chromium.googlesource.com/chromium/src/+/0af364dd5cac55192409e88cbb47cb8ce4209683 which states:

> Don't serialize any DOM objects in V8ValueConverter, it can be extremely slow.
There have been several attempts to implement this in the past, but none have
actually stuck for various reasons. This patch uses the same technique that
Blink has for structured cloning.

It looks like removing the `HasRealNamedCallbackProperty` to get this working initially in #6776 has caused certain objects, specifically the `http.ClientRequest` object in Node to now cause crashes when serialized over IPC.

This pull requests adds a `InternalFieldCount` check that prevents the crash but also removes support for DOM objects over IPC.

I'm not sure if there is another way to fix this to keep DOM objects working but prevent the crashes since the stack trace for the current crash is pretty deep in v8: https://cs.chromium.org/chromium/src/v8/src/objects.cc?l=2981