### PR TITLE
Revert "Smooth corners for vibrancy view"

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -347,12 +347,10 @@ bool ScopedDisableResize::disable_resize_ = false;
 @property NSPoint windowButtonsOffset;
 @property (nonatomic, retain) AtomPreviewItem* quickLookItem;
 @property (nonatomic, retain) NSView* vibrantView;
-@property (nonatomic, retain) NSImage* cornerMask;
 
 - (void)setShell:(atom::NativeWindowMac*)shell;
 - (void)setEnableLargerThanScreen:(bool)enable;
 - (void)enableWindowButtonsOffset;
-- (NSImage*)_cornerMask;
 @end
 
 @implementation AtomNSWindow
@@ -504,12 +502,6 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (NSView*)frameView {
   return [[self contentView] superview];
-}
-
-// By overriding this built-in method the corners of the vibrant view (if set)
-// will be smooth.
-- (NSImage*)_cornerMask {
-  return [self cornerMask];
 }
 
 // Quicklook methods
@@ -1291,28 +1283,6 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
     [effect_view setState:NSVisualEffectStateActive];
-
-    // The default corner radius of a macOS window.
-    CGFloat radius = 5.0f;
-    CGFloat dimension = 2 * radius + 1;
-    NSSize size = NSMakeSize(dimension, dimension);
-    NSImage* maskImage = [[NSImage imageWithSize:size
-                                         flipped:NO
-                                  drawingHandler:^BOOL(NSRect rect) {
-      NSBezierPath* bezierPath = [NSBezierPath
-                                  bezierPathWithRoundedRect:rect
-                                                    xRadius:radius
-                                                    yRadius:radius];
-      [[NSColor blackColor] set];
-      [bezierPath fill];
-      return YES;
-    }] autorelease];
-    [maskImage setCapInsets:NSEdgeInsetsMake(radius, radius, radius, radius)];
-    [maskImage setResizingMode:NSImageResizingModeStretch];
-
-    [effect_view setMaskImage:maskImage];
-    [window_ setCornerMask:maskImage];
-
     [[window_ contentView] addSubview:effect_view
                            positioned:NSWindowBelow
                            relativeTo:nil];


### PR DESCRIPTION
Reverts electron/electron#8354

Looks like this causes the border/shadow to be incorrect windows with no vibrancy set.

### No vibrancy

![screen shot 2017-01-10 at 10 35 28 am](https://cloud.githubusercontent.com/assets/671378/21819437/881431de-d720-11e6-9238-56b8eaee7247.png)
