### PR TITLE
Document com.apple.security.network entitlements

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -172,6 +172,26 @@ Depending on which Electron APIs your app uses, you may need to add additional
 entitlements to your `parent.plist` file to be able to use these APIs from your
 app's Mac App Store build.
 
+#### Network Access
+
+Enable outgoing network connections to allow your app to connect to a server:
+
+```xml
+<key>com.apple.security.network.client</key>
+<true/>
+```
+
+Enable incoming network connections to allow your app to open a network
+listening socket:
+
+```xml
+<key>com.apple.security.network.server</key>
+<true/>
+```
+
+See the [Enabling Network Access documentation][network-access] for more
+details.
+
 #### dialog.showOpenDialog
 
 ```xml
@@ -240,3 +260,4 @@ ERN)][ern-tutorial].
 [ern-tutorial]: https://carouselapps.com/2015/12/15/legally-submit-app-apples-app-store-uses-encryption-obtain-ern/
 [temporary-exception]: https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/AppSandboxTemporaryExceptionEntitlements.html
 [user-selected]: https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6
+[network-access]: https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW9


### PR DESCRIPTION
Document the `com.apple.security.network.client` and `com.apple.security.network.server` entitlements that are required if your app makes outbound requests or wants to bind to a socket such as for hosting a localhost http server.

https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW9

I verified both of these using the Electron API Demos app.

Refs https://github.com/electron-userland/electron-prebuilt/issues/141