### PR TITLE
Add alwaysShowTitleTextInFullscreen flag

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -133,6 +133,9 @@ class NativeWindowMac : public NativeWindow,
 
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
 
+  bool always_show_title_text_in_full_screen() const
+  { return always_show_title_text_in_full_screen_; }
+
  protected:
   // Return a vector of non-draggable regions that fill a window of size
   // |width| by |height|, but leave gaps where the window should be draggable.
@@ -176,6 +179,8 @@ class NativeWindowMac : public NativeWindow,
   bool was_fullscreen_;
 
   bool zoom_to_page_width_;
+
+  bool always_show_title_text_in_full_screen_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -133,8 +133,7 @@ class NativeWindowMac : public NativeWindow,
 
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
 
-  bool always_show_title_text_in_full_screen() const
-  { return always_show_title_text_in_full_screen_; }
+  bool fullscreen_window_title() const { return fullscreen_window_title_; }
 
  protected:
   // Return a vector of non-draggable regions that fill a window of size
@@ -180,7 +179,7 @@ class NativeWindowMac : public NativeWindow,
 
   bool zoom_to_page_width_;
 
-  bool always_show_title_text_in_full_screen_;
+  bool fullscreen_window_title_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -345,9 +345,9 @@ bool ScopedDisableResize::disable_resize_ = false;
       base::mac::IsAtLeastOS10_10() &&
       // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
       // fullscreen mode.
-      // Show title if always_show_title_text_in_full_screen flag is set
+      // Show title if fullscreen_window_title flag is set
       (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
-    shell_->always_show_title_text_in_full_screen())) {
+       shell_->fullscreen_window_title())) {
     [window setTitleVisibility:NSWindowTitleVisible];
   }
 
@@ -372,7 +372,7 @@ bool ScopedDisableResize::disable_resize_ = false;
   if ((shell_->transparent() || !shell_->has_frame()) &&
       base::mac::IsAtLeastOS10_10() &&
       (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
-    shell_->always_show_title_text_in_full_screen())) {
+       shell_->fullscreen_window_title())) {
     [window setTitleVisibility:NSWindowTitleHidden];
   }
 
@@ -802,7 +802,7 @@ NativeWindowMac::NativeWindowMac(
       is_kiosk_(false),
       was_fullscreen_(false),
       zoom_to_page_width_(false),
-      always_show_title_text_in_full_screen_(false),
+      fullscreen_window_title_(false),
       attention_request_id_(0),
       title_bar_style_(NORMAL) {
   int width = 800, height = 600;
@@ -950,7 +950,7 @@ NativeWindowMac::NativeWindowMac(
 
   options.Get(options::kZoomToPageWidth, &zoom_to_page_width_);
 
-  options.Get(options::kFullscreenWindowTitle, &always_show_title_text_in_full_screen_);
+  options.Get(options::kFullscreenWindowTitle, &fullscreen_window_title_);
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -950,7 +950,7 @@ NativeWindowMac::NativeWindowMac(
 
   options.Get(options::kZoomToPageWidth, &zoom_to_page_width_);
 
-  options.Get(options::kAlwaysShowTitleTextInFullscreen, &always_show_title_text_in_full_screen_);
+  options.Get(options::kFullscreenWindowTitle, &always_show_title_text_in_full_screen_);
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -340,7 +340,6 @@ bool ScopedDisableResize::disable_resize_ = false;
   // titlebar is expected to be empty, but after entering fullscreen mode we
   // have to set one, because title bar is visible here.
   NSWindow* window = shell_->GetNativeWindow();
-
   if ((shell_->transparent() || !shell_->has_frame()) &&
       base::mac::IsAtLeastOS10_10() &&
       // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -340,11 +340,14 @@ bool ScopedDisableResize::disable_resize_ = false;
   // titlebar is expected to be empty, but after entering fullscreen mode we
   // have to set one, because title bar is visible here.
   NSWindow* window = shell_->GetNativeWindow();
+
   if ((shell_->transparent() || !shell_->has_frame()) &&
       base::mac::IsAtLeastOS10_10() &&
       // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
       // fullscreen mode.
-      shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET) {
+      // Show title if always_show_title_text_in_full_screen flag is set
+      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+    shell_->always_show_title_text_in_full_screen())) {
     [window setTitleVisibility:NSWindowTitleVisible];
   }
 
@@ -368,7 +371,8 @@ bool ScopedDisableResize::disable_resize_ = false;
   NSWindow* window = shell_->GetNativeWindow();
   if ((shell_->transparent() || !shell_->has_frame()) &&
       base::mac::IsAtLeastOS10_10() &&
-      shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET) {
+      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+    shell_->always_show_title_text_in_full_screen())) {
     [window setTitleVisibility:NSWindowTitleHidden];
   }
 
@@ -798,6 +802,7 @@ NativeWindowMac::NativeWindowMac(
       is_kiosk_(false),
       was_fullscreen_(false),
       zoom_to_page_width_(false),
+      always_show_title_text_in_full_screen_(false),
       attention_request_id_(0),
       title_bar_style_(NORMAL) {
   int width = 800, height = 600;
@@ -944,6 +949,8 @@ NativeWindowMac::NativeWindowMac(
     SetSize(gfx::Size(width, height));
 
   options.Get(options::kZoomToPageWidth, &zoom_to_page_width_);
+
+  options.Get(options::kAlwaysShowTitleTextInFullscreen, &always_show_title_text_in_full_screen_);
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -49,8 +49,8 @@ const char kUseContentSize[] = "useContentSize";
 const char kZoomToPageWidth[] = "zoomToPageWidth";
 
 // Whether always show title text in full screen is enabled.
-const char kAlwaysShowTitleTextInFullscreen[] =
-"alwaysShowTitleTextInFullscreen";
+const char kFullscreenWindowTitle[] =
+"fullscreenWindowTitle";
 
 // The requested title bar style for the window
 const char kTitleBarStyle[] = "titleBarStyle";

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -49,8 +49,7 @@ const char kUseContentSize[] = "useContentSize";
 const char kZoomToPageWidth[] = "zoomToPageWidth";
 
 // Whether always show title text in full screen is enabled.
-const char kFullscreenWindowTitle[] =
-"fullscreenWindowTitle";
+const char kFullscreenWindowTitle[] = "fullscreenWindowTitle";
 
 // The requested title bar style for the window
 const char kTitleBarStyle[] = "titleBarStyle";

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -48,6 +48,10 @@ const char kUseContentSize[] = "useContentSize";
 // Whether window zoom should be to page width.
 const char kZoomToPageWidth[] = "zoomToPageWidth";
 
+// Whether always show title text in full screen is enabled.
+const char kAlwaysShowTitleTextInFullscreen[] =
+"alwaysShowTitleTextInFullscreen";
+
 // The requested title bar style for the window
 const char kTitleBarStyle[] = "titleBarStyle";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -35,6 +35,7 @@ extern const char kAlwaysOnTop[];
 extern const char kAcceptFirstMouse[];
 extern const char kUseContentSize[];
 extern const char kZoomToPageWidth[];
+extern const char kAlwaysShowTitleTextInFullscreen[];
 extern const char kTitleBarStyle[];
 extern const char kTabbingIdentifier[];
 extern const char kAutoHideMenuBar[];

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -35,7 +35,7 @@ extern const char kAlwaysOnTop[];
 extern const char kAcceptFirstMouse[];
 extern const char kUseContentSize[];
 extern const char kZoomToPageWidth[];
-extern const char kAlwaysShowTitleTextInFullscreen[];
+extern const char kFullscreenWindowTitle[];
 extern const char kTitleBarStyle[];
 extern const char kTabbingIdentifier[];
 extern const char kAutoHideMenuBar[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -225,9 +225,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       display unless hovered over in the top left of the window. These custom
       buttons prevent issues with mouse events that occur with the standard
       window toolbar buttons. **Note:** This option is currently experimental.
-  * `alwaysShowTitleTextInFullscreen` Boolean (optional) - Shows the title in
-      tile bar in full screen mode on macOS with all `titleBarStyle` options.
-      Default is `false`.
+  * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
+    tile bar in full screen mode on macOS for all `titleBarStyle` options.
+    Default is `false`.
   * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -225,6 +225,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       display unless hovered over in the top left of the window. These custom
       buttons prevent issues with mouse events that occur with the standard
       window toolbar buttons. **Note:** This option is currently experimental.
+  * `alwaysShowTitleTextInFullscreen` Boolean (optional) - Shows the title in
+      tile bar in full screen mode on macOS with all `titleBarStyle` options.
+      Default is `false`.
   * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.


### PR DESCRIPTION
Fixes #8126 
Add a flag `alwaysShowTitleTextInFullscreen` which enables to show title when `titleBarStyle` is set to `hiddenInset`. Default value is `false`. 

Screenshot with flag enabled:
![image](https://user-images.githubusercontent.com/6316389/27257301-10f743f6-539f-11e7-812d-00a35e04a634.png)
