### PR TITLE
When hiding a window, exit fullscreen

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -309,7 +309,6 @@ bool ScopedDisableResize::disable_resize_ = false;
 @property BOOL acceptsFirstMouse;
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
-@property BOOL hideAfterFullscreenExit;
 @property NSPoint windowButtonsOffset;
 @property (nonatomic, retain) AtomPreviewItem* quickLookItem;
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -309,6 +309,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 @property BOOL acceptsFirstMouse;
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
+@property BOOL hideAfterFullscreenExit;
 @property NSPoint windowButtonsOffset;
 @property (nonatomic, retain) AtomPreviewItem* quickLookItem;
 
@@ -818,7 +819,22 @@ void NativeWindowMac::Hide() {
     return;
   }
 
-  SetFullScreen(false);
+  if (IsFullscreen()) {
+    __block __weak id fullcreenObserver;
+    fullcreenObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowDidExitFullScreenNotification
+        object:nil
+        queue:nil
+        usingBlock:^(NSNotification *note) {
+            [window_ orderOut:nil];
+            [[NSNotificationCenter defaultCenter] removeObserver:fullcreenObserver];
+        }
+    ];
+
+    SetFullScreen(false);
+    return;
+  }
+
   [window_ orderOut:nil];
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -812,6 +812,8 @@ void NativeWindowMac::ShowInactive() {
 }
 
 void NativeWindowMac::Hide() {
+  SetFullScreen(false);
+
   if (is_modal() && parent()) {
     [window_ orderOut:nil];
     [parent()->GetNativeWindow() endSheet:window_];

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -812,14 +812,13 @@ void NativeWindowMac::ShowInactive() {
 }
 
 void NativeWindowMac::Hide() {
-  SetFullScreen(false);
-
   if (is_modal() && parent()) {
     [window_ orderOut:nil];
     [parent()->GetNativeWindow() endSheet:window_];
     return;
   }
 
+  SetFullScreen(false);
   [window_ orderOut:nil];
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -223,6 +223,17 @@ describe('browser-window module', function () {
       assert(!w.isVisible())
     })
 
+    it('should defullscreen the window', function (done) {
+      this.timeout(10000)
+      w.setFullScreen(true)
+
+      w.once('enter-full-screen', () => w.hide())
+      w.once('hide', () => {
+        assert(!w.isFullScreen())
+        done()
+      })
+    })
+
     it('emits when window is hidden', function (done) {
       this.timeout(10000)
       w.show()


### PR DESCRIPTION
This tiny fix ensures that a fullscreen window on macOS can be hidden using `hide()` without the screen turning black.

Closes https://github.com/electron/electron/issues/6033