### PR TITLE
Fix support for dragging urls in Mac

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -297,7 +297,6 @@ const CGFloat kVerticalTitleMargin = 2;
 
   if (NSPointInRect([sender draggingLocation], self.frame)) {
     trayIcon_->NotifyDrop();
-    [self handleDrop:sender];
   }
 }
 
@@ -325,6 +324,7 @@ const CGFloat kVerticalTitleMargin = 2;
 }
 
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender {
+  [self handleDrop:sender];
   return YES;
 }
 


### PR DESCRIPTION
Hey folks!

I'm writing an app that supports drag&drop on the menu bar here and ran into an odd issue: the `drop-text` callback was not triggering for spotify URLs. It works fine if I drag raw text on the tray icon, but otherwise it doesn't seem to trigger all the time for URLs.

Reading some references on how to handle drops in cocoa ([1](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/DragandDrop/Tasks/DraggingFiles.html#//apple_ref/doc/uid/20001288-102943), [2](http://stackoverflow.com/questions/5663887/drag-and-drop-with-nsstatusitem)) I noticed they all process the drop from `performDragOperation` instead of `draggingEnded`, like Electron does. And updating it to use the former fixed this issue here: it's now triggering the callback for raw text and urls 100% of the time.

I didn't dive further to see what's causing issues with `draggingEnded` but hope this is still an acceptable patch!

Thanks,

/cc @nzoschke