### PR TITLE
Improve docs for MenuItem Roles

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -15,7 +15,7 @@ See [`Menu`](menu.md) for examples.
     * `browserWindow` BrowserWindow
     * `event` Event
   * `role` String (optional) - Define the action of the menu item, when specified the
-    `click` property will be ignored.
+    `click` property will be ignored. See [roles](#roles).
   * `type` String (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
     `radio`.
   * `label` String - (optional)
@@ -36,12 +36,16 @@ See [`Menu`](menu.md) for examples.
   * `position` String (optional) - This field allows fine-grained definition of the
     specific location within a given menu.
 
+### Roles
+
+Roles allow menu items to have predefined behaviors.
+
 It is best to specify `role` for any menu item that matches a standard role,
 rather than trying to manually implement the behavior in a `click` function.
 The built-in `role` behavior will give the best native experience.
 
-The `label` and `accelerator` are optional when using a `role` and will default
-to appropriate values for each platform.
+The `label` and `accelerator` values are optional when using a `role` and will
+default to appropriate values for each platform.
 
 The `role` property can have following values:
 
@@ -63,11 +67,10 @@ The `role` property can have following values:
 * `resetzoom` - Reset the focused page's zoom level to the original size
 * `zoomin` - Zoom in the focused page by 10%
 * `zoomout` - Zoom out the focused page by 10%
-
 * `editMenu` - Whole default "Edit" menu (Undo, Copy, etc.)
 * `windowMenu` - Whole default "Window" menu (Minimize, Close, etc.)
 
-On macOS `role` can also have following additional values:
+The following additional roles are avaiable on macOS:
 
 * `about` - Map to the `orderFrontStandardAboutPanel` action
 * `hide` - Map to the `hide` action
@@ -81,8 +84,8 @@ On macOS `role` can also have following additional values:
 * `help` - The submenu is a "Help" menu
 * `services` - The submenu is a "Services" menu
 
-When specifying `role` on macOS, `label` and `accelerator` are the only options
-that will affect the MenuItem. All other options will be ignored.
+When specifying a `role` on macOS, `label` and `accelerator` are the only
+options that will affect the menu item. All other options will be ignored.
 
 ### Instance Properties
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -115,76 +115,36 @@ const template = [
   {
     label: 'Edit',
     submenu: [
-      {
-        role: 'undo'
-      },
-      {
-        role: 'redo'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'cut'
-      },
-      {
-        role: 'copy'
-      },
-      {
-        role: 'paste'
-      },
-      {
-        role: 'pasteandmatchstyle'
-      },
-      {
-        role: 'delete'
-      },
-      {
-        role: 'selectall'
-      }
+      {role: 'undo'},
+      {role: 'redo'},
+      {type: 'separator'},
+      {role: 'cut'},
+      {role: 'copy'},
+      {role: 'paste'},
+      {role: 'pasteandmatchstyle'},
+      {role: 'delete'},
+      {role: 'selectall'}
     ]
   },
   {
     label: 'View',
     submenu: [
-      {
-        role: 'reload'
-      },
-      {
-        role: 'forcereload'
-      },
-      {
-        role: 'toggledevtools'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'resetzoom'
-      },
-      {
-        role: 'zoomin'
-      },
-      {
-        role: 'zoomout'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'togglefullscreen'
-      }
+      {role: 'reload'},
+      {role: 'forcereload'},
+      {role: 'toggledevtools'},
+      {type: 'separator'},
+      {role: 'resetzoom'},
+      {role: 'zoomin'},
+      {role: 'zoomout'},
+      {type: 'separator'},
+      {role: 'togglefullscreen'}
     ]
   },
   {
     role: 'window',
     submenu: [
-      {
-        role: 'minimize'
-      },
-      {
-        role: 'close'
-      }
+      {role: 'minimize'},
+      {role: 'close'}
     ]
   },
   {
@@ -202,76 +162,37 @@ if (process.platform === 'darwin') {
   template.unshift({
     label: app.getName(),
     submenu: [
-      {
-        role: 'about'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'services',
-        submenu: []
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'hide'
-      },
-      {
-        role: 'hideothers'
-      },
-      {
-        role: 'unhide'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'quit'
-      }
+      {role: 'about'},
+      {type: 'separator'},
+      {role: 'services', submenu: []},
+      {type: 'separator'},
+      {role: 'hide'},
+      {role: 'hideothers'},
+      {role: 'unhide'},
+      {type: 'separator'},
+      {role: 'quit'}
     ]
   })
-  // Edit menu.
+
+  // Edit menu
   template[1].submenu.push(
-    {
-      type: 'separator'
-    },
+    {type: 'separator'},
     {
       label: 'Speech',
       submenu: [
-        {
-          role: 'startspeaking'
-        },
-        {
-          role: 'stopspeaking'
-        }
+        {role: 'startspeaking'},
+        {role: 'stopspeaking'}
       ]
     }
   )
-  // Window menu.
+
+  // Window menu
   template[3].submenu = [
-    {
-      label: 'Close',
-      accelerator: 'CmdOrCtrl+W',
-      role: 'close'
-    },
-    {
-      label: 'Minimize',
-      accelerator: 'CmdOrCtrl+M',
-      role: 'minimize'
-    },
-    {
-      label: 'Zoom',
-      role: 'zoom'
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: 'Bring All to Front',
-      role: 'front'
-    }
+    {role: 'close'},
+    {role: 'minimize'},
+    {role: 'zoom'},
+    {type: 'separator'},
+    {role: 'front'}
   ]
 }
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -30,8 +30,8 @@ Returns `Menu` - The application menu, if set, or `null`, if not set.
 * `action` String
 
 Sends the `action` to the first responder of application. This is used for
-emulating default Cocoa menu behaviors, usually you would just use the
-`role` property of `MenuItem`.
+emulating default macOS menu behaviors. Usually you would just use the
+[`role`](menu-item.md#roles) property of a [`MenuItem`](menu-item.md).
 
 See the [macOS Cocoa Event Handling Guide](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/EventOverview/EventArchitecture/EventArchitecture.html#//apple_ref/doc/uid/10000060i-CH3-SW7)
 for more information on macOS' native actions.


### PR DESCRIPTION
I always forget where roles are documented. This PR adds a `### Roles` heading so we can link to the list of roles from elsewhere in the docs. It also cleans up the `Menu` example, tightening the formatting and removing some superfluous `accelerator` and `label` values that didn't need to exist because:

> The `label` and `accelerator` values are optional when using a `role` and will
default to appropriate values for each platform.

cc @bpasero 