### PR TITLE
Fix startDrag crash on macOS with empty image

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1327,7 +1327,7 @@ void WebContents::StartDrag(const mate::Dictionary& item,
 
   // Error checking.
   if (icon.IsEmpty()) {
-    args->ThrowError("icon must be set");
+    args->ThrowError("Must specify non-empty 'icon' option");
     return;
   }
 
@@ -1337,7 +1337,7 @@ void WebContents::StartDrag(const mate::Dictionary& item,
         base::MessageLoop::current());
     DragFileItems(files, icon->image(), web_contents()->GetNativeView());
   } else {
-    args->ThrowError("There is nothing to drag");
+    args->ThrowError("Must specify either 'file' or 'files' option");
   }
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1327,9 +1327,17 @@ void WebContents::StartDrag(const mate::Dictionary& item,
 
   // Error checking.
   if (icon.IsEmpty()) {
+    args->ThrowError("Must specify 'icon' option");
+    return;
+  }
+
+#if defined(OS_MACOSX)
+  // NSWindow.dragImage requires a non-empty NSImage
+  if (icon->image().IsEmpty()) {
     args->ThrowError("Must specify non-empty 'icon' option");
     return;
   }
+#endif
 
   // Start dragging.
   if (!files.empty()) {

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1132,8 +1132,9 @@ End subscribing for frame presentation events.
 #### `contents.startDrag(item)`
 
 * `item` Object
-  * `file` String
-  * `icon` [NativeImage](native-image.md)
+  * `file` String - The path to the file being dragged.
+  * `icon` [NativeImage](native-image.md) - The image must be non-empty on
+    macOS.
 
 Sets the `item` as dragging item for current drag-drop operation, `file` is the
 absolute path of the file to be dragged, and `icon` is the image showing under

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1663,35 +1663,33 @@ describe('BrowserWindow module', function () {
   })
 
   describe('dev tool extensions', function () {
-    let showPanelIntervalId
+    let showPanelTimeoutId
 
     const showLastDevToolsPanel = () => {
       w.webContents.once('devtools-opened', function () {
-        clearInterval(showPanelIntervalId)
-
-        showPanelIntervalId = setInterval(function () {
+        const show = function () {
           if (w == null || w.isDestroyed()) {
-            clearInterval(showLastDevToolsPanel)
             return
           }
-
           const {devToolsWebContents} = w
           if (devToolsWebContents == null || devToolsWebContents.isDestroyed()) {
-            clearInterval(showLastDevToolsPanel)
             return
           }
 
-          var showLastPanel = function () {
-            var lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
+          const showLastPanel = function () {
+            const lastPanelId = WebInspector.inspectorView._tabbedPane._tabs.peekLast().id
             WebInspector.inspectorView.showPanel(lastPanelId)
           }
-          devToolsWebContents.executeJavaScript(`(${showLastPanel})()`)
-        }, 100)
+          devToolsWebContents.executeJavaScript(`(${showLastPanel})()`, false, () => {
+            showPanelTimeoutId = setTimeout(show, 100)
+          })
+        }
+        showPanelTimeoutId = setTimeout(show, 100)
       })
     }
 
     afterEach(function () {
-      clearInterval(showPanelIntervalId)
+      clearTimeout(showPanelTimeoutId)
     })
 
     describe('BrowserWindow.addDevToolsExtension', function () {

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -293,12 +293,14 @@ describe('webContents module', function () {
       }, /Must specify either 'file' or 'files' option/)
 
       assert.throws(() => {
-        w.webContents.startDrag({file: __filename, icon: __filename})
-      }, /Must specify non-empty 'icon' option/)
-
-      assert.throws(() => {
         w.webContents.startDrag({file: __filename})
-      }, /Must specify non-empty 'icon' option/)
+      }, /Must specify 'icon' option/)
+
+      if (process.platform === 'darwin') {
+        assert.throws(() => {
+          w.webContents.startDrag({file: __filename, icon: __filename})
+        }, /Must specify non-empty 'icon' option/)
+      }
     })
   })
 })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -285,4 +285,20 @@ describe('webContents module', function () {
     })
     w.webContents.inspectElement(10, 10)
   })
+
+  describe('startDrag({file, icon})', () => {
+    it('throws errors for a missing file or a missing/empty icon', () => {
+      assert.throws(() => {
+        w.webContents.startDrag({icon: path.join(__dirname, 'fixtures', 'assets', 'logo.png')})
+      }, /Must specify either 'file' or 'files' option/)
+
+      assert.throws(() => {
+        w.webContents.startDrag({file: __filename, icon: __filename})
+      }, /Must specify non-empty 'icon' option/)
+
+      assert.throws(() => {
+        w.webContents.startDrag({file: __filename})
+      }, /Must specify non-empty 'icon' option/)
+    })
+  })
 })


### PR DESCRIPTION
Currently `webContents.startDrag` will crash on macOS if called with an empty image.

This pull request updates `webContents.startDrag` to check for a non-empty image on macOS and raise an error when they happen.

Noticed this while trying to reproduce #8445

Crash report:


```
Crashing on exception: CALayer position contains NaN: [nan nan]

Application Specific Backtrace 1:
0   CoreFoundation                      0x00007fffc2d1de7b __exceptionPreprocess + 171
1   libobjc.A.dylib                     0x00007fffd7907cad objc_exception_throw + 48
2   CoreFoundation                      0x00007fffc2d9c99d +[NSException raise:format:] + 205
3   QuartzCore                          0x00007fffc8ad7f48 _ZN2CA5Layer12set_positionERKNS_4Vec2IdEEb + 152
4   QuartzCore                          0x00007fffc8ad80bd -[CALayer setPosition:] + 44
5   HIToolbox                           0x00007fffc2260f95 _ZL20UpdateLayerPositionsP14OpaqueCoreDrag + 662
6   HIToolbox                           0x00007fffc248f752 _Z29UnflockAnimationTimerCallbackP16__CFRunLoopTimerPv + 784
7   CoreFoundation                      0x00007fffc2c9d244 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
8   CoreFoundation                      0x00007fffc2c9cecf __CFRunLoopDoTimer + 1071
9   CoreFoundation                      0x00007fffc2c9ca2a __CFRunLoopDoTimers + 298
10  CoreFoundation                      0x00007fffc2c943e1 __CFRunLoopRun + 2065
11  CoreFoundation                      0x00007fffc2c93974 CFRunLoopRunSpecific + 420
12  CoreFoundation                      0x00007fffc2cf5da5 CFMessagePortSendRequest + 965
13  HIServices                          0x00007fffc19a0b56 SendDragIPCMessage + 540
14  HIServices                          0x00007fffc199e011 CoreDragMessageHandler + 1321
15  CoreFoundation                      0x00007fffc2d34486 __CFMessagePortPerform + 598
16  CoreFoundation                      0x00007fffc2c9c6c9 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 41
17  CoreFoundation                      0x00007fffc2c9c641 __CFRunLoopDoSource1 + 465
18  CoreFoundation                      0x00007fffc2c94525 __CFRunLoopRun + 2389
19  CoreFoundation                      0x00007fffc2c93974 CFRunLoopRunSpecific + 420
20  HIToolbox                           0x00007fffc221fa5c RunCurrentEventLoopInMode + 240
21  HIToolbox                           0x00007fffc221f891 ReceiveNextEventCommon + 432
22  HIToolbox                           0x00007fffc221f6c6 _BlockUntilNextEventMatchingListInModeWithFilter + 71
23  AppKit                              0x00007fffc07c55b4 _DPSNextEvent + 1120
24  AppKit                              0x00007fffc0f3fd6b -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 2789
25  AppKit                              0x00007fffc0a66012 NSCoreDragCGEventBlockingProc + 175
26  HIServices                          0x00007fffc1997ccc SampleMouseAndKeyboard + 145
27  HIServices                          0x00007fffc19979b1 DragInApplication + 53
28  HIServices                          0x00007fffc199696c CoreDragStartDragging + 486
29  AppKit                              0x00007fffc0a630cc -[NSCoreDragManager _dragUntilMouseUp:accepted:] + 1048
30  AppKit                              0x00007fffc0a60056 -[NSCoreDragManager dragImage:fromWindow:at:offset:event:pasteboard:source:slideBack:] + 1193
31  AppKit                              0x00007fffc0a5fb9c -[NSWindow(NSDrag) dragImage:at:offset:event:pasteboard:source:slideBack:] + 135
32  Electron Framework                  0x00000001044ba92e _ZN4atom13DragFileItemsERKNSt3__16vectorIN4base8FilePathENS0_9allocatorIS3_EEEERKN3gfx5ImageEP6NSView + 510
```

```
Thread 0 Crashed:: CrBrowserMain  Dispatch queue: com.apple.main-thread
0   libbase.dylib                 	0x0000000111474df1 base::debug::BreakDebugger() + 17
1   libbase.dylib                 	0x000000011149792f logging::LogMessage::~LogMessage() + 1391
2   libgfx.dylib                  	0x0000000115f5b957 gfx::Image::ToNSImage() const + 71
3   com.github.electron.framework 	0x000000010ef447a0 atom::DragFileItems(std::__1::vector<base::FilePath, std::__1::allocator<base::FilePath> > const&, gfx::Image const&, NSView*) + 384 (drag_util_mac.mm:49)
4   com.github.electron.framework 	0x000000010edfc6f5 atom::api::WebContents::StartDrag(mate::Dictionary const&, mate::Arguments*) + 2341 (atom_api_web_contents.cc:1338)
```