### PR TITLE
Adding documentation about hidden-inset

### DIFF
--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -27,7 +27,9 @@ both the titlebar and window controls, you may want to have the title bar
 hidden and your content extend to the full window size, yet still preserve
 the window controls ("traffic lights") for standard window actions.
 You can do so by specifying the new `titleBarStyle` option:
-#### Hidden
+
+#### `hidden`
+
 Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls (“traffic lights”) in the top left.
 
 ```javascript
@@ -35,7 +37,9 @@ const {BrowserWindow} = require('electron')
 let win = new BrowserWindow({titleBarStyle: 'hidden'})
 win.show()
 ```
-#### Hidden-inset
+
+#### `hidden-inset`
+
 Results in a hidden title bar with an alternative look where the traffic light buttons are slightly more inset from the window edge.
 
 ```javascript

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -48,8 +48,6 @@ let win = new BrowserWindow({titleBarStyle: 'hidden-inset'})
 win.show()
 ```
 
-
-
 ## Transparent window
 
 By setting the `transparent` option to `true`, you can also make the frameless

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -27,12 +27,24 @@ both the titlebar and window controls, you may want to have the title bar
 hidden and your content extend to the full window size, yet still preserve
 the window controls ("traffic lights") for standard window actions.
 You can do so by specifying the new `titleBarStyle` option:
+#### Hidden
+Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls (“traffic lights”) in the top left.
 
 ```javascript
 const {BrowserWindow} = require('electron')
 let win = new BrowserWindow({titleBarStyle: 'hidden'})
 win.show()
 ```
+#### Hidden-inset
+Results in a hidden title bar with an alternative look where the traffic light buttons are slightly more inset from the window edge.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({titleBarStyle: 'hidden-inset'})
+win.show()
+```
+
+
 
 ## Transparent window
 


### PR DESCRIPTION
documentation about hidden-inset is shown on BrowserWindow docs: http://electron.atom.io/docs/api/browser-window/

But it does not exist under the frameless window api docs. this pull requests adds it here: http://electron.atom.io/docs/api/frameless-window/