### PR TITLE
Fix #8911

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -872,6 +872,15 @@ void WebContents::Observe(int type,
   }
 }
 
+void WebContents::BeforeUnloadDialogCancelled() {
+  if (deferred_load_url_.id) {
+    auto& controller = web_contents()->GetController();
+    if (!controller.GetPendingEntry()) {
+      deferred_load_url_.id = 0;
+    }
+  }
+}
+
 void WebContents::DevToolsReloadPage() {
   Emit("devtools-reload-page");
 }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -340,6 +340,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void Observe(int type,
                const content::NotificationSource& source,
                const content::NotificationDetails& details) override;
+  void BeforeUnloadDialogCancelled() override;
 
   // brightray::InspectableWebContentsDelegate:
   void DevToolsReloadPage() override;

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1174,6 +1174,60 @@ describe('BrowserWindow module', function () {
       })
       w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-empty-string.html'))
     })
+
+    it('emits for each close attempt', function (done) {
+      var beforeUnloadCount = 0
+      w.on('onbeforeunload', function () {
+        beforeUnloadCount++
+        if (beforeUnloadCount < 3) {
+          w.close()
+        } else if (beforeUnloadCount === 3) {
+          done()
+        }
+      })
+      w.webContents.once('did-finish-load', function () {
+        w.close()
+      })
+      w.loadURL('file://' + path.join(fixtures, 'api', 'beforeunload-false-prevent3.html'))
+    })
+
+    it('emits for each reload attempt', function (done) {
+      var beforeUnloadCount = 0
+      w.on('onbeforeunload', function () {
+        beforeUnloadCount++
+        if (beforeUnloadCount < 3) {
+          w.reload()
+        } else if (beforeUnloadCount === 3) {
+          done()
+        }
+      })
+      w.webContents.once('did-finish-load', function () {
+        w.webContents.once('did-finish-load', function () {
+          assert.fail('Reload was not prevented')
+        })
+        w.reload()
+      })
+      w.loadURL('file://' + path.join(fixtures, 'api', 'beforeunload-false-prevent3.html'))
+    })
+
+    it('emits for each navigation attempt', function (done) {
+      var beforeUnloadCount = 0
+      w.on('onbeforeunload', function () {
+        beforeUnloadCount++
+        if (beforeUnloadCount < 3) {
+          w.loadURL('about:blank')
+        } else if (beforeUnloadCount === 3) {
+          done()
+        }
+      })
+      w.webContents.once('did-finish-load', function () {
+        w.webContents.once('did-finish-load', function () {
+          assert.fail('Navigation was not prevented')
+        })
+        w.loadURL('about:blank')
+      })
+      w.loadURL('file://' + path.join(fixtures, 'api', 'beforeunload-false-prevent3.html'))
+    })
   })
 
   describe('new-window event', function () {

--- a/spec/fixtures/api/beforeunload-false-prevent3.html
+++ b/spec/fixtures/api/beforeunload-false-prevent3.html
@@ -1,0 +1,17 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  // Only prevent unload on the first three window closes
+  var unloadPreventedCount = 0;
+  window.onbeforeunload = function() {
+    setTimeout(function() {
+      require('electron').remote.getCurrentWindow().emit('onbeforeunload');
+    }, 0);
+    if (unloadPreventedCount < 3) {
+      unloadPreventedCount++;
+      return false;
+    }
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
This would be an addition to the changes in #8724 to handle cases where the navigation is cancelled.

I'm not completely sure that overriding the `BeforeUnloadDialogCancelled` method is the best way to handle this, or if there's more that should be cleaned up.  This fixes the one case I was testing for (#8911) and doesn't break any unit tests (at least when I run them), but I didn't do much other testing to see if there are any other negative side-effects.

And this is my first time even looking at the Electron source code, so don't make any assumptions that I know what I'm doing here.

Fixes #8911