### PR TITLE
Forward `this` in require wrapper

### DIFF
--- a/spec/fixtures/module/test.coffee
+++ b/spec/fixtures/module/test.coffee
@@ -1,0 +1,1 @@
+module.exports = yes

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -48,6 +48,15 @@ describe('third-party module', function () {
     })
   })
 
+  describe('coffee-script', function () {
+    it('can be registered and used to require .coffee files', function () {
+      assert.doesNotThrow(function () {
+        require('coffee-script').register()
+        assert.strictEqual(require('./fixtures/module/test.coffee'), true)
+      })
+    })
+  })
+
   describe('global variables', function () {
     describe('process', function () {
       it('can be declared in a module', function () {

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -52,8 +52,8 @@ describe('third-party module', function () {
     it('can be registered and used to require .coffee files', function () {
       assert.doesNotThrow(function () {
         require('coffee-script').register()
-        assert.strictEqual(require('./fixtures/module/test.coffee'), true)
       })
+      assert.strictEqual(require('./fixtures/module/test.coffee'), true)
     })
   })
 

--- a/spec/package.json
+++ b/spec/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "basic-auth": "^1.0.4",
+    "coffee-script": "^1.12.3",
     "graceful-fs": "^4.1.9",
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.0",


### PR DESCRIPTION
Updates the node require function wrapper patch to pass through the `this` value of the outer function.

This fixes a regression introduced in #8539 

```diff
diff --git a/lib/internal/bootstrap_node.js b/lib/internal/bootstrap_node.js
index e3d9613..65567de 100644
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -514,7 +514,7 @@
   NativeModule.wrapper = [
     '(function (exports, require, module, __filename, __dirname, process, global) { ' +
     'return function (exports, require, module, __filename, __dirname) { ',
-    '\n}(exports, require, module, __filename, __dirname); });'
+    '\n}.call(this, exports, require, module, __filename, __dirname); });'
   ];
 
   NativeModule.prototype.compile = function() {
```

Hat tip to @MarshallOfSound for investigating and putting forth this fix 👍 🎩 

Closes #8611