### PR TITLE
Fix incorrect window size after restore on Windows

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -327,6 +327,7 @@ NativeWindowViews::NativeWindowViews(
     last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
   else
     last_window_state_ = ui::SHOW_STATE_NORMAL;
+  last_normal_bounds_ = GetBounds();
 #endif
 }
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -211,6 +211,22 @@ class NativeWindowViews : public NativeWindow,
 
   ui::WindowShowState last_window_state_;
 
+  // There's an issue with restore on Windows, that sometimes causes the Window
+  // to receive the wrong size (#2498). To circumvent that, we keep tabs on the
+  // size of the window while in the normal state (not maximized, minimized or
+  // fullscreen), so we restore it correctly.
+  gfx::Rect last_normal_bounds_;
+
+  // last_normal_bounds_ may or may not require update on WM_MOVE. When a
+  // window is maximized, it is moved (WM_MOVE) to maximum size first and then
+  // sized (WM_SIZE). In this case, last_normal_bounds_ should not update. We
+  // keep last_normal_bounds_candidate_ as a candidate which will become valid
+  // last_normal_bounds_ if the moves are consecutive with no WM_SIZE event in
+  // between.
+  gfx::Rect last_normal_bounds_candidate_;
+
+  bool consecutive_moves_;
+
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -216,6 +216,7 @@ class NativeWindowViews : public NativeWindow,
   // size of the window while in the normal state (not maximized, minimized or
   // fullscreen), so we restore it correctly.
   gfx::Rect last_normal_bounds_;
+  gfx::Rect last_normal_bounds_before_move_;
 
   // last_normal_bounds_ may or may not require update on WM_MOVE. When a
   // window is maximized, it is moved (WM_MOVE) to maximum size first and then

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -125,6 +125,7 @@ bool NativeWindowViews::PreHandleMSG(
         return taskbar_host_.HandleThumbarButtonEvent(LOWORD(w_param));
       return false;
     case WM_SIZE: {
+      consecutive_moves_ = false;
       // Handle window state change.
       HandleSizeEvent(w_param, l_param);
       return false;
@@ -132,6 +133,15 @@ bool NativeWindowViews::PreHandleMSG(
     case WM_MOVING: {
       if (!movable_)
         ::GetWindowRect(GetAcceleratedWidget(), (LPRECT)l_param);
+      return false;
+    }
+    case WM_MOVE: {
+      if (last_window_state_ == ui::SHOW_STATE_NORMAL) {
+        if (consecutive_moves_)
+          last_normal_bounds_ = last_normal_bounds_candidate_;
+        last_normal_bounds_candidate_ = GetBounds();
+        consecutive_moves_ = true;
+      }
       return false;
     }
     default:
@@ -152,20 +162,35 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
       NotifyWindowMinimize();
       break;
     case SIZE_RESTORED:
-      switch (last_window_state_) {
-        case ui::SHOW_STATE_MAXIMIZED:
-          last_window_state_ = ui::SHOW_STATE_NORMAL;
-          NotifyWindowUnmaximize();
-          break;
-        case ui::SHOW_STATE_MINIMIZED:
-          if (IsFullscreen()) {
-            last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
-            NotifyWindowEnterFullScreen();
-          } else {
+      if (last_window_state_ == ui::SHOW_STATE_NORMAL) {
+        // Window was resized so we save it's new size.
+        last_normal_bounds_ = GetBounds();
+      } else {
+        switch (last_window_state_) {
+          case ui::SHOW_STATE_MAXIMIZED:
             last_window_state_ = ui::SHOW_STATE_NORMAL;
-            NotifyWindowRestore();
-          }
-          break;
+
+            // When the window is restored we resize it to the previous known
+            // normal size.
+            SetBounds(last_normal_bounds_, false);
+
+            NotifyWindowUnmaximize();
+            break;
+          case ui::SHOW_STATE_MINIMIZED:
+            if (IsFullscreen()) {
+              last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
+              NotifyWindowEnterFullScreen();
+            } else {
+              last_window_state_ = ui::SHOW_STATE_NORMAL;
+
+              // When the window is restored we resize it to the previous known
+              // normal size.
+              SetBounds(last_normal_bounds_, false);
+
+              NotifyWindowRestore();
+            }
+            break;
+        }
       }
       break;
   }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1764,10 +1764,11 @@ describe('browser-window module', function () {
       })
     })
 
-    it('should set the correct width when minWidth is used', function () {
+    it('should restore the correct bounds when minWidth is used', function () {
+      const initialSize = w.getSize()
       w.minimize()
       w.restore()
-      assert.equal(w.getSize()[0], 800)
+      assertBoundsEqual(w.getSize(), initialSize)
     })
   })
 
@@ -1781,7 +1782,7 @@ describe('browser-window module', function () {
       const initialPosition = w.getPosition()
       w.maximize()
       w.unmaximize()
-      assertBoundsEqual(initialPosition, w.getPosition())
+      assertBoundsEqual(w.getPosition(), initialPosition)
     })
   })
 })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1755,7 +1755,7 @@ describe('browser-window module', function () {
     })
   })
 
-  describe('minWidth', function () {
+  describe('Restoring the window', function () {
     beforeEach(function () {
       if (w != null) w.destroy()
       w = new BrowserWindow({
@@ -1764,30 +1764,24 @@ describe('browser-window module', function () {
       })
     })
 
-    it('should not affect the bounds when restoring the window', function (done) {
+    it('should set the correct width when minWidth is used', function () {
       w.minimize()
-      setTimeout(() => {
-        w.restore()
-        assert.equal(w.getSize()[0], 800)
-        done()
-      }, 200)
+      w.restore()
+      assert.equal(w.getSize()[0], 800)
     })
   })
 
-  describe('window position', function () {
+  describe('Unmaximizing the window', function () {
     beforeEach(function () {
       if (w != null) w.destroy()
       w = new BrowserWindow()
     })
 
-    it('should not affect the bounds when restoring the window', function (done) {
-      const originalPos = w.getPosition()
+    it('should set the correct position', function () {
+      const initialPosition = w.getPosition()
       w.maximize()
-      setTimeout(() => {
-        w.unmaximize()
-        assertBoundsEqual(originalPos, w.getPosition())
-        done()
-      }, 200)
+      w.unmaximize()
+      assertBoundsEqual(initialPosition, w.getPosition())
     })
   })
 })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1754,6 +1754,25 @@ describe('browser-window module', function () {
       })
     })
   })
+
+  describe.only('minWidth', function () {
+    beforeEach(function () {
+      if (w != null) w.destroy()
+      w = new BrowserWindow({
+        minWidth: 800,
+        width: 800
+      })
+    })
+
+    it('should persist when restoring the window', function (done) {
+      w.minimize();
+      setTimeout(() => {
+        w.restore();
+        assert.equal(w.getSize()[0], 800);
+        done();
+      }, 200);
+    })
+  })
 })
 
 const assertBoundsEqual = (actual, expect) => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1755,7 +1755,7 @@ describe('browser-window module', function () {
     })
   })
 
-  describe.only('minWidth', function () {
+  describe('minWidth', function () {
     beforeEach(function () {
       if (w != null) w.destroy()
       w = new BrowserWindow({
@@ -1764,11 +1764,28 @@ describe('browser-window module', function () {
       })
     })
 
-    it('should persist when restoring the window', function (done) {
+    it('should not affect the bounds when restoring the window', function (done) {
       w.minimize();
       setTimeout(() => {
         w.restore();
         assert.equal(w.getSize()[0], 800);
+        done();
+      }, 200);
+    })
+  })
+
+  describe.only('window position', function () {
+    beforeEach(function () {
+      if (w != null) w.destroy()
+      w = new BrowserWindow()
+    })
+
+    it('should not affect the bounds when restoring the window', function (done) {
+      const originalPos = w.getPosition();
+      w.maximize();
+      setTimeout(() => {
+        w.unmaximize();
+        assertBoundsEqual(originalPos, w.getPosition());
         done();
       }, 200);
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1765,12 +1765,12 @@ describe('browser-window module', function () {
     })
 
     it('should not affect the bounds when restoring the window', function (done) {
-      w.minimize();
+      w.minimize()
       setTimeout(() => {
-        w.restore();
-        assert.equal(w.getSize()[0], 800);
-        done();
-      }, 200);
+        w.restore()
+        assert.equal(w.getSize()[0], 800)
+        done()
+      }, 200)
     })
   })
 
@@ -1781,13 +1781,13 @@ describe('browser-window module', function () {
     })
 
     it('should not affect the bounds when restoring the window', function (done) {
-      const originalPos = w.getPosition();
-      w.maximize();
+      const originalPos = w.getPosition()
+      w.maximize()
       setTimeout(() => {
-        w.unmaximize();
-        assertBoundsEqual(originalPos, w.getPosition());
-        done();
-      }, 200);
+        w.unmaximize()
+        assertBoundsEqual(originalPos, w.getPosition())
+        done()
+      }, 200)
     })
   })
 })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1774,7 +1774,7 @@ describe('browser-window module', function () {
     })
   })
 
-  describe.only('window position', function () {
+  describe('window position', function () {
     beforeEach(function () {
       if (w != null) w.destroy()
       w = new BrowserWindow()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1320,6 +1320,34 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.restore()', function () {
+    it('should restore the previous window size', function () {
+      if (w != null) w.destroy()
+
+      w = new BrowserWindow({
+        minWidth: 800,
+        width: 800
+      })
+
+      const initialSize = w.getSize()
+      w.minimize()
+      w.restore()
+      assertBoundsEqual(w.getSize(), initialSize)
+    })
+  })
+
+  describe('BrowserWindow.unmaximize()', function () {
+    it('should restore the previous window position', function () {
+      if (w != null) w.destroy()
+      w = new BrowserWindow()
+
+      const initialPosition = w.getPosition()
+      w.maximize()
+      w.unmaximize()
+      assertBoundsEqual(w.getPosition(), initialPosition)
+    })
+  })
+
   describe('parent window', function () {
     let c = null
 
@@ -1752,37 +1780,6 @@ describe('browser-window module', function () {
         })
         w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
       })
-    })
-  })
-
-  describe('Restoring the window', function () {
-    beforeEach(function () {
-      if (w != null) w.destroy()
-      w = new BrowserWindow({
-        minWidth: 800,
-        width: 800
-      })
-    })
-
-    it('should restore the correct bounds when minWidth is used', function () {
-      const initialSize = w.getSize()
-      w.minimize()
-      w.restore()
-      assertBoundsEqual(w.getSize(), initialSize)
-    })
-  })
-
-  describe('Unmaximizing the window', function () {
-    beforeEach(function () {
-      if (w != null) w.destroy()
-      w = new BrowserWindow()
-    })
-
-    it('should set the correct position', function () {
-      const initialPosition = w.getPosition()
-      w.maximize()
-      w.unmaximize()
-      assertBoundsEqual(w.getPosition(), initialPosition)
     })
   })
 })


### PR DESCRIPTION
These reverts #7766 

It fixes #7630 in a different way and also fixes #7951.