### PR TITLE
Use lower-case about panel option keys

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -261,7 +261,18 @@ void Browser::ShowAboutPanel() {
 
 void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
   about_panel_options_.Clear();
-  about_panel_options_.MergeDictionary(&options);
+
+  // Upper case option keys for orderFrontStandardAboutPanelWithOptions format
+  for (base::DictionaryValue::Iterator iter(options);
+       !iter.IsAtEnd();
+       iter.Advance()) {
+    std::string key = iter.key();
+    std::string value;
+    if (!key.empty() && iter.value().GetAsString(&value)) {
+      key[0] = base::ToUpperASCII(key[0]);
+      about_panel_options_.SetString(key, value);
+    }
+  }
 }
 
 }  // namespace atom

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -856,11 +856,11 @@ details.
 ### `app.setAboutPanelOptions(options)` _macOS_
 
 * `options` Object
-  * `ApplicationName` String (optional) - The app's name.
-  * `ApplicationVersion` String (optional) - The app's version.
-  * `Copyright` String (optional) - Copyright information.
-  * `Credits` String (optional) - Credit information.
-  * `Version` String (optional) - The app's build version number.
+  * `applicationName` String (optional) - The app's name.
+  * `applicationVersion` String (optional) - The app's version.
+  * `copyright` String (optional) - Copyright information.
+  * `credits` String (optional) - Credit information.
+  * `version` String (optional) - The app's build version number.
 
 Set the about panel options. This will override the values defined in the app's
 `.plist` file. See the [Apple docs][about-panel-options] for more details.


### PR DESCRIPTION
Follow on to #7549, use lower-case option keys for consistency and upper-case them before passing through to the macOS API.

/cc @enlight 👀 