### PR TITLE
Preview file with QuickLook

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -730,11 +730,11 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
 }
 
 void Window::PreviewFile(const std::string& path, mate::Arguments* args) {
-  std::string fileName;
-  if (!args->GetNext(&fileName)) {
-    fileName = path;
+  std::string display_name;
+  if (!args->GetNext(&display_name)) {
+    display_name = path;
   }
-  window_->PreviewFile(path, fileName);
+  window_->PreviewFile(path, display_name);
 }
 
 void Window::SetParentWindow(v8::Local<v8::Value> value,

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -731,9 +731,8 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
 
 void Window::PreviewFile(const std::string& path, mate::Arguments* args) {
   std::string display_name;
-  if (!args->GetNext(&display_name)) {
+  if (!args->GetNext(&display_name))
     display_name = path;
-  }
   window_->PreviewFile(path, display_name);
 }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -729,7 +729,7 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
-void Window::PreviewFile(const base::string16& filepath, const base::string16& filename) {
+void Window::PreviewFile(const std::string& filepath, const std::string& filename) {
   window_->PreviewFile(filepath, filename);
 }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -733,7 +733,7 @@ void Window::PreviewFile(const std::string& filepath, mate::Arguments* args) {
   std::string filename;
   if (!args->GetNext(&filename)) {
     filename = filepath;
-  } 
+  }
   window_->PreviewFile(filepath, filename);
 }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -729,8 +729,11 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
-void Window::PreviewFile(const std::string& filepath,
-                         const std::string& filename) {
+void Window::PreviewFile(const std::string& filepath, mate::Arguments* args) {
+  std::string filename;
+  if (!args->GetNext(&filename)) {
+    filename = filepath;
+  } 
   window_->PreviewFile(filepath, filename);
 }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -729,12 +729,12 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
-void Window::PreviewFile(const std::string& filepath, mate::Arguments* args) {
-  std::string filename;
-  if (!args->GetNext(&filename)) {
-    filename = filepath;
+void Window::PreviewFile(const std::string& path, mate::Arguments* args) {
+  std::string fileName;
+  if (!args->GetNext(&fileName)) {
+    fileName = path;
   }
-  window_->PreviewFile(filepath, filename);
+  window_->PreviewFile(path, fileName);
 }
 
 void Window::SetParentWindow(v8::Local<v8::Value> value,

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -729,7 +729,8 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
-void Window::PreviewFile(const std::string& filepath, const std::string& filename) {
+void Window::PreviewFile(const std::string& filepath,
+                         const std::string& filename) {
   window_->PreviewFile(filepath, filename);
 }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -729,6 +729,10 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
+void Window::PreviewFile(const base::string16& filepath) {
+  window_->PreviewFile(filepath);
+}
+
 void Window::SetParentWindow(v8::Local<v8::Value> value,
                              mate::Arguments* args) {
   if (IsModal()) {
@@ -825,6 +829,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setFullScreen", &Window::SetFullScreen)
       .SetMethod("isFullScreen", &Window::IsFullscreen)
       .SetMethod("setAspectRatio", &Window::SetAspectRatio)
+      .SetMethod("previewFile", &Window::PreviewFile)
 #if !defined(OS_WIN)
       .SetMethod("setParentWindow", &Window::SetParentWindow)
 #endif

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -729,8 +729,8 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
-void Window::PreviewFile(const base::string16& filepath) {
-  window_->PreviewFile(filepath);
+void Window::PreviewFile(const base::string16& filepath, const base::string16& filename) {
+  window_->PreviewFile(filepath, filename);
 }
 
 void Window::SetParentWindow(v8::Local<v8::Value> value,

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -170,7 +170,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
-  void PreviewFile(const base::string16& filepath);
+  void PreviewFile(const base::string16& filepath, const base::string16& filename);
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   v8::Local<v8::Value> GetParentWindow() const;
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -170,7 +170,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
-  void PreviewFile(const base::string16& filepath, const base::string16& filename);
+  void PreviewFile(const std::string& filepath, const std::string& filename);
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   v8::Local<v8::Value> GetParentWindow() const;
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -170,7 +170,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
-  void PreviewFile(const std::string& filepath, const std::string& filename);
+  void PreviewFile(const std::string& filepath, mate::Arguments* args);
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   v8::Local<v8::Value> GetParentWindow() const;
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -170,6 +170,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
+  void PreviewFile(const base::string16& filepath);
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   v8::Local<v8::Value> GetParentWindow() const;
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -170,7 +170,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
-  void PreviewFile(const std::string& filepath, mate::Arguments* args);
+  void PreviewFile(const std::string& path, mate::Arguments* args);
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   v8::Local<v8::Value> GetParentWindow() const;
   std::vector<v8::Local<v8::Object>> GetChildWindows() const;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -374,8 +374,8 @@ void NativeWindow::SetAspectRatio(double aspect_ratio,
   aspect_ratio_extraSize_ = extra_size;
 }
 
-void NativeWindow::PreviewFile(const std::string& filepath,
-                               const std::string& filename) {
+void NativeWindow::PreviewFile(const std::string& path,
+                               const std::string& fileName) {
 }
 
 void NativeWindow::RequestToClosePage() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -374,7 +374,8 @@ void NativeWindow::SetAspectRatio(double aspect_ratio,
   aspect_ratio_extraSize_ = extra_size;
 }
 
-void NativeWindow::PreviewFile(const std::string& filepath, const std::string& filename) {
+void NativeWindow::PreviewFile(const std::string& filepath,
+                               const std::string& filename) {
 }
 
 void NativeWindow::RequestToClosePage() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -374,7 +374,7 @@ void NativeWindow::SetAspectRatio(double aspect_ratio,
   aspect_ratio_extraSize_ = extra_size;
 }
 
-void NativeWindow::PreviewFile(const base::string16& filepath, const base::string16& filename) {
+void NativeWindow::PreviewFile(const std::string& filepath, const std::string& filename) {
 }
 
 void NativeWindow::RequestToClosePage() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -374,6 +374,9 @@ void NativeWindow::SetAspectRatio(double aspect_ratio,
   aspect_ratio_extraSize_ = extra_size;
 }
 
+void NativeWindow::PreviewFile(const base::string16& filepath) {
+}
+
 void NativeWindow::RequestToClosePage() {
   bool prevent_default = false;
   FOR_EACH_OBSERVER(NativeWindowObserver,

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -375,7 +375,7 @@ void NativeWindow::SetAspectRatio(double aspect_ratio,
 }
 
 void NativeWindow::PreviewFile(const std::string& path,
-                               const std::string& fileName) {
+                               const std::string& display_name) {
 }
 
 void NativeWindow::RequestToClosePage() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -374,7 +374,7 @@ void NativeWindow::SetAspectRatio(double aspect_ratio,
   aspect_ratio_extraSize_ = extra_size;
 }
 
-void NativeWindow::PreviewFile(const base::string16& filepath) {
+void NativeWindow::PreviewFile(const base::string16& filepath, const base::string16& filename) {
 }
 
 void NativeWindow::RequestToClosePage() {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -177,7 +177,7 @@ class NativeWindow : public base::SupportsUserData,
   gfx::Size GetAspectRatioExtraSize();
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
   virtual void PreviewFile(const std::string& path,
-                           const std::string& fileName);
+                           const std::string& display_name);
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -176,8 +176,8 @@ class NativeWindow : public base::SupportsUserData,
   double GetAspectRatio();
   gfx::Size GetAspectRatioExtraSize();
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
-  virtual void PreviewFile(const std::string& filepath,
-                           const std::string& filename);
+  virtual void PreviewFile(const std::string& path,
+                           const std::string& fileName);
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -176,7 +176,7 @@ class NativeWindow : public base::SupportsUserData,
   double GetAspectRatio();
   gfx::Size GetAspectRatioExtraSize();
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
-  virtual void PreviewFile(const base::string16& filepath, const base::string16& filename);
+  virtual void PreviewFile(const std::string& filepath, const std::string& filename);
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -176,6 +176,7 @@ class NativeWindow : public base::SupportsUserData,
   double GetAspectRatio();
   gfx::Size GetAspectRatioExtraSize();
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
+  virtual void PreviewFile(const base::string16& filepath);
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -176,7 +176,8 @@ class NativeWindow : public base::SupportsUserData,
   double GetAspectRatio();
   gfx::Size GetAspectRatioExtraSize();
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
-  virtual void PreviewFile(const std::string& filepath, const std::string& filename);
+  virtual void PreviewFile(const std::string& filepath,
+                           const std::string& filename);
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -176,7 +176,7 @@ class NativeWindow : public base::SupportsUserData,
   double GetAspectRatio();
   gfx::Size GetAspectRatioExtraSize();
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
-  virtual void PreviewFile(const base::string16& filepath);
+  virtual void PreviewFile(const base::string16& filepath, const base::string16& filename);
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -9,7 +9,6 @@
 
 #include <string>
 #include <vector>
-#include <Quartz/Quartz.h>
 
 #include "atom/browser/native_window.h"
 #include "base/mac/scoped_nsobject.h"
@@ -56,7 +55,8 @@ class NativeWindowMac : public NativeWindow,
   void SetMovable(bool movable) override;
   void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size)
     override;
-  void PreviewFile(const base::string16& filepath, const base::string16& filename) override;
+  void PreviewFile(const std::string& filepath, const std::string& filename)
+    override;
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;
   bool IsMinimizable() override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -55,6 +55,7 @@ class NativeWindowMac : public NativeWindow,
   void SetMovable(bool movable) override;
   void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size)
     override;
+  void PreviewFile(const base::string16& filepath) override;
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;
   bool IsMinimizable() override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <Quartz/Quartz.h>
 
 #include "atom/browser/native_window.h"
 #include "base/mac/scoped_nsobject.h"
@@ -55,7 +56,7 @@ class NativeWindowMac : public NativeWindow,
   void SetMovable(bool movable) override;
   void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size)
     override;
-  void PreviewFile(const base::string16& filepath) override;
+  void PreviewFile(const base::string16& filepath, const base::string16& filename) override;
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;
   bool IsMinimizable() override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -55,7 +55,7 @@ class NativeWindowMac : public NativeWindow,
   void SetMovable(bool movable) override;
   void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size)
     override;
-  void PreviewFile(const std::string& path, const std::string& fileName)
+  void PreviewFile(const std::string& path, const std::string& display_name)
     override;
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -55,7 +55,7 @@ class NativeWindowMac : public NativeWindow,
   void SetMovable(bool movable) override;
   void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size)
     override;
-  void PreviewFile(const std::string& filepath, const std::string& filename)
+  void PreviewFile(const std::string& path, const std::string& fileName)
     override;
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -470,21 +470,21 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 // Quicklook methods
 
-- (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel {
+- (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel*)panel {
   return YES;
 }
 
-- (void)beginPreviewPanelControl:(QLPreviewPanel *)panel {
+- (void)beginPreviewPanelControl:(QLPreviewPanel*)panel {
   panel.delegate = self;
   panel.dataSource = self;
 }
 
-- (void)endPreviewPanelControl:(QLPreviewPanel *)panel {
+- (void)endPreviewPanelControl:(QLPreviewPanel*)panel {
   panel.delegate = nil;
   panel.dataSource = nil;
 }
 
-- (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel {
+- (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel*)panel {
   return 1;
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -26,7 +26,6 @@
 #include "third_party/skia/include/core/SkRegion.h"
 #include "ui/gfx/skia_util.h"
 
-
 namespace {
 
 // Prevents window from resizing during the scope.

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -4,8 +4,8 @@
 
 #include "atom/browser/native_window_mac.h"
 
-#include <string>
 #include <Quartz/Quartz.h>
+#include <string>
 
 #include "atom/browser/window_list.h"
 #include "atom/common/color_util.h"

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -10,6 +10,8 @@
 #include "atom/common/color_util.h"
 #include "atom/common/draggable_region.h"
 #include "atom/common/options_switches.h"
+#include "atom/common/native_mate_converters/string16_converter.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/mac/mac_util.h"
 #include "base/mac/scoped_cftyperef.h"
 #include "base/strings/sys_string_conversions.h"
@@ -24,6 +26,7 @@
 #include "skia/ext/skia_utils_mac.h"
 #include "third_party/skia/include/core/SkRegion.h"
 #include "ui/gfx/skia_util.h"
+
 
 namespace {
 
@@ -897,6 +900,15 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
     [window_ setAspectRatio:NSMakeSize(aspect_ratio, 1.0)];
   else
     [window_ setResizeIncrements:NSMakeSize(1.0, 1.0)];
+}
+
+void NativeWindowMac::PreviewFile(const base::string16& filepath) {
+  std::string rtf = base::UTF16ToUTF8(filepath);
+
+  NSString *path = [NSString stringWithCString:rtf.c_str() 
+                                   encoding:[NSString defaultCStringEncoding]];
+  NSAlert *alert = [NSAlert alertWithMessageText:path defaultButton:@"Close anyway" alternateButton:@"Cancel" otherButton:nil informativeTextWithFormat:@""];
+  [alert runModal];
 }
 
 void NativeWindowMac::SetMovable(bool movable) {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -956,14 +956,11 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
     [window_ setResizeIncrements:NSMakeSize(1.0, 1.0)];
 }
 
-void NativeWindowMac::PreviewFile(const base::string16& filepath, const base::string16& filename) {
-  std::string pathStr = base::UTF16ToUTF8(filepath);
-  std::string nameStr = base::UTF16ToUTF8(filename);
-
-  NSString *path = [NSString stringWithCString:pathStr.c_str() 
+void NativeWindowMac::PreviewFile(const std::string& filepath, const std::string& filename) {
+  NSString *path = [NSString stringWithCString:filepath.c_str() 
                                       encoding:[NSString defaultCStringEncoding]];
 
-  NSString *name = [NSString stringWithCString:nameStr.c_str() 
+  NSString *name = [NSString stringWithCString:filename.c_str() 
                                       encoding:[NSString defaultCStringEncoding]];
 
   [window_ previewFileAtPath:path withName:name];

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -290,11 +290,11 @@ bool ScopedDisableResize::disable_resize_ = false;
 @implementation AtomPreviewItem
 
 - (id)initWithURL:(NSURL*)url title:(NSString*)title {
-  self = [super init]; 
+  self = [super init];
   if (self) {
     self.previewItemURL = url;
     self.previewItemTitle = title;
-  }  
+  }
   return self;
 }
 
@@ -953,11 +953,11 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
     [window_ setResizeIncrements:NSMakeSize(1.0, 1.0)];
 }
 
-void NativeWindowMac::PreviewFile(const std::string& path, const std::string& fileName) {
-  NSString* pathStr = [NSString stringWithUTF8String:path.c_str()];
-  NSString* nameStr = [NSString stringWithUTF8String:fileName.c_str()];
-
-  [window_ previewFileAtPath:pathStr withName:nameStr];
+void NativeWindowMac::PreviewFile(const std::string& path,
+                                  const std::string& display_name) {
+  NSString* path_ns = [NSString stringWithUTF8String:path.c_str()];
+  NSString* name_ns = [NSString stringWithUTF8String:display_name.c_str()];
+  [window_ previewFileAtPath:path_ns withName:name_ns];
 }
 
 void NativeWindowMac::SetMovable(bool movable) {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -280,16 +280,16 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 @interface AtomPreviewItem : NSObject <QLPreviewItem>
 
-@property (nonatomic, retain) NSURL *previewItemURL;
-@property (nonatomic, retain) NSString *previewItemTitle;
+@property (nonatomic, retain) NSURL* previewItemURL;
+@property (nonatomic, retain) NSString* previewItemTitle;
 
-- (id)initWithURL:(NSURL *)anURL title:(NSString *)aTitle;
+- (id)initWithURL:(NSURL*)url title:(NSString*)title;
 
 @end
 
 @implementation AtomPreviewItem
 
-- (id)initWithURL:(NSURL *)url title:(NSString *)title {
+- (id)initWithURL:(NSURL*)url title:(NSString*)title {
   self = [super init]; 
   if (self) {
     self.previewItemURL = url;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -954,11 +954,8 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
 }
 
 void NativeWindowMac::PreviewFile(const std::string& filepath, const std::string& filename) {
-  NSString *path = [NSString stringWithCString:filepath.c_str() 
-                                      encoding:[NSString defaultCStringEncoding]];
-
-  NSString *name = [NSString stringWithCString:filename.c_str() 
-                                      encoding:[NSString defaultCStringEncoding]];
+  NSString *path = [NSString stringWithUTF8String:filepath.c_str()];
+  NSString *name = [NSString stringWithUTF8String:filename.c_str()];
 
   [window_ previewFileAtPath:path withName:name];
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -11,8 +11,6 @@
 #include "atom/common/color_util.h"
 #include "atom/common/draggable_region.h"
 #include "atom/common/options_switches.h"
-#include "atom/common/native_mate_converters/string16_converter.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/mac/mac_util.h"
 #include "base/mac/scoped_cftyperef.h"
 #include "base/strings/sys_string_conversions.h"

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -492,9 +492,9 @@ bool ScopedDisableResize::disable_resize_ = false;
   return [self quickLookItem];
 }
 
-- (void)previewFileAtPath:(NSString *)filepath  withName:(NSString *) name {
-  NSURL * url = [[NSURL alloc] initFileURLWithPath:filepath];
-  [self setQuickLookItem:[[AtomPreviewItem alloc] initWithURL:url title:name]];
+- (void)previewFileAtPath:(NSString *)path  withName:(NSString *) fileName {
+  NSURL * url = [[[NSURL alloc] initFileURLWithPath:path] autorelease];
+  [self setQuickLookItem:[[[AtomPreviewItem alloc] initWithURL:url title:fileName] autorelease]];
   [[QLPreviewPanel sharedPreviewPanel] makeKeyAndOrderFront:nil];
 }
 
@@ -953,11 +953,11 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
     [window_ setResizeIncrements:NSMakeSize(1.0, 1.0)];
 }
 
-void NativeWindowMac::PreviewFile(const std::string& filepath, const std::string& filename) {
-  NSString *path = [NSString stringWithUTF8String:filepath.c_str()];
-  NSString *name = [NSString stringWithUTF8String:filename.c_str()];
+void NativeWindowMac::PreviewFile(const std::string& path, const std::string& fileName) {
+  NSString *pathStr = [NSString stringWithUTF8String:path.c_str()];
+  NSString *nameStr = [NSString stringWithUTF8String:fileName.c_str()];
 
-  [window_ previewFileAtPath:path withName:name];
+  [window_ previewFileAtPath:pathStr withName:nameStr];
 }
 
 void NativeWindowMac::SetMovable(bool movable) {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -488,11 +488,11 @@ bool ScopedDisableResize::disable_resize_ = false;
   return 1;
 }
 
-- (id <QLPreviewItem>)previewPanel:(QLPreviewPanel *)panel previewItemAtIndex:(NSInteger)index {
+- (id <QLPreviewItem>)previewPanel:(QLPreviewPanel*)panel previewItemAtIndex:(NSInteger)index {
   return [self quickLookItem];
 }
 
-- (void)previewFileAtPath:(NSString *)path  withName:(NSString *) fileName {
+- (void)previewFileAtPath:(NSString*)path  withName:(NSString*) fileName {
   NSURL * url = [[[NSURL alloc] initFileURLWithPath:path] autorelease];
   [self setQuickLookItem:[[[AtomPreviewItem alloc] initWithURL:url title:fileName] autorelease]];
   [[QLPreviewPanel sharedPreviewPanel] makeKeyAndOrderFront:nil];

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -493,7 +493,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (void)previewFileAtPath:(NSString*)path  withName:(NSString*) fileName {
-  NSURL * url = [[[NSURL alloc] initFileURLWithPath:path] autorelease];
+  NSURL* url = [[[NSURL alloc] initFileURLWithPath:path] autorelease];
   [self setQuickLookItem:[[[AtomPreviewItem alloc] initWithURL:url title:fileName] autorelease]];
   [[QLPreviewPanel sharedPreviewPanel] makeKeyAndOrderFront:nil];
 }
@@ -954,8 +954,8 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
 }
 
 void NativeWindowMac::PreviewFile(const std::string& path, const std::string& fileName) {
-  NSString *pathStr = [NSString stringWithUTF8String:path.c_str()];
-  NSString *nameStr = [NSString stringWithUTF8String:fileName.c_str()];
+  NSString* pathStr = [NSString stringWithUTF8String:path.c_str()];
+  NSString* nameStr = [NSString stringWithUTF8String:fileName.c_str()];
 
   [window_ previewFileAtPath:pathStr withName:nameStr];
 }

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -664,10 +664,12 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Just sum any extra width and
 height areas you have within the overall content view.
 
-#### `win.previewFile(pathname, filename)` _macOS_
+#### `win.previewFile(pathname[, filename])` _macOS_
 
 * `pathname` String - The absolute path to the file to preview with QuickLook. This is important as Quicklook uses the file name and file extension on the path to determine the content_type of the file to open.
-* `filename` String - The name of the file to display on QuickLook modal view. This is purely visual and does not affect the content_type of the file.
+* `filename` String (Optional) - The name of the file to display on the QuickLook modal view. This is purely visual and does not affect the content_type of the file. Defaults to filepath.
+
+Uses QuickLook to preview a file at a given path.
 
 #### `win.setBounds(bounds[, animate])`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -664,12 +664,16 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Just sum any extra width and
 height areas you have within the overall content view.
 
-#### `win.previewFile(pathname[, filename])` _macOS_
+#### `win.previewFile(pathname[, displayName])` _macOS_
 
-* `pathname` String - The absolute path to the file to preview with QuickLook. This is important as Quicklook uses the file name and file extension on the path to determine the content_type of the file to open.
-* `filename` String (Optional) - The name of the file to display on the QuickLook modal view. This is purely visual and does not affect the content_type of the file. Defaults to filepath.
+* `path` String - The absolute path to the file to preview with QuickLook. This
+  is important as Quick Look uses the file name and file extension on the path to
+  determine the content type of the file to open.
+* `displayName` String (Optional) - The name of the file to display on the
+  Quick Look modal view. This is purely visual and does not affect the content
+  type of the file. Defaults to `path`.
 
-Uses QuickLook to preview a file at a given path.
+Uses [Quick Look][quick-look] to preview a file at a given path.
 
 #### `win.setBounds(bounds[, animate])`
 
@@ -1189,3 +1193,4 @@ Returns `BrowserWindow` - The parent window.
 Returns `BrowserWindow[]` - All child windows.
 
 [window-levels]: https://developer.apple.com/reference/appkit/nswindow/1664726-window_levels
+[quick-look]: https://en.wikipedia.org/wiki/Quick_Look

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -664,11 +664,11 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Just sum any extra width and
 height areas you have within the overall content view.
 
-#### `win.previewFile(pathname[, displayName])` _macOS_
+#### `win.previewFile(path[, displayName])` _macOS_
 
 * `path` String - The absolute path to the file to preview with QuickLook. This
-  is important as Quick Look uses the file name and file extension on the path to
-  determine the content type of the file to open.
+  is important as Quick Look uses the file name and file extension on the path
+  to determine the content type of the file to open.
 * `displayName` String (Optional) - The name of the file to display on the
   Quick Look modal view. This is purely visual and does not affect the content
   type of the file. Defaults to `path`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -664,6 +664,11 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Just sum any extra width and
 height areas you have within the overall content view.
 
+#### `win.previewFile(pathname, filename)`
+
+* `pathname` String - The absolute path to the file to preview with QuickLook. This is important as Quicklook uses the file name and file extension on the path to determine the content_type of the file to open.
+* `filename` String - The name of the file to display on QuickLook modal view. This is purely visual and does not affect the content_type of the file.
+
 #### `win.setBounds(bounds[, animate])`
 
 * `bounds` [Rectangle](structures/rectangle.md)

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -664,7 +664,7 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Just sum any extra width and
 height areas you have within the overall content view.
 
-#### `win.previewFile(pathname, filename)`
+#### `win.previewFile(pathname, filename)` _macOS_
 
 * `pathname` String - The absolute path to the file to preview with QuickLook. This is important as Quicklook uses the file name and file extension on the path to determine the content_type of the file to open.
 * `filename` String - The name of the file to display on QuickLook modal view. This is purely visual and does not affect the content_type of the file.

--- a/electron.gyp
+++ b/electron.gyp
@@ -509,6 +509,7 @@
             'libraries': [
               '$(SDKROOT)/System/Library/Frameworks/Carbon.framework',
               '$(SDKROOT)/System/Library/Frameworks/QuartzCore.framework',
+              '$(SDKROOT)/System/Library/Frameworks/Quartz.framework',
             ],
           },
           'mac_bundle': 1,


### PR DESCRIPTION
Hi!

I've never done a PR here so apologies in advance if I'm missing things. 

- Linter is valid
- Some tests are failing but it doesn't feel like this is due to my code. 

I added some documentation too. 

A few things I'm unsure about: 
- Not sure if I have to do anything for other platforms. 
- Not sure about memory. 
```
- (void)previewFileAtPath:(NSString *)filepath  withName:(NSString *) name {
  NSURL * url = [[NSURL alloc] initFileURLWithPath:filepath];
  [self setQuickLookItem:[[AtomPreviewItem alloc] initWithURL:url title:name]];
  [[QLPreviewPanel sharedPreviewPanel] makeKeyAndOrderFront:nil];
}
```
Should I release the url here?

Happy to fix all the issues, and thanks for the feedbacks,

Pierre

<img width="1055" alt="screenshot 2016-10-12 21 24 51" src="https://cloud.githubusercontent.com/assets/979311/19336715/8779df02-90c2-11e6-92b6-f43a9a36df94.png">
