### PR TITLE
Fixed tutorial debugger launching electron incorrectly

### DIFF
--- a/docs/tutorial/debugging-main-process-vscode.md
+++ b/docs/tutorial/debugging-main-process-vscode.md
@@ -19,7 +19,10 @@ $ code electron-quick-start
       "request": "launch",
       "cwd": "${workspaceRoot}",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-      "program": "${workspaceRoot}/main.js"
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
+      "args" : ["."]
     }
   ]
 }


### PR DESCRIPTION
Fixes app.getPath("userData") pointing to the wrong folder. (electron in %appdata%)

The old debugger essentially runs:
.\node_modules\.bin\electron main.js

Which makes userData incorrect and various other things wrong related to app launch.

The new version correctly executes:
.\node_modules\.bin\electron .

Which means when you call app.getPath("userData") it will return the correct folder name, and not 'electron', which is what my app was doing even though the folder was named properly.