### PR TITLE
Add known issue to MAS submission guide

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -215,6 +215,15 @@ more details.
 See the [Enabling User-Selected File Access documentation][user-selected] for
 more details.
 
+## Known issues
+
+#### `shell.openItem(filePath)` #9005
+
+This will fail when the app is signed for distribution in the Mac App Store.
+
+##### Workaround
+`shell.openExternal('file://' + filePath)` will open the file in the default application (as long as the extension is associated with an app).
+
 ## Cryptographic Algorithms Used by Electron
 
 Depending on the country and region you are located, Mac App Store may require

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -217,12 +217,14 @@ more details.
 
 ## Known issues
 
-#### `shell.openItem(filePath)` #9005
+### `shell.openItem(filePath)` 
 
 This will fail when the app is signed for distribution in the Mac App Store.
+Subscribe to [#9005](https://github.com/electron/electron/issues/9005) for updates.
 
-##### Workaround
-`shell.openExternal('file://' + filePath)` will open the file in the default application (as long as the extension is associated with an app).
+#### Workaround
+
+`shell.openExternal('file://' + filePath)` will open the file in the default application as long as the extension is associated with an installed app.
 
 ## Cryptographic Algorithms Used by Electron
 


### PR DESCRIPTION
Gives users a better heads-up of their app being rejected due to the sandbox restriction around `shell.openItem()`. #9005 