### PR TITLE
Change translation of `license` to `授權條款`

### DIFF
--- a/docs-translations/zh-TW/project/README.md
+++ b/docs-translations/zh-TW/project/README.md
@@ -72,6 +72,6 @@ Clone 並使用 [`electron/electron-quick-start`](https://github.com/electron/el
 在 [awesome-electron](https://github.com/sindresorhus/awesome-electron)
 查看由社群維護的清單，包括實用的應用程式、工具以及資源。
 
-## 憑證
+## 授權條款
 
 MIT © 2016 Github


### PR DESCRIPTION
The translation of `license` should not be `憑證`.
`憑證` means certificate but not license in Chinese.

For example, [Symantec](https://www.symantec.com/zh/tw/security_response/glossary/define.jsp?letter=d&word=digital-certificate) translated `digital certificate` as `數位憑證`; [Chrome Support](https://support.google.com/chrome/a/answer/3505249?hl=zh-Hant) used the teams `憑證授權單位` and `SSL 憑證` to describe `CA` and `SSL Certificate`. These are all proving that the word `憑證` is commonly used in the translation of `certificate`, but not `license`

I googled for a while, and found that the team `授權條款` is commonly used to describe `license` in Traditional Chinese. The user of the translation `授權條款` includes governments ([Taiwan Government](https://www.tipo.gov.tw/ct.asp?xItem=365132&ctNode=6885&mp=1), [Hong Kong government](http://www1.itfest.gov.hk/sc/event/supplements/0415_BIP_Asia_Seminar_Series_%28eDM%29.pdf)), communities ([Open Source Hong Kong](https://freehkfonts.opensource.hk/download/) and [OpenFoundry](https://www.openfoundry.org/of/download/openlegal/Analyses_and_applying_policies_of_FOSS_licenses_2parts_2/20131118_d.pdf)), and businesses ([Google](https://www.google.com/intl/zh-TW/chromebook/termsofservice.html)).

So I suggest we should use `授權條款`, which has been widely adopted  as translation of `license`, instead of a wrong translation `憑證`.