### PR TITLE
Mark nativeWindowOpen as experimental

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -339,7 +339,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       'Electron Isolated Context' entry in the combo box at the top of the
       Console tab. **Note:** This option is currently experimental and may
       change or be removed in future Electron releases.
-    * `nativeWindowOpen` Boolean (optional) - Whether to use native `window.open()`. Defaults to `false`.
+    * `nativeWindowOpen` Boolean (optional) - Whether to use native
+      `window.open()`. Defaults to `false`.  **Note:** This option is currently
+      experimental.
     * `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
       Defaults to the value of the `nodeIntegration` option. **Note:** The
       `preload` script configured for the `<webview>` will have node integration


### PR DESCRIPTION
This API was introduced in 1.7.x which is still in beta.

This pull request marks it as still experimental motivated by #9928 and #9961 

Refs #8963