### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -91,6 +91,8 @@ function createWindow () {
   win = new BrowserWindow({width: 800, height: 600})
 
   // and load the index.html of the app.
+  // Note that backticks are required because the arg is an ES6 template literal
+  // and substituting single or double quotes will cause the load to fail.
   win.loadURL(`file://${__dirname}/index.html`)
 
   // Open the DevTools.


### PR DESCRIPTION
I , and likely many others, got tripped up while substituting single or double quotes in place of backticks in the loadURL example:

>   // and load the index.html of the app.
>   win.loadURL(\`file://${__dirname}/index.html\`)

Examples of the confusion being discussed: 
https://github.com/electron/electron-quick-start/issues/18
https://github.com/jaketrent/jaketrent-blog/issues/11
