### PR TITLE
Prevent systemPreferences.getUserDefault crash for missing arrays/dictionaries

### DIFF
--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -37,13 +37,25 @@ describe('systemPreferences module', function () {
     }
 
     it('returns values for known user defaults', function () {
-      let locale = systemPreferences.getUserDefault('AppleLocale', 'string')
-      assert.notEqual(locale, null)
+      const locale = systemPreferences.getUserDefault('AppleLocale', 'string')
+      assert.equal(typeof locale, 'string')
       assert(locale.length > 0)
 
-      let languages = systemPreferences.getUserDefault('AppleLanguages', 'array')
-      assert.notEqual(languages, null)
+      const languages = systemPreferences.getUserDefault('AppleLanguages', 'array')
+      assert(Array.isArray(languages))
       assert(languages.length > 0)
+    })
+
+    it('returns values for unknown user defaults', function () {
+      assert.equal(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'boolean'), false)
+      assert.equal(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'integer'), 0)
+      assert.equal(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'float'), 0)
+      assert.equal(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'double'), 0)
+      assert.equal(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'string'), '')
+      assert.equal(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'url'), '')
+      assert.equal(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'badtype'), undefined)
+      assert.deepEqual(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'array'), [])
+      assert.deepEqual(systemPreferences.getUserDefault('UserDefaultDoesNotExist', 'dictionary'), {})
     })
   })
 


### PR DESCRIPTION
The `NSArrayToListValue` and `NSDictionaryToDictionaryValue` return null pointers when the given value is null which is the case when the requested user default is not an array or dictionary.

This pull requests returns empty array/objects instead of crashing when this happens.

Also adds specs for the values returned when the key has no default.