### PR TITLE
let the typescript module do its own linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.1.0",
-    "electron-typescript-definitions": "^1.0.1",
+    "electron-typescript-definitions": "^1.2.0",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -150,11 +150,8 @@ def create_typescript_definitions():
   env['PATH'] = os.path.pathsep.join([node_bin_dir, env['PATH']])
   infile = os.path.relpath(os.path.join(DIST_DIR, 'electron-api.json'))
   outfile = os.path.relpath(os.path.join(DIST_DIR, 'electron.d.ts'))
-  tslintconfig = os.path.relpath(os.path.join(DIST_DIR,
-           '../node_modules/electron-typescript-definitions/tslint.json'))
   execute(['electron-typescript-definitions', '--in={0}'.format(infile),
            '--out={0}'.format(outfile)], env=env)
-  execute(['tslint', '--config', tslintconfig, outfile], env=env)
 
 def strip_binaries():
   for binary in TARGET_BINARIES[PLATFORM]:


### PR DESCRIPTION
As of 1.2.0, `electron-typescript-definitions` lints its own output.

https://github.com/electron/electron-typescript-definitions/pull/38

cc @MarshallOfSound @kevinsawicki 