### PR TITLE
Expose remote module to sandbox

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -7,8 +7,6 @@ const {WebContents} = process.atomBinding('web_contents')
 
 const {ipcMain, isPromise, webContents} = electron
 
-const fs = require('fs')
-
 const objectsRegistry = require('./objects-registry')
 
 const hasProp = {}.hasOwnProperty
@@ -266,13 +264,6 @@ ipcMain.on('ELECTRON_BROWSER_REQUIRE', function (event, module) {
   } catch (error) {
     event.returnValue = exceptionToMeta(error)
   }
-})
-
-ipcMain.on('ELECTRON_BROWSER_READ_FILE', function (event, file) {
-  fs.readFile(file, (err, data) => {
-    if (err) event.returnValue = {err: err.message}
-    else event.returnValue = {data: data.toString()}
-  })
 })
 
 ipcMain.on('ELECTRON_BROWSER_GET_BUILTIN', function (event, module) {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -1,6 +1,9 @@
 'use strict'
 
-const {Buffer} = require('buffer')
+// Note: Don't use destructuring assignment for `Buffer`, or we'll hit a
+// browserify bug that makes the statement invalid, throwing an error in
+// sandboxed renderer.
+const Buffer = require('buffer').Buffer
 const v8Util = process.atomBinding('v8_util')
 const {ipcRenderer, isPromise, CallbacksRegistry} = require('electron')
 const resolvePromise = Promise.resolve.bind(Promise)

--- a/lib/sandboxed_renderer/api/exports/electron.js
+++ b/lib/sandboxed_renderer/api/exports/electron.js
@@ -4,5 +4,21 @@ Object.defineProperties(exports, {
     get: function () {
       return require('../ipc-renderer')
     }
+  },
+  remote: {
+    enumerable: true,
+    get: function () {
+      return require('../../../renderer/api/remote')
+    }
+  },
+  CallbacksRegistry: {
+    get: function () {
+      return require('../../../common/api/callbacks-registry')
+    }
+  },
+  isPromise: {
+    get: function () {
+      return require('../../../common/api/is-promise')
+    }
   }
 })

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -22,12 +22,15 @@ const preloadModules = new Map([
   ['electron', electron]
 ])
 
-// Fetch the preload script. This needs to be done through the browser process
-// since we may not have filesystem access in a sandboxed renderer.
-let preloadSrc = electron.ipcRenderer.sendSync('ELECTRON_BROWSER_READ_FILE', preloadPath)
-if (preloadSrc.err) {
-  throw new Error(preloadSrc.err)
+const extraModules = [
+  'fs'
+]
+for (let extraModule of extraModules) {
+  preloadModules.set(extraModule, electron.remote.require(extraModule))
 }
+
+// Fetch the preload script using the "fs" module proxy.
+let preloadSrc = preloadModules.get('fs').readFileSync(preloadPath).toString()
 
 // Pass different process object to the preload script(which should not have
 // access to things like `process.atomBinding`).
@@ -62,7 +65,7 @@ function preloadRequire (module) {
 // since browserify won't try to include `electron` in the bundle, falling back
 // to the `preloadRequire` function above.
 let preloadWrapperSrc = `(function(require, process, Buffer, global) {
-${preloadSrc.data}
+${preloadSrc}
 })`
 
 // eval in window scope:


### PR DESCRIPTION
Also implicitly test #8900 since `remote.fs` is used for the preload script