### PR TITLE
Use previous AppVeyor image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 # http://www.appveyor.com/docs/appveyor-yml
 version: "{build}"
 
-os: Visual Studio 2015
+os: Previous Visual Studio 2015
 
 init:
   - git config --global core.autocrlf input


### PR DESCRIPTION
Seeing some odd AppVeyor failures:

```
FAILED: ninja -t msvc -e environment.x64 -- "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\cl.exe" /nologo /showIncludes /FC @obj\atom\browser\api\electron_lib.atom_api_app.obj.rsp /c ..\..\atom\browser\api\atom_api_app.cc /Foobj\atom\browser\api\electron_lib.atom_api_app.obj /Fdobj\electron_lib.cc.pdb 
c:\projects\electron\atom\browser\ui\win\jump_list.h(8): fatal error C1083: Cannot open include file: 'atlbase.h': No such file or directory
```

https://ci.appveyor.com/project/Atom/electron/build/2176/job/ngh0sxfrwjx5cqng#L426

Looks like there was an update today, https://www.appveyor.com/updates/2016/09/19/

Trying to roll back to the old images to see if they build 🍏 