### PR TITLE
Update libcc for electron/libchromiumcontent#285

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -172,6 +172,7 @@ std::string AtomBrowserClient::GetApplicationLocale() {
 }
 
 void AtomBrowserClient::OverrideSiteInstanceForNavigation(
+    content::RenderFrameHost* render_frame_host,
     content::BrowserContext* browser_context,
     content::SiteInstance* current_instance,
     const GURL& url,

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -54,6 +54,7 @@ class AtomBrowserClient : public brightray::BrowserClient,
                            content::WebPreferences* prefs) override;
   std::string GetApplicationLocale() override;
   void OverrideSiteInstanceForNavigation(
+      content::RenderFrameHost* render_frame_host,
       content::BrowserContext* browser_context,
       content::SiteInstance* current_instance,
       const GURL& dest_url,

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '8d551064d2b3d11f89ce8d5c4610f34e0408bad8'
+    '4a0e32606e52c12c50c2e3a0973d015d8cdff494'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
This fixes non-client area DPI scaling on recent Windows 10 versions.
See discussion in #8786.