### PR TITLE
Upgrade libcc for Chrome 56 Linux key event fix

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '76bb29da18cbeec0051e0690bc1b95e78034a422'
+    'd59491fbd40f98ae72dfa575fd2b477c061ce613'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
Pulls in https://github.com/electron/libchromiumcontent/pull/247 which backports a Chrome 56 patch to Chrome 53 to fix issues on Linux where key events were reporting the wrong key when Control was pressed on certain keyboard layouts.

Closes #8116