### PR TITLE
Add async menu.popup option

### DIFF
--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -176,7 +176,8 @@ void Menu::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isItemCheckedAt", &Menu::IsItemCheckedAt)
       .SetMethod("isEnabledAt", &Menu::IsEnabledAt)
       .SetMethod("isVisibleAt", &Menu::IsVisibleAt)
-      .SetMethod("popupAt", &Menu::PopupAt);
+      .SetMethod("popupAt", &Menu::PopupAt)
+      .SetMethod("closePopupAt", &Menu::ClosePopupAt);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -53,8 +53,8 @@ class Menu : public mate::TrackableObject<Menu>,
   void ExecuteCommand(int command_id, int event_flags) override;
   void MenuWillShow(ui::SimpleMenuModel* source) override;
 
-  virtual void PopupAt(Window* window, int x, int y, int positioning_item,
-                      bool async) = 0;
+  virtual void PopupAt(
+      Window* window, int x, int y, int positioning_item, bool async) = 0;
   virtual void ClosePopupAt(int32_t window_id) = 0;
 
   std::unique_ptr<AtomMenuModel> model_;

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -55,6 +55,7 @@ class Menu : public mate::TrackableObject<Menu>,
 
   virtual void PopupAt(Window* window, int x, int y, int positioning_item,
                       bool async) = 0;
+  virtual void ClosePopupAt(int32_t window_id) = 0;
 
   std::unique_ptr<AtomMenuModel> model_;
   Menu* parent_;

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -53,9 +53,8 @@ class Menu : public mate::TrackableObject<Menu>,
   void ExecuteCommand(int command_id, int event_flags) override;
   void MenuWillShow(ui::SimpleMenuModel* source) override;
 
-  virtual void PopupAt(Window* window,
-                       int x = -1, int y = -1,
-                       int positioning_item = 0) = 0;
+  virtual void PopupAt(Window* window, int x, int y, int positioning_item,
+                      bool async) = 0;
 
   std::unique_ptr<AtomMenuModel> model_;
   Menu* parent_;

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -19,9 +19,10 @@ class MenuMac : public Menu {
  protected:
   MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
 
-  void PopupAt(Window* window, int x, int y, int positioning_item) override;
+  void PopupAt(
+      Window* window, int x, int y, int positioning_item, bool async) override;
   void PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
-                 int x, int y, int positioning_item);
+                 int x, int y, int positioning_item, bool async);
 
   base::scoped_nsobject<AtomMenuController> menu_controller_;
 

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -20,6 +20,8 @@ class MenuMac : public Menu {
   MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
 
   void PopupAt(Window* window, int x, int y, int positioning_item) override;
+  void PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
+                 int x, int y, int positioning_item);
 
   base::scoped_nsobject<AtomMenuController> menu_controller_;
 
@@ -27,6 +29,8 @@ class MenuMac : public Menu {
   friend class Menu;
 
   static void SendActionToFirstResponder(const std::string& action);
+
+  base::WeakPtrFactory<MenuMac> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(MenuMac);
 };

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -7,9 +7,12 @@
 
 #include "atom/browser/api/atom_api_menu.h"
 
+#include <map>
 #include <string>
 
 #import "atom/browser/ui/cocoa/atom_menu_controller.h"
+
+using base::scoped_nsobject;
 
 namespace atom {
 
@@ -22,9 +25,12 @@ class MenuMac : public Menu {
   void PopupAt(
       Window* window, int x, int y, int positioning_item, bool async) override;
   void PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
-                 int x, int y, int positioning_item, bool async);
+                 int32_t window_id, int x, int y, int positioning_item,
+                 bool async);
+  void ClosePopupAt(int32_t window_id) override;
 
-  base::scoped_nsobject<AtomMenuController> menu_controller_;
+  scoped_nsobject<AtomMenuController> menu_controller_;
+  std::map<int32_t, scoped_nsobject<AtomMenuController>> popup_controllers_;
 
  private:
   friend class Menu;

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -29,13 +29,15 @@ class MenuMac : public Menu {
                  bool async);
   void ClosePopupAt(int32_t window_id) override;
 
-  scoped_nsobject<AtomMenuController> menu_controller_;
-  std::map<int32_t, scoped_nsobject<AtomMenuController>> popup_controllers_;
-
  private:
   friend class Menu;
 
   static void SendActionToFirstResponder(const std::string& action);
+
+  scoped_nsobject<AtomMenuController> menu_controller_;
+
+  // window ID -> open context menu
+  std::map<int32_t, scoped_nsobject<AtomMenuController>> popup_controllers_;
 
   base::WeakPtrFactory<MenuMac> weak_factory_;
 

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -6,10 +6,12 @@
 
 #include "atom/browser/native_window.h"
 #include "atom/browser/unresponsive_suppressor.h"
+#include "base/mac/scoped_sending_event.h"
 #include "base/message_loop/message_loop.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brightray/browser/inspectable_web_contents.h"
 #include "brightray/browser/inspectable_web_contents_view.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_contents.h"
 
 #include "atom/common/node_includes.h"
@@ -19,11 +21,22 @@ namespace atom {
 namespace api {
 
 MenuMac::MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
-    : Menu(isolate, wrapper) {
+    : Menu(isolate, wrapper),
+      weak_factory_(this) {
 }
 
 void MenuMac::PopupAt(Window* window, int x, int y, int positioning_item) {
   NativeWindow* native_window = window->window();
+  if (!native_window)
+    return;
+
+  content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,
+      base::Bind(&MenuMac::PopupOnUI, weak_factory_.GetWeakPtr(),
+                 native_window->GetWeakPtr(), x, y, positioning_item));
+}
+
+void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
+                        int x, int y, int positioning_item) {
   if (!native_window)
     return;
   brightray::InspectableWebContents* web_contents =
@@ -69,11 +82,24 @@ void MenuMac::PopupAt(Window* window, int x, int y, int positioning_item) {
   if (rightmostMenuPoint > screenRight)
     position.x = position.x - [menu size].width;
 
-  // Don't emit unresponsive event when showing menu.
-  atom::UnresponsiveSuppressor suppressor;
+  {
+    // Make sure events can be pumped while the menu is up.
+    base::MessageLoop::ScopedNestableTaskAllower allow(
+        base::MessageLoop::current());
 
-  // Show the menu.
-  [menu popUpMenuPositioningItem:item atLocation:position inView:view];
+    // One of the events that could be pumped is |window.close()|.
+    // User-initiated event-tracking loops protect against this by
+    // setting flags in -[CrApplication sendEvent:], but since
+    // web-content menus are initiated by IPC message the setup has to
+    // be done manually.
+    base::mac::ScopedSendingEvent sendingEventScoper;
+
+    // Don't emit unresponsive event when showing menu.
+    atom::UnresponsiveSuppressor suppressor;
+
+    // Show the menu.
+    [menu popUpMenuPositioningItem:item atLocation:position inView:view];
+  }
 }
 
 // static

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -20,7 +20,8 @@ MenuViews::MenuViews(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
       weak_factory_(this) {
 }
 
-void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
+void MenuViews::PopupAt(
+    Window* window, int x, int y, int positioning_item, bool async) {
   NativeWindow* native_window = static_cast<NativeWindow*>(window->window());
   if (!native_window)
     return;
@@ -40,13 +41,17 @@ void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
     location = gfx::Point(origin.x() + x, origin.y() + y);
   }
 
+  int flags = MenuRunner::CONTEXT_MENU | MenuRunner::HAS_MNEMONICS;
+  if (async)
+    flags |= MenuRunner::ASYNC;
+
   // Don't emit unresponsive event when showing menu.
   atom::UnresponsiveSuppressor suppressor;
 
   // Show the menu.
   menu_runner_.reset(new MenuRunner(
       model(),
-      MenuRunner::CONTEXT_MENU | MenuRunner::HAS_MNEMONICS | MenuRunner::ASYNC,
+      flags,
       base::Bind(&MenuViews::OnMenuClosed, weak_factory_.GetWeakPtr())));
   ignore_result(menu_runner_->RunMenuAt(
       static_cast<NativeWindowViews*>(window->window())->widget(),

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -49,20 +49,17 @@ void MenuViews::PopupAt(
   atom::UnresponsiveSuppressor suppressor;
 
   // Show the menu.
-  menu_runner_.reset(new MenuRunner(
-      model(),
-      flags,
-      base::Bind(&MenuViews::OnMenuClosed, weak_factory_.GetWeakPtr())));
-  ignore_result(menu_runner_->RunMenuAt(
+  int32_t window_id = window->ID();
+  auto close_callback = base::Bind(
+      &MenuViews::ClosePopupAt, weak_factory_.GetWeakPtr(), window_id);
+  menu_runners_[window_id] = std::unique_ptr<MenuRunner>(new MenuRunner(
+      model(), flags, close_callback));
+  ignore_result(menu_runners_[window_id]->RunMenuAt(
       static_cast<NativeWindowViews*>(window->window())->widget(),
       NULL,
       gfx::Rect(location, gfx::Size()),
       views::MENU_ANCHOR_TOPLEFT,
       ui::MENU_SOURCE_MOUSE));
-}
-
-void MenuViews::OnMenuClosed() {
-  menu_runner_.reset();
 }
 
 // static

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -62,6 +62,10 @@ void MenuViews::PopupAt(
       ui::MENU_SOURCE_MOUSE));
 }
 
+void MenuViews::ClosePopupAt(int32_t window_id) {
+  menu_runners_.erase(window_id);
+}
+
 // static
 mate::WrappableBase* Menu::New(mate::Arguments* args) {
   return new MenuViews(args->isolate(), args->GetThis());

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -6,7 +6,9 @@
 #define ATOM_BROWSER_API_ATOM_API_MENU_VIEWS_H_
 
 #include "atom/browser/api/atom_api_menu.h"
+#include "base/memory/weak_ptr.h"
 #include "ui/display/screen.h"
+#include "ui/views/controls/menu/menu_runner.h"
 
 namespace atom {
 
@@ -18,8 +20,12 @@ class MenuViews : public Menu {
 
  protected:
   void PopupAt(Window* window, int x, int y, int positioning_item) override;
+  void OnMenuClosed();
 
  private:
+  std::unique_ptr<views::MenuRunner> menu_runner_;
+  base::WeakPtrFactory<MenuViews> weak_factory_;
+
   DISALLOW_COPY_AND_ASSIGN(MenuViews);
 };
 

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_MENU_VIEWS_H_
 #define ATOM_BROWSER_API_ATOM_API_MENU_VIEWS_H_
 
+#include <map>
+
 #include "atom/browser/api/atom_api_menu.h"
 #include "base/memory/weak_ptr.h"
 #include "ui/display/screen.h"
@@ -21,10 +23,10 @@ class MenuViews : public Menu {
  protected:
   void PopupAt(
       Window* window, int x, int y, int positioning_item, bool async) override;
-  void OnMenuClosed();
+  void ClosePopupAt(int32_t window_id);
 
  private:
-  std::unique_ptr<views::MenuRunner> menu_runner_;
+  std::map<int32_t, std::unique_ptr<views::MenuRunner>> menu_runners_;
   base::WeakPtrFactory<MenuViews> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(MenuViews);

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -23,7 +23,7 @@ class MenuViews : public Menu {
  protected:
   void PopupAt(
       Window* window, int x, int y, int positioning_item, bool async) override;
-  void ClosePopupAt(int32_t window_id);
+  void ClosePopupAt(int32_t window_id) override;
 
  private:
   std::map<int32_t, std::unique_ptr<views::MenuRunner>> menu_runners_;

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -26,7 +26,9 @@ class MenuViews : public Menu {
   void ClosePopupAt(int32_t window_id) override;
 
  private:
+  // window ID -> open context menu
   std::map<int32_t, std::unique_ptr<views::MenuRunner>> menu_runners_;
+
   base::WeakPtrFactory<MenuViews> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(MenuViews);

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -19,7 +19,8 @@ class MenuViews : public Menu {
   MenuViews(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
 
  protected:
-  void PopupAt(Window* window, int x, int y, int positioning_item) override;
+  void PopupAt(
+      Window* window, int x, int y, int positioning_item, bool async) override;
   void OnMenuClosed();
 
  private:

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -51,6 +51,8 @@ class Window : public mate::TrackableObject<Window>,
 
   NativeWindow* window() const { return window_.get(); }
 
+  int32_t ID() const;
+
  protected:
   Window(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,
          const mate::Dictionary& options);
@@ -202,7 +204,6 @@ class Window : public mate::TrackableObject<Window>,
 
   void SetVibrancy(mate::Arguments* args);
 
-  int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);
 
   // Remove this window from parent window's |child_windows_|.

--- a/atom/browser/ui/cocoa/atom_menu_controller.h
+++ b/atom/browser/ui/cocoa/atom_menu_controller.h
@@ -8,6 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include "base/callback.h"
 #include "base/mac/scoped_nsobject.h"
 #include "base/strings/string16.h"
 
@@ -27,6 +28,7 @@ class AtomMenuModel;
   base::scoped_nsobject<NSMenu> menu_;
   BOOL isMenuOpen_;
   BOOL useDefaultAccelerator_;
+  base::Callback<void()> closeCallback;
 }
 
 @property(nonatomic, assign) atom::AtomMenuModel* model;
@@ -34,6 +36,8 @@ class AtomMenuModel;
 // Builds a NSMenu from the pre-built model (must not be nil). Changes made
 // to the contents of the model after calling this will not be noticed.
 - (id)initWithModel:(atom::AtomMenuModel*)model useDefaultAccelerator:(BOOL)use;
+
+- (void)setCloseCallback:(const base::Callback<void()>&)callback;
 
 // Populate current NSMenu with |model|.
 - (void)populateWithModel:(atom::AtomMenuModel*)model;

--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -12,8 +12,11 @@
 #include "ui/base/accelerators/accelerator.h"
 #include "ui/base/accelerators/platform_accelerator_cocoa.h"
 #include "ui/base/l10n/l10n_util_mac.h"
+#include "content/public/browser/browser_thread.h"
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/gfx/image/image.h"
+
+using content::BrowserThread;
 
 namespace {
 
@@ -271,8 +274,11 @@ Role kRolesMap[] = {
   if (isMenuOpen_) {
     isMenuOpen_ = NO;
     model_->MenuWillClose();
+
+    // Post async task so that itemSelected runs before the close callback
+    // deletes the controller from the map which deallocates it
     if (!closeCallback.is_null())
-      closeCallback.Run();
+      BrowserThread::PostTask(BrowserThread::UI, FROM_HERE, closeCallback);
   }
 }
 

--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -71,6 +71,10 @@ Role kRolesMap[] = {
   [super dealloc];
 }
 
+- (void)setCloseCallback:(const base::Callback<void()>&)callback {
+  closeCallback = callback;
+}
+
 - (void)populateWithModel:(atom::AtomMenuModel*)model {
   if (!menu_)
     return;
@@ -265,8 +269,10 @@ Role kRolesMap[] = {
 
 - (void)menuDidClose:(NSMenu*)menu {
   if (isMenuOpen_) {
-    model_->MenuWillClose();
     isMenuOpen_ = NO;
+    model_->MenuWillClose();
+    if (!closeCallback.is_null())
+      closeCallback.Run();
   }
 }
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -54,8 +54,7 @@ The `menu` object has the following instance methods:
 
 #### `menu.popup([browserWindow, options])`
 
-* `browserWindow` BrowserWindow (optional) - Default is
-  `BrowserWindow.getFocusedWindow()`.
+* `browserWindow` BrowserWindow (optional) - Default is the focused window.
 * `options` Object (optional)
   * `x` Number (optional) - Default is the current mouse cursor position.
   * `y` Number (**required** if `x` is used) - Default is the current mouse
@@ -68,6 +67,12 @@ The `menu` object has the following instance methods:
     is -1.
 
 Pops up this menu as a context menu in the `browserWindow`.
+
+#### `menu.closePopup([browserWindow])`
+
+* `browserWindow` BrowserWindow (optional) - Default is the focused window.
+
+Closes the context menu in the `browserWindow`.
 
 #### `menu.append(menuItem)`
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -52,14 +52,20 @@ will become properties of the constructed menu items.
 
 The `menu` object has the following instance methods:
 
-#### `menu.popup([browserWindow, x, y, positioningItem])`
+#### `menu.popup([browserWindow, options])`
 
-* `browserWindow` BrowserWindow (optional) - Default is `BrowserWindow.getFocusedWindow()`.
-* `x` Number (optional) - Default is the current mouse cursor position.
-* `y` Number (**required** if `x` is used) - Default is the current mouse cursor position.
-* `positioningItem` Number (optional) _macOS_ - The index of the menu item to
-  be positioned under the mouse cursor at the specified coordinates. Default is
-  -1.
+* `browserWindow` BrowserWindow (optional) - Default is
+  `BrowserWindow.getFocusedWindow()`.
+* `options` Object (optional)
+  * `x` Number (optional) - Default is the current mouse cursor position.
+  * `y` Number (**required** if `x` is used) - Default is the current mouse
+    cursor position.
+  * `async` Boolean (optional) - Set to `true` to have this method return
+    immediately called, `false` to return after the menu has been selected
+    or closed. Defaults to `false`.
+  * `positioningItem` Number (optional) _macOS_ - The index of the menu item to
+    be positioned under the mouse cursor at the specified coordinates. Default
+    is -1.
 
 Pops up this menu as a context menu in the `browserWindow`.
 

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -57,6 +57,15 @@ crashReporter.start({
 })
 ```
 
+## `menu`
+
+```js
+// Deprecated
+menu.popup(browserWindow, 100, 200, 2)
+// Replace with
+menu.popup(browserWindow, {x: 100, y: 200, positioningItem: 2})
+```
+
 ## `nativeImage`
 
 ```js

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -156,7 +156,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   }
 
   // menu.popup(window, {})
-  if (typeof x === 'object') {
+  if (x != null && typeof x === 'object') {
     const options = x
     x = options.x
     y = options.y

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -174,6 +174,15 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   this.popupAt(window, x, y, positioningItem, asyncPopup)
 }
 
+Menu.prototype.closePopup = function (window) {
+  if (window == null || window.constructor !== BrowserWindow) {
+    window = BrowserWindow.getFocusedWindow()
+  }
+  if (window != null) {
+    this.closePopupAt(window.id)
+  }
+}
+
 Menu.prototype.append = function (item) {
   return this.insert(this.getItemCount(), item)
 }

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -144,12 +144,24 @@ Menu.prototype._init = function () {
 }
 
 Menu.prototype.popup = function (window, x, y, positioningItem) {
+  let asyncPopup = false
+
+  // menu.popup(x, y, positioningItem)
   if (typeof window !== 'object' || window.constructor !== BrowserWindow) {
     // Shift.
     positioningItem = y
     y = x
     x = window
     window = BrowserWindow.getFocusedWindow()
+  }
+
+  // menu.popup(window, {})
+  if (typeof x === 'object') {
+    const options = x
+    x = options.x
+    y = options.y
+    positioningItem = options.positioningItem
+    asyncPopup = options.async
   }
 
   // Default to showing under mouse location.
@@ -159,7 +171,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   // Default to not highlighting any item.
   if (typeof positioningItem !== 'number') positioningItem = -1
 
-  this.popupAt(window, x, y, positioningItem)
+  this.popupAt(window, x, y, positioningItem, asyncPopup)
 }
 
 Menu.prototype.append = function (item) {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -1,7 +1,8 @@
 const assert = require('assert')
 
 const {ipcRenderer, remote} = require('electron')
-const {Menu, MenuItem} = remote
+const {BrowserWindow, Menu, MenuItem} = remote
+const {closeWindow} = require('./window-helpers')
 
 describe('menu module', function () {
   describe('Menu.buildFromTemplate', function () {
@@ -216,6 +217,30 @@ describe('menu module', function () {
     })
   })
 
+  describe('Menu.popup', function () {
+    let w = null
+
+    afterEach(function () {
+      return closeWindow(w).then(function () { w = null })
+    })
+
+    describe('when called with async: true', function () {
+      it('returns immediately', function () {
+        w = new BrowserWindow({show: false, width: 200, height: 200})
+        const menu = Menu.buildFromTemplate([
+          {
+            label: '1'
+          }, {
+            label: '2'
+          }, {
+            label: '3'
+          }
+        ])
+        menu.popup(w, {x: 100, y: 100, async: true})
+        menu.closePopup(w)
+      })
+    })
+  })
   describe('MenuItem.click', function () {
     it('should be called with the item object passed', function (done) {
       var menu = Menu.buildFromTemplate([

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -429,26 +429,26 @@ describe('menu module', function () {
       assert.equal(item.getDefaultRoleAccelerator(), process.platform === 'win32' ? 'Control+Y' : 'Shift+CommandOrControl+Z')
     })
   })
-})
 
-describe('MenuItem with custom properties in constructor', function () {
-  it('preserves the custom properties', function () {
-    var template = [{
-      label: 'menu 1',
-      customProp: 'foo',
-      submenu: []
-    }]
+  describe('MenuItem with custom properties in constructor', function () {
+    it('preserves the custom properties', function () {
+      var template = [{
+        label: 'menu 1',
+        customProp: 'foo',
+        submenu: []
+      }]
 
-    var menu = Menu.buildFromTemplate(template)
-    menu.items[0].submenu.append(new MenuItem({
-      label: 'item 1',
-      customProp: 'bar',
-      overrideProperty: 'oops not allowed'
-    }))
+      var menu = Menu.buildFromTemplate(template)
+      menu.items[0].submenu.append(new MenuItem({
+        label: 'item 1',
+        customProp: 'bar',
+        overrideProperty: 'oops not allowed'
+      }))
 
-    assert.equal(menu.items[0].customProp, 'foo')
-    assert.equal(menu.items[0].submenu.items[0].label, 'item 1')
-    assert.equal(menu.items[0].submenu.items[0].customProp, 'bar')
-    assert.equal(typeof menu.items[0].submenu.items[0].overrideProperty, 'function')
+      assert.equal(menu.items[0].customProp, 'foo')
+      assert.equal(menu.items[0].submenu.items[0].label, 'item 1')
+      assert.equal(menu.items[0].submenu.items[0].customProp, 'bar')
+      assert.equal(typeof menu.items[0].submenu.items[0].overrideProperty, 'function')
+    })
   })
 })


### PR DESCRIPTION
Adds an `async` option to `menu.popup` that returns immediately on each platform and does not block the render loop on macOS.

The `menu.popup` signature is also updated (but backwards-compatible) to take an `options` object instead of `x`, `y`, and `positioningItem` arguments.

```js
win.webContents.on('context-menu', (event, params) => {
  menu.popup(win, {
    x: params.x,
    y: params.y,
    async: true
  })

  // Close it for some reason after 2 seconds
  setTimeout(function () {
    menu.closePopup(win)
  }, 2000)
})
```

| Sync (current behavior) | Async (new behavior) |
| --- | --- |
| ![sync-menu](https://cloud.githubusercontent.com/assets/671378/23029927/f4beb8d2-f420-11e6-9f89-04e340d05e67.gif) | ![async-menu](https://cloud.githubusercontent.com/assets/671378/23029925/f38e7eb6-f420-11e6-9549-1014c9806541.gif) |

- [x] Implement `async` option on macOS
- [x] Implement `async` option on Linux/Windows
- [x] Implement `menu.closePopup` on macOS
- [x] Implement `menu.closePopup` on Linux/Windows
- [x] Update `menu.md` API docs
- [x] Add new method signature to `planned-breaking-changes.md`
- [x] Add tests

This does not change the default behavior, this new option is opt-in but that default could be revisited in the 2.0 API.

This pull request also adds a new `menu.closePopup([browserWindow])` API that can be used to explicitly close the context menu.

Closes #1854