### PR TITLE
Remove max recursion depth when converting v8 objects

### DIFF
--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -17,30 +17,10 @@
 
 namespace atom {
 
-namespace {
-
-const int kMaxRecursionDepth = 100;
-
-}  // namespace
-
 // The state of a call to FromV8Value.
 class V8ValueConverter::FromV8ValueState {
  public:
-  // Level scope which updates the current depth of some FromV8ValueState.
-  class Level {
-   public:
-    explicit Level(FromV8ValueState* state) : state_(state) {
-      state_->max_recursion_depth_--;
-    }
-    ~Level() {
-      state_->max_recursion_depth_++;
-    }
-
-   private:
-    FromV8ValueState* state_;
-  };
-
-  FromV8ValueState() : max_recursion_depth_(kMaxRecursionDepth) {}
+  FromV8ValueState() {}
 
   // If |handle| is not in |unique_map_|, then add it to |unique_map_| and
   // return true.
@@ -258,10 +238,6 @@ base::Value* V8ValueConverter::FromV8ValueImpl(
     FromV8ValueState* state,
     v8::Local<v8::Value> val,
     v8::Isolate* isolate) const {
-  FromV8ValueState::Level state_level(state);
-  if (state->HasReachedMaxRecursionDepth())
-    return nullptr;
-
   if (val->IsExternal())
     return base::Value::CreateNullValue().release();
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -172,7 +172,6 @@ const removeRemoteListenersAndLogWarning = (meta, args, callIntoRenderer) => {
 // Convert array of meta data from renderer into array of real values.
 const unwrapArgs = function (sender, args) {
   const metaToValue = function (meta) {
-    let i, len, member, ref, returnValue
     switch (meta.type) {
       case 'value':
         return meta.value
@@ -189,18 +188,16 @@ const unwrapArgs = function (sender, args) {
           then: metaToValue(meta.then)
         })
       case 'object': {
-        let ret = {}
+        const ret = {}
         Object.defineProperty(ret.constructor, 'name', { value: meta.name })
 
-        ref = meta.members
-        for (i = 0, len = ref.length; i < len; i++) {
-          member = ref[i]
+        for (const member of meta.members) {
           ret[member.name] = metaToValue(member.value)
         }
         return ret
       }
       case 'function-with-return-value':
-        returnValue = metaToValue(meta.value)
+        const returnValue = metaToValue(meta.value)
         return function () {
           return returnValue
         }

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -143,6 +143,21 @@ describe('ipc module', function () {
         {foo: {bar: null}, bar: 'baz'}
       ])
     })
+
+    it('handles large arguments that get truncated by value converter recursion limit', function () {
+      const object = {}
+      const array = []
+      let currentObject = object
+      let currentArray = array
+      for (let i = 0; i < 250; i++) {
+        currentObject.foo = {}
+        currentObject = currentObject.foo
+        currentArray.push([])
+        currentArray = currentArray[0]
+      }
+      var a = remote.require(path.join(fixtures, 'module', 'function.js'))
+      assert.equal(a.aFunction(object, array), 1127)
+    })
   })
 
   describe('remote.createFunctionWithReturnValue', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -144,7 +144,7 @@ describe('ipc module', function () {
       ])
     })
 
-    it('handles large arguments that get truncated by value converter recursion limit', function () {
+    it('handles large arguments', function () {
       const object = {}
       const array = []
       let currentObject = object


### PR DESCRIPTION
The V8 value converter used for IPC arguments previously had a max recursion depth of 100: https://github.com/electron/electron/blob/cc688d7fa6a48e5133735eb67d665f5d193ec94f/atom/common/native_mate_converters/v8_value_converter.cc#L22

Really deep objects specified as arguments to remote functions currently throw errors because the metadata received gets truncated at the IPC layer and so the format received by `rpc-server.js`  is invalid/incomplete.

This pull request removes this recursion depth completely. This value seemed somewhat arbitrary and was originally inherited from Chrome. Currently we don't limit the size of IPC objects in other ways so this seems okay to do and can be improved upon further via https://github.com/electron/electron/issues/7286.

The other options I can think of here would be:

- Have `remote.js` throw errors when function arguments that will exceed this limit are specified.
- Gracefully handle invalid/incomplete metadata in `rpc-server.js`. This option would seem surprising to developers since large objects they send over would just have `null` fields certain places and would be hard to track the cause.

I noticed this issue while investigating #8423 and trying to send `module` over the remote interface which is pretty nested.

/cc @electron/maintainers 