### PR TITLE
Allow LIBCHROMIUMCONTENT_COMMIT to be overridden from the environment

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -8,7 +8,8 @@ import sys
 
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = 'c5cf295ef93d4ee88bff0c4b06b28ff0969a890e'
+LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
+    'c5cf295ef93d4ee88bff0c4b06b28ff0969a890e'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
For our usecase we would like to specify a custom version of Chromium to include. This commit allows the static definition of LIBCHROMIUMCONTENT_COMMIT in config.py to be optionally overridden with an environment variable.