### PR TITLE
Fix frameless window overflow on Windows

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -283,7 +283,7 @@ NativeWindowViews::NativeWindowViews(
   if (!has_frame()) {
     // Set Window style so that we get a minimize and maximize animation when
     // frameless.
-    DWORD frame_style = WS_CAPTION;
+    DWORD frame_style = WS_POPUP | WS_CAPTION | WS_OVERLAPPED | WS_SYSMENU | WS_CLIPCHILDREN;
     if (resizable_)
       frame_style |= WS_THICKFRAME;
     if (minimizable_)

--- a/atom/browser/ui/views/frameless_view.cc
+++ b/atom/browser/ui/views/frameless_view.cc
@@ -68,6 +68,9 @@ int FramelessView::NonClientHitTest(const gfx::Point& cursor) {
   if (frame_->IsFullscreen())
     return HTCLIENT;
 
+  if (!bounds().Contains(cursor))
+    return HTNOWHERE;
+
   // Check for possible draggable region in the client area for the frameless
   // window.
   SkRegion* draggable_region = window_->draggable_region();
@@ -75,11 +78,18 @@ int FramelessView::NonClientHitTest(const gfx::Point& cursor) {
     return HTCAPTION;
 
   // Support resizing frameless window by dragging the border.
-  int frame_component = ResizingBorderHitTest(cursor);
-  if (frame_component != HTNOWHERE)
-    return frame_component;
+  if (!frame_->IsMaximized()) {
+    int frame_component = ResizingBorderHitTest(cursor);
+    if (frame_component != HTNOWHERE)
+      return frame_component;
+  }
 
-  return HTCLIENT;
+  int client_component = frame_->client_view()->NonClientHitTest(cursor);
+  if (client_component != HTNOWHERE)
+    return client_component;
+
+  // Caption is a safe default.
+  return HTCAPTION;
 }
 
 void FramelessView::GetWindowMask(const gfx::Size& size,

--- a/atom/browser/ui/views/menu_layout.cc
+++ b/atom/browser/ui/views/menu_layout.cc
@@ -11,26 +11,6 @@
 
 namespace atom {
 
-namespace {
-
-#if defined(OS_WIN)
-gfx::Rect SubtractBorderSize(gfx::Rect bounds) {
-  gfx::Point borderSize = gfx::Point(
-      GetSystemMetrics(SM_CXSIZEFRAME) - 1,   // width
-      GetSystemMetrics(SM_CYSIZEFRAME) - 1);  // height
-  gfx::Point dpiAdjustedSize =
-      display::win::ScreenWin::ScreenToDIPPoint(borderSize);
-
-  bounds.set_x(bounds.x() + dpiAdjustedSize.x());
-  bounds.set_y(bounds.y() + dpiAdjustedSize.y());
-  bounds.set_width(bounds.width() - 2 * dpiAdjustedSize.x());
-  bounds.set_height(bounds.height() - 2 * dpiAdjustedSize.y());
-  return bounds;
-}
-#endif
-
-}  // namespace
-
 MenuLayout::MenuLayout(NativeWindowViews* window, int menu_height)
     : window_(window),
       menu_height_(menu_height) {
@@ -40,16 +20,6 @@ MenuLayout::~MenuLayout() {
 }
 
 void MenuLayout::Layout(views::View* host) {
-#if defined(OS_WIN)
-  // Reserve border space for maximized frameless window so we won't have the
-  // content go outside of screen.
-  if (!window_->has_frame() && window_->IsMaximized()) {
-    gfx::Rect bounds = SubtractBorderSize(host->GetContentsBounds());
-    host->child_at(0)->SetBoundsRect(bounds);
-    return;
-  }
-#endif
-
   if (!HasMenu(host)) {
     views::FillLayout::Layout(host);
     return;

--- a/atom/browser/ui/views/win_frame_view.cc
+++ b/atom/browser/ui/views/win_frame_view.cc
@@ -23,6 +23,9 @@ WinFrameView::WinFrameView() {
 WinFrameView::~WinFrameView() {
 }
 
+gfx::Rect WinFrameView::GetBoundsForClientView() const {
+  return bounds();
+}
 
 gfx::Rect WinFrameView::GetWindowBoundsForClientBounds(
     const gfx::Rect& client_bounds) const {

--- a/atom/browser/ui/views/win_frame_view.h
+++ b/atom/browser/ui/views/win_frame_view.h
@@ -15,6 +15,7 @@ class WinFrameView : public FramelessView {
   virtual ~WinFrameView();
 
   // views::NonClientFrameView:
+  gfx::Rect GetBoundsForClientView() const override;
   gfx::Rect GetWindowBoundsForClientBounds(
       const gfx::Rect& client_bounds) const override;
   int NonClientHitTest(const gfx::Point& point) override;


### PR DESCRIPTION
Tested both framed and frameless windows with 100%, 125%, 150%, 175%,
and 200% DPI on Windows 10.

The only issue is that you might get the resize cursor at the right and
bottom edge of maximized frameless windows on some DPIs (>100% DPI for
me). This might just be a VM issue though.

This fixes #5267 and #8728.

# Test Plan

## Windows 7

### With Frame

- [ ] 200% DPI
- [ ] 150% DPI
- [ ] 125% DPI
- [ ] 100% DPI

### Without Frame

- [ ] 200% DPI
- [ ] 150% DPI
- [ ] 125% DPI
- [ ] 100% DPI

## Windows 8

### With Frame

- [ ] 200% DPI
- [ ] 150% DPI
- [ ] 125% DPI
- [ ] 100% DPI

### Without Frame

- [ ] 200% DPI
- [ ] 150% DPI
- [ ] 125% DPI
- [ ] 100% DPI

## Windows 10

### With Frame

- [x] 200% DPI
- [x] 150% DPI
- [x] 125% DPI
- [x] 100% DPI

### Without Frame

- [x] 200% DPI
- [x] 150% DPI
- [x] 125% DPI
- [x] 100% DPI

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <style>
      body, html {
        padding: 0;
        margin: 0;
      }

      #outer {
        border: 5px solid red;
        position: absolute;
        top: 0;
        left: 0;
        right: 0;
        bottom: 0;
      }

      #inner {
        border: 5px solid blue;
        position: absolute;
        top: 0;
        left: 0;
        right: 0;
        bottom: 0;
        padding: 20px;
      }
    </style>
  </head>
  <body>
    <div id="outer">
      <div id="inner">
        <button onclick="require('electron').remote.getCurrentWindow().maximize()">Maximize</button>
        <button onclick="require('electron').remote.getCurrentWindow().unmaximize()">Unmaximize</button>
        <button onclick="window.close()">Close</button>
      </div>
    </div>
  </body>
</html>
```