### PR TITLE
Coerce window.history.go offset argument to number in renderer process

### DIFF
--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -164,7 +164,7 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage) => {
   }
 
   window.history.go = function (offset) {
-    sendHistoryOperation(ipcRenderer, 'goToOffset', offset)
+    sendHistoryOperation(ipcRenderer, 'goToOffset', +offset)
   }
 
   defineProperty(window.history, 'length', {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -989,4 +989,12 @@ describe('chromium feature', function () {
       }, /Cannot convert object to primitive value/)
     })
   })
+
+  describe('window.history.go(offset)', function () {
+    it('throws an exception when the argumnet cannot be converted to a string', function () {
+      assert.throws(function () {
+        window.history.go({toString: null})
+      }, /Cannot convert object to primitive value/)
+    })
+  })
 })


### PR DESCRIPTION
Similar to #9252 and #9286, another case of bad input causing a main process error when the error should be thrown in the render process to match chrome's behavior and make the issue easier to diagnose.