### PR TITLE
Update test dependencies and documentation

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -121,7 +121,7 @@ $ sudo ln -s /usr/lib/libncurses.so.5 /usr/lib/libtinfo.so.5
 
 ## Tests
 
-See [Build System Overview: Tests](docs/development/build-system-overview.md#tests)
+See [Build System Overview: Tests](build-system-overview.md#tests)
 
 ## Advanced topics
 

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -121,17 +121,7 @@ $ sudo ln -s /usr/lib/libncurses.so.5 /usr/lib/libtinfo.so.5
 
 ## Tests
 
-Test your changes conform to the project coding style using:
-
-```bash
-$ npm run lint
-```
-
-Test functionality using:
-
-```bash
-$ ./script/test.py
-```
+See [Build System Overview: Tests](docs/development/build-system-overview.md#tests)
 
 ## Advanced topics
 

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -61,4 +61,4 @@ $ npm run clean
 
 ## Tests
 
-See [Build System Overview: Tests](docs/development/build-system-overview.md#tests)
+See [Build System Overview: Tests](build-system-overview.md#tests)

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -61,31 +61,4 @@ $ npm run clean
 
 ## Tests
 
-Test your changes conform to the project coding style using:
-
-```bash
-$ npm run lint
-```
-
-Test functionality using:
-
-```bash
-$ npm test
-```
-
-You can make the test suite run faster by isolating the specific test or block
-you're currently working on using Mocha's
-[exclusive tests](https://mochajs.org/#exclusive-tests) feature:
-
-```js
-describe.only('some feature', function () {
-  // ... only tests in this block will be run
-})
-```
-
-Alternatively, you can use mocha's `grep` option to only run tests matching the
-given regular expression pattern:
-
-```sh
-npm test -- --grep child_process
-```
+See [Build System Overview: Tests](docs/development/build-system-overview.md#tests)

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -16,7 +16,7 @@ the following Python modules:
 ## Getting the Code
 
 ```bash
-$ git clone https://github.com/electron/electron.git
+$ git clone https://github.com/electron/electron
 ```
 
 ## Bootstrapping
@@ -64,11 +64,28 @@ $ npm run clean
 Test your changes conform to the project coding style using:
 
 ```bash
-$ ./script/cpplint.py
+$ npm run lint
 ```
 
 Test functionality using:
 
 ```bash
-$ ./script/test.py
+$ npm test
+```
+
+You can make the test suite run faster by isolating the specific test or block
+you're currently working on using Mocha's
+[exclusive tests](https://mochajs.org/#exclusive-tests) feature:
+
+```js
+describe.only('some feature', function () {
+  // ... only tests in this block will be run
+})
+```
+
+Alternatively, you can use mocha's `grep` option to only run tests matching the
+given regular expression pattern:
+
+```sh
+npm test -- --grep child_process
 ```

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -87,7 +87,7 @@ $ npm run clean
 
 ## Tests
 
-See [Build System Overview: Tests](docs/development/build-system-overview.md#tests)
+See [Build System Overview: Tests](build-system-overview.md#tests)
 
 ## Troubleshooting
 

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -87,27 +87,7 @@ $ npm run clean
 
 ## Tests
 
-Test your changes conform to the project coding style using:
-
-```powershell
-$ python script\cpplint.py
-```
-
-Test functionality using:
-
-```powershell
-$ python script\test.py
-```
-
-Tests that include native modules (e.g. `runas`) can't be executed with the
-debug build (see [#2558](https://github.com/electron/electron/issues/2558) for
-details), but they will work with the release build.
-
-To run the tests with the release build use:
-
-```powershell
-$ python script\test.py -R
-```
+See [Build System Overview: Tests](docs/development/build-system-overview.md#tests)
 
 ## Troubleshooting
 

--- a/docs/development/build-system-overview.md
+++ b/docs/development/build-system-overview.md
@@ -71,3 +71,44 @@ to generate one target at a time as stated above.
 
 This only affects developers, if you are just building Electron for rebranding
 you are not affected.
+
+## Tests
+
+Test your changes conform to the project coding style using:
+
+```bash
+$ npm run lint
+```
+
+Test functionality using:
+
+```bash
+$ npm test
+```
+
+You can make the test suite run faster by isolating the specific test or block
+you're currently working on using Mocha's
+[exclusive tests](https://mochajs.org/#exclusive-tests) feature:
+
+```js
+describe.only('some feature', function () {
+  // ... only tests in this block will be run
+})
+```
+
+Alternatively, you can use mocha's `grep` option to only run tests matching the
+given regular expression pattern:
+
+```sh
+$ npm test -- --grep child_process
+```
+
+Tests that include native modules (e.g. `runas`) can't be executed with the
+debug build (see [#2558](https://github.com/electron/electron/issues/2558) for
+details), but they will work with the release build.
+
+To run the tests with the release build use:
+
+```bash
+$ npm test -- -R
+```

--- a/docs/development/build-system-overview.md
+++ b/docs/development/build-system-overview.md
@@ -86,6 +86,13 @@ Test functionality using:
 $ npm test
 ```
 
+Whenever you make changes to Electron source code, you'll need to re-run the
+build before the tests:
+
+```bash
+$ npm run build && npm test
+```
+
 You can make the test suite run faster by isolating the specific test or block
 you're currently working on using Mocha's
 [exclusive tests](https://mochajs.org/#exclusive-tests) feature:

--- a/docs/development/build-system-overview.md
+++ b/docs/development/build-system-overview.md
@@ -95,7 +95,8 @@ $ npm run build && npm test
 
 You can make the test suite run faster by isolating the specific test or block
 you're currently working on using Mocha's
-[exclusive tests](https://mochajs.org/#exclusive-tests) feature:
+[exclusive tests](https://mochajs.org/#exclusive-tests) feature. Just append
+`.only` to any `describe` or `it` function call:
 
 ```js
 describe.only('some feature', function () {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -285,6 +285,7 @@ describe('app module', function () {
     it('should set a badge count', function () {
       app.setBadgeCount(42)
       assert.equal(app.getBadgeCount(), shouldFail ? 0 : 42)
+      app.setBadgeCount(0)
     })
   })
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -278,6 +278,10 @@ describe('app module', function () {
     const shouldFail = process.platform === 'win32' ||
                        (process.platform === 'linux' && !app.isUnityRunning())
 
+    afterEach(function () {
+      app.setBadgeCount(0)
+    })
+
     it('returns false when failed', function () {
       assert.equal(app.setBadgeCount(42), !shouldFail)
     })
@@ -285,7 +289,6 @@ describe('app module', function () {
     it('should set a badge count', function () {
       app.setBadgeCount(42)
       assert.equal(app.getBadgeCount(), shouldFail ? 0 : 42)
-      app.setBadgeCount(0)
     })
   })
 

--- a/spec/package.json
+++ b/spec/package.json
@@ -4,16 +4,16 @@
   "main": "static/main.js",
   "version": "0.1.0",
   "devDependencies": {
-    "basic-auth": "^1.0.0",
-    "graceful-fs": "3.0.5",
-    "mocha": "2.1.0",
-    "mkdirp": "0.5.1",
-    "multiparty": "4.1.2",
-    "q": "0.9.7",
-    "temp": "0.8.1",
-    "walkdir": "0.0.7",
-    "ws": "0.7.2",
-    "yargs": "^4.7.1"
+    "basic-auth": "^1.0.4",
+    "graceful-fs": "^4.1.9",
+    "mkdirp": "^0.5.1",
+    "mocha": "^3.1.0",
+    "multiparty": "^4.1.2",
+    "q": "^1.4.1",
+    "temp": "^0.8.3",
+    "walkdir": "0.0.11",
+    "ws": "^1.1.1",
+    "yargs": "^6.0.0"
   },
   "optionalDependencies": {
     "ffi": "2.0.0",


### PR DESCRIPTION
This PR:

- Adds some testing ProTips to the dev docs.
- Updates all the devDependencies in `spec/package.json` to their latest versions. Previously some versions were pinned, others were using `^`. Not sure if there was a rhyme or reason to that.
- Moves the blurb about testing to the Build System Overview page, and links to the blurb from each platform's build info page.
- Removes the badge from the dock icon, because I keep seeing it and thinking it meant 42 tests were failing:

<img width="343" alt="screen shot 2016-10-05 at 9 09 47 pm" src="https://cloud.githubusercontent.com/assets/2289/19140711/3867f42c-8b44-11e6-8153-d3f180678306.png">
