### PR TITLE
Update the Node submodule to use the new module wrapper

### DIFF
--- a/spec/fixtures/module/declare-global.js
+++ b/spec/fixtures/module/declare-global.js
@@ -1,0 +1,2 @@
+const global = {__global: true}
+module.exports = global

--- a/spec/fixtures/module/declare-process.js
+++ b/spec/fixtures/module/declare-process.js
@@ -1,0 +1,2 @@
+const process = require('process')
+module.exports = process

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -47,6 +47,28 @@ describe('third-party module', function () {
       })
     })
   })
+
+  describe('global variables', function () {
+    describe('process', function () {
+      it('can be declared in a module', function () {
+        var exportedProcess
+        assert.doesNotThrow(function () {
+          exportedProcess = require('./fixtures/module/declare-process')
+        })
+        assert.strictEqual(exportedProcess, require('process'))
+      })
+    })
+
+    describe('global', function () {
+      it('can be declared in a module', function () {
+        var exportedGlobal
+        assert.doesNotThrow(function () {
+          exportedGlobal = require('./fixtures/module/declare-global')
+        })
+        assert.deepEqual(exportedGlobal, {__global: true})
+      })
+    })
+  })
 })
 
 describe('Module._nodeModulePaths', function () {


### PR DESCRIPTION
See the fixed issue for the context. This pulls in a vendored copy of Node that includes the described patch. **This commit depends on first merging https://github.com/electron/node/pull/21.**

Fixes #8358

Test Plan: Built Electron and verified it loaded the sample app correctly and that the module wrapper is the new one by viewing Node's source code in the Blink Inspector.