### PR TITLE
Enable LIMIT_OUTPUT_IGNORE_SEGFAULTS on Linux CI

### DIFF
--- a/script/pre-cibuild
+++ b/script/pre-cibuild
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export LIMIT_OUTPUT_IGNORE_SEGFAULTS=1


### PR DESCRIPTION
Extracted from #9570 since this needs to be committed before the re-enable build runs.