### PR TITLE
:penguin: Add support for different trash implementations

### DIFF
--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -11,15 +11,13 @@
 #include "base/process/launch.h"
 #include "url/gurl.h"
 
+#define ELECTRON_TRASH "ELECTRON_TRASH"
+#define ELECTRON_DEFAULT_TRASH "gvfs-trash"
+
 namespace {
 
-bool XDGUtil(const std::string& util,
-             const std::string& arg,
+bool XDGUtilV(const std::vector<std::string>& argv,
              const bool wait_for_exit) {
-  std::vector<std::string> argv;
-  argv.push_back(util);
-  argv.push_back(arg);
-
   base::LaunchOptions options;
   options.allow_new_privs = true;
   // xdg-open can fall back on mailcap which eventually might plumb through
@@ -42,6 +40,16 @@ bool XDGUtil(const std::string& util,
     return false;
 
   return (exit_code == 0);
+}
+
+bool XDGUtil(const std::string& util,
+             const std::string& arg,
+             const bool wait_for_exit) {
+  std::vector<std::string> argv;
+  argv.push_back(util);
+  argv.push_back(arg);
+
+  return XDGUtilV(argv, wait_for_exit);
 }
 
 bool XDGOpen(const std::string& path, const bool wait_for_exit) {
@@ -81,7 +89,28 @@ bool OpenExternal(const GURL& url, bool activate) {
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path) {
-  return XDGUtil("gvfs-trash", full_path.value(), true);
+  std::string trash;
+  if (getenv(ELECTRON_TRASH) != NULL) {
+    trash = getenv(ELECTRON_TRASH);
+  } else {
+    trash = ELECTRON_DEFAULT_TRASH;
+  }
+
+  std::vector<std::string> argv;
+
+  if (trash.compare("kioclient5") == 0 || trash.compare("kioclient") == 0) {
+    argv.push_back(trash);
+    argv.push_back("move");
+    argv.push_back(full_path.value());
+    argv.push_back("trash:/");
+  } else if (trash.compare("trash-cli") == 0) {
+    argv.push_back("trash-put");
+    argv.push_back(full_path.value());
+  } else {
+    argv.push_back(ELECTRON_DEFAULT_TRASH);
+    argv.push_back(full_path.value());
+  }
+  return XDGUtilV(argv, true);
 }
 
 void Beep() {


### PR DESCRIPTION
# Add support for kioclient, kioclient5 and trash-cli in MoveItemToTrash.

The desired implementation has to be specified in the environment variable `ELECTRON_TRASH` . If none is it will fallback to `gvfs-trash`. Valid values for  `ELECTRON_TRASH` are:

- kioclient5
- kioclient5
- trash-cli

It will also fallback to `gvfs-trash` if the value of `ELECTRON_TRASH` is none of the above.

This fixes: 

- #6847
- #637

and allows users of kde, xfce and other desktop environments to delete files and folders without the need of gvfs.



 
 
