### PR TITLE
Remove note in "did-fail-load" about redirect responses

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -71,8 +71,6 @@ Returns:
 This event is like `did-finish-load` but emitted when the load failed or was
 cancelled, e.g. `window.stop()` is invoked.
 The full list of error codes and their meaning is available [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
-Note that redirect responses will emit `errorCode` -3; you may want to ignore
-that error explicitly.
 
 #### Event: 'did-frame-finish-load'
 


### PR DESCRIPTION
`ERR_ABORTED` is suppressed now (https://github.com/electron/electron/pull/6201)