### PR TITLE
Make getURL work irrespective of history

### DIFF
--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -66,11 +66,7 @@ var NavigationController = (function () {
   }
 
   NavigationController.prototype.getURL = function () {
-    if (this.currentIndex === -1) {
-      return ''
-    } else {
-      return this.history[this.currentIndex]
-    }
+    return this.webContents._getURL()
   }
 
   NavigationController.prototype.stop = function () {


### PR DESCRIPTION
After performing some navigation that should be transparent to the user, I'd like to `clearHistory` so that they're unable to traverse it. Problem is, after doing that all calls to `getURL` start returning empty strings. It seems (to me) that `getURL` should always return the current `webContents` location.