### PR TITLE
Clarify remote require of relative modules

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -159,11 +159,7 @@ project/
 ```js
 // main process: main/index.js
 const { app } = require('electron')
-app.on('ready', () => {
-
-// ...
-
-})
+app.on('ready', () => {/* ... */})
 ```
 
 ```js

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -140,7 +140,26 @@ The `remote` module has the following methods:
 
 * `module` String
 
-Returns `any` - The object returned by `require(module)` in the main process.
+Returns `any` - The object returned by `require(module)` in the main process.  Modules specified by their relative path will resolve relative to the entrypoint of the main process.
+
+e.g.
+
+```js
+// main process: main/index.js
+const { app, ipcMain } = require('electron')
+app.on('ready', () => {
+//...
+```
+
+```js
+// some relative module: main/foo.js
+module.exports = 'bar'
+```
+
+```js
+// renderer process: renderer/index.js
+const foo = require('electron').remote.require('./foo') // bar
+```
 
 ### `remote.getCurrentWindow()`
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -158,7 +158,7 @@ project/
 
 ```js
 // main process: main/index.js
-const { app } = require('electron')
+const {app} = require('electron')
 app.on('ready', () => { /* ... */ })
 ```
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -159,7 +159,7 @@ project/
 ```js
 // main process: main/index.js
 const { app } = require('electron')
-app.on('ready', () => {/* ... */})
+app.on('ready', () => { /* ... */ })
 ```
 
 ```js

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -140,7 +140,9 @@ The `remote` module has the following methods:
 
 * `module` String
 
-Returns `any` - The object returned by `require(module)` in the main process.  Modules specified by their relative path will resolve relative to the entrypoint of the main process.
+Returns `any` - The object returned by `require(module)` in the main process.
+Modules specified by their relative path will resolve relative to the entrypoint
+of the main process.
 
 e.g.
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -146,11 +146,24 @@ of the main process.
 
 e.g.
 
+```
+project/
+├── main
+│   ├── foo.js
+│   └── index.js
+├── package.json
+└── renderer
+    └── index.js
+```
+
 ```js
 // main process: main/index.js
-const { app, ipcMain } = require('electron')
+const { app } = require('electron')
 app.on('ready', () => {
-//...
+
+// ...
+
+})
 ```
 
 ```js


### PR DESCRIPTION
The docs for the `remote.require(module)` method were a little too terse for me to understand the behavior of relative module loading for `remote.require` and I had to run an experiment to understand the behavior (e.g. is the relative path relative to caller of `remote.require` or relative to some other path in the project related to the main process?).   I think this is correct but someone please double check my understanding.

Adding an example and additional explanation should help clarify this.  Feel free to edit the copy as needed.