### PR TITLE
Add initial ready-to-show event spec

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -118,6 +118,13 @@ describe('browser-window module', function () {
       w.loadURL('about:blank')
     })
 
+    it('should emit ready-to-show event', function (done) {
+      w.on('ready-to-show', function () {
+        done()
+      })
+      w.loadURL('about:blank')
+    })
+
     it('should emit did-get-response-details event', function (done) {
       // expected {fileName: resourceType} pairs
       var expectedResources = {


### PR DESCRIPTION
Looks like this event was previously untested so this pull request adds an initial spec to guard against regressions and to verify it fires as expected on all platforms.

Refs #7779