### PR TITLE
📝  add notes for peak working set size on macOS

### DIFF
--- a/docs/api/structures/memory-info.md
+++ b/docs/api/structures/memory-info.md
@@ -3,7 +3,7 @@
 * `pid` Integer - Process id of the process.
 * `workingSetSize` Integer - The amount of memory currently pinned to actual physical RAM.
 * `peakWorkingSetSize` Integer - The maximum amount of memory that has ever been pinned
-  to actual physical RAM.
+  to actual physical RAM. On macOS its value will always be 0.
 * `privateBytes` Integer - The amount of memory not shared by other processes, such as
   JS heap or HTML content.
 * `sharedBytes` Integer - The amount of memory shared between processes, typically


### PR DESCRIPTION
According to current [implementation](https://chromium.googlesource.com/chromium/src/base/+/master/process/process_metrics_mac.cc#141) in upstram chromium, the `peakWorkingSetSize` value will always be 0 on macOS (and freebsd, but seems we don't have freebsd releases). I think it is worth noting down for avoid confusions.