### PR TITLE
Only call media::AudioManager::SetGlobalAppName on Linux

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -491,9 +491,11 @@ void App::OnWillFinishLaunching() {
 }
 
 void App::OnFinishLaunching(const base::DictionaryValue& launch_info) {
+#if defined(OS_LINUX)
   // Set the application name for audio streams shown in external
   // applications. Only affects pulseaudio currently.
   media::AudioManager::SetGlobalAppName(Browser::Get()->GetName());
+#endif
   Emit("ready", launch_info);
 }
 


### PR DESCRIPTION
Follow on to #7524, only call media::AudioManager::SetGlobalAppName on Linux.

For some reason AppVeyor did not build that PR so it looked green even though the Mac and Windows builds had failures.

https://travis-ci.org/electron/electron/jobs/165778082

/cc @deepak1556 