### PR TITLE
Check name directly instead of arguments length

### DIFF
--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -259,7 +259,7 @@ class ClientRequest extends EventEmitter {
   }
 
   getHeader (name) {
-    if (arguments.length < 1) {
+    if (name == null) {
       throw new Error('`name` is required for getHeader(name).')
     }
 
@@ -272,7 +272,7 @@ class ClientRequest extends EventEmitter {
   }
 
   removeHeader (name) {
-    if (arguments.length < 1) {
+    if (name == null) {
       throw new Error('`name` is required for removeHeader(name).')
     }
 

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -960,6 +960,26 @@ describe('net module', function () {
       }, 'redirect mode should be one of follow, error or manual')
     })
 
+    it('should throw when calling getHeader without a name', function () {
+      assert.throws(function () {
+        net.request({url: `${server.url}/requestUrl`}).getHeader()
+      }, /`name` is required for getHeader\(name\)\./)
+
+      assert.throws(function () {
+        net.request({url: `${server.url}/requestUrl`}).getHeader(null)
+      }, /`name` is required for getHeader\(name\)\./)
+    })
+
+    it('should throw when calling removeHeader without a name', function () {
+      assert.throws(function () {
+        net.request({url: `${server.url}/requestUrl`}).removeHeader()
+      }, /`name` is required for removeHeader\(name\)\./)
+
+      assert.throws(function () {
+        net.request({url: `${server.url}/requestUrl`}).removeHeader(null)
+      }, /`name` is required for removeHeader\(name\)\./)
+    })
+
     it('should follow redirect when no redirect mode is provided', function (done) {
       const requestUrl = '/301'
       server.on('request', function (request, response) {


### PR DESCRIPTION
Switching from `arguments.length < 1` to `name == null` and adding error specs for `getHeader` and `removeHeader`.

Noticed this while reviewing #9062 