### PR TITLE
Add instructions for native modules using prebuild

### DIFF
--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -76,6 +76,16 @@ following things:
 * After you upgraded Electron, you usually need to rebuild the modules.
 * When in doubt, run `electron-rebuild` first.
 
+## Modules that rely on `prebuild`
+
+[`prebuild`](https://github.com/mafintosh/prebuild) provides a way to easily
+publish native Node modules with prebuilt binaries for multiple versions of Node
+and Electron.
+
+If modules provide binaries for the usage in Electron, make sure to omit
+`--build-from-source` and the `npm_config_build_from_source` environment
+variable in order to take full advantage of the prebuilt binaries.
+
 ## Modules that rely on `node-pre-gyp`
 
 The [`node-pre-gyp` tool][node-pre-gyp] provides a way to deploy native Node


### PR DESCRIPTION
[`prebuild`](https://github.com/mafintosh/prebuild) is now able to provide prebuilt binaries of native Node modules against Electron headers.

If you like to try it, [`zeromq.js`](https://github.com/zeromq/zeromq.js) already ships prebuilts for Electron.
We are using the prebuilt binaries successfully in [nteract](https://github.com/nteract/nteract) and the Atom package [Hydrogen](https://github.com/nteract/hydrogen).

/cc @mafintosh @juliangruber @ralphtheninja @rgbkrk