### PR TITLE
Send window visibility to webview after DOM ready

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -143,6 +143,14 @@ const createGuest = function (embedder, params) {
     sendToEmbedder('ELECTRON_GUEST_VIEW_INTERNAL_SIZE_CHANGED', ...args)
   })
 
+  // Notify guest of embedder window visibility when it is ready
+  guest.on('dom-ready', function () {
+    const guestInstance = guestInstances[guestInstanceId]
+    if (guestInstance != null && guestInstance.visibilityState != null) {
+      guest.send('ELECTRON_GUEST_INSTANCE_VISIBILITY_CHANGE', guestInstance.visibilityState)
+    }
+  })
+
   // Forward internal web contents event to embedder to handle
   // native window.open setup
   guest.on('-add-new-contents', (...args) => {
@@ -280,6 +288,7 @@ const watchEmbedder = function (embedder) {
   const onVisibilityChange = function (visibilityState) {
     for (const guestInstanceId of Object.keys(guestInstances)) {
       const guestInstance = guestInstances[guestInstanceId]
+      guestInstance.visibilityState = visibilityState
       if (guestInstance.embedder === embedder) {
         guestInstance.guest.send('ELECTRON_GUEST_INSTANCE_VISIBILITY_CHANGE', visibilityState)
       }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -144,6 +144,7 @@ const createGuest = function (embedder, params) {
   })
 
   // Notify guest of embedder window visibility when it is ready
+  // FIXME Remove once https://github.com/electron/electron/issues/6828 is fixed
   guest.on('dom-ready', function () {
     const guestInstance = guestInstances[guestInstanceId]
     if (guestInstance != null && guestInstance.visibilityState != null) {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1097,25 +1097,50 @@ describe('<webview> tag', function () {
     })
   })
 
-  it('inherits the parent window visibility state and receives visibilitychange events', function (done) {
-    w = new BrowserWindow({
-      show: false
+  describe('document.visibilityState/hidden', function () {
+    afterEach(function () {
+      ipcMain.removeAllListeners('pong')
     })
 
-    ipcMain.once('pong', function (event, visibilityState, hidden) {
-      assert.equal(visibilityState, 'hidden')
-      assert.equal(hidden, true)
-
-      ipcMain.once('pong', function (event, visibilityState, hidden) {
-        assert.equal(visibilityState, 'visible')
-        assert.equal(hidden, false)
-        done()
+    it('updates when the window is shown after the ready-to-show event', function (done) {
+      w = new BrowserWindow({
+        show: false
       })
 
-      w.webContents.emit('-window-visibility-change', 'visible')
+      w.once('ready-to-show', function () {
+        w.show()
+      })
+
+      ipcMain.on('pong', function (event, visibilityState, hidden) {
+        if (!hidden) {
+          assert.equal(visibilityState, 'visible')
+          done()
+        }
+      })
+
+      w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
     })
 
-    w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
+    it('inherits the parent window visibility state and receives visibilitychange events', function (done) {
+      w = new BrowserWindow({
+        show: false
+      })
+
+      ipcMain.once('pong', function (event, visibilityState, hidden) {
+        assert.equal(visibilityState, 'hidden')
+        assert.equal(hidden, true)
+
+        ipcMain.once('pong', function (event, visibilityState, hidden) {
+          assert.equal(visibilityState, 'visible')
+          assert.equal(hidden, false)
+          done()
+        })
+
+        w.webContents.emit('-window-visibility-change', 'visible')
+      })
+
+      w.loadURL('file://' + fixtures + '/pages/webview-visibilitychange.html')
+    })
   })
 
   describe('will-attach-webview event', () => {


### PR DESCRIPTION
There seems to be a possible race condition where `window-setup.js` is loading and cannot receive IPC events and if the window changes visibility during that time, the `<webview>`'s `document.visibilityState` will be out of sync with the window.

This pull requests listens for `dom-ready` and sends the visibility state to the webview page then to make sure they are in sync.

Closes #9717