### PR TITLE
PrinterInfo options object causes TypeScript error

### DIFF
--- a/docs/api/structures/printer-info.md
+++ b/docs/api/structures/printer-info.md
@@ -4,6 +4,7 @@
 * `description` String
 * `status` Number
 * `isDefault` Boolean
+* `options` Object - Additional fields
 
 ## Example
 


### PR DESCRIPTION
This was reverted in commit 385d6faf1ab6867f04b9d2b5e66b0921d4b71cd4 before the 1.7.2 release to get it out the door.

This pull request adds it back to further investigate the error below:

```
npm run create-typescript-definitions
```

```
Error: Ruh roh, "Options" is already declared
    at Object.keys.sort.forEach (/Users/kevin/github/electron/node_modules/electron-typescript-definitions/lib/dynamic-param-interfaces.js:77:17)
    at Array.forEach (native)
    at Object.flushParamInterfaces (/Users/kevin/github/electron/node_modules/electron-typescript-definitions/lib/dynamic-param-interfaces.js:70:142)
    at module.exports (/Users/kevin/github/electron/node_modules/electron-typescript-definitions/index.js:69:19)
    at apiPromise.then.then.API (/Users/kevin/github/electron/node_modules/electron-typescript-definitions/cli.js:57:18)
    at process._tickCallback (internal/process/next_tick.js:103:7)
    at Module.runMain (module.js:607:11)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:535:3
```