### PR TITLE
Exposes more Handoff related APIs to Electron

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -584,17 +584,35 @@ void App::OnAccessibilitySupportChanged() {
 }
 
 #if defined(OS_MACOSX)
+void App::OnWillContinueUserActivity(
+    bool* prevent_default,
+    const std::string& type) {
+  *prevent_default = Emit("will-continue-activity", type);
+}
+void App::OnDidFailToContinueUserActivity(
+    const std::string& type,
+    const std::string& error) {
+  Emit("continue-activity-error", type, error);
+}
 void App::OnContinueUserActivity(
     bool* prevent_default,
     const std::string& type,
     const base::DictionaryValue& user_info) {
   *prevent_default = Emit("continue-activity", type, user_info);
 }
-
+void App::OnUserActivityWasContinued(
+    const std::string& type,
+    const base::DictionaryValue& user_info) {
+  Emit("activity-was-continued", type, user_info);
+}
+void App::OnUpdateUserActivityState(
+    const std::string& type,
+    const base::DictionaryValue& user_info) {
+  Emit("update-activity-state", type, user_info);
+}
 void App::OnNewWindowForTab() {
   Emit("new-window-for-tab");
 }
-
 #endif
 
 void App::OnLogin(LoginHandler* login_handler,
@@ -1139,6 +1157,10 @@ void App::BuildPrototype(
                  base::Bind(&Browser::SetUserActivity, browser))
       .SetMethod("getCurrentActivityType",
                  base::Bind(&Browser::GetCurrentActivityType, browser))
+      .SetMethod("invalidateCurrentActivity",
+                 base::Bind(&Browser::InvalidateCurrentActivity, browser))
+      .SetMethod("updateCurrentActivity",
+                 base::Bind(&Browser::UpdateCurrentActivity, browser))
       .SetMethod("setAboutPanelOptions",
                  base::Bind(&Browser::SetAboutPanelOptions, browser))
 #endif

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -606,9 +606,10 @@ void App::OnUserActivityWasContinued(
   Emit("activity-was-continued", type, user_info);
 }
 void App::OnUpdateUserActivityState(
+    bool* prevent_default,
     const std::string& type,
     const base::DictionaryValue& user_info) {
-  Emit("update-activity-state", type, user_info);
+  *prevent_default = Emit("update-activity-state", type, user_info);
 }
 void App::OnNewWindowForTab() {
   Emit("new-window-for-tab");

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -589,28 +589,33 @@ void App::OnWillContinueUserActivity(
     const std::string& type) {
   *prevent_default = Emit("will-continue-activity", type);
 }
+
 void App::OnDidFailToContinueUserActivity(
     const std::string& type,
     const std::string& error) {
   Emit("continue-activity-error", type, error);
 }
+
 void App::OnContinueUserActivity(
     bool* prevent_default,
     const std::string& type,
     const base::DictionaryValue& user_info) {
   *prevent_default = Emit("continue-activity", type, user_info);
 }
+
 void App::OnUserActivityWasContinued(
     const std::string& type,
     const base::DictionaryValue& user_info) {
   Emit("activity-was-continued", type, user_info);
 }
+
 void App::OnUpdateUserActivityState(
     bool* prevent_default,
     const std::string& type,
     const base::DictionaryValue& user_info) {
   *prevent_default = Emit("update-activity-state", type, user_info);
 }
+
 void App::OnNewWindowForTab() {
   Emit("new-window-for-tab");
 }

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -113,11 +113,22 @@ class App : public AtomBrowserClient::Delegate,
                const base::DictionaryValue& request_details) override;
   void OnAccessibilitySupportChanged() override;
 #if defined(OS_MACOSX)
+  void OnWillContinueUserActivity(
+      bool* prevent_default,
+      const std::string& type) override;
+  void OnDidFailToContinueUserActivity(
+      const std::string& type,
+      const std::string& error) override;
   void OnContinueUserActivity(
       bool* prevent_default,
       const std::string& type,
       const base::DictionaryValue& user_info) override;
-
+  void OnUserActivityWasContinued(
+      const std::string& type,
+      const base::DictionaryValue& user_info) override;
+  void OnUpdateUserActivityState(
+      const std::string& type,
+      const base::DictionaryValue& user_info) override;
   void OnNewWindowForTab() override;
 #endif
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -127,6 +127,7 @@ class App : public AtomBrowserClient::Delegate,
       const std::string& type,
       const base::DictionaryValue& user_info) override;
   void OnUpdateUserActivityState(
+      bool* prevent_default,
       const std::string& type,
       const base::DictionaryValue& user_info) override;
   void OnNewWindowForTab() override;

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -119,9 +119,31 @@ class Browser : public WindowListObserver {
   // Returns the type name of the current user activity.
   std::string GetCurrentActivityType();
 
+  // Invalidates the current user activity.
+  void InvalidateCurrentActivity();
+
+  // Updates the current user activity
+  void UpdateCurrentActivity(const std::string& type,
+                             const base::DictionaryValue& user_info);
+
+  // Indicates that an user activity is about to be resumed.
+  bool WillContinueUserActivity(const std::string& type);
+
+  // Indicates a failure to resume a Handoff activity.
+  void DidFailToContinueUserActivity(const std::string& type,
+                                     const std::string& error);
+
   // Resumes an activity via hand-off.
   bool ContinueUserActivity(const std::string& type,
                             const base::DictionaryValue& user_info);
+
+  // Indicates that an activity was continued on another device.
+  void UserActivityWasContinued(const std::string& type,
+                                const base::DictionaryValue& user_info);
+
+  // Gives an oportunity to update the Handoff payload.
+  void UpdateUserActivityState(const std::string& type,
+                               const base::DictionaryValue& user_info);
 
   // Bounce the dock icon.
   enum BounceType {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -142,7 +142,7 @@ class Browser : public WindowListObserver {
                                 const base::DictionaryValue& user_info);
 
   // Gives an oportunity to update the Handoff payload.
-  void UpdateUserActivityState(const std::string& type,
+  bool UpdateUserActivityState(const std::string& type,
                                const base::DictionaryValue& user_info);
 
   // Bounce the dock icon.

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -144,12 +144,48 @@ std::string Browser::GetCurrentActivityType() {
   return base::SysNSStringToUTF8(userActivity.activityType);
 }
 
+void Browser::InvalidateCurrentActivity() {
+  [[AtomApplication sharedApplication] invalidateCurrentActivity];
+}
+
+void Browser::UpdateCurrentActivity(const std::string& type,
+                                    const base::DictionaryValue& user_info) {
+  [[AtomApplication sharedApplication] 
+      updateCurrentActivity:base::SysUTF8ToNSString(type)
+               withUserInfo:DictionaryValueToNSDictionary(user_info)];
+}
+
+bool Browser::WillContinueUserActivity(const std::string& type) {
+  bool prevent_default = false;
+    for (BrowserObserver& observer : observers_)
+      observer.OnWillContinueUserActivity(&prevent_default, type);
+  return prevent_default;
+}
+ 
+void Browser::DidFailToContinueUserActivity(const std::string& type,
+                                            const std::string& error) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidFailToContinueUserActivity(type, error);
+}
+
 bool Browser::ContinueUserActivity(const std::string& type,
                                    const base::DictionaryValue& user_info) {
   bool prevent_default = false;
   for (BrowserObserver& observer : observers_)
     observer.OnContinueUserActivity(&prevent_default, type, user_info);
   return prevent_default;
+}
+  
+void Browser::UserActivityWasContinued(const std::string& type,
+                                       const base::DictionaryValue& user_info) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnUserActivityWasContinued(type, user_info);
+}
+
+void Browser::UpdateUserActivityState(const std::string& type,
+                                      const base::DictionaryValue& user_info) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnUpdateUserActivityState(type, user_info);
 }
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings(

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -182,10 +182,12 @@ void Browser::UserActivityWasContinued(const std::string& type,
     observer.OnUserActivityWasContinued(type, user_info);
 }
 
-void Browser::UpdateUserActivityState(const std::string& type,
+bool Browser::UpdateUserActivityState(const std::string& type,
                                       const base::DictionaryValue& user_info) {
+  bool prevent_default = false;
   for (BrowserObserver& observer : observers_)
-    observer.OnUpdateUserActivityState(type, user_info);
+    observer.OnUpdateUserActivityState(&prevent_default, type, user_info);
+  return prevent_default;
 }
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings(

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -150,18 +150,18 @@ void Browser::InvalidateCurrentActivity() {
 
 void Browser::UpdateCurrentActivity(const std::string& type,
                                     const base::DictionaryValue& user_info) {
-  [[AtomApplication sharedApplication] 
+  [[AtomApplication sharedApplication]
       updateCurrentActivity:base::SysUTF8ToNSString(type)
                withUserInfo:DictionaryValueToNSDictionary(user_info)];
 }
 
 bool Browser::WillContinueUserActivity(const std::string& type) {
   bool prevent_default = false;
-    for (BrowserObserver& observer : observers_)
-      observer.OnWillContinueUserActivity(&prevent_default, type);
+  for (BrowserObserver& observer : observers_)
+    observer.OnWillContinueUserActivity(&prevent_default, type);
   return prevent_default;
 }
- 
+
 void Browser::DidFailToContinueUserActivity(const std::string& type,
                                             const std::string& error) {
   for (BrowserObserver& observer : observers_)
@@ -175,7 +175,7 @@ bool Browser::ContinueUserActivity(const std::string& type,
     observer.OnContinueUserActivity(&prevent_default, type, user_info);
   return prevent_default;
 }
-  
+
 void Browser::UserActivityWasContinued(const std::string& type,
                                        const base::DictionaryValue& user_info) {
   for (BrowserObserver& observer : observers_)

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -56,12 +56,27 @@ class BrowserObserver {
   virtual void OnAccessibilitySupportChanged() {}
 
 #if defined(OS_MACOSX)
+  // The browser wants to report that an user activity will resume. (macOS only)
+  virtual void OnWillContinueUserActivity(
+      bool* prevent_default,
+      const std::string& type) {}
+  // The browser wants to report an user activity resuming error. (macOS only)
+  virtual void OnDidFailToContinueUserActivity(
+      const std::string& type,
+      const std::string& error) {}
   // The browser wants to resume a user activity via handoff. (macOS only)
   virtual void OnContinueUserActivity(
       bool* prevent_default,
       const std::string& type,
       const base::DictionaryValue& user_info) {}
-
+  // The browser wants to notify that an user activity was resumed. (macOS only)
+  virtual void OnUserActivityWasContinued(
+      const std::string& type,
+      const base::DictionaryValue& user_info) {}
+  // The browser wants to update an user activity payload. (macOS only)
+  virtual void OnUpdateUserActivityState(
+      const std::string& type,
+      const base::DictionaryValue& user_info) {}
   // User clicked the native macOS new tab button. (macOS only)
   virtual void OnNewWindowForTab() {}
 #endif

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -75,6 +75,7 @@ class BrowserObserver {
       const base::DictionaryValue& user_info) {}
   // The browser wants to update an user activity payload. (macOS only)
   virtual void OnUpdateUserActivityState(
+      bool* prevent_default,
       const std::string& type,
       const base::DictionaryValue& user_info) {}
   // User clicked the native macOS new tab button. (macOS only)

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -6,7 +6,8 @@
 #import "base/mac/scoped_nsobject.h"
 
 @interface AtomApplication : NSApplication<CrAppProtocol,
-                                           CrAppControlProtocol> {
+                                           CrAppControlProtocol,
+                                           NSUserActivityDelegate> {
  @private
   BOOL handlingSendEvent_;
   base::scoped_nsobject<NSUserActivity> currentActivity_;
@@ -24,5 +25,8 @@
 - (void)setCurrentActivity:(NSString*)type
               withUserInfo:(NSDictionary*)userInfo
             withWebpageURL:(NSURL*)webpageURL;
+- (void)invalidateCurrentActivity;
+- (void)updateCurrentActivity:(NSString *)type
+                 withUserInfo:(NSDictionary*)userInfo;
 
 @end

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -11,6 +11,8 @@
  @private
   BOOL handlingSendEvent_;
   base::scoped_nsobject<NSUserActivity> currentActivity_;
+  NSCondition *handoffLock_;
+  BOOL updateReceived_;
 }
 
 + (AtomApplication*)sharedApplication;

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -11,7 +11,7 @@
  @private
   BOOL handlingSendEvent_;
   base::scoped_nsobject<NSUserActivity> currentActivity_;
-  NSCondition *handoffLock_;
+  NSCondition* handoffLock_;
   BOOL updateReceived_;
 }
 
@@ -28,7 +28,7 @@
               withUserInfo:(NSDictionary*)userInfo
             withWebpageURL:(NSURL*)webpageURL;
 - (void)invalidateCurrentActivity;
-- (void)updateCurrentActivity:(NSString *)type
+- (void)updateCurrentActivity:(NSString*)type
                  withUserInfo:(NSDictionary*)userInfo;
 
 @end

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -66,6 +66,7 @@
   atom::Browser* browser = atom::Browser::Get();
   browser->UpdateUserActivityState(activity_type, *user_info);
   
+  [userActivity setNeedsSave:YES];
   [super updateUserActivityState:userActivity];
 }
 

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -10,6 +10,14 @@
 #include "base/strings/sys_string_conversions.h"
 #include "content/public/browser/browser_accessibility_state.h"
 
+static inline void dispatch_sync_main(dispatch_block_t block) {
+    if ([NSThread isMainThread]) {
+        block();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), block);
+    }
+}
+
 @implementation AtomApplication
 
 + (AtomApplication*)sharedApplication {
@@ -68,7 +76,7 @@
 
   __block BOOL shouldWait = NO;
 
-  dispatch_sync(dispatch_get_main_queue(), ^{
+  dispatch_sync_main(^{
     std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
     std::unique_ptr<base::DictionaryValue> user_info =
       atom::NSDictionaryToDictionaryValue(userActivity.userInfo);

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -118,17 +118,17 @@ continueUserActivity:(NSUserActivity*)userActivity
   return browser->ContinueUserActivity(activity_type, *user_info) ? YES : NO;
 }
 
-- (BOOL)application:(NSApplication *)application willContinueUserActivityWithType:(NSString *)userActivityType {
+- (BOOL)application:(NSApplication*)application willContinueUserActivityWithType:(NSString*)userActivityType {
   std::string activity_type(base::SysNSStringToUTF8(userActivityType));
-  
+
   atom::Browser* browser = atom::Browser::Get();
   return browser->WillContinueUserActivity(activity_type) ? YES : NO;
 }
 
-- (void)application:(NSApplication *)application didFailToContinueUserActivityWithType:(NSString *)userActivityType error:(NSError *)error {
+- (void)application:(NSApplication*)application didFailToContinueUserActivityWithType:(NSString*)userActivityType error:(NSError*)error {
   std::string activity_type(base::SysNSStringToUTF8(userActivityType));
   std::string error_message(base::SysNSStringToUTF8([error localizedDescription]));
-  
+
   atom::Browser* browser = atom::Browser::Get();
   browser->DidFailToContinueUserActivity(activity_type, error_message);
 }

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -118,6 +118,21 @@ continueUserActivity:(NSUserActivity*)userActivity
   return browser->ContinueUserActivity(activity_type, *user_info) ? YES : NO;
 }
 
+- (BOOL)application:(NSApplication *)application willContinueUserActivityWithType:(NSString *)userActivityType {
+  std::string activity_type(base::SysNSStringToUTF8(userActivityType));
+  
+  atom::Browser* browser = atom::Browser::Get();
+  return browser->WillContinueUserActivity(activity_type) ? YES : NO;
+}
+
+- (void)application:(NSApplication *)application didFailToContinueUserActivityWithType:(NSString *)userActivityType error:(NSError *)error {
+  std::string activity_type(base::SysNSStringToUTF8(userActivityType));
+  std::string error_message(base::SysNSStringToUTF8([error localizedDescription]));
+  
+  atom::Browser* browser = atom::Browser::Get();
+  browser->DidFailToContinueUserActivity(activity_type, error_message);
+}
+
 - (IBAction)newWindowForTab:(id)sender {
   atom::Browser::Get()->NewWindowForTab();
 }

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -149,6 +149,53 @@ ID as the activity's source app and that supports the activity's type.
 Supported activity types are specified in the app's `Info.plist` under the
 `NSUserActivityTypes` key.
 
+### Event: 'will-continue-activity' _macOS_
+
+Returns:
+
+* `event` Event
+* `type` String - A string identifying the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+
+Emitted during [Handoff][handoff] before an activity from a different device wants
+to be resumed. You should call `event.preventDefault()` if you want to handle
+this event.
+
+### Event: 'continue-activity-error' _macOS_
+
+Returns:
+
+* `event` Event
+* `type` String - A string identifying the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+* `error` String - A string with the error's localized description.
+
+Emitted during [Handoff][handoff] when an activity from a different device
+fails to be resumed.
+
+### Event: 'activity-was-continued' _macOS_
+
+Returns:
+
+* `event` Event
+* `type` String - A string identifying the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+* `userInfo` Object - Contains app-specific state stored by the activity.
+
+Emitted during [Handoff][handoff] after an activity from this device was successfully
+resumed.
+
+### Event: 'update-activity-state' _macOS_
+
+Returns:
+
+* `event` Event
+* `type` String - A string identifying the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+* `userInfo` Object - Contains app-specific state stored by the activity.
+
+Emitted during [Handoff][handoff] when its user info should be updated before resuming.
+
 ### Event: 'new-window-for-tab' _macOS_
 
 Returns:
@@ -747,6 +794,25 @@ is eligible for [Handoff][handoff] to another device afterward.
 ### `app.getCurrentActivityType()` _macOS_
 
 Returns `String` - The type of the currently running activity.
+
+### `app.invalidateCurrentActivity()` _macOS_
+
+* `type` String - Uniquely identifies the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+* `userInfo` Object - App-specific state to store for use by another device.
+* `webpageURL` String (optional) - The webpage to load in a browser if no suitable app is
+  installed on the resuming device. The scheme must be `http` or `https`.
+
+Invalidates de current Handoff user activity.
+
+### `app.updateCurrentActivity(type, userInfo[, webpageURL])` _macOS_
+
+* `type` String - Uniquely identifies the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+* `userInfo` Object - App-specific state to store for use by another device.
+
+Updates the current `NSUserActivity` if its type matches `type`, merging the entries from
+`userInfo` into its current userInfo dictionary.
 
 ### `app.setAppUserModelId(id)` _Windows_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -799,13 +799,10 @@ Returns `String` - The type of the currently running activity.
 
 * `type` String - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
-* `userInfo` Object - App-specific state to store for use by another device.
-* `webpageURL` String (optional) - The webpage to load in a browser if no suitable app is
-  installed on the resuming device. The scheme must be `http` or `https`.
 
-Invalidates de current Handoff user activity.
+Invalidates the current Handoff user activity.
 
-### `app.updateCurrentActivity(type, userInfo[, webpageURL])` _macOS_
+### `app.updateCurrentActivity(type, userInfo)` _macOS_
 
 * `type` String - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -183,7 +183,7 @@ Returns:
 * `userInfo` Object - Contains app-specific state stored by the activity.
 
 Emitted during [Handoff][handoff] after an activity from this device was successfully
-resumed.
+resumed on another one.
 
 ### Event: 'update-activity-state' _macOS_
 
@@ -194,7 +194,7 @@ Returns:
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` Object - Contains app-specific state stored by the activity.
 
-Emitted during [Handoff][handoff] when its user info should be updated before resuming.
+Emitted when [Handoff][handoff] is about to be resumed on another device. If you need to update the state to be transferred, you should call `event.preventDefault()` immediatelly, construct a new `userInfo` dictionary and call `app.updateCurrentActiviy()` in a timely manner. Otherwise the operation will fail and `continue-activity-error` will be called.
 
 ### Event: 'new-window-for-tab' _macOS_
 
@@ -800,7 +800,7 @@ Returns `String` - The type of the currently running activity.
 * `type` String - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 
-Invalidates the current Handoff user activity.
+Invalidates the current [Handoff][handoff] user activity.
 
 ### `app.updateCurrentActivity(type, userInfo)` _macOS_
 
@@ -808,8 +808,8 @@ Invalidates the current Handoff user activity.
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` Object - App-specific state to store for use by another device.
 
-Updates the current `NSUserActivity` if its type matches `type`, merging the entries from
-`userInfo` into its current userInfo dictionary.
+Updates the current activity if its type matches `type`, merging the entries from
+`userInfo` into its current `userInfo` dictionary.
 
 ### `app.setAppUserModelId(id)` _Windows_
 


### PR DESCRIPTION
Hi guys, thanks for the amazing project!
I'm taking a stab at improving Handoff support as in #9622 
My C++ and Js skills are close to zero, so please bear with me!
I attempted mimicking the change points of a few PRs and added what we needed: support for invalidating the current activity, updating the current activity user info and a few delegate callbacks as events.
It looks to work when running the app with command `electron ./electron-source`

```javascript
    const electron = require('electron');
    const { app } = electron;

    [...]

    console.log(app.invalidateCurrentActivity);
    //output: function invalidateCurrentActivity() { [native code] }
```

However, Handoff will only work when the app is properly signed with the Team ID, and in this case my implementation doesn't seem to work:
Running App after package with `electron-packager`

```javascript
    const electron = require('electron');
    const { app } = electron;

    [...]

    dialog.showMessageBox(mainWindow, {
      message: app.invalidateCurrentActivity.toString()
    });
    /**
    A JavaScript error occurred in the main process
    Uncaught Exception:
    TypeError: Cannot read property 'toString' of undefined
        at EventEmitter.<anonymous> (/Users/Shared/myApp/releases/mas-preview/MyApp-mas-x64/My App.app/Contents/Resources/app.asar/js/main.min.js:1:385981)
        at emitTwo (events.js:106:13)
        at EventEmitter.emit (events.js:191:7)
        at WebContents.<anonymous> (/Users/Shared/myApp/releases/mas-preview/My App-mas-x64/My App.app/Contents/Resources/electron.asar/browser/api/web-contents.js:247:37)
        at emitTwo (events.js:106:13)
        at WebContents.emit (events.js:191:7)
    */
```

It would be awesome to get some feedback on what may be missing here to work. I downloaded libchromium-static and ran bootstrap with the -u option as it would never finish downloading within the script itself.
I took the out/R/Electron.app and replaced the one in the dist folder when packaging.