### PR TITLE
Document passing null to Menu.setApplicationMenu

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -16,9 +16,11 @@ The `menu` class has the following static methods:
 
 * `menu` Menu
 
-Sets `menu` as the application menu on macOS. On Windows and Linux, the `menu`
-will be set as each window's top menu. Setting it to `null` will remove the
-menu bar.
+Sets `menu` as the application menu on macOS. On Windows and Linux, the
+`menu` will be set as each window's top menu.
+
+Passing `null` will remove the menu bar on Windows and Linux but has no
+effect on macOS.
 
 **Note:** This API has to be called after the `ready` event of `app` module.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -17,7 +17,8 @@ The `menu` class has the following static methods:
 * `menu` Menu
 
 Sets `menu` as the application menu on macOS. On Windows and Linux, the `menu`
-will be set as each window's top menu.
+will be set as each window's top menu. Setting it to `null` will remove the
+menu bar.
 
 **Note:** This API has to be called after the `ready` event of `app` module.
 


### PR DESCRIPTION
Calling Menu.setApplicationMenu removes the app menu, and you can see from the code that null is a permitted option.
https://github.com/electron/electron/blob/f7e3f9035da3bf3eb946294a4100b6700bd41bc4/lib/browser/api/menu.js#L276