### PR TITLE
override window.confirm in devtools

### DIFF
--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -6,6 +6,22 @@ window.onload = function () {
   window.WebInspector.createFileSelectorElement = createFileSelectorElement
 }
 
+window.confirm = function (message, title) {
+  const {dialog} = require('electron').remote
+  let buttons, cancelId
+  if (title == null) {
+    title = ''
+  }
+  buttons = ['OK', 'Cancel']
+  cancelId = 1
+  return !dialog.showMessageBox({
+    message: message,
+    title: title,
+    buttons: buttons,
+    cancelId: cancelId
+  })
+}
+
 const convertToMenuTemplate = function (items) {
   return items.map(function (item) {
     const transformed = item.type === 'subMenu' ? {

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -8,17 +8,14 @@ window.onload = function () {
 
 window.confirm = function (message, title) {
   const {dialog} = require('electron').remote
-  let buttons, cancelId
   if (title == null) {
     title = ''
   }
-  buttons = ['OK', 'Cancel']
-  cancelId = 1
   return !dialog.showMessageBox({
     message: message,
     title: title,
-    buttons: buttons,
-    cancelId: cancelId
+    buttons: ['OK', 'Cancel'],
+    cancelId: 1
   })
 }
 


### PR DESCRIPTION
Result of the operation is required to complete the `remove from workspace` menu item action in the navigator view. https://cs.chromium.org/chromium/src/third_party/WebKit/Source/devtools/front_end/sources/NavigatorView.js?l=649-658

Fixes #7960 