### PR TITLE
Fix an issue where alwaysOnTop window disappears when restore…

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -208,7 +208,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 - (void)windowWillMiniaturize:(NSNotification*)notification {
   NSWindow* window = shell_->GetNativeWindow();
   // store the current status window level to be restored in windowDidDeminiaturize
-  level_ = NSStatusWindowLevel;
+  level_ = [window level];
   [window setLevel:NSNormalWindowLevel];
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -75,6 +75,7 @@ bool ScopedDisableResize::disable_resize_ = false;
  @private
   atom::NativeWindowMac* shell_;
   bool is_zooming_;
+  int level_;
 }
 - (id)initWithShell:(atom::NativeWindowMac*)shell;
 @end
@@ -204,11 +205,20 @@ bool ScopedDisableResize::disable_resize_ = false;
   shell_->NotifyWindowMoved();
 }
 
+- (void)windowWillMiniaturize:(NSNotification*)notification {
+  NSWindow* window = shell_->GetNativeWindow();
+  // store the current level to be restored in windowDidDeminiaturize
+  level_ = NSStatusWindowLevel;
+  [window setLevel:NSNormalWindowLevel];
+}
+
 - (void)windowDidMiniaturize:(NSNotification*)notification {
   shell_->NotifyWindowMinimize();
 }
 
 - (void)windowDidDeminiaturize:(NSNotification*)notification {
+  NSWindow* window = shell_->GetNativeWindow();
+  [window setLevel:level_];
   shell_->NotifyWindowRestore();
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -207,7 +207,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (void)windowWillMiniaturize:(NSNotification*)notification {
   NSWindow* window = shell_->GetNativeWindow();
-  // store the current level to be restored in windowDidDeminiaturize
+  // store the current status window level to be restored in windowDidDeminiaturize
   level_ = NSStatusWindowLevel;
   [window setLevel:NSNormalWindowLevel];
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -86,6 +86,7 @@ bool ScopedDisableResize::disable_resize_ = false;
   if ((self = [super init])) {
     shell_ = shell;
     is_zooming_ = false;
+    level_ = [shell_->GetNativeWindow() level];
   }
   return self;
 }
@@ -217,8 +218,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (void)windowDidDeminiaturize:(NSNotification*)notification {
-  NSWindow* window = shell_->GetNativeWindow();
-  [window setLevel:level_];
+  [shell_->GetNativeWindow() setLevel:level_];
   shell_->NotifyWindowRestore();
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -620,7 +620,7 @@ describe('BrowserWindow module', function () {
     })
   })
 
-  describe.only('BrowserWindow.alwaysOnTop() resets level on minimize', function () {
+  describe('BrowserWindow.alwaysOnTop() resets level on minimize', function () {
     if (process.platform !== 'darwin') {
       return
     }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -620,6 +620,22 @@ describe('BrowserWindow module', function () {
     })
   })
 
+  describe.only('BrowserWindow.alwaysOnTop() resets level on minimize', function () {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    it('resets the windows level on minimize', function () {
+      assert.equal(w.isAlwaysOnTop(), false)
+      w.setAlwaysOnTop(true, 'screen-saver')
+      assert.equal(w.isAlwaysOnTop(), true)
+      w.minimize()
+      assert.equal(w.isAlwaysOnTop(), false)
+      w.restore()
+      assert.equal(w.isAlwaysOnTop(), true)
+    })
+  })
+
   describe('BrowserWindow.setAutoHideCursor(autoHide)', () => {
     if (process.platform !== 'darwin') {
       it('is not available on non-macOS platforms', () => {


### PR DESCRIPTION
Fixes #9170 
Reset the custom level when windowWillMiniaturize fires and then restores it when windowDidDeminiaturize fires as suggested in issue.

Before: 
![Before Gif](http://i.imgur.com/81KX0Nm.gif)

After:
![After Gif](http://g.recordit.co/KNSZ7jDrhw.gif)

