### PR TITLE
document the process(es) in which APIs are available

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -2,6 +2,8 @@
 
 > Control your application's event lifecycle.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 The following example shows how to quit the application when the last window is
 closed:
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -2,6 +2,8 @@
 
 > Enable apps to automatically update themselves.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 The `autoUpdater` module provides an interface for the
 [Squirrel](https://github.com/Squirrel) framework.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -2,6 +2,8 @@
 
 > Create and control browser windows.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 ```javascript
 // In the main process.
 const {BrowserWindow} = require('electron')

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -2,6 +2,8 @@
 
 > Perform copy and paste operations on the system clipboard.
 
+Processes: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
 The following example shows how to write a string to the clipboard:
 
 ```javascript

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -2,7 +2,7 @@
 
 > Perform copy and paste operations on the system clipboard.
 
-Processes: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
 
 The following example shows how to write a string to the clipboard:
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -2,6 +2,8 @@
 
 > Submit crash reports to a remote server.
 
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
 The following is an example of automatically submitting a crash report to a
 remote server:
 

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -3,6 +3,8 @@
 > Access information about media sources that can be used to capture audio and
 > video from the desktop using the [`navigator.webkitGetUserMedia`] API.
 
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
 The following example shows how to capture video from a desktop window whose
 title is `Electron`:
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -2,6 +2,8 @@
 
 > Display native system dialogs for opening and saving files, alerting, etc.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 An example of showing a dialog to select multiple files and directories:
 
 ```javascript

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -2,6 +2,8 @@
 
 > Control file downloads from remote sources.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 `DownloadItem` is an `EventEmitter` that represents a download item in Electron.
 It is used in `will-download` event of `Session` class, and allows users to
 control the download item.
@@ -59,7 +61,7 @@ Returns:
 * `state` String
 
 Emitted when the download is in a terminal state. This includes a completed
-download, a cancelled download(via `downloadItem.cancel()`), and interrupted
+download, a cancelled download (via `downloadItem.cancel()`), and interrupted
 download that can't be resumed.
 
 The `state` can be one of following:

--- a/docs/api/file-object.md
+++ b/docs/api/file-object.md
@@ -7,7 +7,7 @@ let users work on native files directly with the HTML5 file API. Electron has
 added a `path` attribute to the `File` interface which exposes the file's real
 path on filesystem.
 
-Example on getting a real path from a dragged-onto-the-app file:
+Example of getting a real path from a dragged-onto-the-app file:
 
 ```html
 <div id="holder">

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -2,6 +2,8 @@
 
 > Detect keyboard events when the application does not have keyboard focus.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 The `globalShortcut` module can register/unregister a global keyboard shortcut
 with the operating system so that you can customize the operations for various
 shortcuts.

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -2,6 +2,8 @@
 
 > Communicate asynchronously from the main process to renderer processes.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 The `ipcMain` module is an instance of the
 [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. When used in the main
 process, it handles asynchronous and synchronous messages sent from a renderer

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -2,6 +2,8 @@
 
 > Communicate asynchronously from a renderer process to the main process.
 
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
 The `ipcRenderer` module is an instance of the
 [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. It provides a few
 methods so you can send synchronous and asynchronous messages from the render

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -2,6 +2,8 @@
 
 > Add items to native application menus and context menus.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 See [`Menu`](menu.md) for examples.
 
 ## Class: MenuItem

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -2,6 +2,8 @@
 
 > Create native application menus and context menus.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 Each `Menu` consists of multiple [`MenuItem`](menu-item.md)s and each `MenuItem`
 can have a submenu.
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -157,6 +157,8 @@ Creates a new `NativeImage` instance from `dataURL`.
 
 > Natively wrap images such as tray, dock, and application icons.
 
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
 ### Instance Methods
 
 The following methods are available on instances of the `NativeImage` class:

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -2,6 +2,8 @@
 
 > Create tray, dock, and application icons using PNG or JPG files.
 
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
 In Electron, for the APIs that take images, you can pass either file paths or
 `NativeImage` instances. An empty image will be used when `null` is passed.
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -2,6 +2,8 @@
 
 > Issue HTTP/HTTPS requests using Chromium's native networking library
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 The `net` module is a client-side API for issuing HTTP(S) requests. It is
 similar to the [HTTP](https://nodejs.org/api/http.html) and
 [HTTPS](https://nodejs.org/api/https.html) modules of Node.js but uses

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -74,6 +74,8 @@ specified protocol scheme in the `options` object.
 
 > Make HTTP/HTTPS requests.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 `ClientRequest` implements the [Writable Stream](https://nodejs.org/api/stream.html#stream_writable_streams)
 interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
 
@@ -265,6 +267,8 @@ response object,it will emit the `aborted` event.
 ## Class: IncomingMessage
 
 > Handle responses to HTTP/HTTPS requests.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
 
 `IncomingMessage` implements the [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams)
 interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -2,6 +2,8 @@
 
 > Monitor power state changes.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 You cannot require or use this module until the `ready` event of the `app`
 module is emitted.
 

--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -2,6 +2,8 @@
 
 > Block the system from entering low-power (sleep) mode.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 For example:
 
 ```javascript

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -2,6 +2,8 @@
 
 > Extensions to process object.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 The `process` object is extended in Electron with following APIs:
 
 ## Events

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -2,6 +2,8 @@
 
 > Register a custom protocol and intercept existing protocol requests.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 An example of implementing a protocol that has the same effect as the
 `file://` protocol:
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -2,6 +2,8 @@
 
 > Use main process modules from the renderer process.
 
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
 The `remote` module provides a simple way to do inter-process communication
 (IPC) between the renderer process (web page) and the main process.
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -2,8 +2,7 @@
 
 > Retrieve information about screen size, displays, cursor position, etc.
 
-Process: [Main](../tutorial/quick-start.md#main-process),
-[Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
 
 You cannot require or use this module until the `ready` event of the `app`
 module is emitted.

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -2,6 +2,9 @@
 
 > Retrieve information about screen size, displays, cursor position, etc.
 
+Process: [Main](../tutorial/quick-start.md#main-process),
+[Renderer](../tutorial/quick-start.md#renderer-process)
+
 You cannot require or use this module until the `ready` event of the `app`
 module is emitted.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -2,6 +2,8 @@
 
 > Manage browser sessions, cookies, cache, proxy settings, etc.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 The `session` module can be used to create new `Session` objects.
 
 You can also access the `session` of existing pages by using the `session`

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -54,6 +54,8 @@ A `Session` object, the default session object of the app.
 
 > Get and set properties of a session.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 You can create a `Session` object in the `session` module:
 
 ```javascript
@@ -377,6 +379,8 @@ app.on('ready', function () {
 
 > Query and modify a session's cookies.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 Instances of the `Cookies` class are accessed by using `cookies` property of
 a `Session`.
 
@@ -481,6 +485,8 @@ Removes the cookies matching `url` and `name`, `callback` will called with
 ## Class: WebRequest
 
 > Intercept and modify the contents of a request at various stages of its lifetime.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
 
 Instances of the `WebRequest` class are accessed by using the `webRequest`
 property of a `Session`.

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -2,6 +2,9 @@
 
 > Manage files and URLs using their default applications.
 
+Process: [Main](../tutorial/quick-start.md#main-process),
+[Renderer](../tutorial/quick-start.md#renderer-process)
+
 The `shell` module provides functions related to desktop integration.
 
 An example of opening a URL in the user's default browser:

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -2,8 +2,7 @@
 
 > Manage files and URLs using their default applications.
 
-Process: [Main](../tutorial/quick-start.md#main-process),
-[Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
 
 The `shell` module provides functions related to desktop integration.
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -2,6 +2,8 @@
 
 > Get system preferences.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 ```javascript
 const {systemPreferences} = require('electron')
 console.log(systemPreferences.isDarkMode())

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -2,6 +2,8 @@
 
 > Add icons and context menus to the system's notification area.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 ```javascript
 const {app, Menu, Tray} = require('electron')
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -49,6 +49,8 @@ Returns `WebContents` - A WebContents instance with the given ID.
 
 > Render and control the contents of a BrowserWindow instance.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 ### Instance Events
 
 #### Event: 'did-finish-load'
@@ -1173,6 +1175,8 @@ A Debugger instance for this webContents.
 ## Class: Debugger
 
 > An alternate transport for Chrome's remote debugging protocol.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
 
 Chrome Developer Tools has a [special binding][rdp] available at JavaScript
 runtime that allows interacting with pages and instrumenting them.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -2,6 +2,8 @@
 
 > Render and control web pages.
 
+Process: [Main](../tutorial/quick-start.md#main-process)
+
 `webContents` is an
 [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
 It is responsible for rendering and controlling a web page and is a property of

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -2,6 +2,8 @@
 
 > Customize the rendering of the current web page.
 
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
 An example of zooming current page to 200%.
 
 ```javascript

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -45,6 +45,8 @@ origin preference.
 
 > Manipulate the child browser window
 
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
 The `BrowserWindowProxy` object is returned from `window.open` and provides
 limited functionality with the child window.
 


### PR DESCRIPTION
The docs linter currently contains a [seeds file](https://github.com/electron/electron-docs-linter/blob/6acacf4a15363d6027825574132929ce86afb7ca/lib/seeds.js) that lists all APIs and some extra metadata for each. It looks like this:

```js
module.exports = [
  {
    name: 'clipboard',
    process: {main: true, renderer: true}
  },
  {
    name: 'crashReporter',
    process: {main: true, renderer: true}
  },
  {
    name: 'nativeImage',
    process: {main: true, renderer: true}
  },
  {
    name: 'NativeImage',
    process: {main: true, renderer: true},
    parentDoc: 'native-image',
    instanceName: 'image'
  }
 // etc
]
```

We eventually want to [get rid of this file](#6931) and enable the linter to infer everything it needs to know solely from the contents of `/docs/api`.

So... let's document the process(es) in which each API is available within the markdown docs themselves. I've staged a few files with what seems like a reasonable way to annotate this.

Before updating every doc, I want to get feedback on the idea and implementation. What do you think, @electron/maintainers?