### PR TITLE
fix a bug in navigation-controller where string is used as object

### DIFF
--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -50,7 +50,7 @@ var NavigationController = (function () {
         this.history = this.history.slice(0, this.currentIndex + 1)
         currentEntry = this.history[this.currentIndex]
 
-        if ((currentEntry != null ? currentEntry : void 0) !== url) {
+        if (currentEntry !== url) {
           this.currentIndex++
           this.history.push(url)
         }

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -49,9 +49,10 @@ var NavigationController = (function () {
         // Normal navigation. Clear history.
         this.history = this.history.slice(0, this.currentIndex + 1)
         currentEntry = this.history[this.currentIndex]
-        if ((currentEntry != null ? currentEntry.url : void 0) !== url) {
+
+        if ((currentEntry != null ? currentEntry : void 0) !== url) {
           this.currentIndex++
-          return this.history.push(url)
+          this.history.push(url)
         }
       }
     })


### PR DESCRIPTION
`currentEntry` is taken from string array `this.history`. It represents an url string but not an object. The field `currentEntry.url` should not be accessible by any means. I believe this was a coding error made by mistake. This PR fixes this bug.
This PR also removes `return` statement from the callback in order to keep consistency.