### PR TITLE
Fix #8017: Crash copying cropped image to clipboard

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -7,6 +7,7 @@
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/strings/utf_string_conversions.h"
+#include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/clipboard/scoped_clipboard_writer.h"
 
 #include "atom/common/node_includes.h"
@@ -166,7 +167,12 @@ gfx::Image Clipboard::ReadImage(mate::Arguments* args) {
 
 void Clipboard::WriteImage(const gfx::Image& image, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
-  writer.WriteImage(image.AsBitmap());
+  SkBitmap bmp;
+  if (image.AsBitmap().deepCopyTo(&bmp)) {
+    writer.WriteImage(bmp);
+  } else {
+    writer.WriteImage(image.AsBitmap());
+  }
 }
 
 #if !defined(OS_MACOSX)

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -165,49 +165,14 @@ gfx::Image Clipboard::ReadImage(mate::Arguments* args) {
   return gfx::Image::CreateFrom1xBitmap(bitmap);
 }
 
-// TODO(ferreus): Replace with sk_tools_utils::copy_to when it's available
-bool copy_to(SkBitmap* dst, SkColorType dstColorType, const SkBitmap& src) {
-  SkPixmap srcPM;
-  if (!src.peekPixels(&srcPM)) {
-    return false;
-  }
-  SkBitmap tmpDst;
-  SkImageInfo dstInfo = srcPM.info().makeColorType(dstColorType);
-  if (!tmpDst.setInfo(dstInfo)) {
-    return false;
-  }
-  // allocate colortable if srcConfig == kIndex8_Config
-  sk_sp<SkColorTable> ctable = nullptr;
-  if (dstColorType == kIndex_8_SkColorType) {
-    if (src.colorType() != kIndex_8_SkColorType) {
-      return false;
-    }
-    ctable = sk_ref_sp(srcPM.ctable());
-  }
-  if (!tmpDst.tryAllocPixels(ctable.get())) {
-    return false;
-  }
-  SkPixmap dstPM;
-  if (!tmpDst.peekPixels(&dstPM)) {
-    return false;
-  }
-  if (!srcPM.readPixels(dstPM)) {
-    return false;
-  }
-  dst->swap(tmpDst);
-  return true;
-}
-
 void Clipboard::WriteImage(const gfx::Image& image, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
-
-  SkBitmap dst;
-  SkBitmap src = image.AsBitmap();
-  src.lockPixels();
-  if (copy_to(&dst, src.colorType(), src)) {
-    writer.WriteImage(dst);
+  SkBitmap bmp;
+  if (image.AsBitmap().deepCopyTo(&bmp)) {
+    writer.WriteImage(bmp);
+  } else {
+    writer.WriteImage(image.AsBitmap());
   }
-  src.unlockPixels();
 }
 
 #if !defined(OS_MACOSX)

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -168,6 +168,7 @@ gfx::Image Clipboard::ReadImage(mate::Arguments* args) {
 void Clipboard::WriteImage(const gfx::Image& image, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   SkBitmap bmp;
+  // TODO(ferreus): Replace with sk_tools_utils::copy_to (chrome60)
   if (image.AsBitmap().deepCopyTo(&bmp)) {
     writer.WriteImage(bmp);
   } else {


### PR DESCRIPTION
I tracked down the crash to a place in libchromiumcontent: https://chromium.googlesource.com/experimental/chromium/src/+/58.0.3029.110/ui/base/clipboard/clipboard_win.cc#814

For some reason, even so the image is cropped, getSize() and getPixels() return the actual size of original image, and also the original pixels, so obviously memcpy is crashing, since the size is way to big.
Surprisingly width() and height() does return correct cropped dimensions.

I tried to set the correct size for memcpy, but since the actual pixels are also from original image, this resulted in garbage image being put into clipboard.

The only solution that i found, is to deep copy the image inside Clipboard::WriteImage, this results in the correct image being passed to DrawBitmap, and everything works correctly.
