### PR TITLE
Run crash reporter server specs on CI

### DIFF
--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -10,8 +10,6 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-const isCI = remote.getGlobal('isCi')
-
 describe('crashReporter module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
   var w = null
@@ -37,7 +35,8 @@ describe('crashReporter module', function () {
   }
 
   it('should send minidump when renderer crashes', function (done) {
-    if (isCI) return done()
+    if (process.platform !== 'darwin') return done()
+    if (process.env.TRAVIS === 'true') return done()
 
     this.timeout(120000)
 
@@ -56,7 +55,8 @@ describe('crashReporter module', function () {
   })
 
   it('should send minidump when node processes crash', function (done) {
-    if (isCI) return done()
+    if (process.platform !== 'darwin') return done()
+    if (process.env.TRAVIS === 'true') return done()
 
     this.timeout(120000)
 


### PR DESCRIPTION
This pull request enables the specs that verify crash reports are submitted correctly to a server on non-Travis macOS CI.

They were previously disabled on any CI node but they seemed reasonable to enable on the macOS Jenkins workers and they verify crash reports are submitted successfully and with the expected data