### PR TITLE
Docs: Correct image.getSize() type signature

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -195,8 +195,6 @@ Notice that the returned pointer is a weak pointer to the underlying native
 image instead of a copy, so you _must_ ensure that the associated
 `nativeImage` instance is kept around.
 
-[buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer
-
 #### `image.isEmpty()`
 
 Returns `Boolean` -  Whether the image is empty.
@@ -216,3 +214,5 @@ Marks the image as a template image.
 #### `image.isTemplateImage()`
 
 Returns `Boolean` - Whether the image is a template image.
+
+[buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -195,15 +195,17 @@ Notice that the returned pointer is a weak pointer to the underlying native
 image instead of a copy, so you _must_ ensure that the associated
 `nativeImage` instance is kept around.
 
+[buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer
+
 #### `image.isEmpty()`
 
 Returns `Boolean` -  Whether the image is empty.
 
 #### `image.getSize()`
 
-Returns `Integer[]` - The size of the image.
-
-[buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer
+Returns `Object`:
+* `width` Integer
+* `height` Integer
 
 #### `image.setTemplateImage(option)`
 


### PR DESCRIPTION
I removed the description also because it seemed superfluous given the method name and type signature. I can add it back in if needed though.