### PR TITLE
Allow custom window level when sending window to top

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -487,7 +487,7 @@ bool Window::IsClosable() {
 }
 
 void Window::SetAlwaysOnTop(bool top, mate::Arguments* args) {
-  int level = 0;
+  std::string level = "floating";
   args->GetNext(&level);
   window_->SetAlwaysOnTop(top, level);
 }

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -486,8 +486,10 @@ bool Window::IsClosable() {
   return window_->IsClosable();
 }
 
-void Window::SetAlwaysOnTop(bool top) {
-  window_->SetAlwaysOnTop(top);
+void Window::SetAlwaysOnTop(bool top, mate::Arguments* args) {
+  int level = 0;
+  args->GetNext(&level);
+  window_->SetAlwaysOnTop(top, level);
 }
 
 bool Window::IsAlwaysOnTop() {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -132,7 +132,7 @@ class Window : public mate::TrackableObject<Window>,
   bool IsFullScreenable();
   void SetClosable(bool closable);
   bool IsClosable();
-  void SetAlwaysOnTop(bool top);
+  void SetAlwaysOnTop(bool top, mate::Arguments* args);
   bool IsAlwaysOnTop();
   void Center();
   void SetPosition(int x, int y, mate::Arguments* args);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -118,7 +118,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsFullScreenable() = 0;
   virtual void SetClosable(bool closable) = 0;
   virtual bool IsClosable() = 0;
-  virtual void SetAlwaysOnTop(bool top, int level = 0) = 0;
+  virtual void SetAlwaysOnTop(bool top, const std::string& level) = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;
   virtual void SetTitle(const std::string& title) = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -118,7 +118,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsFullScreenable() = 0;
   virtual void SetClosable(bool closable) = 0;
   virtual bool IsClosable() = 0;
-  virtual void SetAlwaysOnTop(bool top, const std::string& level) = 0;
+  virtual void SetAlwaysOnTop(bool top,
+                              const std::string& level = "floating") = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;
   virtual void SetTitle(const std::string& title) = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -118,7 +118,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsFullScreenable() = 0;
   virtual void SetClosable(bool closable) = 0;
   virtual bool IsClosable() = 0;
-  virtual void SetAlwaysOnTop(bool top) = 0;
+  virtual void SetAlwaysOnTop(bool top, int level = 0) = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;
   virtual void SetTitle(const std::string& title) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -64,7 +64,7 @@ class NativeWindowMac : public NativeWindow,
   bool IsFullScreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
-  void SetAlwaysOnTop(bool top) override;
+  void SetAlwaysOnTop(bool top, int level) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -64,7 +64,7 @@ class NativeWindowMac : public NativeWindow,
   bool IsFullScreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
-  void SetAlwaysOnTop(bool top, int level) override;
+  void SetAlwaysOnTop(bool top, const std::string& level) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -968,7 +968,7 @@ void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level) {
 }
 
 bool NativeWindowMac::IsAlwaysOnTop() {
-  return [window_ level] == NSFloatingWindowLevel;
+  return [window_ level] != NSNormalWindowLevel;
 }
 
 void NativeWindowMac::Center() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -943,11 +943,28 @@ bool NativeWindowMac::IsClosable() {
   return [window_ styleMask] & NSClosableWindowMask;
 }
 
-void NativeWindowMac::SetAlwaysOnTop(bool top, int level) {
-  if (!level) {
-    level = NSFloatingWindowLevel;
+void NativeWindowMac::SetAlwaysOnTop(bool top, std::string level) {
+  int intLevel;
+  if (level == "normal") {
+    intLevel = NSNormalWindowLevel;
+  } else if (level == "floating") {
+    intLevel = NSFloatingWindowLevel;
+  } else if (level == "torn-off-menu") {
+    intLevel = NSTornOffMenuWindowLevel;
+  } else if (level == "modal-panel") {
+    intLevel = NSModalPanelWindowLevel;
+  } else if (level == "main-menu") {
+    intLevel = NSMainMenuWindowLevel;
+  } else if (level == "status") {
+    intLevel = NSStatusWindowLevel;
+  } else if (level == "pop-up-menu") {
+    intLevel = NSPopUpMenuWindowLevel;
+  } else if (level == "screen-saver") {
+    intLevel = NSScreenSaverWindowLevel;
+  } else if (level == "dock") {
+    intLevel = NSDockWindowLevel;
   }
-  [window_ setLevel:(top ? level : NSNormalWindowLevel)];
+  [window_ setLevel:(top ? intLevel : NSNormalWindowLevel)];
 }
 
 bool NativeWindowMac::IsAlwaysOnTop() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -943,8 +943,11 @@ bool NativeWindowMac::IsClosable() {
   return [window_ styleMask] & NSClosableWindowMask;
 }
 
-void NativeWindowMac::SetAlwaysOnTop(bool top) {
-  [window_ setLevel:(top ? NSFloatingWindowLevel : NSNormalWindowLevel)];
+void NativeWindowMac::SetAlwaysOnTop(bool top, int level) {
+  if (!level) {
+    level = NSFloatingWindowLevel;
+  }
+  [window_ setLevel:(top ? level : NSNormalWindowLevel)];
 }
 
 bool NativeWindowMac::IsAlwaysOnTop() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -943,28 +943,28 @@ bool NativeWindowMac::IsClosable() {
   return [window_ styleMask] & NSClosableWindowMask;
 }
 
-void NativeWindowMac::SetAlwaysOnTop(bool top, std::string level) {
-  int intLevel;
-  if (level == "normal") {
-    intLevel = NSNormalWindowLevel;
-  } else if (level == "floating") {
-    intLevel = NSFloatingWindowLevel;
-  } else if (level == "torn-off-menu") {
-    intLevel = NSTornOffMenuWindowLevel;
-  } else if (level == "modal-panel") {
-    intLevel = NSModalPanelWindowLevel;
-  } else if (level == "main-menu") {
-    intLevel = NSMainMenuWindowLevel;
-  } else if (level == "status") {
-    intLevel = NSStatusWindowLevel;
-  } else if (level == "pop-up-menu") {
-    intLevel = NSPopUpMenuWindowLevel;
-  } else if (level == "screen-saver") {
-    intLevel = NSScreenSaverWindowLevel;
-  } else if (level == "dock") {
-    intLevel = NSDockWindowLevel;
+void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level) {
+  int windowLevel = NSNormalWindowLevel;
+  if (top) {
+    if (level == "floating") {
+      windowLevel = NSFloatingWindowLevel;
+    } else if (level == "torn-off-menu") {
+      windowLevel = NSTornOffMenuWindowLevel;
+    } else if (level == "modal-panel") {
+      windowLevel = NSModalPanelWindowLevel;
+    } else if (level == "main-menu") {
+      windowLevel = NSMainMenuWindowLevel;
+    } else if (level == "status") {
+      windowLevel = NSStatusWindowLevel;
+    } else if (level == "pop-up-menu") {
+      windowLevel = NSPopUpMenuWindowLevel;
+    } else if (level == "screen-saver") {
+      windowLevel = NSScreenSaverWindowLevel;
+    } else if (level == "dock") {
+      windowLevel = NSDockWindowLevel;
+    }
   }
-  [window_ setLevel:(top ? intLevel : NSNormalWindowLevel)];
+  [window_ setLevel:windowLevel];
 }
 
 bool NativeWindowMac::IsAlwaysOnTop() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -683,7 +683,7 @@ bool NativeWindowViews::IsClosable() {
 }
 
 void NativeWindowViews::SetAlwaysOnTop(bool top, const std::string& level) {
-  window_->SetAlwaysOnTop(top, level);
+  window_->SetAlwaysOnTop(top);
 }
 
 bool NativeWindowViews::IsAlwaysOnTop() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -682,8 +682,8 @@ bool NativeWindowViews::IsClosable() {
 #endif
 }
 
-void NativeWindowViews::SetAlwaysOnTop(bool top) {
-  window_->SetAlwaysOnTop(top);
+void NativeWindowViews::SetAlwaysOnTop(bool top, int level) {
+  window_->SetAlwaysOnTop(top, level);
 }
 
 bool NativeWindowViews::IsAlwaysOnTop() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -682,7 +682,7 @@ bool NativeWindowViews::IsClosable() {
 #endif
 }
 
-void NativeWindowViews::SetAlwaysOnTop(bool top, int level) {
+void NativeWindowViews::SetAlwaysOnTop(bool top, const std::string& level) {
   window_->SetAlwaysOnTop(top, level);
 }
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -84,7 +84,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsFullScreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
-  void SetAlwaysOnTop(bool top, int level) override;
+  void SetAlwaysOnTop(bool top, const std::string& level) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -84,7 +84,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsFullScreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
-  void SetAlwaysOnTop(bool top) override;
+  void SetAlwaysOnTop(bool top, int level) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -812,13 +812,12 @@ returns `true`.
 #### `win.setAlwaysOnTop(flag[, level])`
 
 * `flag` Boolean
-* `level` Integer (optional) macOS
+* `level` String (optional) _macOS_ - Options include (`normal`, `floating`, `torn-off-menu`,
+`modal-panel`, `main-menu`, `status`, `pop-up-menu`, `screen-saver`, `dock`). Default is `floating`.
 
 Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which
 can not be focused on.
-
-A custom level can be set on MacOS that will override the default `NSFloatingWindowLevel`.
 
 #### `win.isAlwaysOnTop()`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -809,13 +809,16 @@ Sets whether the window can be manually closed by user. On Linux does nothing.
 Returns whether the window can be manually closed by user. On Linux always
 returns `true`.
 
-#### `win.setAlwaysOnTop(flag)`
+#### `win.setAlwaysOnTop(flag[, level])`
 
 * `flag` Boolean
+* `level` Integer (optional) macOS
 
 Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which
 can not be focused on.
+
+A custom level can be set on MacOS that will override the default `NSFloatingWindowLevel`.
 
 #### `win.isAlwaysOnTop()`
 


### PR DESCRIPTION
This allows for a custom window level to be set when sending a window to the top.

```
win.setAlwaysOnTop(true, 102);
```

This can be used when the NSFloatingWindowLevel isn't high enough.  I have used this to put a window above the top menu bar.