### PR TITLE
Add sheet-begin and sheet-end events to macOS BrowserWindow

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -263,6 +263,14 @@ void Window::OnWindowSwipe(const std::string& direction) {
   Emit("swipe", direction);
 }
 
+void Window::OnWindowSheetBegin() {
+  Emit("sheet-begin");
+}
+
+void Window::OnWindowSheetEnd() {
+  Emit("sheet-end");
+}
+
 void Window::OnWindowEnterHtmlFullScreen() {
   Emit("enter-html-full-screen");
 }
@@ -295,16 +303,6 @@ void Window::OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {
         ToBuffer(isolate(), static_cast<void*>(&w_param), sizeof(WPARAM)),
         ToBuffer(isolate(), static_cast<void*>(&l_param), sizeof(LPARAM)));
   }
-}
-#endif
-
-#if defined(OS_MACOSX)
-void Window::OnWindowSheetBegin() {
-  Emit("sheet-begin");
-}
-
-void Window::OnWindowSheetEnd() {
-  Emit("sheet-end");
 }
 #endif
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -298,6 +298,16 @@ void Window::OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {
 }
 #endif
 
+#if defined(OS_MACOSX)
+void Window::OnWindowSheetBegin() {
+  Emit("sheet-begin");
+}
+
+void Window::OnWindowSheetEnd() {
+  Emit("sheet-end");
+}
+#endif
+
 // static
 mate::WrappableBase* Window::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -79,6 +79,8 @@ class Window : public mate::TrackableObject<Window>,
   void OnWindowScrollTouchEnd() override;
   void OnWindowScrollTouchEdge() override;
   void OnWindowSwipe(const std::string& direction) override;
+  void OnWindowSheetBegin() override;
+  void OnWindowSheetEnd() override;
   void OnWindowEnterFullScreen() override;
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;
@@ -91,11 +93,6 @@ class Window : public mate::TrackableObject<Window>,
 
   #if defined(OS_WIN)
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
-  #endif
-
-  #if defined(OS_MACOSX)
-  void OnWindowSheetBegin() override;
-  void OnWindowSheetEnd() override;
   #endif
 
  private:

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -93,6 +93,11 @@ class Window : public mate::TrackableObject<Window>,
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
   #endif
 
+  #if defined(OS_MACOSX)
+  void OnWindowSheetBegin() override;
+  void OnWindowSheetEnd() override;
+  #endif
+
  private:
   void Init(v8::Isolate* isolate,
             v8::Local<v8::Object> wrapper,

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -590,6 +590,18 @@ void NativeWindow::NotifyWindowMessage(
 }
 #endif
 
+#if defined(OS_MACOSX)
+void NativeWindow::NotifyWindowSheetBegin() {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowSheetBegin();
+}
+
+void NativeWindow::NotifyWindowSheetEnd() {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowSheetEnd();
+}
+#endif
+
 std::unique_ptr<SkRegion> NativeWindow::DraggableRegionsToSkRegion(
     const std::vector<DraggableRegion>& regions) {
   std::unique_ptr<SkRegion> sk_region(new SkRegion);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -554,6 +554,16 @@ void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
     observer.OnWindowSwipe(direction);
 }
 
+void NativeWindow::NotifyWindowSheetBegin() {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowSheetBegin();
+}
+
+void NativeWindow::NotifyWindowSheetEnd() {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowSheetEnd();
+}
+
 void NativeWindow::NotifyWindowLeaveFullScreen() {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowLeaveFullScreen();
@@ -587,18 +597,6 @@ void NativeWindow::NotifyWindowMessage(
     UINT message, WPARAM w_param, LPARAM l_param) {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowMessage(message, w_param, l_param);
-}
-#endif
-
-#if defined(OS_MACOSX)
-void NativeWindow::NotifyWindowSheetBegin() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowSheetBegin();
-}
-
-void NativeWindow::NotifyWindowSheetEnd() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowSheetEnd();
 }
 #endif
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -233,6 +233,8 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowScrollTouchEnd();
   void NotifyWindowScrollTouchEdge();
   void NotifyWindowSwipe(const std::string& direction);
+  void NotifyWindowSheetBegin();
+  void NotifyWindowSheetEnd();
   void NotifyWindowEnterFullScreen();
   void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();
@@ -243,11 +245,6 @@ class NativeWindow : public base::SupportsUserData,
 
   #if defined(OS_WIN)
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);
-  #endif
-
-  #if defined(OS_MACOSX)
-  void NotifyWindowSheetBegin();
-  void NotifyWindowSheetEnd();
   #endif
 
   void AddObserver(NativeWindowObserver* obs) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -245,6 +245,11 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);
   #endif
 
+  #if defined(OS_MACOSX)
+  void NotifyWindowSheetBegin();
+  void NotifyWindowSheetEnd();
+  #endif
+
   void AddObserver(NativeWindowObserver* obs) {
     observers_.AddObserver(obs);
   }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -313,6 +313,14 @@ bool ScopedDisableResize::disable_resize_ = false;
   return rect;
 }
 
+- (void)windowWillBeginSheet:(NSNotification *)notification {
+  shell_->NotifyWindowSheetBegin();
+}
+
+- (void)windowDidEndSheet:(NSNotification *)notification {
+  shell_->NotifyWindowSheetEnd();
+}
+
 @end
 
 @interface AtomPreviewItem : NSObject <QLPreviewItem>

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -67,6 +67,8 @@ class NativeWindowObserver {
   virtual void OnWindowScrollTouchEnd() {}
   virtual void OnWindowScrollTouchEdge() {}
   virtual void OnWindowSwipe(const std::string& direction) {}
+  virtual void OnWindowSheetBegin() {}
+  virtual void OnWindowSheetEnd() {}
   virtual void OnWindowEnterFullScreen() {}
   virtual void OnWindowLeaveFullScreen() {}
   virtual void OnWindowEnterHtmlFullScreen() {}
@@ -77,11 +79,6 @@ class NativeWindowObserver {
   // Called when window message received
   #if defined(OS_WIN)
   virtual void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {}
-  #endif
-
-  #if defined(OS_MACOSX)
-  virtual void OnWindowSheetBegin() {}
-  virtual void OnWindowSheetEnd() {}
   #endif
 
   // Called when renderer is hung.

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -79,6 +79,11 @@ class NativeWindowObserver {
   virtual void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {}
   #endif
 
+  #if defined(OS_MACOSX)
+  virtual void OnWindowSheetBegin() {}
+  virtual void OnWindowSheetEnd() {}
+  #endif
+
   // Called when renderer is hung.
   virtual void OnRendererUnresponsive() {}
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -498,6 +498,14 @@ Returns:
 
 Emitted on 3-finger swipe. Possible directions are `up`, `right`, `down`, `left`.
 
+#### Event: 'sheet-begin' _macOS_
+
+Emitted when the window opens a sheet.
+
+#### Event: 'sheet-end' _macOS_
+
+Emitted when the window has closed a sheet.
+
 ### Static Methods
 
 The `BrowserWindow` class has the following static methods:

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1191,6 +1191,54 @@ describe('BrowserWindow module', function () {
     })
   })
 
+  describe('sheet-begin event', function () {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    let sheet = null
+
+    afterEach(function () {
+      return closeWindow(sheet, {assertSingleWindow: false}).then(function () { sheet = null })
+    })
+
+    it('emits when window opens a sheet', function (done) {
+      w.show()
+      w.once('sheet-begin', function () {
+        sheet.close()
+        done()
+      })
+      sheet = new BrowserWindow({
+        modal: true,
+        parent: w
+      })
+    })
+  })
+
+  describe('sheet-end event', function () {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    let sheet = null
+
+    afterEach(function () {
+      return closeWindow(sheet, {assertSingleWindow: false}).then(function () { sheet = null })
+    })
+
+    it('emits when window has closed a sheet', function (done) {
+      w.show()
+      sheet = new BrowserWindow({
+        modal: true,
+        parent: w
+      })
+      w.once('sheet-end', function () {
+        done()
+      })
+      sheet.close()
+    })
+  })
+
   describe('beginFrameSubscription method', function () {
     // This test is too slow, only test it on CI.
     if (!isCI) return


### PR DESCRIPTION
These would be helpful when a dialog is opened without using BrowserWindow's `modal` option or `dialog` module.

For example, when a dialog is opened by `<input type="file">` of a webview, the webview loses focus after the dialog is closed. This new event can tell that the dialog has been closed in order to get focus again.