### PR TITLE
Store frames to guest as Map

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -5,7 +5,7 @@ const {isSameOrigin} = process.atomBinding('v8_util')
 const parseFeaturesString = require('../common/parse-features-string')
 
 const hasProp = {}.hasOwnProperty
-const frameToGuest = {}
+const frameToGuest = new Map()
 
 // Copy attribute of |parent| to |child| if it is not defined in |child|.
 const mergeOptions = function (child, parent, visited) {
@@ -92,10 +92,10 @@ const setupGuest = function (embedder, frameName, guest, options) {
     guest.once('closed', closedByUser)
   }
   if (frameName) {
-    frameToGuest[frameName] = guest
+    frameToGuest.set(frameName, guest)
     guest.frameName = frameName
     guest.once('closed', function () {
-      delete frameToGuest[frameName]
+      frameToGuest.delete(frameName)
     })
   }
   return guestId
@@ -103,7 +103,7 @@ const setupGuest = function (embedder, frameName, guest, options) {
 
 // Create a new guest created by |embedder| with |options|.
 const createGuest = function (embedder, url, frameName, options, postData) {
-  let guest = frameToGuest[frameName]
+  let guest = frameToGuest.get(frameName)
   if (frameName && (guest != null)) {
     guest.loadURL(url)
     return guest.webContents.id

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -371,6 +371,26 @@ describe('chromium feature', function () {
         window.open('', '', {toString: 3})
       }, /Cannot convert object to primitive value/)
     })
+
+    it('sets the window title to the specified frameName', function (done) {
+      let b
+      app.once('browser-window-created', (event, createdWindow) => {
+        assert.equal(createdWindow.getTitle(), 'hello')
+        b.close()
+        done()
+      })
+      b = window.open('', 'hello')
+    })
+
+    it('does not throw an exception when the frameName is a built-in object property', function (done) {
+      let b
+      app.once('browser-window-created', (event, createdWindow) => {
+        assert.equal(createdWindow.getTitle(), '__proto__')
+        b.close()
+        done()
+      })
+      b = window.open('', '__proto__')
+    })
   })
 
   describe('window.opener', function () {


### PR DESCRIPTION
Using an object for this mapping causes errors to be thrown if the frame name matched a built-in object property (like `__proto__`). Now it uses a `Map` which supports all frame names.