### PR TITLE
Support custom launch path in app.setLoginItemSettings

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -12,7 +12,6 @@
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
-#include "atom/browser/browser.h"
 #include "atom/browser/login_handler.h"
 #include "atom/browser/relauncher.h"
 #include "atom/common/atom_command_line.h"
@@ -298,6 +297,8 @@ struct Converter<Browser::LoginItemSettings> {
 
     dict.Get("openAtLogin", &(out->open_at_login));
     dict.Get("openAsHidden", &(out->open_as_hidden));
+    dict.Get("path", &(out->path));
+    dict.Get("args", &(out->args));
     return true;
   }
 
@@ -746,6 +747,12 @@ bool App::IsAccessibilitySupportEnabled() {
   return ax_state->IsAccessibleBrowser();
 }
 
+Browser::LoginItemSettings App::GetLoginItemSettings(mate::Arguments* args) {
+  Browser::LoginItemSettings options;
+  args->GetNext(&options);
+  return Browser::Get()->GetLoginItemSettings(options);
+}
+
 #if defined(USE_NSS_CERTS)
 void App::ImportCertificate(
     const base::DictionaryValue& options,
@@ -867,8 +874,7 @@ void App::BuildPrototype(
                  base::Bind(&Browser::RemoveAsDefaultProtocolClient, browser))
       .SetMethod("setBadgeCount", base::Bind(&Browser::SetBadgeCount, browser))
       .SetMethod("getBadgeCount", base::Bind(&Browser::GetBadgeCount, browser))
-      .SetMethod("getLoginItemSettings",
-                 base::Bind(&Browser::GetLoginItemSettings, browser))
+      .SetMethod("getLoginItemSettings", &App::GetLoginItemSettings)
       .SetMethod("setLoginItemSettings",
                  base::Bind(&Browser::SetLoginItemSettings, browser))
 #if defined(OS_MACOSX)

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -10,6 +10,7 @@
 
 #include "atom/browser/api/event_emitter.h"
 #include "atom/browser/atom_browser_client.h"
+#include "atom/browser/browser.h"
 #include "atom/browser/browser_observer.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "chrome/browser/process_singleton.h"
@@ -123,6 +124,7 @@ class App : public AtomBrowserClient::Delegate,
   bool Relaunch(mate::Arguments* args);
   void DisableHardwareAcceleration(mate::Arguments* args);
   bool IsAccessibilitySupportEnabled();
+  Browser::LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -98,9 +98,11 @@ class Browser : public WindowListObserver {
     bool restore_state = false;
     bool opened_at_login = false;
     bool opened_as_hidden = false;
+    base::string16 path;
+    std::vector<base::string16> args;
   };
-  void SetLoginItemSettings(LoginItemSettings settings, mate::Arguments* args);
-  LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
+  void SetLoginItemSettings(LoginItemSettings settings);
+  LoginItemSettings GetLoginItemSettings(LoginItemSettings options);
 
 #if defined(OS_MACOSX)
   // Hide the application.

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -98,9 +98,8 @@ class Browser : public WindowListObserver {
     bool restore_state = false;
     bool opened_at_login = false;
     bool opened_as_hidden = false;
-    mate::Arguments* start_args;
   };
-  void SetLoginItemSettings(LoginItemSettings settings);
+  void SetLoginItemSettings(LoginItemSettings settings, mate::Arguments* start_args);
   LoginItemSettings GetLoginItemSettings();
 
 #if defined(OS_MACOSX)

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -99,8 +99,8 @@ class Browser : public WindowListObserver {
     bool opened_at_login = false;
     bool opened_as_hidden = false;
   };
-  void SetLoginItemSettings(LoginItemSettings settings, mate::Arguments* start_args);
-  LoginItemSettings GetLoginItemSettings();
+  void SetLoginItemSettings(LoginItemSettings settings, mate::Arguments* args);
+  LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
 
 #if defined(OS_MACOSX)
   // Hide the application.

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -98,6 +98,7 @@ class Browser : public WindowListObserver {
     bool restore_state = false;
     bool opened_at_login = false;
     bool opened_as_hidden = false;
+    mate::Arguments* start_args;
   };
   void SetLoginItemSettings(LoginItemSettings settings);
   LoginItemSettings GetLoginItemSettings();

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -60,12 +60,11 @@ bool Browser::SetBadgeCount(int count) {
   }
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings,
-                                   mate::Arguments* args) {
+void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 }
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings(
-  mate::Arguments* args) {
+    LoginItemSettings options) {
   return LoginItemSettings();
 }
 

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -60,10 +60,12 @@ bool Browser::SetBadgeCount(int count) {
   }
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+void Browser::SetLoginItemSettings(LoginItemSettings settings,
+                                   mate::Arguments* args) {
 }
 
-Browser::LoginItemSettings Browser::GetLoginItemSettings() {
+Browser::LoginItemSettings Browser::GetLoginItemSettings(
+  mate::Arguments* args) {
   return LoginItemSettings();
 }
 

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -152,7 +152,8 @@ bool Browser::ContinueUserActivity(const std::string& type,
   return prevent_default;
 }
 
-Browser::LoginItemSettings Browser::GetLoginItemSettings(mate::Arguments* args) {
+Browser::LoginItemSettings Browser::GetLoginItemSettings(
+    LoginItemSettings options) {
   LoginItemSettings settings;
   settings.open_at_login = base::mac::CheckLoginItemStatus(
       &settings.open_as_hidden);
@@ -162,8 +163,7 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings(mate::Arguments* args) 
   return settings;
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings,
-                                   mate::Arguments* args) {
+void Browser::SetLoginItemSettings(LoginItemSettings settings) {
   if (settings.open_at_login)
     base::mac::AddToLoginItems(settings.open_as_hidden);
   else

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -152,7 +152,7 @@ bool Browser::ContinueUserActivity(const std::string& type,
   return prevent_default;
 }
 
-Browser::LoginItemSettings Browser::GetLoginItemSettings() {
+Browser::LoginItemSettings Browser::GetLoginItemSettings(mate::Arguments* args) {
   LoginItemSettings settings;
   settings.open_at_login = base::mac::CheckLoginItemStatus(
       &settings.open_as_hidden);
@@ -162,7 +162,8 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings() {
   return settings;
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+void Browser::SetLoginItemSettings(LoginItemSettings settings,
+                                   mate::Arguments* args) {
   if (settings.open_at_login)
     base::mac::AddToLoginItems(settings.open_as_hidden);
   else

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -267,7 +267,8 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings,
   }
 }
 
-Browser::LoginItemSettings Browser::GetLoginItemSettings(mate::Arguments* args) {
+Browser::LoginItemSettings Browser::GetLoginItemSettings(
+  mate::Arguments* args) {
   LoginItemSettings settings;
   base::string16 keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
   base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -257,10 +257,32 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
   base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
 
   if (settings.open_at_login) {
-    base::FilePath path;
-    if (PathService::Get(base::FILE_EXE, &path)) {
-      base::string16 exePath(path.value());
-      key.WriteValue(GetAppUserModelID(), exePath.c_str());
+    base::FilePath appDir, execPath;
+    if (PathService::Get(base::DIR_EXE, &appDir) &&
+        PathService::Get(base::FILE_EXE, &execPath)) {
+      base::FilePath updatePath = appDir.Append(
+        FILE_PATH_LITERAL("..\\Update.exe"));
+      base::string16 updateDotExe(updatePath.value());
+      base::string16 appName(execPath.BaseName().value());
+
+      if (GetFileAttributesW(updateDotExe.c_str()) != INVALID_FILE_ATTRIBUTES) {
+        base::string16* args = base::StringPrintf(L" --processStart \"%s\"",
+                                                  appName.c_str());
+
+        std::vector<base::string16> startArgs;
+        if (settings.start_args->GetNext(&startArgs) && !startArgs.empty()) {
+          args += base::StringPrintf(L" --process-start-args \"%s\"",
+                                     base::JoinString(startArgs, L" "));
+        }
+
+        base::string16* regEntry = base::StringPrintf(L"\"%s\" %s \"%%1\"",
+                                                      updateDotExe.c_str(),
+                                                      args.c_str());
+
+        key.WriteValue(GetAppUserModelID(), regEntry.c_str());
+      } else {
+        // TODO(charliehess): No Update.exe found, Windows Store build?
+      }
     }
   } else {
     key.DeleteValue(GetAppUserModelID());
@@ -283,7 +305,6 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings() {
 
   return settings;
 }
-
 
 PCWSTR Browser::GetAppUserModelID() {
   if (app_user_model_id_.empty()) {

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -54,8 +54,8 @@ bool GetProcessExecPath(base::string16* exe) {
 }
 
 bool GetProtocolLaunchPath(mate::Arguments* args, base::string16* exe) {
-  if (!args->GetNext(exe)) {
-    GetProcessExecPath(exe);
+  if (!args->GetNext(exe) && !GetProcessExecPath(exe)) {
+    return false;
   }
 
   // Read in optional args arg
@@ -71,8 +71,8 @@ bool GetProtocolLaunchPath(mate::Arguments* args, base::string16* exe) {
 
 bool FormatCommandLineString(base::string16* exe,
                              const std::vector<base::string16>& launch_args) {
-  if (exe->empty()) {
-    GetProcessExecPath(exe);
+  if (exe->empty() && !GetProcessExecPath(exe)) {
+    return false;
   }
 
   if (!launch_args.empty()) {
@@ -278,9 +278,9 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 
   if (settings.open_at_login) {
     base::string16 exe = settings.path;
-    if (!FormatCommandLineString(&exe, settings.args)) return;
-
-    key.WriteValue(GetAppUserModelID(), exe.c_str());
+    if (FormatCommandLineString(&exe, settings.args)) {
+      key.WriteValue(GetAppUserModelID(), exe.c_str());
+    }
   } else {
     key.DeleteValue(GetAppUserModelID());
   }

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -758,15 +758,16 @@ Returns `Integer` - The current value displayed in the counter badge.
 
 Returns `Boolean` - Whether the current desktop environment is Unity launcher.
 
-### `app.getLoginItemSettings([path, args])` _macOS_ _Windows_
+### `app.getLoginItemSettings([options])` _macOS_ _Windows_
 
-* `path` String (optional) _Windows_ - The executable path to compare against.
-  Defaults to `process.execPath`.
-* `args` String[] (optional) _Windows_ - The command-line arguments to compare
-  against. Defaults to an empty array.
+* `options` Object (optional)
+  * `path` String (optional) _Windows_ - The executable path to compare against.
+    Defaults to `process.execPath`.
+  * `args` String[] (optional) _Windows_ - The command-line arguments to compare
+    against. Defaults to an empty array.
 
-If you provided arguments to `app.setLoginItemSettings` you need to pass the
-same arguments here for `openAtLogin` to be set correctly.
+If you provided `path` and `argg` potions to `app.setLoginItemSettings` then you
+need to pass the same arguments here for `openAtLogin` to be set correctly.
 
 Returns `Object`:
 
@@ -783,8 +784,7 @@ Returns `Object`:
   app should restore the windows that were open the last time the app was
   closed. This setting is only supported on macOS.
 
-**Note:** This API has no effect on
-[MAS builds][mas-builds].
+**Note:** This API has no effect on [MAS builds][mas-builds].
 
 ### `app.setLoginItemSettings(settings[, path, args])` _macOS_ _Windows_
 
@@ -796,15 +796,16 @@ Returns `Object`:
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is only supported on
     macOS.
-* `path` String (optional) _Windows_ - The executable to launch at login.
-  Defaults to `process.execPath`.
-* `args` String[] (optional) _Windows_ - The command-line arguments to pass to the
-  executable. Defaults to an empty array. Take care to wrap paths in quotes.
+  * `path` String (optional) _Windows_ - The executable to launch at login.
+    Defaults to `process.execPath`.
+  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to
+    the executable. Defaults to an empty array. Take care to wrap paths in
+    quotes.
 
 Set the app's login item settings.
 
 To work with Electron's `autoUpdater` on Windows, which uses [Squirrel](Squirrel-Windows),
-you'll want to set the launch path to Update.exe, and pass arguments that specify your 
+you'll want to set the launch path to Update.exe, and pass arguments that specify your
 application name. For example:
 
 ``` javascript
@@ -818,8 +819,7 @@ app.setLoginItemSettings({openAtLogin: true}, updateExe, [
 ])
 ```
 
-**Note:** This API has no effect on
-[MAS builds][mas-builds].
+**Note:** This API has no effect on [MAS builds][mas-builds].
 
 ### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -765,6 +765,9 @@ Returns `Boolean` - Whether the current desktop environment is Unity launcher.
 * `args` String[] (optional) _Windows_ - The command-line arguments to compare
   against. Defaults to an empty array.
 
+If you provided arguments to `app.setLoginItemSettings` you need to pass the
+same arguments here for `openAtLogin` to be set correctly.
+
 Returns `Object`:
 
 * `openAtLogin` Boolean - `true` if the app is set to open at login.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -813,10 +813,14 @@ const appFolder = path.dirname(process.execPath)
 const updateExe = path.resolve(appFolder, '..', 'Update.exe')
 const exeName = path.basename(process.execPath)
 
-app.setLoginItemSettings({openAtLogin: true}, updateExe, [
-  '--processStart', `"${exeName}"`,
-  '--process-start-args', `"--hidden"`
-])
+app.setLoginItemSettings({
+  openAtLogin: true,
+  path: updateExe,
+  args: [
+    '--processStart', `"${exeName}"`,
+    '--process-start-args', `"--hidden"`
+  ]
+})
 ```
 
 **Note:** This API has no effect on [MAS builds][mas-builds].

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -766,7 +766,7 @@ Returns `Boolean` - Whether the current desktop environment is Unity launcher.
   * `args` String[] (optional) _Windows_ - The command-line arguments to compare
     against. Defaults to an empty array.
 
-If you provided `path` and `argg` potions to `app.setLoginItemSettings` then you
+If you provided `path` and `args` options to `app.setLoginItemSettings` then you
 need to pass the same arguments here for `openAtLogin` to be set correctly.
 
 Returns `Object`:

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -758,7 +758,12 @@ Returns `Integer` - The current value displayed in the counter badge.
 
 Returns `Boolean` - Whether the current desktop environment is Unity launcher.
 
-### `app.getLoginItemSettings()` _macOS_ _Windows_
+### `app.getLoginItemSettings([path, args])` _macOS_ _Windows_
+
+* `path` String (optional) _Windows_ - The executable path to compare against.
+  Defaults to `process.execPath`.
+* `args` String[] (optional) _Windows_ - The command-line arguments to compare
+  against. Defaults to an empty array.
 
 Returns `Object`:
 
@@ -778,7 +783,7 @@ Returns `Object`:
 **Note:** This API has no effect on
 [MAS builds][mas-builds].
 
-### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
+### `app.setLoginItemSettings(settings[, path, args])` _macOS_ _Windows_
 
 * `settings` Object
   * `openAtLogin` Boolean (optional) - `true` to open the app at login, `false` to remove
@@ -788,8 +793,27 @@ Returns `Object`:
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is only supported on
     macOS.
+* `path` String (optional) _Windows_ - The executable to launch at login.
+  Defaults to `process.execPath`.
+* `args` String[] (optional) _Windows_ - The command-line arguments to pass to the
+  executable. Defaults to an empty array. Take care to wrap paths in quotes.
 
 Set the app's login item settings.
+
+To work with Electron's `autoUpdater` on Windows, which uses [Squirrel](Squirrel-Windows),
+you'll want to set the launch path to Update.exe, and pass arguments that specify your 
+application name. For example:
+
+``` javascript
+const appFolder = path.dirname(process.execPath)
+const updateExe = path.resolve(appFolder, '..', 'Update.exe')
+const exeName = path.basename(process.execPath)
+
+app.setLoginItemSettings({openAtLogin: true}, updateExe, [
+  '--processStart', `"${exeName}"`,
+  '--process-start-args', `"--hidden"`
+])
+```
 
 **Note:** This API has no effect on
 [MAS builds][mas-builds].
@@ -904,5 +928,6 @@ Sets the `image` associated with this dock icon.
 [activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
 [unity-requirement]: ../tutorial/desktop-environment-integration.md#unity-launcher-shortcuts-linux
 [mas-builds]: ../tutorial/mac-app-store-submission-guide.md
+[Squirrel-Windows]: https://github.com/Squirrel/Squirrel.Windows
 [JumpListBeginListMSDN]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378398(v=vs.85).aspx
 [about-panel-options]: https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -360,7 +360,7 @@ describe('app module', function () {
       const processStartArgs = [
         '--processStart', `"${exeName}"`,
         '--process-start-args', `"--hidden"`
-      ];
+      ]
 
       app.setLoginItemSettings({openAtLogin: true}, updateExe, processStartArgs)
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -357,18 +357,15 @@ describe('app module', function () {
       const updateExe = path.resolve(appFolder, '..', 'Update.exe')
       const exeName = path.basename(process.execPath)
 
-      app.setLoginItemSettings({openAtLogin: true}, updateExe, [
+      const processStartArgs = [
         '--processStart', `"${exeName}"`,
         '--process-start-args', `"--hidden"`
-      ])
+      ];
 
-      assert.deepEqual(app.getLoginItemSettings(), {
-        openAtLogin: true,
-        openAsHidden: false,
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false
-      })
+      app.setLoginItemSettings({openAtLogin: true}, updateExe, processStartArgs)
+
+      assert(!app.getLoginItemSettings().openAtLogin)
+      assert(app.getLoginItemSettings(updateExe, processStartArgs))
     })
   })
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -349,6 +349,27 @@ describe('app module', function () {
         restoreState: false
       })
     })
+
+    it('allows you to pass a custom executable and arguments', () => {
+      if (process.platform !== 'win32') return
+
+      const appFolder = path.dirname(process.execPath)
+      const updateExe = path.resolve(appFolder, '..', 'Update.exe')
+      const exeName = path.basename(process.execPath)
+
+      app.setLoginItemSettings({openAtLogin: true}, updateExe, [
+        '--processStart', `"${exeName}"`,
+        '--process-start-args', `"--hidden"`
+      ])
+
+      assert.deepEqual(app.getLoginItemSettings(), {
+        openAtLogin: true,
+        openAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
+        restoreState: false
+      })
+    })
   })
 
   describe('isAccessibilitySupportEnabled API', function () {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -362,10 +362,10 @@ describe('app module', function () {
         '--process-start-args', `"--hidden"`
       ]
 
-      app.setLoginItemSettings({openAtLogin: true}, updateExe, processStartArgs)
+      app.setLoginItemSettings({openAtLogin: true, path: updateExe, args: processStartArgs})
 
-      assert(!app.getLoginItemSettings().openAtLogin)
-      assert(app.getLoginItemSettings(updateExe, processStartArgs))
+      assert.equal(app.getLoginItemSettings().openAtLogin, false)
+      assert.equal(app.getLoginItemSettings({path: updateExe, args: processStartArgs}).openAtLogin, true)
     })
   })
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -313,12 +313,20 @@ describe('app module', function () {
   describe('app.get/setLoginItemSettings API', function () {
     if (process.platform === 'linux') return
 
+    const updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe')
+    const processStartArgs = [
+      '--processStart', `"${path.basename(process.execPath)}"`,
+      '--process-start-args', `"--hidden"`
+    ]
+
     beforeEach(function () {
       app.setLoginItemSettings({openAtLogin: false})
+      app.setLoginItemSettings({openAtLogin: false, path: updateExe, args: processStartArgs})
     })
 
     afterEach(function () {
       app.setLoginItemSettings({openAtLogin: false})
+      app.setLoginItemSettings({openAtLogin: false, path: updateExe, args: processStartArgs})
     })
 
     it('returns the login item status of the app', function () {
@@ -352,15 +360,6 @@ describe('app module', function () {
 
     it('allows you to pass a custom executable and arguments', () => {
       if (process.platform !== 'win32') return
-
-      const appFolder = path.dirname(process.execPath)
-      const updateExe = path.resolve(appFolder, '..', 'Update.exe')
-      const exeName = path.basename(process.execPath)
-
-      const processStartArgs = [
-        '--processStart', `"${exeName}"`,
-        '--process-start-args', `"--hidden"`
-      ]
 
       app.setLoginItemSettings({openAtLogin: true, path: updateExe, args: processStartArgs})
 


### PR DESCRIPTION
This PR fixes #6901. It leverages the fine work by @MarshallOfSound in https://github.com/electron/electron/pull/6858 to add support for custom executables and command-line arguments in `app.setLoginItemSettings`. This allows it to properly support Squirrel.Windows, which needs to point to Update.exe instead of `process.execPath`. I've updated the documentation to include an example.