### PR TITLE
Stream test output on Windows CI

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -86,8 +86,6 @@ def main():
     run_script('create-dist.py')
     run_script('upload.py')
   else:
-    if PLATFORM == 'win32':
-      os.environ['OUTPUT_TO_FILE'] = 'output.log'
     run_script('build.py', ['-c', 'D'])
     if PLATFORM == 'win32' or target_arch == 'x64':
       run_script('test.py', ['--ci'])


### PR DESCRIPTION
Now that we have new Windows 10 CI machines, remove the output file so test output is streamed making it easier to monitor from the Jenkins console.

I believe this created some crashes in the past but figured it was worth trying to see if this is no longer an issue.