### PR TITLE
change 'request' version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.3",
     "electron-typescript-definitions": "^1.2.7",
-    "request": "*",
+    "request": "^2.68.0",
     "standard": "^8.4.0",
     "standard-markdown": "^2.1.1"
   },


### PR DESCRIPTION
https://nodesecurity.io/advisories/request_remote-memory-exposure
dependency 'request' has a security vulnerability for versions earlier than 2.68.0