### PR TITLE
Add app.getGPUFeatureStatus

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1022,32 +1022,10 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
   return result;
 }
 
-static mate::Dictionary ConvertDictionary(
-    v8::Isolate* isolate, const base::DictionaryValue &dict) {
-  auto result = mate::Dictionary::CreateEmpty(isolate);
-
-  for (base::DictionaryValue::Iterator iterator(dict);
-       !iterator.IsAtEnd();
-       iterator.Advance()) {
-    auto& key = iterator.key();
-    auto& value = iterator.value();
-    if (value.is_string()) {
-      std::string strValue;
-      if (value.GetAsString(&strValue)) {
-        result.Set(key, strValue);
-      }
-    }
-  }
-
-  return result;
-}
-
-mate::Dictionary App::GetGPUFeatureStatus(v8::Isolate* isolate) {
-  if (auto status = content::GetFeatureStatus()) {
-    return ConvertDictionary(isolate, *status);
-  } else {
-    return mate::Dictionary::CreateEmpty(isolate);
-  }
+v8::Local<v8::Value> App::GetGPUFeatureStatus(v8::Isolate* isolate) {
+  auto status = content::GetFeatureStatus();
+  return mate::ConvertToV8(isolate,
+                           status ? *status : base::DictionaryValue());
 }
 
 // static

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -177,6 +177,7 @@ class App : public AtomBrowserClient::Delegate,
                    mate::Arguments* args);
 
   std::vector<mate::Dictionary> GetAppMetrics(v8::Isolate* isolate);
+  mate::Dictionary GetGPUFeatureStatus(v8::Isolate* isolate);
 
 #if defined(OS_WIN)
   // Get the current Jump List settings.

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -177,7 +177,7 @@ class App : public AtomBrowserClient::Delegate,
                    mate::Arguments* args);
 
   std::vector<mate::Dictionary> GetAppMetrics(v8::Isolate* isolate);
-  mate::Dictionary GetGPUFeatureStatus(v8::Isolate* isolate);
+  v8::Local<v8::Value> GetGPUFeatureStatus(v8::Isolate* isolate);
 
 #if defined(OS_WIN)
   // Get the current Jump List settings.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -771,6 +771,10 @@ Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMet
 
 Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
 
+### `app.getGpuFeatureStatus()`
+
+Returns [`GPUFeatureStatus`](structures/gpu-feature-status.md) - The Graphics Feature Status from `chrome://gpu/`.
+
 ### `app.setBadgeCount(count)` _Linux_ _macOS_
 
 * `count` Integer

--- a/docs/api/structures/gpu-feature-status.md
+++ b/docs/api/structures/gpu-feature-status.md
@@ -1,0 +1,29 @@
+# GPUFeatureStatus Object
+
+* `2d_canvas` String - Canvas
+* `flash_3d` String - Flash
+* `flash_stage3d` String - Flash Stage3D
+* `flash_stage3d_baseline` String - Flash Stage3D Baseline profile
+* `gpu_compositing` String - Compositing
+* `multiple_raster_threads` String - Multiple Raster Threads
+* `native_gpu_memory_buffers` String - Native GpuMemoryBuffers
+* `rasterization` String - Rasterization
+* `video_decode` String - Video Decode
+* `video_encode` String - Video Encode
+* `vpx_decode` String - VPx Video Decode
+* `webgl` String - WebGL
+* `webgl2` String - WebGL2
+
+Possible values:
+
+* `disabled_software` - Software only. Hardware acceleration disabled (yellow)
+* `disabled_off` - Disabled (red)
+* `disabled_off_ok` - Disabled (yellow)
+* `unavailable_software` - Software only, hardware acceleration unavailable (yellow)
+* `unavailable_off` - Unavailable (red)
+* `unavailable_off_ok` - Unavailable (yellow)
+* `enabled_readback` - Hardware accelerated but at reduced performance (yellow)
+* `enabled_force` - Hardware accelerated on all pages (green)
+* `enabled` - Hardware accelerated (green)
+* `enabled_on` - Enabled (green)
+* `enabled_force_on` - Force enabled (green)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -558,4 +558,14 @@ describe('app module', function () {
       assert.ok(types.includes('Tab'))
     })
   })
+
+  describe('getGPUFeatureStatus() API', function () {
+    if (process.platform !== 'darwin') return
+
+    it('returns the graphic features statuses', function () {
+      const features = app.getGPUFeatureStatus()
+      assert.equal(typeof features.webgl, 'string')
+      assert.equal(typeof features.gpu_compositing, 'string')
+    })
+  })
 })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -560,8 +560,6 @@ describe('app module', function () {
   })
 
   describe('getGPUFeatureStatus() API', function () {
-    if (process.platform !== 'darwin') return
-
     it('returns the graphic features statuses', function () {
       const features = app.getGPUFeatureStatus()
       assert.equal(typeof features.webgl, 'string')


### PR DESCRIPTION
This method returns the **Graphics Feature Status** from chrome://gpu/ as JSON.
It allows detecting the status of GPU acceleration without having to open a hidden `BrowserWindow` and parsing the data from HTML.

Example output:
```
{  
   "2d_canvas":"enabled",
   "flash_3d":"enabled",
   "flash_stage3d":"enabled",
   "flash_stage3d_baseline":"enabled",
   "gpu_compositing":"enabled",
   "multiple_raster_threads":"enabled_on",
   "native_gpu_memory_buffers":"enabled",
   "rasterization":"enabled",
   "video_decode":"enabled",
   "video_encode":"enabled",
   "vpx_decode":"enabled",
   "webgl":"enabled",
   "webgl2":"enabled"
}"
```

The list of possible values can be found in `chrome://gpu/gpu_internals.js` (`statusMap`).