### PR TITLE
Document using content tracing after app ready

### DIFF
--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -9,22 +9,28 @@ This module does not include a web interface so you need to open
 `chrome://tracing/` in a Chrome browser and load the generated file to view the
 result.
 
+**Note:** You should not use this module until the `ready` event of the app
+module is emitted.
+
+
 ```javascript
-const {contentTracing} = require('electron')
+const {app, contentTracing} = require('electron')
 
-const options = {
-  categoryFilter: '*',
-  traceOptions: 'record-until-full,enable-sampling'
-}
+app.on('ready', () => {
+  const options = {
+    categoryFilter: '*',
+    traceOptions: 'record-until-full,enable-sampling'
+  }
 
-contentTracing.startRecording(options, () => {
-  console.log('Tracing started')
+  contentTracing.startRecording(options, () => {
+    console.log('Tracing started')
 
-  setTimeout(() => {
-    contentTracing.stopRecording('', (path) => {
-      console.log('Tracing data recorded to ' + path)
-    })
-  }, 5000)
+    setTimeout(() => {
+      contentTracing.stopRecording('', (path) => {
+        console.log('Tracing data recorded to ' + path)
+      })
+    }, 5000)
+  })
 })
 ```
 


### PR DESCRIPTION
Looks like `contentTracing.startRecording` does not callback if called before app `ready` fires.

This pull request updates the doc to match how `globalShorcut` documents this. 

Closes #8433