### PR TITLE
Dynamically generate dependencies of browserify build actions

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -436,11 +436,21 @@
         # depend on this target to ensure the '<(js2c_input_dir)' is created
         'atom_js2c_copy',
       ],
+      'variables': {
+        'sandbox_args': [
+          './lib/sandboxed_renderer/init.js',
+          '-r',
+          './lib/sandboxed_renderer/api/exports/electron.js:electron'
+        ],
+        'isolated_args': [
+          'lib/isolated_renderer/init.js',
+        ]
+      },
       'actions': [
         {
           'action_name': 'atom_browserify_sandbox',
           'inputs': [
-            '<@(browserify_entries)',
+            '<!@(python tools/list-browserify-deps.py <(sandbox_args))'
           ],
           'outputs': [
             '<(js2c_input_dir)/preload_bundle.js',
@@ -451,9 +461,7 @@
             '--silent',
             'browserify',
             '--',
-            'lib/sandboxed_renderer/init.js',
-            '-r',
-            './lib/sandboxed_renderer/api/exports/electron.js:electron',
+            '<@(sandbox_args)',
             '-o',
             '<@(_outputs)',
           ],
@@ -461,7 +469,7 @@
         {
           'action_name': 'atom_browserify_isolated_context',
           'inputs': [
-            '<@(isolated_context_browserify_entries)',
+            '<!@(python tools/list-browserify-deps.py <(isolated_args))'
           ],
           'outputs': [
             '<(js2c_input_dir)/isolated_bundle.js',
@@ -472,7 +480,7 @@
             '--silent',
             'browserify',
             '--',
-            'lib/isolated_renderer/init.js',
+            '<@(isolated_args)',
             '-o',
             '<@(_outputs)',
           ],

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -77,14 +77,6 @@
       'lib/renderer/extensions/storage.js',
       'lib/renderer/extensions/web-navigation.js',
     ],
-    'browserify_entries': [
-      'lib/sandboxed_renderer/init.js',
-      'lib/sandboxed_renderer/api/exports/electron.js',
-    ],
-    'isolated_context_browserify_entries': [
-      'lib/renderer/window-setup.js',
-      'lib/isolated_renderer/init.js',
-    ],
     'js2c_sources': [
       'lib/common/asar.js',
       'lib/common/asar_init.js',

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -1,6 +1,3 @@
-// Any requires added here need to be added to the browserify_entries array
-// in filenames.gypi so they get built into the preload_bundle.js bundle
-
 /* eslint no-eval: "off" */
 /* global binding, preloadPath, Buffer */
 const events = require('events')

--- a/tools/list-browserify-deps.py
+++ b/tools/list-browserify-deps.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import sys
+
+
+SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
+BROWSERIFY = os.path.join(SOURCE_ROOT, 'node_modules', '.bin', 'browserify')
+if sys.platform == 'win32':
+  BROWSERIFY += '.cmd'
+
+deps = subprocess.check_output([BROWSERIFY, '--list'] + sys.argv[1:])
+for dep in deps.split('\n'):
+    if dep:
+        dep = os.path.relpath(dep, SOURCE_ROOT)
+        if sys.platform == 'win32':
+            print('/'.join(dep.split('\\')))
+        else:
+            print(dep)


### PR DESCRIPTION
Instead of having to list in filenames.gypi every javascript file that may go
into a browserify build, generate this list dynamically when the build files are
created by gyp.

Extracted from #8815