### PR TITLE
Ignore already closed windows

### DIFF
--- a/atom/browser/window_list.cc
+++ b/atom/browser/window_list.cc
@@ -71,7 +71,8 @@ void WindowList::RemoveObserver(WindowListObserver* observer) {
 void WindowList::CloseAllWindows() {
   WindowVector windows = GetInstance()->windows_;
   for (const auto& window : windows)
-    window->Close();
+    if (!window->IsClosed())
+      window->Close();
 }
 
 WindowList::WindowList() {


### PR DESCRIPTION
When an embedder's render view is deleted, the guest is destroyed, https://github.com/electron/electron/blob/ff6a8fac2a370059aaf54dc027203bfedc08c630/lib/browser/guest-window-manager.js#L108-L109

This is causing issues on Windows when `WindowList::CloseAllWindows()` is called since when the first window is closed, the second window will also be closed causing a crash when `NativeWindow::Close()` is called a second time and a crash occurs when checking the accelerated widget in `IsClosable()`.

This pull request adds a check for `IsClosed()` before calling `Close()` to guard against this.

Not sure if this check is better to put in `NativeWindowViews::Close()`instead.

Closes #7074