### PR TITLE
Route webview window visibility change events in browser process

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -110,7 +110,9 @@ BrowserWindow.prototype._init = function () {
     const newState = this.isVisible() && !this.isMinimized()
     if (isVisible !== newState) {
       isVisible = newState
-      this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', isVisible ? 'visible' : 'hidden')
+      const visibilityState = isVisible ? 'visible' : 'hidden'
+      this.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', visibilityState)
+      this.webContents.emit('-window-visibility-change', visibilityState)
     }
   }
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -252,6 +252,17 @@ const watchEmbedder = function (embedder) {
   }
   watchedEmbedders.add(embedder)
 
+  // Forward embedder window visiblity change events to guest
+  const onVisibilityChange = function (visibilityState) {
+    for (const guestInstanceId of Object.keys(guestInstances)) {
+      const guestInstance = guestInstances[guestInstanceId]
+      if (guestInstance.embedder === embedder) {
+        guestInstance.guest.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', visibilityState)
+      }
+    }
+  }
+  embedder.on('-window-visibility-change', onVisibilityChange)
+
   const destroyEvents = ['will-destroy', 'crashed', 'did-navigate']
   const destroy = function () {
     for (const guestInstanceId of Object.keys(guestInstances)) {
@@ -263,6 +274,7 @@ const watchEmbedder = function (embedder) {
     for (const event of destroyEvents) {
       embedder.removeListener(event, destroy)
     }
+    embedder.removeListener('-window-visibility-change', onVisibilityChange)
 
     watchedEmbedders.delete(embedder)
   }

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -34,10 +34,10 @@ class WebViewImpl {
     this.viewInstanceId = getNextId()
     shadowRoot.appendChild(this.browserPluginNode)
 
+    // Forward window visibility changes to guest contents
     this.onVisibilityChanged = (event, visibilityState) => {
       this.webviewNode.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', visibilityState)
     }
-    ipcRenderer.on('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', this.onVisibilityChanged)
   }
 
   createBrowserPluginNode () {
@@ -315,6 +315,7 @@ var registerWebViewElement = function () {
       return
     }
     if (!internal.elementAttached) {
+      ipcRenderer.on('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', internal.onVisibilityChanged)
       guestViewInternal.registerEvents(internal, internal.viewInstanceId)
       internal.elementAttached = true
       instance = internal.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE].getValue()

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -264,8 +264,7 @@ const registerBrowserPluginElement = function () {
     this.style.flex = '1 1 auto'
   }
   proto.attributeChangedCallback = function (name, oldValue, newValue) {
-    var internal
-    internal = v8Util.getHiddenValue(this, 'internal')
+    const internal = v8Util.getHiddenValue(this, 'internal')
     if (internal) {
       internal.handleBrowserPluginAttributeMutation(name, oldValue, newValue)
     }
@@ -285,21 +284,19 @@ const registerBrowserPluginElement = function () {
 }
 
 // Registers <webview> custom element.
-var registerWebViewElement = function () {
+const registerWebViewElement = function () {
   const proto = Object.create(HTMLObjectElement.prototype)
   proto.createdCallback = function () {
     return new WebViewImpl(this)
   }
   proto.attributeChangedCallback = function (name, oldValue, newValue) {
-    var internal
-    internal = v8Util.getHiddenValue(this, 'internal')
+    const internal = v8Util.getHiddenValue(this, 'internal')
     if (internal) {
       internal.handleWebviewAttributeMutation(name, oldValue, newValue)
     }
   }
   proto.detachedCallback = function () {
-    var internal
-    internal = v8Util.getHiddenValue(this, 'internal')
+    const internal = v8Util.getHiddenValue(this, 'internal')
     if (!internal) {
       return
     }
@@ -309,8 +306,7 @@ var registerWebViewElement = function () {
     internal.reset()
   }
   proto.attachedCallback = function () {
-    var internal, instance
-    internal = v8Util.getHiddenValue(this, 'internal')
+    const internal = v8Util.getHiddenValue(this, 'internal')
     if (!internal) {
       return
     }
@@ -318,7 +314,7 @@ var registerWebViewElement = function () {
       ipcRenderer.on('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', internal.onVisibilityChanged)
       guestViewInternal.registerEvents(internal, internal.viewInstanceId)
       internal.elementAttached = true
-      instance = internal.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE].getValue()
+      const instance = internal.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE].getValue()
       if (instance) {
         internal.attachGuestInstance(instance)
       } else {

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -33,11 +33,6 @@ class WebViewImpl {
     this.setupFocusPropagation()
     this.viewInstanceId = getNextId()
     shadowRoot.appendChild(this.browserPluginNode)
-
-    // Forward window visibility changes to guest contents
-    this.onVisibilityChanged = (event, visibilityState) => {
-      this.webviewNode.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', visibilityState)
-    }
   }
 
   createBrowserPluginNode () {
@@ -50,8 +45,6 @@ class WebViewImpl {
 
   // Resets some state upon reattaching <webview> element to the DOM.
   reset () {
-    ipcRenderer.removeListener('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', this.onVisibilityChanged)
-
     // If guestInstanceId is defined then the <webview> has navigated and has
     // already picked up a partition ID. Thus, we need to reset the initialization
     // state. However, it may be the case that beforeFirstNavigation is false BUT
@@ -311,7 +304,6 @@ const registerWebViewElement = function () {
       return
     }
     if (!internal.elementAttached) {
-      ipcRenderer.on('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', internal.onVisibilityChanged)
       guestViewInternal.registerEvents(internal, internal.viewInstanceId)
       internal.elementAttached = true
       const instance = internal.attributes[webViewConstants.ATTRIBUTE_GUESTINSTANCE].getValue()

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1086,7 +1086,7 @@ describe('<webview> tag', function () {
       assert.equal(visibilityState, 'hidden')
       assert.equal(hidden, true)
 
-      w.webContents.send('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', 'visible')
+      w.webContents.emit('-window-visibility-change', 'visible')
 
       ipcMain.once('pong', function (event, visibilityState, hidden) {
         assert.equal(visibilityState, 'visible')

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1086,13 +1086,13 @@ describe('<webview> tag', function () {
       assert.equal(visibilityState, 'hidden')
       assert.equal(hidden, true)
 
-      w.webContents.emit('-window-visibility-change', 'visible')
-
       ipcMain.once('pong', function (event, visibilityState, hidden) {
         assert.equal(visibilityState, 'visible')
         assert.equal(hidden, false)
         done()
       })
+
+      w.webContents.emit('-window-visibility-change', 'visible')
     })
 
     w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')


### PR DESCRIPTION
This removes the need for an `ipcRenderer` listener in `web-view.js` to forward the window visibility event and instead co-locates it with the other embedder events listened for in `guest-view-internal.js`.

This prevents an event emitter warning when more than 10 web views exist in a window since `webContents` already has max listeners set to Infinity.

The other option to prevent this warning would be to bump the `ipcRenderer` max listeners to Infinity as well but that would seem to possibly cover up legit memory leaks in apps.

Closes #8622