### PR TITLE
fix relative link to CertificatePrincipal doc

### DIFF
--- a/docs/api/structures/certificate.md
+++ b/docs/api/structures/certificate.md
@@ -1,10 +1,10 @@
 # Certificate Object
 
 * `data` String - PEM encoded data
-* `issuer` [CertificatePrincipal](structures/certificate-principal.md) - Issuer principal
+* `issuer` [CertificatePrincipal](certificate-principal.md) - Issuer principal
 * `issuerName` String - Issuer's Common Name
 * `issuerCert` Certificate - Issuer certificate (if not self-signed)
-* `subject` [CertificatePrincipal](structures/certificate-principal.md) - Subject principal
+* `subject` [CertificatePrincipal](certificate-principal.md) - Subject principal
 * `subjectName` String - Subject's Common Name
 * `serialNumber` String - Hex value represented string
 * `validStart` Number - Start date of the certificate being valid in seconds


### PR DESCRIPTION
The doc is in the same directory, so the `structures/` prefix is not needed.