### PR TITLE
Get specs passing on displays using certain device scale factors

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1359,3 +1359,33 @@ describe('browser-window module', function () {
     })
   })
 })
+
+const assertPositionsEqual = (expect, actual) => {
+  if (isIntegerScaleFactor()) {
+    assert.deepEqual(expect, actual)
+  } else {
+    assertWithinDelta(expect[0], actual[0], 1, 'x')
+    assertWithinDelta(expect[1], actual[1], 1, 'y')
+  }
+}
+
+const assertBoundsEqual = (expect, actual) => {
+  if (isIntegerScaleFactor()) {
+    assert.deepEqual(expect, actual)
+  } else {
+    assertWithinDelta(expect.x, actual.x, 1, 'x')
+    assertWithinDelta(expect.y, actual.y, 1, 'y')
+    assertWithinDelta(expect.width, actual.width, 1, 'width')
+    assertWithinDelta(expect.height, actual.height, 1, 'height')
+  }
+}
+
+const assertWithinDelta = (expect, actual, delta, label) => {
+  const result = Math.abs(actual[0] - expect[0])
+  assert.ok(result <= delta, `${label} value of ${expect} was not within ${delta} of ${actual}`)
+}
+
+const isIntegerScaleFactor = () => {
+  const {scaleFactor} = screen.getPrimaryDisplay()
+  return Math.round(scaleFactor) === scaleFactor
+}

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1360,21 +1360,21 @@ describe('browser-window module', function () {
   })
 })
 
-const assertBoundsEqual = (expect, actual) => {
+const assertBoundsEqual = (actual, expect) => {
   if (isIntegerScaleFactor()) {
     assert.deepEqual(expect, actual)
   } else if (Array.isArray(actual)) {
-    assertWithinDelta(expect[0], actual[0], 1, 'x')
-    assertWithinDelta(expect[1], actual[1], 1, 'y')
+    assertWithinDelta(actual[0], expect[0], 1, 'x')
+    assertWithinDelta(actual[1], expect[1], 1, 'y')
   } else {
-    assertWithinDelta(expect.x, actual.x, 1, 'x')
-    assertWithinDelta(expect.y, actual.y, 1, 'y')
-    assertWithinDelta(expect.width, actual.width, 1, 'width')
-    assertWithinDelta(expect.height, actual.height, 1, 'height')
+    assertWithinDelta(actual.x, expect.x, 1, 'x')
+    assertWithinDelta(actual.y, expect.y, 1, 'y')
+    assertWithinDelta(actual.width, expect.width, 1, 'width')
+    assertWithinDelta(actual.height, expect.height, 1, 'height')
   }
 }
 
-const assertWithinDelta = (expect, actual, delta, label) => {
+const assertWithinDelta = (actual, expect, delta, label) => {
   const result = Math.abs(actual[0] - expect[0])
   assert.ok(result <= delta, `${label} value of ${expect} was not within ${delta} of ${actual}`)
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -273,9 +273,7 @@ describe('browser-window module', function () {
     it('sets the window size', function (done) {
       var size = [300, 400]
       w.once('resize', function () {
-        var newSize = w.getSize()
-        assert.equal(newSize[0], size[0])
-        assert.equal(newSize[1], size[1])
+        assertBoundsEqual(w.getSize(), size)
         done()
       })
       w.setSize(size[0], size[1])
@@ -288,12 +286,12 @@ describe('browser-window module', function () {
       assert.deepEqual(w.getMaximumSize(), [0, 0])
 
       w.setMinimumSize(100, 100)
-      assert.deepEqual(w.getMinimumSize(), [100, 100])
-      assert.deepEqual(w.getMaximumSize(), [0, 0])
+      assertBoundsEqual(w.getMinimumSize(), [100, 100])
+      assertBoundsEqual(w.getMaximumSize(), [0, 0])
 
       w.setMaximumSize(900, 600)
-      assert.deepEqual(w.getMinimumSize(), [100, 100])
-      assert.deepEqual(w.getMaximumSize(), [900, 600])
+      assertBoundsEqual(w.getMinimumSize(), [100, 100])
+      assertBoundsEqual(w.getMaximumSize(), [900, 600])
     })
   })
 
@@ -303,9 +301,7 @@ describe('browser-window module', function () {
       w.setAspectRatio(1 / 2)
       w.setAspectRatio(0)
       w.once('resize', function () {
-        var newSize = w.getSize()
-        assert.equal(newSize[0], size[0])
-        assert.equal(newSize[1], size[1])
+        assertBoundsEqual(w.getSize(), size)
         done()
       })
       w.setSize(size[0], size[1])
@@ -354,7 +350,7 @@ describe('browser-window module', function () {
     it('sets the content size and position', function (done) {
       var bounds = {x: 10, y: 10, width: 250, height: 250}
       w.once('resize', function () {
-        assert.deepEqual(w.getContentBounds(), bounds)
+        assertBoundsEqual(w.getContentBounds(), bounds)
         done()
       })
       w.setContentBounds(bounds)
@@ -515,9 +511,7 @@ describe('browser-window module', function () {
       size.width += 100
       size.height += 100
       w.setSize(size.width, size.height)
-      var after = w.getSize()
-      assert.equal(after[0], size.width)
-      assert.equal(after[1], size.height)
+      assertBoundsEqual(w.getSize(), [size.width, size.height])
     })
   })
 
@@ -1375,7 +1369,7 @@ const assertBoundsEqual = (actual, expect) => {
 }
 
 const assertWithinDelta = (actual, expect, delta, label) => {
-  const result = Math.abs(actual[0] - expect[0])
+  const result = Math.abs(actual - expect)
   assert.ok(result <= delta, `${label} value of ${expect} was not within ${delta} of ${actual}`)
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1378,7 +1378,7 @@ const assertWithinDelta = (actual, expect, delta, label) => {
 const isScaleFactorRounding = () => {
   const {scaleFactor} = screen.getPrimaryDisplay()
   // Return true if scale factor is non-integer value
-  if (Math.round(scaleFactor) === scaleFactor) return true
+  if (Math.round(scaleFactor) !== scaleFactor) return true
   // Return true if scale factor is odd number above 2
   return scaleFactor > 2 && scaleFactor % 2 === 1
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1355,7 +1355,7 @@ describe('browser-window module', function () {
 })
 
 const assertBoundsEqual = (actual, expect) => {
-  if (isIntegerScaleFactor()) {
+  if (!isScaleFactorRounding()) {
     assert.deepEqual(expect, actual)
   } else if (Array.isArray(actual)) {
     assertWithinDelta(actual[0], expect[0], 1, 'x')
@@ -1373,7 +1373,12 @@ const assertWithinDelta = (actual, expect, delta, label) => {
   assert.ok(result <= delta, `${label} value of ${expect} was not within ${delta} of ${actual}`)
 }
 
-const isIntegerScaleFactor = () => {
+// Is the display's scale factor possibly causing rounding of pixel coordinate
+// values?
+const isScaleFactorRounding = () => {
   const {scaleFactor} = screen.getPrimaryDisplay()
-  return Math.round(scaleFactor) === scaleFactor
+  // Return true if scale factor is non-integer value
+  if (Math.round(scaleFactor) === scaleFactor) return true
+  // Return true if scale factor is odd number above 2
+  return scaleFactor > 2 && scaleFactor % 2 === 1
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1360,18 +1360,12 @@ describe('browser-window module', function () {
   })
 })
 
-const assertPositionsEqual = (expect, actual) => {
-  if (isIntegerScaleFactor()) {
-    assert.deepEqual(expect, actual)
-  } else {
-    assertWithinDelta(expect[0], actual[0], 1, 'x')
-    assertWithinDelta(expect[1], actual[1], 1, 'y')
-  }
-}
-
 const assertBoundsEqual = (expect, actual) => {
   if (isIntegerScaleFactor()) {
     assert.deepEqual(expect, actual)
+  } else if (Array.isArray(actual)) {
+    assertWithinDelta(expect[0], actual[0], 1, 'x')
+    assertWithinDelta(expect[1], actual[1], 1, 'y')
   } else {
     assertWithinDelta(expect.x, actual.x, 1, 'x')
     assertWithinDelta(expect.y, actual.y, 1, 'y')


### PR DESCRIPTION
Previously there were several `BrowserWindow` specs that failed when run on displays using a non-integer device scale factor such as `1.5` or an odd number value like `3`.

This was due to the rounding of pixel values that occurs when converting content and window size and position.

This pull request switches these specs to use a `assertBoundsEqual` helper method that allows the expected value to be off by 1 when run on non-integer scale factor screen.

An alternative to this would be calling `app.commandLine.appendSwitch('force-device-scale-factor', '2')` in the specs themselves but then the runner window would be a possibly annoying scale factor that might make it hard to use for certain people.

/cc @Haacked 