### PR TITLE
Doc updates related to Fedora and RHEL / CentOS

### DIFF
--- a/docs-translations/es/development/build-instructions-linux.md
+++ b/docs-translations/es/development/build-instructions-linux.md
@@ -3,11 +3,11 @@
 Siga las siguientes pautas para la construcción de Electron en Linux.
 #Requisitos previos
 
-   *  Python 2.7.x. Algunas distribuciones como CentOS siguen utilizando Python 2.6.x por lo que puede que tenga que comprobar su versión de Python con  `Python -V`.
+   *  Python 2.7.x. Algunas distribuciones como CentOS 6.x siguen utilizando Python 2.6.x por lo que puede que tenga que comprobar su versión de Python con  `Python -V`.
    *  Node.js v0.12.x. Hay varias formas de instalar Node. Puede descargar el código fuente de Node.js y compilar desde las fuentes. Si lo hace, permite la instalación de Node en el directorio personal como usuario estándar. O intentar de  repositorios como NodeSource.
    *  Clang 3.4 o mayor.
    *  Cabeceras de desarrollo de GTK + y libnotify.
-   
+
 En Ubuntu, instalar las siguientes bibliotecas:
 
 `$ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
@@ -15,11 +15,19 @@ En Ubuntu, instalar las siguientes bibliotecas:
                        libasound2-dev libcap-dev libcups2-dev libxtst-dev \
                        libxss1 libnss3-dev gcc-multilib g++-multilib`
 
+En RHEL / CentOS, instale las siguientes bibliotecas:
+
+`$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
+                    libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                    cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                    GConf2-devel nss-devel`
+
 En Fedora, instale las siguientes bibliotecas:
 
-`$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel \
-                   xorg-x11-server-utils libcap-devel cups-devel libXtst-devel \
-                   alsa-lib-devel libXrandr-devel GConf2-devel nss-devel`
+`$ sudo dnf install clang dbus-devel gtk2-devel libnotify-devel \
+                    libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                    cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                    GConf2-devel nss-devel`
 
 Otras distribuciones pueden ofrecer paquetes similares para la instalación, a través de gestores de paquetes como el pacman. O  puede compilarlo a partir del código fuente.
 

--- a/docs-translations/jp/development/build-instructions-linux.md
+++ b/docs-translations/jp/development/build-instructions-linux.md
@@ -5,7 +5,7 @@ Linux で Electron をビルドする際は以下のガイドラインに従っ�
 ## 事前準備
 
 * 25GB のディスク空き容量と8GB の RAM が少なくとも必要です
-* Python 2.7.xが必要です。CentOS のようないくつかのディストリビューションはまだ Python 2.6.x を使ってるので、`python -V` で Python のバージョンを確認する必要があるでしょう。
+* Python 2.7.xが必要です。CentOS 6.x のようないくつかのディストリビューションはまだ Python 2.6.x を使ってるので、`python -V` で Python のバージョンを確認する必要があるでしょう。
 * Node.js v0.12.x が必要です。Node のインストールには色んな方法があります。[Node.js](http://nodejs.org) からソースコードをダウンロードしてビルドすることもできます。そうすることで root でないユーザーのホームディレクトリに Node をインストールすることもできます。あるいは [NodeSource](https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories) のようなレポジトリを試してみてください。
 * Clang 3.4 以上が必要です。
 * GTK+ と libnotify の開発用ヘッダーが必要です。
@@ -19,12 +19,22 @@ $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        libxss1 libnss3-dev gcc-multilib g++-multilib curl
 ```
 
+RHEL / CentOS では以下のライブラリをインストールしてください。
+
+```bash
+$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
+```
+
 Fedora では以下のライブラリをインストールしてください。
 
 ```bash
-$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel \
-                   xorg-x11-server-utils libcap-devel cups-devel libXtst-devel \
-                   alsa-lib-devel libXrandr-devel GConf2-devel nss-devel
+$ sudo dnf install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
 ```
 
 他のディストリビューションでは pacman のようなパッケージマネージャーを通して似たようなインストールパッケージを提供しているかもしれません。あるいはソースコードからコンパイルもできます。

--- a/docs-translations/ko-KR/development/build-instructions-linux.md
+++ b/docs-translations/ko-KR/development/build-instructions-linux.md
@@ -5,7 +5,7 @@
 ## 빌드전 요구사양
 
 * 최소한 25GB 이상의 디스크 공간과 8GB 램이 필요합니다.
-* Python 2.7.x. 몇몇 CentOS와 같은 배포판들은 아직도 Python 2.6.x 버전을 사용합니다.
+* Python 2.7.x. 몇몇 CentOS 6.x와 같은 배포판들은 아직도 Python 2.6.x 버전을 사용합니다.
   그래서 먼저 `python -V`를 통해 버전을 확인할 필요가 있습니다.
 * Node.js v0.12.x. Node를 설치하는 방법은 여러 가지가 있습니다. 먼저,
   [Node.js](http://nodejs.org) 사이트에서 소스 코드를 받아 빌드하는 방법입니다.
@@ -26,13 +26,22 @@ $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        gperf bison
 ```
 
+RHEL / CentOS를 사용하고 있다면 다음과 같이 라이브러리를 설치해야 합니다:
+
+```bash
+$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
+```
+
 Fedora를 사용하고 있다면 다음과 같이 라이브러리를 설치해야 합니다:
 
 ```bash
-$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel \
-                   xorg-x11-server-utils libcap-devel cups-devel libXtst-devel \
-                   alsa-lib-devel libXrandr-devel GConf2-devel nss-devel bison \
-                   gperf
+$ sudo dnf install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
 ```
 
 다른 배포판의 경우 pacman 같은 패키지 매니저를 통해 패키지를 설치 할 수 있습니다.

--- a/docs-translations/pt-BR/development/build-instructions-linux.md
+++ b/docs-translations/pt-BR/development/build-instructions-linux.md
@@ -4,11 +4,11 @@ Siga as orientações abaixo pra fazer o build do Electron no Linux.
 
 ## Pré-requisitos
 
-* Python 2.7.x. Algumas distribuições como CentOS ainda usam Python 2.6.x,
+* Python 2.7.x. Algumas distribuições como CentOS 6.x ainda usam Python 2.6.x,
   então você precisa checar a sua versão do Python com `python -V`.
 * Node.js v0.12.x. Há várias maneiras de instalar o Node. Você pode baixar o
   código fonte do [Node.js](http://nodejs.org) e compilar a partir dele.
-  Fazer isto permite que você instale o Node no seu próprio diretório home 
+  Fazer isto permite que você instale o Node no seu próprio diretório home
   como um usuário comum.
   Ou tente repositórios como [NodeSource](https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories).
 * Clang 3.4 ou mais recente.
@@ -23,12 +23,22 @@ $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        libxss1 libnss3-dev gcc-multilib g++-multilib
 ```
 
+No RHEL / CentOS, instale as seguintes bibliotecas:
+
+```bash
+$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
+```
+
 No Fedora, instale as seguintes bibliotecas:
 
 ```bash
-$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel \
-                   xorg-x11-server-utils libcap-devel cups-devel libXtst-devel \
-                   alsa-lib-devel libXrandr-devel GConf2-devel nss-devel
+$ sudo dnf install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
 ```
 
 Outras distribuições podem oferecer pacotes similares para instalação através
@@ -121,7 +131,7 @@ Certifique-se de que você tenha instalado todas as dependências do build.
 ### Error While Loading Shared Libraries: libtinfo.so.5
 
 O `clang` prebuilt irá tentar fazer o link com `libtinfo.so.5`. Dependendo
-da arquitetura do host, faça um link simbólico para o `libncurses` apropriado: 
+da arquitetura do host, faça um link simbólico para o `libncurses` apropriado:
 
 ```bash
 $ sudo ln -s /usr/lib/libncurses.so.5 /usr/lib/libtinfo.so.5

--- a/docs-translations/zh-CN/development/build-instructions-linux.md
+++ b/docs-translations/zh-CN/development/build-instructions-linux.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-* Python 2.7.x. 一些发行版如 CentOS 仍然使用 Python 2.6.x ，所以或许需要 check 你的 Python 版本，使用 `python -V`.
+* Python 2.7.x. 一些发行版如 CentOS 6.x 仍然使用 Python 2.6.x ，所以或许需要 check 你的 Python 版本，使用 `python -V`.
 * Node.js v0.12.x. 有很多方法来安装 Node. 可以从 [Node.js](http://nodejs.org)下载原文件并且编译它 .也可以作为一个标准的用户在 home 目录下安装 node .或者尝试使用仓库 [NodeSource](https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories).
 * Clang 3.4 或更新的版本.
 * GTK+开发头文件和libnotify.
@@ -18,15 +18,25 @@ $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        libxss1 libnss3-dev gcc-multilib g++-multilib
 ```
 
+On RHEL / CentOS, 安装下面的库 :
+
+```bash
+$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
+```
+
 在 Fedora, 安装下面的库 :
 
 ```bash
-$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel \
-                   xorg-x11-server-utils libcap-devel cups-devel libXtst-devel \
-                   alsa-lib-devel libXrandr-devel GConf2-devel nss-devel
+$ sudo dnf install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
 ```
 
-其它版本的也许提供了相似的包来安装，通过包管理器，例如 pacman. 
+其它版本的也许提供了相似的包来安装，通过包管理器，例如 pacman.
 或一个可以编译源文件的.
 
 ## 使用虚拟机  

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -5,7 +5,7 @@ Follow the guidelines below for building Electron on Linux.
 ## Prerequisites
 
 * At least 25GB disk space and 8GB RAM.
-* Python 2.7.x. Some distributions like CentOS still use Python 2.6.x
+* Python 2.7.x. Some distributions like CentOS 6.x still use Python 2.6.x
   so you may need to check your Python version with `python -V`.
 * Node.js. There are various ways to install Node. You can download
   source code from [Node.js](http://nodejs.org) and compile from source.
@@ -24,13 +24,22 @@ $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        gperf bison
 ```
 
+On RHEL / CentOS, install the following libraries:
+
+```bash
+$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
+```
+
 On Fedora, install the following libraries:
 
 ```bash
-$ sudo yum install clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel \
-                   xorg-x11-server-utils libcap-devel cups-devel libXtst-devel \
-                   alsa-lib-devel libXrandr-devel GConf2-devel nss-devel bison \
-                   gperf
+$ sudo dnf install clang dbus-devel gtk2-devel libnotify-devel \
+                   libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
+                   cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
+                   GConf2-devel nss-devel
 ```
 
 Other distributions may offer similar packages for installation via package


### PR DESCRIPTION
* Update build instructions to correctly reflect python version on CentOS
  that has Python 2.6.
* Correct Fedora package install command. Fedora now uses 'dnf' not 'yum'.
* Add RHEL / CentOS section that does use 'yum' for package install.