### PR TITLE
Link against crypt32.lib

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -279,6 +279,7 @@
               '-lcomdlg32.lib',
               '-lwininet.lib',
               '-lwinmm.lib',
+              '-lcrypt32.lib',
             ],
           },
           'dependencies': [


### PR DESCRIPTION
Windows CI is current failing with the following errors:

```
FAILED: C:\Python27\python.exe gyp-win-tool link-with-manifests environment.x64 True electron.exe "C:\Python27\python.exe gyp-win-tool link-wrapper environment.x64 False link.exe /nologo /OUT:electron.exe @electron.exe.rsp" 1 mt.exe rc.exe "obj\electron.electron.exe.intermediate.manifest" obj\electron.electron.exe.generated.manifest ..\..\atom\browser\resources\win\atom.manifest

os_crypt.lib(os_crypt.os_crypt_win.obj) : error LNK2019: unresolved external symbol CryptProtectData referenced in function "public: static bool __cdecl OSCrypt::EncryptString(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?EncryptString@OSCrypt@@SA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAV23@@Z)

os_crypt.lib(os_crypt.os_crypt_win.obj) : error LNK2019: unresolved external symbol CryptUnprotectData referenced in function "public: static bool __cdecl OSCrypt::DecryptString16(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<wchar_t,struct std::char_traits<wchar_t>,class std::allocator<wchar_t> > *)" (?DecryptString16@OSCrypt@@SA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@3@@Z)

electron.exe : fatal error LNK1120: 2 unresolved externals
```

This pull requests adds `crypt32.lib` to the link settings to address this.

I think this might be related to the brightray upgrade for #7073 