### PR TITLE
Add before-input-event event for webContents (fixes #7586)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -493,27 +493,11 @@ bool WebContents::PreHandleKeyboardEvent(
     content::WebContents* source,
     const content::NativeWebKeyboardEvent& event,
     bool* is_keyboard_shortcut) {
-  const char* type =
-    event.type == blink::WebInputEvent::Type::RawKeyDown ? "keyDown" :
-    event.type == blink::WebInputEvent::Type::KeyUp ? "keyUp" :
-    nullptr;
-  DCHECK(type);
-  if (!type) {
+  if (event.type == blink::WebInputEvent::Type::RawKeyDown
+      || event.type == blink::WebInputEvent::Type::KeyUp)
+    return Emit("before-input-event", event);
+  else
     return false;
-  }
-
-  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate());
-  dict.Set("type", type);
-  dict.Set("key", ui::KeycodeConverter::DomKeyToKeyString(event.domKey));
-
-  using Modifiers = blink::WebInputEvent::Modifiers;
-  dict.Set("isAutoRepeat", (event.modifiers & Modifiers::IsAutoRepeat) != 0);
-  dict.Set("shift", (event.modifiers & Modifiers::ShiftKey) != 0);
-  dict.Set("control", (event.modifiers & Modifiers::ControlKey) != 0);
-  dict.Set("alt", (event.modifiers & Modifiers::AltKey) != 0);
-  dict.Set("meta", (event.modifiers & Modifiers::MetaKey) != 0);
-
-  return Emit("before-input-event", dict);
 }
 
 void WebContents::EnterFullscreenModeForTab(content::WebContents* source,

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -70,7 +70,6 @@
 #include "third_party/WebKit/public/web/WebFindOptions.h"
 #include "third_party/WebKit/public/web/WebInputEvent.h"
 #include "ui/display/screen.h"
-#include "ui/events/keycodes/dom/keycode_converter.h"
 
 #if !defined(OS_MACOSX)
 #include "ui/aura/window.h"

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -497,9 +497,8 @@ bool WebContents::PreHandleKeyboardEvent(
     event.type == blink::WebInputEvent::Type::RawKeyDown ? "keyDown" :
     event.type == blink::WebInputEvent::Type::KeyUp ? "keyUp" :
     nullptr;
+  DCHECK(type);
   if (!type) {
-    // This should never happen.
-    assert(false);
     return false;
   }
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -244,6 +244,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void HandleKeyboardEvent(
       content::WebContents* source,
       const content::NativeWebKeyboardEvent& event) override;
+  bool PreHandleKeyboardEvent(content::WebContents* source,
+                              const content::NativeWebKeyboardEvent& event,
+                              bool* is_keyboard_shortcut) override;
   void EnterFullscreenModeForTab(content::WebContents* source,
                                  const GURL& origin) override;
   void ExitFullscreenModeForTab(content::WebContents* source) override;

--- a/atom/common/native_mate_converters/blink_converter.h
+++ b/atom/common/native_mate_converters/blink_converter.h
@@ -45,6 +45,8 @@ template<>
 struct Converter<content::NativeWebKeyboardEvent> {
   static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
                      content::NativeWebKeyboardEvent* out);
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const content::NativeWebKeyboardEvent& in);
 };
 
 template<>

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -250,8 +250,6 @@ Emitted before dispatching the `keydown` and `keyup` events in the page.
 Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events
 from being dispatched.
 
-[keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
-
 #### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.
@@ -1237,3 +1235,5 @@ when the DevTools has been closed.
 #### `contents.debugger`
 
 A [Debugger](debugger.md) instance for this webContents.
+
+[keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -232,6 +232,26 @@ Emitted when a plugin process has crashed.
 
 Emitted when `webContents` is destroyed.
 
+#### Event: 'before-input-event'
+
+Returns:
+
+* `event` Event
+* `input` Object - Input properties
+  * `type` String - Either `keyUp` or `keyDown`
+  * `key` String - Equivalent to [KeyboardEvent.key](keyboardevent)
+  * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat](keyboardevent)
+  * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey](keyboardevent)
+  * `control` Boolean - Equivalent to [KeyboardEvent.controlKey](keyboardevent)
+  * `alt` Boolean - Equivalent to [KeyboardEvent.altKey](keyboardevent)
+  * `meta` Boolean - Equivalent to [KeyboardEvent.metaKey](keyboardevent)
+
+Emitted before dispatching the `keydown` and `keyup` events in the page.
+Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events
+from being dispatched.
+
+[keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+
 #### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -98,25 +98,6 @@ describe('webContents module', function () {
     })
   })
 
-  describe('will-navigate event', function () {
-    it('can be prevented', (done) => {
-      const targetURL = 'file://' + path.join(__dirname, 'fixtures', 'pages', 'location-change.html')
-      w.loadURL(targetURL)
-      w.webContents.once('did-finish-load', () => {
-
-      w.webContents.on('will-navigate', (event, url) => {
-        assert.ok(url, targetURL)
-      })
-
-      setTimeout(done, 5000)
-
-      w.webContents.on('did-navigate', (event, url) => {
-        assert.ok(url, targetURL)
-      })
-      })
-    })
-  })
-
   describe('before-input-event event', () => {
     it('can prevent document keyboard events', (done) => {
       w.loadURL('file://' + path.join(__dirname, 'fixtures', 'pages', 'key-events.html'))

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -8,6 +8,7 @@ const ipcMain = electron.ipcMain
 const dialog = electron.dialog
 const BrowserWindow = electron.BrowserWindow
 const protocol = electron.protocol
+const webContents = electron.webContents
 const v8 = require('v8')
 
 const Coverage = require('electabul').Coverage
@@ -182,6 +183,12 @@ app.on('ready', function () {
       }
     })
     event.returnValue = 'done'
+  })
+
+  ipcMain.on('prevent-next-input-event', (event, key, id) => {
+    webContents.fromId(id).once('before-input-event', (event, input) => {
+      if (key === input.key) event.preventDefault()
+    })
   })
 
   ipcMain.on('executeJavaScript', function (event, code, hasCallback) {


### PR DESCRIPTION
Embedding arbitrary web content is problematic when it comes to keyboard
shortcuts because:

* Web content can steal app shortcuts (see e.g. brave/browser-laptop#4408)

* Blocked web content (e.g. a focused <webview> performing expensive
computation) will also prevent app shortcuts from firing immediately

The new before-input-event event can be used to overcome these issues by
always handle certain keyboard events in the main process.

Note that this requires electron/brightray#261 to compile.

Fixes #7586