### PR TITLE
Add bitmap support to nativeImage.createFromBuffer

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -408,13 +408,16 @@ mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
     mate::Arguments* args, v8::Local<v8::Value> buffer) {
   int width = 0;
   int height = 0;
-  if (args->Length() >= 3) {
-    args->GetNext(&width);
-    args->GetNext(&height);
-  }
-
   double scale_factor = 1.;
+
   args->GetNext(&scale_factor);
+
+  mate::Dictionary options;
+  if (args->GetNext(&options)) {
+    options.Get("width", &width);
+    options.Get("height", &height);
+    options.Get("scaleFactor", &scale_factor);
+  }
 
   gfx::ImageSkia image_skia;
   AddImageSkiaRep(&image_skia,

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -410,13 +410,14 @@ mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
   int height = 0;
   double scale_factor = 1.;
 
-  args->GetNext(&scale_factor);
-
   mate::Dictionary options;
   if (args->GetNext(&options)) {
     options.Get("width", &width);
     options.Get("height", &height);
     options.Get("scaleFactor", &scale_factor);
+  } else {
+    // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
+    args->GetNext(&scale_factor);
   }
 
   gfx::ImageSkia image_skia;

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -79,6 +79,8 @@ float GetScaleFactorFromPath(const base::FilePath& path) {
 bool AddImageSkiaRep(gfx::ImageSkia* image,
                      const unsigned char* data,
                      size_t size,
+                     int width,
+                     int height,
                      double scale_factor) {
   std::unique_ptr<SkBitmap> decoded(new SkBitmap());
 
@@ -87,8 +89,17 @@ bool AddImageSkiaRep(gfx::ImageSkia* image,
     // Try JPEG.
     decoded = gfx::JPEGCodec::Decode(data, size);
 
-  if (!decoded)
-    return false;
+  if (!decoded) {
+    // Try Bitmap
+    if (width > 0 && height > 0) {
+      decoded.reset(new SkBitmap);
+      decoded->allocN32Pixels(width, height, false);
+      decoded->setPixels(
+        const_cast<void*>(reinterpret_cast<const void*>(data)));
+    } else {
+      return false;
+    }
+  }
 
   image->AddRepresentation(gfx::ImageSkiaRep(*decoded, scale_factor));
   return true;
@@ -104,7 +115,7 @@ bool AddImageSkiaRep(gfx::ImageSkia* image,
   const unsigned char* data =
       reinterpret_cast<const unsigned char*>(file_contents.data());
   size_t size = file_contents.size();
-  return AddImageSkiaRep(image, data, size, scale_factor);
+  return AddImageSkiaRep(image, data, size, 0, 0, scale_factor);
 }
 
 bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
@@ -395,6 +406,13 @@ mate::Handle<NativeImage> NativeImage::CreateFromPath(
 // static
 mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
     mate::Arguments* args, v8::Local<v8::Value> buffer) {
+  int width = 0;
+  int height = 0;
+  if (args->Length() >= 3) {
+    args->GetNext(&width);
+    args->GetNext(&height);
+  }
+
   double scale_factor = 1.;
   args->GetNext(&scale_factor);
 
@@ -402,6 +420,8 @@ mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
   AddImageSkiaRep(&image_skia,
                   reinterpret_cast<unsigned char*>(node::Buffer::Data(buffer)),
                   node::Buffer::Length(buffer),
+                  width,
+                  height,
                   scale_factor);
   return Create(args->isolate(), gfx::Image(image_skia));
 }

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -149,7 +149,8 @@ console.log(image)
 Returns `NativeImage`
 
 Creates a new `NativeImage` instance from `buffer`. The default `scaleFactor` is
-1.0. The `width` and `height` options are **required** for bitmap buffers.
+1.0. The `width` and `height` options are **required** and only used for bitmap
+buffers.
 
 ### `nativeImage.createFromDataURL(dataURL)`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -137,17 +137,19 @@ let image = nativeImage.createFromPath('/Users/somebody/images/icon.png')
 console.log(image)
 ```
 
-### `nativeImage.createFromBuffer(buffer[width, height, scaleFactor])`
+### `nativeImage.createFromBuffer(buffer[, scaleFactor, options])`
 
 * `buffer` [Buffer][buffer]
-* `width` Integer (optional)
-* `height` Integer (optional)
 * `scaleFactor` Double (optional)
+* `options` Object (optional)
+  * `width` Integer (optional)
+  * `height` Integer (optional)
+  * `scaleFactor` Double (optional)
 
 Returns `NativeImage`
 
 Creates a new `NativeImage` instance from `buffer`. The default `scaleFactor` is
-1.0. If `buffer` is a bitmap, specify `width` and `height` of the image.
+1.0. The `width` and `height` options are **required** for bitmap buffers.
 
 ### `nativeImage.createFromDataURL(dataURL)`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -137,10 +137,9 @@ let image = nativeImage.createFromPath('/Users/somebody/images/icon.png')
 console.log(image)
 ```
 
-### `nativeImage.createFromBuffer(buffer[, scaleFactor, options])`
+### `nativeImage.createFromBuffer(buffer[, options])`
 
 * `buffer` [Buffer][buffer]
-* `scaleFactor` Double (optional)
 * `options` Object (optional)
   * `width` Integer (optional)
   * `height` Integer (optional)

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -137,15 +137,17 @@ let image = nativeImage.createFromPath('/Users/somebody/images/icon.png')
 console.log(image)
 ```
 
-### `nativeImage.createFromBuffer(buffer[, scaleFactor])`
+### `nativeImage.createFromBuffer(buffer[width, height, scaleFactor])`
 
 * `buffer` [Buffer][buffer]
+* `width` Integer (optional)
+* `height` Integer (optional)
 * `scaleFactor` Double (optional)
 
 Returns `NativeImage`
 
 Creates a new `NativeImage` instance from `buffer`. The default `scaleFactor` is
-1.0.
+1.0. If `buffer` is a bitmap, specify `width` and `height` of the image.
 
 ### `nativeImage.createFromDataURL(dataURL)`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -141,15 +141,13 @@ console.log(image)
 
 * `buffer` [Buffer][buffer]
 * `options` Object (optional)
-  * `width` Integer (optional)
-  * `height` Integer (optional)
-  * `scaleFactor` Double (optional)
+  * `width` Integer (optional) - Required for bitmap buffers.
+  * `height` Integer (optional) - Required for bitmap buffers.
+  * `scaleFactor` Double (optional) - Defaults to 1.0.
 
 Returns `NativeImage`
 
-Creates a new `NativeImage` instance from `buffer`. The default `scaleFactor` is
-1.0. The `width` and `height` options are **required** and only used for bitmap
-buffers.
+Creates a new `NativeImage` instance from `buffer`.
 
 ### `nativeImage.createFromDataURL(dataURL)`
 

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -69,6 +69,13 @@ nativeImage.toPNG()
 nativeImage.toJpeg()
 // Replace with
 nativeImage.toJPEG()
+
+// Deprecated
+nativeImage.createFromBuffer(buffer, 1.0)
+// Replace with
+nativeImage.createFromBuffer(buffer, {
+  scaleFactor: 1.0
+})
 ```
 
 ## `process`

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -44,6 +44,13 @@ describe('nativeImage module', () => {
       const imageH = nativeImage.createFromBuffer(imageA.toJPEG(100),
         {width: 100, height: 200})
       assert.deepEqual(imageH.getSize(), {width: 538, height: 190})
+
+      const imageI = nativeImage.createFromBuffer(imageA.toBitmap(),
+        {width: 538, height: 190, scaleFactor: 2.0})
+      assert.deepEqual(imageI.getSize(), {width: 269, height: 95})
+
+      const imageJ = nativeImage.createFromBuffer(imageA.toPNG(), 2.0)
+      assert.deepEqual(imageJ.getSize(), {width: 269, height: 95})
     })
   })
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -25,6 +25,9 @@ describe('nativeImage module', () => {
 
       const imageC = nativeImage.createFromBuffer(imageA.toJPEG(100))
       assert.deepEqual(imageC.getSize(), {width: 538, height: 190})
+
+      const imageD = nativeImage.createFromBuffer(imageA.toBitmap(), 538, 190)
+      assert.deepEqual(imageD.getSize(), {width: 538, height: 190})
     })
   })
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -26,7 +26,8 @@ describe('nativeImage module', () => {
       const imageC = nativeImage.createFromBuffer(imageA.toJPEG(100))
       assert.deepEqual(imageC.getSize(), {width: 538, height: 190})
 
-      const imageD = nativeImage.createFromBuffer(imageA.toBitmap(), 538, 190)
+      const imageD = nativeImage.createFromBuffer(imageA.toBitmap(),
+        {width: 538, height: 190})
       assert.deepEqual(imageD.getSize(), {width: 538, height: 190})
     })
   })

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -34,13 +34,16 @@ describe('nativeImage module', () => {
         {width: 100, height: 200})
       assert.deepEqual(imageE.getSize(), {width: 100, height: 200})
 
-      const imageF = nativeImage.createFromBuffer(imageA.toPNG(),
-        {width: 100, height: 200})
-      assert.deepEqual(imageF.getSize(), {width: 538, height: 190})
+      const imageF = nativeImage.createFromBuffer(imageA.toBitmap())
+      assert(imageF.isEmpty())
 
-      const imageG = nativeImage.createFromBuffer(imageA.toJPEG(100),
+      const imageG = nativeImage.createFromBuffer(imageA.toPNG(),
         {width: 100, height: 200})
       assert.deepEqual(imageG.getSize(), {width: 538, height: 190})
+
+      const imageH = nativeImage.createFromBuffer(imageA.toJPEG(100),
+        {width: 100, height: 200})
+      assert.deepEqual(imageH.getSize(), {width: 538, height: 190})
     })
   })
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -29,6 +29,18 @@ describe('nativeImage module', () => {
       const imageD = nativeImage.createFromBuffer(imageA.toBitmap(),
         {width: 538, height: 190})
       assert.deepEqual(imageD.getSize(), {width: 538, height: 190})
+
+      const imageE = nativeImage.createFromBuffer(imageA.toBitmap(),
+        {width: 100, height: 200})
+      assert.deepEqual(imageE.getSize(), {width: 100, height: 200})
+
+      const imageF = nativeImage.createFromBuffer(imageA.toPNG(),
+        {width: 100, height: 200})
+      assert.deepEqual(imageF.getSize(), {width: 538, height: 190})
+
+      const imageG = nativeImage.createFromBuffer(imageA.toJPEG(100),
+        {width: 100, height: 200})
+      assert.deepEqual(imageG.getSize(), {width: 538, height: 190})
     })
   })
 


### PR DESCRIPTION
This PR adds support to `nativeImage.createFromBuffer` for creating images from bitmap buffers. #7950 

We cannot obtain size from the buffer, it has to be supplied as well, so I added two optional parameters to the method.