### PR TITLE
Fix frameless window overflow on Windows

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -70,20 +70,6 @@ const int kMenuBarHeight = 25;
 #endif
 
 #if defined(OS_WIN)
-gfx::Rect SubtractBorderSize(gfx::Rect bounds) {
-  gfx::Point borderSize = gfx::Point(
-      GetSystemMetrics(SM_CXSIZEFRAME) - 1,   // width
-      GetSystemMetrics(SM_CYSIZEFRAME) - 1);  // height
-  gfx::Point dpiAdjustedSize =
-      display::win::ScreenWin::ScreenToDIPPoint(borderSize);
-
-  bounds.set_x(bounds.x() + dpiAdjustedSize.x());
-  bounds.set_y(bounds.y() + dpiAdjustedSize.y());
-  bounds.set_width(bounds.width() - 2 * dpiAdjustedSize.x());
-  bounds.set_height(bounds.height() - 2 * dpiAdjustedSize.y());
-  return bounds;
-}
-
 void FlipWindowStyle(HWND handle, bool on, DWORD flag) {
   DWORD style = ::GetWindowLong(handle, GWL_STYLE);
   if (on)
@@ -1279,16 +1265,6 @@ void NativeWindowViews::HandleKeyboardEvent(
 }
 
 void NativeWindowViews::Layout() {
-#if defined(OS_WIN)
-  // Reserve border space for maximized frameless window so we won't have the
-  // content go outside of screen.
-  if (!has_frame() && IsMaximized()) {
-    gfx::Rect bounds = SubtractBorderSize(GetContentsBounds());
-    web_view_->SetBoundsRect(bounds);
-    return;
-  }
-#endif
-
   const auto size = GetContentsBounds().size();
   const auto menu_bar_bounds =
       menu_bar_ ? gfx::Rect(0, 0, size.width(), kMenuBarHeight) : gfx::Rect();

--- a/atom/browser/ui/views/win_frame_view.cc
+++ b/atom/browser/ui/views/win_frame_view.cc
@@ -23,7 +23,6 @@ WinFrameView::WinFrameView() {
 WinFrameView::~WinFrameView() {
 }
 
-
 gfx::Rect WinFrameView::GetWindowBoundsForClientBounds(
     const gfx::Rect& client_bounds) const {
   return views::GetWindowBoundsForClientBounds(

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -25,12 +25,4 @@ bool AtomDesktopWindowTreeHostWin::PreHandleMSG(
   return delegate_->PreHandleMSG(message, w_param, l_param, result);
 }
 
-/** Override the client area inset
- *  Returning true forces a border of 0 for frameless windows
- */
-bool AtomDesktopWindowTreeHostWin::GetClientAreaInsets(
-    gfx::Insets* insets) const {
-  return !HasFrame();
-}
-
 }  // namespace atom

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
@@ -27,7 +27,6 @@ class AtomDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin {
  protected:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
-  bool GetClientAreaInsets(gfx::Insets* insets) const override;
 
  private:
   MessageHandlerDelegate* delegate_;  // weak ref

--- a/electron.gyp
+++ b/electron.gyp
@@ -129,6 +129,8 @@
             },
             'VCLinkerTool': {
               'AdditionalOptions': [
+                # Chrome builds with this minimum environment which changes the
+                # values returned from APIs like GetSystemMetrics(SM_CXSIZEFRAME)
                 "/SUBSYSTEM:WINDOWS,5.02"
               ],
             },

--- a/electron.gyp
+++ b/electron.gyp
@@ -128,11 +128,9 @@
               'AdditionalManifestFiles': 'atom/browser/resources/win/atom.manifest',
             },
             'VCLinkerTool': {
-              'AdditionalOptions': [
-                # Chrome builds with this minimum environment which changes the
-                # values returned from APIs like GetSystemMetrics(SM_CXSIZEFRAME)
-                "/SUBSYSTEM:WINDOWS,5.02"
-              ],
+              # Chrome builds with this minimum environment which changes the
+              # values returned from APIs like GetSystemMetrics(SM_CXSIZEFRAME)
+              'MinimumRequiredVersion': '5.02'
             },
           },
           'copies': [

--- a/electron.gyp
+++ b/electron.gyp
@@ -126,7 +126,12 @@
             'VCManifestTool': {
               'EmbedManifest': 'true',
               'AdditionalManifestFiles': 'atom/browser/resources/win/atom.manifest',
-            }
+            },
+            'VCLinkerTool': {
+              'AdditionalOptions': [
+                "/SUBSYSTEM:WINDOWS,5.02"
+              ],
+            },
           },
           'copies': [
             {

--- a/electron.gyp
+++ b/electron.gyp
@@ -128,9 +128,14 @@
               'AdditionalManifestFiles': 'atom/browser/resources/win/atom.manifest',
             },
             'VCLinkerTool': {
-              # Chrome builds with this minimum environment which changes the
-              # values returned from APIs like GetSystemMetrics(SM_CXSIZEFRAME)
-              'MinimumRequiredVersion': '5.02'
+              # Chrome builds with this minimum environment which makes e.g.
+              # GetSystemMetrics(SM_CXSIZEFRAME) return Windows XP/2003
+              # compatible metrics. See: https://crbug.com/361720
+              #
+              # The following two settings translate to a linker flag
+              # of /SUBSYSTEM:WINDOWS,5.02
+              'MinimumRequiredVersion': '5.02',
+              'SubSystem': '2',
             },
           },
           'copies': [


### PR DESCRIPTION
This pull request is an attempt to fix #5267 and #8728.

It removes the custom inset handling in Electron and instead uses Chrome's default inset handling in  [hwnd_message_handler.cc](https://cs.chromium.org/chromium/src/ui/views/win/hwnd_message_handler.cc?l=1162).

This previously did not work because Electron was using different a different linker flag than Chrome that resulted in the system metrics returning incorrect values.

* [Original Chrome gyp fix](https://chromium.googlesource.com/chromium/src.git/+/68c88b0f0a645ac90365686f82edb5cb5580c2e9%5E%21/)
* [BUILD.gn subsystem setting](https://cs.chromium.org/chromium/src/build/config/win/BUILD.gn?dr=C&l=311)
* [Microsoft SUBSYTEM docs](https://msdn.microsoft.com/en-us/library/fcc1zstk.aspx)

I'm not sure if lowering the `SUBSYSTEM` flag to `5.02` has any other consequences, but it does seem to prevent the overflow of maximized frameless windows.

Fixes #5267 
Fixes #8728
Refs #9140 
Refs #8808

/cc @poiru @bsclifton @thesbros @juturu 