### PR TITLE
Fix #8768

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -400,7 +400,8 @@ void NativeWindowViews::ShowInactive() {
 
 void NativeWindowViews::Hide() {
   if (is_modal() && NativeWindow::parent())
-    static_cast<NativeWindowViews*>(NativeWindow::parent())->SetEnabled(true);
+    static_cast<NativeWindowViews*>(NativeWindow::parent())
+        ->SetEnabled(true, true);
 
   window_->Hide();
 
@@ -1036,8 +1037,12 @@ void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
 }
 #endif
 
-void NativeWindowViews::SetEnabled(bool enable) {
+void NativeWindowViews::SetEnabled(bool enable, bool force) {
   // Handle multiple calls of SetEnabled correctly.
+  if (force) {
+    disable_count_ = enable ? 1 : 0;
+  }
+
   if (enable) {
     --disable_count_;
     if (disable_count_ != 0)
@@ -1100,7 +1105,7 @@ void NativeWindowViews::DeleteDelegate() {
     NativeWindowViews* parent =
         static_cast<NativeWindowViews*>(NativeWindow::parent());
     // Enable parent window after current window gets closed.
-    parent->SetEnabled(true);
+    parent->SetEnabled(true, true);
     // Focus on parent window.
     parent->Focus(true);
   }

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -127,7 +127,7 @@ class NativeWindowViews : public NativeWindow,
   void SetIcon(const gfx::ImageSkia& icon);
 #endif
 
-  void SetEnabled(bool enable);
+  void SetEnabled(bool enable, bool force = false);
 
   views::Widget* widget() const { return window_.get(); }
 


### PR DESCRIPTION
SetEnabled uses internal counter to handle multiple calls to SetEnabled however that resulted in modal dialog not re-enabling the parent window, when used incorrectly.