### PR TITLE
Implement invalidate for non-offscreen mode

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1496,12 +1496,8 @@ void WebContents::Invalidate() {
       osr_rwhv->Invalidate();
   } else {
     const auto ownerWindow = owner_window();
-    const auto nativeWindow = ownerWindow ? ownerWindow->GetNativeWindow() :
-                                            nullptr;
-    if (nativeWindow) {
-      const gfx::Rect& bounds = nativeWindow->bounds();
-      nativeWindow->SchedulePaintInRect(
-        gfx::Rect(0, 0, bounds.width(), bounds.height()));
+    if (ownerWindow) {
+      ownerWindow->Invalidate();
     }
   }
 }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1496,9 +1496,8 @@ void WebContents::Invalidate() {
       osr_rwhv->Invalidate();
   } else {
     const auto ownerWindow = owner_window();
-    if (ownerWindow) {
+    if (ownerWindow)
       ownerWindow->Invalidate();
-    }
   }
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1489,20 +1489,20 @@ int WebContents::GetFrameRate() const {
 }
 
 void WebContents::Invalidate() {
-	if (IsOffScreen()) {
-		auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-			web_contents()->GetRenderWidgetHostView());
-		if (osr_rwhv)
-			osr_rwhv->Invalidate();
-	}
-	else {
-		const auto ownerWindow = owner_window();
-		const auto nativeWindow = ownerWindow ? ownerWindow->GetNativeWindow() : nullptr;
-		if (nativeWindow) {
-			const gfx::Rect& bounds = nativeWindow->bounds();
-			nativeWindow->SchedulePaintInRect(gfx::Rect(0, 0, bounds.width(), bounds.height()));
-		}
-	}
+  if (IsOffScreen()) {
+    auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
+      web_contents()->GetRenderWidgetHostView());
+    if (osr_rwhv)
+      osr_rwhv->Invalidate();
+  }
+  else {
+    const auto ownerWindow = owner_window();
+    const auto nativeWindow = ownerWindow ? ownerWindow->GetNativeWindow() : nullptr;
+    if (nativeWindow) {
+      const gfx::Rect& bounds = nativeWindow->bounds();
+      nativeWindow->SchedulePaintInRect(gfx::Rect(0, 0, bounds.width(), bounds.height()));
+    }
+  }
 }
 
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1494,13 +1494,14 @@ void WebContents::Invalidate() {
       web_contents()->GetRenderWidgetHostView());
     if (osr_rwhv)
       osr_rwhv->Invalidate();
-  }
-  else {
+  } else {
     const auto ownerWindow = owner_window();
-    const auto nativeWindow = ownerWindow ? ownerWindow->GetNativeWindow() : nullptr;
+    const auto nativeWindow = ownerWindow ? ownerWindow->GetNativeWindow() :
+                                            nullptr;
     if (nativeWindow) {
       const gfx::Rect& bounds = nativeWindow->bounds();
-      nativeWindow->SchedulePaintInRect(gfx::Rect(0, 0, bounds.width(), bounds.height()));
+      nativeWindow->SchedulePaintInRect(
+        gfx::Rect(0, 0, bounds.width(), bounds.height()));
     }
   }
 }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1495,9 +1495,9 @@ void WebContents::Invalidate() {
     if (osr_rwhv)
       osr_rwhv->Invalidate();
   } else {
-    const auto ownerWindow = owner_window();
-    if (ownerWindow)
-      ownerWindow->Invalidate();
+    const auto owner_window = owner_window();
+    if (owner_window)
+      owner_window->Invalidate();
   }
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1489,13 +1489,20 @@ int WebContents::GetFrameRate() const {
 }
 
 void WebContents::Invalidate() {
-  if (!IsOffScreen())
-    return;
-
-  auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-      web_contents()->GetRenderWidgetHostView());
-  if (osr_rwhv)
-    osr_rwhv->Invalidate();
+	if (IsOffScreen()) {
+		auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
+			web_contents()->GetRenderWidgetHostView());
+		if (osr_rwhv)
+			osr_rwhv->Invalidate();
+	}
+	else {
+		const auto ownerWindow = owner_window();
+		const auto nativeWindow = ownerWindow ? ownerWindow->GetNativeWindow() : nullptr;
+		if (nativeWindow) {
+			const gfx::Rect& bounds = nativeWindow->bounds();
+			nativeWindow->SchedulePaintInRect(gfx::Rect(0, 0, bounds.width(), bounds.height()));
+		}
+	}
 }
 
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -124,6 +124,7 @@ class NativeWindow : public base::SupportsUserData,
                               std::string* error = nullptr) = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;
+  virtual void Invalidate() = 0;
   virtual void SetTitle(const std::string& title) = 0;
   virtual std::string GetTitle() = 0;
   virtual void FlashFrame(bool flash) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -71,6 +71,7 @@ class NativeWindowMac : public NativeWindow,
                       int relativeLevel, std::string* error) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
+  void Invalidate() override;
   void SetTitle(const std::string& title) override;
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1101,6 +1101,11 @@ void NativeWindowMac::Center() {
   [window_ center];
 }
 
+void NativeWindowMac::Invalidate() {
+  [window_ flushWindow];
+  [[window_ contentView] setNeedsDisplay:TRUE];
+}
+
 void NativeWindowMac::SetTitle(const std::string& title) {
   // For macOS <= 10.9, the setTitleVisibility API is not available, we have
   // to avoid calling setTitle for frameless window.

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1103,7 +1103,7 @@ void NativeWindowMac::Center() {
 
 void NativeWindowMac::Invalidate() {
   [window_ flushWindow];
-  [[window_ contentView] setNeedsDisplay:TRUE];
+  [[window_ contentView] setNeedsDisplay:YES];
 }
 
 void NativeWindowMac::SetTitle(const std::string& title) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -695,6 +695,12 @@ void NativeWindowViews::Center() {
   window_->CenterWindow(GetSize());
 }
 
+void NativeWindowViews::Invalidate() {
+  const gfx::Rect& bounds = GetBounds();
+  window_->SchedulePaintInRect(
+    gfx::Rect(0, 0, bounds.width(), bounds.height()));
+}
+
 void NativeWindowViews::SetTitle(const std::string& title) {
   title_ = title;
   window_->UpdateWindowTitle();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -696,7 +696,6 @@ void NativeWindowViews::Center() {
 }
 
 void NativeWindowViews::Invalidate() {
-  const gfx::Rect& bounds = GetBounds();
   window_->SchedulePaintInRect(gfx::Rect(GetBounds().size()));
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -697,8 +697,7 @@ void NativeWindowViews::Center() {
 
 void NativeWindowViews::Invalidate() {
   const gfx::Rect& bounds = GetBounds();
-  window_->SchedulePaintInRect(
-    gfx::Rect(0, 0, bounds.width(), bounds.height()));
+  window_->SchedulePaintInRect(gfx::Rect(GetBounds().size()));
 }
 
 void NativeWindowViews::SetTitle(const std::string& title) {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -90,6 +90,7 @@ class NativeWindowViews : public NativeWindow,
                       int relativeLevel, std::string* error) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
+  void Invalidate() override;
   void SetTitle(const std::string& title) override;
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1210,6 +1210,8 @@ Returns `Integer` - If *offscreen rendering* is enabled returns the current fram
 
 #### `contents.invalidate()`
 
+Schedules a full repaint of the window this web contents is in.
+
 If *offscreen rendering* is enabled invalidates the frame and generates a new
 one through the `'paint'` event.
 


### PR DESCRIPTION
This PR implements the `webContents.invalidate` method for non-offscreen mode. It will schedule a paint to the native window.

An example use case for this method: A few games on Steam use Electron and [Greenworks](https://github.com/greenheartgames/greenworks). Steam games have an in-game overlay that shows up over the game, which users can toggle via a keybind. This overlay has many issues in electron apps. 

The main issue is that since the overlay is hooked into the renderer, the overlay is frozen / corrupted when the renderer isn't painting or if it's only painting small dirty regions. We used to implement some shady methods to force repaints, such as having multiple 1x1 pixel canvases refreshing, or translateZ(0)ing some elements.. but these hacks stopped working properly in newer Chromium versions.  See [Greenworks#50](https://github.com/greenheartgames/greenworks/issues/50) for detailed discussion.
Calling this invalidate method often (60fps / every animation frame) completely solves this issue.