### PR TITLE
Handle cycles when merging browser window options

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -7,19 +7,25 @@ const hasProp = {}.hasOwnProperty
 const frameToGuest = {}
 
 // Copy attribute of |parent| to |child| if it is not defined in |child|.
-const mergeOptions = function (child, parent) {
-  let key, value
-  for (key in parent) {
+const mergeOptions = function (child, parent, visited) {
+  // Check for circular reference.
+  if (visited == null) visited = new Set()
+  if (visited.has(parent)) return
+
+  visited.add(parent)
+  for (const key in parent) {
     if (!hasProp.call(parent, key)) continue
-    value = parent[key]
-    if (!(key in child)) {
-      if (typeof value === 'object') {
-        child[key] = mergeOptions({}, value)
-      } else {
-        child[key] = value
-      }
+    if (key in child) continue
+
+    const value = parent[key]
+    if (typeof value === 'object') {
+      child[key] = mergeOptions({}, value, visited)
+    } else {
+      child[key] = value
     }
   }
+  visited.delete(parent)
+
   return child
 }
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -46,7 +46,7 @@ describe('chromium feature', function () {
     var w = null
 
     afterEach(function () {
-      w != null ? w.destroy() : void 0
+      return closeWindow(w).then(() => w = null)
     })
 
     it('is set correctly when window is not shown', function (done) {
@@ -157,7 +157,7 @@ describe('chromium feature', function () {
     var w = null
 
     afterEach(function () {
-      w != null ? w.destroy() : void 0
+      return closeWindow(w).then(() => w = null)
     })
 
     it('should register for file scheme', function (done) {
@@ -312,7 +312,7 @@ describe('chromium feature', function () {
     let w = null
 
     afterEach(function () {
-      if (w) w.destroy()
+      return closeWindow(w).then(() => w = null)
     })
 
     it('is null for main window', function (done) {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -46,7 +46,7 @@ describe('chromium feature', function () {
     var w = null
 
     afterEach(function () {
-      return closeWindow(w).then(() => w = null)
+      return closeWindow(w).then(function () { w = null })
     })
 
     it('is set correctly when window is not shown', function (done) {
@@ -157,7 +157,7 @@ describe('chromium feature', function () {
     var w = null
 
     afterEach(function () {
-      return closeWindow(w).then(() => w = null)
+      return closeWindow(w).then(function () { w = null })
     })
 
     it('should register for file scheme', function (done) {
@@ -190,7 +190,7 @@ describe('chromium feature', function () {
     let w = null
 
     afterEach(() => {
-      return closeWindow(w).then(() => w = null)
+      return closeWindow(w).then(function () { w = null })
     })
 
     it('returns a BrowserWindowProxy object', function () {
@@ -269,7 +269,7 @@ describe('chromium feature', function () {
     it('handles cycles when merging the parent options into the child options', (done) => {
       w = BrowserWindow.fromId(ipcRenderer.sendSync('create-window-with-options-cycle'))
       w.loadURL('file://' + fixtures + '/pages/window-open.html')
-      w.webContents.once('new-window',  (event, url, frameName, disposition, options) => {
+      w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
         assert.equal(options.show, false)
         assert.deepEqual(options.foo, {
           bar: null,
@@ -340,7 +340,7 @@ describe('chromium feature', function () {
     let w = null
 
     afterEach(function () {
-      return closeWindow(w).then(() => w = null)
+      return closeWindow(w).then(function () { w = null })
     })
 
     it('is null for main window', function (done) {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -277,6 +277,11 @@ describe('chromium feature', function () {
             hello: {
               world: true
             }
+          },
+          baz2: {
+            hello: {
+              world: true
+            }
           }
         })
         done()

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -270,10 +270,13 @@ describe('chromium feature', function () {
       w = BrowserWindow.fromId(ipcRenderer.sendSync('create-window-with-options-cycle'))
       w.loadURL('file://' + fixtures + '/pages/window-open.html')
       w.webContents.once('new-window',  (event, url, frameName, disposition, options) => {
-        assert.deepEqual(options, {
-          show: false,
-          foo: {
-            bar: null
+        assert.equal(options.show, false)
+        assert.deepEqual(options.foo, {
+          bar: null,
+          baz: {
+            hello: {
+              world: true
+            }
           }
         })
         done()

--- a/spec/fixtures/pages/window-open.html
+++ b/spec/fixtures/pages/window-open.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <script type="text/javascript" charset="utf-8">
-  window.open('http://host', 'host' , 'this-is-not-a-standard-feature');
+  window.open('http://host', 'host', 'this-is-not-a-standard-feature');
 </script>
 </body>
 </html>

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -230,3 +230,13 @@ ipcMain.on('close-on-will-navigate', (event, id) => {
     contents.send('closed-on-will-navigate')
   })
 })
+
+
+ipcMain.on('create-window-with-options-cycle', (event) => {
+  // This can't be done over remote since cycles are already
+  // nulled out at the IPC layer
+  const foo = {}
+  foo.bar  = foo
+  const window = new BrowserWindow({show: false, foo: foo})
+  event.returnValue = window.id
+})

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -231,12 +231,11 @@ ipcMain.on('close-on-will-navigate', (event, id) => {
   })
 })
 
-
 ipcMain.on('create-window-with-options-cycle', (event) => {
   // This can't be done over remote since cycles are already
   // nulled out at the IPC layer
   const foo = {}
-  foo.bar  = foo
+  foo.bar = foo
   foo.baz = {
     hello: {
       world: true

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -242,6 +242,7 @@ ipcMain.on('create-window-with-options-cycle', (event) => {
       world: true
     }
   }
+  foo.baz2 = foo.baz
   const window = new BrowserWindow({show: false, foo: foo})
   event.returnValue = window.id
 })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -237,6 +237,11 @@ ipcMain.on('create-window-with-options-cycle', (event) => {
   // nulled out at the IPC layer
   const foo = {}
   foo.bar  = foo
+  foo.baz = {
+    hello: {
+      world: true
+    }
+  }
   const window = new BrowserWindow({show: false, foo: foo})
   event.returnValue = window.id
 })


### PR DESCRIPTION
Setting `options.parent` in a `new-window` event listener can currently lead to stack overflow errors when merging the options since `webContents` has a reference to itself.

This pull request follows the pattern of https://github.com/electron/electron/pull/6442 for tracking visited objects and nulling out cycles instead of overflowing.

Closes #8202 