### PR TITLE
Guard against missing devToolsWebContents

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -138,14 +138,17 @@ BrowserWindow.getFocusedWindow = () => {
 }
 
 BrowserWindow.fromWebContents = (webContents) => {
-  for (let window of BrowserWindow.getAllWindows()) {
+  for (const window of BrowserWindow.getAllWindows()) {
     if (window.webContents.equal(webContents)) return window
   }
 }
 
 BrowserWindow.fromDevToolsWebContents = (webContents) => {
-  for (let window of BrowserWindow.getAllWindows()) {
-    if (window.devToolsWebContents.equal(webContents)) return window
+  for (const window of BrowserWindow.getAllWindows()) {
+    const {devToolsWebContents} = window
+    if (devToolsWebContents != null && devToolsWebContents.equal(webContents)) {
+      return window
+    }
   }
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -9,11 +9,11 @@ const http = require('http')
 const {closeWindow} = require('./window-helpers')
 
 const {ipcRenderer, remote, screen} = require('electron')
-const {app, ipcMain, BrowserWindow, protocol} = remote
+const {app, ipcMain, BrowserWindow, protocol, webContents} = remote
 
 const isCI = remote.getGlobal('isCi')
 
-describe('browser-window module', function () {
+describe('BrowserWindow module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
   var w = null
   var server, postData
@@ -133,10 +133,10 @@ describe('browser-window module', function () {
 
   describe('BrowserWindow.destroy()', function () {
     it('prevents users to access methods of webContents', function () {
-      var webContents = w.webContents
+      const contents = w.webContents
       w.destroy()
       assert.throws(function () {
-        webContents.getId()
+        contents.getId()
       }, /Object has been destroyed/)
     })
   })
@@ -564,6 +564,23 @@ describe('browser-window module', function () {
   describe('BrowserWindow.fromId(id)', function () {
     it('returns the window with id', function () {
       assert.equal(w.id, BrowserWindow.fromId(w.id).id)
+    })
+  })
+
+  describe('BrowserWindow.fromWebContents(webContents)', function () {
+    let contents = null
+
+    beforeEach(function () {
+      contents = webContents.create({})
+    })
+
+    afterEach(function () {
+      contents.destroy()
+    })
+
+    it('returns the window with the webContents', function () {
+      assert.equal(BrowserWindow.fromWebContents(w.webContents).id, w.id)
+      assert.equal(BrowserWindow.fromWebContents(contents), undefined)
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -584,6 +584,28 @@ describe('BrowserWindow module', function () {
     })
   })
 
+  describe('BrowserWindow.fromDevToolsWebContents(webContents)', function () {
+    let contents = null
+
+    beforeEach(function () {
+      contents = webContents.create({})
+    })
+
+    afterEach(function () {
+      contents.destroy()
+    })
+
+    it('returns the window with the webContents', function (done) {
+      w.webContents.once('devtools-opened', () => {
+        assert.equal(BrowserWindow.fromDevToolsWebContents(w.devToolsWebContents).id, w.id)
+        assert.equal(BrowserWindow.fromDevToolsWebContents(w.webContents), undefined)
+        assert.equal(BrowserWindow.fromDevToolsWebContents(contents), undefined)
+        done()
+      })
+      w.webContents.openDevTools()
+    })
+  })
+
   describe('"useContentSize" option', function () {
     it('make window created with content size when used', function () {
       w.destroy()


### PR DESCRIPTION
This fixes any issue where `BrowserWindow.fromDevToolsWebContents` would through an error if any of the windows didn't have the dev tools already opened.