### PR TITLE
Clear interval before done

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1619,8 +1619,8 @@ describe('browser-window module', function () {
       w.webContents.openDevTools({mode: 'bottom'})
 
       ipcMain.once('answer', function (event, message) {
-        assert.equal(message.runtimeId, 'foo')
         clearInterval(showPanelIntervalId)
+        assert.equal(message.runtimeId, 'foo')
         done()
       })
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1599,8 +1599,10 @@ describe('browser-window module', function () {
       BrowserWindow.removeDevToolsExtension('foo')
       BrowserWindow.addDevToolsExtension(extensionPath)
 
-      w.webContents.on('devtools-opened', function () {
-        var showPanelIntevalId = setInterval(function () {
+      let showPanelIntervalId = null
+
+      w.webContents.once('devtools-opened', function () {
+        showPanelIntervalId = setInterval(function () {
           if (w && w.devToolsWebContents) {
             var showLastPanel = function () {
               var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
@@ -1608,7 +1610,7 @@ describe('browser-window module', function () {
             }
             w.devToolsWebContents.executeJavaScript(`(${showLastPanel})()`)
           } else {
-            clearInterval(showPanelIntevalId)
+            clearInterval(showPanelIntervalId)
           }
         }, 100)
       })
@@ -1618,6 +1620,7 @@ describe('browser-window module', function () {
 
       ipcMain.once('answer', function (event, message) {
         assert.equal(message.runtimeId, 'foo')
+        clearInterval(showPanelIntervalId)
         done()
       })
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1503,7 +1503,7 @@ describe('browser-window module', function () {
 
   describe('dev tool extensions', function () {
     describe('BrowserWindow.addDevToolsExtension', function () {
-      let showPanelIntevalId
+      let showPanelIntervalId
 
       beforeEach(function () {
         BrowserWindow.removeDevToolsExtension('foo')
@@ -1514,7 +1514,7 @@ describe('browser-window module', function () {
         assert.equal(BrowserWindow.getDevToolsExtensions().hasOwnProperty('foo'), true)
 
         w.webContents.on('devtools-opened', function () {
-          showPanelIntevalId = setInterval(function () {
+          showPanelIntervalId = setInterval(function () {
             if (w && w.devToolsWebContents) {
               var showLastPanel = function () {
                 var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
@@ -1522,7 +1522,7 @@ describe('browser-window module', function () {
               }
               w.devToolsWebContents.executeJavaScript(`(${showLastPanel})()`)
             } else {
-              clearInterval(showPanelIntevalId)
+              clearInterval(showPanelIntervalId)
             }
           }, 100)
         })
@@ -1531,7 +1531,7 @@ describe('browser-window module', function () {
       })
 
       afterEach(function () {
-        clearInterval(showPanelIntevalId)
+        clearInterval(showPanelIntervalId)
       })
 
       it('throws errors for missing manifest.json files', function () {


### PR DESCRIPTION
CI specs are occassionally failing with:

```
not ok 117 browser-window module dev tool extensions works when used with partitions
  Error: Cannot call function 'executeJavaScript' on missing remote object 371
  Error: Cannot call function 'executeJavaScript' on missing remote object 371
      at throwRPCError (/Users/jenkins/Home/workspace/electron-osx-x64/out/D/Electron.app/Contents/Resources/electron.asar/browser/rpc-server.js:143:17)
      at EventEmitter.<anonymous> (/Users/jenkins/Home/workspace/electron-osx-x64/out/D/Electron.app/Contents/Resources/electron.asar/browser/rpc-server.js:339:7)
      at emitMany (events.js:127:13)
      at EventEmitter.emit (events.js:201:7)
      at WebContents.<anonymous> (/Users/jenkins/Home/workspace/electron-osx-x64/out/D/Electron.app/Contents/Resources/electron.asar/browser/api/web-contents.js:231:13)
      at emitTwo (events.js:106:13)
      at WebContents.emit (events.js:191:7)
      at metaToValue (/Users/jenkins/Home/workspace/electron-osx-x64/out/D/Electron.app/Contents/Resources/electron.asar/renderer/api/remote.js:217:13)
      at remoteMemberFunction (/Users/jenkins/Home/workspace/electron-osx-x64/out/D/Electron.app/Contents/Resources/electron.asar/renderer/api/remote.js:113:18)
      at /Users/jenkins/Home/workspace/electron-osx-x64/spec/api-browser-window-spec.js:1609:35
```

This pull request clears the interval before `done()` is called so the remote objects won't get accessed after the window has been destroyed.