### PR TITLE
Upgrade to ffi@2.2.0

### DIFF
--- a/spec/package.json
+++ b/spec/package.json
@@ -17,7 +17,7 @@
     "yargs": "^6.0.0"
   },
   "optionalDependencies": {
-    "ffi": "2.0.0",
+    "ffi": "2.2.0",
     "runas": "3.x"
   },
   "standard": {


### PR DESCRIPTION
This gets `modules-spec.js` passing again after the latest node upgrade.