### PR TITLE
Update external frameworks version

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -26,7 +26,10 @@ still some subtle differences on each platform.
 
 On macOS, the `autoUpdater` module is built upon [Squirrel.Mac][squirrel-mac],
 meaning you don't need any special setup to make it work. For server-side
-requirements, you can read [Server Support][server-support].
+requirements, you can read [Server Support][server-support]. Note that [App
+Transport Security](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35) (ATS) applies to all requests made as part of the
+update process. Apps that need to disable ATS can add the
+`NSAllowsArbitraryLoads` key to their app's plist.
 
 **Note:** Your application must be signed for automatic updates on macOS.
 This is a requirement of `Squirrel.Mac`.

--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -8,7 +8,7 @@ from lib.config import get_target_arch
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v1.1.0'
+VERSION = 'v1.2.0'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/electron/electron-frameworks/releases' \
                  '/download/' + VERSION


### PR DESCRIPTION
Bump to [1.2.0](https://github.com/electron/electron-frameworks/releases/tag/v1.2.0) which upgraded Squirrel.Mac.

Note that this version of Squirrel.Mac was built with Xcode 7.2.1. This means App Transport Security (ATS) will apply to its requests. ⚠️ This is a potentially breaking change. ⚠️ 

In the past this was a big problem as S3 failed ATS' checks. S3 now passes (see the output of `/usr/bin/nscurl --ats-diagnostics https://s3.amazonaws.com`). Apps that still need to disable ATS can add the `NSAllowsArbitraryLoads` key to their app's plist.