### PR TITLE
allow GOOGLE_API_KEY to be set

### DIFF
--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -21,7 +21,6 @@ class AtomAccessTokenStore : public content::AccessTokenStore {
                        const base::string16& access_token) override;
 
  private:
-  std::string api_key_;
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);
 };
 

--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -21,6 +21,7 @@ class AtomAccessTokenStore : public content::AccessTokenStore {
                        const base::string16& access_token) override;
 
  private:
+  std::string api_key_;
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);
 };
 

--- a/atom/common/google_api_key.h
+++ b/atom/common/google_api_key.h
@@ -5,6 +5,11 @@
 #ifndef ATOM_COMMON_GOOGLE_API_KEY_H_
 #define ATOM_COMMON_GOOGLE_API_KEY_H_
 
+#ifndef GOOGLEAPIS_ENDPOINT
+#define GOOGLEAPIS_ENDPOINT \
+    "https://www.googleapis.com/geolocation/v1/geolocate?key="
+#endif
+
 #ifndef GOOGLEAPIS_API_KEY
 #define GOOGLEAPIS_API_KEY "AIzaSyAQfxPJiounkhOjODEO5ZieffeBv6yft2Q"
 #endif

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -33,7 +33,7 @@ Google API key in the environment. Place the following code in your main process
 file, before opening any browser windows that will make geocoding requests:
 
 ```javascript
-process.env.GOOGLE_API_KEY='YOUR_KEY_HERE'
+process.env.GOOGLE_API_KEY = 'YOUR_KEY_HERE'
 ```
 
 For instructions on how to acquire a Google API key, see

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -19,6 +19,32 @@ Windows console example:
 > electron
 ```
 
+## Production Variables
+
+The following environment variables are intended primarily for use at runtime
+in packaged Electron applications.
+
+### `GOOGLE_API_KEY`
+
+Electron includes a hardcoded API key for making requests to Google's geocoding
+webservice. Because this API key is included in every version of Electron, it
+often exceeds its usage quota. To work around this, you can supply your own
+Google API key in the environment. Place the following code in your main process
+file, before opening any browser windows that will make geocoding requests:
+
+```javascript
+process.env.GOOGLE_API_KEY='YOUR_KEY_HERE'
+```
+
+By default, a newly generated Google API key may not be allowed to make
+geocoding requests. To enable geocoding requests, visit this page:
+https://console.developers.google.com/apis/api/geolocation/overview
+
+## Development Variables
+
+The following environment variables are intended primarily for development and
+debugging purposes.
+
 ### `ELECTRON_RUN_AS_NODE`
 
 Starts the process as a normal Node.js process.

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -36,6 +36,9 @@ file, before opening any browser windows that will make geocoding requests:
 process.env.GOOGLE_API_KEY='YOUR_KEY_HERE'
 ```
 
+For instructions on how to acquire a Google API key, see
+https://www.chromium.org/developers/how-tos/api-keys
+
 By default, a newly generated Google API key may not be allowed to make
 geocoding requests. To enable geocoding requests, visit this page:
 https://console.developers.google.com/apis/api/geolocation/overview


### PR DESCRIPTION
Another go at #7197 that fixes #6648. The [geolocation code](https://github.com/electron/electron/pull/7104) got a little hairy after the chrome 53 upgrade, so I started over.

This change allows a `GOOGLE_API_KEY` environment variable to be set (before or during runtime) that will override the default key used for making geolocation requests.

We decided to punt on adding an environment variable to customize the host URL (e.g. `https://www.googleapis.com/geolocation/v1/geolocate?key=`). If someone wants that behavior, we could later introduce another environment variable for that, or perhaps a new API for setting the geolocation request URL.

🍐  @kevinsawicki 

