### PR TITLE
Fix broken link in documentation translations 😀

### DIFF
--- a/docs-translations/zh-CN/README.md
+++ b/docs-translations/zh-CN/README.md
@@ -93,7 +93,7 @@
 * [构建步骤（macOS）](development/build-instructions-osx.md)
 * [构建步骤（Windows）](development/build-instructions-windows.md)
 * [构建步骤（Linux）](development/build-instructions-linux.md)
-* [调试步骤 (macOS)](development/debug-instructions-macos.md)
+* [调试步骤 (macOS)](development/debugging-instructions-macos.md)
 * [调试步骤 (Windows)](development/debug-instructions-windows.md)
 * [在调试中使用 Symbol Server](development/setting-up-symbol-server.md)
 * [文档风格指南](styleguide.md)


### PR DESCRIPTION
In Documentation Translations - Simplified Chinese Section, the link to mac os debug instruction was broken.

[document link](https://github.com/electron/electron/tree/master/docs-translations/zh-CN#开发) 

[previous broken link](https://github.com/electron/electron/blob/master/docs-translations/zh-CN/development/debug-instructions-macos.md) 

I replaced with the new link [here](https://github.com/electron/electron/blob/master/docs-translations/zh-CN/development/debugging-instructions-macos.md).