### PR TITLE
:bug: Fix #9231: Don't load url when detached.

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -993,7 +993,7 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
     return;
   }
 
-  if (guest_delegate_ && !guest_delegate_->Attached()) {
+  if (guest_delegate_ && !guest_delegate_->IsAttached()) {
     return;
   }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -993,6 +993,10 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
     return;
   }
 
+  if (guest_delegate_ && !guest_delegate_->Attached()) {
+    return;
+  }
+
   content::NavigationController::LoadURLParams params(url);
 
   GURL http_referrer;

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -28,6 +28,7 @@ WebViewGuestDelegate::WebViewGuestDelegate()
       guest_host_(nullptr),
       auto_size_enabled_(false),
       is_full_page_plugin_(false),
+      attached_(false),
       api_web_contents_(nullptr) {}
 
 WebViewGuestDelegate::~WebViewGuestDelegate() {

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -110,7 +110,12 @@ void WebViewGuestDelegate::DidFinishNavigation(
   }
 }
 
+void WebViewGuestDelegate::DidDetach() {
+  attached_ = false;
+}
+
 void WebViewGuestDelegate::DidAttach(int guest_proxy_routing_id) {
+  attached_ = true;
   api_web_contents_->Emit("did-attach");
   embedder_zoom_controller_ =
       WebContentsZoomController::FromWebContents(embedder_web_contents_);

--- a/atom/browser/web_view_guest_delegate.h
+++ b/atom/browser/web_view_guest_delegate.h
@@ -48,7 +48,7 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   void SetSize(const SetSizeParams& params);
 
   // Return true if attached.
-  bool Attached() const { return attached_; }
+  bool IsAttached() const { return attached_; }
 
  protected:
   // content::WebContentsObserver:

--- a/atom/browser/web_view_guest_delegate.h
+++ b/atom/browser/web_view_guest_delegate.h
@@ -47,6 +47,9 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   // and normal sizes.
   void SetSize(const SetSizeParams& params);
 
+  // Return true if attached.
+  bool Attached() const { return attached_; }
+
  protected:
   // content::WebContentsObserver:
   void DidFinishNavigation(
@@ -54,6 +57,7 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
 
   // content::BrowserPluginGuestDelegate:
   void DidAttach(int guest_proxy_routing_id) final;
+  void DidDetach() final;
   content::WebContents* GetOwnerWebContents() const final;
   void GuestSizeChanged(const gfx::Size& new_size) final;
   void SetGuestHost(content::GuestHost* guest_host) final;
@@ -115,6 +119,9 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
 
   // Whether the guest view is inside a plugin document.
   bool is_full_page_plugin_;
+
+  // Whether attached.
+  bool attached_;
 
   api::WebContents* api_web_contents_;
 


### PR DESCRIPTION
I tracked down this crash to https://chromium.googlesource.com/experimental/chromium/src/+/58.0.3029.110/content/browser/browser_plugin/browser_plugin_guest.h#153
```
WebContentsImpl* embedder_web_contents() const {
    return attached_ ? owner_web_contents_ : nullptr;
}
```

Which results in null pointer access on LoadURL when the view is hidden (Because it's detached).
This is actually not a matter of race condition. As it's simply enough to hide the webview, then issue LoadURL to crash it.

This will avoid the crash by simply refusing to navigate when the view is not attached.