### PR TITLE
Handle Buffer deserialization in sandboxed renderers

### DIFF
--- a/atom/common/native_mate_converters/v8_value_converter.h
+++ b/atom/common/native_mate_converters/v8_value_converter.h
@@ -25,6 +25,7 @@ class V8ValueConverter {
   void SetRegExpAllowed(bool val);
   void SetFunctionAllowed(bool val);
   void SetStripNullFromObjects(bool val);
+  void SetDisableNode(bool val);
   v8::Local<v8::Value> ToV8Value(const base::Value* value,
                                  v8::Local<v8::Context> context) const;
   base::Value* FromV8Value(v8::Local<v8::Value> value,
@@ -63,6 +64,13 @@ class V8ValueConverter {
 
   // If true, we will convert Function JavaScript objects to dictionaries.
   bool function_allowed_;
+
+  // If true, will not use node::Buffer::Copy to deserialize byte arrays.
+  // node::Buffer::Copy depends on a working node.js environment, and this is
+  // not desirable in sandboxed renderers. That means Buffer instances sent from
+  // browser process will be deserialized as browserify-based Buffer(which are
+  // wrappers around Uint8Array).
+  bool disable_node_;
 
   // If true, undefined and null values are ignored when converting v8 objects
   // into Values.

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -10,6 +10,7 @@
 
 #include "atom/common/api/api_messages.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/native_mate_converters/v8_value_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
@@ -135,7 +136,9 @@ class AtomSandboxedRenderViewObserver : public AtomRenderViewObserver {
   AtomSandboxedRenderViewObserver(content::RenderView* render_view,
                                   AtomSandboxedRendererClient* renderer_client)
     : AtomRenderViewObserver(render_view, nullptr),
+    v8_converter_(new atom::V8ValueConverter),
     renderer_client_(renderer_client) {
+      v8_converter_->SetDisableNode(true);
     }
 
  protected:
@@ -151,7 +154,7 @@ class AtomSandboxedRenderViewObserver : public AtomRenderViewObserver {
     v8::Context::Scope context_scope(context);
     v8::Local<v8::Value> argv[] = {
       mate::ConvertToV8(isolate, channel),
-      mate::ConvertToV8(isolate, args)
+      v8_converter_->ToV8Value(&args, context)
     };
     renderer_client_->InvokeIpcCallback(
         context,
@@ -160,6 +163,7 @@ class AtomSandboxedRenderViewObserver : public AtomRenderViewObserver {
   }
 
  private:
+  std::unique_ptr<atom::V8ValueConverter> v8_converter_;
   AtomSandboxedRendererClient* renderer_client_;
   DISALLOW_COPY_AND_ASSIGN(AtomSandboxedRenderViewObserver);
 };

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -5,6 +5,9 @@ const events = require('events')
 process.atomBinding = require('../common/atom-binding-setup')(binding.get, 'renderer')
 
 const v8Util = process.atomBinding('v8_util')
+// Expose browserify Buffer as a hidden value. This is used by C++ code to
+// deserialize Buffer instances sent from browser process.
+v8Util.setHiddenValue(global, 'Buffer', Buffer)
 // The `lib/renderer/api/ipc-renderer.js` module looks for the ipc object in the
 // "ipc" hidden value
 v8Util.setHiddenValue(global, 'ipc', new events.EventEmitter())


### PR DESCRIPTION
In sandboxed renderers we use browserify to provide a node-like environment. The
Buffer class used by browserify is actually just a wrapper around Uint8Array,
but to deserialize Buffer correctly we must expose the class as a hidden value
and use it in V8ValueConverter.

Extracted from #8815