### PR TITLE
Fix typo in docs/api/dialog

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -31,7 +31,7 @@ The `dialog` module has the following methods:
   * `defaultPath` String (optional)
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
-  * `filters` [FileFilter[]](structrs/file-filter.md) (optional)
+  * `filters` [FileFilter[]](structures/file-filter.md) (optional)
   * `properties` String[] - (optional) - Contains which features the dialog should use, can
     contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
     and `showHiddenFiles`.


### PR DESCRIPTION
I fixed typo in dialog.md linked to docs/api/structures/file-filter.md