### PR TITLE
Add app.disableDomainBlockingFor3DAPIs()

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -35,6 +35,7 @@
 #include "chrome/browser/icon_manager.h"
 #include "chrome/common/chrome_paths.h"
 #include "content/browser/gpu/compositor_util.h"
+#include "content/browser/gpu/gpu_data_manager_impl.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/browser/browser_child_process_host.h"
 #include "content/public/browser/child_process_data.h"
@@ -852,6 +853,17 @@ void App::DisableHardwareAcceleration(mate::Arguments* args) {
   content::GpuDataManager::GetInstance()->DisableHardwareAcceleration();
 }
 
+void App::DisableDomainBlockingFor3DAPIs(mate::Arguments* args) {
+  if (Browser::Get()->is_ready()) {
+    args->ThrowError(
+        "app.disableDomainBlockingFor3DAPIs() can only be called "
+        "before app is ready");
+    return;
+  }
+  content::GpuDataManagerImpl::GetInstance()
+      ->DisableDomainBlockingFor3DAPIsForTesting();
+}
+
 bool App::IsAccessibilitySupportEnabled() {
   auto ax_state = content::BrowserAccessibilityState::GetInstance();
   return ax_state->IsAccessibleBrowser();
@@ -1131,6 +1143,8 @@ void App::BuildPrototype(
                  &App::IsAccessibilitySupportEnabled)
       .SetMethod("disableHardwareAcceleration",
                  &App::DisableHardwareAcceleration)
+      .SetMethod("disableDomainBlockingFor3DAPIs",
+                 &App::DisableDomainBlockingFor3DAPIs)
       .SetMethod("getFileIcon", &App::GetFileIcon)
       .SetMethod("getAppMetrics", &App::GetAppMetrics)
       .SetMethod("getGPUFeatureStatus", &App::GetGPUFeatureStatus)

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -169,6 +169,7 @@ class App : public AtomBrowserClient::Delegate,
   void ReleaseSingleInstance();
   bool Relaunch(mate::Arguments* args);
   void DisableHardwareAcceleration(mate::Arguments* args);
+  void DisableDomainBlockingFor3DAPIs(mate::Arguments* args);
   bool IsAccessibilitySupportEnabled();
   Browser::LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
 #if defined(USE_NSS_CERTS)

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -772,6 +772,14 @@ Disables hardware acceleration for current app.
 
 This method can only be called before app is ready.
 
+### `app.disableDomainBlockingFor3DAPIs()`
+
+By default, Chromium disables 3D APIs (e.g. WebGL) until restart on a per
+domain basis if the GPU processes crashes too frequently. This function
+disables that behaviour.
+
+This method can only be called before app is ready.
+
 ### `app.getAppMemoryInfo()` _Deprecated_
 
 Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -647,4 +647,12 @@ describe('app module', function () {
       })
     })
   })
+
+  describe('disableDomainBlockingFor3DAPIs() API', function () {
+    it('throws when called after app is ready', function () {
+      assert.throws(function () {
+        app.disableDomainBlockingFor3DAPIs()
+      }, /before app is ready/)
+    })
+  })
 })


### PR DESCRIPTION
By default, Chromium disables 3D APIs (e.g. WebGL) until restart on a
per domain basis if the GPU processes crashes too frequently. This
function disables that behaviour.