### PR TITLE
Configure ink drops on menu bar buttons

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -63,7 +63,10 @@ void MenuBar::SetMenu(AtomMenuModel* model) {
   RemoveAllChildViews(true);
 
   for (int i = 0; i < model->GetItemCount(); ++i) {
-    SubmenuButton* button = new SubmenuButton(this, model->GetLabelAt(i), this);
+    SubmenuButton* button = new SubmenuButton(this,
+                                              model->GetLabelAt(i),
+                                              this,
+                                              background_color_);
     button->set_tag(i);
 
 #if defined(USE_X11)

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -9,8 +9,8 @@
 #include "ui/gfx/canvas.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/text_utils.h"
-#include "ui/views/animation/ink_drop_host_view.h"
 #include "ui/views/animation/flood_fill_ink_drop_ripple.h"
+#include "ui/views/animation/ink_drop_host_view.h"
 #include "ui/views/controls/button/label_button_border.h"
 
 namespace atom {

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -7,7 +7,10 @@
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "ui/gfx/canvas.h"
+#include "ui/gfx/color_utils.h"
 #include "ui/gfx/text_utils.h"
+#include "ui/views/animation/ink_drop_host_view.h"
+#include "ui/views/animation/flood_fill_ink_drop_ripple.h"
 #include "ui/views/controls/button/label_button_border.h"
 
 namespace atom {
@@ -44,9 +47,39 @@ SubmenuButton::SubmenuButton(views::ButtonListener* listener,
                            &underline_end_))
     gfx::Canvas::SizeStringInt(GetText(), GetFontList(), &text_width_,
                                &text_height_, 0, 0);
+
+  SetHasInkDrop(true);
+  set_ink_drop_base_color(color_utils::BlendTowardOppositeLuma(
+      color_utils::GetSysSkColor(COLOR_MENUBAR), 0x61));
 }
 
 SubmenuButton::~SubmenuButton() {
+}
+
+std::unique_ptr<views::InkDropRipple> SubmenuButton::CreateInkDropRipple()
+    const {
+  return base::MakeUnique<views::FloodFillInkDropRipple>(
+      GetLocalBounds(),
+      GetInkDropCenterBasedOnLastEvent(),
+      GetInkDropBaseColor()
+      ink_drop_visible_opacity());
+}
+
+std::unique_ptr<views::InkDropHighlight>
+    SubmenuButton::CreateInkDropHighlight() const {
+  if (!ShouldShowInkDropHighlight())
+    return nullptr;
+
+  gfx::Size size = GetLocalBounds().size();
+  return base::MakeUnique<views::InkDropHighlight>(
+      size,
+      kInkDropSmallCornerRadius,
+      gfx::RectF(gfx::SizeF(size)).CenterPoint(),
+      GetInkDropBaseColor());
+}
+
+bool SubmenuButton::ShouldShowInkDropForFocus() const {
+  return false;
 }
 
 void SubmenuButton::SetAcceleratorVisibility(bool visible) {

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -28,7 +28,8 @@ base::string16 FilterAccelerator(const base::string16& label) {
 
 SubmenuButton::SubmenuButton(views::ButtonListener* listener,
                              const base::string16& title,
-                             views::MenuButtonListener* menu_button_listener)
+                             views::MenuButtonListener* menu_button_listener,
+                             const SkColor& background_color)
     : views::MenuButton(FilterAccelerator(title),
                         menu_button_listener, false),
       accelerator_(0),
@@ -37,7 +38,8 @@ SubmenuButton::SubmenuButton(views::ButtonListener* listener,
       underline_end_(-1),
       text_width_(0),
       text_height_(0),
-      underline_color_(SK_ColorBLACK) {
+      underline_color_(SK_ColorBLACK),
+      background_color_(background_color) {
 #if defined(OS_LINUX)
   // Dont' use native style border.
   SetBorder(std::move(CreateDefaultBorder()));
@@ -49,8 +51,8 @@ SubmenuButton::SubmenuButton(views::ButtonListener* listener,
                                &text_height_, 0, 0);
 
   SetHasInkDrop(true);
-  set_ink_drop_base_color(color_utils::BlendTowardOppositeLuma(
-      color_utils::GetSysSkColor(COLOR_MENUBAR), 0x61));
+  set_ink_drop_base_color(
+      color_utils::BlendTowardOppositeLuma(background_color_, 0x61));
 }
 
 SubmenuButton::~SubmenuButton() {
@@ -61,7 +63,7 @@ std::unique_ptr<views::InkDropRipple> SubmenuButton::CreateInkDropRipple()
   return base::MakeUnique<views::FloodFillInkDropRipple>(
       GetLocalBounds(),
       GetInkDropCenterBasedOnLastEvent(),
-      GetInkDropBaseColor()
+      GetInkDropBaseColor(),
       ink_drop_visible_opacity());
 }
 

--- a/atom/browser/ui/views/submenu_button.h
+++ b/atom/browser/ui/views/submenu_button.h
@@ -15,7 +15,8 @@ class SubmenuButton : public views::MenuButton {
  public:
   SubmenuButton(views::ButtonListener* listener,
                 const base::string16& title,
-                views::MenuButtonListener* menu_button_listener);
+                views::MenuButtonListener* menu_button_listener,
+                const SkColor& background_color);
   virtual ~SubmenuButton();
 
   void SetAcceleratorVisibility(bool visible);
@@ -51,6 +52,7 @@ class SubmenuButton : public views::MenuButton {
   int text_width_;
   int text_height_;
   SkColor underline_color_;
+  SkColor background_color_;
 
   DISALLOW_COPY_AND_ASSIGN(SubmenuButton);
 };

--- a/atom/browser/ui/views/submenu_button.h
+++ b/atom/browser/ui/views/submenu_button.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_UI_VIEWS_SUBMENU_BUTTON_H_
 
 #include "ui/views/controls/button/menu_button.h"
+#include "ui/views/animation/ink_drop_highlight.h"
 
 namespace atom {
 
@@ -27,6 +28,12 @@ class SubmenuButton : public views::MenuButton {
 
   // views::MenuButton:
   void OnPaint(gfx::Canvas* canvas) override;
+
+  // views::InkDropHostView:
+  std::unique_ptr<views::InkDropRipple> CreateInkDropRipple() const override;
+  std::unique_ptr<views::InkDropHighlight> CreateInkDropHighlight()
+     const override;
+  bool ShouldShowInkDropForFocus() const override;
 
  private:
   bool GetUnderlinePosition(const base::string16& text,

--- a/atom/browser/ui/views/submenu_button.h
+++ b/atom/browser/ui/views/submenu_button.h
@@ -5,8 +5,8 @@
 #ifndef ATOM_BROWSER_UI_VIEWS_SUBMENU_BUTTON_H_
 #define ATOM_BROWSER_UI_VIEWS_SUBMENU_BUTTON_H_
 
-#include "ui/views/controls/button/menu_button.h"
 #include "ui/views/animation/ink_drop_highlight.h"
+#include "ui/views/controls/button/menu_button.h"
 
 namespace atom {
 
@@ -33,7 +33,7 @@ class SubmenuButton : public views::MenuButton {
   // views::InkDropHostView:
   std::unique_ptr<views::InkDropRipple> CreateInkDropRipple() const override;
   std::unique_ptr<views::InkDropHighlight> CreateInkDropHighlight()
-     const override;
+      const override;
   bool ShouldShowInkDropForFocus() const override;
 
  private:


### PR DESCRIPTION
The 1.4 upgrade to Chrome 53 caused the menu bar buttons to no longer show hover/click states on Windows and Linux.

This pull request updates them to use the new ink drop effects that Chrome now uses for buttons to show feedback for press and hover.

| Windows | Ubuntu |
|---|---|
| <img width="249" alt="screen shot 2016-09-28 at 3 29 23 pm" src="https://cloud.githubusercontent.com/assets/671378/18934786/a8bfb5c0-8590-11e6-86fe-9fb18567ddb8.png"> | <img width="219" alt="screen shot 2016-09-28 at 3 26 18 pm" src="https://cloud.githubusercontent.com/assets/671378/18934790/af306eae-8590-11e6-96f8-2b87495f582a.png"> | 

Closes #7279 