### PR TITLE
Fix missing warning icon with dialog.showMessageBox() on macOS

### DIFF
--- a/atom/browser/ui/message_box_mac.mm
+++ b/atom/browser/ui/message_box_mac.mm
@@ -71,10 +71,14 @@ NSAlert* CreateNSAlert(NativeWindow* parent_window,
 
   switch (type) {
     case MESSAGE_BOX_TYPE_INFORMATION:
-      [alert setAlertStyle:NSInformationalAlertStyle];
+      alert.alertStyle = NSInformationalAlertStyle;
       break;
     case MESSAGE_BOX_TYPE_WARNING:
-      [alert setAlertStyle:NSWarningAlertStyle];
+    case MESSAGE_BOX_TYPE_ERROR:
+      // NSWarningAlertStyle shows the app icon while NSCriticalAlertStyle
+      // shows a warning icon with an app icon badge. Since there is no
+      // error variant, lets just use NSCriticalAlertStyle.
+      alert.alertStyle = NSCriticalAlertStyle;
       break;
     default:
       break;
@@ -192,7 +196,7 @@ void ShowErrorBox(const base::string16& title, const base::string16& content) {
   NSAlert* alert = [[NSAlert alloc] init];
   [alert setMessageText:base::SysUTF16ToNSString(title)];
   [alert setInformativeText:base::SysUTF16ToNSString(content)];
-  [alert setAlertStyle:NSWarningAlertStyle];
+  [alert setAlertStyle:NSCriticalAlertStyle];
   [alert runModal];
   [alert release];
 }

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -115,8 +115,9 @@ will be passed via `callback(filename)`
 * `browserWindow` BrowserWindow (optional)
 * `options` Object
   * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
-  `"warning"`. On Windows, "question" displays the same icon as "info", unless
-  you set an icon using the "icon" option.
+  `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
+  you set an icon using the `"icon"` option. On macOS, both `"warning"` and
+  `"error"` display the same warning icon.
   * `buttons` String[] (optional) - Array of texts for buttons. On Windows, an empty array
     will result in one button labeled "OK".
   * `defaultId` Integer (optional) - Index of the button in the buttons array which will


### PR DESCRIPTION
Fixes #9183.