### PR TITLE
Assign Promise.resolve to constant

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -3,6 +3,7 @@
 const {Buffer} = require('buffer')
 const v8Util = process.atomBinding('v8_util')
 const {ipcRenderer, isPromise, CallbacksRegistry} = require('electron')
+const resolvePromise = Promise.resolve.bind(Promise)
 
 const callbacksRegistry = new CallbacksRegistry()
 
@@ -207,9 +208,7 @@ const metaToValue = function (meta) {
     case 'buffer':
       return Buffer.from(meta.value)
     case 'promise':
-      return Promise.resolve({
-        then: metaToValue(meta.then)
-      })
+      return resolvePromise({then: metaToValue(meta.then)})
     case 'error':
       return metaToPlainObject(meta)
     case 'date':

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -3,6 +3,7 @@
 const events = require('events')
 const path = require('path')
 const Module = require('module')
+const resolvePromise = Promise.resolve.bind(Promise)
 
 // We modified the original process.argv to let node.js load the
 // atom-renderer.js, we need to restore it here.
@@ -39,7 +40,7 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (eve
 
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
   const responseCallback = function (result) {
-    Promise.resolve(result)
+    resolvePromise(result)
       .then((resolvedResult) => {
         event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, null, resolvedResult)
       })


### PR DESCRIPTION
Prevent pages overriding this or deleting this from breaking the `webContents` -> `webFrame` IPC forwarding. 

Closes #8752