### PR TITLE
Autorelease NSVisualEffectView

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1231,9 +1231,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
         initWithFrame: [[window_ contentView] bounds]] autorelease];
     [window_ setVibrantView:(NSView*)effect_view];
 
-    [effect_view setAutoresizingMask:
-      NSViewWidthSizable | NSViewHeightSizable];
-
+    [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
     [effect_view setState:NSVisualEffectStateActive];
     [[window_ contentView] addSubview:effect_view

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1227,8 +1227,8 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
   NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
   if (effect_view == nil) {
-    effect_view = [[NSVisualEffectView alloc] initWithFrame:
-      [[window_ contentView] bounds]];
+    effect_view = [[[NSVisualEffectView alloc]
+        initWithFrame: [[window_ contentView] bounds]] autorelease];
     [window_ setVibrantView:(NSView*)effect_view];
 
     [effect_view setAutoresizingMask:


### PR DESCRIPTION
This ensures the view gets deallocated when the vibrancy is removed from the window.

Follow on to #7898