### PR TITLE
Focus window when menu button is pressed

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -63,8 +63,7 @@ void MenuBar::SetMenu(AtomMenuModel* model) {
   RemoveAllChildViews(true);
 
   for (int i = 0; i < model->GetItemCount(); ++i) {
-    SubmenuButton* button = new SubmenuButton(this,
-                                              model->GetLabelAt(i),
+    SubmenuButton* button = new SubmenuButton(model->GetLabelAt(i),
                                               this,
                                               background_color_);
     button->set_tag(i);
@@ -132,9 +131,6 @@ bool MenuBar::GetMenuButtonFromScreenPoint(const gfx::Point& point,
 
 const char* MenuBar::GetClassName() const {
   return kViewClassName;
-}
-
-void MenuBar::ButtonPressed(views::Button* sender, const ui::Event& event) {
 }
 
 void MenuBar::OnMenuButtonClicked(views::MenuButton* source,

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -6,7 +6,6 @@
 #define ATOM_BROWSER_UI_VIEWS_MENU_BAR_H_
 
 #include "atom/browser/ui/atom_menu_model.h"
-#include "ui/views/controls/button/button.h"
 #include "ui/views/controls/button/menu_button_listener.h"
 #include "ui/views/view.h"
 
@@ -19,7 +18,6 @@ namespace atom {
 class MenuDelegate;
 
 class MenuBar : public views::View,
-                public views::ButtonListener,
                 public views::MenuButtonListener {
  public:
   MenuBar();
@@ -49,9 +47,6 @@ class MenuBar : public views::View,
  protected:
   // views::View:
   const char* GetClassName() const override;
-
-  // views::ButtonListener:
-  void ButtonPressed(views::Button* sender, const ui::Event& event) override;
 
   // views::MenuButtonListener:
   void OnMenuButtonClicked(views::MenuButton* source,

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -53,6 +53,10 @@ SubmenuButton::SubmenuButton(views::ButtonListener* listener,
   SetHasInkDrop(true);
   set_ink_drop_base_color(
       color_utils::BlendTowardOppositeLuma(background_color_, 0x61));
+
+  set_request_focus_on_press(true);
+  SetFocusForPlatform();
+  SetFocusPainter(nullptr);
 }
 
 SubmenuButton::~SubmenuButton() {

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -26,8 +26,7 @@ base::string16 FilterAccelerator(const base::string16& label) {
 
 }  // namespace
 
-SubmenuButton::SubmenuButton(views::ButtonListener* listener,
-                             const base::string16& title,
+SubmenuButton::SubmenuButton(const base::string16& title,
                              views::MenuButtonListener* menu_button_listener,
                              const SkColor& background_color)
     : views::MenuButton(FilterAccelerator(title),

--- a/atom/browser/ui/views/submenu_button.h
+++ b/atom/browser/ui/views/submenu_button.h
@@ -13,8 +13,7 @@ namespace atom {
 // Special button that used by menu bar to show submenus.
 class SubmenuButton : public views::MenuButton {
  public:
-  SubmenuButton(views::ButtonListener* listener,
-                const base::string16& title,
+  SubmenuButton(const base::string16& title,
                 views::MenuButtonListener* menu_button_listener,
                 const SkColor& background_color);
   virtual ~SubmenuButton();


### PR DESCRIPTION
Previously, on Windows, clicking the menu on a second window when the first window's menu was open did not focus the correct window.

This pull request configures the submenu buttons to focus on press. Also removes an unused `ButtonListener` listener.

Closes #7282