### PR TITLE
webContents: manage zoom changes on the browser side with HostZoomMap

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -49,6 +49,7 @@
 #include "content/browser/web_contents/web_contents_impl.h"
 #include "content/common/view_messages.h"
 #include "content/public/browser/favicon_status.h"
+#include "content/public/browser/host_zoom_map.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/navigation_details.h"
 #include "content/public/browser/navigation_entry.h"
@@ -1498,6 +1499,24 @@ void WebContents::Invalidate() {
     osr_rwhv->Invalidate();
 }
 
+void WebContents::SetZoomLevel(double level) {
+  content::HostZoomMap::SetZoomLevel(web_contents(), level);
+}
+
+double WebContents::GetZoomLevel() {
+  return content::HostZoomMap::GetZoomLevel(web_contents());
+}
+
+void WebContents::SetZoomFactor(double factor) {
+  auto level = content::ZoomFactorToZoomLevel(factor);
+  SetZoomLevel(level);
+}
+
+double WebContents::GetZoomFactor() {
+  auto level = GetZoomLevel();
+  return content::ZoomLevelToZoomFactor(level);
+}
+
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
   WebContentsPreferences* web_preferences =
       WebContentsPreferences::FromWebContents(web_contents());
@@ -1626,6 +1645,10 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setFrameRate", &WebContents::SetFrameRate)
       .SetMethod("getFrameRate", &WebContents::GetFrameRate)
       .SetMethod("invalidate", &WebContents::Invalidate)
+      .SetMethod("setZoomLevel", &WebContents::SetZoomLevel)
+      .SetMethod("getZoomLevel", &WebContents::GetZoomLevel)
+      .SetMethod("setZoomFactor", &WebContents::SetZoomFactor)
+      .SetMethod("getZoomFactor", &WebContents::GetZoomFactor)
       .SetMethod("getType", &WebContents::GetType)
       .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)
       .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -819,6 +819,10 @@ bool WebContents::OnMessageReceived(const IPC::Message& message) {
     IPC_MESSAGE_HANDLER(AtomViewHostMsg_Message, OnRendererMessage)
     IPC_MESSAGE_HANDLER_DELAY_REPLY(AtomViewHostMsg_Message_Sync,
                                     OnRendererMessageSync)
+    IPC_MESSAGE_HANDLER_DELAY_REPLY(AtomViewHostMsg_SetTemporaryZoomLevel,
+                                    OnSetTemporaryZoomLevel)
+    IPC_MESSAGE_HANDLER_DELAY_REPLY(AtomViewHostMsg_GetZoomLevel,
+                                    OnGetZoomLevel)
     IPC_MESSAGE_HANDLER_CODE(ViewHostMsg_SetCursor, OnCursorChange,
       handled = false)
     IPC_MESSAGE_UNHANDLED(handled = false)
@@ -1521,6 +1525,19 @@ void WebContents::SetZoomFactor(double factor) {
 double WebContents::GetZoomFactor() {
   auto level = GetZoomLevel();
   return content::ZoomLevelToZoomFactor(level);
+}
+
+void WebContents::OnSetTemporaryZoomLevel(double level,
+                                          IPC::Message* reply_msg) {
+  zoom_controller_->SetTemporaryZoomLevel(level);
+  double new_level = zoom_controller_->GetTemporaryZoomLevel();
+  AtomViewHostMsg_SetTemporaryZoomLevel::WriteReplyParams(reply_msg, new_level);
+  Send(reply_msg);
+}
+
+void WebContents::OnGetZoomLevel(IPC::Message* reply_msg) {
+  AtomViewHostMsg_GetZoomLevel::WriteReplyParams(reply_msg, GetZoomLevel());
+  Send(reply_msg);
 }
 
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -248,8 +248,8 @@ WebContents::WebContents(v8::Isolate* isolate,
                          content::WebContents* web_contents,
                          Type type)
     : content::WebContentsObserver(web_contents),
-      zoom_controller_(nullptr),
       embedder_(nullptr),
+      zoom_controller_(nullptr),
       type_(type),
       request_id_(0),
       background_throttling_(true),
@@ -267,8 +267,8 @@ WebContents::WebContents(v8::Isolate* isolate,
 }
 
 WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
-    : zoom_controller_(nullptr),
-      embedder_(nullptr),
+    : embedder_(nullptr),
+      zoom_controller_(nullptr),
       type_(BROWSER_WINDOW),
       request_id_(0),
       background_throttling_(true),
@@ -354,7 +354,7 @@ void WebContents::InitWithSessionAndOptions(v8::Isolate* isolate,
   WebContentsZoomController::CreateForWebContents(web_contents);
   zoom_controller_ = WebContentsZoomController::FromWebContents(web_contents);
   double zoom_factor;
-  if (options.Get("zoomFactor", &zoom_factor))
+  if (options.Get(options::kZoomFactor, &zoom_factor))
     zoom_controller_->SetDefaultZoomFactor(zoom_factor);
 
   web_contents->SetUserAgentOverride(GetBrowserContext()->GetUserAgent());

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1530,7 +1530,7 @@ double WebContents::GetZoomFactor() {
 void WebContents::OnSetTemporaryZoomLevel(double level,
                                           IPC::Message* reply_msg) {
   zoom_controller_->SetTemporaryZoomLevel(level);
-  double new_level = zoom_controller_->GetTemporaryZoomLevel();
+  double new_level = zoom_controller_->GetZoomLevel();
   AtomViewHostMsg_SetTemporaryZoomLevel::WriteReplyParams(reply_msg, new_level);
   Send(reply_msg);
 }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -39,6 +39,7 @@ namespace atom {
 
 struct SetSizeParams;
 class AtomBrowserContext;
+class WebContentsZoomController;
 class WebViewGuestDelegate;
 
 namespace api {
@@ -206,6 +207,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);
   v8::Local<v8::Value> Debugger(v8::Isolate* isolate);
 
+  WebContentsZoomController* GetZoomController() { return zoom_controller_; }
+
  protected:
   WebContents(v8::Isolate* isolate,
               content::WebContents* web_contents,
@@ -349,19 +352,17 @@ class WebContents : public mate::TrackableObject<WebContents>,
                              const base::ListValue& args,
                              IPC::Message* message);
 
-  // Called after committing a navigation, to set the zoom
-  // factor.
-  void SetZoomFactorIfNeeded(const GURL& url);
-
   v8::Global<v8::Value> session_;
   v8::Global<v8::Value> devtools_web_contents_;
   v8::Global<v8::Value> debugger_;
 
   std::unique_ptr<WebViewGuestDelegate> guest_delegate_;
-  std::map<std::string, double> host_zoom_factor_;
 
   // The host webcontents that may contain this webcontents.
   WebContents* embedder_;
+
+  // The zoom controller for this webContents.
+  WebContentsZoomController* zoom_controller_;
 
   // The type of current WebContents.
   Type type_;
@@ -374,9 +375,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether to enable devtools.
   bool enable_devtools_;
-
-  // Initial zoom factor.
-  double zoom_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -349,11 +349,16 @@ class WebContents : public mate::TrackableObject<WebContents>,
                              const base::ListValue& args,
                              IPC::Message* message);
 
+  // Called after committing a navigation, to set the zoom
+  // factor.
+  void SetZoomFactorIfNeeded(const GURL& url);
+
   v8::Global<v8::Value> session_;
   v8::Global<v8::Value> devtools_web_contents_;
   v8::Global<v8::Value> debugger_;
 
   std::unique_ptr<WebViewGuestDelegate> guest_delegate_;
+  std::map<std::string, double> host_zoom_factor_;
 
   // The host webcontents that may contain this webcontents.
   WebContents* embedder_;
@@ -369,6 +374,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether to enable devtools.
   bool enable_devtools_;
+
+  // Initial zoom factor.
+  double zoom_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -174,6 +174,12 @@ class WebContents : public mate::TrackableObject<WebContents>,
   int GetFrameRate() const;
   void Invalidate();
 
+  // Methods for zoom handling.
+  void SetZoomLevel(double level);
+  double GetZoomLevel();
+  void SetZoomFactor(double factor);
+  double GetZoomFactor();
+
   // Callback triggered on permission response.
   void OnEnterFullscreenModeForTab(content::WebContents* source,
                                    const GURL& origin,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -352,6 +352,14 @@ class WebContents : public mate::TrackableObject<WebContents>,
                              const base::ListValue& args,
                              IPC::Message* message);
 
+  // Called when received a synchronous message from renderer to
+  // set temporary zoom level.
+  void OnSetTemporaryZoomLevel(double level, IPC::Message* reply_msg);
+
+  // Called when received a synchronous message from renderer to
+  // get the zoom level.
+  void OnGetZoomLevel(IPC::Message* reply_msg);
+
   v8::Global<v8::Value> session_;
   v8::Global<v8::Value> devtools_web_contents_;
   v8::Global<v8::Value> debugger_;

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -8,6 +8,7 @@
 #include "atom/common/native_mate_converters/content_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
+#include "atom/common/options_switches.h"
 #include "content/public/browser/browser_context.h"
 #include "native_mate/dictionary.h"
 
@@ -26,7 +27,7 @@ void AddGuest(int guest_instance_id,
                       guest_web_contents);
 
   double zoom_factor;
-  if (options.GetDouble("zoomFactor", &zoom_factor)) {
+  if (options.GetDouble(atom::options::kZoomFactor, &zoom_factor)) {
     atom::WebContentsZoomController::FromWebContents(guest_web_contents)
         ->SetDefaultZoomFactor(zoom_factor);
   }

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "atom/browser/web_contents_preferences.h"
+#include "atom/browser/web_contents_zoom_controller.h"
 #include "atom/browser/web_view_manager.h"
 #include "atom/common/native_mate_converters/content_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
@@ -23,6 +24,12 @@ void AddGuest(int guest_instance_id,
   if (manager)
     manager->AddGuest(guest_instance_id, element_instance_id, embedder,
                       guest_web_contents);
+
+  double zoom_factor;
+  if (options.GetDouble("zoomFactor", &zoom_factor)) {
+    atom::WebContentsZoomController::FromWebContents(guest_web_contents)
+        ->SetDefaultZoomFactor(zoom_factor);
+  }
 
   WebContentsPreferences::FromWebContents(guest_web_contents)->Merge(options);
 }

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -130,13 +130,6 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   if (web_preferences.GetString(options::kBackgroundColor, &color))
     command_line->AppendSwitchASCII(switches::kBackgroundColor, color);
 
-  // The zoom factor.
-  double zoom_factor = 1.0;
-  if (web_preferences.GetDouble(options::kZoomFactor, &zoom_factor) &&
-      zoom_factor != 1.0)
-    command_line->AppendSwitchASCII(switches::kZoomFactor,
-                                    base::DoubleToString(zoom_factor));
-
   // --guest-instance-id, which is used to identify guest WebContents.
   int guest_instance_id = 0;
   if (web_preferences.GetInteger(options::kGuestInstanceID, &guest_instance_id))

--- a/atom/browser/web_contents_zoom_controller.cc
+++ b/atom/browser/web_contents_zoom_controller.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/web_contents_zoom_controller.h"
+
+#include "content/public/browser/navigation_details.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/common/page_type.h"
+#include "content/public/common/page_zoom.h"
+#include "net/base/url_util.h"
+
+DEFINE_WEB_CONTENTS_USER_DATA_KEY(atom::WebContentsZoomController);
+
+namespace atom {
+
+WebContentsZoomController::WebContentsZoomController(
+    content::WebContents* web_contents)
+    : content::WebContentsObserver(web_contents) {
+  default_zoom_factor_ = content::kEpsilon;
+  host_zoom_map_ = content::HostZoomMap::GetForWebContents(web_contents);
+  zoom_subscription_ = host_zoom_map_->AddZoomLevelChangedCallback(base::Bind(
+      &WebContentsZoomController::OnZoomLevelChanged, base::Unretained(this)));
+}
+
+WebContentsZoomController::~WebContentsZoomController() {}
+
+void WebContentsZoomController::AddObserver(
+    WebContentsZoomController::Observer* observer) {
+  observers_.AddObserver(observer);
+}
+
+void WebContentsZoomController::RemoveObserver(
+    WebContentsZoomController::Observer* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+void WebContentsZoomController::SetZoomLevel(double level) {
+  if (!web_contents()->GetRenderViewHost()->IsRenderViewLive() ||
+      content::ZoomValuesEqual(GetZoomLevel(), level))
+    return;
+  auto new_zoom_factor = content::ZoomLevelToZoomFactor(level);
+  content::NavigationEntry* entry =
+      web_contents()->GetController().GetLastCommittedEntry();
+  if (entry) {
+    std::string host = net::GetHostOrSpecFromURL(entry->GetURL());
+    // When new zoom level varies from kZoomFactor, it takes preference.
+    if (!content::ZoomValuesEqual(GetDefaultZoomFactor(), new_zoom_factor))
+      host_zoom_factor_[host] = new_zoom_factor;
+    content::HostZoomMap::SetZoomLevel(web_contents(), level);
+    // Notify observers of zoom level changes.
+    FOR_EACH_OBSERVER(WebContentsZoomController::Observer, observers_,
+                      OnZoomLevelChanged(web_contents(), level));
+  }
+}
+
+double WebContentsZoomController::GetZoomLevel() {
+  return content::HostZoomMap::GetZoomLevel(web_contents());
+}
+
+void WebContentsZoomController::SetDefaultZoomFactor(double factor) {
+  default_zoom_factor_ = factor;
+}
+
+double WebContentsZoomController::GetDefaultZoomFactor() {
+  return default_zoom_factor_;
+}
+
+void WebContentsZoomController::DidFinishNavigation(
+    content::NavigationHandle* navigation_handle) {
+  if (!navigation_handle->IsInMainFrame() || !navigation_handle->HasCommitted())
+    return;
+
+  if (navigation_handle->IsErrorPage()) {
+    content::HostZoomMap::SendErrorPageZoomLevelRefresh(web_contents());
+    return;
+  }
+
+  if (!navigation_handle->IsSamePage())
+    SetZoomFactorOnNavigationIfNeeded(navigation_handle->GetURL());
+}
+
+void WebContentsZoomController::WebContentsDestroyed() {
+  observers_.Clear();
+  host_zoom_factor_.clear();
+}
+
+void WebContentsZoomController::RenderFrameHostChanged(
+    content::RenderFrameHost* old_host,
+    content::RenderFrameHost* new_host) {
+  // If our associated HostZoomMap changes, update our event subscription.
+  content::HostZoomMap* new_host_zoom_map =
+      content::HostZoomMap::GetForWebContents(web_contents());
+  if (new_host_zoom_map == host_zoom_map_)
+    return;
+
+  host_zoom_map_ = new_host_zoom_map;
+  zoom_subscription_ = host_zoom_map_->AddZoomLevelChangedCallback(base::Bind(
+      &WebContentsZoomController::OnZoomLevelChanged, base::Unretained(this)));
+}
+
+void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
+    const GURL& url) {
+  if (content::ZoomValuesEqual(GetDefaultZoomFactor(), content::kEpsilon))
+    return;
+
+  // When kZoomFactor is available, it takes precedence over
+  // pref store values but if the host has zoom factor set explicitly
+  // then it takes precendence.
+  // pref store < kZoomFactor < setZoomLevel
+  std::string host = net::GetHostOrSpecFromURL(url);
+  double zoom_factor = GetDefaultZoomFactor();
+  auto it = host_zoom_factor_.find(host);
+  if (it != host_zoom_factor_.end())
+    zoom_factor = it->second;
+  auto level = content::ZoomFactorToZoomLevel(zoom_factor);
+  if (content::ZoomValuesEqual(level, GetZoomLevel()))
+    return;
+
+  SetZoomLevel(level);
+}
+
+void WebContentsZoomController::OnZoomLevelChanged(
+    const content::HostZoomMap::ZoomLevelChange& change) {
+  if (change.mode == content::HostZoomMap::ZOOM_CHANGED_FOR_HOST) {
+    auto it = host_zoom_factor_.find(change.host);
+    if (it == host_zoom_factor_.end())
+      return;
+    host_zoom_factor_.insert(
+        it, std::make_pair(change.host,
+                           content::ZoomLevelToZoomFactor(change.zoom_level)));
+  }
+}
+
+}  // namespace atom

--- a/atom/browser/web_contents_zoom_controller.cc
+++ b/atom/browser/web_contents_zoom_controller.cc
@@ -7,7 +7,6 @@
 #include "content/public/browser/navigation_details.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/navigation_handle.h"
-#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_contents.h"
@@ -31,9 +30,7 @@ WebContentsZoomController::WebContentsZoomController(
       &WebContentsZoomController::OnZoomLevelChanged, base::Unretained(this)));
 }
 
-WebContentsZoomController::~WebContentsZoomController() {
-  embedder_zoom_controller_ = nullptr;
-}
+WebContentsZoomController::~WebContentsZoomController() {}
 
 void WebContentsZoomController::AddObserver(
     WebContentsZoomController::Observer* observer) {
@@ -72,8 +69,8 @@ void WebContentsZoomController::SetZoomLevel(double level) {
       host_zoom_factor_[host] = new_zoom_factor;
     content::HostZoomMap::SetZoomLevel(web_contents(), level);
     // Notify observers of zoom level changes.
-    FOR_EACH_OBSERVER(WebContentsZoomController::Observer, observers_,
-                      OnZoomLevelChanged(web_contents(), level, false));
+    for (Observer& observer : observers_)
+      observer.OnZoomLevelChanged(web_contents(), level, false);
   }
 }
 
@@ -94,8 +91,8 @@ void WebContentsZoomController::SetTemporaryZoomLevel(double level) {
   old_view_id_ = web_contents()->GetRenderViewHost()->GetRoutingID();
   host_zoom_map_->SetTemporaryZoomLevel(old_process_id_, old_view_id_, level);
   // Notify observers of zoom level changes.
-  FOR_EACH_OBSERVER(WebContentsZoomController::Observer, observers_,
-                    OnZoomLevelChanged(web_contents(), level, true));
+  for (Observer& observer : observers_)
+    observer.OnZoomLevelChanged(web_contents(), level, true);
 }
 
 bool WebContentsZoomController::UsesTemporaryZoomLevel() {
@@ -122,6 +119,7 @@ void WebContentsZoomController::DidFinishNavigation(
 void WebContentsZoomController::WebContentsDestroyed() {
   observers_.Clear();
   host_zoom_factor_.clear();
+  embedder_zoom_controller_ = nullptr;
 }
 
 void WebContentsZoomController::RenderFrameHostChanged(

--- a/atom/browser/web_contents_zoom_controller.h
+++ b/atom/browser/web_contents_zoom_controller.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
+#define ATOM_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
+
+#include "content/public/browser/host_zoom_map.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "content/public/browser/web_contents_user_data.h"
+
+namespace atom {
+
+// Manages the zoom changes of WebContents.
+class WebContentsZoomController
+    : public content::WebContentsObserver,
+      public content::WebContentsUserData<WebContentsZoomController> {
+ public:
+  class Observer {
+   public:
+    virtual void OnZoomLevelChanged(content::WebContents* web_contents,
+                                    double level) {}
+
+   protected:
+    virtual ~Observer() {}
+  };
+
+  explicit WebContentsZoomController(content::WebContents* web_contents);
+  ~WebContentsZoomController() override;
+
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
+  // Methods for managing zoom levels.
+  void SetZoomLevel(double level);
+  double GetZoomLevel();
+  void SetDefaultZoomFactor(double factor);
+  double GetDefaultZoomFactor();
+
+ protected:
+  // content::WebContentsObserver:
+  void DidFinishNavigation(content::NavigationHandle* handle) override;
+  void WebContentsDestroyed() override;
+  void RenderFrameHostChanged(content::RenderFrameHost* old_host,
+                              content::RenderFrameHost* new_host) override;
+
+ private:
+  friend class content::WebContentsUserData<WebContentsZoomController>;
+
+  // Called after a navigation has committed to set default zoom factor.
+  void SetZoomFactorOnNavigationIfNeeded(const GURL& url);
+
+  // Track zoom changes of a host in other instances of a partition.
+  void OnZoomLevelChanged(const content::HostZoomMap::ZoomLevelChange& change);
+
+  // kZoomFactor.
+  double default_zoom_factor_;
+
+  // Map between zoom factor and hosts in this webContent.
+  std::map<std::string, double> host_zoom_factor_;
+
+  base::ObserverList<Observer> observers_;
+
+  content::HostZoomMap* host_zoom_map_;
+
+  std::unique_ptr<content::HostZoomMap::Subscription> zoom_subscription_;
+
+  DISALLOW_COPY_AND_ASSIGN(WebContentsZoomController);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_

--- a/atom/browser/web_contents_zoom_controller.h
+++ b/atom/browser/web_contents_zoom_controller.h
@@ -5,6 +5,9 @@
 #ifndef ATOM_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 #define ATOM_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 
+#include <map>
+#include <string>
+
 #include "content/public/browser/host_zoom_map.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
@@ -19,7 +22,8 @@ class WebContentsZoomController
   class Observer {
    public:
     virtual void OnZoomLevelChanged(content::WebContents* web_contents,
-                                    double level) {}
+                                    double level,
+                                    bool is_temporary) {}
 
    protected:
     virtual ~Observer() {}
@@ -36,9 +40,13 @@ class WebContentsZoomController
   double GetZoomLevel();
   void SetDefaultZoomFactor(double factor);
   double GetDefaultZoomFactor();
+  void SetTemporaryZoomLevel(double level);
+  bool UsesTemporaryZoomLevel();
+  double GetTemporaryZoomLevel();
 
  protected:
   // content::WebContentsObserver:
+  void DidStartNavigation(content::NavigationHandle* handle) override;
   void DidFinishNavigation(content::NavigationHandle* handle) override;
   void WebContentsDestroyed() override;
   void RenderFrameHostChanged(content::RenderFrameHost* old_host,
@@ -55,6 +63,7 @@ class WebContentsZoomController
 
   // kZoomFactor.
   double default_zoom_factor_;
+  double temporary_zoom_level_;
 
   // Map between zoom factor and hosts in this webContent.
   std::map<std::string, double> host_zoom_factor_;

--- a/atom/browser/web_contents_zoom_controller.h
+++ b/atom/browser/web_contents_zoom_controller.h
@@ -35,6 +35,8 @@ class WebContentsZoomController
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
+  void SetEmbedderZoomController(WebContentsZoomController* controller);
+
   // Methods for managing zoom levels.
   void SetZoomLevel(double level);
   double GetZoomLevel();
@@ -42,11 +44,9 @@ class WebContentsZoomController
   double GetDefaultZoomFactor();
   void SetTemporaryZoomLevel(double level);
   bool UsesTemporaryZoomLevel();
-  double GetTemporaryZoomLevel();
 
  protected:
   // content::WebContentsObserver:
-  void DidStartNavigation(content::NavigationHandle* handle) override;
   void DidFinishNavigation(content::NavigationHandle* handle) override;
   void WebContentsDestroyed() override;
   void RenderFrameHostChanged(content::RenderFrameHost* old_host,
@@ -64,6 +64,11 @@ class WebContentsZoomController
   // kZoomFactor.
   double default_zoom_factor_;
   double temporary_zoom_level_;
+
+  int old_process_id_;
+  int old_view_id_;
+
+  WebContentsZoomController* embedder_zoom_controller_;
 
   // Map between zoom factor and hosts in this webContent.
   std::map<std::string, double> host_zoom_factor_;

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -23,11 +23,11 @@ const int kDefaultHeight = 300;
 }  // namespace
 
 WebViewGuestDelegate::WebViewGuestDelegate()
-    : guest_host_(nullptr),
+    : embedder_zoom_controller_(nullptr),
+      guest_host_(nullptr),
       auto_size_enabled_(false),
       is_full_page_plugin_(false),
-      api_web_contents_(nullptr) {
-}
+      api_web_contents_(nullptr) {}
 
 WebViewGuestDelegate::~WebViewGuestDelegate() {
 }
@@ -39,9 +39,11 @@ void WebViewGuestDelegate::Initialize(api::WebContents* api_web_contents) {
 
 void WebViewGuestDelegate::Destroy() {
   // Give the content module an opportunity to perform some cleanup.
-  embedder_zoom_controller_->RemoveObserver(this);
+  if (embedder_zoom_controller_) {
+    embedder_zoom_controller_->RemoveObserver(this);
+    embedder_zoom_controller_ = nullptr;
+  }
   guest_host_->WillDestroy();
-  embedder_zoom_controller_ = nullptr;
   guest_host_ = nullptr;
 }
 

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -111,11 +111,9 @@ void WebViewGuestDelegate::DidAttach(int guest_proxy_routing_id) {
   api_web_contents_->Emit("did-attach");
   embedder_zoom_controller_ =
       WebContentsZoomController::FromWebContents(embedder_web_contents_);
+  auto zoom_controller = api_web_contents_->GetZoomController();
   embedder_zoom_controller_->AddObserver(this);
-  if (embedder_zoom_controller_->UsesTemporaryZoomLevel()) {
-    double level = embedder_zoom_controller_->GetTemporaryZoomLevel();
-    api_web_contents_->GetZoomController()->SetTemporaryZoomLevel(level);
-  }
+  zoom_controller->SetEmbedderZoomController(embedder_zoom_controller_);
 }
 
 content::WebContents* WebViewGuestDelegate::GetOwnerWebContents() const {
@@ -153,6 +151,9 @@ void WebViewGuestDelegate::OnZoomLevelChanged(
     } else {
       api_web_contents_->GetZoomController()->SetZoomLevel(level);
     }
+    // Change the default zoom factor to match the embedders' new zoom level.
+    double zoom_factor = content::ZoomLevelToZoomFactor(level);
+    api_web_contents_->GetZoomController()->SetDefaultZoomFactor(zoom_factor);
   }
 }
 

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -112,6 +112,10 @@ void WebViewGuestDelegate::DidAttach(int guest_proxy_routing_id) {
   embedder_zoom_controller_ =
       WebContentsZoomController::FromWebContents(embedder_web_contents_);
   embedder_zoom_controller_->AddObserver(this);
+  if (embedder_zoom_controller_->UsesTemporaryZoomLevel()) {
+    double level = embedder_zoom_controller_->GetTemporaryZoomLevel();
+    api_web_contents_->GetZoomController()->SetTemporaryZoomLevel(level);
+  }
 }
 
 content::WebContents* WebViewGuestDelegate::GetOwnerWebContents() const {
@@ -141,9 +145,14 @@ void WebViewGuestDelegate::WillAttach(
 
 void WebViewGuestDelegate::OnZoomLevelChanged(
     content::WebContents* web_contents,
-    double level) {
+    double level,
+    bool is_temporary) {
   if (web_contents == GetOwnerWebContents()) {
-    api_web_contents_->GetZoomController()->SetZoomLevel(level);
+    if (is_temporary) {
+      api_web_contents_->GetZoomController()->SetTemporaryZoomLevel(level);
+    } else {
+      api_web_contents_->GetZoomController()->SetZoomLevel(level);
+    }
   }
 }
 

--- a/atom/browser/web_view_guest_delegate.h
+++ b/atom/browser/web_view_guest_delegate.h
@@ -67,7 +67,8 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
 
   // WebContentsZoomController::Observer:
   void OnZoomLevelChanged(content::WebContents* web_contents,
-                          double level) override;
+                          double level,
+                          bool is_temporary) override;
 
  private:
   // This method is invoked when the contents auto-resized to give the container

--- a/atom/browser/web_view_guest_delegate.h
+++ b/atom/browser/web_view_guest_delegate.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_WEB_VIEW_GUEST_DELEGATE_H_
 #define ATOM_BROWSER_WEB_VIEW_GUEST_DELEGATE_H_
 
+#include "atom/browser/web_contents_zoom_controller.h"
 #include "content/public/browser/browser_plugin_guest_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
 
@@ -31,7 +32,8 @@ struct SetSizeParams {
 };
 
 class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
-                             public content::WebContentsObserver {
+                             public content::WebContentsObserver,
+                             public WebContentsZoomController::Observer {
  public:
   WebViewGuestDelegate();
   ~WebViewGuestDelegate() override;
@@ -63,6 +65,10 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   content::RenderWidgetHost* GetOwnerRenderWidgetHost() override;
   content::SiteInstance* GetOwnerSiteInstance() override;
 
+  // WebContentsZoomController::Observer:
+  void OnZoomLevelChanged(content::WebContents* web_contents,
+                          double level) override;
+
  private:
   // This method is invoked when the contents auto-resized to give the container
   // an opportunity to match it if it wishes.
@@ -77,6 +83,10 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
 
   // The WebContents that attaches this guest view.
   content::WebContents* embedder_web_contents_;
+
+  // The zoom controller of the embedder that is used
+  // to subscribe for zoom changes.
+  WebContentsZoomController* embedder_zoom_controller_;
 
   // The size of the container element.
   gfx::Size element_size_;

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -41,3 +41,11 @@ IPC_MESSAGE_ROUTED1(AtomViewHostMsg_UpdateDraggableRegions,
 
 // Update renderer process preferences.
 IPC_MESSAGE_CONTROL1(AtomMsg_UpdatePreferences, base::ListValue)
+
+// Sent by renderer to set the temporary zoom level.
+IPC_SYNC_MESSAGE_ROUTED1_1(AtomViewHostMsg_SetTemporaryZoomLevel,
+                           double /* zoom level */,
+                           double /* result */)
+
+// Sent by renderer to get the zoom level.
+IPC_SYNC_MESSAGE_ROUTED0_1(AtomViewHostMsg_GetZoomLevel, double /* result */)

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -155,7 +155,6 @@ const char kAppUserModelId[] = "app-user-model-id";
 
 // The command line switch versions of the options.
 const char kBackgroundColor[]  = "background-color";
-const char kZoomFactor[]       = "zoom-factor";
 const char kPreloadScript[]    = "preload";
 const char kPreloadURL[]       = "preload-url";
 const char kNodeIntegration[]  = "node-integration";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -81,7 +81,6 @@ extern const char kSecureSchemes[];
 extern const char kAppUserModelId[];
 
 extern const char kBackgroundColor[];
-extern const char kZoomFactor[];
 extern const char kPreloadScript[];
 extern const char kPreloadURL[];
 extern const char kNodeIntegration[];

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -73,7 +73,7 @@ void WebFrame::SetName(const std::string& name) {
 }
 
 double WebFrame::SetZoomLevel(double level) {
-  double result;
+  double result = 0.0;
   content::RenderView* render_view =
       content::RenderView::FromWebView(web_frame_->view());
   render_view->Send(new AtomViewHostMsg_SetTemporaryZoomLevel(
@@ -82,7 +82,7 @@ double WebFrame::SetZoomLevel(double level) {
 }
 
 double WebFrame::GetZoomLevel() const {
-  double result;
+  double result = 0.0;
   content::RenderView* render_view =
       content::RenderView::FromWebView(web_frame_->view());
   render_view->Send(

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -4,6 +4,7 @@
 
 #include "atom/renderer/api/atom_api_web_frame.h"
 
+#include "atom/common/api/api_messages.h"
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/blink_converter.h"
 #include "atom/common/native_mate_converters/callback.h"
@@ -72,13 +73,21 @@ void WebFrame::SetName(const std::string& name) {
 }
 
 double WebFrame::SetZoomLevel(double level) {
-  double ret = web_frame_->view()->setZoomLevel(level);
-  mate::EmitEvent(isolate(), GetWrapper(), "zoom-level-changed", ret);
-  return ret;
+  double result;
+  content::RenderView* render_view =
+      content::RenderView::FromWebView(web_frame_->view());
+  render_view->Send(new AtomViewHostMsg_SetTemporaryZoomLevel(
+      render_view->GetRoutingID(), level, &result));
+  return result;
 }
 
 double WebFrame::GetZoomLevel() const {
-  return web_frame_->view()->zoomLevel();
+  double result;
+  content::RenderView* render_view =
+      content::RenderView::FromWebView(web_frame_->view());
+  render_view->Send(
+      new AtomViewHostMsg_GetZoomLevel(render_view->GetRoutingID(), &result));
+  return result;
 }
 
 double WebFrame::SetZoomFactor(double factor) {

--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -14,7 +14,6 @@
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
-#include "atom/common/options_switches.h"
 #include "atom/renderer/atom_renderer_client.h"
 #include "base/command_line.h"
 #include "base/strings/string_number_conversions.h"
@@ -117,17 +116,6 @@ void AtomRenderViewObserver::EmitIPCEvent(blink::WebFrame* frame,
 void AtomRenderViewObserver::DidCreateDocumentElement(
     blink::WebLocalFrame* frame) {
   document_created_ = true;
-
-  // Read --zoom-factor from command line.
-  std::string zoom_factor_str = base::CommandLine::ForCurrentProcess()->
-      GetSwitchValueASCII(switches::kZoomFactor);
-  if (zoom_factor_str.empty())
-    return;
-  double zoom_factor;
-  if (!base::StringToDouble(zoom_factor_str, &zoom_factor))
-    return;
-  double zoom_level = blink::WebView::zoomFactorToZoomLevel(zoom_factor);
-  frame->view()->setZoomLevel(zoom_level);
 }
 
 void AtomRenderViewObserver::DraggableRegionsChanged(blink::WebFrame* frame) {

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -341,6 +341,8 @@
       'atom/browser/web_contents_permission_helper.h',
       'atom/browser/web_contents_preferences.cc',
       'atom/browser/web_contents_preferences.h',
+      'atom/browser/web_contents_zoom_controller.cc',
+      'atom/browser/web_contents_zoom_controller.h',
       'atom/browser/web_dialog_helper.cc',
       'atom/browser/web_dialog_helper.h',
       'atom/browser/web_view_guest_delegate.cc',

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -105,15 +105,10 @@ const webFrameMethods = [
   'insertText',
   'setLayoutZoomLevelLimits',
   'setVisualZoomLevelLimits',
-  'setZoomFactor',
-  'setZoomLevel',
   // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
   'setZoomLevelLimits'
 ]
-const webFrameMethodsWithResult = [
-  'getZoomFactor',
-  'getZoomLevel'
-]
+const webFrameMethodsWithResult = []
 
 const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
   return new Promise((resolve, reject) => {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -184,7 +184,7 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
     guestInstanceId: guestInstanceId,
     nodeIntegration: params.nodeintegration != null ? params.nodeintegration : false,
     plugins: params.plugins,
-    zoomFactor: params.zoomFactor,
+    zoomFactor: embedder.getZoomFactor(),
     webSecurity: !params.disablewebsecurity,
     blinkFeatures: params.blinkfeatures,
     disableBlinkFeatures: params.disableblinkfeatures

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -231,7 +231,6 @@ class WebViewImpl {
     const params = {
       instanceId: this.viewInstanceId,
       userAgentOverride: this.userAgentOverride,
-      zoomFactor: webFrame.getZoomFactor()
     }
     for (const attributeName in this.attributes) {
       if (hasProp.call(this.attributes, attributeName)) {

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -34,12 +34,6 @@ class WebViewImpl {
     this.viewInstanceId = getNextId()
     shadowRoot.appendChild(this.browserPluginNode)
 
-    // Subscribe to host's zoom level changes.
-    this.onZoomLevelChanged = (zoomLevel) => {
-      this.webviewNode.setZoomLevel(zoomLevel)
-    }
-    webFrame.on('zoom-level-changed', this.onZoomLevelChanged)
-
     this.onVisibilityChanged = (event, visibilityState) => {
       this.webviewNode.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', visibilityState)
     }
@@ -56,8 +50,6 @@ class WebViewImpl {
 
   // Resets some state upon reattaching <webview> element to the DOM.
   reset () {
-    // Unlisten the zoom-level-changed event.
-    webFrame.removeListener('zoom-level-changed', this.onZoomLevelChanged)
     ipcRenderer.removeListener('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', this.onVisibilityChanged)
 
     // If guestInstanceId is defined then the <webview> has navigated and has
@@ -230,7 +222,7 @@ class WebViewImpl {
   buildParams () {
     const params = {
       instanceId: this.viewInstanceId,
-      userAgentOverride: this.userAgentOverride,
+      userAgentOverride: this.userAgentOverride
     }
     for (const attributeName in this.attributes) {
       if (hasProp.call(this.attributes, attributeName)) {


### PR DESCRIPTION
With this PR:
- Using zoom api on webContents will persist in a session on per-origin basis (132.content.foo and content.foo will share zoom changes if they are on the same session).
- Webview will still inherit embedder zoom changes. (this behavior is already present and it will continue)
- The zoom changes of each host in a session are persisted with the Preference file, so they will be available on the next load of the app. (If ZoomFactor is set on the webPreference then it will take precedence over the values from preference file, this can be overriden by using the zoom apis). In short the order of precedence is Preference File < ZoomFactor on WebPreference < Zoom api on webContents.
- Use the webframe api if the zoom changes are required only to be temporary. (Does not persist across navigations)

Would like feedback if the above behavior sounds good, thanks!

- [ ] Add Spec
- [x] Map webframe zoom calls to HostZoomMap temporary apis.

Depends on https://github.com/electron/brightray/pull/273

Fixes https://github.com/electron/electron/issues/6958