### PR TITLE
Mention mutating remote arrays and buffers

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -19,7 +19,7 @@ let win = new BrowserWindow({width: 800, height: 600})
 win.loadURL('https://github.com')
 ```
 
-**Note:** for the reverse (access the renderer process from the main process),
+**Note:** For the reverse (access the renderer process from the main process),
 you can use [webContents.executeJavascript](web-contents.md#webcontentsexecutejavascriptcode-usergesture-callback).
 
 ## Remote Objects
@@ -36,8 +36,12 @@ process. Instead, it created a `BrowserWindow` object in the main process and
 returned the corresponding remote object in the renderer process, namely the
 `win` object.
 
-Please note that only [enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) which are present when the remote object is first referenced are
-accessible via remote.
+**Note:** Only [enumerable properties][enumerable-properties] which are present
+when the remote object is first referenced are accessible via remote.
+
+**Note:** Arrays and Buffers are copied over IPC when accessed via the `remote`
+module. Modifying them in the renderer process does not modify them in the main
+process and vice versa.
 
 ## Lifetime of Remote Objects
 
@@ -160,3 +164,4 @@ The `process` object in the main process. This is the same as
 `remote.getGlobal('process')` but is cached.
 
 [rmi]: http://en.wikipedia.org/wiki/Java_remote_method_invocation
+[enumerable-properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties


### PR DESCRIPTION
Add a note to `remote.md` that modifying buffers and arrays returned from the `remote` module does not modify them in the main process.

Closes #6734