### PR TITLE
Fix missing of symbols when linking win32 build

### DIFF
--- a/atom/node/osfhandle.cc
+++ b/atom/node/osfhandle.cc
@@ -24,6 +24,8 @@ void ReferenceSymbols() {
   // for some reason, adding them to ForceSymbolReferences does not work,
   // probably because of VC++ bugs.
   v8::TracingCpuProfiler::Create(nullptr);
+  reinterpret_cast<v8_inspector::V8InspectorSession*>(nullptr)->
+      canDispatchMethod(v8_inspector::StringView());
   reinterpret_cast<v8_inspector::V8InspectorClient*>(nullptr)->unmuteMetrics(0);
 }
 


### PR DESCRIPTION
Close https://github.com/electron/electron/issues/8602

/cc @kevinsawicki 