### PR TITLE
Fix reload/destroy webview guestinstance issues

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -78,7 +78,15 @@ const createGuest = function (embedder, params) {
   guest.on('did-attach', function () {
     params = this.attachParams
     delete this.attachParams
+
+    const previouslyAttached = this.viewInstanceId != null
     this.viewInstanceId = params.instanceId
+
+    // Only load URL and set size on first attach
+    if (previouslyAttached) {
+      return
+    }
+
     this.setSize({
       normal: {
         width: params.elementWidth,

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -162,8 +162,12 @@ const attachGuest = function (embedder, elementInstanceId, guestInstanceId, para
   if (guestInstance.elementInstanceId) {
     const oldKey = `${guestInstance.embedder.getId()}-${guestInstance.elementInstanceId}`
     delete embedderElementsMap[oldKey]
-    webViewManager.removeGuest(guestInstance.embedder, guestInstanceId)
-    guestInstance.embedder.send(`ELECTRON_GUEST_VIEW_INTERNAL_DESTROY_GUEST-${guest.viewInstanceId}`)
+
+    // Remove guest from embedder if moving across web views
+    if (guest.viewInstanceId !== params.instanceId) {
+      webViewManager.removeGuest(guestInstance.embedder, guestInstanceId)
+      guestInstance.embedder.send(`ELECTRON_GUEST_VIEW_INTERNAL_DESTROY_GUEST-${guest.viewInstanceId}`)
+    }
   }
 
   const webPreferences = {

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -72,9 +72,12 @@ class WebViewImpl {
     }
 
     this.webContents = null
-    this.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE].setValueIgnoreMutation(undefined)
     this.beforeFirstNavigation = true
     this.attributes[webViewConstants.ATTRIBUTE_PARTITION].validPartitionId = true
+
+    // Set guestinstance last since this can trigger the attachedCallback to fire
+    // when moving the webview using element.replaceChild
+    this.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE].setValueIgnoreMutation(undefined)
   }
 
   // Sets the <webview>.request property.
@@ -310,8 +313,8 @@ var registerWebViewElement = function () {
     }
     guestViewInternal.deregisterEvents(internal.viewInstanceId)
     internal.elementAttached = false
-    internal.reset()
     this.internalInstanceId = 0
+    internal.reset()
   }
   proto.attachedCallback = function () {
     var internal, instance

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1272,6 +1272,25 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/pages/a.html'
       document.body.appendChild(webview)
     })
+
+    it('does not reload the webContents when hiding/showing the webview (regression)', function (done) {
+      webview.addEventListener('dom-ready', function domReadyListener () {
+        webview.addEventListener('did-start-loading', function () {
+          done(new Error('webview started loading unexpectedly'))
+        })
+
+        // Wait for event directly since attach happens asynchronously over IPC
+        webview.addEventListener('did-attach', function () {
+          done()
+        })
+
+        webview.style.display = 'none'
+        webview.offsetHeight
+        webview.style.display = 'block'
+      })
+      webview.src = 'file://' + fixtures + '/pages/a.html'
+      document.body.appendChild(webview)
+    })
   })
 
   describe('DOM events', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1253,6 +1253,25 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/api/blank.html'
       document.body.appendChild(webview)
     })
+
+    it('does not destroy the webContents when hiding/showing the webview (regression)', function (done) {
+      webview.addEventListener('dom-ready', function domReadyListener () {
+        const instance = webview.getAttribute('guestinstance')
+
+        // Wait for event directly since attach happens asynchronously over IPC
+        ipcMain.once('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function () {
+          assert(webview.getWebContents() != null)
+          assert.equal(instance, webview.getAttribute('guestinstance'))
+          done()
+        })
+
+        webview.style.display = 'none'
+        webview.offsetHeight
+        webview.style.display = 'block'
+      })
+      webview.src = 'file://' + fixtures + '/pages/a.html'
+      document.body.appendChild(webview)
+    })
   })
 
   describe('DOM events', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1254,9 +1254,27 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
+    it('does not delete the guestinstance attribute when moving the webview to another parent node', function (done) {
+      webview.addEventListener('dom-ready', function domReadyListener () {
+        webview.addEventListener('did-attach', function () {
+          assert(webview.guestinstance != null)
+          assert(webview.getWebContents() != null)
+          done()
+        })
+
+        document.body.replaceChild(webview, div)
+      })
+      webview.src = 'file://' + fixtures + '/pages/a.html'
+
+      const div = document.createElement('div')
+      div.appendChild(webview)
+      document.body.appendChild(div)
+    })
+
     it('does not destroy the webContents when hiding/showing the webview (regression)', function (done) {
       webview.addEventListener('dom-ready', function domReadyListener () {
         const instance = webview.getAttribute('guestinstance')
+        assert(instance != null)
 
         // Wait for event directly since attach happens asynchronously over IPC
         ipcMain.once('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function () {


### PR DESCRIPTION
This pull request seeks to address the issues found in #7700 regarding the `guestinstance` attribute disappearing when hiding/showing webviews. This attribute was added in #7157.

- [x] :bug: Only destroy guest when moving between views. Currently hiding and then showing a webview destroys it web contents because it isn't checking that the guest is actually moving across views.
- [x] :bug: Only load URL and set webview size on first attach event. #7700 switched the listener from a `.once` to a `.on` and so currently webviews are reloaded each time they are attached.
- [x] :bug: Guard against the `attachedCallback` firing while handling a `detachedCallback` event. This appears to happen when setting the `guestinstance` attribute and running `replaceChild` to move a webview node, uncovered by the golden layout example from #7700. 
- [x] Merge #7863 first and rebase this pull request on top of it

Fixes #7700