### PR TITLE
Convert about credits to NSAttributedString

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -255,6 +255,16 @@ void Browser::DockSetIcon(const gfx::Image& image) {
 
 void Browser::ShowAboutPanel() {
   NSDictionary* options = DictionaryValueToNSDictionary(about_panel_options_);
+
+  // Credits must be a NSAttributedString instead of NSString
+  id credits = options[@"Credits"];
+  if (credits != nil) {
+    NSMutableDictionary* mutable_options = [options mutableCopy];
+    mutable_options[@"Credits"] = [[[NSAttributedString alloc]
+        initWithString:(NSString*)credits] autorelease];
+    options = [NSDictionary dictionaryWithDictionary:mutable_options];
+  }
+
   [[AtomApplication sharedApplication]
       orderFrontStandardAboutPanelWithOptions:options];
 }


### PR DESCRIPTION
The about panel credits must be a `NSAttributedString`, not a `NSString`.

https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc

Closes #7953