### PR TITLE
Extra properties must be less than 63 characters

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -45,7 +45,7 @@ The `crashReporter` module has the following methods:
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
   * `extra` Object (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly. Nested objects are not
-    supported. The property name and the value must be less than 63 characters.
+    supported and the property names and values must be less than 64 characters long.
 
 You are required to call this method before using any other `crashReporter` APIs
 and in each process (main/renderer) from which you want to collect crash reports.
@@ -117,9 +117,10 @@ called before `start` is called.
 
 ### `crashReporter.setExtraParameter(key, value)` _macOS_
 
-* `key` String - Max length 63 - Parameter key.
-* `value` String - Max length 63 - Parameter value. Specifying `null` or `undefined` will
-  remove the key from the extra parameters.
+* `key` String - Parameter key, must be less than 64 characters long.
+* `value` String - Parameter value, must be less than 64 characters long.
+  Specifying `null` or `undefined` will remove the key from the extra
+  parameters.
 
 Set an extra parameter to set be sent with the crash report. The values
 specified here will be sent in addition to any values set via the `extra` option

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -45,7 +45,7 @@ The `crashReporter` module has the following methods:
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
   * `extra` Object (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly. Nested objects are not
-    supported.
+    supported. The property name and the value must be less than 63 characters.
 
 You are required to call this method before using any other `crashReporter` APIs
 and in each process (main/renderer) from which you want to collect crash reports.
@@ -117,8 +117,8 @@ called before `start` is called.
 
 ### `crashReporter.setExtraParameter(key, value)` _macOS_
 
-* `key` String - Parameter key.
-* `value` String - Parameter value. Specifying `null` or `undefined` will
+* `key` String - Max length 63 - Parameter key.
+* `value` String - Max length 63 - Parameter value. Specifying `null` or `undefined` will
   remove the key from the extra parameters.
 
 Set an extra parameter to set be sent with the crash report. The values


### PR DESCRIPTION
I found out that after trying to putting some long text in my extra properties that it was truncated, digging around I found these:

https://github.com/electron/electron/blob/897d58bde1414d73529a526a4f3fbc237683d9be/atom/common/crash_reporter/crash_reporter_win.cc
const int kNameMaxLength = 64;
const int kValueMaxLength = 64;