### PR TITLE
:memo: mixed devtools behavior with mixed sandbox

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -919,6 +919,9 @@ Enables mixed sandbox mode on the app.
 
 This method can only be called before app is ready.
 
+**Note:** The devtools will no longer open after mixed sandbox mode has been
+enabled (i.e `openDevTools` becomes a no-op).
+
 ### `app.dock.bounce([type])` _macOS_
 
 * `type` String (optional) - Can be `critical` or `informational`. The default is


### PR DESCRIPTION
Just noticed today that in 1.7.4, enabling mixed sandbox mode makes `openDevTools` become a no-op.

  * If it's expected behavior - that's cool! Here's a PR ready to merge to document it.
  * If it's not - I'll happily close this & open an issue instead

🌟 

*edit: my commit summary is snafu, I need more ☕️*