### PR TITLE
Remove `bash` from windows commands to stop syntax highlighting errors

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -183,7 +183,7 @@ $ ./node_modules/.bin/electron .
 
 #### Windows
 
-```bash
+```
 $ .\node_modules\.bin\electron .
 ```
 
@@ -206,7 +206,7 @@ $ ./electron/electron your-app/
 
 #### Windows
 
-```bash
+```
 $ .\electron\electron.exe your-app\
 ```
 


### PR DESCRIPTION
Documentation only
[ci skip]

When referenced as a bash script this displays with what looks like escaped characters: 
![image](https://user-images.githubusercontent.com/3209691/27338580-88cc056c-55cd-11e7-8622-9e378a54e993.png)

After removing the `bash` from code snippet it looks like this:
![image](https://user-images.githubusercontent.com/3209691/27338644-af2ead36-55cd-11e7-9a21-36e5aa9d88dd.png)
