### PR TITLE
Wait for close event instead of exit in spec

### DIFF
--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -85,7 +85,7 @@ describe('node feature', function () {
         child.stdout.on('data', (chunk) => {
           data += String(chunk)
         })
-        child.on('exit', (code) => {
+        child.on('close', (code) => {
           assert.equal(code, 0)
           assert.equal(data, 'pipes stdio')
           done()


### PR DESCRIPTION
Noticing a flaky spec on Windows CI:

```
not ok 644 node feature child_process child_process.fork pipes stdio
  AssertionError: '' == 'pipes stdio'
      at ChildProcess.child.on (C:\Users\electron\workspace\electron-win-ia32\spec\node-spec.js:90:18)
      at emitTwo (events.js:106:13)
      at ChildProcess.emit (events.js:191:7)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
```

The `exit` event, according to the node docs, may fire before the streams are done writing so listen for `close` instead which should be fired after streams are closed.