### PR TITLE
Update standard to v8 to be inline with standard-markdown

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -279,7 +279,7 @@ ipcMain.on('ELECTRON_BROWSER_CONSTRUCTOR', function (event, id, args) {
 
     // Call new with array of arguments.
     // http://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible
-    let obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)))
+    let obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)))()
     event.returnValue = valueToMeta(event.sender, obj)
   } catch (error) {
     event.returnValue = exceptionToMeta(error)
@@ -302,7 +302,7 @@ ipcMain.on('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', function (event, id, method, a
     let constructor = objectsRegistry.get(id)[method]
 
     // Call new with array of arguments.
-    let obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)))
+    let obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)))()
     event.returnValue = valueToMeta(event.sender, obj)
   } catch (error) {
     event.returnValue = exceptionToMeta(error)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "electabul": "~0.0.4",
     "electron-docs-linter": "^1.8.1",
     "request": "*",
-    "standard": "^7.1.2",
+    "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"
   },
   "optionalDependencies": {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -45,7 +45,7 @@ describe('ipc module', function () {
       assert.equal(a.bar, 1234)
       assert.equal(a.anonymous.constructor.name, '')
       assert.equal(a.getConstructorName(Object.create(null)), '')
-      assert.equal(a.getConstructorName(new (class {})), '')
+      assert.equal(a.getConstructorName(new (class {})()), '')
     })
 
     it('should search module from the user app', function () {

--- a/spec/fixtures/module/no-prototype.js
+++ b/spec/fixtures/module/no-prototype.js
@@ -4,7 +4,7 @@ foo.baz = false
 module.exports = {
   foo: foo,
   bar: 1234,
-  anonymous: new (class {}),
+  anonymous: new (class {})(),
   getConstructorName: function (value) {
     return value.constructor.name
   }


### PR DESCRIPTION
This just updates the `standard` dependency and fixes the few linting issues that appeared as a result