### PR TITLE
Fix init check for process.windowsStore

### DIFF
--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -56,7 +56,7 @@ if (process.platform === 'win32') {
   //
   // Nobody else get's to install there, changing the path is forbidden
   // We can therefore say that we're running as appx
-  if (__dirname.indexOf('\\Program Files\\WindowsApps\\') === 2) {
+  if (__dirname.includes('\\WindowsApps\\')) {
     process.windowsStore = true
   }
 }


### PR DESCRIPTION
Windows now allows users to move their `WindowsApps` folder, meaning that it can end up on a different drive (and outside of `Program Files`). This fixes `process.windowsStore`.

Closes #8805 