### PR TITLE
Port --debug-brk support to Node 6.3.0

### DIFF
--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -34,11 +34,6 @@ void JavascriptEnvironment::OnMessageLoopDestroying() {
 
 bool JavascriptEnvironment::Initialize() {
   auto cmd = base::CommandLine::ForCurrentProcess();
-  if (cmd->HasSwitch("debug-brk")) {
-    // Need to be called before v8::Initialize().
-    const char expose_debug_as[] = "--expose_debug_as=v8debug";
-    v8::V8::SetFlagsFromString(expose_debug_as, sizeof(expose_debug_as) - 1);
-  }
 
   // --js-flags.
   std::string js_flags = cmd->GetSwitchValueASCII(switches::kJavaScriptFlags);

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -186,7 +186,10 @@ node::Environment* NodeBindings::CreateEnvironment(
   PathService::Get(content::CHILD_PROCESS_EXE, &helper_exec_path);
   process.Set("helperExecPath", helper_exec_path);
 
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch("debug-brk"))
+  // Set process._debugWaitConnect if --debug-brk was specified to stop
+  // the debugger on the first line
+  if (is_browser_ &&
+      base::CommandLine::ForCurrentProcess()->HasSwitch("debug-brk"))
     process.Set("_debugWaitConnect", true);
 
   return env;

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -185,6 +185,10 @@ node::Environment* NodeBindings::CreateEnvironment(
   base::FilePath helper_exec_path;
   PathService::Get(content::CHILD_PROCESS_EXE, &helper_exec_path);
   process.Set("helperExecPath", helper_exec_path);
+
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("debug-brk"))
+    process.Set("_debugWaitConnect", true);
+
   return env;
 }
 


### PR DESCRIPTION
In commit https://github.com/nodejs/node/commit/4d4cfb27ca7718c7df381ac3b257175927cd17d1, some changes were made to how Node supports the `--debug-brk` flag that caused Electron's support for it to stop working in 1.3.0+.

From that commit's message:

> Do not depend on the existence of global.v8debug as a mechanism to
  determine if --debug-brk was specified.

Excerpts from that commit's diff:

```diff
-  if (debug_wait_connect) {
-    const char expose_debug_as[] = "--expose_debug_as=v8debug";
-    V8::SetFlagsFromString(expose_debug_as, sizeof(expose_debug_as) - 1);
-  }
```

```diff
+  // --debug-brk
+  if (debug_wait_connect) {
+    READONLY_PROPERTY(process, "_debugWaitConnect", True(env->isolate()));
+  }
```

```diff
-        if (global.v8debug &&
+        if (process._debugWaitConnect &&
```

```diff
-      global.v8debug.Debug.setListener(function() {});
-      global.v8debug.Debug.setBreakPoint(compiledWrapper, 0, 0);
+      delete process._debugWaitConnect;
+      const Debug = vm.runInDebugContext('Debug');
+      Debug.setBreakPoint(compiledWrapper, 0, 0);
```

This pull request sets `process._debugWaitConnect` to `true` when `--debug-brk` is specified on the command line and removes setting `--expose_debug_as=v8debug` which is no longer used by Node.

Screenshot of `npm start -- --debug-brk` working on master 👇 
<img width="1280" alt="screen shot 2016-08-26 at 12 14 41 pm" src="https://cloud.githubusercontent.com/assets/671378/18017517/b41cec0e-6b86-11e6-8f44-823c728df0c0.png">

Closes #6608 