### PR TITLE
Update electron-squirrel-startup link

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -40,7 +40,7 @@ On Windows, you have to install your app into a user's machine before you can
 use the `autoUpdater`, so it is recommended that you use the
 [electron-winstaller][installer-lib], [electron-builder][electron-builder-lib] or the [grunt-electron-installer][installer] package to generate a Windows installer.
 
-When using [electron-winstaller][installer-lib] or [electron-builder][electron-builder-lib] make sure you do not try to update your app [the first time it runs](https://github.com/electron/windows-installer#handling-squirrel-events) (Also see [this issue for more info](https://github.com/electron/electron/issues/7155)). It's also recommended to use [electron-squirrel-startup](electron-squirrel-startup) to get desktop shortcuts for your app.
+When using [electron-winstaller][installer-lib] or [electron-builder][electron-builder-lib] make sure you do not try to update your app [the first time it runs](https://github.com/electron/windows-installer#handling-squirrel-events) (Also see [this issue for more info](https://github.com/electron/electron/issues/7155)). It's also recommended to use [electron-squirrel-startup](https://github.com/mongodb-js/electron-squirrel-startup) to get desktop shortcuts for your app.
 
 The installer generated with Squirrel will create a shortcut icon with an
 [Application User Model ID][app-user-model-id] in the format of


### PR DESCRIPTION
The currently link points to a non-existent page.  I updated the link to point to the same place that the [electron/windows-installer](https://github.com/electron/windows-installer/) documentation points.
 
If someone else knows that this is the correct place to link that would be nice to hear.