### PR TITLE
Create base class to share code between sandbox and non-sandbox

### DIFF
--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -8,15 +8,14 @@
 #include <string>
 #include <vector>
 
-#include "content/public/renderer/content_renderer_client.h"
+#include "atom/renderer/renderer_client_base.h"
 
 namespace atom {
 
 class AtomBindings;
-class PreferencesManager;
 class NodeBindings;
 
-class AtomRendererClient : public content::ContentRendererClient {
+class AtomRendererClient : public RendererClientBase {
  public:
   AtomRendererClient();
   virtual ~AtomRendererClient();
@@ -46,25 +45,12 @@ class AtomRendererClient : public content::ContentRendererClient {
   void RenderViewCreated(content::RenderView*) override;
   void RunScriptsAtDocumentStart(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;
-  blink::WebSpeechSynthesizer* OverrideSpeechSynthesizer(
-      blink::WebSpeechSynthesizerClient* client) override;
-  bool OverrideCreatePlugin(content::RenderFrame* render_frame,
-                            blink::WebLocalFrame* frame,
-                            const blink::WebPluginParams& params,
-                            blink::WebPlugin** plugin) override;
   bool ShouldFork(blink::WebLocalFrame* frame,
                   const GURL& url,
                   const std::string& http_method,
                   bool is_initial_navigation,
                   bool is_server_redirect,
                   bool* send_referrer) override;
-  content::BrowserPluginDelegate* CreateBrowserPluginDelegate(
-      content::RenderFrame* render_frame,
-      const std::string& mime_type,
-      const GURL& original_url) override;
-  void AddSupportedKeySystems(
-      std::vector<std::unique_ptr<::media::KeySystemProperties>>* key_systems)
-      override;
   void DidInitializeWorkerContextOnWorkerThread(
       v8::Local<v8::Context> context) override;
   void WillDestroyWorkerContextOnWorkerThread(
@@ -75,7 +61,6 @@ class AtomRendererClient : public content::ContentRendererClient {
 
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<AtomBindings> atom_bindings_;
-  std::unique_ptr<PreferencesManager> preferences_manager_;
   bool isolated_world_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomRendererClient);

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -182,12 +182,13 @@ AtomSandboxedRendererClient::~AtomSandboxedRendererClient() {
 void AtomSandboxedRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {
   new AtomSandboxedRenderFrameObserver(render_frame, this);
-  new printing::PrintWebViewHelper(render_frame);
+  RendererClientBase::RenderFrameCreated(render_frame);
 }
 
 void AtomSandboxedRendererClient::RenderViewCreated(
     content::RenderView* render_view) {
   new AtomSandboxedRenderViewObserver(render_view, this);
+  RendererClientBase::RenderViewCreated(render_view);
 }
 
 void AtomSandboxedRendererClient::DidCreateScriptContext(
@@ -218,6 +219,7 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   // Create and initialize the binding object
   auto binding = v8::Object::New(isolate);
   InitializeBindings(binding, context);
+  AddRenderBindings(isolate, binding);
   v8::Local<v8::Value> args[] = {
     binding,
     mate::ConvertToV8(isolate, preload_script)

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -7,12 +7,11 @@
 #include <string>
 #include <vector>
 
-#include "content/public/renderer/content_renderer_client.h"
-#include "content/public/renderer/render_frame.h"
+#include "atom/renderer/renderer_client_base.h"
 
 namespace atom {
 
-class AtomSandboxedRendererClient : public content::ContentRendererClient {
+class AtomSandboxedRendererClient : public RendererClientBase {
  public:
   AtomSandboxedRendererClient();
   virtual ~AtomSandboxedRendererClient();

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -1,0 +1,190 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/renderer/renderer_client_base.h"
+
+#include <string>
+#include <vector>
+
+#include "atom/common/atom_constants.h"
+#include "atom/common/color_util.h"
+#include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/options_switches.h"
+#include "atom/renderer/content_settings_observer.h"
+#include "atom/renderer/guest_view_container.h"
+#include "atom/renderer/preferences_manager.h"
+#include "base/command_line.h"
+#include "base/strings/string_split.h"
+#include "chrome/renderer/media/chrome_key_systems.h"
+#include "chrome/renderer/pepper/pepper_helper.h"
+#include "chrome/renderer/printing/print_web_view_helper.h"
+#include "chrome/renderer/tts_dispatcher.h"
+#include "content/public/common/content_constants.h"
+#include "content/public/renderer/render_view.h"
+#include "native_mate/dictionary.h"
+#include "third_party/WebKit/public/web/WebCustomElement.h"
+#include "third_party/WebKit/public/web/WebFrameWidget.h"
+#include "third_party/WebKit/public/web/WebKit.h"
+#include "third_party/WebKit/public/web/WebPluginParams.h"
+#include "third_party/WebKit/public/web/WebSecurityPolicy.h"
+
+#if defined(OS_MACOSX)
+#include "base/mac/mac_util.h"
+#include "base/strings/sys_string_conversions.h"
+#endif
+
+#if defined(OS_WIN)
+#include <shlobj.h>
+#endif
+
+namespace atom {
+
+namespace {
+
+v8::Local<v8::Value> GetRenderProcessPreferences(
+    const PreferencesManager* preferences_manager, v8::Isolate* isolate) {
+  if (preferences_manager->preferences())
+    return mate::ConvertToV8(isolate, *preferences_manager->preferences());
+  else
+    return v8::Null(isolate);
+}
+
+std::vector<std::string> ParseSchemesCLISwitch(const char* switch_name) {
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  std::string custom_schemes = command_line->GetSwitchValueASCII(switch_name);
+  return base::SplitString(
+      custom_schemes, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+}
+
+}  // namespace
+
+RendererClientBase::RendererClientBase() {
+  // Parse --standard-schemes=scheme1,scheme2
+  std::vector<std::string> standard_schemes_list =
+      ParseSchemesCLISwitch(switches::kStandardSchemes);
+  for (const std::string& scheme : standard_schemes_list)
+    url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITHOUT_PORT);
+}
+
+RendererClientBase::~RendererClientBase() {
+}
+
+void RendererClientBase::AddRenderBindings(
+    v8::Isolate* isolate,
+    v8::Local<v8::Object> binding_object) {
+  mate::Dictionary dict(isolate, binding_object);
+  dict.SetMethod(
+      "getRenderProcessPreferences",
+      base::Bind(GetRenderProcessPreferences, preferences_manager_.get()));
+}
+
+void RendererClientBase::RenderThreadStarted() {
+  blink::WebCustomElement::addEmbedderCustomElementName("webview");
+  blink::WebCustomElement::addEmbedderCustomElementName("browserplugin");
+
+  preferences_manager_.reset(new PreferencesManager);
+
+#if defined(OS_WIN)
+  // Set ApplicationUserModelID in renderer process.
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  base::string16 app_id =
+      command_line->GetSwitchValueNative(switches::kAppUserModelId);
+  if (!app_id.empty()) {
+    SetCurrentProcessExplicitAppUserModelID(app_id.c_str());
+  }
+#endif
+
+#if defined(OS_MACOSX)
+  // Disable rubber banding by default.
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (!command_line->HasSwitch(switches::kScrollBounce)) {
+    base::ScopedCFTypeRef<CFStringRef> key(
+        base::SysUTF8ToCFStringRef("NSScrollViewRubberbanding"));
+    base::ScopedCFTypeRef<CFStringRef> value(
+        base::SysUTF8ToCFStringRef("false"));
+    CFPreferencesSetAppValue(key, value, kCFPreferencesCurrentApplication);
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
+  }
+#endif
+}
+
+void RendererClientBase::RenderFrameCreated(
+    content::RenderFrame* render_frame) {
+  new PepperHelper(render_frame);
+  new ContentSettingsObserver(render_frame);
+  new printing::PrintWebViewHelper(render_frame);
+
+  // Allow file scheme to handle service worker by default.
+  // FIXME(zcbenz): Can this be moved elsewhere?
+  blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers("file");
+
+  // This is required for widevine plugin detection provided during runtime.
+  blink::resetPluginCache();
+
+  // Allow access to file scheme from pdf viewer.
+  blink::WebSecurityPolicy::addOriginAccessWhitelistEntry(
+      GURL(kPdfViewerUIOrigin), "file", "", true);
+
+  // Parse --secure-schemes=scheme1,scheme2
+  std::vector<std::string> secure_schemes_list =
+      ParseSchemesCLISwitch(switches::kSecureSchemes);
+  for (const std::string& secure_scheme : secure_schemes_list)
+    blink::WebSecurityPolicy::registerURLSchemeAsSecure(
+        blink::WebString::fromUTF8(secure_scheme));
+}
+
+void RendererClientBase::RenderViewCreated(content::RenderView* render_view) {
+  blink::WebFrameWidget* web_frame_widget = render_view->GetWebFrameWidget();
+  if (!web_frame_widget)
+    return;
+
+  base::CommandLine* cmd = base::CommandLine::ForCurrentProcess();
+  if (cmd->HasSwitch(switches::kGuestInstanceID)) {  // webview.
+    web_frame_widget->setBaseBackgroundColor(SK_ColorTRANSPARENT);
+  } else {  // normal window.
+    // If backgroundColor is specified then use it.
+    std::string name = cmd->GetSwitchValueASCII(switches::kBackgroundColor);
+    // Otherwise use white background.
+    SkColor color = name.empty() ? SK_ColorWHITE : ParseHexColor(name);
+    web_frame_widget->setBaseBackgroundColor(color);
+  }
+}
+
+blink::WebSpeechSynthesizer* RendererClientBase::OverrideSpeechSynthesizer(
+    blink::WebSpeechSynthesizerClient* client) {
+  return new TtsDispatcher(client);
+}
+
+bool RendererClientBase::OverrideCreatePlugin(
+    content::RenderFrame* render_frame,
+    blink::WebLocalFrame* frame,
+    const blink::WebPluginParams& params,
+    blink::WebPlugin** plugin) {
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (params.mimeType.utf8() == content::kBrowserPluginMimeType ||
+      params.mimeType.utf8() == kPdfPluginMimeType ||
+      command_line->HasSwitch(switches::kEnablePlugins))
+    return false;
+
+  *plugin = nullptr;
+  return true;
+}
+
+content::BrowserPluginDelegate* RendererClientBase::CreateBrowserPluginDelegate(
+    content::RenderFrame* render_frame,
+    const std::string& mime_type,
+    const GURL& original_url) {
+  if (mime_type == content::kBrowserPluginMimeType) {
+    return new GuestViewContainer(render_frame);
+  } else {
+    return nullptr;
+  }
+}
+
+void RendererClientBase::AddSupportedKeySystems(
+    std::vector<std::unique_ptr<::media::KeySystemProperties>>* key_systems) {
+  AddChromeKeySystems(key_systems);
+}
+
+}  // namespace atom

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_RENDERER_RENDERER_CLIENT_BASE_H_
+#define ATOM_RENDERER_RENDERER_CLIENT_BASE_H_
+
+#include <string>
+#include <vector>
+
+#include "content/public/renderer/content_renderer_client.h"
+
+namespace atom {
+
+class PreferencesManager;
+
+class RendererClientBase : public content::ContentRendererClient {
+ public:
+  RendererClientBase();
+  virtual ~RendererClientBase();
+
+ protected:
+  void AddRenderBindings(v8::Isolate* isolate,
+                         v8::Local<v8::Object> binding_object);
+
+  // content::ContentRendererClient:
+  void RenderThreadStarted() override;
+  void RenderFrameCreated(content::RenderFrame*) override;
+  void RenderViewCreated(content::RenderView*) override;
+  blink::WebSpeechSynthesizer* OverrideSpeechSynthesizer(
+      blink::WebSpeechSynthesizerClient* client) override;
+  bool OverrideCreatePlugin(content::RenderFrame* render_frame,
+                            blink::WebLocalFrame* frame,
+                            const blink::WebPluginParams& params,
+                            blink::WebPlugin** plugin) override;
+  content::BrowserPluginDelegate* CreateBrowserPluginDelegate(
+      content::RenderFrame* render_frame,
+      const std::string& mime_type,
+      const GURL& original_url) override;
+  void AddSupportedKeySystems(
+      std::vector<std::unique_ptr<::media::KeySystemProperties>>* key_systems)
+      override;
+
+ private:
+  std::unique_ptr<PreferencesManager> preferences_manager_;
+};
+
+}  // namespace atom
+
+#endif  // ATOM_RENDERER_RENDERER_CLIENT_BASE_H_

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -480,6 +480,8 @@
       'atom/renderer/node_array_buffer_bridge.h',
       'atom/renderer/preferences_manager.cc',
       'atom/renderer/preferences_manager.h',
+      'atom/renderer/renderer_client_base.cc',
+      'atom/renderer/renderer_client_base.h',
       'atom/renderer/web_worker_observer.cc',
       'atom/renderer/web_worker_observer.h',
       'atom/utility/atom_content_utility_client.cc',


### PR DESCRIPTION
This should give `sandbox` access to a bunch of features not available in non-sandbox, such as custom schemes, background color and plugins(`<webview>` support will be finished in another PR).