### PR TITLE
Added BrowserWindow.setAppDetails to set user model id, icon and relaunch command

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -10,6 +10,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/image_converter.h"
@@ -20,6 +21,7 @@
 #include "content/public/common/content_switches.h"
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
+#include "ui/base/win/shell.h"
 #include "ui/gfx/geometry/rect.h"
 
 #if defined(TOOLKIT_VIEWS)
@@ -708,6 +710,25 @@ bool Window::SetThumbnailToolTip(const std::string& tooltip) {
   return window->taskbar_host().SetThumbnailToolTip(
       window_->GetAcceleratedWidget(), tooltip);
 }
+
+void Window::SetAppDetails(const mate::Dictionary& options) {
+  base::string16 app_id;
+  base::FilePath app_icon_path;
+  int app_icon_index;
+  base::string16 relaunch_command;
+  base::string16 relaunch_display_name;
+
+  options.Get("appId", &app_id);
+  options.Get("appIconPath", &app_icon_path);
+  options.Get("appIconIndex", &app_icon_index);
+  options.Get("relaunchCommand", &relaunch_command);
+  options.Get("relaunchDisplayName", &relaunch_display_name);
+
+  ui::win::SetAppDetailsForWindow(
+      app_id, app_icon_path, app_icon_index,
+      relaunch_command, relaunch_display_name,
+      window_->GetAcceleratedWidget());
+}
 #endif
 
 #if defined(TOOLKIT_VIEWS)
@@ -916,6 +937,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("unhookAllWindowMessages", &Window::UnhookAllWindowMessages)
       .SetMethod("setThumbnailClip", &Window::SetThumbnailClip)
       .SetMethod("setThumbnailToolTip", &Window::SetThumbnailToolTip)
+      .SetMethod("setAppDetails", &Window::SetAppDetails)
 #endif
 #if defined(TOOLKIT_VIEWS)
       .SetMethod("setIcon", &Window::SetIcon)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -714,7 +714,7 @@ bool Window::SetThumbnailToolTip(const std::string& tooltip) {
 void Window::SetAppDetails(const mate::Dictionary& options) {
   base::string16 app_id;
   base::FilePath app_icon_path;
-  int app_icon_index;
+  int app_icon_index = 0;
   base::string16 relaunch_command;
   base::string16 relaunch_display_name;
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -21,7 +21,6 @@
 #include "content/public/common/content_switches.h"
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
-#include "ui/base/win/shell.h"
 #include "ui/gfx/geometry/rect.h"
 
 #if defined(TOOLKIT_VIEWS)
@@ -30,6 +29,7 @@
 
 #if defined(OS_WIN)
 #include "atom/browser/ui/win/taskbar_host.h"
+#include "ui/base/win/shell.h"
 #endif
 
 #include "atom/common/node_includes.h"

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -187,6 +187,7 @@ class Window : public mate::TrackableObject<Window>,
   void UnhookAllWindowMessages();
   bool SetThumbnailClip(const gfx::Rect& region);
   bool SetThumbnailToolTip(const std::string& tooltip);
+  void SetAppDetails(const mate::Dictionary& options);
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1103,6 +1103,26 @@ the entire window by specifying an empty region:
 Sets the toolTip that is displayed when hovering over the window thumbnail
 in the taskbar.
 
+#### `win.setAppDetails(options)` _Windows_
+
+* `options` Object
+  * `appId` String (optional) -
+    Window's [App User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569(v=vs.85).aspx).
+    It has to be set, otherwise the other options will have no effect.
+  * `appIconPath` String (optional) -
+    Window's [Relaunch Icon](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391573(v=vs.85).aspx).
+  * `appIconIndex` Integer (optional) - Index of the icon in `appIconPath`.
+    Ignored when `appIconPath` is not set. Default is `0`.
+  * `relaunchCommand` String (optional) -
+    Window's [Relaunch Command](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391571(v=vs.85).aspx).
+  * `relaunchDisplayName` String (optional) -
+    Window's [Relaunch Display Name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391572(v=vs.85).aspx).
+
+Sets the properties for the window's taskbar button.
+
+**Note:** `relaunchCommand` and `relaunchDisplayName` must always be set together. If one
+of those properties is not set, then neither is used.
+
 #### `win.showDefinitionForSelection()` _macOS_
 
 Same as `webContents.showDefinitionForSelection()`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1106,22 +1106,18 @@ in the taskbar.
 #### `win.setAppDetails(options)` _Windows_
 
 * `options` Object
-  * `appId` String (optional) -
-    Window's [App User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569(v=vs.85).aspx).
+  * `appId` String (optional) - Window's [App User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569(v=vs.85).aspx).
     It has to be set, otherwise the other options will have no effect.
-  * `appIconPath` String (optional) -
-    Window's [Relaunch Icon](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391573(v=vs.85).aspx).
+  * `appIconPath` String (optional) - Window's [Relaunch Icon](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391573(v=vs.85).aspx).
   * `appIconIndex` Integer (optional) - Index of the icon in `appIconPath`.
     Ignored when `appIconPath` is not set. Default is `0`.
-  * `relaunchCommand` String (optional) -
-    Window's [Relaunch Command](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391571(v=vs.85).aspx).
-  * `relaunchDisplayName` String (optional) -
-    Window's [Relaunch Display Name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391572(v=vs.85).aspx).
+  * `relaunchCommand` String (optional) - Window's [Relaunch Command](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391571(v=vs.85).aspx).
+  * `relaunchDisplayName` String (optional) - Window's [Relaunch Display Name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391572(v=vs.85).aspx).
 
 Sets the properties for the window's taskbar button.
 
-**Note:** `relaunchCommand` and `relaunchDisplayName` must always be set together. If one
-of those properties is not set, then neither is used.
+**Note:** `relaunchCommand` and `relaunchDisplayName` must always be set
+together. If one of those properties is not set, then neither will be used.
 
 #### `win.showDefinitionForSelection()` _macOS_
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -518,6 +518,34 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.setAppDetails(options)', function () {
+    if (process.platform !== 'win32') return
+
+    it('supports setting the app details', function () {
+      const iconPath = path.join(fixtures, 'assets', 'icon.ico')
+
+      assert.doesNotThrow(function () {
+        w.setAppDetails({appId: 'my.app.id'})
+        w.setAppDetails({appIconPath: iconPath, appIconIndex: 0})
+        w.setAppDetails({appIconPath: iconPath})
+        w.setAppDetails({relaunchCommand: 'my-app.exe arg1 arg2', relaunchDisplayName: 'My app name'})
+        w.setAppDetails({relaunchCommand: 'my-app.exe arg1 arg2'})
+        w.setAppDetails({relaunchDisplayName: 'My app name'})
+        w.setAppDetails({
+          appId: 'my.app.id',
+          appIconPath: iconPath,
+          appIconIndex: 0,
+          relaunchCommand: 'my-app.exe arg1 arg2',
+          relaunchDisplayName: 'My app name'
+        })
+        w.setAppDetails({})
+      })
+      assert.throws(function () {
+        w.setAppDetails()
+      }, /Insufficient number of arguments./)
+    })
+  })
+
   describe('BrowserWindow.fromId(id)', function () {
     it('returns the window with id', function () {
       assert.equal(w.id, BrowserWindow.fromId(w.id).id)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -519,9 +519,9 @@ describe('browser-window module', function () {
   })
 
   describe('BrowserWindow.setAppDetails(options)', function () {
-    if (process.platform !== 'win32') return
-
     it('supports setting the app details', function () {
+      if (process.platform !== 'win32') return this.skip()
+
       const iconPath = path.join(fixtures, 'assets', 'icon.ico')
 
       assert.doesNotThrow(function () {
@@ -540,9 +540,10 @@ describe('browser-window module', function () {
         })
         w.setAppDetails({})
       })
+
       assert.throws(function () {
         w.setAppDetails()
-      }, /Insufficient number of arguments./)
+      }, /Insufficient number of arguments\./)
     })
   })
 


### PR DESCRIPTION
Calls [ui::win::SetAppDetailsForWindow](https://github.com/nwjs/chromium.src/blob/151b8e5d39b7edcf9eed78ebedf3b4eae9f93d28/ui/base/win/shell.cc#L117) in Chromium.

For Microsoft/vscode#13905