### PR TITLE
:white_check_mark: Test that replacement history entries don't break forward navigation.

### DIFF
--- a/spec/fixtures/pages/history-replace.html
+++ b/spec/fixtures/pages/history-replace.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+window.addEventListener("load", function() {
+  window.history.replaceState(window.history.state, "test page", window.location.href)
+  require('electron').ipcRenderer.sendToHost('history', window.history.length);
+})
+</script>
+</body>
+</html>


### PR DESCRIPTION
This is a test for #7175