### PR TITLE
use new docs linter with support for the new net APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.11.0",
+    "electron-docs-linter": "^1.13.1",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
This brings in an updated linter that is aware of the new `net`, `ClientRequest`, and `IncomingMessage` APIs.

Once we've got [one doc per API](https://github.com/electron/electron/issues/6931), these manual updates to the linter will no longer be necessary.

@zcbenz it would be great to land this in 1.4.5 if possible.