### PR TITLE
Fix net module to accept non-string header values

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -158,17 +158,18 @@ internally buffered inside Electron process memory.
 #### `request.setHeader(name, value)`
 
 * `name` String - An extra HTTP header name.
-* `value` String - An extra HTTP header value.
+* `value` Object - An extra HTTP header value.
 
 Adds an extra HTTP header. The header name will issued as it is without
 lowercasing. It can be called only before first write. Calling this method after
-the first write will throw an error.
+the first write will throw an error. If the passed value is not a `String`, its
+`toString()` method will be called to obtain the final value.
 
 #### `request.getHeader(name)`
 
 * `name` String - Specify an extra header name.
 
-Returns String - The value of a previously set extra header name.
+Returns Object - The value of a previously set extra header name.
 
 #### `request.removeHeader(name)`
 

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -246,7 +246,7 @@ class ClientRequest extends EventEmitter {
     if (typeof name !== 'string') {
       throw new TypeError('`name` should be a string in setHeader(name, value).')
     }
-    if (value === undefined) {
+    if (value == null) {
       throw new Error('`value` required in setHeader("' + name + '", value).')
     }
     if (!this.urlRequest.notStarted) {
@@ -255,7 +255,7 @@ class ClientRequest extends EventEmitter {
 
     const key = name.toLowerCase()
     this.extraHeaders[key] = value
-    this.urlRequest.setExtraHeader(name, value)
+    this.urlRequest.setExtraHeader(name, value.toString())
   }
 
   getHeader (name) {

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -364,6 +364,49 @@ describe('net module', function () {
       urlRequest.end()
     })
 
+    it('should be able to set a non-string object as a header value', function (done) {
+      const requestUrl = '/requestUrl'
+      const customHeaderName = 'Some-Integer-Value'
+      const customHeaderValue = 900
+      server.on('request', function (request, response) {
+        switch (request.url) {
+          case requestUrl:
+            assert.equal(request.headers[customHeaderName.toLowerCase()],
+              customHeaderValue.toString())
+            response.statusCode = 200
+            response.statusMessage = 'OK'
+            response.end()
+            break
+          default:
+            assert.equal(request.url, requestUrl)
+        }
+      })
+      const urlRequest = net.request({
+        method: 'GET',
+        url: `${server.url}${requestUrl}`
+      })
+      urlRequest.on('response', function (response) {
+        const statusCode = response.statusCode
+        assert.equal(statusCode, 200)
+        response.pause()
+        response.on('end', function () {
+          done()
+        })
+        response.resume()
+      })
+      urlRequest.setHeader(customHeaderName, customHeaderValue)
+      assert.equal(urlRequest.getHeader(customHeaderName),
+        customHeaderValue)
+      assert.equal(urlRequest.getHeader(customHeaderName.toLowerCase()),
+        customHeaderValue)
+      urlRequest.write('')
+      assert.equal(urlRequest.getHeader(customHeaderName),
+        customHeaderValue)
+      assert.equal(urlRequest.getHeader(customHeaderName.toLowerCase()),
+        customHeaderValue)
+      urlRequest.end()
+    })
+
     it('should not be able to set a custom HTTP request header after first write', function (done) {
       const requestUrl = '/requestUrl'
       const customHeaderName = 'Some-Custom-Header-Name'


### PR DESCRIPTION
This is required to be compatible with node.js http module.

For the record, I found this issue when trying to make the [request](https://github.com/request/request) module to work with electron's `net` module.