### PR TITLE
Add 'All Files (*.*)' filter for <input> file dialog

### DIFF
--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -147,6 +147,12 @@ file_dialog::Filters GetFileTypesFromAcceptType(
     filters[0].second.push_back(extension);
 #endif
   }
+
+  // Allow all files when extension is specified.
+  filters.push_back(file_dialog::Filter());
+  filters.back().first = "All Files";
+  filters.back().second.push_back("*");
+
   return filters;
 }
 


### PR DESCRIPTION
The dialog would filter files as well as Chrome, especially when using webview or BrowserView.