### PR TITLE
Rename autoUpload to uploadToServer

### DIFF
--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -40,6 +40,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                  base::Bind(&CrashReporter::Start, report));
   dict.SetMethod("_getUploadedReports",
                  base::Bind(&CrashReporter::GetUploadedReports, report));
+  dict.SetMethod("_setShouldUpload",
+                 base::Bind(&CrashReporter::SetShouldUpload, report));
 }
 
 }  // namespace

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -40,10 +40,10 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                  base::Bind(&CrashReporter::Start, report));
   dict.SetMethod("_getUploadedReports",
                  base::Bind(&CrashReporter::GetUploadedReports, report));
-  dict.SetMethod("_setShouldUpload",
-                 base::Bind(&CrashReporter::SetShouldUpload, report));
-  dict.SetMethod("_getShouldUpload",
-                 base::Bind(&CrashReporter::GetShouldUpload, report));
+  dict.SetMethod("_setUploadToServer",
+                 base::Bind(&CrashReporter::SetUploadToServer, report));
+  dict.SetMethod("_getUploadToServer",
+                 base::Bind(&CrashReporter::GetUploadToServer, report));
 }
 
 }  // namespace

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -42,6 +42,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                  base::Bind(&CrashReporter::GetUploadedReports, report));
   dict.SetMethod("_setShouldUpload",
                  base::Bind(&CrashReporter::SetShouldUpload, report));
+  dict.SetMethod("_getShouldUpload",
+                 base::Bind(&CrashReporter::GetShouldUpload, report));
 }
 
 }  // namespace

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -44,7 +44,6 @@ void CrashReporter::SetUploadParameters(const StringMap& parameters) {
 }
 
 void CrashReporter::SetShouldUpload(const bool should_upload) {
-
 }
 
 bool CrashReporter::GetShouldUpload() {

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -26,13 +26,13 @@ void CrashReporter::Start(const std::string& product_name,
                           const std::string& company_name,
                           const std::string& submit_url,
                           const base::FilePath& crashes_dir,
-                          bool should_upload,
+                          bool upload_to_server,
                           bool skip_system_crash_handler,
                           const StringMap& extra_parameters) {
   SetUploadParameters(extra_parameters);
 
   InitBreakpad(product_name, ATOM_VERSION_STRING, company_name, submit_url,
-               crashes_dir, should_upload, skip_system_crash_handler);
+               crashes_dir, upload_to_server, skip_system_crash_handler);
 }
 
 void CrashReporter::SetUploadParameters(const StringMap& parameters) {
@@ -43,10 +43,10 @@ void CrashReporter::SetUploadParameters(const StringMap& parameters) {
   SetUploadParameters();
 }
 
-void CrashReporter::SetShouldUpload(const bool should_upload) {
+void CrashReporter::SetUploadToServer(const bool upload_to_server) {
 }
 
-bool CrashReporter::GetShouldUpload() {
+bool CrashReporter::GetUploadToServer() {
   return true;
 }
 

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -26,13 +26,13 @@ void CrashReporter::Start(const std::string& product_name,
                           const std::string& company_name,
                           const std::string& submit_url,
                           const base::FilePath& crashes_dir,
-                          bool auto_submit,
+                          bool should_upload,
                           bool skip_system_crash_handler,
                           const StringMap& extra_parameters) {
   SetUploadParameters(extra_parameters);
 
   InitBreakpad(product_name, ATOM_VERSION_STRING, company_name, submit_url,
-               crashes_dir, auto_submit, skip_system_crash_handler);
+               crashes_dir, should_upload, skip_system_crash_handler);
 }
 
 void CrashReporter::SetUploadParameters(const StringMap& parameters) {
@@ -41,6 +41,10 @@ void CrashReporter::SetUploadParameters(const StringMap& parameters) {
 
   // Setting platform dependent parameters.
   SetUploadParameters();
+}
+
+void CrashReporter::SetShouldUpload(const bool should_upload) {
+
 }
 
 std::vector<CrashReporter::UploadReportResult>

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -47,6 +47,10 @@ void CrashReporter::SetShouldUpload(const bool should_upload) {
 
 }
 
+bool CrashReporter::GetShouldUpload() {
+  return true;
+}
+
 std::vector<CrashReporter::UploadReportResult>
 CrashReporter::GetUploadedReports(const base::FilePath& crashes_dir) {
   std::string file_content;

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -34,6 +34,7 @@ class CrashReporter {
       const base::FilePath& crashes_dir);
 
   virtual void SetShouldUpload(bool should_upload);
+  virtual bool GetShouldUpload();
 
  protected:
   CrashReporter();

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -26,7 +26,7 @@ class CrashReporter {
              const std::string& company_name,
              const std::string& submit_url,
              const base::FilePath& crashes_dir,
-             bool auto_submit,
+             bool should_upload,
              bool skip_system_crash_handler,
              const StringMap& extra_parameters);
 
@@ -42,9 +42,11 @@ class CrashReporter {
                             const std::string& company_name,
                             const std::string& submit_url,
                             const base::FilePath& crashes_dir,
-                            bool auto_submit,
+                            bool should_upload,
                             bool skip_system_crash_handler);
   virtual void SetUploadParameters();
+
+  virtual void SetShouldUpload();
 
   StringMap upload_parameters_;
   bool is_browser_;

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -33,7 +33,7 @@ class CrashReporter {
   virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports(
       const base::FilePath& crashes_dir);
 
-  virtual void SetShouldUpload();
+  virtual void SetShouldUpload(bool should_upload);
 
  protected:
   CrashReporter();

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -33,6 +33,8 @@ class CrashReporter {
   virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports(
       const base::FilePath& crashes_dir);
 
+  virtual void SetShouldUpload();
+
  protected:
   CrashReporter();
   virtual ~CrashReporter();
@@ -45,8 +47,6 @@ class CrashReporter {
                             bool should_upload,
                             bool skip_system_crash_handler);
   virtual void SetUploadParameters();
-
-  virtual void SetShouldUpload();
 
   StringMap upload_parameters_;
   bool is_browser_;

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -26,15 +26,15 @@ class CrashReporter {
              const std::string& company_name,
              const std::string& submit_url,
              const base::FilePath& crashes_dir,
-             bool should_upload,
+             bool upload_to_server,
              bool skip_system_crash_handler,
              const StringMap& extra_parameters);
 
   virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports(
       const base::FilePath& crashes_dir);
 
-  virtual void SetShouldUpload(bool should_upload);
-  virtual bool GetShouldUpload();
+  virtual void SetUploadToServer(bool upload_to_server);
+  virtual bool GetUploadToServer();
 
  protected:
   CrashReporter();
@@ -45,7 +45,7 @@ class CrashReporter {
                             const std::string& company_name,
                             const std::string& submit_url,
                             const base::FilePath& crashes_dir,
-                            bool should_upload,
+                            bool upload_to_server,
                             bool skip_system_crash_handler);
   virtual void SetUploadParameters();
 

--- a/atom/common/crash_reporter/crash_reporter_linux.cc
+++ b/atom/common/crash_reporter/crash_reporter_linux.cc
@@ -60,7 +60,7 @@ void CrashReporterLinux::InitBreakpad(const std::string& product_name,
                                       const std::string& company_name,
                                       const std::string& submit_url,
                                       const base::FilePath& crashes_dir,
-                                      bool should_upload,
+                                      bool upload_to_server,
                                       bool skip_system_crash_handler) {
   EnableCrashDumping(crashes_dir);
 

--- a/atom/common/crash_reporter/crash_reporter_linux.cc
+++ b/atom/common/crash_reporter/crash_reporter_linux.cc
@@ -60,7 +60,7 @@ void CrashReporterLinux::InitBreakpad(const std::string& product_name,
                                       const std::string& company_name,
                                       const std::string& submit_url,
                                       const base::FilePath& crashes_dir,
-                                      bool auto_submit,
+                                      bool should_upload,
                                       bool skip_system_crash_handler) {
   EnableCrashDumping(crashes_dir);
 

--- a/atom/common/crash_reporter/crash_reporter_linux.h
+++ b/atom/common/crash_reporter/crash_reporter_linux.h
@@ -32,7 +32,7 @@ class CrashReporterLinux : public CrashReporter {
                     const std::string& company_name,
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
-                    bool should_upload,
+                    bool upload_to_server,
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
 

--- a/atom/common/crash_reporter/crash_reporter_linux.h
+++ b/atom/common/crash_reporter/crash_reporter_linux.h
@@ -32,7 +32,7 @@ class CrashReporterLinux : public CrashReporter {
                     const std::string& company_name,
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
-                    bool auto_submit,
+                    bool should_upload,
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
 

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -33,6 +33,7 @@ class CrashReporterMac : public CrashReporter {
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
   void SetShouldUpload(bool should_upload) override;
+  bool GetShouldUpload() override;
 
  private:
   friend struct base::DefaultSingletonTraits<CrashReporterMac>;

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -11,6 +11,7 @@
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "base/compiler_specific.h"
 #include "base/strings/string_piece.h"
+#include "vendor/crashpad/client/crash_report_database.h"
 #include "vendor/crashpad/client/simple_string_dictionary.h"
 
 namespace base {
@@ -31,6 +32,7 @@ class CrashReporterMac : public CrashReporter {
                     bool should_upload,
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
+  void SetShouldUpload(bool should_upload) override;
 
  private:
   friend struct base::DefaultSingletonTraits<CrashReporterMac>;

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -29,11 +29,11 @@ class CrashReporterMac : public CrashReporter {
                     const std::string& company_name,
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
-                    bool should_upload,
+                    bool upload_to_server,
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
-  void SetShouldUpload(bool should_upload) override;
-  bool GetShouldUpload() override;
+  void SetUploadToServer(bool upload_to_server) override;
+  bool GetUploadToServer() override;
 
  private:
   friend struct base::DefaultSingletonTraits<CrashReporterMac>;

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -28,7 +28,7 @@ class CrashReporterMac : public CrashReporter {
                     const std::string& company_name,
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
-                    bool auto_submit,
+                    bool should_upload,
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
 
@@ -46,6 +46,7 @@ class CrashReporterMac : public CrashReporter {
       const base::FilePath& crashes_dir) override;
 
   std::unique_ptr<crashpad::SimpleStringDictionary> simple_string_dictionary_;
+  std::unique_ptr<crashpad::CrashReportDatabase> database_;
 
   DISALLOW_COPY_AND_ASSIGN(CrashReporterMac);
 };

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -75,10 +75,16 @@ void CrashReporterMac::InitBreakpad(const std::string& product_name,
   if (is_browser_) {
     database_ =
         crashpad::CrashReportDatabase::Initialize(crashes_dir);
-    if (database_) {
-      database_->GetSettings()->SetUploadsEnabled(should_upload);
-    }
+    SetShouldUpload(should_upload);
   }
+}
+
+bool CrashReporterMac::GetShouldUpload() {
+  bool enabled = true;
+  if (database_) {
+    database_->GetSettings()->GetUploadsEnabled(&enabled);
+  }
+  return enabled;
 }
 
 void CrashReporterMac::SetShouldUpload(const bool should_upload) {

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -13,7 +13,6 @@
 #include "base/strings/string_piece.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"
-#include "vendor/crashpad/client/crash_report_database.h"
 #include "vendor/crashpad/client/crashpad_client.h"
 #include "vendor/crashpad/client/crashpad_info.h"
 #include "vendor/crashpad/client/settings.h"

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -31,7 +31,7 @@ void CrashReporterMac::InitBreakpad(const std::string& product_name,
                                     const std::string& company_name,
                                     const std::string& submit_url,
                                     const base::FilePath& crashes_dir,
-                                    bool auto_submit,
+                                    bool should_upload,
                                     bool skip_system_crash_handler) {
   // check whether crashpad has been initialized.
   // Only need to initialize once.
@@ -73,11 +73,17 @@ void CrashReporterMac::InitBreakpad(const std::string& product_name,
     SetCrashKeyValue(upload_parameter.first, upload_parameter.second);
   }
   if (is_browser_) {
-    std::unique_ptr<crashpad::CrashReportDatabase> database =
+    database_ =
         crashpad::CrashReportDatabase::Initialize(crashes_dir);
-    if (database) {
-      database->GetSettings()->SetUploadsEnabled(auto_submit);
+    if (database_) {
+      database_->GetSettings()->SetUploadsEnabled(should_upload);
     }
+  }
+}
+
+void CrashReporterMac::SetShouldUpload(const bool should_upload) {
+  if (database_) {
+    database_->GetSettings()->SetUploadsEnabled(should_upload);
   }
 }
 

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -31,7 +31,7 @@ void CrashReporterMac::InitBreakpad(const std::string& product_name,
                                     const std::string& company_name,
                                     const std::string& submit_url,
                                     const base::FilePath& crashes_dir,
-                                    bool should_upload,
+                                    bool upload_to_server,
                                     bool skip_system_crash_handler) {
   // check whether crashpad has been initialized.
   // Only need to initialize once.
@@ -75,11 +75,11 @@ void CrashReporterMac::InitBreakpad(const std::string& product_name,
   if (is_browser_) {
     database_ =
         crashpad::CrashReportDatabase::Initialize(crashes_dir);
-    SetShouldUpload(should_upload);
+    SetUploadToServer(upload_to_server);
   }
 }
 
-bool CrashReporterMac::GetShouldUpload() {
+bool CrashReporterMac::GetUploadToServer() {
   bool enabled = true;
   if (database_) {
     database_->GetSettings()->GetUploadsEnabled(&enabled);
@@ -87,9 +87,9 @@ bool CrashReporterMac::GetShouldUpload() {
   return enabled;
 }
 
-void CrashReporterMac::SetShouldUpload(const bool should_upload) {
+void CrashReporterMac::SetUploadToServer(const bool upload_to_server) {
   if (database_) {
-    database_->GetSettings()->SetUploadsEnabled(should_upload);
+    database_->GetSettings()->SetUploadsEnabled(upload_to_server);
   }
 }
 

--- a/atom/common/crash_reporter/crash_reporter_win.cc
+++ b/atom/common/crash_reporter/crash_reporter_win.cc
@@ -150,7 +150,7 @@ void CrashReporterWin::InitBreakpad(const std::string& product_name,
                                     const std::string& company_name,
                                     const std::string& submit_url,
                                     const base::FilePath& crashes_dir,
-                                    bool auto_submit,
+                                    bool should_upload,
                                     bool skip_system_crash_handler) {
   skip_system_crash_handler_ = skip_system_crash_handler;
 

--- a/atom/common/crash_reporter/crash_reporter_win.cc
+++ b/atom/common/crash_reporter/crash_reporter_win.cc
@@ -150,7 +150,7 @@ void CrashReporterWin::InitBreakpad(const std::string& product_name,
                                     const std::string& company_name,
                                     const std::string& submit_url,
                                     const base::FilePath& crashes_dir,
-                                    bool should_upload,
+                                    bool upload_to_server,
                                     bool skip_system_crash_handler) {
   skip_system_crash_handler_ = skip_system_crash_handler;
 

--- a/atom/common/crash_reporter/crash_reporter_win.h
+++ b/atom/common/crash_reporter/crash_reporter_win.h
@@ -28,7 +28,7 @@ class CrashReporterWin : public CrashReporter {
                     const std::string& company_name,
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
-                    bool should_upload,
+                    bool upload_to_server,
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
 

--- a/atom/common/crash_reporter/crash_reporter_win.h
+++ b/atom/common/crash_reporter/crash_reporter_win.h
@@ -28,7 +28,7 @@ class CrashReporterWin : public CrashReporter {
                     const std::string& company_name,
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
-                    bool auto_submit,
+                    bool should_upload,
                     bool skip_system_crash_handler) override;
   void SetUploadParameters() override;
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -75,15 +75,16 @@ ID.
 Returns `Boolean` - Whether reports should be submitted to the server.  Set through
 the `start` method or `setUploadToServer`.
 
-**NOTE:** This API can only be used from the main process
+**Note:** This API can only be used from the main process.
 
 ### `crashReporter.setUploadToServer(uploadToServer)` _macOS_
 
 * `uploadToServer` Boolean _macOS_ - Whether reports should be submitted to the server
 
-This would normally be controlled by user preferences.
+This would normally be controlled by user preferences. This has no effect if
+called before `start` is called.
 
-**NOTE:** This API can only be used from the main process
+**Note:** This API can only be used from the main process.
 
 ## Crash Report Payload
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -70,6 +70,11 @@ Returns [`CrashReport[]`](structures/crash-report.md):
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.
 
+### `crashReporter.getShouldUpload()`
+
+Returns `Boolean` - Whether reports should be submitted to the server.  Set through
+the `start` method or `setShouldUpload`.
+
 ### `crashReporter.setShouldUpload(shouldUpload)`
 
 * `shouldUpload` Boolean _macOS_ - Whether reports should be submitted to the server

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -70,12 +70,12 @@ Returns [`CrashReport[]`](structures/crash-report.md):
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.
 
-### `crashReporter.getShouldUpload()`
+### `crashReporter.getShouldUpload()` _macOS_
 
 Returns `Boolean` - Whether reports should be submitted to the server.  Set through
 the `start` method or `setShouldUpload`.
 
-### `crashReporter.setShouldUpload(shouldUpload)`
+### `crashReporter.setShouldUpload(shouldUpload)` _macOS_
 
 * `shouldUpload` Boolean _macOS_ - Whether reports should be submitted to the server
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -75,11 +75,15 @@ ID.
 Returns `Boolean` - Whether reports should be submitted to the server.  Set through
 the `start` method or `setShouldUpload`.
 
+**NOTE:** This API can only be used from the main process
+
 ### `crashReporter.setShouldUpload(shouldUpload)` _macOS_
 
 * `shouldUpload` Boolean _macOS_ - Whether reports should be submitted to the server
 
 This would normally be controlled by user preferences.
+
+**NOTE:** This API can only be used from the main process
 
 ## Crash Report Payload
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -40,7 +40,7 @@ The `crashReporter` module has the following methods:
   * `companyName` String (optional)
   * `submitURL` String - URL that crash reports will be sent to as POST.
   * `productName` String (optional) - Defaults to `app.getName()`.
-  * `shouldUpload` Boolean (optional) _macOS_ - Whether crash reports should be sent to the server
+  * `uploadToServer` Boolean (optional) _macOS_ - Whether crash reports should be sent to the server
     Default is `true`.
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
   * `extra` Object (optional) - An object you can define that will be sent along with the
@@ -70,16 +70,16 @@ Returns [`CrashReport[]`](structures/crash-report.md):
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.
 
-### `crashReporter.getShouldUpload()` _macOS_
+### `crashReporter.getUploadToServer()` _macOS_
 
 Returns `Boolean` - Whether reports should be submitted to the server.  Set through
-the `start` method or `setShouldUpload`.
+the `start` method or `setUploadToServer`.
 
 **NOTE:** This API can only be used from the main process
 
-### `crashReporter.setShouldUpload(shouldUpload)` _macOS_
+### `crashReporter.setUploadToServer(uploadToServer)` _macOS_
 
-* `shouldUpload` Boolean _macOS_ - Whether reports should be submitted to the server
+* `uploadToServer` Boolean _macOS_ - Whether reports should be submitted to the server
 
 This would normally be controlled by user preferences.
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -40,7 +40,7 @@ The `crashReporter` module has the following methods:
   * `companyName` String (optional)
   * `submitURL` String - URL that crash reports will be sent to as POST.
   * `productName` String (optional) - Defaults to `app.getName()`.
-  * `autoSubmit` Boolean (optional) - Send the crash report without user interaction.
+  * `shouldUpload` Boolean (optional) _macOS_ - Whether crash reports should be sent to the server
     Default is `true`.
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
   * `extra` Object (optional) - An object you can define that will be sent along with the
@@ -69,6 +69,12 @@ Returns [`CrashReport[]`](structures/crash-report.md):
 
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.
+
+### `crashReporter.setShouldUpload(shouldUpload)`
+
+* `shouldUpload` Boolean _macOS_ - Whether reports should be submitted to the server
+
+This would normally be controlled by user preferences.
 
 ## Crash Report Payload
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -75,7 +75,7 @@ ID.
 Returns `Boolean` - Whether reports should be submitted to the server.  Set through
 the `start` method or `setUploadToServer`.
 
-**Note:** This API can only be used from the main process.
+**Note:** This API can only be called from the main process.
 
 ### `crashReporter.setUploadToServer(uploadToServer)` _macOS_
 
@@ -84,7 +84,7 @@ the `start` method or `setUploadToServer`.
 This would normally be controlled by user preferences. This has no effect if
 called before `start` is called.
 
-**Note:** This API can only be used from the main process.
+**Note:** This API can only be called from the main process.
 
 ## Crash Report Payload
 

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -40,6 +40,23 @@ clipboard.writeHtml()
 clipboard.writeHTML()
 ```
 
+## `crashReporter`
+
+```js
+// Deprecated
+crashReporter.start({
+  companyName: 'Crashly',
+  submitURL: 'https://crash.server.com',
+  autoSubmit: true
+})
+// Replace with
+crashReporter.start({
+  companyName: 'Crashly',
+  submitURL: 'https://crash.server.com',
+  uploadToServer: true
+})
+```
+
 ## `nativeImage`
 
 ```js

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -13,17 +13,17 @@ class CrashReporter {
       options = {}
     }
     this.productName = options.productName != null ? options.productName : app.getName()
-    let {autoSubmit, companyName, extra, ignoreSystemCrashHandler, submitURL, uploadToServer} = options
+    let {companyName, extra, ignoreSystemCrashHandler, submitURL, uploadToServer} = options
 
-    if (autoSubmit == null && uploadToServer == null) {
-      uploadToServer = true
-    } else {
-      if (typeof autoSubmit !== 'undefined') {
-        // TODO: Remove depreceated property in 2.0.0
-        console.warn('The "autoSubmit" attribute on electron.crashReporter.start is depreceated.  Please use "uploadToServer" instead.')
-      }
-      uploadToServer = uploadToServer || autoSubmit
+    if (uploadToServer == null) {
+      // TODO: Remove deprecated autoSubmit property in 2.0
+      uploadToServer = options.autoSubmit
     }
+
+    if (uploadToServer == null) {
+      uploadToServer = true
+    }
+
     if (ignoreSystemCrashHandler == null) {
       ignoreSystemCrashHandler = false
     }

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -18,6 +18,10 @@ class CrashReporter {
     if (autoSubmit == null && shouldUpload == null) {
       shouldUpload = true
     } else {
+      if (typeof autoSubmit !== 'undefined') {
+        // TODO: Remove depreceated property in 2.0.0
+        console.warn('The "autoSubmit" attribute on electron.crashReporter is depreceated.  Please use "shouldUpload" instead.')
+      }
       shouldUpload = shouldUpload || autoSubmit
     }
     if (ignoreSystemCrashHandler == null) {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -62,7 +62,6 @@ class CrashReporter {
       })
     }
 
-    this._shouldUpload = shouldUpload
     binding.start(this.getProductName(), companyName, submitURL, this.getCrashesDirectory(), shouldUpload, ignoreSystemCrashHandler, extra)
   }
 
@@ -104,12 +103,19 @@ class CrashReporter {
   }
 
   getShouldUpload() {
-    return this._shouldUpload
+    if (process.type === 'browser') {
+      return binding._getShouldUpload()
+    } else {
+      throw new Error('getShouldUpload can only be called from the main process')
+    }
   }
 
   setShouldUpload(shouldUpload) {
-    this._shouldUpload = shouldUpload
-    return binding._setShouldUpload(shouldUpload)
+    if (process.type === 'browser') {
+      return binding._setShouldUpload(shouldUpload)
+    } else {
+      throw new Error('setShouldUpload can only be called from the main process')
+    }
   }
 }
 

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -13,16 +13,16 @@ class CrashReporter {
       options = {}
     }
     this.productName = options.productName != null ? options.productName : app.getName()
-    let {autoSubmit, companyName, extra, ignoreSystemCrashHandler, submitURL, shouldUpload} = options
+    let {autoSubmit, companyName, extra, ignoreSystemCrashHandler, submitURL, uploadToServer} = options
 
-    if (autoSubmit == null && shouldUpload == null) {
-      shouldUpload = true
+    if (autoSubmit == null && uploadToServer == null) {
+      uploadToServer = true
     } else {
       if (typeof autoSubmit !== 'undefined') {
         // TODO: Remove depreceated property in 2.0.0
-        console.warn('The "autoSubmit" attribute on electron.crashReporter.start is depreceated.  Please use "shouldUpload" instead.')
+        console.warn('The "autoSubmit" attribute on electron.crashReporter.start is depreceated.  Please use "uploadToServer" instead.')
       }
-      shouldUpload = shouldUpload || autoSubmit
+      uploadToServer = uploadToServer || autoSubmit
     }
     if (ignoreSystemCrashHandler == null) {
       ignoreSystemCrashHandler = false
@@ -62,7 +62,7 @@ class CrashReporter {
       })
     }
 
-    binding.start(this.getProductName(), companyName, submitURL, this.getCrashesDirectory(), shouldUpload, ignoreSystemCrashHandler, extra)
+    binding.start(this.getProductName(), companyName, submitURL, this.getCrashesDirectory(), uploadToServer, ignoreSystemCrashHandler, extra)
   }
 
   getLastCrashReport () {
@@ -102,19 +102,19 @@ class CrashReporter {
     return this.tempDirectory
   }
 
-  getShouldUpload () {
+  getUploadToServer () {
     if (process.type === 'browser') {
-      return binding._getShouldUpload()
+      return binding._getUploadToServer()
     } else {
-      throw new Error('getShouldUpload can only be called from the main process')
+      throw new Error('getUploadToServer can only be called from the main process')
     }
   }
 
-  setShouldUpload (shouldUpload) {
+  setUploadToServer (uploadToServer) {
     if (process.type === 'browser') {
-      return binding._setShouldUpload(shouldUpload)
+      return binding._setUploadToServer(uploadToServer)
     } else {
-      throw new Error('setShouldUpload can only be called from the main process')
+      throw new Error('setUploadToServer can only be called from the main process')
     }
   }
 }

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -13,10 +13,12 @@ class CrashReporter {
       options = {}
     }
     this.productName = options.productName != null ? options.productName : app.getName()
-    let {autoSubmit, companyName, extra, ignoreSystemCrashHandler, submitURL} = options
+    let {autoSubmit, companyName, extra, ignoreSystemCrashHandler, submitURL, shouldUpload} = options
 
-    if (autoSubmit == null) {
-      autoSubmit = true
+    if (autoSubmit == null && shouldUpload == null) {
+      shouldUpload = true
+    } else {
+      shouldUpload = shouldUpload || autoSubmit
     }
     if (ignoreSystemCrashHandler == null) {
       ignoreSystemCrashHandler = false
@@ -56,7 +58,8 @@ class CrashReporter {
       })
     }
 
-    binding.start(this.getProductName(), companyName, submitURL, this.getCrashesDirectory(), autoSubmit, ignoreSystemCrashHandler, extra)
+    this._shouldUpload = shouldUpload
+    binding.start(this.getProductName(), companyName, submitURL, this.getCrashesDirectory(), shouldUpload, ignoreSystemCrashHandler, extra)
   }
 
   getLastCrashReport () {
@@ -94,6 +97,15 @@ class CrashReporter {
       }
     }
     return this.tempDirectory
+  }
+
+  getShouldUpload() {
+    return this._shouldUpload
+  }
+
+  setShouldUpload(shouldUpload) {
+    this._shouldUpload = shouldUpload
+    return bindings._setShouldUpload(shouldUpload)
   }
 }
 

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -102,7 +102,7 @@ class CrashReporter {
     return this.tempDirectory
   }
 
-  getShouldUpload() {
+  getShouldUpload () {
     if (process.type === 'browser') {
       return binding._getShouldUpload()
     } else {
@@ -110,7 +110,7 @@ class CrashReporter {
     }
   }
 
-  setShouldUpload(shouldUpload) {
+  setShouldUpload (shouldUpload) {
     if (process.type === 'browser') {
       return binding._setShouldUpload(shouldUpload)
     } else {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -20,7 +20,7 @@ class CrashReporter {
     } else {
       if (typeof autoSubmit !== 'undefined') {
         // TODO: Remove depreceated property in 2.0.0
-        console.warn('The "autoSubmit" attribute on electron.crashReporter is depreceated.  Please use "shouldUpload" instead.')
+        console.warn('The "autoSubmit" attribute on electron.crashReporter.start is depreceated.  Please use "shouldUpload" instead.')
       }
       shouldUpload = shouldUpload || autoSubmit
     }
@@ -109,7 +109,7 @@ class CrashReporter {
 
   setShouldUpload(shouldUpload) {
     this._shouldUpload = shouldUpload
-    return bindings._setShouldUpload(shouldUpload)
+    return binding._setShouldUpload(shouldUpload)
   }
 }
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -134,7 +134,7 @@ describe('crashReporter module', function () {
         crashReporter.setUploadToServer(false)
         assert.equal(crashReporter.getUploadToServer(), false)
       } else {
-        assert.equal(crashReporter.getUploadToServer(), false)
+        assert.equal(crashReporter.getUploadToServer(), true)
       }
     })
   })

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -117,6 +117,27 @@ describe('crashReporter module', function () {
       })
     })
   })
+
+  describe('.get/setUploadToServer', function () {
+    it('throws an error when called from the renderer process', function () {
+      assert.throws(() => require('electron').crashReporter.getUploadToServer())
+    })
+
+    it('can be read/set from the main process', function () {
+      if (process.platform === 'darwin') {
+        crashReporter.start({
+          companyName: 'Umbrella Corporation',
+          submitURL: 'http://127.0.0.1/crashes',
+          autoSubmit: true
+        })
+        assert.equal(crashReporter.getUploadToServer(), true)
+        crashReporter.setUploadToServer(false)
+        assert.equal(crashReporter.getUploadToServer(), false)
+      } else {
+        assert.equal(crashReporter.getUploadToServer(), false)
+      }
+    })
+  })
 })
 
 const waitForCrashReport = () => {


### PR DESCRIPTION
This PR handles three things

1. `autoUpload` only ever did anything on macOS so the docs have been updated to reflect that
2. `autoUpload` has been renamed to `shouldUpload` *you can still use 'autoUpload' it is backwards compatable'
3. `shouldUpload` now has an API to change it dynamically

The reasoning behind No. 2 is that by calling something `autoUpload` you are inherently implying there is a manual way to send the report which the API does not provide.  The method that we call on macOS is even documented like so.

>   //! \brief Sets the user’s preference for submitting crash reports to a
  //!     collection server.

Which indicateds that even when false you shouldn't be submitting anyway 👍 

Also given that this is the kind of thing that should be user preference orientated I added an API to change the value on the fly.