### PR TITLE
Upgrade libcc to b4dd78df

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '25ec31e58d23002a02dc85dd4b8200b72d50a6c7'
+    'b4dd78df3f4fa271057ecdaa54441501e63e7c55'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
Nothing major here, more just a test of CI and that this SHA was published correctly.

This mac builds at this version were built with XCode 8.2.1 to work around a linker error on 7.3.1.