### PR TITLE
Fixed linting on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "devDependencies": {
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
-    "cross-conf-env": "^1.0.6",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.16.0",
+    "electron-docs-linter": "^1.16.1",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"
@@ -38,7 +37,7 @@
     "lint-cpp": "python ./script/cpplint.py",
     "lint-py": "python ./script/pylint.py",
     "lint-api-docs-js": "standard-markdown docs && standard-markdown docs-translations",
-    "lint-api-docs": "cross-conf-env electron-docs-linter docs/api --version=$npm_package_version --outfile=out/electron-api.json",
+    "lint-api-docs": "electron-docs-linter --outfile=out/electron-api.json",
     "preinstall": "node -e 'process.exit(0)'",
     "release": "./script/upload.py -p",
     "repl": "python ./script/start.py --interactive",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
+    "cross-conf-env": "^1.0.6",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^1.16.0",
     "request": "*",
@@ -37,7 +38,7 @@
     "lint-cpp": "python ./script/cpplint.py",
     "lint-py": "python ./script/pylint.py",
     "lint-api-docs-js": "standard-markdown docs && standard-markdown docs-translations",
-    "lint-api-docs": "electron-docs-linter docs/api --version=$npm_package_version --outfile=out/electron-api.json",
+    "lint-api-docs": "cross-conf-env electron-docs-linter docs/api --version=$npm_package_version --outfile=out/electron-api.json",
     "preinstall": "node -e 'process.exit(0)'",
     "release": "./script/upload.py -p",
     "repl": "python ./script/start.py --interactive",

--- a/script/pylint.py
+++ b/script/pylint.py
@@ -14,8 +14,9 @@ def main():
   pylint = os.path.join(SOURCE_ROOT, 'vendor', 'depot_tools', 'pylint.py')
   settings = ['--rcfile=vendor/depot_tools/pylintrc']
   pys = glob.glob('script/*.py')
-  subprocess.check_call([sys.executable, pylint] + settings + pys,
-                        env=dict(PYTHONPATH='script'))
+  env = os.environ.copy()
+  env['PYTHONPATH'] = 'script'
+  subprocess.check_call([sys.executable, pylint] + settings + pys, env=env)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When I tried run lint on Windows 10 x64, I got two errors:

1. `WindowsError: [Error -2146893795] Provider DLL failed to initialize correctly` when running pylint
2. `electron-docs-linter` command referenced the `npm_package_version` env variable using unix style

This PR fixes both.