### PR TITLE
electron-api.json is under out/ instead of out/R/

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -130,7 +130,7 @@ def copy_license():
   shutil.copy2(os.path.join(SOURCE_ROOT, 'LICENSE'), DIST_DIR)
 
 def copy_api_json_schema():
-  shutil.copy2(os.path.join(OUT_DIR, 'electron-api.json'), DIST_DIR)
+  shutil.copy2(os.path.join(SOURCE_ROOT, 'out', 'electron-api.json'), DIST_DIR)
 
 def strip_binaries():
   for binary in TARGET_BINARIES[PLATFORM]:


### PR DESCRIPTION
It caused an error when running create-dist.