### PR TITLE
Always set NSScrollViewRubberbanding scroll bounce pref

### DIFF
--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -96,16 +96,14 @@ void RendererClientBase::RenderThreadStarted() {
 #endif
 
 #if defined(OS_MACOSX)
-  // Disable rubber banding by default.
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (!command_line->HasSwitch(switches::kScrollBounce)) {
-    base::ScopedCFTypeRef<CFStringRef> key(
-        base::SysUTF8ToCFStringRef("NSScrollViewRubberbanding"));
-    base::ScopedCFTypeRef<CFStringRef> value(
-        base::SysUTF8ToCFStringRef("false"));
-    CFPreferencesSetAppValue(key, value, kCFPreferencesCurrentApplication);
-    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
-  }
+  bool scroll_bounce = command_line->HasSwitch(switches::kScrollBounce);
+  base::ScopedCFTypeRef<CFStringRef> rubber_banding_key(
+    base::SysUTF8ToCFStringRef("NSScrollViewRubberbanding"));
+  CFPreferencesSetAppValue(rubber_banding_key,
+                           scroll_bounce ? kCFBooleanTrue : kCFBooleanFalse,
+                           kCFPreferencesCurrentApplication);
+  CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 #endif
 }
 


### PR DESCRIPTION
Previously Electron was only ever setting this pref to `false` when the `scrollBounce` web preferences was set `false`.

Now it is always set, and set to `true` when enabled so Chrome picks it up and enables it on the renderer.

![scroll-bounce](https://cloud.githubusercontent.com/assets/671378/24778571/33838bca-1ae0-11e7-8da5-579c4e65da54.gif)

Refs #5412
Closes #9033