### PR TITLE
Add protocol.registerSecureSchemes

### DIFF
--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -204,4 +204,17 @@ void AtomContentClient::AddServiceWorkerSchemes(
   service_worker_schemes->insert(url::kFileScheme);
 }
 
+void AtomContentClient::AddSecureSchemesAndOrigins(
+    std::set<std::string>* secure_schemes,
+    std::set<GURL>* secure_origins) {
+  std::vector<std::string> schemes;
+  ConvertStringWithSeparatorToVector(&schemes, ",",
+                                     switches::kRegisterSecureSchemes);                        
+  if (!schemes.empty()) {
+    for (const std::string& scheme : schemes) {
+      secure_schemes->insert(scheme);
+    }
+  }
+}
+
 }  // namespace atom

--- a/atom/app/atom_content_client.h
+++ b/atom/app/atom_content_client.h
@@ -31,6 +31,9 @@ class AtomContentClient : public brightray::ContentClient {
       std::vector<content::PepperPluginInfo>* plugins) override;
   void AddServiceWorkerSchemes(
       std::set<std::string>* service_worker_schemes) override;
+  void AddSecureSchemesAndOrigins(
+      std::set<std::string>* secure_schemes,
+      std::set<GURL>* secure_origins) override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(AtomContentClient);

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -223,11 +223,24 @@ void RegisterStandardSchemes(
   atom::api::RegisterStandardSchemes(schemes);
 }
 
+void RegisterSecureSchemes(
+    const std::vector<std::string>& schemes, mate::Arguments* args) {
+  if (atom::Browser::Get()->is_ready()) {
+    args->ThrowError("protocol.registerSecureSchemes should be called before "
+                     "app is ready");
+    return;
+  }
+
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      atom::switches::kRegisterSecureSchemes, base::JoinString(schemes, ","));
+}
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.SetMethod("registerStandardSchemes", &RegisterStandardSchemes);
+  dict.SetMethod("registerSecureSchemes", &RegisterSecureSchemes);
   dict.SetMethod("getStandardSchemes", &atom::api::GetStandardSchemes);
 }
 

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -93,6 +93,9 @@ class Protocol : public mate::TrackableObject<Protocol> {
   // Register schemes that can handle service worker.
   void RegisterServiceWorkerSchemes(const std::vector<std::string>& schemes);
 
+  // Register schemes that are secure.
+  void RegisterSecureSchemes(const std::vector<std::string>& schemes);
+
   // Register the protocol with certain request job.
   template<typename RequestJob>
   void RegisterProtocol(const std::string& scheme,

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -138,6 +138,9 @@ const char kStandardSchemes[] = "standard-schemes";
 // Register schemes to handle service worker.
 const char kRegisterServiceWorkerSchemes[] = "register-service-worker-schemes";
 
+// Register schemes as secure.
+const char kRegisterSecureSchemes[] = "register-secure-schemes";
+
 // The minimum SSL/TLS version ("tls1", "tls1.1", or "tls1.2") that
 // TLS fallback will accept.
 const char kSSLVersionFallbackMin[] = "ssl-version-fallback-min";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -74,6 +74,7 @@ extern const char kPpapiFlashVersion[];
 extern const char kDisableHttpCache[];
 extern const char kStandardSchemes[];
 extern const char kRegisterServiceWorkerSchemes[];
+extern const char kRegisterSecureSchemes[];
 extern const char kSSLVersionFallbackMin[];
 extern const char kCipherSuiteBlacklist[];
 extern const char kAppUserModelId[];

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -68,6 +68,17 @@ app.on('ready', () => {
 **Note:** This method can only be used before the `ready` event of the `app`
 module gets emitted.
 
+### `protocol.registerSecureSchemes(schemes)`
+
+* `schemes` String[] - Custom schemes to be registered as secure.
+
+This should be called on any scheme which is registered as secure using
+[webFrame.registerURLSchemeAsSecure](web-frame.md#webframeregisterurlschemeassecurescheme)
+or [webFrame.registerURLSchemeAsPrivileged](web-frame.md#webframeregisterurlschemeasprivilegedscheme)
+
+**Note:** This method can only be used before the `ready` event of the `app`
+module gets emitted.
+
 ### `protocol.registerServiceWorkerSchemes(schemes)`
 
 * `schemes` String[] - Custom schemes to be registered to handle service workers.


### PR DESCRIPTION
Solves https://github.com/electron/electron/issues/7670

Per @deepak1556's advice, I added an interface to the `ContentClient:: AddSecureSchemesAndOrigins` method. Due to the timing in my tests, I found it had to be called before the 'ready' event, as with `registerStandardSchemes`.

I'm not sure what the best way is to automatically test this. Suggestions? I was able to confirm it works in my bug demo, https://github.com/pfrazee/electron-bug-securewebviewcrash.
