### PR TITLE
fix docs for thumbnailSize

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -60,8 +60,9 @@ The `desktopCapturer` module has the following methods:
 * `options` Object
   * `types` String[] - An array of Strings that lists the types of desktop sources
     to be captured, available types are `screen` and `window`.
-  * `thumbnailSize` Object (optional) - The suggested size that the media source
-    thumbnail should be scaled to, defaults to `{width: 150, height: 150}`.
+  * `thumbnailSize` Object (optional) - The size that the media source thumbnail should be scaled to.
+    * `width` Integer - Default is `150`
+    * `height` Integer - Default is `150`
 * `callback` Function
   * `error` Error
   * `sources` [DesktopCapturerSource[]](structures/desktop-capturer-source.md)


### PR DESCRIPTION
This fixes an API documentation issue we found while working on https://github.com/electron/electron-definitelytyped/pull/7