### PR TITLE
Support retrieving Windows system colors

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -52,6 +52,7 @@ void SystemPreferences::BuildPrototype(
 #if defined(OS_WIN)
       .SetMethod("getAccentColor", &SystemPreferences::GetAccentColor)
       .SetMethod("isAeroGlassEnabled", &SystemPreferences::IsAeroGlassEnabled)
+      .SetMethod("getColor", &SystemPreferences::GetColor)
 #elif defined(OS_MACOSX)
       .SetMethod("postNotification",
                  &SystemPreferences::PostNotification)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -44,6 +44,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
                                             "DwmGetColorizationColor");
 
   std::string GetAccentColor();
+  std::string GetColor(const std::string& color, mate::Arguments* args);
 
   void InitializeWindow();
 

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -4,8 +4,10 @@
 
 #include "atom/browser/api/atom_api_system_preferences.h"
 
+#include "atom/common/color_util.h"
 #include "base/win/wrapped_window_proc.h"
 #include "ui/base/win/shell.h"
+#include "ui/gfx/color_utils.h"
 #include "ui/gfx/win/hwnd_util.h"
 
 namespace atom {
@@ -39,6 +41,85 @@ std::string SystemPreferences::GetAccentColor() {
   }
 
   return hexColorDWORDToRGBA(color);
+}
+
+std::string SystemPreferences::GetColor(const std::string& color,
+                                        mate::Arguments* args) {
+  int id;
+  if (color == "3d-dark-shadow") {
+    id = COLOR_3DDKSHADOW;
+  } else if (color == "3d-face") {
+    id = COLOR_3DFACE;
+  } else if (color == "3d-highlight") {
+    id = COLOR_3DHIGHLIGHT;
+  } else if (color == "3d-light") {
+    id = COLOR_3DLIGHT;
+  } else if (color == "3d-shadow") {
+    id = COLOR_3DSHADOW;
+  } else if (color == "active-border") {
+    id = COLOR_ACTIVEBORDER;
+  } else if (color == "active-caption") {
+    id = COLOR_ACTIVECAPTION;
+  } else if (color == "active-caption-gradient") {
+    id = COLOR_GRADIENTACTIVECAPTION;
+  } else if (color == "app-workspace") {
+    id = COLOR_APPWORKSPACE;
+  } else if (color == "background") {
+    id = COLOR_BACKGROUND;
+  } else if (color == "button-face") {
+    id = COLOR_BTNFACE;
+  } else if (color == "button-highlight") {
+    id = COLOR_BTNHIGHLIGHT;
+  } else if (color == "button-shadow") {
+    id = COLOR_BTNSHADOW;
+  } else if (color == "button-text") {
+    id = COLOR_BTNTEXT;
+  } else if (color == "caption-text") {
+    id = COLOR_CAPTIONTEXT;
+  } else if (color == "desktop") {
+    id = COLOR_DESKTOP;
+  } else if (color == "disabled-text") {
+    id = COLOR_GRAYTEXT;
+  } else if (color == "highlight") {
+    id = COLOR_HIGHLIGHT;
+  } else if (color == "highlight-text") {
+    id = COLOR_HIGHLIGHTTEXT;
+  } else if (color == "hotlight") {
+    id = COLOR_HOTLIGHT;
+  } else if (color == "inactive-border") {
+    id = COLOR_INACTIVEBORDER;
+  } else if (color == "inactive-caption") {
+    id = COLOR_INACTIVECAPTION;
+  } else if (color == "inactive-caption-gradient") {
+    id = COLOR_GRADIENTINACTIVECAPTION;
+  } else if (color == "inactive-caption-text") {
+    id = COLOR_INACTIVECAPTIONTEXT;
+  } else if (color == "info-background") {
+    id = COLOR_INFOBK;
+  } else if (color == "info-text") {
+    id = COLOR_INFOTEXT;
+  } else if (color == "menu") {
+    id = COLOR_MENU;
+  } else if (color == "menu-highlight") {
+    id = COLOR_MENUHILIGHT;
+  } else if (color == "menubar") {
+    id = COLOR_MENUBAR;
+  } else if (color == "menu-text") {
+    id = COLOR_MENUTEXT;
+  } else if (color == "scrollbar") {
+    id = COLOR_SCROLLBAR;
+  } else if (color == "window") {
+    id = COLOR_WINDOW;
+  } else if (color == "window-frame") {
+    id = COLOR_WINDOWFRAME;
+  } else if (color == "window-text") {
+    id = COLOR_WINDOWTEXT;
+  } else {
+    args->ThrowError("Unknown color: " + color);
+    return "";
+  }
+
+  return ToRGBHex(color_utils::GetSysSkColor(id));
 }
 
 void SystemPreferences::InitializeWindow() {

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -169,6 +169,7 @@ void SystemPreferences::OnSysColorChange() {
     invertered_color_scheme_ = new_invertered_color_scheme;
     Emit("inverted-color-scheme-changed", new_invertered_color_scheme);
   }
+  Emit("color-changed");
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -64,14 +64,6 @@ std::string SystemPreferences::GetColor(const std::string& color,
     id = COLOR_GRADIENTACTIVECAPTION;
   } else if (color == "app-workspace") {
     id = COLOR_APPWORKSPACE;
-  } else if (color == "background") {
-    id = COLOR_BACKGROUND;
-  } else if (color == "button-face") {
-    id = COLOR_BTNFACE;
-  } else if (color == "button-highlight") {
-    id = COLOR_BTNHIGHLIGHT;
-  } else if (color == "button-shadow") {
-    id = COLOR_BTNSHADOW;
   } else if (color == "button-text") {
     id = COLOR_BTNTEXT;
   } else if (color == "caption-text") {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -647,11 +647,7 @@ void WebContents::MediaStoppedPlaying(const MediaPlayerId& id) {
 }
 
 void WebContents::DidChangeThemeColor(SkColor theme_color) {
-  std::string hex_theme_color = base::StringPrintf("#%02X%02X%02X",
-    SkColorGetR(theme_color),
-    SkColorGetG(theme_color),
-    SkColorGetB(theme_color));
-  Emit("did-change-theme-color", hex_theme_color);
+  Emit("did-change-theme-color", atom::ToRGBHex(theme_color));
 }
 
 void WebContents::DocumentLoadedInFrame(

--- a/atom/common/color_util.cc
+++ b/atom/common/color_util.cc
@@ -8,6 +8,7 @@
 
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
+#include "base/strings/stringprintf.h"
 
 namespace atom {
 
@@ -43,6 +44,13 @@ SkColor ParseHexColor(const std::string& color_string) {
     return SK_ColorWHITE;
 
   return SkColorSetARGB(bytes[0], bytes[1], bytes[2], bytes[3]);
+}
+
+std::string ToRGBHex(const SkColor color) {
+  return base::StringPrintf("#%02X%02X%02X",
+                            SkColorGetR(color),
+                            SkColorGetG(color),
+                            SkColorGetB(color));
 }
 
 }  // namespace atom

--- a/atom/common/color_util.cc
+++ b/atom/common/color_util.cc
@@ -46,7 +46,7 @@ SkColor ParseHexColor(const std::string& color_string) {
   return SkColorSetARGB(bytes[0], bytes[1], bytes[2], bytes[3]);
 }
 
-std::string ToRGBHex(const SkColor color) {
+std::string ToRGBHex(SkColor color) {
   return base::StringPrintf("#%02X%02X%02X",
                             SkColorGetR(color),
                             SkColorGetG(color),

--- a/atom/common/color_util.h
+++ b/atom/common/color_util.h
@@ -15,7 +15,7 @@ namespace atom {
 SkColor ParseHexColor(const std::string& name);
 
 // Convert color to RGB hex value like "#ABCDEF"
-std::string ToRGBHex(const SkColor color);
+std::string ToRGBHex(SkColor color);
 
 }  // namespace atom
 

--- a/atom/common/color_util.h
+++ b/atom/common/color_util.h
@@ -14,6 +14,9 @@ namespace atom {
 // Parse hex color like "#FFF" or "#EFEFEF"
 SkColor ParseHexColor(const std::string& name);
 
+// Convert color to RGB hex value like "#ABCDEF"
+std::string ToRGBHex(const SkColor color);
+
 }  // namespace atom
 
 #endif  // ATOM_COMMON_COLOR_UTIL_H_

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -19,6 +19,12 @@ Returns:
 * `newColor` String - The new RGBA color the user assigned to be there system
   accent color.
 
+### Event: 'color-changed' _Windows_
+
+Returns:
+
+* `event` Event
+
 ### Event: 'inverted-color-scheme-changed' _Windows_
 
 Returns:

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -147,8 +147,8 @@ if (browserOptions.transparent) {
 
 ### `systemPreferences.getAccentColor()` _Windows_
 
-Returns the users current system wide color preference in the form of an RGBA
-hexadecimal string.
+Returns `String` - The users current system wide accent color preference in RGBA
+hexadecimal form.
 
 ```js
 const color = systemPreferences.getAccentColor() // `"aabbccdd"`
@@ -158,7 +158,56 @@ const blue = color.substr(4, 2) // "cc"
 const alpha = color.substr(6, 2) // "dd"
 ```
 
+### `systemPreferences.getColor(color)` _Windows_
+
+* `color` String - One of the following values:
+  * `3d-dark-shadow` - Dark shadow for three-dimensional display elements.
+  * `3d-face` - Face color for three-dimensional display elements and for dialog
+    box backgrounds.
+  * `3d-highlight` - Highlight color for three-dimensional display elements.
+  * `3d-light` - Light color for three-dimensional display elements.
+  * `3d-shadow` - Shadow color for three-dimensional display elements.
+  * `active-border` - Active window border.
+  * `active-caption` - Active window title bar. Specifies the left side color in
+    the color gradient of an active window's title bar if the gradient effect is
+    enabled.
+  * `active-caption-gradient` - Right side color in the color gradient of an
+    active window's title bar.
+  * `app-workspace` - Background color of multiple document interface (MDI)
+    applications.
+  * `button-text` - Text on push buttons.
+  * `caption-text` - Text in caption, size box, and scroll bar arrow box.
+  * `desktop` - Desktop background color.
+  * `disabled-text` - Grayed (disabled) text.
+  * `highlight` - Item(s) selected in a control.
+  * `highlight-text` - Text of item(s) selected in a control.
+  * `hotlight` - Color for a hyperlink or hot-tracked item.
+  * `inactive-border` - Inactive window border.
+  * `inactive-caption` - Inactive window caption. Specifies the left side color
+    in the color gradient of an inactive window's title bar if the gradient
+    effect is enabled.
+  * `inactive-caption-gradient` - Right side color in the color gradient of an
+    inactive window's title bar.
+  * `inactive-caption-text` - Color of text in an inactive caption.
+  * `info-background` - Background color for tooltip controls.
+  * `info-text` - Text color for tooltip controls.
+  * `menu` - Menu background.
+  * `menu-highlight` - The color used to highlight menu items when the menu
+    appears as a flat menu.
+  * `menubar` - The background color for the menu bar when menus appear as flat
+    menus.
+  * `menu-text` - Text in menus.
+  * `scrollbar` - Scroll bar gray area.
+  * `window` - Window background.
+  * `window-frame` - Window frame.
+  * `window-text` - Text in windows.
+
+Returns `String` - The system color setting in RGB hexadecimal form (`#ABCDEF`).
+See the [Windows docs][windows-colors] for more details.
+
 ### `systemPreferences.isInvertedColorScheme()` _Windows_
 
 Returns `Boolean` - `true` if an inverted color scheme, such as a high contrast
 theme, is active, `false` otherwise.
+
+[windows-colors]:https://msdn.microsoft.com/en-us/library/windows/desktop/ms724371(v=vs.85).aspx

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -15,6 +15,22 @@ describe('systemPreferences module', function () {
     })
   })
 
+  describe('systemPreferences.getColor(id)', function () {
+    if (process.platform !== 'win32') {
+      return
+    }
+
+    it('throws an error when the id is invalid', function () {
+      assert.throws(function () {
+        systemPreferences.getColor('not-a-color')
+      }, /Unknown color: not-a-color/)
+    })
+
+    it('returns a hex RGB color string', function () {
+      assert.equal(/^#[0-9A-F]{6}$/i.test(systemPreferences.getColor('window')), true)
+    })
+  })
+
   describe('systemPreferences.getUserDefault(key, type)', function () {
     if (process.platform !== 'darwin') {
       return


### PR DESCRIPTION
Adds a `systemPreferences.getColor` method on Windows that supports retrieving all the colors from https://msdn.microsoft.com/en-us/library/windows/desktop/ms724371(v=vs.85).aspx

- [x] Add `systemPreferences.getColor`
- [x]  Add `color-changed` event
- [x] Add specs
- [x] Add docs

/cc @MarshallOfSound @paulcbetts :eyes:


Refs #7518 

