### PR TITLE
Emphasize asking for repo URL in bug reports

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -19,16 +19,17 @@ Thanks for opening an issue! A few things to keep in mind:
 <!-- What actually happens? -->
 
 ### How to reproduce
+
 <!-- 
 
-Your best chance of getting the bug fixed quickly is to provide a REPOSITORY that can be cloned and run.
+Your best chance of getting this bug looked at quickly is to provide a REPOSITORY that can be cloned and run.
+
+You can fork https://github.com/electron/electron-quick-start and include a link to the branch with your changes.
 
 If you provide a URL, please list the commands required to clone/setup/run your repo e.g.
 
   $ git clone $YOUR_URL -b $BRANCH
   $ npm install
   $ npm start || electron .
-
-You can fork https://github.com/electron/electron-quick-start and submit the branch with your changes
 
 -->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -19,5 +19,16 @@ Thanks for opening an issue! A few things to keep in mind:
 <!-- What actually happens? -->
 
 ### How to reproduce
+<!-- 
 
-<!-- For bugs, provide sample code or a repo URL that demos the problem -->
+Your best chance of getting the bug fixed quickly is to provide a REPOSITORY that can be cloned and run.
+
+If you provide a URL, please list the commands required to clone/setup/run your repo e.g.
+
+  $ git clone $YOUR_URL -b $BRANCH
+  $ npm install
+  $ npm start || electron .
+
+You can fork https://github.com/electron/electron-quick-start and submit the branch with your changes
+
+-->


### PR DESCRIPTION
I ❤️ getting a repro URL - something that can be `git clone ...` and then you're up and running. I want to gently encourage bugs to include such.

Thoughts on wording?