### PR TITLE
Adds vibrancy effect for macos

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -786,16 +786,11 @@ bool Window::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();
 }
 
-void Window::SetVibrancy(v8::Local<v8::Value> value, mate::Arguments* args) {
+void Window::SetVibrancy(mate::Arguments* args) {
   std::string type;
 
-  if (value->IsNull()) {
-    window_->SetVibrancy(std::string());
-  } else if (mate::ConvertFromV8(isolate(), value, &type)) {
-    window_->SetVibrancy(type);
-  } else {
-    args->ThrowError("Must pass a string or null");
-  }
+  args->GetNext(&type);
+  window_->SetVibrancy(type);
 }
 
 int32_t Window::ID() const {

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -786,6 +786,14 @@ bool Window::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();
 }
 
+void Window::SetVibrancy(const std::string& type) {
+  window_->SetVibrancy(type);
+}
+
+void Window::RemoveVibrancy() {
+  window_->RemoveVibrancy();
+}
+
 int32_t Window::ID() const {
   return weak_map_id();
 }
@@ -901,6 +909,8 @@ void Window::BuildPrototype(v8::Isolate* isolate,
                  &Window::SetVisibleOnAllWorkspaces)
       .SetMethod("isVisibleOnAllWorkspaces",
                  &Window::IsVisibleOnAllWorkspaces)
+      .SetMethod("setVibrancy", &Window::SetVibrancy)
+      .SetMethod("removeVibrancy", &Window::RemoveVibrancy)
 #if defined(OS_WIN)
       .SetMethod("hookWindowMessage", &Window::HookWindowMessage)
       .SetMethod("isWindowMessageHooked", &Window::IsWindowMessageHooked)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -786,12 +786,16 @@ bool Window::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();
 }
 
-void Window::SetVibrancy(const std::string& type) {
-  window_->SetVibrancy(type);
-}
+void Window::SetVibrancy(v8::Local<v8::Value> value, mate::Arguments* args) {
+  std::string type;
 
-void Window::RemoveVibrancy() {
-  window_->RemoveVibrancy();
+  if (value->IsNull()) {
+    window_->SetVibrancy(std::string());
+  } else if (mate::ConvertFromV8(isolate(), value, &type)) {
+    window_->SetVibrancy(type);
+  } else {
+    args->ThrowError("Must pass a string or null");
+  }
 }
 
 int32_t Window::ID() const {
@@ -910,7 +914,6 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isVisibleOnAllWorkspaces",
                  &Window::IsVisibleOnAllWorkspaces)
       .SetMethod("setVibrancy", &Window::SetVibrancy)
-      .SetMethod("removeVibrancy", &Window::RemoveVibrancy)
 #if defined(OS_WIN)
       .SetMethod("hookWindowMessage", &Window::HookWindowMessage)
       .SetMethod("isWindowMessageHooked", &Window::IsWindowMessageHooked)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -196,8 +196,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetVisibleOnAllWorkspaces(bool visible);
   bool IsVisibleOnAllWorkspaces();
 
-  void SetVibrancy(const std::string& type);
-  void RemoveVibrancy();
+  void SetVibrancy(v8::Local<v8::Value> value, mate::Arguments* args);
 
   int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -196,6 +196,9 @@ class Window : public mate::TrackableObject<Window>,
   void SetVisibleOnAllWorkspaces(bool visible);
   bool IsVisibleOnAllWorkspaces();
 
+  void SetVibrancy(const std::string& type);
+  void RemoveVibrancy();
+
   int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);
 

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -196,7 +196,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetVisibleOnAllWorkspaces(bool visible);
   bool IsVisibleOnAllWorkspaces();
 
-  void SetVibrancy(v8::Local<v8::Value> value, mate::Arguments* args);
+  void SetVibrancy(mate::Arguments* args);
 
   int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -340,6 +340,9 @@ void NativeWindow::SetParentWindow(NativeWindow* parent) {
   parent_ = parent;
 }
 
+void NativeWindow::SetVibrancy(const std::string& filename) {
+}
+
 void NativeWindow::FocusOnWebView() {
   web_contents()->GetRenderViewHost()->GetWidget()->Focus();
 }

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -201,13 +201,6 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   options.Get(options::kShow, &show);
   if (show)
     Show();
-
-#if defined(OS_MACOSX)
-  std::string type;
-  if (options.Get(options::kVibrancyType, &type)) {
-    SetVibrancy(type);
-  }
-#endif
 }
 
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -201,6 +201,13 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   options.Get(options::kShow, &show);
   if (show)
     Show();
+
+#if defined(OS_MACOSX)
+  std::string type;
+  if (options.Get(options::kVibrancyType, &type)) {
+    SetVibrancy(type);
+  }
+#endif
 }
 
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -161,6 +161,10 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetVisibleOnAllWorkspaces(bool visible) = 0;
   virtual bool IsVisibleOnAllWorkspaces() = 0;
 
+  // Vibrancy API
+  virtual void SetVibrancy(const std::string& type) = 0;
+  virtual void RemoveVibrancy() = 0;
+
   // Webview APIs.
   virtual void FocusOnWebView();
   virtual void BlurWebView();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -162,8 +162,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsVisibleOnAllWorkspaces() = 0;
 
   // Vibrancy API
-  virtual void SetVibrancy(const std::string& type) = 0;
-  virtual void RemoveVibrancy() = 0;
+  virtual void SetVibrancy(const std::string& type);
 
   // Webview APIs.
   virtual void FocusOnWebView();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -92,6 +92,8 @@ class NativeWindowMac : public NativeWindow,
                       const std::string& description) override;
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
+  void SetVibrancy(const std::string& type) override;
+  void RemoveVibrancy() override;
 
   // content::RenderWidgetHost::InputEventObserver:
   void OnInputEvent(const blink::WebInputEvent& event) override;
@@ -161,6 +163,9 @@ class NativeWindowMac : public NativeWindow,
 
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_;
+
+  // Vibrancy view
+  NSView* vibrant_view_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -93,7 +93,6 @@ class NativeWindowMac : public NativeWindow,
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
   void SetVibrancy(const std::string& type) override;
-  void RemoveVibrancy() override;
 
   // content::RenderWidgetHost::InputEventObserver:
   void OnInputEvent(const blink::WebInputEvent& event) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -163,9 +163,6 @@ class NativeWindowMac : public NativeWindow,
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_;
 
-  // Vibrancy view
-  NSView* vibrant_view_;
-
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1208,18 +1208,27 @@ bool NativeWindowMac::IsVisibleOnAllWorkspaces() {
 void NativeWindowMac::SetVibrancy(const std::string& type) {
   if (!(base::mac::IsOSMavericks() || base::mac::IsOSYosemiteOrLater())) return;
 
-  NSVisualEffectView *vview = (NSVisualEffectView *)vibrant_view_;
-  if (vview == nil) {
-    vview = [[NSVisualEffectView alloc] initWithFrame:
-      [[window_ contentView] bounds]];
-    vibrant_view_ = (NSView *)vview;
+  if (type.empty()) {
+    if (vibrant_view_ == nil) return;
 
-    [vview setAutoresizingMask:
+    [vibrant_view_ removeFromSuperview];
+    vibrant_view_ = nil;
+
+    return;
+  }
+
+  NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view_;
+  if (effect_view == nil) {
+    effect_view = [[NSVisualEffectView alloc] initWithFrame:
+      [[window_ contentView] bounds]];
+    vibrant_view_ = (NSView*)effect_view;
+
+    [effect_view setAutoresizingMask:
       NSViewWidthSizable | NSViewHeightSizable];
 
-    [vview setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
-    [vview setState:NSVisualEffectStateActive];
-    [[window_ contentView] addSubview:vview
+    [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
+    [effect_view setState:NSVisualEffectStateActive];
+    [[window_ contentView] addSubview:effect_view
                            positioned:NSWindowBelow
                            relativeTo:nil];
   }
@@ -1252,14 +1261,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     }
   }
 
-  [vview setMaterial:vibrancyType];
-}
-
-void NativeWindowMac::RemoveVibrancy() {
-  if (vibrant_view_ == nil) return;
-
-  [vibrant_view_ removeFromSuperview];
-  vibrant_view_ = nil;
+  [effect_view setMaterial:vibrancyType];
 }
 
 void NativeWindowMac::OnInputEvent(const blink::WebInputEvent& event) {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1205,6 +1205,63 @@ bool NativeWindowMac::IsVisibleOnAllWorkspaces() {
   return collectionBehavior & NSWindowCollectionBehaviorCanJoinAllSpaces;
 }
 
+void NativeWindowMac::SetVibrancy(const std::string& type) {
+  if (!(base::mac::IsOSMavericks() || base::mac::IsOSYosemiteOrLater())) return;
+
+  NSVisualEffectView *vview = (NSVisualEffectView *)vibrant_view_;
+  if (vview == nil) {
+    vview = [[NSVisualEffectView alloc] initWithFrame:
+      [[window_ contentView] bounds]];
+    vibrant_view_ = (NSView *)vview;
+
+    [vview setAutoresizingMask:
+      NSViewWidthSizable | NSViewHeightSizable];
+
+    [vview setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
+    [vview setState:NSVisualEffectStateActive];
+    [[window_ contentView] addSubview:vview
+                           positioned:NSWindowBelow
+                           relativeTo:nil];
+  }
+
+  NSVisualEffectMaterial vibrancyType = NSVisualEffectMaterialLight;
+
+  if (type == "appearance-based") {
+    vibrancyType = NSVisualEffectMaterialAppearanceBased;
+  } else if (type == "light") {
+    vibrancyType = NSVisualEffectMaterialLight;
+  } else if (type == "dark") {
+    vibrancyType = NSVisualEffectMaterialDark;
+  } else if (type == "titlebar") {
+    vibrancyType = NSVisualEffectMaterialTitlebar;
+  }
+
+  if (base::mac::IsOSYosemiteOrLater()) {
+    if (type == "selection") {
+      vibrancyType = NSVisualEffectMaterialSelection;
+    } else if (type == "menu") {
+      vibrancyType = NSVisualEffectMaterialMenu;
+    } else if (type == "popover") {
+      vibrancyType = NSVisualEffectMaterialPopover;
+    } else if (type == "sidebar") {
+      vibrancyType = NSVisualEffectMaterialSidebar;
+    } else if (type == "medium-light") {
+      vibrancyType = NSVisualEffectMaterialMediumLight;
+    } else if (type == "ultra-dark") {
+      vibrancyType = NSVisualEffectMaterialUltraDark;
+    }
+  }
+
+  [vview setMaterial:vibrancyType];
+}
+
+void NativeWindowMac::RemoveVibrancy() {
+  if (vibrant_view_ == nil) return;
+
+  [vibrant_view_ removeFromSuperview];
+  vibrant_view_ = nil;
+}
+
 void NativeWindowMac::OnInputEvent(const blink::WebInputEvent& event) {
   switch (event.type) {
     case blink::WebInputEvent::GestureScrollBegin:

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -81,6 +81,9 @@ const char kFocusable[] = "focusable";
 // The WebPreferences.
 const char kWebPreferences[] = "webPreferences";
 
+// Add a vibrancy effect to the browser window
+const char kVibrancyType[] = "vibrancy";
+
 // The factor of which page should be zoomed.
 const char kZoomFactor[] = "zoomFactor";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -46,6 +46,7 @@ extern const char kBackgroundColor[];
 extern const char kHasShadow[];
 extern const char kFocusable[];
 extern const char kWebPreferences[];
+extern const char kVibrancyType[];
 
 // WebPreferences.
 extern const char kZoomFactor[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -265,6 +265,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `offscreen` Boolean - Whether to enable offscreen rendering for the browser
       window. Defaults to `false`.
     * `sandbox` Boolean - Whether to enable Chromium OS-level sandbox.
+    * `vibrancy` String - Add a type of vibrancy effect to the window, only on
+      macOS. See supported types at the `setVibrancy` method.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from
@@ -1188,3 +1190,16 @@ Returns `BrowserWindow[]` - All child windows.
 
 [window-levels]: https://developer.apple.com/reference/appkit/nswindow/1664726-window_levels
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
+
+#### `win.setVibrancy(type)` _macOS_
+
+* `type` String - Adds a vibrancy effect to the browser window. Values include
+  `appearance-based`, `light`, `dark`, `titlebar`, `selection`, `menu`,
+  `popover`, `sidebar`, `medium-light`, `ultra-dark`. See the
+  [macOS documentation][vibrancy-docs] for more details.
+
+[vibrancy-docs]: https://developer.apple.com/reference/appkit/nsvisualeffectview?language=objc
+
+#### `win.removeVibrancy()` _macOS_
+
+Removes the vibrancy effect on the window.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -198,6 +198,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `thickFrame` Boolean - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
+  * `vibrancy` String - Add a type of vibrancy effect to the window, only on
+    macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
+    `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.
   * `webPreferences` Object - Settings of web page's features.
     * `devTools` Boolean - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
     * `nodeIntegration` Boolean - Whether node integration is enabled. Default
@@ -265,8 +268,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `offscreen` Boolean - Whether to enable offscreen rendering for the browser
       window. Defaults to `false`.
     * `sandbox` Boolean - Whether to enable Chromium OS-level sandbox.
-    * `vibrancy` String - Add a type of vibrancy effect to the window, only on
-      macOS. See supported types at the `setVibrancy` method.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from
@@ -1193,8 +1194,8 @@ Returns `BrowserWindow[]` - All child windows.
 
 #### `win.setVibrancy(type)` _macOS_
 
-* `type` String - Values include `appearance-based`, `light`, `dark`, `titlebar`,
-  `selection`, `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`. See
+* `type` String - Can be `appearance-based`, `light`, `dark`, `titlebar`,
+  `selection`, `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`. See
   the [macOS documentation][vibrancy-docs] for more details.
 
 Adds a vibrancy effect to the browser window.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1198,10 +1198,7 @@ Returns `BrowserWindow[]` - All child windows.
   `selection`, `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`. See
   the [macOS documentation][vibrancy-docs] for more details.
 
-Adds a vibrancy effect to the browser window.
+Adds a vibrancy effect to the browser window. Passing `null` or an empty string
+will remove the vibrancy effect on the window.
 
 [vibrancy-docs]: https://developer.apple.com/reference/appkit/nsvisualeffectview?language=objc
-
-#### `win.removeVibrancy()` _macOS_
-
-Removes the vibrancy effect on the window.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1193,10 +1193,11 @@ Returns `BrowserWindow[]` - All child windows.
 
 #### `win.setVibrancy(type)` _macOS_
 
-* `type` String - Adds a vibrancy effect to the browser window. Values include
-  `appearance-based`, `light`, `dark`, `titlebar`, `selection`, `menu`,
-  `popover`, `sidebar`, `medium-light`, `ultra-dark`. See the
-  [macOS documentation][vibrancy-docs] for more details.
+* `type` String - Values include `appearance-based`, `light`, `dark`, `titlebar`,
+  `selection`, `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`. See
+  the [macOS documentation][vibrancy-docs] for more details.
+
+Adds a vibrancy effect to the browser window.
 
 [vibrancy-docs]: https://developer.apple.com/reference/appkit/nsvisualeffectview?language=objc
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -427,6 +427,18 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.setVibrancy(type)', function () {
+    it('allows setting, changing, and removing the vibrancy', function () {
+      assert.doesNotThrow(function () {
+        w.setVibrancy('light')
+        w.setVibrancy('dark')
+        w.setVibrancy(null)
+        w.setVibrancy('ultra-dark')
+        w.setVibrancy('')
+      })
+    })
+  })
+
   describe('BrowserWindow.fromId(id)', function () {
     it('returns the window with id', function () {
       assert.equal(w.id, BrowserWindow.fromId(w.id).id)


### PR DESCRIPTION
This PR adds the native macOS vibrancy effect to `BrowserWindow`. #3002 

``` js
let win = new BrowserWindow({
  width: 800,
  height: 600,
  vibrancy: 'dark'  // 'light', 'medium-light' etc
})
```

<p align="center">
  <img width="560" alt="vibrancy" src="https://cloud.githubusercontent.com/assets/1059699/20074570/09c6a300-a531-11e6-98c6-dbee26ad301f.png">
</p>

