### PR TITLE
Ensure webviews get reset after spec finishes

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -17,9 +17,10 @@ describe('<webview> tag', function () {
   })
 
   afterEach(function () {
-    if (document.body.contains(webview)) {
-      document.body.removeChild(webview)
+    if (!document.body.contains(webview)) {
+      document.body.appendChild(webview)
     }
+    webview.remove()
     if (w) {
       w.destroy()
       w = null


### PR DESCRIPTION
Noticed the following warning in the build logs:

```
(node:972) Warning: Possible EventEmitter memory leak detected. 11 ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE listeners added. Use emitter.setMaxListeners() to increase limit
```

This was because listeners in `<webview>` tags are only removed when `reset()` is called which happens only when the tag is removed from the DOM.

This pull request updates the `afterEach` in the specs to ensure the `<webview>` is always reset since some specs never attach it causing the listener count to continually grow.

This brings up a broader discussion about which (or all) Electron API event emitters should be configured to have infinite listeners. `webFrame` and `webContents` already have this enabled but perhaps this should be enabled for all Electron APIs since 10 listeners is pretty low.