### PR TITLE
add CRT to glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,12 +20,10 @@ majority of Electron users.
 
 ### CRT
 
-It's a Microsoft Visual Studio thing.
-
-> The C Run-time Library (CRT) is the part of the C++ Standard Library that 
+The C Run-time Library (CRT) is the part of the C++ Standard Library that 
 incorporates the ISO C99 standard library. The Visual C++ libraries that 
 implement the CRT support native code development, and both mixed native and 
-managed code, and pure managed code for .NET development. 
+managed code, and pure managed code for .NET development.
 
 ### DMG
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -18,6 +18,15 @@ easier to use in applications.
 Brightray is a low-level dependency of Electron that does not concern the
 majority of Electron users.
 
+### CRT
+
+It's a Microsoft Visual Studio thing.
+
+> The C Run-time Library (CRT) is the part of the C++ Standard Library that 
+incorporates the ISO C99 standard library. The Visual C++ libraries that 
+implement the CRT support native code development, and both mixed native and 
+managed code, and pure managed code for .NET development. 
+
 ### DMG
 
 An Apple Disk Image is a packaging format used by macOS. DMG files are


### PR DESCRIPTION
Something I had to look up after viewing https://github.com/electron/electron/pull/9764, knowing it probably wasn't Cathode Ray Tube. :)