### PR TITLE
Fix docs: app.md `setLoginItemSettings`

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -825,7 +825,7 @@ Returns `Object`:
 
 **Note:** This API has no effect on [MAS builds][mas-builds].
 
-### `app.setLoginItemSettings(settings[, path, args])` _macOS_ _Windows_
+### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
 
 * `settings` Object
   * `openAtLogin` Boolean (optional) - `true` to open the app at login, `false` to remove
@@ -835,11 +835,11 @@ Returns `Object`:
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is only supported on
     macOS.
-* `path` String (optional) _Windows_ - The executable to launch at login.
-  Defaults to `process.execPath`.
-* `args` String[] (optional) _Windows_ - The command-line arguments to pass to
-  the executable. Defaults to an empty array. Take care to wrap paths in
-  quotes.
+  * `path` String (optional) _Windows_ - The executable to launch at login.
+    Defaults to `process.execPath`.
+  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to
+    the executable. Defaults to an empty array. Take care to wrap paths in
+    quotes.
 
 Set the app's login item settings.
 


### PR DESCRIPTION
`app.setLoginItemSettings` documented arguments are misleading -- `path` and `args` should be passed in the `settings` object, not as separate params, like the code sample below it or in the test file here: https://github.com/electron/electron/blob/9250b559f91c3c1654484df46a8ba83f9bdbecd2/spec/api-app-spec.js#L336
and in the actual C++ function declaration here: https://github.com/electron/electron/blob/f5a75c4e87a73a802c41e9fb3608e10772dbe600/atom/browser/browser.h#L104