### PR TITLE
Add to security checklist about permission requests

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -58,6 +58,7 @@ This is not bulletproof, but at the least, you should attempt the following:
   (setting `nodeIntegration` to `false` in `webPreferences`)
 * Enable context isolation in all renderers that display remote content
   (setting `contextIsolation` to `true` in `webPreferences`)
+* Use `ses.setPermissionRequestHandler()` in all sessions that load remote content
 * Do not disable `webSecurity`. Disabling it will disable the same-origin policy.
 * Define a [`Content-Security-Policy`](http://www.html5rocks.com/en/tutorials/security/content-security-policy/)
 , and use restrictive rules (i.e. `script-src 'self'`)

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -56,7 +56,7 @@ This is not bulletproof, but at the least, you should attempt the following:
 * Only display secure (https) content
 * Disable the Node integration in all renderers that display remote content
   (setting `nodeIntegration` to `false` in `webPreferences`)
-* Enable context isolation in all rendererers that display remote content
+* Enable context isolation in all renderers that display remote content
   (setting `contextIsolation` to `true` in `webPreferences`)
 * Do not disable `webSecurity`. Disabling it will disable the same-origin policy.
 * Define a [`Content-Security-Policy`](http://www.html5rocks.com/en/tutorials/security/content-security-policy/)


### PR DESCRIPTION
If the handler is not set, remote content can access to user's information without allowing the permission. e.g. UserMedia