### PR TITLE
Use actual Chromium l10n_util list in locales.md

### DIFF
--- a/docs/api/locales.md
+++ b/docs/api/locales.md
@@ -8,132 +8,135 @@ values are listed below:
 | Language Code | Language Name |
 |---------------|---------------|
 | af | Afrikaans |
-| an | Aragonese |
-| ar-AE | Arabic (U.A.E.) |
-| ar-IQ | Arabic (Iraq) |
-| ar | Arabic (Standard) |
-| ar-BH | Arabic (Bahrain) |
-| ar-DZ | Arabic (Algeria) |
-| ar-EG | Arabic (Egypt) |
-| ar-JO | Arabic (Jordan) |
-| ar-KW | Arabic (Kuwait) |
-| ar-LB | Arabic (Lebanon) |
-| ar-LY | Arabic (Libya) |
-| ar-MA | Arabic (Morocco) |
-| ar-OM | Arabic (Oman) |
-| ar-QA | Arabic (Qatar) |
-| ar-SA | Arabic (Saudi Arabia) |
-| ar-SY | Arabic (Syria) |
-| ar-TN | Arabic (Tunisia) |
-| ar-YE | Arabic (Yemen) |
-| as | Assamese |
-| ast | Asturian |
+| am | Amharic |
+| ar | Arabic |
 | az | Azerbaijani |
 | be | Belarusian |
 | bg | Bulgarian |
-| bg | Bulgarian |
+| bh | Bihari |
 | bn | Bengali |
 | br | Breton |
 | bs | Bosnian |
 | ca | Catalan |
-| ce | Chechen |
-| ch | Chamorro |
 | co | Corsican |
-| cr | Cree |
 | cs | Czech |
-| cv | Chuvash |
+| cy | Welsh |
 | da | Danish |
-| de | German (Standard) |
+| de | German |
 | de-AT | German (Austria) |
 | de-CH | German (Switzerland) |
 | de-DE | German (Germany) |
-| de-LI | German (Liechtenstein) |
-| de-LU | German (Luxembourg) |
 | el | Greek |
-| en-AU | English (Australia) |
-| en-BZ | English (Belize) |
 | en | English |
+| en-AU | English (Australia) |
 | en-CA | English (Canada) |
-| en-GB | English (United Kingdom) |
-| en-IE | English (Ireland) |
-| en-JM | English (Jamaica) |
+| en-GB | English (UK) |
 | en-NZ | English (New Zealand) |
-| en-PH | English (Philippines) |
-| en-TT | English (Trinidad & Tobago) |
-| en-US | English (United States) |
+| en-US | English (US) |
 | en-ZA | English (South Africa) |
-| en-ZW | English (Zimbabwe) |
 | eo | Esperanto |
+| es | Spanish |
+| es-419 | Spanish (Latin America) |
 | et | Estonian |
 | eu | Basque |
 | fa | Persian |
-| fa | Farsi |
-| fa-IR | Persian/Iran |
 | fi | Finnish |
-| fj | Fijian |
-| fo | Faeroese |
+| fil | Filipino |
+| fo | Faroese |
+| fr | French |
+| fr-CA | French (Canada) |
 | fr-CH | French (Switzerland) |
 | fr-FR | French (France) |
-| fr-LU | French (Luxembourg) |
-| fr-MC | French (Monaco) |
-| fr | French (Standard) |
-| fr-BE | French (Belgium) |
-| fr-CA | French (Canada) |
-| fur | Friulian |
 | fy | Frisian |
 | ga | Irish |
-| gd-IE | Gaelic (Irish) |
-| gd | Gaelic (Scots) |
-| gl | Galacian |
-| gu | Gujurati |
+| gd | Scots Gaelic |
+| gl | Galician |
+| gn | Guarani |
+| gu | Gujarati |
+| ha | Hausa |
+| haw | Hawaiian |
 | he | Hebrew |
 | hi | Hindi |
 | hr | Croatian |
-| ht | Haitian |
 | hu | Hungarian |
 | hy | Armenian |
+| ia | Interlingua |
 | id | Indonesian |
 | is | Icelandic |
+| it | Italian |
 | it-CH | Italian (Switzerland) |
-| it | Italian (Standard) |
-| iu | Inuktitut |
+| it-IT | Italian (Italy) |
 | ja | Japanese |
+| jw | Javanese |
 | ka | Georgian |
 | kk | Kazakh |
-| km | Khmer |
+| km | Cambodian |
 | kn | Kannada |
 | ko | Korean |
-| ko-KP | Korean (North Korea) |
-| ko-KR | Korean (South Korea) |
-| ks | Kashmiri |
-| ky | Kirghiz |
+| ku | Kurdish |
+| ky | Kyrgyz |
 | la | Latin |
-| lb | Luxembourgish |
+| ln | Lingala |
+| lo | Laothian |
 | lt | Lithuanian |
 | lv | Latvian |
-| mi | Maori |
-| mk | FYRO Macedonian |
+| mk | Macedonian |
 | ml | Malayalam |
+| mn | Mongolian |
 | mo | Moldavian |
 | mr | Marathi |
 | ms | Malay |
 | mt | Maltese |
-| my | Burmese |
 | nb | Norwegian (Bokmal) |
 | ne | Nepali |
-| ng | Ndonga |
-| nl | Dutch (Standard) |
-| nl-BE | Dutch (Belgian) |
+| nl | Dutch |
 | nn | Norwegian (Nynorsk) |
 | no | Norwegian |
-| nv | Navajo |
 | oc | Occitan |
 | om | Oromo |
 | or | Oriya |
+| pa | Punjabi |
+| pl | Polish |
+| ps | Pashto |
+| pt | Portuguese |
+| pt-BR | Portuguese (Brazil) |
+| pt-PT | Portuguese (Portugal) |
+| qu | Quechua |
+| rm | Romansh |
+| ro | Romanian |
+| ru | Russian |
+| sd | Sindhi |
+| sh | Serbo-Croatian |
+| si | Sinhalese |
+| sk | Slovak |
+| sl | Slovenian |
+| sn | Shona |
+| so | Somali |
 | sq | Albanian |
-| tlh | Klingon |
-| zh-TW | Chinese (Taiwan) |
+| sr | Serbian |
+| st | Sesotho |
+| su | Sundanese |
+| sv | Swedish |
+| sw | Swahili |
+| ta | Tamil |
+| te | Telugu |
+| tg | Tajik |
+| th | Thai |
+| ti | Tigrinya |
+| tk | Turkmen |
+| to | Tonga |
+| tr | Turkish |
+| tt | Tatar |
+| tw | Twi |
+| ug | Uighur |
+| uk | Ukrainian |
+| ur | Urdu |
+| uz | Uzbek |
+| vi | Vietnamese |
+| xh | Xhosa |
+| yi | Yiddish |
+| yo | Yoruba |
 | zh | Chinese |
-| zh-CN | Chinese (PRC) |
-| zh-HK | Chinese (Hong Kong) |
-| zh-SG | Chinese (Singapore) |
+| zh-CN | Chinese (Simplified) |
+| zh-TW | Chinese (Traditional) |
+| zu | Zulu |


### PR DESCRIPTION
I’m not sure where the locale list from the [original commit](https://github.com/electron/electron/pull/6324/commits/bbaab9b35536691ad4c8effab147c8797e629fbe) came from, but it clearly wasn’t copied from `l10n_util`. It was missing Spanish, Portuguese, Polish, Vietnamese, to name a few…

This commit overwrites the whole list with [`l10n_util` as-is](https://github.com/adobe/chromium/blob/61cfc2b0a8508649bf99c5f842d8184fc35e8a01/ui/base/l10n/l10n_util.cc#L41-L175).