### PR TITLE
[Win] Allow favicon.png to be on the root of any drive letter

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -524,7 +524,7 @@ describe('<webview> tag', function () {
       webview.addEventListener('page-favicon-updated', function (e) {
         assert.equal(e.favicons.length, 2)
         if (process.platform === 'win32') {
-          assert(/^file:\/\/\/[a-zA-Z]:\/favicon.png$/i.test(e.favicons[0]))
+          assert(/^file:\/\/\/[A-Z]:\/favicon.png$/i.test(e.favicons[0]))
         } else {
           assert.equal(e.favicons[0], 'file:///favicon.png')
         }

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -523,8 +523,11 @@ describe('<webview> tag', function () {
     it('emits when favicon urls are received', function (done) {
       webview.addEventListener('page-favicon-updated', function (e) {
         assert.equal(e.favicons.length, 2)
-        var pageUrl = process.platform === 'win32' ? 'file:///C:/favicon.png' : 'file:///favicon.png'
-        assert.equal(e.favicons[0], pageUrl)
+        if (process.platform === 'win32') {
+          assert(/^file:\/\/\/[a-zA-Z]:\/favicon.png$/.test(e.favicons[0]))
+        } else {
+          assert.equal(e.favicons[0], 'file:///favicon.png')
+        }
         done()
       })
       webview.src = 'file://' + fixtures + '/pages/a.html'

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -524,7 +524,7 @@ describe('<webview> tag', function () {
       webview.addEventListener('page-favicon-updated', function (e) {
         assert.equal(e.favicons.length, 2)
         if (process.platform === 'win32') {
-          assert(/^file:\/\/\/[a-zA-Z]:\/favicon.png$/.test(e.favicons[0]))
+          assert(/^file:\/\/\/[a-zA-Z]:\/favicon.png$/i.test(e.favicons[0]))
         } else {
           assert.equal(e.favicons[0], 'file:///favicon.png')
         }


### PR DESCRIPTION
Hi, I work on the Microsoft C++ compiler team and we build & run the Electron tests as part of daily compiler validation.

The "emits when favicon urls are received" test fails for us as we are building & running the tests on drive F, and it appears that the test is checking precisely for file:///C:/favicon.png. This PR changes it to a regex to match any drive letter (Windows only).

Thanks!
Eric Brumer