### PR TITLE
Adding CPU & Memory metrics for App

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -995,16 +995,15 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
     mate::Dictionary cpu_dict = mate::Dictionary::CreateEmpty(isolate);
 
     memory_dict.Set("workingSetSize",
-            static_cast<double>(
-              process_metric.second->metrics->GetWorkingSetSize() >> 10));
+        static_cast<double>(
+            process_metric.second->metrics->GetWorkingSetSize() >> 10));
     memory_dict.Set("peakWorkingSetSize",
-            static_cast<double>(
-              process_metric.second->metrics->GetPeakWorkingSetSize() >> 10));
+        static_cast<double>(
+            process_metric.second->metrics->GetPeakWorkingSetSize() >> 10));
 
     size_t private_bytes, shared_bytes;
-    if (process_metric.second->metrics->GetMemoryBytes(
-                  &private_bytes,
-                  &shared_bytes)) {
+    if (process_metric.second->metrics->GetMemoryBytes(&private_bytes,
+                                                       &shared_bytes)) {
       memory_dict.Set("privateBytes", static_cast<double>(private_bytes >> 10));
       memory_dict.Set("sharedBytes", static_cast<double>(shared_bytes >> 10));
     }

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -508,12 +508,7 @@ App::App(v8::Isolate* isolate) {
   Browser::Get()->AddObserver(this);
   content::GpuDataManager::GetInstance()->AddObserver(this);
   content::BrowserChildProcessObserver::Add(this);
-  int pid = 0;
-  #if defined(OS_WIN)
-    pid = GetCurrentProcessId();
-  #elif defined(OS_POSIX)
-    pid = getpid();
-  #endif
+  base::ProcessId pid = base::GetCurrentProcId();
   std::unique_ptr<atom::ProcessMetric> process_metric(
               new atom::ProcessMetric(
                       "Browser",
@@ -691,8 +686,7 @@ void App::BrowserChildProcessLaunchedAndConnected(
 
 void App::BrowserChildProcessHostDisconnected(
     const content::ChildProcessData& data) {
-  this->ChildProcessDisconnected(
-    base::GetProcId(data.handle));
+  this->ChildProcessDisconnected(base::GetProcId(data.handle));
 }
 
 void App::RenderProcessReady(
@@ -704,8 +698,7 @@ void App::RenderProcessReady(
 
 void App::RenderProcessDisconnected(
     content::RenderProcessHost* host) {
-  this->ChildProcessDisconnected(
-    base::GetProcId(host->GetHandle()));
+  this->ChildProcessDisconnected(base::GetProcId(host->GetHandle()));
 }
 
 void App::ChildProcessLaunched(

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -710,11 +710,11 @@ void App::ChildProcessLaunched(int process_type, base::ProcessHandle handle) {
 
 #if defined(OS_MACOSX)
   std::unique_ptr<base::ProcessMetrics> metrics(
-    base::ProcessMetrics::CreateProcessMetrics(
-      handle, content::BrowserChildProcessHost::GetPortProvider()));
+      base::ProcessMetrics::CreateProcessMetrics(
+          handle, content::BrowserChildProcessHost::GetPortProvider()));
 #else
   std::unique_ptr<base::ProcessMetrics> metrics(
-    base::ProcessMetrics::CreateProcessMetrics(handle));
+      base::ProcessMetrics::CreateProcessMetrics(handle));
 #endif
   std::unique_ptr<atom::ProcessMetric> process_metric(
       new atom::ProcessMetric(process_type, pid, std::move(metrics)));

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -510,10 +510,10 @@ App::App(v8::Isolate* isolate) {
   content::BrowserChildProcessObserver::Add(this);
   base::ProcessId pid = base::GetCurrentProcId();
   std::unique_ptr<atom::ProcessMetric> process_metric(
-              new atom::ProcessMetric(
-                      "Browser",
-                      pid,
-                      base::ProcessMetrics::CreateCurrentProcessMetrics()));
+      new atom::ProcessMetric(
+          "Browser",
+          pid,
+          base::ProcessMetrics::CreateCurrentProcessMetrics()));
   app_metrics_[pid] = std::move(process_metric);
   Init(isolate);
 }
@@ -679,26 +679,20 @@ void App::OnGpuProcessCrashed(base::TerminationStatus status) {
 
 void App::BrowserChildProcessLaunchedAndConnected(
     const content::ChildProcessData& data) {
-  this->ChildProcessLaunched(
-    data.process_type,
-    data.handle);
+  ChildProcessLaunched(data.process_type, data.handle);
 }
 
 void App::BrowserChildProcessHostDisconnected(
     const content::ChildProcessData& data) {
-  this->ChildProcessDisconnected(base::GetProcId(data.handle));
+  ChildProcessDisconnected(base::GetProcId(data.handle));
 }
 
-void App::RenderProcessReady(
-    content::RenderProcessHost* host) {
-  this->ChildProcessLaunched(
-    content::PROCESS_TYPE_RENDERER,
-    host->GetHandle());
+void App::RenderProcessReady(content::RenderProcessHost* host) {
+  ChildProcessLaunched(content::PROCESS_TYPE_RENDERER, host->GetHandle());
 }
 
-void App::RenderProcessDisconnected(
-    content::RenderProcessHost* host) {
-  this->ChildProcessDisconnected(base::GetProcId(host->GetHandle()));
+void App::RenderProcessDisconnected(content::RenderProcessHost* host) {
+  ChildProcessDisconnected(base::GetProcId(host->GetHandle()));
 }
 
 void App::ChildProcessLaunched(
@@ -707,23 +701,22 @@ void App::ChildProcessLaunched(
   auto pid = base::GetProcId(handle);
 
 #if defined(OS_MACOSX)
-    std::unique_ptr<base::ProcessMetrics> metrics(
-      base::ProcessMetrics::CreateProcessMetrics(
-        handle, content::BrowserChildProcessHost::GetPortProvider()));
+  std::unique_ptr<base::ProcessMetrics> metrics(
+    base::ProcessMetrics::CreateProcessMetrics(
+      handle, content::BrowserChildProcessHost::GetPortProvider()));
 #else
-    std::unique_ptr<base::ProcessMetrics> metrics(
-      base::ProcessMetrics::CreateProcessMetrics(handle));
+  std::unique_ptr<base::ProcessMetrics> metrics(
+    base::ProcessMetrics::CreateProcessMetrics(handle));
 #endif
   std::unique_ptr<atom::ProcessMetric> process_metric(
-              new atom::ProcessMetric(
-                      content::GetProcessTypeNameInEnglish(process_type),
-                      pid,
-                      std::move(metrics)));
+      new atom::ProcessMetric(
+          content::GetProcessTypeNameInEnglish(process_type),
+          pid,
+          std::move(metrics)));
   app_metrics_[pid] = std::move(process_metric);
 }
 
-void App::ChildProcessDisconnected(
-    base::ProcessId pid) {
+void App::ChildProcessDisconnected(base::ProcessId pid) {
   app_metrics_.erase(pid);
 }
 
@@ -1095,9 +1088,9 @@ void App::BuildPrototype(
       .SetMethod("disableHardwareAcceleration",
                  &App::DisableHardwareAcceleration)
       .SetMethod("getFileIcon", &App::GetFileIcon)
-      // TODO(juturu): Deprecate getAppMemoryInfo.
-      .SetMethod("getAppMemoryInfo", &App::GetAppMetrics)
-      .SetMethod("getAppMetrics", &App::GetAppMetrics);
+      .SetMethod("getAppMetrics", &App::GetAppMetrics)
+      // TODO(juturu): Remove in 2.0, deprecate before then with warnings
+      .SetMethod("getAppMemoryInfo", &App::GetAppMetrics);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -511,7 +511,7 @@ App::App(v8::Isolate* isolate) {
   base::ProcessId pid = base::GetCurrentProcId();
   std::unique_ptr<atom::ProcessMetric> process_metric(
       new atom::ProcessMetric(
-          "Browser",
+          content::PROCESS_TYPE_BROWSER,
           pid,
           base::ProcessMetrics::CreateCurrentProcessMetrics()));
   app_metrics_[pid] = std::move(process_metric);
@@ -717,10 +717,7 @@ void App::ChildProcessLaunched(int process_type, base::ProcessHandle handle) {
     base::ProcessMetrics::CreateProcessMetrics(handle));
 #endif
   std::unique_ptr<atom::ProcessMetric> process_metric(
-      new atom::ProcessMetric(
-          content::GetProcessTypeNameInEnglish(process_type),
-          pid,
-          std::move(metrics)));
+      new atom::ProcessMetric(process_type, pid, std::move(metrics)));
   app_metrics_[pid] = std::move(process_metric);
 }
 
@@ -1016,7 +1013,8 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
         process_metric.second->metrics->GetIdleWakeupsPerSecond());
     pid_dict.Set("cpu", cpu_dict);
     pid_dict.Set("pid", process_metric.second->pid);
-    pid_dict.Set("type", process_metric.second->type);
+    pid_dict.Set("type",
+        content::GetProcessTypeNameInEnglish(process_metric.second->type));
     result.push_back(pid_dict);
   }
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -29,12 +29,14 @@
 #include "base/files/file_util.h"
 #include "base/path_service.h"
 #include "base/strings/string_util.h"
+#include "base/sys_info.h"
 #include "brightray/browser/brightray_paths.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/common/chrome_paths.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/browser/browser_child_process_host.h"
+#include "content/public/browser/child_process_data.h"
 #include "content/public/browser/client_certificate_delegate.h"
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/render_frame_host.h"
@@ -505,6 +507,19 @@ App::App(v8::Isolate* isolate) {
   static_cast<AtomBrowserClient*>(AtomBrowserClient::Get())->set_delegate(this);
   Browser::Get()->AddObserver(this);
   content::GpuDataManager::GetInstance()->AddObserver(this);
+  content::BrowserChildProcessObserver::Add(this);
+  int pid = 0;
+  #if defined(OS_WIN)
+    pid = GetCurrentProcessId();
+  #elif defined(OS_POSIX)
+    pid = getpid();
+  #endif
+  std::unique_ptr<atom::ProcessMetric> process_metric(
+              new atom::ProcessMetric(
+                      "Browser",
+                      pid,
+                      base::ProcessMetrics::CreateCurrentProcessMetrics()));
+  app_metrics_[pid] = std::move(process_metric);
   Init(isolate);
 }
 
@@ -513,6 +528,7 @@ App::~App() {
       nullptr);
   Browser::Get()->RemoveObserver(this);
   content::GpuDataManager::GetInstance()->RemoveObserver(this);
+  content::BrowserChildProcessObserver::Remove(this);
 }
 
 void App::OnBeforeQuit(bool* prevent_default) {
@@ -664,6 +680,58 @@ void App::SelectClientCertificate(
 void App::OnGpuProcessCrashed(base::TerminationStatus status) {
   Emit("gpu-process-crashed",
     status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
+}
+
+void App::BrowserChildProcessLaunchedAndConnected(
+    const content::ChildProcessData& data) {
+  this->ChildProcessLaunched(
+    data.process_type,
+    base::GetProcId(data.handle));
+}
+
+void App::BrowserChildProcessHostDisconnected(
+    const content::ChildProcessData& data) {
+  this->ChildProcessDisconnected(
+    base::GetProcId(data.handle));
+}
+
+void App::RenderProcessReady(
+    content::RenderProcessHost* host) {
+  this->ChildProcessLaunched(
+    content::PROCESS_TYPE_RENDERER,
+    base::GetProcId(host->GetHandle()));
+}
+
+void App::RenderProcessDisconnected(
+    content::RenderProcessHost* host) {
+  this->ChildProcessDisconnected(
+    base::GetProcId(host->GetHandle()));
+}
+
+void App::ChildProcessLaunched(
+    int process_type,
+    base::ProcessId pid) {
+  auto process = base::Process::OpenWithExtraPrivileges(pid);
+
+#if defined(OS_MACOSX)
+    std::unique_ptr<base::ProcessMetrics> metrics(
+      base::ProcessMetrics::CreateProcessMetrics(
+        process.Handle(), content::BrowserChildProcessHost::GetPortProvider()));
+#else
+    std::unique_ptr<base::ProcessMetrics> metrics(
+      base::ProcessMetrics::CreateProcessMetrics(process.Handle()));
+#endif
+  std::unique_ptr<atom::ProcessMetric> process_metric(
+              new atom::ProcessMetric(
+                      content::GetProcessTypeNameInEnglish(process_type),
+                      pid,
+                      std::move(metrics)));
+  app_metrics_[pid] = std::move(process_metric);
+}
+
+void App::ChildProcessDisconnected(
+    base::ProcessId pid) {
+  app_metrics_.erase(pid);
 }
 
 base::FilePath App::GetAppPath() const {
@@ -923,42 +991,40 @@ void App::GetFileIcon(const base::FilePath& path,
   }
 }
 
-std::vector<mate::Dictionary> App::GetAppMemoryInfo(v8::Isolate* isolate) {
-  AppIdProcessIterator process_iterator;
-  auto process_entry = process_iterator.NextProcessEntry();
+std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
   std::vector<mate::Dictionary> result;
+  int processor_count = base::SysInfo::NumberOfProcessors();
 
-  while (process_entry != nullptr) {
-    int64_t pid = process_entry->pid();
-    auto process = base::Process::OpenWithExtraPrivileges(pid);
-
-#if defined(OS_MACOSX)
-    std::unique_ptr<base::ProcessMetrics> metrics(
-      base::ProcessMetrics::CreateProcessMetrics(
-        process.Handle(), content::BrowserChildProcessHost::GetPortProvider()));
-#else
-    std::unique_ptr<base::ProcessMetrics> metrics(
-      base::ProcessMetrics::CreateProcessMetrics(process.Handle()));
-#endif
-
+  for (const auto& process_metric : app_metrics_) {
     mate::Dictionary pid_dict = mate::Dictionary::CreateEmpty(isolate);
     mate::Dictionary memory_dict = mate::Dictionary::CreateEmpty(isolate);
+    mate::Dictionary cpu_dict = mate::Dictionary::CreateEmpty(isolate);
 
     memory_dict.Set("workingSetSize",
-            static_cast<double>(metrics->GetWorkingSetSize() >> 10));
+            static_cast<double>(
+              process_metric.second->metrics->GetWorkingSetSize() >> 10));
     memory_dict.Set("peakWorkingSetSize",
-            static_cast<double>(metrics->GetPeakWorkingSetSize() >> 10));
+            static_cast<double>(
+              process_metric.second->metrics->GetPeakWorkingSetSize() >> 10));
 
     size_t private_bytes, shared_bytes;
-    if (metrics->GetMemoryBytes(&private_bytes, &shared_bytes)) {
+    if (process_metric.second->metrics->GetMemoryBytes(
+                  &private_bytes,
+                  &shared_bytes)) {
       memory_dict.Set("privateBytes", static_cast<double>(private_bytes >> 10));
       memory_dict.Set("sharedBytes", static_cast<double>(shared_bytes >> 10));
     }
 
     pid_dict.Set("memory", memory_dict);
-    pid_dict.Set("pid", pid);
+    cpu_dict.Set("percentCPUUsage",
+        process_metric.second->metrics->GetPlatformIndependentCPUUsage()
+        / processor_count);
+    cpu_dict.Set("idleWakeupsPerSecond",
+        process_metric.second->metrics->GetIdleWakeupsPerSecond());
+    pid_dict.Set("cpu", cpu_dict);
+    pid_dict.Set("pid", process_metric.second->pid);
+    pid_dict.Set("type", process_metric.second->type);
     result.push_back(pid_dict);
-    process_entry = process_iterator.NextProcessEntry();
   }
 
   return result;
@@ -1036,7 +1102,9 @@ void App::BuildPrototype(
       .SetMethod("disableHardwareAcceleration",
                  &App::DisableHardwareAcceleration)
       .SetMethod("getFileIcon", &App::GetFileIcon)
-      .SetMethod("getAppMemoryInfo", &App::GetAppMemoryInfo);
+      // TODO(juturu): Deprecate getAppMemoryInfo.
+      .SetMethod("getAppMemoryInfo", &App::GetAppMetrics)
+      .SetMethod("getAppMetrics", &App::GetAppMetrics);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -686,7 +686,7 @@ void App::BrowserChildProcessLaunchedAndConnected(
     const content::ChildProcessData& data) {
   this->ChildProcessLaunched(
     data.process_type,
-    base::GetProcId(data.handle));
+    data.handle);
 }
 
 void App::BrowserChildProcessHostDisconnected(
@@ -699,7 +699,7 @@ void App::RenderProcessReady(
     content::RenderProcessHost* host) {
   this->ChildProcessLaunched(
     content::PROCESS_TYPE_RENDERER,
-    base::GetProcId(host->GetHandle()));
+    host->GetHandle());
 }
 
 void App::RenderProcessDisconnected(
@@ -710,16 +710,16 @@ void App::RenderProcessDisconnected(
 
 void App::ChildProcessLaunched(
     int process_type,
-    base::ProcessId pid) {
-  auto process = base::Process::OpenWithExtraPrivileges(pid);
+    base::ProcessHandle handle) {
+  auto pid = base::GetProcId(handle);
 
 #if defined(OS_MACOSX)
     std::unique_ptr<base::ProcessMetrics> metrics(
       base::ProcessMetrics::CreateProcessMetrics(
-        process.Handle(), content::BrowserChildProcessHost::GetPortProvider()));
+        handle, content::BrowserChildProcessHost::GetPortProvider()));
 #else
     std::unique_ptr<base::ProcessMetrics> metrics(
-      base::ProcessMetrics::CreateProcessMetrics(process.Handle()));
+      base::ProcessMetrics::CreateProcessMetrics(handle));
 #endif
   std::unique_ptr<atom::ProcessMetric> process_metric(
               new atom::ProcessMetric(

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -687,17 +687,25 @@ void App::BrowserChildProcessHostDisconnected(
   ChildProcessDisconnected(base::GetProcId(data.handle));
 }
 
+void App::BrowserChildProcessCrashed(const content::ChildProcessData& data,
+                                     int exit_code) {
+  ChildProcessDisconnected(base::GetProcId(data.handle));
+}
+
+void App::BrowserChildProcessKilled(const content::ChildProcessData& data,
+                                    int exit_code) {
+  ChildProcessDisconnected(base::GetProcId(data.handle));
+}
+
 void App::RenderProcessReady(content::RenderProcessHost* host) {
   ChildProcessLaunched(content::PROCESS_TYPE_RENDERER, host->GetHandle());
 }
 
-void App::RenderProcessDisconnected(content::RenderProcessHost* host) {
-  ChildProcessDisconnected(base::GetProcId(host->GetHandle()));
+void App::RenderProcessDisconnected(base::ProcessId host_pid) {
+  ChildProcessDisconnected(host_pid);
 }
 
-void App::ChildProcessLaunched(
-    int process_type,
-    base::ProcessHandle handle) {
+void App::ChildProcessLaunched(int process_type, base::ProcessHandle handle) {
   auto pid = base::GetProcId(handle);
 
 #if defined(OS_MACOSX)

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_API_ATOM_API_APP_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/browser/api/event_emitter.h"
@@ -46,7 +47,8 @@ struct ProcessMetric {
   std::string type;
   base::ProcessId pid;
   std::unique_ptr<base::ProcessMetrics> metrics;
-  ProcessMetric(std::string type,
+
+  ProcessMetric(const std::string& type,
                 base::ProcessId pid,
                 std::unique_ptr<base::ProcessMetrics> metrics) {
     this->type = type;

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -17,7 +17,9 @@
 #include "base/task/cancelable_task_tracker.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/browser/process_singleton.h"
+#include "content/public/browser/browser_child_process_observer.h"
 #include "content/public/browser/gpu_data_manager_observer.h"
+#include "content/public/browser/render_process_host.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/handle.h"
 #include "net/base/completion_callback.h"
@@ -40,12 +42,26 @@ namespace atom {
 enum class JumpListResult : int;
 #endif
 
+struct ProcessMetric {
+  std::string type;
+  base::ProcessId pid;
+  std::unique_ptr<base::ProcessMetrics> metrics;
+  ProcessMetric(std::string type,
+                base::ProcessId pid,
+                std::unique_ptr<base::ProcessMetrics> metrics) {
+    this->type = type;
+    this->pid = pid;
+    this->metrics = std::move(metrics);
+  }
+};
+
 namespace api {
 
 class App : public AtomBrowserClient::Delegate,
             public mate::EventEmitter<App>,
             public BrowserObserver,
-            public content::GpuDataManagerObserver {
+            public content::GpuDataManagerObserver,
+            public content::BrowserChildProcessObserver {
  public:
   using FileIconCallback = base::Callback<void(v8::Local<v8::Value>,
                                                const gfx::Image&)>;
@@ -73,6 +89,10 @@ class App : public AtomBrowserClient::Delegate,
 #endif
 
   base::FilePath GetAppPath() const;
+  void RenderProcessReady(
+      content::RenderProcessHost* host);
+  void RenderProcessDisconnected(
+      content::RenderProcessHost* host);
 
  protected:
   explicit App(v8::Isolate* isolate);
@@ -118,8 +138,19 @@ class App : public AtomBrowserClient::Delegate,
   // content::GpuDataManagerObserver:
   void OnGpuProcessCrashed(base::TerminationStatus status) override;
 
+  // content::BrowserChildProcessObserver:
+  void BrowserChildProcessLaunchedAndConnected(
+      const content::ChildProcessData& data) override;
+  void BrowserChildProcessHostDisconnected(
+      const content::ChildProcessData& data) override;
+
  private:
   void SetAppPath(const base::FilePath& app_path);
+  void ChildProcessLaunched(
+      int process_type,
+      base::ProcessId id);
+  void ChildProcessDisconnected(
+      base::ProcessId pid);
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(mate::Arguments* args, const std::string& name);
@@ -143,7 +174,7 @@ class App : public AtomBrowserClient::Delegate,
   void GetFileIcon(const base::FilePath& path,
                    mate::Arguments* args);
 
-  std::vector<mate::Dictionary> GetAppMemoryInfo(v8::Isolate* isolate);
+  std::vector<mate::Dictionary> GetAppMetrics(v8::Isolate* isolate);
 
 #if defined(OS_WIN)
   // Get the current Jump List settings.
@@ -163,6 +194,11 @@ class App : public AtomBrowserClient::Delegate,
   base::CancelableTaskTracker cancelable_task_tracker_;
 
   base::FilePath app_path_;
+
+  using ProcessMetricMap =
+      std::unordered_map<base::ProcessId,
+                         std::unique_ptr<atom::ProcessMetric>>;
+  ProcessMetricMap app_metrics_;
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_APP_H_
 #define ATOM_BROWSER_API_ATOM_API_APP_H_
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -92,7 +93,7 @@ class App : public AtomBrowserClient::Delegate,
 
   base::FilePath GetAppPath() const;
   void RenderProcessReady(content::RenderProcessHost* host);
-  void RenderProcessDisconnected(content::RenderProcessHost* host);
+  void RenderProcessDisconnected(base::ProcessId host_pid);
 
  protected:
   explicit App(v8::Isolate* isolate);
@@ -143,6 +144,10 @@ class App : public AtomBrowserClient::Delegate,
       const content::ChildProcessData& data) override;
   void BrowserChildProcessHostDisconnected(
       const content::ChildProcessData& data) override;
+  void BrowserChildProcessCrashed(
+      const content::ChildProcessData& data, int exit_code) override;
+  void BrowserChildProcessKilled(
+      const content::ChildProcessData& data, int exit_code) override;
 
  private:
   void SetAppPath(const base::FilePath& app_path);

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -89,10 +89,8 @@ class App : public AtomBrowserClient::Delegate,
 #endif
 
   base::FilePath GetAppPath() const;
-  void RenderProcessReady(
-      content::RenderProcessHost* host);
-  void RenderProcessDisconnected(
-      content::RenderProcessHost* host);
+  void RenderProcessReady(content::RenderProcessHost* host);
+  void RenderProcessDisconnected(content::RenderProcessHost* host);
 
  protected:
   explicit App(v8::Isolate* isolate);
@@ -146,11 +144,8 @@ class App : public AtomBrowserClient::Delegate,
 
  private:
   void SetAppPath(const base::FilePath& app_path);
-  void ChildProcessLaunched(
-      int process_type,
-      base::ProcessHandle handle);
-  void ChildProcessDisconnected(
-      base::ProcessId pid);
+  void ChildProcessLaunched(int process_type, base::ProcessHandle handle);
+  void ChildProcessDisconnected(base::ProcessId pid);
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(mate::Arguments* args, const std::string& name);

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -148,7 +148,7 @@ class App : public AtomBrowserClient::Delegate,
   void SetAppPath(const base::FilePath& app_path);
   void ChildProcessLaunched(
       int process_type,
-      base::ProcessId id);
+      base::ProcessHandle handle);
   void ChildProcessDisconnected(
       base::ProcessId pid);
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -45,11 +45,11 @@ enum class JumpListResult : int;
 #endif
 
 struct ProcessMetric {
-  std::string type;
+  int type;
   base::ProcessId pid;
   std::unique_ptr<base::ProcessMetrics> metrics;
 
-  ProcessMetric(const std::string& type,
+  ProcessMetric(int type,
                 base::ProcessId pid,
                 std::unique_ptr<base::ProcessMetrics> metrics) {
     this->type = type;

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -408,6 +408,16 @@ void AtomBrowserClient::RenderProcessHostDestroyed(
     }
   }
   RemoveProcessPreferences(process_id);
+  if (delegate_) {
+    static_cast<api::App*>(delegate_)->RenderProcessDisconnected(host);
+  }
+}
+
+void AtomBrowserClient::RenderProcessReady(
+    content::RenderProcessHost* host) {
+  if (delegate_) {
+    static_cast<api::App*>(delegate_)->RenderProcessReady(host);
+  }
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -413,8 +413,7 @@ void AtomBrowserClient::RenderProcessHostDestroyed(
   }
 }
 
-void AtomBrowserClient::RenderProcessReady(
-    content::RenderProcessHost* host) {
+void AtomBrowserClient::RenderProcessReady(content::RenderProcessHost* host) {
   if (delegate_) {
     static_cast<api::App*>(delegate_)->RenderProcessReady(host);
   }

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -109,6 +109,7 @@ class AtomBrowserClient : public brightray::BrowserClient,
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;
+  void RenderProcessReady(content::RenderProcessHost* host) override;
 
  private:
   bool ShouldCreateNewSiteInstance(content::RenderFrameHost* render_frame_host,

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -110,6 +110,9 @@ class AtomBrowserClient : public brightray::BrowserClient,
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;
   void RenderProcessReady(content::RenderProcessHost* host) override;
+  void RenderProcessExited(content::RenderProcessHost* host,
+                           base::TerminationStatus status,
+                           int exit_code) override;
 
  private:
   bool ShouldCreateNewSiteInstance(content::RenderFrameHost* render_frame_host,
@@ -129,6 +132,7 @@ class AtomBrowserClient : public brightray::BrowserClient,
   std::map<int, int> pending_processes_;
 
   std::map<int, ProcessPreferences> process_preferences_;
+  std::map<int, base::ProcessId> render_process_host_pids_;
   base::Lock process_preferences_lock_;
 
   std::unique_ptr<AtomResourceDispatcherHostDelegate>

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -762,9 +762,13 @@ Disables hardware acceleration for current app.
 
 This method can only be called before app is ready.
 
-### `app.getAppMemoryInfo()`
+### `app.getAppMemoryInfo()` _Deprecate_
 
-Returns [ProcessMemoryInfo[]](structures/process-memory-info.md):  Array of `ProcessMemoryInfo` objects that correspond to memory usage statistics of all the processes associated with the app.
+Returns [ProcessMetric[]](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
+
+### `app.getAppMetrics()`
+
+Returns [ProcessMetric[]](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
 
 ### `app.setBadgeCount(count)` _Linux_ _macOS_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -127,7 +127,7 @@ Returns:
 
 Emitted when the application is activated. Various actions can trigger
 this event, such as launching the application for the first time, attempting
-to re-launch the application when it's already running, or clicking on the 
+to re-launch the application when it's already running, or clicking on the
 application's dock or taskbar icon.
 
 ### Event: 'continue-activity' _macOS_
@@ -762,9 +762,10 @@ Disables hardware acceleration for current app.
 
 This method can only be called before app is ready.
 
-### `app.getAppMemoryInfo()` _Deprecate_
+### `app.getAppMemoryInfo()` _Deprecated_
 
 Returns [ProcessMetric[]](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
+**Note:** This method is deprecated, use `app.getAppMetrics()` instead.
 
 ### `app.getAppMetrics()`
 

--- a/docs/api/structures/process-memory-info.md
+++ b/docs/api/structures/process-memory-info.md
@@ -1,4 +1,0 @@
-# ProcessMemoryInfo Object
-
-* `pid` Integer - Process id of the process.
-* `memory` [MemoryInfo](memory-info.md) - Memory information of the process.

--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -1,0 +1,6 @@
+# ProcessMetric Object
+
+* `pid` Integer - Process id of the process.
+* `type` String - Process type (Browser or Tab or GPU etc).
+* `memory` [MemoryInfo](memory-info.md) - Memory information of the process.
+* `cpu` [CPUUsage](cpu-usage.md) - CPU Of the process

--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -2,5 +2,5 @@
 
 * `pid` Integer - Process id of the process.
 * `type` String - Process type (Browser or Tab or GPU etc).
-* `memory` [MemoryInfo](memory-info.md) - Memory information of the process.
-* `cpu` [CPUUsage](cpu-usage.md) - CPU Of the process
+* `memory` [MemoryInfo](memory-info.md) - Memory information for the process.
+* `cpu` [CPUUsage](cpu-usage.md) - CPU usage of the process.

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -5,6 +5,15 @@ The following list includes the APIs that will be removed in Electron 2.0.
 There is no timetable for when this release will occur but deprecation
 warnings will be added at least 90 days beforehand.
 
+## `app`
+
+```js
+// Deprecated
+app.getAppMemoryInfo()
+// Replace with
+app.getAppMetrics()
+```
+
 ## `BrowserWindow`
 
 ```js

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -534,15 +534,18 @@ describe('app module', function () {
     })
   })
 
-  describe('getAppMemoryInfo() API', function () {
+  describe.only('getAppMetrics() API', function () {
     it('returns the process memory of all running electron processes', function () {
-      const appMemoryInfo = app.getAppMemoryInfo()
-      assert.ok(appMemoryInfo.length > 0, 'App memory info object is not > 0')
-      for (const {memory, pid} of appMemoryInfo) {
+      const appMetrics = app.getAppMetrics()
+      assert.ok(appMetrics.length > 0, 'App memory info object is not > 0')
+      for (const {memory, pid, type, cpu} of appMetrics) {
         assert.ok(memory.workingSetSize > 0, 'working set size is not > 0')
         assert.ok(memory.privateBytes > 0, 'private bytes is not > 0')
         assert.ok(memory.sharedBytes > 0, 'shared bytes is not > 0')
         assert.ok(pid > 0, 'pid is not > 0')
+        assert.ok(type.length > 0, 'process type is null')
+        assert.equal(typeof cpu.percentCPUUsage, 'number')
+        assert.equal(typeof cpu.idleWakeupsPerSecond, 'number')
       }
     })
   })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -535,7 +535,7 @@ describe('app module', function () {
   })
 
   describe('getAppMetrics() API', function () {
-    it('returns the process memory of all running electron processes', function () {
+    it('returns memory and cpu stats of all running electron processes', function () {
       const appMetrics = app.getAppMetrics()
       assert.ok(appMetrics.length > 0, 'App memory info object is not > 0')
       for (const {memory, pid, type, cpu} of appMetrics) {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -550,7 +550,10 @@ describe('app module', function () {
         assert.equal(typeof cpu.idleWakeupsPerSecond, 'number')
       }
 
-      assert.ok(types.includes('GPU'))
+      if (process.platform !== 'linux') {
+        assert.ok(types.includes('GPU'))
+      }
+
       assert.ok(types.includes('Browser'))
       assert.ok(types.includes('Tab'))
     })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -534,7 +534,7 @@ describe('app module', function () {
     })
   })
 
-  describe.only('getAppMetrics() API', function () {
+  describe('getAppMetrics() API', function () {
     it('returns the process memory of all running electron processes', function () {
       const appMetrics = app.getAppMetrics()
       assert.ok(appMetrics.length > 0, 'App memory info object is not > 0')

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -538,15 +538,21 @@ describe('app module', function () {
     it('returns memory and cpu stats of all running electron processes', function () {
       const appMetrics = app.getAppMetrics()
       assert.ok(appMetrics.length > 0, 'App memory info object is not > 0')
+      const types = []
       for (const {memory, pid, type, cpu} of appMetrics) {
         assert.ok(memory.workingSetSize > 0, 'working set size is not > 0')
         assert.ok(memory.privateBytes > 0, 'private bytes is not > 0')
         assert.ok(memory.sharedBytes > 0, 'shared bytes is not > 0')
         assert.ok(pid > 0, 'pid is not > 0')
         assert.ok(type.length > 0, 'process type is null')
+        types.push(type)
         assert.equal(typeof cpu.percentCPUUsage, 'number')
         assert.equal(typeof cpu.idleWakeupsPerSecond, 'number')
       }
+
+      assert.ok(types.includes('GPU'))
+      assert.ok(types.includes('Browser'))
+      assert.ok(types.includes('Tab'))
     })
   })
 })


### PR DESCRIPTION
- [x] TODO: Need to deprecate getAppMemoryInfo. What is the process of deprecation?

New API getAppMetrics will return something like below
```
    {  
      "memory":{  
         "workingSetSize":64920,
         "peakWorkingSetSize":0,
         "privateBytes":21300,
         "sharedBytes":68552
      },
      "cpu":{  
         "percentCPUUsage":0,
         "idleWakeupsPerSecond":0
      },
      "pid":85123,
      "type":"Tab"
   },
   {  
      "memory":{  
         "workingSetSize":78604,
         "peakWorkingSetSize":0,
         "privateBytes":17488,
         "sharedBytes":84520
      },
      "cpu":{  
         "percentCPUUsage":0.40786608393219276,
         "idleWakeupsPerSecond":0
      },
      "pid":85092,
      "type":"GPU"
   },
   {  
      "memory":{  
         "workingSetSize":77032,
         "peakWorkingSetSize":0,
         "privateBytes":29612,
         "sharedBytes":80568
      },
      "cpu":{  
         "percentCPUUsage":0.7511017533585603,
         "idleWakeupsPerSecond":4
      },
      "pid":85091,
      "type":"Browser"
   }
```