### PR TITLE
Check runner.hasOnly for focused spec check

### DIFF
--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -54,17 +54,6 @@
 
   var mocha = new Mocha();
 
-  if (isCi) {
-    mocha.grep = function () {
-      try {
-        throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
-      } catch (error) {
-        console.error(error.stack || error)
-      }
-      ipcRenderer.send('process.exit', 1)
-    }
-  }
-
   mocha.ui('bdd').reporter(isCi ? 'tap' : 'html');
 
   var query = Mocha.utils.parseQuery(window.location.search || '');
@@ -83,6 +72,16 @@
 
   walker.on('end', function() {
     var runner = mocha.run(function() {
+      if (isCi && runner.hasOnly) {
+        try {
+          throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
+        } catch (error) {
+          console.error(error.stack || error)
+        }
+        ipcRenderer.send('process.exit', 1)
+        return
+      }
+
       Mocha.utils.highlightTags('code');
 
       var coverage = new Coverage({


### PR DESCRIPTION
Looks like the mocha check that prevents specs from passing when calling `.only` on CI has regressed, possibly due to the Mocha upgrade in #7505.

This pull request adds it back by check the `runner.hasOnly` flag which is set when `it.only` or `describe.only` is called.

This check was originally added in https://github.com/electron/electron/pull/5975.