### PR TITLE
Allow web frame methods to return async promises

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -621,7 +621,7 @@ Injects CSS into the current web page.
   * `result` Any
 
 Returns `Promise` - A promise that resolves with the result of the executed code
-or is rejected if the result of the code is a rejected promise
+or is rejected if the result of the code is a rejected promise.
 
 Evaluates `code` in page.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -620,11 +620,25 @@ Injects CSS into the current web page.
 * `callback` Function (optional) - Called after script has been executed.
   * `result` Any
 
+Returns `Promise` - A promise that resolves with the result of the executed code
+or is rejected if the result of the code is a rejected promise
+
 Evaluates `code` in page.
 
 In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
+
+If the result of the executed code is a promise the callback result will be the
+resolved value of the promise.  We recommend that you use the returned Promise
+to handle code that results in a Promise.
+
+```js
+contents.executeJavaScript('fetch("https://jsonplaceholder.typicode.com/users/1").then(resp => resp.json())', true)
+  .then((result) => {
+    console.log(result) // Will be the JSON object from the fetch call
+  })
+```
 
 #### `contents.setAudioMuted(muted)`
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -113,9 +113,12 @@ const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
   return new Promise((resolve, reject) => {
     this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
     ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, error, result) {
-      if (callback && !error) callback(result)
-      if (error) return reject(error)
-      return resolve(result)
+      if (error == null) {
+        if (callback != null) callback(result)
+        resolve(result)
+      } else {
+        reject(error)
+      }
     })
   })
 }

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -112,12 +112,10 @@ const webFrameMethodsWithResult = [
 const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
   return new Promise((resolve, reject) => {
     this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
-    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
-      if (callback) callback(result)
-      resolve(result)
-    })
-    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_ERROR_${requestId}`, (event, error) => {
-      reject(error)
+    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, error, result) {
+      if (callback && !error) callback(result)
+      if (error) return reject(error)
+      return resolve(result)
     })
   })
 }

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -110,9 +110,15 @@ const webFrameMethodsWithResult = [
 ]
 
 const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
-  this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
-  ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
-    if (callback) callback(result)
+  return new Promise((resolve, reject) => {
+    this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
+    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
+      if (callback) callback(result)
+      resolve(result)
+    })
+    ipcMain.once(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_ERROR_${requestId}`, (event, error) => {
+      reject(error)
+    })
   })
 }
 
@@ -146,10 +152,12 @@ WebContents.prototype.executeJavaScript = function (code, hasUserGesture, callba
     hasUserGesture = false
   }
   if (this.getURL() && !this.isLoadingMainFrame()) {
-    asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
+    return asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
   } else {
-    this.once('did-finish-load', () => {
-      asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
+    return new Promise((resolve, reject) => {
+      this.once('did-finish-load', () => {
+        asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture).then(resolve).catch(reject)
+      })
     })
   }
 }

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -44,7 +44,7 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (ev
         event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, resolvedResult)
       })
       .catch((resolvedError) => {
-        console.error(`An async web frame method (${method}) returned a promise that threw an error: `, resolvedError)
+        event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_ERROR_${requestId}`, resolvedError)
       })
   }
   args.push(responseCallback)

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -41,10 +41,10 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (ev
   const responseCallback = function (result) {
     Promise.resolve(result)
       .then((resolvedResult) => {
-        event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, resolvedResult)
+        event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, null, resolvedResult)
       })
       .catch((resolvedError) => {
-        event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_ERROR_${requestId}`, resolvedError)
+        event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, resolvedError)
       })
   }
   args.push(responseCallback)

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -39,7 +39,13 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (eve
 
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
   const responseCallback = function (result) {
-    event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, result)
+    Promise.resolve(result)
+      .then((resolvedResult) => {
+        event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, resolvedResult)
+      })
+      .catch((resolvedError) => {
+        console.error(`An async web frame method (${method}) returned a promise that threw an error: `, resolvedError)
+      })
   }
   args.push(responseCallback)
   electron.webFrame[method].apply(electron.webFrame, args)

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -48,7 +48,7 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (ev
       })
   }
   args.push(responseCallback)
-  electron.webFrame[method].apply(electron.webFrame, args)
+  electron.webFrame[method](...args)
 })
 
 // Process command line arguments.

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1463,9 +1463,9 @@ describe('browser-window module', function () {
   describe('window.webContents.executeJavaScript', function () {
     var expected = 'hello, world!'
     var expectedErrorMsg = 'woops!'
-    var code = '(() => "' + expected + '")()'
-    var asyncCode = '(() => new Promise(r => setTimeout(() => r("' + expected + '"), 500)))()'
-    var badAsyncCode = '(() => new Promise((r, e) => setTimeout(() => e("' + expectedErrorMsg + '"), 500)))()'
+    var code = `(() => "${expected}")()`
+    var asyncCode = `(() => new Promise(r => setTimeout(() => r("${expected}"), 500)))()`
+    var badAsyncCode = `(() => new Promise((r, e) => setTimeout(() => e("${expectedErrorMsg}"), 500)))()`
 
     it('doesnt throw when no calback is provided', function () {
       const result = ipcRenderer.sendSync('executeJavaScript', code, false)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1463,6 +1463,7 @@ describe('browser-window module', function () {
   describe('window.webContents.executeJavaScript', function () {
     var expected = 'hello, world!'
     var code = '(() => "' + expected + '")()'
+    var asyncCode = '(() => new Promise(r => setTimeout(() => r("' + expected + '"), 500)))()'
 
     it('doesnt throw when no calback is provided', function () {
       const result = ipcRenderer.sendSync('executeJavaScript', code, false)
@@ -1471,6 +1472,14 @@ describe('browser-window module', function () {
 
     it('returns result when calback is provided', function (done) {
       ipcRenderer.send('executeJavaScript', code, true)
+      ipcRenderer.once('executeJavaScript-response', function (event, result) {
+        assert.equal(result, expected)
+        done()
+      })
+    })
+
+    it('returns result if the code returns an asyncronous promise', function (done) {
+      ipcRenderer.send('executeJavaScript', asyncCode, true)
       ipcRenderer.once('executeJavaScript-response', function (event, result) {
         assert.equal(result, expected)
         done()

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -173,6 +173,10 @@ app.on('ready', function () {
     if (hasCallback) {
       window.webContents.executeJavaScript(code, (result) => {
         window.webContents.send('executeJavaScript-response', result)
+      }).then((result) => {
+        window.webContents.send('executeJavaScript-promise-response', result)
+      }).catch((err) => {
+        window.webContents.send('executeJavaScript-promise-error', err)
       })
     } else {
       window.webContents.executeJavaScript(code)


### PR DESCRIPTION
Fixes #7532

Basically this handles `executeJavaScript` calls returning instances of `Promise` and resolving that promise before passing it back through IPC to the caller.

This trick works because

``` js
Promise.resolve(123).then((resolvedValue) => console.log(resolvedValue))
// This would print out 123
// Promise.resolve either immediately resolves with the given value or resolves the given promise
```

It allows for truly asyncronous execution like so

``` js
webContents.executeJavaScript(
  `new Promise(resolve => {
    setTimeout(() => resolve('myString'), 2000);
  });`,
  (returnValue) => {
     // returnValue === 'myString'
  }
);
```

This is non-blocking async execution 👍 
