### PR TITLE
exit tab fullscreen on destroy

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -775,6 +775,8 @@ bool WebContents::OnMessageReceived(const IPC::Message& message) {
 // be destroyed on close, and WebContentsDestroyed would be called for it, so
 // we need to make sure the api::WebContents is also deleted.
 void WebContents::WebContentsDestroyed() {
+  // clear out tab fullscreen state
+  ExitFullscreenModeForTab(web_contents());
   // This event is only for internal use, which is emitted when WebContents is
   // being destroyed.
   Emit("will-destroy");


### PR DESCRIPTION
fixes main window remaining in fullscreen when a webview in html fullscreen is removed