### PR TITLE
Fix invisible titlebar on macOS 10.13

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -899,9 +899,7 @@ NativeWindowMac::NativeWindowMac(
   if (transparent() || !has_frame()) {
     if (base::mac::IsAtLeastOS10_10()) {
       // Don't show title bar.
-      if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER) {
-        [window_ setTitlebarAppearsTransparent:YES];
-      }
+      [window_ setTitlebarAppearsTransparent:YES];
       [window_ setTitleVisibility:NSWindowTitleHidden];
     }
     // Remove non-transparent corners, see http://git.io/vfonD.


### PR DESCRIPTION
Should fix #9711.
From https://developer.apple.com/library/content/releasenotes/AppKit/RN-AppKit/index.html:

> Previously NSWindow would make the titlebar transparent for certain windows with NSWindowStyleMaskTexturedBackground set, even if titlebarAppearsTransparent was NO. When linking against the 10.13 SDK, textured windows must explicitly set titlebarAppearsTransparent to YES for this behavior.

I checked the behaviour on 10.12 and 10.13.
Are there any possible downsides on 10.12 i don't see?

/cc @poiru 