### PR TITLE
Initialize color listener after app is ready

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -14,11 +14,7 @@ namespace atom {
 
 namespace api {
 
-SystemPreferences::SystemPreferences(v8::Isolate* isolate)
-#if defined(OS_WIN)
-    : color_change_listener_(this)
-#endif
-    {
+SystemPreferences::SystemPreferences(v8::Isolate* isolate) {
   Init(isolate);
 #if defined(OS_WIN)
   InitializeWindow();
@@ -26,6 +22,9 @@ SystemPreferences::SystemPreferences(v8::Isolate* isolate)
 }
 
 SystemPreferences::~SystemPreferences() {
+#if defined(OS_WIN)
+  Browser::Get()->RemoveObserver(this);
+#endif
 }
 
 #if !defined(OS_MACOSX)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -13,6 +13,8 @@
 #include "native_mate/handle.h"
 
 #if defined(OS_WIN)
+#include "atom/browser/browser.h"
+#include "atom/browser/browser_observer.h"
 #include "ui/gfx/sys_color_change_listener.h"
 #endif
 
@@ -26,6 +28,7 @@ namespace api {
 
 class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 #if defined(OS_WIN)
+    , public BrowserObserver
     , public gfx::SysColorChangeListener
 #endif
   {
@@ -50,6 +53,9 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   // gfx::SysColorChangeListener:
   void OnSysColorChange() override;
+
+  // BrowserObserver:
+  void OnFinishLaunching(const base::DictionaryValue& launch_info) override;
 
 #elif defined(OS_MACOSX)
   using NotificationCallback = base::Callback<
@@ -111,7 +117,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   bool invertered_color_scheme_;
 
-  gfx::ScopedSysColorChangeListener color_change_listener_;
+  std::unique_ptr<gfx::ScopedSysColorChangeListener> color_change_listener_;
 #endif
   DISALLOW_COPY_AND_ASSIGN(SystemPreferences);
 };


### PR DESCRIPTION
Creating a `ScopedSysColorChangeListener` before the app is ready appears to somehow interfere with global shortcuts (and possibly other things). This affects apps that require `systemPreferences` before app `ready` fires which is a common pattern.

This pull request changes it so the listener is only created after `OnFinishLaunching` is fired.

Fixes #7859