### PR TITLE
Deprecate process.versions['atom-shell']

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -117,7 +117,7 @@ void AtomBrowserMainParts::PostEarlyInitialization() {
   if (node_debugger_->IsRunning())
     env->AssignToContext(v8::Debug::GetDebugContext());
 
-  // Add atom-shell extended APIs.
+  // Add Electron extended APIs.
   atom_bindings_->BindTo(js_env_->isolate(), env->process_object());
 
   // Load everything.

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -60,7 +60,7 @@ class Browser : public WindowListObserver {
   // Overrides the application version.
   void SetVersion(const std::string& version);
 
-  // Returns the application's name, default is just Atom-Shell.
+  // Returns the application's name, default is just Electron.
   std::string GetName() const;
 
   // Overrides the application name.

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -117,8 +117,10 @@ void AtomBindings::BindTo(v8::Isolate* isolate,
   mate::Dictionary versions;
   if (dict.Get("versions", &versions)) {
     versions.Set(ATOM_PROJECT_NAME, ATOM_VERSION_STRING);
-    versions.Set("atom-shell", ATOM_VERSION_STRING);  // For compatibility.
     versions.Set("chrome", CHROME_VERSION_STRING);
+
+    // TODO(kevinsawicki): Remove in 2.0
+    versions.Set("atom-shell", ATOM_VERSION_STRING);
   }
 }
 

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -24,7 +24,7 @@ class AtomBindings {
   virtual ~AtomBindings();
 
   // Add process.atomBinding function, which behaves like process.binding but
-  // load native code from atom-shell instead.
+  // load native code from Electron instead.
   void BindTo(v8::Isolate* isolate, v8::Local<v8::Object> process);
 
  private:

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -266,7 +266,7 @@ void AtomRendererClient::DidCreateScriptContext(
   // Setup node environment for each window.
   node::Environment* env = node_bindings_->CreateEnvironment(context);
 
-  // Add atom-shell extended APIs.
+  // Add Electron extended APIs.
   atom_bindings_->BindTo(env->isolate(), env->process_object());
   AddRenderBindings(env->isolate(), env->process_object(),
                     preferences_manager_.get());

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -54,6 +54,15 @@ nativeImage.toJpeg()
 nativeImage.toJPEG()
 ```
 
+## `process`
+
+```js
+// Deprecated
+process.versions['atom-shell']
+// Replace with
+process.versions.electron
+```
+
 ## `Tray`
 
 ```js


### PR DESCRIPTION
Adds `process.versions['atom-shell']` to the 2.0 breakage doc in favor of `process.versions.electron`