### PR TITLE
:memo: Add flashFrame to desktop env integration

### DIFF
--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -396,3 +396,4 @@ ipcMain.on('ondragstart', (event, filePath) => {
 [tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/
+[flashframe]: ../api/browser-window.md#winflashframeflag

--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -306,6 +306,29 @@ let win = new BrowserWindow()
 win.setOverlayIcon('path/to/overlay.png', 'Description for overlay')
 ```
 
+## Flash Frame (Windows)
+
+On Windows you can cause the taskbar button to become highlighted. This can be
+used similarly to macOS's Bounce Dock Icon to get the users attention. From the
+MSDN reference documentation:
+
+> Typically, a window is flashed to inform the user that the window requires
+> attention but that it does not currently have the keyboard focus.
+
+To flash the BrowserWindow taskbar button, you can use the
+[BrowserWindow.flashFrame][flashframe] API:
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+win.once('focus', () => win.flashFrame(false))
+win.flashFrame(true)
+```
+
+Don't forget to call the `flashFrame` method with false to turn off the flash. In
+the above example, it is called when the window comes into focus, but you might
+use a timeout or some other event to trigger it off.
+
 ## Represented File of Window (macOS)
 
 On macOS a window can set its represented file, so the file's icon can show in

--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -308,9 +308,9 @@ win.setOverlayIcon('path/to/overlay.png', 'Description for overlay')
 
 ## Flash Frame (Windows)
 
-On Windows you can cause the taskbar button to become highlighted. This can be
-used similarly to macOS's Bounce Dock Icon to get the users attention. From the
-MSDN reference documentation:
+On Windows you can highlight the taskbar button to get the user's attention.
+This is similar to bouncing the dock icon on macOS.
+From the MSDN reference documentation:
 
 > Typically, a window is flashed to inform the user that the window requires
 > attention but that it does not currently have the keyboard focus.
@@ -325,9 +325,9 @@ win.once('focus', () => win.flashFrame(false))
 win.flashFrame(true)
 ```
 
-Don't forget to call the `flashFrame` method with false to turn off the flash. In
+Don't forget to call the `flashFrame` method with `false` to turn off the flash. In
 the above example, it is called when the window comes into focus, but you might
-use a timeout or some other event to trigger it off.
+use a timeout or some other event to disable it.
 
 ## Represented File of Window (macOS)
 


### PR DESCRIPTION
It took me a bit to find the Windows equivalent to bouncing the dock icon, so once I came across `flashFrame`, it seems like it was worth making it easier to find for future devs. Not a great writer, so I'm definitely open to feedback on tone and grammar. ✏️ 