### PR TITLE
silent uncaugt error when getting objects from registry storage that …

### DIFF
--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -41,7 +41,12 @@ class ObjectsRegistry {
 
   // Get an object according to its ID.
   get (id) {
-    return this.storage[id].object
+    if (this.storage[id]) {
+      return this.storage[id].object
+    }
+
+    console.error(`Object id '${id}' does not exists in the object storage!`, this.storage)
+    return null
   }
 
   // Dereference an object according to its ID.


### PR DESCRIPTION
addresses #7351 

Does not fix the error but adds login and removes `Uncaught exception` possibility

