### PR TITLE
Default async to false when object is specified

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -144,7 +144,7 @@ Menu.prototype._init = function () {
 }
 
 Menu.prototype.popup = function (window, x, y, positioningItem) {
-  let asyncPopup = false
+  let asyncPopup
 
   // menu.popup(x, y, positioningItem)
   if (window != null && (typeof window !== 'object' || window.constructor !== BrowserWindow)) {
@@ -173,6 +173,9 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
 
   // Default to not highlighting any item.
   if (typeof positioningItem !== 'number') positioningItem = -1
+
+  // Default to synchronous for backwards compatibility.
+  if (typeof asyncPopup !== 'boolean') asyncPopup = false
 
   this.popupAt(window, x, y, positioningItem, asyncPopup)
 }


### PR DESCRIPTION
Previously the `async` option would be null/undefined if an object was specified that did not contain it as a property and the C++ side would expect as a `boolean`.

Closes #8973