### PR TITLE
Specified default value of nodeintegration in webview tag

### DIFF
--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -118,8 +118,9 @@ than the minimum values or greater than the maximum.
 <webview src="http://www.google.com/" nodeintegration></webview>
 ```
 
-If "on", the guest page in `webview` will have node integration and can use node
+If "true", the guest page in `webview` will have node integration and can use node
 APIs like `require` and `process` to access low level system resources.
+Note that by including attribute, `nodeintegration` in `webview` tag, nodeintegration is automatically sets to "true".
 
 ### `plugins`
 


### PR DESCRIPTION
Solving issue #6939
Added one line after line 122 in docs/api/web-view-tag.md specifying default value of nodeintegration.
<img width="1277" alt="screen shot 2016-10-12 at 3 32 40 am" src="https://cloud.githubusercontent.com/assets/10228876/19290661/547314f0-902e-11e6-9896-61abf4c68ec8.png">
