### PR TITLE
Pass correct window to menu items

### DIFF
--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -41,15 +41,15 @@ const MenuItem = function (options) {
   this.overrideReadOnlyProperty('commandId', ++nextCommandId)
 
   const click = options.click
-  this.click = (event, focusedWindow, focusedWebContents) => {
+  this.click = (event, menuWindow, menuWebContents) => {
     // Manually flip the checked flags when clicked.
     if (this.type === 'checkbox' || this.type === 'radio') {
       this.checked = !this.checked
     }
 
-    if (!roles.execute(this.role, focusedWindow, focusedWebContents)) {
+    if (!roles.execute(this.role, menuWindow, menuWebContents)) {
       if (typeof click === 'function') {
-        click(this, focusedWindow, event)
+        click(this, menuWindow, event)
       } else if (typeof this.selector === 'string' && process.platform === 'darwin') {
         Menu.sendActionToFirstResponder(this.selector)
       }

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -89,6 +89,7 @@ const Menu = bindings.Menu
 Object.setPrototypeOf(Menu.prototype, EventEmitter.prototype)
 
 Menu.prototype._init = function () {
+  this.window = null
   this.commandsMap = {}
   this.groupsMap = {}
   this.items = []
@@ -118,7 +119,11 @@ Menu.prototype._init = function () {
     executeCommand: (event, commandId) => {
       const command = this.commandsMap[commandId]
       if (command == null) return
-      command.click(event, BrowserWindow.getFocusedWindow(), webContents.getFocusedWebContents())
+      // If there was a window passed to `popup()` method, use it.
+      // Otherwise use a focused one.
+      const menuWindow = this.window || BrowserWindow.getFocusedWindow()
+      const menuWebContents = this.window ? this.window.webContents : webContents.getFocusedWebContents()
+      command.click(event, menuWindow, menuWebContents)
     },
     menuWillShow: () => {
       // Make sure radio groups have at least one menu item seleted.
@@ -143,6 +148,10 @@ Menu.prototype._init = function () {
   }
 }
 
+Menu.prototype._setWindow = function (window) {
+  this.window = window
+}
+
 Menu.prototype.popup = function (window, x, y, positioningItem) {
   let asyncPopup
 
@@ -152,7 +161,10 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     positioningItem = y
     y = x
     x = window
-    window = null
+    window = BrowserWindow.getFocusedWindow()
+    this.window = null
+  } else {
+    this.window = window
   }
 
   // menu.popup(window, {})

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -90,6 +90,7 @@ Object.setPrototypeOf(Menu.prototype, EventEmitter.prototype)
 
 Menu.prototype._init = function () {
   this.window = null
+  this.webContents = null
   this.commandsMap = {}
   this.groupsMap = {}
   this.items = []
@@ -119,10 +120,8 @@ Menu.prototype._init = function () {
     executeCommand: (event, commandId) => {
       const command = this.commandsMap[commandId]
       if (command == null) return
-      // If there was a window passed to `popup()` method, use it.
-      // Otherwise use a focused one.
       const menuWindow = this.window || BrowserWindow.getFocusedWindow()
-      const menuWebContents = this.window ? this.window.webContents : webContents.getFocusedWebContents()
+      const menuWebContents = this.webContents || webContents.getFocusedWebContents()
       command.click(event, menuWindow, menuWebContents)
     },
     menuWillShow: () => {
@@ -148,10 +147,6 @@ Menu.prototype._init = function () {
   }
 }
 
-Menu.prototype._setWindow = function (window) {
-  this.window = window
-}
-
 Menu.prototype.popup = function (window, x, y, positioningItem) {
   let asyncPopup
 
@@ -161,10 +156,11 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     positioningItem = y
     y = x
     x = window
-    window = BrowserWindow.getFocusedWindow()
-    this.window = null
+    this.window = BrowserWindow.getFocusedWindow()
+    this.webContents = webContents.getFocusedWebContents()
   } else {
     this.window = window
+    this.webContents = window.webContents
   }
 
   // menu.popup(window, {})
@@ -174,10 +170,10 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     y = options.y
     positioningItem = options.positioningItem
     asyncPopup = options.async
+    if (options.webContents) {
+      this.webContents = options.webContents
+    }
   }
-
-  // Default to showing in focused window.
-  if (window == null) window = BrowserWindow.getFocusedWindow()
 
   // Default to showing under mouse location.
   if (typeof x !== 'number') x = -1
@@ -189,7 +185,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   // Default to synchronous for backwards compatibility.
   if (typeof asyncPopup !== 'boolean') asyncPopup = false
 
-  this.popupAt(window, x, y, positioningItem, asyncPopup)
+  this.popupAt(this.window, x, y, positioningItem, asyncPopup)
 }
 
 Menu.prototype.closePopup = function (window) {
@@ -280,6 +276,11 @@ Menu.prototype._callMenuWillShow = function () {
       item.submenu._callMenuWillShow()
     }
   })
+}
+
+// The method is used in tests.
+Menu.prototype._setWindow = function (window) {
+  this.window = window
 }
 
 var applicationMenu = null

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -53,7 +53,7 @@ const convertToMenuTemplate = function (items) {
 
 const createMenu = function (x, y, items) {
   const {remote} = require('electron')
-  const {Menu} = remote
+  const {Menu, webContents} = remote
 
   let template = convertToMenuTemplate(items)
   if (useEditMenuItems(x, y, template)) {
@@ -63,7 +63,9 @@ const createMenu = function (x, y, items) {
 
   // The menu is expected to show asynchronously.
   setTimeout(function () {
-    menu.popup(remote.getCurrentWindow())
+    menu.popup(remote.getCurrentWindow(), {
+      webContents: webContents.getFocusedWebContents()
+    })
   })
 }
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -255,6 +255,41 @@ describe('menu module', function () {
       ])
       menu.delegate.executeCommand({}, menu.items[0].commandId)
     })
+
+    it('should be called with focused window passed by default', function (done) {
+      var menu = Menu.buildFromTemplate([
+        {
+          label: 'text',
+          click: function (item, window) {
+            assert.equal(window, BrowserWindow.getFocusedWindow())
+            done()
+          }
+        }
+      ])
+      menu.delegate.executeCommand({}, menu.items[0].commandId)
+    })
+
+    it('should be called with the menu window if one is passed', function (done) {
+      var window1 = new BrowserWindow({title: 'a'})
+      var window2 = new BrowserWindow({title: 'b'})
+      window1.focus()
+
+      var menu = Menu.buildFromTemplate([
+        {
+          label: 'text',
+          click: function (item, window) {
+            assert.equal(BrowserWindow.getFocusedWindow().getTitle(), 'a')
+            assert.equal(window.getTitle(), 'b')
+            window1.close()
+            window2.close()
+            done()
+          }
+        }
+      ])
+
+      menu._setWindow(window2)
+      menu.delegate.executeCommand({}, menu.items[0].commandId)
+    })
   })
 
   describe('MenuItem with checked property', function () {


### PR DESCRIPTION
Fix for #8209.

In situation when there are two windows open, with one being in focus and another one being blurred, if we popup menu for the blurred window, click callbacks for menu items will get either `null` or focused window as second parameter.
That fix passes information about window used in `popup` method with fallback to a focused window.

Note that even though Chrome focuses a blurred window when you right-click on it, I don't think that will be a desired behavior for Electron users. Plus devs can always focus desired window manually. So I didn't modify that "focusing" logic.

I had trouble with the test. Apparently if I just use `menu.popup(window)`, the test gets stuck because no code after that line is run before I manually click on the window to close context menu. And I see no way to close it programmatically. So as a workaround I just set `menu.window` property (which should be done by `popup` method) and for that I created a testing-only method `_setWindow`. I don't like how it all looks, so I'll be grateful for advice on how to write a good test for my changes.