### PR TITLE
Add BrowserWindow.setCursorAutoHide

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -811,6 +811,10 @@ bool Window::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();
 }
 
+void Window::SetAutoHideCursor(bool auto_hide) {
+  window_->SetAutoHideCursor(auto_hide);
+}
+
 void Window::SetVibrancy(mate::Arguments* args) {
   std::string type;
 
@@ -934,6 +938,9 @@ void Window::BuildPrototype(v8::Isolate* isolate,
                  &Window::SetVisibleOnAllWorkspaces)
       .SetMethod("isVisibleOnAllWorkspaces",
                  &Window::IsVisibleOnAllWorkspaces)
+#if defined(OS_MACOSX)
+      .SetMethod("setAutoHideCursor", &Window::SetAutoHideCursor)
+#endif
       .SetMethod("setVibrancy", &Window::SetVibrancy)
 #if defined(OS_WIN)
       .SetMethod("hookWindowMessage", &Window::HookWindowMessage)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -198,6 +198,8 @@ class Window : public mate::TrackableObject<Window>,
   void SetVisibleOnAllWorkspaces(bool visible);
   bool IsVisibleOnAllWorkspaces();
 
+  void SetAutoHideCursor(bool auto_hide);
+
   void SetVibrancy(mate::Arguments* args);
 
   int32_t ID() const;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -333,6 +333,9 @@ void NativeWindow::SetParentWindow(NativeWindow* parent) {
   parent_ = parent;
 }
 
+void NativeWindow::SetAutoHideCursor(bool auto_hide) {
+}
+
 void NativeWindow::SetVibrancy(const std::string& filename) {
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -161,6 +161,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetVisibleOnAllWorkspaces(bool visible) = 0;
   virtual bool IsVisibleOnAllWorkspaces() = 0;
 
+  virtual void SetAutoHideCursor(bool auto_hide);
+
   // Vibrancy API
   virtual void SetVibrancy(const std::string& type);
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -95,7 +95,7 @@ class NativeWindowMac : public NativeWindow,
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
 
-  void SetAutoHideCursor(bool auto_hide);
+  void SetAutoHideCursor(bool auto_hide) override;
 
   void SetVibrancy(const std::string& type) override;
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -91,8 +91,12 @@ class NativeWindowMac : public NativeWindow,
   void SetProgressBar(double progress, const ProgressState state) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
+
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
+
+  void SetAutoHideCursor(bool auto_hide);
+
   void SetVibrancy(const std::string& type) override;
 
   // content::RenderWidgetHost::InputEventObserver:

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1255,6 +1255,10 @@ bool NativeWindowMac::IsVisibleOnAllWorkspaces() {
   return collectionBehavior & NSWindowCollectionBehaviorCanJoinAllSpaces;
 }
 
+void NativeWindowMac::SetAutoHideCursor(bool auto_hide) {
+  [window_ setDisableAutoHideCursor:!auto_hide];
+}
+
 void NativeWindowMac::SetVibrancy(const std::string& type) {
   if (!base::mac::IsOSYosemiteOrLater()) return;
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1218,6 +1218,12 @@ Returns `BrowserWindow` - The parent window.
 
 Returns `BrowserWindow[]` - All child windows.
 
+#### `win.setAutoHideCursor(autoHide)` _macOS_
+
+* `autoHide` Boolean
+
+Controls whether to hide cursor when typing.
+
 #### `win.setVibrancy(type)` _macOS_
 
 * `type` String - Can be `appearance-based`, `light`, `dark`, `titlebar`,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -506,6 +506,23 @@ describe('browser-window module', function () {
     })
   })
 
+  describe('BrowserWindow.setAutoHideCursor(autoHide)', () => {
+    if (process.platform !== 'darwin') {
+      it('is not available on non-macOS platforms', () => {
+        assert.ok(!w.setAutoHideCursor)
+      })
+
+      return
+    }
+
+    it('allows changing cursor auto-hiding', () => {
+      assert.doesNotThrow(() => {
+        w.setAutoHideCursor(false)
+        w.setAutoHideCursor(true)
+      })
+    })
+  })
+
   describe('BrowserWindow.setVibrancy(type)', function () {
     it('allows setting, changing, and removing the vibrancy', function () {
       assert.doesNotThrow(function () {


### PR DESCRIPTION
The `disableAutoHideCursor` BrowserWindow option can be used to control
auto-hiding behavior when the window is created. This new API is needed
to dynamically change the behavior after the fact.