### PR TITLE
Fix context leak in ObjectLifeMonitor.

### DIFF
--- a/atom/common/api/object_life_monitor.cc
+++ b/atom/common/api/object_life_monitor.cc
@@ -12,8 +12,7 @@ namespace atom {
 
 ObjectLifeMonitor::ObjectLifeMonitor(v8::Isolate* isolate,
                                      v8::Local<v8::Object> target)
-    : context_(isolate, isolate->GetCurrentContext()),
-      target_(isolate, target),
+    : target_(isolate, target),
       weak_ptr_factory_(this) {
   target_.SetWeak(this, OnObjectGC, v8::WeakCallbackType::kParameter);
 }

--- a/atom/common/api/object_life_monitor.h
+++ b/atom/common/api/object_life_monitor.h
@@ -22,7 +22,6 @@ class ObjectLifeMonitor {
   static void OnObjectGC(const v8::WeakCallbackInfo<ObjectLifeMonitor>& data);
   static void Free(const v8::WeakCallbackInfo<ObjectLifeMonitor>& data);
 
-  v8::Global<v8::Context> context_;
   v8::Global<v8::Object> target_;
 
   base::WeakPtrFactory<ObjectLifeMonitor> weak_ptr_factory_;


### PR DESCRIPTION
The RemoteObjectFreer class is keeping the context alive even when the window is
closed. For electron applications that use sandbox, this will cause a memory
leak every time a new window is created with `window.open`.

Close #9191