### PR TITLE
Update `ses.resolveProxy` return type

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -204,7 +204,7 @@ The `proxyBypassRules` is a comma separated list of rules described below:
 
 * `url` URL
 * `callback` Function
-  * `proxy` Object
+  * `proxy` string
 
 Resolves the proxy information for `url`. The `callback` will be called with
 `callback(proxy)` when the request is performed.

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -204,7 +204,7 @@ The `proxyBypassRules` is a comma separated list of rules described below:
 
 * `url` URL
 * `callback` Function
-  * `proxy` string
+  * `proxy` String
 
 Resolves the proxy information for `url`. The `callback` will be called with
 `callback(proxy)` when the request is performed.


### PR DESCRIPTION
As far as I'm aware, after using the `ses.resolveProxy` API, this call seems to return a string in the shape of `PROXY foopy:80;SOCKS5 bar.com:1080`, not an object. Correct me if I'm wrong.