### PR TITLE
Add newline before return list

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -812,6 +812,7 @@ Returns `Boolean` - Whether the current desktop environment is Unity launcher.
 ### `app.getLoginItemSettings()` _macOS_ _Windows_
 
 Returns `Object`:
+
 * `openAtLogin` Boolean - `true` if the app is set to open at login.
 * `openAsHidden` Boolean - `true` if the app is set to open as hidden at login.
   This setting is only supported on macOS.


### PR DESCRIPTION
This looks to be required by the markdown parser used on http://electron.atom.io/docs/

| Before | After |
| --- | --- |
| <img width="848" alt="screen shot 2016-10-05 at 9 26 51 am" src="https://cloud.githubusercontent.com/assets/671378/19122103/e0b54ae2-8add-11e6-8c77-c26e62fd933f.png"> | <img width="845" alt="screen shot 2016-10-05 at 9 35 11 am" src="https://cloud.githubusercontent.com/assets/671378/19122382/11912d6a-8adf-11e6-8d0e-4821f4b383d4.png"> |

