### PR TITLE
Add cookie changed event

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -55,7 +55,6 @@ struct Converter<net::CanonicalCookie> {
   }
 };
 
-
 template<>
 struct Converter<AtomCookieDelegate::ChangeCause> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
@@ -76,7 +75,6 @@ struct Converter<AtomCookieDelegate::ChangeCause> {
     }
   }
 };
-
 
 }  // namespace mate
 

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -267,8 +267,6 @@ void Cookies::Set(const base::DictionaryValue& details,
 void Cookies::OnCookieChanged(const net::CanonicalCookie& cookie,
                               bool removed,
                               AtomCookieDelegate::ChangeCause cause) {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
   Emit("changed", cookie, cause, removed);
 }
 

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -61,7 +61,7 @@ class Cookies : public mate::TrackableObject<Cookies>,
 
  private:
   net::URLRequestContextGetter* request_context_getter_;
-  AtomCookieDelegate* cookie_delegate_;
+  scoped_refptr<AtomCookieDelegate> cookie_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(Cookies);
 };

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "atom/browser/api/trackable_object.h"
+#include "atom/browser/net/atom_cookie_delegate.h"
 #include "base/callback.h"
 #include "native_mate/handle.h"
 #include "net/cookies/canonical_cookie.h"
@@ -26,7 +27,8 @@ class AtomBrowserContext;
 
 namespace api {
 
-class Cookies : public mate::TrackableObject<Cookies> {
+class Cookies : public mate::TrackableObject<Cookies>,
+                public AtomCookieDelegate::Observer {
  public:
   enum Error {
     SUCCESS,
@@ -52,8 +54,14 @@ class Cookies : public mate::TrackableObject<Cookies> {
               const base::Closure& callback);
   void Set(const base::DictionaryValue& details, const SetCallback& callback);
 
+  // AtomCookieDelegate::Observer:
+  void OnCookieChanged(const net::CanonicalCookie& cookie,
+                       bool removed,
+                       AtomCookieDelegate::ChangeCause cause) override;
+
  private:
   net::URLRequestContextGetter* request_context_getter_;
+  AtomCookieDelegate* cookie_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(Cookies);
 };

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -49,6 +49,7 @@
 #include "net/url_request/url_request_context_getter.h"
 #include "ui/base/l10n/l10n_util.h"
 
+using atom::api::Cookies;
 using content::BrowserThread;
 using content::StoragePartition;
 
@@ -335,7 +336,7 @@ void OnClearStorageDataDone(const base::Closure& callback) {
 Session::Session(v8::Isolate* isolate, AtomBrowserContext* browser_context)
     : devtools_network_emulation_client_id_(base::GenerateGUID()),
       browser_context_(browser_context) {
-  // Observe DownloadManger to get download notifications.
+  // Observe DownloadManager to get download notifications.
   content::BrowserContext::GetDownloadManager(browser_context)->
       AddObserver(this);
 
@@ -521,7 +522,7 @@ void Session::GetBlobData(
 
 v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   if (cookies_.IsEmpty()) {
-    auto handle = atom::api::Cookies::Create(isolate, browser_context());
+    auto handle = Cookies::Create(isolate, browser_context());
     cookies_.Reset(isolate, handle.ToV8());
   }
   return v8::Local<v8::Value>::New(isolate, cookies_);
@@ -631,6 +632,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("Session", Session::GetConstructor(isolate)->GetFunction());
+  dict.Set("Cookies", Cookies::GetConstructor(isolate)->GetFunction());
   dict.SetMethod("fromPartition", &FromPartition);
 }
 

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -71,7 +71,8 @@ AtomBrowserContext::AtomBrowserContext(
     const std::string& partition, bool in_memory,
     const base::DictionaryValue& options)
     : brightray::BrowserContext(partition, in_memory),
-      network_delegate_(new AtomNetworkDelegate) {
+      network_delegate_(new AtomNetworkDelegate),
+      cookie_delegate_(new AtomCookieDelegate) {
   // Construct user agent string.
   Browser* browser = Browser::Get();
   std::string name = RemoveWhitespace(browser->GetName());
@@ -105,6 +106,10 @@ void AtomBrowserContext::SetUserAgent(const std::string& user_agent) {
 
 net::NetworkDelegate* AtomBrowserContext::CreateNetworkDelegate() {
   return network_delegate_;
+}
+
+net::CookieMonsterDelegate* AtomBrowserContext::CreateCookieDelegate() {
+  return cookie_delegate();
 }
 
 std::string AtomBrowserContext::GetUserAgent() {

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -8,7 +8,9 @@
 #include <string>
 #include <vector>
 
+#include "atom/browser/net/atom_cookie_delegate.h"
 #include "brightray/browser/browser_context.h"
+#include "net/cookies/cookie_monster.h"
 
 namespace atom {
 
@@ -31,6 +33,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // brightray::URLRequestContextGetter::Delegate:
   net::NetworkDelegate* CreateNetworkDelegate() override;
+  net::CookieMonsterDelegate* CreateCookieDelegate() override;
   std::string GetUserAgent() override;
   std::unique_ptr<net::URLRequestJobFactory> CreateURLRequestJobFactory(
       content::ProtocolHandlerMap* protocol_handlers) override;
@@ -50,6 +53,9 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   AtomBlobReader* GetBlobReader();
   AtomNetworkDelegate* network_delegate() const { return network_delegate_; }
+  AtomCookieDelegate* cookie_delegate() const {
+    return cookie_delegate_.get();
+  }
 
  protected:
   AtomBrowserContext(const std::string& partition, bool in_memory,
@@ -66,6 +72,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // Managed by brightray::BrowserContext.
   AtomNetworkDelegate* network_delegate_;
+  scoped_refptr<AtomCookieDelegate> cookie_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserContext);
 };

--- a/atom/browser/net/atom_cookie_delegate.cc
+++ b/atom/browser/net/atom_cookie_delegate.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2016 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/net/atom_cookie_delegate.h"
+
+#include "content/public/browser/browser_thread.h"
+
+namespace atom {
+
+AtomCookieDelegate::AtomCookieDelegate() {
+}
+
+AtomCookieDelegate::~AtomCookieDelegate() {
+}
+
+void AtomCookieDelegate::AddObserver(Observer* observer) {
+  observers_.AddObserver(observer);
+}
+
+void AtomCookieDelegate::RemoveObserver(Observer* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+void AtomCookieDelegate::NotifyObservers(
+  const net::CanonicalCookie& cookie, bool removed, ChangeCause cause) {
+  FOR_EACH_OBSERVER(Observer,
+                    observers_,
+                    OnCookieChanged(cookie, removed, cause));
+}
+
+void AtomCookieDelegate::OnCookieChanged(
+    const net::CanonicalCookie& cookie, bool removed, ChangeCause cause) {
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI,
+      FROM_HERE,
+      base::Bind(&AtomCookieDelegate::NotifyObservers,
+                 this, cookie, removed, cause));
+}
+
+}  // namespace atom

--- a/atom/browser/net/atom_cookie_delegate.h
+++ b/atom/browser/net/atom_cookie_delegate.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_NET_ATOM_COOKIE_DELEGATE_H_
+#define ATOM_BROWSER_NET_ATOM_COOKIE_DELEGATE_H_
+
+#include "base/observer_list.h"
+#include "net/cookies/cookie_monster.h"
+
+namespace atom {
+
+class AtomCookieDelegate : public net::CookieMonsterDelegate {
+ public:
+  AtomCookieDelegate();
+  ~AtomCookieDelegate() override;
+
+  class Observer {
+   public:
+    virtual void OnCookieChanged(const net::CanonicalCookie& cookie,
+                                 bool removed,
+                                 ChangeCause cause) {}
+   protected:
+    virtual ~Observer() {}
+  };
+
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
+  // net::CookieMonsterDelegate:
+  void OnCookieChanged(const net::CanonicalCookie& cookie,
+                       bool removed,
+                       ChangeCause cause) override;
+
+
+ private:
+  base::ObserverList<Observer> observers_;
+
+  void NotifyObservers(const net::CanonicalCookie& cookie,
+                       bool removed,
+                       ChangeCause cause);
+
+  DISALLOW_COPY_AND_ASSIGN(AtomCookieDelegate);
+};
+
+}   // namespace atom
+
+#endif  // ATOM_BROWSER_NET_ATOM_COOKIE_DELEGATE_H_

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -395,6 +395,27 @@ session.defaultSession.cookies.set(cookie, (error) => {
 })
 ```
 
+### Instance Events
+
+The following events are available on instances of `Cookies`:
+
+#### Event: 'changed'
+
+* `event` Event
+* `cookie` Object - The cookie that was changed
+* `cause` String - The cause of the change with one of the following values:
+  * `explicit` - The cookie was changed directly by a consumer's action.
+  * `overwrite` - The cookie was automatically removed due to an insert
+    operation that overwrote it.
+  * `expired` - The cookie was automatically removed as it expired.
+  * `evicted` - The cookie was automatically evicted during garbage collection.
+  * `expired-overwrite` - The cookie was overwritten with an already-expired
+    expiration date.
+* `removed` Boolean - `true` if the cookie was removed, `false` otherwise.
+
+Emitted when a cookie is changed because it was added, edited, removed, or
+expired.
+
 ### Instance Methods
 
 The following methods are available on instances of `Cookies`:

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -227,6 +227,8 @@
       'atom/browser/net/asar/url_request_asar_job.h',
       'atom/browser/net/atom_cert_verifier.cc',
       'atom/browser/net/atom_cert_verifier.h',
+      'atom/browser/net/atom_cookie_delegate.cc',
+      'atom/browser/net/atom_cookie_delegate.h',
       'atom/browser/net/atom_network_delegate.cc',
       'atom/browser/net/atom_network_delegate.h',
       'atom/browser/net/atom_ssl_config_service.cc',

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -1,6 +1,6 @@
 const {EventEmitter} = require('events')
 const {app} = require('electron')
-const {fromPartition, Session} = process.atomBinding('session')
+const {fromPartition, Session, Cookies} = process.atomBinding('session')
 
 // Public API.
 Object.defineProperties(exports, {
@@ -15,6 +15,7 @@ Object.defineProperties(exports, {
 })
 
 Object.setPrototypeOf(Session.prototype, EventEmitter.prototype)
+Object.setPrototypeOf(Cookies.prototype, EventEmitter.prototype)
 
 Session.prototype._init = function () {
   app.emit('session-created', this)

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -180,48 +180,34 @@ describe('session module', function () {
       })
     })
 
-    describe('changed events', function () {
-      it('emits an event when a cookie is set', function (done) {
-        session.defaultSession.cookies.on('changed', function cookieChanged(event, cookie, cause, removed) {
-          if (cookie.name !== 'foo') return
+    it('emits a changed event when a cookie is added or removed', function (done) {
+      const {cookies} = session.fromPartition('cookies-changed')
 
+      cookies.once('changed', function (event, cookie, cause, removed) {
+        assert.equal(cookie.name, 'foo')
+        assert.equal(cookie.value, 'bar')
+        assert.equal(cause, 'explicit')
+        assert.equal(removed, false)
+
+        cookies.once('changed', function (event, cookie, cause, removed) {
           assert.equal(cookie.name, 'foo')
           assert.equal(cookie.value, 'bar')
           assert.equal(cause, 'explicit')
-          assert.equal(removed, false)
-          session.defaultSession.cookies.removeListener('changed', cookieChanged)
+          assert.equal(removed, true)
           done()
         })
-        session.defaultSession.cookies.set({
-          url: url,
-          name: 'foo',
-          value: 'bar'
-        }, function (error) {
+
+        cookies.remove(url, 'foo', function (error) {
           if (error) return done(error)
         })
       })
 
-      it('emits an event when a cookie is removed', function (done) {
-        session.defaultSession.cookies.on('changed', function cookieChanged(event, cookie, cause, removed) {
-          if (cookie.name !== 'foo' || removed == false) return
-
-          assert.equal(cookie.name, 'foo')
-          assert.equal(cookie.value, 'bar')
-          assert.equal(cause, 'overwrite')
-          assert.equal(removed, true)
-          session.defaultSession.cookies.removeListener('changed', cookieChanged)
-          done()
-        })
-        session.defaultSession.cookies.set({
-          url: url,
-          name: 'foo',
-          value: 'bar'
-        }, function (error) {
-          if (error) return done(error)
-          session.defaultSession.cookies.remove(url, 'foo', function (error) {
-            if (error) return done(error)
-          })
-        })
+      cookies.set({
+        url: url,
+        name: 'foo',
+        value: 'bar'
+      }, function (error) {
+        if (error) return done(error)
       })
     })
   })

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -179,6 +179,51 @@ describe('session module', function () {
         })
       })
     })
+
+    describe('changed events', function () {
+      it('emits an event when a cookie is set', function (done) {
+        session.defaultSession.cookies.on('changed', function cookieChanged(event, cookie, cause, removed) {
+          if (cookie.name !== 'foo') return
+
+          assert.equal(cookie.name, 'foo')
+          assert.equal(cookie.value, 'bar')
+          assert.equal(cause, 'explicit')
+          assert.equal(removed, false)
+          session.defaultSession.cookies.removeListener('changed', cookieChanged)
+          done()
+        })
+        session.defaultSession.cookies.set({
+          url: url,
+          name: 'foo',
+          value: 'bar'
+        }, function (error) {
+          if (error) return done(error)
+        })
+      })
+
+      it('emits an event when a cookie is removed', function (done) {
+        session.defaultSession.cookies.on('changed', function cookieChanged(event, cookie, cause, removed) {
+          if (cookie.name !== 'foo' || removed == false) return
+
+          assert.equal(cookie.name, 'foo')
+          assert.equal(cookie.value, 'bar')
+          assert.equal(cause, 'overwrite')
+          assert.equal(removed, true)
+          session.defaultSession.cookies.removeListener('changed', cookieChanged)
+          done()
+        })
+        session.defaultSession.cookies.set({
+          url: url,
+          name: 'foo',
+          value: 'bar'
+        }, function (error) {
+          if (error) return done(error)
+          session.defaultSession.cookies.remove(url, 'foo', function (error) {
+            if (error) return done(error)
+          })
+        })
+      })
+    })
   })
 
   describe('ses.clearStorageData(options)', function () {


### PR DESCRIPTION
This pull requests add a `'changed'` event to the `Cookies` class that will fire when a cookie is added, edited, removed, or evicted.

- [x] Update brigthray https://github.com/electron/brightray/pull/251
- [x] Add tests

/cc @brian-mann is this along the lines of what you are looking to get access to?

Closes #5643