### PR TITLE
Mention using fallback text when writing bookmarks on Windows

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -90,6 +90,17 @@ bookmark is unavailable.
 
 Writes the `title` and `url` into the clipboard as a bookmark.
 
+**Note:** Most apps on Windows don't support pasting bookmarks into them so
+you can use `clipboard.write` to write both a bookmark and fallback text to the
+clipboard.
+
+```js
+clipboard.write({
+  text: 'http://electron.atom.io',
+  bookmark: 'Electron Homepage'
+})
+```
+
 ### `clipboard.clear([type])`
 
 * `type` String (optional)


### PR DESCRIPTION
Update docs for a better way to write bookmarks with fallback text links to the clipboard on Windows.

On Windows, only a few places, like the Chrome address bar, supports pasting bookmarks directly.

So using `clipboard.write` with both text and bookmark keys is the better option.

Closes #7190 