### PR TITLE
Throw string conversion errors in render process

### DIFF
--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -32,6 +32,10 @@ const resolveURL = function (url) {
   return a.href
 }
 
+const toString = (value) => {
+  return value != null ? `${value}` : value
+}
+
 const windowProxies = {}
 
 const getOrCreateProxy = (ipcRenderer, guestId) => {
@@ -112,7 +116,7 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage) => {
     if (url != null && url !== '') {
       url = resolveURL(url)
     }
-    const guestId = ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, frameName, features)
+    const guestId = ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, toString(frameName), toString(features))
     if (guestId != null) {
       return getOrCreateProxy(ipcRenderer, guestId)
     } else {
@@ -121,11 +125,11 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage) => {
   }
 
   window.alert = function (message, title) {
-    ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_ALERT', `${message}`, `${title}`)
+    ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_ALERT', toString(message), toString(title))
   }
 
   window.confirm = function (message, title) {
-    return ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_CONFIRM', `${message}`, `${title}`)
+    return ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_CONFIRM', toString(message), toString(title))
   }
 
   // But we do not support prompt().

--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -32,6 +32,9 @@ const resolveURL = function (url) {
   return a.href
 }
 
+// Use this method to ensure value expected as string in the main process
+// are convertible to string in the renderer process. This ensures exceptions
+// converting values to string are thrown in this process.
 const toString = (value) => {
   return value != null ? `${value}` : value
 }
@@ -86,7 +89,7 @@ function BrowserWindowProxy (ipcRenderer, guestId) {
   }
 
   this.postMessage = (message, targetOrigin) => {
-    ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', guestId, message, targetOrigin, window.location.origin)
+    ipcRenderer.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', guestId, message, toString(targetOrigin), window.location.origin)
   }
 
   this.eval = (...args) => {

--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -32,9 +32,9 @@ const resolveURL = function (url) {
   return a.href
 }
 
-// Use this method to ensure value expected as string in the main process
-// are convertible to string in the renderer process. This ensures exceptions
-// converting values to string are thrown in this process.
+// Use this method to ensure values expected as strings in the main process
+// are convertible to strings in the renderer process. This ensures exceptions
+// converting values to strings are thrown in this process.
 const toString = (value) => {
   return value != null ? `${value}` : value
 }

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -548,6 +548,14 @@ describe('chromium feature', function () {
       })
       b = window.open('file://' + fixtures + '/pages/window-open-postMessage.html', '', 'show=no')
     })
+
+    it('throws an exception when the targetOrigin cannot be converted to a string', function () {
+      var b = window.open('')
+      assert.throws(function () {
+        b.postMessage('test', {toString: null})
+      }, /Cannot convert object to primitive value/)
+      b.close()
+    })
   })
 
   describe('window.opener.postMessage', function () {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -361,6 +361,16 @@ describe('chromium feature', function () {
       })
       b = window.open()
     })
+
+    it('throws an exception when the arguments cannot be converted to strings', function () {
+      assert.throws(function () {
+        window.open('', {toString: null})
+      }, /Cannot convert object to primitive value/)
+
+      assert.throws(function () {
+        window.open('', '', {toString: 3})
+      }, /Cannot convert object to primitive value/)
+    })
   })
 
   describe('window.opener', function () {


### PR DESCRIPTION
Follow on to #9252, throw errors converting arguments to strings in the renderer process instead of the main process.