### PR TITLE
Undefined browser causes error in dialog APIs

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -19,7 +19,7 @@ const messageBoxOptions = {
 }
 
 const parseArgs = function (window, options, callback, ...args) {
-  if (window !== null && window.constructor !== BrowserWindow) {
+  if (window != null && window.constructor !== BrowserWindow) {
     // Shift.
     [callback, options, window] = [options, window, null]
   }

--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -41,11 +41,11 @@ describe('dialog module', () => {
   describe('showMessageBox', () => {
     it('throws errors when the options are invalid', () => {
       assert.throws(() => {
-        dialog.showMessageBox({type: 'not-a-valid-type'})
+        dialog.showMessageBox(undefined, {type: 'not-a-valid-type'})
       }, /Invalid message box type/)
 
       assert.throws(() => {
-        dialog.showMessageBox({buttons: false})
+        dialog.showMessageBox(null, {buttons: false})
       }, /Buttons must be an array/)
 
       assert.throws(() => {


### PR DESCRIPTION
`null` was handled but `undefined` results in a `Cannot read property 'constructor' of undefined` error.