### PR TITLE
Added support for generating a monochrome bitmap to NativeImage.

### DIFF
--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -75,6 +75,7 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
   v8::Local<v8::Value> ToBitmap(mate::Arguments* args);
   v8::Local<v8::Value> GetBitmap(mate::Arguments* args);
+  v8::Local<v8::Value> GetBitmapMonochrome(mate::Arguments* args);
   v8::Local<v8::Value> GetNativeHandle(
     v8::Isolate* isolate,
     mate::Arguments* args);


### PR DESCRIPTION
Needed to use the capturePage functionality and then turn my NativeImage into a monochrome bitmap. Doing the monochrome conversion in nodejs was incredibly slow and therefore I added it as a separate function to NativeImage.

This is very useful when printing images to any kind of thermal printer.