### PR TITLE
Add process.setDefaultErrorMode()

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -144,7 +144,7 @@ void NodeBindings::Initialize() {
   // uv_init overrides error mode to suppress the default crash dialog, bring
   // it back if user wants to show it.
   std::unique_ptr<base::Environment> env(base::Environment::Create());
-  if (env->HasVar("ELECTRON_DEFAULT_ERROR_MODE"))
+  if (is_browser_ || env->HasVar("ELECTRON_DEFAULT_ERROR_MODE"))
     SetErrorMode(GetErrorMode() & ~SEM_NOGPFAULTERRORBOX);
 #endif
 }


### PR DESCRIPTION
This method has the same effect as https://github.com/electron/electron/blob/master/docs/api/environment-variables.md#electron_default_error_mode-windows

This is useful for apps not using the `crashReporter` module and/or for debugging.