### PR TITLE
Build with Debian Jessie sysroot image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@
 /external_binaries/
 /out/
 /vendor/download/
-/vendor/debian_wheezy_amd64-sysroot/
-/vendor/debian_wheezy_arm-sysroot/
-/vendor/debian_wheezy_i386-sysroot/
+/vendor/debian_jessie_amd64-sysroot/
+/vendor/debian_jessie_arm-sysroot/
+/vendor/debian_jessie_arm64-sysroot/
+/vendor/debian_jessie_i386-sysroot/
 /vendor/python_26/
 /vendor/npm/
 /vendor/llvm/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /vendor/debian_jessie_arm-sysroot/
 /vendor/debian_jessie_arm64-sysroot/
 /vendor/debian_jessie_i386-sysroot/
+/vendor/debian_wheezy_amd64-sysroot/
+/vendor/debian_wheezy_arm-sysroot/
+/vendor/debian_wheezy_i386-sysroot/
 /vendor/python_26/
 /vendor/npm/
 /vendor/llvm/

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -227,7 +227,8 @@ def download_sysroot(target_arch):
     target_arch = 'amd64'
   execute_stdout([sys.executable,
                   os.path.join(SOURCE_ROOT, 'script', 'install-sysroot.py'),
-                  '--arch', target_arch])
+                  '--arch', target_arch],
+                  cwd=VENDOR_DIR)
 
 def create_chrome_version_h():
   version_file = os.path.join(VENDOR_DIR, 'libchromiumcontent', 'VERSION')

--- a/script/cibuild
+++ b/script/cibuild
@@ -32,7 +32,8 @@ LINUX_DEPS_ARM = [
 def main():
   os.environ['CI'] = '1'
 
-  if os.environ.has_key('JANKY_SHA1'):
+  is_janky = os.environ.has_key('JANKY_SHA1')
+  if is_janky:
     setup_nodenv()
 
   # Ignore the CXX and CC env in CI.
@@ -88,7 +89,9 @@ def main():
     run_script('upload.py')
   else:
     run_script('build.py', ['-c', 'D'])
-    if PLATFORM == 'win32' or target_arch == 'x64':
+    if PLATFORM == 'win32' or \
+       (PLATFORM == 'darwin' and target_arch == 'x64') or \
+       (PLATFORM == 'linux' and not is_janky and target_arch == 'x64'):
       run_script('test.py', ['--ci'])
       run_script('verify-ffmpeg.py')
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -32,8 +32,7 @@ LINUX_DEPS_ARM = [
 def main():
   os.environ['CI'] = '1'
 
-  is_janky = os.environ.has_key('JANKY_SHA1')
-  if is_janky:
+  if os.environ.has_key('JANKY_SHA1'):
     setup_nodenv()
 
   # Ignore the CXX and CC env in CI.
@@ -89,9 +88,7 @@ def main():
     run_script('upload.py')
   else:
     run_script('build.py', ['-c', 'D'])
-    if PLATFORM == 'win32' or \
-       (PLATFORM == 'darwin' and target_arch == 'x64') or \
-       (PLATFORM == 'linux' and not is_janky and target_arch == 'x64'):
+    if PLATFORM == 'win32' or target_arch == 'x64':
       run_script('test.py', ['--ci'])
       run_script('verify-ffmpeg.py')
 

--- a/script/install-sysroot.py
+++ b/script/install-sysroot.py
@@ -85,7 +85,10 @@ def main(args):
 def InstallDefaultSysrootForArch(target_arch):
   if target_arch not in VALID_ARCHS:
     raise Error('Unknown architecture: %s' % target_arch)
-  InstallSysroot('Jessie', target_arch)
+  if target_arch == 'arm64':
+    InstallSysroot('Jessie', target_arch)
+  else:
+    InstallSysroot('Wheezy', target_arch)
 
 
 def InstallSysroot(target_platform, target_arch):

--- a/script/install-sysroot.py
+++ b/script/install-sysroot.py
@@ -121,7 +121,7 @@ def InstallSysroot(target_platform, target_arch):
   revision = sysroot_dict['Revision']
   tarball_filename = sysroot_dict['Tarball']
   tarball_sha1sum = sysroot_dict['Sha1Sum']
-  sysroot = os.path.join(linux_dir, sysroot_dict['SysrootDir'])
+  sysroot = os.path.join(linux_dir, 'vendor', sysroot_dict['SysrootDir'])
 
   url = '%s/%s/%s/%s' % (URL_PREFIX, URL_PATH, revision, tarball_filename)
 

--- a/script/install-sysroot.py
+++ b/script/install-sysroot.py
@@ -54,24 +54,6 @@ def GetSha1(filename):
   return sha1.hexdigest()
 
 
-def InstallDefaultSysroots(host_arch):
-  """Install the default set of sysroot images.
-
-  This includes at least the sysroot for host architecture, and the 32-bit
-  sysroot for building the v8 snapshot image.  It can also include the cross
-  compile sysroot for ARM/MIPS if cross compiling environment can be detected.
-
-  Another reason we're installing this by default is so that developers can
-  compile and run on our supported platforms without having to worry about
-  flipping things back and forth and whether the sysroots have been downloaded
-  or not.
-  """
-  InstallSysroot('amd64')
-  InstallSysroot('i386')
-  InstallSysroot('arm')
-  InstallSysroot('arm64')
-
-
 def main(args):
   parser = optparse.OptionParser('usage: %prog [OPTIONS]', description=__doc__)
   parser.add_option('--running-as-hook', action='store_true',
@@ -148,7 +130,7 @@ def InstallSysroot(target_platform, target_arch):
       with open(tarball, "wb") as f:
         f.write(response.read())
       break
-    except:
+    except Exception:
       pass
   else:
     raise Error('Failed to download %s' % url)

--- a/script/install-sysroot.py
+++ b/script/install-sysroot.py
@@ -3,19 +3,23 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Script to install a Debian Wheezy sysroot for making official Google Chrome
-# Linux builds.
-# The sysroot is needed to make Chrome work for Debian Wheezy.
-# This script can be run manually but is more often run as part of gclient
-# hooks. When run from hooks this script should be a no-op on non-linux
-# platforms.
+"""Install Debian sysroots for building chromium.
+"""
 
-# The sysroot image could be constructed from scratch based on the current
-# state or Debian Wheezy but for consistency we currently use a pre-built root
-# image. The image will normally need to be rebuilt every time chrome's build
-# dependancies are changed.
+# The sysroot is needed to ensure that binaries that get built will run on
+# the oldest stable version of Debian that we currently support.
+# This script can be run manually but is more often run as part of gclient
+# hooks. When run from hooks this script is a no-op on non-linux platforms.
+
+# The sysroot image could be constructed from scratch based on the current state
+# of the Debian archive but for consistency we use a pre-built root image (we
+# don't want upstream changes to Debian to effect the chromium build until we
+# choose to pull them in). The images will normally need to be rebuilt every
+# time chrome's build dependencies are changed but should also be updated
+# periodically to include upstream security fixes from Debian.
 
 import hashlib
+import json
 import platform
 import optparse
 import os
@@ -23,27 +27,19 @@ import re
 import shutil
 import subprocess
 import sys
-
-from lib.util import get_host_arch
-
+import urllib2
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-URL_PREFIX = 'https://github.com'
-URL_PATH = 'atom/debian-sysroot-image-creator/releases/download'
-REVISION_AMD64 = 'v0.5.0'
-REVISION_I386 = 'v0.5.0'
-REVISION_ARM = 'v0.5.0'
-TARBALL_AMD64 = 'debian_wheezy_amd64_sysroot.tgz'
-TARBALL_I386 = 'debian_wheezy_i386_sysroot.tgz'
-TARBALL_ARM = 'debian_wheezy_arm_sysroot.tgz'
-TARBALL_AMD64_SHA1SUM = '981b2440d446156801c6fdecffb5edcadf27593c'
-TARBALL_I386_SHA1SUM = '2e4e43c1e8718595e37c6b6ab89256dae53adf23'
-TARBALL_ARM_SHA1SUM = '448e635f38e99d6d860db538a9db85ac74d36e41'
-SYSROOT_DIR_AMD64 = 'debian_wheezy_amd64-sysroot'
-SYSROOT_DIR_I386 = 'debian_wheezy_i386-sysroot'
-SYSROOT_DIR_ARM = 'debian_wheezy_arm-sysroot'
 
-valid_archs = ('arm', 'i386', 'amd64')
+
+URL_PREFIX = 'http://s3.amazonaws.com'
+URL_PATH = 'gh-contractor-zcbenz/toolchain'
+
+VALID_ARCHS = ('arm', 'arm64', 'i386', 'amd64')
+
+
+class Error(Exception):
+  pass
 
 
 def GetSha1(filename):
@@ -58,81 +54,74 @@ def GetSha1(filename):
   return sha1.hexdigest()
 
 
-def DetectArch(gyp_defines):
-  # Check for optional target_arch and only install for that architecture.
-  # If target_arch is not specified, then only install for the host
-  # architecture.
-  if 'target_arch=x64' in gyp_defines:
-    return 'amd64'
-  elif 'target_arch=ia32' in gyp_defines:
-    return 'i386'
-  elif 'target_arch=arm' in gyp_defines:
-    return 'arm'
+def InstallDefaultSysroots(host_arch):
+  """Install the default set of sysroot images.
 
-  detected_host_arch = get_host_arch()
-  if detected_host_arch == 'x64':
-    return 'amd64'
-  elif detected_host_arch == 'ia32':
-    return 'i386'
-  elif detected_host_arch == 'arm':
-    return 'arm'
+  This includes at least the sysroot for host architecture, and the 32-bit
+  sysroot for building the v8 snapshot image.  It can also include the cross
+  compile sysroot for ARM/MIPS if cross compiling environment can be detected.
+
+  Another reason we're installing this by default is so that developers can
+  compile and run on our supported platforms without having to worry about
+  flipping things back and forth and whether the sysroots have been downloaded
+  or not.
+  """
+  InstallSysroot('amd64')
+  InstallSysroot('i386')
+  InstallSysroot('arm')
+  InstallSysroot('arm64')
+
+
+def main(args):
+  parser = optparse.OptionParser('usage: %prog [OPTIONS]', description=__doc__)
+  parser.add_option('--running-as-hook', action='store_true',
+                    default=False, help='Used when running from gclient hooks.'
+                                        ' Installs default sysroot images.')
+  parser.add_option('--arch', type='choice', choices=VALID_ARCHS,
+                    help='Sysroot architecture: %s' % ', '.join(VALID_ARCHS))
+  parser.add_option('--all', action='store_true',
+                    help='Install all sysroot images (useful when updating the'
+                         ' images)')
+  options, _ = parser.parse_args(args)
+  if options.running_as_hook and not sys.platform.startswith('linux'):
+    return 0
+
+  if options.running_as_hook:
+    return 0
+  elif options.arch:
+    InstallDefaultSysrootForArch(options.arch)
+  elif options.all:
+    for arch in VALID_ARCHS:
+      InstallDefaultSysrootForArch(arch)
   else:
-    print "Unknown host arch: %s" % detected_host_arch
+    print 'You much specify either --arch, --all or --running-as-hook'
+    return 1
 
-  return None
+  return 0
 
 
-def main():
-  if options.linux_only:
-    # This argument is passed when run from the gclient hooks.
-    # In this case we return early on non-linux platforms.
-    if not sys.platform.startswith('linux'):
-      return 0
+def InstallDefaultSysrootForArch(target_arch):
+  if target_arch not in VALID_ARCHS:
+    raise Error('Unknown architecture: %s' % target_arch)
+  InstallSysroot('Jessie', target_arch)
 
-  gyp_defines = os.environ.get('GYP_DEFINES', '')
 
-  if options.arch:
-    target_arch = options.arch
-  else:
-    target_arch = DetectArch(gyp_defines)
-    if not target_arch:
-      print 'Unable to detect host architecture'
-      return 1
-
-  if options.linux_only and target_arch != 'arm':
-    # When run from runhooks, only install the sysroot for an Official Chrome
-    # Linux build, except on ARM where we always use a sysroot.
-    defined = ['branding=Chrome', 'buildtype=Official']
-    undefined = ['chromeos=1']
-    for option in defined:
-      if option not in gyp_defines:
-        return 0
-    for option in undefined:
-      if option in gyp_defines:
-        return 0
-
+def InstallSysroot(target_platform, target_arch):
   # The sysroot directory should match the one specified in build/common.gypi.
-  # TODO(thestig) Consider putting this else where to avoid having to recreate
+  # TODO(thestig) Consider putting this elsewhere to avoid having to recreate
   # it on every build.
-  linux_dir = os.path.join(SCRIPT_DIR, '..', 'vendor')
-  if target_arch == 'amd64':
-    sysroot = os.path.join(linux_dir, SYSROOT_DIR_AMD64)
-    tarball_filename = TARBALL_AMD64
-    tarball_sha1sum = TARBALL_AMD64_SHA1SUM
-    revision = REVISION_AMD64
-  elif target_arch == 'arm':
-    sysroot = os.path.join(linux_dir, SYSROOT_DIR_ARM)
-    tarball_filename = TARBALL_ARM
-    tarball_sha1sum = TARBALL_ARM_SHA1SUM
-    revision = REVISION_ARM
-  elif target_arch == 'i386':
-    sysroot = os.path.join(linux_dir, SYSROOT_DIR_I386)
-    tarball_filename = TARBALL_I386
-    tarball_sha1sum = TARBALL_I386_SHA1SUM
-    revision = REVISION_I386
-  else:
-    print 'Unknown architecture: %s' % target_arch
-    assert(False)
+  linux_dir = os.path.dirname(SCRIPT_DIR)
+
+  sysroots_file = os.path.join(SCRIPT_DIR, 'sysroots.json')
+  sysroots = json.load(open(sysroots_file))
+  sysroot_key = '%s_%s' % (target_platform.lower(), target_arch)
+  if sysroot_key not in sysroots:
+    raise Error('No sysroot for: %s %s' % (target_platform, target_arch))
+  sysroot_dict = sysroots[sysroot_key]
+  revision = sysroot_dict['Revision']
+  tarball_filename = sysroot_dict['Tarball']
+  tarball_sha1sum = sysroot_dict['Sha1Sum']
+  sysroot = os.path.join(linux_dir, sysroot_dict['SysrootDir'])
 
   url = '%s/%s/%s/%s' % (URL_PREFIX, URL_PATH, revision, tarball_filename)
 
@@ -140,11 +129,12 @@ def main():
   if os.path.exists(stamp):
     with open(stamp) as s:
       if s.read() == url:
-        print 'Debian Wheezy %s root image already up-to-date: %s' % \
-            (target_arch, sysroot)
-        return 0
+        print '%s %s sysroot image already up to date: %s' % \
+            (target_platform, target_arch, sysroot)
+        return
 
-  print 'Installing Debian Wheezy %s root image: %s' % (target_arch, sysroot)
+  print 'Installing Debian %s %s root image: %s' % \
+      (target_platform, target_arch, sysroot)
   if os.path.isdir(sysroot):
     shutil.rmtree(sysroot)
   os.mkdir(sysroot)
@@ -152,26 +142,30 @@ def main():
   print 'Downloading %s' % url
   sys.stdout.flush()
   sys.stderr.flush()
-  subprocess.check_call(['curl', '--fail', '-L', url, '-o', tarball])
+  for _ in range(3):
+    try:
+      response = urllib2.urlopen(url)
+      with open(tarball, "wb") as f:
+        f.write(response.read())
+      break
+    except:
+      pass
+  else:
+    raise Error('Failed to download %s' % url)
   sha1sum = GetSha1(tarball)
   if sha1sum != tarball_sha1sum:
-    print 'Tarball sha1sum is wrong.'
-    print 'Expected %s, actual: %s' % (tarball_sha1sum, sha1sum)
-    return 1
+    raise Error('Tarball sha1sum is wrong.'
+                'Expected %s, actual: %s' % (tarball_sha1sum, sha1sum))
   subprocess.check_call(['tar', 'xf', tarball, '-C', sysroot])
   os.remove(tarball)
 
   with open(stamp, 'w') as s:
     s.write(url)
-  return 0
 
 
 if __name__ == '__main__':
-  parser = optparse.OptionParser('usage: %prog [OPTIONS]')
-  parser.add_option('--linux-only', action='store_true',
-                    default=False, help='Only install sysroot for official '
-                                        'Linux builds')
-  parser.add_option('--arch', type='choice', choices=valid_archs,
-                    help='Sysroot architecture: %s' % ', '.join(valid_archs))
-  options, _ = parser.parse_args()
-  sys.exit(main())
+  try:
+    sys.exit(main(sys.argv[1:]))
+  except Error as e:
+    sys.stderr.write(str(e) + '\n')
+    sys.exit(1)

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -170,11 +170,11 @@ def execute(argv, env=os.environ):
     raise e
 
 
-def execute_stdout(argv, env=os.environ):
+def execute_stdout(argv, env=os.environ, cwd=None):
   if is_verbose_mode():
     print ' '.join(argv)
     try:
-      subprocess.check_call(argv, env=env)
+      subprocess.check_call(argv, env=env, cwd=cwd)
     except subprocess.CalledProcessError as e:
       print e.output
       raise e

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -1,31 +1,31 @@
 {
     "jessie_amd64": {
-        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
-        "Sha1Sum": "7c9be8b9b4e25e0c9db1daa4079750214b5af398",
+        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
+        "Sha1Sum": "90d3c0d2c304d86612f907f431a7bb3cff23723f",
         "SysrootDir": "debian_jessie_amd64-sysroot",
         "Tarball": "debian_jessie_amd64_sysroot.tgz"
     },
     "jessie_arm": {
-        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
-        "Sha1Sum": "787218fe581d331dc0376412a980f06bfca83bbe",
+        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
+        "Sha1Sum": "17c036070db081966204400844ac95dbb363d54f",
         "SysrootDir": "debian_jessie_arm-sysroot",
         "Tarball": "debian_jessie_arm_sysroot.tgz"
     },
     "jessie_arm64": {
-        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
-        "Sha1Sum": "d9021670c8437e2ca72d456a492534ebf031cefc",
+        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
+        "Sha1Sum": "2bfb71d559bdac8083c42befb69c17ef9a966a98",
         "SysrootDir": "debian_jessie_arm64-sysroot",
         "Tarball": "debian_jessie_arm64_sysroot.tgz"
     },
     "jessie_i386": {
-        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
-        "Sha1Sum": "153442b029152c3ad7cde26434febd79cb8814ee",
+        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
+        "Sha1Sum": "3ea0deb3cb14737e43100ec8803693f50f2504fd",
         "SysrootDir": "debian_jessie_i386-sysroot",
         "Tarball": "debian_jessie_i386_sysroot.tgz"
     },
     "jessie_mips": {
-        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
-        "Sha1Sum": "5edd7a179f69c4df1b800e19ee20479b8254c057",
+        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
+        "Sha1Sum": "d8c55d8b826aa011d57fe7bc51dc6db62ecedc7a",
         "SysrootDir": "debian_jessie_mips-sysroot",
         "Tarball": "debian_jessie_mips_sysroot.tgz"
     }

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -1,32 +1,56 @@
 {
     "jessie_amd64": {
-        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
-        "Sha1Sum": "90d3c0d2c304d86612f907f431a7bb3cff23723f",
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "8b2167b36f3cd85ebbec5c2a39a1842ef613f6a2",
         "SysrootDir": "debian_jessie_amd64-sysroot",
         "Tarball": "debian_jessie_amd64_sysroot.tgz"
     },
     "jessie_arm": {
-        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
-        "Sha1Sum": "17c036070db081966204400844ac95dbb363d54f",
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "3fa13635be0c6d8ed461715ad51cdb3809a19422",
         "SysrootDir": "debian_jessie_arm-sysroot",
         "Tarball": "debian_jessie_arm_sysroot.tgz"
     },
     "jessie_arm64": {
-        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
-        "Sha1Sum": "2bfb71d559bdac8083c42befb69c17ef9a966a98",
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "bcf92ed2a033b4b2d1032df3b53eac4910c78fde",
         "SysrootDir": "debian_jessie_arm64-sysroot",
         "Tarball": "debian_jessie_arm64_sysroot.tgz"
     },
     "jessie_i386": {
-        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
-        "Sha1Sum": "3ea0deb3cb14737e43100ec8803693f50f2504fd",
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "4e83ed9a1b457a1ca59512c3d4823e87e950deb4",
         "SysrootDir": "debian_jessie_i386-sysroot",
         "Tarball": "debian_jessie_i386_sysroot.tgz"
     },
     "jessie_mips": {
-        "Revision": "ed40e6a18ede7915e2bcba11e684108c1d158a7c",
-        "Sha1Sum": "d8c55d8b826aa011d57fe7bc51dc6db62ecedc7a",
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "0f550cd150f077a6e749a629e2fda0f0a4348eae",
         "SysrootDir": "debian_jessie_mips-sysroot",
         "Tarball": "debian_jessie_mips_sysroot.tgz"
+    },
+    "wheezy_amd64": {
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "fe372c4394ece7fd1d853a205de8c13b46e2f45a",
+        "SysrootDir": "debian_wheezy_amd64-sysroot",
+        "Tarball": "debian_wheezy_amd64_sysroot.tgz"
+    },
+    "wheezy_arm": {
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "73323fae0b5597398a38f0d7e64f48309da112fa",
+        "SysrootDir": "debian_wheezy_arm-sysroot",
+        "Tarball": "debian_wheezy_arm_sysroot.tgz"
+    },
+    "wheezy_i386": {
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "7e96584297a5c9916b3bed4b88abe332fc79a247",
+        "SysrootDir": "debian_wheezy_i386-sysroot",
+        "Tarball": "debian_wheezy_i386_sysroot.tgz"
+    },
+    "wheezy_mips": {
+        "Revision": "d65c31e063bab0486665e087a1b4c5bb7bc7423c",
+        "Sha1Sum": "b2f173905a41ec9f23c329fe529508b4bdc76230",
+        "SysrootDir": "debian_wheezy_mips-sysroot",
+        "Tarball": "debian_wheezy_mips_sysroot.tgz"
     }
 }

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -1,31 +1,31 @@
 {
     "jessie_amd64": {
-        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
-        "Sha1Sum": "82c0c27b1cbb7a7c2e496aeb6d9f6e28373126db",
+        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
+        "Sha1Sum": "2b0063007eb89ba915dac19223d772e306406a8d",
         "SysrootDir": "debian_jessie_amd64-sysroot",
         "Tarball": "debian_jessie_amd64_sysroot.tgz"
     },
     "jessie_arm": {
-        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
-        "Sha1Sum": "c41fd22e33afe9a6037ecac8880e40f99a6a2522",
+        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
+        "Sha1Sum": "3c3d7830fe1cf97497a8cb66dfa416e5d5e6b4cd",
         "SysrootDir": "debian_jessie_arm-sysroot",
         "Tarball": "debian_jessie_arm_sysroot.tgz"
     },
     "jessie_arm64": {
-        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
-        "Sha1Sum": "a8579b53d7e6c14cd6f15bf9f25d3a938755d834",
+        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
+        "Sha1Sum": "cc1fb0f0598d8b9bc56459ec980599cafbf2867c",
         "SysrootDir": "debian_jessie_arm64-sysroot",
         "Tarball": "debian_jessie_arm64_sysroot.tgz"
     },
     "jessie_i386": {
-        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
-        "Sha1Sum": "85c86f16036e952e33a70ae74e37775f26c54d48",
+        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
+        "Sha1Sum": "74d967eda22f754334afdd132dc3f157d905134e",
         "SysrootDir": "debian_jessie_i386-sysroot",
         "Tarball": "debian_jessie_i386_sysroot.tgz"
     },
     "jessie_mips": {
-        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
-        "Sha1Sum": "b6d4cdb21fb61c5669eea5135f7c87a19fc16876",
+        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
+        "Sha1Sum": "2ab2669d422f5cdfcc0bef51ede260db7f197164",
         "SysrootDir": "debian_jessie_mips-sysroot",
         "Tarball": "debian_jessie_mips_sysroot.tgz"
     }

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -1,31 +1,31 @@
 {
     "jessie_amd64": {
-        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
-        "Sha1Sum": "2b0063007eb89ba915dac19223d772e306406a8d",
+        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
+        "Sha1Sum": "7c9be8b9b4e25e0c9db1daa4079750214b5af398",
         "SysrootDir": "debian_jessie_amd64-sysroot",
         "Tarball": "debian_jessie_amd64_sysroot.tgz"
     },
     "jessie_arm": {
-        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
-        "Sha1Sum": "3c3d7830fe1cf97497a8cb66dfa416e5d5e6b4cd",
+        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
+        "Sha1Sum": "787218fe581d331dc0376412a980f06bfca83bbe",
         "SysrootDir": "debian_jessie_arm-sysroot",
         "Tarball": "debian_jessie_arm_sysroot.tgz"
     },
     "jessie_arm64": {
-        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
-        "Sha1Sum": "cc1fb0f0598d8b9bc56459ec980599cafbf2867c",
+        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
+        "Sha1Sum": "d9021670c8437e2ca72d456a492534ebf031cefc",
         "SysrootDir": "debian_jessie_arm64-sysroot",
         "Tarball": "debian_jessie_arm64_sysroot.tgz"
     },
     "jessie_i386": {
-        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
-        "Sha1Sum": "74d967eda22f754334afdd132dc3f157d905134e",
+        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
+        "Sha1Sum": "153442b029152c3ad7cde26434febd79cb8814ee",
         "SysrootDir": "debian_jessie_i386-sysroot",
         "Tarball": "debian_jessie_i386_sysroot.tgz"
     },
     "jessie_mips": {
-        "Revision": "b6dd965b53da1e379e784d8450811c583547e271",
-        "Sha1Sum": "2ab2669d422f5cdfcc0bef51ede260db7f197164",
+        "Revision": "6101296b34af9688b9269fee9b70bb1900e365cb",
+        "Sha1Sum": "5edd7a179f69c4df1b800e19ee20479b8254c057",
         "SysrootDir": "debian_jessie_mips-sysroot",
         "Tarball": "debian_jessie_mips_sysroot.tgz"
     }

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -1,0 +1,32 @@
+{
+    "jessie_amd64": {
+        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
+        "Sha1Sum": "82c0c27b1cbb7a7c2e496aeb6d9f6e28373126db",
+        "SysrootDir": "debian_jessie_amd64-sysroot",
+        "Tarball": "debian_jessie_amd64_sysroot.tgz"
+    },
+    "jessie_arm": {
+        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
+        "Sha1Sum": "c41fd22e33afe9a6037ecac8880e40f99a6a2522",
+        "SysrootDir": "debian_jessie_arm-sysroot",
+        "Tarball": "debian_jessie_arm_sysroot.tgz"
+    },
+    "jessie_arm64": {
+        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
+        "Sha1Sum": "a8579b53d7e6c14cd6f15bf9f25d3a938755d834",
+        "SysrootDir": "debian_jessie_arm64-sysroot",
+        "Tarball": "debian_jessie_arm64_sysroot.tgz"
+    },
+    "jessie_i386": {
+        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
+        "Sha1Sum": "85c86f16036e952e33a70ae74e37775f26c54d48",
+        "SysrootDir": "debian_jessie_i386-sysroot",
+        "Tarball": "debian_jessie_i386_sysroot.tgz"
+    },
+    "jessie_mips": {
+        "Revision": "d18016aaa5283f85bd8c722c42e55d2f5f13384e",
+        "Sha1Sum": "b6d4cdb21fb61c5669eea5135f7c87a19fc16876",
+        "SysrootDir": "debian_jessie_mips-sysroot",
+        "Tarball": "debian_jessie_mips_sysroot.tgz"
+    }
+}

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -50,16 +50,16 @@
             ['target_arch=="arm"', {
               # sysroot needs to be an absolute path otherwise it generates
               # incorrect results when passed to pkg-config
-              'sysroot%': '<(source_root)/vendor/debian_jessie_arm-sysroot',
+              'sysroot%': '<(source_root)/vendor/debian_wheezy_arm-sysroot',
             }],
             ['target_arch=="arm64"', {
               'sysroot%': '<(source_root)/vendor/debian_jessie_arm64-sysroot',
             }],
             ['target_arch=="ia32"', {
-              'sysroot%': '<(source_root)/vendor/debian_jessie_i386-sysroot',
+              'sysroot%': '<(source_root)/vendor/debian_wheezy_i386-sysroot',
             }],
             ['target_arch=="x64"', {
-              'sysroot%': '<(source_root)/vendor/debian_jessie_amd64-sysroot',
+              'sysroot%': '<(source_root)/vendor/debian_wheezy_amd64-sysroot',
             }],
           ],
         },

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -50,13 +50,16 @@
             ['target_arch=="arm"', {
               # sysroot needs to be an absolute path otherwise it generates
               # incorrect results when passed to pkg-config
-              'sysroot%': '<(source_root)/vendor/debian_wheezy_arm-sysroot',
+              'sysroot%': '<(source_root)/vendor/debian_jessie_arm-sysroot',
+            }],
+            ['target_arch=="arm64"', {
+              'sysroot%': '<(source_root)/vendor/debian_jessie_arm64-sysroot',
             }],
             ['target_arch=="ia32"', {
-              'sysroot%': '<(source_root)/vendor/debian_wheezy_i386-sysroot',
+              'sysroot%': '<(source_root)/vendor/debian_jessie_i386-sysroot',
             }],
             ['target_arch=="x64"', {
-              'sysroot%': '<(source_root)/vendor/debian_wheezy_amd64-sysroot',
+              'sysroot%': '<(source_root)/vendor/debian_jessie_amd64-sysroot',
             }],
           ],
         },


### PR DESCRIPTION
This is to match Chromium's build settings, and it is also a requirement for arm64 build.

Note that the sysroot scripts in Electron and debian-sysroot-image-creator have been updated to Chromium's upstream ones, and assets are now stored in S3 instead of GitHub Releases to minimize the diffs with upstream.

/cc @kolach.