### PR TITLE
Clarify dialog blocking functionality

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -161,8 +161,8 @@ It returns the index of the clicked button.
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
-If a `callback` is passed, the API call will be asynchronous and the result
-will be passed via `callback(response)`.
+If a `callback` is passed, the dialog will not block the process. The API call
+will be asynchronous and the result will be passed via `callback(response)`.
 
 ### `dialog.showErrorBox(title, content)`
 


### PR DESCRIPTION
Potentially this is a bug and not intended functionality (in my case it is useful), but passing a custom array of `buttons` into `dialog. showMessageBox` will mean that the process is no longer blocked by the dialog. I've updated the documentation to make this explicit.

I have also opened https://github.com/electron/electron/issues/9405 with a suggestion to add a new parameter to make blocking/non-blocking more explicit.

[ci skip]