### PR TITLE
Feature/macOS relative window levels

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -512,8 +512,10 @@ bool Window::IsClosable() {
 
 void Window::SetAlwaysOnTop(bool top, mate::Arguments* args) {
   std::string level = "floating";
+  int relativeLevel = 0;
   args->GetNext(&level);
-  window_->SetAlwaysOnTop(top, level);
+  args->GetNext(&relativeLevel);
+  window_->SetAlwaysOnTop(top, level, relativeLevel);
 }
 
 bool Window::IsAlwaysOnTop() {

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -513,9 +513,16 @@ bool Window::IsClosable() {
 void Window::SetAlwaysOnTop(bool top, mate::Arguments* args) {
   std::string level = "floating";
   int relativeLevel = 0;
+  std::string error;
+
   args->GetNext(&level);
   args->GetNext(&relativeLevel);
-  window_->SetAlwaysOnTop(top, level, relativeLevel);
+
+  window_->SetAlwaysOnTop(top, level, relativeLevel, &error);
+
+  if (!error.empty()) {
+    args->ThrowError(error);
+  }
 }
 
 bool Window::IsAlwaysOnTop() {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -120,7 +120,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsClosable() = 0;
   virtual void SetAlwaysOnTop(bool top,
                               const std::string& level = "floating",
-                              int relativeLevel = 0) = 0;
+                              int relativeLevel = 0,
+                              std::string* error = nullptr) = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;
   virtual void SetTitle(const std::string& title) = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -119,7 +119,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetClosable(bool closable) = 0;
   virtual bool IsClosable() = 0;
   virtual void SetAlwaysOnTop(bool top,
-                              const std::string& level = "floating") = 0;
+                              const std::string& level = "floating",
+                              int relativeLevel = 0) = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;
   virtual void SetTitle(const std::string& title) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -68,7 +68,7 @@ class NativeWindowMac : public NativeWindow,
   void SetClosable(bool closable) override;
   bool IsClosable() override;
   void SetAlwaysOnTop(bool top, const std::string& level,
-                      int relativeLevel) override;
+                      int relativeLevel, std::string* error) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -67,7 +67,8 @@ class NativeWindowMac : public NativeWindow,
   bool IsFullScreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
-  void SetAlwaysOnTop(bool top, const std::string& level) override;
+  void SetAlwaysOnTop(bool top, const std::string& level,
+                      int relativeLevel) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1056,8 +1056,10 @@ bool NativeWindowMac::IsClosable() {
   return [window_ styleMask] & NSClosableWindowMask;
 }
 
-void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level, int relativeLevel) {
+void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level, int relativeLevel,
+                                     std::string* error) {
   int windowLevel = NSNormalWindowLevel;
+  CGWindowLevel maxWindowLevel = CGWindowLevelForKey(kCGMaximumWindowLevelKey);
   
   if (top) {
     if (level == "floating") {
@@ -1081,10 +1083,12 @@ void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level, int rel
   }
 
   NSInteger newLevel = windowLevel + relativeLevel;
-  if (newLevel >= 0 && newLevel < CGWindowLevelForKey(kCGMaximumWindowLevelKey)) {
+  
+  if (newLevel >= 0 && newLevel <= maxWindowLevel) {
     [window_ setLevel:newLevel];
   } else {
-    [window_ setLevel:windowLevel];
+    *error = std::string([[NSString stringWithFormat:
+      @"relativeLevel must be between 0 and %d", maxWindowLevel] UTF8String]);
   }
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1056,8 +1056,9 @@ bool NativeWindowMac::IsClosable() {
   return [window_ styleMask] & NSClosableWindowMask;
 }
 
-void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level) {
+void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level, int relativeLevel) {
   int windowLevel = NSNormalWindowLevel;
+  
   if (top) {
     if (level == "floating") {
       windowLevel = NSFloatingWindowLevel;
@@ -1078,7 +1079,13 @@ void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level) {
       windowLevel = NSDockWindowLevel;
     }
   }
-  [window_ setLevel:windowLevel];
+
+  NSInteger newLevel = windowLevel + relativeLevel;
+  if (newLevel >= 0 && newLevel < CGWindowLevelForKey(kCGMaximumWindowLevelKey)) {
+    [window_ setLevel:newLevel];
+  } else {
+    [window_ setLevel:windowLevel];
+  }
 }
 
 bool NativeWindowMac::IsAlwaysOnTop() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1060,6 +1060,7 @@ void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level, int rel
                                      std::string* error) {
   int windowLevel = NSNormalWindowLevel;
   CGWindowLevel maxWindowLevel = CGWindowLevelForKey(kCGMaximumWindowLevelKey);
+  CGWindowLevel minWindowLevel = CGWindowLevelForKey(kCGMinimumWindowLevelKey);
   
   if (top) {
     if (level == "floating") {
@@ -1083,12 +1084,12 @@ void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level, int rel
   }
 
   NSInteger newLevel = windowLevel + relativeLevel;
-  
-  if (newLevel >= 0 && newLevel <= maxWindowLevel) {
+  if (newLevel >= minWindowLevel && newLevel <= maxWindowLevel) {
     [window_ setLevel:newLevel];
   } else {
     *error = std::string([[NSString stringWithFormat:
-      @"relativeLevel must be between 0 and %d", maxWindowLevel] UTF8String]);
+      @"relativeLevel must be between %d and %d", minWindowLevel,
+      maxWindowLevel] UTF8String]);
   }
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1056,8 +1056,8 @@ bool NativeWindowMac::IsClosable() {
   return [window_ styleMask] & NSClosableWindowMask;
 }
 
-void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level, int relativeLevel,
-                                     std::string* error) {
+void NativeWindowMac::SetAlwaysOnTop(bool top, const std::string& level,
+                                     int relativeLevel, std::string* error) {
   int windowLevel = NSNormalWindowLevel;
   CGWindowLevel maxWindowLevel = CGWindowLevelForKey(kCGMaximumWindowLevelKey);
   CGWindowLevel minWindowLevel = CGWindowLevelForKey(kCGMinimumWindowLevelKey);

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -683,7 +683,7 @@ bool NativeWindowViews::IsClosable() {
 }
 
 void NativeWindowViews::SetAlwaysOnTop(bool top, const std::string& level,
-                                       int relativeLevel) {
+                                       int relativeLevel, std::string* error) {
   window_->SetAlwaysOnTop(top);
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -682,7 +682,8 @@ bool NativeWindowViews::IsClosable() {
 #endif
 }
 
-void NativeWindowViews::SetAlwaysOnTop(bool top, const std::string& level) {
+void NativeWindowViews::SetAlwaysOnTop(bool top, const std::string& level,
+                                       int relativeLevel) {
   window_->SetAlwaysOnTop(top);
 }
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -87,7 +87,7 @@ class NativeWindowViews : public NativeWindow,
   void SetClosable(bool closable) override;
   bool IsClosable() override;
   void SetAlwaysOnTop(bool top, const std::string& level,
-                      int relativeLevel) override;
+                      int relativeLevel, std::string& error) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -86,7 +86,8 @@ class NativeWindowViews : public NativeWindow,
   bool IsFullScreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
-  void SetAlwaysOnTop(bool top, const std::string& level) override;
+  void SetAlwaysOnTop(bool top, const std::string& level,
+                      int relativeLevel) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -87,7 +87,7 @@ class NativeWindowViews : public NativeWindow,
   void SetClosable(bool closable) override;
   bool IsClosable() override;
   void SetAlwaysOnTop(bool top, const std::string& level,
-                      int relativeLevel, std::string& error) override;
+                      int relativeLevel, std::string* error) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
   void SetTitle(const std::string& title) override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -846,13 +846,16 @@ Returns `Boolean` - Whether the window can be manually closed by user.
 
 On Linux always returns `true`.
 
-#### `win.setAlwaysOnTop(flag[, level])`
+#### `win.setAlwaysOnTop(flag[, level][, relativeLevel])`
 
 * `flag` Boolean
 * `level` String (optional) _macOS_ - Values include `normal`, `floating`,
   `torn-off-menu`, `modal-panel`, `main-menu`, `status`, `pop-up-menu`,
   `screen-saver`, and ~~`dock`~~ (Deprecated). The default is `floating`. See the
   [macOS docs][window-levels] for more details.
+* `relativeLevel` Integer (optional) _macOS_ - The number of layers higher to set
+this window relative to the given `level`. The default is `0`. Note that Apple
+discourages setting levels higher than 1 above `screen-saver`. 
 
 Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -854,8 +854,8 @@ On Linux always returns `true`.
   `screen-saver`, and ~~`dock`~~ (Deprecated). The default is `floating`. See the
   [macOS docs][window-levels] for more details.
 * `relativeLevel` Integer (optional) _macOS_ - The number of layers higher to set
-this window relative to the given `level`. The default is `0`. Note that Apple
-discourages setting levels higher than 1 above `screen-saver`. 
+  this window relative to the given `level`. The default is `0`. Note that Apple
+  discourages setting levels higher than 1 above `screen-saver`. 
 
 Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -514,14 +514,14 @@ describe('BrowserWindow module', function () {
       assert.equal(w.isAlwaysOnTop(), true)
     })
 
-    it('raises an error when relativeLevel is out of bounds', function() {
-      if (process.platform !== 'darwin') return;
+    it('raises an error when relativeLevel is out of bounds', function () {
+      if (process.platform !== 'darwin') return
 
-      assert.throws(function() {
+      assert.throws(function () {
         w.setAlwaysOnTop(true, '', -1)
       })
 
-      assert.throws(function() {
+      assert.throws(function () {
         w.setAlwaysOnTop(true, '', 2147483632)
       })
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -518,7 +518,7 @@ describe('BrowserWindow module', function () {
       if (process.platform !== 'darwin') return
 
       assert.throws(function () {
-        w.setAlwaysOnTop(true, '', -1)
+        w.setAlwaysOnTop(true, '', -2147483644)
       })
 
       assert.throws(function () {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -513,6 +513,18 @@ describe('BrowserWindow module', function () {
       w.setAlwaysOnTop(true)
       assert.equal(w.isAlwaysOnTop(), true)
     })
+
+    it('raises an error when relativeLevel is out of bounds', function() {
+      if (process.platform !== 'darwin') return;
+
+      assert.throws(function() {
+        w.setAlwaysOnTop(true, '', -1)
+      })
+
+      assert.throws(function() {
+        w.setAlwaysOnTop(true, '', 2147483632)
+      })
+    })
   })
 
   describe('BrowserWindow.setAutoHideCursor(autoHide)', () => {


### PR DESCRIPTION
Small change to implement https://github.com/electron/electron/issues/8153. I don't have a test for it because then I'd have to expose the [getter for `level`](https://developer.apple.com/reference/appkit/nswindow/1419511-level?language=objc) to verify that the levels were taken into account which would feel like a strange thing to do for just a test, unless you guys think it should be in the API.
