### PR TITLE
Don't allow webPreferences to be overridden in features string

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -202,6 +202,10 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, frameName, 
     if (value === undefined) {
       additionalFeatures.push(key)
     } else {
+      // Don't allow webPreferences to be set since it must be an object
+      // that cannot be directly overridden
+      if (key === 'webPreferences') return
+
       if (webPreferences.includes(key)) {
         if (options.webPreferences == null) {
           options.webPreferences = {}

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -347,6 +347,14 @@ describe('chromium feature', function () {
       })
       b = window.open()
     })
+
+    it('does not throw an error when the features include webPreferences', function () {
+      let b
+      assert.doesNotThrow(function () {
+        b = window.open('', '', 'webPreferences=')
+      })
+      b.close()
+    })
   })
 
   describe('window.opener', function () {


### PR DESCRIPTION
Specifying a features string of `webPreferences=` would previously throw an uncaught main process exception since that options key is assumed to be an object.

This pull request prevents it from being set since the feature string isn't intended to support setting objects directly anyway. This does not change the behavior of setting other window options or web preferences from the features string.