### PR TITLE
Throw an error when users attempt to remove all listeners from the IPC modules

### DIFF
--- a/lib/browser/api/ipc-main.js
+++ b/lib/browser/api/ipc-main.js
@@ -2,5 +2,13 @@ const EventEmitter = require('events').EventEmitter
 
 module.exports = new EventEmitter()
 
+const removeAllListeners = module.exports.removeAllListeners
+module.exports.removeAllListeners = function (...args) {
+  if (args.length === 0) {
+    throw new Error('Removing all listeners from ipcMain will make Electron internals stop working.  Please specify a event name')
+  }
+  removeAllListeners.apply(this, args)
+}
+
 // Do not throw exception when channel name is "error".
 module.exports.on('error', () => {})

--- a/lib/renderer/api/ipc-renderer-setup.js
+++ b/lib/renderer/api/ipc-renderer-setup.js
@@ -29,4 +29,12 @@ module.exports = function (ipcRenderer, binding) {
 
     ipcRenderer.send('ELECTRON_BROWSER_SEND_TO', true, webContentsId, channel, ...args)
   }
+
+  const removeAllListeners = ipcRenderer.removeAllListeners
+  ipcRenderer.removeAllListeners = function (...args) {
+    if (args.length === 0) {
+      throw new Error('Removing all listeners from ipcRenderer will make Electron internals stop working.  Please specify a event name')
+    }
+    removeAllListeners.apply(this, args)
+  }
 }


### PR DESCRIPTION
Closes #8039

Basically users might not be aware that removing all listeners kills Electron internal handlers (which should never really be removed).  They should always specify event names to remove listeners for.