### PR TITLE
Clarify where Electron's resources directory can be found

### DIFF
--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -1,9 +1,11 @@
 # Application Distribution
 
-To distribute your app with Electron, the folder containing your app should be
-named `app` and placed under Electron's resources directory (on macOS it is
-`Electron.app/Contents/Resources/` and on Linux and Windows it is `resources/`),
-like this:
+To distribute your app with Electron, you need to download Electron's [prebuilt
+binaries](https://github.com/electron/electron/releases). Next, the folder
+containing your app should be named `app` and placed in Electron's resources
+directory as shown in the following examples. Note that the location of
+Electron's prebuilt binaries is indicated with `electron/` in the examples
+below.
 
 On macOS:
 


### PR DESCRIPTION
I am new to Electron and was therefore reading the [Quick Start](http://electron.atom.io/docs/tutorial/quick-start/) guide. Eventually, I ended up at the [Application Distribution](http://electron.atom.io/docs/tutorial/application-distribution/) page, which was a bit confusing. In fact, I did not know where `electron/` (in e.g. `electron/resources/app`) was located. Finally, after some Googling I discovered that I had to download the prebuilt binaries, which in my opinion could be made more explicit in the documentation. Therefore, in this patch I attempt to solve this.

I am looking forward to hearing your feedback :grimacing: 