### PR TITLE
Disable node integration in chrome-devtools URLs

### DIFF
--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -78,7 +78,7 @@ for (let arg of process.argv) {
 if (window.location.protocol === 'chrome-devtools:') {
   // Override some inspector APIs.
   require('./inspector')
-  nodeIntegration = 'true'
+  nodeIntegration = 'false'
 } else if (window.location.protocol === 'chrome-extension:') {
   // Add implementations of chrome API.
   require('./chrome-api').injectTo(window.location.hostname, isBackgroundPage, window)

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -229,6 +229,20 @@ describe('chromium feature', function () {
       b = window.open(windowUrl, '', 'nodeIntegration=no,show=no')
     })
 
+    it('disables node integration when it is disabled on the parent window for chrome devtools URLs', function (done) {
+      var b
+      app.once('web-contents-created', (event, contents) => {
+        contents.once('did-finish-load', () => {
+          contents.executeJavaScript('typeof process').then((typeofProcessGlobal) => {
+            assert.equal(typeofProcessGlobal, 'undefined')
+            b.close()
+            done()
+          }).catch(done)
+        })
+      })
+      b = window.open('chrome-devtools://devtools/bundled/inspector.html', '', 'nodeIntegration=no,show=no')
+    })
+
     it('disables JavaScript when it is disabled on the parent window', function (done) {
       var b
       app.once('web-contents-created', (event, contents) => {


### PR DESCRIPTION
This pull request update the renderer `init.js` script to disable node integration in `chrome-devtools` URLs.

The `inspector.js` script seems to only depend on `require` which will be available when node integration is disabled since the script is `require`-ed directly in `init.js`.

Tested this change manually and the dialog and menu still appeared in the dev tools.
