### PR TITLE
Update libchromiumcontent: fix usage of private API in MAS build

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    'ea20b8dfe0a7fad61bb4917404950ddcd2224588'
+    '4f5b89374df7ee69095b9f7d50b30fb46ddd7407'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
Refs https://github.com/electron/libchromiumcontent/pull/261.
Close https://github.com/electron/electron/issues/8555.