### PR TITLE
Clarify requirements for resumable downloads

### DIFF
--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -100,7 +100,7 @@ Returns `Boolean` - Whether the download is paused.
 
 Resumes the download that has been paused.
 
-**Note:** To enable resumable downloads the server you are downloading from must support range requests and provide a Last-Modified as well as an ETag header value. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning. 
+**Note:** To enable resumable downloads the server you are downloading from must support range requests and provide a `Last-Modified` and `ETag` header value. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning. 
 
 #### `downloadItem.canResume()`
 

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -100,6 +100,8 @@ Returns `Boolean` - Whether the download is paused.
 
 Resumes the download that has been paused.
 
+**Note:** To enable resumable downloads in the narrow sense the server you are downloading from must support range requests and provide a Last-Modified as well as an ETag header value. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning. 
+
 #### `downloadItem.canResume()`
 
 Resumes `Boolean` - Whether the download can resume.

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -100,7 +100,7 @@ Returns `Boolean` - Whether the download is paused.
 
 Resumes the download that has been paused.
 
-**Note:** To enable resumable downloads in the narrow sense the server you are downloading from must support range requests and provide a Last-Modified as well as an ETag header value. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning. 
+**Note:** To enable resumable downloads the server you are downloading from must support range requests and provide a Last-Modified as well as an ETag header value. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning. 
 
 #### `downloadItem.canResume()`
 

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -100,7 +100,7 @@ Returns `Boolean` - Whether the download is paused.
 
 Resumes the download that has been paused.
 
-**Note:** To enable resumable downloads the server you are downloading from must support range requests and provide a `Last-Modified` and `ETag` header value. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning. 
+**Note:** To enable resumable downloads the server you are downloading from must support range requests and provide both `Last-Modified` and `ETag` header values. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning. 
 
 #### `downloadItem.canResume()`
 


### PR DESCRIPTION
I stumbled upon this while trying to make use of resumable downloads in electron. Although the server supported range requests that worked well with other clients like (Chrome, curl and wget) `DownloadItem.resume()` always started over at 0 bytes after resuming from `interrupted` state instead of continuing where the download was paused.


