### PR TITLE
Don't crash when calling stale remote listeners

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -146,6 +146,28 @@ const throwRPCError = function (message) {
   throw error
 }
 
+const rendererMissingErrorMessage = function (meta, args, callIntoRenderer) {
+  let message = `Attempting to call a function in a renderer window that has been closed or released.` +
+    `Function provided here: ${meta.location}.`;
+
+  if (!args || args.length === 0) return message;
+  if (!args[0].sender || !args[0].sender._events) return message;
+
+  const eventsAttached = args[0].sender._events;
+  const remoteEvents = Object.keys(eventsAttached).filter((eventName) => {
+    return Array.isArray(eventsAttached[eventName]) ?
+      eventsAttached[eventName].includes(callIntoRenderer) :
+      eventsAttached[eventName] === callIntoRenderer
+  });
+
+  if (remoteEvents && remoteEvents.length > 0) {
+    message += `\nRemote event names:`
+    remoteEvents.forEach((eventName) => message += ` ${eventName} `);
+  }
+
+  return message;
+}
+
 // Convert array of meta data from renderer into array of real values.
 const unwrapArgs = function (sender, args) {
   const metaToValue = function (meta) {
@@ -196,7 +218,7 @@ const unwrapArgs = function (sender, args) {
           if (!sender.isDestroyed() && webContentsId === sender.getId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
-            throw new Error(`Attempting to call a function in a renderer window that has been closed or released. Function provided here: ${meta.location}.`)
+            throw new Error(rendererMissingErrorMessage(meta, args, callIntoRenderer));
           }
         }
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -146,7 +146,7 @@ const throwRPCError = function (message) {
   throw error
 }
 
-const rendererMissingErrorMessage = (meta, args, callIntoRenderer) => {
+const removeRemoteListenersAndLogWarning = (meta, args, callIntoRenderer) => {
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
     `\nFunction provided here: ${meta.location}`
 
@@ -218,7 +218,7 @@ const unwrapArgs = function (sender, args) {
           if (!sender.isDestroyed() && webContentsId === sender.getId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
-            console.warn(rendererMissingErrorMessage(meta, args, callIntoRenderer))
+            console.warn(removeRemoteListenersAndLogWarning(meta, args, callIntoRenderer))
           }
         }
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -155,14 +155,16 @@ const rendererMissingErrorMessage = function (meta, args, callIntoRenderer) {
 
   const eventsAttached = args[0].sender._events
   const remoteEvents = Object.keys(eventsAttached).filter((eventName) => {
-    return Array.isArray(eventsAttached[eventName]) ?
-      eventsAttached[eventName].includes(callIntoRenderer) :
-      eventsAttached[eventName] === callIntoRenderer
+    return Array.isArray(eventsAttached[eventName])
+      ? eventsAttached[eventName].includes(callIntoRenderer)
+      : eventsAttached[eventName] === callIntoRenderer
   })
 
   if (remoteEvents && remoteEvents.length > 0) {
     message += `\nRemote event names:`
-    remoteEvents.forEach((eventName) => message += ` ${eventName} `)
+    remoteEvents.forEach((eventName) => {
+      message += ` ${eventName} `
+    })
   }
 
   return message

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -146,11 +146,11 @@ const throwRPCError = function (message) {
   throw error
 }
 
-const rendererMissingErrorMessage = function (meta, args, callIntoRenderer) {
+const rendererMissingErrorMessage = (meta, args, callIntoRenderer) => {
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
     `\nFunction provided here: ${meta.location}`
 
-  if (!args || args.length === 0) return message
+  if (args.length === 0) return message
   if (!args[0].sender || !args[0].sender._events) return message
 
   const eventsAttached = args[0].sender._events
@@ -160,7 +160,7 @@ const rendererMissingErrorMessage = function (meta, args, callIntoRenderer) {
       : eventsAttached[eventName] === callIntoRenderer
   })
 
-  if (remoteEvents && remoteEvents.length > 0) {
+  if (remoteEvents.length > 0) {
     message += `\nRemote event names:`
     remoteEvents.forEach((eventName) => {
       message += ` ${eventName} `

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -155,7 +155,7 @@ const rendererMissingErrorMessage = (meta, args, callIntoRenderer) => {
 
   const sender = args[0].sender
   const remoteEvents = sender.eventNames().filter((eventName) => {
-    return sender.listeners(eventName).includes(callIntoRenderer);
+    return sender.listeners(eventName).includes(callIntoRenderer)
   })
 
   if (remoteEvents.length > 0) {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -161,10 +161,7 @@ const rendererMissingErrorMessage = (meta, args, callIntoRenderer) => {
   })
 
   if (remoteEvents.length > 0) {
-    message += `\nRemote event names:`
-    remoteEvents.forEach((eventName) => {
-      message += ` ${eventName} `
-    })
+    message += `\nRemote event names: ${remoteEvents.join(' ')}`
   }
 
   return message

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -148,24 +148,24 @@ const throwRPCError = function (message) {
 
 const rendererMissingErrorMessage = function (meta, args, callIntoRenderer) {
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
-    `Function provided here: ${meta.location}.`;
+    `\nFunction provided here: ${meta.location}`
 
-  if (!args || args.length === 0) return message;
-  if (!args[0].sender || !args[0].sender._events) return message;
+  if (!args || args.length === 0) return message
+  if (!args[0].sender || !args[0].sender._events) return message
 
-  const eventsAttached = args[0].sender._events;
+  const eventsAttached = args[0].sender._events
   const remoteEvents = Object.keys(eventsAttached).filter((eventName) => {
     return Array.isArray(eventsAttached[eventName]) ?
       eventsAttached[eventName].includes(callIntoRenderer) :
       eventsAttached[eventName] === callIntoRenderer
-  });
+  })
 
   if (remoteEvents && remoteEvents.length > 0) {
     message += `\nRemote event names:`
-    remoteEvents.forEach((eventName) => message += ` ${eventName} `);
+    remoteEvents.forEach((eventName) => message += ` ${eventName} `)
   }
 
-  return message;
+  return message
 }
 
 // Convert array of meta data from renderer into array of real values.
@@ -218,7 +218,7 @@ const unwrapArgs = function (sender, args) {
           if (!sender.isDestroyed() && webContentsId === sender.getId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
-            throw new Error(rendererMissingErrorMessage(meta, args, callIntoRenderer));
+            throw new Error(rendererMissingErrorMessage(meta, args, callIntoRenderer))
           }
         }
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -161,7 +161,7 @@ const rendererMissingErrorMessage = (meta, args, callIntoRenderer) => {
   })
 
   if (remoteEvents.length > 0) {
-    message += `\nRemote event names: ${remoteEvents.join(' ')}`
+    message += `\nRemote event names: ${remoteEvents.join(', ')}`
   }
 
   return message

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -151,13 +151,11 @@ const rendererMissingErrorMessage = (meta, args, callIntoRenderer) => {
     `\nFunction provided here: ${meta.location}`
 
   if (args.length === 0) return message
-  if (!args[0].sender || !args[0].sender._events) return message
+  if (!args[0].sender || !args[0].sender.eventNames) return message
 
-  const eventsAttached = args[0].sender._events
-  const remoteEvents = Object.keys(eventsAttached).filter((eventName) => {
-    return Array.isArray(eventsAttached[eventName])
-      ? eventsAttached[eventName].includes(callIntoRenderer)
-      : eventsAttached[eventName] === callIntoRenderer
+  const sender = args[0].sender
+  const remoteEvents = sender.eventNames().filter((eventName) => {
+    return sender.listeners(eventName).includes(callIntoRenderer);
   })
 
   if (remoteEvents.length > 0) {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -160,6 +160,9 @@ const rendererMissingErrorMessage = (meta, args, callIntoRenderer) => {
 
   if (remoteEvents.length > 0) {
     message += `\nRemote event names: ${remoteEvents.join(', ')}`
+    remoteEvents.forEach((eventName) => {
+      sender.removeListener(eventName, callIntoRenderer)
+    })
   }
 
   return message
@@ -215,7 +218,7 @@ const unwrapArgs = function (sender, args) {
           if (!sender.isDestroyed() && webContentsId === sender.getId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
-            throw new Error(rendererMissingErrorMessage(meta, args, callIntoRenderer))
+            console.warn(rendererMissingErrorMessage(meta, args, callIntoRenderer))
           }
         }
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -150,22 +150,21 @@ const removeRemoteListenersAndLogWarning = (meta, args, callIntoRenderer) => {
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
     `\nFunction provided here: ${meta.location}`
 
-  if (args.length === 0) return message
-  if (!args[0].sender || !args[0].sender.eventNames) return message
-
-  const sender = args[0].sender
-  const remoteEvents = sender.eventNames().filter((eventName) => {
-    return sender.listeners(eventName).includes(callIntoRenderer)
-  })
-
-  if (remoteEvents.length > 0) {
-    message += `\nRemote event names: ${remoteEvents.join(', ')}`
-    remoteEvents.forEach((eventName) => {
-      sender.removeListener(eventName, callIntoRenderer)
+  if (args.length > 0 && args[0].sender && args[0].sender.eventNames) {
+    const sender = args[0].sender
+    const remoteEvents = sender.eventNames().filter((eventName) => {
+      return sender.listeners(eventName).includes(callIntoRenderer)
     })
+
+    if (remoteEvents.length > 0) {
+      message += `\nRemote event names: ${remoteEvents.join(', ')}`
+      remoteEvents.forEach((eventName) => {
+        sender.removeListener(eventName, callIntoRenderer)
+      })
+    }
   }
 
-  return message
+  console.warn(message)
 }
 
 // Convert array of meta data from renderer into array of real values.
@@ -218,7 +217,7 @@ const unwrapArgs = function (sender, args) {
           if (!sender.isDestroyed() && webContentsId === sender.getId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
-            console.warn(removeRemoteListenersAndLogWarning(meta, args, callIntoRenderer))
+            removeRemoteListenersAndLogWarning(meta, args, callIntoRenderer)
           }
         }
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -3,6 +3,8 @@
 const {Buffer} = require('buffer')
 const electron = require('electron')
 const v8Util = process.atomBinding('v8_util')
+const {WebContents} = process.atomBinding('web_contents')
+
 const {ipcMain, isPromise, webContents} = electron
 
 const fs = require('fs')
@@ -150,8 +152,8 @@ const removeRemoteListenersAndLogWarning = (meta, args, callIntoRenderer) => {
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
     `\nFunction provided here: ${meta.location}`
 
-  if (args.length > 0 && args[0].sender && args[0].sender.eventNames) {
-    const sender = args[0].sender
+  if (args.length > 0 && (args[0].sender instanceof WebContents)) {
+    const {sender} = args[0]
     const remoteEvents = sender.eventNames().filter((eventName) => {
       return sender.listeners(eventName).includes(callIntoRenderer)
     })

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -506,10 +506,12 @@ describe('ipc module', function () {
             'Function provided here: remote-event-handler.html:11:33',
             'Remote event names: remote-handler, other-remote-handler'
           ].join('\n')
-          const {warningMessage, listenerCountBefore, listenerCountAfter} =
-            ipcRenderer.sendSync('try-emit-web-contents-event', w.webContents.id, 'remote-handler')
-          assert.equal(warningMessage, expectedMessage)
-          assert.equal(listenerCountAfter, listenerCountBefore - 1)
+          const results = ipcRenderer.sendSync('try-emit-web-contents-event', w.webContents.id, 'remote-handler')
+          assert.deepEqual(results, {
+            warningMessage: expectedMessage,
+            listenerCountBefore: 2,
+            listenerCountAfter: 1
+          })
           done()
         })
         w.webContents.reload()

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -494,6 +494,18 @@ describe('ipc module', function () {
       w.removeListener('test', listener)
       assert.equal(w.listenerCount('test'), 0)
     })
+
+    it('throws an error when a function is called in a destroyed renderer', (done) => {
+      w = new BrowserWindow({
+        show: false
+      })
+      w.loadURL('file://' + path.join(fixtures, 'api', 'reload-page.html'))
+      setTimeout(() => {
+        assert.throws(() => w.webContents.emit('remote-handler'),
+          /Attempting to call a function in a renderer window that has been closed or released./)
+        done()
+      }, 400)
+    })
   })
 
   it('throws an error when removing all the listeners', () => {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -495,7 +495,7 @@ describe('ipc module', function () {
       assert.equal(w.listenerCount('test'), 0)
     })
 
-    it('throws an error when a function is called in a destroyed renderer', (done) => {
+    it('shows a warning when a function is called in a destroyed renderer', (done) => {
       w = new BrowserWindow({
         show: false
       })
@@ -506,8 +506,8 @@ describe('ipc module', function () {
             'Function provided here: remote-event-handler.html:11:33',
             'Remote event names: remote-handler, other-remote-handler'
           ].join('\n')
-          const errorMessage = ipcRenderer.sendSync('try-emit-web-contents-event', w.webContents.id, 'remote-handler')
-          assert.equal(errorMessage, expectedMessage)
+          const warningMessage = ipcRenderer.sendSync('try-emit-web-contents-event', w.webContents.id, 'remote-handler')
+          assert.equal(warningMessage, expectedMessage)
           done()
         })
         w.webContents.reload()

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -495,7 +495,7 @@ describe('ipc module', function () {
       assert.equal(w.listenerCount('test'), 0)
     })
 
-    it('shows a warning when a function is called in a destroyed renderer', (done) => {
+    it('detaches listeners subscribed to destroyed renderers, and shows a warning', (done) => {
       w = new BrowserWindow({
         show: false
       })
@@ -506,8 +506,10 @@ describe('ipc module', function () {
             'Function provided here: remote-event-handler.html:11:33',
             'Remote event names: remote-handler, other-remote-handler'
           ].join('\n')
-          const warningMessage = ipcRenderer.sendSync('try-emit-web-contents-event', w.webContents.id, 'remote-handler')
+          const {warningMessage, listenerCountBefore, listenerCountAfter} =
+            ipcRenderer.sendSync('try-emit-web-contents-event', w.webContents.id, 'remote-handler')
           assert.equal(warningMessage, expectedMessage)
+          assert.equal(listenerCountAfter, listenerCountBefore - 1)
           done()
         })
         w.webContents.reload()

--- a/spec/fixtures/api/reload-page.html
+++ b/spec/fixtures/api/reload-page.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <script>
+      const {remote} = require('electron')
+      const browserWindow = remote.getCurrentWindow()
+
+      browserWindow.webContents.on('remote-handler', () => { })
+      browserWindow.reload()
+    </script>
+  </head>
+  <body>
+
+  </body>
+</html>

--- a/spec/fixtures/api/remote-event-handler.html
+++ b/spec/fixtures/api/remote-event-handler.html
@@ -7,8 +7,9 @@
       const {remote} = require('electron')
       const browserWindow = remote.getCurrentWindow()
 
-      browserWindow.webContents.on('remote-handler', () => { })
-      browserWindow.reload()
+      const handler = () => {}
+      browserWindow.webContents.on('remote-handler', handler)
+      browserWindow.webContents.on('other-remote-handler', handler)
     </script>
   </head>
   <body>

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -249,3 +249,13 @@ ipcMain.on('create-window-with-options-cycle', (event) => {
 ipcMain.on('prevent-next-new-window', (event, id) => {
   webContents.fromId(id).once('new-window', event => event.preventDefault())
 })
+
+ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
+  const contents = webContents.fromId(id)
+  try {
+    contents.emit(eventName, {sender: contents})
+    event.returnValue = null
+  } catch (error) {
+    event.returnValue = error.message
+  }
+})

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -253,13 +253,16 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
 ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
   const consoleWarn = console.warn
   let warningMessage = null
-  console.warn = (message) => {
-    warningMessage = message
-  }
-
   const contents = webContents.fromId(id)
   const listenerCountBefore = contents.listenerCount(eventName)
-  contents.emit(eventName, {sender: contents})
+
+  try {
+    console.warn = (message) => warningMessage = message
+    contents.emit(eventName, {sender: contents})
+  } finally {
+    console.warn = consoleWarn
+  }
+
   const listenerCountAfter = contents.listenerCount(eventName)
 
   event.returnValue = {
@@ -267,5 +270,4 @@ ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
     listenerCountBefore,
     listenerCountAfter
   }
-  console.warn = consoleWarn
 })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -252,12 +252,20 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
 
 ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
   const consoleWarn = console.warn
-  let lastWarning = null
+  let warningMessage = null
   console.warn = (message) => {
-    lastWarning = message
+    warningMessage = message
   }
+
   const contents = webContents.fromId(id)
+  const listenerCountBefore = contents.listenerCount(eventName)
   contents.emit(eventName, {sender: contents})
-  event.returnValue = lastWarning
+  const listenerCountAfter = contents.listenerCount(eventName)
+
+  event.returnValue = {
+    warningMessage,
+    listenerCountBefore,
+    listenerCountAfter
+  }
   console.warn = consoleWarn
 })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -257,7 +257,9 @@ ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
   const listenerCountBefore = contents.listenerCount(eventName)
 
   try {
-    console.warn = (message) => warningMessage = message
+    console.warn = (message) => {
+      warningMessage = message
+    }
     contents.emit(eventName, {sender: contents})
   } finally {
     console.warn = consoleWarn

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -251,11 +251,13 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
 })
 
 ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
-  const contents = webContents.fromId(id)
-  try {
-    contents.emit(eventName, {sender: contents})
-    event.returnValue = null
-  } catch (error) {
-    event.returnValue = error.message
+  const consoleWarn = console.warn
+  let lastWarning = null
+  console.warn = (message) => {
+    lastWarning = message
   }
+  const contents = webContents.fromId(id)
+  contents.emit(eventName, {sender: contents})
+  event.returnValue = lastWarning
+  console.warn = consoleWarn
 })


### PR DESCRIPTION
When Electron tries to call a method in a deceased renderer it throws an exception. This behavior makes the `remote` module a bit of a hornet's nest, because it's quite easy to listen to events from the main process but often non-trivial to clean them up properly. Instead of crashing, we could dig into the underlying `EventEmitter` and remove the listeners that are hooked to `callIntoRenderer`. We could also display a `console.warn` so that the user knows they did something bad and still has a chance to fix it.

In addition this PR adds the names of the remote events to the error message, to make them easier to find. Increasingly often methods are wrapped in higher-level abstractions such as `Promise` or `Observable` so `meta.location` is not enough information on its own. The new warning looks like:

```
Attempting to call a function in a renderer window that has been closed or released.
Function provided here: remote-event-handler.html:11:33
Remote event names: remote-handler, other-remote-handler
```

