### PR TITLE
Don't clear until render view is deleted for process id

### DIFF
--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -19,17 +19,14 @@ class ObjectsRegistry {
   // registered then the already assigned ID would be returned.
   add (webContents, obj) {
     // Get or assign an ID to the object.
-    let id = this.saveToStorage(obj)
+    const id = this.saveToStorage(obj)
 
     // Add object to the set of referenced objects.
-    let webContentsId = webContents.getId()
+    const webContentsId = webContents.getId()
     let owner = this.owners[webContentsId]
     if (!owner) {
       owner = this.owners[webContentsId] = new Set()
-      // Clear the storage when webContents is reloaded/navigated.
-      webContents.once('render-view-deleted', () => {
-        this.clear(webContentsId)
-      })
+      this.registerDeleteListener(webContents, webContentsId)
     }
     if (!owner.has(id)) {
       owner.add(id)
@@ -37,6 +34,18 @@ class ObjectsRegistry {
       this.storage[id].count++
     }
     return id
+  }
+
+  // Clear the storage when webContents is reloaded/navigated.
+  registerDeleteListener (webContents, webContentsId) {
+    const processId = webContents.getProcessId()
+    const listener = (event, deletedProcessId) => {
+      if (deletedProcessId === processId) {
+        webContents.removeListener('render-view-deleted', listener)
+        this.clear(webContentsId)
+      }
+    }
+    webContents.on('render-view-deleted', listener)
   }
 
   // Get an object according to its ID.
@@ -90,7 +99,7 @@ class ObjectsRegistry {
     pointer.count -= 1
     if (pointer.count === 0) {
       v8Util.deleteHiddenValue(pointer.object, 'atomId')
-      return delete this.storage[id]
+      delete this.storage[id]
     }
   }
 }

--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -36,18 +36,6 @@ class ObjectsRegistry {
     return id
   }
 
-  // Clear the storage when webContents is reloaded/navigated.
-  registerDeleteListener (webContents, webContentsId) {
-    const processId = webContents.getProcessId()
-    const listener = (event, deletedProcessId) => {
-      if (deletedProcessId === processId) {
-        webContents.removeListener('render-view-deleted', listener)
-        this.clear(webContentsId)
-      }
-    }
-    webContents.on('render-view-deleted', listener)
-  }
-
   // Get an object according to its ID.
   get (id) {
     const pointer = this.storage[id]
@@ -101,6 +89,18 @@ class ObjectsRegistry {
       v8Util.deleteHiddenValue(pointer.object, 'atomId')
       delete this.storage[id]
     }
+  }
+
+  // Private: Clear the storage when webContents is reloaded/navigated.
+  registerDeleteListener (webContents, webContentsId) {
+    const processId = webContents.getProcessId()
+    const listener = (event, deletedProcessId) => {
+      if (deletedProcessId === processId) {
+        webContents.removeListener('render-view-deleted', listener)
+        this.clear(webContentsId)
+      }
+    }
+    webContents.on('render-view-deleted', listener)
   }
 }
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -517,4 +517,19 @@ describe('ipc module', function () {
     ipcRenderer.removeAllListeners('test-event')
     assert.equal(ipcRenderer.listenerCount('test-event'), 0)
   })
+
+  describe('remote objects registry', function () {
+    it('does not dereference until the render view is deleted (regression)', function (done) {
+      w = new BrowserWindow({
+        show: true
+      })
+
+      ipcMain.once('error-message', (event, message) => {
+        assert(message.startsWith('Cannot call function \'getURL\' on missing remote object'), message)
+        done()
+      })
+
+      w.loadURL('file://' + path.join(fixtures, 'api', 'render-view-deleted.html'))
+    })
+  })
 })

--- a/spec/fixtures/api/render-view-deleted.html
+++ b/spec/fixtures/api/render-view-deleted.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <script>
+      const {ipcRenderer, remote} = require('electron')
+
+      const contents = remote.getCurrentWebContents()
+
+      // This should not trigger a dereference and a remote getURL call should not fail
+      contents.emit('render-view-deleted', {}, 'not-a-process-id')
+      try {
+        contents.getURL()
+      } catch (error) {
+        ipcRenderer.send('error-message', 'Unexpected error on getURL call')
+      }
+
+      // This should trigger a dereference and a remote getURL call should fail
+      contents.emit('render-view-deleted', {}, contents.getProcessId())
+      try {
+        contents.getURL()
+        ipcRenderer.send('error-message', 'No error thrown')
+      } catch (error) {
+        ipcRenderer.send('error-message', error.message)
+      }
+    </script>
+  </head>
+  <body>
+
+  </body>
+</html>


### PR DESCRIPTION
When a `webContents` is navigated or reloaded, the remote objects it was referencing are cleared from the objects registry via a `render-view-deleted` event listener.

Previously this was registered using a `.once` but it looks like render views are deleted asynchronously so sometimes the new render view would be created and the listener registered before the previous delete event fired. This would cause both to get deleted when the old one was eventually deleted since they were both listening and there was no process id checks done for the deleted render view.

This pull request switches to using a `.on` listener and waiting for the deleted render view process id to match the process id being listened to which ensures the registry is only cleared when the proper render view has been deleted.

Refs #7351 
Refs https://github.com/electron/electron/pull/6857