### PR TITLE
create electron-api.json in dist, not as a side-effect of linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint-cpp": "python ./script/cpplint.py",
     "lint-py": "python ./script/pylint.py",
     "lint-api-docs-js": "standard-markdown docs && standard-markdown docs-translations",
-    "lint-api-docs": "electron-docs-linter --outfile=out/electron-api.json",
+    "lint-api-docs": "electron-docs-linter",
     "preinstall": "node -e 'process.exit(0)'",
     "release": "./script/upload.py -p",
     "repl": "python ./script/start.py --interactive",

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -133,8 +133,7 @@ def copy_license():
 
 def create_api_json_schema():
   outfile = os.path.join(DIST_DIR, 'electron-api.json')
-  execute(['electron-docs-linter',
-           '--outfile={0}'.format(outfile)])
+  execute(['electron-docs-linter', '--outfile={0}'.format(outfile)])
 
 def strip_binaries():
   for binary in TARGET_BINARIES[PLATFORM]:

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -87,7 +87,7 @@ def main():
   copy_license()
 
   if PLATFORM != 'win32':
-    copy_api_json_schema()
+    create_api_json_schema()
 
   if PLATFORM == 'linux':
     strip_binaries()
@@ -131,8 +131,10 @@ def copy_license():
                DIST_DIR)
   shutil.copy2(os.path.join(SOURCE_ROOT, 'LICENSE'), DIST_DIR)
 
-def copy_api_json_schema():
-  shutil.copy2(os.path.join(SOURCE_ROOT, 'out', 'electron-api.json'), DIST_DIR)
+def create_api_json_schema():
+  outfile = os.path.join(DIST_DIR, 'electron-api.json')
+  execute(['electron-docs-linter',
+           '--outfile={0}'.format(outfile)])
 
 def strip_binaries():
   for binary in TARGET_BINARIES[PLATFORM]:


### PR DESCRIPTION
This is a follow-up to https://github.com/electron/electron/pull/8222

> I feel like linting shouldn't have side effects and it shouldn't be required to build and create a distribution.

Hopefully the `electron-docs-linter` binary is on the PATH here. 🤞 