### PR TITLE
net: catch source stream creation failure for content encoding

### DIFF
--- a/atom/browser/net/atom_url_request.cc
+++ b/atom/browser/net/atom_url_request.cc
@@ -348,6 +348,14 @@ void AtomURLRequest::OnReadCompleted(net::URLRequest* request, int bytes_read) {
   DCHECK_EQ(request, request_.get());
 
   const auto status = request_->status();
+  if (status.error() == bytes_read &&
+      bytes_read == net::ERR_CONTENT_DECODING_INIT_FAILED) {
+    // When the request job is unable to create a source stream for the
+    // content encoding, we fail the request.
+    DoCancelWithError(net::ErrorToString(net::ERR_CONTENT_DECODING_INIT_FAILED),
+                      true);
+    return;
+  }
 
   bool response_error = false;
   bool data_ended = false;


### PR DESCRIPTION
This is the only scenario where `URLRequest::Delegate::OnResponseStarted` will not be notified before `URLRequest::Delegate::OnReadCompleted`. https://codereview.chromium.org/2451233002 , made that if there is no sdch implementation then request should fail with `net::ERR_CONTENT_DECODING_INIT_FAILED` but this is fixed later on in https://codereview.chromium.org/2512263002 where raw response body is passed through for sdch when it is not implemented just like other unsupported content encoding types, we should get the fix probably with chrome 57 or 58 upgrade. For the same reason its not possible to test this scenario as the test case in the original issue will no longer fail with the above fix, but its good to catch this scenario.

Fixes https://github.com/electron/electron/issues/8867