### PR TITLE
Assert OS pid after load finishes

### DIFF
--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -325,13 +325,16 @@ describe('webContents module', function () {
   })
 
   describe('getOSProcessId()', function () {
-    it('returns a valid procress id', function () {
+    it('returns a valid procress id', function (done) {
       assert.strictEqual(w.webContents.getOSProcessId(), 0)
 
+      w.webContents.once('did-finish-load', () => {
+        const pid = w.webContents.getOSProcessId()
+        assert.equal(typeof pid, 'number')
+        assert(pid > 0, `pid ${pid} is not greater than 0`)
+        done()
+      })
       w.loadURL('about:blank')
-      const pid = w.webContents.getOSProcessId()
-      assert(typeof pid === 'number', 'is a number')
-      assert(pid > 0, 'superior to 0')
     })
   })
 


### PR DESCRIPTION
This spec failed on CI once:

```
not ok 471 webContents module getOSProcessId() returns a valid procress id
  AssertionError: superior to 0
      at Context.<anonymous> (C:\Users\electron\workspace\electron-win-x64\spec\api-web-contents-spec.js:334:7)
```

Wait until load finishes before asserting the PID of the renderer process.