### PR TITLE
Add documentation note on dynamic Menu items

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -25,6 +25,10 @@ will be set as each window's top menu.
 
 Returns `Menu` - The application menu, if set, or `null`, if not set.
 
+**Note:** The returned `Menu` instance doesn't support dynamic addition or
+removal of menu items. [Instance properties](#instance-properties) can still
+be dynamically modified.
+
 #### `Menu.sendActionToFirstResponder(action)` _macOS_
 
 * `action` String


### PR DESCRIPTION
Added this where I thought it made the most sense. Let me know if there’s a better location in the `Menu` docs or if the wording could be clearer. (See #8928 for details.)