### PR TITLE
browser: provide a default filename when unable to generate from download data

### DIFF
--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -135,7 +135,7 @@ std::string DownloadItem::GetFilename() const {
                            std::string(),
                            download_item_->GetSuggestedFilename(),
                            GetMimeType(),
-                           std::string()).LossyDisplayName());
+                           "download").LossyDisplayName());
 }
 
 std::string DownloadItem::GetContentDisposition() const {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -134,6 +134,7 @@ struct Converter<WindowOpenDisposition> {
       case NEW_FOREGROUND_TAB: disposition = "foreground-tab"; break;
       case NEW_BACKGROUND_TAB: disposition = "background-tab"; break;
       case NEW_POPUP: case NEW_WINDOW: disposition = "new-window"; break;
+      case SAVE_TO_DISK: disposition = "save-to-disk"; break;
       default: break;
     }
     return mate::ConvertToV8(isolate, disposition);

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -60,7 +60,7 @@ void AtomDownloadManagerDelegate::CreateDownloadPath(
                                               std::string(),
                                               suggested_filename,
                                               mime_type,
-                                              std::string());
+                                              "download");
 
   if (!base::PathExists(default_download_path))
     base::CreateDirectory(default_download_path);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -144,7 +144,7 @@ Returns:
 * `url` String
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
-  `new-window` and `other`.
+  `new-window`, `save-to-disk` and `other`.
 * `options` Object - The options which will be used for creating the new
   `BrowserWindow`.
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -670,7 +670,7 @@ Returns:
 * `url` String
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
-  `new-window` and `other`.
+  `new-window`, `save-to-disk` and `other`.
 * `options` Object - The options which should be used for creating the new
   `BrowserWindow`.
 


### PR DESCRIPTION
Also we didn't handle alt+click on links with no download attribute, chrome downloads for that gesture but we generate a `new-window` event. This patch fixes it in a separate commit, can be reverted if not desired. 

Fixes #7151 