### PR TITLE
Remove page url check during `history.pushState`

### DIFF
--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -27,7 +27,6 @@ var NavigationController = (function () {
       this.history.push(this.webContents._getURL())
     }
     this.webContents.on('navigation-entry-commited', (event, url, inPage, replaceEntry) => {
-      var currentEntry
       if (this.inPageIndex > -1 && !inPage) {
         // Navigated to a new page, clear in-page mark.
         this.inPageIndex = -1
@@ -46,12 +45,8 @@ var NavigationController = (function () {
       } else {
         // Normal navigation. Clear history.
         this.history = this.history.slice(0, this.currentIndex + 1)
-        currentEntry = this.history[this.currentIndex]
-
-        if (currentEntry !== url) {
-          this.currentIndex++
-          this.history.push(url)
-        }
+        this.currentIndex++
+        this.history.push(url)
       }
     })
   }

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -647,4 +647,20 @@ describe('webContents module', function () {
       gen.next()
     })
   })
+
+  describe('History API', () => {
+    it('should push state after calling history.pushState() from the same url', (done) => {
+      w.loadURL('about:blank')
+      w.webContents.once('did-finish-load', () => {
+        // History should have current page by now.
+        assert.equal(w.webContents.length(), 1)
+
+        w.webContents.executeJavaScript('window.history.pushState({}, "")', (result) => {
+          // Initial page + pushed state
+          assert.equal(w.webContents.length(), 2)
+          done()
+        })
+      })
+    })
+  })
 })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -647,20 +647,4 @@ describe('webContents module', function () {
       gen.next()
     })
   })
-
-  describe('History API', () => {
-    it('should push state after calling history.pushState() from the same url', (done) => {
-      w.loadURL('about:blank')
-      w.webContents.once('did-finish-load', () => {
-        // History should have current page by now.
-        assert.equal(w.webContents.length(), 1)
-
-        w.webContents.executeJavaScript('window.history.pushState({}, "")', (result) => {
-          // Initial page + pushed state
-          assert.equal(w.webContents.length(), 2)
-          done()
-        })
-      })
-    })
-  })
 })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1100,11 +1100,32 @@ describe('chromium feature', function () {
     })
   })
 
-  describe('window.history.go(offset)', function () {
-    it('throws an exception when the argumnet cannot be converted to a string', function () {
-      assert.throws(function () {
-        window.history.go({toString: null})
-      }, /Cannot convert object to primitive value/)
+  describe('window.history', function () {
+    describe('window.history.go(offset)', function () {
+      it('throws an exception when the argumnet cannot be converted to a string', function () {
+        assert.throws(function () {
+          window.history.go({toString: null})
+        }, /Cannot convert object to primitive value/)
+      })
+    })
+
+    describe('window.history.pushState', function () {
+      it('should push state after calling history.pushState() from the same url', (done) => {
+        w = new BrowserWindow({
+          show: false
+        })
+        w.loadURL('about:blank')
+        w.webContents.once('did-finish-load', () => {
+          // History should have current page by now.
+          assert.equal(w.webContents.length(), 1)
+
+          w.webContents.executeJavaScript('window.history.pushState({}, "")', () => {
+            // Initial page + pushed state
+            assert.equal(w.webContents.length(), 2)
+            done()
+          })
+        })
+      })
     })
   })
 })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1114,7 +1114,6 @@ describe('chromium feature', function () {
         w = new BrowserWindow({
           show: false
         })
-        w.loadURL('about:blank')
         w.webContents.once('did-finish-load', () => {
           // History should have current page by now.
           assert.equal(w.webContents.length(), 1)
@@ -1125,6 +1124,7 @@ describe('chromium feature', function () {
             done()
           })
         })
+        w.loadURL('about:blank')
       })
     })
   })


### PR DESCRIPTION
This should fix #9296.
Test repo: https://github.com/tonyganch/electron-quick-start/tree/history-regression

**TL;DR:** Current implementation of NavigationController does not allow using
`history.pushState()` if page url is not changed.
I think it worked by mistake in versions < 1.3.6 and got visible after fix 180a77e6.

**The issue:** live.com website uses `history.pushState()` and `history.back()` to navigate between different views of login form. Click on "Sign in" button calls `history.pushState({viewId: viewId}, '')` and click on "Back" button calls `history.back()`.
On `history.pushState()` NavigationController checks if the url of the page has changed and if not, then it doesn't push new state to history, meaning that `history.pushState()` called from js does absolutely nothing.
When the page then tries to call `history.back()`, NavigationController checks if the history is empty, sees that it is and does nothing (which makes sense).

Electron has its implementation of NavigationController which was introduced by this commit: 0143a4548869c1e8201ef3c3b6c2e098d5dd5140.
You can see that on line 19 we added the check if the page has the same url or a new one:
https://github.com/electron/electron/commit/0143a4548869c1e8201ef3c3b6c2e098d5dd5140#diff-35a86eec0f3148dfbe7621bd8f9bab7cR19
I don't see such check in previous code which makes me think that maybe it was introduced by mistake?

Commit after which everything "broke" is 180a77e6, but i honestly think that it just made the situation obvious and the things didn't work properly even before that.