### PR TITLE
Don't use Mocha's skip method

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -523,7 +523,7 @@ describe('browser-window module', function () {
 
   describe('BrowserWindow.setAppDetails(options)', function () {
     it('supports setting the app details', function () {
-      if (process.platform !== 'win32') return this.skip()
+      if (process.platform !== 'win32') return
 
       const iconPath = path.join(fixtures, 'assets', 'icon.ico')
 
@@ -660,7 +660,7 @@ describe('browser-window module', function () {
 
   describe('"zoomToPageWidth" option', function () {
     it('sets the window width to the page width when used', function () {
-      if (process.platform !== 'darwin') return this.skip()
+      if (process.platform !== 'darwin') return
 
       w.destroy()
       w = new BrowserWindow({
@@ -1723,7 +1723,7 @@ describe('browser-window module', function () {
 
   describe('previewFile', function () {
     it('opens the path in Quick Look on macOS', function () {
-      if (process.platform !== 'darwin') return this.skip()
+      if (process.platform !== 'darwin') return
 
       assert.doesNotThrow(function () {
         w.previewFile(__filename)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -82,10 +82,7 @@ describe('browser-window module', function () {
   })
 
   afterEach(function () {
-    return closeWindow(w).then(function () {
-      w = null
-      assert.equal(BrowserWindow.getAllWindows().length, 1)
-    })
+    return closeWindow(w).then(function () { w = null })
   })
 
   describe('BrowserWindow.close()', function () {
@@ -859,7 +856,7 @@ describe('browser-window module', function () {
               assert(/Blocked a frame with origin/.test(exceptionMessage))
 
               // FIXME this popup window should be closed in sandbox.html
-              closeWindow(popupWindow).then(() => {
+              closeWindow(popupWindow, {assertSingleWindow: false}).then(() => {
                 popupWindow = null
                 done()
               })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -82,7 +82,10 @@ describe('browser-window module', function () {
   })
 
   afterEach(function () {
-    return closeWindow(w).then(function () { w = null })
+    return closeWindow(w).then(function () {
+      w = null
+      assert.equal(BrowserWindow.getAllWindows().length, 1)
+    })
   })
 
   describe('BrowserWindow.close()', function () {

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -87,7 +87,7 @@ describe('clipboard module', function () {
 
   describe('clipboard.read/writeFindText(text)', function () {
     it('reads and write text to the find pasteboard', function () {
-      if (process.platform !== 'darwin') return this.skip()
+      if (process.platform !== 'darwin') return
 
       clipboard.writeFindText('find this')
       assert.equal(clipboard.readFindText(), 'find this')

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -236,18 +236,13 @@ describe('session module', function () {
   })
 
   describe('will-download event', function () {
-    var w = null
-
     beforeEach(function () {
+      if (w != null) w.destroy()
       w = new BrowserWindow({
         show: false,
         width: 400,
         height: 400
       })
-    })
-
-    afterEach(function () {
-      return closeWindow(w).then(function () { w = null })
     })
 
     it('can cancel default download behavior', function (done) {

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -6,6 +6,11 @@ const {BrowserWindow, protocol, ipcMain} = remote
 
 describe('webFrame module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
+  var w = null
+
+  afterEach(function () {
+    return closeWindow(w).then(function () { w = null })
+  })
 
   describe('webFrame.registerURLSchemeAsPrivileged', function () {
     it('supports fetch api by default', function (done) {
@@ -96,14 +101,11 @@ describe('webFrame module', function () {
       runNumber++
 
       const url = standardScheme + '://fake-host'
-      var w = new BrowserWindow({show: false})
+      w = new BrowserWindow({show: false})
       after(function (done) {
         protocol.unregisterProtocol(corsScheme, function () {
           protocol.unregisterProtocol(standardScheme, function () {
-            closeWindow(w).then(function () {
-              w = null
-              done()
-            })
+            done()
           })
         })
       })

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -792,6 +792,11 @@ describe('asar package', function () {
 
   describe('asar protocol', function () {
     var url = require('url')
+    var w = null
+
+    afterEach(function () {
+      return closeWindow(w).then(function () { w = null })
+    })
 
     it('can request a file in package', function (done) {
       var p = path.resolve(fixtures, 'asar', 'a.asar', 'file1')
@@ -839,10 +844,9 @@ describe('asar package', function () {
     it('sets __dirname correctly', function (done) {
       after(function () {
         ipcMain.removeAllListeners('dirname')
-        return closeWindow(w).then(function () { w = null })
       })
 
-      var w = new BrowserWindow({
+      w = new BrowserWindow({
         show: false,
         width: 400,
         height: 400
@@ -863,10 +867,9 @@ describe('asar package', function () {
     it('loads script tag in html', function (done) {
       after(function () {
         ipcMain.removeAllListeners('ping')
-        return closeWindow(w).then(function () { w = null })
       })
 
-      var w = new BrowserWindow({
+      w = new BrowserWindow({
         show: false,
         width: 400,
         height: 400
@@ -889,10 +892,9 @@ describe('asar package', function () {
 
       after(function () {
         ipcMain.removeAllListeners('asar-video')
-        return closeWindow(w).then(function () { w = null })
       })
 
-      var w = new BrowserWindow({
+      w = new BrowserWindow({
         show: false,
         width: 400,
         height: 400

--- a/spec/window-helpers.js
+++ b/spec/window-helpers.js
@@ -1,9 +1,18 @@
-exports.closeWindow = (window) => {
+const assert = require('assert')
+const {BrowserWindow} = require('electron').remote
+
+exports.closeWindow = (window, {assertSingleWindow} = {assertSingleWindow: true}) => {
   if (window == null || window.isDestroyed()) {
+    if (assertSingleWindow) {
+      assert.equal(BrowserWindow.getAllWindows().length, 1)
+    }
     return Promise.resolve()
   } else {
     return new Promise((resolve, reject) => {
       window.once('closed', () => {
+        if (assertSingleWindow) {
+          assert.equal(BrowserWindow.getAllWindows().length, 1)
+        }
         resolve()
       })
       window.setClosable(true)


### PR DESCRIPTION
Calling `this.skip()` from a spec causes the `after`/`afterEach` blocks to not run meaning windows aren't destroyed in skipped specs.

This can be used again if/when https://github.com/mochajs/mocha/pull/2571 is merged.

This pull request also asserts only one open window after specs finish to ensure windows aren't leaking.