### PR TITLE
Notification actions

### DIFF
--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -162,8 +162,16 @@ void Notification::Show() {
   if (presenter_) {
     notification_ = presenter_->CreateNotification(this);
     if (notification_) {
-      notification_->Show(title_, body_, "", GURL(), icon_.AsBitmap(), silent_,
-                          has_reply_, reply_placeholder_, actions_);
+      brightray::NotificationOptions options;
+      options.title = title_;
+      options.msg = body_;
+      options.icon_url = GURL();
+      options.icon = icon_.AsBitmap();
+      options.silent = silent_;
+      options.has_reply = has_reply_;
+      options.reply_placeholder = reply_placeholder_;
+      options.actions = actions_;
+      notification_->Show(options);
     }
   }
 }

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -126,7 +126,7 @@ void Notification::SetHasReply(bool new_has_reply) {
 }
 
 void Notification::SetActions(
-  const std::vector<brightray::NotificationAction> actions) {
+  const std::vector<brightray::NotificationAction>& actions) {
   actions_ = actions;
 }
 

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -29,14 +29,14 @@ struct Converter<brightray::NotificationAction> {
     if (!dict.Get("type", &(out->type))) {
       return false;
     }
-    dict.Get("label", &(out->label));
+    dict.Get("text", &(out->text));
     return true;
   }
 
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                     brightray::NotificationAction val) {
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
-    dict.Set("label", val.label);
+    dict.Set("text", val.text);
     dict.Set("type", val.type);
     return dict.GetHandle();
   }

--- a/atom/browser/api/atom_api_notification.h
+++ b/atom/browser/api/atom_api_notification.h
@@ -60,7 +60,7 @@ class Notification : public mate::TrackableObject<Notification>,
   void SetSilent(bool new_silent);
   void SetReplyPlaceholder(const base::string16& new_reply_placeholder);
   void SetHasReply(bool new_has_reply);
-  void SetActions(const std::vector<brightray::NotificationAction> actions);
+  void SetActions(const std::vector<brightray::NotificationAction>& actions);
 
  private:
   base::string16 title_;

--- a/atom/browser/api/atom_api_notification.h
+++ b/atom/browser/api/atom_api_notification.h
@@ -31,6 +31,7 @@ class Notification : public mate::TrackableObject<Notification>,
                              v8::Local<v8::FunctionTemplate> prototype);
 
   // NotificationDelegate:
+  void NotificationAction(int index) override;
   void NotificationClick() override;
   void NotificationReplied(const std::string& reply) override;
   void NotificationDisplayed() override;
@@ -51,6 +52,7 @@ class Notification : public mate::TrackableObject<Notification>,
   bool GetSilent();
   base::string16 GetReplyPlaceholder();
   bool GetHasReply();
+  std::vector<brightray::NotificationAction> GetActions();
 
   // Prop Setters
   void SetTitle(const base::string16& new_title);
@@ -58,6 +60,7 @@ class Notification : public mate::TrackableObject<Notification>,
   void SetSilent(bool new_silent);
   void SetReplyPlaceholder(const base::string16& new_reply_placeholder);
   void SetHasReply(bool new_has_reply);
+  void SetActions(const std::vector<brightray::NotificationAction> actions);
 
  private:
   base::string16 title_;
@@ -68,6 +71,7 @@ class Notification : public mate::TrackableObject<Notification>,
   bool silent_ = false;
   base::string16 reply_placeholder_;
   bool has_reply_ = false;
+  std::vector<brightray::NotificationAction> actions_;
 
   brightray::NotificationPresenter* presenter_;
 

--- a/brightray/browser/linux/libnotify_notification.cc
+++ b/brightray/browser/linux/libnotify_notification.cc
@@ -85,19 +85,10 @@ LibnotifyNotification::~LibnotifyNotification() {
   }
 }
 
-void LibnotifyNotification::Show(const base::string16& title,
-                                 const base::string16& body,
-                                 const std::string& tag,
-                                 const GURL& icon_url,
-                                 const SkBitmap& icon,
-                                 bool silent,
-                                 bool has_reply,
-                                 const base::string16& reply_placeholder,
-                                 const std::vector<NotificationAction> actions
-                                ) {
+void LibnotifyNotification::Show(const NotificationOptions& options) {
   notification_ = libnotify_loader_.notify_notification_new(
-      base::UTF16ToUTF8(title).c_str(),
-      base::UTF16ToUTF8(body).c_str(),
+      base::UTF16ToUTF8(options.title).c_str(),
+      base::UTF16ToUTF8(options.msg).c_str(),
       nullptr);
 
   g_signal_connect(
@@ -111,8 +102,8 @@ void LibnotifyNotification::Show(const base::string16& title,
         nullptr);
   }
 
-  if (!icon.drawsNothing()) {
-    GdkPixbuf* pixbuf = libgtkui::GdkPixbufFromSkBitmap(icon);
+  if (!options.icon.drawsNothing()) {
+    GdkPixbuf* pixbuf = libgtkui::GdkPixbufFromSkBitmap(options.icon);
     libnotify_loader_.notify_notification_set_image_from_pixbuf(
         notification_, pixbuf);
     libnotify_loader_.notify_notification_set_timeout(
@@ -120,8 +111,8 @@ void LibnotifyNotification::Show(const base::string16& title,
     g_object_unref(pixbuf);
   }
 
-  if (!tag.empty()) {
-    GQuark id = g_quark_from_string(tag.c_str());
+  if (!options.tag.empty()) {
+    GQuark id = g_quark_from_string(options.tag.c_str());
     g_object_set(G_OBJECT(notification_), "id", id, NULL);
   }
 

--- a/brightray/browser/linux/libnotify_notification.cc
+++ b/brightray/browser/linux/libnotify_notification.cc
@@ -4,6 +4,8 @@
 
 #include "brightray/browser/linux/libnotify_notification.h"
 
+#include <vector>
+
 #include "base/files/file_enumerator.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -90,7 +92,9 @@ void LibnotifyNotification::Show(const base::string16& title,
                                  const SkBitmap& icon,
                                  bool silent,
                                  bool has_reply,
-                                 const base::string16& reply_placeholder) {
+                                 const base::string16& reply_placeholder,
+                                 const std::vector<NotificationAction> actions
+                                ) {
   notification_ = libnotify_loader_.notify_notification_new(
       base::UTF16ToUTF8(title).c_str(),
       base::UTF16ToUTF8(body).c_str(),

--- a/brightray/browser/linux/libnotify_notification.h
+++ b/brightray/browser/linux/libnotify_notification.h
@@ -6,6 +6,7 @@
 #define BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_NOTIFICATION_H_
 
 #include <string>
+#include <vector>
 
 #include "brightray/browser/linux/libnotify_loader.h"
 #include "brightray/browser/notification.h"
@@ -29,7 +30,8 @@ class LibnotifyNotification : public Notification {
             const SkBitmap& icon,
             bool silent,
             bool has_reply,
-            const base::string16& reply_placeholder) override;
+            const base::string16& reply_placeholder,
+            const std::vector<NotificationAction> actions) override;
   void Dismiss() override;
 
  private:

--- a/brightray/browser/linux/libnotify_notification.h
+++ b/brightray/browser/linux/libnotify_notification.h
@@ -23,15 +23,7 @@ class LibnotifyNotification : public Notification {
   static bool Initialize();
 
   // Notification:
-  void Show(const base::string16& title,
-            const base::string16& msg,
-            const std::string& tag,
-            const GURL& icon_url,
-            const SkBitmap& icon,
-            bool silent,
-            bool has_reply,
-            const base::string16& reply_placeholder,
-            const std::vector<NotificationAction> actions) override;
+  void Show(const NotificationOptions& options) override;
   void Dismiss() override;
 
  private:

--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -33,7 +33,7 @@ class CocoaNotification : public Notification {
 
  private:
   base::scoped_nsobject<NSUserNotification> notification_;
-  int actionIndex_;
+  int action_index_;
 
   DISALLOW_COPY_AND_ASSIGN(CocoaNotification);
 };

--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -22,15 +22,7 @@ class CocoaNotification : public Notification {
   ~CocoaNotification();
 
   // Notification:
-  void Show(const base::string16& title,
-            const base::string16& msg,
-            const std::string& tag,
-            const GURL& icon_url,
-            const SkBitmap& icon,
-            bool silent,
-            const bool has_reply,
-            const base::string16& reply_placeholder,
-            const std::vector<NotificationAction> actions) override;
+  void Show(const NotificationOptions& options) override;
   void Dismiss() override;
 
   void NotificationDisplayed();

--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #include <string>
+#include <vector>
 
 #include "base/mac/scoped_nsobject.h"
 #include "brightray/browser/notification.h"
@@ -28,16 +29,19 @@ class CocoaNotification : public Notification {
             const SkBitmap& icon,
             bool silent,
             const bool has_reply,
-            const base::string16& reply_placeholder) override;
+            const base::string16& reply_placeholder,
+            const std::vector<NotificationAction> actions) override;
   void Dismiss() override;
 
   void NotificationDisplayed();
   void NotificationReplied(const std::string& reply);
+  void NotificationButtonClicked();
 
   NSUserNotification* notification() const { return notification_; }
 
  private:
   base::scoped_nsobject<NSUserNotification> notification_;
+  int actionIndex_;
 
   DISALLOW_COPY_AND_ASSIGN(CocoaNotification);
 };

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -57,7 +57,7 @@ void CocoaNotification::Show(const base::string16& title,
 
     if (action.type == base::UTF8ToUTF16("button")) {
       [notification_ setHasActionButton:true];
-      [notification_ setActionButtonTitle:base::SysUTF16ToNSString(action.label)];
+      [notification_ setActionButtonTitle:base::SysUTF16ToNSString(action.text)];
       actionIndex_ = i;
     }
   }

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -24,27 +24,19 @@ CocoaNotification::~CocoaNotification() {
         removeDeliveredNotification:notification_];
 }
 
-void CocoaNotification::Show(const base::string16& title,
-                             const base::string16& body,
-                             const std::string& tag,
-                             const GURL& icon_url,
-                             const SkBitmap& icon,
-                             bool silent,
-                             bool has_reply,
-                             const base::string16& reply_placeholder,
-                             const std::vector<NotificationAction> actions) {
+void CocoaNotification::Show(const NotificationOptions& options) {
   notification_.reset([[NSUserNotification alloc] init]);
-  [notification_ setTitle:base::SysUTF16ToNSString(title)];
-  [notification_ setInformativeText:base::SysUTF16ToNSString(body)];
+  [notification_ setTitle:base::SysUTF16ToNSString(options.title)];
+  [notification_ setInformativeText:base::SysUTF16ToNSString(options.msg)];
 
   if ([notification_ respondsToSelector:@selector(setContentImage:)] &&
-      !icon.drawsNothing()) {
+      !options.icon.drawsNothing()) {
     NSImage* image = skia::SkBitmapToNSImageWithColorSpace(
-        icon, base::mac::GetGenericRGBColorSpace());
+        options.icon, base::mac::GetGenericRGBColorSpace());
     [notification_ setContentImage:image];
   }
 
-  if (silent) {
+  if (options.silent) {
     [notification_ setSoundName:nil];
   } else {
     [notification_ setSoundName:NSUserNotificationDefaultSoundName];
@@ -52,8 +44,8 @@ void CocoaNotification::Show(const base::string16& title,
 
   [notification_ setHasActionButton:false];
 
-  for (size_t i = 0; i < actions.size(); i++) {
-    NotificationAction action = actions[i];
+  for (size_t i = 0; i < options.actions.size(); i++) {
+    NotificationAction action = options.actions[i];
 
     if (action.type == base::UTF8ToUTF16("button")) {
       [notification_ setHasActionButton:true];
@@ -62,8 +54,8 @@ void CocoaNotification::Show(const base::string16& title,
     }
   }
 
-  if (has_reply) {
-    [notification_ setResponsePlaceholder:base::SysUTF16ToNSString(reply_placeholder)];
+  if (options.has_reply) {
+    [notification_ setResponsePlaceholder:base::SysUTF16ToNSString(options.reply_placeholder)];
     [notification_ setHasReplyButton:true];
   }
 

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -44,14 +44,14 @@ void CocoaNotification::Show(const NotificationOptions& options) {
 
   [notification_ setHasActionButton:false];
 
-  for (size_t i = 0; i < options.actions.size(); i++) {
-    NotificationAction action = options.actions[i];
-
-    if (action.type == base::UTF8ToUTF16("button")) {
+  int i = 0;
+  for (const auto& action : options.actions) {
+    if (action.type == base::ASCIIToUTF16("button")) {
       [notification_ setHasActionButton:true];
       [notification_ setActionButtonTitle:base::SysUTF16ToNSString(action.text)];
-      actionIndex_ = i;
+      action_index_ = i;
     }
+    i++;
   }
 
   if (options.has_reply) {
@@ -82,7 +82,7 @@ void CocoaNotification::NotificationReplied(const std::string& reply) {
 
 void CocoaNotification::NotificationButtonClicked() {
   if (delegate())
-    delegate()->NotificationAction(actionIndex_);
+    delegate()->NotificationAction(action_index_);
 }
 
 }  // namespace brightray

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -29,8 +29,10 @@
        didActivateNotification:(NSUserNotification *)notif {
   auto notification = presenter_->GetNotification(notif);
   if (notification) {
-    if (notif.activationType == NSUserNotificationActivationTypeReplied){
+    if (notif.activationType == NSUserNotificationActivationTypeReplied) {
       notification->NotificationReplied([notif.response.string UTF8String]);
+    } else if (notif.activationType == NSUserNotificationActivationTypeActionButtonClicked) {
+      notification->NotificationButtonClicked();
     } else {
       notification->NotificationClicked(); 
     }

--- a/brightray/browser/notification.h
+++ b/brightray/browser/notification.h
@@ -10,9 +10,8 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/strings/string16.h"
-
-class GURL;
-class SkBitmap;
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "url/gurl.h"
 
 namespace brightray {
 
@@ -24,20 +23,24 @@ struct NotificationAction {
   base::string16 text;
 };
 
+struct NotificationOptions {
+  base::string16 title;
+  base::string16 msg;
+  std::string tag;
+  GURL icon_url;
+  SkBitmap icon;
+  bool silent;
+  bool has_reply;
+  base::string16 reply_placeholder;
+  std::vector<NotificationAction> actions;
+};
+
 class Notification {
  public:
   virtual ~Notification();
 
   // Shows the notification.
-  virtual void Show(const base::string16& title,
-                    const base::string16& msg,
-                    const std::string& tag,
-                    const GURL& icon_url,
-                    const SkBitmap& icon,
-                    bool silent,
-                    bool has_reply,
-                    const base::string16& reply_placeholder,
-                    const std::vector<NotificationAction> actions) = 0;
+  virtual void Show(const NotificationOptions& options) = 0;
   // Closes the notification, this instance will be destroyed after the
   // notification gets closed.
   virtual void Dismiss() = 0;

--- a/brightray/browser/notification.h
+++ b/brightray/browser/notification.h
@@ -21,7 +21,7 @@ class NotificationPresenter;
 
 struct NotificationAction {
   base::string16 type;
-  base::string16 label;
+  base::string16 text;
 };
 
 class Notification {

--- a/brightray/browser/notification.h
+++ b/brightray/browser/notification.h
@@ -6,6 +6,7 @@
 #define BRIGHTRAY_BROWSER_NOTIFICATION_H_
 
 #include <string>
+#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "base/strings/string16.h"
@@ -17,6 +18,11 @@ namespace brightray {
 
 class NotificationDelegate;
 class NotificationPresenter;
+
+struct NotificationAction {
+  base::string16 type;
+  base::string16 label;
+};
 
 class Notification {
  public:
@@ -30,7 +36,8 @@ class Notification {
                     const SkBitmap& icon,
                     bool silent,
                     bool has_reply,
-                    const base::string16& reply_placeholder) = 0;
+                    const base::string16& reply_placeholder,
+                    const std::vector<NotificationAction> actions) = 0;
   // Closes the notification, this instance will be destroyed after the
   // notification gets closed.
   virtual void Dismiss() = 0;

--- a/brightray/browser/notification_delegate.h
+++ b/brightray/browser/notification_delegate.h
@@ -21,6 +21,7 @@ class NotificationDelegate : public content::DesktopNotificationDelegate {
 
   // Notification was replied to
   virtual void NotificationReplied(const std::string& reply) {}
+  virtual void NotificationAction(int index) {}
 };
 
 }  // namespace brightray

--- a/brightray/browser/platform_notification_service.cc
+++ b/brightray/browser/platform_notification_service.cc
@@ -32,7 +32,7 @@ void OnWebNotificationAllowed(base::WeakPtr<Notification> notification,
   if (allowed)
     notification->Show(data.title, data.body, data.tag, data.icon, icon,
                        audio_muted ? true : data.silent, false,
-                       base::UTF8ToUTF16(""));
+                       base::UTF8ToUTF16(""), {});
   else
     notification->Destroy();
 }

--- a/brightray/browser/platform_notification_service.cc
+++ b/brightray/browser/platform_notification_service.cc
@@ -29,12 +29,19 @@ void OnWebNotificationAllowed(base::WeakPtr<Notification> notification,
                               bool allowed) {
   if (!notification)
     return;
-  if (allowed)
-    notification->Show(data.title, data.body, data.tag, data.icon, icon,
-                       audio_muted ? true : data.silent, false,
-                       base::UTF8ToUTF16(""), {});
-  else
+  if (allowed) {
+    brightray::NotificationOptions options;
+    options.title = data.title;
+    options.msg = data.body;
+    options.tag = data.tag;
+    options.icon_url = data.icon;
+    options.icon = icon;
+    options.silent = audio_muted ? true : data.silent;
+    options.has_reply = false;
+    notification->Show(options);
+  } else {
     notification->Destroy();
+  }
 }
 
 }  // namespace

--- a/brightray/browser/win/win32_notification.cc
+++ b/brightray/browser/win/win32_notification.cc
@@ -4,6 +4,7 @@
 
 #include <windows.h>
 #include <string>
+#include <vector>
 
 #include "third_party/skia/include/core/SkBitmap.h"
 
@@ -13,7 +14,8 @@ void Win32Notification::Show(
     const base::string16& title, const base::string16& msg,
     const std::string& tag, const GURL& icon_url,
     const SkBitmap& icon, bool silent,
-    bool has_reply, const base::string16& reply_placeholder) {
+    bool has_reply, const base::string16& reply_placeholder,
+    const std::vector<NotificationAction> actions) {
     auto presenter = static_cast<NotificationPresenterWin7*>(this->presenter());
     if (!presenter) return;
 

--- a/brightray/browser/win/win32_notification.cc
+++ b/brightray/browser/win/win32_notification.cc
@@ -10,50 +10,49 @@
 
 namespace brightray {
 
-void Win32Notification::Show(
-    const base::string16& title, const base::string16& msg,
-    const std::string& tag, const GURL& icon_url,
-    const SkBitmap& icon, bool silent,
-    bool has_reply, const base::string16& reply_placeholder,
-    const std::vector<NotificationAction> actions) {
+void Win32Notification::Show(const NotificationOptions& options) {
     auto presenter = static_cast<NotificationPresenterWin7*>(this->presenter());
     if (!presenter) return;
 
     HBITMAP image = NULL;
 
-    if (!icon.drawsNothing()) {
-        if (icon.colorType() == kBGRA_8888_SkColorType) {
-            icon.lockPixels();
+    if (!options.icon.drawsNothing()) {
+        if (options.icon.colorType() == kBGRA_8888_SkColorType) {
+            options.icon.lockPixels();
 
             BITMAPINFOHEADER bmi = { sizeof(BITMAPINFOHEADER) };
-            bmi.biWidth = icon.width();
-            bmi.biHeight = -icon.height();
+            bmi.biWidth = options.icon.width();
+            bmi.biHeight = -options.icon.height();
             bmi.biPlanes = 1;
             bmi.biBitCount = 32;
             bmi.biCompression = BI_RGB;
 
             HDC hdcScreen = GetDC(NULL);
-            image = CreateDIBitmap(hdcScreen, &bmi, CBM_INIT, icon.getPixels(),
+            image = CreateDIBitmap(hdcScreen, &bmi, CBM_INIT,
+                                   options.icon.getPixels(),
                                    reinterpret_cast<BITMAPINFO*>(&bmi),
                                    DIB_RGB_COLORS);
             ReleaseDC(NULL, hdcScreen);
 
-            icon.unlockPixels();
+            options.icon.unlockPixels();
         }
     }
 
     Win32Notification* existing = nullptr;
-    if (!tag.empty()) existing = presenter->GetNotificationObjectByTag(tag);
+    if (!options.tag.empty())
+        existing = presenter->GetNotificationObjectByTag(options.tag);
 
     if (existing) {
         existing->tag_.clear();
         this->notification_ref_ = std::move(existing->notification_ref_);
-        this->notification_ref_.Set(title, msg, image);
+        this->notification_ref_.Set(options.title, options.msg, image);
     } else {
-        this->notification_ref_ = presenter->AddNotification(title, msg, image);
+        this->notification_ref_ = presenter->AddNotification(options.title,
+                                                             options.msg,
+                                                             image);
     }
 
-    this->tag_ = tag;
+    this->tag_ = options.tag;
 
     if (image) DeleteObject(image);
 }

--- a/brightray/browser/win/win32_notification.h
+++ b/brightray/browser/win/win32_notification.h
@@ -13,7 +13,8 @@ class Win32Notification : public brightray::Notification {
     void Show(const base::string16& title, const base::string16& msg,
               const std::string& tag, const GURL& icon_url,
               const SkBitmap& icon, bool silent,
-              bool has_reply, const base::string16& reply_placeholder) override;
+              bool has_reply, const base::string16& reply_placeholder,
+              const std::vector<NotificationAction> actions) override;
     void Dismiss() override;
 
     const DesktopNotificationController::Notification& GetRef() const {

--- a/brightray/browser/win/win32_notification.h
+++ b/brightray/browser/win/win32_notification.h
@@ -10,11 +10,7 @@ class Win32Notification : public brightray::Notification {
                       NotificationPresenterWin7* presenter) :
         Notification(delegate, presenter) {
     }
-    void Show(const base::string16& title, const base::string16& msg,
-              const std::string& tag, const GURL& icon_url,
-              const SkBitmap& icon, bool silent,
-              bool has_reply, const base::string16& reply_placeholder,
-              const std::vector<NotificationAction> actions) override;
+    void Show(const NotificationOptions& options) override;
     void Dismiss() override;
 
     const DesktopNotificationController::Notification& GetRef() const {

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -9,6 +9,7 @@
 #include "brightray/browser/win/windows_toast_notification.h"
 
 #include <shlobj.h>
+#include <vector>
 
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/notification_delegate.h"
@@ -91,7 +92,10 @@ void WindowsToastNotification::Show(const base::string16& title,
                                     const SkBitmap& icon,
                                     bool silent,
                                     bool has_reply,
-                                    const base::string16& reply_placeholder) {
+                                    const base::string16& reply_placeholder,
+                                    const std::vector<
+                                      NotificationAction
+                                    > actions) {
   auto presenter_win = static_cast<NotificationPresenterWin*>(presenter());
   std::wstring icon_path = presenter_win->SaveIconToFilesystem(icon, icon_url);
 

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -85,23 +85,15 @@ WindowsToastNotification::~WindowsToastNotification() {
   }
 }
 
-void WindowsToastNotification::Show(const base::string16& title,
-                                    const base::string16& msg,
-                                    const std::string& tag,
-                                    const GURL& icon_url,
-                                    const SkBitmap& icon,
-                                    bool silent,
-                                    bool has_reply,
-                                    const base::string16& reply_placeholder,
-                                    const std::vector<
-                                      NotificationAction
-                                    > actions) {
+void WindowsToastNotification::Show(const NotificationOptions& options) {
   auto presenter_win = static_cast<NotificationPresenterWin*>(presenter());
-  std::wstring icon_path = presenter_win->SaveIconToFilesystem(icon, icon_url);
+  std::wstring icon_path = presenter_win->SaveIconToFilesystem(
+    options.icon,
+    options.icon_url);
 
   ComPtr<IXmlDocument> toast_xml;
-  if (FAILED(GetToastXml(toast_manager_.Get(), title, msg, icon_path, silent,
-                         &toast_xml))) {
+  if (FAILED(GetToastXml(toast_manager_.Get(), options.title, options.msg,
+                         icon_path, options.silent, &toast_xml))) {
     NotificationFailed();
     return;
   }

--- a/brightray/browser/win/windows_toast_notification.h
+++ b/brightray/browser/win/windows_toast_notification.h
@@ -51,15 +51,7 @@ class WindowsToastNotification : public Notification {
 
  protected:
   // Notification:
-  void Show(const base::string16& title,
-            const base::string16& msg,
-            const std::string& tag,
-            const GURL& icon_url,
-            const SkBitmap& icon,
-            bool silent,
-            bool has_reply,
-            const base::string16& reply_placeholder,
-            const std::vector<NotificationAction> actions) override;
+  void Show(const NotificationOptions& options) override;
   void Dismiss() override;
 
  private:

--- a/brightray/browser/win/windows_toast_notification.h
+++ b/brightray/browser/win/windows_toast_notification.h
@@ -13,6 +13,7 @@
 #include <windows.ui.notifications.h>
 #include <wrl/implements.h>
 #include <string>
+#include <vector>
 
 #include "brightray/browser/notification.h"
 
@@ -57,7 +58,8 @@ class WindowsToastNotification : public Notification {
             const SkBitmap& icon,
             bool silent,
             bool has_reply,
-            const base::string16& reply_placeholder) override;
+            const base::string16& reply_placeholder,
+            const std::vector<NotificationAction> actions) override;
   void Dismiss() override;
 
  private:

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -23,7 +23,7 @@ It creates a new `Notification` with native properties as set by the `options`.
 
 The `Notification` class has the following static methods:
 
-#### `BrowserWindow.isSupported()`
+#### `Notification.isSupported()`
 
 Returns `Boolean` - Whether or not desktop notifications are supported on the current system
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -36,6 +36,7 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
   * `icon` [NativeImage](native-image.md) - (optional) An icon to use in the notification
   * `hasReply` Boolean - (optional) Whether or not to add an inline reply option to the notification.  _macOS_
   * `replyPlaceholder` String - (optional) The placeholder to write in the inline reply input field. _macOS_
+  * `actions` [NotificationAction[]](structures/notification-action.md) - Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
 
 
 ### Instance Events
@@ -82,6 +83,13 @@ Returns:
 * `reply` String - The string the user entered into the inline reply field
 
 Emitted when the user clicks the "Reply" button on a notification with `hasReply: true`.
+
+#### Event: 'action' _macOS_
+
+Returns:
+
+* `event` Event
+* `index` Number - The index of the action that was activated
 
 ### Instance Methods
 

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -7,7 +7,7 @@
 
 | Action Type | Platform Support | Limitations |
 |-------------|------------------|-------------|
-| `button`    | macOS            | Maximum of one button, if multiple are provided only the last is used |
+| `button`    | macOS            | Maximum of one button, if multiple are provided only the last is used.  This action is also incomptible with `hasReply` and will be ignored if `hasReply` is `true`. |
 
 ### Button support on macOS
 

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -1,0 +1,20 @@
+# NotificationAction Object
+
+* `type` String - The type of action, can be `button`.
+* `label` String - The label for the given action.
+
+## Platform / Action Support
+
+| Action Type | Platform Support | Limitations |
+|-------------|------------------|-------------|
+| `button`    | macOS            | Maximum of one button, if multiple are provided only the last is used |
+
+### Button support on macOS
+
+In order for extra notification buttons to work on macOS your app must meet the
+following criteria.
+
+* App is signed
+* App has it's `NSUserNotificationAlertStyle` set to `alert` in the `info.plist`.
+
+If either of these requirements are not met the button simply won't appear.

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -6,7 +6,7 @@
 ## Platform / Action Support
 
 | Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
-|-------------|------------------|------------------|-------------|
+|-------------|------------------|-----------------|----------------|-------------|
 | `button`    | macOS            | Used as the label for the button | "Show" | Maximum of one button, if multiple are provided only the last is used.  This action is also incomptible with `hasReply` and will be ignored if `hasReply` is `true`. |
 
 ### Button support on macOS

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -1,13 +1,13 @@
 # NotificationAction Object
 
 * `type` String - The type of action, can be `button`.
-* `label` String - The label for the given action.
+* `text` String - (optional) The label for the given action.
 
 ## Platform / Action Support
 
-| Action Type | Platform Support | Limitations |
-|-------------|------------------|-------------|
-| `button`    | macOS            | Maximum of one button, if multiple are provided only the last is used.  This action is also incomptible with `hasReply` and will be ignored if `hasReply` is `true`. |
+| Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
+|-------------|------------------|------------------|-------------|
+| `button`    | macOS            | Used as the label for the button | "Show" | Maximum of one button, if multiple are provided only the last is used.  This action is also incomptible with `hasReply` and will be ignored if `hasReply` is `true`. |
 
 ### Button support on macOS
 


### PR DESCRIPTION
Adds support for "notification actions" to the main process Notification API.

The only supported action at the moment is "button" on macOS.  In theory this could be expanded to support windows as well in a future PR along with other types of actions (like dropdowns in windows)