### PR TITLE
Surface errors setting remote properties

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -139,7 +139,12 @@ const setObjectMembers = function (ref, object, metaId, members) {
       // Only set setter when it is writable.
       if (member.writable) {
         descriptor.set = function (value) {
-          ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_SET', metaId, member.name, value)
+          const meta = ipcRenderer.sendSync('ELECTRON_BROWSER_MEMBER_SET', metaId, member.name, value)
+          // Meta will be non-null when a setter error occurred so parse it
+          // to a value so it gets re-thrown.
+          if (meta != null) {
+            metaToValue(meta)
+          }
           return value
         }
       }

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -187,6 +187,18 @@ describe('ipc module', function () {
       property.property = 1127
     })
 
+    it('rethrows errors getting/setting properties', function () {
+      const foo = remote.require(path.join(fixtures, 'module', 'error-properties.js'))
+
+      assert.throws(function () {
+        foo.bar
+      }, /getting error/)
+
+      assert.throws(function () {
+        foo.bar = 'test'
+      }, /setting error/)
+    })
+
     it('can construct an object from its member', function () {
       var call = remote.require(path.join(fixtures, 'module', 'call.js'))
       var obj = new call.constructor()

--- a/spec/fixtures/module/error-properties.js
+++ b/spec/fixtures/module/error-properties.js
@@ -1,0 +1,11 @@
+class Foo {
+  set bar (value) {
+    throw new Error('setting error')
+  }
+
+  get bar () {
+    throw new Error('getting error')
+  }
+}
+
+module.exports = new Foo()


### PR DESCRIPTION
Currently if you have a remote setter that throws an exception in the main process, that exception is not surfaced in the renderer process. This is because the IPC response was previously not parsed so any errors in it were ignored.

This pull request wraps the setter response in a `metaToValue` call so that errors from the main process are re-thrown in the render process, similar to getters and function calls.

Noticed this while working on #9023 