### PR TITLE
fix typo in macOS debugging doc

### DIFF
--- a/docs/development/debugging-instructions-macos.md
+++ b/docs/development/debugging-instructions-macos.md
@@ -88,7 +88,7 @@ which will show you that the app is currently setting the name to "Electron".
 ```
 
 To do a source level single step in the currently selected thread, execute `step` (or `s`).
-This would take you into into `name_override_.empty()`. To proceed and do a step over,
+This would take you into `name_override_.empty()`. To proceed and do a step over,
 run `next` (or `n`).
 
 ```bash


### PR DESCRIPTION
Reported by @Toinane 

https://crowdin.com/translate/electron/19/en-fr#q=739x