### PR TITLE
Make OSX child windows honor the show option to fix #8836

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -158,6 +158,7 @@ class NativeWindowMac : public NativeWindow,
   void UpdateDraggableRegions(
       const std::vector<DraggableRegion>& regions) override;
 
+  void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void ShowWindowButton(NSWindowButton button);
 
   void InstallView();

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1085,7 +1085,7 @@ void NativeWindowMac::Show() {
                             completionHandler:^(NSModalResponse) {}];
     return;
   }
-  
+
   // Reattach the window to the parent to actually show it.
   if (parent())
     InternalSetParentWindow(parent(), true);
@@ -1101,7 +1101,7 @@ void NativeWindowMac::ShowInactive() {
   // Reattach the window to the parent to actually show it.
   if (parent())
     InternalSetParentWindow(parent(), true);
-  
+
   [window_ orderFrontRegardless];
 }
 
@@ -1111,7 +1111,7 @@ void NativeWindowMac::Hide() {
     [parent()->GetNativeWindow() endSheet:window_];
     return;
   }
-  
+
   // Deattach the window from the parent before.
   if (parent())
     InternalSetParentWindow(parent(), false);
@@ -1548,26 +1548,6 @@ void NativeWindowMac::SetBrowserView(NativeBrowserView* browser_view) {
   native_view.hidden = NO;
 }
 
-void NativeWindowMac::InternalSetParentWindow(NativeWindow* parent, bool attach) {
-  if (is_modal())
-    return;
-  
-  NativeWindow::SetParentWindow(parent);
-  
-  // Do not remove/add if we are already properly attached.
-  if (attach && parent && [window_ parentWindow] == parent->GetNativeWindow())
-    return;
-  
-  // Remove current parent window.
-  if ([window_ parentWindow])
-    [[window_ parentWindow] removeChildWindow:window_];
-    
-  // Set new parent window.
-  // Note that this method will force the window to become visible.
-  if (parent && attach)
-    [parent->GetNativeWindow() addChildWindow:window_ ordered:NSWindowAbove];
-}
-
 void NativeWindowMac::SetParentWindow(NativeWindow* parent) {
   InternalSetParentWindow(parent, IsVisible());
 }
@@ -1576,7 +1556,7 @@ gfx::NativeView NativeWindowMac::GetNativeView() const {
   return inspectable_web_contents()->GetView()->GetNativeView();
 }
 
-gfx::NativeWindow NativeWindowMac::GetNativeWindow() {
+gfx::NativeWindow NativeWindowMac::GetNativeWindow() const {
   return window_;
 }
 
@@ -1816,6 +1796,26 @@ void NativeWindowMac::UpdateDraggableRegions(
   NativeWindow::UpdateDraggableRegions(regions);
   draggable_regions_ = regions;
   UpdateDraggableRegionViews(regions);
+}
+
+void NativeWindowMac::InternalSetParentWindow(NativeWindow* parent, bool attach) {
+  if (is_modal())
+    return;
+
+  NativeWindow::SetParentWindow(parent);
+
+  // Do not remove/add if we are already properly attached.
+  if (attach && parent && [window_ parentWindow] == parent->GetNativeWindow())
+    return;
+
+  // Remove current parent window.
+  if ([window_ parentWindow])
+    [[window_ parentWindow] removeChildWindow:window_];
+
+  // Set new parent window.
+  // Note that this method will force the window to become visible.
+  if (parent && attach)
+    [parent->GetNativeWindow() addChildWindow:window_ ordered:NSWindowAbove];
 }
 
 void NativeWindowMac::ShowWindowButton(NSWindowButton button) {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1098,6 +1098,10 @@ void NativeWindowMac::Show() {
 }
 
 void NativeWindowMac::ShowInactive() {
+  // Reattach the window to the parent to actually show it.
+  if (parent())
+    InternalSetParentWindow(parent(), true);
+  
   [window_ orderFrontRegardless];
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -914,8 +914,7 @@ NativeWindowMac::NativeWindowMac(
 
   // Only use native parent window for non-modal windows.
   if (parent && !is_modal()) {
-    // It will be properly attached on show and detached on hide.
-    InternalSetParentWindow(parent, false);
+    SetParentWindow(parent);
   }
 
   if (transparent()) {
@@ -1566,7 +1565,7 @@ void NativeWindowMac::InternalSetParentWindow(NativeWindow* parent, bool attach)
 }
 
 void NativeWindowMac::SetParentWindow(NativeWindow* parent) {
-  InternalSetParentWindow(parent, true);
+  InternalSetParentWindow(parent, IsVisible());
 }
 
 gfx::NativeView NativeWindowMac::GetNativeView() const {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1278,7 +1278,7 @@ describe('BrowserWindow module', function () {
             const currentWebContents = webContents.getAllWebContents().map((i) => i.id)
             assert.deepEqual(currentWebContents, initialWebContents)
             done()
-          }, 100);
+          }, 100)
         })
         w.loadURL('file://' + path.join(fixtures, 'pages', 'window-open.html'))
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1273,8 +1273,12 @@ describe('BrowserWindow module', function () {
         const initialWebContents = webContents.getAllWebContents().map((i) => i.id)
         ipcRenderer.send('prevent-next-new-window', w.webContents.id)
         w.webContents.once('new-window', () => {
-          assert.deepEqual(webContents.getAllWebContents().map((i) => i.id), initialWebContents)
-          done()
+          // We need to give it some time so the windows get properly disposed (at least on OSX).
+          setTimeout(() => {
+            const currentWebContents = webContents.getAllWebContents().map((i) => i.id)
+            assert.deepEqual(currentWebContents, initialWebContents)
+            done()
+          }, 100);
         })
         w.loadURL('file://' + path.join(fixtures, 'pages', 'window-open.html'))
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2369,6 +2369,11 @@ describe('BrowserWindow module', function () {
         })
         c.close()
       })
+
+      it('should not affect the show option', function () {
+        assert.equal(c.isVisible(), false)
+        assert.equal(c.getParentWindow().isVisible(), false)
+      })
     })
 
     describe('win.setParentWindow(parent)', function () {


### PR DESCRIPTION
Basically, there's no way for OSX child windows to be hidden if they are added to a parent. To fix this child windows will be attached when they are shown and detached when they are hidden. This however does not modify the public api (getParentWindow() and getChildWindow()), since the relationship is properly kept on the NativeWindow.

This fixes #8836 