### PR TITLE
Update dialog.md

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -32,7 +32,7 @@ The `dialog` module has the following methods:
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structrs/file-filter.md) (optional)
-  * `properties` String[] (optional) - Contains which features the dialog should use, can
+  * `properties` `String[]` (optional) - Contains which features the dialog should use, can
     contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
     and `showHiddenFiles`.
 * `callback` Function (optional)

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -32,7 +32,7 @@ The `dialog` module has the following methods:
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structrs/file-filter.md) (optional)
-  * `properties` `String[]` (optional) - Contains which features the dialog should use, can
+  * `properties` String[] - (optional) - Contains which features the dialog should use, can
     contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
     and `showHiddenFiles`.
 * `callback` Function (optional)


### PR DESCRIPTION
Fix 'properties' type in documentation (was missing `[]` notation due to lack of Markdown escaping).