### PR TITLE
Support cursive/fantasy default font families

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -251,6 +251,10 @@ void WebContentsPreferences::OverrideWebkitPrefs(
       prefs->sans_serif_font_family_map[content::kCommonScript] = font;
     if (fonts->GetString("monospace", &font))
       prefs->fixed_font_family_map[content::kCommonScript] = font;
+    if (fonts->GetString("cursive", &font))
+      prefs->cursive_font_family_map[content::kCommonScript] = font;
+    if (fonts->GetString("fantasy", &font))
+      prefs->fantasy_font_family_map[content::kCommonScript] = font;
   }
   int size;
   if (self->web_preferences_.GetInteger("defaultFontSize", &size))

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -269,6 +269,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       * `serif` String (optional) - Defaults to `Times New Roman`.
       * `sansSerif` String (optional) - Defaults to `Arial`.
       * `monospace` String (optional) - Defaults to `Courier New`.
+      * `cursive` String (optional) - Defaults to `Script`.
+      * `fantasy` String (optional) - Defaults to `Impact`.
     * `defaultFontSize` Integer (optional) - Defaults to `16`.
     * `defaultMonospaceFontSize` Integer (optional) - Defaults to `13`.
     * `minimumFontSize` Integer (optional) - Defaults to `0`.


### PR DESCRIPTION
Allows the `cursive` and `fantasy` font families to be configurable via the web preferences.

Closes #8286