### PR TITLE
Add clipboard.readBuffer(format)

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -47,6 +47,13 @@ std::string Clipboard::Read(const std::string& format_string,
   return data;
 }
 
+v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
+                                           mate::Arguments* args) {
+  std::string data = Read(format_string, args);
+  return node::Buffer::Copy(
+      args->isolate(), data.data(), data.length()).ToLocalChecked();
+}
+
 void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   base::string16 text, html, bookmark;
@@ -184,6 +191,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("writeImage", &atom::api::Clipboard::WriteImage);
   dict.SetMethod("readFindText", &atom::api::Clipboard::ReadFindText);
   dict.SetMethod("writeFindText", &atom::api::Clipboard::WriteFindText);
+  dict.SetMethod("readBuffer", &atom::api::Clipboard::ReadBuffer);
   dict.SetMethod("clear", &atom::api::Clipboard::Clear);
 
   // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -37,8 +37,7 @@ bool Clipboard::Has(const std::string& format_string, mate::Arguments* args) {
   return clipboard->IsFormatAvailable(format, GetClipboardType(args));
 }
 
-std::string Clipboard::Read(const std::string& format_string,
-                            mate::Arguments* args) {
+std::string Clipboard::Read(const std::string& format_string) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   ui::Clipboard::FormatType format(ui::Clipboard::GetFormatType(format_string));
 
@@ -49,7 +48,7 @@ std::string Clipboard::Read(const std::string& format_string,
 
 v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
                                            mate::Arguments* args) {
-  std::string data = Read(format_string, args);
+  std::string data = Read(format_string);
   return node::Buffer::Copy(
       args->isolate(), data.data(), data.length()).ToLocalChecked();
 }

--- a/atom/common/api/atom_api_clipboard.h
+++ b/atom/common/api/atom_api_clipboard.h
@@ -24,8 +24,7 @@ class Clipboard {
   static bool Has(const std::string& format_string, mate::Arguments* args);
   static void Clear(mate::Arguments* args);
 
-  static std::string Read(const std::string& format_string,
-                          mate::Arguments* args);
+  static std::string Read(const std::string& format_string);
   static void Write(const mate::Dictionary& data, mate::Arguments* args);
 
   static base::string16 ReadText(mate::Arguments* args);
@@ -50,7 +49,6 @@ class Clipboard {
 
   static v8::Local<v8::Value> ReadBuffer(const std::string& format_string,
                                          mate::Arguments* args);
-
 
  private:
   DISALLOW_COPY_AND_ASSIGN(Clipboard);

--- a/atom/common/api/atom_api_clipboard.h
+++ b/atom/common/api/atom_api_clipboard.h
@@ -48,6 +48,10 @@ class Clipboard {
   static base::string16 ReadFindText();
   static void WriteFindText(const base::string16& text);
 
+  static v8::Local<v8::Value> ReadBuffer(const std::string& format_string,
+                                         mate::Arguments* args);
+
+
  private:
   DISALLOW_COPY_AND_ASSIGN(Clipboard);
 };

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -133,24 +133,29 @@ Clears the clipboard content.
 
 Returns `String[]` - An array of supported formats for the clipboard `type`.
 
-### `clipboard.has(data[, type])` _Experimental_
+### `clipboard.has(format[, type])` _Experimental_
 
-* `data` String
+* `format` String
 * `type` String (optional)
 
-Returns `Boolean` - Whether the clipboard supports the format of specified `data`.
+Returns `Boolean` - Whether the clipboard supports the specified `format`.
 
 ```javascript
 const {clipboard} = require('electron')
 console.log(clipboard.has('<p>selection</p>'))
 ```
 
-### `clipboard.read(data[, type])` _Experimental_
+### `clipboard.read(format)` _Experimental_
 
-* `data` String
-* `type` String (optional)
+* `format` String
 
-Returns `String` - Reads `data` from the clipboard.
+Returns `String` - Reads `format` type from the clipboard.
+
+### `clipboard.readBuffer(format)` _Experimental_
+
+* `format` String
+
+Returns `Buffer` - Reads `format` type from the clipboard.
 
 ### `clipboard.write(data[, type])`
 

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -2,8 +2,7 @@ const assert = require('assert')
 const path = require('path')
 const {Buffer} = require('buffer')
 
-const clipboard = require('electron').clipboard
-const nativeImage = require('electron').nativeImage
+const {clipboard, nativeImage} = require('electron')
 
 describe('clipboard module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const path = require('path')
+const {Buffer} = require('buffer')
 
 const clipboard = require('electron').clipboard
 const nativeImage = require('electron').nativeImage
@@ -91,6 +92,16 @@ describe('clipboard module', function () {
 
       clipboard.writeFindText('find this')
       assert.equal(clipboard.readFindText(), 'find this')
+    })
+  })
+
+  describe('clipboard.readBuffer(format)', function () {
+    it('returns a Buffer of the content for the specified format', function () {
+      if (process.platform !== 'darwin') return
+
+      const buffer = Buffer.from('this is binary', 'utf8')
+      clipboard.writeText(buffer.toString())
+      assert(buffer.equals(clipboard.readBuffer('public.utf8-plain-text')))
     })
   })
 })


### PR DESCRIPTION
Adds support for reading a custom data format as a `Buffer` from the clipboard.

Closes #8877