### PR TITLE
Add {secure:} opt to protocol.registerStandardSchemes

### DIFF
--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -209,7 +209,7 @@ void AtomContentClient::AddSecureSchemesAndOrigins(
     std::set<GURL>* secure_origins) {
   std::vector<std::string> schemes;
   ConvertStringWithSeparatorToVector(&schemes, ",",
-                                     switches::kRegisterSecureSchemes);                        
+                                     switches::kSecureSchemes);                        
   if (!schemes.empty()) {
     for (const std::string& scheme : schemes) {
       secure_schemes->insert(scheme);

--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -197,10 +197,9 @@ void AtomContentClient::AddServiceWorkerSchemes(
   std::vector<std::string> schemes;
   ConvertStringWithSeparatorToVector(&schemes, ",",
                                      switches::kRegisterServiceWorkerSchemes);
-  if (!schemes.empty()) {
-    for (const std::string& scheme : schemes)
-      service_worker_schemes->insert(scheme);
-  }
+  for (const std::string& scheme : schemes)
+    service_worker_schemes->insert(scheme);
+
   service_worker_schemes->insert(url::kFileScheme);
 }
 
@@ -209,12 +208,9 @@ void AtomContentClient::AddSecureSchemesAndOrigins(
     std::set<GURL>* secure_origins) {
   std::vector<std::string> schemes;
   ConvertStringWithSeparatorToVector(&schemes, ",",
-                                     switches::kSecureSchemes);                        
-  if (!schemes.empty()) {
-    for (const std::string& scheme : schemes) {
-      secure_schemes->insert(scheme);
-    }
-  }
+                                     switches::kSecureSchemes);
+  for (const std::string& scheme : schemes)
+    secure_schemes->insert(scheme);
 }
 
 

--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -204,4 +204,18 @@ void AtomContentClient::AddServiceWorkerSchemes(
   service_worker_schemes->insert(url::kFileScheme);
 }
 
+void AtomContentClient::AddSecureSchemesAndOrigins(
+    std::set<std::string>* secure_schemes,
+    std::set<GURL>* secure_origins) {
+  std::vector<std::string> schemes;
+  ConvertStringWithSeparatorToVector(&schemes, ",",
+                                     switches::kRegisterSecureSchemes);                        
+  if (!schemes.empty()) {
+    for (const std::string& scheme : schemes) {
+      secure_schemes->insert(scheme);
+    }
+  }
+}
+
+
 }  // namespace atom

--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -207,8 +207,7 @@ void AtomContentClient::AddSecureSchemesAndOrigins(
     std::set<std::string>* secure_schemes,
     std::set<GURL>* secure_origins) {
   std::vector<std::string> schemes;
-  ConvertStringWithSeparatorToVector(&schemes, ",",
-                                     switches::kSecureSchemes);
+  ConvertStringWithSeparatorToVector(&schemes, ",", switches::kSecureSchemes);
   for (const std::string& scheme : schemes)
     secure_schemes->insert(scheme);
 }

--- a/atom/app/atom_content_client.h
+++ b/atom/app/atom_content_client.h
@@ -31,6 +31,9 @@ class AtomContentClient : public brightray::ContentClient {
       std::vector<content::PepperPluginInfo>* plugins) override;
   void AddServiceWorkerSchemes(
       std::set<std::string>* service_worker_schemes) override;
+  void AddSecureSchemesAndOrigins(
+      std::set<std::string>* secure_schemes,
+      std::set<GURL>* secure_origins) override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(AtomContentClient);

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -46,7 +46,7 @@ std::vector<std::string> GetStandardSchemes() {
   return g_standard_schemes;
 }
 
-void RegisterStandardSchemes(const std::vector<std::string>& schemes) {
+void RegisterStandardSchemes(const std::vector<std::string>& schemes, mate::Arguments* args) {
   g_standard_schemes = schemes;
 
   auto* policy = content::ChildProcessSecurityPolicy::GetInstance();
@@ -55,8 +55,17 @@ void RegisterStandardSchemes(const std::vector<std::string>& schemes) {
     policy->RegisterWebSafeScheme(scheme);
   }
 
+  // add switches to register as standard
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       atom::switches::kStandardSchemes, base::JoinString(schemes, ","));
+
+  mate::Dictionary opts;
+  bool secure = false;
+  if (args->GetNext(&opts) && opts.Get("secure", &secure) && secure) {
+    // add switches to register as secure
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      atom::switches::kRegisterSecureSchemes, base::JoinString(schemes, ","));
+  }
 }
 
 Protocol::Protocol(v8::Isolate* isolate, AtomBrowserContext* browser_context)
@@ -220,7 +229,7 @@ void RegisterStandardSchemes(
     return;
   }
 
-  atom::api::RegisterStandardSchemes(schemes);
+  atom::api::RegisterStandardSchemes(schemes, args);
 }
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -64,7 +64,7 @@ void RegisterStandardSchemes(const std::vector<std::string>& schemes, mate::Argu
   if (args->GetNext(&opts) && opts.Get("secure", &secure) && secure) {
     // add switches to register as secure
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-      atom::switches::kRegisterSecureSchemes, base::JoinString(schemes, ","));
+      atom::switches::kSecureSchemes, base::JoinString(schemes, ","));
   }
 }
 

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -46,7 +46,8 @@ std::vector<std::string> GetStandardSchemes() {
   return g_standard_schemes;
 }
 
-void RegisterStandardSchemes(const std::vector<std::string>& schemes, mate::Arguments* args) {
+void RegisterStandardSchemes(const std::vector<std::string>& schemes,
+                             mate::Arguments* args) {
   g_standard_schemes = schemes;
 
   auto* policy = content::ChildProcessSecurityPolicy::GetInstance();

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -29,7 +29,8 @@ namespace atom {
 namespace api {
 
 std::vector<std::string> GetStandardSchemes();
-void RegisterStandardSchemes(const std::vector<std::string>& schemes, mate::Arguments* args);
+void RegisterStandardSchemes(const std::vector<std::string>& schemes,
+                             mate::Arguments* args);
 
 class Protocol : public mate::TrackableObject<Protocol> {
  public:

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -29,7 +29,7 @@ namespace atom {
 namespace api {
 
 std::vector<std::string> GetStandardSchemes();
-void RegisterStandardSchemes(const std::vector<std::string>& schemes);
+void RegisterStandardSchemes(const std::vector<std::string>& schemes, mate::Arguments* args);
 
 class Protocol : public mate::TrackableObject<Protocol> {
  public:

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -234,7 +234,8 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
   // Copy following switches to child process.
   static const char* const kCommonSwitchNames[] = {
     switches::kStandardSchemes,
-    switches::kEnableSandbox
+    switches::kEnableSandbox,
+    switches::kSecureSchemes
   };
   command_line->CopySwitchesFrom(
       *base::CommandLine::ForCurrentProcess(),

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -144,6 +144,9 @@ const char kStandardSchemes[] = "standard-schemes";
 // Register schemes to handle service worker.
 const char kRegisterServiceWorkerSchemes[] = "register-service-worker-schemes";
 
+// Register schemes as secure.
+const char kRegisterSecureSchemes[] = "register-secure-schemes";
+
 // The minimum SSL/TLS version ("tls1", "tls1.1", or "tls1.2") that
 // TLS fallback will accept.
 const char kSSLVersionFallbackMin[] = "ssl-version-fallback-min";

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -145,7 +145,7 @@ const char kStandardSchemes[] = "standard-schemes";
 const char kRegisterServiceWorkerSchemes[] = "register-service-worker-schemes";
 
 // Register schemes as secure.
-const char kRegisterSecureSchemes[] = "register-secure-schemes";
+const char kSecureSchemes[] = "secure-schemes";
 
 // The minimum SSL/TLS version ("tls1", "tls1.1", or "tls1.2") that
 // TLS fallback will accept.

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -76,7 +76,7 @@ extern const char kPpapiFlashVersion[];
 extern const char kDisableHttpCache[];
 extern const char kStandardSchemes[];
 extern const char kRegisterServiceWorkerSchemes[];
-extern const char kRegisterSecureSchemes[];
+extern const char kSecureSchemes[];
 extern const char kSSLVersionFallbackMin[];
 extern const char kCipherSuiteBlacklist[];
 extern const char kAppUserModelId[];

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -76,6 +76,7 @@ extern const char kPpapiFlashVersion[];
 extern const char kDisableHttpCache[];
 extern const char kStandardSchemes[];
 extern const char kRegisterServiceWorkerSchemes[];
+extern const char kRegisterSecureSchemes[];
 extern const char kSSLVersionFallbackMin[];
 extern const char kCipherSuiteBlacklist[];
 extern const char kAppUserModelId[];

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -133,6 +133,7 @@ void WebFrame::SetSpellCheckProvider(mate::Arguments* args,
 }
 
 void WebFrame::RegisterURLSchemeAsSecure(const std::string& scheme) {
+  // TODO(pfrazee): Remove 2.0
   // Register scheme to secure list (https, wss, data).
   blink::WebSecurityPolicy::registerURLSchemeAsSecure(
       blink::WebString::fromUTF8(scheme));
@@ -165,6 +166,7 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
   // Register scheme to privileged list (https, wss, data, chrome-extension)
   blink::WebString privileged_scheme(blink::WebString::fromUTF8(scheme));
   if (secure) {
+    // TODO(pfrazee): Remove 2.0
     blink::WebSecurityPolicy::registerURLSchemeAsSecure(privileged_scheme);
   }
   if (bypassCSP) {

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -139,7 +139,6 @@ void WebFrame::RegisterURLSchemeAsSecure(const std::string& scheme) {
   // Register scheme to secure list (https, wss, data).
   blink::WebSecurityPolicy::registerURLSchemeAsSecure(
       blink::WebString::fromUTF8(scheme));
-  std::cout << "webFrame.registerURLSchemeAsSecure is deprecated. Use protocol.registerStandardSchemes with {secure:true}" << std::endl;
 }
 
 void WebFrame::RegisterURLSchemeAsBypassingCSP(const std::string& scheme) {
@@ -170,7 +169,6 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
   blink::WebString privileged_scheme(blink::WebString::fromUTF8(scheme));
   if (secure) {
     // TODO(pfrazee): Remove 2.0
-    std::cout << "webFrame.registerURLSchemeAsPrivileged with {secure:true} is deprecated. Use protocol.registerStandardSchemes with {secure:true}" << std::endl;
     blink::WebSecurityPolicy::registerURLSchemeAsSecure(privileged_scheme);
   }
   if (bypassCSP) {

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -4,8 +4,6 @@
 
 #include "atom/renderer/api/atom_api_web_frame.h"
 
-#include <iostream>
-
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/blink_converter.h"
 #include "atom/common/native_mate_converters/callback.h"

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -4,6 +4,8 @@
 
 #include "atom/renderer/api/atom_api_web_frame.h"
 
+#include <iostream>
+
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/blink_converter.h"
 #include "atom/common/native_mate_converters/callback.h"
@@ -137,6 +139,7 @@ void WebFrame::RegisterURLSchemeAsSecure(const std::string& scheme) {
   // Register scheme to secure list (https, wss, data).
   blink::WebSecurityPolicy::registerURLSchemeAsSecure(
       blink::WebString::fromUTF8(scheme));
+  std::cout << "webFrame.registerURLSchemeAsSecure is deprecated. Use protocol.registerStandardSchemes with {secure:true}" << std::endl;
 }
 
 void WebFrame::RegisterURLSchemeAsBypassingCSP(const std::string& scheme) {
@@ -167,6 +170,7 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
   blink::WebString privileged_scheme(blink::WebString::fromUTF8(scheme));
   if (secure) {
     // TODO(pfrazee): Remove 2.0
+    std::cout << "webFrame.registerURLSchemeAsPrivileged with {secure:true} is deprecated. Use protocol.registerStandardSchemes with {secure:true}" << std::endl;
     blink::WebSecurityPolicy::registerURLSchemeAsSecure(privileged_scheme);
   }
   if (bypassCSP) {

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -121,20 +121,24 @@ bool IsDevToolsExtension(content::RenderFrame* render_frame) {
       .SchemeIs("chrome-extension");
 }
 
+std::vector<std::string> ParseSchemesCLISwitch(const char* switch_name) {
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  std::string custom_schemes = command_line->GetSwitchValueASCII(switch_name);
+  if (!custom_schemes.empty()) {
+    return base::SplitString(custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  }
+  return std::vector<std::string>();
+}
+
 }  // namespace
 
 AtomRendererClient::AtomRendererClient()
     : node_bindings_(NodeBindings::Create(false)),
       atom_bindings_(new AtomBindings) {
   // Parse --standard-schemes=scheme1,scheme2
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  std::string custom_schemes = command_line->GetSwitchValueASCII(
-      switches::kStandardSchemes);
-  if (!custom_schemes.empty()) {
-    std::vector<std::string> schemes_list = base::SplitString(
-        custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-    for (const std::string& scheme : schemes_list)
-      url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITHOUT_PORT);
+  std::vector<std::string> standard_schemes_list = ParseSchemesCLISwitch(switches::kStandardSchemes);
+  for (const std::string& scheme : standard_schemes_list) {
+    url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITHOUT_PORT);
   }
 }
 
@@ -182,6 +186,12 @@ void AtomRendererClient::RenderFrameCreated(
   // Allow file scheme to handle service worker by default.
   // FIXME(zcbenz): Can this be moved elsewhere?
   blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers("file");
+  
+  // Parse --secure-schemes=scheme1,scheme2
+  std::vector<std::string> secure_schemes_list = ParseSchemesCLISwitch(switches::kSecureSchemes);
+  for (const std::string& secure_scheme : secure_schemes_list) {
+    blink::WebSecurityPolicy::registerURLSchemeAsSecure(blink::WebString::fromUTF8(secure_scheme));
+  }
 }
 
 void AtomRendererClient::RenderViewCreated(content::RenderView* render_view) {

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -124,7 +124,8 @@ bool IsDevToolsExtension(content::RenderFrame* render_frame) {
 std::vector<std::string> ParseSchemesCLISwitch(const char* switch_name) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   std::string custom_schemes = command_line->GetSwitchValueASCII(switch_name);
-  return base::SplitString(custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  return base::SplitString(
+      custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 }
 
 }  // namespace
@@ -133,10 +134,10 @@ AtomRendererClient::AtomRendererClient()
     : node_bindings_(NodeBindings::Create(false)),
       atom_bindings_(new AtomBindings) {
   // Parse --standard-schemes=scheme1,scheme2
-  std::vector<std::string> standard_schemes_list = ParseSchemesCLISwitch(switches::kStandardSchemes);
-  for (const std::string& scheme : standard_schemes_list) {
+  std::vector<std::string> standard_schemes_list =
+      ParseSchemesCLISwitch(switches::kStandardSchemes);
+  for (const std::string& scheme : standard_schemes_list)
     url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITHOUT_PORT);
-  }
 }
 
 AtomRendererClient::~AtomRendererClient() {
@@ -185,10 +186,11 @@ void AtomRendererClient::RenderFrameCreated(
   blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers("file");
 
   // Parse --secure-schemes=scheme1,scheme2
-  std::vector<std::string> secure_schemes_list = ParseSchemesCLISwitch(switches::kSecureSchemes);
-  for (const std::string& secure_scheme : secure_schemes_list) {
-    blink::WebSecurityPolicy::registerURLSchemeAsSecure(blink::WebString::fromUTF8(secure_scheme));
-  }
+  std::vector<std::string> secure_schemes_list =
+      ParseSchemesCLISwitch(switches::kSecureSchemes);
+  for (const std::string& secure_scheme : secure_schemes_list)
+    blink::WebSecurityPolicy::registerURLSchemeAsSecure(
+        blink::WebString::fromUTF8(secure_scheme));
 }
 
 void AtomRendererClient::RenderViewCreated(content::RenderView* render_view) {

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -124,10 +124,7 @@ bool IsDevToolsExtension(content::RenderFrame* render_frame) {
 std::vector<std::string> ParseSchemesCLISwitch(const char* switch_name) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   std::string custom_schemes = command_line->GetSwitchValueASCII(switch_name);
-  if (!custom_schemes.empty()) {
-    return base::SplitString(custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-  }
-  return std::vector<std::string>();
+  return base::SplitString(custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 }
 
 }  // namespace
@@ -186,7 +183,7 @@ void AtomRendererClient::RenderFrameCreated(
   // Allow file scheme to handle service worker by default.
   // FIXME(zcbenz): Can this be moved elsewhere?
   blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers("file");
-  
+
   // Parse --secure-schemes=scheme1,scheme2
   std::vector<std::string> secure_schemes_list = ParseSchemesCLISwitch(switches::kSecureSchemes);
   for (const std::string& secure_scheme : secure_schemes_list) {

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -121,12 +121,12 @@ webFrame.setVisualZoomLevelLimits(1, 2)
 // Deprecated
 webFrame.registerURLSchemeAsSecure('app')
 // Replace with
-protocol.registerStandardSchemes('app', {secure: true})
+protocol.registerStandardSchemes(['app'], {secure: true})
 
 // Deprecated
 webFrame.registerURLSchemeAsPrivileged('app', {secure: true})
 // Replace with
-protocol.registerStandardSchemes('app', {secure: true})
+protocol.registerStandardSchemes(['app'], {secure: true})
 ```
 
 ## `<webview>`

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -117,6 +117,16 @@ webContents.setVisualZoomLevelLimits(1, 2)
 webFrame.setZoomLevelLimits(1, 2)
 // Replace with
 webFrame.setVisualZoomLevelLimits(1, 2)
+
+// Deprecated
+webFrame.registerURLSchemeAsSecure('app')
+// Replace with
+protocol.registerStandardSchemes('app', {secure: true})
+
+// Deprecated
+webFrame.registerURLSchemeAsPrivileged('app', {secure: true})
+// Replace with
+protocol.registerStandardSchemes('app', {secure: true})
 ```
 
 ## `<webview>`

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -985,5 +985,19 @@ describe('protocol module', function () {
       ipcMain.once('file-system-error', (event, err) => done(err))
       ipcMain.once('file-system-write-end', () => done())
     })
+
+    it('registers secure, when {secure: true}', function (done) {
+      // the CacheStorage API will only work if secure == true
+      let filePath = path.join(__dirname, 'fixtures', 'pages', 'cache-storage.html')
+      const handler = function (request, callback) {
+        callback({path: filePath})
+      }
+      ipcMain.once('success', () => done())
+      ipcMain.once('failure', (event, err) => done(err))
+      protocol.registerFileProtocol(standardScheme, handler, function (error) {
+        if (error) return done(error)
+        w.loadURL(origin)
+      })
+    })
   })
 })

--- a/spec/fixtures/pages/cache-storage.html
+++ b/spec/fixtures/pages/cache-storage.html
@@ -1,0 +1,7 @@
+<script>
+  const ipcRenderer = require('electron').ipcRenderer;
+  caches.open('foo').then(
+    () => ipcRenderer.send('success'),
+    err => ipcRenderer.send('failure', err)
+  )
+</script>

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -92,7 +92,7 @@ if (global.isCi) {
 
 // Register app as standard scheme.
 global.standardScheme = 'app'
-protocol.registerStandardSchemes([global.standardScheme])
+protocol.registerStandardSchemes([global.standardScheme], { secure: true })
 
 app.on('window-all-closed', function () {
   app.quit()


### PR DESCRIPTION
This PR replaces https://github.com/electron/electron/pull/7671. It will:

 - [x] Add a second arg to `registerStandardSchemes`, which is an optional object where you can specify `{ secure: true }` to enable secure registration. Update `protocol.registerStandardSchemes` to register a scheme as secure on the browser side, and to propagate that registration to renderers.
 - [x] Add deprecation notices to `webFrame.registerURLSchemeAsSecure` and `webFrame.registerURLSchemeAsPrivileged`

Still in progress. I'm opening this PR to discuss the changes while I work.