### PR TITLE
Mention createFromPath bad path return value

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -120,7 +120,9 @@ Creates an empty `NativeImage` instance.
 
 * `path` String
 
-Creates a new `NativeImage` instance from a file located at `path`.
+Creates a new `NativeImage` instance from a file located at `path`. This method
+returns an empty image if the `path` does not exist, cannot be read, or is not
+a valid image.
 
 ```javascript
 const nativeImage = require('electron').nativeImage

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -10,6 +10,8 @@ describe('nativeImage module', () => {
       assert(nativeImage.createFromPath('').isEmpty())
       assert(nativeImage.createFromPath('does-not-exist.png').isEmpty())
       assert(nativeImage.createFromPath('does-not-exist.ico').isEmpty())
+      assert(nativeImage.createFromPath(__dirname).isEmpty())
+      assert(nativeImage.createFromPath(__filename).isEmpty())
     })
 
     it('loads images from paths relative to the current working directory', () => {


### PR DESCRIPTION
Document that `nativeImage.createFromPath` returns an empty image for a bad `path`.

Closes #6844 