### PR TITLE
Chromium 59

### DIFF
--- a/script/update-clang.sh
+++ b/script/update-clang.sh
@@ -8,7 +8,7 @@
 # Do NOT CHANGE this if you don't know what you're doing -- see
 # https://code.google.com/p/chromium/wiki/UpdatingClang
 # Reverting problematic clang rolls is safe, though.
-CLANG_REVISION=284979
+CLANG_REVISION=299960
 
 # This is incremented when pushing a new build of Clang at the same revision.
 CLANG_SUB_REVISION=1


### PR DESCRIPTION
`Update CLANG_VERSION to match version Chrome is using in update.py`

was following https://electron.atom.io/docs/development/upgrading-chrome/ a bit loosely;

I followed this locally: https://github.com/electron/electron/blob/master/docs/development/build-instructions-osx.md
ran bootstrap.py, then build.py, then test.py scripts -- Wasn't 100% sure if I missed anything, the instructions in the upgrade guide didn't have instructions as detailed as the ones for building electron itself. Let me know if you want me to take this PR down. Cheers.