### PR TITLE
Add OS pid to web-contents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -39,6 +39,7 @@
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/options_switches.h"
+#include "base/process/process_handle.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "brightray/browser/inspectable_web_contents.h"
@@ -46,7 +47,6 @@
 #include "chrome/browser/printing/print_preview_message_handler.h"
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "chrome/browser/ssl/security_state_tab_helper.h"
-#include "base/process/process_handle.h"
 #include "content/browser/frame_host/navigation_entry_impl.h"
 #include "content/browser/renderer_host/render_widget_host_impl.h"
 #include "content/browser/web_contents/web_contents_impl.h"
@@ -77,7 +77,6 @@
 #include "third_party/WebKit/public/platform/WebInputEvent.h"
 #include "third_party/WebKit/public/web/WebFindOptions.h"
 #include "ui/display/screen.h"
-
 
 #if !defined(OS_MACOSX)
 #include "ui/aura/window.h"

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -46,6 +46,7 @@
 #include "chrome/browser/printing/print_preview_message_handler.h"
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "chrome/browser/ssl/security_state_tab_helper.h"
+#include "base/process/process_handle.h"
 #include "content/browser/frame_host/navigation_entry_impl.h"
 #include "content/browser/renderer_host/render_widget_host_impl.h"
 #include "content/browser/web_contents/web_contents_impl.h"
@@ -76,6 +77,7 @@
 #include "third_party/WebKit/public/platform/WebInputEvent.h"
 #include "third_party/WebKit/public/web/WebFindOptions.h"
 #include "ui/display/screen.h"
+
 
 #if !defined(OS_MACOSX)
 #include "ui/aura/window.h"
@@ -959,6 +961,11 @@ int WebContents::GetProcessID() const {
   return web_contents()->GetRenderProcessHost()->GetID();
 }
 
+int WebContents::GetOSProcessID() const {
+  auto process_handle = web_contents()->GetRenderProcessHost()->GetHandle();
+  return base::GetProcId(process_handle);
+}
+
 WebContents::Type WebContents::GetType() const {
   return type_;
 }
@@ -1708,6 +1715,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .MakeDestroyable()
       .SetMethod("getId", &WebContents::GetID)
       .SetMethod("getProcessId", &WebContents::GetProcessID)
+      .SetMethod("getOSProcessId", &WebContents::GetOSProcessID)
       .SetMethod("equal", &WebContents::Equal)
       .SetMethod("_loadURL", &WebContents::LoadURL)
       .SetMethod("downloadURL", &WebContents::DownloadURL)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -82,6 +82,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   int64_t GetID() const;
   int GetProcessID() const;
+  int GetOSProcessID() const;
   Type GetType() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1259,6 +1259,10 @@ Setting the WebRTC IP handling policy allows you to control which IPs are
 exposed via WebRTC.  See [BrowserLeaks](https://browserleaks.com/webrtc) for
 more details.
 
+#### `contents.getOSProcessId()`
+
+Returns `Integer` - The `pid` of the associated renderer process.
+
 ### Instance Properties
 
 #### `contents.id`

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -324,9 +324,8 @@ describe('webContents module', function () {
     })
   })
 
-  describe('getOSProcessId()', function() {
-    it('returns a valid procress id', function() {
-
+  describe('getOSProcessId()', function () {
+    it('returns a valid procress id', function () {
       // load URL otherwise getOSProcessId() returns 0
       w.loadURL('file://' + path.join(__dirname, 'fixtures', 'pages', 'focus-web-contents.html'))
 
@@ -336,7 +335,7 @@ describe('webContents module', function () {
         pid = specWebContents.getOSProcessId()
       })
       assert(typeof pid === 'number', 'is a number')
-      assert(pid > 0 , 'superior to 0')
+      assert(pid > 0, 'superior to 0')
     })
   })
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -324,6 +324,22 @@ describe('webContents module', function () {
     })
   })
 
+  describe('getOSProcessId()', function() {
+    it('returns a valid procress id', function() {
+
+      // load URL otherwise getOSProcessId() returns 0
+      w.loadURL('file://' + path.join(__dirname, 'fixtures', 'pages', 'focus-web-contents.html'))
+
+      const specWebContents = w.webContents
+      let pid = null
+      assert.doesNotThrow(function () {
+        pid = specWebContents.getOSProcessId()
+      })
+      assert(typeof pid === 'number', 'is a number')
+      assert(pid > 0 , 'superior to 0')
+    })
+  })
+
   describe('zoom api', () => {
     const zoomScheme = remote.getGlobal('zoomScheme')
     const hostZoomMap = {


### PR DESCRIPTION
This pull request adds a method (`getOSProcessId`) to `webContents` to have access to the `pid` (actual OS process id) of the associated host render process.

- [x] documentation and testing: should I add a note in documentation and test about it? `getProcessId` is not documented nor tested: what is the logic?
- [x] naming: is method naming ok? `getProcessId` is already [taken](https://github.com/electron/electron/blob/master/atom/browser/api/atom_api_web_contents.cc#L1756) but undocumented.

----
I'm trying to have an overview of `webcontents` resource consumption (in detail, not in a whole), inspired from Chromium task manager (related #820, #3653).
As far as i understand, `process.getProcessMemoryInfo` gives only the *current process* statistics (and no CPU) => having an overview would require to "instrument" every new web-contents and report the stats.

I guessed a more handy and extensible way would be have access to the `pids` of the webcontents and use [whatever userland method](https://github.com/soyuka/pidusage) to get the statistics.