### PR TITLE
Don't show window in specs

### DIFF
--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -521,7 +521,7 @@ describe('ipc module', function () {
   describe('remote objects registry', function () {
     it('does not dereference until the render view is deleted (regression)', function (done) {
       w = new BrowserWindow({
-        show: true
+        show: false
       })
 
       ipcMain.once('error-message', (event, message) => {


### PR DESCRIPTION
Cleans up a spec from #8110 that was incorrectly showing the window in the spec accidentally left in for debugging purposes.