### PR TITLE
[WIP] MPRemoteCommandCenter integration

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -670,6 +670,12 @@ void App::ReleaseSingleInstance() {
   }
 }
 
+#if defined(OS_MACOSX)
+#else
+void App::InitializeAsMediaPlayer() {}
+void App::SetNowPlaying(mate::Arguments* args) {}
+#endif
+
 bool App::Relaunch(mate::Arguments* js_args) {
   // Parse parameters.
   bool override_argv = false;
@@ -877,6 +883,8 @@ void App::BuildPrototype(
       .SetMethod("relaunch", &App::Relaunch)
       .SetMethod("isAccessibilitySupportEnabled",
                  &App::IsAccessibilitySupportEnabled)
+      .SetMethod("initializeAsMediaPlayer", &App::InitializeAsMediaPlayer)
+      .SetMethod("setNowPlaying", &App::SetNowPlaying)
       .SetMethod("disableHardwareAcceleration",
                  &App::DisableHardwareAcceleration);
 }

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -108,6 +108,9 @@ class App : public AtomBrowserClient::Delegate,
   // content::GpuDataManagerObserver:
   void OnGpuProcessCrashed(base::TerminationStatus status) override;
 
+  virtual void InitializeAsMediaPlayer();
+  virtual void SetNowPlaying(mate::Arguments* args);
+
  private:
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(mate::Arguments* args, const std::string& name);
@@ -127,6 +130,7 @@ class App : public AtomBrowserClient::Delegate,
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);
 #endif
+  bool media_controller_initialized_ = false;
 
 #if defined(OS_WIN)
   // Get the current Jump List settings.

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -108,7 +108,7 @@ class App : public AtomBrowserClient::Delegate,
   // content::GpuDataManagerObserver:
   void OnGpuProcessCrashed(base::TerminationStatus status) override;
 
-  virtual void InitializeAsMediaPlayer();
+  virtual void InitializeAsMediaPlayer(mate::Arguments* args);
   virtual void SetNowPlaying(mate::Arguments* args);
 
  private:

--- a/atom/browser/api/atom_api_app_mac.h
+++ b/atom/browser/api/atom_api_app_mac.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_API_ATOM_API_APP_MAC_H_
+#define ATOM_BROWSER_API_ATOM_API_APP_MAC_H_
+
+#include "atom/browser/api/atom_api_app.h"
+
+#import "base/mac/scoped_nsobject.h"
+
+@class ElectronMediaController;
+
+#endif  // ATOM_BROWSER_API_ATOM_API_APP_MAC_H_

--- a/atom/browser/api/atom_api_app_mac.mm
+++ b/atom/browser/api/atom_api_app_mac.mm
@@ -1,0 +1,114 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#import "atom/browser/api/atom_api_app_mac.h"
+
+#include "atom/browser/native_window.h"
+#include "atom/browser/unresponsive_suppressor.h"
+#include "base/message_loop/message_loop.h"
+#include "base/strings/sys_string_conversions.h"
+#include "brightray/browser/inspectable_web_contents.h"
+#include "brightray/browser/inspectable_web_contents_view.h"
+#include "content/public/browser/web_contents.h"
+#include "native_mate/dictionary.h"
+
+#include "atom/common/node_includes.h"
+
+@interface ElectronMediaController : NSObject {
+}
+- (void)setApp:(atom::api::App*)atomApp;
+- (void)setOptions:(mate::Dictionary)opts;
+@end
+
+@implementation ElectronMediaController
+  atom::api::App* _app;
+
+- (void)setApp:(atom::api::App*)atomApp {
+  _app = atomApp;
+  _app->Emit("foo");
+}
+
+- (void)setOptions:(mate::Dictionary)opts {
+  bool skipB = false;
+  opts.Get("skipBackward", &skipB);
+  bool skipF = false;
+  opts.Get("skipForward", &skipF);
+  bool seekB = false;
+  opts.Get("seekBackward", &seekB);
+  bool seekF = false;
+  opts.Get("seekForward", &seekF);
+  bool togglePP = false;
+  opts.Get("togglePlayPause", &togglePP);
+  bool pause = false;
+  opts.Get("pause", &pause);
+  bool play = false;
+  opts.Get("play", &play);
+  bool stop = false;
+  opts.Get("stop", &stop);
+  bool changeRate = false;
+  opts.Get("changeRate", &changeRate);
+  bool nextTrack = false;
+  opts.Get("nextTrack", &nextTrack);
+  bool prevTrack = false;
+  opts.Get("previousTrack", &prevTrack);
+  bool changeRating = false;
+  opts.Get("rating", &changeRating);
+  bool changeLike = false;
+  opts.Get("like", &changeLike);
+  bool changeDislike = false;
+  opts.Get("dislike", &changeDislike);
+
+  MPRemoteCommandCenter *remoteCommandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+  if (play) [[remoteCommandCenter playCommand] addTarget:self action:@selector(remotePlay)];
+
+  // [[remoteCommandCenter skipForwardCommand] addTarget:self action:@selector(remoteSkipForward)];
+  // [[remoteCommandCenter skipForwardCommand] addTarget:self action:@selector(remoteSkipForward)];
+  // [[remoteCommandCenter togglePlayPauseCommand] addTarget:self action:@selector(remoteTogglePlayPause)];
+  // [[remoteCommandCenter pauseCommand] addTarget:self action:@selector(remotePause)];
+  // [[remoteCommandCenter stopCommand] addTarget:self action:@selector(remoteStop)];
+}
+
+- (void)remotePlay { NSLog("@play"); }
+
+@end
+
+namespace atom {
+
+namespace api {
+
+  ElectronMediaController* controller;
+
+  void App::InitializeAsMediaPlayer(mate::Arguments* args) {
+    if (media_controller_initialized_) {
+      args->ThrowError("You can only initialize the app as a media player once");
+      return;
+    }
+    mate::Dictionary opts;
+    if (!args->GetNext(&opts)) {
+      args->ThrowError("The first argument must be an options object");
+      return;
+    }
+    if (!controller) {
+      controller = [[ElectronMediaController alloc] init];
+      [controller setApp:this];
+      [controller setOptions:opts];
+    }
+    media_controller_initialized_ = true;
+  }
+
+  void App::SetNowPlaying(mate::Arguments* args) {
+    if (!media_controller_initialized_) {
+      args->ThrowError("You must initialize the app as a media player before settings now playing");
+      return;
+    }
+    mate::Dictionary opts;
+    if (!args->GetNext(&opts)) {
+      args->ThrowError("The first argument must be an options object");
+      return;
+    }
+  }
+
+}  // namespace api
+
+}  // namespace atom

--- a/electron.gyp
+++ b/electron.gyp
@@ -507,6 +507,7 @@
               '$(SDKROOT)/System/Library/Frameworks/Carbon.framework',
               '$(SDKROOT)/System/Library/Frameworks/QuartzCore.framework',
               '$(SDKROOT)/System/Library/Frameworks/Quartz.framework',
+              '$(SDKROOT)/System/Library/Frameworks/MediaPlayer.framework',
             ],
           },
           'mac_bundle': 1,

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -99,6 +99,8 @@
       'atom/app/uv_task_runner.h',
       'atom/browser/api/atom_api_app.cc',
       'atom/browser/api/atom_api_app.h',
+      'atom/browser/api/atom_api_app_mac.mm',
+      'atom/browser/api/atom_api_app_mac.h',
       'atom/browser/api/atom_api_auto_updater.cc',
       'atom/browser/api/atom_api_auto_updater.h',
       'atom/browser/api/atom_api_content_tracing.cc',


### PR DESCRIPTION
This allows apps to hook into the new `MPRemoteCommandCenter` API's on macOS 10.12.2.  Pretty sure this breaks on older macOS versions so I need to add a few ifs.  It add's two new `app` API's.

```js
app.initializeAsMediaPlayer()
```

```js
app.setNowPlaying({
  currentTime,
  duration,
  title,
  artist,
  album,
  id,
  state,
});
```

When I hooked this up to GPMDP it generates the correct system wide touch bar 😄 

<img width="1085" alt="touch bar shot 2016-12-25 at 10 30 24 am" src="https://cloud.githubusercontent.com/assets/6634592/21468814/876ccfa6-ca8d-11e6-9cb8-09bcf171f1f3.png">

**NOTE:** I totally did this on the plane on my way home still it still needs a bit of cleanup 👍 