### PR TITLE
Fix indentation in menu template example

### DIFF
--- a/docs-translations/jp/tutorial/desktop-environment-integration.md
+++ b/docs-translations/jp/tutorial/desktop-environment-integration.md
@@ -92,10 +92,11 @@ const {app, Menu} = require('electron')
 const dockMenu = Menu.buildFromTemplate([
   {label: 'New Window', click () { console.log('New Window') }},
   {label: 'New Window with Settings',
-  submenu: [
-    {label: 'Basic'},
-    {label: 'Pro'}
-  ]},
+    submenu: [
+      {label: 'Basic'},
+      {label: 'Pro'}
+    ]
+  },
   {label: 'New Command...'}
 ])
 app.dock.setMenu(dockMenu)

--- a/docs-translations/pt-BR/tutorial/desktop-environment-integration.md
+++ b/docs-translations/pt-BR/tutorial/desktop-environment-integration.md
@@ -72,10 +72,11 @@ const {app, Menu} = require('electron')
 const dockMenu = Menu.buildFromTemplate([
   {label: 'New Window', click () { console.log('New Window') }},
   {label: 'New Window with Settings',
-  submenu: [
-    {label: 'Basic'},
-    {label: 'Pro'}
-  ]},
+    submenu: [
+      {label: 'Basic'},
+      {label: 'Pro'}
+    ]
+  },
   {label: 'New Command...'}
 ])
 app.dock.setMenu(dockMenu)

--- a/docs-translations/zh-CN/tutorial/desktop-environment-integration.md
+++ b/docs-translations/zh-CN/tutorial/desktop-environment-integration.md
@@ -82,10 +82,11 @@ const {app, Menu} = require('electron')
 const dockMenu = Menu.buildFromTemplate([
   {label: 'New Window', click () { console.log('New Window') }},
   {label: 'New Window with Settings',
-  submenu: [
-    {label: 'Basic'},
-    {label: 'Pro'}
-  ]},
+    submenu: [
+      {label: 'Basic'},
+      {label: 'Pro'}
+    ]
+  },
   {label: 'New Command...'}
 ])
 app.dock.setMenu(dockMenu)


### PR DESCRIPTION
`npm run lint-api-docs-js` is currently failing with:

```
Linting file 315 of 315


   jp/tutorial/desktop-environment-integration.md
         95:3:     Expected indentation of 4 spaces but found 2.

   pt-BR/tutorial/desktop-environment-integration.md
         75:3:     Expected indentation of 4 spaces but found 2.

   zh-CN/tutorial/desktop-environment-integration.md
         85:3:     Expected indentation of 4 spaces but found 2.
```