### PR TITLE
Allow vetoing successful SSL certificate verification

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -192,7 +192,7 @@ content::PermissionManager* AtomBrowserContext::GetPermissionManager() {
 }
 
 std::unique_ptr<net::CertVerifier> AtomBrowserContext::CreateCertVerifier() {
-  return base::WrapUnique(new AtomCertVerifier(ct_delegate_.get()));
+  return base::WrapUnique(new AtomCertVerifier());
 }
 
 net::SSLConfigService* AtomBrowserContext::CreateSSLConfigService() {

--- a/atom/browser/net/atom_cert_verifier.cc
+++ b/atom/browser/net/atom_cert_verifier.cc
@@ -5,7 +5,6 @@
 #include "atom/browser/net/atom_cert_verifier.h"
 
 #include "atom/browser/browser.h"
-#include "atom/browser/net/atom_ct_delegate.h"
 #include "atom/common/native_mate_converters/net_converter.h"
 #include "content/public/browser/browser_thread.h"
 #include "net/base/net_errors.h"
@@ -20,19 +19,41 @@ namespace atom {
 namespace {
 
 void OnResult(
+    const AtomCertVerifier::RequestParams& params,
     net::CertVerifyResult* verify_result,
     const net::CompletionCallback& callback,
+    int default_result_val,
     bool result) {
+  if (result && default_result_val != net::OK) {
+    verify_result->Reset();
+    verify_result->verified_cert = params.certificate();
+  }
+
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
       base::Bind(callback, result ? net::OK : net::ERR_FAILED));
 }
 
+void OnDefaultResult(
+    const AtomCertVerifier::VerifyProc& proc,
+    const AtomCertVerifier::RequestParams& params,
+    net::CertVerifyResult* verify_result,
+    const net::CompletionCallback& callback,
+    int default_result_val) {
+  BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::Bind(proc, params.hostname(), params.certificate(),
+                 base::Bind(
+                   OnResult, params, verify_result, callback,
+                   default_result_val),
+                 default_result_val == net::OK));
+}
+
 }  // namespace
 
-AtomCertVerifier::AtomCertVerifier(AtomCTDelegate* ct_delegate)
-    : default_cert_verifier_(net::CertVerifier::CreateDefault()),
-      ct_delegate_(ct_delegate) {}
+AtomCertVerifier::AtomCertVerifier()
+    : default_cert_verifier_(net::CertVerifier::CreateDefault()) {
+}
 
 AtomCertVerifier::~AtomCertVerifier() {}
 
@@ -49,20 +70,16 @@ int AtomCertVerifier::Verify(
     const net::BoundNetLog& net_log) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
-  if (verify_proc_.is_null()) {
-    ct_delegate_->ClearCTExcludedHostsList();
-    return default_cert_verifier_->Verify(
-        params, crl_set, verify_result, callback, out_req, net_log);
+  int default_result_val = default_cert_verifier_->Verify(
+      params, crl_set, verify_result,
+      base::Bind(
+          OnDefaultResult, verify_proc_, params, verify_result, callback),
+      out_req, net_log);
+  if (default_result_val != net::ERR_IO_PENDING) {
+    OnDefaultResult(
+        verify_proc_, params, verify_result, callback, default_result_val);
   }
 
-  verify_result->Reset();
-  verify_result->verified_cert = params.certificate();
-  ct_delegate_->AddCTExcludedHost(params.hostname());
-
-  BrowserThread::PostTask(
-      BrowserThread::UI, FROM_HERE,
-      base::Bind(verify_proc_, params.hostname(), params.certificate(),
-                 base::Bind(OnResult, verify_result, callback)));
   return net::ERR_IO_PENDING;
 }
 

--- a/atom/browser/net/atom_cert_verifier.h
+++ b/atom/browser/net/atom_cert_verifier.h
@@ -16,7 +16,7 @@ class AtomCTDelegate;
 
 class AtomCertVerifier : public net::CertVerifier {
  public:
-  explicit AtomCertVerifier();
+  AtomCertVerifier();
   virtual ~AtomCertVerifier();
 
   using VerifyProc =

--- a/atom/browser/net/atom_cert_verifier.h
+++ b/atom/browser/net/atom_cert_verifier.h
@@ -16,13 +16,14 @@ class AtomCTDelegate;
 
 class AtomCertVerifier : public net::CertVerifier {
  public:
-  explicit AtomCertVerifier(AtomCTDelegate* ct_delegate);
+  explicit AtomCertVerifier();
   virtual ~AtomCertVerifier();
 
   using VerifyProc =
       base::Callback<void(const std::string& hostname,
                           scoped_refptr<net::X509Certificate>,
-                          const base::Callback<void(bool)>&)>;
+                          const base::Callback<void(bool)>&,
+                          bool default_result)>;
 
   void SetVerifyProc(const VerifyProc& proc);
 
@@ -39,7 +40,6 @@ class AtomCertVerifier : public net::CertVerifier {
  private:
   VerifyProc verify_proc_;
   std::unique_ptr<net::CertVerifier> default_cert_verifier_;
-  AtomCTDelegate* ct_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomCertVerifier);
 };


### PR DESCRIPTION
First go at resolving #7891.

/cc @deepak1556: Thanks for your guidance in the issue report. Would you mind taking a look at this and see if you can see any issues please? I removed the call into the CT delegate that I see you added in #7651 since I don't want to bypass CT checking. I'm not clear exactly when CT checking happens though (before or after the CertVerifier::Verify call?) and perhaps there should still be a way of bypassing it?

I thought about maybe changing the interpretation of the callback value to:
* true - resets the verify_result, bypass CT and send back OK result
* false - send back ERR_FAILED result regardless of default cert verifier's result
* null - send back whatever result the default cert verifier sent and let CT checking happen normally; this assumes that CT checking happens afterwards

What do you think?