### PR TITLE
Make note about sync webview calls in docs

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -12,7 +12,7 @@ rendered.
 Unlike an `iframe`, the `webview` runs in a separate process than your
 app. It doesn't have the same permissions as your web page and all interactions
 between your app and embedded content will be asynchronous. This keeps your app
-safe from the embedded content. Note, however, that most methods called on the
+safe from the embedded content. **Note:** Most methods called on the
 webview from the host page require a syncronous call to the main process.
 
 For security purposes, `webview` can only be used in `BrowserWindow`s that have

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -12,7 +12,8 @@ rendered.
 Unlike an `iframe`, the `webview` runs in a separate process than your
 app. It doesn't have the same permissions as your web page and all interactions
 between your app and embedded content will be asynchronous. This keeps your app
-safe from the embedded content.
+safe from the embedded content. Note, however, that most methods called on the
+webview from the host page require a syncronous call to the main process.
 
 For security purposes, `webview` can only be used in `BrowserWindow`s that have
 `nodeIntegration` enabled.


### PR DESCRIPTION
This is in reference to the methods defined at https://github.com/electron/electron/blob/master/lib/renderer/web-view/web-view.js#L319-L371

I realized that a workload in the main process was slowing down my render thread. Turns out, it was due to the webview calls, which use sync IPC to main.

I'm not sure this is the ideal wording. It might be a good idea to list the actual methods.