### PR TITLE
Delete Buffer global when node integration is disabled

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -80,22 +80,3 @@ This is not bulletproof, but at the least, you should attempt the following:
 
 Again, this list merely minimizes the risk, it does not remove it. If your goal
 is to display a website, a browser will be a more secure option.
-
-## Buffer Global
-
-Node's [Buffer](https://nodejs.org/api/buffer.html) class is currently available
-as a global even when the `nodeintegration` attribute is not added. You can
-delete this in your app by doing the following in your `preload` script:
-
-```js
-delete global.Buffer
-```
-
-Deleting it may break Node modules used in your preload script and app since
-many libraries expect it to be a global instead of requiring it directly via:
-
-```js
-const {Buffer} = require('buffer')
-```
-
-The `Buffer` global may be removed in future major versions of Electron.

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -127,6 +127,7 @@ if (nodeIntegration === 'true') {
   // Delete Node's symbols after the Environment has been loaded.
   process.once('loaded', function () {
     delete global.process
+    delete global.Buffer
     delete global.setImmediate
     delete global.clearImmediate
     delete global.global

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -801,8 +801,9 @@ describe('BrowserWindow module', function () {
     describe('"node-integration" option', function () {
       it('disables node integration when specified to false', function (done) {
         var preload = path.join(fixtures, 'module', 'send-later.js')
-        ipcMain.once('answer', function (event, test) {
-          assert.equal(test, 'undefined')
+        ipcMain.once('answer', function (event, typeofProcess, typeofBuffer) {
+          assert.equal(typeofProcess, 'undefined')
+          assert.equal(typeofBuffer, 'undefined')
           done()
         })
         w.destroy()

--- a/spec/fixtures/module/declare-buffer.js
+++ b/spec/fixtures/module/declare-buffer.js
@@ -1,0 +1,2 @@
+const Buffer = 'declared Buffer'
+module.exports = Buffer

--- a/spec/fixtures/module/preload-node-off.js
+++ b/spec/fixtures/module/preload-node-off.js
@@ -1,6 +1,6 @@
 setImmediate(function () {
   try {
-    console.log([typeof process, typeof setImmediate, typeof global].join(' '))
+    console.log([typeof process, typeof setImmediate, typeof global, typeof Buffer].join(' '))
   } catch (e) {
     console.log(e.message)
   }

--- a/spec/fixtures/module/preload.js
+++ b/spec/fixtures/module/preload.js
@@ -1,1 +1,1 @@
-console.log([typeof require, typeof module, typeof process].join(' '))
+console.log([typeof require, typeof module, typeof process, typeof Buffer].join(' '))

--- a/spec/fixtures/module/send-later.js
+++ b/spec/fixtures/module/send-later.js
@@ -1,4 +1,4 @@
 var ipcRenderer = require('electron').ipcRenderer
 window.onload = function () {
-  ipcRenderer.send('answer', typeof window.process)
+  ipcRenderer.send('answer', typeof window.process, typeof window.Buffer)
 }

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -69,6 +69,12 @@ describe('third-party module', function () {
         assert.strictEqual(require('./fixtures/module/declare-global'), 'declared global')
       })
     })
+
+    describe('Buffer', function () {
+      it('can be declared in a module', function () {
+        assert.strictEqual(require('./fixtures/module/declare-buffer'), 'declared Buffer')
+      })
+    })
   })
 })
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -171,7 +171,7 @@ describe('<webview> tag', function () {
   describe('preload attribute', function () {
     it('loads the script before other scripts in window', function (done) {
       var listener = function (e) {
-        assert.equal(e.message, 'function object object')
+        assert.equal(e.message, 'function object object function')
         webview.removeEventListener('console-message', listener)
         done()
       }
@@ -181,9 +181,9 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
-    it('preload script can still use "process" in required modules when nodeintegration is off', function (done) {
+    it('preload script can still use "process" and "Buffer" in required modules when nodeintegration is off', function (done) {
       webview.addEventListener('console-message', function (e) {
-        assert.equal(e.message, 'object undefined object')
+        assert.equal(e.message, 'object undefined object function')
         done()
       })
       webview.setAttribute('preload', fixtures + '/module/preload-node-off.js')
@@ -212,7 +212,7 @@ describe('<webview> tag', function () {
 
     it('works without script tag in page', function (done) {
       var listener = function (e) {
-        assert.equal(e.message, 'function object object')
+        assert.equal(e.message, 'function object object function')
         webview.removeEventListener('console-message', listener)
         done()
       }
@@ -224,7 +224,7 @@ describe('<webview> tag', function () {
 
     it('resolves relative URLs', function (done) {
       var listener = function (e) {
-        assert.equal(e.message, 'function object object')
+        assert.equal(e.message, 'function object object function')
         webview.removeEventListener('console-message', listener)
         done()
       }

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -318,7 +318,7 @@ describe('<webview> tag', function () {
 
     it('does not break preload script', function (done) {
       var listener = function (e) {
-        assert.equal(e.message, 'function object object')
+        assert.equal(e.message, 'function object object function')
         webview.removeEventListener('console-message', listener)
         done()
       }


### PR DESCRIPTION
This was originally done in #7114 but was pulled back because at the time there wasn't a known way to do this without breaking existing apps and libraries.

This pull request builds on the change done in #8539 for `process` and `global` by adding `Buffer` as an argument to the require wrapper function.

The new wrapper node patch is at https://github.com/electron/node/commit/439dbac

The diff is:

```diff
diff --git a/lib/internal/bootstrap_node.js b/lib/internal/bootstrap_node.js
index 65567de..085ea00 100644
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -512,7 +512,7 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, __filename, __dirname, process, global) { ' +
+    '(function (exports, require, module, __filename, __dirname, process, global, Buffer) { ' +
     'return function (exports, require, module, __filename, __dirname) { ',
     '\n}.call(this, exports, require, module, __filename, __dirname); });'
   ];
@@ -529,7 +529,7 @@
         lineOffset: 0,
         displayErrors: true
       });
-      fn(this.exports, NativeModule.require, this, this.filename, undefined, process, localGlobal);
+      fn(this.exports, NativeModule.require, this, this.filename, undefined, process, localGlobal, localGlobal.Buffer);
 
       this.loaded = true;
     } finally {
diff --git a/lib/module.js b/lib/module.js
index ff24970..1bc27c0 100644
--- a/lib/module.js
+++ b/lib/module.js
@@ -565,7 +565,7 @@ Module.prototype._compile = function(content, filename) {
   }
   var dirname = path.dirname(filename);
   var require = internalModule.makeRequireFunction.call(this);
-  var args = [this.exports, require, this, filename, dirname, process, global];
+  var args = [this.exports, require, this, filename, dirname, process, global, global.Buffer];
   var depth = internalModule.requireDepth;
   if (depth === 0) stat.cache = new Map();
   var result = compiledWrapper.apply(this.exports, args);
```

Closes #7081

/cc @ide 