### PR TITLE
Upgrade libcc

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -9,8 +9,7 @@ import subprocess
 import sys
 import stat
 
-from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
-                       get_target_arch, get_zip_name
+from lib.config import BASE_URL, PLATFORM, get_target_arch, get_zip_name
 from lib.util import scoped_cwd, rm_rf, get_electron_version, make_zip, \
                      execute, electron_gyp
 

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '549af32d00045c7b9dbb2760c090586c8d3a2638'
+    'a3cff052273b659702c6a8728e28a3b45659cd76'
 
 PLATFORM = {
   'cygwin': 'win32',

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -8,8 +8,6 @@ import sys
 
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    'a3cff052273b659702c6a8728e28a3b45659cd76'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
Pulls in the following:

* https://github.com/electron/libchromiumcontent/pull/295
* https://github.com/electron/libchromiumcontent/pull/297
* https://github.com/electron/libchromiumcontent/pull/298
* https://github.com/electron/libchromiumcontent/pull/299

Also switches the build to download prebuilds using the SHA-1 from the `vendor/libchromiumcontent` submodule instead if storing it two places.