### PR TITLE
Add npm_config_target_arch to native module doc

### DIFF
--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -21,6 +21,7 @@ An example of installing all dependencies for Electron:
 export npm_config_target=1.2.3
 # The architecture of Electron, can be ia32 or x64.
 export npm_config_arch=x64
+export npm_config_target_arch=x64
 # Download headers for Electron.
 export npm_config_disturl=https://atom.io/download/atom-shell
 # Tell node-pre-gyp that we are building for Electron.


### PR DESCRIPTION
We ran into an issue when creating a 32-bit binary on 64-bit Windows where node-pre-gyp kept using the 64-bit library. Setting the `npm_config_target_arch` environment variable resolved the problem for us and caused the 32-bit binary to be built and used.