### PR TITLE
Ensure correct types for commandLine

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -28,15 +28,13 @@ Object.assign(app, {
       const castedArgs = args.map((arg) => {
         return typeof arg !== 'string' ? `${arg}` : arg
       })
-
-      return binding.appendSwitch(...castedArgs)
+      return bindings.appendSwitch(...castedArgs)
     },
     appendArgument (...args) {
-      const castedArgs = [...arguments].map((arg) => {
+      const castedArgs = args.map((arg) => {
         return typeof arg !== 'string' ? `${arg}` : arg
       })
-
-      return binding.appendArgument(...castedArgs)
+      return bindings.appendArgument(...castedArgs)
     }
   }
 })

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -24,15 +24,15 @@ Object.assign(app, {
     return Menu.getApplicationMenu()
   },
   commandLine: {
-    appendSwitch() {
-      let castedArgs = [...arguments].map((arg) => {
+    appendSwitch (...args) {
+      const castedArgs = args.map((arg) => {
         return typeof arg !== 'string' ? `${arg}` : arg
       })
 
       return binding.appendSwitch(...castedArgs)
     },
-    appendArgument() {
-      let castedArgs = [...arguments].map((arg) => {
+    appendArgument (...args) {
+      const castedArgs = [...arguments].map((arg) => {
         return typeof arg !== 'string' ? `${arg}` : arg
       })
 

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -24,8 +24,20 @@ Object.assign(app, {
     return Menu.getApplicationMenu()
   },
   commandLine: {
-    appendSwitch: bindings.appendSwitch,
-    appendArgument: bindings.appendArgument
+    appendSwitch() {
+      let castedArgs = [...arguments].map((arg) => {
+        return typeof arg !== 'string' ? `${arg}` : arg
+      })
+
+      return binding.appendSwitch(...castedArgs)
+    },
+    appendArgument() {
+      let castedArgs = [...arguments].map((arg) => {
+        return typeof arg !== 'string' ? `${arg}` : arg
+      })
+
+      return binding.appendArgument(...castedArgs)
+    }
   }
 })
 


### PR DESCRIPTION
This commit ensures that arguments passed to `appendSwitch` and `appendArgument` are turned into strings before passing them over to the binding.

I'm not super married to this one (since the documentation dooooeeeees say that the method expects a string), but this is a really easy thing for us to do in order to make dev's lives easier.

Closes #7220