### PR TITLE
#9128: Removed unused dll from distribution.

### DIFF
--- a/docs-translations/ko-KR/tutorial/windows-store-guide.md
+++ b/docs-translations/ko-KR/tutorial/windows-store-guide.md
@@ -67,8 +67,7 @@ npm install -g electron-windows-store
 │   └── atom.asar
 ├── snapshot_blob.bin
 ├── squirrel.exe
-├── ui_resources_200_percent.pak
-└── xinput1_3.dll
+└── ui_resources_200_percent.pak
 ```
 
 ## `electron-windows-store` 실행하기

--- a/docs-translations/zh-CN/tutorial/windows-store-guide.md
+++ b/docs-translations/zh-CN/tutorial/windows-store-guide.md
@@ -49,8 +49,7 @@ npm install -g electron-windows-store
 │   └── atom.asar
 ├── snapshot_blob.bin
 ├── squirrel.exe
-├── ui_resources_200_percent.pak
-└── xinput1_3.dll
+└── ui_resources_200_percent.pak
 ```
 
 ## 步骤 2: 运行 electron-windows-store

--- a/docs/tutorial/windows-store-guide.md
+++ b/docs/tutorial/windows-store-guide.md
@@ -69,8 +69,7 @@ The output should look roughly like this:
 │   └── atom.asar
 ├── snapshot_blob.bin
 ├── squirrel.exe
-├── ui_resources_200_percent.pak
-└── xinput1_3.dll
+└── ui_resources_200_percent.pak
 ```
 
 ## Step 2: Running electron-windows-store

--- a/electron.gyp
+++ b/electron.gyp
@@ -159,7 +159,6 @@
                 '<(libchromiumcontent_dir)/natives_blob.bin',
                 '<(libchromiumcontent_dir)/snapshot_blob.bin',
                 'external_binaries/d3dcompiler_47.dll',
-                'external_binaries/xinput1_3.dll',
               ],
             },
           ],

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -43,7 +43,6 @@ TARGET_BINARIES = {
     'content_resources_200_percent.pak',
     'ui_resources_200_percent.pak',
     'views_resources_200_percent.pak',
-    'xinput1_3.dll',
     'natives_blob.bin',
     'snapshot_blob.bin',
   ],


### PR DESCRIPTION
Follow up: I don't have right to create a release here: https://github.com/electron/electron-frameworks/releases

At first I would publish the zip as before but without the `xinput1_3.dll`. Or even better we could modify: https://github.com/electron/electron/blob/master/script/update-external-binaries.py and download only `d3dcompiler_47.dll`

Fixes #9128 