### PR TITLE
Search for module from app path when URL is not file protocol

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -655,11 +655,11 @@ void App::OnGpuProcessCrashed(base::TerminationStatus status) {
     status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 }
 
-std::string App::GetAppPath() {
+base::FilePath App::GetAppPath() {
   return app_path_;
 }
 
-void App::SetAppPath(const std::string& app_path) {
+void App::SetAppPath(const base::FilePath& app_path) {
   app_path_ = app_path;
 }
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -655,6 +655,14 @@ void App::OnGpuProcessCrashed(base::TerminationStatus status) {
     status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 }
 
+std::string App::GetAppPath() {
+  return app_path_;
+}
+
+void App::SetAppPath(const std::string& app_path) {
+  app_path_ = app_path;
+}
+
 base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
   bool succeed = false;
   base::FilePath path;
@@ -959,6 +967,8 @@ void App::BuildPrototype(
       .SetMethod("isUnityRunning",
                  base::Bind(&Browser::IsUnityRunning, browser))
 #endif
+      .SetMethod("setAppPath", &App::SetAppPath)
+      .SetMethod("getAppPath", &App::GetAppPath)
       .SetMethod("setPath", &App::SetPath)
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("setDesktopName", &App::SetDesktopName)

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -655,7 +655,7 @@ void App::OnGpuProcessCrashed(base::TerminationStatus status) {
     status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 }
 
-base::FilePath App::GetAppPath() {
+base::FilePath App::GetAppPath() const {
   return app_path_;
 }
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -70,7 +70,7 @@ class App : public AtomBrowserClient::Delegate,
       std::unique_ptr<CertificateManagerModel> model);
 #endif
 
-  base::FilePath GetAppPath();
+  base::FilePath GetAppPath() const;
 
  protected:
   explicit App(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -70,6 +70,8 @@ class App : public AtomBrowserClient::Delegate,
       std::unique_ptr<CertificateManagerModel> model);
 #endif
 
+  std::string GetAppPath();
+
  protected:
   explicit App(v8::Isolate* isolate);
   ~App() override;
@@ -115,6 +117,8 @@ class App : public AtomBrowserClient::Delegate,
   void OnGpuProcessCrashed(base::TerminationStatus status) override;
 
  private:
+  void SetAppPath(const std::string& app_path);
+
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(mate::Arguments* args, const std::string& name);
   void SetPath(mate::Arguments* args,
@@ -153,6 +157,8 @@ class App : public AtomBrowserClient::Delegate,
 
   // Tracks tasks requesting file icons.
   base::CancelableTaskTracker cancelable_task_tracker_;
+
+  std::string app_path_;
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -70,7 +70,7 @@ class App : public AtomBrowserClient::Delegate,
       std::unique_ptr<CertificateManagerModel> model);
 #endif
 
-  std::string GetAppPath();
+  base::FilePath GetAppPath();
 
  protected:
   explicit App(v8::Isolate* isolate);
@@ -117,7 +117,7 @@ class App : public AtomBrowserClient::Delegate,
   void OnGpuProcessCrashed(base::TerminationStatus status) override;
 
  private:
-  void SetAppPath(const std::string& app_path);
+  void SetAppPath(const base::FilePath& app_path);
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(mate::Arguments* args, const std::string& name);
@@ -158,7 +158,7 @@ class App : public AtomBrowserClient::Delegate,
   // Tracks tasks requesting file icons.
   base::CancelableTaskTracker cancelable_task_tracker_;
 
-  std::string app_path_;
+  base::FilePath app_path_;
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -234,6 +234,12 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
   }
 #endif
 
+  if (delegate_) {
+    auto app_path = static_cast<api::App*>(delegate_)->GetAppPath();
+    command_line->AppendSwitchASCII(switches::kAppPath,
+                                    app_path);
+  }
+
   content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);
   if (!web_contents)
     return;

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -236,8 +236,7 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
 
   if (delegate_) {
     auto app_path = static_cast<api::App*>(delegate_)->GetAppPath();
-    command_line->AppendSwitchASCII(switches::kAppPath,
-                                    app_path);
+    command_line->AppendSwitchASCII(switches::kAppPath, app_path);
   }
 
   content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -236,7 +236,7 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
 
   if (delegate_) {
     auto app_path = static_cast<api::App*>(delegate_)->GetAppPath();
-    command_line->AppendSwitchASCII(switches::kAppPath, app_path);
+    command_line->AppendSwitchPath(switches::kAppPath, app_path);
   }
 
   content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -159,6 +159,9 @@ const char kSecureSchemes[] = "secure-schemes";
 // The browser process app model ID
 const char kAppUserModelId[] = "app-user-model-id";
 
+// The application path
+const char kAppPath[] = "app-path";
+
 // The command line switch versions of the options.
 const char kBackgroundColor[]  = "background-color";
 const char kPreloadScript[]    = "preload";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -81,6 +81,7 @@ extern const char kStandardSchemes[];
 extern const char kRegisterServiceWorkerSchemes[];
 extern const char kSecureSchemes[];
 extern const char kAppUserModelId[];
+extern const char kAppPath[];
 
 extern const char kBackgroundColor[];
 extern const char kPreloadScript[];

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -12,11 +12,7 @@ const {EventEmitter} = require('events')
 
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 
-let appPath = null
-
 Object.assign(app, {
-  getAppPath () { return appPath },
-  setAppPath (path) { appPath = path },
   setApplicationMenu (menu) {
     return Menu.setApplicationMenu(menu)
   },

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -117,8 +117,11 @@ if (nodeIntegration === 'true') {
     global.__filename = __filename
     global.__dirname = __dirname
 
-    // Search for module under the app directory
-    module.paths = module.paths.concat(Module._nodeModulePaths(electron.remote.app.getAppPath()))
+    if (window.location.protocol !== 'chrome-devtools:') {
+      // Search for module under the app directory
+      // (remote.app doesn't work in devtools)
+      module.paths = module.paths.concat(Module._nodeModulePaths(electron.remote.app.getAppPath()))
+    }
   }
 
   // Redirect window.onerror to uncaughtException.

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -56,6 +56,7 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (ev
 let nodeIntegration = 'false'
 let preloadScript = null
 let isBackgroundPage = false
+let appPath = null
 for (let arg of process.argv) {
   if (arg.indexOf('--guest-instance-id=') === 0) {
     // This is a guest web view.
@@ -69,6 +70,8 @@ for (let arg of process.argv) {
     preloadScript = arg.substr(arg.indexOf('=') + 1)
   } else if (arg === '--background-page') {
     isBackgroundPage = true
+  } else if (arg.indexOf('--app-path=') === 0) {
+    appPath = arg.substr(arg.indexOf('=') + 1)
   }
 }
 
@@ -117,10 +120,9 @@ if (nodeIntegration === 'true') {
     global.__filename = __filename
     global.__dirname = __dirname
 
-    if (window.location.protocol !== 'chrome-devtools:') {
+    if (appPath) {
       // Search for module under the app directory
-      // (remote.app doesn't work in devtools)
-      module.paths = module.paths.concat(Module._nodeModulePaths(electron.remote.app.getAppPath()))
+      module.paths = module.paths.concat(Module._nodeModulePaths(appPath))
     }
   }
 

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -116,6 +116,9 @@ if (nodeIntegration === 'true') {
   } else {
     global.__filename = __filename
     global.__dirname = __dirname
+
+    // Search for module under the app directory
+    module.paths = module.paths.concat(Module._nodeModulePaths(electron.remote.app.getAppPath()))
   }
 
   // Redirect window.onerror to uncaughtException.

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -134,13 +134,21 @@ describe('Module._nodeModulePaths', function () {
 
 describe('require', () => {
   describe('when loaded URL is not file: protocol', () => {
-    it('searches for module under app directory', async () => {
-      const w = new BrowserWindow({
+    let w
+
+    beforeEach(() => {
+      w = new BrowserWindow({
         show: false
       })
+    })
+
+    it('searches for module under app directory', async () => {
       w.loadURL('about:blank')
       const result = await w.webContents.executeJavaScript('typeof require("q").when')
       assert.equal(result, 'function')
+    })
+
+    afterEach(() => {
       w.destroy()
     })
   })

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -4,6 +4,7 @@ const path = require('path')
 const temp = require('temp')
 const {remote} = require('electron')
 const {BrowserWindow} = remote
+const {closeWindow} = require('./window-helpers')
 
 describe('third-party module', function () {
   var fixtures = path.join(__dirname, 'fixtures')
@@ -142,14 +143,15 @@ describe('require', () => {
       })
     })
 
+    afterEach(async () => {
+      await closeWindow(w)
+      w = null
+    })
+
     it('searches for module under app directory', async () => {
       w.loadURL('about:blank')
       const result = await w.webContents.executeJavaScript('typeof require("q").when')
       assert.equal(result, 'function')
-    })
-
-    afterEach(() => {
-      w.destroy()
     })
   })
 })

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -2,6 +2,8 @@ const assert = require('assert')
 const Module = require('module')
 const path = require('path')
 const temp = require('temp')
+const {remote} = require('electron')
+const {BrowserWindow} = remote
 
 describe('third-party module', function () {
   var fixtures = path.join(__dirname, 'fixtures')
@@ -126,6 +128,20 @@ describe('Module._nodeModulePaths', function () {
         path.join(modulePath, 'node_modules'),
         path.resolve('/node_modules')
       ])
+    })
+  })
+})
+
+describe('require', () => {
+  describe('when loaded URL is not file: protocol', () => {
+    it('searches for module under app directory', async () => {
+      const w = new BrowserWindow({
+        show: false,
+      })
+      w.loadURL('about:blank')
+      const result = await w.webContents.executeJavaScript('typeof require("q").when')
+      assert.equal(result, 'function')
+      w.destroy()
     })
   })
 })

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -136,7 +136,7 @@ describe('require', () => {
   describe('when loaded URL is not file: protocol', () => {
     it('searches for module under app directory', async () => {
       const w = new BrowserWindow({
-        show: false,
+        show: false
       })
       w.loadURL('about:blank')
       const result = await w.webContents.executeJavaScript('typeof require("q").when')


### PR DESCRIPTION
This PR makes `require()`to search for modules from app directory when the URL is not file protocol (such as http, data or `about:blank`).

I think this would be more intuitive solution for #8425 and https://github.com/electron/electron/pull/8963#issuecomment-291064820.