### PR TITLE
Make process.versions.electron/chrome read-only

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/electron/chromium-breakpad.git
 [submodule "vendor/native_mate"]
 	path = vendor/native_mate
-	url = https://github.com/zcbenz/native-mate.git
+	url = https://github.com/electron/native-mate.git
 [submodule "vendor/crashpad"]
 	path = vendor/crashpad
 	url = https://github.com/electron/crashpad.git

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -112,6 +112,7 @@ void AtomBindings::BindTo(v8::Isolate* isolate,
 
   mate::Dictionary versions;
   if (dict.Get("versions", &versions)) {
+    // TODO(kevinsawicki): Make read-only in 2.0 to match node
     versions.Set(ATOM_PROJECT_NAME, ATOM_VERSION_STRING);
     versions.Set("chrome", CHROME_VERSION_STRING);
 

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -87,6 +87,10 @@ process.versions['atom-shell']
 process.versions.electron
 ```
 
+* `process.versions.electron` and `process.version.chrome` will be made
+  read-only properties for consistency with the other `process.versions`
+  properties set by Node.
+
 ## `Tray`
 
 ```js

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -290,4 +290,12 @@ describe('node feature', function () {
       require('vm').runInNewContext('')
     })
   })
+
+  it('includes the electron version in process.versions', () => {
+    assert(/^\d+\.\d+\.\d+$/.test(process.versions.electron))
+  })
+
+  it('includes the chrome version in process.versions', () => {
+    assert(/^\d+\.\d+\.\d+\.\d+$/.test(process.versions.chrome))
+  })
 })


### PR DESCRIPTION
Make `process.versions.electron` and `process.versions.chrome` read-only to match the behavior in node: https://github.com/nodejs/node/blob/334be0feba771a22568760d8160d5a4789218cff/src/node.cc#L3046-L3048

Refs #8083 