### PR TITLE
Add 'will-prevent-unload' event for #2579.

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -13,6 +13,7 @@
 #include "atom/browser/atom_browser_client.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
+#include "atom/browser/atom_javascript_dialog_manager.h"
 #include "atom/browser/child_web_contents_tracker.h"
 #include "atom/browser/lib/bluetooth_chooser.h"
 #include "atom/browser/native_window.h"
@@ -681,6 +682,15 @@ std::unique_ptr<content::BluetoothChooser> WebContents::RunBluetoothChooser(
   std::unique_ptr<BluetoothChooser> bluetooth_chooser(
       new BluetoothChooser(this, event_handler));
   return std::move(bluetooth_chooser);
+}
+
+content::JavaScriptDialogManager*
+WebContents::GetJavaScriptDialogManager(
+    content::WebContents* source) {
+  if (!dialog_manager_)
+    dialog_manager_.reset(new AtomJavaScriptDialogManager(this));
+
+  return dialog_manager_.get();
 }
 
 void WebContents::BeforeUnloadFired(const base::TimeTicks& proceed_time) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -41,6 +41,7 @@ namespace atom {
 
 struct SetSizeParams;
 class AtomBrowserContext;
+class AtomJavaScriptDialogManager;
 class WebContentsZoomController;
 class WebViewGuestDelegate;
 
@@ -296,6 +297,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   std::unique_ptr<content::BluetoothChooser> RunBluetoothChooser(
       content::RenderFrameHost* frame,
       const content::BluetoothChooser::EventHandler& handler) override;
+  content::JavaScriptDialogManager* GetJavaScriptDialogManager(
+      content::WebContents* source) override;
 
   // content::WebContentsObserver:
   void BeforeUnloadFired(const base::TimeTicks& proceed_time) override;
@@ -388,6 +391,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   v8::Global<v8::Value> devtools_web_contents_;
   v8::Global<v8::Value> debugger_;
 
+  std::unique_ptr<AtomJavaScriptDialogManager> dialog_manager_;
   std::unique_ptr<WebViewGuestDelegate> guest_delegate_;
 
   // The host webcontents that may contain this webcontents.

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/ui/message_box.h"
 #include "base/bind.h"
@@ -17,6 +18,10 @@ using content::JavaScriptDialogType;
 
 namespace atom {
 
+AtomJavaScriptDialogManager::AtomJavaScriptDialogManager(
+    api::WebContents* api_web_contents)
+    : api_web_contents_(api_web_contents) {}
+
 void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     content::WebContents* web_contents,
     const GURL& origin_url,
@@ -25,7 +30,6 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     const base::string16& default_prompt_text,
     const DialogClosedCallback& callback,
     bool* did_suppress_message) {
-
   if (dialog_type != JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_ALERT &&
       dialog_type != JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_CONFIRM) {
     callback.Run(false, base::string16());
@@ -49,8 +53,9 @@ void AtomJavaScriptDialogManager::RunBeforeUnloadDialog(
     content::WebContents* web_contents,
     bool is_reload,
     const DialogClosedCallback& callback) {
-  // FIXME(zcbenz): the |message_text| is removed, figure out what should we do.
-  callback.Run(false, base::ASCIIToUTF16("This should not be displayed"));
+  bool default_prevented = api_web_contents_->Emit("will-prevent-unload");
+  callback.Run(default_prevented, base::string16());
+  return;
 }
 
 void AtomJavaScriptDialogManager::CancelDialogs(

--- a/atom/browser/atom_javascript_dialog_manager.h
+++ b/atom/browser/atom_javascript_dialog_manager.h
@@ -11,8 +11,14 @@
 
 namespace atom {
 
+namespace api {
+class WebContents;
+}
+
 class AtomJavaScriptDialogManager : public content::JavaScriptDialogManager {
  public:
+  explicit AtomJavaScriptDialogManager(api::WebContents* api_web_contents);
+
   // content::JavaScriptDialogManager implementations.
   void RunJavaScriptDialog(
       content::WebContents* web_contents,
@@ -33,6 +39,7 @@ class AtomJavaScriptDialogManager : public content::JavaScriptDialogManager {
   static void OnMessageBoxCallback(const DialogClosedCallback& callback,
                                    int code,
                                    bool checkbox_checked);
+  api::WebContents* api_web_contents_;
 };
 
 }  // namespace atom

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "atom/browser/atom_browser_context.h"
-#include "atom/browser/atom_javascript_dialog_manager.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/ui/file_dialog.h"
 #include "atom/browser/web_dialog_helper.h"
@@ -228,15 +227,6 @@ content::WebContents* CommonWebContentsDelegate::OpenURLFromTab(
 
 bool CommonWebContentsDelegate::CanOverscrollContent() const {
   return false;
-}
-
-content::JavaScriptDialogManager*
-CommonWebContentsDelegate::GetJavaScriptDialogManager(
-    content::WebContents* source) {
-  if (!dialog_manager_)
-    dialog_manager_.reset(new AtomJavaScriptDialogManager);
-
-  return dialog_manager_.get();
 }
 
 content::ColorChooser* CommonWebContentsDelegate::OpenColorChooser(

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -20,7 +20,6 @@ using brightray::DevToolsFileSystemIndexer;
 namespace atom {
 
 class AtomBrowserContext;
-class AtomJavaScriptDialogManager;
 class NativeWindow;
 class WebDialogHelper;
 
@@ -62,8 +61,6 @@ class CommonWebContentsDelegate
       content::WebContents* source,
       const content::OpenURLParams& params) override;
   bool CanOverscrollContent() const override;
-  content::JavaScriptDialogManager* GetJavaScriptDialogManager(
-      content::WebContents* source) override;
   content::ColorChooser* OpenColorChooser(
       content::WebContents* web_contents,
       SkColor color,
@@ -147,7 +144,6 @@ class CommonWebContentsDelegate
   bool native_fullscreen_;
 
   std::unique_ptr<WebDialogHelper> web_dialog_helper_;
-  std::unique_ptr<AtomJavaScriptDialogManager> dialog_manager_;
   scoped_refptr<DevToolsFileSystemIndexer> devtools_file_system_indexer_;
 
   // Make sure BrowserContext is alwasys destroyed after WebContents.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -218,6 +218,36 @@ When in-page navigation happens, the page URL changes but does not cause
 navigation outside of the page. Examples of this occurring are when anchor links
 are clicked or when the DOM `hashchange` event is triggered.
 
+#### Event: 'will-prevent-unload'
+
+Returns:
+
+* `event` Event
+
+Emitted when a `beforeunload` event handler is attempting to cancel a page unload.
+
+Calling `event.preventDefault()` will ignore the `beforeunload` event handler
+and allow the page to be unloaded.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({width: 800, height: 600})
+win.webContents.on('will-prevent-unload', (event) => {
+  let choice = dialog.showMessageBox(mainWindow, {
+    type: 'question',
+    buttons: ['Leave', 'Stay'],
+    title: 'Do you want to leave this site?',
+    message: 'Changes you made may not be saved.',
+    defaultId: 0,
+    cancelId: 1
+  })
+  let leave = (choice === 0)
+  if (leave) {
+    event.preventDefault()
+  }
+})
+```
+
 #### Event: 'crashed'
 
 Returns:

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -230,10 +230,10 @@ Calling `event.preventDefault()` will ignore the `beforeunload` event handler
 and allow the page to be unloaded.
 
 ```javascript
-const {BrowserWindow} = require('electron')
-let win = new BrowserWindow({width: 800, height: 600})
+const {BrowserWindow, dialog} = require('electron')
+const win = new BrowserWindow({width: 800, height: 600})
 win.webContents.on('will-prevent-unload', (event) => {
-  let choice = dialog.showMessageBox(mainWindow, {
+  const choice = dialog.showMessageBox(win, {
     type: 'question',
     buttons: ['Leave', 'Stay'],
     title: 'Do you want to leave this site?',
@@ -241,7 +241,7 @@ win.webContents.on('will-prevent-unload', (event) => {
     defaultId: 0,
     cancelId: 1
   })
-  let leave = (choice === 0)
+  const leave = (choice === 0)
   if (leave) {
     event.preventDefault()
   }

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -543,6 +543,31 @@ describe('webContents module', function () {
     })
   })
 
+  describe('will-prevent-unload event', function () {
+    it('does not emit if beforeunload returns undefined', function (done) {
+      w.once('closed', function () {
+        done()
+      })
+      w.webContents.on('will-prevent-unload', function (e) {
+        assert.fail('should not have fired')
+      })
+      w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-undefined.html'))
+    })
+
+    it('emits if beforeunload returns false', (done) => {
+      w.webContents.on('will-prevent-unload', () => {
+        done()
+      })
+      w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-false.html'))
+    })
+
+    it('supports calling preventDefault on will-prevent-unload events', function (done) {
+      ipcRenderer.send('prevent-next-will-prevent-unload', w.webContents.id)
+      w.once('closed', () => done())
+      w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-false.html'))
+    })
+  })
+
   describe('destroy()', () => {
     let server
 

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -266,6 +266,10 @@ ipcMain.on('prevent-next-will-attach-webview', (event) => {
   event.sender.once('will-attach-webview', event => event.preventDefault())
 })
 
+ipcMain.on('prevent-next-will-prevent-unload', (event, id) => {
+  webContents.fromId(id).once('will-prevent-unload', event => event.preventDefault())
+})
+
 ipcMain.on('disable-node-on-next-will-attach-webview', (event, id) => {
   event.sender.once('will-attach-webview', (event, webPreferences, params) => {
     params.src = `file://${path.join(__dirname, '..', 'fixtures', 'pages', 'c.html')}`


### PR DESCRIPTION
This change is based on my [comment in issue 2579](https://github.com/electron/electron/issues/2579#issuecomment-297879503).  I have very little experience with the Electron code, so I hope that "help/beginner" tag still applies.


Restructure
===========
The biggest part of this change is getting access to the event emitting methods of the `atom::api::WebContents` class from the `atom::AtomJavaScriptDialogManager` class.  That requirement led me to shuffling around a couple dependencies.

I based the changes to `atom::AtomJavaScriptDialogManager` on the existing `atom::BluetoothChooser` class: have a constructor that accepts an `api::WebContents*` object, save a reference to it, and use its `Emit` method later.

The second part of that change is in constructing the `atom::AtomJavaScriptDialogManager` object.  Right now creating and managing that `dialog_manager` object happens in the `atom::CommonWebContentsDelegate` base class, which isn't ideal for this change since it doesn't have access to any of the Emit methods.  So I moved that (including all references to `atom::AtomJavaScriptDialogManager`) into the `atom::api::WebContents` class.

One thing that makes me a little nervous about that change is this comment from `common_web_contents_delegate.h`:

```cpp
  // The stored InspectableWebContents object.
  // Notice that web_contents_ must be placed after dialog_manager_, so we can
  // make sure web_contents_ is destroyed before dialog_manager_, otherwise a
  // crash would happen.
  std::unique_ptr<brightray::InspectableWebContents> web_contents_;
```

The `dialog_manager_` field is in a subclass now, so it should still be destroyed before `web_contents_` field.  But this change does affect the destruction order, so if there are any other dependencies on the destruction order then it's possible that some other problem could come from this.


Reloads
=======
One additional piece of information that the `RunBeforeUnloadDialog` method has is an `is_reload` flag.  The Chromium browser uses that to choose a different title for the confirmation dialog if the unload is for a reload (`Do you want to reload this site?` instead of `Do you want to leave this site?`).

Originally I planned to make that `is_reload` flag available in the new `will-prevent-unload` event.  But in my testing the flag was always false, even for a reload (using the reload menu option from the default app).  So at least for now, I left the `is_reload` flag out since it would be misleading to provide it if it doesn't work, and it would probably be possible to add later if there's a demand for it.