### PR TITLE
Clarify modal windows being sheets on macOS

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -100,6 +100,7 @@ child.once('ready-to-show', () => {
 
 ### Platform notices
 
+* On macOS modal windows will be displayed as sheets attached to the parent window.
 * On macOS the child windows will keep the relative position to parent window
   when parent window moves, while on Windows and Linux child windows will not
   move.


### PR DESCRIPTION
This was not obvious to me until I saw it in action (actually expected the opposite).