### PR TITLE
Explicitly close popup window from sandbox spec

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -698,6 +698,7 @@ describe('browser-window module', function () {
         })
         let htmlPath = path.join(fixtures, 'api', 'sandbox.html?window-open-external')
         const pageUrl = 'file://' + htmlPath
+        let openedWindow
         w.loadURL(pageUrl)
         w.webContents.once('new-window', (e, url, frameName, disposition, options) => {
           assert.equal(url, 'http://www.google.com/#q=electron')
@@ -710,10 +711,16 @@ describe('browser-window module', function () {
             assert.equal(html, '<h1>http://www.google.com/#q=electron</h1>')
             ipcMain.once('answer', function (event, exceptionMessage) {
               assert(/Blocked a frame with origin/.test(exceptionMessage))
-              done()
+
+              // FIXME this opened window should be closed in sandbox.html
+              closeWindow(openedWindow).then(done)
             })
             w.webContents.send('child-loaded')
           })
+        })
+
+        app.once('browser-window-created', function (event, window) {
+          openedWindow = window
         })
       })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -598,7 +598,7 @@ describe('browser-window module', function () {
 
       const preload = path.join(fixtures, 'module', 'preload-sandbox.js')
 
-      // http protocol to simulate accessing a another domain. this is required
+      // http protocol to simulate accessing another domain. This is required
       // because the code paths for cross domain popups is different.
       function crossDomainHandler (request, callback) {
         callback({

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -698,7 +698,7 @@ describe('browser-window module', function () {
         })
         let htmlPath = path.join(fixtures, 'api', 'sandbox.html?window-open-external')
         const pageUrl = 'file://' + htmlPath
-        let openedWindow
+        let popupWindow
         w.loadURL(pageUrl)
         w.webContents.once('new-window', (e, url, frameName, disposition, options) => {
           assert.equal(url, 'http://www.google.com/#q=electron')
@@ -712,15 +712,18 @@ describe('browser-window module', function () {
             ipcMain.once('answer', function (event, exceptionMessage) {
               assert(/Blocked a frame with origin/.test(exceptionMessage))
 
-              // FIXME this opened window should be closed in sandbox.html
-              closeWindow(openedWindow).then(done)
+              // FIXME this popup window should be closed in sandbox.html
+              closeWindow(popupWindow).then(() => {
+                popupWindow = null
+                done()
+              })
             })
             w.webContents.send('child-loaded')
           })
         })
 
         app.once('browser-window-created', function (event, window) {
-          openedWindow = window
+          popupWindow = window
         })
       })
 

--- a/spec/fixtures/api/sandbox.html
+++ b/spec/fixtures/api/sandbox.html
@@ -1,9 +1,9 @@
 <html>
 <script type="text/javascript" charset="utf-8">
   if (window.opener) {
-    window.callback = function() {
+    window.callback = () => {
       opener.require('electron').ipcRenderer.send('answer', document.body.innerHTML)
-    };
+    }
   } else {
     const {ipcRenderer} = require('electron')
     const tests = {
@@ -69,8 +69,8 @@
     }, false)
 
     let [,test] = window.location.href.split('?')
-      if (tests.hasOwnProperty(test))
-        tests[test]()
+    if (tests.hasOwnProperty(test))
+      tests[test]()
   }
 </script>
 </html>


### PR DESCRIPTION
This pull request is an attempt to get the specs green on the Windows CI machines, they are currently failing on a focused web contents spec that seems to be caused by a window left around after the sandbox specs.

If you run the `should open windows in another domain with cross-scripting disabled` spec locally you can see the popup window sticks around after the spec finishes.

I added an explicitly listener and close call for this window so it doesn't impact later running specs.

/cc @tarruda 

Refs https://github.com/electron/electron/pull/6919