### PR TITLE
Guard against missing remote function properties

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -167,6 +167,11 @@ const proxyFunctionProperties = function (remoteMemberFunction, metaId, name) {
   }
 
   return new Proxy(remoteMemberFunction, {
+    set: (target, property, value, receiver) => {
+      if (property !== 'ref') loadRemoteProperties()
+      target[property] = value
+      return true
+    },
     get: (target, property, receiver) => {
       if (!target.hasOwnProperty(property)) loadRemoteProperties()
       return target[property]

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -161,7 +161,9 @@ const proxyFunctionProperties = function (remoteMemberFunction, metaId, name) {
     if (loaded) return
     loaded = true
     const meta = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_GET', metaId, name)
-    setObjectMembers(remoteMemberFunction, remoteMemberFunction, meta.id, meta.members)
+    if (Array.isArray(meta.members)) {
+      setObjectMembers(remoteMemberFunction, remoteMemberFunction, meta.id, meta.members)
+    }
   }
 
   return new Proxy(remoteMemberFunction, {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -69,6 +69,10 @@ describe('ipc module', function () {
       assert.ok(Object.keys(a.foo).includes('bar'))
       assert.ok(Object.keys(a.foo).includes('nested'))
       assert.ok(Object.keys(a.foo).includes('method1'))
+
+      a = remote.require(path.join(fixtures, 'module', 'function-with-missing-properties.js'))
+      assert.equal(a.bar(), true)
+      assert.equal(typeof a.bar.baz, 'function')
     })
 
     it('should work with static class members', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -72,7 +72,7 @@ describe('ipc module', function () {
 
       a = remote.require(path.join(fixtures, 'module', 'function-with-missing-properties.js')).setup()
       assert.equal(a.bar(), true)
-      assert.equal(typeof a.bar.baz, 'function')
+      assert.equal(a.bar.baz, undefined)
     })
 
     it('should work with static class members', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -70,7 +70,7 @@ describe('ipc module', function () {
       assert.ok(Object.keys(a.foo).includes('nested'))
       assert.ok(Object.keys(a.foo).includes('method1'))
 
-      a = remote.require(path.join(fixtures, 'module', 'function-with-missing-properties.js'))
+      a = remote.require(path.join(fixtures, 'module', 'function-with-missing-properties.js')).setup()
       assert.equal(a.bar(), true)
       assert.equal(typeof a.bar.baz, 'function')
     })

--- a/spec/fixtures/module/function-with-missing-properties.js
+++ b/spec/fixtures/module/function-with-missing-properties.js
@@ -1,0 +1,11 @@
+const foo = {}
+
+foo.bar = function () {
+  return delete foo.bar.baz && delete foo.bar
+}
+
+foo.bar.baz = function () {
+  return 3
+}
+
+module.exports = foo

--- a/spec/fixtures/module/function-with-missing-properties.js
+++ b/spec/fixtures/module/function-with-missing-properties.js
@@ -1,11 +1,13 @@
-const foo = {}
+exports.setup = function () {
+  const foo = {}
 
-foo.bar = function () {
-  return delete foo.bar.baz && delete foo.bar
+  foo.bar = function () {
+    return delete foo.bar.baz && delete foo.bar
+  }
+
+  foo.bar.baz = function () {
+    return 3
+  }
+
+  return foo
 }
-
-foo.bar.baz = function () {
-  return 3
-}
-
-module.exports = foo


### PR DESCRIPTION
A remote function that is no longer available when its properties are accessed will throws error when the member metadata is lazily loaded.

This pull request guards against this case and at least partially fixes #7196, specifically the `Cannot read property 'Symbol(Symbol.iterator)' of undefined` errors.