### PR TITLE
fix build-instructions-linux.md

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -85,6 +85,7 @@ happens because the Release target binary contains debugging symbols.
 To reduce the file size, run the `create-dist.py` script:
 
 ```bash
+$ npm run lint-api-docs
 $ ./script/create-dist.py
 ```
 


### PR DESCRIPTION
:memo:
because if file is absent
IOError: [Errno 2] No such file or directory: 'your/path/electron/out/electron-api.json'