### PR TITLE
Use electron version in Chromedriver asset name

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -9,8 +9,7 @@ import sys
 import stat
 
 from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
-                       get_target_arch, get_chromedriver_version, \
-                       get_zip_name
+                       get_target_arch, get_zip_name
 from lib.util import scoped_cwd, rm_rf, get_electron_version, make_zip, \
                      execute, electron_gyp
 
@@ -94,7 +93,7 @@ def main():
 
   create_version()
   create_dist_zip()
-  create_chrome_binary_zip('chromedriver', get_chromedriver_version())
+  create_chrome_binary_zip('chromedriver', ELECTRON_VERSION)
   create_chrome_binary_zip('mksnapshot', ELECTRON_VERSION)
   create_ffmpeg_zip()
   create_symbols_zip()

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -42,9 +42,6 @@ def get_target_arch():
   return 'x64'
 
 
-def get_chromedriver_version():
-  return 'v2.21'
-
 def get_env_var(name):
   value = os.environ.get('ELECTRON_' + name, '')
   if not value:

--- a/script/upload.py
+++ b/script/upload.py
@@ -10,8 +10,8 @@ import sys
 import tempfile
 
 from io import StringIO
-from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
-                       get_env_var, s3_config, get_zip_name
+from lib.config import PLATFORM, get_target_arch,  get_env_var, s3_config, \
+                       get_zip_name
 from lib.util import electron_gyp, execute, get_electron_version, \
                      parse_version, scoped_cwd, s3put
 from lib.github import GitHub
@@ -91,7 +91,7 @@ def main():
 
   # Upload chromedriver and mksnapshot for minor version update.
   if parse_version(args.version)[2] == '0':
-    chromedriver = get_zip_name('chromedriver', get_chromedriver_version())
+    chromedriver = get_zip_name('chromedriver', ELECTRON_VERSION)
     upload_electron(github, release, os.path.join(DIST_DIR, chromedriver))
     mksnapshot = get_zip_name('mksnapshot', ELECTRON_VERSION)
     upload_electron(github, release, os.path.join(DIST_DIR, mksnapshot))


### PR DESCRIPTION
Put the electron version in the asset name of the Chromedriver asset that ships with each new minor Electron release.

This prevents issue with caching by asset name and also makes it consistent with the `ffmpeg` and `mksnapshot` asset names.

Fixes #8653