### PR TITLE
Native tabs on macOS

### DIFF
--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -10,10 +10,6 @@
 #include "base/strings/sys_string_conversions.h"
 #include "base/values.h"
 
-@interface NSWindow (SierraSDK)
-@property(class) BOOL allowsAutomaticWindowTabbing;
-@end
-
 @implementation AtomApplicationDelegate
 
 - (void)setApplicationDockMenu:(atom::AtomMenuModel*)model {
@@ -26,8 +22,9 @@
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
 
   // Don't add the "Show Tab Bar" menu item.
-  if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
+  if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
     NSWindow.allowsAutomaticWindowTabbing = NO;
+  }
 
   atom::Browser::Get()->WillFinishLaunching();
 }

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -21,11 +21,6 @@
   // Don't add the "Enter Full Screen" menu item automatically.
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
 
-  // Don't add the "Show Tab Bar" menu item.
-  if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
-    NSWindow.allowsAutomaticWindowTabbing = NO;
-  }
-
   atom::Browser::Get()->WillFinishLaunching();
 }
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -179,6 +179,8 @@ class NativeWindowMac : public NativeWindow,
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_;
 
+  std::string tabbing_identifier_;
+
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -179,8 +179,6 @@ class NativeWindowMac : public NativeWindow,
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_;
 
-  std::string tabbing_identifier_;
-
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -764,17 +764,15 @@ NativeWindowMac::NativeWindowMac(
     [window_ setOpaque:NO];
   }
 
-  if (base::mac::IsAtLeastOS10_12()) {
-    // Create a tab only if tabbing identifier is specified and window has
-    // a native title bar.
-    if (tabbing_identifier_.empty() || transparent() || !has_frame()) {
-      if ([window_ respondsToSelector:@selector(tabbingMode)]) {
-        [window_ setTabbingMode:NSWindowTabbingModeDisallowed];
-      }
-    } else {
-      if ([window_ respondsToSelector:@selector(tabbingIdentifier)]) {
-        [window_ setTabbingIdentifier:base::SysUTF8ToNSString(tabbing_identifier_)];
-      }
+  // Create a tab only if tabbing identifier is specified and window has
+  // a native title bar.
+  if (tabbing_identifier_.empty() || transparent() || !has_frame()) {
+    if ([window_ respondsToSelector:@selector(tabbingMode)]) {
+      [window_ setTabbingMode:NSWindowTabbingModeDisallowed];
+    }
+  } else {
+    if ([window_ respondsToSelector:@selector(tabbingIdentifier)]) {
+      [window_ setTabbingIdentifier:base::SysUTF8ToNSString(tabbing_identifier_)];
     }
   }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -690,7 +690,8 @@ NativeWindowMac::NativeWindowMac(
 
   options.Get(options::kTitleBarStyle, &title_bar_style_);
 
-  options.Get(options::kTabbingIdentifier, &tabbing_identifier_);
+  std::string tabbingIdentifier;
+  options.Get(options::kTabbingIdentifier, &tabbingIdentifier);
 
   std::string windowType;
   options.Get(options::kType, &windowType);
@@ -766,13 +767,13 @@ NativeWindowMac::NativeWindowMac(
 
   // Create a tab only if tabbing identifier is specified and window has
   // a native title bar.
-  if (tabbing_identifier_.empty() || transparent() || !has_frame()) {
+  if (tabbingIdentifier.empty() || transparent() || !has_frame()) {
     if ([window_ respondsToSelector:@selector(tabbingMode)]) {
       [window_ setTabbingMode:NSWindowTabbingModeDisallowed];
     }
   } else {
     if ([window_ respondsToSelector:@selector(tabbingIdentifier)]) {
-      [window_ setTabbingIdentifier:base::SysUTF8ToNSString(tabbing_identifier_)];
+      [window_ setTabbingIdentifier:base::SysUTF8ToNSString(tabbingIdentifier)];
     }
   }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -656,7 +656,8 @@ NativeWindowMac::NativeWindowMac(
       was_fullscreen_(false),
       zoom_to_page_width_(false),
       attention_request_id_(0),
-      title_bar_style_(NORMAL) {
+      title_bar_style_(NORMAL),
+      tabbing_identifier_(""){
   int width = 800, height = 600;
   options.Get(options::kWidth, &width);
   options.Get(options::kHeight, &height);
@@ -681,6 +682,8 @@ NativeWindowMac::NativeWindowMac(
   options.Get(options::kClosable, &closable);
 
   options.Get(options::kTitleBarStyle, &title_bar_style_);
+
+  options.Get(options::kTabbingIdentifier, &tabbing_identifier_);
 
   std::string windowType;
   options.Get(options::kType, &windowType);
@@ -752,6 +755,16 @@ NativeWindowMac::NativeWindowMac(
     }
     // Remove non-transparent corners, see http://git.io/vfonD.
     [window_ setOpaque:NO];
+  }
+
+  if (base::mac::IsAtLeastOS10_12()) {
+    // Create a tab only if tabbing identifier is specified and window has
+    // a native title bar.
+    if (tabbing_identifier_.empty() || transparent() || !has_frame()) {
+      [window_ setTabbingMode:NSWindowTabbingModeDisallowed];
+    } else {
+      [window_ setTabbingIdentifier:base::SysUTF8ToNSString(tabbing_identifier_)];
+    }
   }
 
   // We will manage window's lifetime ourselves.

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -51,6 +51,9 @@ const char kZoomToPageWidth[] = "zoomToPageWidth";
 // The requested title bar style for the window
 const char kTitleBarStyle[] = "titleBarStyle";
 
+// Tabbing identifier for the window if native tabs are enabled on macOS.
+const char kTabbingIdentifier[] = "tabbingIdentifier";
+
 // The menu bar is hidden unless "Alt" is pressed.
 const char kAutoHideMenuBar[] = "autoHideMenuBar";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -36,6 +36,7 @@ extern const char kAcceptFirstMouse[];
 extern const char kUseContentSize[];
 extern const char kZoomToPageWidth[];
 extern const char kTitleBarStyle[];
+extern const char kTabbingIdentifier[];
 extern const char kAutoHideMenuBar[];
 extern const char kEnableLargerThanScreen[];
 extern const char kDarkTheme[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -264,6 +264,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       canvas features. Default is `false`.
     * `scrollBounce` Boolean (optional) - Enables scroll bounce (rubber banding) effect on
       macOS. Default is `false`.
+    * `tabbingIdentifier` String (optional) - Tab group name, allows opening the
+       window as a native tab on macOS 10.12+. Windows with the same tabbing identifier will
+       be grouped together.
     * `blinkFeatures` String (optional) - A list of feature strings separated by `,`, like
       `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
       strings can be found in the [RuntimeEnabledFeatures.json5][blink-feature-string]

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -211,6 +211,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     width of the web page when zoomed, `false` will cause it to zoom to the
     width of the screen. This will also affect the behavior when calling
     `maximize()` directly. Default is `false`.
+  * `tabbingIdentifier` String (optional) - Tab group name, allows opening the
+    window as a native tab on macOS 10.12+. Windows with the same tabbing
+    identifier will be grouped together.
   * `webPreferences` Object (optional) - Settings of web page's features.
     * `devTools` Boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
     * `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default
@@ -264,9 +267,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       canvas features. Default is `false`.
     * `scrollBounce` Boolean (optional) - Enables scroll bounce (rubber banding) effect on
       macOS. Default is `false`.
-    * `tabbingIdentifier` String (optional) - Tab group name, allows opening the
-       window as a native tab on macOS 10.12+. Windows with the same tabbing identifier will
-       be grouped together.
     * `blinkFeatures` String (optional) - A list of feature strings separated by `,`, like
       `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
       strings can be found in the [RuntimeEnabledFeatures.json5][blink-feature-string]

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -692,7 +692,7 @@ describe('BrowserWindow module', function () {
     })
   })
 
-  describe('"title-bar-style" option', function () {
+  describe('"titleBarStyle" option', function () {
     if (process.platform !== 'darwin') {
       return
     }
@@ -769,6 +769,20 @@ describe('BrowserWindow module', function () {
       })
       w.maximize()
       assert.equal(w.getSize()[0], 500)
+    })
+  })
+
+  describe('"tabbingIdentifier" option', function () {
+    it('can be set on a window', function () {
+      w.destroy()
+      w = new BrowserWindow({
+        tabbingIdentifier: 'group1'
+      })
+      w.destroy()
+      w = new BrowserWindow({
+        tabbingIdentifier: 'group2',
+        frame: false
+      })
     })
   })
 


### PR DESCRIPTION
Should fix #6124.
Testing app: https://github.com/tonyganch/electron-quick-start/tree/native-tabs
**Video:** https://yadi.sk/i/vzAhnDkd3GTC5b

The idea is to make windows not tabbable by default.
That will allow existing applications to save user experience as they have it right now.
In order to open a window as a native tab, `tabbingIdentifier` option should be passed, like:
`new BrowserWindow({tabbingIdentifier: 'mainGroup'})`.
If tabbing identifier is missing/empty, or a window has custom/no title bar (is frameless/transparent), such window will not be tabbed.

/cc @alespergl @bpasero 