### PR TITLE
Enable emoji as fallback font on Windows 10

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '292bc81e83686ae5e7125163290928bf9b839560'
+    '82751b122d7f5cbedee5c662acc8cd1f1be8036d'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
This pull request pulls in https://github.com/electron/libchromiumcontent/pull/235 which enables better font fallbacks on Windows to support color emojis (among other things).

This patching of `libchromiumcontent` can be removed once the fix for https://bugs.chromium.org/p/chromium/issues/detail?id=652898 lands upstream.

Closes #7334