### PR TITLE
Additional small OSR fixes

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1644,6 +1644,18 @@ void WebContents::Invalidate() {
   }
 }
 
+gfx::Size WebContents::GetSizeForNewRenderView(
+    content::WebContents* wc) const {
+  if (IsOffScreen() && wc == web_contents()) {
+    auto relay = NativeWindowRelay::FromWebContents(web_contents());
+    if (relay) {
+      return relay->window->GetSize();
+    }
+  }
+
+  return gfx::Size();
+}
+
 void WebContents::SetZoomLevel(double level) {
   zoom_controller_->SetZoomLevel(level);
 }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -183,6 +183,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetFrameRate(int frame_rate);
   int GetFrameRate() const;
   void Invalidate();
+  gfx::Size GetSizeForNewRenderView(content::WebContents*) const override;
 
   // Methods for zoom handling.
   void SetZoomLevel(double level);

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -858,6 +858,8 @@ std::unique_ptr<cc::SoftwareOutputDevice>
   DCHECK(!copy_frame_generator_);
   DCHECK(!software_output_device_);
 
+  ResizeRootLayer();
+
   software_output_device_ = new OffScreenOutputDevice(
       transparent_,
       base::Bind(&OffScreenRenderWidgetHostView::OnPaint,
@@ -1127,8 +1129,8 @@ void OffScreenRenderWidgetHostView::InvalidateBounds(const gfx::Rect& bounds) {
 void OffScreenRenderWidgetHostView::ResizeRootLayer() {
   SetupFrameRate(false);
 
-  const float orgScaleFactor = scale_factor_;
-  const bool scaleFactorDidChange = (orgScaleFactor != scale_factor_);
+  const float compositorScaleFactor = GetCompositor()->device_scale_factor();
+  const bool scaleFactorDidChange = (compositorScaleFactor != scale_factor_);
 
   gfx::Size size;
   if (!IsPopupWidget())

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2272,6 +2272,8 @@ describe('BrowserWindow module', function () {
     beforeEach(function () {
       if (w != null) w.destroy()
       w = new BrowserWindow({
+        width: 100,
+        height: 100,
         show: false,
         webPreferences: {
           backgroundThrottling: false,
@@ -2280,9 +2282,12 @@ describe('BrowserWindow module', function () {
       })
     })
 
-    it('creates offscreen window', function (done) {
-      w.webContents.once('paint', function (event, rect, data, size) {
+    it('creates offscreen window with correct size', function (done) {
+      w.webContents.once('paint', function (event, rect, data) {
         assert.notEqual(data.length, 0)
+        let size = data.getSize()
+        assertWithinDelta(size.width, 100, 2, 'width')
+        assertWithinDelta(size.height, 100, 2, 'height')
         done()
       })
       w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
@@ -2303,7 +2308,7 @@ describe('BrowserWindow module', function () {
 
     describe('window.webContents.isPainting()', function () {
       it('returns whether is currently painting', function (done) {
-        w.webContents.once('paint', function (event, rect, data, size) {
+        w.webContents.once('paint', function (event, rect, data) {
           assert.equal(w.webContents.isPainting(), true)
           done()
         })
@@ -2327,7 +2332,7 @@ describe('BrowserWindow module', function () {
         w.webContents.on('dom-ready', function () {
           w.webContents.stopPainting()
           w.webContents.startPainting()
-          w.webContents.once('paint', function (event, rect, data, size) {
+          w.webContents.once('paint', function (event, rect, data) {
             assert.equal(w.webContents.isPainting(), true)
             done()
           })
@@ -2338,7 +2343,7 @@ describe('BrowserWindow module', function () {
 
     describe('window.webContents.getFrameRate()', function () {
       it('has default frame rate', function (done) {
-        w.webContents.once('paint', function (event, rect, data, size) {
+        w.webContents.once('paint', function (event, rect, data) {
           assert.equal(w.webContents.getFrameRate(), 60)
           done()
         })
@@ -2350,7 +2355,7 @@ describe('BrowserWindow module', function () {
       it('sets custom frame rate', function (done) {
         w.webContents.on('dom-ready', function () {
           w.webContents.setFrameRate(30)
-          w.webContents.once('paint', function (event, rect, data, size) {
+          w.webContents.once('paint', function (event, rect, data) {
             assert.equal(w.webContents.getFrameRate(), 30)
             done()
           })


### PR DESCRIPTION
I've re-added the removed `GetSizeForNewRenderView` method since it is now required to initialize the size of OSR views (otherwise html pages won't see a proper window size, and will not render properly initially). I only saw this happening once I started testing a bit more with the release build, so this is why I didn't include this commit in the - now merged - PR.

Also fixes a scale factor change in the compositor affecting high DPI Macs.