### PR TITLE
Fix unresponsive app after fullscreen->normal state toggle (Windows)

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -512,7 +512,7 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
   // else a non-responsive window shell could be rendered.
   // (this situation may arise when app starts with fullscreen: true)
   // Note: the following must be after "window_->SetFullscreen(fullscreen);"
-  if (leaving_fullscreen && !IsVisible()) 
+  if (leaving_fullscreen && !IsVisible())
     FlipWindowStyle(GetAcceleratedWidget(), true, WS_VISIBLE);
 #else
   if (IsVisible())

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -480,7 +480,7 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
 
 #if defined(OS_WIN)
   // There is no native fullscreen state on Windows.
-  bool fullscreen_to_normal_detected = IsFullscreen() && !fullscreen;
+  bool leaving_fullscreen = IsFullscreen() && !fullscreen;
 
   if (fullscreen) {
     last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
@@ -512,11 +512,8 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
   // else a non-responsive window shell could be rendered.
   // (this situation may arise when app starts with fullscreen: true)
   // Note: the following must be after "window_->SetFullscreen(fullscreen);"
-  if (fullscreen_to_normal_detected && !IsVisible()) {
-    LONG frame_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
-    frame_style |= WS_VISIBLE;
-    ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
-  }
+  if (leaving_fullscreen && !IsVisible()) 
+    FlipWindowStyle(GetAcceleratedWidget(), true, WS_VISIBLE);
 #else
   if (IsVisible())
     window_->SetFullscreen(fullscreen);

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1973,12 +1973,12 @@ describe('BrowserWindow module', function () {
 
     it('should keep window hidden if already in hidden state', function (done) {
       w.webContents.once('did-finish-load', function () {
-        w.setFullScreen(false)
-        setTimeout(() => {
+        w.once('leave-full-screen', () => {
           assert.equal(w.isVisible(), false)
           assert.equal(w.isFullScreen(), false)
           done()
-        }, 1000)
+        })
+        w.setFullScreen(false)
       })
       w.loadURL('about:blank')
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1949,6 +1949,41 @@ describe('BrowserWindow module', function () {
     })
   })
 
+  describe('BrowserWindow.setFullScreen(false)', function () {
+    // only applicable to windows: https://github.com/electron/electron/issues/6036
+    if (process.platform !== 'win32') return
+
+    it('should restore a normal visible window from a fullscreen startup state', function (done) {
+      w.webContents.once('did-finish-load', function () {
+        // start fullscreen and hidden
+        w.setFullScreen(true)
+        w.once('show', function () {
+          // restore window to normal state
+          w.setFullScreen(false)
+        })
+        w.once('leave-full-screen', function () {
+          assert.equal(w.isVisible(), true)
+          assert.equal(w.isFullScreen(), false)
+          done()
+        })
+        w.show()
+      })
+      w.loadURL('about:blank')
+    })
+
+    it('should keep window hidden if already in hidden state', function (done) {
+      w.webContents.once('did-finish-load', function () {
+        w.setFullScreen(false)
+        setTimeout(() => {
+          assert.equal(w.isVisible(), false)
+          assert.equal(w.isFullScreen(), false)
+          done()
+        }, 1000)
+      })
+      w.loadURL('about:blank')
+    })
+  })
+
   describe('parent window', function () {
     let c = null
 


### PR DESCRIPTION
Fixes #6036

**Summary**

In **Windows only**, starting an app in the fullscreen state i.e. with the BrowserWindow options `{ fullscreen: true }` produces an unresponsive window after toggling to the normal window state. e.g. Pressing F11 or `setFullScreen(false)`. See issue #6036

The window visibility flag `WS_VISIBLE` is never set for the `GWL_STYLE` when we start in fullscreen mode. This fix simply detects the fullscreen->normal window state transition and checks if the window is visible (which it always should be). If it isn't, it sets the visibility to true. i.e. :

```cpp
void NativeWindowViews::SetFullScreen(bool fullscreen) {
   bool fullscreen_to_normal_detected = IsFullscreen() && !fullscreen;
   ...
   if (fullscreen_to_normal_detected && !IsVisible()) {
       LONG frame_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
       frame_style |= WS_VISIBLE;
       ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
   }
   ...
}
```

Includes tests (this branch passes, old behavior fails)

Fixes #6036