### PR TITLE
Fix mixed content errors when loading content from `chrome-extension`

### DIFF
--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -89,6 +89,22 @@ void RendererClientBase::RenderThreadStarted() {
   blink::WebCustomElement::AddEmbedderCustomElementName("webview");
   blink::WebCustomElement::AddEmbedderCustomElementName("browserplugin");
 
+  WTF::String extension_scheme("chrome-extension");
+  // Extension resources are HTTP-like and safe to expose to the fetch API. The
+  // rules for the fetch API are consistent with XHR.
+  blink::SchemeRegistry::RegisterURLSchemeAsSupportingFetchAPI(
+      extension_scheme);
+  // Extension resources, when loaded as the top-level document, should bypass
+  // Blink's strict first-party origin checks.
+  blink::SchemeRegistry::RegisterURLSchemeAsFirstPartyWhenTopLevel(
+      extension_scheme);
+  // In Chrome we should set extension's origins to match the pages they can
+  // work on, but in Electron currently we just let extensions do anything.
+  blink::SchemeRegistry::RegisterURLSchemeAsSecure(extension_scheme);
+  blink::SchemeRegistry::RegisterURLSchemeAsCORSEnabled(extension_scheme);
+  blink::SchemeRegistry::RegisterURLSchemeAsBypassingContentSecurityPolicy(
+      extension_scheme);
+
   // Parse --secure-schemes=scheme1,scheme2
   std::vector<std::string> secure_schemes_list =
       ParseSchemesCLISwitch(switches::kSecureSchemes);

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -1,5 +1,7 @@
-const {ipcRenderer} = require('electron')
+const {ipcRenderer, webFrame} = require('electron')
 const {runInThisContext} = require('vm')
+
+webFrame.registerURLSchemeAsPrivileged('chrome-extension')
 
 // Check whether pattern matches.
 // https://developer.chrome.com/extensions/match_patterns

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -1,7 +1,5 @@
-const {ipcRenderer, webFrame} = require('electron')
+const {ipcRenderer} = require('electron')
 const {runInThisContext} = require('vm')
-
-webFrame.registerURLSchemeAsPrivileged('chrome-extension')
 
 // Check whether pattern matches.
 // https://developer.chrome.com/extensions/match_patterns


### PR DESCRIPTION
Loading content from `chrome-extension` is considered as mixed-content.

<img width="775" alt="screenshot 2017-07-07 02 24 23" src="https://user-images.githubusercontent.com/687961/27938055-c2c3b9cc-62bb-11e7-8e34-f6bc6f57c5c9.png">
