### PR TITLE
:memo: Fixed typo

### DIFF
--- a/docs/tutorial/debugging-main-process.md
+++ b/docs/tutorial/debugging-main-process.md
@@ -3,7 +3,7 @@
 The DevTools in an Electron browser window can only debug JavaScript that's
 executed in that window (i.e. the web pages). To debug JavaScript that's
 executed in the main process you will need to use an external debugger and
-launch Electron with the `--inspector` or `--inspector-brk` switch.
+launch Electron with the `--inspect` or `--inspect-brk` switch.
 
 ## Command Line Switches
 


### PR DESCRIPTION
Fixed a simple typo in the docs.