### PR TITLE
Convert alert/confirm arguments to strings in render process

### DIFF
--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -121,11 +121,11 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage) => {
   }
 
   window.alert = function (message, title) {
-    ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_ALERT', message, title)
+    ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_ALERT', `${message}`, `${title}`)
   }
 
   window.confirm = function (message, title) {
-    return ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_CONFIRM', message, title)
+    return ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_CONFIRM', `${message}`, `${title}`)
   }
 
   // But we do not support prompt().

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -880,4 +880,28 @@ describe('chromium feature', function () {
       })
     })
   })
+
+  describe('window.alert(message, title)', function () {
+    it('throws an exception when the arguments cannot be converted to strings', function () {
+      assert.throws(function () {
+        window.alert({toString: null})
+      }, /Cannot convert object to primitive value/)
+
+      assert.throws(function () {
+        window.alert('message', {toString: 3})
+      }, /Cannot convert object to primitive value/)
+    })
+  })
+
+  describe('window.confirm(message, title)', function () {
+    it('throws an exception when the arguments cannot be converted to strings', function () {
+      assert.throws(function () {
+        window.confirm({toString: null}, 'title')
+      }, /Cannot convert object to primitive value/)
+
+      assert.throws(function () {
+        window.confirm('message', {toString: 3})
+      }, /Cannot convert object to primitive value/)
+    })
+  })
 })


### PR DESCRIPTION
Currently if converting the message or title arguments to a string in the main process throws an exception then the IPC return value is never set and so the render process becomes unresponsive.

This pull request switches `window.alert` and `window.confirm` to convert the arguments to strings in the render process so the errors are properly thrown there which is the same behavior in standalone Chrome.