### PR TITLE
Minor updates to webContents.getOSProcessId()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1008,7 +1008,7 @@ int WebContents::GetProcessID() const {
   return web_contents()->GetRenderProcessHost()->GetID();
 }
 
-int WebContents::GetOSProcessID() const {
+base::ProcessId WebContents::GetOSProcessID() const {
   auto process_handle = web_contents()->GetRenderProcessHost()->GetHandle();
   return base::GetProcId(process_handle);
 }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -83,7 +83,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   int64_t GetID() const;
   int GetProcessID() const;
-  int GetOSProcessID() const;
+  base::ProcessId GetOSProcessID() const;
   Type GetType() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -63,7 +63,7 @@ const constraints = {
       chromeMediaSource: 'desktop'
     }
   }
-};
+}
 ```
 
 ## Methods
@@ -75,7 +75,7 @@ The `desktopCapturer` module has the following methods:
 * `options` Object
   * `types` String[] - An array of Strings that lists the types of desktop sources
     to be captured, available types are `screen` and `window`.
-  * `thumbnailSize` [Size](structures/size.md) (optional) - The size that the media source thumbnail 
+  * `thumbnailSize` [Size](structures/size.md) (optional) - The size that the media source thumbnail
     should be scaled to. Default is `150` x `150`.
 * `callback` Function
   * `error` Error

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -326,14 +326,10 @@ describe('webContents module', function () {
 
   describe('getOSProcessId()', function () {
     it('returns a valid procress id', function () {
-      // load URL otherwise getOSProcessId() returns 0
-      w.loadURL('file://' + path.join(__dirname, 'fixtures', 'pages', 'focus-web-contents.html'))
+      assert.strictEqual(w.webContents.getOSProcessId(), 0)
 
-      const specWebContents = w.webContents
-      let pid = null
-      assert.doesNotThrow(function () {
-        pid = specWebContents.getOSProcessId()
-      })
+      w.loadURL('about:blank')
+      const pid = w.webContents.getOSProcessId()
       assert(typeof pid === 'number', 'is a number')
       assert(pid > 0, 'superior to 0')
     })


### PR DESCRIPTION
Follow on to #9222 

* Return `base::ProcessId` typedef instead of `int`
* Assert pid is 0 for `webContents` with no URL
