### PR TITLE
Add tray icon workaround for newer Ubuntu releases (fixes #9046)

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -163,7 +163,7 @@ require('./api/protocol')
 const mainStartupScript = packageJson.main || 'index.js'
 
 // Workaround for electron/electron#5050 and electron/electron#9046
-if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7'].indexOf(process.env.XDG_CURRENT_DESKTOP) !== -1) {
+if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7'].includes(process.env.XDG_CURRENT_DESKTOP)) {
   process.env.XDG_CURRENT_DESKTOP = 'Unity'
 }
 

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -162,8 +162,8 @@ require('./api/protocol')
 // Set main startup script of the app.
 const mainStartupScript = packageJson.main || 'index.js'
 
-// Workaround for electron/electron#5050
-if (process.platform === 'linux' && process.env.XDG_CURRENT_DESKTOP === 'Pantheon') {
+// Workaround for electron/electron#5050 and electron/electron#9046
+if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7'].indexOf(process.env.XDG_CURRENT_DESKTOP) !== -1) {
   process.env.XDG_CURRENT_DESKTOP = 'Unity'
 }
 


### PR DESCRIPTION
Starting with 17.04, Ubuntu sets XDG_CURRENT_DESKTOP to `Unity:Unity7` which prevents tray icons from being displayed. There already is a workaround for a similiar situation (for ElementaryOS).

I tested [this fix](https://github.com/electron/electron/issues/9046#issuecomment-296169661) by @MarshallOfSound in Ubuntu 17.04, and regression-tested it on older releases. Everythings works as expected.

Fixes #9046 