### PR TITLE
Simplify the trick used for referencing symbols

### DIFF
--- a/atom/node/osfhandle.cc
+++ b/atom/node/osfhandle.cc
@@ -6,6 +6,22 @@
 
 #include <io.h>
 
+#define U_I18N_IMPLEMENTATION
+
+#include "third_party/icu/source/common/unicode/ubidi.h"
+#include "third_party/icu/source/common/unicode/uchar.h"
+#include "third_party/icu/source/common/unicode/uidna.h"
+#include "third_party/icu/source/common/unicode/unistr.h"
+#include "third_party/icu/source/common/unicode/unorm.h"
+#include "third_party/icu/source/common/unicode/urename.h"
+#include "third_party/icu/source/common/unicode/ustring.h"
+#include "third_party/icu/source/i18n/unicode/measfmt.h"
+#include "third_party/icu/source/i18n/unicode/translit.h"
+#include "third_party/icu/source/i18n/unicode/ucsdet.h"
+#include "third_party/icu/source/i18n/unicode/ulocdata.h"
+#include "third_party/icu/source/i18n/unicode/uregex.h"
+#include "third_party/icu/source/i18n/unicode/uspoof.h"
+#include "third_party/icu/source/i18n/unicode/usearch.h"
 #include "v8-profiler.h"
 #include "v8-inspector.h"
 
@@ -21,12 +37,30 @@ int close(int fd) {
 
 void ReferenceSymbols() {
   // Following symbols are used by electron.exe but got stripped by compiler,
-  // for some reason, adding them to ForceSymbolReferences does not work,
-  // probably because of VC++ bugs.
+  // by using the symbols we can force compiler to keep the objects in node.dll,
+  // thus electron.exe can link with the exported symbols.
+
+  // v8_profiler symbols:
   v8::TracingCpuProfiler::Create(nullptr);
+  // v8_inspector symbols:
   reinterpret_cast<v8_inspector::V8InspectorSession*>(nullptr)->
       canDispatchMethod(v8_inspector::StringView());
   reinterpret_cast<v8_inspector::V8InspectorClient*>(nullptr)->unmuteMetrics(0);
+  // icu symbols:
+  u_errorName(U_ZERO_ERROR);
+  ubidi_setPara(nullptr, nullptr, 0, 0, nullptr, nullptr);
+  ucsdet_getName(nullptr, nullptr);
+  uidna_openUTS46(UIDNA_CHECK_BIDI, nullptr);
+  ulocdata_close(nullptr);
+  unorm_normalize(nullptr, 0, UNORM_NFC, 0, nullptr, 0, nullptr);
+  uregex_matches(nullptr, 0, nullptr);
+  uspoof_open(nullptr);
+  usearch_setPattern(nullptr, nullptr, 0, nullptr);
+  usearch_setPattern(nullptr, nullptr, 0, nullptr);
+  UMeasureFormatWidth width = UMEASFMT_WIDTH_WIDE;
+  UErrorCode status = U_ZERO_ERROR;
+  icu::MeasureFormat format(icu::Locale::getRoot(), width, status);
+  reinterpret_cast<icu::Transliterator*>(nullptr)->clone();
 }
 
 }  // namespace node

--- a/common.gypi
+++ b/common.gypi
@@ -129,6 +129,9 @@
       }],
       ['_target_name=="node"', {
         'include_dirs': [
+          '<(libchromiumcontent_src_dir)',
+          '<(libchromiumcontent_src_dir)/third_party/icu/source/common',
+          '<(libchromiumcontent_src_dir)/third_party/icu/source/i18n',
           '<(libchromiumcontent_src_dir)/v8',
           '<(libchromiumcontent_src_dir)/v8/include',
         ],
@@ -154,59 +157,6 @@
               # Needed by V8.
               '-ldbghelp.lib',
               '-lshlwapi.lib',
-            ],
-            # Force referencing symbols of ICU and v8_inspector to make sure
-            # they are included in the final DLL.
-            'conditions': [
-              ['libchromiumcontent_component==0', {
-                'variables': {
-                  'conditions': [
-                    ['target_arch=="ia32"', {
-                      'reference_symbols': [
-                        # ICU symbols:
-                        '_u_errorName_58',
-                        '_ubidi_setPara_58',
-                        '_ucsdet_getName_58',
-                        '_uidna_openUTS46_58',
-                        '_ulocdata_close_58',
-                        '_unorm_normalize_58',
-                        '_uregex_matches_58',
-                        '_uscript_getCode_58',
-                        '_uspoof_open_58',
-                        '_usearch_setPattern_58',
-                        '?createInstance@Transliterator@icu_58@@SAPAV12@ABVUnicodeString@2@W4UTransDirection@@AAW4UErrorCode@@@Z',
-                        '??0MeasureFormat@icu_58@@QAE@ABVLocale@1@W4UMeasureFormatWidth@@AAW4UErrorCode@@@Z',
-                      ],
-                    }, {
-                      'reference_symbols': [
-                        # ICU symbols:
-                        'u_errorName_58',
-                        'ubidi_setPara_58',
-                        'ucsdet_getName_58',
-                        'uidna_openUTS46_58',
-                        'ulocdata_close_58',
-                        'unorm_normalize_58',
-                        'uregex_matches_58',
-                        'uspoof_open_58',
-                        'usearch_setPattern_58',
-                        '?createInstance@Transliterator@icu_58@@SAPEAV12@AEBVUnicodeString@2@W4UTransDirection@@AEAW4UErrorCode@@@Z',
-                        '??0MeasureFormat@icu_58@@QEAA@AEBVLocale@1@W4UMeasureFormatWidth@@AEAW4UErrorCode@@@Z',
-                        # v8_inspector symbols:
-                        '?DOM@ReasonEnum@Paused@API@Debugger@protocol@v8_inspector@@3PEBDEB',
-                        '?canDispatchMethod@V8InspectorSession@v8_inspector@@SA_NAEBVStringView@2@@Z',
-                      ],
-                    }],
-                  ],
-                },
-                'msvs_settings': {
-                  'VCLinkerTool': {
-                    # There is nothing like "whole-archive" on Windows, so we
-                    # have to manually force some objets files to be included
-                    # by referencing them.
-                    'ForceSymbolReferences': [ '<@(reference_symbols)' ],  # '/INCLUDE'
-                  },
-                },
-              }],
             ],
           }],
           ['OS=="linux" and libchromiumcontent_component==0', {


### PR DESCRIPTION
Instead of using `/INCLUDE` to reference symbols, this PR changes to use plain C++ for the same purpose, so the trick is more easier to maintain and understand.