### PR TITLE
Upgrade libcc for v8 snapshot patch

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '27add4cfef98f21d5910539bebb47ae175f024c2'
+    'e93c6a82d7ab1e3b97a294200186d7254ad3f868'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
This change pulls in https://github.com/electron/libchromiumcontent/pull/271 which removes the verification of snapshot data on Windows.

This has been removed upstream in https://codereview.chromium.org/2680653002 and this backports it to 1.3.x so Atom can use it via https://github.com/atom/atom/pull/13916