### PR TITLE
support --disk-cache-size flag

### DIFF
--- a/brightray/browser/url_request_context_getter.cc
+++ b/brightray/browser/url_request_context_getter.cc
@@ -15,6 +15,7 @@
 #include "base/command_line.h"
 #include "base/memory/ptr_util.h"
 #include "base/strings/string_util.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/threading/sequenced_worker_pool.h"
 #include "base/threading/worker_pool.h"
 #include "content/public/browser/browser_thread.h"
@@ -92,12 +93,18 @@ URLRequestContextGetter::Delegate::CreateURLRequestJobFactory(
 net::HttpCache::BackendFactory*
 URLRequestContextGetter::Delegate::CreateHttpCacheBackendFactory(
     const base::FilePath& base_path) {
+  auto& command_line = *base::CommandLine::ForCurrentProcess();
+  int max_size = 0;
+  if (command_line.HasSwitch(switches::kDiskCacheSize)) {
+    base::StringToInt(command_line.GetSwitchValueASCII(switches::kDiskCacheSize),
+                      &max_size);
+  }
   base::FilePath cache_path = base_path.Append(FILE_PATH_LITERAL("Cache"));
   return new net::HttpCache::DefaultBackend(
       net::DISK_CACHE,
       net::CACHE_BACKEND_DEFAULT,
       cache_path,
-      0,
+      max_size,
       BrowserThread::GetTaskRunnerForThread(BrowserThread::CACHE));
 }
 

--- a/brightray/browser/url_request_context_getter.cc
+++ b/brightray/browser/url_request_context_getter.cc
@@ -96,8 +96,9 @@ URLRequestContextGetter::Delegate::CreateHttpCacheBackendFactory(
   auto& command_line = *base::CommandLine::ForCurrentProcess();
   int max_size = 0;
   if (command_line.HasSwitch(switches::kDiskCacheSize)) {
-    base::StringToInt(command_line.GetSwitchValueASCII(switches::kDiskCacheSize),
-                      &max_size);
+    base::StringToInt(
+        command_line.GetSwitchValueASCII(switches::kDiskCacheSize),
+        &max_size);
   }
   base::FilePath cache_path = base_path.Append(FILE_PATH_LITERAL("Cache"));
   return new net::HttpCache::DefaultBackend(

--- a/brightray/browser/url_request_context_getter.cc
+++ b/brightray/browser/url_request_context_getter.cc
@@ -93,13 +93,11 @@ URLRequestContextGetter::Delegate::CreateURLRequestJobFactory(
 net::HttpCache::BackendFactory*
 URLRequestContextGetter::Delegate::CreateHttpCacheBackendFactory(
     const base::FilePath& base_path) {
-  auto& command_line = *base::CommandLine::ForCurrentProcess();
+  auto command_line = base::CommandLine::ForCurrentProcess();
   int max_size = 0;
-  if (command_line.HasSwitch(switches::kDiskCacheSize)) {
-    base::StringToInt(
-        command_line.GetSwitchValueASCII(switches::kDiskCacheSize),
-        &max_size);
-  }
+  base::StringToInt(command_line->GetSwitchValueASCII(switches::kDiskCacheSize),
+                    &max_size);
+
   base::FilePath cache_path = base_path.Append(FILE_PATH_LITERAL("Cache"));
   return new net::HttpCache::DefaultBackend(
       net::DISK_CACHE,

--- a/brightray/common/switches.cc
+++ b/brightray/common/switches.cc
@@ -53,6 +53,9 @@ const char kAuthNegotiateDelegateWhitelist[] =
 // Ignores certificate-related errors.
 const char kIgnoreCertificateErrors[] = "ignore-certificate-errors";
 
+// Forces the maximum disk space to be used by the disk cache, in bytes.
+const char kDiskCacheSize[] = "disk-cache-size";
+
 }  // namespace switches
 
 }  // namespace brightray

--- a/brightray/common/switches.h
+++ b/brightray/common/switches.h
@@ -18,6 +18,7 @@ extern const char kDisableHttp2[];
 extern const char kAuthServerWhitelist[];
 extern const char kAuthNegotiateDelegateWhitelist[];
 extern const char kIgnoreCertificateErrors[];
+extern const char kDiskCacheSize[];
 
 }  // namespace switches
 

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -36,6 +36,10 @@ Debug-related flags, see the [Debugging the Main Process][debugging-main-process
 
 Enables remote debugging over HTTP on the specified `port`.
 
+## --disk-cache-size=`size`
+
+Forces the maximum disk space to be used by the disk cache, in bytes.
+
 ## --js-flags=`flags`
 
 Specifies the flags passed to the Node JS engine. It has to be passed when starting


### PR DESCRIPTION
simply parse the command line arguments and pass to `net::HttpCache::DefaultBackend`

Refs https://github.com/electron/brightray/issues/290
Ported over from https://github.com/electron/brightray/pull/291

/cc @cjld