### PR TITLE
Add the sender's WebContents ID to IPC messages

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -839,10 +839,7 @@ void WebContents::NavigationEntryCommitted(
 }
 
 int64_t WebContents::GetID() const {
-  int64_t process_id = web_contents()->GetRenderProcessHost()->GetID();
-  int64_t routing_id = web_contents()->GetRoutingID();
-  int64_t rv = (process_id << 32) + routing_id;
-  return rv;
+  return WebContents::GetIDFromWebContents(web_contents());
 }
 
 int WebContents::GetProcessID() const {
@@ -1631,7 +1628,7 @@ AtomBrowserContext* WebContents::GetBrowserContext() const {
 void WebContents::OnRendererMessage(const base::string16& channel,
                                     const base::ListValue& args) {
   // webContents.emit(channel, new Event(), args...);
-  Emit(base::UTF16ToUTF8(channel), args);
+  EmitWithSender(base::UTF16ToUTF8(channel), web_contents(), nullptr, args);
 }
 
 void WebContents::OnRendererMessageSync(const base::string16& channel,
@@ -1665,6 +1662,17 @@ mate::Handle<WebContents> WebContents::CreateFrom(
 mate::Handle<WebContents> WebContents::Create(
     v8::Isolate* isolate, const mate::Dictionary& options) {
   return mate::CreateHandle(isolate, new WebContents(isolate, options));
+}
+
+
+int64_t WebContents::GetIDFromWebContents(
+    content::WebContents* web_contents) {
+
+  int64_t process_id = web_contents->GetRenderProcessHost()->GetID();
+  int64_t routing_id = web_contents->GetRoutingID();
+  int64_t rv = (process_id << 32) + routing_id;
+
+  return rv;
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -61,6 +61,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   static mate::Handle<WebContents> CreateFrom(
       v8::Isolate* isolate, content::WebContents* web_contents, Type type);
 
+  static int64_t GetIDFromWebContents(content::WebContents* web_contents);
+
   // Create a new WebContents.
   static mate::Handle<WebContents> Create(
       v8::Isolate* isolate, const mate::Dictionary& options);

--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -2,15 +2,15 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/api/event_emitter.h"
 
+#include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/api/event.h"
+#include "content/public/browser/web_contents.h"
 #include "native_mate/arguments.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "ui/events/event_constants.h"
-#include "content/public/browser/web_contents.h"
 
 #include "atom/common/node_includes.h"
 
@@ -58,7 +58,8 @@ v8::Local<v8::Object> CreateJSEvent(
   }
   mate::Dictionary(isolate, event).Set("sender", object);
   if (sender) {
-    mate::Dictionary(isolate, event).Set("senderWebContentsId", atom::api::WebContents::GetIDFromWebContents(sender));
+    mate::Dictionary(isolate, event).Set("senderWebContentsId",
+      atom::api::WebContents::GetIDFromWebContents(sender));
   } else {
     mate::Dictionary(isolate, event).Set("senderWebContentsId", 0);
   }

--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/api/event_emitter.h"
 
 #include "atom/browser/api/event.h"
@@ -9,6 +10,7 @@
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "ui/events/event_constants.h"
+#include "content/public/browser/web_contents.h"
 
 #include "atom/common/node_includes.h"
 
@@ -55,6 +57,11 @@ v8::Local<v8::Object> CreateJSEvent(
     event = CreateEventObject(isolate);
   }
   mate::Dictionary(isolate, event).Set("sender", object);
+  if (sender) {
+    mate::Dictionary(isolate, event).Set("senderWebContentsId", atom::api::WebContents::GetIDFromWebContents(sender));
+  } else {
+    mate::Dictionary(isolate, event).Set("senderWebContentsId", 0);
+  }
   return event;
 }
 

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -90,8 +90,14 @@ Set this to the value to be returned in a synchronous message.
 
 ### `event.sender`
 
-Returns the `webContents` that sent the message, you can call
+Returns the `ipcRenderer` that sent the message, you can call
 `event.sender.send` to reply to the asynchronous message, see
 [webContents.send][web-contents-send] for more information.
 
 [web-contents-send]: web-contents.md#webcontentssendchannel-arg1-arg2-
+
+### `event.senderWebContentsId`
+
+In the Main process only, returns the WebContents ID of the sender of
+the message, this can be compared to `webContents.id` to securely determine
+the sender of a message.

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -99,5 +99,5 @@ Returns the `ipcRenderer` that sent the message, you can call
 ### `event.senderWebContentsId`
 
 In the Main process only, returns the WebContents ID of the sender of
-the message, this can be compared to `webContents.id` to securely determine
+the message, this can be compared to `webContents.getId()` to securely determine
 the sender of a message.

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -324,7 +324,7 @@ describe('ipc module', function () {
     })
   })
 
-  describe('ipc.senderWebContentsId', function() {
+  describe('ipc.senderWebContentsId', function () {
     it('should reply with the sender web contents', function (done) {
       ipcRenderer.once('replyWithSender', function (event, message) {
         assert.equal(message, remote.getCurrentWindow().webContents.getId())

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -324,6 +324,17 @@ describe('ipc module', function () {
     })
   })
 
+  describe('ipc.senderWebContentsId', function() {
+    it('should reply with the sender web contents', function (done) {
+      ipcRenderer.once('replyWithSender', function (event, message) {
+        assert.equal(message, remote.getCurrentWindow().webContents.getId())
+        done()
+      })
+
+      ipcRenderer.send('replyWithSender')
+    })
+  })
+
   describe('ipc.sender.send', function () {
     it('should work when sending an object containing id property', function (done) {
       var obj = {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -40,6 +40,11 @@ ipcMain.on('message', function (event, ...args) {
   event.sender.send('message', ...args)
 })
 
+ipcMain.on('replyWithSender', function (event, ...args) {
+  event.sender.send('replyWithSender', event.senderWebContentsId)
+})
+
+
 // Set productName so getUploadedReports() uses the right directory in specs
 if (process.platform !== 'darwin') {
   crashReporter.productName = 'Zombies'

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -44,7 +44,6 @@ ipcMain.on('replyWithSender', function (event, ...args) {
   event.sender.send('replyWithSender', event.senderWebContentsId)
 })
 
-
 // Set productName so getUploadedReports() uses the right directory in specs
 if (process.platform !== 'darwin') {
   crashReporter.productName = 'Zombies'


### PR DESCRIPTION
This PR adds a new field to the `sender` parameter of the browser's IPC callout `senderWebContentsId`. This along with a corresponding PR to `electron-remote` will allow Electron applications to consider certain frames as "Trusted" vs "Untrusted" with regards to allowing access to remote objects - without this, the only way to determine the source of an IPC message is via the sender sending along its WebContents ID, which means that a potentially compromised sender could possibly impersonate a trusted frame simply by guessing IDs until it works.