### PR TITLE
browser: Create separate request context for geolocation service.

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -411,12 +411,16 @@ WebContents::~WebContents() {
     if (type_ == WEB_VIEW)
       guest_delegate_->Destroy();
 
-    // The WebContentsDestroyed will not be called automatically because we
-    // unsubscribe from webContents before destroying it. So we have to manually
-    // call it here to make sure "destroyed" event is emitted.
     RenderViewDeleted(web_contents()->GetRenderViewHost());
-    WebContentsDestroyed();
+    DestroyWebContents();
   }
+}
+
+void WebContents::DestroyWebContents() {
+  // This event is only for internal use, which is emitted when WebContents is
+  // being destroyed.
+  Emit("will-destroy");
+  CommonWebContentsDelegate::DestroyWebContents();
 }
 
 bool WebContents::DidAddMessageToConsole(content::WebContents* source,
@@ -919,10 +923,6 @@ bool WebContents::OnMessageReceived(const IPC::Message& message) {
 // be destroyed on close, and WebContentsDestroyed would be called for it, so
 // we need to make sure the api::WebContents is also deleted.
 void WebContents::WebContentsDestroyed() {
-  // This event is only for internal use, which is emitted when WebContents is
-  // being destroyed.
-  Emit("will-destroy");
-
   // Cleanup relationships with other parts.
   RemoveFromWeakMap();
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -420,7 +420,7 @@ void WebContents::DestroyWebContents() {
   // This event is only for internal use, which is emitted when WebContents is
   // being destroyed.
   Emit("will-destroy");
-  CommonWebContentsDelegate::DestroyWebContents();
+  ResetManagedWebContents();
 }
 
 bool WebContents::DidAddMessageToConsole(content::WebContents* source,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -76,6 +76,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
+  // Notifies to destroy any guest web contents before destroying self.
+  void DestroyWebContents();
+
   int64_t GetID() const;
   int GetProcessID() const;
   Type GetType() const;

--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -7,11 +7,13 @@
 #include <string>
 #include <utility>
 
-#include "atom/browser/atom_browser_context.h"
 #include "atom/common/google_api_key.h"
 #include "base/environment.h"
 #include "content/public/browser/browser_thread.h"
 #include "device/geolocation/geolocation_provider.h"
+#include "net/url_request/url_request_context.h"
+#include "net/url_request/url_request_context_builder.h"
+#include "net/url_request/url_request_context_getter.h"
 
 using content::BrowserThread;
 
@@ -19,51 +21,40 @@ namespace atom {
 
 namespace internal {
 
-// Loads access tokens and other necessary data on the UI thread, and
-// calls back to the originator on the originating thread.
-class TokenLoadingJob : public base::RefCountedThreadSafe<TokenLoadingJob> {
+class GeoURLRequestContextGetter : public net::URLRequestContextGetter {
  public:
-  explicit TokenLoadingJob(
-      const device::AccessTokenStore::LoadAccessTokensCallback& callback)
-      : callback_(callback), request_context_getter_(nullptr) {}
+  net::URLRequestContext* GetURLRequestContext() override {
+    DCHECK_CURRENTLY_ON(BrowserThread::IO);
+    if (!url_request_context_.get()) {
+      net::URLRequestContextBuilder builder;
+      builder.set_proxy_config_service(
+          net::ProxyService::CreateSystemProxyConfigService(
+              BrowserThread::GetTaskRunnerForThread(BrowserThread::IO),
+              BrowserThread::GetTaskRunnerForThread(BrowserThread::FILE)));
+      url_request_context_ = builder.Build();
+    }
+    return url_request_context_.get();
+  }
 
-  void Run(AtomBrowserContext* browser_context) {
-    DCHECK_CURRENTLY_ON(BrowserThread::UI);
-    request_context_getter_ = browser_context->GetRequestContext();
-    std::unique_ptr<base::Environment> env(base::Environment::Create());
-    if (!env->GetVar("GOOGLE_API_KEY", &api_key_))
-      api_key_ = GOOGLEAPIS_API_KEY;
-    BrowserThread::PostTask(
-        BrowserThread::IO, FROM_HERE,
-        base::Bind(&TokenLoadingJob::RespondOnIOThread, this));
+  scoped_refptr<base::SingleThreadTaskRunner> GetNetworkTaskRunner()
+      const override {
+    return BrowserThread::GetTaskRunnerForThread(BrowserThread::IO);
   }
 
  private:
-  friend class base::RefCountedThreadSafe<TokenLoadingJob>;
+  friend class atom::AtomAccessTokenStore;
 
-  ~TokenLoadingJob() {}
+  GeoURLRequestContextGetter() {}
+  ~GeoURLRequestContextGetter() override {}
 
-  void RespondOnIOThread() {
-    // Equivalent to access_token_map[kGeolocationProviderURL].
-    // Somehow base::string16 is causing compilation errors when used in a pair
-    // of std::map on Linux, this can work around it.
-    device::AccessTokenStore::AccessTokenMap access_token_map;
-    std::pair<GURL, base::string16> token_pair;
-    token_pair.first = GURL(GOOGLEAPIS_ENDPOINT + api_key_);
-    access_token_map.insert(token_pair);
-
-    callback_.Run(access_token_map, request_context_getter_);
-  }
-
-  device::AccessTokenStore::LoadAccessTokensCallback callback_;
-  net::URLRequestContextGetter* request_context_getter_;
-  std::string api_key_;
+  std::unique_ptr<net::URLRequestContext> url_request_context_;
+  DISALLOW_COPY_AND_ASSIGN(GeoURLRequestContextGetter);
 };
 
 }  // namespace internal
 
-AtomAccessTokenStore::AtomAccessTokenStore() {
-  browser_context_ = AtomBrowserContext::From("", false);
+AtomAccessTokenStore::AtomAccessTokenStore()
+    : request_context_getter_(new internal::GeoURLRequestContextGetter) {
   device::GeolocationProvider::GetInstance()->UserDidOptIntoLocationServices();
 }
 
@@ -72,16 +63,19 @@ AtomAccessTokenStore::~AtomAccessTokenStore() {
 
 void AtomAccessTokenStore::LoadAccessTokens(
     const LoadAccessTokensCallback& callback) {
-  scoped_refptr<internal::TokenLoadingJob> job(
-      new internal::TokenLoadingJob(callback));
-  BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
-                          base::Bind(&AtomAccessTokenStore::RunTokenLoadingJob,
-                                     this, base::RetainedRef(job)));
-}
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  std::string api_key;
+  if (!env->GetVar("GOOGLE_API_KEY", &api_key))
+    api_key = GOOGLEAPIS_API_KEY;
+  // Equivalent to access_token_map[kGeolocationProviderURL].
+  // Somehow base::string16 is causing compilation errors when used in a pair
+  // of std::map on Linux, this can work around it.
+  device::AccessTokenStore::AccessTokenMap access_token_map;
+  std::pair<GURL, base::string16> token_pair;
+  token_pair.first = GURL(GOOGLEAPIS_ENDPOINT + api_key);
+  access_token_map.insert(token_pair);
 
-void AtomAccessTokenStore::RunTokenLoadingJob(
-    scoped_refptr<internal::TokenLoadingJob> job) {
-  job->Run(browser_context_.get());
+  callback.Run(access_token_map, request_context_getter_.get());
 }
 
 void AtomAccessTokenStore::SaveAccessToken(const GURL& server_url,

--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -9,10 +9,8 @@
 
 namespace atom {
 
-class AtomBrowserContext;
-
 namespace internal {
-class TokenLoadingJob;
+class GeoURLRequestContextGetter;
 }
 
 class AtomAccessTokenStore : public device::AccessTokenStore {
@@ -27,9 +25,7 @@ class AtomAccessTokenStore : public device::AccessTokenStore {
                        const base::string16& access_token) override;
 
  private:
-  void RunTokenLoadingJob(scoped_refptr<internal::TokenLoadingJob> job);
-
-  scoped_refptr<AtomBrowserContext> browser_context_;
+  scoped_refptr<internal::GeoURLRequestContextGetter> request_context_getter_;
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);
 };
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -183,7 +183,7 @@ void CommonWebContentsDelegate::SetOwnerWindow(
   web_contents->SetUserData(relay->key, relay);
 }
 
-void CommonWebContentsDelegate::DestroyWebContents() {
+void CommonWebContentsDelegate::ResetManagedWebContents() {
   web_contents_.reset();
 }
 

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -42,9 +42,6 @@ class CommonWebContentsDelegate
   void SetOwnerWindow(content::WebContents* web_contents,
                       NativeWindow* owner_window);
 
-  // Destroy the managed InspectableWebContents object.
-  void DestroyWebContents();
-
   // Returns the WebContents managed by this delegate.
   content::WebContents* GetWebContents() const;
 
@@ -113,6 +110,9 @@ class CommonWebContentsDelegate
   void GetDevToolsWindowWMClass(
       std::string* name, std::string* class_name) override;
 #endif
+
+  // Destroy the managed InspectableWebContents object.
+  void ResetManagedWebContents();
 
  private:
   // Callback for when DevToolsSaveToFile has completed.


### PR DESCRIPTION
This fixes a crash which happens when navigating from a webpage that uses geolocation service and then quitting the app. Test this after applying https://github.com/electron/brightray/pull/278

```
#2 0x7f329989b51c content::RenderProcessHostImpl::ClearWebRtcLogMessageCallback()
#3 0x7f329989a7b3 content::RenderProcessHostImpl::Cleanup()
#4 0x7f329991cf34 content::ServiceWorkerProcessManager::Shutdown()
#5 0x7f329996ff90 content::StoragePartitionImplMap::ForEach()
#6 0x7f329962aad8 content::BrowserContext::NotifyWillBeDestroyed()
#7 0x000000e49f91 brightray::BrowserContext::~BrowserContext()
#8 0x000000cd65fc atom::AtomBrowserContext::~AtomBrowserContext()
#9 0x000000cd6649 atom::AtomBrowserContext::~AtomBrowserContext()
#10 0x000000ba71ff base::RefCounted<>::Release()
#11 0x000000ba71a9 scoped_refptr<>::Release()
#12 0x000000b9ae1a scoped_refptr<>::~scoped_refptr()
#13 0x000000ccec30 atom::AtomAccessTokenStore::~AtomAccessTokenStore()
#14 0x000000ccecc9 atom::AtomAccessTokenStore::~AtomAccessTokenStore()
#15 0x7f32987e8fb6 device::LocationArbitrator::~LocationArbitrator()
#16 0x7f32987e9029 device::LocationArbitrator::~LocationArbitrator()
#17 0x7f3295a4a802 base::Thread::ThreadMain()
#18 0x7f3295a44e03 <unknown>
#19 0x7f328b9062e7 start_thread
```

To reproduce:

* Navigate to `youtube.com`
* Then navigate to `google.com`
* window.history.back()
* quit the qpp

The reason for the crash is that geolocation service is managed by a global leaky pointer, since we were holding a reference to browser context, it will therefore be destroyed at the end of everything and messes with the cleanup process.

This also Fixes https://github.com/electron/electron/issues/8754 , geolocation service has its own dedicated thread, the response from `AtomAccessTokenStore` were being sent back to IO thread instead, hence the UI freezed.