### PR TITLE
Get specs passing on new macOS CI machines

### DIFF
--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -56,7 +56,7 @@ class CrashReporter {
       const env = {
         ELECTRON_INTERNAL_CRASH_SERVICE: 1
       }
-      spawn(process.execPath, args, {
+      this._crashServiceProcess = spawn(process.execPath, args, {
         env: env,
         detached: true
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1474,13 +1474,19 @@ describe('BrowserWindow module', function () {
       // Only implemented on macOS.
       if (process.platform !== 'darwin') return
 
-      it('can be changed with setKiosk method', function () {
+      it('can be changed with setKiosk method', function (done) {
         w.destroy()
         w = new BrowserWindow()
         w.setKiosk(true)
         assert.equal(w.isKiosk(), true)
-        w.setKiosk(false)
-        assert.equal(w.isKiosk(), false)
+
+        w.once('enter-full-screen', () => {
+          w.setKiosk(false)
+          assert.equal(w.isKiosk(), false)
+        })
+        w.once('leave-full-screen', () => {
+          done()
+        })
       })
     })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -86,7 +86,7 @@ describe('crashReporter module', function () {
 
         stopServer = startServer({
           callback (port) {
-            const crashesDir = path.join(app.getPath('temp'), `Zombies Crashes`)
+            const crashesDir = path.join(app.getPath('temp'), `${process.platform === 'win32' ? 'Zombies' : app.getName()} Crashes`)
             const version = app.getVersion()
             const crashPath = path.join(fixtures, 'module', 'crash.js')
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -176,7 +176,7 @@ describe('crashReporter module', function () {
   }
 
   generateSpecs('without sandbox', {})
-  generateSpecs('with sandbox ', {
+  generateSpecs('with sandbox', {
     webPreferences: {
       sandbox: true,
       preload: path.join(fixtures, 'module', 'preload-sandbox.js')

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -157,7 +157,7 @@ describe('crashReporter module', function () {
         if (process.env.APPVEYOR === 'True') return done()
         if (process.env.TRAVIS === 'true') return done()
 
-        this.timeout(10000)
+        this.timeout(120000)
 
         startServer({
           callback (port) {

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -96,10 +96,10 @@ describe('crashReporter module', function () {
                 '--application-name=Zombies',
                 `--crashes-directory=${crashesDir}`
               ], {
-               env: {
-                 ELECTRON_INTERNAL_CRASH_SERVICE: 1
-               },
-               detached: true
+                env: {
+                  ELECTRON_INTERNAL_CRASH_SERVICE: 1
+                },
+                detached: true
               })
               remote.process.crashServicePid = crashServiceProcess.pid
             }

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -49,6 +49,8 @@ describe('crashReporter module', function () {
       afterEach(function (done) {
         if (stopServer != null) {
           stopServer(done)
+        } else {
+          done()
         }
       })
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -90,13 +90,7 @@ describe('chromium feature', function () {
   })
 
   describe('navigator.mediaDevices', function () {
-    if (process.env.TRAVIS === 'true') {
-      return
-    }
-    if (isCI && process.platform === 'linux') {
-      return
-    }
-    if (isCI && process.platform === 'win32') {
+    if (isCI) {
       return
     }
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -107,7 +107,7 @@ describe('chromium feature', function () {
         if (labelFound) {
           done()
         } else {
-          done('No device labels found: ' + JSON.stringify(labels))
+          done(new Error(`No device labels found: ${JSON.stringify(labels)}`))
         }
       }).catch(done)
     })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -13,12 +13,17 @@ const isCI = remote.getGlobal('isCi')
 describe('chromium feature', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
   var listener = null
+  let w = null
 
   afterEach(function () {
     if (listener != null) {
       window.removeEventListener('message', listener)
     }
     listener = null
+  })
+
+  afterEach(function () {
+    return closeWindow(w).then(function () { w = null })
   })
 
   describe('heap snapshot', function () {
@@ -44,11 +49,6 @@ describe('chromium feature', function () {
 
   describe('document.hidden', function () {
     var url = 'file://' + fixtures + '/pages/document-hidden.html'
-    var w = null
-
-    afterEach(function () {
-      return closeWindow(w).then(function () { w = null })
-    })
 
     it('is set correctly when window is not shown', function (done) {
       w = new BrowserWindow({
@@ -119,7 +119,7 @@ describe('chromium feature', function () {
       }
       const deviceIds = []
       const ses = session.fromPartition('persist:media-device-id')
-      let w = new BrowserWindow({
+      w = new BrowserWindow({
         show: false,
         webPreferences: {
           session: ses
@@ -155,11 +155,6 @@ describe('chromium feature', function () {
 
   describe('navigator.serviceWorker', function () {
     var url = 'file://' + fixtures + '/pages/service-worker/index.html'
-    var w = null
-
-    afterEach(function () {
-      return closeWindow(w).then(function () { w = null })
-    })
 
     it('should register for file scheme', function (done) {
       w = new BrowserWindow({
@@ -187,12 +182,6 @@ describe('chromium feature', function () {
     if (process.env.TRAVIS === 'true' && process.platform === 'darwin') {
       return
     }
-
-    let w = null
-
-    afterEach(() => {
-      return closeWindow(w).then(function () { w = null })
-    })
 
     it('returns a BrowserWindowProxy object', function () {
       var b = window.open('about:blank', '', 'show=no')
@@ -343,11 +332,6 @@ describe('chromium feature', function () {
 
   describe('window.opener', function () {
     let url = 'file://' + fixtures + '/pages/window-opener.html'
-    let w = null
-
-    afterEach(function () {
-      return closeWindow(w).then(function () { w = null })
-    })
 
     it('is null for main window', function (done) {
       w = new BrowserWindow({
@@ -849,7 +833,6 @@ describe('chromium feature', function () {
   })
 
   describe('PDF Viewer', function () {
-    let w = null
     const pdfSource = url.format({
       pathname: path.join(fixtures, 'assets', 'cat.pdf').replace(/\\/g, '/'),
       protocol: 'file',
@@ -863,10 +846,6 @@ describe('chromium feature', function () {
           preload: path.join(fixtures, 'module', 'preload-inject-ipc.js')
         }
       })
-    })
-
-    afterEach(function () {
-      return closeWindow(w).then(function () { w = null })
     })
 
     it('opens when loading a pdf resource as top level navigation', function (done) {

--- a/spec/fixtures/api/crash-restart.html
+++ b/spec/fixtures/api/crash-restart.html
@@ -3,7 +3,7 @@
 <script type="text/javascript" charset="utf-8">
 
 const {port} = require('url').parse(window.location.href, true).query
-const {crashReporter} = require('electron')
+const {crashReporter, ipcRenderer} = require('electron')
 
 crashReporter.start({
   productName: 'Zombies',
@@ -17,6 +17,10 @@ crashReporter.start({
     extra3: 'extra3'
   }
 })
+
+if (process.platform === 'win32') {
+  ipcRenderer.sendSync('crash-service-pid', crashReporter._crashServiceProcess.pid)
+}
 
 setImmediate(() => {
   if (process.platform === 'darwin') {

--- a/spec/fixtures/api/crash.html
+++ b/spec/fixtures/api/crash.html
@@ -16,6 +16,11 @@ crashReporter.start({
     'extra2': 'extra2',
   }
 });
+
+if (process.platform === 'win32') {
+  ipcRenderer.sendSync('crash-service-pid', crashReporter._crashServiceProcess.pid)
+}
+
 if (!uploadToServer) {
   ipcRenderer.sendSync('list-existing-dumps')
 }

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -24,7 +24,10 @@ var argv = require('yargs')
   .argv
 
 var window = null
-process.port = 0 // will be used by crash-reporter spec.
+
+ // will be used by crash-reporter spec.
+process.port = 0
+process.crashServicePid = 0
 
 v8.setFlagsFromString('--expose_gc')
 app.commandLine.appendSwitch('js-flags', '--expose_gc')
@@ -327,6 +330,11 @@ ipcMain.on('navigate-with-pending-entry', (event, id) => {
   w.webContents.session.clearHostResolverCache(() => {
     w.loadURL('http://host')
   })
+})
+
+ipcMain.on('crash-service-pid', (event, pid) => {
+  process.crashServicePid = pid
+  event.returnValue = null
 })
 
 // Suspend listeners until the next event and then restore them


### PR DESCRIPTION
This pull requests get the mac specs passing on our new CI cluster.

- Disable `navigator.mediaDevices` specs on macOS CI since these machines have no devices
- Fix racy kiosk mode spec
- Kill crash service process on Windows after spec completes
- Ensure windows get cleaned up if chromium specs fail