### PR TITLE
Fixing net doc formatting

### DIFF
--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -59,7 +59,7 @@ The `net` module has the following methods:
 
 ### `net.request(options)`
 
-* `options` (Object | String) - The `ClientRequest` constructor options.
+* `options` Object or String - The `ClientRequest` constructor options.
 
 Returns `ClientRequest`
 
@@ -77,7 +77,7 @@ interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#
 
 ### `new ClientRequest(options)`
 
-* `options` (Object | String) - If `options` is a String, it is interpreted as
+* `options` Object or String - If `options` is a String, it is interpreted as
   the request URL. If it is an object, it is expected to fully specify an HTTP
   request via the following properties:
   * `method` String (optional) - The HTTP request method. Defaults to the GET
@@ -228,7 +228,7 @@ before first write. Trying to call it after the first write will throw an error.
 
 #### `request.write(chunk[, encoding][, callback])`
 
-* `chunk` (String | Buffer) - A chunk of the request body's data. If it is a
+* `chunk` String or Buffer - A chunk of the request body's data. If it is a
   string, it is converted into a Buffer using the specified encoding.
 * `encoding` String (optional) - Used to convert string chunks into Buffer
   objects. Defaults to 'utf-8'.
@@ -246,7 +246,7 @@ it is not allowed to add or remove a custom header.
 
 #### `request.end([chunk][, encoding][, callback])`
 
-* `chunk` (String | Buffer) (optional)
+* `chunk` String or Buffer (optional)
 * `encoding` String (optional)
 * `callback` Function (optional)
 


### PR DESCRIPTION
A very long space is inserted between union type if I use for instance (String | Object).