### PR TITLE
Revert #9934

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -34,7 +34,7 @@
 
 namespace {
 
-const auto kRunAsNode = "ELECTRON_RUN_AS_NODE";
+const char* kRunAsNode = "ELECTRON_RUN_AS_NODE";
 
 bool IsEnvSet(const char* name) {
 #if defined(OS_WIN)
@@ -55,30 +55,6 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   wchar_t** wargv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
 
   bool run_as_node = IsEnvSet(kRunAsNode);
-
-#ifdef _DEBUG
-  // Don't display assert dialog boxes in CI test runs
-  static const auto kCI = "ELECTRON_CI";
-  bool is_ci = IsEnvSet(kCI);
-  if (!is_ci) {
-    for (int i = 0; i < argc; ++i) {
-      if (!_wcsicmp(wargv[i], L"--ci")) {
-        is_ci = true;
-        _putenv_s(kCI, "1");  // set flag for child processes
-        break;
-      }
-    }
-  }
-  if (is_ci) {
-    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
-
-    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
-
-    _set_error_mode(_OUT_TO_STDERR);
-  }
-#endif
 
   // Make sure the output is printed to console.
   if (run_as_node || !IsEnvSet("ELECTRON_NO_ATTACH_CONSOLE"))

--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -92,6 +92,8 @@
       'Common_Base': {
         'abstract': 1,
         'defines': [
+          # We are using Release version libchromiumcontent:
+          'NDEBUG',
           # Needed by gin:
           'V8_USE_EXTERNAL_STARTUP_DATA',
           # From skia_for_chromium_defines.gypi:
@@ -187,7 +189,6 @@
           # Use this instead of "NDEBUG" to determine whether we are in
           # Debug build, because "NDEBUG" is already used by Chromium.
           'DEBUG',
-          '_DEBUG',
           # Require when using libchromiumcontent.
           'COMPONENT_BUILD',
           'GURL_DLL',
@@ -197,32 +198,15 @@
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': '3',  # /MDd (debug DLL)
+            'RuntimeLibrary': '2',  # /MD (nondebug DLL)
             'Optimization': '0',  # 0 = /Od
             # See http://msdn.microsoft.com/en-us/library/8wtf2dfz(VS.71).aspx
             'BasicRuntimeChecks': '3',  # 3 = all checks enabled, 0 = off
           },
-          'VCLinkerTool': {
-            'OptimizeReferences': 2, # /OPT:REF 
-            'EnableCOMDATFolding': 2, # /OPT:ICF
-          },
         },
-        'conditions': [
-          ['OS=="linux"', {
-            'defines': [
-              '_GLIBCXX_DEBUG',
-            ],
-            'cflags': [
-              '-g',
-            ],
-          }],  # OS=="linux"
-        ],
       },  # Debug_Base
       'Release_Base': {
         'abstract': 1,
-        'defines': [
-          'NDEBUG',
-        ],
         'msvs_settings': {
           'VCCLCompilerTool': {
             'RuntimeLibrary': '2',  # /MD (nondebug DLL)


### PR DESCRIPTION
Reverts https://github.com/electron/electron/pull/9934, seems to be causing build failures on CI.

```
ok 192 BrowserWindow module offscreen rendering creates offscreen window with correct size
abort() has been calledTraceback (most recent call last):
```

/cc @alespergl 