### PR TITLE
Add backticks around return types

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -764,12 +764,12 @@ This method can only be called before app is ready.
 
 ### `app.getAppMemoryInfo()` _Deprecated_
 
-Returns [ProcessMetric[]](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
+Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
 **Note:** This method is deprecated, use `app.getAppMetrics()` instead.
 
 ### `app.getAppMetrics()`
 
-Returns [ProcessMetric[]](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
+Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
 
 ### `app.setBadgeCount(count)` _Linux_ _macOS_
 

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -169,7 +169,7 @@ the first write will throw an error. If the passed value is not a `String`, its
 
 * `name` String - Specify an extra header name.
 
-Returns Object - The value of a previously set extra header name.
+Returns `Object` - The value of a previously set extra header name.
 
 #### `request.removeHeader(name)`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -923,7 +923,7 @@ when the JS promise is rejected.
 
 Get the system printer list.
 
-Returns [PrinterInfo[]](structures/printer-info.md)
+Returns [`PrinterInfo[]`](structures/printer-info.md)
 
 #### `contents.print([options])`
 


### PR DESCRIPTION
Changes the typescript definitions from:

```ts
getAppMemoryInfo(): void;
getAppMetrics(): void;
getPrinters(): void;
```

to:

```ts
getAppMemoryInfo(): ProcessMetric[];
getAppMetrics(): ProcessMetric[];
getPrinters(): PrinterInfo[];
```