### PR TITLE
Support detecting inverted color scheme on Windows

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -16,9 +16,9 @@ namespace api {
 
 SystemPreferences::SystemPreferences(v8::Isolate* isolate) {
   Init(isolate);
-  #if defined(OS_WIN)
+#if defined(OS_WIN)
   InitializeWindow();
-  #endif
+#endif
 }
 
 SystemPreferences::~SystemPreferences() {
@@ -29,6 +29,10 @@ bool SystemPreferences::IsDarkMode() {
   return false;
 }
 #endif
+
+bool SystemPreferences::IsInvertedColorScheme() {
+  return color_utils::IsInvertedColorScheme();
+}
 
 // static
 mate::Handle<SystemPreferences> SystemPreferences::Create(
@@ -62,7 +66,7 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::IsSwipeTrackingFromScrollEventsEnabled)
 #endif
       .SetMethod("isInvertedColorScheme",
-                 &color_utils::IsInvertedColorScheme)
+                 &SystemPreferences::IsInvertedColorScheme)
       .SetMethod("isDarkMode", &SystemPreferences::IsDarkMode);
 }
 

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -8,6 +8,7 @@
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
 #include "native_mate/dictionary.h"
+#include "ui/gfx/color_utils.h"
 
 namespace atom {
 
@@ -60,6 +61,8 @@ void SystemPreferences::BuildPrototype(
       .SetMethod("isSwipeTrackingFromScrollEventsEnabled",
                  &SystemPreferences::IsSwipeTrackingFromScrollEventsEnabled)
 #endif
+      .SetMethod("isInvertedColorScheme",
+                 &color_utils::IsInvertedColorScheme)
       .SetMethod("isDarkMode", &SystemPreferences::IsDarkMode);
 }
 

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -14,7 +14,11 @@ namespace atom {
 
 namespace api {
 
-SystemPreferences::SystemPreferences(v8::Isolate* isolate) {
+SystemPreferences::SystemPreferences(v8::Isolate* isolate)
+#if defined(OS_WIN)
+    : color_change_listener_(this)
+#endif
+    {
   Init(isolate);
 #if defined(OS_WIN)
   InitializeWindow();

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -24,7 +24,11 @@ namespace atom {
 
 namespace api {
 
-class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
+class SystemPreferences : public mate::EventEmitter<SystemPreferences>
+#if defined(OS_WIN)
+    , public gfx::SysColorChangeListener
+#endif
+  {
  public:
   static mate::Handle<SystemPreferences> Create(v8::Isolate* isolate);
 
@@ -43,8 +47,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
 
   void InitializeWindow();
 
-  void OnColorChanged();
-
+  // gfx::SysColorChangeListener:
+  void OnSysColorChange() override;
 
 #elif defined(OS_MACOSX)
   using NotificationCallback = base::Callback<
@@ -101,9 +105,9 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
 
   std::string current_color_;
 
-  bool invertered_color_scheme_ = false;
+  bool invertered_color_scheme_;
 
-  std::unique_ptr<gfx::ScopedSysColorChangeListener> color_change_listener_;
+  gfx::ScopedSysColorChangeListener color_change_listener_;
 #endif
   DISALLOW_COPY_AND_ASSIGN(SystemPreferences);
 };

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -12,6 +12,10 @@
 #include "base/values.h"
 #include "native_mate/handle.h"
 
+#if defined(OS_WIN)
+#include "ui/gfx/sys_color_change_listener.h"
+#endif
+
 namespace base {
 class DictionaryValue;
 }
@@ -39,6 +43,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
 
   void InitializeWindow();
 
+  void OnColorChanged();
+
 
 #elif defined(OS_MACOSX)
   using NotificationCallback = base::Callback<
@@ -59,6 +65,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
   bool IsSwipeTrackingFromScrollEventsEnabled();
 #endif
   bool IsDarkMode();
+  bool IsInvertedColorScheme();
 
  protected:
   explicit SystemPreferences(v8::Isolate* isolate);
@@ -93,6 +100,10 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences> {
   HWND window_;
 
   std::string current_color_;
+
+  bool invertered_color_scheme_ = false;
+
+  std::unique_ptr<gfx::ScopedSysColorChangeListener> color_change_listener_;
 #endif
   DISALLOW_COPY_AND_ASSIGN(SystemPreferences);
 };

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -19,21 +19,6 @@ const wchar_t kSystemPreferencesWindowClass[] =
 
 namespace api {
 
-class SystemPreferencesColorChangeListener
-    : public gfx::SysColorChangeListener {
- public:
-  explicit SystemPreferencesColorChangeListener(SystemPreferences* prefs)
-      : prefs_(prefs) {
-  }
-
-  void OnSysColorChange() {
-    prefs_->OnColorChanged();
-  }
-
- private:
-  SystemPreferences* prefs_;
-};
-
 bool SystemPreferences::IsAeroGlassEnabled() {
   return ui::win::IsAeroGlassEnabled();
 }
@@ -57,6 +42,8 @@ std::string SystemPreferences::GetAccentColor() {
 }
 
 void SystemPreferences::InitializeWindow() {
+  invertered_color_scheme_ = IsInvertedColorScheme();
+
   WNDCLASSEX window_class;
   base::win::InitializeWindowClass(
       kSystemPreferencesWindowClass,
@@ -74,10 +61,6 @@ void SystemPreferences::InitializeWindow() {
                          0, WS_POPUP, 0, 0, 0, 0, 0, 0, instance_, 0);
   gfx::CheckWindowCreated(window_);
   gfx::SetWindowUserData(window_, this);
-
-  color_change_listener_.reset(
-      new gfx::ScopedSysColorChangeListener(
-          new SystemPreferencesColorChangeListener(this)));
 }
 
 LRESULT CALLBACK SystemPreferences::WndProcStatic(HWND hwnd,
@@ -107,7 +90,7 @@ LRESULT CALLBACK SystemPreferences::WndProc(HWND hwnd,
   return ::DefWindowProc(hwnd, message, wparam, lparam);
 }
 
-void SystemPreferences::OnColorChanged() {
+void SystemPreferences::OnSysColorChange() {
   bool new_invertered_color_scheme = IsInvertedColorScheme();
   if (new_invertered_color_scheme != invertered_color_scheme_) {
     invertered_color_scheme_ = new_invertered_color_scheme;

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -19,11 +19,11 @@ const wchar_t kSystemPreferencesWindowClass[] =
 
 namespace api {
 
-class SystemPreferencesColorChangeListener :
-    public gfx::SysColorChangeListener {
+class SystemPreferencesColorChangeListener
+    : public gfx::SysColorChangeListener {
  public:
-  explicit SystemPreferencesColorChangeListener(SystemPreferences* prefs):
-        prefs_(prefs) {
+  explicit SystemPreferencesColorChangeListener(SystemPreferences* prefs)
+      : prefs_(prefs) {
   }
 
   void OnSysColorChange() {

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -19,6 +19,21 @@ const wchar_t kSystemPreferencesWindowClass[] =
 
 namespace api {
 
+class SystemPreferencesColorChangeListener :
+    public gfx::SysColorChangeListener {
+ public:
+  explicit SystemPreferencesColorChangeListener(SystemPreferences* prefs):
+        prefs_(prefs) {
+  }
+
+  void OnSysColorChange() {
+    prefs_->OnColorChanged();
+  }
+
+ private:
+  SystemPreferences* prefs_;
+};
+
 bool SystemPreferences::IsAeroGlassEnabled() {
   return ui::win::IsAeroGlassEnabled();
 }
@@ -59,6 +74,10 @@ void SystemPreferences::InitializeWindow() {
                          0, WS_POPUP, 0, 0, 0, 0, 0, 0, instance_, 0);
   gfx::CheckWindowCreated(window_);
   gfx::SetWindowUserData(window_, this);
+
+  color_change_listener_.reset(
+      new gfx::ScopedSysColorChangeListener(
+          new SystemPreferencesColorChangeListener(this)));
 }
 
 LRESULT CALLBACK SystemPreferences::WndProcStatic(HWND hwnd,
@@ -86,6 +105,14 @@ LRESULT CALLBACK SystemPreferences::WndProc(HWND hwnd,
     }
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);
+}
+
+void SystemPreferences::OnColorChanged() {
+  bool new_invertered_color_scheme = IsInvertedColorScheme();
+  if (new_invertered_color_scheme != invertered_color_scheme_) {
+    Emit("inverted-color-scheme-changed", new_invertered_color_scheme);
+    invertered_color_scheme_ = new_invertered_color_scheme;
+  }
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -110,8 +110,8 @@ LRESULT CALLBACK SystemPreferences::WndProc(HWND hwnd,
 void SystemPreferences::OnColorChanged() {
   bool new_invertered_color_scheme = IsInvertedColorScheme();
   if (new_invertered_color_scheme != invertered_color_scheme_) {
-    Emit("inverted-color-scheme-changed", new_invertered_color_scheme);
     invertered_color_scheme_ = new_invertered_color_scheme;
+    Emit("inverted-color-scheme-changed", new_invertered_color_scheme);
   }
 }
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -24,7 +24,7 @@ Returns:
 Returns:
 
 * `event` Event
-* `invertedColorScheme` Boolean - `true` if a inverted color scheme, such as
+* `invertedColorScheme` Boolean - `true` if an inverted color scheme, such as
   a high contrast theme, is being used, `false` otherwise.
 
 ## Methods

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -17,8 +17,15 @@ Returns:
 
 * `event` Event
 * `newColor` String - The new RGBA color the user assigned to be there system
-accent color.
+  accent color.
 
+### Event: 'inverted-color-scheme-changed' _Windows_
+
+Returns:
+
+* `event` Event
+* `invertedColorScheme` Boolean - `true` if a inverted color scheme, such as
+  a high contrast theme, is being used, `false` otherwise.
 
 ## Methods
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -150,3 +150,8 @@ const green = color.substr(2, 2) // "bb"
 const blue = color.substr(4, 2) // "cc"
 const alpha = color.substr(6, 2) // "dd"
 ```
+
+### `systemPreferences.isInvertedColorScheme()` _Windows_
+
+Returns `Boolean` - `true` if an inverted color scheme, such as a high contrast
+theme, is active, `false` otherwise.

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -30,4 +30,10 @@ describe('systemPreferences module', function () {
       assert(languages.length > 0)
     })
   })
+
+  describe('systemPreferences.isInvertedColorScheme()', function () {
+    it('returns a boolean', function () {
+      assert.equal(typeof systemPreferences.isInvertedColorScheme(), 'boolean')
+    })
+  })
 })


### PR DESCRIPTION
This API allows app's to determine if a high contrast theme is active on Windows in case they want to adjust their styles at startup or when the value is changed.

Chrome currently uses this API to show a popover about installing a dark theme and high contrast extension.

- [x] Add `isInvertedColorScheme` helper
- [x] Add `inverted-color-scheme-changed` event for when the theme/colors switched into and out of an inverted color scheme.

Closes #7469