### PR TITLE
Use point / size / rectangle structures consistently in API docs

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -682,10 +682,8 @@ Returns `Boolean` - Whether the window is in fullscreen mode.
 
 * `aspectRatio` Float - The aspect ratio to maintain for some portion of the
 content view.
-* `extraSize` Object (optional) - The extra size not to be included while
+* `extraSize` [Size](structures/size.md) - The extra size not to be included while
 maintaining the aspect ratio.
-  * `width` Integer
-  * `height` Integer
 
 This will make a window maintain an aspect ratio. The extra size allows a
 developer to have space, specified in pixels, not included within the aspect

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -60,9 +60,8 @@ The `desktopCapturer` module has the following methods:
 * `options` Object
   * `types` String[] - An array of Strings that lists the types of desktop sources
     to be captured, available types are `screen` and `window`.
-  * `thumbnailSize` Object (optional) - The size that the media source thumbnail should be scaled to.
-    * `width` Integer - Default is `150`
-    * `height` Integer - Default is `150`
+  * `thumbnailSize` [Size](structures/size.md) (optional) - The size that the media source thumbnail 
+    should be scaled to. Default is `150` x `150`.
 * `callback` Function
   * `error` Error
   * `sources` [DesktopCapturerSource[]](structures/desktop-capturer-source.md)

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -219,10 +219,7 @@ Returns `Boolean` -  Whether the image is empty.
 
 #### `image.getSize()`
 
-Returns `Object`:
-
-* `width` Integer
-* `height` Integer
+Returns [`Size`](structures/size.md)
 
 #### `image.setTemplateImage(option)`
 
@@ -236,11 +233,7 @@ Returns `Boolean` - Whether the image is a template image.
 
 #### `image.crop(rect)`
 
-* `rect` Object - The area of the image to crop
-  * `x` Integer
-  * `y` Integer
-  * `width` Integer
-  * `height` Integer
+* `rect` [Rectangle](structures/rectangle.md) - The area of the image to crop
 
 Returns `NativeImage` - The cropped image.
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -91,10 +91,7 @@ The `screen` module has the following methods:
 
 ### `screen.getCursorScreenPoint()`
 
-Returns `Object`:
-
-* `x` Integer
-* `y` Integer
+Returns [`Point`](structures/point.md)
 
 The current absolute position of the mouse pointer.
 
@@ -108,9 +105,7 @@ Returns [`Display[]`](structures/display.md) - An array of displays that are cur
 
 ### `screen.getDisplayNearestPoint(point)`
 
-* `point` Object
-  * `x` Integer
-  * `y` Integer
+* `point` [Point](structures/point.md)
 
 Returns [`Display`](structures/display.md) - The display nearest the specified point.
 

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -6,13 +6,9 @@
 * `scaleFactor` Number - Output device's pixel scale factor.
 * `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
 * `bounds` [Rectangle](rectangle.md)
-* `size` Object
-  * `height` Number
-  * `width` Number
+* `size` [Size](size.md)
 * `workArea` [Rectangle](rectangle.md)
-* `workAreaSize` Object
-  * `height` Number
-  * `width` Number
+* `workAreaSize` [Size](size.md)
 
 The `Display` object represents a physical display connected to the system. A
 fake `Display` may exist on a headless system, or a `Display` may correspond to

--- a/docs/api/structures/point.md
+++ b/docs/api/structures/point.md
@@ -1,0 +1,4 @@
+# Point Object
+
+* `x` Number
+* `y` Number

--- a/docs/api/structures/size.md
+++ b/docs/api/structures/size.md
@@ -1,0 +1,4 @@
+# Size Object
+
+* `width` Number
+* `height` Number

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -219,9 +219,7 @@ Displays a tray balloon.
 #### `tray.popUpContextMenu([menu, position])` _macOS_ _Windows_
 
 * `menu` Menu (optional)
-* `position` Object (optional) - The pop up position.
-  * `x` Integer
-  * `y` Integer
+* `position` [Point](structures/point.md) (optional) - The pop up position.
 
 Pops up the context menu of the tray icon. When `menu` is passed, the `menu` will
 be shown instead of the tray icon's context menu.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -375,12 +375,8 @@ Returns:
 * `type` String
 * `image` NativeImage (optional)
 * `scale` Float (optional) - scaling factor for the custom cursor
-* `size` Object (optional) - the size of the `image`
-  * `width` Integer
-  * `height` Integer
-* `hotspot` Object (optional) - coordinates of the custom cursor's hotspot
-  * `x` Integer - x coordinate
-  * `y` Integer - y coordinate
+* `size` [Size](structures/size.md) (optional) - the size of the `image`
+* `hotspot` [Point](structures/point.md) (optional) - coordinates of the custom cursor's hotspot
 
 Emitted when the cursor's type changes. The `type` parameter can be `default`,
 `crosshair`, `pointer`, `text`, `wait`, `help`, `e-resize`, `n-resize`,
@@ -1067,24 +1063,16 @@ app.on('ready', () => {
       (default: `desktop`)
     * `desktop` - Desktop screen type
     * `mobile` - Mobile screen type
-  * `screenSize` Object - Set the emulated screen size (screenPosition == mobile)
-    * `width` Integer - Set the emulated screen width
-    * `height` Integer - Set the emulated screen height
-  * `viewPosition` Object - Position the view on the screen
+  * `screenSize` [Size](structures/size.md) - Set the emulated screen size (screenPosition == mobile)
+  * `viewPosition` [Point](structures/point.md) - Position the view on the screen
       (screenPosition == mobile) (default: `{x: 0, y: 0}`)
-    * `x` Integer - Set the x axis offset from top left corner
-    * `y` Integer - Set the y axis offset from top left corner
   * `deviceScaleFactor` Integer - Set the device scale factor (if zero defaults to
       original device scale factor) (default: `0`)
-  * `viewSize` Object - Set the emulated view size (empty means no override)
-    * `width` Integer - Set the emulated view width
-    * `height` Integer - Set the emulated view height
+  * `viewSize` [Size](structures/size.md) - Set the emulated view size (empty means no override)
   * `fitToView` Boolean - Whether emulated view should be scaled down if
       necessary to fit into available space (default: `false`)
-  * `offset` Object - Offset of the emulated view inside available space (not in
-      fit to view mode) (default: `{x: 0, y: 0}`)
-    * `x` Float - Set the x axis offset from top left corner
-    * `y` Float - Set the y axis offset from top left corner
+  * `offset` [Point](structures/point.md) - Offset of the emulated view inside available space
+      (not in fit to view mode) (default: `{x: 0, y: 0}`)
   * `scale` Float - Scale of emulated view inside available space (not in fit to
       view mode) (default: `1`)
 


### PR DESCRIPTION
I've added `Point` and `Size` types to avoid duplicate types being generated. I've also fixed a few places where `Rectangle` was not being used.

Related to https://github.com/electron/electron/issues/4875