### PR TITLE
Use owner browser window in pepper context menu

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -147,7 +147,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   let asyncPopup = false
 
   // menu.popup(x, y, positioningItem)
-  if (typeof window !== 'object' || window.constructor !== BrowserWindow) {
+  if (window != null && (typeof window !== 'object' || window.constructor !== BrowserWindow)) {
     // Shift.
     positioningItem = y
     y = x

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -152,7 +152,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     positioningItem = y
     y = x
     x = window
-    window = BrowserWindow.getFocusedWindow()
+    window = null
   }
 
   // menu.popup(window, {})
@@ -163,6 +163,9 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     positioningItem = options.positioningItem
     asyncPopup = options.async
   }
+
+  // Default to showing in focused window.
+  if (window == null) window = BrowserWindow.getFocusedWindow()
 
   // Default to showing under mouse location.
   if (typeof x !== 'number') x = -1

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -253,7 +253,7 @@ WebContents.prototype._init = function () {
   this.on('pepper-context-menu', function (event, params) {
     // Access Menu via electron.Menu to prevent circular require
     const menu = electron.Menu.buildFromTemplate(params.menu)
-    menu.popup(params.x, params.y)
+    menu.popup(event.sender.getOwnerBrowserWindow(), params.x, params.y)
   })
 
   // The devtools requests the webContents to reload.


### PR DESCRIPTION
In a fullscreen flash player, `BrowserWindow.getFocusedWindow()` will return `null` which causes the popup menu to throw an exception.

This pull request switches it to use `webContents.getOwnerBrowserWindow()` instead.

Closes #8632