### PR TITLE
Add app.setDisplayNotifications method

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -31,6 +31,7 @@
 #include "base/strings/string_util.h"
 #include "base/sys_info.h"
 #include "brightray/browser/brightray_paths.h"
+#include "brightray/browser/platform_notification_service.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/common/chrome_paths.h"
@@ -1077,6 +1078,13 @@ mate::Handle<App> App::Create(v8::Isolate* isolate) {
   return mate::CreateHandle(isolate, new App(isolate));
 }
 
+void App::SetDisplayNotifications(bool display) {
+  brightray::PlatformNotificationService* platform =
+    static_cast<brightray::PlatformNotificationService*>(
+      AtomBrowserClient::Get()->GetPlatformNotificationService());
+  platform->SetDisplayNotifications(display);
+}
+
 // static
 void App::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
@@ -1150,7 +1158,8 @@ void App::BuildPrototype(
       .SetMethod("getGPUFeatureStatus", &App::GetGPUFeatureStatus)
       .SetMethod("enableMixedSandbox", &App::EnableMixedSandbox)
       // TODO(juturu): Remove in 2.0, deprecate before then with warnings
-      .SetMethod("getAppMemoryInfo", &App::GetAppMetrics);
+      .SetMethod("getAppMemoryInfo", &App::GetAppMetrics)
+      .SetMethod("setDisplayNotifications", &App::SetDisplayNotifications);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -151,6 +151,8 @@ class App : public AtomBrowserClient::Delegate,
   void BrowserChildProcessKilled(
       const content::ChildProcessData& data, int exit_code) override;
 
+  void SetDisplayNotifications(bool display);
+
  private:
   void SetAppPath(const base::FilePath& app_path);
   void ChildProcessLaunched(int process_type, base::ProcessHandle handle);

--- a/brightray/browser/platform_notification_service.cc
+++ b/brightray/browser/platform_notification_service.cc
@@ -49,7 +49,8 @@ void OnWebNotificationAllowed(base::WeakPtr<Notification> notification,
 PlatformNotificationService::PlatformNotificationService(
     BrowserClient* browser_client)
     : browser_client_(browser_client),
-      render_process_id_(-1) {
+      render_process_id_(-1),
+      display_(true) {
 }
 
 PlatformNotificationService::~PlatformNotificationService() {}
@@ -80,7 +81,7 @@ void PlatformNotificationService::DisplayNotification(
     std::unique_ptr<content::DesktopNotificationDelegate> delegate,
     base::Closure* cancel_callback) {
   auto presenter = browser_client_->GetNotificationPresenter();
-  if (!presenter)
+  if (!presenter || !display_)
     return;
   std::unique_ptr<NotificationDelegateAdapter> adapter(
       new NotificationDelegateAdapter(std::move(delegate)));
@@ -113,6 +114,10 @@ bool PlatformNotificationService::GetDisplayedNotifications(
     content::BrowserContext* browser_context,
     std::set<std::string>* displayed_notifications) {
   return false;
+}
+
+void PlatformNotificationService::SetDisplayNotifications(bool display) {
+    display_ = display;
 }
 
 }  // namespace brightray

--- a/brightray/browser/platform_notification_service.h
+++ b/brightray/browser/platform_notification_service.h
@@ -21,6 +21,8 @@ class PlatformNotificationService
   explicit PlatformNotificationService(BrowserClient* browser_client);
   ~PlatformNotificationService() override;
 
+  void SetDisplayNotifications(bool display);
+
  protected:
   // content::PlatformNotificationService:
   blink::mojom::PermissionStatus CheckPermissionOnUIThread(
@@ -55,6 +57,7 @@ class PlatformNotificationService
  private:
   BrowserClient* browser_client_;
   int render_process_id_;
+  bool display_;
 
   DISALLOW_COPY_AND_ASSIGN(PlatformNotificationService);
 };

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -927,6 +927,12 @@ Enables mixed sandbox mode on the app.
 
 This method can only be called before app is ready.
 
+### `app.setDisplayNotifications(display)`
+
+* `display` Boolean
+
+Sets whether to display incoming notifications.
+
 ### `app.dock.bounce([type])` _macOS_
 
 * `type` String (optional) - Can be `critical` or `informational`. The default is


### PR DESCRIPTION
This PR adds a `setDisplayNotifications` method to the `app` object.

This allows to add a quick option for Electron apps to disable and enable displaying notifications, sort of like a more fine grained Do not disturb mode.