### PR TITLE
Backport disabling crash specs on linux to 1.6

### DIFF
--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -9,10 +9,17 @@ const url = require('url')
 const {closeWindow} = require('./window-helpers')
 
 const {remote} = require('electron')
+const isCI = remote.getGlobal('isCi')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
 describe('crashReporter module', function () {
   if (process.mas) {
+    return
+  }
+
+  // FIXME internal Linux CI is failing when it detects a process crashes
+  // which is a false positive here since crashes are explicitly triggered
+  if (isCI && process.platform === 'linux') {
     return
   }
 


### PR DESCRIPTION
Backport https://github.com/electron/electron/pull/9476 to 1.6.x so the linux specs are green there.