### PR TITLE
Add newlines before lists

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -542,6 +542,7 @@ Returns `Boolean` - Whether the call succeeded.
 ### `app.getJumpListSettings()` _Windows_
 
 Returns `Object`:
+
 * `minItems` Integer - The minimum number of items that will be shown in the
   Jump List (for a more detailed description of this value see the
   [MSDN docs][JumpListBeginListMSDN]).

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -79,6 +79,7 @@ Writes the `text` into the clipboard in RTF.
 ### `clipboard.readBookmark()` _macOS_ _Windows_
 
 Returns `Object`:
+
 * `title` String
 * `url` String
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -57,6 +57,7 @@ crash reports.
 ### `crashReporter.getLastCrashReport()`
 
 Returns `Object`:
+
 * `date` String
 * `ID` Integer
 
@@ -66,6 +67,7 @@ sent or the crash reporter has not been started, `null` is returned.
 ### `crashReporter.getUploadedReports()`
 
 Returns `Object[]`:
+
 * `date` String
 * `ID` Integer
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -84,6 +84,7 @@ limit, whichever is lower for the current process.
 ### `process.getProcessMemoryInfo()`
 
 Returns `Object`:
+
 * `workingSetSize` Integer - The amount of memory currently pinned to actual physical
   RAM.
 * `peakWorkingSetSize` Integer - The maximum amount of memory that has ever been pinned
@@ -99,6 +100,7 @@ that all statistics are reported in Kilobytes.
 ### `process.getSystemMemoryInfo()`
 
 Returns `Object`:
+
 * `total` Integer - The total amount of physical memory in Kilobytes available to the
   system.
 * `free` Integer - The total amount of memory not being used by applications or disk

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -90,6 +90,7 @@ The `screen` module has the following methods:
 ### `screen.getCursorScreenPoint()`
 
 Returns `Object`:
+
 * `x` Integer
 * `y` Integer
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -124,6 +124,7 @@ this limitation.
 ### `webFrame.getResourceUsage()`
 
 Returns `Object`:
+
 * `images` [MemoryUsageDetails](structures/memory-usage-details.md)
 * `cssStyleSheets` [MemoryUsageDetails](structures/memory-usage-details.md)
 * `xslStyleSheets` [MemoryUsageDetails](structures/memory-usage-details.md)

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -26,6 +26,7 @@ The `features` string follows the format of standard browser, but each feature
 has to be a field of `BrowserWindow`'s options.
 
 **Notes:**
+
 * Node integration will always be disabled in the opened `window` if it is
   disabled on the parent window.
 * Non-standard features (that are not handled by Chromium or Electron) given in


### PR DESCRIPTION
This is required for the markdown parser used by http://electron.atom.io/docs/

Currently these are rendering like:

<img width="867" alt="screen shot 2016-10-25 at 12 35 29 pm" src="https://cloud.githubusercontent.com/assets/671378/19672204/6e5dde8c-9aaf-11e6-9493-f9f183005b82.png">
