### PR TITLE
incorrect position when restored from maximize-on-top-drag under Windows #7630

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -327,7 +327,6 @@ NativeWindowViews::NativeWindowViews(
     last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
   else
     last_window_state_ = ui::SHOW_STATE_NORMAL;
-  last_normal_bounds_ = GetBounds();
 #endif
 }
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -211,22 +211,6 @@ class NativeWindowViews : public NativeWindow,
 
   ui::WindowShowState last_window_state_;
 
-  // There's an issue with restore on Windows, that sometimes causes the Window
-  // to receive the wrong size (#2498). To circumvent that, we keep tabs on the
-  // size of the window while in the normal state (not maximized, minimized or
-  // fullscreen), so we restore it correctly.
-  gfx::Rect last_normal_bounds_;
-
-  // last_normal_bounds_ may or may not require update on WM_MOVE. When a
-  // window is maximized, it is moved (WM_MOVE) to maximum size first and then
-  // sized (WM_SIZE). In this case, last_normal_bounds_ should not update. We
-  // keep last_normal_bounds_candidate_ as a candidate which will become valid
-  // last_normal_bounds_ if the moves are consecutive with no WM_SIZE event in
-  // between.
-  gfx::Rect last_normal_bounds_candidate_;
-
-  bool consecutive_moves_;
-
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -125,7 +125,6 @@ bool NativeWindowViews::PreHandleMSG(
         return taskbar_host_.HandleThumbarButtonEvent(LOWORD(w_param));
       return false;
     case WM_SIZE: {
-      consecutive_moves_ = false;
       // Handle window state change.
       HandleSizeEvent(w_param, l_param);
       return false;
@@ -133,15 +132,6 @@ bool NativeWindowViews::PreHandleMSG(
     case WM_MOVING: {
       if (!movable_)
         ::GetWindowRect(GetAcceleratedWidget(), (LPRECT)l_param);
-      return false;
-    }
-    case WM_MOVE: {
-      if (last_window_state_ == ui::SHOW_STATE_NORMAL) {
-        if (consecutive_moves_)
-          last_normal_bounds_ = last_normal_bounds_candidate_;
-        last_normal_bounds_candidate_ = GetBounds();
-        consecutive_moves_ = true;
-      }
       return false;
     }
     default:
@@ -162,35 +152,20 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
       NotifyWindowMinimize();
       break;
     case SIZE_RESTORED:
-      if (last_window_state_ == ui::SHOW_STATE_NORMAL) {
-        // Window was resized so we save it's new size.
-        last_normal_bounds_ = GetBounds();
-      } else {
-        switch (last_window_state_) {
-          case ui::SHOW_STATE_MAXIMIZED:
+      switch (last_window_state_) {
+        case ui::SHOW_STATE_MAXIMIZED:
+          last_window_state_ = ui::SHOW_STATE_NORMAL;
+          NotifyWindowUnmaximize();
+          break;
+        case ui::SHOW_STATE_MINIMIZED:
+          if (IsFullscreen()) {
+            last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
+            NotifyWindowEnterFullScreen();
+          } else {
             last_window_state_ = ui::SHOW_STATE_NORMAL;
-
-            // When the window is restored we resize it to the previous known
-            // normal size.
-            SetBounds(last_normal_bounds_, false);
-
-            NotifyWindowUnmaximize();
-            break;
-          case ui::SHOW_STATE_MINIMIZED:
-            if (IsFullscreen()) {
-              last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
-              NotifyWindowEnterFullScreen();
-            } else {
-              last_window_state_ = ui::SHOW_STATE_NORMAL;
-
-              // When the window is restored we resize it to the previous known
-              // normal size.
-              SetBounds(last_normal_bounds_, false);
-
-              NotifyWindowRestore();
-            }
-            break;
-        }
+            NotifyWindowRestore();
+          }
+          break;
       }
       break;
   }


### PR DESCRIPTION
Fix for #7630 

Issues regarding restore/maximize/minimize in general are because default windows behaviour is overridden by handling `WM_SIZE` message and `SetBounds()` to `last_normal_bounds_`. It is difficult to keep `last_normal_bounds_` up-to-date since there are many platform-specific scenarios need to be handled. 

This fix is to remove overrides and rely on default windows behaviour. I have tested by switching between maximize / restore / minimize / fullscreen and it is working.

I do have a question though why was the override implemented in the first place. Was it to fix some other bugs?
