### PR TITLE
Debug mode (take 2)

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -216,7 +216,7 @@ void AtomSandboxedRendererClient::InvokeIpcCallback(
   auto callback_value = binding->Get(callback_key);
   DCHECK(callback_value->IsFunction());  // set by sandboxed_renderer/init.js
   auto callback = v8::Handle<v8::Function>::Cast(callback_value);
-  ignore_result(callback->Call(context, binding, args.size(), &args[0]));
+  ignore_result(callback->Call(context, binding, args.size(), args.data()));
 }
 
 }  // namespace atom

--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -92,8 +92,6 @@
       'Common_Base': {
         'abstract': 1,
         'defines': [
-          # We are using Release version libchromiumcontent:
-          'NDEBUG',
           # Needed by gin:
           'V8_USE_EXTERNAL_STARTUP_DATA',
           # From skia_for_chromium_defines.gypi:
@@ -189,6 +187,7 @@
           # Use this instead of "NDEBUG" to determine whether we are in
           # Debug build, because "NDEBUG" is already used by Chromium.
           'DEBUG',
+          '_DEBUG',
           # Require when using libchromiumcontent.
           'COMPONENT_BUILD',
           'GURL_DLL',
@@ -198,15 +197,32 @@
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': '2',  # /MD (nondebug DLL)
+            'RuntimeLibrary': '3',  # /MDd (debug DLL)
             'Optimization': '0',  # 0 = /Od
             # See http://msdn.microsoft.com/en-us/library/8wtf2dfz(VS.71).aspx
             'BasicRuntimeChecks': '3',  # 3 = all checks enabled, 0 = off
           },
+          'VCLinkerTool': {
+            'OptimizeReferences': 2, # /OPT:REF 
+            'EnableCOMDATFolding': 2, # /OPT:ICF
+          },
         },
+        'conditions': [
+          ['OS=="linux"', {
+            'defines': [
+              '_GLIBCXX_DEBUG',
+            ],
+            'cflags': [
+              '-g',
+            ],
+          }],  # OS=="linux"
+        ],
       },  # Debug_Base
       'Release_Base': {
         'abstract': 1,
+        'defines': [
+          'NDEBUG',
+        ],
         'msvs_settings': {
           'VCCLCompilerTool': {
             'RuntimeLibrary': '2',  # /MD (nondebug DLL)


### PR DESCRIPTION
Another attempt at enabling debug mode (the first was #9934). I disabled an assert in libcc which caused some Electron tests to fail. This PR is identical to #9934, it only references an updated libcc.