### PR TITLE
Add killed argument for webContents.on("crashed") and app.on("gpu-process-crashed") events

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -585,8 +585,9 @@ void App::SelectClientCertificate(
         cert_request_info->client_certs[0].get());
 }
 
-void App::OnGpuProcessCrashed(base::TerminationStatus exit_code) {
-  Emit("gpu-process-crashed");
+void App::OnGpuProcessCrashed(base::TerminationStatus status) {
+  Emit("gpu-process-crashed",
+    status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 }
 
 base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -102,7 +102,7 @@ class App : public AtomBrowserClient::Delegate,
       std::unique_ptr<content::ClientCertificateDelegate> delegate) override;
 
   // content::GpuDataManagerObserver:
-  void OnGpuProcessCrashed(base::TerminationStatus exit_code) override;
+  void OnGpuProcessCrashed(base::TerminationStatus status) override;
 
  private:
   // Get/Set the pre-defined path in PathService.

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -586,7 +586,7 @@ void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
 }
 
 void WebContents::RenderProcessGone(base::TerminationStatus status) {
-  Emit("crashed");
+  Emit("crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 }
 
 void WebContents::PluginCrashed(const base::FilePath& plugin_path,

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -280,7 +280,12 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
 
 ### Event: 'gpu-process-crashed'
 
-Emitted when the gpu process crashes.
+Returns:
+
+* `event` Event
+* `killed` Boolean
+
+Emitted when the gpu process crashes or is killed.
 
 ### Event: 'accessibility-support-changed' _macOS_ _Windows_
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -203,7 +203,12 @@ are clicked or when the DOM `hashchange` event is triggered.
 
 #### Event: 'crashed'
 
-Emitted when the renderer process has crashed.
+Returns:
+
+* `event` Event
+* `killed` Boolean
+
+Emitted when the renderer process crashes or is killed.
 
 #### Event: 'plugin-crashed'
 


### PR DESCRIPTION
This indicates whether the renderer or gpu process was killed intentionally. Chrome's sad tab also distinguishes between crashed and killed tabs.