### PR TITLE
Fix incorrect extension when filters is used

### DIFF
--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -73,9 +73,9 @@ void SetupDialog(NSSavePanel* dialog,
     }
   }
 
-  if (settings.filters.empty())
+  if (settings.filters.empty()) {
     [dialog setAllowsOtherFileTypes:YES];
-  else {
+  } else {
     // Set setAllowedFileTypes before setNameFieldStringValue as it might
     // override the extension set using setNameFieldStringValue
     SetAllowedFileTypes(dialog, settings.filters);

--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -75,8 +75,11 @@ void SetupDialog(NSSavePanel* dialog,
 
   if (settings.filters.empty())
     [dialog setAllowsOtherFileTypes:YES];
-  else
+  else {
+    // Set setAllowedFileTypes before setNameFieldStringValue as it might
+    // override the extension set using setNameFieldStringValue
     SetAllowedFileTypes(dialog, settings.filters);
+  }
 
   if (default_dir)
     [dialog setDirectoryURL:[NSURL fileURLWithPath:default_dir]];

--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -40,6 +40,7 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   if ([file_type_set count])
     file_types = [file_type_set allObjects];
 
+  [dialog setExtensionHidden:NO];
   [dialog setAllowedFileTypes:file_types];
 }
 
@@ -72,15 +73,16 @@ void SetupDialog(NSSavePanel* dialog,
     }
   }
 
+  if (settings.filters.empty())
+    [dialog setAllowsOtherFileTypes:YES];
+  else
+    SetAllowedFileTypes(dialog, settings.filters);
+
   if (default_dir)
     [dialog setDirectoryURL:[NSURL fileURLWithPath:default_dir]];
   if (default_filename)
     [dialog setNameFieldStringValue:default_filename];
 
-  if (settings.filters.empty())
-    [dialog setAllowsOtherFileTypes:YES];
-  else
-    SetAllowedFileTypes(dialog, settings.filters);
 }
 
 void SetupDialogForProperties(NSOpenPanel* dialog, int properties) {


### PR DESCRIPTION
Running `[dialog setAllowedFileTypes:file_types];` replaces the extension in `nameFieldStringValue` with first value in `file_types` variable however if `[dialog setNameFieldStringValue:default_filename];` is run after setting the `allowedFileTypes` the extension initially passed with the default filename is retained. Explicitly setting `setExtensionHidden` makes sure that extension is shown everytime. 
Screenshots to confirm that issue is fixed:

Code:
 ```
    const {dialog} = require('electron')
    dialog.showSaveDialog(mainWindow, {
      defaultPath:'/tmp/test.jpg',
      filters: [
        { name: 'Image', extensions: ['jpg', 'jpeg', 'png', 'gif'] }
      ]
    }, function(filename) {})
```
Result:
![image](https://cloud.githubusercontent.com/assets/6316389/26531626/9a33c4d6-43ba-11e7-83fc-9d22b7d5a4ff.png)

#9455 