### PR TITLE
Re enable crash reporter specs on Linux CI

### DIFF
--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -9,17 +9,10 @@ const url = require('url')
 const {closeWindow} = require('./window-helpers')
 
 const {remote} = require('electron')
-const isCI = remote.getGlobal('isCi')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
 describe('crashReporter module', function () {
   if (process.mas) {
-    return
-  }
-
-  // FIXME internal Linux CI is failing when it detects a process crashes
-  // which is a false positive here since crashes are explicitly triggered
-  if (isCI && process.platform === 'linux') {
     return
   }
 


### PR DESCRIPTION
Reverts #9476 now that setting `LIMIT_OUTPUT_IGNORE_SEGFAULTS` will cause segfaults (expected in crash reporter specs) to not be detected as build failures.