### PR TITLE
backport electron.d.ts fixes 1.6

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -667,6 +667,8 @@ app.setJumpList([
   * `argv` String[] - An array of the second instance's command line arguments
   * `workingDirectory` String - The second instance's working directory
 
+Returns `Boolean`.
+
 This method makes your application a Single Instance Application - instead of
 allowing multiple instances of your app to run, this will ensure that only a
 single instance of your app is running, and other instances signal this

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -46,15 +46,15 @@ Objects created with `new BrowserView` have the following properties:
 
 A [`webContents`](web-contents.md) object owned by this view.
 
-#### `win.id` _Experimental_
+#### `view.id` _Experimental_
 
 A `Integer` representing the unique ID of the view.
 
 ### Instance Methods
 
-Objects created with `new BrowserWindow` have the following instance methods:
+Objects created with `new BrowserView` have the following instance methods:
 
-#### `win.setAutoResize(options)` _Experimental_
+#### `view.setAutoResize(options)` _Experimental_
 
 * `options` Object
   * `width`: If `true`, the view's width will grow and shrink together with
@@ -62,13 +62,13 @@ Objects created with `new BrowserWindow` have the following instance methods:
   * `height`: If `true`, the view's height will grow and shrink together with
     the window. `false` by default.
 
-#### `win.setBounds(bounds)` _Experimental_
+#### `view.setBounds(bounds)` _Experimental_
 
 * `bounds` [Rectangle](structures/rectangle.md)
 
 Resizes and moves the view to the supplied bounds relative to the window.
 
-#### `win.setBackgroundColor(color)` _Experimental_
+#### `view.setBackgroundColor(color)` _Experimental_
 
 * `color` String - Color in `#aarrggbb` or `#argb` form. The alpha channel is
   optional.

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -57,10 +57,10 @@ Objects created with `new BrowserView` have the following instance methods:
 #### `view.setAutoResize(options)` _Experimental_
 
 * `options` Object
-  * `width`: If `true`, the view's width will grow and shrink together with
-    the window. `false` by default.
-  * `height`: If `true`, the view's height will grow and shrink together with
-    the window. `false` by default.
+  * `width` Boolean - If `true`, the view's width will grow and shrink together
+    with the window. `false` by default.
+  * `height` Boolean - If `true`, the view's height will grow and shrink
+    together with the window. `false` by default.
 
 #### `view.setBounds(bounds)` _Experimental_
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -44,7 +44,7 @@ Objects created with `new BrowserView` have the following properties:
 
 #### `view.webContents` _Experimental_
 
-A [`webContents`](web-contents.md) object owned by this view.
+A [`WebContents`](web-contents.md) object owned by this view.
 
 #### `view.id` _Experimental_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1027,7 +1027,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] - (optional)
+  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) - (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Same as `webContents.loadURL(url[, options])`.

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -153,6 +153,8 @@ Creates a new `NativeImage` instance from `buffer`.
 
 * `dataURL` String
 
+Returns `NativeImage`
+
 Creates a new `NativeImage` instance from `dataURL`.
 
 ## Class: NativeImage

--- a/docs/api/structures/memory-info.md
+++ b/docs/api/structures/memory-info.md
@@ -1,6 +1,6 @@
 # MemoryInfo Object
 
-* `workingSetSize` Integer - Process id of the process.
+* `pid` Integer - Process id of the process.
 * `workingSetSize` Integer - The amount of memory currently pinned to actual physical RAM.
 * `peakWorkingSetSize` Integer - The maximum amount of memory that has ever been pinned
   to actual physical RAM.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -537,7 +537,7 @@ that can't be set via `<webview>` attributes.
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] - (optional)
+  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) - (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Loads the `url` in the window. The `url` must contain the protocol prefix,

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -312,8 +312,8 @@ webview.addEventListener('dom-ready', () => {
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] - (optional)
-  * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files. 
+  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) - (optional)
+  * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Loads the `url` in the webview, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -511,14 +511,14 @@ Inserts `text` to the focused element.
 
 * `text` String - Content to be searched, must not be empty.
 * `options` Object (optional)
-  * `forward` Boolean - Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean - Whether the operation is first request or a follow up,
+  * `forward` Boolean - (optional) Whether to search forward or backward, defaults to `true`.
+  * `findNext` Boolean - (optional) Whether the operation is first request or a follow up,
     defaults to `false`.
-  * `matchCase` Boolean - Whether search should be case-sensitive,
+  * `matchCase` Boolean - (optional) Whether search should be case-sensitive,
     defaults to `false`.
-  * `wordStart` Boolean - Whether to look only at the start of words.
+  * `wordStart` Boolean - (optional) Whether to look only at the start of words.
     defaults to `false`.
-  * `medialCapitalAsWordStart` Boolean - When combined with `wordStart`,
+  * `medialCapitalAsWordStart` Boolean - (optional) When combined with `wordStart`,
     accepts a match in the middle of a word if the match begins with an
     uppercase letter followed by a lowercase or non-letter.
     Accepts several other intra-word matches, defaults to `false`.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^2.1.0",
-    "electron-typescript-definitions": "^1.2.0",
+    "electron-docs-linter": "^2.3.3",
+    "electron-typescript-definitions": "^1.2.5",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "lint-py": "python ./script/pylint.py",
     "lint-api-docs-js": "standard-markdown docs && standard-markdown docs-translations",
     "lint-api-docs": "electron-docs-linter",
+    "create-api-json": "electron-docs-linter docs --outfile=out/electron-api.json --version=$npm_package_version",
+    "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=out/electron-api.json --out=out/electron.d.ts",
     "preinstall": "node -e 'process.exit(0)'",
     "release": "./script/upload.py -p",
     "repl": "python ./script/start.py --interactive",


### PR DESCRIPTION
This PR cherry picks some fixes to the API docs, the docs linter, and the typescript generator to bring 1.6's `electron.d.ts` file up to snuff.

🍒 

cc @kevinsawicki 