### PR TITLE
Only run browserify when sandbox files change

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -436,10 +436,6 @@
           'action_name': 'atom_browserify',
           'inputs': [
             '<@(browserify_entries)',
-            # Any js file under `lib/` can be included in the preload bundle.
-            # Add all js sources as dependencies so any change to a js file will
-            # trigger a rebuild of the bundle(and consequently of js2c).
-            '<@(js_sources)',
           ],
           'outputs': [
             '<(js2c_input_dir)/preload_bundle.js',
@@ -449,7 +445,7 @@
             'run',
             'browserify',
             '--',
-            '<@(browserify_entries)',
+            'lib/sandboxed_renderer/init.js',
             '-o',
             '<@(_outputs)',
           ],

--- a/electron.gyp
+++ b/electron.gyp
@@ -443,6 +443,7 @@
           'action': [
             'npm',
             'run',
+            '--silent',
             'browserify',
             '--',
             'lib/sandboxed_renderer/init.js',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -73,6 +73,7 @@
       'lib/renderer/extensions/web-navigation.js',
     ],
     'browserify_entries': [
+      'lib/renderer/api/ipc-renderer-setup.js',
       'lib/sandboxed_renderer/init.js',
     ],
     'js2c_sources': [

--- a/lib/renderer/api/ipc-renderer-setup.js
+++ b/lib/renderer/api/ipc-renderer-setup.js
@@ -1,3 +1,6 @@
+// Any requires added here need to be added to the browserify_entries array
+// in filenames.gypi so they get built into the preload_bundle.js bundle
+
 module.exports = function (ipcRenderer, binding) {
   ipcRenderer.send = function (...args) {
     return binding.send('ipc-message', args)

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -1,3 +1,6 @@
+// Any requires added here need to be added to the browserify_entries array
+// in filenames.gypi so they get built into the preload_bundle.js bundle
+
 /* eslint no-eval: "off" */
 /* global binding, preloadPath, process, Buffer */
 const events = require('events')


### PR DESCRIPTION
Currently the build is re-generating the `preload_bundle.js` file whenever any file in `lib/*.js` changes. This makes any JavaScript change there take roughly 10-15 seconds to build since the `browserify` target triggers the `js2c` target which triggers a repack of the app since `atom_native.h` is regenerated.

This pull request switches the browserify task to only run when `lib/renderer/api/ipc-renderer-setup.js` or `lib/sandboxed_renderer/init.js` change since these are the only two files currently used in the bundle.

This will require any additional requires to `lib/*.js` files added to either of those two files to be added to `filenames.gypi` but this seems like something that will very infrequently happen and should lead to spec failures when files are missing from the preload bundle.

### Timings

Running `npm run build`  after changing a single line in a `lib/*.js` file:

#### Before

```sh
real	0m10.277s
user	0m9.554s
sys	0m1.912s
```

#### After

```sh
real	0m1.945s
user	0m1.230s
sys	0m0.658s
```

/cc @tarruda 