### PR TITLE
Prevent circular Menu require

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const {EventEmitter} = require('events')
-const {app, ipcMain, session, Menu, NavigationController} = require('electron')
+const electron = require('electron')
+const {app, ipcMain, session, NavigationController} = electron
 
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
@@ -220,7 +221,8 @@ WebContents.prototype._init = function () {
 
   // Handle context menu action request from pepper plugin.
   this.on('pepper-context-menu', function (event, params) {
-    const menu = Menu.buildFromTemplate(params.menu)
+    // Access Menu via electron.Menu to prevent circular require
+    const menu = electron.Menu.buildFromTemplate(params.menu)
     menu.popup(params.x, params.y)
   })
 


### PR DESCRIPTION
https://github.com/electron/electron/pull/6480 added requiring `webContents` from `Menu` which caused a circular require causing the `Menu.buildFromTemplate` function to be missing which was used by the pepper flash context menu.

This pull request accesses `Menu` from `webContents` via `electron.Menu` so that the function is available once the require loop completes.

Closes #7086 