### PR TITLE
Fix missed parameter in example.

### DIFF
--- a/docs-translations/ko-KR/api/ipc-main.md
+++ b/docs-translations/ko-KR/api/ipc-main.md
@@ -40,7 +40,7 @@ ipcMain.on('synchronous-message', (event, arg) => {
 const {ipcRenderer} = require('electron')
 console.log(ipc.sendSync('synchronous-message', 'ping')) // "pong" 출력
 
-ipcRenderer.on('asynchronous-reply', (arg) => {
+ipcRenderer.on('asynchronous-reply', (event, arg) => {
   console.log(arg) // "pong" 출력
 })
 ipcRenderer.send('asynchronous-message', 'ping')


### PR DESCRIPTION
Below example (in line 43 ~ 45) not working like comment. Because `ipcRenderer` callback function have two parameters (event, arg).

```javascript
ipcRenderer.on('asynchronous-reply', (arg) => {
  console.log(arg) // "pong" 출력
})
```