### PR TITLE
Mark touch bar apis with _Experimental_ in docs

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1267,7 +1267,7 @@ Controls whether to hide cursor when typing.
 Adds a vibrancy effect to the browser window. Passing `null` or an empty string
 will remove the vibrancy effect on the window.
 
-#### `win.setTouchBar(touchBar)` _macOS_
+#### `win.setTouchBar(touchBar)` _macOS_ _Experimental_
 
 * `touchBar` TouchBar
 

--- a/docs/api/touch-bar-button.md
+++ b/docs/api/touch-bar-button.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarButton(options)`
+### `new TouchBarButton(options)` _Experimental_
 
 * `options` Object
   * `label` String (optional) - Button text.

--- a/docs/api/touch-bar-color-picker.md
+++ b/docs/api/touch-bar-color-picker.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarColorPicker(options)`
+### `new TouchBarColorPicker(options)` _Experimental_
 
 * `options` Object
   * `availableColors` String[] (optional) - Array of hex color strings to

--- a/docs/api/touch-bar-group.md
+++ b/docs/api/touch-bar-group.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarGroup(options)`
+### `new TouchBarGroup(options)` _Experimental_
 
 * `options` Object
   * `items` [TouchBar](touch-bar.md) - Items to display as a group.

--- a/docs/api/touch-bar-label.md
+++ b/docs/api/touch-bar-label.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarLabel(options)`
+### `new TouchBarLabel(options)` _Experimental_
 
 * `options` Object
   * `label` String (optional) - Text to display.

--- a/docs/api/touch-bar-popover.md
+++ b/docs/api/touch-bar-popover.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarPopover(options)`
+### `new TouchBarPopover(options)` _Experimental_
 
 * `options` Object
   * `label` String (optional) - Popover button text.

--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarScrubber(options)`
+### `new TouchBarScrubber(options)` _Experimental_
 
 * `options` Object
   * `items` [ScrubberItem[]](structures/scrubber-item.md) - An array of items to place in this scrubber

--- a/docs/api/touch-bar-segmented-control.md
+++ b/docs/api/touch-bar-segmented-control.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarSegmentedControl(options)`
+### `new TouchBarSegmentedControl(options)` _Experimental_
 
 * `options` Object
   * `segmentStyle` String - (Optional) Style of the segments:

--- a/docs/api/touch-bar-slider.md
+++ b/docs/api/touch-bar-slider.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarSlider(options)`
+### `new TouchBarSlider(options)` _Experimental_
 
 * `options` Object
   * `label` String (optional) - Label text.

--- a/docs/api/touch-bar-spacer.md
+++ b/docs/api/touch-bar-spacer.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBarSpacer(options)`
+### `new TouchBarSpacer(options)` _Experimental_
 
 * `options` Object
   * `size` String (optional) - Size of spacer, possible values are:

--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../tutorial/quick-start.md#main-process)
 
-### `new TouchBar(items)`
+### `new TouchBar(items)` _Experimental_
 
 * `items` ([TouchBarButton](touch-bar-button.md) | [TouchBarColorPicker](touch-bar-color-picker.md) | [TouchBarGroup](touch-bar-group.md) | [TouchBarLabel](touch-bar-label.md) | [TouchBarPopover](touch-bar-popover.md) | [TouchBarSlider](touch-bar-slider.md) | [TouchBarSpacer](touch-bar-spacer.md))[]
 


### PR DESCRIPTION
Noticed this tag was used in `docs/api/clipboard.md` and put it in on the touch bar APIs to reinforce the `Note:` that also mentions it.