### PR TITLE
renderer: reset plugin cache when render frame is created

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -271,6 +271,9 @@ void AtomRendererClient::RenderFrameCreated(
   // FIXME(zcbenz): Can this be moved elsewhere?
   blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers("file");
 
+  // This is required for widevine plugin detection provided during runtime.
+  blink::resetPluginCache();
+
   // Parse --secure-schemes=scheme1,scheme2
   std::vector<std::string> secure_schemes_list =
       ParseSchemesCLISwitch(switches::kSecureSchemes);


### PR DESCRIPTION
Plugin list on the browser side needs to be created before any cdm creation happens, chrome warms up the cache in `ChromeRendererClient::OverrideCreatePlugin` and hence it doesn't face the problem of widevine detection. The reason why flash plugin detection worked is that `content::MimeSniffingResourceHandler` warms up the cache when it detects an object resource. This is a necessary hack to make widevine detection work in Electron without having to access `navigator.plugins`.

Fixes https://github.com/electron/electron/issues/6516
Ref https://github.com/electron/electron/issues/8824