### PR TITLE
Cherry pick node fix for ChildProcess.fork --eval bug

### DIFF
--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -92,10 +92,10 @@ describe('node feature', function () {
         })
       })
 
-      it('works when sending message to a forked process using the --eval argument', function (done) {
-        const source = "process.on('message', function (msg) { process.send(msg) })"
+      it('works when sending a message to a process forked with the --eval argument', function (done) {
+        const source = "process.on('message', (message) => { process.send(message) })"
         const forked = ChildProcess.fork('--eval', [source])
-        forked.on('message', (message) => {
+        forked.once('message', (message) => {
           assert.equal(message, 'hello')
           done()
         })

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -91,6 +91,16 @@ describe('node feature', function () {
           done()
         })
       })
+
+      it('works when sending message to a forked process using the --eval argument', function (done) {
+        const source = "process.on('message', function (msg) { process.send(msg) })"
+        const forked = ChildProcess.fork('--eval', [source])
+        forked.on('message', (message) => {
+          assert.equal(message, 'hello')
+          done()
+        })
+        forked.send('hello')
+      })
     })
 
     describe('child_process.spawn', function () {


### PR DESCRIPTION
Pulls in https://github.com/nodejs/node/pull/11958 which fixed https://github.com/nodejs/node/issues/11948

Fix landed upstream in https://github.com/nodejs/node/commit/9ff7ed23cd822dc810ddd99d63d4e2ca68635474 and this was cherry-picked into our node fork as https://github.com/electron/node/commit/3fe90cfcf54dd946980e59daf550a7cdb2317c8f

/cc @bpasero 

Closes #8944