### PR TITLE
Fix error message of `assertWithinDelta()`

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2678,7 +2678,7 @@ const assertBoundsEqual = (actual, expect) => {
 
 const assertWithinDelta = (actual, expect, delta, label) => {
   const result = Math.abs(actual - expect)
-  assert.ok(result <= delta, `${label} value of ${expect} was not within ${delta} of ${actual}`)
+  assert.ok(result <= delta, `${label} value of ${actual} was not within ${delta} of ${expect}`)
 }
 
 // Is the display's scale factor possibly causing rounding of pixel coordinate


### PR DESCRIPTION
Is it only me, or
`"x value of 102 [actual] was not within 1 of 100 [expected]"`
actually sounds better than
`"x value of 100 [expected] was not within 1 of 102 [actual]"`?