### PR TITLE
[Docs] Fix list item number rendering in distribution tutorial

### DIFF
--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -149,11 +149,11 @@ we appreciate your help.
 
 2. Create a new S3 bucket and create the following empty directory structure:
 
-```
-- atom-shell/
-  - symbols/
-  - dist/
-```
+    ```
+    - atom-shell/
+      - symbols/
+      - dist/
+    ```
 
 3. Set the following Environment Variables:
 


### PR DESCRIPTION
Minor docs fix. Without indentation, the items underneath this have their numbering started over.