### PR TITLE
Update windows-store-guide.md

### DIFF
--- a/docs-translations/id/tutorial/windows-store-guide.md
+++ b/docs-translations/id/tutorial/windows-store-guide.md
@@ -1,6 +1,6 @@
 # Panduan Windows Store
 
-Dengan Windows 8, eksekusi win32 yg lama mendapatkan saudara yang baru: *The
+Dengan Windows 10, eksekusi win32 yg lama mendapatkan saudara yang baru: *The
 Universal Windows Platform*. Format `.appx` yang baru tidak hanya memungkinkan
 sejumlah API yang baru dan hebat seperti *Cortana* atau *Push Notifications*,
 tetapi juga melalui *Windows Store*, ini akan menyederhanakan instalasi dan update.

--- a/docs-translations/ko-KR/tutorial/windows-store-guide.md
+++ b/docs-translations/ko-KR/tutorial/windows-store-guide.md
@@ -1,6 +1,6 @@
 # Windows 스토어 가이드
 
-Windows 8부터, 오래되고 좋은 win32 실행 파일이 새로운 형제를 얻었습니다: Universial
+Windows 10부터, 오래되고 좋은 win32 실행 파일이 새로운 형제를 얻었습니다: Universial
 Windows Platform. 새로운 `.appx` 포맷은 Cortana와 푸시 알림과 같은 다수의 강력한
 API뿐만 아니라, Windows Store를 통해 설치와 업데이트를 단순화합니다.
 

--- a/docs-translations/zh-CN/tutorial/windows-store-guide.md
+++ b/docs-translations/zh-CN/tutorial/windows-store-guide.md
@@ -1,6 +1,6 @@
 # Windows商店指南
 
-在 Windows 8 中, 一些不错的旧 win32 程序迎来了一个新朋友: 通用Windows平台(UWP)。 新的 `.appx` 格式不仅启用了许多新的强大的 API，如 Cortana 或推送通知，而且通过Windows 应用商店，也同时简化了安装和更新。
+在 Windows 10 中, 一些不错的旧 win32 程序迎来了一个新朋友: 通用Windows平台(UWP)。 新的 `.appx` 格式不仅启用了许多新的强大的 API，如 Cortana 或推送通知，而且通过Windows 应用商店，也同时简化了安装和更新。
 
 Microsoft 开发了一个工具，将 Electron 应用程序[编译为 `.appx` 软件包][electron-windows-store]，使开发人员能够使用新应用程序模型中的一些好东西。 本指南解释了如何使用它 - 以及 Electron AppX 包的功能和限制。
 

--- a/docs/tutorial/windows-store-guide.md
+++ b/docs/tutorial/windows-store-guide.md
@@ -1,6 +1,6 @@
 # Windows Store Guide
 
-With Windows 8, the good old win32 executable got a new sibling: The Universal
+With Windows 10, the good old win32 executable got a new sibling: The Universal
 Windows Platform. The new `.appx` format does not only enable a number of new
 powerful APIs like Cortana or Push Notifications, but through the Windows Store,
 also simplifies installation and updating.


### PR DESCRIPTION
Replace "Windows 8" to "Windows 10"

**Windows 10** introduced **UWP**, although **WinRT** the API had been since Windows 8.

Application Containerization/Virtualization within UWP called _Project Centennial_ aka **Desktop Bridge** introduced _Windows 10 Build 14393_ aka **Anniversary Update**.

I think this should clarify some things...