### PR TITLE
End sheet in parent when closing modal window

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -619,6 +619,7 @@ NativeWindowMac::~NativeWindowMac() {
 void NativeWindowMac::Close() {
   // When this is a sheet showing, performClose won't work.
   if (is_modal() && parent() && IsVisible()) {
+    [parent()->GetNativeWindow() endSheet:window_];
     CloseImmediately();
     return;
   }


### PR DESCRIPTION
Call `endSheet` on parent when explicitly closing modal window so that other sheets (like message boxes) can be shown on the parent in the future.

Closes #6293