### PR TITLE
Add docs tip about testing Touch Bar usage

### DIFF
--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -16,6 +16,10 @@ Creates a new touch bar with the specified items. Use
 **Note:** The TouchBar API is currently experimental and may change or be
 removed in future Electron releases.
 
+**Tip:** If you don't have a MacBook with Touch Bar, you can use
+[Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator)
+to test Touch Bar usage in your app.
+
 ### Instance Properties
 
 The following properties are available on instances of `TouchBar`:


### PR DESCRIPTION
Disclosure: I made it.

https://github.com/sindresorhus/touch-bar-simulator

Most devs don't have the new MacBook with Touch Bar, but would like to support it. I think it would be useful to point out how to easily develop and test Touch Bar usage in Electron apps.