### PR TITLE
[browser] fix the memory leak

### DIFF
--- a/atom/browser/atom_blob_reader.cc
+++ b/atom/browser/atom_blob_reader.cc
@@ -127,6 +127,7 @@ void AtomBlobReader::BlobReadHelper::DidReadBlobData(
   memcpy(data, blob_data->data(), size);
   BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
       base::Bind(completion_callback_, data, size));
+  delete[] data;
   delete this;
 }
 


### PR DESCRIPTION
:bug: label: [hacktoberfest](https://hacktoberfest.digitalocean.com)

Greetings,

On line number `131` of [atom_blob_reader.cc](https://github.com/electron/electron/blob/master/atom/browser/atom_blob_reader.cc#L131) we believe there is a memory leak, which is an bug. The reason we should delete is that memory is a finite resource within our running programs. Sure in very short running simple programs, failing to delete memory won't have a noticeable effect. However on long running programs, failing to delete memory means we will be consuming a finite resource without replenishing it. Eventually it will run out and our program will abruptly crash. This is why we must delete memory.

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com