### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting Security Issues
+
+The Electron team and community take security bugs in Electron seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, email [electron@github.com](mailto:electron@github.com) and include the word "SECURITY" in the subject line.
+
+The Electron team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining the module. You can also report a vulnerability through the [Node Security Project](https://nodesecurity.io/report).

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -20,7 +20,7 @@ display primarily local content (or trusted, secure remote content without Node
 integration) – if your application executes code from an online source, it is
 your responsibility to ensure that the code is not malicious.
 
-## Disclosing Security Vulnerabilities
+## Reporting Security Issues
 
 For information on how to properly disclose an Electron vulnerability,
 see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -20,6 +20,11 @@ display primarily local content (or trusted, secure remote content without Node
 integration) – if your application executes code from an online source, it is
 your responsibility to ensure that the code is not malicious.
 
+## Disclosing Security Vulnerabilities
+
+For information on how to properly disclose an Electron vulnerability,
+see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
+
 ## Chromium Security Issues and Upgrades
 
 While Electron strives to support new versions of Chromium as soon as possible,


### PR DESCRIPTION
This PR adds a `SECURITY.md` file to the root of the repo, which outlines the protocol for disclosing vulnerabilities.

Note: the link in `tutorial/security.md` uses a fully-qualified URL so that the link won't break when it shows up on the website at http://electron.atom.io/docs/tutorial/security/