### PR TITLE
Remove RegisterURLSchemeAsPrivileged lint error

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -63,10 +63,8 @@ class WebFrame : public mate::Wrappable<WebFrame> {
 
   void RegisterURLSchemeAsSecure(const std::string& scheme);
   void RegisterURLSchemeAsBypassingCSP(const std::string& scheme);
-  void RegisterURLSchemeAsPrivileged(
-      const std::string& scheme,
-      mate::Arguments* args
-  );
+  void RegisterURLSchemeAsPrivileged(const std::string& scheme,
+                                     mate::Arguments* args);
 
   // Editing.
   void InsertText(const std::string& text);


### PR DESCRIPTION
Follow on to #7665, remove lint error in `atom_api_web_frame.h` 👕 

```
atom/renderer/api/atom_api_web_frame.h:69:  Closing ) should be moved to the previous line  [whitespace/parens] [2]
```