### PR TITLE
Redo node 7.4 error handling patch

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -163,9 +163,13 @@ node::Environment* NodeBindings::CreateEnvironment(
       new node::IsolateData(context->GetIsolate(), uv_default_loop()), context,
       args.size(), c_argv.get(), 0, nullptr);
 
-  // Node uses the deprecated SetAutorunMicrotasks(false) mode, we should switch
-  // to use the scoped policy to match blink's behavior.
-  if (!is_browser_) {
+  if (is_browser_) {
+    // SetAutorunMicrotasks is no longer called in node::CreateEnvironment
+    // so instead call it here to match expected node behavior
+    context->GetIsolate()->SetMicrotasksPolicy(v8::MicrotasksPolicy::kExplicit);
+  } else {
+    // Node uses the deprecated SetAutorunMicrotasks(false) mode, we should
+    // switch to use the scoped policy to match blink's behavior.
     context->GetIsolate()->SetMicrotasksPolicy(v8::MicrotasksPolicy::kScoped);
   }
 

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -3,7 +3,7 @@ const ChildProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
-const {remote} = require('electron')
+const {ipcRenderer, remote} = require('electron')
 
 const isCI = remote.getGlobal('isCi')
 
@@ -130,23 +130,29 @@ describe('node feature', function () {
       })
     })
 
-    describe('throw error in node context', function () {
-      it('gets caught', function (done) {
-        var error = new Error('boo!')
-        var lsts = process.listeners('uncaughtException')
+    describe('error thrown in renderer process node context', function () {
+      it('gets emitted as an process uncaughtException event', function (done) {
+        const error = new Error('boo!')
+        const listeners = process.listeners('uncaughtException')
         process.removeAllListeners('uncaughtException')
-        process.on('uncaughtException', function () {
-          var i, len, lst
+        process.on('uncaughtException', (thrown) => {
+          assert.strictEqual(thrown, error)
           process.removeAllListeners('uncaughtException')
-          for (i = 0, len = lsts.length; i < len; i++) {
-            lst = lsts[i]
-            process.on('uncaughtException', lst)
-          }
+          listeners.forEach((listener) => {
+            process.on('uncaughtException', listener)
+          })
           done()
         })
-        fs.readFile(__filename, function () {
+        fs.readFile(__filename, () => {
           throw error
         })
+      })
+    })
+
+    describe('error thrown in main process node context', function () {
+      it('gets emitted as an process uncaughtException event', function () {
+        const error = ipcRenderer.sendSync('handle-uncaught-exception', 'hello')
+        assert.equal(error, 'hello')
       })
     })
 

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -131,7 +131,7 @@ describe('node feature', function () {
     })
 
     describe('error thrown in renderer process node context', function () {
-      it('gets emitted as an process uncaughtException event', function (done) {
+      it('gets emitted as a process uncaughtException event', function (done) {
         const error = new Error('boo!')
         const listeners = process.listeners('uncaughtException')
         process.removeAllListeners('uncaughtException')
@@ -152,6 +152,13 @@ describe('node feature', function () {
     describe('error thrown in main process node context', function () {
       it('gets emitted as an process uncaughtException event', function () {
         const error = ipcRenderer.sendSync('handle-uncaught-exception', 'hello')
+        assert.equal(error, 'hello')
+      })
+    })
+
+    describe('promise rejection in main process node context', function () {
+      it('gets emitted as a process unhandledRejection event', function () {
+        const error = ipcRenderer.sendSync('handle-unhandled-rejection', 'hello')
         assert.equal(error, 'hello')
       })
     })

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -150,7 +150,7 @@ describe('node feature', function () {
     })
 
     describe('error thrown in main process node context', function () {
-      it('gets emitted as an process uncaughtException event', function () {
+      it('gets emitted as a process uncaughtException event', function () {
         const error = ipcRenderer.sendSync('handle-uncaught-exception', 'hello')
         assert.equal(error, 'hello')
       })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -275,16 +275,32 @@ ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
 })
 
 ipcMain.on('handle-uncaught-exception', (event, message) => {
-  const listeners = process.listeners('uncaughtException')
-  process.removeAllListeners('uncaughtException')
-  process.on('uncaughtException', (error) => {
-    process.removeAllListeners('uncaughtException')
-    listeners.forEach((listener) => {
-      process.on('uncaughtException', listener)
-    })
+  suspendListeners(process, 'uncaughtException', (error) => {
     event.returnValue = error.message
   })
   fs.readFile(__filename, () => {
     throw new Error(message)
   })
 })
+
+ipcMain.on('handle-unhandled-rejection', (event, message) => {
+  suspendListeners(process, 'unhandledRejection', (error) => {
+    event.returnValue = error.message
+  })
+  fs.readFile(__filename, () => {
+    Promise.reject(new Error(message))
+  })
+})
+
+// Suspend listeners until the next event and then restore them
+const suspendListeners = (emitter, eventName, callback) => {
+  const listeners = emitter.listeners(eventName)
+  emitter.removeAllListeners(eventName)
+  emitter.once(eventName, (...args) => {
+    emitter.removeAllListeners(eventName)
+    listeners.forEach((listener) => {
+      emitter.on(eventName, listener)
+    })
+    callback(...args)
+  })
+}

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -273,3 +273,18 @@ ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
     listenerCountAfter
   }
 })
+
+ipcMain.on('handle-uncaught-exception', (event, message) => {
+  const listeners = process.listeners('uncaughtException')
+  process.removeAllListeners('uncaughtException')
+  process.on('uncaughtException', (error) => {
+    process.removeAllListeners('uncaughtException')
+    listeners.forEach((listener) => {
+      process.on('uncaughtException', listener)
+    })
+    event.returnValue = error.message
+  })
+  fs.readFile(__filename, () => {
+    throw new Error(message)
+  })
+})


### PR DESCRIPTION
This pull request redoes the patch we apply to node to configure error handling for things like `uncaughtException` events.

When I upgraded to Node 7.4.0 in #8406 the patch was ported forward but the diff lines were moved to a new function that isn't called by either `LoadEnvironment` or `CreateEnvironment` so they weren't getting properly set.

Node 6.5.0 patch: https://github.com/electron/node/commit/f0987748ce7b86a76b1ba70f349f71c315f1ebf2

Original Node 7.4.0 patch:  https://github.com/electron/node/commit/f1e3c10575cfe1b61469b8ef328e6730002ef491

New Node 7.4.0 patch: https://github.com/electron/node/commit/8416f53f558dcfbc9019575e785d03764620e7e1

The diff of the old patch vs the new patch is:

```diff
diff --git a/src/node.cc b/src/node.cc
index f80157e..66233d4 100644
--- a/src/node.cc
+++ b/src/node.cc
@@ -3415,6 +3415,13 @@ static void RawDebug(const FunctionCallbackInfo<Value>& args) {
 
 
 void LoadEnvironment(Environment* env) {
+  if (g_standalone_mode) {
+    env->isolate()->AddMessageListener(OnMessage);
+  }
+  if (g_upstream_node_mode) {
+    env->isolate()->SetFatalErrorHandler(OnFatalError);
+  }
+
   HandleScope handle_scope(env->isolate());
 
   TryCatch try_catch(env->isolate());
@@ -4500,14 +4507,10 @@ inline int Start(uv_loop_t* event_loop,
   if (isolate == nullptr)
     return 12;  // Signal internal error.
 
-  if (g_standalone_mode) {  // No indent to minimize diff.
   isolate->AddMessageListener(OnMessage);
-  } // g_standalone_mode
   isolate->SetAbortOnUncaughtExceptionCallback(ShouldAbortOnUncaughtException);
   isolate->SetAutorunMicrotasks(false);
-  if (g_upstream_node_mode) {  // No indent to minimize diff.
   isolate->SetFatalErrorHandler(OnFatalError);
-  } // g_upstream_node_mode
 
   if (track_heap_objects) {
     isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
```

Closes #8499 