### PR TITLE
Docs update

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -27,7 +27,7 @@ See [`Menu`](menu.md) for examples.
   * `visible` Boolean - (optional) If false, the menu item will be entirely hidden.
   * `checked` Boolean - (optional) Should only be specified for `checkbox` or `radio` type
     menu items.
-  * `submenu` MenuItemConstructorOptions[] - (optional) Should be specified for `submenu` type menu items. If
+  * `submenu` (MenuItemConstructorOptions[] | Menu) - (optional) Should be specified for `submenu` type menu items. If
     `submenu` is specified, the `type: 'submenu'` can be omitted. If the value
     is not a `Menu` then it will be automatically converted to one using
     `Menu.buildFromTemplate`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -481,6 +481,10 @@ win.webContents.on('paint', (event, dirty, image) => {
 win.loadURL('http://github.com')
 ```
 
+#### Event: 'devtools-reload-page'
+
+Emitted when the devtools window instructs the webContents to reload
+
 ### Instance Methods
 
 #### `contents.loadURL(url[, options])`


### PR DESCRIPTION
Just two quick fixes that came up while testing the TS definition.

The event on `webContents` appeared to be undocumented but perfectly functional?

/cc @zeke 