### PR TITLE
added setExtraParameters to crashReporter

### DIFF
--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -39,6 +39,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                  base::Bind(&CrashReporter::Start, report));
   dict.SetMethod("_getUploadedReports",
                  base::Bind(&CrashReporter::GetUploadedReports, report));
+  dict.SetMethod("setExtraParameters",
+                 base::Bind(&CrashReporter::SetExtraParameters, report));
 }
 
 }  // namespace

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -42,6 +42,10 @@ void CrashReporter::SetUploadParameters(const StringMap& parameters) {
   SetUploadParameters();
 }
 
+void CrashReporter::SetExtraParameters(const StringMap& parameters) {
+  SetUploadParameters(parameters);
+}
+
 std::vector<CrashReporter::UploadReportResult>
 CrashReporter::GetUploadedReports(const std::string& path) {
   std::string file_content;

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -31,6 +31,8 @@ class CrashReporter {
   virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports(
       const std::string& path);
 
+  void SetExtraParameters(const StringMap& parameters);
+
  protected:
   CrashReporter();
   virtual ~CrashReporter();

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -36,7 +36,7 @@ The `crash-reporter` module has the following methods:
     Default is `true`.
   * `ignoreSystemCrashHandler` Boolean - Default is `false`.
   * `extra` Object - An object you can define that will be sent along with the
-    report. Only string properties are sent correctly, Nested objects are not
+    report. Only string properties are sent correctly. Nested objects are not
     supported.
 
 You are required to call this method before using other `crashReporter`
@@ -61,7 +61,7 @@ ID.
 ### `crashReporter.setExtraParameters(extra)`
 
 * `extra` Object - An object you can define that will be sent along with the
-  report. Only string properties are sent correctly, Nested objects are not
+  report. Only string properties are sent correctly. Nested objects are not
   supported.
 
 Updates the extra value that will be sent along with the report. This allows

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -58,6 +58,17 @@ sent or the crash reporter has not been started, `null` is returned.
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.
 
+### `crashReporter.setExtraParameters(extra)`
+
+* `extra` Object - An object you can define that will be sent along with the
+  report. Only string properties are sent correctly, Nested objects are not
+  supported.
+
+Updates the extra value that will be sent along with the report. This allows
+you to add extra data while the crashReporter is already started. It could be
+possible that you did not have access to certain data while you wanted to start
+the crashReporter.
+
 ## crash-reporter Payload
 
 The crash reporter will send the following data to the `submitURL` as

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -82,6 +82,10 @@ var CrashReporter = (function () {
     return binding._getUploadedReports(log)
   }
 
+  CrashReporter.prototype.setExtraParameters = function (extra) {
+    return binding.setExtraParameters(extra)
+  }
+
   return CrashReporter
 })()
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -50,6 +50,7 @@ describe('crashReporter module', function () {
         assert.equal(fields['platform'], process.platform)
         assert.equal(fields['extra1'], 'extra1')
         assert.equal(fields['extra2'], 'extra2')
+        assert.equal(fields['extra3'], 'extra3')
         assert.equal(fields['_productName'], 'Zombies')
         assert.equal(fields['_companyName'], 'Umbrella Corporation')
         assert.equal(fields['_version'], app.getVersion())

--- a/spec/fixtures/api/crash.html
+++ b/spec/fixtures/api/crash.html
@@ -15,6 +15,12 @@ crashReporter.start({
   }
 });
 
+crashReporter.setExtraParameters({
+    'extra1': 'extra1',
+    'extra2': 'extra2',
+    'extra3': 'extra3'
+})
+
 setImmediate(function() { process.crash(); });
 </script>
 </body>


### PR DESCRIPTION
We want to send along the logged in user in our application when submitting a crash report.
But we want to start the crash report directly on start so we wont miss any crashes.

When we load our website we can get the logged in user from the loaded website and add that info to the extra_parameters of the crashReporter. This was not possible so i've added it.

![screen shot 2016-09-02 at 17 08 35](https://cloud.githubusercontent.com/assets/951290/18208466/e5c42d72-712f-11e6-8951-b0f7e0043adb.png)
