### PR TITLE
Return booleans from more shell APIs

### DIFF
--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -25,7 +25,7 @@ bool ShowItemInFolder(const base::FilePath& full_path);
 
 // Open the given file in the desktop's default manner.
 // Must be called from the UI thread.
-void OpenItem(const base::FilePath& full_path);
+bool OpenItem(const base::FilePath& full_path);
 
 // Open the given external protocol URL in the desktop's default manner.
 // (For example, mailto: URLs in the default mail user agent.)

--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -21,7 +21,7 @@ namespace platform_util {
 
 // Show the given file in a file manager. If possible, select the file.
 // Must be called from the UI thread.
-void ShowItemInFolder(const base::FilePath& full_path);
+bool ShowItemInFolder(const base::FilePath& full_path);
 
 // Open the given file in the desktop's default manner.
 // Must be called from the UI thread.

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -59,12 +59,12 @@ namespace platform_util {
 // TODO(estade): It would be nice to be able to select the file in the file
 // manager, but that probably requires extending xdg-open. For now just
 // show the folder.
-void ShowItemInFolder(const base::FilePath& full_path) {
+bool ShowItemInFolder(const base::FilePath& full_path) {
   base::FilePath dir = full_path.DirName();
   if (!base::DirectoryExists(dir))
-    return;
+    return false;
 
-  XDGOpen(dir.value(), true);
+  return XDGOpen(dir.value(), true);
 }
 
 void OpenItem(const base::FilePath& full_path) {

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -67,8 +67,8 @@ bool ShowItemInFolder(const base::FilePath& full_path) {
   return XDGOpen(dir.value(), true);
 }
 
-void OpenItem(const base::FilePath& full_path) {
-  XDGOpen(full_path.value(), true);
+bool OpenItem(const base::FilePath& full_path) {
+  return XDGOpen(full_path.value(), true);
 }
 
 bool OpenExternal(const GURL& url, bool activate) {

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -18,7 +18,7 @@
 
 namespace platform_util {
 
-void ShowItemInFolder(const base::FilePath& path) {
+bool ShowItemInFolder(const base::FilePath& path) {
   // The API only takes absolute path.
   base::FilePath full_path =
       path.IsAbsolute() ? path : base::MakeAbsoluteFilePath(path);
@@ -26,8 +26,11 @@ void ShowItemInFolder(const base::FilePath& path) {
   DCHECK([NSThread isMainThread]);
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
   if (!path_string || ![[NSWorkspace sharedWorkspace] selectFile:path_string
-                                        inFileViewerRootedAtPath:@""])
+                                        inFileViewerRootedAtPath:@""]) {
     LOG(WARNING) << "NSWorkspace failed to select file " << full_path.value();
+    return false;
+  }
+  return true;
 }
 
 // This function opens a file.  This doesn't use LaunchServices or NSWorkspace

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -292,11 +292,11 @@ bool ShowItemInFolder(const base::FilePath& full_path) {
   }
 }
 
-void OpenItem(const base::FilePath& full_path) {
+bool OpenItem(const base::FilePath& full_path) {
   if (base::DirectoryExists(full_path))
-    ui::win::OpenFolderViaShell(full_path);
+    return ui::win::OpenFolderViaShell(full_path);
   else
-    ui::win::OpenFileViaShell(full_path);
+    return ui::win::OpenFileViaShell(full_path);
 }
 
 bool OpenExternal(const base::string16& url, bool activate) {

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -206,7 +206,7 @@ namespace platform_util {
 bool ShowItemInFolder(const base::FilePath& full_path) {
   base::win::ScopedCOMInitializer com_initializer;
   if (!com_initializer.succeeded())
-    return;
+    return false;
 
   base::FilePath dir = full_path.DirName().AsEndingWithSeparator();
   // ParseDisplayName will fail if the directory is "C:", it must be "C:\\".

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -203,7 +203,7 @@ HRESULT DeleteFileProgressSink::ResumeTimer() {
 
 namespace platform_util {
 
-void ShowItemInFolder(const base::FilePath& full_path) {
+bool ShowItemInFolder(const base::FilePath& full_path) {
   base::win::ScopedCOMInitializer com_initializer;
   if (!com_initializer.succeeded())
     return;
@@ -211,7 +211,7 @@ void ShowItemInFolder(const base::FilePath& full_path) {
   base::FilePath dir = full_path.DirName().AsEndingWithSeparator();
   // ParseDisplayName will fail if the directory is "C:", it must be "C:\\".
   if (dir.empty())
-    return;
+    return false;
 
   typedef HRESULT (WINAPI *SHOpenFolderAndSelectItemsFuncPtr)(
       PCIDLIST_ABSOLUTE pidl_Folder,
@@ -232,29 +232,27 @@ void ShowItemInFolder(const base::FilePath& full_path) {
     HMODULE shell32_base = GetModuleHandle(L"shell32.dll");
     if (!shell32_base) {
       NOTREACHED() << " " << __FUNCTION__ << "(): Can't open shell32.dll";
-      return;
+      return false;
     }
     open_folder_and_select_itemsPtr =
         reinterpret_cast<SHOpenFolderAndSelectItemsFuncPtr>
             (GetProcAddress(shell32_base, "SHOpenFolderAndSelectItems"));
   }
   if (!open_folder_and_select_itemsPtr) {
-    ui::win::OpenFolderViaShell(dir);
-    return;
+    return ui::win::OpenFolderViaShell(dir);
   }
 
   base::win::ScopedComPtr<IShellFolder> desktop;
   HRESULT hr = SHGetDesktopFolder(desktop.Receive());
   if (FAILED(hr))
-    return;
+    return false;
 
   base::win::ScopedCoMem<ITEMIDLIST> dir_item;
   hr = desktop->ParseDisplayName(NULL, NULL,
                                  const_cast<wchar_t *>(dir.value().c_str()),
                                  NULL, &dir_item, NULL);
   if (FAILED(hr)) {
-    ui::win::OpenFolderViaShell(dir);
-    return;
+    return ui::win::OpenFolderViaShell(dir);
   }
 
   base::win::ScopedCoMem<ITEMIDLIST> file_item;
@@ -262,36 +260,35 @@ void ShowItemInFolder(const base::FilePath& full_path) {
       const_cast<wchar_t *>(full_path.value().c_str()),
       NULL, &file_item, NULL);
   if (FAILED(hr)) {
-    ui::win::OpenFolderViaShell(dir);
-    return;
+    return ui::win::OpenFolderViaShell(dir);
   }
 
   const ITEMIDLIST* highlight[] = { file_item };
 
   hr = (*open_folder_and_select_itemsPtr)(dir_item, arraysize(highlight),
                                           highlight, NULL);
+  if (!FAILED(hr))
+    return true;
 
-  if (FAILED(hr)) {
-    // On some systems, the above call mysteriously fails with "file not
-    // found" even though the file is there.  In these cases, ShellExecute()
-    // seems to work as a fallback (although it won't select the file).
-    if (hr == ERROR_FILE_NOT_FOUND) {
-      ui::win::OpenFolderViaShell(dir);
-    } else {
-      LPTSTR message = NULL;
-      DWORD message_length = FormatMessage(
-          FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-          0, hr, 0, reinterpret_cast<LPTSTR>(&message), 0, NULL);
-      LOG(WARNING) << " " << __FUNCTION__
-                   << "(): Can't open full_path = \""
-                   << full_path.value() << "\""
-                   << " hr = " << hr
-                   << " " << reinterpret_cast<LPTSTR>(&message);
-      if (message)
-        LocalFree(message);
+  // On some systems, the above call mysteriously fails with "file not
+  // found" even though the file is there.  In these cases, ShellExecute()
+  // seems to work as a fallback (although it won't select the file).
+  if (hr == ERROR_FILE_NOT_FOUND) {
+    return ui::win::OpenFolderViaShell(dir);
+  } else {
+    LPTSTR message = NULL;
+    DWORD message_length = FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+        0, hr, 0, reinterpret_cast<LPTSTR>(&message), 0, NULL);
+    LOG(WARNING) << " " << __FUNCTION__
+                 << "(): Can't open full_path = \""
+                 << full_path.value() << "\""
+                 << " hr = " << hr
+                 << " " << reinterpret_cast<LPTSTR>(&message);
+    if (message)
+      LocalFree(message);
 
-      ui::win::OpenFolderViaShell(dir);
-    }
+    return ui::win::OpenFolderViaShell(dir);
   }
 }
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -20,7 +20,8 @@ The `shell` module has the following methods:
 
 * `fullPath` String
 
-Show the given file in a file manager. If possible, select the file.
+Show the given file in a file manager. If possible, select the file. Returns
+true if the item was successfully shown, false otherwse.
 
 ### `shell.openItem(fullPath)`
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -46,6 +46,7 @@ application was available to open the URL, false otherwise.
 * `fullPath` String
 
 Move the given file to trash and returns a boolean status for the operation.
+Returns true if the item was successfully moved to the trash, false otherwise.
 
 ### `shell.beep()`
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -21,13 +21,14 @@ The `shell` module has the following methods:
 * `fullPath` String
 
 Show the given file in a file manager. If possible, select the file. Returns
-true if the item was successfully shown, false otherwse.
+true if the item was successfully shown, false otherwise.
 
 ### `shell.openItem(fullPath)`
 
 * `fullPath` String
 
-Open the given file in the desktop's default manner.
+Open the given file in the desktop's default manner. Returns true if the item
+was successfully opened, false otherwise.
 
 ### `shell.openExternal(url[, options])`
 


### PR DESCRIPTION
This pull request switches `shell.showItemInFolder` and `shell.openItem` to return a `Boolean` instead of undefined indicating the success of the call. This makes these two APIs consistent with `shell.openExternal` that already returns a Boolean.

Refs https://github.com/electron/electron/issues/7176