### PR TITLE
[WIP] Wrap API's to use the Squirrel trampoline when it is available

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -9,6 +9,8 @@ module.exports = app
 const electron = require('electron')
 const {deprecate, Menu} = electron
 const {EventEmitter} = require('events')
+const fs = require('fs')
+const path = require('path')
 
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 
@@ -28,6 +30,24 @@ Object.assign(app, {
     appendArgument: bindings.appendArgument
   }
 })
+
+// Wrap methods that default to process.execPath with Squirrel related syntax
+const squirrelUpdateExePath = path.join(path.dirname(process.execPath), '..', 'update.exe')
+
+if (process.platform === 'win32' && fs.existsSync(squirrelUpdateExePath)) {
+  const wrapProtocolClientMethod = (methodName) => {
+    const originalMethod = app[methodName]
+    app[methodName] = (protocol, targetPath, args = []) => {
+      if (targetPath) {
+        return originalMethod(protocol, targetPath, args)
+      }
+      return originalMethod(protocol, squirrelUpdateExePath, `--processStart="${path.basename(process.execPath)}" --process-start-args=${JSON.stringify(args.join(' '))}`)
+    }
+  };
+  wrapProtocolClientMethod('setAsDefaultProtocolClient')
+  wrapProtocolClientMethod('removeAsDefaultProtocolClient')
+  wrapProtocolClientMethod('isDefaultProtocolClient')
+}
 
 if (process.platform === 'darwin') {
   app.dock = {

--- a/lib/common/api/shell.js
+++ b/lib/common/api/shell.js
@@ -1,1 +1,24 @@
-module.exports = process.atomBinding('shell')
+const fs = require('fs')
+const path = require('path')
+const shell = process.atomBinding('shell')
+
+module.exports = shell
+
+const squirrelUpdateExePath = path.join(path.dirname(process.execPath), '..', 'update.exe')
+
+if (process.platform === 'win32' && fs.existsSync(squirrelUpdateExePath)) {
+  const originalWriteShortcutLink = shell.writeShortcutLink
+  shell.writeShortcutLink = (shortcutPath, operation, opts) => {
+    const options = opts || operation || {}
+
+    if (!options.target) {
+      options.target = squirrelUpdateExePath
+      const processArgs = options.args || ''
+      options.args = `--processStart="${path.basename(process.execPath)}" --process-start-args=${JSON.stringify(processArgs)}`
+    }
+    if (opts) {
+      return originalWriteShortcutLink(shortcutPath, operation, options)
+    }
+    return originalWriteShortcutLink(shortcutPath, options)
+  };
+}


### PR DESCRIPTION
This is the easiest and most unintrusive way I could come up with to implement this.

Basically I didn't want to put it into the native code as I don't think Squirrel specific things should end up there (this is consistent with all our other Squirrel specific customization).  The general idea was to keep the API consistent with the documentation but override the defaults to be Squirrel.Windows compatible if we could.

Fixes #7148 

/cc @paulcbetts Would be good if you could verify I haven't screwed up the arguments syntax 👍 
