### PR TITLE
:apple: Document that the `dock` window level is deprecated

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1073,6 +1073,7 @@ void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level) {
     } else if (level == "screen-saver") {
       windowLevel = NSScreenSaverWindowLevel;
     } else if (level == "dock") {
+      // Deprecated by macOS, but kept for backwards compatibility
       windowLevel = NSDockWindowLevel;
     }
   }

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -832,7 +832,7 @@ On Linux always returns `true`.
 * `flag` Boolean
 * `level` String (optional) _macOS_ - Values include `normal`, `floating`,
   `torn-off-menu`, `modal-panel`, `main-menu`, `status`, `pop-up-menu`,
-  `screen-saver`, and `dock`. The default is `floating`. See the
+  `screen-saver`, and ~~`dock`~~ (Deprecated). The default is `floating`. See the
   [macOS docs][window-levels] for more details.
 
 Sets whether the window should show always on top of other windows. After

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -494,7 +494,7 @@ describe('BrowserWindow module', function () {
   describe('BrowserWindow.setAlwaysOnTop(flag, level)', function () {
     it('sets the window as always on top', function () {
       assert.equal(w.isAlwaysOnTop(), false)
-      w.setAlwaysOnTop(true, 'dock')
+      w.setAlwaysOnTop(true, 'screen-saver')
       assert.equal(w.isAlwaysOnTop(), true)
       w.setAlwaysOnTop(false)
       assert.equal(w.isAlwaysOnTop(), false)


### PR DESCRIPTION
According to the Apple docs, the `NSDockWindowLevel` constant is deprecated: https://developer.apple.com/reference/appkit/nsdockwindowlevel?language=objc