### PR TITLE
update docs linter to support parsing of function parameter types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.8.2",
+    "electron-docs-linter": "^1.10.0",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
This pulls in the latest docs linter, which now supports parsing the function parameters' types, e.g.

```
* `callback` Function
  * `argv` String[] - An array of the second instance's command line arguments
  * `workingDirectory` String - The second instance's working directory
```

See https://github.com/electron/electron-docs-linter/pull/60 and https://github.com/electron/electron/pull/7596