### PR TITLE
Add Redux DevTools Extension to support list

### DIFF
--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -51,6 +51,7 @@ Following Devtools Extensions are tested and guaranteed to work in Electron:
 * [AngularJS Batarang](https://chrome.google.com/webstore/detail/angularjs-batarang/ighdmehidhipcmcojjgiloacoafjmpfk)
 * [Vue.js devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
 * [Cerebral Debugger](http://www.cerebraljs.com/documentation/the_debugger)
+* [Redux DevTools Extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
 
 ### What should I do if a DevTools Extension is not working?
 


### PR DESCRIPTION
I think it's stable on the Electron, I wrote an integration test for it (https://github.com/zalmoxisus/redux-devtools-extension/pull/155), and it has been in [electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate/pull/254).

Also, It will be better if we got #7923.