### PR TITLE
Adds link to PyObjC installation instructions

### DIFF
--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -9,7 +9,7 @@ Follow the guidelines below for building Electron on macOS.
 * [node.js](http://nodejs.org) (external)
 
 If you are using the Python downloaded by Homebrew, you also need to install
-following python modules:
+the following Python modules:
 
 * [pyobjc](https://pythonhosted.org/pyobjc/install.html)
 

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -11,7 +11,7 @@ Follow the guidelines below for building Electron on macOS.
 If you are using the Python downloaded by Homebrew, you also need to install
 following python modules:
 
-* pyobjc
+* [pyobjc](https://pythonhosted.org/pyobjc/install.html)
 
 ## Getting the Code
 


### PR DESCRIPTION
Adds a link to [PyObjC installation instructions](https://pythonhosted.org/pyobjc/install.html) in [Build Instructions (macOS)](http://electron.atom.io/docs/development/build-instructions-osx/).