### PR TITLE
Unify spec timeouts

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -163,8 +163,6 @@ describe('app module', function () {
   describe('app.importCertificate', function () {
     if (process.platform !== 'linux') return
 
-    this.timeout(5000)
-
     var w = null
     var certPath = path.join(__dirname, 'fixtures', 'certificates')
     var options = {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -127,7 +127,8 @@ describe('app module', function () {
     })
 
     it('relaunches the app', function (done) {
-      this.timeout(100000)
+      this.timeout(120000)
+
       let state = 'none'
       server.once('error', (error) => {
         done(error)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -81,7 +81,7 @@ describe('app module', function () {
     var appProcess = null
 
     afterEach(function () {
-      appProcess != null ? appProcess.kill() : void 0
+      if (appProcess != null) appProcess.kill()
     })
 
     it('emits a process exit event with the code', function (done) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -211,7 +211,6 @@ describe('browser-window module', function () {
     })
 
     it('does not crash in did-fail-provisional-load handler', function (done) {
-      this.timeout(10000)
       w.webContents.once('did-fail-provisional-load', function () {
         w.loadURL('http://127.0.0.1:11111')
         done()
@@ -284,7 +283,6 @@ describe('browser-window module', function () {
     })
 
     it('emits when window is shown', function (done) {
-      this.timeout(10000)
       w.once('show', function () {
         assert.equal(w.isVisible(), true)
         done()
@@ -310,7 +308,6 @@ describe('browser-window module', function () {
     })
 
     it('emits when window is hidden', function (done) {
-      this.timeout(10000)
       w.show()
       w.once('hide', function () {
         assert.equal(w.isVisible(), false)
@@ -1002,7 +999,6 @@ describe('browser-window module', function () {
     })
 
     it('emits when link with target is called', function (done) {
-      this.timeout(10000)
       w.webContents.once('new-window', function (e, url, frameName) {
         e.preventDefault()
         assert.equal(url, 'http://host/')
@@ -1019,7 +1015,6 @@ describe('browser-window module', function () {
     }
 
     it('emits when window is maximized', function (done) {
-      this.timeout(10000)
       w.once('maximize', function () {
         done()
       })
@@ -1034,7 +1029,6 @@ describe('browser-window module', function () {
     }
 
     it('emits when window is unmaximized', function (done) {
-      this.timeout(10000)
       w.once('unmaximize', function () {
         done()
       })
@@ -1050,7 +1044,6 @@ describe('browser-window module', function () {
     }
 
     it('emits when window is minimized', function (done) {
-      this.timeout(10000)
       w.once('minimize', function () {
         done()
       })
@@ -1062,8 +1055,6 @@ describe('browser-window module', function () {
   describe('beginFrameSubscription method', function () {
     // This test is too slow, only test it on CI.
     if (!isCI) return
-
-    this.timeout(20000)
 
     it('subscribes to frame updates', function (done) {
       let called = false
@@ -1513,7 +1504,6 @@ describe('browser-window module', function () {
   describe('dev tool extensions', function () {
     describe('BrowserWindow.addDevToolsExtension', function () {
       let showPanelIntevalId
-      this.timeout(10000)
 
       beforeEach(function () {
         BrowserWindow.removeDevToolsExtension('foo')
@@ -1595,8 +1585,6 @@ describe('browser-window module', function () {
     })
 
     it('works when used with partitions', function (done) {
-      this.timeout(10000)
-
       if (w != null) {
         w.destroy()
       }
@@ -1747,8 +1735,6 @@ describe('browser-window module', function () {
   })
 
   describe('offscreen rendering', function () {
-    this.timeout(10000)
-
     beforeEach(function () {
       if (w != null) w.destroy()
       w = new BrowserWindow({

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -36,7 +36,7 @@ describe('crashReporter module', function () {
   }
 
   it('should send minidump when renderer crashes', function (done) {
-    if (isCI) return
+    if (isCI) return done()
 
     this.timeout(120000)
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -36,7 +36,7 @@ describe('crashReporter module', function () {
   }
 
   it('should send minidump when renderer crashes', function (done) {
-    if (isCi) return
+    if (isCI) return
 
     this.timeout(120000)
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -9,6 +9,8 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
+const isCI = remote.getGlobal('isCi')
+
 describe('crashReporter module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
   var w = null
@@ -33,12 +35,9 @@ describe('crashReporter module', function () {
     return
   }
 
-  var isCI = remote.getGlobal('isCi')
-  if (isCI) {
-    return
-  }
-
   it('should send minidump when renderer crashes', function (done) {
+    if (isCi) return
+
     this.timeout(120000)
 
     var called = false

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -434,8 +434,6 @@ describe('ipc module', function () {
     })
 
     it('does not crash when reply is not sent and browser is destroyed', function (done) {
-      this.timeout(10000)
-
       w = new BrowserWindow({
         show: false
       })

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -26,7 +26,6 @@ const kOneKiloByte = 1024
 const kOneMegaByte = kOneKiloByte * kOneKiloByte
 
 describe('net module', function () {
-  // this.timeout(0)
   describe('HTTP basics', function () {
     let server
     beforeEach(function (done) {

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -9,8 +9,6 @@ const {ipcRenderer, remote} = require('electron')
 const {ipcMain, session, BrowserWindow} = remote
 
 describe('session module', function () {
-  this.timeout(10000)
-
   var fixtures = path.resolve(__dirname, 'fixtures')
   var w = null
   var url = 'http://127.0.0.1'

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -888,7 +888,7 @@ describe('asar package', function () {
     })
 
     it('loads video tag in html', function (done) {
-      this.timeout(20000)
+      this.timeout(60000)
 
       after(function () {
         ipcMain.removeAllListeners('asar-video')

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -61,11 +61,9 @@ describe('chromium feature', function () {
       w.loadURL(url)
     })
 
-    if (isCI && process.platform === 'win32') {
-      return
-    }
-
     it('is set correctly when window is inactive', function (done) {
+      if (isCI && process.platform === 'win32') return done()
+
       w = new BrowserWindow({
         show: false
       })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -152,8 +152,6 @@ describe('chromium feature', function () {
       return
     }
 
-    this.timeout(20000)
-
     it('returns a BrowserWindowProxy object', function () {
       var b = window.open('about:blank', '', 'show=no')
       assert.equal(b.closed, false)

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -28,8 +28,6 @@ describe('chromium feature', function () {
 
   describe('sending request of http protocol urls', function () {
     it('does not crash', function (done) {
-      this.timeout(5000)
-
       var server = http.createServer(function (req, res) {
         res.end()
         server.close()
@@ -78,8 +76,6 @@ describe('chromium feature', function () {
 
   xdescribe('navigator.webkitGetUserMedia', function () {
     it('calls its callbacks', function (done) {
-      this.timeout(5000)
-
       navigator.webkitGetUserMedia({
         audio: true,
         video: false
@@ -279,8 +275,6 @@ describe('chromium feature', function () {
   })
 
   describe('window.opener', function () {
-    this.timeout(10000)
-
     let url = 'file://' + fixtures + '/pages/window-opener.html'
     let w = null
 
@@ -312,8 +306,6 @@ describe('chromium feature', function () {
   })
 
   describe('window.opener access from BrowserWindow', function () {
-    this.timeout(10000)
-
     const scheme = 'other'
     let url = `${scheme}://${fixtures}/pages/window-opener-location.html`
     let w = null
@@ -363,8 +355,6 @@ describe('chromium feature', function () {
   })
 
   describe('window.opener access from <webview>', function () {
-    this.timeout(10000)
-
     const scheme = 'other'
     const srcPath = `${fixtures}/pages/webview-opener-postMessage.html`
     const pageURL = `file://${fixtures}/pages/window-opener-location.html`

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -55,6 +55,7 @@
   var mocha = new Mocha();
 
   mocha.ui('bdd').reporter(isCi ? 'tap' : 'html');
+  mocha.timeout(isCi ? 30000 : 10000)
 
   var query = Mocha.utils.parseQuery(window.location.search || '');
   if (query.grep) mocha.grep(query.grep);

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1045,8 +1045,6 @@ describe('<webview> tag', function () {
   })
 
   it('loads devtools extensions registered on the parent window', function (done) {
-    this.timeout(10000)
-
     w = new BrowserWindow({
       show: false
     })


### PR DESCRIPTION
This pull request unifies the various timeouts used across the specs to hopefully get them passing more consistently on CI (and locally).

- [x] Default local spec timeout to 10 seconds
- [x] Default CI spec timeout to 30 seconds
- [x] Remove explicit calls to timeout that are unneeded because of the higher default timeout
- [x] Unify on 1 or 2 minute timeout for lengthiest specs