### PR TITLE
Restore process.noAsar in finally block

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -675,9 +675,11 @@
       childProcess[functionName] = function () {
         const processNoAsarOriginalValue = process.noAsar
         process.noAsar = true
-        const result = old.apply(this, arguments)
-        process.noAsar = processNoAsarOriginalValue
-        return result
+        try {
+          return old.apply(this, arguments)
+        } finally {
+          process.noAsar = processNoAsarOriginalValue
+        }
       }
     })
 

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -744,6 +744,14 @@ describe('asar package', function () {
           fs.readdirSync(asar)
         }, /ENOTDIR/)
       })
+
+      it('is reset to its original value when execSync throws an error', function () {
+        process.noAsar = false
+        assert.throws(function () {
+          ChildProcess.execSync(path.join(__dirname, 'does-not-exist.txt'))
+        })
+        assert.equal(process.noAsar, false)
+      })
     })
   })
 


### PR DESCRIPTION
Previously is `execSync` threw an error the value of `process.noAsar` would be left as `true` instead of reset to its original value.

Closes #7011 