### PR TITLE
Add process properties in lieu of command line options.

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -30,60 +30,81 @@ process.once('loaded', () => {
 
 ## Properties
 
-### `process.noAsar`
+### `process.defaultApp`
 
-A `Boolean` that controls ASAR support inside your application. Setting this to `true`
-will disable the support for `asar` archives in Node's built-in modules.
-
-### `process.type`
-
-A `String` representing the current process's type, can be `"browser"` (i.e. main process) or `"renderer"`.
-
-### `process.versions.electron`
-
-A `String` representing Electron's version string.
-
-### `process.versions.chrome`
-
-A `String` representing Chrome's version string.
-
-### `process.resourcesPath`
-
-A `String` representing the path to the resources directory.
+A `Boolean`. When app is started by being passed as parameter to the default app, this
+property is `true` in the main process, otherwise it is `undefined`.
 
 ### `process.mas`
 
 A `Boolean`. For Mac App Store build, this property is `true`, for other builds it is
 `undefined`.
 
+### `process.noAsar`
+
+A `Boolean` that controls ASAR support inside your application. Setting this to `true`
+will disable the support for `asar` archives in Node's built-in modules.
+
+### `process.noDeprecation`
+
+A `Boolean` that controls whether or not deprecation warnings are printed to `stderr`.  
+Setting this to `true` will silence deprecation warnings.  This property is used
+instead of the `--no-deprecation` command line flag.
+
+### `process.resourcesPath`
+
+A `String` representing the path to the resources directory.
+
+### `process.throwDeprecation`
+
+A `Boolean` that controls whether or not deprecation warnings will be thrown as
+exceptions.  Setting this to `true` will throw errors for deprecations.  This
+property is used instead of the `--throw-deprecation` command line flag.
+
+### `process.traceDeprecation`
+
+A `Boolean` that controls whether or not deprecations printed to `stderr` include
+ their stack trace.  Setting this to `true` will print  stack traces for deprecations.
+   This property is instead of the `--trace-deprecation` command line flag.
+
+### `process.traceProcessWarnings`
+A `Boolean` that controls whether or not process warnings printed to `stderr` include
+ their stack trace.  Setting this to `true` will print stack traces for process warnings
+  (including deprecations).  This property is instead of the `trace-warnings` command
+  line flag.
+
+### `process.type`
+
+A `String` representing the current process's type, can be `"browser"` (i.e. main process) or `"renderer"`.
+
+### `process.versions.chrome`
+
+A `String` representing Chrome's version string.
+
+### `process.versions.electron`
+
+A `String` representing Electron's version string.
+
 ### `process.windowsStore`
 
 A `Boolean`. If the app is running as a Windows Store app (appx), this property is `true`,
 for otherwise it is `undefined`.
 
-### `process.defaultApp`
-
-A `Boolean`. When app is started by being passed as parameter to the default app, this
-property is `true` in the main process, otherwise it is `undefined`.
-
 ## Methods
 
-The `process` object has the following method:
+The `process` object has the following methods:
 
 ### `process.crash()`
 
 Causes the main thread of the current process crash.
 
-### `process.hang()`
+### `process.getCPUUsage()`
 
-Causes the main thread of the current process hang.
+Returns [`CPUUsage`](structures/cpu-usage.md)
 
-### `process.setFdLimit(maxDescriptors)` _macOS_ _Linux_
+### `process.getIOCounters()` _Windows_ _Linux_
 
-* `maxDescriptors` Integer
-
-Sets the file descriptor soft limit to `maxDescriptors` or the OS hard
-limit, whichever is lower for the current process.
+Returns [`IOCounters`](structures/io-counters.md)
 
 ### `process.getProcessMemoryInfo()`
 
@@ -117,10 +138,13 @@ Returns `Object`:
 Returns an object giving memory usage statistics about the entire system. Note
 that all statistics are reported in Kilobytes.
 
-### `process.getCPUUsage()`
+### `process.hang()`
 
-Returns [`CPUUsage`](structures/cpu-usage.md)
+Causes the main thread of the current process hang.
 
-### `process.getIOCounters()` _Windows_ _Linux_
+### `process.setFdLimit(maxDescriptors)` _macOS_ _Linux_
 
-Returns [`IOCounters`](structures/io-counters.md)
+* `maxDescriptors` Integer
+
+Sets the file descriptor soft limit to `maxDescriptors` or the OS hard
+limit, whichever is lower for the current process.

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -70,7 +70,7 @@ A `Boolean` that controls whether or not deprecations printed to `stderr` includ
 ### `process.traceProcessWarnings`
 A `Boolean` that controls whether or not process warnings printed to `stderr` include
  their stack trace.  Setting this to `true` will print stack traces for process warnings
-  (including deprecations).  This property is instead of the `trace-warnings` command
+  (including deprecations).  This property is instead of the `--trace-warnings` command
   line flag.
 
 ### `process.type`


### PR DESCRIPTION
Resolves #9139
For certain node command line options, those options can be set via the
process object, so there isn't a need to add them to Electron's command line options.
The following properties were added to the documentation:

- `process.noDeprecation` to set the `--no-deprecation` flag
- `process.throwDeprecation` to set the `--throw-deprecation` flag
- `process.traceDeprecation` to set the `--trace-deprecation` flag
- `process.traceProcessWarnings` to set the `--trace-warnings` flag

Also, sorted properties and methods alphabetically for easier readability.