### PR TITLE
Destroy web contents if new-window event is prevented

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -419,9 +419,11 @@ void WebContents::AddNewContents(content::WebContents* source,
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   auto api_web_contents = CreateFrom(isolate(), new_contents);
-  Emit("-add-new-contents", api_web_contents, disposition, user_gesture,
+  if (Emit("-add-new-contents", api_web_contents, disposition, user_gesture,
       initial_rect.x(), initial_rect.y(), initial_rect.width(),
-      initial_rect.height());
+      initial_rect.height())) {
+    api_web_contents->DestroyWebContents();
+  }
 }
 
 content::WebContents* WebContents::OpenURLFromTab(

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1018,7 +1018,7 @@ describe('BrowserWindow module', function () {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            sandbox: true,
+            sandbox: true
           }
         })
         const initialWebContents = webContents.getAllWebContents()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1024,10 +1024,8 @@ describe('BrowserWindow module', function () {
         const initialWebContents = webContents.getAllWebContents()
         ipcRenderer.send('prevent-next-new-window', w.webContents.id)
         w.webContents.once('new-window', () => {
-          process.nextTick(() => {
-            assert.deepEqual(webContents.getAllWebContents().length, initialWebContents.length)
-            done()
-          })
+          assert.deepEqual(webContents.getAllWebContents(), initialWebContents)
+          done()
         })
         w.loadURL('file://' + path.join(fixtures, 'pages', 'window-open.html'))
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1012,6 +1012,25 @@ describe('BrowserWindow module', function () {
           })
         })
       })
+
+      it('supports calling preventDefault on new-window events', (done) => {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true,
+          }
+        })
+        const initialWebContents = webContents.getAllWebContents()
+        ipcRenderer.send('prevent-next-new-window', w.webContents.id)
+        w.webContents.once('new-window', () => {
+          process.nextTick(() => {
+            assert.deepEqual(webContents.getAllWebContents().length, initialWebContents.length)
+            done()
+          })
+        })
+        w.loadURL('file://' + path.join(fixtures, 'pages', 'window-open.html'))
+      })
     })
   })
 

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -245,3 +245,8 @@ ipcMain.on('create-window-with-options-cycle', (event) => {
   const window = new BrowserWindow({show: false, foo: foo})
   event.returnValue = window.id
 })
+
+
+ipcMain.on('prevent-next-new-window', (event, id) => {
+  webContents.fromId(id).once('new-window', event => event.preventDefault())
+})

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -246,7 +246,6 @@ ipcMain.on('create-window-with-options-cycle', (event) => {
   event.returnValue = window.id
 })
 
-
 ipcMain.on('prevent-next-new-window', (event, id) => {
   webContents.fromId(id).once('new-window', event => event.preventDefault())
 })


### PR DESCRIPTION
This pull request seeks to prevent a crash when calling `preventDefault()` on a `new-window` event emitted from a sandboxed renderer process.

@zcbenz was this what you were thinking for https://github.com/electron/electron/issues/7490#issuecomment-255669721?

Fixes #7490