### PR TITLE
Hide Show Tab Bar menu item on macOS Sierra

### DIFF
--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -10,6 +10,10 @@
 #include "base/strings/sys_string_conversions.h"
 #include "base/values.h"
 
+@interface NSWindow (SierraSDK)
+@property(class) BOOL allowsAutomaticWindowTabbing;
+@end
+
 @implementation AtomApplicationDelegate
 
 - (void)setApplicationDockMenu:(atom::AtomMenuModel*)model {
@@ -22,9 +26,8 @@
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
 
   // Don't add the "Show Tab Bar" menu item.
-  if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
+  if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
     NSWindow.allowsAutomaticWindowTabbing = NO;
-  }
 
   atom::Browser::Get()->WillFinishLaunching();
 }

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -21,6 +21,11 @@
   // Don't add the "Enter Full Screen" menu item automatically.
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
 
+  // Don't add the "Show Tab Bar" menu item.
+  if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
+    NSWindow.allowsAutomaticWindowTabbing = NO;
+  }
+
   atom::Browser::Get()->WillFinishLaunching();
 }
 


### PR DESCRIPTION
This pull request ports the fix for https://bugs.chromium.org/p/chromium/issues/detail?id=642155 into Electron to remove the "Show Tab Bar" on macOS Sierra.

Closes #7406 
Refs #6124 