### PR TITLE
Remove support for --debug/--debug-brk

### DIFF
--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -6,7 +6,6 @@
 
 #include "atom/app/uv_task_runner.h"
 #include "atom/browser/javascript_environment.h"
-#include "atom/browser/node_debugger.h"
 #include "atom/common/api/atom_bindings.h"
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
@@ -50,11 +49,6 @@ int NodeMain(int argc, char *argv[]) {
     node::Environment* env = node::CreateEnvironment(
         &isolate_data, gin_env.context(), argc, argv,
         exec_argc, exec_argv);
-
-    // Start our custom debugger implementation.
-    NodeDebugger node_debugger(gin_env.isolate());
-    if (node_debugger.IsRunning())
-      env->AssignToContext(v8::Debug::GetDebugContext(gin_env.isolate()));
 
     mate::Dictionary process(gin_env.isolate(), env->process_object());
 #if defined(OS_WIN)

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -12,7 +12,6 @@
 #include "atom/browser/bridge_task_runner.h"
 #include "atom/browser/browser.h"
 #include "atom/browser/javascript_environment.h"
-#include "atom/browser/node_debugger.h"
 #include "atom/common/api/atom_bindings.h"
 #include "atom/common/asar/asar_util.h"
 #include "atom/common/node_bindings.h"
@@ -129,17 +128,10 @@ void AtomBrowserMainParts::PostEarlyInitialization() {
 
   node_bindings_->Initialize();
 
-  // Support the "--debug" switch.
-  node_debugger_.reset(new NodeDebugger(js_env_->isolate()));
-
   // Create the global environment.
   node::Environment* env =
       node_bindings_->CreateEnvironment(js_env_->context());
   node_env_.reset(new NodeEnvironment(env));
-
-  // Make sure node can get correct environment when debugging.
-  if (node_debugger_->IsRunning())
-    env->AssignToContext(v8::Debug::GetDebugContext(js_env_->isolate()));
 
   // Add Electron extended APIs.
   atom_bindings_->BindTo(js_env_->isolate(), env->process_object());

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -21,7 +21,6 @@ class AtomBindings;
 class Browser;
 class JavascriptEnvironment;
 class NodeBindings;
-class NodeDebugger;
 class NodeEnvironment;
 class BridgeTaskRunner;
 
@@ -83,7 +82,6 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<AtomBindings> atom_bindings_;
   std::unique_ptr<NodeEnvironment> node_env_;
-  std::unique_ptr<NodeDebugger> node_debugger_;
 
   base::Timer gc_timer_;
 


### PR DESCRIPTION
Looks like the old v8 debugger protocol was removed in v8 5.8, https://github.com/nodejs/node/issues/9789 and the debug agent of node was also removed in https://github.com/nodejs/node/pull/12197.

Right now running `electron --debug` is crashing since there is no debug context available from v8 and so it fails when assigning the context to the node env.

This pull request removes the use of the `NodeDebugger` class to stop this crash from happening.

This would be a stopgap solution until we can ship support for `--inspect`/`--inspect-brk` via #6634.

I've left the classes in there for now, they are just no longer created on startup.

Refs https://github.com/nodejs/node/issues/11421
Refs https://github.com/nodejs/node/pull/12197