### PR TITLE
Don't require browser process API in renderer process

### DIFF
--- a/lib/browser/api/exports/electron.js
+++ b/lib/browser/api/exports/electron.js
@@ -5,6 +5,7 @@ common.defineProperties(exports)
 
 Object.defineProperties(exports, {
   // Browser side modules, please sort with alphabet order.
+  // Any new modules added here must also be added to the array in remote.js
   app: {
     enumerable: true,
     get: function () {
@@ -35,16 +36,16 @@ Object.defineProperties(exports, {
       return require('../dialog')
     }
   },
-  ipcMain: {
-    enumerable: true,
-    get: function () {
-      return require('../ipc-main')
-    }
-  },
   globalShortcut: {
     enumerable: true,
     get: function () {
       return require('../global-shortcut')
+    }
+  },
+  ipcMain: {
+    enumerable: true,
+    get: function () {
+      return require('../ipc-main')
     }
   },
   Menu: {
@@ -57,6 +58,12 @@ Object.defineProperties(exports, {
     enumerable: true,
     get: function () {
       return require('../menu-item')
+    }
+  },
+  net: {
+    enumerable: true,
+    get: function () {
+      return require('../net')
     }
   },
   powerMonitor: {
@@ -105,12 +112,6 @@ Object.defineProperties(exports, {
     enumerable: true,
     get: function () {
       return require('../web-contents')
-    }
-  },
-  net: {
-    enumerable: true,
-    get: function () {
-      return require('../net')
     }
   },
 

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -288,18 +288,6 @@ ipcRenderer.on('ELECTRON_RENDERER_RELEASE_CALLBACK', function (event, id) {
   callbacksRegistry.remove(id)
 })
 
-// List all built-in modules in browser process.
-const browserModules = require('../../browser/api/exports/electron')
-
-// And add a helper receiver for each one.
-for (let name of Object.getOwnPropertyNames(browserModules)) {
-  Object.defineProperty(exports, name, {
-    get: function () {
-      return exports.getBuiltin(name)
-    }
-  })
-}
-
 // Get remote module.
 exports.require = function (module) {
   return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_REQUIRE', module))
@@ -344,3 +332,40 @@ exports.getGuestWebContents = function (guestInstanceId) {
   const meta = ipcRenderer.sendSync('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', guestInstanceId)
   return metaToValue(meta)
 }
+
+const addBuiltinProperty = (name) => {
+  Object.defineProperty(exports, name, {
+    get: function () {
+      return exports.getBuiltin(name)
+    }
+  })
+}
+
+// Add each browser module name as a property
+// This list should match the exports in browser/api/exports/electron.js
+const browserModules = [
+  'app',
+  'autoUpdater',
+  'BrowserWindow',
+  'contentTracing',
+  'dialog',
+  'globalShortcut',
+  'ipcMain',
+  'Menu',
+  'MenuItem',
+  'net',
+  'powerMonitor',
+  'powerSaveBlocker',
+  'protocol',
+  'screen',
+  'session',
+  'systemPreferences',
+  'Tray',
+  'webContents'
+]
+browserModules.forEach(addBuiltinProperty)
+
+// Add each common module name as a property
+const commonModules = {}
+require('../../common/api/exports/electron').defineProperties(commonModules)
+Object.getOwnPropertyNames(commonModules).forEach(addBuiltinProperty)

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -154,6 +154,15 @@ describe('ipc module', function () {
     })
   })
 
+  describe('remote modules', function () {
+    it('includes browser process modules as properties', function () {
+      assert.equal(typeof remote.app.getPath, 'function')
+      assert.equal(typeof remote.webContents.getFocusedWebContents, 'function')
+      assert.equal(typeof remote.clipboard.readText, 'function')
+      assert.equal(typeof remote.shell.openExternal, 'function')
+    })
+  })
+
   describe('remote object in renderer', function () {
     it('can change its properties', function () {
       var property = remote.require(path.join(fixtures, 'module', 'property.js'))


### PR DESCRIPTION
Currently the `remote` module loads the browser process `require('electron')` in the renderer process to get a list of module names to add as properties to the `remote` object (like `remote.app`).

Requiring this file puts it in the require cache which can then cause issues if it is accessed from that cache directly or indirectly since the properties on the `exports` object will throw errors when accessed since it will lazily require modules that cannot run in the renderer process.

This pull request switches `remote.js` to use a local list of module names to add as properties so this file isn't required at all.

This does mean the lists need to be kept in sync but that seems better to do than attempting to load browser process code in the renderer process. Also we infrequently add new top-level modules and the comment at the top of `electron.js` now mentions it.

Closes #8423