### PR TITLE
Process doc followup

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -2,7 +2,7 @@
 
 > Extensions to process object.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
 
 The `process` object is extended in Electron with following APIs:
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -4,7 +4,9 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
 
-The `process` object is extended in Electron with following APIs:
+Electron's `process` object is extended from the
+[Node.js `process` object](https://nodejs.org/api/process.html).
+It adds the following events, properties, and methods:
 
 ## Events
 


### PR DESCRIPTION
This is a followup to #7985 to make it more clear that Electron extends the Node `process` object.

cc @zcbenz @kevinsawicki @crilleengvall