### PR TITLE
Switch to footer link syntax for keyboard event docs

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -239,12 +239,12 @@ Returns:
 * `event` Event
 * `input` Object - Input properties
   * `type` String - Either `keyUp` or `keyDown`
-  * `key` String - Equivalent to [KeyboardEvent.key](keyboardevent)
-  * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat](keyboardevent)
-  * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey](keyboardevent)
-  * `control` Boolean - Equivalent to [KeyboardEvent.controlKey](keyboardevent)
-  * `alt` Boolean - Equivalent to [KeyboardEvent.altKey](keyboardevent)
-  * `meta` Boolean - Equivalent to [KeyboardEvent.metaKey](keyboardevent)
+  * `key` String - Equivalent to [KeyboardEvent.key][keyboardevent]
+  * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat][keyboardevent]
+  * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey][keyboardevent]
+  * `control` Boolean - Equivalent to [KeyboardEvent.controlKey][keyboardevent]
+  * `alt` Boolean - Equivalent to [KeyboardEvent.altKey][keyboardevent]
+  * `meta` Boolean - Equivalent to [KeyboardEvent.metaKey][keyboardevent]
 
 Emitted before dispatching the `keydown` and `keyup` events in the page.
 Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events


### PR DESCRIPTION
Noticed the keyboard event links are broken to http://electron.atom.io/docs/api/web-contents/#event-before-input-event

Switched them from `()` to `[]` since they are footer links.