### PR TITLE
Add zoomToPageWidth window option

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -117,7 +117,7 @@ class NativeWindowMac : public NativeWindow,
   };
   TitleBarStyle title_bar_style() const { return title_bar_style_; }
 
-  bool zoom_to_content_size() const { return zoom_to_content_size_; }
+  bool zoom_to_page_width() const { return zoom_to_page_width_; }
 
  protected:
   // Return a vector of non-draggable regions that fill a window of size
@@ -157,7 +157,7 @@ class NativeWindowMac : public NativeWindow,
 
   bool is_kiosk_;
 
-  bool zoom_to_content_size_;
+  bool zoom_to_page_width_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -117,6 +117,8 @@ class NativeWindowMac : public NativeWindow,
   };
   TitleBarStyle title_bar_style() const { return title_bar_style_; }
 
+  bool zoom_to_content_size() const { return zoom_to_content_size_; }
+
  protected:
   // Return a vector of non-draggable regions that fill a window of size
   // |width| by |height|, but leave gaps where the window should be draggable.
@@ -154,6 +156,8 @@ class NativeWindowMac : public NativeWindow,
   std::vector<DraggableRegion> draggable_regions_;
 
   bool is_kiosk_;
+
+  bool zoom_to_content_size_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -117,22 +117,22 @@ bool ScopedDisableResize::disable_resize_ = false;
   if (!web_contents)
     return frame;
 
-  CGFloat pageWidth = static_cast<CGFloat>(
+  CGFloat page_width = static_cast<CGFloat>(
       web_contents->GetPreferredSize().width());
-  NSRect currentFrame = [window frame];
+  NSRect window_frame = [window frame];
 
   // Never shrink from the current size on zoom.
-  CGFloat zoomedWidth = std::max(pageWidth, NSWidth(currentFrame));
+  CGFloat zoomed_width = std::max(page_width, NSWidth(window_frame));
 
   // |frame| determines our maximum extents. We need to set the origin of the
   // frame -- and only move it left if necessary.
-  if (currentFrame.origin.x + zoomedWidth > NSMaxX(frame))
-    frame.origin.x = NSMaxX(frame) - zoomedWidth;
+  if (window_frame.origin.x + zoomed_width > NSMaxX(frame))
+    frame.origin.x = NSMaxX(frame) - zoomed_width;
   else
-    frame.origin.x = currentFrame.origin.x;
+    frame.origin.x = window_frame.origin.x;
 
   // Set the width. Don't touch y or height.
-  frame.size.width = zoomedWidth;
+  frame.size.width = zoomed_width;
 
   return frame;
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -117,13 +117,12 @@ bool ScopedDisableResize::disable_resize_ = false;
   if (!web_contents)
     return frame;
 
-  CGFloat intrinsicWidth = static_cast<CGFloat>(
+  CGFloat pageWidth = static_cast<CGFloat>(
       web_contents->GetPreferredSize().width());
-
   NSRect currentFrame = [window frame];
 
   // Never shrink from the current size on zoom.
-  CGFloat zoomedWidth = std::max(intrinsicWidth, NSWidth(currentFrame));
+  CGFloat zoomedWidth = std::max(pageWidth, NSWidth(currentFrame));
 
   // |frame| determines our maximum extents. We need to set the origin of the
   // frame -- and only move it left if necessary.

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -106,7 +106,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 // menu) to determine the "standard size" of the window.
 - (NSRect)windowWillUseStandardFrame:(NSWindow*)window
                         defaultFrame:(NSRect)frame {
-  if (!shell_->zoom_to_content_size())
+  if (!shell_->zoom_to_page_width())
     return frame;
 
   // If the shift key is down, maximize.
@@ -630,7 +630,7 @@ NativeWindowMac::NativeWindowMac(
     NativeWindow* parent)
     : NativeWindow(web_contents, options, parent),
       is_kiosk_(false),
-      zoom_to_content_size_(false),
+      zoom_to_page_width_(false),
       attention_request_id_(0),
       title_bar_style_(NORMAL) {
   int width = 800, height = 600;
@@ -753,7 +753,7 @@ NativeWindowMac::NativeWindowMac(
   if (!has_frame() || !use_content_size)
     SetSize(gfx::Size(width, height));
 
-  options.Get(options::kZoomToContentSize, &zoom_to_content_size_);
+  options.Get(options::kZoomToPageWidth, &zoom_to_page_width_);
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -45,8 +45,8 @@ const char kAcceptFirstMouse[] = "acceptFirstMouse";
 // Whether window size should include window frame.
 const char kUseContentSize[] = "useContentSize";
 
-// Whether window zoom should be to content size.
-const char kZoomToContentSize[] = "zoomToContentSize";
+// Whether window zoom should be to page width.
+const char kZoomToPageWidth[] = "zoomToPageWidth";
 
 // The requested title bar style for the window
 const char kTitleBarStyle[] = "titleBarStyle";

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -45,6 +45,9 @@ const char kAcceptFirstMouse[] = "acceptFirstMouse";
 // Whether window size should include window frame.
 const char kUseContentSize[] = "useContentSize";
 
+// Whether window zoom should be to content size.
+const char kZoomToContentSize[] = "zoomToContentSize";
+
 // The requested title bar style for the window
 const char kTitleBarStyle[] = "titleBarStyle";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -34,6 +34,7 @@ extern const char kKiosk[];
 extern const char kAlwaysOnTop[];
 extern const char kAcceptFirstMouse[];
 extern const char kUseContentSize[];
+extern const char kZoomToContentSize[];
 extern const char kTitleBarStyle[];
 extern const char kAutoHideMenuBar[];
 extern const char kEnableLargerThanScreen[];

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -34,7 +34,7 @@ extern const char kKiosk[];
 extern const char kAlwaysOnTop[];
 extern const char kAcceptFirstMouse[];
 extern const char kUseContentSize[];
-extern const char kZoomToContentSize[];
+extern const char kZoomToPageWidth[];
 extern const char kTitleBarStyle[];
 extern const char kAutoHideMenuBar[];
 extern const char kEnableLargerThanScreen[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -205,7 +205,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `vibrancy` String - Add a type of vibrancy effect to the window, only on
     macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
     `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.
-  * `zoomToContentSize` Boolean - The zoom behavior on macOS, accessible by
+  * `zoomToPageWidth` Boolean - The zoom behavior on macOS, accessible by
     option-clicking the green stoplight button on the toolbar or running the
     Window > Zoom menu item. If `true`, the window will grow to the width of the
     web page, `false` will cause it to zoom to the width of the screen. This

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -205,6 +205,12 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `vibrancy` String - Add a type of vibrancy effect to the window, only on
     macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
     `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.
+  * `zoomToContentSize` Boolean - The zoom behavior on macOS, accessible by
+    option-clicking the green stoplight button on the toolbar or running the
+    Window > Zoom menu item. If `true`, the window will grow to the width of the
+    web page, `false` will cause it to zoom to the width of the screen. This
+    will also affect the behavior when calling `maximize()` directly. Default is
+    `false`.
   * `webPreferences` Object (optional) - Settings of web page's features.
     * `devTools` Boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
     * `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -205,12 +205,12 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `vibrancy` String - Add a type of vibrancy effect to the window, only on
     macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
     `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.
-  * `zoomToPageWidth` Boolean - The zoom behavior on macOS, accessible by
-    option-clicking the green stoplight button on the toolbar or running the
-    Window > Zoom menu item. If `true`, the window will grow to the width of the
-    web page, `false` will cause it to zoom to the width of the screen. This
-    will also affect the behavior when calling `maximize()` directly. Default is
-    `false`.
+  * `zoomToPageWidth` Boolean - Controls the behavior on macOS when
+    option-clicking the green stoplight button on the toolbar or by clicking the
+    Window > Zoom menu item. If `true`, the window will grow to the preferred
+    width of the web page when zoomed, `false` will cause it to zoom to the
+    width of the screen. This will also affect the behavior when calling
+    `maximize()` directly. Default is `false`.
   * `webPreferences` Object (optional) - Settings of web page's features.
     * `devTools` Boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
     * `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -626,6 +626,22 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('"zoomToPageWidth" option', function () {
+    it('sets the window width to the page width when used', function () {
+      if (process.platform !== 'darwin') return this.skip()
+
+      w.destroy()
+      w = new BrowserWindow({
+        show: false,
+        width: 500,
+        height: 400,
+        zoomToPageWidth: true
+      })
+      w.maximize()
+      assert.equal(w.getSize()[0], 500)
+    })
+  })
+
   describe('"web-preferences" option', function () {
     afterEach(function () {
       ipcMain.removeAllListeners('answer')


### PR DESCRIPTION
This pull request adds support for a `zoomToPageWidth` window option (defaults to `false`) that changes the macOS zoom behavior to use the preferred width of the page instead of zooming to to the full width of the screen.

This allows apps to opt-in to a more "native" feeling zoom behavior where their windows grow the full height of the screen but only expands to the needed width, such as the how the Finder handles zoom.

This was inspired by Chrome's implementation of this in [chrome/browser/ui/cocoa/browser_window_controller.mm](https://cs.chromium.org/chromium/src/chrome/browser/ui/cocoa/browser_window_controller.mm).
### Current behavior

![zoom-before](https://cloud.githubusercontent.com/assets/671378/19781406/f75682cc-9c3d-11e6-8f86-1780324c426b.gif)
### New behavior with `zoomToPageWidth` set to `true`

![zoom-after](https://cloud.githubusercontent.com/assets/671378/19781408/f90f3eb0-9c3d-11e6-8594-3f9c02f02293.gif)

/cc @dgraham
