### PR TITLE
Focus window on menu bar click

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -846,7 +846,7 @@ void NativeWindowViews::SetMenu(AtomMenuModel* menu_model) {
 
   if (!menu_bar_) {
     gfx::Size content_size = GetContentSize();
-    menu_bar_.reset(new MenuBar);
+    menu_bar_.reset(new MenuBar(this));
     menu_bar_->set_owned_by_client();
 
     if (!menu_bar_autohide_) {

--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -47,9 +47,10 @@ void GetMenuBarColor(SkColor* enabled, SkColor* disabled, SkColor* highlight,
 
 }  // namespace
 
-MenuBar::MenuBar()
+MenuBar::MenuBar(NativeWindow* window)
     : background_color_(kDefaultColor),
-      menu_model_(NULL) {
+      menu_model_(NULL),
+      window_(window) {
   UpdateMenuBarColor();
   SetLayoutManager(new views::BoxLayout(
       views::BoxLayout::kHorizontal, 0, 0, 0));
@@ -141,6 +142,9 @@ void MenuBar::OnMenuButtonClicked(views::MenuButton* source,
 
   if (!menu_model_)
     return;
+
+  if (!window_->IsFocused())
+    window_->Focus(true);
 
   int id = source->tag();
   AtomMenuModel::ItemType type = menu_model_->GetTypeAt(id);

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_UI_VIEWS_MENU_BAR_H_
 #define ATOM_BROWSER_UI_VIEWS_MENU_BAR_H_
 
+#include "atom/browser/native_window.h"
 #include "atom/browser/ui/atom_menu_model.h"
 #include "ui/views/controls/button/menu_button_listener.h"
 #include "ui/views/view.h"
@@ -20,7 +21,7 @@ class MenuDelegate;
 class MenuBar : public views::View,
                 public views::MenuButtonListener {
  public:
-  MenuBar();
+  explicit MenuBar(NativeWindow* window);
   virtual ~MenuBar();
 
   // Replaces current menu with a new one.
@@ -66,6 +67,7 @@ class MenuBar : public views::View,
   SkColor hover_color_;
 #endif
 
+  NativeWindow* window_;
   AtomMenuModel* menu_model_;
 
   DISALLOW_COPY_AND_ASSIGN(MenuBar);

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -52,10 +52,6 @@ SubmenuButton::SubmenuButton(const base::string16& title,
   SetHasInkDrop(true);
   set_ink_drop_base_color(
       color_utils::BlendTowardOppositeLuma(background_color_, 0x61));
-
-  set_request_focus_on_press(true);
-  SetFocusForPlatform();
-  SetFocusPainter(nullptr);
 }
 
 SubmenuButton::~SubmenuButton() {


### PR DESCRIPTION
This pull request reverts #7468 and instead just explicitly focuses the window when a menu bar button is clicked so that the original issue (#7282) is still addressed and the menu items are targeting the right window.

Previously focusing the menu bar caused the web contents to lose focus meaning input fields or the dev tools would not regain focus after the menu was closed.

Closes https://github.com/electron/electron/issues/7663