### PR TITLE
Fix broken link in original docs

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -177,7 +177,7 @@ of argument is notated by either the common types:
 * [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 * [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
 * [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
-* Or a custom type like Electron's [`WebContent`](api/web-content.md)
+* Or a custom type like Electron's [`WebContent`](api/web-contents.md)
 
 If an argument or a method is unique to certain platforms, those platforms are
 denoted using a space-delimited italicized list following the datatype. Values


### PR DESCRIPTION
This problem also exists in translated documents.
Korean document is to be processed by separately with more changes.
Docs in other languages have not modified, because the characters that are not supported by my editor.