### PR TITLE
Tweak how empty URLs are resolved

### DIFF
--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -139,7 +139,7 @@ window.open = function (url, frameName, features) {
   }
 
   // Resolve relative urls.
-  if (url == null || url == '') {
+  if (url == null || url === '') {
     url = 'about:blank'
   } else {
     url = resolveURL(url)

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -139,7 +139,11 @@ window.open = function (url, frameName, features) {
   }
 
   // Resolve relative urls.
-  url = resolveURL(url)
+  if (url == null || url == '') {
+    url = 'about:blank'
+  } else {
+    url = resolveURL(url)
+  }
   for (j = 0, len1 = ints.length; j < len1; j++) {
     name = ints[j]
     if (options[name] != null) {

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -9,6 +9,7 @@ const remote = require('electron').remote
 var a = document.createElement('a')
 
 var resolveURL = function (url) {
+  if (url === '') return ''
   a.href = url
   return a.href
 }

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -250,14 +250,30 @@ describe('chromium feature', function () {
 
     it('defines a window.location setter', function (done) {
       // Load a page that definitely won't redirect
-      var b
-      b = window.open('about:blank')
+      var b = window.open('about:blank')
       webContents.fromId(b.guestId).once('did-finish-load', function () {
         // When it loads, redirect
         b.location = 'file://' + fixtures + '/pages/base-page.html'
         webContents.fromId(b.guestId).once('did-finish-load', function () {
           // After our second redirect, cleanup and callback
           b.close()
+          done()
+        })
+      })
+    })
+
+    it('open a blank page when no URL is specified', function (done) {
+      let b = window.open()
+      webContents.fromId(b.guestId).once('did-finish-load', function () {
+        const {location} = b
+        b.close()
+        assert.equal(location, 'about:blank')
+
+        let c = window.open('')
+        webContents.fromId(c.guestId).once('did-finish-load', function () {
+          const {location} = c
+          c.close()
+          assert.equal(location, 'about:blank')
           done()
         })
       })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -76,9 +76,15 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
-    it('resolves relative URLs', function () {
-      webview.src = '../fixtures/test.html'
-      assert.equal(webview.src, 'file://' + fixtures + '/test.html')
+    it('resolves relative URLs', function (done) {
+      var listener = function (e) {
+        assert.equal(e.message, 'Window script is loaded before preload script')
+        webview.removeEventListener('console-message', listener)
+        done()
+      }
+      webview.addEventListener('console-message', listener)
+      webview.src = '../fixtures/pages/e.html'
+      document.body.appendChild(webview)
     })
 
     it('ignores empty values', function () {
@@ -214,9 +220,16 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
-    it('resolves relative URLs', function () {
-      webview.preload = '../fixtures/test.js'
-      assert.equal(webview.preload, 'file://' + fixtures + '/test.js')
+    it('resolves relative URLs', function (done) {
+      var listener = function (e) {
+        assert.equal(e.message, 'function object object')
+        webview.removeEventListener('console-message', listener)
+        done()
+      }
+      webview.addEventListener('console-message', listener)
+      webview.src = 'file://' + fixtures + '/pages/e.html'
+      webview.preload = '../fixtures/module/preload.js'
+      document.body.appendChild(webview)
     })
 
     it('ignores empty values', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -75,6 +75,12 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/pages/a.html'
       document.body.appendChild(webview)
     })
+
+    it('ignores empty values', function () {
+      assert.equal(webview.src, '')
+      webview.src = ''
+      assert.equal(webview.src, '')
+    })
   })
 
   describe('nodeintegration attribute', function () {
@@ -197,6 +203,12 @@ describe('<webview> tag', function () {
       webview.setAttribute('preload', fixtures + '/module/preload.js')
       webview.src = 'file://' + fixtures + '/pages/base-page.html'
       document.body.appendChild(webview)
+    })
+
+    it('ignores empty values', function () {
+      assert.equal(webview.preload, '')
+      webview.preload = ''
+      assert.equal(webview.preload, '')
     })
   })
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -77,8 +77,8 @@ describe('<webview> tag', function () {
     })
 
     it('resolves relative URLs', function () {
-      webview.preload = '../fixtures/test.js'
-      assert.equal(webview.preload, 'file://' + fixtures + '/test.js')
+      webview.src = '../fixtures/test.html'
+      assert.equal(webview.src, 'file://' + fixtures + '/test.html')
     })
 
     it('ignores empty values', function () {
@@ -215,8 +215,8 @@ describe('<webview> tag', function () {
     })
 
     it('resolves relative URLs', function () {
-      webview.src = '../fixtures/test.html'
-      assert.equal(webview.src, 'file://' + fixtures + '/test.html')
+      webview.preload = '../fixtures/test.js'
+      assert.equal(webview.preload, 'file://' + fixtures + '/test.js')
     })
 
     it('ignores empty values', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -76,6 +76,11 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
+    it('resolves relative URLs', function () {
+      webview.preload = '../fixtures/test.js'
+      assert.equal(webview.preload, 'file://' + fixtures + '/test.js')
+    })
+
     it('ignores empty values', function () {
       assert.equal(webview.src, '')
       webview.src = ''
@@ -207,6 +212,11 @@ describe('<webview> tag', function () {
       webview.setAttribute('preload', fixtures + '/module/preload.js')
       webview.src = 'file://' + fixtures + '/pages/base-page.html'
       document.body.appendChild(webview)
+    })
+
+    it('resolves relative URLs', function () {
+      webview.src = '../fixtures/test.html'
+      assert.equal(webview.src, 'file://' + fixtures + '/test.html')
     })
 
     it('ignores empty values', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -80,6 +80,10 @@ describe('<webview> tag', function () {
       assert.equal(webview.src, '')
       webview.src = ''
       assert.equal(webview.src, '')
+      webview.src = null
+      assert.equal(webview.src, '')
+      webview.src = undefined
+      assert.equal(webview.src, '')
     })
   })
 
@@ -208,6 +212,10 @@ describe('<webview> tag', function () {
     it('ignores empty values', function () {
       assert.equal(webview.preload, '')
       webview.preload = ''
+      assert.equal(webview.preload, '')
+      webview.preload = null
+      assert.equal(webview.preload, '')
+      webview.preload = undefined
       assert.equal(webview.preload, '')
     })
   })


### PR DESCRIPTION
This pull request changes how the URLs passed to `window.open`, the `<webview>` `src` attribute, and the `<webview>` `preload` attribute are resolved.

`window.open` with either a null URL or an empty string URL now opens `about:blank`. Previously it would resolve `null` agains the current path and open something like `file:///foo/bar/null` and empty string would open the current page. Opening `about:blank` instead seems to be more consistent with the Chrome behavior and the [`window.open`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) docs.

Empty string `src` and `preload` attributes are now ignored instead of resolved to the current page's URL.  This prevents accidentally loading the current HTML page as a `preload` script or accidentally loading the current page into the `<webview>`.

Closes #7035 