### PR TITLE
Add new method to set layout-based zoom level limit

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -88,7 +88,7 @@ double WebFrame::GetZoomFactor() const {
   return blink::WebView::zoomLevelToZoomFactor(GetZoomLevel());
 }
 
-void WebFrame::SetZoomLevelLimits(double min_level, double max_level) {
+void WebFrame::SetVisualZoomLevelLimits(double min_level, double max_level) {
   web_frame_->view()->setDefaultPageScaleLimits(min_level, max_level);
 }
 
@@ -231,7 +231,9 @@ void WebFrame::BuildPrototype(
       .SetMethod("getZoomLevel", &WebFrame::GetZoomLevel)
       .SetMethod("setZoomFactor", &WebFrame::SetZoomFactor)
       .SetMethod("getZoomFactor", &WebFrame::GetZoomFactor)
-      .SetMethod("setZoomLevelLimits", &WebFrame::SetZoomLevelLimits)
+      .SetMethod("setZoomLevelLimits", &WebFrame::SetVisualZoomLevelLimits)
+      .SetMethod("setVisualZoomLevelLimits",
+                 &WebFrame::SetVisualZoomLevelLimits)
       .SetMethod("setLayoutZoomLevelLimits",
                  &WebFrame::SetLayoutZoomLevelLimits)
       .SetMethod("registerEmbedderCustomElement",

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -92,6 +92,10 @@ void WebFrame::SetZoomLevelLimits(double min_level, double max_level) {
   web_frame_->view()->setDefaultPageScaleLimits(min_level, max_level);
 }
 
+void WebFrame::SetLayoutZoomLevelLimits(double min_level, double max_level) {
+  web_frame_->view()->zoomLimitsChanged(min_level, max_level);
+}
+
 v8::Local<v8::Value> WebFrame::RegisterEmbedderCustomElement(
     const base::string16& name, v8::Local<v8::Object> options) {
   blink::WebExceptionCode c = 0;
@@ -228,6 +232,7 @@ void WebFrame::BuildPrototype(
       .SetMethod("setZoomFactor", &WebFrame::SetZoomFactor)
       .SetMethod("getZoomFactor", &WebFrame::GetZoomFactor)
       .SetMethod("setZoomLevelLimits", &WebFrame::SetZoomLevelLimits)
+      .SetMethod("setLayoutZoomLevelLimits", &WebFrame::SetLayoutZoomLevelLimits)
       .SetMethod("registerEmbedderCustomElement",
                  &WebFrame::RegisterEmbedderCustomElement)
       .SetMethod("registerElementResizeCallback",

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -232,7 +232,8 @@ void WebFrame::BuildPrototype(
       .SetMethod("setZoomFactor", &WebFrame::SetZoomFactor)
       .SetMethod("getZoomFactor", &WebFrame::GetZoomFactor)
       .SetMethod("setZoomLevelLimits", &WebFrame::SetZoomLevelLimits)
-      .SetMethod("setLayoutZoomLevelLimits", &WebFrame::SetLayoutZoomLevelLimits)
+      .SetMethod("setLayoutZoomLevelLimits",
+                 &WebFrame::SetLayoutZoomLevelLimits)
       .SetMethod("registerEmbedderCustomElement",
                  &WebFrame::RegisterEmbedderCustomElement)
       .SetMethod("registerElementResizeCallback",

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -231,7 +231,6 @@ void WebFrame::BuildPrototype(
       .SetMethod("getZoomLevel", &WebFrame::GetZoomLevel)
       .SetMethod("setZoomFactor", &WebFrame::SetZoomFactor)
       .SetMethod("getZoomFactor", &WebFrame::GetZoomFactor)
-      .SetMethod("setZoomLevelLimits", &WebFrame::SetVisualZoomLevelLimits)
       .SetMethod("setVisualZoomLevelLimits",
                  &WebFrame::SetVisualZoomLevelLimits)
       .SetMethod("setLayoutZoomLevelLimits",
@@ -252,7 +251,9 @@ void WebFrame::BuildPrototype(
       .SetMethod("insertText", &WebFrame::InsertText)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
-      .SetMethod("clearCache", &WebFrame::ClearCache);
+      .SetMethod("clearCache", &WebFrame::ClearCache)
+      // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
+      .SetMethod("setZoomLevelLimits", &WebFrame::SetVisualZoomLevelLimits);
 }
 
 }  // namespace api

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -46,6 +46,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   double GetZoomFactor() const;
 
   void SetZoomLevelLimits(double min_level, double max_level);
+  void SetLayoutZoomLevelLimits(double min_level, double max_level);
 
   v8::Local<v8::Value> RegisterEmbedderCustomElement(
       const base::string16& name, v8::Local<v8::Object> options);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -45,7 +45,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   double SetZoomFactor(double factor);
   double GetZoomFactor() const;
 
-  void SetZoomLevelLimits(double min_level, double max_level);
+  void SetVisualZoomLevelLimits(double min_level, double max_level);
   void SetLayoutZoomLevelLimits(double min_level, double max_level);
 
   v8::Local<v8::Value> RegisterEmbedderCustomElement(

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -691,7 +691,22 @@ Sends a request to get current zoom level, the `callback` will be called with
 * `minimumLevel` Number
 * `maximumLevel` Number
 
-Sets the maximum and minimum zoom level.
+**Deprecated:** Call `setVisualZoomLevelLimits` instead to set the visual zoom
+level limits. This method will be removed in Electron 2.0.
+
+#### `contents.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum pinch-to-zoom level.
+
+#### `contents.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 #### `contents.undo()`
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -44,18 +44,22 @@ Returns `Number` - The current zoom level.
 * `minimumLevel` Number
 * `maximumLevel` Number
 
-Sets the maximum and minimum pinch-to-zoom level. In future versions of Electron
-this method will be called `setVisualZoomLevelLimits`.
+**Deprecated:** Call `setVisualZoomLevelLimits` instead to set the visual zoom
+level limits. This method will be removed in Electron 2.0.
+
+### `webFrame.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum pinch-to-zoom level.
 
 ### `webFrame.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
 
 * `minimumLevel` Number
 * `maximumLevel` Number
 
-Sets the maximum and minimum layout-based (i.e. non-visual only) zoom level. In 
-future versions of Electron this will be renamed `setZoomLevelLimits`, but the
-current naming is kept for backwards-compatibility purposes.
-
+Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 ### `webFrame.setSpellCheckProvider(language, autoCorrectWord, provider)`
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -44,7 +44,18 @@ Returns `Number` - The current zoom level.
 * `minimumLevel` Number
 * `maximumLevel` Number
 
-Sets the maximum and minimum zoom level.
+Sets the maximum and minimum pinch-to-zoom level. In future versions of Electron
+this method will be called `setVisualZoomLevelLimits`.
+
+### `webFrame.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum layout-based (i.e. non-visual only) zoom level. In 
+future versions of Electron this will be renamed `setZoomLevelLimits`, but the
+current naming is kept for backwards-compatibility purposes.
+
 
 ### `webFrame.setSpellCheckProvider(language, autoCorrectWord, provider)`
 

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -86,6 +86,31 @@ webContents.openDevTools({detach: true})
 webContents.openDevTools({mode: 'detach'})
 ```
 
+```js
+// Deprecated
+webContents.setZoomLevelLimits(1, 2)
+// Replace with
+webContents.setVisualZoomLevelLimits(1, 2)
+```
+
+## `webFrame`
+
+```js
+// Deprecated
+webFrame.setZoomLevelLimits(1, 2)
+// Replace with
+webFrame.setVisualZoomLevelLimits(1, 2)
+```
+
+## `<webview>`
+
+```js
+// Deprecated
+webview.setZoomLevelLimits(1, 2)
+// Replace with
+webview.setVisualZoomLevelLimits(1, 2)
+```
+
 ## Node Headers URL
 
 This is the URL specified as `disturl` in a `.npmrc` file or as the `--dist-url`

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -100,6 +100,7 @@ WebContents.prototype.sendToAll = function (channel, ...args) {
 // Following methods are mapped to webFrame.
 const webFrameMethods = [
   'insertText',
+  'setLayoutZoomLevelLimits',
   'setZoomFactor',
   'setZoomLevel',
   'setZoomLevelLimits'

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -101,8 +101,10 @@ WebContents.prototype.sendToAll = function (channel, ...args) {
 const webFrameMethods = [
   'insertText',
   'setLayoutZoomLevelLimits',
+  'setVisualZoomLevelLimits',
   'setZoomFactor',
   'setZoomLevel',
+  // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
   'setZoomLevelLimits'
 ]
 const webFrameMethodsWithResult = [

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -391,8 +391,10 @@ var registerWebViewElement = function () {
     'send',
     'sendInputEvent',
     'setLayoutZoomLevelLimits',
+    'setVisualZoomLevelLimits',
     'setZoomFactor',
     'setZoomLevel',
+    // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
     'setZoomLevelLimits'
   ]
 

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -390,6 +390,7 @@ var registerWebViewElement = function () {
     'insertText',
     'send',
     'sendInputEvent',
+    'setLayoutZoomLevelLimits',
     'setZoomFactor',
     'setZoomLevel',
     'setZoomLevelLimits'

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -6,6 +6,7 @@ const {BrowserWindow, protocol, ipcMain} = remote
 
 describe('webFrame module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
+
   describe('webFrame.registerURLSchemeAsPrivileged', function () {
     it('supports fetch api by default', function (done) {
       webFrame.registerURLSchemeAsPrivileged('file')
@@ -125,5 +126,13 @@ describe('webFrame module', function () {
         w.loadURL(url)
       })
     }
+  })
+
+  it('supports setting the visual and layout zoom level limits', function () {
+    assert.doesNotThrow(function () {
+      webFrame.setZoomLevelLimits(1, 100)
+      webFrame.setVisualZoomLevelLimits(1, 50)
+      webFrame.setLayoutZoomLevelLimits(0, 25)
+    })
   })
 })


### PR DESCRIPTION
The current behavior of `setZoomLevelLimits` affects the visual-based zoom (i.e. no layout changes) despite all of the rest of the methods affecting layout-based zoom. While this zoom survives in-page navigations such as iframes being loaded, it also causes pages to be cut-off.

The ideal fix for this would to be to just change the behavior of this method but that would be a breaking change. This PR introduces a new zoom level limit method to limit layout-based zoom.

This allows you to work around #6958 by doing the following:

```js
function setZoomHarder(wv, zoomLevel) {
  wv.setLayoutZoomLevelLimits(zoomLevel, zoomLevel);
  wv.setZoomLevel(zoomLevel);
}
```

Refs #6958 