### PR TITLE
Use local Buffer variable in module.js require wrapper

### DIFF
--- a/spec/fixtures/module/preload-node-off-wrapper.js
+++ b/spec/fixtures/module/preload-node-off-wrapper.js
@@ -1,0 +1,3 @@
+setImmediate(function () {
+  require('./preload-required-module')
+})

--- a/spec/fixtures/module/preload-required-module.js
+++ b/spec/fixtures/module/preload-required-module.js
@@ -1,5 +1,5 @@
 try {
-  console.log([typeof process, typeof setImmediate, typeof global, typeof Buffer].join(' '))
+  console.log([typeof process, typeof setImmediate, typeof global, typeof Buffer, typeof global.Buffer].join(' '))
 } catch (e) {
   console.log(e.message)
 }

--- a/spec/fixtures/module/preload-required-module.js
+++ b/spec/fixtures/module/preload-required-module.js
@@ -1,0 +1,5 @@
+try {
+  console.log([typeof process, typeof setImmediate, typeof global, typeof Buffer].join(' '))
+} catch (e) {
+  console.log(e.message)
+}

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -193,7 +193,7 @@ describe('<webview> tag', function () {
 
     it('preload script can require modules that still use "process" and "Buffer" when nodeintegration is off', function (done) {
       webview.addEventListener('console-message', function (e) {
-        assert.equal(e.message, 'object undefined object function')
+        assert.equal(e.message, 'object undefined object function undefined')
         done()
       })
       webview.setAttribute('preload', fixtures + '/module/preload-node-off-wrapper.js')

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -181,12 +181,22 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
-    it('preload script can still use "process" and "Buffer" in required modules when nodeintegration is off', function (done) {
+    it('preload script can still use "process" and "Buffer" when nodeintegration is off', function (done) {
       webview.addEventListener('console-message', function (e) {
         assert.equal(e.message, 'object undefined object function')
         done()
       })
       webview.setAttribute('preload', fixtures + '/module/preload-node-off.js')
+      webview.src = 'file://' + fixtures + '/api/blank.html'
+      document.body.appendChild(webview)
+    })
+
+    it('preload script can require modules that still use "process" and "Buffer"when nodeintegration is off', function (done) {
+      webview.addEventListener('console-message', function (e) {
+        assert.equal(e.message, 'object undefined object function')
+        done()
+      })
+      webview.setAttribute('preload', fixtures + '/module/preload-node-off-wrapper.js')
       webview.src = 'file://' + fixtures + '/api/blank.html'
       document.body.appendChild(webview)
     })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -191,7 +191,7 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
-    it('preload script can require modules that still use "process" and "Buffer"when nodeintegration is off', function (done) {
+    it('preload script can require modules that still use "process" and "Buffer" when nodeintegration is off', function (done) {
       webview.addEventListener('console-message', function (e) {
         assert.equal(e.message, 'object undefined object function')
         done()


### PR DESCRIPTION
This pull request is a minor update to #8605 to use `Buffer` instead of `global.Buffer` in the `module.js` require wrapper.

Previously modules required from preload scripts after the `loaded` event fires on `process` would not have `Buffer`  specified as an argument to the require wrapper since it would be deleted from the `global` in `init.js`.

Node diff:

```diff
diff --git a/lib/module.js b/lib/module.js
index 1bc27c0..c526fb0 100644
--- a/lib/module.js
+++ b/lib/module.js
@@ -565,7 +565,7 @@ Module.prototype._compile = function(content, filename) {
   }
   var dirname = path.dirname(filename);
   var require = internalModule.makeRequireFunction.call(this);
-  var args = [this.exports, require, this, filename, dirname, process, global, global.Buffer];
+  var args = [this.exports, require, this, filename, dirname, process, global, Buffer];
   var depth = internalModule.requireDepth;
   if (depth === 0) stat.cache = new Map();
   var result = compiledWrapper.apply(this.exports, args);
```