### PR TITLE
Update rectangle.md (issue #9552)

### DIFF
--- a/docs/api/structures/rectangle.md
+++ b/docs/api/structures/rectangle.md
@@ -4,3 +4,5 @@
 * `y` Number - The y coordinate of the origin of the rectangle
 * `width` Number
 * `height` Number
+
+Note numeric values must be integers.

--- a/docs/api/structures/rectangle.md
+++ b/docs/api/structures/rectangle.md
@@ -1,8 +1,6 @@
 # Rectangle Object
 
-* `x` Number - The x coordinate of the origin of the rectangle
-* `y` Number - The y coordinate of the origin of the rectangle
-* `width` Number
-* `height` Number
-
-Note numeric values must be integers.
+* `x` Number - The x coordinate of the origin of the rectangle (must be an integer)
+* `y` Number - The y coordinate of the origin of the rectangle (must be an integer)
+* `width` Number - The width of the rectangle (must be an integer)
+* `height` Number - The height of the rectangle (must be an integer)


### PR DESCRIPTION
`typeError` is shown when floating point values are passed to the rectangle object. 

For example, `BrowserWindow.setBounds(5, 10, 15.5, 20.5)` results in `typeError`

Added a small note in rectangle.md to add clarity.