### PR TITLE
Backport suppress dispatching to PDF viewer if plugins are disabled to 1.6.x

### DIFF
--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -6,6 +6,7 @@
 
 #include "atom/browser/login_handler.h"
 #include "atom/browser/web_contents_permission_helper.h"
+#include "atom/browser/web_contents_preferences.h"
 #include "atom/common/atom_constants.h"
 #include "atom/common/platform_util.h"
 #include "base/strings/stringprintf.h"
@@ -124,7 +125,9 @@ bool AtomResourceDispatcherHostDelegate::ShouldInterceptResourceAsStream(
     std::string* payload) {
   const content::ResourceRequestInfo* info =
       content::ResourceRequestInfo::ForRequest(request);
-  if (mime_type == "application/pdf" && info->IsMainFrame()) {
+  content::WebContents* web_contents = info->GetWebContentsGetterForRequest().Run();
+  if (mime_type == "application/pdf" && info->IsMainFrame() && 
+      WebContentsPreferences::IsPluginsEnabled(web_contents)) {
     *origin = GURL(kPdfViewerUIOrigin);
     content::BrowserThread::PostTask(
         BrowserThread::UI, FROM_HERE,

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -125,8 +125,9 @@ bool AtomResourceDispatcherHostDelegate::ShouldInterceptResourceAsStream(
     std::string* payload) {
   const content::ResourceRequestInfo* info =
       content::ResourceRequestInfo::ForRequest(request);
-  content::WebContents* web_contents = info->GetWebContentsGetterForRequest().Run();
-  if (mime_type == "application/pdf" && info->IsMainFrame() && 
+  content::WebContents* web_contents =
+      info->GetWebContentsGetterForRequest().Run();
+  if (mime_type == "application/pdf" && info->IsMainFrame() &&
       WebContentsPreferences::IsPluginsEnabled(web_contents)) {
     *origin = GURL(kPdfViewerUIOrigin);
     content::BrowserThread::PostTask(

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -228,7 +228,8 @@ bool WebContentsPreferences::UsesNativeWindowOpen(
   return use;
 }
 
-bool WebContentsPreferences::IsPluginsEnabled(content::WebContents* web_contents) {
+bool WebContentsPreferences::IsPluginsEnabled(
+    content::WebContents* web_contents) {
   WebContentsPreferences* self;
   if (!web_contents)
     return false;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -197,7 +197,9 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   }
 }
 
-bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
+bool WebContentsPreferences::IsPreferenceEnabled(
+    const std::string& attributeName,
+    content::WebContents* web_contents) {
   WebContentsPreferences* self;
   if (!web_contents)
     return false;
@@ -207,41 +209,23 @@ bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
     return false;
 
   base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool sandboxed = false;
-  web_preferences.GetBoolean("sandbox", &sandboxed);
-  return sandboxed;
+  bool boolValue = false;
+  web_preferences.GetBoolean(attributeName, &boolValue);
+  return boolValue;
+}
+
+bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
+  return IsPreferenceEnabled("sandbox", web_contents);
 }
 
 bool WebContentsPreferences::UsesNativeWindowOpen(
     content::WebContents* web_contents) {
-  WebContentsPreferences* self;
-  if (!web_contents)
-    return false;
-
-  self = FromWebContents(web_contents);
-  if (!self)
-    return false;
-
-  base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool use = false;
-  web_preferences.GetBoolean("nativeWindowOpen", &use);
-  return use;
+  return IsPreferenceEnabled("nativeWindowOpen", web_contents);
 }
 
 bool WebContentsPreferences::IsPluginsEnabled(
     content::WebContents* web_contents) {
-  WebContentsPreferences* self;
-  if (!web_contents)
-    return false;
-
-  self = FromWebContents(web_contents);
-  if (!self)
-    return false;
-
-  base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool plugins = false;
-  web_preferences.GetBoolean("plugins", &plugins);
-  return plugins;
+  return IsPreferenceEnabled("plugins", web_contents);
 }
 
 // static

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -212,6 +212,37 @@ bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
   return sandboxed;
 }
 
+bool WebContentsPreferences::UsesNativeWindowOpen(
+    content::WebContents* web_contents) {
+  WebContentsPreferences* self;
+  if (!web_contents)
+    return false;
+
+  self = FromWebContents(web_contents);
+  if (!self)
+    return false;
+
+  base::DictionaryValue& web_preferences = self->web_preferences_;
+  bool use = false;
+  web_preferences.GetBoolean("nativeWindowOpen", &use);
+  return use;
+}
+
+bool WebContentsPreferences::IsPluginsEnabled(content::WebContents* web_contents) {
+  WebContentsPreferences* self;
+  if (!web_contents)
+    return false;
+
+  self = FromWebContents(web_contents);
+  if (!self)
+    return false;
+
+  base::DictionaryValue& web_preferences = self->web_preferences_;
+  bool plugins = false;
+  web_preferences.GetBoolean("plugins", &plugins);
+  return plugins;
+}
+
 // static
 void WebContentsPreferences::OverrideWebkitPrefs(
     content::WebContents* web_contents, content::WebPreferences* prefs) {

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -198,7 +198,7 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
 }
 
 bool WebContentsPreferences::IsPreferenceEnabled(
-    const std::string& attributeName,
+    const std::string& attribute_name,
     content::WebContents* web_contents) {
   WebContentsPreferences* self;
   if (!web_contents)
@@ -209,9 +209,9 @@ bool WebContentsPreferences::IsPreferenceEnabled(
     return false;
 
   base::DictionaryValue& web_preferences = self->web_preferences_;
-  bool boolValue = false;
-  web_preferences.GetBoolean(attributeName, &boolValue);
-  return boolValue;
+  bool bool_value = false;
+  web_preferences.GetBoolean(attribute_name, &bool_value);
+  return bool_value;
 }
 
 bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -218,11 +218,6 @@ bool WebContentsPreferences::IsSandboxed(content::WebContents* web_contents) {
   return IsPreferenceEnabled("sandbox", web_contents);
 }
 
-bool WebContentsPreferences::UsesNativeWindowOpen(
-    content::WebContents* web_contents) {
-  return IsPreferenceEnabled("nativeWindowOpen", web_contents);
-}
-
 bool WebContentsPreferences::IsPluginsEnabled(
     content::WebContents* web_contents) {
   return IsPreferenceEnabled("plugins", web_contents);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -37,7 +37,7 @@ class WebContentsPreferences
   static void AppendExtraCommandLineSwitches(
       content::WebContents* web_contents, base::CommandLine* command_line);
 
-  static bool IsPreferenceEnabled(const std::string& attributeName,
+  static bool IsPreferenceEnabled(const std::string& attribute_name,
                                   content::WebContents* web_contents);
   static bool IsSandboxed(content::WebContents* web_contents);
   static bool UsesNativeWindowOpen(content::WebContents* web_contents);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -38,6 +38,8 @@ class WebContentsPreferences
       content::WebContents* web_contents, base::CommandLine* command_line);
 
   static bool IsSandboxed(content::WebContents* web_contents);
+  static bool UsesNativeWindowOpen(content::WebContents* web_contents);
+  static bool IsPluginsEnabled(content::WebContents* web_contents);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.
   static void OverrideWebkitPrefs(

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -37,6 +37,8 @@ class WebContentsPreferences
   static void AppendExtraCommandLineSwitches(
       content::WebContents* web_contents, base::CommandLine* command_line);
 
+  static bool IsPreferenceEnabled(const std::string& attributeName,
+                                  content::WebContents* web_contents);
   static bool IsSandboxed(content::WebContents* web_contents);
   static bool UsesNativeWindowOpen(content::WebContents* web_contents);
   static bool IsPluginsEnabled(content::WebContents* web_contents);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -40,7 +40,6 @@ class WebContentsPreferences
   static bool IsPreferenceEnabled(const std::string& attribute_name,
                                   content::WebContents* web_contents);
   static bool IsSandboxed(content::WebContents* web_contents);
-  static bool UsesNativeWindowOpen(content::WebContents* web_contents);
   static bool IsPluginsEnabled(content::WebContents* web_contents);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -952,16 +952,18 @@ describe('chromium feature', function () {
       slashes: true
     })
 
-    beforeEach(function () {
+    function createBrowserWindow (isPluginsEnabled) {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
-          preload: path.join(fixtures, 'module', 'preload-inject-ipc.js')
+          preload: path.join(fixtures, 'module', 'preload-inject-ipc.js'),
+          plugins: isPluginsEnabled
         }
       })
-    })
+    }
 
     it('opens when loading a pdf resource as top level navigation', function (done) {
+      createBrowserWindow(true)
       ipcMain.once('pdf-loaded', function (event, success) {
         if (success) done()
       })
@@ -983,7 +985,23 @@ describe('chromium feature', function () {
       w.webContents.loadURL(pdfSource)
     })
 
+    it('should download a pdf when plugins are disabled', function (done) {
+      createBrowserWindow(false)
+      ipcRenderer.sendSync('set-download-option', false, false)
+      ipcRenderer.once('download-done', function (event, state, url,
+                                                mimeType, receivedBytes,
+                                                totalBytes, disposition,
+                                                filename) {
+        assert.equal(state, 'completed')
+        assert.equal(filename, 'cat.pdf')
+        assert.equal(mimeType, 'application/pdf')
+        done()
+      })
+      w.webContents.loadURL(pdfSource)
+    })
+
     it('should not open when pdf is requested as sub resource', function (done) {
+      createBrowserWindow(true)
       webFrame.registerURLSchemeAsPrivileged('file', {
         secure: false,
         bypassCSP: false,

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -952,18 +952,18 @@ describe('chromium feature', function () {
       slashes: true
     })
 
-    function createBrowserWindow (isPluginsEnabled) {
+    function createBrowserWindow ({plugins}) {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
           preload: path.join(fixtures, 'module', 'preload-inject-ipc.js'),
-          plugins: isPluginsEnabled
+          plugins: plugins
         }
       })
     }
 
     it('opens when loading a pdf resource as top level navigation', function (done) {
-      createBrowserWindow(true)
+      createBrowserWindow({plugins: true})
       ipcMain.once('pdf-loaded', function (event, success) {
         if (success) done()
       })
@@ -986,19 +986,20 @@ describe('chromium feature', function () {
     })
 
     it('should download a pdf when plugins are disabled', function (done) {
-      createBrowserWindow(false)
+      createBrowserWindow({plugins: false})
       ipcRenderer.sendSync('set-download-option', false, false)
       ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
         assert.equal(state, 'completed')
         assert.equal(filename, 'cat.pdf')
         assert.equal(mimeType, 'application/pdf')
+        fs.unlinkSync(path.join(fixtures, 'mock.pdf'))
         done()
       })
       w.webContents.loadURL(pdfSource)
     })
 
     it('should not open when pdf is requested as sub resource', function (done) {
-      createBrowserWindow(true)
+      createBrowserWindow({plugins: true})
       webFrame.registerURLSchemeAsPrivileged('file', {
         secure: false,
         bypassCSP: false,

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -988,10 +988,7 @@ describe('chromium feature', function () {
     it('should download a pdf when plugins are disabled', function (done) {
       createBrowserWindow(false)
       ipcRenderer.sendSync('set-download-option', false, false)
-      ipcRenderer.once('download-done', function (event, state, url,
-                                                mimeType, receivedBytes,
-                                                totalBytes, disposition,
-                                                filename) {
+      ipcRenderer.once('download-done', function (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
         assert.equal(state, 'completed')
         assert.equal(filename, 'cat.pdf')
         assert.equal(mimeType, 'application/pdf')


### PR DESCRIPTION
This PR backports [#9507](https://github.com/electron/electron/pull/9507#issuecomment-303226315) to the 1.6.x branch.

🍒 