### PR TITLE
Fix webpreferences not accepting numeric options

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -5,7 +5,6 @@
 #include "atom/browser/web_contents_preferences.h"
 
 #include <algorithm>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -225,11 +224,10 @@ bool WebContentsPreferences::ConvertValueToIntegerFromString(
     return true;
   }
 
-  std::string stringValue;
+  base::string16 stringValue;
 
   if (pref->web_preferences_.GetString(attributeName, &stringValue)) {
-    std::stringstream(stringValue) >> *intValue;
-    return true;
+    return base::StringToInt(stringValue, intValue);
   }
 
   return false;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -216,24 +216,6 @@ bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
 }
 
 // static
-bool WebContentsPreferences::ConvertValueToIntegerFromString(
-    WebContentsPreferences* pref, std::string attributeName, int* intValue) {
-
-  // if it is already an integer, no conversion needed
-  if (pref->web_preferences_.GetInteger(attributeName, intValue)) {
-    return true;
-  }
-
-  base::string16 stringValue;
-
-  if (pref->web_preferences_.GetString(attributeName, &stringValue)) {
-    return base::StringToInt(stringValue, intValue);
-  }
-
-  return false;
-}
-
-// static
 void WebContentsPreferences::OverrideWebkitPrefs(
     content::WebContents* web_contents, content::WebPreferences* prefs) {
   WebContentsPreferences* self = FromWebContents(web_contents);
@@ -272,15 +254,28 @@ void WebContentsPreferences::OverrideWebkitPrefs(
       prefs->fantasy_font_family_map[content::kCommonScript] = font;
   }
   int size;
-  if (ConvertValueToIntegerFromString(self, "defaultFontSize", &size))
+  if (self->GetInteger("defaultFontSize", &size))
     prefs->default_font_size = size;
-  if (ConvertValueToIntegerFromString(self, "defaultMonospaceFontSize", &size))
+  if (self->GetInteger("defaultMonospaceFontSize", &size))
     prefs->default_fixed_font_size = size;
-  if (ConvertValueToIntegerFromString(self, "minimumFontSize", &size))
+  if (self->GetInteger("minimumFontSize", &size))
     prefs->minimum_font_size = size;
   std::string encoding;
   if (self->web_preferences_.GetString("defaultEncoding", &encoding))
     prefs->default_encoding = encoding;
+}
+
+bool WebContentsPreferences::GetInteger(const std::string& attributeName,
+                                        int* intValue) {
+  // if it is already an integer, no conversion needed
+  if (web_preferences_.GetInteger(attributeName, intValue))
+    return true;
+
+  base::string16 stringValue;
+  if (web_preferences_.GetString(attributeName, &stringValue))
+    return base::StringToInt(stringValue, intValue);
+
+  return false;
 }
 
 }  // namespace atom

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/web_contents_preferences.h"
 
 #include <algorithm>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -216,6 +217,25 @@ bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
 }
 
 // static
+bool WebContentsPreferences::ConvertValueToIntegerFromString(
+    WebContentsPreferences* pref, std::string attributeName, int* intValue) {
+
+  // if it is already an integer, no conversion needed
+  if (pref->web_preferences_.GetInteger(attributeName, intValue)) {
+    return true;
+  }
+
+  std::string stringValue;
+
+  if (pref->web_preferences_.GetString(attributeName, &stringValue)) {
+    std::stringstream(stringValue) >> *intValue;
+    return true;
+  }
+
+  return false;
+}
+
+// static
 void WebContentsPreferences::OverrideWebkitPrefs(
     content::WebContents* web_contents, content::WebPreferences* prefs) {
   WebContentsPreferences* self = FromWebContents(web_contents);
@@ -254,11 +274,11 @@ void WebContentsPreferences::OverrideWebkitPrefs(
       prefs->fantasy_font_family_map[content::kCommonScript] = font;
   }
   int size;
-  if (self->web_preferences_.GetInteger("defaultFontSize", &size))
+  if (ConvertValueToIntegerFromString(self, "defaultFontSize", &size))
     prefs->default_font_size = size;
-  if (self->web_preferences_.GetInteger("defaultMonospaceFontSize", &size))
+  if (ConvertValueToIntegerFromString(self, "defaultMonospaceFontSize", &size))
     prefs->default_fixed_font_size = size;
-  if (self->web_preferences_.GetInteger("minimumFontSize", &size))
+  if (ConvertValueToIntegerFromString(self, "minimumFontSize", &size))
     prefs->minimum_font_size = size;
   std::string encoding;
   if (self->web_preferences_.GetString("defaultEncoding", &encoding))

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -39,9 +39,6 @@ class WebContentsPreferences
 
   static bool IsSandboxed(content::WebContents* web_contents);
 
-  static bool ConvertValueToIntegerFromString(
-      WebContentsPreferences* pref, std::string attributeName, int* intValue);
-
   // Modify the WebPreferences according to |web_contents|'s preferences.
   static void OverrideWebkitPrefs(
       content::WebContents* web_contents, content::WebPreferences* prefs);
@@ -63,6 +60,9 @@ class WebContentsPreferences
 
   content::WebContents* web_contents_;
   base::DictionaryValue web_preferences_;
+
+  // Get preferences value as integer possibly coercing it from a string
+  bool GetInteger(const std::string& attributeName, int* intValue);
 
   DISALLOW_COPY_AND_ASSIGN(WebContentsPreferences);
 };

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_WEB_CONTENTS_PREFERENCES_H_
 #define ATOM_BROWSER_WEB_CONTENTS_PREFERENCES_H_
 
+#include <string>
 #include <vector>
 
 #include "base/values.h"
@@ -37,6 +38,9 @@ class WebContentsPreferences
       content::WebContents* web_contents, base::CommandLine* command_line);
 
   static bool IsSandboxed(content::WebContents* web_contents);
+
+  static bool ConvertValueToIntegerFromString(
+      WebContentsPreferences* pref, std::string attributeName, int* intValue);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.
   static void OverrideWebkitPrefs(


### PR DESCRIPTION
The webpreferences attribute values are parsed as strings instead
of numbers. Therefore, a conversion is required.

Fixes #8492.

![fix-min-size](https://cloud.githubusercontent.com/assets/3168908/22450620/dd2e5a68-e7a2-11e6-92a2-f6640cdbb050.png)
