### PR TITLE
mention ARM and FIXME in breaking changes doc

### DIFF
--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -188,3 +188,27 @@ command line flag when building native Node modules.
 Deprecated: https://atom.io/download/atom-shell
 
 Replace with: https://atom.io/download/electron
+
+## Duplicate ARM Assets
+
+Each Electron release includes two identical ARM builds with slightly different 
+filenames, like `electron-v1.7.3-linux-arm.zip` and 
+`electron-v1.7.3-linux-armv7l.zip`. The asset with the `v7l` prefix was added 
+to clarify to users which ARM version it supports, and to disambiguate it from 
+future armv6l and arm64 assets that may be produced.
+
+The file _without the prefix_ is still being published to avoid breaking any 
+setups that may be consuming it. Starting at 2.0, the un-prefixed file will 
+no longer be published.
+
+For details, see
+[6986](https://github.com/electron/electron/pull/6986)
+and 
+[7189](https://github.com/electron/electron/pull/7189).
+
+
+## `FIXME` comments
+
+The `FIXME` string is used in code comments to denote things that should be 
+fixed for the 2.0 release. See 
+https://github.com/electron/electron/search?q=fixme


### PR DESCRIPTION
This PR updates the list of things that we plan to change in 2.0:

- deprecate `*-arm.zip` release asset
- look for FIXME comments