### PR TITLE
Fix API docs for webview tag

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -820,11 +820,11 @@ Returns `Object`:
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is only supported on
     macOS.
-  * `path` String (optional) _Windows_ - The executable to launch at login.
-    Defaults to `process.execPath`.
-  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to
-    the executable. Defaults to an empty array. Take care to wrap paths in
-    quotes.
+* `path` String (optional) _Windows_ - The executable to launch at login.
+  Defaults to `process.execPath`.
+* `args` String[] (optional) _Windows_ - The command-line arguments to pass to
+  the executable. Defaults to an empty array. Take care to wrap paths in
+  quotes.
 
 Set the app's login item settings.
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -38,14 +38,14 @@ The `dialog` module has the following methods:
     * `openDirectory` - Allow directories to be selected.
     * `multiSelections` - Allow multiple paths to be selected.
     * `showHiddenFiles` - Show hidden files in dialog.
-    * `createDirectory` _macOS_ - Allow creating new directories from dialog.
-    * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
+    * `createDirectory` - Allow creating new directories from dialog. _macOS_
+    * `promptToCreate` - Prompt for creation if the file path entered
       in the dialog does not exist. This does not actually create the file at
       the path but allows non-existent paths to be returned that should be
-      created by the application.
-    * `noResolveAliases` _macOS_ - Disable the automatic alias (symlink) path
+      created by the application. _Windows_
+    * `noResolveAliases` - Disable the automatic alias (symlink) path
       resolution.  Selected aliases will now return the alias path instead of
-      their target path.
+      their target path. _macOS_
   * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
     across platforms. Default is `false`. Enabling this assumes `&` is used in
     the button labels for the placement of the keyboard shortcut access key

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -537,20 +537,42 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
 
 ### `<webview>.print([options])`
 
+* `options` Object (optional)
+  * `silent` Boolean - Don't ask user for print settings. Default is `false`.
+  * `printBackground` Boolean - Also prints the background color and image of
+    the web page. Default is `false`.
+
 Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 ### `<webview>.printToPDF(options, callback)`
 
+* `options` Object
+  * `marginsType` Integer - (optional) Specifies the type of margins to use. Uses 0 for
+    default margin, 1 for no margin, and 2 for minimum margin.
+  * `pageSize` String - (optional) Specify page size of the generated PDF. Can be `A3`,
+    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
+    and `width` in microns.
+  * `printBackground` Boolean - (optional) Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean - (optional) Whether to print selection only.
+  * `landscape` Boolean - (optional) `true` for landscape, `false` for portrait.
+* `callback` Function
+  * `error` Error
+  * `data` Buffer
+
 Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
 
 ### `<webview>.capturePage([rect, ]callback)`
+
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured
+* `callback` Function
+  * `image` [NativeImage](native-image.md)
 
 Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([rect, ]callback)`.
 
 ### `<webview>.send(channel[, arg1][, arg2][, ...])`
 
 * `channel` String
-* `arg` (optional)
+* `...args` any[]
 
 Send an asynchronous message to renderer process via `channel`, you can also
 send arbitrary arguments. The renderer process can handle the message by

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -2,6 +2,8 @@
 
 > Display external web content in an isolated frame and process.
 
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
 Use the `webview` tag to embed 'guest' content (such as web pages) in your
 Electron app. The guest content is contained within the `webview` container.
 An embedded page within your app controls how the guest content is laid out and

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^1.16.1",
+    "electron-docs-linter": "^2.1.0",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
@MarshallOfSound and I are working to wrap up the `electron.d.ts` effort. The last (known) holdout is the [webview-tag](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md) doc, which has some unique qualities like its name and the fact that it has `attributes`.

This PR contains fixes to the webview API doc, as well as some fixes for other issues found by the linter along the way.