### PR TITLE
Don't load URL if web contents is destroyed

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -439,6 +439,11 @@ content::WebContents* WebContents::OpenURLFromTab(
   if (Emit("will-navigate", params.url))
     return nullptr;
 
+  // Don't load the URL if the web contents was marked as destroyed from a
+  // will-navigate event listener
+  if (IsDestroyed())
+    return nullptr;
+
   return CommonWebContentsDelegate::OpenURLFromTab(source, params);
 }
 

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -65,6 +65,12 @@ class TrackableObject : public TrackableObjectBase,
     Wrappable<T>::GetWrapper()->SetAlignedPointerInInternalField(0, nullptr);
   }
 
+  bool IsDestroyed() {
+    v8::Local<v8::Object> wrapper = Wrappable<T>::GetWrapper();
+    return wrapper->InternalFieldCount() == 0 ||
+           wrapper->GetAlignedPointerFromInternalField(0) == nullptr;
+  }
+
   // Finds out the TrackableObject from its ID in weak map.
   static T* FromWeakMapID(v8::Isolate* isolate, int32_t id) {
     if (!weak_map_)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -267,6 +267,16 @@ describe('BrowserWindow module', function () {
     })
   })
 
+  describe('will-navigate event', function () {
+    it('allows the window to be closed from the event listener', (done) => {
+      ipcRenderer.send('close-on-will-navigate', w.id)
+      ipcRenderer.once('closed-on-will-navigate', () => {
+        done()
+      })
+      w.loadURL('file://' + fixtures + '/pages/will-navigate.html')
+    })
+  })
+
   describe('BrowserWindow.show()', function () {
     if (isCI) {
       return

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -221,3 +221,12 @@ ipcMain.on('set-client-certificate-option', function (event, skip) {
   })
   event.returnValue = 'done'
 })
+
+ipcMain.on('close-on-will-navigate', (event, id) => {
+  const contents = event.sender
+  const window = BrowserWindow.fromId(id)
+  window.webContents.once('will-navigate', (event, input) => {
+    window.close()
+    contents.send('closed-on-will-navigate')
+  })
+})


### PR DESCRIPTION
Closing a window from a `will-navigate` listener but not calling `event.preventDefault()` would crash the app because the URL would continue to load in a destroyed web contents.

This adds a check to see if the web contents was marked as destroyed after the `will-navigate` event is emitted.

Closes #4374