### PR TITLE
Update dist url to be electron instead of atom-shell

### DIFF
--- a/docs-translations/es/tutorial/using-native-node-modules.md
+++ b/docs-translations/es/tutorial/using-native-node-modules.md
@@ -1,7 +1,7 @@
 # Utilizando módulos Node nativos
 
 Los módulos Node nativos son soportados por Electron, pero dado que Electron
-está utilizando una versión distinta de V8, debes especificar manualmente la 
+está utilizando una versión distinta de V8, debes especificar manualmente la
 ubicación de las cabeceras de Electron a la hora de compilar módulos nativos.
 
 ## Compatibilidad de módulos nativos
@@ -19,8 +19,8 @@ En el caso de los módulos antiguos que sólo soportan Node v0.10.x, debes usar 
 
 ### La forma fácil
 
-La forma más sencilla de recompilar módulos nativos es a través del paquete 
-[`electron-rebuild`](https://github.com/paulcbetts/electron-rebuild), 
+La forma más sencilla de recompilar módulos nativos es a través del paquete
+[`electron-rebuild`](https://github.com/paulcbetts/electron-rebuild),
 el cual abstrae y maneja los pasos de descargar las cabeceras y compilar los módulos nativos:
 
 ```sh
@@ -37,7 +37,7 @@ desde dónde descargar las cabeceras y cuál versión usar:
 
 ```bash
 $ cd /path-to-module/
-$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell
+$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/electron
 ```
 
 Los cambios en `HOME=~/.electron-gyp` fueron para especificar la ruta de las cabeceras.
@@ -50,7 +50,7 @@ También puedes usar `npm` para instalar módulos, los pasos son exactamente igu
 con la excepción de que necesitas establecer algunas variables de entorno primero:
 
 ```bash
-export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_disturl=https://atom.io/download/electron
 export npm_config_target=0.29.1
 export npm_config_arch=x64
 HOME=~/.electron-gyp npm install module-name

--- a/docs-translations/jp/tutorial/debugging-main-process.md
+++ b/docs-translations/jp/tutorial/debugging-main-process.md
@@ -35,8 +35,8 @@ $ npm install git+https://git@github.com/enlight/node-pre-gyp.git#detect-electro
 ### 4. Electron用の `node-inspector` `v8` モジュールをリコンパイルする(対象のElectronのバージョン番号を変更する)
 
 ```bash
-$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/atom-shell reinstall
-$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/atom-shell reinstall
+$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/electron reinstall
+$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/electron reinstall
 ```
 
 [How to install native modules](how-to-install-native-modules)を見る。

--- a/docs-translations/jp/tutorial/using-native-node-modules.md
+++ b/docs-translations/jp/tutorial/using-native-node-modules.md
@@ -31,7 +31,7 @@ npm install --save-dev electron-rebuild
 モジュールをインストールするために`npm` を使用できます。環境変数の設定を除いて、Nodeモジュールと完全に同じ手順です。
 
 ```bash
-export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_disturl=https://atom.io/download/electron
 export npm_config_target=0.33.1
 export npm_config_arch=x64
 export npm_config_runtime=electron
@@ -44,7 +44,7 @@ ElectronのヘッダーでNodeモジュールをビルドするために、ど�
 
 ```bash
 $ cd /path-to-module/
-$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell
+$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/electron
 ```
 
 開発ヘッダーを探し、 `HOME=~/.electron-gyp` を変更します。`--target=0.29.1`がElectronのバージョンです。 `--dist-url=...` で、どこからヘッダーをダウンロードするかを指定します。`--arch=x64`を使用して、64bit システム用にモジュールをビルドします。

--- a/docs-translations/ko-KR/tutorial/debugging-main-process-node-inspector.md
+++ b/docs-translations/ko-KR/tutorial/debugging-main-process-node-inspector.md
@@ -88,8 +88,8 @@ $ npm install node-pre-gyp
 **참고:** 사용하는 Electron의 버전에 맞춰 target 인수를 변경하세요.
 
 ```bash
-$ node_modules/.bin/node-pre-gyp --target=1.2.5 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/atom-shell reinstall
-$ node_modules/.bin/node-pre-gyp --target=1.2.5 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/atom-shell reinstall
+$ node_modules/.bin/node-pre-gyp --target=1.2.5 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/electron reinstall
+$ node_modules/.bin/node-pre-gyp --target=1.2.5 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/electron reinstall
 ```
 
 또한 [네이티브 모듈 설치 방법][how-to-install-native-modules] 문서도 참고해보세요.

--- a/docs-translations/ko-KR/tutorial/using-native-node-modules.md
+++ b/docs-translations/ko-KR/tutorial/using-native-node-modules.md
@@ -22,7 +22,7 @@ export npm_config_target=1.2.3
 export npm_config_arch=x64
 export npm_config_target_arch=x64
 # Electron에 대한 헤더 다운로드 링크.
-export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_disturl=https://atom.io/download/electron
 # node-pre-gyp에 Electron을 빌드한다는 것을 알려줍니다.
 export npm_config_runtime=electron
 # node-pre-gyp에 소스 코드로부터 모듈을 빌드한다는 것을 알려줍니다.
@@ -60,7 +60,7 @@ npm install --save-dev electron-rebuild
 
 ```bash
 cd /path-to-module/
-HOME=~/.electron-gyp node-gyp rebuild --target=1.2.3 --arch=x64 --dist-url=https://atom.io/download/atom-shell
+HOME=~/.electron-gyp node-gyp rebuild --target=1.2.3 --arch=x64 --dist-url=https://atom.io/download/electron
 ```
 
 `HOME=~/.electron-gyp`은 변경할 헤더의 위치를 찾습니다. `--target=0.29.1`은

--- a/docs-translations/pt-BR/tutorial/using-native-node-modules.md
+++ b/docs-translations/pt-BR/tutorial/using-native-node-modules.md
@@ -46,7 +46,7 @@ os mesmos com os módulos Node, exceto que você precisa configurar algumas
 variáveis da ambiente:
 
 ```bash
-export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_disturl=https://atom.io/download/electron
 export npm_config_target=0.33.1
 export npm_config_arch=x64
 export npm_config_runtime=electron
@@ -60,7 +60,7 @@ ao `node-gyp` onde baixar as headers e qual versão usar:
 
 ```bash
 $ cd /path-to-module/
-$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell
+$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/electron
 ```
 
 A tag `HOME=~/.electron-gyp` altera onde encontrar as headers de desenvolvimento.

--- a/docs-translations/zh-CN/tutorial/debugging-main-process.md
+++ b/docs-translations/zh-CN/tutorial/debugging-main-process.md
@@ -38,8 +38,8 @@ $ npm install git+https://git@github.com/enlight/node-pre-gyp.git#detect-electro
 ### 4. 为 Electron 重新编译 `node-inspector` `v8` 模块（将 target 参数修改为你的 Electron 的版本号）
 
 ```bash
-$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/atom-shell reinstall
-$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/atom-shell reinstall
+$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/electron reinstall
+$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/electron reinstall
 ```
 
 [How to install native modules][how-to-install-native-modules].

--- a/docs-translations/zh-CN/tutorial/using-native-node-modules.md
+++ b/docs-translations/zh-CN/tutorial/using-native-node-modules.md
@@ -31,7 +31,7 @@ npm install --save-dev electron-rebuild
 你当然也可以通过 `npm` 安装原生模块。大部分步骤和安装普通模块时一样，除了以下一些系统环境变量你需要自己操作：
 
 ```bash
-export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_disturl=https://atom.io/download/electron
 export npm_config_target=0.33.1
 export npm_config_arch=x64
 export npm_config_runtime=electron
@@ -44,7 +44,7 @@ HOME=~/.electron-gyp npm install module-name
 
 ```bash
 $ cd /path-to-module/
-$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell
+$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/electron
 ```
 
 `HOME=~/.electron-gyp` 设置去哪找开发时的 headers。

--- a/docs-translations/zh-TW/tutorial/debugging-main-process.md
+++ b/docs-translations/zh-TW/tutorial/debugging-main-process.md
@@ -35,8 +35,8 @@ $ npm install git+https://git@github.com/enlight/node-pre-gyp.git#detect-electro
 ### 4. 除心編譯 `node-inspector` `v8` 模組給 Electron (變更 target 為你的 Electron 編號)
 
 ```bash
-$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/atom-shell reinstall
-$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/atom-shell reinstall
+$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/electron reinstall
+$ node_modules/.bin/node-pre-gyp --target=0.36.2 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/electron reinstall
 ```
 
 參閱 [如何安裝原生模組](how-to-install-native-modules).

--- a/docs-translations/zh-TW/tutorial/using-native-node-modules.md
+++ b/docs-translations/zh-TW/tutorial/using-native-node-modules.md
@@ -31,7 +31,7 @@ npm install --save-dev electron-rebuild
 你也可以使用 `npm` 安裝模組，步驟與 Node 模組的安裝相同，除了你需要設定一些環境變數：
 
 ```bash
-export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_disturl=https://atom.io/download/electron
 export npm_config_target=0.33.1
 export npm_config_arch=x64
 export npm_config_runtime=electron
@@ -44,7 +44,7 @@ HOME=~/.electron-gyp npm install module-name
 
 ```bash
 $ cd /path-to-module/
-$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell
+$ HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/electron
 ```
 
 `HOME=~/.electron-gyp` 改變了尋找開發標頭的地方，`--target=0.29.1` 是 Eletron 的版本， `--dist-url=...` 指定了下載標頭到哪， `--arch=x64` 指出模組要建置在 64 位元系統。

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -85,3 +85,12 @@ webContents.openDevTools({detach: true})
 // Replace with
 webContents.openDevTools({mode: 'detach'})
 ```
+
+## Node Headers URL
+
+This is the URL specified as `disturl` in a `.npmrc` file or as the `--dist-url`
+command line flag when building native Node modules.
+
+Deprecated: https://atom.io/download/atom-shell
+
+Replace with: https://atom.io/download/electron

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -23,7 +23,7 @@ export npm_config_target=1.2.3
 export npm_config_arch=x64
 export npm_config_target_arch=x64
 # Download headers for Electron.
-export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_disturl=https://atom.io/download/electron
 # Tell node-pre-gyp that we are building for Electron.
 export npm_config_runtime=electron
 # Tell node-pre-gyp to build module from source code.
@@ -59,7 +59,7 @@ use `node-gyp` directly to build for Electron:
 
 ```bash
 cd /path-to-module/
-HOME=~/.electron-gyp node-gyp rebuild --target=1.2.3 --arch=x64 --dist-url=https://atom.io/download/atom-shell
+HOME=~/.electron-gyp node-gyp rebuild --target=1.2.3 --arch=x64 --dist-url=https://atom.io/download/electron
 ```
 
 The `HOME=~/.electron-gyp` changes where to find development headers. The

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -186,7 +186,7 @@ def update_electron_modules(dirname, target_arch):
   env = os.environ.copy()
   env['npm_config_arch']    = target_arch
   env['npm_config_target']  = get_electron_version()
-  env['npm_config_disturl'] = 'https://atom.io/download/atom-shell'
+  env['npm_config_disturl'] = 'https://atom.io/download/electron'
   update_node_modules(dirname, env)
 
 

--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -9,7 +9,7 @@ from lib.config import s3_config
 from lib.util import download, rm_rf, s3put
 
 
-DIST_URL = 'https://atom.io/download/atom-shell/'
+DIST_URL = 'https://atom.io/download/electron/'
 
 
 def main():

--- a/tools/dump-version-info.js
+++ b/tools/dump-version-info.js
@@ -2,7 +2,7 @@ var app = require('electron').app
 var fs = require('fs')
 var request = require('request')
 
-var TARGET_URL = 'https://atom.io/download/atom-shell/index.json'
+var TARGET_URL = 'https://atom.io/download/electron/index.json'
 
 function getDate () {
   var today = new Date()


### PR DESCRIPTION
Renames the distribution URL used for downloading the v8 headers from `https://atom.io/download/atom-shell` to `https://atom.io/download/electron`.

Both URLs will be supported going forward but the old one may possibly be removed in Electron 2.0.