### PR TITLE
ask for more info in the issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,8 @@
 Thanks for opening an issue! A few things to keep in mind:
 
 - The issue tracker is only for bugs and feature requests.
-- Please update to the latest version of Electron before reporting a bug.
+- Before reporting a bug, please try reproducing your issue against
+  the latest version of Electron.
 - If you need general advice, join our Slack: http://atom-slack.herokuapp.com
 -->
 
@@ -11,11 +12,11 @@ Thanks for opening an issue! A few things to keep in mind:
 
 ### Expected behavior
 
-<!-- what do you think should happen? -->
+<!-- What do you think should happen? -->
 
 ### Actual behavior
 
-<!-- what actually happens? -->
+<!-- What actually happens? -->
 
 ### How to reproduce
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,11 @@
+<!--
+Thanks for opening an issue! A few things to keep in mind:
+
+- The issue tracker is only for bugs and feature requests.
+- Please update to the latest version of Electron before reporting a bug.
+- If you need general advice, join our Slack: http://atom-slack.herokuapp.com
+-->
+
 * Electron version:
 * Operating system:
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,2 +1,14 @@
 * Electron version:
 * Operating system:
+
+### Expected behavior
+
+<!-- what do you think should happen? -->
+
+### Actual behavior
+
+<!-- what actually happens? -->
+
+### How to reproduce
+
+<!-- For bugs, provide sample code or a repo URL that demos the problem -->


### PR DESCRIPTION
I've been noticing that a lot of popular open source projects have pretty extensive issue templates:

- https://github.com/nodejs/node/issues/new
- https://github.com/yarnpkg/yarn/issues/new
- https://github.com/facebook/react/issues/new

This PR is intended to get the conversation started around how we can improve Electron's issue template. A few things that others are doing that we might consider:

- :bulb: Mention that the issue tracker is only for bugs and feature requests
- :bulb: Encourage users to update to the latest version before reporting the issue.
- :bulb: Include info about where to seek guidance for Electron development in general
