### PR TITLE
Call content::WebContentsObserver first

### DIFF
--- a/atom/browser/web_contents_zoom_controller.cc
+++ b/atom/browser/web_contents_zoom_controller.cc
@@ -20,10 +20,10 @@ namespace atom {
 
 WebContentsZoomController::WebContentsZoomController(
     content::WebContents* web_contents)
-    : old_process_id_(-1),
+    : content::WebContentsObserver(web_contents),
+      old_process_id_(-1),
       old_view_id_(-1),
-      embedder_zoom_controller_(nullptr),
-      content::WebContentsObserver(web_contents) {
+      embedder_zoom_controller_(nullptr) {
   default_zoom_factor_ = content::kEpsilon;
   host_zoom_map_ = content::HostZoomMap::GetForWebContents(web_contents);
   zoom_subscription_ = host_zoom_map_->AddZoomLevelChangedCallback(base::Bind(


### PR DESCRIPTION
Mac build is currently failing with the following compiler error:

```
../../atom/browser/web_contents_zoom_controller.cc:25:7: error: field 'embedder_zoom_controller_' will be initialized after base 'content::WebContentsObserver' [-Werror,-Wreorder]
      embedder_zoom_controller_(nullptr),
      ^
1 error generated.
```