### PR TITLE
:bug: Fix Menu example code.

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -109,7 +109,9 @@ An example of creating the application menu in the main process with the
 simple template API:
 
 ```javascript
-const {app, Menu} = require('electron')
+const electron = require('electron')
+const app = electron.app
+const Menu = electron.Menu
 
 const template = [
   {


### PR DESCRIPTION
Fixes #5862 "Menu.buildFromTemplate" is not a function because of new electron require 