### PR TITLE
Fix thick frame overflow onto secondary monitor.

### DIFF
--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -147,6 +147,15 @@ bool NativeWindowViews::PreHandleMSG(
       }
       return false;
     }
+    /**
+     * Reset max position to stop overflow onto different monitor.
+     */
+    case WM_GETMINMAXINFO: {
+      MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(l_param);
+      info->ptMaxPosition.x = 0;
+      info->ptMaxPosition.y = 0;
+      return true;
+    }
     default:
       return false;
   }


### PR DESCRIPTION
Resolves #5267.

A frameless window with a thick frame (default) would overflow onto another monitor when maximized.

This PR fixes the issue by resetting the `maxPosition` pointer of `MINMAXINFO` to (0, 0) - before it was (-7, -7), which caused overflow onto the left monitor.