### PR TITLE
Update web-frame.md

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -87,11 +87,11 @@ Content Security Policy.
 
 * `scheme` String
 * `options` Object (optional)
-  * `secure` (optional) Default true.
-  * `bypassCSP` (optional) Default true.
-  * `allowServiceWorkers` (optional) Default true.
-  * `supportFetchAPI` (optional) Default true.
-  * `corsEnabled` (optional) Default true.
+  * `secure` Boolean - (optional) Default true.
+  * `bypassCSP` Boolean - (optional) Default true.
+  * `allowServiceWorkers` Boolean - (optional) Default true.
+  * `supportFetchAPI` Boolean - (optional) Default true.
+  * `corsEnabled` Boolean - (optional) Default true.
 
 Registers the `scheme` as secure, bypasses content security policy for resources,
 allows registering ServiceWorker and supports fetch API.


### PR DESCRIPTION
These new docs resulted in the object properties having the type "optional" due to the new linter supporting types in brackets.

/cc @zeke 