### PR TITLE
Make dialog work with BrowserWindow subclasses

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -21,7 +21,7 @@ const messageBoxOptions = {
 }
 
 const parseArgs = function (window, options, callback, ...args) {
-  if (window != null && window.constructor !== BrowserWindow) {
+  if (window != null && !(window instanceof BrowserWindow)) {
     // Shift.
     [callback, options, window] = [options, window, null]
   }

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -12,13 +12,13 @@ const MenuItem = function (options) {
     if (!(key in this)) this[key] = options[key]
   }
   this.submenu = this.submenu || roles.getDefaultSubmenu(this.role)
-  if (this.submenu != null && this.submenu.constructor !== Menu) {
+  if (this.submenu != null && !(this.submenu instanceof Menu)) {
     this.submenu = Menu.buildFromTemplate(this.submenu)
   }
   if (this.type == null && this.submenu != null) {
     this.type = 'submenu'
   }
-  if (this.type === 'submenu' && (this.submenu == null || this.submenu.constructor !== Menu)) {
+  if (this.type === 'submenu' && (this.submenu == null || !(this.submenu instanceof Menu))) {
     throw new Error('Invalid submenu')
   }
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -147,7 +147,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   let asyncPopup
 
   // menu.popup(x, y, positioningItem)
-  if (window != null && (typeof window !== 'object' || window.constructor !== BrowserWindow)) {
+  if (window != null && (typeof window !== 'object' || !(window instanceof BrowserWindow))) {
     // Shift.
     positioningItem = y
     y = x
@@ -181,7 +181,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
 }
 
 Menu.prototype.closePopup = function (window) {
-  if (window == null || window.constructor !== BrowserWindow) {
+  if (window == null || !(window instanceof BrowserWindow)) {
     window = BrowserWindow.getFocusedWindow()
   }
   if (window != null) {
@@ -273,7 +273,7 @@ Menu.prototype._callMenuWillShow = function () {
 var applicationMenu = null
 
 Menu.setApplicationMenu = function (menu) {
-  if (!(menu === null || menu.constructor === Menu)) {
+  if (!(menu === null || menu instanceof Menu)) {
     throw new TypeError('Invalid menu')
   }
 


### PR DESCRIPTION
In case you want to use a BrowserWindow subclass the current implementation of `showSaveDialog` from `Electron.Dialog` fails in `parseArgs`.

The unwanted result of the current implementation leads to:

- window = null
- options = my_given_browserwindow_subclass_instance
- callback = my_given_options

With this PR I hopefully provide a solution.