### PR TITLE
Fix windows spec failures

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -31,7 +31,7 @@ The `crash-reporter` module has the following methods:
 * `options` Object
   * `companyName` String
   * `submitURL` String - URL that crash reports will be sent to as POST.
-  * `productName` String (optional) - Default is `Electron`.
+  * `productName` String (optional) - Defaults to `app.getName()`.
   * `autoSubmit` Boolean - Send the crash report without user interaction.
     Default is `true`.
   * `ignoreSystemCrashHandler` Boolean - Default is `false`.

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -236,10 +236,11 @@ describe('node feature', function () {
     it('should have isTTY defined on Mac and Linux', function () {
       if (isCI) return
 
-      if (process.platform === 'win32')
+      if (process.platform === 'win32') {
         assert.equal(process.stdout.isTTY, undefined)
-      else
+      } else {
         assert.equal(typeof process.stdout.isTTY, 'boolean')
+      }
     })
   })
 

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -233,10 +233,13 @@ describe('node feature', function () {
       })
     })
 
-    it('should have isTTY defined', function () {
+    it('should have isTTY defined on Mac and Linux', function () {
       if (isCI) return
 
-      assert.equal(typeof process.stdout.isTTY, 'boolean')
+      if (process.platform === 'win32')
+        assert.equal(process.stdout.isTTY, undefined)
+      else
+        assert.equal(typeof process.stdout.isTTY, 'boolean')
     })
   })
 

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -3,6 +3,7 @@ process.throwDeprecation = true
 
 const electron = require('electron')
 const app = electron.app
+const crashReporter = electron.crashReporter
 const ipcMain = electron.ipcMain
 const dialog = electron.dialog
 const BrowserWindow = electron.BrowserWindow
@@ -38,6 +39,11 @@ console
 ipcMain.on('message', function (event, ...args) {
   event.sender.send('message', ...args)
 })
+
+// Set productName so getUploadedReports() uses the right directory in specs
+if (process.platform === 'win32') {
+  crashReporter.productName = 'Zombies'
+}
 
 // Write output to file if OUTPUT_TO_FILE is defined.
 const outputToFile = process.env.OUTPUT_TO_FILE


### PR DESCRIPTION
This pull request address two spec failures currently happening when running the specs on Windows not in CI mode.

```
crashReporter module
  should send minidump when renderer crashes

process.stdout
  should have isTTY defined
```

/cc @Haacked 