### PR TITLE
Use isSameOrigin helper when checking postMessage targetOrigin

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -309,7 +309,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, 
   // The W3C does not seem to have word on how postMessage should work when the
   // origins do not match, so we do not do |canAccessWindow| check here since
   // postMessage across origins is useful and not harmful.
-  if (guestContents.getURL().indexOf(targetOrigin) === 0 || targetOrigin === '*') {
+  if (targetOrigin === '*' || isSameOrigin(guestContents.getURL(), targetOrigin)) {
     const sourceId = event.sender.id
     guestContents.send('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin)
   }

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -645,7 +645,7 @@ describe('chromium feature', function () {
         listener = function (event) {
           window.removeEventListener('message', listener)
           b.close()
-          assert.equal(event.data, 'second message')
+          assert.equal(event.data, 'deliver')
           done()
         }
         window.addEventListener('message', listener)

--- a/spec/fixtures/pages/window-opener-targetOrigin.html
+++ b/spec/fixtures/pages/window-opener-targetOrigin.html
@@ -4,10 +4,16 @@
   const url = require('url')
   if (url.parse(window.location.href, true).query.opened != null) {
     // Ensure origins are properly checked by removing a single character from the end
-    window.opener.postMessage('first message', window.location.origin.substring(0, window.location.origin.length - 1))
-    window.opener.postMessage('second message', window.location.origin)
+    window.opener.postMessage('do not deliver substring origin', window.location.origin.substring(0, window.location.origin.length - 1))
+    window.opener.postMessage('do not deliver file://', 'file://')
+    window.opener.postMessage('do not deliver http without port', 'http://127.0.0.1')
+    window.opener.postMessage('do not deliver atom', 'atom://')
+    window.opener.postMessage('do not deliver null', 'null')
+    window.opener.postMessage('do not deliver \\:/', '\\:/')
+    window.opener.postMessage('do not deliver empty', '')
+    window.opener.postMessage('deliver', window.location.origin)
   } else {
-    const opened = window.open(`${window.location.href}?opened=true`)
+    const opened = window.open(`${window.location.href}?opened=true`, '', 'show=no')
     window.addEventListener('message', function (event) {
       window.opener.postMessage(event.data, '*')
       opened.close()

--- a/spec/fixtures/pages/window-opener-targetOrigin.html
+++ b/spec/fixtures/pages/window-opener-targetOrigin.html
@@ -1,0 +1,18 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const url = require('url')
+  if (url.parse(window.location.href, true).query.opened != null) {
+    // Ensure origin are properly checked by removing a single character from the end
+    window.opener.postMessage('first message', window.location.origin.substring(0, window.location.origin.length - 1))
+    window.opener.postMessage('second message', window.location.origin)
+  } else {
+    const opened = window.open(`${window.location.href}?opened=true`)
+    window.addEventListener('message', function (event) {
+      window.opener.postMessage(event.data, '*')
+      opened.close()
+    })
+  }
+</script>
+</body>
+</html>

--- a/spec/fixtures/pages/window-opener-targetOrigin.html
+++ b/spec/fixtures/pages/window-opener-targetOrigin.html
@@ -3,7 +3,7 @@
 <script type="text/javascript" charset="utf-8">
   const url = require('url')
   if (url.parse(window.location.href, true).query.opened != null) {
-    // Ensure origin are properly checked by removing a single character from the end
+    // Ensure origins are properly checked by removing a single character from the end
     window.opener.postMessage('first message', window.location.origin.substring(0, window.location.origin.length - 1))
     window.opener.postMessage('second message', window.location.origin)
   } else {


### PR DESCRIPTION
This helper is a better implementation than the current string checks and is used from the `canAcccessWindow` helper.