### PR TITLE
Fix type definitions for getCPUUsage / getIOCounters

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -119,12 +119,8 @@ that all statistics are reported in Kilobytes.
 
 ### `process.getCPUUsage()`
 
-Returns:
-
-* `CPUUsage` [CPUUsage](structures/cpu-usage.md)
+Returns [`CPUUsage`](structures/cpu-usage.md)
 
 ### `process.getIOCounters()` _Windows_ _Linux_
 
-Returns:
-
-* `IOCounters` [IOCounters](structures/io-counters.md)
+Returns [`IOCounters`](structures/io-counters.md)

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -119,8 +119,8 @@ that all statistics are reported in Kilobytes.
 
 ### `process.getCPUUsage()`
 
-Returns [`CPUUsage`](structures/cpu-usage.md)
+Returns [`Electron.CPUUsage`](structures/cpu-usage.md)
 
 ### `process.getIOCounters()` _Windows_ _Linux_
 
-Returns [`IOCounters`](structures/io-counters.md)
+Returns [`Electron.IOCounters`](structures/io-counters.md)

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -119,8 +119,8 @@ that all statistics are reported in Kilobytes.
 
 ### `process.getCPUUsage()`
 
-Returns [`Electron.CPUUsage`](structures/cpu-usage.md)
+Returns [`CPUUsage`](structures/cpu-usage.md)
 
 ### `process.getIOCounters()` _Windows_ _Linux_
 
-Returns [`Electron.IOCounters`](structures/io-counters.md)
+Returns [`IOCounters`](structures/io-counters.md)


### PR DESCRIPTION
These are turning up in `electron.d.ts` as:

``` ts
getCPUUsage(CPUUsage: Electron.CPUUsage): void;
getIOCounters(IOCounters: Electron.IOCounters): void;
```