### PR TITLE
Update docs linter with Rectangle structure fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.8.1",
+    "electron-docs-linter": "^1.8.2",
     "request": "*",
     "standard": "^7.1.2",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
This bumps the docs linter to a new version with support for the renamed `Rectangle` object.

Once we've [separated each API doc into its own file](https://github.com/electron/electron/issues/6931), we can get rid of the (manually updated) [seeds file](https://github.com/electron/electron-docs-linter/blob/f681fa91ae43e6635ad5ed2f84db32fd4ec6a915/lib/seeds.js) in the linter, and we'll be able to construct a list of APIs dynamically purely by parsing the files. Then we won't have to keep pulling in these little updates.

cc @MarshallOfSound 