### PR TITLE
Support normalizing access keys in dialog buttons

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -35,6 +35,14 @@ The `dialog` module has the following methods:
   * `properties` String[] (optional) - Contains which features the dialog should use, can
     contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
     and `showHiddenFiles`.
+  * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
+    across platforms. Default is `false`. Enabling this assumes `&` is used in
+    the button labels for the placement of the keyboard shortcut access key
+    and labels will be converted so they work correctly on each platform, `&`
+    characters are removed on macOS, converted to `_` on Linux, and left
+    untouched on Windows. For example, a button label of `Vie&w` will be
+    converted to `Vie_w` on Linux and `View` on macOS and can be selected
+    via `Alt-W` on Windows and Linux.
 * `callback` Function (optional)
   * `filePaths` String[] - An array of file paths chosen by the user
 

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -38,6 +38,29 @@ const parseArgs = function (window, options, callback, ...args) {
   return [window, options, callback]
 }
 
+const normalizeAccessKey = (text) => {
+  if (typeof text !== 'string') return text
+
+  // macOS does not have access keys so remove single ampersands
+  // and replace double ampersands with a single ampersand
+  if (process.platform === 'darwin') {
+    return text.replace(/&(&?)/g, '$1')
+  }
+
+  // Linux uses a single underscore as an access key prefix so escape
+  // existing single underscores with a second underscore, replace double
+  // ampersands with a single ampersand, and replace a single ampersand with
+  // a single underscore
+  if (process.platform === 'linux') {
+    return text.replace(/_/g, '__').replace(/&(.?)/g, (match, after) => {
+      if (after === '&') return after
+      return `_${after}`
+    })
+  }
+
+  return text
+}
+
 const checkAppInitialized = function () {
   if (!app.isReady()) {
     throw new Error('dialog module can only be used after app is ready')
@@ -154,7 +177,7 @@ module.exports = {
       }
     }
 
-    let {buttons, cancelId, defaultId, detail, icon, message, title, type} = options
+    let {buttons, cancelId, defaultId, detail, icon, message, title, type, normalizeAccessKeys} = options
 
     if (type == null) {
       type = 'none'
@@ -169,6 +192,10 @@ module.exports = {
       buttons = []
     } else if (!Array.isArray(buttons)) {
       throw new TypeError('Buttons must be an array')
+    }
+
+    if (normalizeAccessKeys) {
+      buttons = buttons.map(normalizeAccessKey)
     }
 
     if (title == null) {

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -177,7 +177,7 @@ module.exports = {
       }
     }
 
-    let {buttons, cancelId, defaultId, detail, icon, message, title, type, normalizeAccessKeys} = options
+    let {buttons, cancelId, defaultId, detail, icon, message, title, type} = options
 
     if (type == null) {
       type = 'none'
@@ -194,7 +194,7 @@ module.exports = {
       throw new TypeError('Buttons must be an array')
     }
 
-    if (normalizeAccessKeys) {
+    if (options.normalizeAccessKeys) {
       buttons = buttons.map(normalizeAccessKey)
     }
 


### PR DESCRIPTION
This pull requests adds a new option to `dialog.showMessageBox` API called `normalizeAccessKeys` that, when `true`, will convert all the button labels to have the correct special character access keys on each platform.

This option is off by default to not break existing apps. It could be switched to `true` by default in 2.0.

`&` is used as the default access key since that is the [Window standard](https://msdn.microsoft.com/en-us/library/190kw3at.aspx). That value is then converted to `_` on Linux since that is the [GTK convention](https://developer.gnome.org/gtk3/unstable/GtkButton.html#gtk-button-new-with-mnemonic).

`&&` can be used for escaped values.

Access keys are removed when on macOS since there isn't support for them there.

Below is a table of the normalized values when this option is specified:

| Button Text | macOS | Windows | Linux |
| :------------- | :------------- | :------------- | :------------- |
| `Hello`       | `Hello`       | `Hello` | `Hello` |
| `He&llo`       | `Hello`       | `He&llo` | `He_llo` |
| `Contact R&&D` | `Contact R&D` | `Contact R&&D` | `Contact R&D` |
| `Contact R&&&D` | `Contact R&D` | `Contact R&&&D`| `Contact R&_D` |
| `Contact R&&&&D` | `Contact R&&D` | `Contact R&&&&D`| `Contact R&&D` |
| `Chee&rs ^_^` | `Cheers ^_^` | `Chee&rs ^_^`| `Chee_rs ^__^` |


/cc @damieng just want to confirm with you this looks good for Atom's use cases.

Closes #7517