### PR TITLE
Introduce ELECTRON_NO_ASAR

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -45,7 +45,8 @@ https://console.developers.google.com/apis/api/geolocation/overview
 
 ### `ELECTRON_NO_ASAR`
 
-Disables ASAR support. Note that this variable can only be used when forking a process to disable any ASAR support in that process.
+Disables ASAR support. This variable is only supported in forked child processes
+and spawned child processes that set `ELECTRON_RUN_AS_NODE`.
 
 ## Development Variables
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -43,6 +43,10 @@ By default, a newly generated Google API key may not be allowed to make
 geocoding requests. To enable geocoding requests, visit this page:
 https://console.developers.google.com/apis/api/geolocation/overview
 
+### `ELECTRON_NO_ASAR`
+
+Disables ASAR support. Note that this variable can only be used when forking a process to disable any ASAR support in that process.
+
 ## Development Variables
 
 The following environment variables are intended primarily for development and

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -10,6 +10,16 @@
   // Cache asar archive objects.
   const cachedArchives = {}
 
+  const isAsarDisabled = function () {
+    if (process.noAsar) {
+      return true
+    }
+    if (process.env.ELECTRON_NO_ASAR && process.type !== 'browser' && process.type !== 'renderer') {
+      return true
+    }
+    return false
+  }
+
   const getOrCreateArchive = function (p) {
     let archive = cachedArchives[p]
     if (archive != null) {
@@ -34,7 +44,7 @@
   // Separate asar package's path from full path.
   const splitPath = function (p) {
     // shortcut to disable asar.
-    if (process.noAsar || process.env.ELECTRON_NO_ASAR) {
+    if (isAsarDisabled()) {
       return [false]
     }
 

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -34,7 +34,7 @@
   // Separate asar package's path from full path.
   const splitPath = function (p) {
     // shortcut to disable asar.
-    if (process.noAsar) {
+    if (process.noAsar || process.env.ELECTRON_NO_ASAR) {
       return [false]
     }
 

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -753,6 +753,41 @@ describe('asar package', function () {
         assert.equal(process.noAsar, false)
       })
     })
+
+    describe('process.env.ELECTRON_NO_ASAR', function () {
+      it('disables asar support in forked processes', function (done) {
+        const forked = ChildProcess.fork(path.join(__dirname, 'fixtures', 'module', 'no-asar.js'), [], {
+          env: {
+            ELECTRON_NO_ASAR: true
+          }
+        })
+        forked.on('message', function (stats) {
+          assert.equal(stats.isFile, true)
+          assert.equal(stats.size, 778)
+          done()
+        })
+      })
+
+      it('disables asar support in spawned processes', function (done) {
+        const spawned = ChildProcess.spawn(process.execPath, [path.join(__dirname, 'fixtures', 'module', 'no-asar.js')], {
+          env: {
+            ELECTRON_NO_ASAR: true,
+            ELECTRON_RUN_AS_NODE: true
+          }
+        })
+
+        let output = ''
+        spawned.stdout.on('data', function (data) {
+          output += data
+        })
+        spawned.stdout.on('close', function () {
+          stats = JSON.parse(output)
+          assert.equal(stats.isFile, true)
+          assert.equal(stats.size, 778)
+          done()
+        })
+      })
+    })
   })
 
   describe('asar protocol', function () {

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -781,7 +781,7 @@ describe('asar package', function () {
           output += data
         })
         spawned.stdout.on('close', function () {
-          stats = JSON.parse(output)
+          const stats = JSON.parse(output)
           assert.equal(stats.isFile, true)
           assert.equal(stats.size, 778)
           done()

--- a/spec/fixtures/module/no-asar.js
+++ b/spec/fixtures/module/no-asar.js
@@ -1,0 +1,15 @@
+const fs = require('fs')
+const path = require('path')
+
+const stats = fs.statSync(path.join(__dirname, '..', 'asar', 'a.asar'))
+
+const details = {
+  isFile: stats.isFile(),
+  size: stats.size
+}
+
+if (process.send != null) {
+  process.send(details)
+} else {
+  console.log(JSON.stringify(details))
+}


### PR DESCRIPTION
For https://github.com/electron/electron/issues/6295 

This new environment variable can be used to disable ASAR support in forked processes. The use case is:

```javascript
var res = cp.fork(path.join(__dirname, "forked.js"), { env: { "ELECTRON_NO_ASAR": "true" }});
```

This disables ASAR support in forked processes and does not force the forked process to set `process.noAsar`. This specifically enables to run a forked process in an environment that comes close to the real node.js environment without forcing it to use the non-node.js `process.noAsar` trick.