### PR TITLE
Fix page's URL used to test against content_scripts[].matches

### DIFF
--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -6,7 +6,7 @@ const {runInThisContext} = require('vm')
 const matchesPattern = function (pattern) {
   if (pattern === '<all_urls>') return true
   const regexp = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$')
-  const url = location.protocol + '//' + location.host + location.pathname
+  const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }
 

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -5,9 +5,9 @@ const {runInThisContext} = require('vm')
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern) {
   if (pattern === '<all_urls>') return true
-
   const regexp = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$')
-  return location.href.match(regexp)
+  const url = location.protocol + '//' + location.host + location.pathname
+  return url.match(regexp)
 }
 
 // Run the code with chrome API integrated.


### PR DESCRIPTION
`content_scripts[].matches` are tested against page URL without fragment part.