### PR TITLE
Introduce Chrome extensions management APIs independent of Dev Tools Extensions

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -379,7 +379,7 @@ remove the reference to the window and avoid using it any more.
 
 #### Event: 'session-end' _Windows_
 
-Emitted when window session is going to end due to force shutdown or machine restart 
+Emitted when window session is going to end due to force shutdown or machine restart
 or session log off.
 
 #### Event: 'unresponsive'
@@ -535,6 +535,34 @@ Returns `BrowserWindow` - The window that owns the given `webContents`.
 * `id` Integer
 
 Returns `BrowserWindow` - The window with the given `id`.
+
+#### `BrowserWindow.addExtension(path)`
+
+* `path` String
+
+Adds Chrome extension located at `path`, and returns extension's name.
+
+The method will also not return if the extension's manifest is missing or incomplete.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `BrowserWindow.removeExtension(name)`
+
+* `name` String
+
+Remove a Chrome extension by name.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `BrowserWindow.getExtensions()`
+
+Returns `Object` - The keys are the extension names and each value is
+an Object containing `name` and `version` properties.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
 
 #### `BrowserWindow.addDevToolsExtension(path)`
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -15,6 +15,7 @@ const objectValues = function (object) {
 // Mapping between extensionId(hostname) and manifest.
 const manifestMap = {}  // extensionId => manifest
 const manifestNameMap = {}  // name => manifest
+const devToolsExtensionNames = new Set()
 
 const generateExtensionIdFromName = function (name) {
   return name.replace(/[\W_]+/g, '-').toLowerCase()
@@ -64,6 +65,7 @@ const getManifestFromPath = function (srcDirectory) {
     return manifest
   } else if (manifest && manifest.name) {
     console.warn(`Attempted to load extension "${manifest.name}" that has already been loaded.`)
+    return manifest
   }
 }
 
@@ -329,22 +331,21 @@ app.on('session-created', function (ses) {
 })
 
 // The persistent path of "DevTools Extensions" preference file.
-let loadedExtensionsPath = null
+let loadedDevToolsExtensionsPath = null
 
 app.on('will-quit', function () {
   try {
-    const loadedExtensions = objectValues(manifestMap).map(function (manifest) {
-      return manifest.srcDirectory
-    })
-    if (loadedExtensions.length > 0) {
+    const loadedDevToolsExtensions = Array.from(devToolsExtensionNames)
+      .map(name => manifestNameMap[name].srcDirectory)
+    if (loadedDevToolsExtensions.length > 0) {
       try {
-        fs.mkdirSync(path.dirname(loadedExtensionsPath))
+        fs.mkdirSync(path.dirname(loadedDevToolsExtensionsPath))
       } catch (error) {
         // Ignore error
       }
-      fs.writeFileSync(loadedExtensionsPath, JSON.stringify(loadedExtensions))
+      fs.writeFileSync(loadedDevToolsExtensionsPath, JSON.stringify(loadedDevToolsExtensions))
     } else {
-      fs.unlinkSync(loadedExtensionsPath)
+      fs.unlinkSync(loadedDevToolsExtensionsPath)
     }
   } catch (error) {
     // Ignore error
@@ -354,14 +355,13 @@ app.on('will-quit', function () {
 // We can not use protocol or BrowserWindow until app is ready.
 app.once('ready', function () {
   // Load persisted extensions.
-  loadedExtensionsPath = path.join(app.getPath('userData'), 'DevTools Extensions')
+  loadedDevToolsExtensionsPath = path.join(app.getPath('userData'), 'DevTools Extensions')
   try {
-    const loadedExtensions = JSON.parse(fs.readFileSync(loadedExtensionsPath))
-    if (Array.isArray(loadedExtensions)) {
-      for (const srcDirectory of loadedExtensions) {
+    const loadedDevToolsExtensions = JSON.parse(fs.readFileSync(loadedDevToolsExtensionsPath))
+    if (Array.isArray(loadedDevToolsExtensions)) {
+      for (const srcDirectory of loadedDevToolsExtensions) {
         // Start background pages and set content scripts.
-        const manifest = getManifestFromPath(srcDirectory)
-        loadExtension(manifest)
+        BrowserWindow.addDevToolsExtension(srcDirectory)
       }
     }
   } catch (error) {
@@ -369,7 +369,7 @@ app.once('ready', function () {
   }
 
   // The public API to add/remove extensions.
-  BrowserWindow.addDevToolsExtension = function (srcDirectory) {
+  BrowserWindow.addExtension = function (srcDirectory) {
     const manifest = getManifestFromPath(srcDirectory)
     if (manifest) {
       loadExtension(manifest)
@@ -382,7 +382,7 @@ app.once('ready', function () {
     }
   }
 
-  BrowserWindow.removeDevToolsExtension = function (name) {
+  BrowserWindow.removeExtension = function (name) {
     const manifest = manifestNameMap[name]
     if (!manifest) return
 
@@ -392,12 +392,35 @@ app.once('ready', function () {
     delete manifestNameMap[name]
   }
 
-  BrowserWindow.getDevToolsExtensions = function () {
+  BrowserWindow.getExtensions = function () {
     const extensions = {}
     Object.keys(manifestNameMap).forEach(function (name) {
       const manifest = manifestNameMap[name]
       extensions[name] = {name: manifest.name, version: manifest.version}
     })
     return extensions
+  }
+
+  BrowserWindow.addDevToolsExtension = function (srcDirectory) {
+    const manifestName = BrowserWindow.addExtension(srcDirectory)
+    if (manifestName) {
+      devToolsExtensionNames.add(manifestName)
+    }
+    return manifestName
+  }
+
+  BrowserWindow.removeDevToolsExtension = function (name) {
+    BrowserWindow.removeExtension(name)
+    devToolsExtensionNames.delete(name)
+  }
+
+  BrowserWindow.getDevToolsExtensions = function () {
+    const extensions = BrowserWindow.getExtensions()
+    const devExtensions = {}
+    Array.from(devToolsExtensionNames).forEach(function (name) {
+      if (extensions[name]) return
+      devExtensions[name] = extensions[name]
+    })
+    return devExtensions
   }
 })

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -418,7 +418,7 @@ app.once('ready', function () {
     const extensions = BrowserWindow.getExtensions()
     const devExtensions = {}
     Array.from(devToolsExtensionNames).forEach(function (name) {
-      if (extensions[name]) return
+      if (!extensions[name]) return
       devExtensions[name] = extensions[name]
     })
     return devExtensions

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1995,7 +1995,7 @@ describe('BrowserWindow module', function () {
       clearTimeout(showPanelTimeoutId)
     })
 
-    describe.only('BrowserWindow.addDevToolsExtension', function () {
+    describe('BrowserWindow.addDevToolsExtension', function () {
       beforeEach(function () {
         BrowserWindow.removeDevToolsExtension('foo')
         assert.equal(BrowserWindow.getDevToolsExtensions().hasOwnProperty('foo'), false)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1995,7 +1995,7 @@ describe('BrowserWindow module', function () {
       clearTimeout(showPanelTimeoutId)
     })
 
-    describe('BrowserWindow.addDevToolsExtension', function () {
+    describe.only('BrowserWindow.addDevToolsExtension', function () {
       beforeEach(function () {
         BrowserWindow.removeDevToolsExtension('foo')
         assert.equal(BrowserWindow.getDevToolsExtensions().hasOwnProperty('foo'), false)
@@ -2123,43 +2123,6 @@ describe('BrowserWindow module', function () {
         assert.throws(function () {
           BrowserWindow.addExtension(path.join(__dirname, 'fixtures', 'devtools-extensions', 'bad-manifest'))
         }, /Unexpected token }/)
-      })
-
-      describe('when the devtools is docked', function () {
-        it('creates the extension', function (done) {
-          w.webContents.openDevTools({mode: 'bottom'})
-
-          ipcMain.once('answer', function (event, message) {
-            assert.equal(message.runtimeId, 'foo')
-            assert.equal(message.tabId, w.webContents.id)
-            assert.equal(message.i18nString, 'foo - bar (baz)')
-            assert.deepEqual(message.storageItems, {
-              local: {
-                set: {hello: 'world', world: 'hello'},
-                remove: {world: 'hello'},
-                clear: {}
-              },
-              sync: {
-                set: {foo: 'bar', bar: 'foo'},
-                remove: {foo: 'bar'},
-                clear: {}
-              }
-            })
-            done()
-          })
-        })
-      })
-
-      describe('when the devtools is undocked', function () {
-        it('creates the extension', function (done) {
-          w.webContents.openDevTools({mode: 'undocked'})
-
-          ipcMain.once('answer', function (event, message, extensionId) {
-            assert.equal(message.runtimeId, 'foo')
-            assert.equal(message.tabId, w.webContents.id)
-            done()
-          })
-        })
       })
     })
   })


### PR DESCRIPTION
With the objective to load some Chrome extensions in an Electron app, I introduce here an API to add/remove/get extensions. It's the same mechanism than the one used in `addDevToolsExtension` except the loaded [extensions are not persisted](https://github.com/electron/electron/blob/master/lib/browser/chrome-extension.js#L331).

- [x] documentation
- [x] tests

_Related: #1498_