### PR TITLE
Block non-`file://` URLs when `nodeIntegration` is enabled

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -84,7 +84,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   int GetProcessID() const;
   Type GetType() const;
   bool Equal(const WebContents* web_contents) const;
-  void LoadURL(const GURL& url, const mate::Dictionary& options);
+  void LoadURL(const GURL& url,
+               const mate::Dictionary& options,
+               mate::Arguments* args);
   void DownloadURL(const GURL& url);
   GURL GetURL() const;
   base::string16 GetTitle() const;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -197,12 +197,28 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   }
 }
 
-bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
-  WebContentsPreferences* self;
+// static
+bool WebContentsPreferences::IsNodeIntegrationEnabled(
+    content::WebContents* web_contents) {
   if (!web_contents)
     return false;
 
-  self = FromWebContents(web_contents);
+  WebContentsPreferences* self = FromWebContents(web_contents);
+  if (!self)
+    return false;
+
+  base::DictionaryValue& web_preferences = self->web_preferences_;
+  bool nodeIntegration = true;
+  web_preferences.GetBoolean(options::kNodeIntegration, &nodeIntegration);
+  return nodeIntegration;
+}
+
+// static
+bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
+  if (!web_contents)
+    return false;
+
+  WebContentsPreferences* self = FromWebContents(web_contents);
   if (!self)
     return false;
 

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -37,6 +37,8 @@ class WebContentsPreferences
   static void AppendExtraCommandLineSwitches(
       content::WebContents* web_contents, base::CommandLine* command_line);
 
+  static bool IsNodeIntegrationEnabled(content::WebContents* web_contents);
+
   static bool IsSandboxed(content::WebContents* web_contents);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -542,4 +542,53 @@ describe('webContents module', function () {
       })
     })
   })
+
+
+  describe('nodeIntegration only works for file:// scheme', function () {
+    it('blocks non-file:// URLs when nodeIntegration is enabled', function (done) {
+      assert.throws(function () {
+        w.loadURL('https://www.google.com')
+      })
+      done()
+    })
+
+    it('blocks non-file:// navigations when nodeIntegration is enabled', function (done) {
+      w.webContents.on('will-navigate', function (event, url) {
+        assert.ok(false, 'unexpected will-navigate')
+        event.preventDefault()
+      })
+
+      w.loadURL(`file://${fixtures}/pages/will-navigate-google.html`)
+      setTimeout(done, 1000)
+    })
+
+    it('allows non-file:// URLs when nodeIntegration is disabled', function (done) {
+      w.destroy()
+      w = new BrowserWindow({
+        webPreferences: {
+          nodeIntegration: false,
+        }
+      })
+
+      w.loadURL('https://www.google.com')
+      done()
+    })
+
+    it('allows non-file:// navigations when nodeIntegration is disabled', function (done) {
+      w.destroy()
+      w = new BrowserWindow({
+        webPreferences: {
+          nodeIntegration: false,
+        }
+      })
+
+      w.webContents.on('will-navigate', function (event, url) {
+        assert.equal(url, 'https://www.google.com/')
+        event.preventDefault()
+        done()
+      })
+
+      w.loadURL(`file://${fixtures}/pages/will-navigate-google.html`)
+    })
+  })
 })

--- a/spec/fixtures/pages/will-navigate-google.html
+++ b/spec/fixtures/pages/will-navigate-google.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  location.href = 'https://www.google.com'
+</script>
+</body>
+</html>


### PR DESCRIPTION
This is a breaking change, but we must to do what we can to make
Electron secure by default. This is a small and necessary step towards
that goal.