### PR TITLE
Fix navigation controller

### DIFF
--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -33,7 +33,7 @@ var NavigationController = (function () {
       if (this.inPageIndex > -1 && !inPage) {
         // Navigated to a new page, clear in-page mark.
         this.inPageIndex = -1
-      } else if (this.inPageIndex === -1 && inPage) {
+      } else if (this.inPageIndex === -1 && inPage && !replaceEntry) {
         // Started in-page navigations.
         this.inPageIndex = this.currentIndex
       }


### PR DESCRIPTION
In-page navigation has not actually started if the current entry is
being replaced. Do not set inPageIndex if replaceEntry is true.

Load Twitch frontpage
![image](https://cloud.githubusercontent.com/assets/47231/18420904/b2fd5c2e-7832-11e6-86c9-bf637974ac76.png)

Navigate out of page to game directory
![image](https://cloud.githubusercontent.com/assets/47231/18420828/ed04da20-7830-11e6-8339-b3ac749b0d3d.png)

Go back in history to frontpage
![image](https://cloud.githubusercontent.com/assets/47231/18420910/c52caea4-7832-11e6-8f41-8cc4001ec5d1.png)

Attempt to go forward in history

I believe the Twitch frontpage uses `window.history.replaceState()` on load and this leads `NavigationController` to believe that in-page navigation has started and that `this.webContents._goForward()` should be used instead of out-of-page navigation `this.webContents._loadURL()`.