### PR TITLE
Supports Object and Array for `extraHeaders` option in loadURL

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -959,7 +959,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
 * `options` Object (optional)
   * `httpReferrer` String - A HTTP Referrer url.
   * `userAgent` String - A user agent originating the request.
-  * `extraHeaders` String - Extra headers separated by "\n"
+  * `extraHeaders` String|Array[Array]|Object - Extra headers
 
 Same as `webContents.loadURL(url[, options])`.
 

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -64,10 +64,12 @@ var NavigationController = (function () {
     this.pendingIndex = -1
     if (options.hasOwnProperty('extraHeaders')) {
       let extraHeaders = options['extraHeaders']
-      if (typeof extraHeaders === "object") {
+      if (typeof extraHeaders === 'object') {
         let newExtraHeaders = []
-        for (let key in extraHeaders) if (extraHeaders.hasOwnProperty(key)) {
-          newExtraHeaders.push([key, extraHeaders[key]])
+        for (let key in extraHeaders) {
+          if (extraHeaders.hasOwnProperty(key)) {
+            newExtraHeaders.push([key, extraHeaders[key]])
+          }
         }
         extraHeaders = newExtraHeaders
       }
@@ -75,7 +77,7 @@ var NavigationController = (function () {
         // Escape header values for security:
         //   replace LWS with a single SP
         //   remove CR and LF since the char is invalid here
-        extraHeaders = extraHeaders.map(pair => pair.map(v => v.replace(/\015\012[\040\011]/g, " ").replace(/[\015\012]/g, "")).join(": ")).join("\n")
+        extraHeaders = extraHeaders.map(pair => pair.map(v => v.replace(/\015\012[\040\011]/g, ' ').replace(/[\015\012]/g, '')).join(': ')).join('\n')
       }
       options['extraHeaders'] = extraHeaders
     }

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -58,10 +58,27 @@ var NavigationController = (function () {
   }
 
   NavigationController.prototype.loadURL = function (url, options) {
-    if (options == null) {
+    if (!options) {
       options = {}
     }
     this.pendingIndex = -1
+    if (options.hasOwnProperty('extraHeaders')) {
+      let extraHeaders = options['extraHeaders']
+      if (typeof extraHeaders === "object") {
+        let newExtraHeaders = []
+        for (let key in extraHeaders) if (extraHeaders.hasOwnProperty(key)) {
+          newExtraHeaders.push([key, extraHeaders[key]])
+        }
+        extraHeaders = newExtraHeaders
+      }
+      if (Array.isArray(extraHeaders)) {
+        // Escape header values for security:
+        //   replace LWS with a single SP
+        //   remove CR and LF since the char is invalid here
+        extraHeaders = extraHeaders.map(pair => pair.map(v => v.replace(/\015\012[\040\011]/g, " ").replace(/[\015\012]/g, "")).join(": ")).join("\n")
+      }
+      options['extraHeaders'] = extraHeaders
+    }
     this.webContents._loadURL(url, options)
     return this.webContents.emit('load-url', url, options)
   }

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -58,7 +58,7 @@ var NavigationController = (function () {
   }
 
   NavigationController.prototype.loadURL = function (url, options) {
-    if (!options) {
+    if (options == null) {
       options = {}
     }
     this.pendingIndex = -1


### PR DESCRIPTION
I need it:
```es6
webContents.loadUrl('https://www.example.com', {
  extraHeaders: {
    'Accept-Encoding': 'gzip;q=0,deflate;q=0'
  }
});
```