### PR TITLE
Set parameter type to Object instead of Dictionary

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -999,7 +999,7 @@ menu bar.
 
 * `progress` Double
 * `options` Object (optional)
-  * `mode` String _Windows_ - Mode for the progres bar (`none`, `normal`, `indeterminate`, `error`, or `paused`)
+  * `mode` String _Windows_ - Mode for the progress bar (`none`, `normal`, `indeterminate`, `error`, or `paused`)
 
 Sets progress value in progress bar. Valid range is [0, 1.0].
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -33,7 +33,7 @@ This method returns `true` if the Swipe between pages setting is on, and `false`
 ### `systemPreferences.postNotification(event, userInfo)` _macOS_
 
 * `event` String
-* `userInfo` Dictionary
+* `userInfo` Object
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
@@ -41,7 +41,7 @@ that contains the user information dictionary sent along with the notification.
 ### `systemPreferences.postLocalNotification(event, userInfo)` _macOS_
 
 * `event` String
-* `userInfo` Dictionary
+* `userInfo` Object
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.


### PR DESCRIPTION
Small docs change, switch parameter types of `Dictionary` to `Object` which the rest of the docs use and is more accurate to the expected JavaScript type.