### PR TITLE
Add options to webFrame.registerURLSchemeAsPrivileged

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -140,17 +140,44 @@ void WebFrame::RegisterURLSchemeAsBypassingCSP(const std::string& scheme) {
       blink::WebString::fromUTF8(scheme));
 }
 
-void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme) {
+void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
+                                             mate::Arguments* args) {
+  // Read optional flags
+  bool secure = true;
+  bool bypassCSP = true;
+  bool allowServiceWorkers = true;
+  bool supportFetchAPI = true;
+  bool corsEnabled = true;
+  if (args->Length() == 2) {
+    mate::Dictionary options;
+    if (args->GetNext(&options)) {
+      options.Get("secure", &secure);
+      options.Get("bypassCSP", &bypassCSP);
+      options.Get("allowServiceWorkers", &allowServiceWorkers);
+      options.Get("supportFetchAPI", &supportFetchAPI);
+      options.Get("corsEnabled", &corsEnabled);
+    }
+  }
   // Register scheme to privileged list (https, wss, data, chrome-extension)
   blink::WebString privileged_scheme(blink::WebString::fromUTF8(scheme));
-  blink::WebSecurityPolicy::registerURLSchemeAsSecure(privileged_scheme);
-  blink::WebSecurityPolicy::registerURLSchemeAsBypassingContentSecurityPolicy(
-      privileged_scheme);
-  blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers(
-      privileged_scheme);
-  blink::WebSecurityPolicy::registerURLSchemeAsSupportingFetchAPI(
-      privileged_scheme);
-  blink::WebSecurityPolicy::registerURLSchemeAsCORSEnabled(privileged_scheme);
+  if (secure) {
+    blink::WebSecurityPolicy::registerURLSchemeAsSecure(privileged_scheme);
+  }
+  if (bypassCSP) {
+    blink::WebSecurityPolicy::registerURLSchemeAsBypassingContentSecurityPolicy(
+        privileged_scheme);
+  }
+  if (allowServiceWorkers) {
+    blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers(
+        privileged_scheme);
+  }
+  if (supportFetchAPI) {
+    blink::WebSecurityPolicy::registerURLSchemeAsSupportingFetchAPI(
+        privileged_scheme);
+  }
+  if (corsEnabled) {
+    blink::WebSecurityPolicy::registerURLSchemeAsCORSEnabled(privileged_scheme);
+  }
 }
 
 void WebFrame::InsertText(const std::string& text) {

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -63,7 +63,10 @@ class WebFrame : public mate::Wrappable<WebFrame> {
 
   void RegisterURLSchemeAsSecure(const std::string& scheme);
   void RegisterURLSchemeAsBypassingCSP(const std::string& scheme);
-  void RegisterURLSchemeAsPrivileged(const std::string& scheme);
+  void RegisterURLSchemeAsPrivileged(
+      const std::string& scheme,
+      mate::Arguments* args
+  );
 
   // Editing.
   void InsertText(const std::string& text);

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -87,11 +87,11 @@ Content Security Policy.
 
 * `scheme` String
 * `options` Object (optional)
-  * `secure` Default true.
-  * `bypassCSP` Default true.
-  * `allowServiceWorkers` Default true.
-  * `supportFetchAPI` Default true.
-  * `corsEnabled` Default true.
+  * `secure` (optional) Default true.
+  * `bypassCSP` (optional) Default true.
+  * `allowServiceWorkers` (optional) Default true.
+  * `supportFetchAPI` (optional) Default true.
+  * `corsEnabled` (optional) Default true.
 
 Registers the `scheme` as secure, bypasses content security policy for resources,
 allows registering ServiceWorker and supports fetch API.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -83,12 +83,26 @@ attackers.
 Resources will be loaded from this `scheme` regardless of the current page's
 Content Security Policy.
 
-### `webFrame.registerURLSchemeAsPrivileged(scheme)`
+### `webFrame.registerURLSchemeAsPrivileged(scheme[, options])`
 
 * `scheme` String
+* `options` Object (optional)
+  * `secure` Default true.
+  * `bypassCSP` Default true.
+  * `allowServiceWorkers` Default true.
+  * `supportFetchAPI` Default true.
+  * `corsEnabled` Default true.
 
 Registers the `scheme` as secure, bypasses content security policy for resources,
 allows registering ServiceWorker and supports fetch API.
+
+Specify an option with the value of `false` to omit it from the registration.
+An example of registering a privileged scheme, without bypassing Content Security Policy:
+
+```javascript
+const {webFrame} = require('electron')
+webFrame.registerURLSchemeAsPrivileged('foo', { bypassCSP: false })
+```
 
 ### `webFrame.insertText(text)`
 

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -7,7 +7,7 @@ const {BrowserWindow, protocol, ipcMain} = remote
 describe('webFrame module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
   describe('webFrame.registerURLSchemeAsPrivileged', function () {
-    it('supports fetch api', function (done) {
+    it('supports fetch api by default', function (done) {
       webFrame.registerURLSchemeAsPrivileged('file')
       var url = 'file://' + fixtures + '/assets/logo.png'
       window.fetch(url).then(function (response) {
@@ -18,21 +18,86 @@ describe('webFrame module', function () {
       })
     })
 
-    it('allows CORS requests', function (done) {
-      const standardScheme = remote.getGlobal('standardScheme')
+    it('allows CORS requests by default', function (done) {
+      allowsCORSRequests(200, `<html>
+        <script>
+        const {ipcRenderer, webFrame} = require('electron')
+        webFrame.registerURLSchemeAsPrivileged('cors1')
+        fetch('cors1://myhost').then(function (response) {
+          ipcRenderer.send('response', response.status)
+        }).catch(function (response) {
+          ipcRenderer.send('response', 'failed')
+        })
+        </script>
+      </html>`, done)
+    })
+
+    it('allows CORS and fetch requests when specified', function (done) {
+      allowsCORSRequests(200, `<html>
+        <script>
+        const {ipcRenderer, webFrame} = require('electron')
+        webFrame.registerURLSchemeAsPrivileged('cors2', { supportFetchAPI: true, corsEnabled: true })
+        fetch('cors2://myhost').then(function (response) {
+          ipcRenderer.send('response', response.status)
+        }).catch(function (response) {
+          ipcRenderer.send('response', 'failed')
+        })
+        </script>
+      </html>`, done)
+    })
+
+    it('allows CORS and fetch requests when half-specified', function (done) {
+      allowsCORSRequests(200, `<html>
+        <script>
+        const {ipcRenderer, webFrame} = require('electron')
+        webFrame.registerURLSchemeAsPrivileged('cors3', { supportFetchAPI: true })
+        fetch('cors3://myhost').then(function (response) {
+          ipcRenderer.send('response', response.status)
+        }).catch(function (response) {
+          ipcRenderer.send('response', 'failed')
+        })
+        </script>
+      </html>`, done)
+    })
+
+    it('disallows CORS, but allows fetch requests, when specified', function (done) {
+      allowsCORSRequests('failed', `<html>
+        <script>
+        const {ipcRenderer, webFrame} = require('electron')
+        webFrame.registerURLSchemeAsPrivileged('cors4', { supportFetchAPI: true, corsEnabled: false })
+        fetch('cors4://myhost').then(function (response) {
+          ipcRenderer.send('response', response.status)
+        }).catch(function (response) {
+          ipcRenderer.send('response', 'failed')
+        })
+        </script>
+      </html>`, done)
+    })
+
+    it('allows CORS, but disallows fetch requests, when specified', function (done) {
+      allowsCORSRequests('failed', `<html>
+        <script>
+        const {ipcRenderer, webFrame} = require('electron')
+        webFrame.registerURLSchemeAsPrivileged('cors5', { supportFetchAPI: false, corsEnabled: true })
+        fetch('cors5://myhost').then(function (response) {
+          ipcRenderer.send('response', response.status)
+        }).catch(function (response) {
+          ipcRenderer.send('response', 'failed')
+        })
+        </script>
+      </html>`, done)
+    })
+
+    var runNumber = 1
+    function allowsCORSRequests (expected, content, done) {
+      const standardScheme = remote.getGlobal('standardScheme') + runNumber
+      const corsScheme = 'cors' + runNumber
+      runNumber++
+
       const url = standardScheme + '://fake-host'
-      const content = `<html>
-                       <script>
-                        const {ipcRenderer, webFrame} = require('electron')
-                        webFrame.registerURLSchemeAsPrivileged('cors')
-                        fetch('cors://myhost').then(function (response) {
-                          ipcRenderer.send('response', response.status)
-                        })
-                       </script>
-                       </html>`
       var w = new BrowserWindow({show: false})
       after(function (done) {
-        protocol.unregisterProtocol('cors', function () {
+        protocol.unregisterProtocol(corsScheme, function () {
           protocol.unregisterProtocol(standardScheme, function () {
             closeWindow(w).then(function () {
               w = null
@@ -49,16 +114,16 @@ describe('webFrame module', function () {
         if (error) return done(error)
       })
 
-      protocol.registerStringProtocol('cors', function (request, callback) {
+      protocol.registerStringProtocol(corsScheme, function (request, callback) {
         callback('')
       }, function (error) {
         if (error) return done(error)
         ipcMain.once('response', function (event, status) {
-          assert.equal(status, 200)
+          assert.equal(status, expected)
           done()
         })
         w.loadURL(url)
       })
-    })
+    }
   })
 })


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/7430

Adds an options argument for choosing which features to register:

```markdown
### `webFrame.registerURLSchemeAsPrivileged(scheme[, options])`

* `scheme` String
* `options` Object (optional)
  * `secure` Default true.
  * `bypassCSP` Default true.
  * `allowServiceWorkers` Default true.
  * `supportFetchAPI` Default true.
  * `corsEnabled` Default true.
```