### PR TITLE
[WIP] macOS: Add certificate trust API

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/browser/api/atom_api_certificate_trust.h"
 #include "atom/browser/api/atom_api_menu.h"
 #include "atom/browser/api/atom_api_session.h"
 #include "atom/browser/api/atom_api_web_contents.h"
@@ -810,6 +811,16 @@ void App::OnCertificateManagerModelCreated(
 }
 #endif
 
+#if defined(OS_MACOSX)
+void App::ShowCertificateTrust(atom::NativeWindow* parent_window,
+                               const net::X509Certificate& cert,
+                               std::string message,
+                               const ShowTrustCallback& callback,
+                               mate::Arguments* args) {
+  ShowCertificateTrustUI(parent_window, cert, message, callback);
+}
+#endif
+
 #if defined(OS_WIN)
 v8::Local<v8::Value> App::GetJumpListSettings() {
   JumpList jump_list(Browser::Get()->GetAppUserModelID());
@@ -949,6 +960,7 @@ void App::BuildPrototype(
                  base::Bind(&Browser::GetCurrentActivityType, browser))
       .SetMethod("setAboutPanelOptions",
                  base::Bind(&Browser::SetAboutPanelOptions, browser))
+      // .SetMethod("showCertificateTrust", &App::ShowCertificateTrust)
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -813,7 +813,7 @@ void App::OnCertificateManagerModelCreated(
 
 #if defined(OS_MACOSX)
 void App::ShowCertificateTrust(atom::NativeWindow* parent_window,
-                               const net::X509Certificate& cert,
+                               const scoped_refptr<net::X509Certificate>& cert,
                                std::string message,
                                const ShowTrustCallback& callback,
                                mate::Arguments* args) {
@@ -960,7 +960,7 @@ void App::BuildPrototype(
                  base::Bind(&Browser::GetCurrentActivityType, browser))
       .SetMethod("setAboutPanelOptions",
                  base::Bind(&Browser::SetAboutPanelOptions, browser))
-      // .SetMethod("showCertificateTrust", &App::ShowCertificateTrust)
+      .SetMethod("showCertificateTrust", &App::ShowCertificateTrust)
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/browser/api/atom_api_certificate_trust.h"
 #include "atom/browser/api/event_emitter.h"
 #include "atom/browser/atom_browser_client.h"
 #include "atom/browser/browser.h"
@@ -19,6 +20,7 @@
 #include "content/public/browser/gpu_data_manager_observer.h"
 #include "native_mate/handle.h"
 #include "net/base/completion_callback.h"
+#include "net/cert/x509_certificate.h"
 
 #if defined(USE_NSS_CERTS)
 #include "chrome/browser/certificate_manager_model.h"
@@ -149,6 +151,15 @@ class App : public AtomBrowserClient::Delegate,
 
 #if defined(USE_NSS_CERTS)
   std::unique_ptr<CertificateManagerModel> certificate_manager_model_;
+#endif
+
+
+#if defined(OS_MACOSX)
+  void ShowCertificateTrust(atom::NativeWindow* parent_window,
+                            const net::X509Certificate& cert,
+                            std::string message,
+                            const ShowTrustCallback& callback,
+                            mate::Arguments* args);
 #endif
 
   // Tracks tasks requesting file icons.

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -156,7 +156,7 @@ class App : public AtomBrowserClient::Delegate,
 
 #if defined(OS_MACOSX)
   void ShowCertificateTrust(atom::NativeWindow* parent_window,
-                            const net::X509Certificate& cert,
+                            const scoped_refptr<net::X509Certificate>& cert,
                             std::string message,
                             const ShowTrustCallback& callback,
                             mate::Arguments* args);

--- a/atom/browser/api/atom_api_certificate_trust.h
+++ b/atom/browser/api/atom_api_certificate_trust.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/callback_forward.h"
+#include "base/memory/ref_counted.h"
 
 namespace net {
 class X509Certificate;
@@ -22,7 +23,7 @@ namespace api {
 typedef base::Callback<void(bool result)> ShowTrustCallback;
 
 void ShowCertificateTrustUI(atom::NativeWindow* parent_window,
-                            const net::X509Certificate& cert,
+                            const scoped_refptr<net::X509Certificate>& cert,
                             std::string message,
                             const ShowTrustCallback& callback);
 

--- a/atom/browser/api/atom_api_certificate_trust.h
+++ b/atom/browser/api/atom_api_certificate_trust.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_API_ATOM_API_CERTIFICATE_TRUST_H_
+#define ATOM_BROWSER_API_ATOM_API_CERTIFICATE_TRUST_H_
+
+#include <string>
+
+#include "base/callback_forward.h"
+
+namespace net {
+class X509Certificate;
+}  // namespace net
+
+namespace atom {
+
+class NativeWindow;
+
+namespace api {
+
+typedef base::Callback<void(bool result)> ShowTrustCallback;
+
+void ShowCertificateTrustUI(atom::NativeWindow* parent_window,
+                            const net::X509Certificate& cert,
+                            std::string message,
+                            const ShowTrustCallback& callback);
+
+}  // namespace api
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_API_ATOM_API_CERTIFICATE_TRUST_H_

--- a/atom/browser/api/atom_api_certificate_trust_mac.mm
+++ b/atom/browser/api/atom_api_certificate_trust_mac.mm
@@ -21,12 +21,12 @@ namespace atom {
 namespace api {
 
 void ShowCertificateTrustUI(atom::NativeWindow* parent_window,
-                            const net::X509Certificate& cert,
+                            const scoped_refptr<net::X509Certificate>& cert,
                             std::string message,
                             const ShowTrustCallback& callback) {
   auto sec_policy = SecPolicyCreateBasicX509();
   SecTrustRef trust = nullptr;
-  SecTrustCreateWithCertificates(cert.CreateOSCertChainForCert(), sec_policy, &trust);
+  SecTrustCreateWithCertificates(cert->CreateOSCertChainForCert(), sec_policy, &trust);
   // CFRelease(sec_policy);
 
   NSWindow* window = parent_window ?

--- a/atom/browser/api/atom_api_certificate_trust_mac.mm
+++ b/atom/browser/api/atom_api_certificate_trust_mac.mm
@@ -15,6 +15,7 @@
 #include "base/mac/scoped_cftyperef.h"
 #include "base/strings/sys_string_conversions.h"
 #include "net/cert/x509_certificate.h"
+#include "net/cert/cert_database.h"
 
 namespace atom {
 
@@ -29,14 +30,20 @@ void ShowCertificateTrustUI(atom::NativeWindow* parent_window,
   SecTrustCreateWithCertificates(cert->CreateOSCertChainForCert(), sec_policy, &trust);
   // CFRelease(sec_policy);
 
-  NSWindow* window = parent_window ?
-      parent_window->GetNativeWindow() :
-      NULL;
+  // NSWindow* window = parent_window ?
+  //     parent_window->GetNativeWindow() :
+  //     NULL;
 
   auto msg = base::SysUTF8ToNSString(message);
 
   SFCertificateTrustPanel *panel = [[SFCertificateTrustPanel alloc] init];
-  [panel beginSheetForWindow:window modalDelegate:nil didEndSelector:NULL contextInfo:NULL trust:trust message:msg];
+  [panel runModalForTrust:trust message:msg];
+  // [panel beginSheetForWindow:window modalDelegate:nil didEndSelector:NULL contextInfo:NULL trust:trust message:msg];
+
+  auto cert_db = net::CertDatabase::GetInstance();
+  // This forces Chromium to reload the certificate since it might be trusted
+  // now.
+  cert_db->NotifyObserversCertDBChanged(cert.get());
 
   callback.Run(true);
   // CFRelease(trust);

--- a/atom/browser/api/atom_api_certificate_trust_mac.mm
+++ b/atom/browser/api/atom_api_certificate_trust_mac.mm
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/api/atom_api_certificate_trust.h"
+
+#import <Cocoa/Cocoa.h>
+#import <CoreServices/CoreServices.h>
+#import <SecurityInterface/SFCertificateTrustPanel.h>
+
+#include "atom/browser/native_window.h"
+#include "base/files/file_util.h"
+#include "base/mac/foundation_util.h"
+#include "base/mac/mac_util.h"
+#include "base/mac/scoped_cftyperef.h"
+#include "base/strings/sys_string_conversions.h"
+#include "net/cert/x509_certificate.h"
+
+namespace atom {
+
+namespace api {
+
+void ShowCertificateTrustUI(atom::NativeWindow* parent_window,
+                            const net::X509Certificate& cert,
+                            std::string message,
+                            const ShowTrustCallback& callback) {
+  auto sec_policy = SecPolicyCreateBasicX509();
+  SecTrustRef trust = nullptr;
+  SecTrustCreateWithCertificates(cert.CreateOSCertChainForCert(), sec_policy, &trust);
+  // CFRelease(sec_policy);
+
+  NSWindow* window = parent_window ?
+      parent_window->GetNativeWindow() :
+      NULL;
+
+  auto msg = base::SysUTF8ToNSString(message);
+
+  SFCertificateTrustPanel *panel = [[SFCertificateTrustPanel alloc] init];
+  [panel beginSheetForWindow:window modalDelegate:nil didEndSelector:NULL contextInfo:NULL trust:trust message:msg];
+
+  callback.Run(true);
+  // CFRelease(trust);
+  // [panel release];
+}
+
+}  // namespace api
+
+}  // namespace atom

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -73,6 +73,12 @@ v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
   return dict.GetHandle();
 }
 
+bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(v8::Isolate* isolate,
+                                             v8::Local<v8::Value> val,
+                                             scoped_refptr<net::X509Certificate>* out) {
+  return true;
+}
+
 // static
 v8::Local<v8::Value> Converter<net::CertPrincipal>::ToV8(
     v8::Isolate* isolate, const net::CertPrincipal& val) {

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -73,9 +73,16 @@ v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
   return dict.GetHandle();
 }
 
-bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(v8::Isolate* isolate,
-                                             v8::Local<v8::Value> val,
-                                             scoped_refptr<net::X509Certificate>* out) {
+bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(
+    v8::Isolate* isolate, v8::Local<v8::Value> val,
+    scoped_refptr<net::X509Certificate>* out) {
+  mate::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+
+  std::string data;
+  dict.Get("data", &data);
+  *out = net::X509Certificate::CreateFromBytes(data.c_str(), data.length());
   return true;
 }
 

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -118,9 +118,9 @@ bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(
   dict.Get("intermediates", &intermediates_encoded);
   std::vector<net::X509Certificate::OSCertHandle> intermediates;
   for (size_t i = 0; i < intermediates_encoded.size(); i++) {
-    auto data = intermediates_encoded[i];
+    auto intermediate_data = intermediates_encoded[i];
     scoped_refptr<net::X509Certificate> cert;
-    if (!CertFromData(data, &cert))
+    if (!CertFromData(intermediate_data, &cert))
       return false;
 
     intermediates.push_back(cert->os_cert_handle());

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -82,7 +82,18 @@ bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(
 
   std::string data;
   dict.Get("data", &data);
-  *out = net::X509Certificate::CreateFromBytes(data.c_str(), data.length());
+
+  auto certificate_list = net::X509Certificate::CreateCertificateListFromBytes(
+    data.c_str(), data.length(),
+    net::X509Certificate::FORMAT_SINGLE_CERTIFICATE);
+  if (certificate_list.empty())
+    return false;
+
+  auto certificate = certificate_list.front();
+  if (!certificate)
+    return false;
+
+  *out = certificate;
   return true;
 }
 

--- a/atom/common/native_mate_converters/net_converter.h
+++ b/atom/common/native_mate_converters/net_converter.h
@@ -33,6 +33,10 @@ template<>
 struct Converter<scoped_refptr<net::X509Certificate>> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
       const scoped_refptr<net::X509Certificate>& val);
+
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     scoped_refptr<net::X509Certificate>* out);
 };
 
 template<>

--- a/electron.gyp
+++ b/electron.gyp
@@ -549,6 +549,8 @@
               '$(SDKROOT)/System/Library/Frameworks/Carbon.framework',
               '$(SDKROOT)/System/Library/Frameworks/QuartzCore.framework',
               '$(SDKROOT)/System/Library/Frameworks/Quartz.framework',
+              '$(SDKROOT)/System/Library/Frameworks/Security.framework',
+              '$(SDKROOT)/System/Library/Frameworks/SecurityInterface.framework',
             ],
           },
           'mac_bundle': 1,

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -103,6 +103,8 @@
       'atom/browser/api/atom_api_app.h',
       'atom/browser/api/atom_api_auto_updater.cc',
       'atom/browser/api/atom_api_auto_updater.h',
+      'atom/browser/api/atom_api_certificate_trust_mac.mm',
+      'atom/browser/api/atom_api_certificate_trust.h',
       'atom/browser/api/atom_api_content_tracing.cc',
       'atom/browser/api/atom_api_cookies.cc',
       'atom/browser/api/atom_api_cookies.h',


### PR DESCRIPTION
Add the `app.showCertificateTrust` API to show the OS-provided UI to let the user decide to accept and trust a self-signed or untrusted certificate:

![cert_trust_panel_5b4faf16-9b52-4d4f-8aa0-63b89361dd60](https://cloud.githubusercontent.com/assets/13760/24527176/0b9a9dfe-156f-11e7-9795-ecb429b25949.jpg)

~~I believe this would address https://github.com/electron/electron/issues/1956.~~ Negative, see the discussion below.

This is only the macOS-side of things. I think we can get @shiftkey to do the Windows side.

I'm opening this early because I have no idea what I'm doing and I'd welcome any feedback or advice anyone would like to provide.