### PR TITLE
Guard against missing members in setObjectMembers

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -95,6 +95,8 @@ const wrapArgs = function (args, visited) {
 // The |ref| will be kept referenced by |members|.
 // This matches |getObjectMemebers| in rpc-server.
 const setObjectMembers = function (ref, object, metaId, members) {
+  if (!Array.isArray(members)) return
+
   for (let member of members) {
     if (object.hasOwnProperty(member.name)) continue
 
@@ -161,9 +163,7 @@ const proxyFunctionProperties = function (remoteMemberFunction, metaId, name) {
     if (loaded) return
     loaded = true
     const meta = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_GET', metaId, name)
-    if (Array.isArray(meta.members)) {
-      setObjectMembers(remoteMemberFunction, remoteMemberFunction, meta.id, meta.members)
-    }
+    setObjectMembers(remoteMemberFunction, remoteMemberFunction, meta.id, meta.members)
   }
 
   return new Proxy(remoteMemberFunction, {


### PR DESCRIPTION
This moves the guard added in #7209 to extend to all cases where `setObjectMembers` is called.

It has been reported there are still cases where `Uncaught TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined` errors can occur.

Closes #7918