### PR TITLE
Don't mutate the accelerator character with the shift key if it's a number

### DIFF
--- a/atom/browser/ui/accelerator_util_mac.mm
+++ b/atom/browser/ui/accelerator_util_mac.mm
@@ -26,8 +26,7 @@ void SetPlatformAccelerator(ui::Accelerator* accelerator) {
                                   &characterIgnoringModifiers);
 
   if (character != characterIgnoringModifiers) {
-    // 48 === '0', 57 === '9'
-    if (characterIgnoringModifiers >= 48 && characterIgnoringModifiers <= 57) {
+    if (isdigit(characterIgnoringModifiers)) {
       // The character is a number so lets not mutate it with the modifiers
       character = characterIgnoringModifiers;
     } else {

--- a/atom/browser/ui/accelerator_util_mac.mm
+++ b/atom/browser/ui/accelerator_util_mac.mm
@@ -26,7 +26,13 @@ void SetPlatformAccelerator(ui::Accelerator* accelerator) {
                                   &characterIgnoringModifiers);
 
   if (character != characterIgnoringModifiers) {
-    modifiers ^= NSShiftKeyMask;
+    // 48 === '0', 57 === '9'
+    if (characterIgnoringModifiers >= 48 && characterIgnoringModifiers <= 57) {
+      // The character is a number so lets not mutate it with the modifiers
+      character = characterIgnoringModifiers;
+    } else {
+      modifiers ^= NSShiftKeyMask;
+    }
   }
 
   if (character == NSDeleteFunctionKey) {


### PR DESCRIPTION
Before this fix if you had an accelerator.

```
CommandOrControl+Shift+1
```

It would be represented in menus as "Command+!" which although is correct in regards to keycodes it isn't semantically correct from a users perspective, nor from the intention of the shortcut in most cases.

This fix will unmutate the character if it is a number