### PR TITLE
Default menu items for 'Edit' and 'Window' #2814

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -64,6 +64,9 @@ The `role` property can have following values:
 * `zoomin` - Zoom in the focused page by 10%
 * `zoomout` - Zoom out the focused page by 10%
 
+* `menuEdit` - Whole default "Edit" menu (Undo,Copy, etc.)
+* `menuWindow` - Whole default "Window" menu (Minimize, Close, etc.)
+
 On macOS `role` can also have following additional values:
 
 * `about` - Map to the `orderFrontStandardAboutPanel` action

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -64,8 +64,8 @@ The `role` property can have following values:
 * `zoomin` - Zoom in the focused page by 10%
 * `zoomout` - Zoom out the focused page by 10%
 
-* `menuEdit` - Whole default "Edit" menu (Undo,Copy, etc.)
-* `menuWindow` - Whole default "Window" menu (Minimize, Close, etc.)
+* `editMenu` - Whole default "Edit" menu (Undo, Copy, etc.)
+* `windowMenu` - Whole default "Window" menu (Minimize, Close, etc.)
 
 On macOS `role` can also have following additional values:
 

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -178,8 +178,7 @@ const roles = {
         role: 'paste'
       },
 
-      process.platform === 'darwin' ?
-      {
+      process.platform === 'darwin' ? {
         role: 'pasteandmatchstyle'
       } : {},
 
@@ -187,9 +186,8 @@ const roles = {
         role: 'delete'
       },
 
-      process.platform === 'win32' ?
-      {
-          type: 'separator'
+      process.platform === 'win32' ? {
+        type: 'separator'
       } : {},
 
       {
@@ -209,13 +207,11 @@ const roles = {
         role: 'close'
       },
 
-      process.platform === 'darwin' ?
-      {
+      process.platform === 'darwin' ? {
         type: 'separator'
       } : {},
 
-      process.platform === 'darwin' ?
-      {
+      process.platform === 'darwin' ? {
         label: 'Bring All to Front',
         role: 'front'
       } : {}
@@ -245,13 +241,14 @@ exports.getDefaultAccelerator = (role) => {
 
 exports.getDefaultSubmenu = (role) => {
   if (roles.hasOwnProperty(role)) {
-    submenu = roles[role].submenu
+    let submenu = roles[role].submenu
 
     // remove empty objects from within the submenu
-    if (Array.isArray(submenu))
-      submenu = submenu.filter(function(n){
+    if (Array.isArray(submenu)) {
+      submenu = submenu.filter(function (n) {
         return n.constructor !== Object || Object.keys(n).length > 0
       })
+    }
 
     return submenu
   }

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -180,7 +180,7 @@ const roles = {
 
       process.platform === 'darwin' ? {
         role: 'pasteandmatchstyle'
-      } : {},
+      } : null,
 
       {
         role: 'delete'
@@ -188,7 +188,7 @@ const roles = {
 
       process.platform === 'win32' ? {
         type: 'separator'
-      } : {},
+      } : null,
 
       {
         role: 'selectall'
@@ -209,12 +209,11 @@ const roles = {
 
       process.platform === 'darwin' ? {
         type: 'separator'
-      } : {},
+      } : null,
 
       process.platform === 'darwin' ? {
-        label: 'Bring All to Front',
         role: 'front'
-      } : {}
+      } : null
 
     ]
   }
@@ -246,7 +245,7 @@ exports.getDefaultSubmenu = (role) => {
     // remove empty objects from within the submenu
     if (Array.isArray(submenu)) {
       submenu = submenu.filter(function (n) {
-        return n.constructor !== Object || Object.keys(n).length > 0
+        return n != null
       })
     }
 

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -154,6 +154,73 @@ const roles = {
         webContents.setZoomLevel(zoomLevel - 0.5)
       })
     }
+  },
+  // submenu Edit (should fit both Mac & Windows)
+  menuEdit: {
+    label: 'Edit',
+    submenu: [
+      {
+        role: 'undo'
+      },
+      {
+        role: 'redo'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'cut'
+      },
+      {
+        role: 'copy'
+      },
+      {
+        role: 'paste'
+      },
+
+      process.platform === 'darwin' ?
+      {
+        role: 'pasteandmatchstyle'
+      } : {},
+
+      {
+        role: 'delete'
+      },
+
+      process.platform === 'win32' ?
+      {
+          type: 'separator'
+      } : {},
+
+      {
+        role: 'selectall'
+      }
+    ]
+  },
+
+  // submenu Window should be used for Mac only
+  menuWindow: {
+    label: 'Window',
+    submenu: [
+      {
+        role: 'minimize'
+      },
+      {
+        role: 'close'
+      },
+
+      process.platform === 'darwin' ?
+      {
+        type: 'separator'
+      } : {},
+
+      process.platform === 'darwin' ?
+      {
+        label: 'Bring All to Front',
+        role: 'front'
+      } : {}
+
+    ]
   }
 }
 
@@ -174,6 +241,20 @@ exports.getDefaultLabel = (role) => {
 
 exports.getDefaultAccelerator = (role) => {
   if (roles.hasOwnProperty(role)) return roles[role].accelerator
+}
+
+exports.getDefaultSubmenu = (role) => {
+  if (roles.hasOwnProperty(role)) {
+    submenu = roles[role].submenu
+
+    // remove empty objects from within the submenu
+    if (Array.isArray(submenu))
+      submenu = submenu.filter(function(n){
+        return n.constructor !== Object || Object.keys(n).length > 0
+      })
+
+    return submenu
+  }
 }
 
 exports.execute = (role, focusedWindow, focusedWebContents) => {

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -155,7 +155,7 @@ const roles = {
       })
     }
   },
-  // submenu Edit (should fit both Mac & Windows)
+  // Edit submenu (should fit both Mac & Windows)
   editMenu: {
     label: 'Edit',
     submenu: [
@@ -196,7 +196,7 @@ const roles = {
     ]
   },
 
-  // submenu Window should be used for Mac only
+  // Window submenu should be used for Mac only
   windowMenu: {
     label: 'Window',
     submenu: [
@@ -239,18 +239,16 @@ exports.getDefaultAccelerator = (role) => {
 }
 
 exports.getDefaultSubmenu = (role) => {
-  if (roles.hasOwnProperty(role)) {
-    let submenu = roles[role].submenu
+  if (!roles.hasOwnProperty(role)) return
 
-    // remove empty objects from within the submenu
-    if (Array.isArray(submenu)) {
-      submenu = submenu.filter(function (n) {
-        return n != null
-      })
-    }
+  let {submenu} = roles[role]
 
-    return submenu
+  // remove null items from within the submenu
+  if (Array.isArray(submenu)) {
+    submenu = submenu.filter((item) => item != null)
   }
+
+  return submenu
 }
 
 exports.execute = (role, focusedWindow, focusedWebContents) => {

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -156,7 +156,7 @@ const roles = {
     }
   },
   // submenu Edit (should fit both Mac & Windows)
-  menuEdit: {
+  editMenu: {
     label: 'Edit',
     submenu: [
       {
@@ -197,7 +197,7 @@ const roles = {
   },
 
   // submenu Window should be used for Mac only
-  menuWindow: {
+  windowMenu: {
     label: 'Window',
     submenu: [
       {

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -11,7 +11,7 @@ const MenuItem = function (options) {
   for (let key in options) {
     if (!(key in this)) this[key] = options[key]
   }
-
+  this.submenu = this.submenu || roles.getDefaultSubmenu(this.role)
   if (this.submenu != null && this.submenu.constructor !== Menu) {
     this.submenu = Menu.buildFromTemplate(this.submenu)
   }

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -455,6 +455,52 @@ describe('menu module', function () {
     })
   })
 
+  describe('MenuItem editMenu', function() {
+    it('includes a default submenu layout when submenu is empty', function() {
+      var item = new MenuItem({role: 'editMenu'})
+      assert.equal(item.label, 'Edit')
+      assert.equal(item.submenu.items[0].role, 'undo')
+      assert.equal(item.submenu.items[1].role, 'redo')
+      assert.equal(item.submenu.items[2].type, 'separator')
+      assert.equal(item.submenu.items[3].role, 'cut')
+      assert.equal(item.submenu.items[4].role, 'copy')
+      assert.equal(item.submenu.items[5].role, 'paste')
+      if (process.platform == 'darwin') {
+        assert.equal(item.submenu.items[6].role, 'pasteandmatchstyle')
+        assert.equal(item.submenu.items[7].role, 'delete')
+        assert.equal(item.submenu.items[8].role, 'selectall')
+      }
+      if (process.platform == 'win32') {
+        assert.equal(item.submenu.items[6].role, 'delete')
+        assert.equal(item.submenu.items[7].type, 'separator')
+        assert.equal(item.submenu.items[8].role, 'selectall')
+      }
+    })
+    it('overrides default layout when submenu is specified', function() {
+      var item = new MenuItem({role: 'editMenu', submenu: [{ role: 'close'}]})
+      assert.equal(item.label, 'Edit')
+      assert.equal(item.submenu.items[0].role, 'close')
+    })
+  })
+
+  describe('MenuItem windowMenu', function() {
+    it('includes a default submenu layout when submenu is empty', function() {
+      var item = new MenuItem({role: 'windowMenu'})
+      assert.equal(item.label, 'Window')
+      assert.equal(item.submenu.items[0].role, 'minimize')
+      assert.equal(item.submenu.items[1].role, 'close')
+      if (process.platform == 'darwin') {
+        assert.equal(item.submenu.items[2].type, 'separator')
+        assert.equal(item.submenu.items[3].role, 'front')
+      }
+    })
+    it('overrides default layout when submenu is specified', function() {
+      var item = new MenuItem({role: 'windowMenu', submenu: [{ role: 'copy'}]})
+      assert.equal(item.label, 'Window')
+      assert.equal(item.submenu.items[0].role, 'copy')
+    })
+  })
+
   describe('MenuItem with custom properties in constructor', function () {
     it('preserves the custom properties', function () {
       var template = [{

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -465,17 +465,20 @@ describe('menu module', function () {
       assert.equal(item.submenu.items[3].role, 'cut')
       assert.equal(item.submenu.items[4].role, 'copy')
       assert.equal(item.submenu.items[5].role, 'paste')
+
       if (process.platform === 'darwin') {
         assert.equal(item.submenu.items[6].role, 'pasteandmatchstyle')
         assert.equal(item.submenu.items[7].role, 'delete')
         assert.equal(item.submenu.items[8].role, 'selectall')
       }
+
       if (process.platform === 'win32') {
         assert.equal(item.submenu.items[6].role, 'delete')
         assert.equal(item.submenu.items[7].type, 'separator')
         assert.equal(item.submenu.items[8].role, 'selectall')
       }
     })
+
     it('overrides default layout when submenu is specified', function () {
       var item = new MenuItem({role: 'editMenu', submenu: [{role: 'close'}]})
       assert.equal(item.label, 'Edit')
@@ -489,11 +492,13 @@ describe('menu module', function () {
       assert.equal(item.label, 'Window')
       assert.equal(item.submenu.items[0].role, 'minimize')
       assert.equal(item.submenu.items[1].role, 'close')
+
       if (process.platform === 'darwin') {
         assert.equal(item.submenu.items[2].type, 'separator')
         assert.equal(item.submenu.items[3].role, 'front')
       }
     })
+
     it('overrides default layout when submenu is specified', function () {
       var item = new MenuItem({role: 'windowMenu', submenu: [{role: 'copy'}]})
       assert.equal(item.label, 'Window')

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -455,8 +455,8 @@ describe('menu module', function () {
     })
   })
 
-  describe('MenuItem editMenu', function() {
-    it('includes a default submenu layout when submenu is empty', function() {
+  describe('MenuItem editMenu', function () {
+    it('includes a default submenu layout when submenu is empty', function () {
       var item = new MenuItem({role: 'editMenu'})
       assert.equal(item.label, 'Edit')
       assert.equal(item.submenu.items[0].role, 'undo')
@@ -465,37 +465,37 @@ describe('menu module', function () {
       assert.equal(item.submenu.items[3].role, 'cut')
       assert.equal(item.submenu.items[4].role, 'copy')
       assert.equal(item.submenu.items[5].role, 'paste')
-      if (process.platform == 'darwin') {
+      if (process.platform === 'darwin') {
         assert.equal(item.submenu.items[6].role, 'pasteandmatchstyle')
         assert.equal(item.submenu.items[7].role, 'delete')
         assert.equal(item.submenu.items[8].role, 'selectall')
       }
-      if (process.platform == 'win32') {
+      if (process.platform === 'win32') {
         assert.equal(item.submenu.items[6].role, 'delete')
         assert.equal(item.submenu.items[7].type, 'separator')
         assert.equal(item.submenu.items[8].role, 'selectall')
       }
     })
-    it('overrides default layout when submenu is specified', function() {
-      var item = new MenuItem({role: 'editMenu', submenu: [{ role: 'close'}]})
+    it('overrides default layout when submenu is specified', function () {
+      var item = new MenuItem({role: 'editMenu', submenu: [{role: 'close'}]})
       assert.equal(item.label, 'Edit')
       assert.equal(item.submenu.items[0].role, 'close')
     })
   })
 
-  describe('MenuItem windowMenu', function() {
-    it('includes a default submenu layout when submenu is empty', function() {
+  describe('MenuItem windowMenu', function () {
+    it('includes a default submenu layout when submenu is empty', function () {
       var item = new MenuItem({role: 'windowMenu'})
       assert.equal(item.label, 'Window')
       assert.equal(item.submenu.items[0].role, 'minimize')
       assert.equal(item.submenu.items[1].role, 'close')
-      if (process.platform == 'darwin') {
+      if (process.platform === 'darwin') {
         assert.equal(item.submenu.items[2].type, 'separator')
         assert.equal(item.submenu.items[3].role, 'front')
       }
     })
-    it('overrides default layout when submenu is specified', function() {
-      var item = new MenuItem({role: 'windowMenu', submenu: [{ role: 'copy'}]})
+    it('overrides default layout when submenu is specified', function () {
+      var item = new MenuItem({role: 'windowMenu', submenu: [{role: 'copy'}]})
       assert.equal(item.label, 'Window')
       assert.equal(item.submenu.items[0].role, 'copy')
     })


### PR DESCRIPTION
New roles menuEdit and menuWindow were added to layout a kind of default Edit and Window submenu to the top menu bar. If there is a submenu in the item, default layout do not apply. Layout slightly differs for MacOS and Windows.

Closes #2814 