### PR TITLE
:bug: Add toString support to remote functions

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -175,6 +175,9 @@ const proxyFunctionProperties = function (remoteMemberFunction, metaId, name) {
       return true
     },
     get: (target, property, receiver) => {
+      if (property === 'toString' && typeof target.toString === 'function') {
+        return target.toString.bind(target)
+      }
       if (!target.hasOwnProperty(property)) loadRemoteProperties()
       return target[property]
     },

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -175,11 +175,16 @@ const proxyFunctionProperties = function (remoteMemberFunction, metaId, name) {
       return true
     },
     get: (target, property, receiver) => {
-      if (property === 'toString' && typeof target.toString === 'function') {
-        return target.toString.bind(target)
-      }
       if (!target.hasOwnProperty(property)) loadRemoteProperties()
-      return target[property]
+      const value = target[property]
+
+      // Bind toString to target if it is a function to avoid
+      // Function.prototype.toString is not generic errors
+      if (property === 'toString' && typeof value === 'function') {
+        return value.bind(target)
+      }
+
+      return value
     },
     ownKeys: (target) => {
       loadRemoteProperties()

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -163,8 +163,11 @@ describe('ipc module', function () {
     })
 
     it('returns toString() of original function via toString()', function () {
-      var readText = remote.clipboard.readText
+      const {readText} = remote.clipboard
       assert(readText.toString().startsWith('function'))
+
+      var {functionWithToStringProperty} = remote.require(path.join(fixtures, 'module', 'to-string-non-function.js'))
+      assert.equal(functionWithToStringProperty.toString, 'hello')
     })
   })
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -161,6 +161,11 @@ describe('ipc module', function () {
       assert.equal(typeof remote.clipboard.readText, 'function')
       assert.equal(typeof remote.shell.openExternal, 'function')
     })
+
+    it('returns toString() of original function via toString()', function () {
+      var readText = remote.clipboard.readText
+      assert(readText.toString().startsWith('function'))
+    })
   })
 
   describe('remote object in renderer', function () {

--- a/spec/fixtures/module/to-string-non-function.js
+++ b/spec/fixtures/module/to-string-non-function.js
@@ -1,0 +1,4 @@
+function hello () {
+}
+hello.toString = 'hello'
+module.exports = {functionWithToStringProperty: hello}


### PR DESCRIPTION
In https://github.com/twolfson/karma-electron/issues/20, we received a bug report of not being able to stringify remote `electron` functions. After some searching, we found this was being caused by `new Proxy` which doesn't support `toString()` in any scenario:

https://github.com/electron/electron/blob/v1.6.3/lib/renderer/api/remote.js#L170-L190

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString

```js
new Proxy(function x () {}, {}).toString()
// VM594:1 Uncaught TypeError: Function.prototype.toString is not generic
//    at Proxy.toString (<anonymous>)
//    at <anonymous>:1:33
```

We have implemented a fallback implementation for Karma (where this issue was occurring):

https://github.com/karma-runner/karma/pull/2595

but believe we should fix the source of the problem by providing a `toString` proxy solution. In this PR:

- Added bound target `toString` function when `toString` is requested via `remote` proxy
- Added test

The result looks like:

```js
electron.remote.clipboard.write.toString();
// function (...args) {
//   if (this && this.constructor === remoteMemberFunction) {
//     // Constructor call.
//     let ret = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', metaId, member.name, wrapArgs(args))
//     return metaToValue(ret)
//   } else {
//     // Call member function.
//     let ret = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_CALL', metaId, member.name, wrapArgs(args))
//     return metaToValue(ret)
//   }
// } 
```