### PR TITLE
check for secrets before git push and npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "devDependencies": {
     "asar": "^0.11.0",
     "browserify": "^13.1.0",
+    "check-for-leaks": "^1.0.2",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.3",
     "electron-typescript-definitions": "^1.2.7",
+    "husky": "^0.14.3",
     "request": "^2.68.0",
     "standard": "^8.4.0",
     "standard-markdown": "^4.0.0"
@@ -41,6 +43,8 @@
     "create-api-json": "electron-docs-linter docs --outfile=out/electron-api.json --version=$npm_package_version",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=out/electron-api.json --out=out/electron.d.ts",
     "preinstall": "node -e 'process.exit(0)'",
+    "prepack": "check-for-leaks",
+    "prepush": "check-for-leaks",
     "release": "./script/upload.py -p",
     "repl": "python ./script/start.py --interactive",
     "start": "python ./script/start.py",


### PR DESCRIPTION
This PR adds some lifecycle scripts to prevent `.env` and `.npmrc` files from being inadvertently pushed to GitHub or published to npm. If a user tries to `git push` or `npm publish` when these secret files exist but are not gitignored and npmignored, warnings are displayed and the process exits:

```
warning: .env is not in your .gitignore file
```

This is using the [husky](http://ghub.io/husky) module to set up the `prepush` git hook (without replacing any existing hooks). If this proves to be cumbersome or problematic, we can remove the husky git hook and only apply the check to npm operations.