### PR TITLE
use lowercase for optional annotation

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -753,7 +753,7 @@ height areas you have within the overall content view.
 * `path` String - The absolute path to the file to preview with QuickLook. This
   is important as Quick Look uses the file name and file extension on the path
   to determine the content type of the file to open.
-* `displayName` String (Optional) - The name of the file to display on the
+* `displayName` String (optional) - The name of the file to display on the
   Quick Look modal view. This is purely visual and does not affect the content
   type of the file. Defaults to `path`.
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -32,10 +32,10 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
 * `options` Object
   * `title` String - A title for the notification, which will be shown at the top of the notification window when it is shown
   * `body` String - The body text of the notification, which will be displayed below the title
-  * `silent` Boolean - (Optional) Whether or not to emit an OS notification noise when showing the notification
-  * `icon` [NativeImage](native-image.md) - (Optional) An icon to use in the notification
-  * `hasReply` Boolean - (Optional) Whether or not to add an inline reply option to the notification.  _macOS_
-  * `replyPlaceholder` String - (Optional) The placeholder to write in the inline reply input field. _macOS_
+  * `silent` Boolean - (optional) Whether or not to emit an OS notification noise when showing the notification
+  * `icon` [NativeImage](native-image.md) - (optional) An icon to use in the notification
+  * `hasReply` Boolean - (optional) Whether or not to add an inline reply option to the notification.  _macOS_
+  * `replyPlaceholder` String - (optional) The placeholder to write in the inline reply input field. _macOS_
 
 
 ### Instance Events

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -109,12 +109,12 @@ Clears the session’s HTTP cache.
 #### `ses.clearStorageData([options, callback])`
 
 * `options` Object (optional)
-  * `origin` String - (Optional) Should follow `window.location.origin`’s representation
+  * `origin` String - (optional) Should follow `window.location.origin`’s representation
     `scheme://host:port`.
-  * `storages` String[] - (Optional) The types of storages to clear, can contain:
+  * `storages` String[] - (optional) The types of storages to clear, can contain:
     `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`,
     `shadercache`, `websql`, `serviceworkers`
-  * `quotas` String[] - (Optional) The types of quotas to clear, can contain:
+  * `quotas` String[] - (optional) The types of quotas to clear, can contain:
     `temporary`, `persistent`, `syncable`.
 * `callback` Function (optional) - Called when operation is done.
 

--- a/docs/api/structures/scrubber-item.md
+++ b/docs/api/structures/scrubber-item.md
@@ -1,4 +1,4 @@
 # ScrubberItem Object
 
-* `label` String - (Optional) The text to appear in this item
-* `icon` NativeImage - (Optional) The image to appear in this item
+* `label` String - (optional) The text to appear in this item
+* `icon` NativeImage - (optional) The image to appear in this item

--- a/docs/api/structures/segmented-control-segment.md
+++ b/docs/api/structures/segmented-control-segment.md
@@ -1,5 +1,5 @@
 # SegmentedControlSegment Object
 
-* `label` String - (Optional) The text to appear in this segment
-* `icon` NativeImage - (Optional) The image to appear in this segment
-* `enabled` Boolean - (Optional) Whether this segment is selectable. Default: true
+* `label` String - (optional) The text to appear in this segment
+* `icon` NativeImage - (optional) The image to appear in this segment
+* `enabled` Boolean - (optional) Whether this segment is selectable. Default: true

--- a/docs/api/touch-bar-segmented-control.md
+++ b/docs/api/touch-bar-segmented-control.md
@@ -7,7 +7,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
 ### `new TouchBarSegmentedControl(options)` _Experimental_
 
 * `options` Object
-  * `segmentStyle` String - (Optional) Style of the segments:
+  * `segmentStyle` String - (optional) Style of the segments:
     * `automatic` - Default. The appearance of the segmented control is
       automatically determined based on the type of window in which the control
       is displayed and the position within the window.
@@ -21,12 +21,12 @@ Process: [Main](../tutorial/quick-start.md#main-process)
     * `small-square` - The control is displayed using the small square style.
     * `separated` - The segments in the control are displayed very close to each
       other but not touching.
-  * `mode` String - (Optional) The selection mode of the control:
+  * `mode` String - (optional) The selection mode of the control:
     * `single` - Default. One item selected at a time, selecting one deselects the previously selected item.
     * `multiple` - Multiple items can be selected at a time.
     * `buttons` - Make the segments act as buttons, each segment can be pressed and released but never marked as active.
   * `segments` [SegmentedControlSegment[]](structures/segmented-control-segment.md) - An array of segments to place in this control.
-  * `selectedIndex` Integer (Optional) - The index of the currently selected segment, will update automatically with user interaction.  When the mode is multiple it will be the last selected item.
+  * `selectedIndex` Integer (optional) - The index of the currently selected segment, will update automatically with user interaction.  When the mode is multiple it will be the last selected item.
   * `change` Function - Called when the user selects a new segment
     * `selectedIndex` Integer - The index of the segment the user selected.
     * `isSelected` Boolean - Whether as a result of user selection the segment is selected or not.


### PR DESCRIPTION
A little followup to #9750 that favors lowercase `(optional)` over `(Optional)` in API documentation.