### PR TITLE
Memoize ELECTRON_NO_ASAR env var check

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -10,14 +10,9 @@
   // Cache asar archive objects.
   const cachedArchives = {}
 
+  const envNoAsar = process.env.ELECTRON_NO_ASAR && process.type !== 'browser' && process.type !== 'renderer'
   const isAsarDisabled = function () {
-    if (process.noAsar) {
-      return true
-    }
-    if (process.env.ELECTRON_NO_ASAR && process.type !== 'browser' && process.type !== 'renderer') {
-      return true
-    }
-    return false
+    return process.noAsar || envNoAsar
   }
 
   const getOrCreateArchive = function (p) {


### PR DESCRIPTION
The `ELECTRON_NO_ASAR` var is supported for spawned/forked child processes so it only needs to be checked once and the value can be cached for future calls.

🐎 Seeks to improve on the costly checks reported in #7948

/cc @paulcbetts 👀 

Closes #7948