### PR TITLE
Fix sandboxed crashReporter for windows

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -447,6 +447,8 @@
           '-r',
           './lib/sandboxed_renderer/api/exports/os.js:os',
           '-r',
+          './lib/sandboxed_renderer/api/exports/path.js:path',
+          '-r',
           './lib/sandboxed_renderer/api/exports/child_process.js:child_process'
         ],
         'isolated_args': [

--- a/lib/sandboxed_renderer/api/exports/path.js
+++ b/lib/sandboxed_renderer/api/exports/path.js
@@ -1,0 +1,1 @@
+module.exports = require('electron').remote.require('path')

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -27,6 +27,7 @@ const preloadModules = new Map([
   ['electron', electron],
   ['fs', fs],
   ['os', require('os')],
+  ['path', require('path')],
   ['url', require('url')],
   ['timers', require('timers')]
 ])
@@ -36,8 +37,9 @@ const preloadSrc = fs.readFileSync(preloadPath).toString()
 // Pass different process object to the preload script(which should not have
 // access to things like `process.atomBinding`).
 const preloadProcess = new events.EventEmitter()
-preloadProcess.platform = electron.remote.process.platform
 preloadProcess.crash = () => binding.crash()
+process.platform = preloadProcess.platform = electron.remote.process.platform
+process.execPath = preloadProcess.execPath = electron.remote.process.execPath
 process.on('exit', () => preloadProcess.emit('exit'))
 
 // This is the `require` function that will be visible to the preload script

--- a/spec/fixtures/api/crash.html
+++ b/spec/fixtures/api/crash.html
@@ -17,7 +17,7 @@ crashReporter.start({
   }
 });
 if (!uploadToServer) {
-  ipcRenderer.sendSync('set-crash-directory', crashReporter.getCrashesDirectory())
+  ipcRenderer.sendSync('list-existing-dumps')
 }
 setImmediate(function() { process.crash(); });
 </script>


### PR DESCRIPTION
- Use `path` module from browser process in sandboxed renderer. This is required
      because the return value of `path.join` is platform-specific, and this is an
      assumtion of crash-reporter.js which is shared between sandboxed and
      non-sandboxed renderers.
- Set `process.platform` and `process.execPath` in sandboxed renderer
      environment. This is required to spawn the windows crash service from
      sandboxed renderer.
- Use a single temporary directory for all crashReporter tests. This is required
      to make tests more deterministic across platforms(since mac's crashpad doesn't
      support changing the crash dump directory). Also make a few improvements/fixes
      to the `uploadToServer` test.
