### PR TITLE
Memoize isAsarDisabled because it's called a lot

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -10,13 +10,20 @@
   // Cache asar archive objects.
   const cachedArchives = {}
 
+  let asarDisabled
   const isAsarDisabled = function () {
+    if (asarDisabled !== undefined) return asarDisabled
+
     if (process.noAsar) {
+      asarDisabled = true
       return true
     }
     if (process.env.ELECTRON_NO_ASAR && process.type !== 'browser' && process.type !== 'renderer') {
+      asarDisabled = true
       return true
     }
+
+    asarDisabled = true
     return false
   }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1396/20233847/19937fce-a829-11e6-8689-a99fbfcee224.png)

I suspect that on Windows, calling into process.env is not a very snappy operation 