### PR TITLE
Emit auto updater error directly as Error

### DIFF
--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -7,6 +7,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/window_list.h"
+#include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/node_includes.h"
 #include "base/time/time.h"
@@ -47,7 +48,9 @@ void AutoUpdater::OnError(const std::string& message) {
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   auto error = v8::Exception::Error(mate::StringToV8(isolate(), message));
-  EmitCustomEvent(
+  mate::EmitEvent(
+      isolate(),
+      GetWrapper(),
       "error",
       error->ToObject(isolate()->GetCurrentContext()).ToLocalChecked(),
       // Message is also emitted to keep compatibility with old code.

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -67,6 +67,10 @@ if (!process.mas) {
 
     describe('error event', function () {
       it('serializes correctly over the remote module', function (done) {
+        if (process.platform === 'linux') {
+          return done()
+        }
+
         autoUpdater.once('error', function (error) {
           assert.equal(error instanceof Error, true)
           assert.deepEqual(Object.getOwnPropertyNames(error), ['stack', 'message', 'name'])

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
-const autoUpdater = require('electron').remote.autoUpdater
-const ipcRenderer = require('electron').ipcRenderer
+const {autoUpdater} = require('electron').remote
+const {ipcRenderer} = require('electron')
 
 // Skip autoUpdater tests in MAS build.
 if (!process.mas) {
@@ -62,6 +62,22 @@ if (!process.mas) {
           done()
         })
         autoUpdater.quitAndInstall()
+      })
+    })
+
+    describe('error event', function () {
+      it('serializes correctly over the remote module', function (done) {
+        autoUpdater.once('error', function (error) {
+          assert.equal(error instanceof Error, true)
+          assert.deepEqual(Object.getOwnPropertyNames(error), ['stack', 'message', 'name'])
+          done()
+        })
+
+        autoUpdater.setFeedURL('')
+
+        if (process.platform === 'win32') {
+          autoUpdater.checkForUpdates()
+        }
       })
     })
   })


### PR DESCRIPTION
Previously the error was wrapped up as an event object which meant its `stack` and `message` properties were stripped from it when transferred over the `remote` module.

Now it is emitted directly as an `Error` object which keeps all its standard property descriptors.

/cc @joshaber 