### PR TITLE
Call OnWindowScrollTouchEnd instead of Edge

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -531,7 +531,7 @@ void NativeWindow::NotifyWindowScrollTouchBegin() {
 
 void NativeWindow::NotifyWindowScrollTouchEnd() {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowScrollTouchEdge();
+    observer.OnWindowScrollTouchEnd();
 }
 
 void NativeWindow::NotifyWindowScrollTouchEdge() {


### PR DESCRIPTION
Previously it was notifying edge listeners when an end event fired, this updates it to notify end listeners instead.

Refs #8501 
Closes #8621