### PR TITLE
Update require wrapper to allow redefinition of process and global

### DIFF
--- a/spec/fixtures/module/declare-global.js
+++ b/spec/fixtures/module/declare-global.js
@@ -1,0 +1,2 @@
+const global = {__global: true}
+module.exports = global

--- a/spec/fixtures/module/declare-global.js
+++ b/spec/fixtures/module/declare-global.js
@@ -1,2 +1,2 @@
-const global = {__global: true}
+const global = 'declared global'
 module.exports = global

--- a/spec/fixtures/module/declare-process.js
+++ b/spec/fixtures/module/declare-process.js
@@ -1,0 +1,2 @@
+const process = require('process')
+module.exports = process

--- a/spec/fixtures/module/declare-process.js
+++ b/spec/fixtures/module/declare-process.js
@@ -1,2 +1,2 @@
-const process = require('process')
+const process = 'declared process'
 module.exports = process

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -51,13 +51,13 @@ describe('third-party module', function () {
   describe('global variables', function () {
     describe('process', function () {
       it('can be declared in a module', function () {
-        assert.strictEqual(require('./fixtures/module/declare-process'), require('process'))
+        assert.strictEqual(require('./fixtures/module/declare-process'), 'declared process')
       })
     })
 
     describe('global', function () {
       it('can be declared in a module', function () {
-        assert.deepEqual(require('./fixtures/module/declare-global'), {__global: true})
+        assert.deepEqual(require('./fixtures/module/declare-global'), 'declared global')
       })
     })
   })

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -47,6 +47,28 @@ describe('third-party module', function () {
       })
     })
   })
+
+  describe('global variables', function () {
+    describe('process', function () {
+      it('can be declared in a module', function () {
+        var exportedProcess
+        assert.doesNotThrow(function () {
+          exportedProcess = require('./fixtures/module/declare-process')
+        })
+        assert.strictEqual(exportedProcess, require('process'))
+      })
+    })
+
+    describe('global', function () {
+      it('can be declared in a module', function () {
+        var exportedGlobal
+        assert.doesNotThrow(function () {
+          exportedGlobal = require('./fixtures/module/declare-global')
+        })
+        assert.deepEqual(exportedGlobal, {__global: true})
+      })
+    })
+  })
 })
 
 describe('Module._nodeModulePaths', function () {

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -51,21 +51,13 @@ describe('third-party module', function () {
   describe('global variables', function () {
     describe('process', function () {
       it('can be declared in a module', function () {
-        var exportedProcess
-        assert.doesNotThrow(function () {
-          exportedProcess = require('./fixtures/module/declare-process')
-        })
-        assert.strictEqual(exportedProcess, require('process'))
+        assert.strictEqual(require('./fixtures/module/declare-process'), require('process'))
       })
     })
 
     describe('global', function () {
       it('can be declared in a module', function () {
-        var exportedGlobal
-        assert.doesNotThrow(function () {
-          exportedGlobal = require('./fixtures/module/declare-global')
-        })
-        assert.deepEqual(exportedGlobal, {__global: true})
+        assert.deepEqual(require('./fixtures/module/declare-global'), {__global: true})
       })
     })
   })

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -57,7 +57,7 @@ describe('third-party module', function () {
 
     describe('global', function () {
       it('can be declared in a module', function () {
-        assert.deepEqual(require('./fixtures/module/declare-global'), 'declared global')
+        assert.strictEqual(require('./fixtures/module/declare-global'), 'declared global')
       })
     })
   })


### PR DESCRIPTION
This pull request is an update of #8382 

It rebases the node patch on top of the Node 7.4.0 upgrade in #8406 

The `vendor/node` diff is a redo of the `NativeModule` patch with the following diff:

```diff
diff --git a/lib/internal/bootstrap_node.js b/lib/internal/bootstrap_node.js
index e3d9613..1c15912 100644
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -512,9 +512,8 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, __filename, __dirname, process, global) { ' +
-    'return function (exports, require, module, __filename, __dirname) { ',
-    '\n}(exports, require, module, __filename, __dirname); });'
+    '(function (exports, require, module, __filename, __dirname, process, global) { ',
+    '\n});'
   ];
 
   NativeModule.prototype.compile = function() {
```

/cc @ide