### PR TITLE
Fix memory leak of g_nss_cert_database

### DIFF
--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener_win.cc
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener_win.cc
@@ -20,9 +20,9 @@ namespace extensions {
 // static
 GlobalShortcutListener* GlobalShortcutListener::GetInstance() {
   CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
-  static GlobalShortcutListenerWin* instance =
-      new GlobalShortcutListenerWin();
-  return instance;
+  static std::unique_ptr<GlobalShortcutListenerWin> instance(
+      new GlobalShortcutListenerWin());
+  return instance.get();
 }
 
 GlobalShortcutListenerWin::GlobalShortcutListenerWin()

--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener_x11.cc
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener_x11.cc
@@ -50,9 +50,9 @@ namespace extensions {
 // static
 GlobalShortcutListener* GlobalShortcutListener::GetInstance() {
   CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
-  static GlobalShortcutListenerX11* instance =
-      new GlobalShortcutListenerX11();
-  return instance;
+  static std::unique_ptr<GlobalShortcutListenerX11> instance(
+      new GlobalShortcutListenerX11());
+  return instance.get();
 }
 
 GlobalShortcutListenerX11::GlobalShortcutListenerX11()


### PR DESCRIPTION
This also narrows the scope of the static global variable to inside the only function it is used in.