### PR TITLE
Fix #8768: Show() on already open modal

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -374,7 +374,8 @@ bool NativeWindowViews::IsFocused() {
 }
 
 void NativeWindowViews::Show() {
-  if (is_modal() && NativeWindow::parent())
+  if (is_modal() && NativeWindow::parent() &&
+      !window_->native_widget_private()->IsVisible())
     static_cast<NativeWindowViews*>(NativeWindow::parent())->SetEnabled(false);
 
   window_->native_widget_private()->ShowWithWindowState(GetRestoredState());


### PR DESCRIPTION
Calling show() on an already open modal causes the parent to become unusable

Because SetEnabled tracks number of calls and re-enables the window only when counter is back to 0,
Calling Show() on already visible window would prevent the modal lock to be released when modal is closed. This PR fixes it, by calling SetEnabled only when window is invisible. Preventing duplicate calls to SetEnabled.