### PR TITLE
Disable the ActiveVerifier

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -102,6 +102,9 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 #if defined(OS_WIN)
   // Ignore invalid parameter errors.
   _set_invalid_parameter_handler(InvalidParameterHandler);
+  // Disable the ActiveVerifier, which is used by Chrome to track possible
+  // bugs, but no use in Electron.
+  base::win::DisableHandleVerifier();
 #endif
 
   return brightray::MainDelegate::BasicStartupComplete(exit_code);


### PR DESCRIPTION
Close https://github.com/electron/electron/issues/8055.

This is probably not the best fix, but it gives better performance and avoids all related crashes and locks. It is also disabled on Release version of Chrome browser:
https://cs.chromium.org/chromium/src/chrome/app/chrome_main_delegate.cc?type=cs&q=InstallHandleHooks&l=206