### PR TITLE
save a fullscreen state when Kiosk mode is called

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -162,6 +162,8 @@ class NativeWindowMac : public NativeWindow,
 
   bool is_kiosk_;
 
+  bool was_fullscreen_;
+
   bool zoom_to_page_width_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -619,6 +619,7 @@ NativeWindowMac::NativeWindowMac(
     NativeWindow* parent)
     : NativeWindow(web_contents, options, parent),
       is_kiosk_(false),
+      was_fullscreen_(false),
       zoom_to_page_width_(false),
       attention_request_id_(0),
       title_bar_style_(NORMAL) {
@@ -1126,10 +1127,11 @@ void NativeWindowMac::SetKiosk(bool kiosk) {
         NSApplicationPresentationDisableHideApplication;
     [NSApp setPresentationOptions:options];
     is_kiosk_ = true;
+    was_fullscreen_ = IsFullscreen();
     SetFullScreen(true);
   } else if (!kiosk && is_kiosk_) {
     is_kiosk_ = false;
-    SetFullScreen(false);
+    if (!was_fullscreen_) SetFullScreen(false);
     [NSApp setPresentationOptions:kiosk_options_];
   }
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1417,6 +1417,42 @@ describe('BrowserWindow module', function () {
       })
     })
 
+    describe('kiosk state', function () {
+      // Only implemented on macOS.
+      if (process.platform !== 'darwin') return
+
+      it('can be changed with setKiosk method', function () {
+        w.destroy()
+        w = new BrowserWindow()
+        w.setKiosk(true)
+        assert.equal(w.isKiosk(), true)
+        w.setKiosk(false)
+        assert.equal(w.isKiosk(), false)
+      })
+    })
+
+    describe('fullscreen state', function () {
+      // Only implemented on macOS.
+      if (process.platform !== 'darwin') return
+
+      it('can be changed with setFullScreen method', function () {
+        w.destroy()
+        w = new BrowserWindow()
+        w.setFullScreen(true)
+        assert.equal(w.isFullScreen(), true)
+        w.setFullScreen(false)
+        assert.equal(w.isFullScreen(), false)
+      })
+
+      it('should not be changed by setKiosk method', function () {
+        w.setFullScreen(true)
+        assert.equal(w.isFullScreen(), true)
+        w.setKiosk(true)
+        w.setKiosk(false)
+        assert.equal(w.isFullScreen(), true)
+      })
+    })
+
     describe('closable state', function () {
       it('can be changed with closable option', function () {
         w.destroy()


### PR DESCRIPTION
Hello!

This patch fixes https://github.com/electron/electron/issues/8338, and I've added some of the test cases related to the patch.

Here is an example code:
+ https://gist.github.com/watilde/c47eba263e6048c93ebf7c90a5e60c00