### PR TITLE
Support returning non-existent file paths from Windows open dialog

### DIFF
--- a/atom/browser/ui/file_dialog.h
+++ b/atom/browser/ui/file_dialog.h
@@ -28,6 +28,7 @@ enum FileDialogProperty {
   FILE_DIALOG_MULTI_SELECTIONS  = 1 << 2,
   FILE_DIALOG_CREATE_DIRECTORY  = 1 << 3,
   FILE_DIALOG_SHOW_HIDDEN_FILES = 1 << 4,
+  FILE_DIALOG_PROMPT_TO_CREATE  = 1 << 5,
 };
 
 typedef base::Callback<void(

--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -205,6 +205,8 @@ bool ShowOpenDialog(atom::NativeWindow* parent_window,
     options |= FOS_ALLOWMULTISELECT;
   if (properties & FILE_DIALOG_SHOW_HIDDEN_FILES)
     options |= FOS_FORCESHOWHIDDEN;
+  if (properties & FILE_DIALOG_PROMPT_TO_CREATE)
+    options |= FOS_CREATEPROMPT;
 
   FileDialog<CShellFileOpenDialog> open_dialog(
       default_path, title, button_label, filters, options);

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -32,9 +32,17 @@ The `dialog` module has the following methods:
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `properties` String[] (optional) - Contains which features the dialog should use, can
-    contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
-    and `showHiddenFiles`.
+  * `properties` String[] (optional) - Contains which features the dialog should
+    use. The following values are supported:
+    * `openFile` - Allow files to be selected.
+    * `openDirectory` - Allow directories to be selected.
+    * `multiSelections` - Allow multiple paths to be selected.
+    * `showHiddenFiles` - Show hidden files in dialog.
+    * `createDirectory` _macOS_ - Allow creating new directories from dialog.
+    * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
+      in the dialog does not exist. This does not actually create the file at
+      the path but allows non-existent paths to be returned that should be
+      created by the application.
   * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
     across platforms. Default is `false`. Enabling this assumes `&` is used in
     the button labels for the placement of the keyboard shortcut access key

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -9,7 +9,8 @@ const fileDialogProperties = {
   openDirectory: 1 << 1,
   multiSelections: 1 << 2,
   createDirectory: 1 << 3,
-  showHiddenFiles: 1 << 4
+  showHiddenFiles: 1 << 4,
+  promptToCreate: 1 << 5
 }
 
 const messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']


### PR DESCRIPTION
This pull requests add support for allowing non-existent paths to files to be entered in the Windows open dialog.

The new option is called `promptToCreate` and maps to the `FOS_CREATEPROMPT` dialog option on Windows. The returned path in these cases will not exist and should be created by the application.

<img width="1235" alt="screen shot 2017-02-02 at 8 51 59 am" src="https://cloud.githubusercontent.com/assets/671378/22559141/12cb7d08-e925-11e6-8146-0cff70fd85b9.png">

<img width="803" alt="screen shot 2017-02-02 at 8 52 08 am" src="https://cloud.githubusercontent.com/assets/671378/22559140/12b809e4-e925-11e6-94b6-77bed21478f0.png">



Closes #8236