### PR TITLE
Rethrow caught errors from process.binding

### DIFF
--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -44,7 +44,7 @@ v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
   if (!Browser::Get()->is_ready()) {
     isolate->ThrowException(v8::Exception::Error(mate::StringToV8(
         isolate,
-        "Cannot initialize \"power-monitor\" module before app is ready")));
+        "Cannot initialize \"powerMonitor\" module before app is ready")));
     return v8::Null(isolate);
   }
 

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -44,7 +44,7 @@ v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
   if (!Browser::Get()->is_ready()) {
     isolate->ThrowException(v8::Exception::Error(mate::StringToV8(
         isolate,
-        "Cannot initialize \"powerMonitor\" module before app is ready")));
+        "Cannot require \"powerMonitor\" module before app is ready")));
     return v8::Null(isolate);
   }
 

--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -97,7 +97,7 @@ v8::Local<v8::Value> Screen::Create(v8::Isolate* isolate) {
   if (!Browser::Get()->is_ready()) {
     isolate->ThrowException(v8::Exception::Error(mate::StringToV8(
         isolate,
-        "Cannot initialize \"screen\" module before app is ready")));
+        "Cannot require \"screen\" module before app is ready")));
     return v8::Null(isolate);
   }
 

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -2,16 +2,17 @@
 
 > Monitor power state changes.
 
-You can only use it in the main process. You should not use this module until the `ready`
-event of the `app` module is emitted.
+You cannot require or use this module until the `ready` event of the `app`
+module is emitted.
 
 For example:
 
 ```javascript
-const {app} = require('electron')
+const electron = require('electron')
+const {app} = electron
 
 app.on('ready', () => {
-  require('electron').powerMonitor.on('suspend', () => {
+  electron.powerMonitor.on('suspend', () => {
     console.log('The system is going to sleep')
   })
 })
@@ -19,7 +20,7 @@ app.on('ready', () => {
 
 ## Events
 
-The `power-monitor` module emits the following events:
+The `powerMonitor` module emits the following events:
 
 ### Event: 'suspend'
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -2,8 +2,8 @@
 
 > Retrieve information about screen size, displays, cursor position, etc.
 
-You cannot use this module until the `ready` event of the `app` module is
-emitted (by invoking or requiring it).
+You cannot require or use this module until the `ready` event of the `app`
+module is emitted.
 
 `screen` is an [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
 

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -6,6 +6,8 @@ process.atomBinding = function (name) {
   } catch (error) {
     if (/No such module/.test(error.message)) {
       return process.binding('atom_common_' + name)
+    } else {
+      throw error
     }
   }
 }

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -2,10 +2,10 @@ const timers = require('timers')
 
 process.atomBinding = function (name) {
   try {
-    return process.binding('atom_' + process.type + '_' + name)
+    return process.binding(`atom_${process.type}_${name}`)
   } catch (error) {
     if (/No such module/.test(error.message)) {
-      return process.binding('atom_common_' + name)
+      return process.binding(`atom_common_${name}`)
     } else {
       throw error
     }


### PR DESCRIPTION
This pull request rethrows caught errors from `process.binding` to surface the exceptions that certain modules like `screen` and `powerMonitor` throw if called before the app ready event is fired

Previously requiring `powerMonitor` too early would throw error messages like:

```
TypeError: Cannot match against 'undefined' or 'null'.
```

Now it throws messages like:

```
Error: Cannot initialize "powerMonitor" module before app is ready.
```

Closes #7225 