### PR TITLE
Set context isolation origin policy

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -86,14 +86,21 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
   }
 
   void CreateIsolatedWorldContext() {
+    auto frame = render_frame_->GetWebFrame();
+
     // This maps to the name shown in the context combo box in the Console tab
     // of the dev tools.
-    render_frame_->GetWebFrame()->setIsolatedWorldHumanReadableName(
+    frame->setIsolatedWorldHumanReadableName(
         World::ISOLATED_WORLD,
         blink::WebString::fromUTF8("Electron Isolated Context"));
 
+    // Setup document's origin policy in isolated world
+    frame->setIsolatedWorldSecurityOrigin(
+      World::ISOLATED_WORLD, frame->document().getSecurityOrigin());
+
+    // Create initial script context in isolated world
     blink::WebScriptSource source("void 0");
-    render_frame_->GetWebFrame()->executeScriptInIsolatedWorld(
+    frame->executeScriptInIsolatedWorld(
         World::ISOLATED_WORLD, &source, 1, ExtensionGroup::MAIN_GROUP);
   }
 

--- a/spec/fixtures/api/isolated-preload.js
+++ b/spec/fixtures/api/isolated-preload.js
@@ -9,7 +9,6 @@ window.foo = 3
 
 webFrame.executeJavaScript('window.preloadExecuteJavaScriptProperty = 1234;')
 
-
 window.addEventListener('message', (event) => {
   ipcRenderer.send('isolated-world', {
     preloadContext: {

--- a/spec/fixtures/api/isolated-preload.js
+++ b/spec/fixtures/api/isolated-preload.js
@@ -1,8 +1,14 @@
+// Ensure fetch works from isolated world origin
+fetch('http://localhost:1234')
+fetch('https://localhost:1234')
+fetch(`file://${__filename}`)
+
 const {ipcRenderer, webFrame} = require('electron')
 
 window.foo = 3
 
 webFrame.executeJavaScript('window.preloadExecuteJavaScriptProperty = 1234;')
+
 
 window.addEventListener('message', (event) => {
   ipcRenderer.send('isolated-world', {


### PR DESCRIPTION
This allows things like `fetch` to work from preload scripts in renderers with `contextIsolation` enabled to work and not crash.

Closes #8802