### PR TITLE
Reorder BrowserProcess constructor to avoid invalid memory

### DIFF
--- a/chromium_src/chrome/browser/browser_process.cc
+++ b/chromium_src/chrome/browser/browser_process.cc
@@ -9,10 +9,9 @@
 
 BrowserProcess* g_browser_process = NULL;
 
-BrowserProcess::BrowserProcess() {
+BrowserProcess::BrowserProcess()
+    : print_job_manager_(new printing::PrintJobManager) {
   g_browser_process = this;
-
-  print_job_manager_.reset(new printing::PrintJobManager);
 }
 
 BrowserProcess::~BrowserProcess() {


### PR DESCRIPTION
If allocating memory for a `printing::PrintJobManager` fails, the `g_browser_process` variable will be left pointing to an invalid variable.  By reordering these, we simplify the code and remove the possibility for this edge case.