### PR TITLE
Inherit javascript preference in opened windows

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -30,6 +30,10 @@ has to be a field of `BrowserWindow`'s options.
 
 * Node integration will always be disabled in the opened `window` if it is
   disabled on the parent window.
+* Context isolation will always be enabled in the opened `window` if it is
+  enabled on the parent window.
+* JavaScript will always be disabled in the opened `window` if it is disabled on
+  the parent window.
 * Non-standard features (that are not handled by Chromium or Electron) given in
   `features` will be passed to any registered `webContent`'s `new-window` event
   handler in the `additionalFeatures` argument.

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -48,7 +48,7 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     options.webPreferences.nodeIntegration = false
   }
 
-  // Enable context isolation on child window if enable on parent window
+  // Enable context isolation on child window if enabled on parent window
   if (embedder.getWebPreferences().contextIsolation === true) {
     options.webPreferences.contextIsolation = true
   }
@@ -186,7 +186,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, frameName, 
   const options = {}
 
   const ints = ['x', 'y', 'width', 'height', 'minWidth', 'maxWidth', 'minHeight', 'maxHeight', 'zoomFactor']
-  const webPreferences = ['zoomFactor', 'nodeIntegration', 'preload']
+  const webPreferences = ['zoomFactor', 'nodeIntegration', 'preload', 'javascript', 'contextIsolation']
   const disposition = 'new-window'
 
   // Used to store additional features

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -53,6 +53,11 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     options.webPreferences.contextIsolation = true
   }
 
+  // Disable JavaScript on child window if disabled on parent window
+  if (embedder.getWebPreferences().javascript === false) {
+    options.webPreferences.javascript = false
+  }
+
   // Sets correct openerId here to give correct options to 'new-window' event handler
   options.webPreferences.openerId = embedder.id
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -229,6 +229,31 @@ describe('chromium feature', function () {
       b = window.open(windowUrl, '', 'nodeIntegration=no,show=no')
     })
 
+    it('disables JavaScript when it is disabled on the parent window', function (done) {
+      var b
+      app.once('web-contents-created', (event, contents) => {
+        contents.once('did-finish-load', () => {
+          app.once('browser-window-created', (event, window) => {
+            const preferences = window.webContents.getWebPreferences()
+            assert.equal(preferences.javascript, false)
+            window.destroy()
+            b.close()
+            done()
+          })
+          // Click link on page
+          contents.sendInputEvent({type: 'mouseDown', clickCount: 1, x: 1, y: 1})
+          contents.sendInputEvent({type: 'mouseUp', clickCount: 1, x: 1, y: 1})
+        })
+      })
+
+      var windowUrl = require('url').format({
+        pathname: `${fixtures}/pages/window-no-javascript.html`,
+        protocol: 'file',
+        slashes: true
+      })
+      b = window.open(windowUrl, '', 'javascript=no,show=no')
+    })
+
     it('does not override child options', function (done) {
       var b, size
       size = {

--- a/spec/fixtures/pages/window-no-javascript.html
+++ b/spec/fixtures/pages/window-no-javascript.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<style>
+  * {
+    padding: 0;
+    margin: 0;
+  }
+</style>
+<body>
+<a href="about:blank>" target="_blank">CLICK</a>
+</body>
+</html>


### PR DESCRIPTION
Currently the `nodeIntegration` and `contextIsolation` web preferences are inherited in windows opened via `window.open`.

This pull request adds the `javascript` web preference to that list so that windows with JavaScript disabled cannot open windows with JavaScript enabled.