### PR TITLE
Fix the IPC docs so the docs-linter finds the methods

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -46,7 +46,7 @@ ipcRenderer.on('asynchronous-reply', (event, arg) => {
 ipcRenderer.send('asynchronous-message', 'ping')
 ```
 
-## Listening for Messages
+## Methods
 
 The `ipcMain` module has the following method to listen for events:
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -10,7 +10,7 @@ main process.
 
 See [ipcMain](ipc-main.md) for code examples.
 
-## Listening for Messages
+## Methods
 
 The `ipcRenderer` module has the following method to listen for events:
 


### PR DESCRIPTION
/cc @zeke 

Previously the IPC Main and IPC Renderer docs in the JSON output were empty (had no methods)