### PR TITLE
Update nodejs requirement for building on linux

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -7,7 +7,7 @@ Follow the guidelines below for building Electron on Linux.
 * At least 25GB disk space and 8GB RAM.
 * Python 2.7.x. Some distributions like CentOS still use Python 2.6.x
   so you may need to check your Python version with `python -V`.
-* Node.js v0.12.x. There are various ways to install Node. You can download
+* Node.js. There are various ways to install Node. You can download
   source code from [Node.js](http://nodejs.org) and compile from source.
   Doing so permits installing Node on your own home directory as a standard user.
   Or try repositories such as [NodeSource](https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories).


### PR DESCRIPTION
None of the other building guides (windows or osx) specify a nodejs version requirement and the `.node-version` is set to `v6.3.0`, considerably higher than `v0.12.x`.