### PR TITLE
Add -lcups to link settings on mac

### DIFF
--- a/brightray/brightray.gyp
+++ b/brightray/brightray.gyp
@@ -244,6 +244,8 @@
                   '$(SDKROOT)/System/Library/Frameworks/IOBluetooth.framework',
                   # components/wifi/BUILD.gn:
                   '$(SDKROOT)/System/Library/Frameworks/CoreWLAN.framework',
+                  # printing/BUILD.gn:
+                  '-lcups',
                 ],
               },
             }],


### PR DESCRIPTION
Master is currently failing to link the macOS release builds.

Reported by @TimNZ over in https://github.com/electron/electron/issues/9548#issuecomment-303666608

Probably related to the changes in #8596 