### PR TITLE
Fixed a couple of failing debug checks when calling Chromium APIs

### DIFF
--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -61,11 +61,11 @@ bool GetProtocolLaunchPath(mate::Arguments* args, base::string16* exe) {
   // Read in optional args arg
   std::vector<base::string16> launch_args;
   if (args->GetNext(&launch_args) && !launch_args.empty())
-    *exe = base::StringPrintf(L"\"%s\" %s \"%%1\"",
+    *exe = base::StringPrintf(L"\"%ls\" %ls \"%%1\"",
                               exe->c_str(),
                               base::JoinString(launch_args, L" ").c_str());
   else
-    *exe = base::StringPrintf(L"\"%s\" \"%%1\"", exe->c_str());
+    *exe = base::StringPrintf(L"\"%ls\" \"%%1\"", exe->c_str());
   return true;
 }
 
@@ -76,8 +76,7 @@ bool FormatCommandLineString(base::string16* exe,
   }
 
   if (!launch_args.empty()) {
-    base::string16 formatString = L"%s %s";
-    *exe = base::StringPrintf(formatString.c_str(),
+    *exe = base::StringPrintf(L"%ls %ls",
                               exe->c_str(),
                               base::JoinString(launch_args, L" ").c_str());
   }

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -23,8 +23,8 @@ SubmenuButton::SubmenuButton(const base::string16& title,
                         menu_button_listener, false),
       accelerator_(0),
       show_underline_(false),
-      underline_start_(-1),
-      underline_end_(-1),
+      underline_start_(0),
+      underline_end_(0),
       text_width_(0),
       text_height_(0),
       underline_color_(SK_ColorBLACK),
@@ -106,7 +106,7 @@ bool SubmenuButton::GetUnderlinePosition(const base::string16& text,
 
 void SubmenuButton::GetCharacterPosition(
     const base::string16& text, int index, int* pos) {
-  int height;
+  int height = 0;
   gfx::Canvas::SizeStringInt(text.substr(0, index), GetFontList(), pos, &height,
                              0, 0);
 }


### PR DESCRIPTION
I'm fixing just a few easy DCHECK failures that I encountered.

- The `%s` format string fails the `IsWprintfFormatPortable` check
- The variables pointed to in a call to `SizeStringInt` need to be initialized to a non-negative value (>= 0)