### PR TITLE
Only define NSWindowTabbingModeDisallowed on pre-10.12 SDKs

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -336,13 +336,18 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 @end
 
+#if !defined(MAC_OS_X_VERSION_10_12)
+
 enum {
   NSWindowTabbingModeDisallowed = 2
 };
+
 @interface NSWindow (SierraSDK)
 - (void)setTabbingMode:(NSInteger)mode;
-- (void)setTabbingIdentifier:(NSString *)identifier;
+- (void)setTabbingIdentifier:(NSString*)identifier;
 @end
+
+#endif  // MAC_OS_X_VERSION_10_12
 
 @interface AtomNSWindow : EventDispatchingWindow<QLPreviewPanelDataSource, QLPreviewPanelDelegate, NSTouchBarDelegate> {
  @private


### PR DESCRIPTION
Follow on to #9052 

Only define `NSWindowTabbingModeDisallowed` on pre-10.12 SDK versions.

This enables Electron to still build with a 10.12 SDK.