### PR TITLE
Update Windows symbols server URL

### DIFF
--- a/docs-translations/ko-KR/development/setting-up-symbol-server.md
+++ b/docs-translations/ko-KR/development/setting-up-symbol-server.md
@@ -13,7 +13,7 @@
 있습니다. 유일한 해결 방법은 최적화되지 않은 로컬 빌드를 하는 것입니다.
 
 공식적인 Electron의 심볼 서버의 URL은
-http://54.249.141.255:8086/atom-shell/symbols 입니다. 일단 이 URL에 직접적으로
+https://electron-symbols.githubapp.com 입니다. 일단 이 URL에 직접적으로
 접근할 수는 없습니다: 디버깅 툴에 심볼의 경로를 추가해야 합니다. 아래의 예시를 참고하면
 로컬 캐시 디렉터리는 서버로부터 중복되지 않게 PDB를 가져오는데 사용됩니다.
 `c:\code\symbols` 캐시 디렉터리를 사용중인 OS에 맞춰 적당한 경로로 변경하세요.
@@ -25,7 +25,7 @@ Windbg 심볼 경로는 구분자와 `*` 문자로 설정되어 있습니다. El
 디렉터리 경로를 PC가 원하는 경로로 수정할 수 있습니다):
 
 ```
-SRV*c:\code\symbols\*http://54.249.141.255:8086/atom-shell/symbols
+SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
 ```
 
 Windbg 메뉴 또는 `.sympath` 커맨드를 이용하여 환경에 `_NT_SYMBOL_PATH` 문자열을
@@ -33,7 +33,7 @@ Windbg 메뉴 또는 `.sympath` 커맨드를 이용하여 환경에 `_NT_SYMBOL_
 먼저해야 합니다:
 
 ```
-SRV*c:\code\symbols\*http://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*http://54.249.141.255:8086/atom-shell/symbols
+SRV*c:\code\symbols\*http://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
 ```
 
 ## Visual Studio에서 심볼 서버 사용하기

--- a/docs-translations/zh-CN/development/setting-up-symbol-server.md
+++ b/docs-translations/zh-CN/development/setting-up-symbol-server.md
@@ -5,8 +5,8 @@
 
 注意，因为公众版本的 Electron 构建是最优化的，调试不一定一直简单.调试器将不会给显示出所有变量内容，并且因为内联，尾调用，和其它编译器优化，执行路径会看起来很怪异 . 唯一的解决办法是搭建一个不优化的本地构建.
 
-Electron 使用的官方 symbol 服务器地址为 
-`http://54.249.141.255:8086/atom-shell/symbols` .
+Electron 使用的官方 symbol 服务器地址为
+`https://electron-symbols.githubapp.com` .
 你不能直接访问这个路径，必须将其添加到你的调试工具的 symbol 路径上.在下面的例子中，使用了一个本地缓存目录来避免重复从服务器获取 PDB.  在你的电脑上使用一个恰当的缓存目录来代替 `c:\code\symbols` .
 
 ## Using the Symbol Server in Windbg
@@ -14,13 +14,13 @@ Electron 使用的官方 symbol 服务器地址为
 Windbg symbol 路径被配制为一个限制带星号字符的字符串. 要只使用  Electron 的 symbol 服务器, 将下列记录添加到你的 symbol 路径 (__注意:__ 如果你愿意使用一个不同的地点来下载 symbols，你可以在你的电脑中使用任何可写的目录来代替 `c:\code\symbols`):
 
 ```
-SRV*c:\code\symbols\*http://54.249.141.255:8086/atom-shell/symbols
+SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
 ```
 
 使用 Windbg 菜单或通过输入 `.sympath` 命令，在环境中设置一个 `_NT_SYMBOL_PATH` 字符串.如果你也想从微软的 symbol 服务器获得 symbols ，你应当首先将它们先列出来 :
 
 ```
-SRV*c:\code\symbols\*http://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*http://54.249.141.255:8086/atom-shell/symbols
+SRV*c:\code\symbols\*http://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
 ```
 
 ## 在 Visual Studio 中使用 symbol 服务器

--- a/docs/development/setting-up-symbol-server.md
+++ b/docs/development/setting-up-symbol-server.md
@@ -15,7 +15,7 @@ calls, and other compiler optimizations. The only workaround is to build an
 unoptimized local build.
 
 The official symbol server URL for Electron is
-http://54.249.141.255:8086/atom-shell/symbols.
+https://electron-symbols.githubapp.com.
 You cannot visit this URL directly, you must add it to the symbol path of your
 debugging tool. In the examples below, a local cache directory is used to avoid
 repeatedly fetching the PDB from the server. Replace `c:\code\symbols` with an
@@ -30,7 +30,7 @@ directory on your computer, if you'd prefer a different location for downloaded
 symbols):
 
 ```
-SRV*c:\code\symbols\*http://54.249.141.255:8086/atom-shell/symbols
+SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
 ```
 
 Set this string as `_NT_SYMBOL_PATH` in the environment, using the Windbg menus,
@@ -38,7 +38,7 @@ or by typing the `.sympath` command. If you would like to get symbols from
 Microsoft's symbol server as well, you should list that first:
 
 ```
-SRV*c:\code\symbols\*http://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*http://54.249.141.255:8086/atom-shell/symbols
+SRV*c:\code\symbols\*http://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
 ```
 
 ## Using the symbol server in Visual Studio


### PR DESCRIPTION
`https://electron-symbols.githubapp.com` is the new home of the symbols server.

Updated the docs with this new URL.