### PR TITLE
Typescript menu popup fix

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -64,8 +64,9 @@ The `menu` object has the following instance methods:
 * `browserWindow` BrowserWindow (optional) - Default is the focused window.
 * `options` Object (optional)
   * `x` Number (optional) - Default is the current mouse cursor position.
-  * `y` Number (**required** if `x` is used) - Default is the current mouse
-    cursor position.
+  Must be declared if y is declared.
+  * `y` Number (optional) - Default is the current mouse cursor position.
+  Must be declared if x is declared.
   * `async` Boolean (optional) - Set to `true` to have this method return
     immediately called, `false` to return after the menu has been selected
     or closed. Defaults to `false`.

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -64,9 +64,9 @@ The `menu` object has the following instance methods:
 * `browserWindow` BrowserWindow (optional) - Default is the focused window.
 * `options` Object (optional)
   * `x` Number (optional) - Default is the current mouse cursor position.
-  Must be declared if y is declared.
+    Must be declared if `y` is declared.
   * `y` Number (optional) - Default is the current mouse cursor position.
-  Must be declared if x is declared.
+    Must be declared if `x` is declared.
   * `async` Boolean (optional) - Set to `true` to have this method return
     immediately called, `false` to return after the menu has been selected
     or closed. Defaults to `false`.


### PR DESCRIPTION
This removes the weird required syntax in menu docs that tricked the parser

Fixes electron/electron-typescript-definitions/issues/54