### PR TITLE
Use spread syntax instead of apply

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -81,7 +81,7 @@ app.allowNTLMCredentialsForAllDomains = function (allow) {
 const events = ['login', 'certificate-error', 'select-client-certificate']
 for (let name of events) {
   app.on(name, (event, webContents, ...args) => {
-    webContents.emit.apply(webContents, [name, event].concat(args))
+    webContents.emit(name, event, ...args)
   })
 }
 

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -152,19 +152,19 @@ BrowserWindow.fromDevToolsWebContents = (webContents) => {
 // Helpers.
 Object.assign(BrowserWindow.prototype, {
   loadURL (...args) {
-    return this.webContents.loadURL.apply(this.webContents, args)
+    return this.webContents.loadURL(...args)
   },
   getURL (...args) {
     return this.webContents.getURL()
   },
   reload (...args) {
-    return this.webContents.reload.apply(this.webContents, args)
+    return this.webContents.reload(...args)
   },
   send (...args) {
-    return this.webContents.send.apply(this.webContents, args)
+    return this.webContents.send(...args)
   },
   openDevTools (...args) {
-    return this.webContents.openDevTools.apply(this.webContents, args)
+    return this.webContents.openDevTools(...args)
   },
   closeDevTools () {
     return this.webContents.closeDevTools()
@@ -179,7 +179,7 @@ Object.assign(BrowserWindow.prototype, {
     return this.webContents.toggleDevTools()
   },
   inspectElement (...args) {
-    return this.webContents.inspectElement.apply(this.webContents, args)
+    return this.webContents.inspectElement(...args)
   },
   inspectServiceWorker () {
     return this.webContents.inspectServiceWorker()
@@ -188,7 +188,7 @@ Object.assign(BrowserWindow.prototype, {
     return this.webContents.showDefinitionForSelection()
   },
   capturePage (...args) {
-    return this.webContents.capturePage.apply(this.webContents, args)
+    return this.webContents.capturePage(...args)
   }
 })
 

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -50,7 +50,7 @@ module.exports = {
   showOpenDialog: function (...args) {
     var prop, properties, value, wrappedCallback
     checkAppInitialized()
-    let [window, options, callback] = parseArgs.apply(null, args)
+    let [window, options, callback] = parseArgs(...args)
     if (options == null) {
       options = {
         title: 'Open',
@@ -97,7 +97,7 @@ module.exports = {
   showSaveDialog: function (...args) {
     var wrappedCallback
     checkAppInitialized()
-    let [window, options, callback] = parseArgs.apply(null, args)
+    let [window, options, callback] = parseArgs(...args)
     if (options == null) {
       options = {
         title: 'Save'
@@ -130,7 +130,7 @@ module.exports = {
   showMessageBox: function (...args) {
     var flags, i, j, len, messageBoxType, ref2, ref3, text
     checkAppInitialized()
-    let [window, options, callback] = parseArgs.apply(null, args)
+    let [window, options, callback] = parseArgs(...args)
     if (options == null) {
       options = {
         type: 'none'
@@ -185,7 +185,7 @@ module.exports = {
   },
 
   showErrorBox: function (...args) {
-    return binding.showErrorBox.apply(binding, args)
+    return binding.showErrorBox(...args)
   }
 }
 

--- a/lib/browser/api/ipc-main.js
+++ b/lib/browser/api/ipc-main.js
@@ -1,14 +1,16 @@
 const EventEmitter = require('events').EventEmitter
 
-module.exports = new EventEmitter()
+const emitter = new EventEmitter()
 
-const removeAllListeners = module.exports.removeAllListeners
-module.exports.removeAllListeners = function (...args) {
+const removeAllListeners = emitter.removeAllListeners.bind(emitter)
+emitter.removeAllListeners = function (...args) {
   if (args.length === 0) {
     throw new Error('Removing all listeners from ipcMain will make Electron internals stop working.  Please specify a event name')
   }
-  removeAllListeners.apply(this, args)
+  removeAllListeners(...args)
 }
 
 // Do not throw exception when channel name is "error".
-module.exports.on('error', () => {})
+emitter.on('error', () => {})
+
+module.exports = emitter

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -4,13 +4,11 @@ const {ipcMain} = require('electron')
 
 // The history operation in renderer is redirected to browser.
 ipcMain.on('ELECTRON_NAVIGATION_CONTROLLER', function (event, method, ...args) {
-  var ref
-  (ref = event.sender)[method].apply(ref, args)
+  event.sender[method](...args)
 })
 
 ipcMain.on('ELECTRON_SYNC_NAVIGATION_CONTROLLER', function (event, method, ...args) {
-  var ref
-  event.returnValue = (ref = event.sender)[method].apply(ref, args)
+  event.returnValue = event.sender[method](...args)
 })
 
 // JavaScript implementation of Chromium's NavigationController.

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -83,20 +83,20 @@ class IncomingMessage extends Readable {
 URLRequest.prototype._emitRequestEvent = function (isAsync, ...rest) {
   if (isAsync) {
     process.nextTick(() => {
-      this.clientRequest.emit.apply(this.clientRequest, rest)
+      this.clientRequest.emit(...rest)
     })
   } else {
-    this.clientRequest.emit.apply(this.clientRequest, rest)
+    this.clientRequest.emit(...rest)
   }
 }
 
 URLRequest.prototype._emitResponseEvent = function (isAsync, ...rest) {
   if (isAsync) {
     process.nextTick(() => {
-      this._response.emit.apply(this._response, rest)
+      this._response.emit(...rest)
     })
   } else {
-    this._response.emit.apply(this._response, rest)
+    this._response.emit(...rest)
   }
 }
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -246,7 +246,7 @@ WebContents.prototype._init = function () {
   // Delays the page-title-updated event to next tick.
   this.on('-page-title-updated', function (...args) {
     setImmediate(() => {
-      this.emit.apply(this, ['page-title-updated'].concat(args))
+      this.emit('page-title-updated', ...args)
     })
   })
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -211,7 +211,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guest
 
   const guestWindow = getGuestWindow(guestContents)
   if (guestWindow != null) {
-    event.returnValue = guestWindow[method].apply(guestWindow, args)
+    event.returnValue = guestWindow[method](...args)
   } else {
     event.returnValue = null
   }
@@ -235,7 +235,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event,
   if (guestContents == null) return
 
   if (canAccessWindow(event.sender, guestContents)) {
-    guestContents[method].apply(guestContents, args)
+    guestContents[method](...args)
   } else {
     console.error(`Blocked ${event.sender.getURL()} from calling ${method} on its opener.`)
   }
@@ -249,7 +249,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', function (e
   }
 
   if (canAccessWindow(event.sender, guestContents)) {
-    event.returnValue = guestContents[method].apply(guestContents, args)
+    event.returnValue = guestContents[method](...args)
   } else {
     console.error(`Blocked ${event.sender.getURL()} from calling ${method} on its opener.`)
     event.returnValue = null

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -26,7 +26,7 @@ if (process.platform === 'win32') {
   // Redirect node's console to use our own implementations, since node can not
   // handle console output when running as GUI program.
   var consoleLog = function (...args) {
-    return process.log(util.format.apply(util, args) + '\n')
+    return process.log(util.format(...args) + '\n')
   }
   var streamWrite = function (chunk, encoding, callback) {
     if (Buffer.isBuffer(chunk)) {

--- a/lib/common/api/callbacks-registry.js
+++ b/lib/common/api/callbacks-registry.js
@@ -44,10 +44,6 @@ class CallbacksRegistry {
     return (ref = this.callbacks[id]) != null ? ref : function () {}
   }
 
-  call (id, ...args) {
-    return this.get(id).call(global, ...args)
-  }
-
   apply (id, ...args) {
     return this.get(id).apply(global, ...args)
   }

--- a/lib/common/api/callbacks-registry.js
+++ b/lib/common/api/callbacks-registry.js
@@ -45,13 +45,11 @@ class CallbacksRegistry {
   }
 
   call (id, ...args) {
-    var ref
-    return (ref = this.get(id)).call.apply(ref, [global].concat(args))
+    return this.get(id).call(global, ...args)
   }
 
   apply (id, ...args) {
-    var ref
-    return (ref = this.get(id)).apply.apply(ref, [global].concat(args))
+    return this.get(id).apply(global, ...args)
   }
 
   remove (id) {

--- a/lib/renderer/api/ipc-renderer-setup.js
+++ b/lib/renderer/api/ipc-renderer-setup.js
@@ -30,11 +30,11 @@ module.exports = function (ipcRenderer, binding) {
     ipcRenderer.send('ELECTRON_BROWSER_SEND_TO', true, webContentsId, channel, ...args)
   }
 
-  const removeAllListeners = ipcRenderer.removeAllListeners
+  const removeAllListeners = ipcRenderer.removeAllListeners.bind(ipcRenderer)
   ipcRenderer.removeAllListeners = function (...args) {
     if (args.length === 0) {
       throw new Error('Removing all listeners from ipcRenderer will make Electron internals stop working.  Please specify a event name')
     }
-    removeAllListeners.apply(this, args)
+    removeAllListeners(...args)
   }
 }

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -29,11 +29,11 @@ const electron = require('electron')
 
 // Call webFrame method.
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, method, args) => {
-  electron.webFrame[method].apply(electron.webFrame, args)
+  electron.webFrame[method](...args)
 })
 
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
-  const result = electron.webFrame[method].apply(electron.webFrame, args)
+  const result = electron.webFrame[method](...args)
   event.sender.send(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, result)
 })
 

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -74,7 +74,7 @@ var BrowserWindowProxy = (function () {
   }
 
   BrowserWindowProxy.prototype['eval'] = function (...args) {
-    ipcRenderer.send.apply(ipcRenderer, ['ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, 'executeJavaScript'].concat(args))
+    ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, 'executeJavaScript', ...args)
   }
 
   return BrowserWindowProxy
@@ -207,11 +207,11 @@ ipcRenderer.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId, m
 
 // Forward history operations to browser.
 var sendHistoryOperation = function (...args) {
-  ipcRenderer.send.apply(ipcRenderer, ['ELECTRON_NAVIGATION_CONTROLLER'].concat(args))
+  ipcRenderer.send('ELECTRON_NAVIGATION_CONTROLLER', ...args)
 }
 
 var getHistoryOperation = function (...args) {
-  return ipcRenderer.sendSync.apply(ipcRenderer, ['ELECTRON_SYNC_NAVIGATION_CONTROLLER'].concat(args))
+  return ipcRenderer.sendSync('ELECTRON_SYNC_NAVIGATION_CONTROLLER', ...args)
 }
 
 window.history.back = function () {

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -14,7 +14,7 @@ const geval = eval
 require('../renderer/api/ipc-renderer-setup')(ipcRenderer, binding)
 
 binding.onMessage = function (channel, args) {
-  ipcRenderer.emit.apply(ipcRenderer, [channel].concat(args))
+  ipcRenderer.emit(channel, ...args)
 }
 
 binding.onExit = function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -495,4 +495,26 @@ describe('ipc module', function () {
       assert.equal(w.listenerCount('test'), 0)
     })
   })
+
+  it('throws an error when removing all the listeners', () => {
+    ipcMain.on('test-event', () => {})
+    assert.equal(ipcMain.listenerCount('test-event'), 1)
+
+    ipcRenderer.on('test-event', () => {})
+    assert.equal(ipcRenderer.listenerCount('test-event'), 1)
+
+    assert.throws(() => {
+      ipcMain.removeAllListeners()
+    }, /Removing all listeners from ipcMain will make Electron internals stop working/)
+
+    assert.throws(() => {
+      ipcRenderer.removeAllListeners()
+    }, /Removing all listeners from ipcRenderer will make Electron internals stop working/)
+
+    ipcMain.removeAllListeners('test-event')
+    assert.equal(ipcMain.listenerCount('test-event'), 0)
+
+    ipcRenderer.removeAllListeners('test-event')
+    assert.equal(ipcRenderer.listenerCount('test-event'), 0)
+  })
 })


### PR DESCRIPTION
This cleans up the CoffeeScript leftovers where `apply` would be called to mimic the spread operator. ☕️ 

This is no longer needed since Electron can use the spread syntax natively when invoking the methods.

There are still a few valid cases for using it which this pull request does not update.

/cc @groundwater 