### PR TITLE
Test window against its prototype chain in dialog `parseArgs`

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -19,7 +19,7 @@ const messageBoxOptions = {
 }
 
 const parseArgs = function (window, options, callback, ...args) {
-  if (window != null && window.constructor !== BrowserWindow) {
+  if (window != null && !(window instanceof BrowserWindow)) {
     // Shift.
     [callback, options, window] = [options, window, null]
   }


### PR DESCRIPTION
I don’t know what’s your point of view on `instanceof`, for there a very few in the codebase and `var.constructor === Class` seems to be the preferred way. However, that doesn’t take inheritance into account.

In my app my windows instances are instantiated from classes that extends `BrowserWindow` and AFAIK that shouldn’t be an anti-pattern(?). Checking for `window.constructor` is always false, which means arguments are shifted making it impossible to attach a dialog to my windows and throws the `Buttons must be an array` error because it doesn’t properly find the `options` argument.

[api-dialog-spec.js](https://github.com/electron/electron/blob/master/spec/api-dialog-spec.js) only tests thrown errors, so I didn’t update them.