### PR TITLE
Upgrade libcc with 1.6.x fixes

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -72,7 +72,7 @@ def main():
                                              os.environ.get('PATH', '')])
 
   is_release = os.environ.has_key('ELECTRON_RELEASE')
-  args = ['--target_arch=' + target_arch]
+  args = ['--target_arch=' + target_arch, '-v']
   if not is_release:
     args += ['--dev']
   run_script('bootstrap.py', args)

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '4a0e32606e52c12c50c2e3a0973d015d8cdff494'
+    'e2ec6935fbf034207d5ad00fa905a4b2cdd60bb7'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
Pulls the following libchromiumcontent fixes into 1.6.x:

* https://github.com/electron/libchromiumcontent/pull/303
* https://github.com/electron/libchromiumcontent/pull/304
* https://github.com/electron/libchromiumcontent/pull/305