### PR TITLE
Allow multiple verification results in specs

### DIFF
--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -556,9 +556,9 @@ describe('session module', function () {
       server.close()
     })
 
-    it('accepts the request when the callback is called with true', function (done) {
+    it('accepts the request when the callback is called with 0', function (done) {
       session.defaultSession.setCertificateVerifyProc(function ({hostname, certificate, verificationResult}, callback) {
-        assert.equal(verificationResult, 'net::ERR_CERT_AUTHORITY_INVALID')
+        assert(['net::ERR_CERT_AUTHORITY_INVALID', 'net::ERR_CERT_COMMON_NAME_INVALID'].includes(verificationResult), verificationResult)
         callback(0)
       })
 
@@ -598,7 +598,7 @@ describe('session module', function () {
       })
     })
 
-    it('rejects the request when the callback is called with false', function (done) {
+    it('rejects the request when the callback is called with -2', function (done) {
       session.defaultSession.setCertificateVerifyProc(function ({hostname, certificate, verificationResult}, callback) {
         assert.equal(hostname, '127.0.0.1')
         assert.equal(certificate.issuerName, 'Intermediate CA')
@@ -610,7 +610,7 @@ describe('session module', function () {
         assert.equal(certificate.issuerCert.issuerCert.issuer.commonName, 'Root CA')
         assert.equal(certificate.issuerCert.issuerCert.subject.commonName, 'Root CA')
         assert.equal(certificate.issuerCert.issuerCert.issuerCert, undefined)
-        assert.equal(verificationResult, 'net::ERR_CERT_AUTHORITY_INVALID')
+        assert(['net::ERR_CERT_AUTHORITY_INVALID', 'net::ERR_CERT_COMMON_NAME_INVALID'].includes(verificationResult), verificationResult)
         callback(-2)
       })
 


### PR DESCRIPTION
Looks like CI on Linux failed because it got a different message.

Update the specs to allow either.

```
not ok 356 session module ses.setCertificateVerifyProc(callback) accepts the request when the callback is called with true
  AssertionError: 'net::ERR_CERT_COMMON_NAME_INVALID' == 'net::ERR_CERT_AUTHORITY_INVALID'
      at /var/lib/jenkins/workspace/electron-linux-x64/spec/api-session-spec.js:561:16
      at CallbacksRegistry.apply (/var/lib/jenkins/workspace/electron-linux-x64/out/D/resources/electron.asar/common/api/callbacks-registry.js:48:42)
      at EventEmitter.<anonymous> (/var/lib/jenkins/workspace/electron-linux-x64/out/D/resources/electron.asar/renderer/api/remote.js:283:21)
      at emitThree (events.js:116:13)
      at EventEmitter.emit (events.js:194:7)
```

Refs #7955 