### PR TITLE
update docs linter to add support for inline ENUM values

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.10.0",
+    "electron-docs-linter": "^1.11.0",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
See https://github.com/electron/electron-docs-linter/pull/64 and https://github.com/electron/electron/pull/7741

cc @MarshallOfSound 
