### PR TITLE
Wait for window to transition before leaving full screen

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1437,13 +1437,16 @@ describe('BrowserWindow module', function () {
       // Only implemented on macOS.
       if (process.platform !== 'darwin') return
 
-      it('can be changed with setFullScreen method', function () {
+      it('can be changed with setFullScreen method', function (done) {
         w.destroy()
         w = new BrowserWindow()
+        w.once('enter-full-screen', () => {
+          w.setFullScreen(false)
+          assert.equal(w.isFullScreen(), false)
+          done()
+        })
         w.setFullScreen(true)
         assert.equal(w.isFullScreen(), true)
-        w.setFullScreen(false)
-        assert.equal(w.isFullScreen(), false)
       })
 
       it('should not be changed by setKiosk method', function () {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1441,20 +1441,31 @@ describe('BrowserWindow module', function () {
         w.destroy()
         w = new BrowserWindow()
         w.once('enter-full-screen', () => {
+          assert.equal(w.isFullScreen(), true)
           w.setFullScreen(false)
+        })
+        w.once('leave-full-screen', () => {
           assert.equal(w.isFullScreen(), false)
           done()
         })
         w.setFullScreen(true)
-        assert.equal(w.isFullScreen(), true)
       })
 
-      it('should not be changed by setKiosk method', function () {
+      it('should not be changed by setKiosk method', function (done) {
+        w.destroy()
+        w = new BrowserWindow()
+        w.once('enter-full-screen', () => {
+          assert.equal(w.isFullScreen(), true)
+          w.setKiosk(true)
+          w.setKiosk(false)
+          assert.equal(w.isFullScreen(), true)
+          w.setFullScreen(false)
+        })
+        w.once('leave-full-screen', () => {
+          assert.equal(w.isFullScreen(), false)
+          done()
+        })
         w.setFullScreen(true)
-        assert.equal(w.isFullScreen(), true)
-        w.setKiosk(true)
-        w.setKiosk(false)
-        assert.equal(w.isFullScreen(), true)
       })
     })
 


### PR DESCRIPTION
This spec was a bit flaky on CI, looks like leaving full screen on a window transitioning to fullscreen is a no-op in macOS.

Currently "not in fullscreen state" is printed when running this spec.

Chrome has a related comment about it: https://cs.chromium.org/chromium/src/ui/views/cocoa/bridged_native_widget.mm?type=cs&q=%22not+in+fullscreen+state%22&sq=package:chromium&l=772

This pull request changes the spec to wait until full screening is complete before leaving.