### PR TITLE
Use last selected directory when using default file name in dialog.showSaveDialog()

### DIFF
--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -72,8 +72,12 @@ class FileChooserDialog {
         gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog_),
             settings.default_path.value().c_str());
       } else {
-        gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog_),
-            settings.default_path.DirName().value().c_str());
+        if (settings.default_path.IsAbsolute()) {
+          gtk_file_chooser_set_current_folder(
+              GTK_FILE_CHOOSER(dialog_),
+              settings.default_path.DirName().value().c_str());
+        }
+
         gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog_),
             settings.default_path.BaseName().value().c_str());
       }

--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -65,8 +65,11 @@ void SetupDialog(NSSavePanel* dialog,
     if (base::DirectoryExists(settings.default_path)) {
       default_dir = base::SysUTF8ToNSString(settings.default_path.value());
     } else {
-      default_dir =
-          base::SysUTF8ToNSString(settings.default_path.DirName().value());
+      if (settings.default_path.IsAbsolute()) {
+        default_dir =
+            base::SysUTF8ToNSString(settings.default_path.DirName().value());
+      }
+
       default_filename =
           base::SysUTF8ToNSString(settings.default_path.BaseName().value());
     }

--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -105,7 +105,9 @@ class FileDialog {
       }
     }
 
-    SetDefaultFolder(settings.default_path);
+    if (settings.default_path.IsAbsolute()) {
+      SetDefaultFolder(settings.default_path);
+    }
   }
 
   bool Show(atom::NativeWindow* parent_window) {

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -87,7 +87,8 @@ shown.
 * `browserWindow` BrowserWindow (optional)
 * `options` Object
   * `title` String (optional)
-  * `defaultPath` String (optional)
+  * `defaultPath` String (optional) - Absolute directory path, absolute file
+    path, or file name to use by default.
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structures/file-filter.md) (optional)


### PR DESCRIPTION
Prior to this change, attempting to use `dialog.showSaveDialog({ defaultPath: 'foo.png' })` would open the save dialog to the current directory with the default file name set to `foo.png`. We now use the last selected directory instead of the current directory.

Absolute paths are not affected by this change.