### PR TITLE
Add forcereload menu item role

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -87,6 +87,9 @@ app.once('ready', () => {
           role: 'reload'
         },
         {
+          role: 'forcereload'
+        },
+        {
           role: 'toggledevtools'
         },
         {

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -57,6 +57,7 @@ The `role` property can have following values:
 * `close` - Close current window
 * `quit`- Quit the application
 * `reload` - Reload the current window
+* `forcereload` - Reload the current window ignoring the cache.
 * `toggledevtools` - Toggle developer tools in the current window
 * `togglefullscreen`- Toggle full screen mode on the current window
 * `resetzoom` - Reset the focused page's zoom level to the original size

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -140,6 +140,9 @@ const template = [
         role: 'reload'
       },
       {
+        role: 'forcereload'
+      },
+      {
         role: 'toggledevtools'
       },
       {

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -25,6 +25,14 @@ const roles = {
     label: 'Delete',
     webContentsMethod: 'delete'
   },
+  forcereload: {
+    label: 'Force Reload',
+    accelerator: 'Shift+CmdOrCtrl+R',
+    nonNativeMacOSRole: true,
+    windowMethod: (window) => {
+      window.webContents.reloadIgnoringCache()
+    }
+  },
   front: {
     label: 'Bring All to Front'
   },
@@ -75,11 +83,13 @@ const roles = {
   reload: {
     label: 'Reload',
     accelerator: 'CmdOrCtrl+R',
+    nonNativeMacOSRole: true,
     windowMethod: 'reload'
   },
   resetzoom: {
     label: 'Actual Size',
     accelerator: 'CommandOrControl+0',
+    nonNativeMacOSRole: true,
     webContentsMethod: (webContents) => {
       webContents.setZoomLevel(0)
     }
@@ -101,6 +111,7 @@ const roles = {
   toggledevtools: {
     label: 'Toggle Developer Tools',
     accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+    nonNativeMacOSRole: true,
     windowMethod: 'toggleDevTools'
   },
   togglefullscreen: {
@@ -127,6 +138,7 @@ const roles = {
   zoomin: {
     label: 'Zoom In',
     accelerator: 'CommandOrControl+Plus',
+    nonNativeMacOSRole: true,
     webContentsMethod: (webContents) => {
       webContents.getZoomLevel((zoomLevel) => {
         webContents.setZoomLevel(zoomLevel + 0.5)
@@ -136,6 +148,7 @@ const roles = {
   zoomout: {
     label: 'Zoom Out',
     accelerator: 'CommandOrControl+-',
+    nonNativeMacOSRole: true,
     webContentsMethod: (webContents) => {
       webContents.getZoomLevel((zoomLevel) => {
         webContents.setZoomLevel(zoomLevel - 0.5)
@@ -147,8 +160,8 @@ const roles = {
 const canExecuteRole = (role) => {
   if (!roles.hasOwnProperty(role)) return false
   if (process.platform !== 'darwin') return true
-  // macOS handles all roles natively except the ones listed below
-  return ['reload', 'resetzoom', 'toggledevtools', 'zoomin', 'zoomout'].includes(role)
+  // macOS handles all roles natively except for a few
+  return roles[role].nonNativeMacOSRole
 }
 
 exports.getDefaultLabel = (role) => {


### PR DESCRIPTION
Adds a `forcereload` menu item role that maps to `webContents.reloadIgnoringCache` available from the View menu and using the same shortcut as reload but with an added `Shift`.

Closes #8465