### PR TITLE
Set Google API keys with environment variables

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -110,6 +110,8 @@ void AtomMainDelegate::PreSandboxStartup() {
 
   // Set google API key.
   std::unique_ptr<base::Environment> env(base::Environment::Create());
+  if (!env->HasVar("GOOGLE_API_ENDPOINT"))
+    env->SetVar("GOOGLE_API_ENDPOINT", GOOGLEAPIS_ENDPOINT);
   if (!env->HasVar("GOOGLE_API_KEY"))
     env->SetVar("GOOGLE_API_KEY", GOOGLEAPIS_API_KEY);
 

--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -13,19 +13,14 @@
 
 namespace atom {
 
-namespace {
-
-// Notice that we just combined the api key with the url together here, because
-// if we use the standard {url: key} format Chromium would override our key with
-// the predefined one in common.gypi of libchromiumcontent, which is empty.
-const char* kGeolocationProviderURL =
-    "https://www.googleapis.com/geolocation/v1/geolocate?key="
-    GOOGLEAPIS_API_KEY;
-
-}  // namespace
-
 AtomAccessTokenStore::AtomAccessTokenStore() {
   content::GeolocationProvider::GetInstance()->UserDidOptIntoLocationServices();
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  if (!env->GetVar("GOOGLE_API_ENDPOINT", &endpoint_))
+    endpoint_ = GOOGLEAPIS_ENDPOINT;
+
+  if (!env->GetVar("GOOGLE_API_KEY", &api_key_))
+    api_key_ = GOOGLEAPIS_API_KEY;
 }
 
 AtomAccessTokenStore::~AtomAccessTokenStore() {
@@ -57,7 +52,7 @@ void AtomAccessTokenStore::RespondOnOriginatingThread(
   // of std::map on Linux, this can work around it.
   AccessTokenMap access_token_map;
   std::pair<GURL, base::string16> token_pair;
-  token_pair.first = GURL(kGeolocationProviderURL);
+  token_pair.first = GURL(endpoint_ + api_key_);
   access_token_map.insert(token_pair);
 
   callback.Run(access_token_map, request_context_getter_.get());

--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -8,6 +8,7 @@
 
 #include "atom/browser/atom_browser_context.h"
 #include "atom/common/google_api_key.h"
+#include "base/environment.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/geolocation_provider.h"
 

--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -24,6 +24,8 @@ class AtomAccessTokenStore : public content::AccessTokenStore {
   void GetRequestContextOnUIThread();
   void RespondOnOriginatingThread(const LoadAccessTokensCallback& callback);
 
+  std::string endpoint_;
+  std::string api_key_;
   scoped_refptr<net::URLRequestContextGetter> request_context_getter_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);

--- a/atom/common/google_api_key.h
+++ b/atom/common/google_api_key.h
@@ -5,6 +5,11 @@
 #ifndef ATOM_COMMON_GOOGLE_API_KEY_H_
 #define ATOM_COMMON_GOOGLE_API_KEY_H_
 
+#ifndef GOOGLEAPIS_ENDPOINT
+#define GOOGLEAPIS_ENDPOINT \
+    "https://www.googleapis.com/geolocation/v1/geolocate?key="
+#endif
+
 #ifndef GOOGLEAPIS_API_KEY
 #define GOOGLEAPIS_API_KEY "AIzaSyAQfxPJiounkhOjODEO5ZieffeBv6yft2Q"
 #endif


### PR DESCRIPTION
I cherry-picked these commits from the [brave fork](https://github.com/brave/electron), per @bbondy's suggestion.

Fixes #6648 
