### PR TITLE
Allow setting Activity Monitor's title dynamically

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -11,6 +11,9 @@
 #include "atom/common/api/locker.h"
 #include "atom/common/atom_command_line.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
+#include "atom/common/node_includes.h"
+#include "atom/common/platform_util.h"
+#include "base/command_line.h"
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/environment.h"
@@ -180,9 +183,11 @@ node::Environment* NodeBindings::CreateEnvironment(
   mate::Dictionary process(context->GetIsolate(), env->process_object());
   process.Set("type", process_type);
   process.Set("resourcesPath", resources_path);
+
   // Do not set DOM globals for renderer process.
   if (!is_browser_)
     process.Set("_noBrowserGlobals", resources_path);
+
   // The path to helper app.
   base::FilePath helper_exec_path;
   PathService::Get(content::CHILD_PROCESS_EXE, &helper_exec_path);
@@ -193,6 +198,10 @@ node::Environment* NodeBindings::CreateEnvironment(
   if (is_browser_ &&
       base::CommandLine::ForCurrentProcess()->HasSwitch("debug-brk"))
     process.Set("_debugWaitConnect", true);
+
+  process.SetMethod(
+    "setProcessTitle",
+    &platform_util::SetProcessTitleActivityMonitor);
 
   return env;
 }

--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -57,6 +57,8 @@ bool MoveItemToTrash(const base::FilePath& full_path);
 
 void Beep();
 
+void SetProcessTitleActivityMonitor(const std::string& name);
+
 }  // namespace platform_util
 
 #endif  // ATOM_COMMON_PLATFORM_UTIL_H_

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -129,4 +129,9 @@ void Beep() {
   fclose(console);
 }
 
+void SetProcessTitleActivityMonitor(const std::string& name) {
+  setproctitle(name.c_str());
+}
+
+
 }  // namespace platform_util

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -133,5 +133,4 @@ void SetProcessTitleActivityMonitor(const std::string& name) {
   setproctitle(name.c_str());
 }
 
-
 }  // namespace platform_util

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -100,93 +100,7 @@ std::string OpenURL(NSURL* ns_url, bool activate) {
 }  // namespace
 
 namespace platform_util {
-
-#if !defined MAS_BUILD
-void SetProcessName(CFStringRef process_name) {
-  if (!process_name || CFStringGetLength(process_name) == 0) {
-    NOTREACHED() << "SetProcessName given bad name.";
-    return;
-  }
-
-  // Warning: here be dragons! This is SPI reverse-engineered from WebKit's
-  // plugin host, and could break at any time (although realistically it's only
-  // likely to break in a new major release).
-  // When 10.7 is available, check that this still works, and update this
-  // comment for 10.8.
-
-  // Private CFType used in these LaunchServices calls.
-  typedef CFTypeRef PrivateLSASN;
-  typedef PrivateLSASN (*LSGetCurrentApplicationASNType)();
-  typedef OSStatus (*LSSetApplicationInformationItemType)(int, PrivateLSASN,
-                                                          CFStringRef,
-                                                          CFStringRef,
-                                                          CFDictionaryRef*);
-
-  static LSGetCurrentApplicationASNType ls_get_current_application_asn_func =
-      NULL;
-  static LSSetApplicationInformationItemType
-      ls_set_application_information_item_func = NULL;
-  static CFStringRef ls_display_name_key = NULL;
-
-  static bool did_symbol_lookup = false;
-  if (!did_symbol_lookup) {
-    did_symbol_lookup = true;
-    CFBundleRef launch_services_bundle =
-        CFBundleGetBundleWithIdentifier(CFSTR("com.apple.LaunchServices"));
-    if (!launch_services_bundle) {
-      LOG(ERROR) << "Failed to look up LaunchServices bundle";
-      return;
-    }
-
-    ls_get_current_application_asn_func =
-        reinterpret_cast<LSGetCurrentApplicationASNType>(
-            CFBundleGetFunctionPointerForName(
-                launch_services_bundle, CFSTR("_LSGetCurrentApplicationASN")));
-    if (!ls_get_current_application_asn_func)
-      LOG(ERROR) << "Could not find _LSGetCurrentApplicationASN";
-
-    ls_set_application_information_item_func =
-        reinterpret_cast<LSSetApplicationInformationItemType>(
-            CFBundleGetFunctionPointerForName(
-                launch_services_bundle,
-                CFSTR("_LSSetApplicationInformationItem")));
-    if (!ls_set_application_information_item_func)
-      LOG(ERROR) << "Could not find _LSSetApplicationInformationItem";
-
-    CFStringRef* key_pointer = reinterpret_cast<CFStringRef*>(
-        CFBundleGetDataPointerForName(launch_services_bundle,
-                                      CFSTR("_kLSDisplayNameKey")));
-    ls_display_name_key = key_pointer ? *key_pointer : NULL;
-    if (!ls_display_name_key)
-      LOG(ERROR) << "Could not find _kLSDisplayNameKey";
-
-    // Internally, this call relies on the Mach ports that are started up by the
-    // Carbon Process Manager.  In debug builds this usually happens due to how
-    // the logging layers are started up; but in release, it isn't started in as
-    // much of a defined order.  So if the symbols had to be loaded, go ahead
-    // and force a call to make sure the manager has been initialized and hence
-    // the ports are opened.
-    ProcessSerialNumber psn;
-    GetCurrentProcess(&psn);
-  }
-  if (!ls_get_current_application_asn_func ||
-      !ls_set_application_information_item_func ||
-      !ls_display_name_key) {
-    return;
-  }
-
-  PrivateLSASN asn = ls_get_current_application_asn_func();
-  // Constant used by WebKit; what exactly it means is unknown.
-  const int magic_session_constant = -2;
-  OSErr err =
-      ls_set_application_information_item_func(magic_session_constant, asn,
-                                               ls_display_name_key,
-                                               process_name,
-                                               NULL /* optional out param */);
-  LOG_IF(ERROR, err) << "Call to set process name failed, err " << err;
-}
-#endif
-
+  
 void ShowItemInFolder(const base::FilePath& full_path) {
   DCHECK([NSThread isMainThread]);
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
@@ -340,7 +254,84 @@ void SetProcessTitleActivityMonitor(const std::string& name) {
 }
 #else
 void SetProcessTitleActivityMonitor(const std::string& name) {
-  SetProcessName(base::SysUTF8ToCFStringRef(name));
+  if (name.length() < 1) {
+    NOTREACHED() << "SetProcessTitleActivityMonitor given bad name.";
+    return;
+  }
+
+  CFStringRef process_name = base::SysUTF8ToCFStringRef(name);
+
+  // Private CFType used in these LaunchServices calls.
+  typedef CFTypeRef PrivateLSASN;
+  typedef PrivateLSASN (*LSGetCurrentApplicationASNType)();
+  typedef OSStatus (*LSSetApplicationInformationItemType)(int, PrivateLSASN,
+                                                          CFStringRef,
+                                                          CFStringRef,
+                                                          CFDictionaryRef*);
+
+  static LSGetCurrentApplicationASNType ls_get_current_application_asn_func =
+      NULL;
+  static LSSetApplicationInformationItemType
+      ls_set_application_information_item_func = NULL;
+  static CFStringRef ls_display_name_key = NULL;
+
+  static bool did_symbol_lookup = false;
+  if (!did_symbol_lookup) {
+    did_symbol_lookup = true;
+    CFBundleRef launch_services_bundle =
+        CFBundleGetBundleWithIdentifier(CFSTR("com.apple.LaunchServices"));
+    if (!launch_services_bundle) {
+      LOG(ERROR) << "Failed to look up LaunchServices bundle";
+      return;
+    }
+
+    ls_get_current_application_asn_func =
+        reinterpret_cast<LSGetCurrentApplicationASNType>(
+            CFBundleGetFunctionPointerForName(
+                launch_services_bundle, CFSTR("_LSGetCurrentApplicationASN")));
+    if (!ls_get_current_application_asn_func)
+      LOG(ERROR) << "Could not find _LSGetCurrentApplicationASN";
+
+    ls_set_application_information_item_func =
+        reinterpret_cast<LSSetApplicationInformationItemType>(
+            CFBundleGetFunctionPointerForName(
+                launch_services_bundle,
+                CFSTR("_LSSetApplicationInformationItem")));
+    if (!ls_set_application_information_item_func)
+      LOG(ERROR) << "Could not find _LSSetApplicationInformationItem";
+
+    CFStringRef* key_pointer = reinterpret_cast<CFStringRef*>(
+        CFBundleGetDataPointerForName(launch_services_bundle,
+                                      CFSTR("_kLSDisplayNameKey")));
+    ls_display_name_key = key_pointer ? *key_pointer : NULL;
+    if (!ls_display_name_key)
+      LOG(ERROR) << "Could not find _kLSDisplayNameKey";
+
+    // Internally, this call relies on the Mach ports that are started up by the
+    // Carbon Process Manager.  In debug builds this usually happens due to how
+    // the logging layers are started up; but in release, it isn't started in as
+    // much of a defined order.  So if the symbols had to be loaded, go ahead
+    // and force a call to make sure the manager has been initialized and hence
+    // the ports are opened.
+    ProcessSerialNumber psn;
+    GetCurrentProcess(&psn);
+  }
+  if (!ls_get_current_application_asn_func ||
+      !ls_set_application_information_item_func ||
+      !ls_display_name_key) {
+    return;
+  }
+
+  PrivateLSASN asn = ls_get_current_application_asn_func();
+
+  // Constant used by WebKit; what exactly it means is unknown.
+  const int magic_session_constant = -2;
+  OSErr err =
+      ls_set_application_information_item_func(magic_session_constant, asn,
+                                               ls_display_name_key,
+                                               process_name,
+                                               NULL /* optional out param */);
+  LOG_IF(ERROR, err) << "Call to set process name failed, err " << err;
 }
 #endif
 

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -101,11 +101,93 @@ std::string OpenURL(NSURL* ns_url, bool activate) {
 
 namespace platform_util {
 
-bool ShowItemInFolder(const base::FilePath& path) {
-  // The API only takes absolute path.
-  base::FilePath full_path =
-      path.IsAbsolute() ? path : base::MakeAbsoluteFilePath(path);
+#if !defined MAS_BUILD
+void SetProcessName(CFStringRef process_name) {
+  if (!process_name || CFStringGetLength(process_name) == 0) {
+    NOTREACHED() << "SetProcessName given bad name.";
+    return;
+  }
 
+  // Warning: here be dragons! This is SPI reverse-engineered from WebKit's
+  // plugin host, and could break at any time (although realistically it's only
+  // likely to break in a new major release).
+  // When 10.7 is available, check that this still works, and update this
+  // comment for 10.8.
+
+  // Private CFType used in these LaunchServices calls.
+  typedef CFTypeRef PrivateLSASN;
+  typedef PrivateLSASN (*LSGetCurrentApplicationASNType)();
+  typedef OSStatus (*LSSetApplicationInformationItemType)(int, PrivateLSASN,
+                                                          CFStringRef,
+                                                          CFStringRef,
+                                                          CFDictionaryRef*);
+
+  static LSGetCurrentApplicationASNType ls_get_current_application_asn_func =
+      NULL;
+  static LSSetApplicationInformationItemType
+      ls_set_application_information_item_func = NULL;
+  static CFStringRef ls_display_name_key = NULL;
+
+  static bool did_symbol_lookup = false;
+  if (!did_symbol_lookup) {
+    did_symbol_lookup = true;
+    CFBundleRef launch_services_bundle =
+        CFBundleGetBundleWithIdentifier(CFSTR("com.apple.LaunchServices"));
+    if (!launch_services_bundle) {
+      LOG(ERROR) << "Failed to look up LaunchServices bundle";
+      return;
+    }
+
+    ls_get_current_application_asn_func =
+        reinterpret_cast<LSGetCurrentApplicationASNType>(
+            CFBundleGetFunctionPointerForName(
+                launch_services_bundle, CFSTR("_LSGetCurrentApplicationASN")));
+    if (!ls_get_current_application_asn_func)
+      LOG(ERROR) << "Could not find _LSGetCurrentApplicationASN";
+
+    ls_set_application_information_item_func =
+        reinterpret_cast<LSSetApplicationInformationItemType>(
+            CFBundleGetFunctionPointerForName(
+                launch_services_bundle,
+                CFSTR("_LSSetApplicationInformationItem")));
+    if (!ls_set_application_information_item_func)
+      LOG(ERROR) << "Could not find _LSSetApplicationInformationItem";
+
+    CFStringRef* key_pointer = reinterpret_cast<CFStringRef*>(
+        CFBundleGetDataPointerForName(launch_services_bundle,
+                                      CFSTR("_kLSDisplayNameKey")));
+    ls_display_name_key = key_pointer ? *key_pointer : NULL;
+    if (!ls_display_name_key)
+      LOG(ERROR) << "Could not find _kLSDisplayNameKey";
+
+    // Internally, this call relies on the Mach ports that are started up by the
+    // Carbon Process Manager.  In debug builds this usually happens due to how
+    // the logging layers are started up; but in release, it isn't started in as
+    // much of a defined order.  So if the symbols had to be loaded, go ahead
+    // and force a call to make sure the manager has been initialized and hence
+    // the ports are opened.
+    ProcessSerialNumber psn;
+    GetCurrentProcess(&psn);
+  }
+  if (!ls_get_current_application_asn_func ||
+      !ls_set_application_information_item_func ||
+      !ls_display_name_key) {
+    return;
+  }
+
+  PrivateLSASN asn = ls_get_current_application_asn_func();
+  // Constant used by WebKit; what exactly it means is unknown.
+  const int magic_session_constant = -2;
+  OSErr err =
+      ls_set_application_information_item_func(magic_session_constant, asn,
+                                               ls_display_name_key,
+                                               process_name,
+                                               NULL /* optional out param */);
+  LOG_IF(ERROR, err) << "Call to set process name failed, err " << err;
+}
+#endif
+
+void ShowItemInFolder(const base::FilePath& full_path) {
   DCHECK([NSThread isMainThread]);
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
   if (!path_string || ![[NSWorkspace sharedWorkspace] selectFile:path_string
@@ -251,5 +333,15 @@ bool MoveItemToTrash(const base::FilePath& full_path) {
 void Beep() {
   NSBeep();
 }
+
+#if defined MAS_BUILD
+void SetProcessTitleActivityMonitor(const std::string& name) {
+  // NB: Can't be implemented with public APIs
+}
+#else
+void SetProcessTitleActivityMonitor(const std::string& name) {
+  SetProcessName(base::SysUTF8ToCFStringRef(name));
+}
+#endif
 
 }  // namespace platform_util

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -376,4 +376,8 @@ void Beep() {
   MessageBeep(MB_OK);
 }
 
+void SetProcessTitleActivityMonitor(const std::string& name) {
+  // NB: Can't implement this on Windows
+}
+
 }  // namespace platform_util


### PR DESCRIPTION
This PR uses dodgy private APIs in order to set the application's title in Activity Monitor dynamically:

![image](https://cloud.githubusercontent.com/assets/1396/21331411/23aee6d8-c5f7-11e6-8319-198211d8d7c9.png)

On Windows you can't do this at all, and on Linux this calls `setproctitle`