### PR TITLE
Fix crash happened in UvRunOnce

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -232,6 +232,12 @@ void NodeBindings::RunMessageLoop() {
 void NodeBindings::UvRunOnce() {
   node::Environment* env = uv_env();
 
+  // When doing navigation without restarting renderer process, it may happen
+  // that the node environment is destroyed but the message loop is still there.
+  // In this case we should not run uv loop.
+  if (!env)
+    return;
+
   // Use Locker in browser process.
   mate::Locker locker(env->isolate());
   v8::HandleScope handle_scope(env->isolate());


### PR DESCRIPTION
When doing navigation without restarting renderer process, it may happen that the node environment is destroyed but the message loop is still there. In this case we should not run uv loop.

Fix https://github.com/electron/electron/issues/9004.