### PR TITLE
Clean up nested objects and string ENUMS in the docs

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -185,13 +185,84 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     Default is `false`.
   * `type` String - The type of window, default is normal window. See more about
     this below.
-  * `titleBarStyle` String - The style of window title bar. See more about this
-    below.
+  * `titleBarStyle` String - The style of window title bar.  Possible values are:
+    * `default` or not specified, results in the standard gray opaque Mac title
+      bar.
+    * `hidden` results in a hidden title bar and a full size content window, yet
+      the title bar still has the standard window controls ("traffic lights") in
+      the top left.
+    * `hidden-inset` results in a hidden title bar with an alternative look
+      where the traffic light buttons are slightly more inset from the window edge.
   * `thickFrame` Boolean - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
-  * `webPreferences` Object - Settings of web page's features. See more about
-    this below.
+  * `webPreferences` Object - Settings of web page's features.
+    * `devTools` Boolean - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
+    * `nodeIntegration` Boolean - Whether node integration is enabled. Default
+      is `true`.
+    * `preload` String - Specifies a script that will be loaded before other
+      scripts run in the page. This script will always have access to node APIs
+      no matter whether node integration is turned on or off. The value should
+      be the absolute file path to the script.
+      When node integration is turned off, the preload script can reintroduce
+      Node global symbols back to the global scope. See example
+      [here](process.md#event-loaded).
+    * `session` [Session](session.md#class-session) - Sets the session used by the
+      page. Instead of passing the Session object directly, you can also choose to
+      use the `partition` option instead, which accepts a partition string. When
+      both `session` and `partition` are provided, `session` will be preferred.
+      Default is the default session.
+    * `partition` String - Sets the session used by the page according to the
+      session's partition string. If `partition` starts with `persist:`, the page
+      will use a persistent session available to all pages in the app with the
+      same `partition`. If there is no `persist:` prefix, the page will use an
+      in-memory session. By assigning the same `partition`, multiple pages can share
+      the same session. Default is the default session.
+    * `zoomFactor` Number - The default zoom factor of the page, `3.0` represents
+      `300%`. Default is `1.0`.
+    * `javascript` Boolean - Enables JavaScript support. Default is `true`.
+    * `webSecurity` Boolean - When `false`, it will disable the
+      same-origin policy (usually using testing websites by people), and set
+      `allowDisplayingInsecureContent` and `allowRunningInsecureContent` to
+      `true` if these two options are not set by user. Default is `true`.
+    * `allowDisplayingInsecureContent` Boolean - Allow an https page to display
+      content like images from http URLs. Default is `false`.
+    * `allowRunningInsecureContent` Boolean - Allow an https page to run
+      JavaScript, CSS or plugins from http URLs. Default is `false`.
+    * `images` Boolean - Enables image support. Default is `true`.
+    * `textAreasAreResizable` Boolean - Make TextArea elements resizable. Default
+      is `true`.
+    * `webgl` Boolean - Enables WebGL support. Default is `true`.
+    * `webaudio` Boolean - Enables WebAudio support. Default is `true`.
+    * `plugins` Boolean - Whether plugins should be enabled. Default is `false`.
+    * `experimentalFeatures` Boolean - Enables Chromium's experimental features.
+      Default is `false`.
+    * `experimentalCanvasFeatures` Boolean - Enables Chromium's experimental
+      canvas features. Default is `false`.
+    * `scrollBounce` Boolean - Enables scroll bounce (rubber banding) effect on
+      macOS. Default is `false`.
+    * `blinkFeatures` String - A list of feature strings separated by `,`, like
+      `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
+      strings can be found in the [RuntimeEnabledFeatures.in][blink-feature-string]
+      file.
+    * `disableBlinkFeatures` String - A list of feature strings separated by `,`,
+      like `CSSVariables,KeyboardEventKey` to disable. The full list of supported
+      feature strings can be found in the
+      [RuntimeEnabledFeatures.in][blink-feature-string] file.
+    * `defaultFontFamily` Object - Sets the default font for the font-family.
+      * `standard` String - Defaults to `Times New Roman`.
+      * `serif` String - Defaults to `Times New Roman`.
+      * `sansSerif` String - Defaults to `Arial`.
+      * `monospace` String - Defaults to `Courier New`.
+    * `defaultFontSize` Integer - Defaults to `16`.
+    * `defaultMonospaceFontSize` Integer - Defaults to `13`.
+    * `minimumFontSize` Integer - Defaults to `0`.
+    * `defaultEncoding` String - Defaults to `ISO-8859-1`.
+    * `backgroundThrottling` Boolean - Whether to throttle animations and timers
+      when the page becomes background. Defaults to `true`.
+    * `offscreen` Boolean - Whether to enable offscreen rendering for the browser
+      window. Defaults to `false`.
+    * `sandbox` Boolean - Whether to enable Chromium OS-level sandbox.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from
@@ -211,85 +282,6 @@ Possible values are:
     focus, keyboard or mouse events, but you can use `globalShortcut` to receive
     input sparingly.
 * On Windows, possible type is `toolbar`.
-
-Possible values of the `titleBarStyle` option are:
-
-* `default` or not specified, results in the standard gray opaque Mac title
-  bar.
-* `hidden` results in a hidden title bar and a full size content window, yet
-  the title bar still has the standard window controls ("traffic lights") in
-  the top left.
-* `hidden-inset` results in a hidden title bar with an alternative look
-  where the traffic light buttons are slightly more inset from the window edge.
-
-The `webPreferences` option is an object that can have the following properties:
-
-* `devTools` Boolean - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
-* `nodeIntegration` Boolean - Whether node integration is enabled. Default
-  is `true`.
-* `preload` String - Specifies a script that will be loaded before other
-  scripts run in the page. This script will always have access to node APIs
-  no matter whether node integration is turned on or off. The value should
-  be the absolute file path to the script.
-  When node integration is turned off, the preload script can reintroduce
-  Node global symbols back to the global scope. See example
-  [here](process.md#event-loaded).
-* `session` [Session](session.md#class-session) - Sets the session used by the
-  page. Instead of passing the Session object directly, you can also choose to
-  use the `partition` option instead, which accepts a partition string. When
-  both `session` and `partition` are provided, `session` will be preferred.
-  Default is the default session.
-* `partition` String - Sets the session used by the page according to the
-  session's partition string. If `partition` starts with `persist:`, the page
-  will use a persistent session available to all pages in the app with the
-  same `partition`. If there is no `persist:` prefix, the page will use an
-  in-memory session. By assigning the same `partition`, multiple pages can share
-  the same session. Default is the default session.
-* `zoomFactor` Number - The default zoom factor of the page, `3.0` represents
-  `300%`. Default is `1.0`.
-* `javascript` Boolean - Enables JavaScript support. Default is `true`.
-* `webSecurity` Boolean - When `false`, it will disable the
-  same-origin policy (usually using testing websites by people), and set
-  `allowDisplayingInsecureContent` and `allowRunningInsecureContent` to
-  `true` if these two options are not set by user. Default is `true`.
-* `allowDisplayingInsecureContent` Boolean - Allow an https page to display
-  content like images from http URLs. Default is `false`.
-* `allowRunningInsecureContent` Boolean - Allow an https page to run
-  JavaScript, CSS or plugins from http URLs. Default is `false`.
-* `images` Boolean - Enables image support. Default is `true`.
-* `textAreasAreResizable` Boolean - Make TextArea elements resizable. Default
-  is `true`.
-* `webgl` Boolean - Enables WebGL support. Default is `true`.
-* `webaudio` Boolean - Enables WebAudio support. Default is `true`.
-* `plugins` Boolean - Whether plugins should be enabled. Default is `false`.
-* `experimentalFeatures` Boolean - Enables Chromium's experimental features.
-  Default is `false`.
-* `experimentalCanvasFeatures` Boolean - Enables Chromium's experimental
-  canvas features. Default is `false`.
-* `scrollBounce` Boolean - Enables scroll bounce (rubber banding) effect on
-  macOS. Default is `false`.
-* `blinkFeatures` String - A list of feature strings separated by `,`, like
-  `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
-  strings can be found in the [RuntimeEnabledFeatures.in][blink-feature-string]
-  file.
-* `disableBlinkFeatures` String - A list of feature strings separated by `,`,
-  like `CSSVariables,KeyboardEventKey` to disable. The full list of supported
-  feature strings can be found in the
-  [RuntimeEnabledFeatures.in][blink-feature-string] file.
-* `defaultFontFamily` Object - Sets the default font for the font-family.
-  * `standard` String - Defaults to `Times New Roman`.
-  * `serif` String - Defaults to `Times New Roman`.
-  * `sansSerif` String - Defaults to `Arial`.
-  * `monospace` String - Defaults to `Courier New`.
-* `defaultFontSize` Integer - Defaults to `16`.
-* `defaultMonospaceFontSize` Integer - Defaults to `13`.
-* `minimumFontSize` Integer - Defaults to `0`.
-* `defaultEncoding` String - Defaults to `ISO-8859-1`.
-* `backgroundThrottling` Boolean - Whether to throttle animations and timers
-  when the page becomes background. Defaults to `true`.
-* `offscreen` Boolean - Whether to enable offscreen rendering for the browser
-  window. Defaults to `false`.
-* `sandbox` Boolean - Whether to enable Chromium OS-level sandbox.
 
 ### Instance Events
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -185,13 +185,13 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     Default is `false`.
   * `type` String - The type of window, default is normal window. See more about
     this below.
-  * `titleBarStyle` String - The style of window title bar.  Possible values are:
-    * `default` or not specified, results in the standard gray opaque Mac title
+  * `titleBarStyle` String - The style of window title bar. Default is `default`. Possible values are:
+    * `default` - Results in the standard gray opaque Mac title
       bar.
-    * `hidden` results in a hidden title bar and a full size content window, yet
+    * `hidden` - Results in a hidden title bar and a full size content window, yet
       the title bar still has the standard window controls ("traffic lights") in
       the top left.
-    * `hidden-inset` results in a hidden title bar with an alternative look
+    * `hidden-inset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
   * `thickFrame` Boolean - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -399,31 +399,25 @@ Returns:
     Can be `none`, `mouse`, `keyboard`, `touch`, `touchMenu`.
   * `mediaFlags` Object - The flags for the media element the context menu was
     invoked on. See more about this below.
+    * `inError` Boolean - Whether the media element has crashed.
+    * `isPaused` Boolean - Whether the media element is paused.
+    * `isMuted` Boolean - Whether the media element is muted.
+    * `hasAudio` Boolean - Whether the media element has audio.
+    * `isLooping` Boolean - Whether the media element is looping.
+    * `isControlsVisible` Boolean - Whether the media element's controls are
+      visible.
+    * `canToggleControls` Boolean - Whether the media element's controls are
+      toggleable.
+    * `canRotate` Boolean - Whether the media element can be rotated.
   * `editFlags` Object - These flags indicate whether the renderer believes it is
     able to perform the corresponding action. See more about this below.
-
-The `mediaFlags` is an object with the following properties:
-
-* `inError` Boolean - Whether the media element has crashed.
-* `isPaused` Boolean - Whether the media element is paused.
-* `isMuted` Boolean - Whether the media element is muted.
-* `hasAudio` Boolean - Whether the media element has audio.
-* `isLooping` Boolean - Whether the media element is looping.
-* `isControlsVisible` Boolean - Whether the media element's controls are
-  visible.
-* `canToggleControls` Boolean - Whether the media element's controls are
-  toggleable.
-* `canRotate` Boolean - Whether the media element can be rotated.
-
-The `editFlags` is an object with the following properties:
-
-* `canUndo` Boolean - Whether the renderer believes it can undo.
-* `canRedo` Boolean - Whether the renderer believes it can redo.
-* `canCut` Boolean - Whether the renderer believes it can cut.
-* `canCopy` Boolean - Whether the renderer believes it can copy
-* `canPaste` Boolean - Whether the renderer believes it can paste.
-* `canDelete` Boolean - Whether the renderer believes it can delete.
-* `canSelectAll` Boolean - Whether the renderer believes it can select all.
+    * `canUndo` Boolean - Whether the renderer believes it can undo.
+    * `canRedo` Boolean - Whether the renderer believes it can redo.
+    * `canCut` Boolean - Whether the renderer believes it can cut.
+    * `canCopy` Boolean - Whether the renderer believes it can copy
+    * `canPaste` Boolean - Whether the renderer believes it can paste.
+    * `canDelete` Boolean - Whether the renderer believes it can delete.
+    * `canSelectAll` Boolean - Whether the renderer believes it can select all.
 
 Emitted when there is a new context menu that needs to be handled.
 
@@ -982,8 +976,8 @@ app.on('ready', () => {
 * `parameters` Object
   * `screenPosition` String - Specify the screen type to emulate
       (default: `desktop`)
-    * `desktop` String - Desktop screen type
-    * `mobile` String - Mobile screen type
+    * `desktop` - Desktop screen type
+    * `mobile` - Mobile screen type
   * `screenSize` Object - Set the emulated screen size (screenPosition == mobile)
     * `width` Integer - Set the emulated screen width
     * `height` Integer - Set the emulated screen height
@@ -1229,7 +1223,7 @@ Detaches the debugger from the `webContents`.
 * `commandParams` Object (optional) - JSON object with request parameters.
 * `callback` Function (optional) - Response
   * `error` Object - Error message indicating the failure of the command.
-  * `result` Object - Response defined by the 'returns' attribute of
+  * `result` Any - Response defined by the 'returns' attribute of
      the command description in the remote debugging protocol.
 
 Send given command to the debugging target.


### PR DESCRIPTION
In their previous location `electron-docs-linter` would not output an Object structure for `webPreferences` (which is a key part of the constructor)

Also this fixes quite a few string ENUMS now that electron/electron-docs-linter/pull/64 attempts to parse a lot more of them

/cc @zeke 