### PR TITLE
Link to return class type

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -56,7 +56,7 @@ Writes `markup` to the clipboard.
 
 * `type` String (optional)
 
-Returns `NativeImage` - The content in the clipboard as a [NativeImage](native-image.md).
+Returns [`NativeImage`](native-image.md) - The image content in the clipboard.
 
 ### `clipboard.writeImage(image[, type])`
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -63,7 +63,7 @@ The `net` module has the following methods:
 
 * `options` (Object | String) - The `ClientRequest` constructor options.
 
-Returns `ClientRequest`
+Returns [`ClientRequest`](./client-request.md)
 
 Creates a [`ClientRequest`](./client-request.md) instance using the provided
 `options` which are directly forwarded to the `ClientRequest` constructor.

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -144,12 +144,12 @@ Returns `any` - The object returned by `require(module)` in the main process.
 
 ### `remote.getCurrentWindow()`
 
-Returns `BrowserWindow` - The [`BrowserWindow`](browser-window.md) object to which this web page
+Returns [`BrowserWindow`](browser-window.md) - The window to which this web page
 belongs.
 
 ### `remote.getCurrentWebContents()`
 
-Returns `WebContents` - The [`WebContents`](web-contents.md) object of this web page.
+Returns [`WebContents`](web-contents.md) - The web contents of this web page.
 
 ### `remote.getGlobal(name)`
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -100,11 +100,11 @@ The current absolute position of the mouse pointer.
 
 ### `screen.getPrimaryDisplay()`
 
-Returns `Display` - The primary display.
+Returns [`Display`](structures/display.md) - The primary display.
 
 ### `screen.getAllDisplays()`
 
-Returns `Display[]` - An array of displays that are currently available.
+Returns [`Display[]`](structures/display.md) - An array of displays that are currently available.
 
 ### `screen.getDisplayNearestPoint(point)`
 
@@ -112,10 +112,11 @@ Returns `Display[]` - An array of displays that are currently available.
   * `x` Integer
   * `y` Integer
 
-Returns `Display` - The display nearest the specified point.
+Returns [`Display`](structures/display.md) - The display nearest the specified point.
 
 ### `screen.getDisplayMatching(rect)`
 
 * `rect` [Rectangle](structures/rectangle.md)
 
-Returns `Display` - The display that most closely intersects the provided bounds.
+Returns `Display`](structures/display.md) - The display that most closely
+intersects the provided bounds.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -581,7 +581,8 @@ Shows pop-up dictionary that searches the selected word on the page.
 
 ### `<webview>.getWebContents()`
 
-Returns `WebContents` - The [WebContents](web-contents.md) associated with this `webview`.
+Returns [`WebContents`](web-contents.md) - The web contents associated with
+this `webview`.
 
 ## DOM events
 

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -20,7 +20,8 @@ string.
 * `frameName` String (optional)
 * `features` String (optional)
 
-Returns `BrowserWindowProxy` - Creates a new window and returns an instance of `BrowserWindowProxy` class.
+Returns [`BrowserWindowProxy`](browser-window-proxy.md) - Creates a new window
+and returns an instance of `BrowserWindowProxy` class.
 
 The `features` string follows the format of standard browser, but each feature
 has to be a field of `BrowserWindow`'s options.


### PR DESCRIPTION
Noticed a few return types weren't linking to their type docs.