### PR TITLE
Add macOS find pasteboard support

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -152,7 +152,7 @@ void Clipboard::WriteImage(const gfx::Image& image, mate::Arguments* args) {
 
 #if !defined(OS_MACOSX)
 void Clipboard::WriteFindText(const base::string16& text) {}
-base::string16 Clipboard::ReadFindText() { return ""; }
+base::string16 Clipboard::ReadFindText() { return base::string16(); }
 #endif
 
 void Clipboard::Clear(mate::Arguments* args) {

--- a/atom/common/api/atom_api_clipboard.h
+++ b/atom/common/api/atom_api_clipboard.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_API_ATOM_API_CLIPBOARD_H_
+#define ATOM_COMMON_API_ATOM_API_CLIPBOARD_H_
+
+#include <string>
+#include <vector>
+
+#include "native_mate/arguments.h"
+#include "native_mate/dictionary.h"
+#include "ui/base/clipboard/clipboard.h"
+#include "ui/gfx/image/image.h"
+
+namespace atom {
+
+namespace api {
+
+class Clipboard {
+ public:
+  static ui::ClipboardType GetClipboardType(mate::Arguments* args);
+  static std::vector<base::string16> AvailableFormats(mate::Arguments* args);
+  static bool Has(const std::string& format_string, mate::Arguments* args);
+  static void Clear(mate::Arguments* args);
+
+  static std::string Read(const std::string& format_string,
+                          mate::Arguments* args);
+  static void Write(const mate::Dictionary& data, mate::Arguments* args);
+
+  static base::string16 ReadText(mate::Arguments* args);
+  static void WriteText(const base::string16& text, mate::Arguments* args);
+
+  static base::string16 ReadRtf(mate::Arguments* args);
+  static void WriteRtf(const std::string& text, mate::Arguments* args);
+
+  static base::string16 ReadHtml(mate::Arguments* args);
+  static void WriteHtml(const base::string16& html, mate::Arguments* args);
+
+  static v8::Local<v8::Value> ReadBookmark(mate::Arguments* args);
+  static void WriteBookmark(const base::string16& title,
+                            const std::string& url,
+                            mate::Arguments* args);
+
+  static gfx::Image ReadImage(mate::Arguments* args);
+  static void WriteImage(const gfx::Image& image, mate::Arguments* args);
+
+  static base::string16 ReadFindText();
+  static void WriteFindText(const base::string16& text);
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(Clipboard);
+};
+
+}  // namespace api
+
+}  // namespace atom
+
+#endif  // ATOM_COMMON_API_ATOM_API_CLIPBOARD_H_

--- a/atom/common/api/atom_api_clipboard_mac.mm
+++ b/atom/common/api/atom_api_clipboard_mac.mm
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/api/atom_api_clipboard.h"
+#include "base/strings/sys_string_conversions.h"
+#include "ui/base/cocoa/find_pasteboard.h"
+
+namespace atom {
+
+namespace api {
+
+void Clipboard::WriteFindText(const base::string16& text) {
+  NSString* text_ns = base::SysUTF16ToNSString(text);
+  [[FindPasteboard sharedInstance] setFindText:text_ns];
+}
+
+base::string16 Clipboard::ReadFindText() {
+  return GetFindPboardText();
+}
+
+}  // namespace api
+
+}  // namespace atom

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -106,6 +106,19 @@ clipboard.write({
 })
 ```
 
+### `clipboard.readFindText()` _macOS_
+
+Returns `String` - The text on the find pasteboard. This method uses synchronous
+IPC when called from the renderer process. The cached value is reread from the
+find pasteboard whenever the application is activated.
+
+### `clipboard.writeFindText(text)` _macOS_
+
+* `text` String
+
+Writes the `text` into the find pasteboard as plain text. This method uses
+synchronous IPC when called from the renderer process.
+
 ### `clipboard.clear([type])`
 
 * `type` String (optional)

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -340,6 +340,8 @@
       'atom/common/api/api_messages.h',
       'atom/common/api/atom_api_asar.cc',
       'atom/common/api/atom_api_clipboard.cc',
+      'atom/common/api/atom_api_clipboard.h',
+      'atom/common/api/atom_api_clipboard_mac.mm',
       'atom/common/api/atom_api_crash_reporter.cc',
       'atom/common/api/atom_api_key_weak_map.h',
       'atom/common/api/atom_api_native_image.cc',

--- a/lib/common/api/clipboard.js
+++ b/lib/common/api/clipboard.js
@@ -2,5 +2,14 @@ if (process.platform === 'linux' && process.type === 'renderer') {
   // On Linux we could not access clipboard in renderer process.
   module.exports = require('electron').remote.clipboard
 } else {
-  module.exports = process.atomBinding('clipboard')
+  const clipboard = process.atomBinding('clipboard')
+
+  // Read/write to find pasteboard over IPC since only main process is notified
+  // of changes
+  if (process.platform === 'darwin' && process.type === 'renderer') {
+    clipboard.readFindText = require('electron').remote.clipboard.readFindText
+    clipboard.writeFindText = require('electron').remote.clipboard.writeFindText
+  }
+
+  module.exports = clipboard
 }

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -84,4 +84,13 @@ describe('clipboard module', function () {
       }
     })
   })
+
+  describe('clipboard.read/writeFindText(text)', function () {
+    it('reads and write text to the find pasteboard', function () {
+      if (process.platform !== 'darwin') return this.skip()
+
+      clipboard.writeFindText('find this')
+      assert.equal(clipboard.readFindText(), 'find this')
+    })
+  })
 })


### PR DESCRIPTION
This pull request exposed Chrome's API support for the [NSFindPboard](https://developer.apple.com/reference/appkit/nsfindpboard) so you can read and write text to that board.

- [x] Add `readFindText`/`writeFindText`
- [x] Add tests
- [x] Add docs

Closes #7656 