### PR TITLE
Add Math.ceil to pageSize.height and pageSize.width to printToPDF() o…

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -198,8 +198,8 @@ WebContents.prototype.printToPDF = function (options, callback) {
       printingSetting.mediaSize = {
         name: 'CUSTOM',
         custom_display_name: 'Custom',
-        height_microns: pageSize.height,
-        width_microns: pageSize.width
+        height_microns: Math.ceil(pageSize.height),
+        width_microns: Math.ceil(pageSize.width)
       }
     } else if (PDFPageSizes[pageSize]) {
       printingSetting.mediaSize = PDFPageSizes[pageSize]


### PR DESCRIPTION
…ptions to prevent error on display.

In reference to #9361, Math.ceil()'ed the height and width parameters. Tested on Ubuntu 16.04 as working. 

## Proposed solution:
in /lib/browser/api/web-contents.js

```
// Translate the options of printToPDF.
WebContents.prototype.printToPDF = function (options, callback) {
...
      printingSetting.mediaSize = {
        name: 'CUSTOM',
        custom_display_name: 'Custom',
        // Add Math.ceil() to page height and width.
        height_microns: Math.ceil(pageSize.height),
        width_microns: Math.ceil(pageSize.width)
      }
```
