### PR TITLE
Workaround for electron/electron#5050

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -164,7 +164,7 @@ const mainStartupScript = packageJson.main || 'index.js'
 
 // Workaround for electron/electron#5050
 if (process.platform === 'linux' && process.env.XDG_CURRENT_DESKTOP === 'Pantheon') {
-  process.env.XDG_CURRENT_DESKTOP = 'Unity';
+  process.env.XDG_CURRENT_DESKTOP = 'Unity'
 }
 
 // Finally load app's main.js and transfer control to C++.

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -162,5 +162,10 @@ require('./api/protocol')
 // Set main startup script of the app.
 const mainStartupScript = packageJson.main || 'index.js'
 
+// Workaround for electron/electron#5050
+if (process.platform === 'linux' && process.env.XDG_CURRENT_DESKTOP === 'Pantheon') {
+  process.env.XDG_CURRENT_DESKTOP = 'Unity';
+}
+
 // Finally load app's main.js and transfer control to C++.
 Module._load(path.join(packagePath, mainStartupScript), Module, true)

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -58,8 +58,3 @@ if (process.platform === 'win32') {
     process.windowsStore = true
   }
 }
-
-// Workaround for electron/electron#5050
-if (process.platform === 'linux' && process.env.XDG_CURRENT_DESKTOP === 'Pantheon') {
-  process.env.XDG_CURRENT_DESKTOP = 'Unity';
-}

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -58,3 +58,8 @@ if (process.platform === 'win32') {
     process.windowsStore = true
   }
 }
+
+// Workaround for electron/electron#5050
+if (process.platform === 'linux' && process.env.XDG_CURRENT_DESKTOP === 'Pantheon') {
+  process.env.XDG_CURRENT_DESKTOP = 'Unity';
+}


### PR DESCRIPTION
Workaround for electron/electron#5050

Chromium only show the Tray icon with libappindicator when the env `XDG_CURRENT_DESKTOP`'s value is `Unity`. But under elementaryOS its value is 'Pantheon'.

Set it to `Unity` before app startup make the tray icon show under elementaryOS.