### PR TITLE
Clarifying how to generate distributable package and usual package size

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ behavior to electron@github.com.
 Please note that apps packaged by electron may be large (50 ~ 127MB).
 
 ## Generating distributable package
-Check [electron-packager project](https://github.com/electron-userland/electron-packager).
+Check [electron-packager](https://github.com/electron-userland/electron-packager) project.
 
 ## Downloads
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDU
 By participating, you are expected to uphold this code. Please report unacceptable
 behavior to electron@github.com.
 
+## Package size
+Please note that apps packaged by electron may be large (50 ~ 127MB).
+
+## Generating distributable package
+Check [electron-packager project](https://github.com/electron-userland/electron-packager).
+
 ## Downloads
 
 To install prebuilt Electron binaries, use

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ behavior to electron@github.com.
 ## Package size
 Please note that apps packaged by electron may be large (50 ~ 127MB).
 
-## Generating distributable package
-Check [electron-packager](https://github.com/electron-userland/electron-packager) project.
-
 ## Downloads
 
 To install prebuilt Electron binaries, use
@@ -50,6 +47,10 @@ prebuilt binaries, debug symbols, and more.
 Guides and the API reference are located in the
 [docs](https://github.com/electron/electron/tree/master/docs) directory. It also
 contains documents describing how to build and contribute to Electron.
+
+In particular, check the
+[Application Packaging](https://github.com/electron/electron/tree/master/docs/tutorial/application-packaging.md)
+section which explains how to generate a distributable package.
 
 ## Documentation Translations
 


### PR DESCRIPTION
Many users should benefit from knowing upfront how to generate a distributable package and how large will it be. For those reasons, I'm opening this pull request to include that info on README.md.