### PR TITLE
Send notification info to app.ready, on macOS

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -274,8 +274,8 @@ void App::OnWillFinishLaunching() {
   Emit("will-finish-launching");
 }
 
-void App::OnFinishLaunching() {
-  Emit("ready");
+void App::OnFinishLaunching(const base::DictionaryValue& launch_info) {
+  Emit("ready", launch_info);
 }
 
 void App::OnAccessibilitySupportChanged() {

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -69,7 +69,7 @@ class App : public AtomBrowserClient::Delegate,
   void OnOpenURL(const std::string& url) override;
   void OnActivate(bool has_visible_windows) override;
   void OnWillFinishLaunching() override;
-  void OnFinishLaunching() override;
+  void OnFinishLaunching(const base::DictionaryValue& launch_info) override;
   void OnLogin(LoginHandler* login_handler,
                const base::DictionaryValue& request_details) override;
   void OnAccessibilitySupportChanged() override;

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -156,7 +156,8 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
 #if !defined(OS_MACOSX)
   // The corresponding call in macOS is in AtomApplicationDelegate.
   Browser::Get()->WillFinishLaunching();
-  Browser::Get()->DidFinishLaunching();
+  base::DictionaryValue* empty_info = new base::DictionaryValue();
+  Browser::Get()->DidFinishLaunching(empty_info);
 #endif
 }
 

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -156,7 +156,7 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
 #if !defined(OS_MACOSX)
   // The corresponding call in macOS is in AtomApplicationDelegate.
   Browser::Get()->WillFinishLaunching();
-  base::DictionaryValue* empty_info = new base::DictionaryValue();
+  std::unique_ptr<base::DictionaryValue> empty_info(new base::DictionaryValue);
   Browser::Get()->DidFinishLaunching(*empty_info);
 #endif
 }

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -157,7 +157,7 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
   // The corresponding call in macOS is in AtomApplicationDelegate.
   Browser::Get()->WillFinishLaunching();
   base::DictionaryValue* empty_info = new base::DictionaryValue();
-  Browser::Get()->DidFinishLaunching(empty_info);
+  Browser::Get()->DidFinishLaunching(*empty_info);
 #endif
 }
 

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -148,14 +148,14 @@ void Browser::WillFinishLaunching() {
   FOR_EACH_OBSERVER(BrowserObserver, observers_, OnWillFinishLaunching());
 }
 
-void Browser::DidFinishLaunching() {
+void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
   // Make sure the userData directory is created.
   base::FilePath user_data;
   if (PathService::Get(brightray::DIR_USER_DATA, &user_data))
     base::CreateDirectoryAndGetError(user_data, nullptr);
 
   is_ready_ = true;
-  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnFinishLaunching());
+  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnFinishLaunching(launch_info));
 }
 
 void Browser::OnAccessibilitySupportChanged() {

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -155,7 +155,8 @@ void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
     base::CreateDirectoryAndGetError(user_data, nullptr);
 
   is_ready_ = true;
-  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnFinishLaunching(launch_info));
+  FOR_EACH_OBSERVER(BrowserObserver, observers_,
+    OnFinishLaunching(launch_info));
 }
 
 void Browser::OnAccessibilitySupportChanged() {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -184,7 +184,7 @@ class Browser : public WindowListObserver {
 
   // Tell the application the loading has been done.
   void WillFinishLaunching();
-  void DidFinishLaunching();
+  void DidFinishLaunching(const base::DictionaryValue& launch_info);
 
   void OnAccessibilitySupportChanged();
 

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -46,7 +46,7 @@ class BrowserObserver {
 
   // The browser has finished loading.
   virtual void OnWillFinishLaunching() {}
-  virtual void OnFinishLaunching() {}
+  virtual void OnFinishLaunching(const base::DictionaryValue& launch_info) {}
 
   // The browser requests HTTP login.
   virtual void OnLogin(LoginHandler* login_handler,

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -32,8 +32,8 @@
       atom::NSDictionaryToDictionaryValue(user_notification.userInfo);
     atom::Browser::Get()->DidFinishLaunching(*launch_info);
   } else {
-    base::DictionaryValue* launch_info = new base::DictionaryValue();
-    atom::Browser::Get()->DidFinishLaunching(*launch_info);
+    std::unique_ptr<base::DictionaryValue> empty_info(new base::DictionaryValue);
+    atom::Browser::Get()->DidFinishLaunching(*empty_info);
   }
 }
 

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -25,7 +25,16 @@
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification*)notify {
-  atom::Browser::Get()->DidFinishLaunching();
+  NSUserNotification *user_notification = [notify userInfo][(id)@"NSApplicationLaunchUserNotificationKey"];
+
+  if (user_notification.userInfo != nil) {
+    std::unique_ptr<base::DictionaryValue> launch_info =
+      atom::NSDictionaryToDictionaryValue(user_notification.userInfo);
+    atom::Browser::Get()->DidFinishLaunching(*launch_info);
+  } else {
+    base::DictionaryValue* launch_info = new base::DictionaryValue();
+    atom::Browser::Get()->DidFinishLaunching(*launch_info);
+  }
 }
 
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
@@ -64,7 +73,7 @@ continueUserActivity:(NSUserActivity*)userActivity
   restorationHandler:(void (^)(NSArray*restorableObjects))restorationHandler {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
   std::unique_ptr<base::DictionaryValue> user_info =
-      atom::NSDictionaryToDictionaryValue(userActivity.userInfo);
+    atom::NSDictionaryToDictionaryValue(userActivity.userInfo);
   if (!user_info)
     return NO;
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -28,7 +28,13 @@ In most cases, you should just do everything in the `ready` event handler.
 
 ### Event: 'ready'
 
-Emitted when Electron has finished initialization.
+Returns:
+
+* `launchInfo` Object _macOS_
+
+Emitted when Electron has finished initialization. On macOS, `launchInfo` holds
+the `userInfo` of the `NSUserNotification` that was used to open the application,
+if it was launched from Notification Center.
 
 ### Event: 'window-all-closed'
 


### PR DESCRIPTION
This PR is an attempt to address https://github.com/electron/brightray/issues/168. Rather than clear out all notifications, we'll check for the `NSApplicationLaunchUserNotificationKey` and if found, send any notification arguments stashed in `userInfo` to the `app.ready` event. For Windows & Linux, this will always be an empty dictionary.