### PR TITLE
Add instruction for debugging main process in VSCode

### DIFF
--- a/docs/tutorial/debugging-main-process.md
+++ b/docs/tutorial/debugging-main-process.md
@@ -17,6 +17,41 @@ messages on the `port`. The default `port` is `5858`.
 
 Like `--debug` but pauses the script on the first line.
 
+## Use VSCode for Debugging
+
+### 1. Open an Electron project in VSCode.
+
+```bash
+$ git clone git@github.com:electron/electron-quick-start.git
+$ code electron-quick-start
+```
+
+### 2. Add a file `.vscode/launch.json` with the following configuration:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+      "program": "${workspaceRoot}/main.js"
+    }
+  ]
+}
+```
+
+**Note:** For Windows, use `"${workspaceRoot}/node_modules/.bin/electron.cmd"` for `runtimeExecutable`.
+
+### 3. Debugging
+
+Set some breakpoints in `main.js`, and start debugging in the [Debug View](https://code.visualstudio.com/docs/editor/debugging). You should be able to hit the breakpoints.
+
+Here is a pre-configured project that you can download and directly debug in VSCode: https://github.com/octref/vscode-electron-debug/tree/master/electron-quick-start
+
 ## Use node-inspector for Debugging
 
 **Note:** Electron doesn't currently work very well with node-inspector, and the


### PR DESCRIPTION
I hope you don't mind me putting the VSCode part before `node-inspector`, because VSCode seems easier to setup, and VSCode could inspect `process` without crashing.