### PR TITLE
Delete Buffer global when node integration is disabled

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -2,6 +2,7 @@ const {app, ipcMain, webContents, BrowserWindow} = require('electron')
 const {getAllWebContents} = process.atomBinding('web_contents')
 const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllWebContents()
 
+const {Buffer} = require('buffer')
 const fs = require('fs')
 const path = require('path')
 const url = require('url')

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const {Buffer} = require('buffer')
 const fs = require('fs')
 const path = require('path')
 const util = require('util')

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const {Buffer} = require('buffer')
 const electron = require('electron')
 const v8Util = process.atomBinding('v8_util')
 const {ipcMain, isPromise, webContents} = electron

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -1,5 +1,6 @@
 (function () {
   const asar = process.binding('atom_common_asar')
+  const {Buffer} = require('buffer')
   const childProcess = require('child_process')
   const path = require('path')
   const util = require('util')

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const {Buffer} = require('buffer')
 const v8Util = process.atomBinding('v8_util')
 const {ipcRenderer, isPromise, CallbacksRegistry} = require('electron')
 

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -123,7 +123,8 @@ if (nodeIntegration === 'true') {
     delete global.process
     delete global.setImmediate
     delete global.clearImmediate
-    return delete global.global
+    delete global.Buffer
+    delete global.global
   })
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -547,8 +547,9 @@ describe('browser-window module', function () {
     describe('"node-integration" option', function () {
       it('disables node integration when specified to false', function (done) {
         var preload = path.join(fixtures, 'module', 'send-later.js')
-        ipcMain.once('answer', function (event, test) {
-          assert.equal(test, 'undefined')
+        ipcMain.once('answer', function (event, typeofProcess, typeofBuffer) {
+          assert.equal(typeofProcess, 'undefined')
+          assert.equal(typeofBuffer, 'undefined')
           done()
         })
         w.destroy()

--- a/spec/fixtures/module/preload-node-off.js
+++ b/spec/fixtures/module/preload-node-off.js
@@ -1,6 +1,6 @@
 setImmediate(function () {
   try {
-    console.log([typeof process, typeof setImmediate, typeof global].join(' '))
+    console.log([typeof process, typeof setImmediate, typeof global, typeof Buffer].join(' '))
   } catch (e) {
     console.log(e.message)
   }

--- a/spec/fixtures/module/preload.js
+++ b/spec/fixtures/module/preload.js
@@ -1,1 +1,1 @@
-console.log([typeof require, typeof module, typeof process].join(' '))
+console.log([typeof require, typeof module, typeof process, typeof Buffer].join(' '))

--- a/spec/fixtures/module/send-later.js
+++ b/spec/fixtures/module/send-later.js
@@ -1,4 +1,4 @@
 var ipcRenderer = require('electron').ipcRenderer
 window.onload = function () {
-  ipcRenderer.send('answer', typeof window.process)
+  ipcRenderer.send('answer', typeof window.process, typeof window.Buffer)
 }

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -148,7 +148,7 @@ describe('<webview> tag', function () {
   describe('preload attribute', function () {
     it('loads the script before other scripts in window', function (done) {
       var listener = function (e) {
-        assert.equal(e.message, 'function object object')
+        assert.equal(e.message, 'function object object function')
         webview.removeEventListener('console-message', listener)
         done()
       }
@@ -158,9 +158,9 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
-    it('preload script can still use "process" in required modules when nodeintegration is off', function (done) {
+    it('preload script can still use "process" and "Buffer" in required modules when nodeintegration is off', function (done) {
       webview.addEventListener('console-message', function (e) {
-        assert.equal(e.message, 'object undefined object')
+        assert.equal(e.message, 'object undefined object function')
         done()
       })
       webview.setAttribute('preload', fixtures + '/module/preload-node-off.js')
@@ -189,7 +189,7 @@ describe('<webview> tag', function () {
 
     it('works without script tag in page', function (done) {
       var listener = function (e) {
-        assert.equal(e.message, 'function object object')
+        assert.equal(e.message, 'function object object function')
         webview.removeEventListener('console-message', listener)
         done()
       }


### PR DESCRIPTION
This pull request deletes the [`Buffer`](https://nodejs.org/api/buffer.html) global when node integration is disabled.

It also switches places using that global to use a `const {Buffer} = require('buffer')` instead.

It seems expected that `Buffer` would be unavailable when node integration is disabled since it is a node global but I'm curious what others think.

This pull request does run the risk of breaking existing apps that were previously relying on this global (accidentally or deliberately) so perhaps this should wait for Electron 2.0.

/cc @electron/maintainers 

Closes #7081