### PR TITLE
Fix ELECTRON_DEFAULT_ERROR_MODE

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -145,7 +145,7 @@ void NodeBindings::Initialize() {
   // it back if user wants to show it.
   std::unique_ptr<base::Environment> env(base::Environment::Create());
   if (env->HasVar("ELECTRON_DEFAULT_ERROR_MODE"))
-    SetErrorMode(0);
+    SetErrorMode(GetErrorMode() & ~SEM_NOGPFAULTERRORBOX);
 #endif
 }
 


### PR DESCRIPTION
IMHO we should only drop the `SEM_NOGPFAULTERRORBOX` flag from the currently set error mode, which includes the recommended `SEM_FAILCRITICALERRORS`.