### PR TITLE
Update icon loading API implementation

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -30,6 +30,7 @@
 #include "base/path_service.h"
 #include "base/strings/string_util.h"
 #include "brightray/browser/brightray_paths.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/common/chrome_paths.h"
 #include "content/public/browser/browser_accessibility_state.h"
@@ -890,18 +891,16 @@ void App::GetFileIcon(const base::FilePath& path,
     return;
   }
 
-  if (!icon_manager_.get()) {
-    icon_manager_.reset(new IconManager());
-  }
-
-  gfx::Image* icon = icon_manager_->LookupIconFromFilepath(normalized_path,
-                                                          icon_size);
+  auto icon_manager = g_browser_process->GetIconManager();
+  gfx::Image* icon =
+      icon_manager->LookupIconFromFilepath(normalized_path, icon_size);
   if (icon) {
     callback.Run(v8::Null(isolate()), *icon);
   } else {
-    icon_manager_->LoadIcon(normalized_path, icon_size,
-                           base::Bind(&OnIconDataAvailable, isolate(),
-                                      callback), &cancelable_task_tracker_);
+    icon_manager->LoadIcon(
+        normalized_path, icon_size,
+        base::Bind(&OnIconDataAvailable, isolate(), callback),
+        &cancelable_task_tracker_);
   }
 }
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -890,15 +890,18 @@ void App::GetFileIcon(const base::FilePath& path,
     return;
   }
 
-  IconManager* icon_manager = IconManager::GetInstance();
-  gfx::Image* icon = icon_manager->LookupIconFromFilepath(normalized_path,
+  if (!icon_manager_.get()) {
+    icon_manager_.reset(new IconManager());
+  }
+
+  gfx::Image* icon = icon_manager_->LookupIconFromFilepath(normalized_path,
                                                           icon_size);
   if (icon) {
     callback.Run(v8::Null(isolate()), *icon);
   } else {
-    icon_manager->LoadIcon(normalized_path, icon_size,
+    icon_manager_->LoadIcon(normalized_path, icon_size,
                            base::Bind(&OnIconDataAvailable, isolate(),
-                                      callback));
+                                      callback), &cancelable_task_tracker_);
   }
 }
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -130,8 +130,6 @@ class App : public AtomBrowserClient::Delegate,
   void DisableHardwareAcceleration(mate::Arguments* args);
   bool IsAccessibilitySupportEnabled();
   Browser::LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
-  base::CancelableTaskTracker cancelable_task_tracker_;
-  std::unique_ptr<IconManager> icon_manager_;
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);
@@ -152,6 +150,9 @@ class App : public AtomBrowserClient::Delegate,
 #if defined(USE_NSS_CERTS)
   std::unique_ptr<CertificateManagerModel> certificate_manager_model_;
 #endif
+
+  // Tracks tasks requesting file icons.
+  base::CancelableTaskTracker cancelable_task_tracker_;
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -13,7 +13,8 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/browser_observer.h"
 #include "atom/common/native_mate_converters/callback.h"
-#include "chrome/browser/icon_loader.h"
+#include "base/task/cancelable_task_tracker.h"
+#include "chrome/browser/icon_manager.h"
 #include "chrome/browser/process_singleton.h"
 #include "content/public/browser/gpu_data_manager_observer.h"
 #include "native_mate/handle.h"
@@ -129,6 +130,8 @@ class App : public AtomBrowserClient::Delegate,
   void DisableHardwareAcceleration(mate::Arguments* args);
   bool IsAccessibilitySupportEnabled();
   Browser::LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
+  base::CancelableTaskTracker cancelable_task_tracker_;
+  std::unique_ptr<IconManager> icon_manager_;
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);

--- a/chromium_src/chrome/browser/browser_process.cc
+++ b/chromium_src/chrome/browser/browser_process.cc
@@ -4,13 +4,15 @@
 
 #include "chrome/browser/browser_process.h"
 
+#include "chrome/browser/icon_manager.h"
 #include "chrome/browser/printing/print_job_manager.h"
 #include "ui/base/l10n/l10n_util.h"
 
 BrowserProcess* g_browser_process = NULL;
 
 BrowserProcess::BrowserProcess()
-    : print_job_manager_(new printing::PrintJobManager) {
+    : print_job_manager_(new printing::PrintJobManager),
+      icon_manager_(new IconManager) {
   g_browser_process = this;
 }
 
@@ -20,6 +22,12 @@ BrowserProcess::~BrowserProcess() {
 
 std::string BrowserProcess::GetApplicationLocale() {
   return l10n_util::GetApplicationLocale("");
+}
+
+IconManager* BrowserProcess::GetIconManager() {
+  if (!icon_manager_.get())
+    icon_manager_.reset(new IconManager);
+  return icon_manager_.get();
 }
 
 printing::PrintJobManager* BrowserProcess::print_job_manager() {

--- a/chromium_src/chrome/browser/browser_process.h
+++ b/chromium_src/chrome/browser/browser_process.h
@@ -15,6 +15,8 @@
 
 #include "base/macros.h"
 
+class IconManager;
+
 namespace printing {
 class PrintJobManager;
 }
@@ -27,11 +29,13 @@ class BrowserProcess {
   ~BrowserProcess();
 
   std::string GetApplicationLocale();
+  IconManager* GetIconManager();
 
   printing::PrintJobManager* print_job_manager();
 
  private:
   std::unique_ptr<printing::PrintJobManager> print_job_manager_;
+  std::unique_ptr<IconManager> icon_manager_;
 
   DISALLOW_COPY_AND_ASSIGN(BrowserProcess);
 };

--- a/chromium_src/chrome/browser/icon_loader.cc
+++ b/chromium_src/chrome/browser/icon_loader.cc
@@ -3,46 +3,40 @@
 // found in the LICENSE file.
 
 #include "chrome/browser/icon_loader.h"
-
 #include "base/bind.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "content/public/browser/browser_thread.h"
 
 using content::BrowserThread;
 
-IconLoader::IconLoader(const base::FilePath& file_path,
-                       IconSize size,
-                       Delegate* delegate)
-    : target_task_runner_(NULL),
-      file_path_(file_path),
-      icon_size_(size),
-      delegate_(delegate) {}
-
-IconLoader::~IconLoader() {}
+// static
+IconLoader* IconLoader::Create(const base::FilePath& file_path,
+                               IconSize size,
+                               IconLoadedCallback callback) {
+  return new IconLoader(file_path, size, callback);
+}
 
 void IconLoader::Start() {
   target_task_runner_ = base::ThreadTaskRunnerHandle::Get();
-
-  BrowserThread::PostTaskAndReply(BrowserThread::FILE, FROM_HERE,
-                                  base::Bind(&IconLoader::ReadGroup, this),
-                                  base::Bind(&IconLoader::OnReadGroup, this));
+  BrowserThread::PostTaskAndReply(
+      BrowserThread::FILE, FROM_HERE,
+      base::Bind(&IconLoader::ReadGroup, base::Unretained(this)),
+      base::Bind(&IconLoader::OnReadGroup, base::Unretained(this)));
 }
 
+IconLoader::IconLoader(const base::FilePath& file_path,
+                       IconSize size,
+                       IconLoadedCallback callback)
+    : file_path_(file_path), icon_size_(size), callback_(callback) {}
+
+IconLoader::~IconLoader() {}
+
 void IconLoader::ReadGroup() {
-  group_ = ReadGroupIDFromFilepath(file_path_);
+  group_ = GroupForFilepath(file_path_);
 }
 
 void IconLoader::OnReadGroup() {
-  if (IsIconMutableFromFilepath(file_path_) ||
-      !delegate_->OnGroupLoaded(this, group_)) {
-    BrowserThread::PostTask(ReadIconThreadID(), FROM_HERE,
-                            base::Bind(&IconLoader::ReadIcon, this));
-  }
-}
-
-void IconLoader::NotifyDelegate() {
-  // If the delegate takes ownership of the Image, release it from the scoped
-  // pointer.
-  if (delegate_->OnImageLoaded(this, image_.get(), group_))
-    ignore_result(image_.release());  // Can't ignore return value.
+  BrowserThread::PostTask(
+      ReadIconThreadID(), FROM_HERE,
+      base::Bind(&IconLoader::ReadIcon, base::Unretained(this)));
 }

--- a/chromium_src/chrome/browser/icon_loader.h
+++ b/chromium_src/chrome/browser/icon_loader.h
@@ -8,22 +8,13 @@
 #include <memory>
 #include <string>
 
+#include "base/callback.h"
 #include "base/files/file_path.h"
 #include "base/macros.h"
-#include "base/memory/ref_counted.h"
 #include "base/single_thread_task_runner.h"
 #include "build/build_config.h"
 #include "content/public/browser/browser_thread.h"
 #include "ui/gfx/image/image.h"
-
-#if defined(OS_WIN)
-// On Windows, we group files by their extension, with several exceptions:
-// .dll, .exe, .ico. See IconManager.h for explanation.
-typedef std::wstring IconGroupID;
-#elif defined(OS_POSIX)
-// On POSIX, we group files by MIME type.
-typedef std::string IconGroupID;
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -31,8 +22,16 @@ typedef std::string IconGroupID;
 // thread. Returns the icon in the form of an ImageSkia.
 //
 ////////////////////////////////////////////////////////////////////////////////
-class IconLoader : public base::RefCountedThreadSafe<IconLoader> {
+class IconLoader {
  public:
+  // An IconGroup is a class of files that all share the same icon. For all
+  // platforms but Windows, and for most files on Windows, it is the file type
+  // (e.g. all .mp3 files share an icon, all .html files share an icon). On
+  // Windows, for certain file types (.exe, .dll, etc), each file of that type
+  // is assumed to have a unique icon. In that case, each of those files is a
+  // group to itself.
+  using IconGroup = base::FilePath::StringType;
+
   enum IconSize {
     SMALL = 0,  // 16x16
     NORMAL,     // 32x32
@@ -40,42 +39,32 @@ class IconLoader : public base::RefCountedThreadSafe<IconLoader> {
     ALL,        // All sizes available
   };
 
-  class Delegate {
-   public:
-    // Invoked when an icon group has been read, but before the icon data
-    // is read. If the icon is already cached, this method should call and
-    // return the results of OnImageLoaded with the cached image.
-    virtual bool OnGroupLoaded(IconLoader* source,
-                               const IconGroupID& group) = 0;
-    // Invoked when an icon has been read. |source| is the IconLoader. If the
-    // icon has been successfully loaded, result is non-null. This method must
-    // return true if it is taking ownership of the returned image.
-    virtual bool OnImageLoaded(IconLoader* source,
-                               gfx::Image* result,
-                               const IconGroupID& group) = 0;
+  // The callback invoked when an icon has been read. The parameters are:
+  // - The icon that was loaded, or null if there was a failure to load it.
+  // - The determined group from the original requested path.
+  using IconLoadedCallback =
+      base::Callback<void(std::unique_ptr<gfx::Image>, const IconGroup&)>;
 
-   protected:
-    virtual ~Delegate() {}
-  };
+  // Creates an IconLoader, which owns itself. If the IconLoader might outlive
+  // the caller, be sure to use a weak pointer in the |callback|.
+  static IconLoader* Create(const base::FilePath& file_path,
+                            IconSize size,
+                            IconLoadedCallback callback);
 
-  IconLoader(const base::FilePath& file_path,
-             IconSize size,
-             Delegate* delegate);
-
-  // Start reading the icon on the file thread.
+  // Starts the process of reading the icon. When the reading of the icon is
+  // complete, the IconLoadedCallback callback will be fulfilled, and the
+  // IconLoader will delete itself.
   void Start();
 
  private:
-  friend class base::RefCountedThreadSafe<IconLoader>;
+  IconLoader(const base::FilePath& file_path,
+             IconSize size,
+             IconLoadedCallback callback);
 
-  virtual ~IconLoader();
+  ~IconLoader();
 
-  // Get the identifying string for the given file. The implementation
-  // is in icon_loader_[platform].cc.
-  static IconGroupID ReadGroupIDFromFilepath(const base::FilePath& path);
-
-  // Some icons (exe's on windows) can change as they're loaded.
-  static bool IsIconMutableFromFilepath(const base::FilePath& path);
+  // Given a file path, get the group for the given file.
+  static IconGroup GroupForFilepath(const base::FilePath& file_path);
 
   // The thread ReadIcon() should be called on.
   static content::BrowserThread::ID ReadIconThreadID();
@@ -84,20 +73,18 @@ class IconLoader : public base::RefCountedThreadSafe<IconLoader> {
   void OnReadGroup();
   void ReadIcon();
 
-  void NotifyDelegate();
-
   // The task runner object of the thread in which we notify the delegate.
   scoped_refptr<base::SingleThreadTaskRunner> target_task_runner_;
 
   base::FilePath file_path_;
 
-  IconGroupID group_;
+  IconGroup group_;
 
   IconSize icon_size_;
 
   std::unique_ptr<gfx::Image> image_;
 
-  Delegate* delegate_;
+  IconLoadedCallback callback_;
 
   DISALLOW_COPY_AND_ASSIGN(IconLoader);
 };

--- a/chromium_src/chrome/browser/icon_loader_auralinux.cc
+++ b/chromium_src/chrome/browser/icon_loader_auralinux.cc
@@ -10,14 +10,9 @@
 #include "ui/views/linux_ui/linux_ui.h"
 
 // static
-IconGroupID IconLoader::ReadGroupIDFromFilepath(
-    const base::FilePath& filepath) {
-  return base::nix::GetFileMimeType(filepath);
-}
-
-// static
-bool IconLoader::IsIconMutableFromFilepath(const base::FilePath&) {
-  return false;
+IconLoader::IconGroup IconLoader::GroupForFilepath(
+    const base::FilePath& file_path) {
+  return base::nix::GetFileMimeType(file_path);
 }
 
 // static
@@ -50,6 +45,7 @@ void IconLoader::ReadIcon() {
       image_.reset(new gfx::Image(image));
   }
 
-  target_task_runner_->PostTask(FROM_HERE,
-                                base::Bind(&IconLoader::NotifyDelegate, this));
+  target_task_runner_->PostTask(
+      FROM_HERE, base::Bind(callback_, base::Passed(&image_), group_));
+  delete this;
 }

--- a/chromium_src/chrome/browser/icon_loader_mac.mm
+++ b/chromium_src/chrome/browser/icon_loader_mac.mm
@@ -15,14 +15,9 @@
 #include "ui/gfx/image/image_skia_util_mac.h"
 
 // static
-IconGroupID IconLoader::ReadGroupIDFromFilepath(
-    const base::FilePath& filepath) {
-  return filepath.Extension();
-}
-
-// static
-bool IconLoader::IsIconMutableFromFilepath(const base::FilePath&) {
-  return false;
+IconLoader::IconGroup IconLoader::GroupForFilepath(
+    const base::FilePath& file_path) {
+  return file_path.Extension();
 }
 
 // static
@@ -57,6 +52,7 @@ void IconLoader::ReadIcon() {
     }
   }
 
-  target_task_runner_->PostTask(FROM_HERE,
-                                base::Bind(&IconLoader::NotifyDelegate, this));
+  target_task_runner_->PostTask(
+      FROM_HERE, base::Bind(callback_, base::Passed(&image_), group_));
+  delete this;
 }

--- a/chromium_src/chrome/browser/icon_loader_win.cc
+++ b/chromium_src/chrome/browser/icon_loader_win.cc
@@ -17,18 +17,15 @@
 #include "ui/gfx/image/image_skia.h"
 
 // static
-IconGroupID IconLoader::ReadGroupIDFromFilepath(
-    const base::FilePath& filepath) {
-  if (!IsIconMutableFromFilepath(filepath))
-    return filepath.Extension();
-  return filepath.value();
-}
+IconLoader::IconGroup IconLoader::GroupForFilepath(
+    const base::FilePath& file_path) {
+  if (file_path.MatchesExtension(L".exe") ||
+      file_path.MatchesExtension(L".dll") ||
+      file_path.MatchesExtension(L".ico")) {
+    return file_path.value();
+  }
 
-// static
-bool IconLoader::IsIconMutableFromFilepath(const base::FilePath& filepath) {
-  return filepath.MatchesExtension(L".exe") ||
-         filepath.MatchesExtension(L".dll") ||
-         filepath.MatchesExtension(L".ico");
+  return file_path.Extension();
 }
 
 // static
@@ -54,22 +51,22 @@ void IconLoader::ReadIcon() {
 
   image_.reset();
 
-  SHFILEINFO file_info = {0};
+  SHFILEINFO file_info = { 0 };
   if (SHGetFileInfo(group_.c_str(), FILE_ATTRIBUTE_NORMAL, &file_info,
-                    sizeof(SHFILEINFO),
-                    SHGFI_ICON | size | SHGFI_USEFILEATTRIBUTES)) {
+                     sizeof(SHFILEINFO),
+                     SHGFI_ICON | size | SHGFI_USEFILEATTRIBUTES)) {
     std::unique_ptr<SkBitmap> bitmap(
         IconUtil::CreateSkBitmapFromHICON(file_info.hIcon));
     if (bitmap.get()) {
-      gfx::ImageSkia image_skia(
-          gfx::ImageSkiaRep(*bitmap, display::win::GetDPIScale()));
+      gfx::ImageSkia image_skia(gfx::ImageSkiaRep(*bitmap,
+                                                  display::win::GetDPIScale()));
       image_skia.MakeThreadSafe();
       image_.reset(new gfx::Image(image_skia));
       DestroyIcon(file_info.hIcon);
     }
   }
 
-  // Always notify the delegate, regardless of success.
-  target_task_runner_->PostTask(FROM_HERE,
-                                base::Bind(&IconLoader::NotifyDelegate, this));
+  target_task_runner_->PostTask(
+      FROM_HERE, base::Bind(callback_, base::Passed(&image_), group_));
+  delete this;
 }


### PR DESCRIPTION
See: https://github.com/electron/electron/pull/8631#issuecomment-278461065

As per [commit](https://chromium.googlesource.com/chromium/src/+/f0a7b5b81faa4d2abf594b6e3ac135ed60dad504%5E%21/): 
> There are lifetime issues due to IconLoader being refcounted for no good reason, so stop doing that.

And from [Chromium Issue 674743](https://bugs.chromium.org/p/chromium/issues/detail?id=674743):

> In reviewing this code it seems like IconManager is racy. In particular
IconManager is not ref counted, but IconLoader is. IconLoader references
IconManager through it's a delegate. This means it's possible for IconLoader to
outlive it's delegate. Seems this function should null out the delegates (and
you should keep the null check in IconLoader::NotifyDelegate).
 