### PR TITLE
Use Ctrl+Y as the accelerator of redo on Windows

### DIFF
--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -69,7 +69,7 @@ const roles = {
   },
   redo: {
     label: 'Redo',
-    accelerator: 'Shift+CommandOrControl+Z',
+    accelerator: process.platform === 'win32' ? 'Control+Y' : 'Shift+CommandOrControl+Z',
     webContentsMethod: 'redo'
   },
   resetzoom: {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -417,6 +417,16 @@ describe('menu module', function () {
       assert.equal(item.label, 'Hide Electron Test')
       assert.equal(item.accelerator, undefined)
       assert.equal(item.getDefaultRoleAccelerator(), 'Command+H')
+
+      item = new MenuItem({role: 'undo'})
+      assert.equal(item.label, 'Undo')
+      assert.equal(item.accelerator, undefined)
+      assert.equal(item.getDefaultRoleAccelerator(), 'CommandOrControl+Z')
+
+      item = new MenuItem({role: 'redo'})
+      assert.equal(item.label, 'Redo')
+      assert.equal(item.accelerator, undefined)
+      assert.equal(item.getDefaultRoleAccelerator(), process.platform === 'win32' ? 'Control+Y' : 'Shift+CommandOrControl+Z')
     })
   })
 })


### PR DESCRIPTION
For `redo` role, `Ctrl+Y` is more consistent with other Windows applications.