### PR TITLE
Support nativeWindowOpen from <webview> tags

### DIFF
--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -122,11 +122,13 @@ class AtomBrowserClient : public brightray::BrowserClient,
   struct ProcessPreferences {
     bool sandbox;
     bool native_window_open;
+    bool disable_popups;
   };
   void AddProcessPreferences(int process_id, ProcessPreferences prefs);
   void RemoveProcessPreferences(int process_id);
   bool IsRendererSandboxed(int process_id);
   bool RendererUsesNativeWindowOpen(int process_id);
+  bool RendererDisablesPopups(int process_id);
 
   // pending_render_process => current_render_process.
   std::map<int, int> pending_processes_;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -237,6 +237,11 @@ bool WebContentsPreferences::IsPluginsEnabled(
   return IsPreferenceEnabled("plugins", web_contents);
 }
 
+bool WebContentsPreferences::DisablePopups(
+    content::WebContents* web_contents) {
+  return IsPreferenceEnabled("disablePopups", web_contents);
+}
+
 // static
 void WebContentsPreferences::OverrideWebkitPrefs(
     content::WebContents* web_contents, content::WebPreferences* prefs) {

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -41,6 +41,7 @@ class WebContentsPreferences
                                   content::WebContents* web_contents);
   static bool IsSandboxed(content::WebContents* web_contents);
   static bool UsesNativeWindowOpen(content::WebContents* web_contents);
+  static bool DisablePopups(content::WebContents* web_contents);
   static bool IsPluginsEnabled(content::WebContents* web_contents);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -191,6 +191,8 @@ content::SiteInstance* WebViewGuestDelegate::GetOwnerSiteInstance() {
 
 content::WebContents* WebViewGuestDelegate::CreateNewGuestWindow(
     const content::WebContents::CreateParams& create_params) {
+  // Code below mirrors what content::WebContentsImpl::CreateNewWindow
+  // does for non-guest sources
   content::WebContents::CreateParams guest_params(create_params);
   guest_params.initial_size =
       embedder_web_contents_->GetContainerBounds().size();

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -6,6 +6,7 @@
 
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
+#include "content/browser/web_contents/web_contents_impl.h"
 #include "content/public/browser/guest_host.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
@@ -186,6 +187,21 @@ content::RenderWidgetHost* WebViewGuestDelegate::GetOwnerRenderWidgetHost() {
 
 content::SiteInstance* WebViewGuestDelegate::GetOwnerSiteInstance() {
   return embedder_web_contents_->GetSiteInstance();
+}
+
+content::WebContents* WebViewGuestDelegate::CreateNewGuestWindow(
+    const content::WebContents::CreateParams& create_params) {
+  content::WebContents::CreateParams guest_params(create_params);
+  guest_params.initial_size =
+      embedder_web_contents_->GetContainerBounds().size();
+  guest_params.context = embedder_web_contents_->GetNativeView();
+  auto guest_contents = content::WebContents::Create(guest_params);
+  auto guest_contents_impl =
+      static_cast<content::WebContentsImpl*>(guest_contents);
+  guest_contents_impl->GetView()->CreateViewForWidget(
+      guest_contents->GetRenderViewHost()->GetWidget(), false);
+
+  return guest_contents;
 }
 
 }  // namespace atom

--- a/atom/browser/web_view_guest_delegate.h
+++ b/atom/browser/web_view_guest_delegate.h
@@ -64,6 +64,8 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   bool CanBeEmbeddedInsideCrossProcessFrames() override;
   content::RenderWidgetHost* GetOwnerRenderWidgetHost() override;
   content::SiteInstance* GetOwnerSiteInstance() override;
+  content::WebContents* CreateNewGuestWindow(
+     const content::WebContents::CreateParams& create_params) override;
 
   // WebContentsZoomController::Observer:
   void OnZoomLevelChanged(content::WebContents* web_contents,

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -46,12 +46,22 @@ has to be a field of `BrowserWindow`'s options.
 Sends a message to the parent window with the specified origin or `*` for no
 origin preference.
 
-### Use Native `window.open()`
+### Using Chrome's `window.open()` implementation
 
-If you want to use native `window.open()` implementation, pass `nativeWindowOpen: true` in `webPreferences` option.
-Native `window.open()` allows synchronous access to opened windows so it is convenient choice if you need to open a dialog or a preferences window.
+If you want to use Chrome's built-in `window.open()` implementation, set
+`nativeWindowOpen` to `true` in the `webPreferences` options object.
 
-The creation of the `BrowserWindow` is customizable in `WebContents`'s `new-window` event.
+Native `window.open()` allows synchronous access to opened windows so it is
+convenient choice if you need to open a dialog or a preferences window.
+
+This option can also be set on `<webview>` tags as well:
+
+```html
+<webview webpreferences="nativeWindowOpen=yes"></webview>
+```
+
+The creation of the `BrowserWindow` is customizable via `WebContents`'s
+`new-window` event.
 
 ```javascript
 // main process

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -48,7 +48,7 @@ origin preference.
 
 ### Use Native `window.open()`
 
-If you want to use native `window.open()` implementation, pass `useNativeWindowOpen: true` in `webPreferences` option.
+If you want to use native `window.open()` implementation, pass `nativeWindowOpen: true` in `webPreferences` option.
 Native `window.open()` allows synchronous access to opened windows so it is convenient choice if you need to open a dialog or a preferences window.
 
 The creation of the `BrowserWindow` is customizable in `WebContents`'s `new-window` event.

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -36,8 +36,9 @@ BrowserWindow.prototype._init = function () {
                                                 frameName) => {
     v8Util.setHiddenValue(webContents, 'url-framename', {url, frameName})
   })
+
   // Create a new browser window for the native implementation of
-  // "window.open"(sandbox mode only)
+  // "window.open", used in sandbox and nativeWindowOpen mode
   this.webContents.on('-add-new-contents', (event, webContents, disposition,
                                             userGesture, left, top, width,
                                             height) => {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -225,6 +225,10 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
     webPreferences.preloadURL = params.preload
   }
 
+  if (webPreferences.nativeWindowOpen === true && !params.allowpopups) {
+    webPreferences.disablePopups = true
+  }
+
   embedder.emit('will-attach-webview', event, webPreferences, params)
   if (event.defaultPrevented) {
     if (guest.viewInstanceId == null) guest.viewInstanceId = params.instanceId

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -116,6 +116,20 @@ const createGuest = function (embedder, params) {
     guest.allowPopups = params.allowpopups
   })
 
+  guest.on('-add-new-contents', (...args) => {
+    const embedder = getEmbedder(guestInstanceId)
+    if (embedder != null) {
+      embedder.emit('-add-new-contents', ...args)
+    }
+  })
+
+  guest.on('-web-contents-created', (...args) => {
+    const embedder = getEmbedder(guestInstanceId)
+    if (embedder != null) {
+      embedder.emit('-web-contents-created', ...args)
+    }
+  })
+
   const sendToEmbedder = (channel, ...args) => {
     const embedder = getEmbedder(guestInstanceId)
     if (embedder != null) {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -116,20 +116,6 @@ const createGuest = function (embedder, params) {
     guest.allowPopups = params.allowpopups
   })
 
-  guest.on('-add-new-contents', (...args) => {
-    const embedder = getEmbedder(guestInstanceId)
-    if (embedder != null) {
-      embedder.emit('-add-new-contents', ...args)
-    }
-  })
-
-  guest.on('-web-contents-created', (...args) => {
-    const embedder = getEmbedder(guestInstanceId)
-    if (embedder != null) {
-      embedder.emit('-web-contents-created', ...args)
-    }
-  })
-
   const sendToEmbedder = (channel, ...args) => {
     const embedder = getEmbedder(guestInstanceId)
     if (embedder != null) {
@@ -155,6 +141,25 @@ const createGuest = function (embedder, params) {
   // Autosize.
   guest.on('size-changed', function (_, ...args) {
     sendToEmbedder('ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED', ...args)
+  })
+
+  // Forward internal web contents event to embedder to handle
+  // native window.open setup
+  guest.on('-add-new-contents', (...args) => {
+    if (guest.getWebPreferences().nativeWindowOpen === true) {
+      const embedder = getEmbedder(guestInstanceId)
+      if (embedder != null) {
+        embedder.emit('-add-new-contents', ...args)
+      }
+    }
+  })
+  guest.on('-web-contents-created', (...args) => {
+    if (guest.getWebPreferences().nativeWindowOpen === true) {
+      const embedder = getEmbedder(guestInstanceId)
+      if (embedder != null) {
+        embedder.emit('-web-contents-created', ...args)
+      }
+    }
   })
 
   return guestInstanceId

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -225,6 +225,7 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
     webPreferences.preloadURL = params.preload
   }
 
+  // Return null from native window.open if allowpopups is unset
   if (webPreferences.nativeWindowOpen === true && !params.allowpopups) {
     webPreferences.disablePopups = true
   }

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -47,7 +47,7 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     // Inherit the original options if it is a BrowserWindow.
     mergeOptions(options, embedder.browserWindowOptions)
   } else {
-    // Or only inherit web-preferences if it is a webview.
+    // Or only inherit webPreferences if it is a webview.
     mergeOptions(options.webPreferences, embedder.getWebPreferences())
   }
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -252,9 +252,9 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', function (event
                                                                   additionalFeatures, postData) {
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures)
-  const newGuest = event.newGuest
+  const {newGuest} = event
   if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {
-    if (newGuest !== undefined && newGuest !== null) {
+    if (newGuest != null) {
       if (options.webContents === newGuest.webContents) {
         // the webContents is not changed, so set defaultPrevented to false to
         // stop the callers of this event from destroying the webContents.

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -550,7 +550,7 @@ describe('app module', function () {
         assert.equal(typeof cpu.idleWakeupsPerSecond, 'number')
       }
 
-      if (process.platform !== 'linux') {
+      if (process.platform === 'darwin') {
         assert.ok(types.includes('GPU'))
       }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1285,6 +1285,14 @@ describe('BrowserWindow module', function () {
         w.loadURL('file://' + path.join(fixtures, 'api', 'native-window-open-file.html'))
       })
 
+      it('blocks accessing cross-origin frames', (done) => {
+        ipcMain.once('answer', (event, content) => {
+          assert.equal(content, 'Blocked a frame with origin "file://" from accessing a cross-origin frame.')
+          done()
+        })
+        w.loadURL('file://' + path.join(fixtures, 'api', 'native-window-open-cross-origin.html'))
+      })
+
       it('opens window from <iframe> tags', (done) => {
         ipcMain.once('answer', (event, content) => {
           assert.equal(content, 'Hello')

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1285,6 +1285,14 @@ describe('BrowserWindow module', function () {
         w.loadURL('file://' + path.join(fixtures, 'api', 'native-window-open-file.html'))
       })
 
+      it('opens window from <iframe> tags', (done) => {
+        ipcMain.once('answer', (event, content) => {
+          assert.equal(content, 'Hello')
+          done()
+        })
+        w.loadURL('file://' + path.join(fixtures, 'api', 'native-window-open-iframe.html'))
+      })
+
       if (process.platform !== 'win32' || process.execPath.toLowerCase().indexOf('\\out\\d\\') === -1) {
         it('loads native addons correctly after reload', (done) => {
           ipcMain.once('answer', (event, content) => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -854,7 +854,7 @@ describe('BrowserWindow module', function () {
     })
   })
 
-  describe('"web-preferences" option', function () {
+  describe('"webPreferences" option', function () {
     afterEach(function () {
       ipcMain.removeAllListeners('answer')
     })

--- a/spec/fixtures/api/native-window-open-blank.html
+++ b/spec/fixtures/api/native-window-open-blank.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <script type="text/javascript" charset="utf-8">
-  const {ipcRenderer} = require('electron')
+  const {ipcRenderer} = window.top != null ? window.top.require('electron') : require('electron')
   const popup = window.open()
   popup.document.write('<h1>Hello</h1>')
   const content = popup.document.querySelector('h1').innerText

--- a/spec/fixtures/api/native-window-open-cross-origin.html
+++ b/spec/fixtures/api/native-window-open-cross-origin.html
@@ -1,0 +1,19 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const {ipcRenderer} = require('electron')
+  const popup = window.open('http://host')
+  const intervalID = setInterval(function () {
+    try {
+      if (popup.location.toString() !== 'about:blank') {
+        clearInterval(intervalID)
+        ipcRenderer.send('answer', 'did not throw error')
+      }
+    } catch (error) {
+      clearInterval(intervalID)
+      ipcRenderer.send('answer', error.message)
+    }
+  }, 10)
+</script>
+</body>
+</html>

--- a/spec/fixtures/api/native-window-open-cross-origin.html
+++ b/spec/fixtures/api/native-window-open-cross-origin.html
@@ -7,7 +7,7 @@
     try {
       if (popup.location.toString() !== 'about:blank') {
         clearInterval(intervalID)
-        ipcRenderer.send('answer', 'did not throw error')
+        ipcRenderer.send('answer', `Did not throw error accessing location: ${popup.location}`)
       }
     } catch (error) {
       clearInterval(intervalID)

--- a/spec/fixtures/api/native-window-open-iframe.html
+++ b/spec/fixtures/api/native-window-open-iframe.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    <iframe src="./native-window-open-blank.html"></iframe>
+  </body>
+</html>

--- a/spec/fixtures/api/native-window-open-no-allowpopups.html
+++ b/spec/fixtures/api/native-window-open-no-allowpopups.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const {ipcRenderer} = require('electron')
+  const popup = window.open()
+  ipcRenderer.send('answer', {windowOpenReturnedNull: popup == null})
+</script>
+</body>
+</html>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1676,6 +1676,16 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
+    it('returns null from window.open when allowpopups is not set', (done) => {
+      webview.removeAttribute('allowpopups')
+      ipcMain.once('answer', (event, {windowOpenReturnedNull}) => {
+        assert.equal(windowOpenReturnedNull, true)
+        done()
+      })
+      webview.src = 'file://' + path.join(fixtures, 'api', 'native-window-open-no-allowpopups.html')
+      document.body.appendChild(webview)
+    })
+
     it('emits a new-window event', (done) => {
       webview.addEventListener('new-window', function (e) {
         assert.equal(e.url, 'http://host/')

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -524,6 +524,17 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/pages/target-name.html'
       document.body.appendChild(webview)
     })
+
+    it('emits when nativeWindowOpen is enabled', function(done) {
+      webview.addEventListener('new-window', function (e) {
+        assert.equal(e.url, 'http://host/')
+        assert.equal(e.frameName, 'host')
+        done()
+      })
+      webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
+      webview.src = 'file://' + fixtures + '/pages/window-open.html'
+      document.body.appendChild(webview)
+    })
   })
 
   describe('ipc-message event', function () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1685,5 +1685,24 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/pages/window-open.html'
       document.body.appendChild(webview)
     })
+
+    it('emits a browser-window-created event', (done) => {
+      app.once('browser-window-created', () => {
+        done()
+      })
+      webview.src = 'file://' + fixtures + '/pages/window-open.html'
+      document.body.appendChild(webview)
+    })
+
+    it('emits a web-contents-created event', (done) => {
+      app.on('web-contents-created', function listener (event, contents) {
+        if (contents.getType() === 'window') {
+          app.removeListener('web-contents-created', listener)
+          done()
+        }
+      })
+      webview.src = 'file://' + fixtures + '/pages/window-open.html'
+      document.body.appendChild(webview)
+    })
   })
 })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1686,6 +1686,15 @@ describe('<webview> tag', function () {
       document.body.appendChild(webview)
     })
 
+    it('blocks accessing cross-origin frames', (done) => {
+      ipcMain.once('answer', (event, content) => {
+        assert.equal(content, 'Blocked a frame with origin "file://" from accessing a cross-origin frame.')
+        done()
+      })
+      webview.src = 'file://' + path.join(fixtures, 'api', 'native-window-open-cross-origin.html')
+      document.body.appendChild(webview)
+    })
+
     it('emits a new-window event', (done) => {
       webview.addEventListener('new-window', function (e) {
         assert.equal(e.url, 'http://host/')

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1653,6 +1653,7 @@ describe('<webview> tag', function () {
 
   describe('nativeWindowOpen option', () => {
     beforeEach(function () {
+      webview.setAttribute('allowpopups', 'on')
       webview.setAttribute('nodeintegration', 'on')
       webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
     })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1652,7 +1652,7 @@ describe('<webview> tag', function () {
   })
 
   describe('nativeWindowOpen option', () => {
-    it('opens a windows with cross-scripting enabled', (done) => {
+    it('opens window of about:blank with cross-scripting enabled', (done) => {
       ipcMain.once('answer', (event, content) => {
         assert.equal(content, 'Hello')
         done()
@@ -1661,6 +1661,17 @@ describe('<webview> tag', function () {
       webview.setAttribute('nodeintegration', 'on')
       webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
       webview.src = 'file://' + path.join(fixtures, 'api', 'native-window-open-blank.html')
+      document.body.appendChild(webview)
+    })
+
+    it('opens window of same domain with cross-scripting enabled', (done) => {
+      ipcMain.once('answer', (event, content) => {
+        assert.equal(content, 'Hello')
+        done()
+      })
+      webview.setAttribute('nodeintegration', 'on')
+      webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
+      webview.src = 'file://' + path.join(fixtures, 'api', 'native-window-open-file.html')
       document.body.appendChild(webview)
     })
   })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -524,17 +524,6 @@ describe('<webview> tag', function () {
       webview.src = 'file://' + fixtures + '/pages/target-name.html'
       document.body.appendChild(webview)
     })
-
-    it('emits when nativeWindowOpen is enabled', function(done) {
-      webview.addEventListener('new-window', function (e) {
-        assert.equal(e.url, 'http://host/')
-        assert.equal(e.frameName, 'host')
-        done()
-      })
-      webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
-      webview.src = 'file://' + fixtures + '/pages/window-open.html'
-      document.body.appendChild(webview)
-    })
   })
 
   describe('ipc-message event', function () {
@@ -1663,14 +1652,16 @@ describe('<webview> tag', function () {
   })
 
   describe('nativeWindowOpen option', () => {
+    beforeEach(function () {
+      webview.setAttribute('nodeintegration', 'on')
+      webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
+    })
+
     it('opens window of about:blank with cross-scripting enabled', (done) => {
       ipcMain.once('answer', (event, content) => {
         assert.equal(content, 'Hello')
         done()
       })
-
-      webview.setAttribute('nodeintegration', 'on')
-      webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
       webview.src = 'file://' + path.join(fixtures, 'api', 'native-window-open-blank.html')
       document.body.appendChild(webview)
     })
@@ -1680,9 +1671,17 @@ describe('<webview> tag', function () {
         assert.equal(content, 'Hello')
         done()
       })
-      webview.setAttribute('nodeintegration', 'on')
-      webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
       webview.src = 'file://' + path.join(fixtures, 'api', 'native-window-open-file.html')
+      document.body.appendChild(webview)
+    })
+
+    it('emits a new-window event', (done) => {
+      webview.addEventListener('new-window', function (e) {
+        assert.equal(e.url, 'http://host/')
+        assert.equal(e.frameName, 'host')
+        done()
+      })
+      webview.src = 'file://' + fixtures + '/pages/window-open.html'
       document.body.appendChild(webview)
     })
   })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1650,4 +1650,18 @@ describe('<webview> tag', function () {
       w.loadURL(`file://${fixtures}/pages/webview-origin-zoom-level.html`)
     })
   })
+
+  describe('nativeWindowOpen option', () => {
+    it('opens a windows with cross-scripting enabled', (done) => {
+      ipcMain.once('answer', (event, content) => {
+        assert.equal(content, 'Hello')
+        done()
+      })
+
+      webview.setAttribute('nodeintegration', 'on')
+      webview.setAttribute('webpreferences', 'nativeWindowOpen=1')
+      webview.src = 'file://' + path.join(fixtures, 'api', 'native-window-open-blank.html')
+      document.body.appendChild(webview)
+    })
+  })
 })


### PR DESCRIPTION
Support setting `webpreferences="nativeWindowOpen=1"` on `<webview>` tags.

- [x] Don't crash when using `nativeWindowOpen` on a `<webview>` tag
- [x] Return `null` from native `window.open` when called from a `<webview>` tag that does not have `allowpopups` set
- [x] Add more specs

Refs #8963 
Fixes #9556 