### PR TITLE
Docs: clarify ignoring object files with electron-packager

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -135,8 +135,9 @@ electron-osx-sign YourApp.app YourApp.app/Contents/Resources/app/node_modules/na
 
 Also note that native modules may have intermediate files produced which should
 not be included (as they would also need to be signed). If you use
-[electron-packager][electron-packager], add `--ignore=.+\.o$` to build step to
-ignore these files.
+[electron-packager][electron-packager] before version 8.1.0, add
+`--ignore=.+\.o$` to your build step to ignore these files. Versions 8.1.0 and
+later ignores those files by default.
 
 ### Upload Your App
 


### PR DESCRIPTION
Note that Electron Packager 8.1.0 and later ignores object files by default.

See: https://github.com/electron-userland/electron-packager/pull/491