### PR TITLE
Inherit webPreferences in windows opened via sandbox or nativeWindowOpen

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -102,14 +102,18 @@ Window::Window(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,
 #endif
 
   if (options.Get("webContents", &web_contents)) {
-    // Set webPreferences from options if using existing webContents
+    // Set webPreferences from options if using an existing webContents.
+    // These preferences will be used when the webContent launches new
+    // render processes.
     auto* existing_preferences =
         WebContentsPreferences::FromWebContents(web_contents->web_contents());
     base::DictionaryValue web_preferences_dict;
-    mate::ConvertFromV8(isolate, web_preferences.GetHandle(),
-                        &web_preferences_dict);
-    existing_preferences->web_preferences()->Clear();
-    existing_preferences->Merge(web_preferences_dict);
+    if (mate::ConvertFromV8(isolate, web_preferences.GetHandle(),
+                        &web_preferences_dict)) {
+      existing_preferences->web_preferences()->Clear();
+      existing_preferences->Merge(web_preferences_dict);
+    }
+
   } else {
     // Creates the WebContents used by BrowserWindow.
     web_contents = WebContents::Create(isolate, web_preferences);

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -38,6 +38,7 @@
 #include "content/public/browser/resource_dispatcher_host.h"
 #include "content/public/browser/site_instance.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/common/content_switches.h"
 #include "content/public/common/url_constants.h"
 #include "content/public/common/web_preferences.h"
 #include "net/ssl/ssl_cert_request_info.h"
@@ -241,8 +242,9 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
 void AtomBrowserClient::AppendExtraCommandLineSwitches(
     base::CommandLine* command_line,
     int process_id) {
-  std::string process_type = command_line->GetSwitchValueASCII("type");
-  if (process_type != "renderer")
+  std::string process_type =
+      command_line->GetSwitchValueASCII(::switches::kProcessType);
+  if (process_type != ::switches::kRendererProcess)
     return;
 
   // Copy following switches to child process.

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -79,9 +79,10 @@ AtomBrowserClient::~AtomBrowserClient() {
 
 content::WebContents* AtomBrowserClient::GetWebContentsFromProcessID(
     int process_id) {
-  // If the process is a pending process, we should use the old one.
+  // If the process is a pending process, we should use the web contents
+  // for the frame host passed into OverrideSiteInstanceForNavigation.
   if (base::ContainsKey(pending_processes_, process_id))
-    process_id = pending_processes_[process_id];
+    return pending_processes_[process_id];
 
   // Certain render process will be created with no associated render view,
   // for example: ServiceWorker.
@@ -231,12 +232,12 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(&Noop, base::RetainedRef(site_instance)));
 
-  // Remember the original renderer process of the pending renderer process.
-  auto current_process = current_instance->GetProcess();
+  // Remember the original web contents for the pending renderer process.
   auto pending_process = (*new_instance)->GetProcess();
-  pending_processes_[pending_process->GetID()] = current_process->GetID();
+  pending_processes_[pending_process->GetID()] =
+      content::WebContents::FromRenderFrameHost(render_frame_host);;
   // Clear the entry in map when process ends.
-  current_process->AddObserver(this);
+  pending_process->AddObserver(this);
 }
 
 void AtomBrowserClient::AppendExtraCommandLineSwitches(
@@ -277,11 +278,9 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
   }
 
   content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);
-  if (!web_contents)
-    return;
-
-  WebContentsPreferences::AppendExtraCommandLineSwitches(
-      web_contents, command_line);
+  if (web_contents)
+    WebContentsPreferences::AppendExtraCommandLineSwitches(
+        web_contents, command_line);
 }
 
 void AtomBrowserClient::DidCreatePpapiPlugin(
@@ -421,12 +420,7 @@ void AtomBrowserClient::WebNotificationAllowed(
 void AtomBrowserClient::RenderProcessHostDestroyed(
     content::RenderProcessHost* host) {
   int process_id = host->GetID();
-  for (const auto& entry : pending_processes_) {
-    if (entry.first == process_id || entry.second == process_id) {
-      pending_processes_.erase(entry.first);
-      break;
-    }
-  }
+  pending_processes_.erase(process_id);
   RemoveProcessPreferences(process_id);
 }
 

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -130,8 +130,8 @@ class AtomBrowserClient : public brightray::BrowserClient,
   bool RendererUsesNativeWindowOpen(int process_id);
   bool RendererDisablesPopups(int process_id);
 
-  // pending_render_process => current_render_process.
-  std::map<int, int> pending_processes_;
+  // pending_render_process => web contents.
+  std::map<int, content::WebContents*> pending_processes_;
 
   std::map<int, ProcessPreferences> process_preferences_;
   std::map<int, base::ProcessId> render_process_host_pids_;

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -80,19 +80,8 @@ const setupGuest = function (embedder, frameName, guest, options) {
     embedder.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + guestId)
     embedder.removeListener('render-view-deleted', closedByEmbedder)
   }
-  if (!options.webPreferences.sandbox) {
-    // These events should only be handled when the guest window is opened by a
-    // non-sandboxed renderer for two reasons:
-    //
-    // - `render-view-deleted` is emitted when the popup is closed by the user,
-    //   and that will eventually result in NativeWindow::NotifyWindowClosed
-    //   using a dangling pointer since `destroy()` would have been called by
-    //   `closeByEmbedded`
-    // - No need to emit `ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_` since
-    //   there's no renderer code listening to it.,
-    embedder.once('render-view-deleted', closedByEmbedder)
-    guest.once('closed', closedByUser)
-  }
+  embedder.once('render-view-deleted', closedByEmbedder)
+  guest.once('closed', closedByUser)
   if (frameName) {
     frameToGuest.set(frameName, guest)
     guest.frameName = frameName

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -13,6 +13,7 @@ const inheritedWebPreferences = new Map([
   ['javascript', false],
   ['nativeWindowOpen', true],
   ['nodeIntegration', false],
+  ['sandbox', true],
   ['webviewTag', false]
 ])
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -11,6 +11,7 @@ const frameToGuest = new Map()
 const inheritedWebPreferences = new Map([
   ['contextIsolation', true],
   ['javascript', false],
+  ['nativeWindowOpen', true],
   ['nodeIntegration', false],
   ['webviewTag', false]
 ])

--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -127,6 +127,10 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNative
         return null
       }
     }
+
+    if (openerId != null) {
+      window.opener = getOrCreateProxy(ipcRenderer, openerId)
+    }
   }
 
   window.alert = function (message, title) {
@@ -140,10 +144,6 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNative
   // But we do not support prompt().
   window.prompt = function () {
     throw new Error('prompt() is and will not be supported.')
-  }
-
-  if (openerId != null) {
-    window.opener = getOrCreateProxy(ipcRenderer, openerId)
   }
 
   ipcRenderer.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId, message, sourceOrigin) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1066,6 +1066,26 @@ describe('BrowserWindow module', function () {
         })
       })
 
+      it('should open windows with the options configured via new-window event listeners', function (done) {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true
+          }
+        })
+
+        const preloadPath = path.join(fixtures, 'api', 'new-window-preload.js')
+        ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preloadPath)
+        ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'sandbox', true)
+        ipcMain.once('answer', (event, args) => {
+          assert.ok(args.includes('--enable-sandbox'))
+          assert.ok(args.includes(`--preload=${path.join(fixtures, 'api', 'new-window-preload.js')}`))
+          done()
+        })
+        w.loadURL(`file://${path.join(fixtures, 'api', 'new-window.html')}`)
+      })
+
       it('should set ipc event sender correctly', function (done) {
         w.destroy()
         w = new BrowserWindow({

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1097,7 +1097,6 @@ describe('BrowserWindow module', function () {
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preloadPath)
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'foo', 'bar')
         ipcMain.once('answer', (event, args, webPreferences) => {
-          assert.equal(args.includes('--enable-sandbox'), true)
           assert.equal(webPreferences.foo, 'bar')
           done()
         })
@@ -1363,6 +1362,43 @@ describe('BrowserWindow module', function () {
           w.reload()
         })
         w.loadURL('file://' + path.join(fixtures, 'api', 'native-window-open-native-addon.html'))
+      })
+
+      it('should inherit the nativeWindowOpen setting in opened windows', function (done) {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nativeWindowOpen: true
+          }
+        })
+
+        const preloadPath = path.join(fixtures, 'api', 'new-window-preload.js')
+        ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preloadPath)
+        ipcMain.once('answer', (event, args) => {
+          assert.equal(args.includes('--native-window-open'), true)
+          done()
+        })
+        w.loadURL(`file://${path.join(fixtures, 'api', 'new-window.html')}`)
+      })
+
+      it('should open windows with the options configured via new-window event listeners', function (done) {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nativeWindowOpen: true
+          }
+        })
+
+        const preloadPath = path.join(fixtures, 'api', 'new-window-preload.js')
+        ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preloadPath)
+        ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'foo', 'bar')
+        ipcMain.once('answer', (event, args, webPreferences) => {
+          assert.equal(webPreferences.foo, 'bar')
+          done()
+        })
+        w.loadURL(`file://${path.join(fixtures, 'api', 'new-window.html')}`)
       })
     })
   })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1005,6 +1005,7 @@ describe('BrowserWindow module', function () {
             preload: preload
           }
         })
+        ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
         let htmlPath = path.join(fixtures, 'api', 'sandbox.html?window-open')
         const pageUrl = 'file://' + htmlPath
         w.loadURL(pageUrl)
@@ -1035,6 +1036,7 @@ describe('BrowserWindow module', function () {
             preload: preload
           }
         })
+        ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
         let htmlPath = path.join(fixtures, 'api', 'sandbox.html?window-open-external')
         const pageUrl = 'file://' + htmlPath
         let popupWindow

--- a/spec/fixtures/api/new-window-preload.js
+++ b/spec/fixtures/api/new-window-preload.js
@@ -1,4 +1,4 @@
-const {ipcRenderer} = require('electron')
+const {ipcRenderer, remote} = require('electron')
 
-ipcRenderer.send('answer', process.argv)
+ipcRenderer.send('answer', process.argv, remote.getCurrentWindow().webContents.getWebPreferences())
 window.close()

--- a/spec/fixtures/api/new-window-preload.js
+++ b/spec/fixtures/api/new-window-preload.js
@@ -1,0 +1,4 @@
+const {ipcRenderer} = require('electron')
+
+ipcRenderer.send('answer', process.argv)
+window.close()

--- a/spec/fixtures/api/new-window.html
+++ b/spec/fixtures/api/new-window.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    <script type="text/javascript">
+      setTimeout(function () {
+        window.open('http://localhost')
+      })
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/api/window-open-location-change.html
+++ b/spec/fixtures/api/window-open-location-change.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    foo
+    <script type="text/javascript">
+      setTimeout(function () {
+        window.location = 'bar://page'
+      })
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/api/window-open-location-final.html
+++ b/spec/fixtures/api/window-open-location-final.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    bar
+  </body>
+</html>

--- a/spec/fixtures/api/window-open-location-open.html
+++ b/spec/fixtures/api/window-open-location-open.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    <script>
+      window.open('foo://page')
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/api/window-open-preload.js
+++ b/spec/fixtures/api/window-open-preload.js
@@ -1,0 +1,8 @@
+const {ipcRenderer} = require('electron')
+
+setImmediate(function () {
+  if (window.location.toString() === 'bar://page') {
+    ipcRenderer.send('answer', process.argv, typeof global.process)
+    window.close()
+  }
+})

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -264,6 +264,14 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
   webContents.fromId(id).once('new-window', event => event.preventDefault())
 })
 
+ipcMain.on('set-web-preferences-on-next-new-window', (event, id, key, value) => {
+  webContents.fromId(id).once('new-window', (event, url, frameName, disposition, options) => {
+    options.webPreferences[key] = value
+
+    console.log('her?', options.webPreferences)
+  })
+})
+
 ipcMain.on('prevent-next-will-attach-webview', (event) => {
   event.sender.once('will-attach-webview', event => event.preventDefault())
 })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -267,8 +267,6 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
 ipcMain.on('set-web-preferences-on-next-new-window', (event, id, key, value) => {
   webContents.fromId(id).once('new-window', (event, url, frameName, disposition, options) => {
     options.webPreferences[key] = value
-
-    console.log('her?', options.webPreferences)
   })
 })
 


### PR DESCRIPTION
Previously both `nativeWindowOpen` and `sandbox` options did not support overriding `webPreferences` via `new-window` events. The preferences from the opener window were used instead when launching render processes for the new windows.

This pull request changes this behavior to set configured `webPreferences` when creating new windows with an existing `webContents`. These preferences are then used when the render process is launched for the `webContents` (if applicable).

- [x] Reset `webContents` web preferences with the configured options when creating a new window with an existing contents.
- [x] Track pending render process launches via `RenderFrameHost` instead of `RenderProcessHost` so that lookup via `WebContents` can be done later on.
- [x] Register `sandbox` as an inherited option in `guest-window-manager.js` so windows opened from sandboxed windows have it enabled by default.
- [x] Register `nativeWindowOpen` as an inherited option in `guest-window-manager.js` so windows opened from native window open windows have it enabled by default.
- [x] Add specs for inherited options behavior
- [x] Add specs `new-window` option overriding for `sandbox`/`nativeWindowOpen` windows.
- [x] Add spec for reload bug from #9928 

Refs #9961 
Closes #9928 