### PR TITLE
Use focused window web contents as fallback for role menu items

### DIFF
--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -1,4 +1,4 @@
-const {app} = require('electron')
+const {app, webContents} = require('electron')
 
 const roles = {
   about: {
@@ -141,6 +141,19 @@ const canExecuteRole = (role) => {
   return ['zoomin', 'zoomout', 'resetzoom'].includes(role)
 }
 
+const getFocusedWebContents = (window) => {
+  let contents = webContents.getFocusedWebContents()
+
+  // Fall back to using focused window's web contents
+  if (contents == null && window != null) {
+    contents = window.webContents
+    if (contents != null && contents.isDevToolsFocused()) {
+      contents = contents.devToolsWebContents
+    }
+  }
+  return contents
+}
+
 exports.getDefaultLabel = (role) => {
   if (roles.hasOwnProperty(role)) {
     return roles[role].label
@@ -153,7 +166,7 @@ exports.getDefaultAccelerator = (role) => {
   if (roles.hasOwnProperty(role)) return roles[role].accelerator
 }
 
-exports.execute = (role, focusedWindow, focusedWebContents) => {
+exports.execute = (role, focusedWindow) => {
   if (!canExecuteRole(role)) return false
 
   const {appMethod, webContentsMethod, windowMethod} = roles[role]
@@ -172,6 +185,7 @@ exports.execute = (role, focusedWindow, focusedWebContents) => {
     return true
   }
 
+  const focusedWebContents = getFocusedWebContents(focusedWindow)
   if (webContentsMethod && focusedWebContents != null) {
     if (typeof webContentsMethod === 'function') {
       webContentsMethod(focusedWebContents)

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -41,13 +41,13 @@ const MenuItem = function (options) {
   this.overrideReadOnlyProperty('commandId', ++nextCommandId)
 
   const click = options.click
-  this.click = (event, focusedWindow, focusedWebContents) => {
+  this.click = (event, focusedWindow) => {
     // Manually flip the checked flags when clicked.
     if (this.type === 'checkbox' || this.type === 'radio') {
       this.checked = !this.checked
     }
 
-    if (!roles.execute(this.role, focusedWindow, focusedWebContents)) {
+    if (!roles.execute(this.role, focusedWindow)) {
       if (typeof click === 'function') {
         click(this, focusedWindow, event)
       } else if (typeof this.selector === 'string' && process.platform === 'darwin') {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {BrowserWindow, MenuItem, webContents} = require('electron')
+const {BrowserWindow, MenuItem} = require('electron')
 const EventEmitter = require('events').EventEmitter
 const v8Util = process.atomBinding('v8_util')
 const bindings = process.atomBinding('menu')
@@ -118,7 +118,7 @@ Menu.prototype._init = function () {
     executeCommand: (event, commandId) => {
       const command = this.commandsMap[commandId]
       if (command == null) return
-      command.click(event, BrowserWindow.getFocusedWindow(), webContents.getFocusedWebContents())
+      command.click(event, BrowserWindow.getFocusedWindow())
     },
     menuWillShow: () => {
       // Make sure radio groups have at least one menu item seleted.


### PR DESCRIPTION
https://github.com/electron/electron/pull/7468 introduced focusing the menu bar button when clicked.

This caused the web contents to no longer report as focused causing some role-based menu items to no longer work on Windows.

This pull request updates the menu item role behavior to use the focused window's web contents as a fallback when the web contents itself is not reporting as focused.

Closes #7663