### PR TITLE
Support setting about panel options

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -850,6 +850,8 @@ void App::BuildPrototype(
                  base::Bind(&Browser::SetUserActivity, browser))
       .SetMethod("getCurrentActivityType",
                  base::Bind(&Browser::GetCurrentActivityType, browser))
+      .SetMethod("setAboutPanelOptions",
+                 base::Bind(&Browser::SetAboutPanelOptions, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -14,6 +14,7 @@
 #include "base/macros.h"
 #include "base/observer_list.h"
 #include "base/strings/string16.h"
+#include "base/values.h"
 #include "native_mate/arguments.h"
 
 #if defined(OS_WIN)
@@ -21,7 +22,6 @@
 #endif
 
 namespace base {
-class DictionaryValue;
 class FilePath;
 }
 
@@ -146,6 +146,9 @@ class Browser : public WindowListObserver {
 
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
+
+  void ShowAboutPanel();
+  void SetAboutPanelOptions(const base::DictionaryValue& options);
 #endif  // defined(OS_MACOSX)
 
 #if defined(OS_WIN)
@@ -243,6 +246,10 @@ class Browser : public WindowListObserver {
 
 #if defined(OS_WIN)
   base::string16 app_user_model_id_;
+#endif
+
+#if defined(OS_MACOSX)
+  base::DictionaryValue about_panel_options_;
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(Browser);

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -253,4 +253,15 @@ void Browser::DockSetIcon(const gfx::Image& image) {
       setApplicationIconImage:image.AsNSImage()];
 }
 
+void Browser::ShowAboutPanel() {
+  NSDictionary* options = DictionaryValueToNSDictionary(about_panel_options_);
+  [[AtomApplication sharedApplication]
+      orderFrontStandardAboutPanelWithOptions:options];
+}
+
+void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
+  about_panel_options_.Clear();
+  about_panel_options_.MergeDictionary(&options);
+}
+
 }  // namespace atom

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -87,4 +87,8 @@
   atom::Browser::Get()->OnAccessibilitySupportChanged();
 }
 
+- (void)orderFrontStandardAboutPanel:(id)sender {
+  atom::Browser::Get()->ShowAboutPanel();
+}
+
 @end

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -853,6 +853,18 @@ technologies, such as screen readers, has been detected. See
 https://www.chromium.org/developers/design-documents/accessibility for more
 details.
 
+### `app.setAboutPanelOptions(options)` _macOS_
+
+* `options` Object
+  * `ApplicationName` String (optional) - The app's name.
+  * `ApplicationVersion` String (optional) - The app's version.
+  * `Copyright` String (optional) - Copyright information.
+  * `Credits` String (optional) - Credit information.
+  * `Version` String (optional) - The app's build version number.
+
+Set the about panel options. This will override the values defined in the app's
+`.plist` file. See the [Apple docs][about-panel-options] for more details.
+
 ### `app.commandLine.appendSwitch(switch[, value])`
 
 * `switch` String - A command-line switch
@@ -943,3 +955,4 @@ Sets the `image` associated with this dock icon.
 [activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
 [unity-requiremnt]: ../tutorial/desktop-environment-integration.md#unity-launcher-shortcuts-linux
 [JumpListBeginListMSDN]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378398(v=vs.85).aspx
+[about-panel-options]: https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc


### PR DESCRIPTION
Allow the application name, version, copyright, and credits shown in the about panel on macOS to be configurable at runtime.

See https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc for more details.

Fixes #6955