### PR TITLE
Add /LARGEADDRESSAWARE to linker options for electron.exe

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -122,6 +122,9 @@
             '<(libchromiumcontent_dir)/gen/ui/resources',
           ],
           'msvs_settings': {
+            'VCLinkerTool': {
+              'LargeAddressAware': '2'
+            },
             'VCManifestTool': {
               'EmbedManifest': 'true',
               'AdditionalManifestFiles': 'atom/browser/resources/win/atom.manifest',


### PR DESCRIPTION
Is there a reason, why electron.exe (32-bit) is not `/LARGEADDRESSAWARE` by default?