### PR TITLE
Add reload and toggledevtools menu item roles

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -87,11 +87,7 @@ app.once('ready', () => {
           role: 'reload'
         },
         {
-          label: 'Toggle Developer Tools',
-          accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-          click (item, focusedWindow) {
-            if (focusedWindow) focusedWindow.toggleDevTools()
-          }
+          role: 'toggledevtools'
         },
         {
           type: 'separator'

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -84,11 +84,7 @@ app.once('ready', () => {
       label: 'View',
       submenu: [
         {
-          label: 'Reload',
-          accelerator: 'CmdOrCtrl+R',
-          click (item, focusedWindow) {
-            if (focusedWindow) focusedWindow.reload()
-          }
+          role: 'reload'
         },
         {
           label: 'Toggle Developer Tools',

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -56,6 +56,8 @@ The `role` property can have following values:
 * `minimize` - Minimize current window
 * `close` - Close current window
 * `quit`- Quit the application
+* `reload` - Reload the current window
+* `toggledevtools` - Toggle developer tools in the current window
 * `togglefullscreen`- Toggle full screen mode on the current window
 * `resetzoom` - Reset the focused page's zoom level to the original size
 * `zoomin` - Zoom in the focused page by 10%

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -137,18 +137,10 @@ const template = [
     label: 'View',
     submenu: [
       {
-        label: 'Reload',
-        accelerator: 'CmdOrCtrl+R',
-        click (item, focusedWindow) {
-          if (focusedWindow) focusedWindow.reload()
-        }
+        role: 'reload'
       },
       {
-        label: 'Toggle Developer Tools',
-        accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-        click (item, focusedWindow) {
-          if (focusedWindow) focusedWindow.webContents.toggleDevTools()
-        }
+        role: 'toggledevtools'
       },
       {
         type: 'separator'

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -72,6 +72,11 @@ const roles = {
     accelerator: process.platform === 'win32' ? 'Control+Y' : 'Shift+CommandOrControl+Z',
     webContentsMethod: 'redo'
   },
+  reload: {
+    label: 'Reload',
+    accelerator: 'CmdOrCtrl+R',
+    windowMethod: 'reload'
+  },
   resetzoom: {
     label: 'Actual Size',
     accelerator: 'CommandOrControl+0',
@@ -138,7 +143,7 @@ const canExecuteRole = (role) => {
   if (!roles.hasOwnProperty(role)) return false
   if (process.platform !== 'darwin') return true
   // macOS handles all roles natively except the ones listed below
-  return ['zoomin', 'zoomout', 'resetzoom'].includes(role)
+  return ['reload', 'resetzoom', 'zoomin', 'zoomout'].includes(role)
 }
 
 exports.getDefaultLabel = (role) => {

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -98,6 +98,11 @@ const roles = {
   stopspeaking: {
     label: 'Stop Speaking'
   },
+  toggledevtools: {
+    label: 'Toggle Developer Tools',
+    accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+    windowMethod: 'toggleDevTools'
+  },
   togglefullscreen: {
     label: 'Toggle Full Screen',
     accelerator: process.platform === 'darwin' ? 'Control+Command+F' : 'F11',
@@ -143,7 +148,7 @@ const canExecuteRole = (role) => {
   if (!roles.hasOwnProperty(role)) return false
   if (process.platform !== 'darwin') return true
   // macOS handles all roles natively except the ones listed below
-  return ['reload', 'resetzoom', 'zoomin', 'zoomout'].includes(role)
+  return ['reload', 'resetzoom', 'toggledevtools', 'zoomin', 'zoomout'].includes(role)
 }
 
 exports.getDefaultLabel = (role) => {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -363,6 +363,11 @@ ipcMain.on('ELECTRON_BROWSER_MEMBER_SET', function (event, id, name, value) {
 ipcMain.on('ELECTRON_BROWSER_MEMBER_GET', function (event, id, name) {
   try {
     let obj = objectsRegistry.get(id)
+
+    if (obj == null) {
+      throwRPCError(`Cannot get property '${name}' on missing remote object ${id}`)
+    }
+
     event.returnValue = valueToMeta(event.sender, obj[name])
   } catch (error) {
     event.returnValue = exceptionToMeta(error)


### PR DESCRIPTION
Noticed these were still being implemented manually in the default app even though they just called a method directly on the focused window.

This pull request adds them as `reload` and `toggledevtools` role for less code duplication.