### PR TITLE
Fix document of MimeTypedBuffer Object

### DIFF
--- a/docs/api/structures/mime-typed-buffer.md
+++ b/docs/api/structures/mime-typed-buffer.md
@@ -1,4 +1,4 @@
 # MimeTypedBuffer Object
 
 * `mimeType` String - The mimeType of the Buffer that you are sending
-* `buffer` Buffer - The actual Buffer content
+* `data` Buffer - The actual Buffer content


### PR DESCRIPTION
Hi, I found that a key of `MimeTypedBuffer Object` structure was wrong in the document when I was trying `protocol.registerBufferProtocol()` API.  This PR fixes it.

## basis

https://github.com/electron/electron/blob/v1.6.5/spec/api-protocol-spec.js#L265-L268
