### PR TITLE
Suppress dispatching to PDF viewer if plugins are disabled

### DIFF
--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -6,6 +6,7 @@
 
 #include "atom/browser/login_handler.h"
 #include "atom/browser/web_contents_permission_helper.h"
+#include "atom/browser/web_contents_preferences.h"
 #include "atom/common/atom_constants.h"
 #include "atom/common/platform_util.h"
 #include "base/strings/stringprintf.h"
@@ -124,7 +125,9 @@ bool AtomResourceDispatcherHostDelegate::ShouldInterceptResourceAsStream(
     std::string* payload) {
   const content::ResourceRequestInfo* info =
       content::ResourceRequestInfo::ForRequest(request);
-  if (mime_type == "application/pdf" && info->IsMainFrame()) {
+  content::WebContents* web_contents = info->GetWebContentsGetterForRequest().Run();
+  if (mime_type == "application/pdf" && info->IsMainFrame() && 
+      WebContentsPreferences::IsPluginsEnabled(web_contents)) {
     *origin = GURL(kPdfViewerUIOrigin);
     content::BrowserThread::PostTask(
         BrowserThread::UI, FROM_HERE,

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -125,8 +125,9 @@ bool AtomResourceDispatcherHostDelegate::ShouldInterceptResourceAsStream(
     std::string* payload) {
   const content::ResourceRequestInfo* info =
       content::ResourceRequestInfo::ForRequest(request);
-  content::WebContents* web_contents = info->GetWebContentsGetterForRequest().Run();
-  if (mime_type == "application/pdf" && info->IsMainFrame() && 
+  content::WebContents* web_contents =
+      info->GetWebContentsGetterForRequest().Run();
+  if (mime_type == "application/pdf" && info->IsMainFrame() &&
       WebContentsPreferences::IsPluginsEnabled(web_contents)) {
     *origin = GURL(kPdfViewerUIOrigin);
     content::BrowserThread::PostTask(

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -237,7 +237,8 @@ bool WebContentsPreferences::UsesNativeWindowOpen(
   return use;
 }
 
-bool WebContentsPreferences::IsPluginsEnabled(content::WebContents* web_contents) {
+bool WebContentsPreferences::IsPluginsEnabled(
+    content::WebContents* web_contents) {
   WebContentsPreferences* self;
   if (!web_contents)
     return false;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -237,6 +237,21 @@ bool WebContentsPreferences::UsesNativeWindowOpen(
   return use;
 }
 
+bool WebContentsPreferences::IsPluginsEnabled(content::WebContents* web_contents) {
+  WebContentsPreferences* self;
+  if (!web_contents)
+    return false;
+
+  self = FromWebContents(web_contents);
+  if (!self)
+    return false;
+
+  base::DictionaryValue& web_preferences = self->web_preferences_;
+  bool plugins = false;
+  web_preferences.GetBoolean("plugins", &plugins);
+  return plugins;
+}
+
 // static
 void WebContentsPreferences::OverrideWebkitPrefs(
     content::WebContents* web_contents, content::WebPreferences* prefs) {

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -206,7 +206,9 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   }
 }
 
-bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
+bool WebContentsPreferences::IsPreferenceEnabled(
+    const std::string& attributeName,
+    content::WebContents* web_contents) {
   WebContentsPreferences* self;
   if (!web_contents)
     return false;
@@ -216,41 +218,23 @@ bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
     return false;
 
   base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool sandboxed = false;
-  web_preferences.GetBoolean("sandbox", &sandboxed);
-  return sandboxed;
+  bool boolValue = false;
+  web_preferences.GetBoolean(attributeName, &boolValue);
+  return boolValue;
+}
+
+bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
+  return IsPreferenceEnabled("sandbox", web_contents);
 }
 
 bool WebContentsPreferences::UsesNativeWindowOpen(
     content::WebContents* web_contents) {
-  WebContentsPreferences* self;
-  if (!web_contents)
-    return false;
-
-  self = FromWebContents(web_contents);
-  if (!self)
-    return false;
-
-  base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool use = false;
-  web_preferences.GetBoolean("nativeWindowOpen", &use);
-  return use;
+  return IsPreferenceEnabled("nativeWindowOpen", web_contents);
 }
 
 bool WebContentsPreferences::IsPluginsEnabled(
     content::WebContents* web_contents) {
-  WebContentsPreferences* self;
-  if (!web_contents)
-    return false;
-
-  self = FromWebContents(web_contents);
-  if (!self)
-    return false;
-
-  base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool plugins = false;
-  web_preferences.GetBoolean("plugins", &plugins);
-  return plugins;
+  return IsPreferenceEnabled("plugins", web_contents);
 }
 
 // static

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -207,7 +207,7 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
 }
 
 bool WebContentsPreferences::IsPreferenceEnabled(
-    const std::string& attributeName,
+    const std::string& attribute_name,
     content::WebContents* web_contents) {
   WebContentsPreferences* self;
   if (!web_contents)
@@ -218,9 +218,9 @@ bool WebContentsPreferences::IsPreferenceEnabled(
     return false;
 
   base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool boolValue = false;
-  web_preferences.GetBoolean(attributeName, &boolValue);
-  return boolValue;
+  bool bool_value = false;
+  web_preferences.GetBoolean(attribute_name, &bool_value);
+  return bool_value;
 }
 
 bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -39,6 +39,7 @@ class WebContentsPreferences
 
   static bool IsSandboxed(content::WebContents* web_contents);
   static bool UsesNativeWindowOpen(content::WebContents* web_contents);
+  static bool IsPluginsEnabled(content::WebContents* web_contents);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.
   static void OverrideWebkitPrefs(

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -37,7 +37,7 @@ class WebContentsPreferences
   static void AppendExtraCommandLineSwitches(
       content::WebContents* web_contents, base::CommandLine* command_line);
 
-  static bool IsPreferenceEnabled(const std::string& attributeName,
+  static bool IsPreferenceEnabled(const std::string& attribute_name,
                                   content::WebContents* web_contents);
   static bool IsSandboxed(content::WebContents* web_contents);
   static bool UsesNativeWindowOpen(content::WebContents* web_contents);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -37,6 +37,8 @@ class WebContentsPreferences
   static void AppendExtraCommandLineSwitches(
       content::WebContents* web_contents, base::CommandLine* command_line);
 
+  static bool IsPreferenceEnabled(const std::string& attributeName,
+                                  content::WebContents* web_contents);
   static bool IsSandboxed(content::WebContents* web_contents);
   static bool UsesNativeWindowOpen(content::WebContents* web_contents);
   static bool IsPluginsEnabled(content::WebContents* web_contents);

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1012,16 +1012,18 @@ describe('chromium feature', function () {
       slashes: true
     })
 
-    beforeEach(function () {
+    function createBrowserWindow (isPluginsEnabled) {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
-          preload: path.join(fixtures, 'module', 'preload-inject-ipc.js')
+          preload: path.join(fixtures, 'module', 'preload-inject-ipc.js'),
+          plugins: isPluginsEnabled
         }
       })
-    })
+    }
 
     it('opens when loading a pdf resource as top level navigation', function (done) {
+      createBrowserWindow(true)
       ipcMain.once('pdf-loaded', function (event, success) {
         if (success) done()
       })
@@ -1043,7 +1045,23 @@ describe('chromium feature', function () {
       w.webContents.loadURL(pdfSource)
     })
 
+    it('should download a pdf when plugins are disabled', function (done) {
+      createBrowserWindow(false)
+      ipcRenderer.sendSync('set-download-option', false, false)
+      ipcRenderer.once('download-done', function (event, state, url,
+                                                mimeType, receivedBytes,
+                                                totalBytes, disposition,
+                                                filename) {
+        assert.equal(state, 'completed')
+        assert.equal(filename, 'cat.pdf')
+        assert.equal(mimeType, 'application/pdf')
+        done()
+      })
+      w.webContents.loadURL(pdfSource)
+    })
+
     it('should not open when pdf is requested as sub resource', function (done) {
+      createBrowserWindow(true)
       webFrame.registerURLSchemeAsPrivileged('file', {
         secure: false,
         bypassCSP: false,

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1048,10 +1048,7 @@ describe('chromium feature', function () {
     it('should download a pdf when plugins are disabled', function (done) {
       createBrowserWindow(false)
       ipcRenderer.sendSync('set-download-option', false, false)
-      ipcRenderer.once('download-done', function (event, state, url,
-                                                mimeType, receivedBytes,
-                                                totalBytes, disposition,
-                                                filename) {
+      ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
         assert.equal(state, 'completed')
         assert.equal(filename, 'cat.pdf')
         assert.equal(mimeType, 'application/pdf')

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1012,18 +1012,18 @@ describe('chromium feature', function () {
       slashes: true
     })
 
-    function createBrowserWindow (isPluginsEnabled) {
+    function createBrowserWindow ({plugins}) {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
           preload: path.join(fixtures, 'module', 'preload-inject-ipc.js'),
-          plugins: isPluginsEnabled
+          plugins: plugins
         }
       })
     }
 
     it('opens when loading a pdf resource as top level navigation', function (done) {
-      createBrowserWindow(true)
+      createBrowserWindow({plugins: true})
       ipcMain.once('pdf-loaded', function (event, success) {
         if (success) done()
       })
@@ -1046,19 +1046,20 @@ describe('chromium feature', function () {
     })
 
     it('should download a pdf when plugins are disabled', function (done) {
-      createBrowserWindow(false)
+      createBrowserWindow({plugins: false})
       ipcRenderer.sendSync('set-download-option', false, false)
       ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
         assert.equal(state, 'completed')
         assert.equal(filename, 'cat.pdf')
         assert.equal(mimeType, 'application/pdf')
+        fs.unlinkSync(path.join(fixtures, 'mock.pdf'))
         done()
       })
       w.webContents.loadURL(pdfSource)
     })
 
     it('should not open when pdf is requested as sub resource', function (done) {
-      createBrowserWindow(true)
+      createBrowserWindow({plugins: true})
       webFrame.registerURLSchemeAsPrivileged('file', {
         secure: false,
         bypassCSP: false,


### PR DESCRIPTION
Suppress dispatching pdf resource requests to the native pdf viewer if plugins are disabled in `BrowserWindow.webPreferences` as suggested by @deepak1556 in https://github.com/electron/electron/issues/9412#issuecomment-300208701.

Note to the reviewer(s):
Since i've no clue about writing C++ code i tried to keep the changes as small as possible and skipped the following potential improvements:
* `web_contents_getter.Run()` is now called twice during the request at [ShouldInterceptResourceAsStream](https://github.com/rreimann/electron/blob/2f08b55a8a21cdc6a340ec663afcb79b6f48b6fc/atom/browser/atom_resource_dispatcher_host_delegate.cc#L128) and at [OnPdfResourceIntercepted](https://github.com/rreimann/electron/blob/2f08b55a8a21cdc6a340ec663afcb79b6f48b6fc/atom/browser/atom_resource_dispatcher_host_delegate.cc#L69). If i'd known the required syntax i would have called it just once and passed the resulting `WebContents` to `OnPdfResourceIntercepted`

* After adding `IsPluginsEnabled` to the existing methods `IsSandboxed` and `UsesNativeWindowOpen` there are now [three methods](https://github.com/rreimann/electron/blob/2f08b55a8a21cdc6a340ec663afcb79b6f48b6fc/atom/browser/web_contents_preferences.cc#L202-L246) that seem widely redundant. I did't know if the preexisting redundancy was intentional so i didn't try to extract a common method for all of them.

Fixes #9412