### PR TITLE
Fix notification crash when using permission handler

### DIFF
--- a/spec/fixtures/pages/permissions/notification.html
+++ b/spec/fixtures/pages/permissions/notification.html
@@ -1,0 +1,10 @@
+<script>
+var n1 = new Notification('Electron Notification.requestPermission test 1')
+var n2 = new Notification('Electron Notification.requestPermission test 2')
+Notification.requestPermission().then((result) => {
+  n1.close()
+  n2.close()
+
+  require('electron').ipcRenderer.sendToHost('message', result)
+})
+</script>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -946,6 +946,24 @@ describe('<webview> tag', function () {
       setUpRequestHandler(webview, 'openExternal', done)
       document.body.appendChild(webview)
     })
+
+    it('emits when using Notification.requestPermission', function (done) {
+      webview.addEventListener('ipc-message', function (e) {
+        assert.equal(e.channel, 'message')
+        assert.deepEqual(e.args, ['granted'])
+        done()
+      })
+      webview.src = 'file://' + fixtures + '/pages/permissions/notification.html'
+      webview.partition = 'permissionTest'
+      webview.setAttribute('nodeintegration', 'on')
+      session.fromPartition(webview.partition).setPermissionRequestHandler(function (webContents, permission, callback) {
+        if (webContents.getId() === webview.getId()) {
+          assert.equal(permission, 'notifications')
+          callback(true)
+        }
+      })
+      document.body.appendChild(webview)
+    })
   })
 
   describe('<webview>.getWebContents', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -959,7 +959,9 @@ describe('<webview> tag', function () {
       session.fromPartition(webview.partition).setPermissionRequestHandler(function (webContents, permission, callback) {
         if (webContents.getId() === webview.getId()) {
           assert.equal(permission, 'notifications')
-          callback(true)
+          setTimeout(function () {
+            callback(true)
+          }, 10)
         }
       })
       document.body.appendChild(webview)

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -903,8 +903,8 @@ describe('<webview> tag', function () {
 
     it('emits when using navigator.getUserMedia api', function (done) {
       webview.addEventListener('ipc-message', function (e) {
-        assert(e.channel, 'message')
-        assert(e.args, ['PermissionDeniedError'])
+        assert.equal(e.channel, 'message')
+        assert.deepEqual(e.args, ['PermissionDeniedError'])
         done()
       })
       webview.src = 'file://' + fixtures + '/pages/permissions/media.html'
@@ -916,8 +916,8 @@ describe('<webview> tag', function () {
 
     it('emits when using navigator.geolocation api', function (done) {
       webview.addEventListener('ipc-message', function (e) {
-        assert(e.channel, 'message')
-        assert(e.args, ['ERROR(1): User denied Geolocation'])
+        assert.equal(e.channel, 'message')
+        assert.deepEqual(e.args, ['User denied Geolocation'])
         done()
       })
       webview.src = 'file://' + fixtures + '/pages/permissions/geolocation.html'
@@ -929,8 +929,8 @@ describe('<webview> tag', function () {
 
     it('emits when using navigator.requestMIDIAccess api', function (done) {
       webview.addEventListener('ipc-message', function (e) {
-        assert(e.channel, 'message')
-        assert(e.args, ['SecurityError'])
+        assert.equal(e.channel, 'message')
+        assert.deepEqual(e.args, ['SecurityError'])
         done()
       })
       webview.src = 'file://' + fixtures + '/pages/permissions/midi.html'


### PR DESCRIPTION
This pull request upgrades Brightray to include https://github.com/electron/brightray/pull/258 and also adds a spec for using `setPermissionRequestHandler` with notifications.

Also updates a few asserts that were using `assert` instead of `assert.equal`/`assert.deepEqual`.

/cc @deepak1556 :eyes:

Fixes #7645 
