### PR TITLE
Shorten Socket path for makeSingleInstance in sandboxed apps

### DIFF
--- a/chromium_src/chrome/browser/process_singleton_posix.cc
+++ b/chromium_src/chrome/browser/process_singleton_posix.cc
@@ -348,6 +348,21 @@ bool CheckCookie(const base::FilePath& path, const base::FilePath& cookie) {
   return (cookie == ReadLink(path));
 }
 
+bool IsAppSandboxed() {
+#if defined(OS_MACOSX)
+  // NB: There is no sane API for this, we have to just guess by
+  // reading tea leaves
+  base::FilePath home_dir;
+  if (!PathService.Get(base::DIR_HOME, &home_dir)) {
+    return false;
+  }
+
+  return home_dir.value().find("Library/Containers") != std::string::npos;
+#else
+  return false;
+#endif  // defined(OS_MACOSX)
+}
+
 bool ConnectSocket(ScopedSocket* socket,
                    const base::FilePath& socket_path,
                    const base::FilePath& cookie_path) {

--- a/chromium_src/chrome/browser/process_singleton_posix.cc
+++ b/chromium_src/chrome/browser/process_singleton_posix.cc
@@ -353,7 +353,7 @@ bool IsAppSandboxed() {
   // NB: There is no sane API for this, we have to just guess by
   // reading tea leaves
   base::FilePath home_dir;
-  if (!PathService.Get(base::DIR_HOME, &home_dir)) {
+  if (!base::PathService::Get(base::DIR_HOME, &home_dir)) {
     return false;
   }
 


### PR DESCRIPTION
This PR amends #5236 to work with apps that are sandboxed, non-MAS applications, by detecting dynamically whether we should apply the sandbox workaround instead of restricting it to the MAS build