### PR TITLE
Only begin sheet when no sheet parent

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -740,8 +740,9 @@ bool NativeWindowMac::IsFocused() {
 
 void NativeWindowMac::Show() {
   if (is_modal() && parent()) {
-    [parent()->GetNativeWindow() beginSheet:window_
-                          completionHandler:^(NSModalResponse) {}];
+    if ([window_ sheetParent] == nil)
+      [parent()->GetNativeWindow() beginSheet:window_
+                            completionHandler:^(NSModalResponse) {}];
     return;
   }
 


### PR DESCRIPTION
Previously, calling `show()` on a modal window multiple times would cause `beginSheet` to be called multiple times on the parent window.

This would then cause issues when `close()` was called because the number of begin/end calls would not align.

This pull request checks `sheetParent` property on the `NSWindow` and if it is present, it does not begin the sheet since it is already in progress.

Closes #7401 