### PR TITLE
Show console output from Windows when ELECTRON_RUN_AS_NODE is set

### DIFF
--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -8,14 +8,18 @@
 #include "atom/browser/javascript_environment.h"
 #include "atom/browser/node_debugger.h"
 #include "atom/common/api/atom_bindings.h"
-#include "atom/common/native_mate_converters/string16_converter.h"
+
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "gin/array_buffer.h"
 #include "gin/public/isolate_holder.h"
 #include "gin/v8_initializer.h"
+
+#if defined(OS_WIN)
+#include "atom/common/native_mate_converters/string16_converter.h"
 #include "native_mate/dictionary.h"
+#endif
 
 #include "atom/common/node_includes.h"
 
@@ -54,8 +58,10 @@ int NodeMain(int argc, char *argv[]) {
     if (node_debugger.IsRunning())
       env->AssignToContext(v8::Debug::GetDebugContext());
 
+#if defined(OS_WIN)
     mate::Dictionary process(gin_env.isolate(), env->process_object());
     process.SetMethod("log", &AtomBindings::Log);
+#endif
 
     node::LoadEnvironment(env);
 

--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -4,19 +4,27 @@
 
 #include "atom/app/node_main.h"
 
+#include <iostream>
+
 #include "atom/app/uv_task_runner.h"
 #include "atom/browser/javascript_environment.h"
 #include "atom/browser/node_debugger.h"
+#include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "gin/array_buffer.h"
 #include "gin/public/isolate_holder.h"
 #include "gin/v8_initializer.h"
+#include "native_mate/dictionary.h"
 
 #include "atom/common/node_includes.h"
 
 namespace atom {
+
+void Log(const base::string16& message) {
+  std::cout << message << std::flush;
+}
 
 int NodeMain(int argc, char *argv[]) {
   base::CommandLine::Init(argc, argv);
@@ -52,6 +60,9 @@ int NodeMain(int argc, char *argv[]) {
       env->AssignToContext(v8::Debug::GetDebugContext());
 
     node::LoadEnvironment(env);
+
+    mate::Dictionary dict(gin_env.isolate(), env->process_object());
+    dict.SetMethod("log", &Log);
 
     bool more;
     do {

--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -4,11 +4,10 @@
 
 #include "atom/app/node_main.h"
 
-#include <iostream>
-
 #include "atom/app/uv_task_runner.h"
 #include "atom/browser/javascript_environment.h"
 #include "atom/browser/node_debugger.h"
+#include "atom/common/api/atom_bindings.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
@@ -21,10 +20,6 @@
 #include "atom/common/node_includes.h"
 
 namespace atom {
-
-void Log(const base::string16& message) {
-  std::cout << message << std::flush;
-}
 
 int NodeMain(int argc, char *argv[]) {
   base::CommandLine::Init(argc, argv);
@@ -59,10 +54,10 @@ int NodeMain(int argc, char *argv[]) {
     if (node_debugger.IsRunning())
       env->AssignToContext(v8::Debug::GetDebugContext());
 
-    node::LoadEnvironment(env);
+    mate::Dictionary process(gin_env.isolate(), env->process_object());
+    process.SetMethod("log", &AtomBindings::Log);
 
-    mate::Dictionary dict(gin_env.isolate(), env->process_object());
-    dict.SetMethod("log", &Log);
+    node::LoadEnvironment(env);
 
     bool more;
     do {

--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -7,8 +7,6 @@
 #include "atom/app/uv_task_runner.h"
 #include "atom/browser/javascript_environment.h"
 #include "atom/browser/node_debugger.h"
-#include "atom/common/api/atom_bindings.h"
-
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/threading/thread_task_runner_handle.h"
@@ -17,6 +15,7 @@
 #include "gin/v8_initializer.h"
 
 #if defined(OS_WIN)
+#include "atom/common/api/atom_bindings.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "native_mate/dictionary.h"
 #endif

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -79,10 +79,6 @@ void FatalErrorCallback(const char* location, const char* message) {
   Crash();
 }
 
-void Log(const base::string16& message) {
-  std::cout << message << std::flush;
-}
-
 }  // namespace
 
 
@@ -155,6 +151,11 @@ void AtomBindings::OnCallNextTick(uv_async_t* handle) {
   }
 
   self->pending_next_ticks_.clear();
+}
+
+// static
+void AtomBindings::Log(const base::string16& message) {
+  std::cout << message << std::flush;
 }
 
 }  // namespace atom

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -27,6 +27,8 @@ class AtomBindings {
   // load native code from Electron instead.
   void BindTo(v8::Isolate* isolate, v8::Local<v8::Object> process);
 
+  static void Log(const base::string16& message);
+
  private:
   void ActivateUVLoop(v8::Isolate* isolate);
 

--- a/spec/fixtures/module/run-as-node.js
+++ b/spec/fixtures/module/run-as-node.js
@@ -1,0 +1,5 @@
+console.log(JSON.stringify({
+  processLog: typeof process.log,
+  processType: typeof process.type,
+  window: typeof window
+}))

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -92,6 +92,29 @@ describe('node feature', function () {
         })
       })
     })
+
+    describe('child_process.spawn', function () {
+      it('supports spawning Electron as a node process via the ELECTRON_RUN_AS_NODE env var', function (done) {
+        const child = ChildProcess.spawn(process.execPath, [path.join(__dirname, 'fixtures', 'module', 'run-as-node.js')], {
+          env: {
+            ELECTRON_RUN_AS_NODE: true
+          }
+        })
+
+        let output = ''
+        child.stdout.on('data', function (data) {
+          output += data
+        })
+        child.stdout.on('close', function () {
+          assert.deepEqual(JSON.parse(output), {
+            processLog: process.platform === 'win32' ? 'function' : 'undefined',
+            processType: 'undefined',
+            window: 'undefined'
+          })
+          done()
+        })
+      })
+    })
   })
 
   describe('contexts', function () {


### PR DESCRIPTION
This pull request follows the approach outlined in https://github.com/electron/electron/issues/5715#issuecomment-245683085 to enable console output on Windows when electron is run with `ELECTRON_RUN_AS_NODE`.

Exposes `process.log` when run in a node context and calls that from the fallback streams created when `stdout` and `stderr` fail to initialize in node (which is happening on release builds).

<img width="232" alt="screen shot 2016-10-12 at 10 30 52 am" src="https://cloud.githubusercontent.com/assets/671378/19320626/e784995c-9066-11e6-8640-2914477835ab.png">

Depends on https://github.com/electron/node/pull/19

/cc @bpasero 