### PR TITLE
Add will-attach-webview event

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -507,7 +507,6 @@ Emitted when the devtools window instructs the webContents to reload
 Returns:
 
 * `event` Event
-* `guest` WebContents - The contents of the guest page.
 * `webPreferences` Object - The web preferences that will be used by the guest
   page. This object can be modified to adjust the preferences for the guest
   page.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -502,6 +502,18 @@ win.loadURL('http://github.com')
 
 Emitted when the devtools window instructs the webContents to reload
 
+#### Event: 'will-attach-webview'
+
+Returns:
+
+* `event` Event
+* `guest` WebContents - The contents of the guest page.
+* `webPreferences` Object - The web preferences that will be used by the guest
+  page. This object can be modified to adjust the preferences for the guest
+  page.
+
+Calling `event.preventDefault()` will destroy the guest page.
+
 ### Instance Methods
 
 #### `contents.loadURL(url[, options])`

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -511,8 +511,11 @@ Returns:
 * `webPreferences` Object - The web preferences that will be used by the guest
   page. This object can be modified to adjust the preferences for the guest
   page.
+* `params` Object - The other `<webview>` parameters such as the `src` URL.
+  This object can be modified to adjust the parameters of the guest page.
 
-Calling `event.preventDefault()` will destroy the guest page.
+Emitted when a `<webview>`'s web contents is being attached to this web
+contents. Calling `event.preventDefault()` will destroy the guest page.
 
 ### Instance Methods
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -206,7 +206,7 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
     webPreferences.preloadURL = params.preload
   }
 
-  event.sender.emit('new-webview', event, guest, webPreferences)
+  event.sender.emit('will-attach-webview', event, guest, webPreferences)
   if (event.defaultPrevented) {
     if (guest.viewInstanceId == null) guest.viewInstanceId = params.instanceId
     destroyGuest(embedder, guestInstanceId)

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -206,7 +206,7 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
     webPreferences.preloadURL = params.preload
   }
 
-  event.sender.emit('will-attach-webview', event, guest, webPreferences, params)
+  event.sender.emit('will-attach-webview', event, webPreferences, params)
   if (event.defaultPrevented) {
     if (guest.viewInstanceId == null) guest.viewInstanceId = params.instanceId
     destroyGuest(embedder, guestInstanceId)

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -206,7 +206,7 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
     webPreferences.preloadURL = params.preload
   }
 
-  event.sender.emit('will-attach-webview', event, webPreferences, params)
+  embedder.emit('will-attach-webview', event, webPreferences, params)
   if (event.defaultPrevented) {
     if (guest.viewInstanceId == null) guest.viewInstanceId = params.instanceId
     destroyGuest(embedder, guestInstanceId)

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -147,7 +147,8 @@ const createGuest = function (embedder, params) {
 }
 
 // Attach the guest to an element of embedder.
-const attachGuest = function (embedder, elementInstanceId, guestInstanceId, params) {
+const attachGuest = function (event, elementInstanceId, guestInstanceId, params) {
+  const embedder = event.sender
   // Destroy the old guest when attaching.
   const key = `${embedder.getId()}-${elementInstanceId}`
   const oldGuestInstanceId = embedderElementsMap[key]
@@ -204,6 +205,14 @@ const attachGuest = function (embedder, elementInstanceId, guestInstanceId, para
   if (params.preload) {
     webPreferences.preloadURL = params.preload
   }
+
+  event.sender.emit('new-webview', event, guest, webPreferences)
+  if (event.defaultPrevented) {
+    if (guest.viewInstanceId == null) guest.viewInstanceId = params.instanceId
+    destroyGuest(embedder, guestInstanceId)
+    return
+  }
+
   webViewManager.addGuest(guestInstanceId, elementInstanceId, embedder, guest, webPreferences)
   guest.attachParams = params
   embedderElementsMap[key] = guestInstanceId
@@ -276,7 +285,7 @@ ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params, 
 })
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, elementInstanceId, guestInstanceId, params) {
-  attachGuest(event.sender, elementInstanceId, guestInstanceId, params)
+  attachGuest(event, elementInstanceId, guestInstanceId, params)
 })
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_DESTROY_GUEST', function (event, guestInstanceId) {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -206,7 +206,7 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
     webPreferences.preloadURL = params.preload
   }
 
-  event.sender.emit('will-attach-webview', event, guest, webPreferences)
+  event.sender.emit('will-attach-webview', event, guest, webPreferences, params)
   if (event.defaultPrevented) {
     if (guest.viewInstanceId == null) guest.viewInstanceId = params.instanceId
     destroyGuest(embedder, guestInstanceId)

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -250,6 +250,16 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
   webContents.fromId(id).once('new-window', event => event.preventDefault())
 })
 
+ipcMain.on('prevent-next-new-webview', (event) => {
+  event.sender.once('new-webview', event => event.preventDefault())
+})
+
+ipcMain.on('disable-node-on-next-new-webview', (event, id) => {
+  event.sender.once('new-webview', (event, guest, webPreferences) => {
+    webPreferences.nodeIntegration = false
+  })
+})
+
 ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
   const consoleWarn = console.warn
   let warningMessage = null

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -255,7 +255,7 @@ ipcMain.on('prevent-next-will-attach-webview', (event) => {
 })
 
 ipcMain.on('disable-node-on-next-will-attach-webview', (event, id) => {
-  event.sender.once('will-attach-webview', (event, guest, webPreferences, params) => {
+  event.sender.once('will-attach-webview', (event, webPreferences, params) => {
     params.src = `file://${path.join(__dirname, '..', 'fixtures', 'pages', 'c.html')}`
     webPreferences.nodeIntegration = false
   })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -250,12 +250,12 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
   webContents.fromId(id).once('new-window', event => event.preventDefault())
 })
 
-ipcMain.on('prevent-next-new-webview', (event) => {
-  event.sender.once('new-webview', event => event.preventDefault())
+ipcMain.on('prevent-next-will-attach-webview', (event) => {
+  event.sender.once('will-attach-webview', event => event.preventDefault())
 })
 
-ipcMain.on('disable-node-on-next-new-webview', (event, id) => {
-  event.sender.once('new-webview', (event, guest, webPreferences) => {
+ipcMain.on('disable-node-on-next-will-attach-webview', (event, id) => {
+  event.sender.once('will-attach-webview', (event, guest, webPreferences) => {
     webPreferences.nodeIntegration = false
   })
 })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -255,7 +255,8 @@ ipcMain.on('prevent-next-will-attach-webview', (event) => {
 })
 
 ipcMain.on('disable-node-on-next-will-attach-webview', (event, id) => {
-  event.sender.once('will-attach-webview', (event, guest, webPreferences) => {
+  event.sender.once('will-attach-webview', (event, guest, webPreferences, params) => {
+    params.src = `file://${path.join(__dirname, '..', 'fixtures', 'pages', 'c.html')}`
     webPreferences.nodeIntegration = false
   })
 })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1100,9 +1100,9 @@ describe('<webview> tag', function () {
     w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
   })
 
-  describe('new-webview event', () => {
+  describe('will-attach-webview event', () => {
     it('supports changing the web preferences', (done) => {
-      ipcRenderer.send('disable-node-on-next-new-webview')
+      ipcRenderer.send('disable-node-on-next-will-attach-webview')
       webview.addEventListener('console-message', (event) => {
         assert.equal(event.message, 'undefined undefined undefined undefined')
         done()
@@ -1113,7 +1113,7 @@ describe('<webview> tag', function () {
     })
 
     it('supports preventing a webview from being created', (done) => {
-      ipcRenderer.send('prevent-next-new-webview')
+      ipcRenderer.send('prevent-next-will-attach-webview')
       webview.addEventListener('destroyed', () => {
         done()
       })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1100,7 +1100,7 @@ describe('<webview> tag', function () {
     w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
   })
 
-  describe('will-attach-webview event', () => {
+  describe.only('will-attach-webview event', () => {
     it('supports changing the web preferences', (done) => {
       ipcRenderer.send('disable-node-on-next-will-attach-webview')
       webview.addEventListener('console-message', (event) => {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -2,7 +2,7 @@ const assert = require('assert')
 const path = require('path')
 const http = require('http')
 const url = require('url')
-const {remote} = require('electron')
+const {ipcRenderer, remote} = require('electron')
 const {app, session, getGuestWebContents, ipcMain, BrowserWindow, webContents} = remote
 const {closeWindow} = require('./window-helpers')
 
@@ -1098,6 +1098,31 @@ describe('<webview> tag', function () {
     })
 
     w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
+  })
+
+  describe('new-webview event', () => {
+    it('supports changing the web preferences', (done) => {
+      ipcRenderer.send('disable-node-on-next-new-webview')
+      webview.addEventListener('console-message', (event) => {
+        assert.equal(event.message, 'undefined undefined undefined undefined')
+        done()
+      })
+      webview.setAttribute('nodeintegration', 'yes')
+      webview.src = 'file://' + fixtures + '/pages/c.html'
+      document.body.appendChild(webview)
+    })
+
+    it('supports preventing a webview from being created', (done) => {
+      ipcRenderer.send('prevent-next-new-webview')
+      webview.addEventListener('destroyed', () => {
+        done()
+      })
+      webview.src = 'file://' + fixtures + '/pages/c.html'
+      document.body.appendChild(webview)
+    })
+  })
+
+  it('emits a new-webview event when first attached that ', () => {
   })
 
   it('loads devtools extensions registered on the parent window', function (done) {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1108,7 +1108,7 @@ describe('<webview> tag', function () {
         done()
       })
       webview.setAttribute('nodeintegration', 'yes')
-      webview.src = 'file://' + fixtures + '/pages/c.html'
+      webview.src = 'file://' + fixtures + '/pages/a.html'
       document.body.appendChild(webview)
     })
 
@@ -1120,9 +1120,6 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/pages/c.html'
       document.body.appendChild(webview)
     })
-  })
-
-  it('emits a new-webview event when first attached that ', () => {
   })
 
   it('loads devtools extensions registered on the parent window', function (done) {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1100,7 +1100,7 @@ describe('<webview> tag', function () {
     w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
   })
 
-  describe.only('will-attach-webview event', () => {
+  describe('will-attach-webview event', () => {
     it('supports changing the web preferences', (done) => {
       ipcRenderer.send('disable-node-on-next-will-attach-webview')
       webview.addEventListener('console-message', (event) => {


### PR DESCRIPTION
This event is similar to `new-window`, in that it allows you to configure the `webPreferences` of the `<webview>`'s `webContents` before it gets read in and calling `event.preventDefault()` will destroy the guest page.

This event can be used to enforce/configure settings in the main process for created webviews and also allow finer grain option setting than the current `<webview>` attributes support.

Closes #2749