### PR TITLE
Integrity check for ASAR files

### DIFF
--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -163,7 +163,7 @@ void InitAsarSupport(v8::Isolate* isolate,
 // and put unverified code to app directory)
 std::vector<std::string> GetSearchPath() {
   #if defined(OS_MACOSX)
-  if (asar::GetAsarChecksums().empty()) {
+  if (asar::GetAsarIntegrity().empty()) {
     return {"app", "app.asar", "default_app.asar"};
   } else {
     return {"app.asar"};
@@ -179,7 +179,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("createArchive", &Archive::Create);
   dict.SetMethod("initAsarSupport", &InitAsarSupport);
   #if defined(OS_MACOSX)
-  dict.SetMethod("getChecksums", &asar::GetAsarChecksums);
+  dict.SetMethod("getIntegrity", &asar::GetAsarIntegrity);
   #endif
   dict.SetMethod("getSearchPath", &GetSearchPath);
 }

--- a/atom/common/asar/manifest_asar_mac.h
+++ b/atom/common/asar/manifest_asar_mac.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_ASAR_MANIFEST_ASAR_MAC_H_
+#define ATOM_COMMON_ASAR_MANIFEST_ASAR_MAC_H_
+
+#include <string>
+
+namespace asar {
+
+std::string GetAsarChecksums();
+
+}  // namespace asar
+
+#endif  // ATOM_COMMON_ASAR_MANIFEST_ASAR_MAC_H_
+

--- a/atom/common/asar/manifest_asar_mac.h
+++ b/atom/common/asar/manifest_asar_mac.h
@@ -9,7 +9,7 @@
 
 namespace asar {
 
-std::string GetAsarChecksums();
+std::string GetAsarIntegrity();
 
 }  // namespace asar
 

--- a/atom/common/asar/manifest_asar_mac.mm
+++ b/atom/common/asar/manifest_asar_mac.mm
@@ -7,13 +7,13 @@
 
 namespace asar {
 
-std::string GetAsarChecksums() {
+std::string GetAsarIntegrity() {
   NSBundle* bundle = chrome::OuterAppBundle();
   if (!bundle) {
     return "";
   }
 
-  NSString *checksums = [bundle objectForInfoDictionaryKey:@"AsarChecksums"];
+  NSString *checksums = [bundle objectForInfoDictionaryKey:@"AsarIntegrity"];
   return checksums ? std::string([checksums UTF8String]) : "";
 }
 

--- a/atom/common/asar/manifest_asar_mac.mm
+++ b/atom/common/asar/manifest_asar_mac.mm
@@ -1,0 +1,20 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "chrome/common/chrome_paths_internal.h"
+#import "base/mac/foundation_util.h"
+
+namespace asar {
+
+std::string GetAsarChecksums() {
+  NSBundle* bundle = chrome::OuterAppBundle();
+  if (!bundle) {
+    return "";
+  }
+
+  NSString *checksums = [bundle objectForInfoDictionaryKey:@"AsarChecksums"];
+  return checksums ? std::string([checksums UTF8String]) : "";
+}
+
+}

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -414,6 +414,8 @@
       'atom/common/asar/asar_util.h',
       'atom/common/asar/scoped_temporary_file.cc',
       'atom/common/asar/scoped_temporary_file.h',
+      'atom/common/asar/manifest_asar_mac.h',
+      'atom/common/asar/manifest_asar_mac.mm',
       'atom/common/atom_command_line.cc',
       'atom/common/atom_command_line.h',
       'atom/common/atom_constants.cc',

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -6,6 +6,7 @@ const path = require('path')
 const util = require('util')
 const Module = require('module')
 const v8 = require('v8')
+const asar = process.binding('atom_common_asar')
 
 // We modified the original process.argv to let node.js load the atom.js,
 // we need to restore it here.
@@ -103,14 +104,15 @@ require('./guest-window-manager')
 // Now we try to load app's package.json.
 let packagePath = null
 let packageJson = null
-const searchPaths = ['app', 'app.asar', 'default_app.asar']
-for (packagePath of searchPaths) {
+for (packagePath of asar.getSearchPath()) {
   try {
     packagePath = path.join(process.resourcesPath, packagePath)
     packageJson = require(path.join(packagePath, 'package.json'))
     break
   } catch (error) {
-    continue
+    if (error.code && error.code.startsWith('EDAMAGED')) {
+      throw error
+    }
   }
 }
 

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -33,40 +33,48 @@
       position += bytesRead
     }
     while (bytesRead === BUFFER_SIZE)
-    return hash.digest('hex')
+    return hash.digest('base64')
   }
 
-  let asarFilenameToChecksum
+  let asarIntegrity
 
   const validateAsarIntegrity = function (archive, filePath) {
     if (process.platform !== 'darwin') {
       return
     }
 
-    if (!asarFilenameToChecksum) {
-      if (asarFilenameToChecksum === null) {
+    if (!asarIntegrity) {
+      if (asarIntegrity === null) {
         // checksums not specified at all
         return
       }
 
-      const checksumData = asar.getChecksums()
-      if (!checksumData) {
-        asarFilenameToChecksum = null
+      const asarIntegrityData = asar.getIntegrity()
+      if (!asarIntegrityData) {
+        asarIntegrity = null
         return
       }
 
       if (process.env.ELECTRON_DEBUG_ASAR_CHECK) {
-        console.log(checksumData)
+        console.log(asarIntegrityData)
       }
 
       try {
-        asarFilenameToChecksum = JSON.parse(checksumData)
+        asarIntegrity = JSON.parse(asarIntegrityData)
       } catch (e) {
-        throwErrorAndExit(`Cannot parse asar files checksums from application manifest: ${e}\nData: ${checksumData}`, 'EDAMAGEDAPP')
+        throwErrorAndExit(`Cannot parse asar files checksums from application manifest: ${e}\nData: ${asarIntegrityData}`, 'EDAMAGEDAPP')
       }
     }
 
-    const expected = asarFilenameToChecksum[path.basename(filePath)]
+    let resourcesPath = process.resourcesPath
+    if (!filePath.startsWith(resourcesPath)) {
+      if (asarIntegrity.externalAllowed === true) {
+        return
+      }
+      throwErrorAndExit(`${filePath} not located in the application resources path (${resourcesPath}) but loading of external files is disallowed (externalAllowed: ${asarIntegrity.externalAllowed})`)
+    }
+
+    const expected = asarIntegrity.checksums[path.basename(filePath)]
     if (!expected) {
       throwErrorAndExit(`Application is corrupted, checksum not specified for ${filePath}`, 'EDAMAGEDAPP')
     }
@@ -89,6 +97,11 @@
     if (process.env.ELECTRON_DEBUG_ASAR_CHECK) {
       // to debug if someone swallows exception (get clear error text in any case)
       console.error(message)
+
+      // otherwise error modal dialog and not easy to test
+      if (process.env.ELECTRON_TEST_ASAR_CHECK) {
+        process.exit(1)
+      }
     }
 
     // to ensure that app will be terminated

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -4,6 +4,8 @@
   const childProcess = require('child_process')
   const path = require('path')
   const util = require('util')
+  let crypto
+  let originalFs
 
   const hasProp = {}.hasOwnProperty
 
@@ -15,6 +17,89 @@
     return process.noAsar || envNoAsar
   }
 
+  const hashSync = function (fd) {
+    if (crypto == null) {
+      crypto = require('crypto')
+    }
+
+    const hash = crypto.createHash('sha512')
+    const BUFFER_SIZE = Buffer.poolSize
+    const buffer = Buffer.allocUnsafe(BUFFER_SIZE)
+    let bytesRead
+    let position = 0
+    do {
+      bytesRead = originalFs.readSync(fd, buffer, 0, BUFFER_SIZE, position)
+      hash.update(buffer.slice(0, bytesRead))
+      position += bytesRead
+    }
+    while (bytesRead === BUFFER_SIZE)
+    return hash.digest('hex')
+  }
+
+  let asarFilenameToChecksum
+
+  const validateAsarIntegrity = function (archive, filePath) {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    if (!asarFilenameToChecksum) {
+      if (asarFilenameToChecksum === null) {
+        // checksums not specified at all
+        return
+      }
+
+      const checksumData = asar.getChecksums()
+      if (!checksumData) {
+        asarFilenameToChecksum = null
+        return
+      }
+
+      if (process.env.ELECTRON_DEBUG_ASAR_CHECK) {
+        console.log(checksumData)
+      }
+
+      try {
+        asarFilenameToChecksum = JSON.parse(checksumData)
+      } catch (e) {
+        throwErrorAndExit(`Cannot parse asar files checksums from application manifest: ${e}\nData: ${checksumData}`, 'EDAMAGEDAPP')
+      }
+    }
+
+    const expected = asarFilenameToChecksum[path.basename(filePath)]
+    if (!expected) {
+      throwErrorAndExit(`Application is corrupted, checksum not specified for ${filePath}`, 'EDAMAGEDAPP')
+    }
+
+    const fd = archive.getFd()
+    if (fd < 0) {
+      const error = new Error(`ENOENT, ${filePath} not found`)
+      error.code = 'ENOENT'
+      error.errno = -2
+      throw error
+    }
+
+    const actual = hashSync(fd)
+    if (expected !== actual) {
+      throwErrorAndExit(`${filePath} is corrupted, checksum mismatch.\nexpected: ${expected}\nactual  : ${actual}`, 'EDAMAGEDFILE')
+    }
+  }
+
+  const throwErrorAndExit = function (message, code) {
+    if (process.env.ELECTRON_DEBUG_ASAR_CHECK) {
+      // to debug if someone swallows exception (get clear error text in any case)
+      console.error(message)
+    }
+
+    // to ensure that app will be terminated
+    process.nextTick(function () {
+      process.exit(1)
+    })
+    const error = new Error(message)
+    error.code = code
+    throw error
+  }
+
   const getOrCreateArchive = function (p) {
     let archive = cachedArchives[p]
     if (archive != null) {
@@ -24,6 +109,7 @@
     if (!archive) {
       return false
     }
+    validateAsarIntegrity(archive, p)
     cachedArchives[p] = archive
     return archive
   }
@@ -222,6 +308,7 @@
 
   // Override fs APIs.
   exports.wrapFsWithAsar = function (fs) {
+    originalFs = fs
     const logFDs = {}
     const logASARAccess = function (asarPath, filePath, offset) {
       if (!process.env.ELECTRON_LOG_ASAR_READS) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "release": "./script/upload.py -p",
     "repl": "python ./script/start.py --interactive",
     "start": "python ./script/start.py",
-    "test": "python ./script/test.py"
+    "test": "python ./script/test.py",
+    "test-asar-integrity": "./spec/node_modules/.bin/mocha ./spec/asar-integrity-test"
   }
 }

--- a/spec/asar-integrity-test-app/index.js
+++ b/spec/asar-integrity-test-app/index.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { app } = require('electron')
+const { join } = require('path')
+
+app.on('ready', () => {
+  if (process.env.TEST_REQUIRE_EXTERNAL) {
+    require(join(process.resourcesPath, '..', 'external.asar'))
+  }
+
+  process.exit(0)
+})

--- a/spec/asar-integrity-test-app/package.json
+++ b/spec/asar-integrity-test-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "TestApp",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Foo"
+}

--- a/spec/asar-integrity-test.js
+++ b/spec/asar-integrity-test.js
@@ -1,0 +1,100 @@
+const path = require('path')
+const plist = require('plist')
+const fs = require('fs')
+const { computeData } = require('asar-integrity')
+const { execFileSync } = require('child_process')
+
+const testAppAsar = Buffer.from('BAAAAGQAAABgAAAAWgAAAHsiZmlsZXMiOnsiaW5kZXguanMiOnsic2l6ZSI6MjQxLCJvZmZzZXQiOiIwIn0sInBhY2thZ2UuanNvbiI6eyJzaXplIjo4NCwib2Zmc2V0IjoiMjQxIn19fQAAJ3VzZSBzdHJpY3QnCgpjb25zdCB7IGFwcCB9ID0gcmVxdWlyZSgnZWxlY3Ryb24nKQpjb25zdCB7IGpvaW4gfSA9IHJlcXVpcmUoJ3BhdGgnKQoKYXBwLm9uKCdyZWFkeScsICgpID0+IHsKICBpZiAocHJvY2Vzcy5lbnYuVEVTVF9SRVFVSVJFX0VYVEVSTkFMKSB7CiAgICByZXF1aXJlKGpvaW4ocHJvY2Vzcy5yZXNvdXJjZXNQYXRoLCAnLi4nLCAnZXh0ZXJuYWwuYXNhcicpKQogIH0KCiAgcHJvY2Vzcy5leGl0KDApCn0pCnsKICAibmFtZSI6ICJUZXN0QXBwIiwKICAidmVyc2lvbiI6ICIxLjAuMCIsCiAgImxpY2Vuc2UiOiAiTUlUIiwKICAiYXV0aG9yIjogIkZvbyIKfQ==', 'base64')
+
+describe('Asar Integrity', function () {
+  if (process.platform !== 'darwin') {
+    return
+  }
+
+  const originalAppDir = path.join(__dirname, '../out/D/Electron.app')
+  const appDir = path.join(__dirname, '../out/test/Electron.app')
+  execFileSync('rm', ['-rf', appDir])
+  execFileSync('mkdir', ['-p', appDir])
+  execFileSync('cp', ['-R', originalAppDir + '/', appDir])
+
+  const resourcesDir = path.join(appDir, 'Contents/Resources')
+  fs.writeFileSync(path.join(resourcesDir, 'app.asar'), testAppAsar)
+
+  const testEnv = Object.assign({}, process.env, {ELECTRON_DEBUG_ASAR_CHECK: 'true', ELECTRON_TEST_ASAR_CHECK: 'true'})
+
+  // test that works correctly without AsarIntegrity
+  const runApp = () => {
+    execFileSync(path.join(appDir, 'Contents/MacOS/Electron'), {
+      timeout: 30 * 1000,
+      env: testEnv,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+  }
+
+  const infoPlistFile = path.join(appDir, 'Contents/Info.plist')
+  const manifest = plist.parse(fs.readFileSync(infoPlistFile, 'utf8'))
+
+  let asarIntegrity
+
+  // https://github.com/mochajs/mocha/issues/1431
+  before(() => computeData(resourcesDir)
+    .then(it => {
+      asarIntegrity = it
+    }))
+
+  function saveManifest (data) {
+    manifest.AsarIntegrity = JSON.stringify(data)
+    fs.writeFileSync(infoPlistFile, plist.build(manifest))
+  }
+
+  const runExternalAsarTest = (task) => {
+    const externalFile = path.join(resourcesDir, '..', 'external.asar')
+    // file must exists
+    fs.writeFileSync(externalFile, testAppAsar)
+    try {
+      testEnv.TEST_REQUIRE_EXTERNAL = 'true'
+      task()
+    } finally {
+      delete testEnv.TEST_REQUIRE_EXTERNAL
+      fs.unlinkSync(externalFile)
+    }
+  }
+
+  it('without AsarIntegrity', () => runApp())
+
+  it('with valid AsarIntegrity', () => {
+    saveManifest(asarIntegrity)
+    runApp()
+  })
+
+  it('invalid checksum', () => {
+    saveManifest(Object.assign({}, asarIntegrity, {checksums: Object.assign({}, asarIntegrity.checksums, {'app.asar': 'invalid checksum'})}))
+    expectError(runApp, 'is corrupted, checksum mismatch')
+  })
+
+  it('load external if disallowed', () => {
+    saveManifest(asarIntegrity)
+    runExternalAsarTest(() => expectError(runApp, 'but loading of external files is disallowed'))
+  })
+
+  it('load external if allowed', () => {
+    saveManifest(Object.assign({}, asarIntegrity, {externalAllowed: true}))
+    runExternalAsarTest(runApp)
+  })
+})
+
+function expectError (task, s) {
+  let errorOccurred = false
+  try {
+    task()
+  } catch (e) {
+    errorOccurred = true
+    if (!e.message.includes(s)) {
+      throw e
+    }
+  }
+
+  if (!errorOccurred) {
+    throw new Error(`Error expected: ${s}`)
+  }
+}

--- a/spec/package.json
+++ b/spec/package.json
@@ -15,7 +15,9 @@
     "temp": "^0.8.3",
     "walkdir": "0.0.11",
     "ws": "^1.1.1",
-    "yargs": "^6.0.0"
+    "yargs": "^6.0.0",
+    "plist": "^2.1.0",
+    "asar-integrity": "^0.1.0"
   },
   "optionalDependencies": {
     "ffi": "2.2.0",


### PR DESCRIPTION
Addresses [Code Signing of ASAR files](https://github.com/electron/asar/issues/123).

* Any application that uses external files as code sources are not protected and code signing doesn't make sense.
* Anyone can use trusted app from trusted vendor as a template for malicious app.
  * macOS: Static validation failed (when you manually check using codesign tool or another tools), dynamic (performed on run for quarantined apps) passed.
  * Windows: no app bundle concept at all, no way to statically check app, no dynamic validation at all. Nothing prevents.
* Java, Electron apps are affected. 

How do we can fix it?

1. Embedding code sources into the executables.
    1.1 Modifying existing executable.
    * macOS: [Not possible](https://stackoverflow.com/questions/4022495/how-can-i-add-sections-to-an-existing-os-x-executable).
    * Windows: using windows resources.

     As it is not possible on macOS, this approach is rejected.

    1.2 Linking during build. It will complicate Electron app development. Another approach should be used.

    So, although embedding code sources into the executables approach is the most secured, price is too high. 

2. Really sign ASAR file and verify on ASAR file load. Well, implementation will be complex and fragile (very easy to verify code integrity, but identity validation...). So, this approach is rejected.

3. Keep code integrity data in the application manifest and verify only integrity on ASAR file load. As application manifest is a part of executable file (Windows) and `Info.plist` is a part of application bundle (macOS), we don't need to verify identity and so, our implementation is robust and straightforward. If integrity data will be changed — code signature will be broken and application will be marked as damaged by OS.

Third approach, "code integrity data in the application manifest", is implemented in this PR.

Some notes:
* macOS specific: Depending on not yet known reasons even modified Info.plist is not a reason to prevent run on macOS sometimes. Under some conditions app is marked as damaged, but under another conditions not (interestingly, in both cases app is quarantined (`com.apple.quarantine`, can be checked using `xattr` tool)). Well, it doesn't invalidate the whole idea of this PR:
    * small amount of data can be embedded into existing Mach-O object file if will be proven that `Info.plist` is not really secured. So, it can be implemented later if need.
    * static validation is not passed (since code signature will be broken), so, user has ability to verify application using standard tools.
* sha512 is used because [it is faster](https://crypto.stackexchange.com/questions/26336/sha512-faster-than-sha256) than sha256 on x64 machines.
   * 5MB hashed in 4ms, 30MB hashed in 45ms. So, integrity check doesn't slow down app loading.
* macOS specific: Officially [not recommended](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG201) to sign non-Mach-O executables. So, unlikely PR to `electron-osx-sign` will be filed to sign ASAR files.
* Windows is unsecured, even macOS Gatekeeper doesn't work as expected... Should we worry about code integrity if even checks on OS level so insecure? Well... no excuse for us. Integrity check is cheap, build process is not complicated. So, why not to make sure that on our level user is protected and we do our best to protect users?

Checksums stored as JSON object under the key `AsarChecksums`. If key not specified — no integrity check. `electron-builder` (asar is enabled by default) will add integrity data on build (will be implemented as separated npm module to reuse this logic in other build tools).

Implemented for macOS only for now, I want to hear your feedback.

update 1: macOS performs full static validation on first run of downloaded application. So, changes in this PR not "should", but "must" be implemented (planned fix on `electron-osx-sign` under investigation).