### PR TITLE
protocol: provide default response code for custom request jobs

### DIFF
--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -82,6 +82,9 @@ class JsAsker : public RequestJob {
                    base::Bind(&JsAsker::OnResponse,
                               weak_factory_.GetWeakPtr())));
   }
+
+  int GetResponseCode() const override { return 200; }
+
   void GetResponseInfo(net::HttpResponseInfo* info) override {
     info->headers = new net::HttpResponseHeaders("");
   }

--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -13,6 +13,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_response_headers.h"
+#include "net/http/http_status_code.h"
 #include "net/url_request/url_request_context_getter.h"
 #include "net/url_request/url_request_job.h"
 #include "v8/include/v8.h"
@@ -83,7 +84,7 @@ class JsAsker : public RequestJob {
                               weak_factory_.GetWeakPtr())));
   }
 
-  int GetResponseCode() const override { return 200; }
+  int GetResponseCode() const override { return net::HTTP_OK; }
 
   void GetResponseInfo(net::HttpResponseInfo* info) override {
     info->headers = new net::HttpResponseHeaders("");

--- a/atom/browser/net/url_request_buffer_job.cc
+++ b/atom/browser/net/url_request_buffer_job.cc
@@ -67,7 +67,7 @@ void URLRequestBufferJob::StartAsync(std::unique_ptr<base::Value> options) {
 }
 
 void URLRequestBufferJob::GetResponseInfo(net::HttpResponseInfo* info) {
-  std::string status("HTTP/1.1 ");
+  std::string status("HTTP/1.1 200 OK");
   status.append(base::IntToString(status_code_));
   status.append(" ");
   status.append(net::GetHttpReasonPhrase(status_code_));

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -149,8 +149,6 @@ describe('chromium feature', function () {
   })
 
   describe('navigator.serviceWorker', function () {
-    var url = 'file://' + fixtures + '/pages/service-worker/index.html'
-
     it('should register for file scheme', function (done) {
       w = new BrowserWindow({
         show: false
@@ -169,7 +167,45 @@ describe('chromium feature', function () {
           })
         }
       })
-      w.loadURL(url)
+      w.loadURL(`file://${fixtures}/pages/service-worker/index.html`)
+    })
+
+    it('should register for intercepted file scheme', function (done) {
+      const customSession = session.fromPartition('intercept-file')
+      customSession.protocol.interceptBufferProtocol('file', function (request, callback) {
+        const file = url.parse(request.url).pathname
+        const content = fs.readFileSync(path.normalize(file))
+        const ext = path.extname(file)
+        let type = 'text/html'
+        if (ext === '.js') {
+          type = 'application/javascript'
+        }
+        callback({data: content, mimeType: type})
+      }, function (error) {
+        if (error) done(error)
+      })
+
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          session: customSession
+        }
+      })
+      w.webContents.on('ipc-message', function (event, args) {
+        if (args[0] === 'reload') {
+          w.webContents.reload()
+        } else if (args[0] === 'error') {
+          done('unexpected error : ' + args[1])
+        } else if (args[0] === 'response') {
+          assert.equal(args[1], 'Hello from serviceWorker!')
+          customSession.clearStorageData({
+            storages: ['serviceworkers']
+          }, function () {
+            customSession.protocol.uninterceptProtocol('file', (error) => done(error))
+          })
+        }
+      })
+      w.loadURL(`file://${fixtures}/pages/service-worker/index.html`)
     })
   })
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -173,7 +173,11 @@ describe('chromium feature', function () {
     it('should register for intercepted file scheme', function (done) {
       const customSession = session.fromPartition('intercept-file')
       customSession.protocol.interceptBufferProtocol('file', function (request, callback) {
-        const file = url.parse(request.url).pathname
+        let file = url.parse(request.url).pathname
+        // Remove leading slash before drive letter on Windows
+        if (file[0] === '/' && process.platform === 'win32') {
+          file = file.slice(1)
+        }
         const content = fs.readFileSync(path.normalize(file))
         const ext = path.extname(file)
         let type = 'text/html'


### PR DESCRIPTION
Service worker registration requires a successful response code https://cs.chromium.org/chromium/src/content/browser/service_worker/service_worker_write_to_cache_job.cc?l=285, until https://bugs.chromium.org/p/chromium/issues/detail?id=688481 gets landed we have to provide a default success response code.

Fixes https://github.com/electron/electron/issues/9354