### PR TITLE
Fixed language code for Aragonese

### DIFF
--- a/docs/api/locales.md
+++ b/docs/api/locales.md
@@ -14,7 +14,7 @@ values are listed below:
 | ar-BH | Arabic (Bahrain) |
 | ar-DZ | Arabic (Algeria) |
 | ar-EG | Arabic (Egypt) |
-| ar | Aragonese |
+| an | Aragonese |
 | ar-JO | Arabic (Jordan) |
 | ar-KW | Arabic (Kuwait) |
 | ar-LB | Arabic (Lebanon) |

--- a/docs/api/locales.md
+++ b/docs/api/locales.md
@@ -8,13 +8,13 @@ values are listed below:
 | Language Code | Language Name |
 |---------------|---------------|
 | af | Afrikaans |
+| an | Aragonese |
 | ar-AE | Arabic (U.A.E.) |
 | ar-IQ | Arabic (Iraq) |
 | ar | Arabic (Standard) |
 | ar-BH | Arabic (Bahrain) |
 | ar-DZ | Arabic (Algeria) |
 | ar-EG | Arabic (Egypt) |
-| an | Aragonese |
 | ar-JO | Arabic (Jordan) |
 | ar-KW | Arabic (Kuwait) |
 | ar-LB | Arabic (Lebanon) |


### PR DESCRIPTION
The language code for Aragonese was the same one used for Arabic.

I'm not sure if this just affects the docs or if it is in the code as well.