### PR TITLE
node::Environment should be destroyed before AtomBindings

### DIFF
--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -80,9 +80,9 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
 
   std::unique_ptr<Browser> browser_;
   std::unique_ptr<JavascriptEnvironment> js_env_;
-  std::unique_ptr<NodeEnvironment> node_env_;
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<AtomBindings> atom_bindings_;
+  std::unique_ptr<NodeEnvironment> node_env_;
   std::unique_ptr<NodeDebugger> node_debugger_;
 
   base::Timer gc_timer_;


### PR DESCRIPTION
The shutdown code may still uses the APIs provieded by AtomBindings.

Close https://github.com/electron/electron/issues/8957.