### PR TITLE
use tsconfig file when linting electron.d.ts

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -151,7 +151,7 @@ def create_typescript_definitions():
   infile = os.path.relpath(os.path.join(DIST_DIR, 'electron-api.json'))
   outfile = os.path.relpath(os.path.join(DIST_DIR, 'electron.d.ts'))
   tslintconfig = os.path.relpath(os.path.join(DIST_DIR,
-           'node_modules/electron-typescript-definitions/tslint.json'))
+           '../node_modules/electron-typescript-definitions/tslint.json'))
   execute(['electron-typescript-definitions', '--in={0}'.format(infile),
            '--out={0}'.format(outfile)], env=env)
   execute(['tslint', '--config', tslintconfig, outfile], env=env)

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -150,9 +150,11 @@ def create_typescript_definitions():
   env['PATH'] = os.path.pathsep.join([node_bin_dir, env['PATH']])
   infile = os.path.relpath(os.path.join(DIST_DIR, 'electron-api.json'))
   outfile = os.path.relpath(os.path.join(DIST_DIR, 'electron.d.ts'))
+  tslintconfig = os.path.relpath(os.path.join(DIST_DIR,
+           'node_modules/electron-typescript-definitions/tslint.json'))
   execute(['electron-typescript-definitions', '--in={0}'.format(infile),
            '--out={0}'.format(outfile)], env=env)
-  execute(['tslint', outfile], env=env)
+  execute(['tslint', '--config', tslintconfig, outfile], env=env)
 
 def strip_binaries():
   for binary in TARGET_BINARIES[PLATFORM]:


### PR DESCRIPTION
This is a followup to https://github.com/electron/electron/pull/7857 that passes config to `tslint`. Without it, the create-dist process will print a bunch of warnings and exit nonzerø. 🔥

cc @kevinsawicki @MarshallOfSound 