### PR TITLE
Always create offscreen window frameless

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -90,6 +90,15 @@ Window::Window(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,
     if (options.Get("transparent", &transparent))
       web_preferences.Set("transparent", transparent);
 
+    // Offscreen windows are always created frameless.
+    bool offscreen;
+    if (web_preferences.Get("offscreen", &offscreen)) {
+      if (offscreen) {
+        auto window_options = const_cast<mate::Dictionary&>(options);
+        window_options.Set(options::kFrame, false);
+      }
+    }
+
     // Creates the WebContents used by BrowserWindow.
     web_contents = WebContents::Create(isolate, web_preferences);
   }


### PR DESCRIPTION
This PR creates the browser window in offscreen mode always without a frame, since in offscreen mode the frame is not accessible, so this way, the window size will be consistent. #8224