### PR TITLE
Add detail for the browserWindow argument in dialog docs

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -41,6 +41,8 @@ The `dialog` module has the following methods:
 Returns `String[]`, an array of file paths chosen by the user,
 if the callback is provided it returns `undefined`.
 
+The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+
 The `filters` specifies an array of file types that can be displayed or
 selected when you want to limit the user to a specific type. For example:
 
@@ -82,6 +84,8 @@ shown.
 Returns `String`, the path of the file chosen by the user,
 if a callback is provided it returns `undefined`.
 
+The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+
 The `filters` specifies an array of file types that can be displayed, see
 `dialog.showOpenDialog` for an example.
 
@@ -121,6 +125,8 @@ it returns undefined.
 
 Shows a message box, it will block the process until the message box is closed.
 It returns the index of the clicked button.
+
+The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
 If a `callback` is passed, the API call will be asynchronous and the result
 will be passed via `callback(response)`.


### PR DESCRIPTION
There is no description of what the browserWindow argument actually does in the documentation. It only lists that it's optional. Without it, the user can accidentally open numerous dialogs because they can go back to the previous window and click to open another dialog. By setting the browserWindow argument, that window becomes modal and can't be acted upon until the user closes the dialog.