### PR TITLE
Surface require errors via answer IPC message

### DIFF
--- a/spec/fixtures/api/native-window-open-native-addon.html
+++ b/spec/fixtures/api/native-window-open-native-addon.html
@@ -2,8 +2,21 @@
 <body>
 <script type="text/javascript" charset="utf-8">
   const {ipcRenderer} = require('electron')
-  const runas = require('runas')
-  ipcRenderer.send('answer', typeof runas)
+
+  let runas
+  let requireError
+
+  try {
+    runas = require('runas')
+  } catch (error) {
+    requireError = error
+  }
+
+  if (requireError != null) {
+    ipcRenderer.send('answer', `Require runas failed: ${requireError.message}`)
+  } else {
+    ipcRenderer.send('answer', typeof runas)
+  }
 </script>
 </body>
 </html>


### PR DESCRIPTION
If `require('runas')` failed because the module was compiled using the wrong module version the the

> BrowserWindow module "webPreferences" option nativeWindowOpen option loads native addons correctly after reload

spec would timeout since the `answer` message would never get sent.

This pull request updates it to send the error message so it will fail with something like:

> AssertionError: 'The module \'/Users/kevin/github/electron/spec/node_modules/runas/build/Release/runas.node\'\nwas compiled against a different  == 'function'

This will then make it easier to know that you should re-run  `npm test` with `--rebuild_native_modules` so the modules get re-built.

Noticed this while switching between master and #9946 