### PR TITLE
New-window event handler can return its own BrowserWindow instance

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -155,7 +155,9 @@ requested by `window.open` or an external link like `<a target='_blank'>`.
 
 By default a new `BrowserWindow` will be created for the `url`.
 
-Calling `event.preventDefault()` will prevent creating new windows.
+Calling `event.preventDefault()` will prevent creating new windows. In such case, the
+`event.newGuest` may be set with a reference to a `BrowserWindow` instance to make it
+used by the Electron's runtime.
 
 #### Event: 'will-navigate'
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -141,13 +141,13 @@ const getGuestWindow = function (guestId) {
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, frameName, disposition, options, additionalFeatures) {
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures)
-  var newGuest = event.newGuest
+  const newGuest = event.newGuest
   if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {
-	if (newGuest != undefined && newGuest != null) {
+    if (newGuest != undefined && newGuest != null) {
       event.returnValue = setupGuest(event.sender, frameName, newGuest)
-	} else {
+    } else {
       event.returnValue = null
-	}
+    }
   } else {
     event.returnValue = createGuest(event.sender, url, frameName, options)
   }

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -40,6 +40,9 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     options.webPreferences.nodeIntegration = false
   }
 
+  // Sets correct openerId here to give correct options to 'new-window' event handler
+  options.webPreferences.openerId = embedder.id
+
   return options
 }
 
@@ -93,7 +96,7 @@ const createGuest = function (embedder, url, frameName, options) {
   if (options.webPreferences == null) {
     options.webPreferences = {}
   }
-  options.webPreferences.openerId = embedder.id
+
   guest = new BrowserWindow(options)
   if (!options.webContents || url !== 'about:blank') {
     // We should not call `loadURL` if the window was constructed from an

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -51,7 +51,7 @@ const setupGuest = function (embedder, frameName, guest, options) {
   // When |embedder| is destroyed we should also destroy attached guest, and if
   // guest is closed by user then we should prevent |embedder| from double
   // closing guest.
-  const guestId = guest.id
+  const guestId = guest.webContents.id
   const closedByEmbedder = function () {
     guest.removeListener('closed', closedByUser)
     guest.destroy()
@@ -80,7 +80,7 @@ const setupGuest = function (embedder, frameName, guest, options) {
       delete frameToGuest[frameName]
     })
   }
-  return guest.id
+  return guestId
 }
 
 // Create a new guest created by |embedder| with |options|.
@@ -88,7 +88,7 @@ const createGuest = function (embedder, url, frameName, options) {
   let guest = frameToGuest[frameName]
   if (frameName && (guest != null)) {
     guest.loadURL(url)
-    return guest.id
+    return guest.webContents.id
   }
 
   // Remember the embedder window's id.

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -43,20 +43,8 @@ const mergeBrowserWindowOptions = function (embedder, options) {
   return options
 }
 
-// Create a new guest created by |embedder| with |options|.
-const createGuest = function (embedder, url, frameName, options) {
-  let guest = frameToGuest[frameName]
-  if (frameName && (guest != null)) {
-    guest.loadURL(url)
-    return guest.id
-  }
-
-  // Remember the embedder window's id.
-  if (options.webPreferences == null) {
-    options.webPreferences = {}
-  }
-  options.webPreferences.openerId = embedder.id
-  guest = new BrowserWindow(options)
+// Setup a new guest with |embedder|
+const setupGuest = function (embedder, frameName, guest) {
   if (!options.webContents || url !== 'about:blank') {
     // We should not call `loadURL` if the window was constructed from an
     // existing webContents(window.open in a sandboxed renderer) and if the url
@@ -81,12 +69,10 @@ const createGuest = function (embedder, url, frameName, options) {
     // here, since the window would be cleared of all changes in the next tick.
     guest.loadURL(url)
   }
-
   // When |embedder| is destroyed we should also destroy attached guest, and if
   // guest is closed by user then we should prevent |embedder| from double
   // closing guest.
-  const guestId = guest.webContents.id
-
+  const guestId = guest.id
   const closedByEmbedder = function () {
     guest.removeListener('closed', closedByUser)
     guest.destroy()
@@ -108,7 +94,6 @@ const createGuest = function (embedder, url, frameName, options) {
     embedder.once('render-view-deleted', closedByEmbedder)
     guest.once('closed', closedByUser)
   }
-
   if (frameName) {
     frameToGuest[frameName] = guest
     guest.frameName = frameName
@@ -116,8 +101,26 @@ const createGuest = function (embedder, url, frameName, options) {
       delete frameToGuest[frameName]
     })
   }
+  return guest.id
+}	
 
-  return guestId
+// Create a new guest created by |embedder| with |options|.
+const createGuest = function (embedder, url, frameName, options) {
+  const guest = frameToGuest[frameName]
+  if (frameName && (guest != null)) {
+    guest.loadURL(url)
+    return guest.id
+  }
+
+  // Remember the embedder window's id.
+  if (options.webPreferences == null) {
+    options.webPreferences = {}
+  }
+  options.webPreferences.openerId = embedder.id
+  guest = new BrowserWindow(options)
+  guest.loadURL(url)
+
+  return setupGuest(embedder, frameName, guest)
 }
 
 const getGuestWindow = function (guestId) {
@@ -138,8 +141,13 @@ const getGuestWindow = function (guestId) {
 ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, frameName, disposition, options, additionalFeatures) {
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures)
+  var newGuest = event.newGuest
   if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {
-    event.returnValue = null
+	if (newGuest != undefined && newGuest != null) {
+      event.returnValue = setupGuest(event.sender, frameName, newGuest)
+	} else {
+      event.returnValue = null
+	}
   } else {
     event.returnValue = createGuest(event.sender, url, frameName, options)
   }

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -45,30 +45,7 @@ const mergeBrowserWindowOptions = function (embedder, options) {
 
 // Setup a new guest with |embedder|
 const setupGuest = function (embedder, frameName, guest) {
-  if (!options.webContents || url !== 'about:blank') {
-    // We should not call `loadURL` if the window was constructed from an
-    // existing webContents(window.open in a sandboxed renderer) and if the url
-    // is not 'about:blank'.
-    //
-    // Navigating to the url when creating the window from an existing
-    // webContents would not be necessary(it will navigate there anyway), but
-    // apparently there's a bug that allows the child window to be scripted by
-    // the opener, even when the child window is from another origin.
-    //
-    // That's why the second condition(url !== "about:blank") is required: to
-    // force `OverrideSiteInstanceForNavigation` to be called and consequently
-    // spawn a new renderer if the new window is targeting a different origin.
-    //
-    // If the URL is "about:blank", then it is very likely that the opener just
-    // wants to synchronously script the popup, for example:
-    //
-    //     let popup = window.open()
-    //     popup.document.body.write('<h1>hello</h1>')
-    //
-    // The above code would not work if a navigation to "about:blank" is done
-    // here, since the window would be cleared of all changes in the next tick.
-    guest.loadURL(url)
-  }
+
   // When |embedder| is destroyed we should also destroy attached guest, and if
   // guest is closed by user then we should prevent |embedder| from double
   // closing guest.
@@ -118,7 +95,30 @@ const createGuest = function (embedder, url, frameName, options) {
   }
   options.webPreferences.openerId = embedder.id
   guest = new BrowserWindow(options)
-  guest.loadURL(url)
+  if (!options.webContents || url !== 'about:blank') {
+    // We should not call `loadURL` if the window was constructed from an
+    // existing webContents(window.open in a sandboxed renderer) and if the url
+    // is not 'about:blank'.
+    //
+    // Navigating to the url when creating the window from an existing
+    // webContents would not be necessary(it will navigate there anyway), but
+    // apparently there's a bug that allows the child window to be scripted by
+    // the opener, even when the child window is from another origin.
+    //
+    // That's why the second condition(url !== "about:blank") is required: to
+    // force `OverrideSiteInstanceForNavigation` to be called and consequently
+    // spawn a new renderer if the new window is targeting a different origin.
+    //
+    // If the URL is "about:blank", then it is very likely that the opener just
+    // wants to synchronously script the popup, for example:
+    //
+    //     let popup = window.open()
+    //     popup.document.body.write('<h1>hello</h1>')
+    //
+    // The above code would not work if a navigation to "about:blank" is done
+    // here, since the window would be cleared of all changes in the next tick.
+    guest.loadURL(url)
+  }
 
   return setupGuest(embedder, frameName, guest)
 }

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -47,8 +47,7 @@ const mergeBrowserWindowOptions = function (embedder, options) {
 }
 
 // Setup a new guest with |embedder|
-const setupGuest = function (embedder, frameName, guest) {
-
+const setupGuest = function (embedder, frameName, guest, options) {
   // When |embedder| is destroyed we should also destroy attached guest, and if
   // guest is closed by user then we should prevent |embedder| from double
   // closing guest.
@@ -82,11 +81,11 @@ const setupGuest = function (embedder, frameName, guest) {
     })
   }
   return guest.id
-}	
+}
 
 // Create a new guest created by |embedder| with |options|.
 const createGuest = function (embedder, url, frameName, options) {
-  const guest = frameToGuest[frameName]
+  let guest = frameToGuest[frameName]
   if (frameName && (guest != null)) {
     guest.loadURL(url)
     return guest.id
@@ -123,7 +122,7 @@ const createGuest = function (embedder, url, frameName, options) {
     guest.loadURL(url)
   }
 
-  return setupGuest(embedder, frameName, guest)
+  return setupGuest(embedder, frameName, guest, options)
 }
 
 const getGuestWindow = function (guestId) {
@@ -146,8 +145,8 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function (event, url, fr
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures)
   const newGuest = event.newGuest
   if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {
-    if (newGuest != undefined && newGuest != null) {
-      event.returnValue = setupGuest(event.sender, frameName, newGuest)
+    if (newGuest !== undefined && newGuest !== null) {
+      event.returnValue = setupGuest(event.sender, frameName, newGuest, options)
     } else {
       event.returnValue = null
     }


### PR DESCRIPTION
This pull request allows 'new-window' event handlers (running in the master process) to give back the BrowserWindow instance they created when the default behavior is prevented.

The suggested way to return this window is to set the new property newGuest with the newly created BrowserWindow. This may not be the best way to achieve this so others suggestions are welcome.