### PR TITLE
atom-shell -> electron in node_release_urlbase

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -16,7 +16,7 @@
     'openssl_no_asm': 1,
     'use_openssl_def': 0,
     'OPENSSL_PRODUCT': 'libopenssl.a',
-    'node_release_urlbase': 'https://atom.io/download/atom-shell',
+    'node_release_urlbase': 'https://atom.io/download/electron',
     'node_byteorder': '<!(node <(DEPTH)/tools/get-endianness.js)',
     'node_target_type': 'shared_library',
     'node_install_npm': 'false',


### PR DESCRIPTION
This URL was updated a bunch of other places in https://github.com/electron/electron/pull/7881 but this one was missed.