### PR TITLE
bump ts linter with fixes for numeric keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "browserify": "^13.1.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.3",
-    "electron-typescript-definitions": "^1.2.5",
+    "electron-typescript-definitions": "^1.2.7",
     "request": "*",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"


### PR DESCRIPTION
Explicit bump to get TypeScript file generation working on master for everyone.

Details at https://github.com/electron/electron-typescript-definitions/pull/61