### PR TITLE
Extract script tags to renderer.js file in default app

### DIFF
--- a/default_app/index.html
+++ b/default_app/index.html
@@ -113,24 +113,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const {remote, shell} = require('electron');
-
-    const execPath = remote.process.execPath;
-    const command = execPath + ' path-to-your-app';
-
-    document.onclick = function(e) {
-      e.preventDefault();
-      if (e.target.tagName == 'A')
-        shell.openExternal(e.target.href);
-      return false;
-    };
-    document.ondragover = document.ondrop = function(e) {
-      e.preventDefault();
-      return false;
-    };
-  </script>
-
   <div class="header">
     <svg class="header-icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
       <g stroke="none" fill="none" fill-rule="evenodd">
@@ -185,31 +167,7 @@
   </div>
 
   <script>
-    const holder = document.getElementById('holder');
-    holder.ondragover = function () {
-      this.className = 'hover';
-      return false;
-    };
-    holder.ondragleave = holder.ondragend = function () {
-      this.className = '';
-      return false;
-    };
-    holder.ondrop = function (e) {
-      this.className = '';
-      e.preventDefault();
-
-      const file = e.dataTransfer.files[0];
-      require('child_process').execFile(execPath, [file.path], {
-        detached: true, stdio: 'ignore'
-      }).unref();
-      return false;
-    };
-
-    const version = process.versions.electron;
-    document.querySelector('.header-version').innerText = version;
-    document.querySelector('.command-example').innerText = command;
-    document.querySelector('.quick-start-link').href = `https://github.com/electron/electron/blob/v${version}/docs/tutorial/quick-start.md`;
-    document.querySelector('.docs-link').href = `https://github.com/electron/electron/tree/v${version}/docs#readme`;
+    require('./renderer')
   </script>
 </body>
 </html>

--- a/default_app/renderer.js
+++ b/default_app/renderer.js
@@ -1,0 +1,45 @@
+const {remote, shell} = require('electron')
+const {execFile} = require('child_process')
+
+const {execPath} = remote.process
+
+document.onclick = function (e) {
+  e.preventDefault()
+  if (e.target.tagName === 'A') {
+    shell.openExternal(e.target.href)
+  }
+  return false
+}
+
+document.ondragover = document.ondrop = function (e) {
+  e.preventDefault()
+  return false
+}
+
+const holder = document.getElementById('holder')
+holder.ondragover = function () {
+  this.className = 'hover'
+  return false
+}
+
+holder.ondragleave = holder.ondragend = function () {
+  this.className = ''
+  return false
+}
+
+holder.ondrop = function (e) {
+  this.className = ''
+  e.preventDefault()
+
+  const file = e.dataTransfer.files[0]
+  execFile(execPath, [file.path], {
+    detached: true, stdio: 'ignore'
+  }).unref()
+  return false
+}
+
+const version = process.versions.electron
+document.querySelector('.header-version').innerText = version
+document.querySelector('.command-example').innerText = `${execPath} path-to-your-app`
+document.querySelector('.quick-start-link').href = `https://github.com/electron/electron/blob/v${version}/docs/tutorial/quick-start.md`
+document.querySelector('.docs-link').href = `https://github.com/electron/electron/tree/v${version}/docs#readme`

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -89,6 +89,7 @@
       'default_app/index.html',
       'default_app/main.js',
       'default_app/package.json',
+      'default_app/renderer.js',
     ],
     'lib_sources': [
       'atom/app/atom_content_client.cc',


### PR DESCRIPTION
This pull request extracts the multiple script tags in  `default_app` to a single `renderer.js` script.

- Removes lots of JS lint since `index.html` wasn't being linted
- Makes the default app more consistent with the quick start app
- Variables no longer leak into global context