### PR TITLE
use updated docs linter with required param parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.15.0",
+    "electron-docs-linter": "^1.16.0",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
This updates to a new version of the docs linter that adds a `required` boolean to method parameters:


```js
{
  name: "inspectElement",
  signature: "(x, y)",
  description: "Starts inspecting element at position (x, y).",
  parameters: [
    {
      name: "x",
      type: "Integer",
      required: true
    },
    {
      name: "y",
      type: "Integer",
      required: true
    }
  ]
},
```