### PR TITLE
Fix empty image crashes

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -238,6 +238,8 @@ v8::Local<v8::Value> NativeImage::ToPNG(v8::Isolate* isolate) {
 }
 
 v8::Local<v8::Value> NativeImage::ToBitmap(v8::Isolate* isolate) {
+  if (IsEmpty()) return node::Buffer::New(isolate, 0).ToLocalChecked();
+
   const SkBitmap* bitmap = image_.ToSkBitmap();
   SkPixelRef* ref = bitmap->pixelRef();
   return node::Buffer::Copy(isolate,
@@ -264,6 +266,8 @@ std::string NativeImage::ToDataURL() {
 }
 
 v8::Local<v8::Value> NativeImage::GetBitmap(v8::Isolate* isolate) {
+  if (IsEmpty()) return node::Buffer::New(isolate, 0).ToLocalChecked();
+
   const SkBitmap* bitmap = image_.ToSkBitmap();
   SkPixelRef* ref = bitmap->pixelRef();
   return node::Buffer::New(isolate,
@@ -276,6 +280,8 @@ v8::Local<v8::Value> NativeImage::GetBitmap(v8::Isolate* isolate) {
 v8::Local<v8::Value> NativeImage::GetNativeHandle(v8::Isolate* isolate,
                                                   mate::Arguments* args) {
 #if defined(OS_MACOSX)
+  if (IsEmpty()) return node::Buffer::New(isolate, 0).ToLocalChecked();
+
   NSImage* ptr = image_.AsNSImage();
   return node::Buffer::Copy(
       isolate,

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -7,7 +7,16 @@ const path = require('path')
 describe('nativeImage module', () => {
   describe('createEmpty()', () => {
     it('returns an empty image', () => {
-      assert(nativeImage.createEmpty().isEmpty())
+      const empty = nativeImage.createEmpty()
+      assert.equal(empty.isEmpty(), true)
+      assert.equal(empty.getAspectRatio(), 1)
+      assert.equal(empty.toDataURL(), 'data:image/png;base64,')
+      assert.deepEqual(empty.getNativeHandle(), [])
+      assert.deepEqual(empty.getBitmap(), [])
+      assert.deepEqual(empty.getSize(), {width: 0, height: 0})
+      assert.deepEqual(empty.toBitmap(), [])
+      assert.deepEqual(empty.toJPEG(100), [])
+      assert.deepEqual(empty.toPNG(), [])
     })
   })
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -11,12 +11,15 @@ describe('nativeImage module', () => {
       assert.equal(empty.isEmpty(), true)
       assert.equal(empty.getAspectRatio(), 1)
       assert.equal(empty.toDataURL(), 'data:image/png;base64,')
-      assert.deepEqual(empty.getNativeHandle(), [])
-      assert.deepEqual(empty.getBitmap(), [])
       assert.deepEqual(empty.getSize(), {width: 0, height: 0})
+      assert.deepEqual(empty.getBitmap(), [])
       assert.deepEqual(empty.toBitmap(), [])
       assert.deepEqual(empty.toJPEG(100), [])
       assert.deepEqual(empty.toPNG(), [])
+
+      if (process.platform === 'darwin') {
+        assert.deepEqual(empty.getNativeHandle(), [])
+      }
     })
   })
 


### PR DESCRIPTION
Noticed while trying to reproduce #8445 that several methods on `NativeImage` will crash if called on an empty image.

This pull request changes those methods to be consistent with what the other methods already do, return an empty array/buffer when the image is empty.