### PR TITLE
Cleanup docs and standardize structs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -184,14 +184,7 @@ Returns:
 * `webContents` [WebContents](web-contents.md)
 * `url` URL
 * `error` String - The error code
-* `certificate` Object
-  * `data` String - PEM encoded data
-  * `issuerName` String - Issuer's Common Name
-  * `subjectName` String - Subject's Common Name
-  * `serialNumber` String - Hex value represented string
-  * `validStart` Integer - Start date of the certificate being valid in seconds
-  * `validExpiry` Integer - End date of the certificate being valid in seconds
-  * `fingerprint` String - Fingerprint of the certificate
+* `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
 
 Emitted when failed to verify the `certificate` for `url`, to trust the

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -402,7 +402,7 @@ The following events are available on instances of `Cookies`:
 #### Event: 'changed'
 
 * `event` Event
-* `cookie` Object - The cookie that was changed
+* `cookie` [Cookie](structures/cookie.md) - The cookie that was changed
 * `cause` String - The cause of the change with one of the following values:
   * `explicit` - The cookie was changed directly by a consumer's action.
   * `overwrite` - The cookie was automatically removed due to an insert
@@ -436,21 +436,7 @@ The following methods are available on instances of `Cookies`:
 Sends a request to get all cookies matching `details`, `callback` will be called
 with `callback(error, cookies)` on complete.
 
-`cookies` is an Array of `cookie` objects.
-
-* `cookie` Object
-  *  `name` String - The name of the cookie.
-  *  `value` String - The value of the cookie.
-  *  `domain` String - The domain of the cookie.
-  *  `hostOnly` String - Whether the cookie is a host-only cookie.
-  *  `path` String - The path of the cookie.
-  *  `secure` Boolean - Whether the cookie is marked as secure.
-  *  `httpOnly` Boolean - Whether the cookie is marked as HTTP only.
-  *  `session` Boolean - Whether the cookie is a session cookie or a persistent
-     cookie with an expiration date.
-  *  `expirationDate` Double (optional) - The expiration date of the cookie as
-     the number of seconds since the UNIX epoch. Not provided for session
-     cookies.
+`cookies` is an Array of [`cookie`](structures/cookie.md) objects.
 
 #### `cookies.set(details, callback)`
 

--- a/docs/api/structures/bluetooth-device.md
+++ b/docs/api/structures/bluetooth-device.md
@@ -1,4 +1,4 @@
-# Bluetooth Device Object
+# BluetoothDevice Object
 
 * `deviceName` String
 * `deviceId` String

--- a/docs/api/structures/bluetooth-device.md
+++ b/docs/api/structures/bluetooth-device.md
@@ -1,0 +1,4 @@
+# Bluetooth Device Object
+
+* `deviceName` String
+* `deviceId` String

--- a/docs/api/structures/cookie.md
+++ b/docs/api/structures/cookie.md
@@ -1,0 +1,14 @@
+# Certificate Object
+
+*  `name` String - The name of the cookie.
+*  `value` String - The value of the cookie.
+*  `domain` String - The domain of the cookie.
+*  `hostOnly` String - Whether the cookie is a host-only cookie.
+*  `path` String - The path of the cookie.
+*  `secure` Boolean - Whether the cookie is marked as secure.
+*  `httpOnly` Boolean - Whether the cookie is marked as HTTP only.
+*  `session` Boolean - Whether the cookie is a session cookie or a persistent
+   cookie with an expiration date.
+*  `expirationDate` Double (optional) - The expiration date of the cookie as
+   the number of seconds since the UNIX epoch. Not provided for session
+   cookies.

--- a/docs/api/structures/cookie.md
+++ b/docs/api/structures/cookie.md
@@ -1,14 +1,14 @@
-# Certificate Object
+# Cookie Object
 
-*  `name` String - The name of the cookie.
-*  `value` String - The value of the cookie.
-*  `domain` String - The domain of the cookie.
-*  `hostOnly` String - Whether the cookie is a host-only cookie.
-*  `path` String - The path of the cookie.
-*  `secure` Boolean - Whether the cookie is marked as secure.
-*  `httpOnly` Boolean - Whether the cookie is marked as HTTP only.
-*  `session` Boolean - Whether the cookie is a session cookie or a persistent
-   cookie with an expiration date.
-*  `expirationDate` Double (optional) - The expiration date of the cookie as
-   the number of seconds since the UNIX epoch. Not provided for session
-   cookies.
+* `name` String - The name of the cookie.
+* `value` String - The value of the cookie.
+* `domain` String - The domain of the cookie.
+* `hostOnly` String - Whether the cookie is a host-only cookie.
+* `path` String - The path of the cookie.
+* `secure` Boolean - Whether the cookie is marked as secure.
+* `httpOnly` Boolean - Whether the cookie is marked as HTTP only.
+* `session` Boolean - Whether the cookie is a session cookie or a persistent
+  cookie with an expiration date.
+* `expirationDate` Double (optional) - The expiration date of the cookie as
+  the number of seconds since the UNIX epoch. Not provided for session
+  cookies.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -147,7 +147,7 @@ Returns:
   `new-window`, `save-to-disk` and `other`.
 * `options` Object - The options which will be used for creating the new
   `BrowserWindow`.
-* `additionalFeatures` Array - The non-standard features (features not handled
+* `additionalFeatures` String[] - The non-standard features (features not handled
   by Chromium or Electron) given to `window.open()`.
 
 Emitted when the page requests to open a new window for a `url`. It could be
@@ -428,9 +428,7 @@ Emitted when there is a new context menu that needs to be handled.
 Returns:
 
 * `event` Event
-* `devices` [Objects]
-  * `deviceName` String
-  * `deviceId` String
+* `devices` [BluetoothDevice[]](structures/bluetooth-device.md)
 * `callback` Function
   * `deviceId` String
 
@@ -1069,7 +1067,7 @@ End subscribing for frame presentation events.
 
 #### `contents.startDrag(item)`
 
-* `item` object
+* `item` Object
   * `file` String
   * `icon` [NativeImage](native-image.md)
 


### PR DESCRIPTION
While parsing the docs into typescript I throw a few errors that are slightly more strict than the docs linter.  These fix a few of the issues 👍 

/cc @zeke 