### PR TITLE
Add 'webpreferences' attribute to webview

### DIFF
--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -194,6 +194,20 @@ value will fail with a DOM exception.
 
 If "on", the guest page will be allowed to open new windows.
 
+### `webpreferences`
+
+```html
+<webview src="https://github.com" webpreferences="allowDisplayingInsecureContent, javascript=no"></webview>
+```
+
+A list of strings which specifies the web preferences to be set on the webview, separated by `,`.
+The full list of supported preference strings can be found in [BrowserWindow](browser-window.md#new-browserwindowoptions)
+
+The string follows the same format as the features string in `window.open`.
+A name by itself is given a `true` boolean value.
+A preference can be set to another value by including an `=`, followed by the value.
+Special values `yes` and `1` are interpreted as true, while `no` and `0` are interpreted as false.  
+
 ### `blinkfeatures`
 
 ```html

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -201,12 +201,12 @@ If "on", the guest page will be allowed to open new windows.
 ```
 
 A list of strings which specifies the web preferences to be set on the webview, separated by `,`.
-The full list of supported preference strings can be found in [BrowserWindow](browser-window.md#new-browserwindowoptions)
+The full list of supported preference strings can be found in [BrowserWindow](browser-window.md#new-browserwindowoptions).
 
 The string follows the same format as the features string in `window.open`.
 A name by itself is given a `true` boolean value.
 A preference can be set to another value by including an `=`, followed by the value.
-Special values `yes` and `1` are interpreted as true, while `no` and `0` are interpreted as false.  
+Special values `yes` and `1` are interpreted as `true`, while `no` and `0` are interpreted as `false`.  
 
 ### `blinkfeatures`
 

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -48,6 +48,7 @@
       'lib/common/api/native-image.js',
       'lib/common/api/shell.js',
       'lib/common/init.js',
+      'lib/common/parse-features-string.js',
       'lib/common/reset-search-paths.js',
       'lib/renderer/chrome-api.js',
       'lib/renderer/content-scripts-injector.js',

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -188,6 +188,7 @@ const attachGuest = function (embedder, elementInstanceId, guestInstanceId, para
   // this uses the same parsing rules as window.open uses for its features
   if (typeof params.webpreferences === 'string') {
     // split the attribute's value by ','
+    let i, len
     let webpreferencesTokens = params.webpreferences.split(/,\s*/)
     for (i = 0, len = webpreferencesTokens.length; i < len; i++) {
       // expected form is either a name by itself (true boolean flag)
@@ -195,8 +196,8 @@ const attachGuest = function (embedder, elementInstanceId, guestInstanceId, para
       // split the tokens by '='
       let pref = webpreferencesTokens[i]
       let prefTokens = pref.split(/\s*=/)
-      name = prefTokens[0]
-      value = prefTokens[1]
+      let name = prefTokens[0]
+      let value = prefTokens[1]
       if (!name) continue
 
       // interpret the value as a boolean, if possible 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -2,6 +2,7 @@
 
 const ipcMain = require('electron').ipcMain
 const webContents = require('electron').webContents
+const parseFeaturesString = require('../common/parse-features-string')
 
 // Doesn't exist in early initialization.
 let webViewManager = null
@@ -187,27 +188,13 @@ const attachGuest = function (embedder, elementInstanceId, guestInstanceId, para
   // parse the 'webpreferences' attribute string, if set
   // this uses the same parsing rules as window.open uses for its features
   if (typeof params.webpreferences === 'string') {
-    // split the attribute's value by ','
-    let i, len
-    let webpreferencesTokens = params.webpreferences.split(/,\s*/)
-    for (i = 0, len = webpreferencesTokens.length; i < len; i++) {
-      // expected form is either a name by itself (true boolean flag)
-      // or a key/value, in the form of 'name=value'
-      // split the tokens by '='
-      let pref = webpreferencesTokens[i]
-      let prefTokens = pref.split(/\s*=/)
-      let name = prefTokens[0]
-      let value = prefTokens[1]
-      if (!name) continue
-
-      // interpret the value as a boolean, if possible 
-      value = (value === 'yes' || value === '1') ? true : (value === 'no' || value === '0') ? false : value
+    parseFeaturesString(params.webpreferences, function (key, value) {
       if (value === undefined) {
         // no value was specified, default it to true
         value = true
       }
       webPreferences[name] = value
-    }
+    })
   }
 
   if (params.preload) {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -193,7 +193,7 @@ const attachGuest = function (embedder, elementInstanceId, guestInstanceId, para
         // no value was specified, default it to true
         value = true
       }
-      webPreferences[name] = value
+      webPreferences[key] = value
     })
   }
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -184,6 +184,31 @@ const attachGuest = function (embedder, elementInstanceId, guestInstanceId, para
     disableBlinkFeatures: params.disableblinkfeatures
   }
 
+  // parse the 'webpreferences' attribute string, if set
+  // this uses the same parsing rules as window.open uses for its features
+  if (typeof params.webpreferences === 'string') {
+    // split the attribute's value by ','
+    let webpreferencesTokens = params.webpreferences.split(/,\s*/)
+    for (i = 0, len = webpreferencesTokens.length; i < len; i++) {
+      // expected form is either a name by itself (true boolean flag)
+      // or a key/value, in the form of 'name=value'
+      // split the tokens by '='
+      let pref = webpreferencesTokens[i]
+      let prefTokens = pref.split(/\s*=/)
+      name = prefTokens[0]
+      value = prefTokens[1]
+      if (!name) continue
+
+      // interpret the value as a boolean, if possible 
+      value = (value === 'yes' || value === '1') ? true : (value === 'no' || value === '0') ? false : value
+      if (value === undefined) {
+        // no value was specified, default it to true
+        value = true
+      }
+      webPreferences[name] = value
+    }
+  }
+
   if (params.preload) {
     webPreferences.preloadURL = params.preload
   }

--- a/lib/common/parse-features-string.js
+++ b/lib/common/parse-features-string.js
@@ -1,0 +1,24 @@
+// parses a feature string that has the format used in window.open()
+// - `str` input string
+// - `emit` function(key, value) - called for each parsed KV
+module.exports = function parseFeaturesString (str, emit) {
+  // split the string by ','
+  let i, len
+  let strTokens = params.str.split(/,\s*/)
+  for (i = 0, len = strTokens.length; i < len; i++) {
+    // expected form is either a key by itself (true boolean flag)
+    // or a key/value, in the form of 'key=value'
+    // split the tokens by '='
+    let kv = strTokens[i]
+    let kvTokens = kv.split(/\s*=/)
+    let key = kvTokens[0]
+    let value = kvTokens[1]
+    if (!key) continue
+
+    // interpret the value as a boolean, if possible 
+    value = (value === 'yes' || value === '1') ? true : (value === 'no' || value === '0') ? false : value
+
+    // emit the parsed pair
+    emit(key, value)
+  }
+}

--- a/lib/common/parse-features-string.js
+++ b/lib/common/parse-features-string.js
@@ -1,24 +1,19 @@
 // parses a feature string that has the format used in window.open()
 // - `str` input string
 // - `emit` function(key, value) - called for each parsed KV
-module.exports = function parseFeaturesString (str, emit) {
+module.exports = function parseFeaturesString (features, emit) {
   // split the string by ','
-  let i, len
-  let strTokens = params.str.split(/,\s*/)
-  for (i = 0, len = strTokens.length; i < len; i++) {
+  features.split(/,\s*/).forEach((feature) => {
     // expected form is either a key by itself (true boolean flag)
     // or a key/value, in the form of 'key=value'
     // split the tokens by '='
-    let kv = strTokens[i]
-    let kvTokens = kv.split(/\s*=/)
-    let key = kvTokens[0]
-    let value = kvTokens[1]
-    if (!key) continue
+    let [key, value] = feature.split(/\s*=/)
+    if (!key) return
 
-    // interpret the value as a boolean, if possible 
+    // interpret the value as a boolean, if possible
     value = (value === 'yes' || value === '1') ? true : (value === 'no' || value === '0') ? false : value
 
     // emit the parsed pair
     emit(key, value)
-  }
+  })
 }

--- a/lib/common/parse-features-string.js
+++ b/lib/common/parse-features-string.js
@@ -1,12 +1,11 @@
 // parses a feature string that has the format used in window.open()
-// - `str` input string
+// - `features` input string
 // - `emit` function(key, value) - called for each parsed KV
 module.exports = function parseFeaturesString (features, emit) {
   // split the string by ','
   features.split(/,\s*/).forEach((feature) => {
-    // expected form is either a key by itself (true boolean flag)
-    // or a key/value, in the form of 'key=value'
-    // split the tokens by '='
+    // expected form is either a key by itself or a key/value pair in the form of
+    // 'key=value'
     let [key, value] = feature.split(/\s*=/)
     if (!key) return
 

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -2,6 +2,7 @@
 
 const ipcRenderer = require('electron').ipcRenderer
 const remote = require('electron').remote
+const parseFeaturesString = require('../common/parse-features-string')
 
 // Helper function to resolve relative url.
 var a = window.top.document.createElement('a')
@@ -104,27 +105,21 @@ window.open = function (url, frameName, features) {
   // Used to store additional features
   additionalFeatures = []
 
-  // Make sure to get rid of excessive whitespace in the property name
-  ref1 = features.split(/,\s*/)
-  for (i = 0, len = ref1.length; i < len; i++) {
-    feature = ref1[i]
-    ref2 = feature.split(/\s*=/)
-    name = ref2[0]
-    value = ref2[1]
-    value = value === 'yes' || value === '1' ? true : value === 'no' || value === '0' ? false : value
+  // Parse the features
+  parseFeaturesString(features, function (key, value) {
     if (value === undefined) {
-      additionalFeatures.push(feature)
+      additionalFeatures.push(key)
     } else {
-      if (webPreferences.includes(name)) {
+      if (webPreferences.includes(key)) {
         if (options.webPreferences == null) {
           options.webPreferences = {}
         }
-        options.webPreferences[name] = value
+        options.webPreferences[key] = value
       } else {
-        options[name] = value
+        options[key] = value
       }
     }
-  }
+  })
   if (options.left) {
     if (options.x == null) {
       options.x = options.left

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -89,7 +89,7 @@ if (process.guestInstanceId == null) {
 
 // Make the browser window or guest view emit "new-window" event.
 window.open = function (url, frameName, features) {
-  var feature, guestId, i, j, len, len1, name, options, ref1, ref2, value, additionalFeatures
+  var guestId, j, len1, name, options, additionalFeatures
   if (frameName == null) {
     frameName = ''
   }

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -335,7 +335,7 @@ WebViewImpl.prototype.setupWebViewAttributes = function () {
   this.attributes[webViewConstants.ATTRIBUTE_BLINKFEATURES] = new BlinkFeaturesAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_DISABLEBLINKFEATURES] = new DisableBlinkFeaturesAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE] = new GuestInstanceAttribute(this)
-  this.attributes[webviewConstants.ATTRIBUTE_WEBPREFERENCES] = new WebPreferencesAttribute(this)
+  this.attributes[webViewConstants.ATTRIBUTE_WEBPREFERENCES] = new WebPreferencesAttribute(this)
 
   const autosizeAttributes = [webViewConstants.ATTRIBUTE_MAXHEIGHT, webViewConstants.ATTRIBUTE_MAXWIDTH, webViewConstants.ATTRIBUTE_MINHEIGHT, webViewConstants.ATTRIBUTE_MINWIDTH]
   autosizeAttributes.forEach((attribute) => {

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -312,6 +312,13 @@ class DisableBlinkFeaturesAttribute extends WebViewAttribute {
   }
 }
 
+// Attribute that specifies the web preferences to be enabled.
+class WebPreferencesAttribute extends WebViewAttribute {
+  constructor (webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_WEBPREFERENCES, webViewImpl)
+  }
+}
+
 // Sets up all of the webview attributes.
 WebViewImpl.prototype.setupWebViewAttributes = function () {
   this.attributes = {}
@@ -328,6 +335,7 @@ WebViewImpl.prototype.setupWebViewAttributes = function () {
   this.attributes[webViewConstants.ATTRIBUTE_BLINKFEATURES] = new BlinkFeaturesAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_DISABLEBLINKFEATURES] = new DisableBlinkFeaturesAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE] = new GuestInstanceAttribute(this)
+  this.attributes[webviewConstants.ATTRIBUTE_WEBPREFERENCES] = new WebPreferencesAttribute(this)
 
   const autosizeAttributes = [webViewConstants.ATTRIBUTE_MAXHEIGHT, webViewConstants.ATTRIBUTE_MAXWIDTH, webViewConstants.ATTRIBUTE_MINHEIGHT, webViewConstants.ATTRIBUTE_MINWIDTH]
   autosizeAttributes.forEach((attribute) => {

--- a/lib/renderer/web-view/web-view-constants.js
+++ b/lib/renderer/web-view/web-view-constants.js
@@ -18,6 +18,7 @@ module.exports = {
   ATTRIBUTE_BLINKFEATURES: 'blinkfeatures',
   ATTRIBUTE_DISABLEBLINKFEATURES: 'disableblinkfeatures',
   ATTRIBUTE_GUESTINSTANCE: 'guestinstance',
+  ATTRIBUTE_WEBPREFERENCES: 'webpreferences',
 
   // Internal attribute.
   ATTRIBUTE_INTERNALINSTANCEID: 'internalinstanceid',

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -406,6 +406,33 @@ describe('<webview> tag', function () {
     })
   })
 
+  describe('webpreferences attribute', function () {
+    it('can enable nodeintegration', function (done) {
+      webview.addEventListener('console-message', function (e) {
+        assert.equal(e.message, 'function object object')
+        done()
+      })
+      webview.setAttribute('webpreferences', 'nodeIntegration')
+      webview.src = 'file://' + fixtures + '/pages/d.html'
+      document.body.appendChild(webview)
+    })
+
+    it('can disables web security and enable nodeintegration', function (done) {
+      var jqueryPath = path.join(__dirname, '/static/jquery-2.0.3.min.js')
+      var src = `<script src='file://${jqueryPath}'></script> <script>console.log('ok '+(typeof require));</script>`
+      var encoded = btoa(unescape(encodeURIComponent(src)))
+      var listener = function (e) {
+        assert.equal(e.message, 'ok function')
+        webview.removeEventListener('console-message', listener)
+        done()
+      }
+      webview.addEventListener('console-message', listener)
+      webview.setAttribute('webpreferences', 'webSecurity=no, nodeIntegration=yes')
+      webview.src = 'data:text/html;base64,' + encoded
+      document.body.appendChild(webview)
+    })
+  })
+
   describe('new-window event', function () {
     if (process.env.TRAVIS === 'true' && process.platform === 'darwin') {
       return


### PR DESCRIPTION
Per https://github.com/electron/electron/pull/7431 and https://github.com/electron/electron/issues/2749, this PR adds a `webpreferences` attribute to the webview tag. The string is implemented using the same parsing logic as the features string in `window.open`.