### PR TITLE
Update open-url docs to mention NSPrincipalClass

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -108,8 +108,9 @@ Returns:
 * `event` Event
 * `url` String
 
-Emitted when the user wants to open a URL with the application. The URL scheme
-must be registered to be opened by your application.
+Emitted when the user wants to open a URL with the application. Your application's
+Info.plist file must define the url scheme within the `CFBundleURLTypes` key, and 
+set `NSPrincipalClass` to `AtomApplication`.
 
 You should call `event.preventDefault()` if you want to handle this event.
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -109,7 +109,7 @@ Returns:
 * `url` String
 
 Emitted when the user wants to open a URL with the application. Your application's
-Info.plist file must define the url scheme within the `CFBundleURLTypes` key, and 
+`Info.plist` file must define the url scheme within the `CFBundleURLTypes` key, and 
 set `NSPrincipalClass` to `AtomApplication`.
 
 You should call `event.preventDefault()` if you want to handle this event.


### PR DESCRIPTION
We got bit by a nasty bug today - if you change your app's info.plist `NSPrincipalClass` to something other to `AtomApplication` (We set it to NylasApplication via a bad find-replace), everything works except open-url is never fired. Add a small reference to the docs so folks know to check this key.