### PR TITLE
Support writing custom formats into clipboard

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -4,8 +4,6 @@
 
 #include "atom/common/api/atom_api_clipboard.h"
 
-#include <map>
-
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/strings/utf_string_conversions.h"
@@ -68,7 +66,6 @@ void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   base::string16 text, html, bookmark;
   gfx::Image image;
-  std::map<std::string, v8::Local<v8::Value>> customBuffers;
 
   if (data.Get("text", &text)) {
     writer.WriteText(text);
@@ -87,14 +84,6 @@ void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {
 
   if (data.Get("image", &image))
     writer.WriteImage(image.AsBitmap());
-
-  if (data.Get("buffers", &customBuffers)) {
-    for (auto i = customBuffers.begin(); i != customBuffers.end(); ++i) {
-      writer.WriteData(node::Buffer::Data(i->second),
-                       node::Buffer::Length(i->second),
-                       ui::Clipboard::GetFormatType(i->first));
-    }
-  }
 }
 
 base::string16 Clipboard::ReadText(mate::Arguments* args) {

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -53,13 +53,17 @@ v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
       args->isolate(), data.data(), data.length()).ToLocalChecked();
 }
 
-void Clipboard::WriteBuffer(const std::string& format_string,
+void Clipboard::WriteBuffer(const std::string& format,
                             const v8::Local<v8::Value> buffer,
                             mate::Arguments* args) {
-  auto format = ui::Clipboard::GetFormatType(format_string);
+  if (!node::Buffer::HasInstance(buffer)) {
+    args->ThrowError("buffer must be a node Buffer");
+    return;
+  }
+
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   writer.WriteData(node::Buffer::Data(buffer), node::Buffer::Length(buffer),
-                   format);
+                   ui::Clipboard::GetFormatType(format));
 }
 
 void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -53,6 +53,15 @@ v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
       args->isolate(), data.data(), data.length()).ToLocalChecked();
 }
 
+void Clipboard::WriteBuffer(const std::string& format_string,
+                            const v8::Local<v8::Value> buffer,
+                            mate::Arguments* args) {
+  auto format = ui::Clipboard::GetFormatType(format_string);
+  ui::ScopedClipboardWriter writer(GetClipboardType(args));
+  writer.WriteData(node::Buffer::Data(buffer), node::Buffer::Length(buffer),
+                   format);
+}
+
 void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   base::string16 text, html, bookmark;
@@ -191,6 +200,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("readFindText", &atom::api::Clipboard::ReadFindText);
   dict.SetMethod("writeFindText", &atom::api::Clipboard::WriteFindText);
   dict.SetMethod("readBuffer", &atom::api::Clipboard::ReadBuffer);
+  dict.SetMethod("writeBuffer", &atom::api::Clipboard::WriteBuffer);
   dict.SetMethod("clear", &atom::api::Clipboard::Clear);
 
   // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -86,7 +86,7 @@ void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {
   if (data.Get("image", &image))
     writer.WriteImage(image.AsBitmap());
 
-  if (data.Get("buffer", &customBuffers)) {
+  if (data.Get("buffers", &customBuffers)) {
     for (auto i = customBuffers.begin(); i != customBuffers.end(); ++i) {
       writer.WriteData(node::Buffer::Data(i->second),
                        node::Buffer::Length(i->second),

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -4,6 +4,8 @@
 
 #include "atom/common/api/atom_api_clipboard.h"
 
+#include <map>
+
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/strings/utf_string_conversions.h"

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -66,6 +66,7 @@ void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   base::string16 text, html, bookmark;
   gfx::Image image;
+  std::map<std::string, v8::Local<v8::Value>> customBuffers;
 
   if (data.Get("text", &text)) {
     writer.WriteText(text);
@@ -84,6 +85,14 @@ void Clipboard::Write(const mate::Dictionary& data, mate::Arguments* args) {
 
   if (data.Get("image", &image))
     writer.WriteImage(image.AsBitmap());
+
+  if (data.Get("buffer", &customBuffers)) {
+    for (auto i = customBuffers.begin(); i != customBuffers.end(); ++i) {
+      writer.WriteData(node::Buffer::Data(i->second),
+                       node::Buffer::Length(i->second),
+                       ui::Clipboard::GetFormatType(i->first));
+    }
+  }
 }
 
 base::string16 Clipboard::ReadText(mate::Arguments* args) {

--- a/atom/common/api/atom_api_clipboard.h
+++ b/atom/common/api/atom_api_clipboard.h
@@ -49,6 +49,9 @@ class Clipboard {
 
   static v8::Local<v8::Value> ReadBuffer(const std::string& format_string,
                                          mate::Arguments* args);
+  static void WriteBuffer(const std::string& format_string,
+                          const v8::Local<v8::Value> buffer,
+                          mate::Arguments* args);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(Clipboard);

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -173,7 +173,7 @@ Writes the `buffer` as `format` into the clipboard.
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` String (optional)
   * `bookmark` String (optional) - The title of the url at `text`.
-  * `buffer` {[format: String]: Buffer} (optional) _Experimental_ - The buffers for each format you want to write
+  * `buffers` {[format: String]: Buffer} (optional) _Experimental_ - The buffers for each format you want to write
 * `type` String (optional)
 
 ```javascript
@@ -181,7 +181,7 @@ const {clipboard} = require('electron')
 clipboard.write({
   text: 'test',
   html: '<b>test</b>',
-  buffer: {
+  buffers: {
     'com.adobe.pdf': pdfData
   }
 })

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -157,7 +157,7 @@ Returns `String` - Reads `format` type from the clipboard.
 
 Returns `Buffer` - Reads `format` type from the clipboard.
 
-### `clipboard.writeBuffer(format, buffer[, type])`
+### `clipboard.writeBuffer(format, buffer[, type])` _Experimental_
 
 * `format` String
 * `buffer` Buffer
@@ -173,7 +173,7 @@ Writes the `buffer` as `format` into the clipboard.
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` String (optional)
   * `bookmark` String (optional) - The title of the url at `text`.
-  * `buffer` {[format: String]: Buffer} (optional) - The buffers for each format you want to write
+  * `buffer` {[format: String]: Buffer} (optional) _Experimental_ - The buffers for each format you want to write
 * `type` String (optional)
 
 ```javascript

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -157,6 +157,14 @@ Returns `String` - Reads `format` type from the clipboard.
 
 Returns `Buffer` - Reads `format` type from the clipboard.
 
+### `clipboard.writeBuffer(format, buffer[, type])`
+
+* `format` String
+* `buffer` Buffer
+* `type` String (optional)
+
+Writes the `buffer` as `format` into the clipboard.
+
 ### `clipboard.write(data[, type])`
 
 * `data` Object
@@ -165,10 +173,17 @@ Returns `Buffer` - Reads `format` type from the clipboard.
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` String (optional)
   * `bookmark` String (optional) - The title of the url at `text`.
+  * `buffer` {[format: String]: Buffer} (optional) - The buffers for each format you want to write
 * `type` String (optional)
 
 ```javascript
 const {clipboard} = require('electron')
-clipboard.write({text: 'test', html: '<b>test</b>'})
+clipboard.write({
+  text: 'test',
+  html: '<b>test</b>',
+  buffer: {
+    'com.adobe.pdf': pdfData
+  }
+})
 ```
 Writes `data` to the clipboard.

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -173,17 +173,10 @@ Writes the `buffer` into the clipboard as `format`.
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` String (optional)
   * `bookmark` String (optional) - The title of the url at `text`.
-  * `buffers` {[format: String]: Buffer} (optional) _Experimental_ - The buffers for each format you want to write
 * `type` String (optional)
 
 ```javascript
 const {clipboard} = require('electron')
-clipboard.write({
-  text: 'test',
-  html: '<b>test</b>',
-  buffers: {
-    'com.adobe.pdf': pdfData
-  }
-})
+clipboard.write({text: 'test', html: '<b>test</b>'})
 ```
 Writes `data` to the clipboard.

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -163,7 +163,7 @@ Returns `Buffer` - Reads `format` type from the clipboard.
 * `buffer` Buffer
 * `type` String (optional)
 
-Writes the `buffer` as `format` into the clipboard.
+Writes the `buffer` into the clipboard as `format`.
 
 ### `clipboard.write(data[, type])`
 

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -107,7 +107,6 @@ describe('clipboard module', function () {
 
       const buffer = Buffer.from('writeBuffer', 'utf8')
       clipboard.writeBuffer('public.utf8-plain-text', buffer)
-      console.log(clipboard.readText())
       assert.equal(clipboard.readText(), 'writeBuffer')
     })
   })

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -94,6 +94,17 @@ describe('clipboard module', function () {
     })
   })
 
+  describe('clipboard.writeBuffer(format, buffer)', () => {
+    it('writes a Buffer for the specified format', () => {
+      if (process.platform !== 'darwin') return
+
+      const buffer = Buffer.from('writeBuffer', 'utf8')
+      clipboard.writeBuffer('public.utf8-plain-text', buffer)
+      console.log(clipboard.readText())
+      assert.equal(clipboard.readText(), 'writeBuffer')
+    })
+  })
+
   describe('clipboard.readBuffer(format)', function () {
     it('returns a Buffer of the content for the specified format', function () {
       if (process.platform !== 'darwin') return

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -76,7 +76,7 @@ describe('clipboard module', function () {
         rtf: '{\\rtf1\\utf8 text}',
         bookmark: 'a title',
         image: p,
-        buffer: {
+        buffers: {
           [pdfType]: pdf
         }
       })

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -1,6 +1,5 @@
 const assert = require('assert')
 const path = require('path')
-const fs = require('fs')
 const {Buffer} = require('buffer')
 
 const {clipboard, nativeImage} = require('electron')
@@ -68,23 +67,17 @@ describe('clipboard module', function () {
       var i = nativeImage.createFromPath(p)
       var markup = process.platform === 'darwin' ? "<meta charset='utf-8'><b>Hi</b>" : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><b>Hi</b>' : '<b>Hi</b>'
       var bookmark = {title: 'a title', url: 'test'}
-      const pdfType = process.platform === 'darwin' ? 'com.adobe.pdf' : 'application/pdf'
-      const pdf = fs.readFileSync(path.join(fixtures, 'assets', 'cat.pdf'))
       clipboard.write({
         text: 'test',
         html: '<b>Hi</b>',
         rtf: '{\\rtf1\\utf8 text}',
         bookmark: 'a title',
-        image: p,
-        buffers: {
-          [pdfType]: pdf
-        }
+        image: p
       })
       assert.equal(clipboard.readText(), text)
       assert.equal(clipboard.readHTML(), markup)
       assert.equal(clipboard.readRTF(), rtf)
       assert.equal(clipboard.readImage().toDataURL(), i.toDataURL())
-      assert.deepEqual(clipboard.readBuffer(pdfType), pdf)
 
       if (process.platform !== 'linux') {
         assert.deepEqual(clipboard.readBookmark(), bookmark)

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -109,6 +109,12 @@ describe('clipboard module', function () {
       clipboard.writeBuffer('public.utf8-plain-text', buffer)
       assert.equal(clipboard.readText(), 'writeBuffer')
     })
+
+    it('throws an error when a non-Buffer is specified', () => {
+      assert.throws(() => {
+        clipboard.writeBuffer('public.utf8-plain-text', 'hello')
+      }, /buffer must be a node Buffer/)
+    })
   })
 
   describe('clipboard.readBuffer(format)', function () {

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const path = require('path')
+const fs = require('fs')
 const {Buffer} = require('buffer')
 
 const {clipboard, nativeImage} = require('electron')
@@ -67,17 +68,23 @@ describe('clipboard module', function () {
       var i = nativeImage.createFromPath(p)
       var markup = process.platform === 'darwin' ? "<meta charset='utf-8'><b>Hi</b>" : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><b>Hi</b>' : '<b>Hi</b>'
       var bookmark = {title: 'a title', url: 'test'}
+      const pdfType = process.platform === 'darwin' ? 'com.adobe.pdf' : 'application/pdf'
+      const pdf = fs.readFileSync(path.join(fixtures, 'assets', 'cat.pdf'))
       clipboard.write({
         text: 'test',
         html: '<b>Hi</b>',
         rtf: '{\\rtf1\\utf8 text}',
         bookmark: 'a title',
-        image: p
+        image: p,
+        buffer: {
+          [pdfType]: pdf
+        }
       })
       assert.equal(clipboard.readText(), text)
       assert.equal(clipboard.readHTML(), markup)
       assert.equal(clipboard.readRTF(), rtf)
       assert.equal(clipboard.readImage().toDataURL(), i.toDataURL())
+      assert.deepEqual(clipboard.readBuffer(pdfType), pdf)
 
       if (process.platform !== 'linux') {
         assert.deepEqual(clipboard.readBookmark(), bookmark)


### PR DESCRIPTION
This adds APIs for writing custom formats into clipboard. (Thanks @poiru for https://github.com/electron/libchromiumcontent/pull/278)

Fix #5698