### PR TITLE
fix crash when using geolocation api with enableHighAccuracy option

### DIFF
--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -11,6 +11,8 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/geolocation_provider.h"
 
+using content::BrowserThread;
+
 namespace atom {
 
 namespace {
@@ -21,6 +23,49 @@ namespace {
 const char* kGeolocationProviderURL =
     "https://www.googleapis.com/geolocation/v1/geolocate?key="
     GOOGLEAPIS_API_KEY;
+
+// Loads access tokens and other necessary data on the UI thread, and
+// calls back to the originator on the originating thread.
+class TokenLoadingJob : public base::RefCountedThreadSafe<TokenLoadingJob> {
+ public:
+  explicit TokenLoadingJob(
+      const content::AccessTokenStore::LoadAccessTokensCallback& callback)
+      : callback_(callback), request_context_getter_(nullptr) {}
+
+  void Run() {
+    BrowserThread::PostTaskAndReply(
+        BrowserThread::UI,
+        FROM_HERE,
+        base::Bind(&TokenLoadingJob::PerformWorkOnUIThread, this),
+        base::Bind(&TokenLoadingJob::RespondOnOriginatingThread, this));
+  }
+
+ private:
+  friend class base::RefCountedThreadSafe<TokenLoadingJob>;
+
+  ~TokenLoadingJob() {}
+
+  void PerformWorkOnUIThread() {
+    DCHECK_CURRENTLY_ON(BrowserThread::UI);
+    auto browser_context = AtomBrowserContext::From("", false);
+    request_context_getter_ = browser_context->GetRequestContext();
+  }
+
+  void RespondOnOriginatingThread() {
+    // Equivelent to access_token_map[kGeolocationProviderURL].
+    // Somehow base::string16 is causing compilation errors when used in a pair
+    // of std::map on Linux, this can work around it.
+    content::AccessTokenStore::AccessTokenMap access_token_map;
+    std::pair<GURL, base::string16> token_pair;
+    token_pair.first = GURL(kGeolocationProviderURL);
+    access_token_map.insert(token_pair);
+
+    callback_.Run(access_token_map, request_context_getter_);
+  }
+
+  content::AccessTokenStore::LoadAccessTokensCallback callback_;
+  net::URLRequestContextGetter* request_context_getter_;
+};
 
 }  // namespace
 
@@ -33,35 +78,12 @@ AtomAccessTokenStore::~AtomAccessTokenStore() {
 
 void AtomAccessTokenStore::LoadAccessTokens(
     const LoadAccessTokensCallback& callback) {
-  content::BrowserThread::PostTaskAndReply(
-      content::BrowserThread::UI,
-      FROM_HERE,
-      base::Bind(&AtomAccessTokenStore::GetRequestContextOnUIThread, this),
-      base::Bind(&AtomAccessTokenStore::RespondOnOriginatingThread,
-                 this, callback));
+  scoped_refptr<TokenLoadingJob> job(new TokenLoadingJob(callback));
+  job->Run();
 }
 
 void AtomAccessTokenStore::SaveAccessToken(const GURL& server_url,
                                            const base::string16& access_token) {
-}
-
-void AtomAccessTokenStore::GetRequestContextOnUIThread() {
-  auto browser_context = AtomBrowserContext::From("", false);
-  request_context_getter_ = browser_context->GetRequestContext();
-}
-
-void AtomAccessTokenStore::RespondOnOriginatingThread(
-    const LoadAccessTokensCallback& callback) {
-  // Equivelent to access_token_map[kGeolocationProviderURL].
-  // Somehow base::string16 is causing compilation errors when used in a pair
-  // of std::map on Linux, this can work around it.
-  AccessTokenMap access_token_map;
-  std::pair<GURL, base::string16> token_pair;
-  token_pair.first = GURL(kGeolocationProviderURL);
-  access_token_map.insert(token_pair);
-
-  callback.Run(access_token_map, request_context_getter_.get());
-  request_context_getter_ = nullptr;
 }
 
 }  // namespace atom

--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -21,11 +21,6 @@ class AtomAccessTokenStore : public content::AccessTokenStore {
                        const base::string16& access_token) override;
 
  private:
-  void GetRequestContextOnUIThread();
-  void RespondOnOriginatingThread(const LoadAccessTokensCallback& callback);
-
-  scoped_refptr<net::URLRequestContextGetter> request_context_getter_;
-
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);
 };
 


### PR DESCRIPTION
When the option is set, `AtomAccessTokenStore::LoadAccessTokens` will be called multiple times. This resulted in a race condition with destruction of `request_context_getter_` member. The patch moves the loading task to a separate class where the lifetime is managed separately.


/cc @zcbenz 