### PR TITLE
Supress released window errors when an env var is set

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -189,7 +189,9 @@ const unwrapArgs = function (sender, args) {
           if (!sender.isDestroyed() && webContentsId === sender.getId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
-            throw new Error(`Attempting to call a function in a renderer window that has been closed or released. Function provided here: ${meta.location}.`)
+            if (!process.env.ELECTRON_DONT_THROW_RELEASED_WINDOW_ERRORS) {
+              throw new Error(`Attempting to call a function in a renderer window that has been closed or released. Function provided here: ${meta.location}.`)
+            }
           }
         }
 


### PR DESCRIPTION
This might be up for debate but I've recently come across some really annoying errors on Sentry that I can't catch, prevent or handle in any way.  Here is an example of one.

``` js
Attempting to call a function in a renderer window that has been closed or released. Function provided here:  
n._triggerFile (C:\Users\<username>\AppData\Local\GPMDP_3\app-4.0.1\resources\app.asar\build\renderer\ui\components\settings\FileInput.js:9:1841.
```

This traces to a callback [here](https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/blob/master/src/renderer/ui/components/settings/FileInput.js#L28) from a call to `showOpenDialog`.  Somehow the `webContents` is being destroyed before that callback is fired.  There is literally nothing I can do about this as I can't "unbind" a callback.

I don't want to completely remove these errors as during development they are good and catch some issues.  However in production I don't want random webContents crashes or race conditions to throw errors at my users that I can't catch in a sensible way (`process.on('uncaughtException')`) doesn't count....

This PR adds a single environment variable which will stop these errors being thrown.  By default they will still be thrown but it means in production we can disable them.
