### PR TITLE
do not call SetFullScreen in SetKiosk if it's already fullscreen mode

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1128,7 +1128,7 @@ void NativeWindowMac::SetKiosk(bool kiosk) {
     [NSApp setPresentationOptions:options];
     is_kiosk_ = true;
     was_fullscreen_ = IsFullscreen();
-    SetFullScreen(true);
+    if (!was_fullscreen_) SetFullScreen(true);
   } else if (!kiosk && is_kiosk_) {
     is_kiosk_ = false;
     if (!was_fullscreen_) SetFullScreen(false);


### PR DESCRIPTION
Minor tweaks to https://github.com/electron/electron/pull/8399. In `SetKiosk`, `SetFullScreen` doesn't need to be called if the window is already fullScreen.