### PR TITLE
Fix TypeScript bugs and make it easier to debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.1.0",
-    "electron-typescript-definitions": "^1.2.0",
+    "electron-typescript-definitions": "^1.2.3",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "lint-py": "python ./script/pylint.py",
     "lint-api-docs-js": "standard-markdown docs && standard-markdown docs-translations",
     "lint-api-docs": "electron-docs-linter",
+    "create-api-json": "electron-docs-linter docs --outfile=out/electron-api.json --version=$npm_package_version",
+    "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=out/electron-api.json --out=out/electron.d.ts",
     "preinstall": "node -e 'process.exit(0)'",
     "release": "./script/upload.py -p",
     "repl": "python ./script/start.py --interactive",


### PR DESCRIPTION
This PR updates `electron-typescript-definitions` to a new version that includes `@types/node` as a dependency and runs additional `tsc` checks on `electron.d.ts`

I've also added two new npm scripts. Their purpose is to make it easier for folks to hack on Electron's API docs and preview the resultant `electron.d.ts` without intimate knowledge of the tooling.

cc @shiftkey @MarshallOfSound @poiru 

Related:

- https://github.com/electron/electron-typescript-definitions/issues/39
-  https://github.com/electron/electron-typescript-definitions/pull/41
- https://github.com/electron/electron-typescript-definitions/issues/43
- https://github.com/electron/electron-typescript-definitions/pull/45