### PR TITLE
Add EOF process.stdin in  render process

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -39,14 +39,6 @@ if (process.platform === 'win32') {
   }
   console.log = console.error = console.warn = consoleLog
   process.stdout.write = process.stderr.write = streamWrite
-
-  // Always returns EOF for stdin stream.
-  var Readable = require('stream').Readable
-  var stdin = new Readable()
-  stdin.push(null)
-  process.__defineGetter__('stdin', function () {
-    return stdin
-  })
 }
 
 // Don't quit on fatal error.

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -38,11 +38,21 @@ if (process.type === 'browser') {
   global.setInterval = wrapWithActivateUvLoop(timers.setInterval)
 }
 
-// If we're running as a Windows Store app, __dirname will be set
-// to C:/Program Files/WindowsApps.
-//
-// Nobody else get's to install there, changing the path is forbidden
-// We can therefore say that we're running as appx
-if (process.platform === 'win32' && __dirname.indexOf('\\Program Files\\WindowsApps\\') === 2) {
-  process.windowsStore = true
+if (process.platform === 'win32') {
+  // Always returns EOF for stdin stream.
+  const {Readable} = require('stream')
+  const stdin = new Readable()
+  stdin.push(null)
+  process.__defineGetter__('stdin', function () {
+    return stdin
+  })
+
+  // If we're running as a Windows Store app, __dirname will be set
+  // to C:/Program Files/WindowsApps.
+  //
+  // Nobody else get's to install there, changing the path is forbidden
+  // We can therefore say that we're running as appx
+  if (__dirname.indexOf('\\Program Files\\WindowsApps\\') === 2) {
+    process.windowsStore = true
+  }
 }

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -247,10 +247,8 @@ describe('node feature', function () {
       })
     })
 
-    it('does not throw an exception when calling read()', function () {
-      assert.doesNotThrow(function () {
-        assert.equal(process.stdin.read(), null)
-      })
+    it('returns null when read from', function () {
+      assert.equal(process.stdin.read(), null)
     })
   })
 

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -221,18 +221,36 @@ describe('node feature', function () {
   })
 
   describe('process.stdout', function () {
-    it('should not throw exception', function () {
-      process.stdout
+    it('does not throw an exception when accessed', function () {
+      assert.doesNotThrow(function () {
+        process.stdout
+      })
     })
 
-    it('should not throw exception when calling write()', function () {
-      process.stdout.write('test')
+    it('does not throw an exception when calling write()', function () {
+      assert.doesNotThrow(function () {
+        process.stdout.write('test')
+      })
     })
 
     it('should have isTTY defined', function () {
       if (isCI) return
 
       assert.equal(typeof process.stdout.isTTY, 'boolean')
+    })
+  })
+
+  describe('process.stdin', function () {
+    it('does not throw an exception when accessed', function () {
+      assert.doesNotThrow(function () {
+        process.stdin
+      })
+    })
+
+    it('does not throw an exception when calling read()', function () {
+      assert.doesNotThrow(function () {
+        assert.equal(process.stdin.read(), null)
+      })
     })
   })
 


### PR DESCRIPTION
This pull requests moves the `process.stdin` patching from the `browser/init.js` to `common/init.js` so it happens in both the browser and renderer processes on Windows.

This prevents errors accessing and reading from it from the renderer processes.

Previously it would throw a `Implement me. Unknown stdin file type!` when accessed.

Closes #7088 