### PR TITLE
Remove unnecessary escape characters

### DIFF
--- a/lib/common/api/callbacks-registry.js
+++ b/lib/common/api/callbacks-registry.js
@@ -29,7 +29,7 @@ class CallbacksRegistry {
       if (location.indexOf('electron.asar') !== -1) {
         continue
       }
-      ref = /([^\/^\)]*)\)?$/gi.exec(location)
+      ref = /([^/^)]*)\)?$/gi.exec(location)
       filenameAndLine = ref[1]
       break
     }


### PR DESCRIPTION
standard@8.6.0 is throwing linter errors about these on master currently:

```
standard: Use JavaScript Standard Style (http://standardjs.com)
  /Users/kevin/github/electron/lib/common/api/callbacks-registry.js:32:17: Unnecessary escape character: \/.
  /Users/kevin/github/electron/lib/common/api/callbacks-registry.js:32:20: Unnecessary escape character: \).
```