### PR TITLE
do not recommend yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ behavior to electron@github.com.
 ## Downloads
 
 To install prebuilt Electron binaries, use
-[`npm`](https://docs.npmjs.com/) (or [`yarn`](https://yarnpkg.com/en/docs/managing-dependencies)):
+[`npm`](https://docs.npmjs.com/):
 
 ```sh
 # Install as a development dependency


### PR DESCRIPTION
A followup to https://github.com/electron/electron/pull/7971

> Yarn doesn't run post-install scripts (by design apparently) which lots of Electron packages use (i.e. node-gyp-pre), and because it's p broken on Windows, we probably shouldn't suggest that people use it.

cc @paulcbetts 