### PR TITLE
Don't write back to passed in options object

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -4,8 +4,6 @@ const {app, BrowserWindow} = require('electron')
 const binding = process.atomBinding('dialog')
 const v8Util = process.atomBinding('v8_util')
 
-var includes = [].includes
-
 const fileDialogProperties = {
   openFile: 1 << 0,
   openDirectory: 1 << 1,
@@ -14,13 +12,13 @@ const fileDialogProperties = {
   showHiddenFiles: 1 << 4
 }
 
-var messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']
+const messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']
 
-var messageBoxOptions = {
+const messageBoxOptions = {
   noLink: 1 << 0
 }
 
-var parseArgs = function (window, options, callback, ...args) {
+const parseArgs = function (window, options, callback, ...args) {
   if (window !== null && window.constructor !== BrowserWindow) {
     // Shift.
     [callback, options, window] = [options, window, null]
@@ -32,7 +30,7 @@ var parseArgs = function (window, options, callback, ...args) {
   }
 
   // Fallback to using very last argument as the callback function
-  var lastArgument = args[args.length - 1]
+  const lastArgument = args[args.length - 1]
   if ((callback == null) && typeof lastArgument === 'function') {
     callback = lastArgument
   }
@@ -40,7 +38,7 @@ var parseArgs = function (window, options, callback, ...args) {
   return [window, options, callback]
 }
 
-var checkAppInitialized = function () {
+const checkAppInitialized = function () {
   if (!app.isReady()) {
     throw new Error('dialog module can only be used after app is ready')
   }
@@ -48,140 +46,173 @@ var checkAppInitialized = function () {
 
 module.exports = {
   showOpenDialog: function (...args) {
-    var prop, properties, value, wrappedCallback
     checkAppInitialized()
+
     let [window, options, callback] = parseArgs(...args)
+
     if (options == null) {
       options = {
         title: 'Open',
         properties: ['openFile']
       }
     }
-    if (options.properties == null) {
-      options.properties = ['openFile']
+
+    let {buttonLabel, defaultPath, filters, properties, title} = options
+
+    if (properties == null) {
+      properties = ['openFile']
     }
-    if (!Array.isArray(options.properties)) {
+
+    if (!Array.isArray(properties)) {
       throw new TypeError('Properties must be an array')
     }
-    properties = 0
-    for (prop in fileDialogProperties) {
-      value = fileDialogProperties[prop]
-      if (includes.call(options.properties, prop)) {
-        properties |= value
+
+    let dialogProperties = 0
+    for (const prop in fileDialogProperties) {
+      if (properties.includes(prop)) {
+        dialogProperties |= fileDialogProperties[prop]
       }
     }
-    if (options.title == null) {
-      options.title = ''
-    } else if (typeof options.title !== 'string') {
+
+    if (title == null) {
+      title = ''
+    } else if (typeof title !== 'string') {
       throw new TypeError('Title must be a string')
     }
-    if (options.buttonLabel == null) {
-      options.buttonLabel = ''
-    } else if (typeof options.buttonLabel !== 'string') {
+
+    if (buttonLabel == null) {
+      buttonLabel = ''
+    } else if (typeof buttonLabel !== 'string') {
       throw new TypeError('Button label must be a string')
     }
-    if (options.defaultPath == null) {
-      options.defaultPath = ''
-    } else if (typeof options.defaultPath !== 'string') {
+
+    if (defaultPath == null) {
+      defaultPath = ''
+    } else if (typeof defaultPath !== 'string') {
       throw new TypeError('Default path must be a string')
     }
-    if (options.filters == null) {
-      options.filters = []
+
+    if (filters == null) {
+      filters = []
     }
-    wrappedCallback = typeof callback === 'function' ? function (success, result) {
+
+    const wrappedCallback = typeof callback === 'function' ? function (success, result) {
       return callback(success ? result : void 0)
     } : null
-    return binding.showOpenDialog(options.title, options.buttonLabel, options.defaultPath, options.filters, properties, window, wrappedCallback)
+    return binding.showOpenDialog(title, buttonLabel, defaultPath, filters,
+                                  dialogProperties, window, wrappedCallback)
   },
 
   showSaveDialog: function (...args) {
-    var wrappedCallback
     checkAppInitialized()
+
     let [window, options, callback] = parseArgs(...args)
+
     if (options == null) {
       options = {
         title: 'Save'
       }
     }
-    if (options.title == null) {
-      options.title = ''
-    } else if (typeof options.title !== 'string') {
+
+    let {buttonLabel, defaultPath, filters, title} = options
+
+    if (title == null) {
+      title = ''
+    } else if (typeof title !== 'string') {
       throw new TypeError('Title must be a string')
     }
-    if (options.buttonLabel == null) {
-      options.buttonLabel = ''
-    } else if (typeof options.buttonLabel !== 'string') {
+
+    if (buttonLabel == null) {
+      buttonLabel = ''
+    } else if (typeof buttonLabel !== 'string') {
       throw new TypeError('Button label must be a string')
     }
-    if (options.defaultPath == null) {
-      options.defaultPath = ''
-    } else if (typeof options.defaultPath !== 'string') {
+
+    if (defaultPath == null) {
+      defaultPath = ''
+    } else if (typeof defaultPath !== 'string') {
       throw new TypeError('Default path must be a string')
     }
-    if (options.filters == null) {
-      options.filters = []
+
+    if (filters == null) {
+      filters = []
     }
-    wrappedCallback = typeof callback === 'function' ? function (success, result) {
+
+    const wrappedCallback = typeof callback === 'function' ? function (success, result) {
       return callback(success ? result : void 0)
     } : null
-    return binding.showSaveDialog(options.title, options.buttonLabel, options.defaultPath, options.filters, window, wrappedCallback)
+    return binding.showSaveDialog(title, buttonLabel, defaultPath, filters,
+                                  window, wrappedCallback)
   },
 
   showMessageBox: function (...args) {
-    var flags, i, j, len, messageBoxType, ref2, ref3, text
     checkAppInitialized()
+
     let [window, options, callback] = parseArgs(...args)
+
     if (options == null) {
       options = {
         type: 'none'
       }
     }
-    if (options.type == null) {
-      options.type = 'none'
+
+    let {buttons, cancelId, defaultId, detail, icon, message, title, type} = options
+
+    if (type == null) {
+      type = 'none'
     }
-    messageBoxType = messageBoxTypes.indexOf(options.type)
-    if (!(messageBoxType > -1)) {
+
+    const messageBoxType = messageBoxTypes.indexOf(type)
+    if (messageBoxType === -1) {
       throw new TypeError('Invalid message box type')
     }
-    if (!Array.isArray(options.buttons)) {
+
+    if (!Array.isArray(buttons)) {
       throw new TypeError('Buttons must be an array')
     }
-    if (options.title == null) {
-      options.title = ''
-    } else if (typeof options.title !== 'string') {
+
+    if (title == null) {
+      title = ''
+    } else if (typeof title !== 'string') {
       throw new TypeError('Title must be a string')
     }
-    if (options.message == null) {
-      options.message = ''
-    } else if (typeof options.message !== 'string') {
+
+    if (message == null) {
+      message = ''
+    } else if (typeof message !== 'string') {
       throw new TypeError('Message must be a string')
     }
-    if (options.detail == null) {
-      options.detail = ''
-    } else if (typeof options.detail !== 'string') {
+
+    if (detail == null) {
+      detail = ''
+    } else if (typeof detail !== 'string') {
       throw new TypeError('Detail must be a string')
     }
-    if (options.icon == null) {
-      options.icon = null
+
+    if (icon == null) {
+      icon = null
     }
-    if (options.defaultId == null) {
-      options.defaultId = -1
+
+    if (defaultId == null) {
+      defaultId = -1
     }
 
     // Choose a default button to get selected when dialog is cancelled.
-    if (options.cancelId == null) {
-      options.cancelId = 0
-      ref2 = options.buttons
-      for (i = j = 0, len = ref2.length; j < len; i = ++j) {
-        text = ref2[i]
-        if ((ref3 = text.toLowerCase()) === 'cancel' || ref3 === 'no') {
-          options.cancelId = i
+    if (cancelId == null) {
+      cancelId = 0
+      for (let i = 0; i < buttons.length; i++) {
+        const text = buttons[i].toLowerCase()
+        if (text === 'cancel' || text === 'no') {
+          cancelId = i
           break
         }
       }
     }
-    flags = options.noLink ? messageBoxOptions.noLink : 0
-    return binding.showMessageBox(messageBoxType, options.buttons, options.defaultId, options.cancelId, flags, options.title, options.message, options.detail, options.icon, window, callback)
+
+    const flags = options.noLink ? messageBoxOptions.noLink : 0
+    return binding.showMessageBox(messageBoxType, buttons, defaultId, cancelId,
+                                  flags, title, message, detail, icon, window,
+                                  callback)
   },
 
   showErrorBox: function (...args) {
@@ -190,9 +221,6 @@ module.exports = {
 }
 
 // Mark standard asynchronous functions.
-var ref1 = ['showMessageBox', 'showOpenDialog', 'showSaveDialog']
-var j, len, api
-for (j = 0, len = ref1.length; j < len; j++) {
-  api = ref1[j]
-  v8Util.setHiddenValue(module.exports[api], 'asynchronous', true)
-}
+v8Util.setHiddenValue(module.exports.showMessageBox, 'asynchronous', true)
+v8Util.setHiddenValue(module.exports.showOpenDialog, 'asynchronous', true)
+v8Util.setHiddenValue(module.exports.showSaveDialog, 'asynchronous', true)


### PR DESCRIPTION
Currently the `options` parameter passed to `dialog` APIs is written to in certain cases to add default values which can lead to unsurprising results in the calling code.

This pull request updates those APIs to not modify any of the specified parameters.

Also removes the CoffeeScript leftovers in `dialog.js`. ☕️ 