### PR TITLE
Record JavaScript calls in DevTools timeline on Node/ipc callback

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -18,7 +18,6 @@
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
 #include "base/trace_event/trace_event.h"
-#include "base/trace_event/trace_event_argument.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_paths.h"
 #include "native_mate/dictionary.h"
@@ -242,9 +241,7 @@ void NodeBindings::UvRunOnce() {
                                    v8::MicrotasksScope::kRunMicrotasks);
 
   if (!is_browser_)
-    TRACE_EVENT_BEGIN1("devtools.timeline", "FunctionCall", "data",
-                       std::unique_ptr<base::trace_event::TracedValue>(
-                           new base::trace_event::TracedValue()));
+    TRACE_EVENT_BEGIN0("devtools.timeline", "FunctionCall");
 
   // Deal with uv events.
   int r = uv_run(uv_loop_, UV_RUN_NOWAIT);

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -17,6 +17,8 @@
 #include "base/files/file_path.h"
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
+#include "base/trace_event/trace_event.h"
+#include "base/trace_event/trace_event_argument.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_paths.h"
 #include "native_mate/dictionary.h"
@@ -239,8 +241,17 @@ void NodeBindings::UvRunOnce() {
   v8::MicrotasksScope script_scope(env->isolate(),
                                    v8::MicrotasksScope::kRunMicrotasks);
 
+  if (!is_browser_)
+    TRACE_EVENT_BEGIN1("devtools.timeline", "FunctionCall", "data",
+                       std::unique_ptr<base::trace_event::TracedValue>(
+                           new base::trace_event::TracedValue()));
+
   // Deal with uv events.
   int r = uv_run(uv_loop_, UV_RUN_NOWAIT);
+
+  if (!is_browser_)
+    TRACE_EVENT_END0("devtools.timeline", "FunctionCall");
+
   if (r == 0)
     message_loop_->QuitWhenIdle();  // Quit from uv.
 

--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -19,7 +19,6 @@
 #include "base/command_line.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/trace_event/trace_event.h"
-#include "base/trace_event/trace_event_argument.h"
 #include "content/public/renderer/render_view.h"
 #include "ipc/ipc_message_macros.h"
 #include "native_mate/dictionary.h"
@@ -104,9 +103,7 @@ void AtomRenderViewObserver::EmitIPCEvent(blink::WebFrame* frame,
 
   v8::Local<v8::Object> ipc;
   if (GetIPCObject(isolate, context, &ipc)) {
-    TRACE_EVENT1("devtools.timeline", "FunctionCall", "data",
-                 std::unique_ptr<base::trace_event::TracedValue>(
-                     new base::trace_event::TracedValue()));
+    TRACE_EVENT0("devtools.timeline", "FunctionCall");
     auto args_vector = ListValueToVector(isolate, args);
     // Insert the Event object, event.sender is ipc.
     mate::Dictionary event = mate::Dictionary::CreateEmpty(isolate);

--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -18,6 +18,8 @@
 #include "atom/renderer/atom_renderer_client.h"
 #include "base/command_line.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/trace_event/trace_event.h"
+#include "base/trace_event/trace_event_argument.h"
 #include "content/public/renderer/render_view.h"
 #include "ipc/ipc_message_macros.h"
 #include "native_mate/dictionary.h"
@@ -102,6 +104,9 @@ void AtomRenderViewObserver::EmitIPCEvent(blink::WebFrame* frame,
 
   v8::Local<v8::Object> ipc;
   if (GetIPCObject(isolate, context, &ipc)) {
+    TRACE_EVENT1("devtools.timeline", "FunctionCall", "data",
+                 std::unique_ptr<base::trace_event::TracedValue>(
+                     new base::trace_event::TracedValue()));
     auto args_vector = ListValueToVector(isolate, args);
     // Insert the Event object, event.sender is ipc.
     mate::Dictionary event = mate::Dictionary::CreateEmpty(isolate);


### PR DESCRIPTION
Fix for https://github.com/electron/electron/issues/7920, using TRACE_EVENT API of Chromium.

Looks like below in [this example](https://github.com/seanchas116/electron-testings/tree/master/timeline-ipc)

![image](https://cloud.githubusercontent.com/assets/1025246/20965885/1716d1be-bcbb-11e6-9032-4bc7bdf685f7.png)
