### PR TITLE
[WIP] Fix and addition on content_scripts basic support

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -237,7 +237,8 @@ const injectContentScripts = function (manifest) {
   const contentScriptToEntry = function (script) {
     return {
       matches: script.matches,
-      js: script.js.map(readArrayOfFiles),
+      js: script.js ? script.js.map(readArrayOfFiles) : [],
+      css: script.css ? script.css.map(readArrayOfFiles) : [],
       runAt: script.run_at || 'document_idle'
     }
   }

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -26,9 +26,7 @@ const runContentScript = function (extensionId, url, code) {
 // Run injected scripts.
 // https://developer.chrome.com/extensions/content_scripts
 const injectContentScript = function (extensionId, script) {
-  for (const match of script.matches) {
-    if (!matchesPattern(match)) return
-  }
+  if (!script.matches.some(matchesPattern)) return
 
   for (const {url, code} of script.js) {
     const fire = runContentScript.bind(window, extensionId, url, code)

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -1,5 +1,5 @@
 const {ipcRenderer} = require('electron')
-const {runInThisContext} = require('vm')
+const vm = require('vm')
 
 // Check whether pattern matches.
 // https://developer.chrome.com/extensions/match_patterns
@@ -11,16 +11,22 @@ const matchesPattern = function (pattern) {
 }
 
 // Run the code with chrome API integrated.
-const runContentScript = function (extensionId, url, code) {
-  const context = {}
-  require('./chrome-api').injectTo(extensionId, false, context)
-  const wrapper = `(function (chrome) {\n  ${code}\n  })`
-  const compiledWrapper = runInThisContext(wrapper, {
-    filename: url,
-    lineOffset: 1,
-    displayErrors: true
-  })
-  return compiledWrapper.call(this, context.chrome)
+const runContentScripts = function (extensionId, js) {
+  const sandbox = {}
+  require('./chrome-api').injectTo(extensionId, false, sandbox)
+  Object.assign(sandbox, global)
+  const context = vm.createContext(sandbox)
+
+  let result = null
+  for (const {url, code} of js) {
+    result = vm.runInContext(code, context, {
+      filename: url,
+      lineOffset: 1,
+      displayErrors: true
+    })
+  }
+
+  return result
 }
 
 // Run injected scripts.
@@ -28,21 +34,22 @@ const runContentScript = function (extensionId, url, code) {
 const injectContentScript = function (extensionId, script) {
   if (!script.matches.some(matchesPattern)) return
 
-  for (const {url, code} of script.js) {
-    const fire = runContentScript.bind(window, extensionId, url, code)
-    if (script.runAt === 'document_start') {
-      process.once('document-start', fire)
-    } else if (script.runAt === 'document_end') {
-      process.once('document-end', fire)
-    } else if (script.runAt === 'document_idle') {
-      document.addEventListener('DOMContentLoaded', fire)
-    }
+  const fire = function () {
+    runContentScripts(extensionId, script.js)
+  }
+
+  if (script.runAt === 'document_start') {
+    process.once('document-start', fire)
+  } else if (script.runAt === 'document_end') {
+    process.once('document-end', fire)
+  } else if (script.runAt === 'document_idle') {
+    document.addEventListener('DOMContentLoaded', fire)
   }
 }
 
 // Handle the request of chrome.tabs.executeJavaScript.
 ipcRenderer.on('CHROME_TABS_EXECUTESCRIPT', function (event, senderWebContentsId, requestId, extensionId, url, code) {
-  const result = runContentScript.call(window, extensionId, url, code)
+  const result = runContentScripts(extensionId, [{ url, code }])
   ipcRenderer.sendToAll(senderWebContentsId, `CHROME_TABS_EXECUTESCRIPT_RESULT_${requestId}`, result)
 })
 

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -35,6 +35,7 @@ const injectContentScript = function (extensionId, script) {
   if (!script.matches.some(matchesPattern)) return
 
   const fire = function () {
+    if (!script.js) return
     runContentScripts(extensionId, script.js)
   }
 

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -29,14 +29,22 @@ const runContentScripts = function (extensionId, js) {
   return result
 }
 
+const runContentScriptsCSS = function (css) {
+  for (const {url, code} of css) {
+    var node = document.createElement('style')
+    node.innerHTML = code
+    window.document.body.appendChild(node)
+  }
+}
+
 // Run injected scripts.
 // https://developer.chrome.com/extensions/content_scripts
 const injectContentScript = function (extensionId, script) {
   if (!script.matches.some(matchesPattern)) return
 
   const fire = function () {
-    if (!script.js) return
-    runContentScripts(extensionId, script.js)
+    if (script.js) runContentScripts(extensionId, script.js)
+    if (script.css) runContentScriptsCSS(script.css)
   }
 
   if (script.runAt === 'document_start') {

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -30,7 +30,7 @@ const runContentScripts = function (extensionId, js) {
 }
 
 const runContentScriptsCSS = function (css) {
-  for (const {url, code} of css) {
+  for (const {code} of css) {
     var node = document.createElement('style')
     node.innerHTML = code
     window.document.body.appendChild(node)


### PR DESCRIPTION
With the objective to load some Chrome extensions in an Electron app, I noticed few things to add or correct in Electron's [`content_scripts`](https://developer.chrome.com/extensions/content_scripts) basic support that I propose in this PR:

1. Fixed: script was injected only if the current URL matched the first item of `content_scripts[].matchs` ignoring the following items
2. Fixed: run the different scripts in a same context. I stumbled upon a popular extension ([mailtracker](https://chrome.google.com/webstore/detail/mailtracker-for-gmail/pgbdljpkijehgoacbjpolaomhkoffhnl)) that works and expects this behavior, so I assumed it is the expected behavior. ⚠️ _bug: see below_
3. Added support for CSS injection
---
However, it looks like the changes I introduced in 48cff0c make the webContents crash when a script of the extension tries to modify `window` (`window.what = 'whatever'`).

I was able to setup an [environment](https://github.com/alexstrat/electron-boilerplate/pull/3) to reproduce and got this stack trace:
```
Received signal 11 SEGV_MAPERR 003f7b840822
 [0x00010b26d7ec]
 [0x00010b26d6a1]
 [0x7fffe71fab3a]
 [0x00010ab6fa12]
 [0x00010b4dc59a]
 [0x00010b4a2ee0]
 [0x00010b494830]
 [0x00010c054b7e]
 [0x00010ac17144]
 [0x00010ac99b13]
 [0x00010aca6c28]
 [0x00010aca6aa6]
 [0x00010ac0bbbc]
 [0x00010ac10854]
 [0x19664be8437d]
[end of stack trace]
```
How can I move forward with this stack trace?
Has anyone an idea of what may causes this?

_Related: #1498_