### PR TITLE
Updated shebangs in all python files to be python2

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os

--- a/script/build-libchromiumcontent.py
+++ b/script/build-libchromiumcontent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os

--- a/script/build.py
+++ b/script/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import re

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import subprocess

--- a/script/clean.py
+++ b/script/clean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import fnmatch
 import os

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import glob

--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/script/install-sysroot.py
+++ b/script/install-sysroot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import errno
 import os

--- a/script/lib/env_util.py
+++ b/script/lib/env_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 

--- a/script/lib/github.py
+++ b/script/lib/github.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import json
 import os

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import atexit
 import contextlib

--- a/script/merge-electron-checksums.py
+++ b/script/merge-electron-checksums.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Download individual checksum files for Electron zip files from S3,
 # concatenate them, and upload to GitHub.

--- a/script/pylint.py
+++ b/script/pylint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import glob
 import os

--- a/script/start.py
+++ b/script/start.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import subprocess

--- a/script/test.py
+++ b/script/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import shutil

--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import errno
 import sys

--- a/script/update.py
+++ b/script/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os

--- a/script/upload-index-json.py
+++ b/script/upload-index-json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import hashlib

--- a/script/upload-node-headers.py
+++ b/script/upload-node-headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import glob

--- a/script/upload-windows-pdb.py
+++ b/script/upload-windows-pdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import glob

--- a/script/upload.py
+++ b/script/upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import errno

--- a/script/verify-ffmpeg.py
+++ b/script/verify-ffmpeg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import shutil

--- a/tools/js2asar.py
+++ b/tools/js2asar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import errno
 import os

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import contextlib
 import glob

--- a/tools/linux/rewrite_dirs.py
+++ b/tools/linux/rewrite_dirs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2011 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/list-browserify-deps.py
+++ b/tools/list-browserify-deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import subprocess
 import sys

--- a/tools/mac/apply_locales.py
+++ b/tools/mac/apply_locales.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2009 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/mac/copy-locales.py
+++ b/tools/mac/copy-locales.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2013 GitHub, Inc.
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.

--- a/tools/mac/find_sdk.py
+++ b/tools/mac/find_sdk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/make_locale_paks.py
+++ b/tools/make_locale_paks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # usage: make_locale_paks build_dir [...]
 #

--- a/tools/posix/generate_breakpad_symbols.py
+++ b/tools/posix/generate_breakpad_symbols.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2013 GitHub, Inc.
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/win/generate_breakpad_symbols.py
+++ b/tools/win/generate_breakpad_symbols.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2013 GitHub, Inc.
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
I found that it's a pain to build electron when you are running os with main python version to be python3. I think shebangs need to be more strict. This pull request updates all shebangs from: 

```
#!/usr/bin/env python
```

to

```
#!/usr/bin/env python2
```