### PR TITLE
Log all crashes during spec running

### DIFF
--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -2,20 +2,15 @@
 process.throwDeprecation = true
 
 const electron = require('electron')
-const app = electron.app
-const crashReporter = electron.crashReporter
-const ipcMain = electron.ipcMain
-const dialog = electron.dialog
-const BrowserWindow = electron.BrowserWindow
-const protocol = electron.protocol
-const webContents = electron.webContents
-const v8 = require('v8')
+const {app, BrowserWindow, crashReporter, dialog, ipcMain, protocol, webContents} = electron
 
-const Coverage = require('electabul').Coverage
+const {Coverage} = require('electabul')
+
 const fs = require('fs')
 const path = require('path')
 const url = require('url')
 const util = require('util')
+const v8 = require('v8')
 
 var argv = require('yargs')
   .boolean('ci')
@@ -101,6 +96,12 @@ protocol.registerStandardSchemes([global.standardScheme, global.zoomScheme], { s
 
 app.on('window-all-closed', function () {
   app.quit()
+})
+
+app.on('web-contents-created', (event, contents) => {
+  contents.on('crashed', (event, killed) => {
+    console.log(`webContents ${contents.id} crashed: ${contents.getURL()} (killed=${killed})`)
+  })
 })
 
 app.on('ready', function () {


### PR DESCRIPTION
There is a flaky spec on CI that is timing out and possibly crashing:

```
not ok 677 <webview> tag nodeintegration attribute loads node symbols after POST navigation when set
  Error: Timeout of 180000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at C:\Users\electron\workspace\electron-win-x64\spec\node_modules\mocha\lib\runnable.js:232:19
```

This pull request logs out all crashes during test runs to help diagnose.