### PR TITLE
Pin electron-docs-linter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.14.1",
+    "electron-docs-linter": "1.14.1",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
Seeing the following failures on CI:

```
[Error: `window.open` Function does not appear to have a source document]
[Error: `window.open` Function does not appear to have a source document]
```

Pinning the docs linter to a specific version to see if it starts passing.