### PR TITLE
Upgrade Travis node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ git:
 notifications:
   email: false
 
-language: cpp
-compiler: clang
+language: node_js
+node_js:
+  - "4"
 os:
   - linux
   - osx
 env:
   - TARGET_ARCH=x64
-osx_image: xcode7
+osx_image: xcode7.3
 
 matrix:
   include:


### PR DESCRIPTION
Experimenting with upgrading the version of node Travis builds with.

- Switches to use `node_js` workers instead of `cpp` workers for easier node version management
- Upgrade to `xcode7.3` osx workers since they have `nvm` pre-installed