### PR TITLE
Change NSIS topic level from 2 to 3

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -67,7 +67,7 @@ building native modules.
 
 See also [Using Native Node Modules].
 
-## NSIS
+### NSIS
 
 Nullsoft Scriptable Install System is a script-driven Installer
 authoring tool for Microsoft Windows. It is released under a combination of


### PR DESCRIPTION
Why: this can mislead interpretation of the rest of the document. The `NSIS` is just one more topic at the same level of Process and Native Modules.