### PR TITLE
browser: fix race in creation of default browser context by AtomAccessTokenStore

### DIFF
--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -9,6 +9,12 @@
 
 namespace atom {
 
+class AtomBrowserContext;
+
+namespace internal {
+class TokenLoadingJob;
+}
+
 class AtomAccessTokenStore : public content::AccessTokenStore {
  public:
   AtomAccessTokenStore();
@@ -21,6 +27,9 @@ class AtomAccessTokenStore : public content::AccessTokenStore {
                        const base::string16& access_token) override;
 
  private:
+  void RunTokenLoadingJob(scoped_refptr<internal::TokenLoadingJob> job);
+
+  scoped_refptr<AtomBrowserContext> browser_context_;
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);
 };
 


### PR DESCRIPTION
When no default browser context is created, multiple calls to `TokenLoadingJob` will cause a race in browser context creation and crash. The patch creates the browser context when access token store is initialized and passes it to `TokenLoadingJob`.

Fixes #7607 