### PR TITLE
Dev/vladimir fix8768

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -982,6 +982,10 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
     return;
   }
 
+  if (guest_delegate_ && !guest_delegate_->Attached()) {
+    return;
+  }
+
   content::NavigationController::LoadURLParams params(url);
 
   GURL http_referrer;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -374,7 +374,8 @@ bool NativeWindowViews::IsFocused() {
 }
 
 void NativeWindowViews::Show() {
-  if (is_modal() && NativeWindow::parent())
+  if (is_modal() && NativeWindow::parent() &&
+      !window_->native_widget_private()->IsVisible())
     static_cast<NativeWindowViews*>(NativeWindow::parent())->SetEnabled(false);
 
   window_->native_widget_private()->ShowWithWindowState(GetRestoredState());

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -110,7 +110,12 @@ void WebViewGuestDelegate::DidFinishNavigation(
   }
 }
 
+void WebViewGuestDelegate::DidDetach() {
+  attached_ = false;
+}
+
 void WebViewGuestDelegate::DidAttach(int guest_proxy_routing_id) {
+  attached_ = true;
   api_web_contents_->Emit("did-attach");
   embedder_zoom_controller_ =
       WebContentsZoomController::FromWebContents(embedder_web_contents_);

--- a/atom/browser/web_view_guest_delegate.h
+++ b/atom/browser/web_view_guest_delegate.h
@@ -47,6 +47,9 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   // and normal sizes.
   void SetSize(const SetSizeParams& params);
 
+  // Return true if attached.
+  bool Attached() const { return attached_; }
+
  protected:
   // content::WebContentsObserver:
   void DidFinishNavigation(
@@ -54,6 +57,7 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
 
   // content::BrowserPluginGuestDelegate:
   void DidAttach(int guest_proxy_routing_id) final;
+  void DidDetach() final;
   content::WebContents* GetOwnerWebContents() const final;
   void GuestSizeChanged(const gfx::Size& new_size) final;
   void SetGuestHost(content::GuestHost* guest_host) final;
@@ -115,6 +119,9 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
 
   // Whether the guest view is inside a plugin document.
   bool is_full_page_plugin_;
+
+  // Whether attached.
+  bool attached_;
 
   api::WebContents* api_web_contents_;
 


### PR DESCRIPTION
Because SetEnabled tracks number of calls and re-enables the window only when counter is back to 0,
Calling Show() on already visible window would prevent the modal lock to be released when modal is closed. This PR fixes it, by calling SetEnabled only when window is invisible. Preventing duplicate calls to SetEnabled.

