### PR TITLE
Upgrade to node 8.2.1

### DIFF
--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -27,9 +27,9 @@ void NodeDebugger::Start() {
   node::DebugOptions options;
   for (auto& arg : base::CommandLine::ForCurrentProcess()->argv()) {
 #if defined(OS_WIN)
-    options.ParseOption(base::UTF16ToUTF8(arg));
+    options.ParseOption("Electron", base::UTF16ToUTF8(arg));
 #else
-    options.ParseOption(arg);
+    options.ParseOption("Electron", arg);
 #endif
   }
 

--- a/atom/common/api/event_emitter_caller.cc
+++ b/atom/common/api/event_emitter_caller.cc
@@ -20,7 +20,8 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                    v8::MicrotasksScope::kRunMicrotasks);
   // Use node::MakeCallback to call the callback, and it will also run pending
   // tasks in Node.js.
-  return node::MakeCallback(isolate, obj, method, args->size(), &args->front());
+  return node::MakeCallback(isolate, obj, method, args->size(), &args->front(),
+                            0, 0).ToLocalChecked();
 }
 
 }  // namespace internal

--- a/common.gypi
+++ b/common.gypi
@@ -43,7 +43,7 @@
     'V8_BASE': '',
     'v8_postmortem_support': 'false',
     'v8_enable_i18n_support': 'false',
-    'v8_inspector': 'true',
+    'v8_enable_inspector': '1',
   },
   # Settings to compile node under Windows.
   'target_defaults': {

--- a/electron.gyp
+++ b/electron.gyp
@@ -233,6 +233,7 @@
         # We need to access internal implementations of Node.
         'NODE_WANT_INTERNALS=1',
         'NODE_SHARED_MODE',
+        'HAVE_OPENSSL=1',
         'HAVE_INSPECTOR=1',
         # This is defined in skia/skia_common.gypi.
         'SK_SUPPORT_LEGACY_GETTOPDEVICE',

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -144,7 +144,7 @@ describe('node feature', function () {
         child.stderr.on('data', function (data) {
           output += data
 
-          if (output.trim().startsWith('Debugger listening on port')) {
+          if (output.trim().startsWith('Debugger listening on ws://')) {
             done()
           }
         })


### PR DESCRIPTION
Pull request to upgrade the chrome 59 pull request to Node 8.2.1 (from 7.9).

Node patches applied against 8.2.1 via https://github.com/electron/node/pull/23

Fixes #9970 