### PR TITLE
Fix OS version check of vibrancy

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1280,7 +1280,7 @@ void NativeWindowMac::SetAutoHideCursor(bool auto_hide) {
 }
 
 void NativeWindowMac::SetVibrancy(const std::string& type) {
-  if (!base::mac::IsOS10_10()) return;
+  if (!base::mac::IsAtLeastOS10_10()) return;
 
   NSView* vibrant_view = [window_ vibrantView];
 


### PR DESCRIPTION
This PR fixes the version check of `BrowserWindow.setVibrancy` method. #8714 