### PR TITLE
set version arg when creating electron-api.json

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -133,7 +133,8 @@ def copy_license():
 
 def create_api_json_schema():
   outfile = os.path.join(DIST_DIR, 'electron-api.json')
-  execute(['electron-docs-linter', '--outfile={0}'.format(outfile)])
+  execute(['electron-docs-linter', '--outfile={0}'.format(outfile)],
+           '--version={}'.format(ELECTRON_VERSION.replace('v', '')))
 
 def strip_binaries():
   for binary in TARGET_BINARIES[PLATFORM]:

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -132,9 +132,9 @@ def copy_license():
   shutil.copy2(os.path.join(SOURCE_ROOT, 'LICENSE'), DIST_DIR)
 
 def create_api_json_schema():
-  outfile = os.path.join(DIST_DIR, 'electron-api.json')
-  execute(['electron-docs-linter', '--outfile={0}'.format(outfile)],
-           '--version={}'.format(ELECTRON_VERSION.replace('v', '')))
+  outfile = os.path.relpath(os.path.join(DIST_DIR, 'electron-api.json'))
+  execute(['electron-docs-linter', 'docs', '--outfile={0}'.format(outfile),
+           '--version={}'.format(ELECTRON_VERSION.replace('v', ''))])
 
 def strip_binaries():
   for binary in TARGET_BINARIES[PLATFORM]:


### PR DESCRIPTION
The linter uses `$npm_package_version` env var by default for determining Electron version, but when `create-dist.py` is not run from an npm script, this variable does not exist.

This PR updates the dist script to explicitly specify the version as a command line argument.

This passed the linter, but I'm still waiting for the build to complete for conclusive proof that this works.

@kevinsawicki 