### PR TITLE
Use helper function to show last dev tools panel

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1667,6 +1667,8 @@ describe('BrowserWindow module', function () {
 
     const showLastDevToolsPanel = () => {
       w.webContents.once('devtools-opened', function () {
+        clearInterval(showPanelIntervalId)
+
         showPanelIntervalId = setInterval(function () {
           if (w == null || w.isDestroyed())  {
             clearInterval(showLastDevToolsPanel)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1670,7 +1670,7 @@ describe('BrowserWindow module', function () {
         clearInterval(showPanelIntervalId)
 
         showPanelIntervalId = setInterval(function () {
-          if (w == null || w.isDestroyed())  {
+          if (w == null || w.isDestroyed()) {
             clearInterval(showLastDevToolsPanel)
             return
           }


### PR DESCRIPTION
We are still seeing an occasional CI failure with a missing remote object error.

This pull request consolidates the helper function used to show the last dev tools panel to try and narrow down when/where/why this is happening.

Saw this yesterday on AppVeyor, https://ci.appveyor.com/project/Atom/electron/build/3789/job/c4r3s64i6o9bp179:

```
not ok 123 BrowserWindow module dev tool extensions works when used with partitions
  Error: Cannot call function 'executeJavaScript' on missing remote object 411
  Error: Cannot call function 'executeJavaScript' on missing remote object 411
      at throwRPCError (C:\projects\electron\out\D\resources\electron.asar\browser\rpc-server.js:145:17)
      at EventEmitter.<anonymous> (C:\projects\electron\out\D\resources\electron.asar\browser\rpc-server.js:362:7)
      at emitMany (events.js:127:13)
      at EventEmitter.emit (events.js:201:7)
      at WebContents.<anonymous> (C:\projects\electron\out\D\resources\electron.asar\browser\api\web-contents.js:232:13)
      at emitTwo (events.js:106:13)
      at WebContents.emit (events.js:191:7)
      at metaToValue (C:\projects\electron\out\D\resources\electron.asar\renderer\api\remote.js:217:13)
      at Object.remoteMemberFunction (C:\projects\electron\out\D\resources\electron.asar\renderer\api\remote.js:113:18)
      at C:\projects\electron\spec\api-browser-window-spec.js:1772:35
```

