### PR TITLE
Properly handle borders on frameless window for DPI > 100% (Windows only)

### DIFF
--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -147,6 +147,18 @@ bool NativeWindowViews::PreHandleMSG(
       }
       return false;
     }
+    /** Return zero (no-op) for non-client area events when window is frameless.
+     *  \see WM_NCPAINT - https://msdn.microsoft.com/en-us/library/windows/desktop/dd145212(v=vs.85).aspx
+     *  \see WM_NCCALCSIZE - https://msdn.microsoft.com/en-us/library/windows/desktop/ms632634(v=vs.85).aspx
+     */
+    case WM_NCPAINT:
+    case WM_NCCALCSIZE: {
+      if (!has_frame()) {
+        *result = 0;
+        return true;
+      }
+      return false;
+    }
     default:
       return false;
   }

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -147,18 +147,6 @@ bool NativeWindowViews::PreHandleMSG(
       }
       return false;
     }
-    /** Return zero (no-op) for non-client area events when window is frameless.
-     *  \see WM_NCPAINT - https://msdn.microsoft.com/en-us/library/windows/desktop/dd145212(v=vs.85).aspx
-     *  \see WM_NCCALCSIZE - https://msdn.microsoft.com/en-us/library/windows/desktop/ms632634(v=vs.85).aspx
-     */
-    case WM_NCPAINT:
-    case WM_NCCALCSIZE: {
-      if (!has_frame()) {
-        *result = 0;
-        return true;
-      }
-      return false;
-    }
     default:
       return false;
   }

--- a/atom/browser/ui/views/menu_layout.cc
+++ b/atom/browser/ui/views/menu_layout.cc
@@ -6,6 +6,7 @@
 
 #if defined(OS_WIN)
 #include "atom/browser/native_window_views.h"
+#include "ui/display/win/screen_win.h"
 #endif
 
 namespace atom {
@@ -13,13 +14,17 @@ namespace atom {
 namespace {
 
 #if defined(OS_WIN)
-gfx::Rect SubstractBorderSize(gfx::Rect bounds) {
-  int border_width = GetSystemMetrics(SM_CXSIZEFRAME) - 1;
-  int border_height = GetSystemMetrics(SM_CYSIZEFRAME) - 1;
-  bounds.set_x(bounds.x() + border_width);
-  bounds.set_y(bounds.y() + border_height);
-  bounds.set_width(bounds.width() - 2 * border_width);
-  bounds.set_height(bounds.height() - 2 * border_height);
+gfx::Rect SubtractBorderSize(gfx::Rect bounds) {
+  gfx::Point borderSize = gfx::Point(
+    GetSystemMetrics(SM_CXSIZEFRAME) - 1, // width
+    GetSystemMetrics(SM_CYSIZEFRAME) - 1  // height
+  );
+  gfx::Point dpiAdjustedSize = display::win::ScreenWin::ScreenToDIPPoint(borderSize);
+
+  bounds.set_x(bounds.x() + dpiAdjustedSize.x());
+  bounds.set_y(bounds.y() + dpiAdjustedSize.y());
+  bounds.set_width(bounds.width() - 2 * dpiAdjustedSize.x());
+  bounds.set_height(bounds.height() - 2 * dpiAdjustedSize.y());
   return bounds;
 }
 #endif
@@ -39,7 +44,7 @@ void MenuLayout::Layout(views::View* host) {
   // Reserve border space for maximized frameless window so we won't have the
   // content go outside of screen.
   if (!window_->has_frame() && window_->IsMaximized()) {
-    gfx::Rect bounds = SubstractBorderSize(host->GetContentsBounds());
+    gfx::Rect bounds = SubtractBorderSize(host->GetContentsBounds());
     host->child_at(0)->SetBoundsRect(bounds);
     return;
   }

--- a/atom/browser/ui/views/menu_layout.cc
+++ b/atom/browser/ui/views/menu_layout.cc
@@ -16,10 +16,10 @@ namespace {
 #if defined(OS_WIN)
 gfx::Rect SubtractBorderSize(gfx::Rect bounds) {
   gfx::Point borderSize = gfx::Point(
-    GetSystemMetrics(SM_CXSIZEFRAME) - 1, // width
-    GetSystemMetrics(SM_CYSIZEFRAME) - 1  // height
-  );
-  gfx::Point dpiAdjustedSize = display::win::ScreenWin::ScreenToDIPPoint(borderSize);
+      GetSystemMetrics(SM_CXSIZEFRAME) - 1,   // width
+      GetSystemMetrics(SM_CYSIZEFRAME) - 1);  // height
+  gfx::Point dpiAdjustedSize =
+      display::win::ScreenWin::ScreenToDIPPoint(borderSize);
 
   bounds.set_x(bounds.x() + dpiAdjustedSize.x());
   bounds.set_y(bounds.y() + dpiAdjustedSize.y());

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -25,4 +25,12 @@ bool AtomDesktopWindowTreeHostWin::PreHandleMSG(
   return delegate_->PreHandleMSG(message, w_param, l_param, result);
 }
 
+/** Override the client area inset
+ *  Returning true forces a border of 0 for frameless windows
+ */
+bool AtomDesktopWindowTreeHostWin::GetClientAreaInsets(
+    gfx::Insets* insets) const {
+  return !HasFrame();
+}
+
 }  // namespace atom

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
@@ -27,6 +27,7 @@ class AtomDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin {
  protected:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
+  bool GetClientAreaInsets(gfx::Insets* insets) const override;
 
  private:
   MessageHandlerDelegate* delegate_;  // weak ref


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/4573

cc: @zcbenz, @kevinsawicki, @zeke

## The problems this fixes
- The parent window tries to process non-client events for frameless. This results in borders being added (was not present with Chromium 53, but presented itself with Chromium 54)
- Because of a bug in the menu adjustment code, the web contents object ends up being incorrectly sized. This causes borders to be added when at a DPI > 100% on Chromium 54 (53 does not show them).

## History / description

I had originally submitted a "fix" with https://github.com/electron/electron/pull/7416, which @zcbenz accepted (and later reverted with https://github.com/electron/electron/pull/7461, because it failed the tests).  I believe this fix masked the issue in Chromium 53.

When upgrading our fork of Electron to Chromium 54 for Brave, we noticed various issues when DPI is greater than 100%.  I spent at least a week digging into the Chromium code and discovered the root causes.  Remembering the reverted PR above helped when troubleshooting.


