### PR TITLE
add installation advice to FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,20 @@
 # Electron FAQ
 
+## Why am I having trouble installing Electron?
+
+When running `npm install electron`, some users occasionally encounter 
+installation errors.
+
+In almost all cases, these errors are the result of network problems and not 
+actual issues with the `electron` npm package. Errors like `ELIFECYCLE`, 
+`EAI_AGAIN`, `ECONNRESET`, and `ETIMEDOUT` are all indications of such 
+network problems.  The best resolution is to try switching networks, or 
+just wait a bit and try installing again.
+
+You can also attempt to download Electron directly from 
+[electron/electron/releases](https://github.com/electron/electron/releases) 
+if installing via `npm` is failing.
+
 ## When will Electron upgrade to latest Chrome?
 
 The Chrome version of Electron is usually bumped within one or two weeks after


### PR DESCRIPTION
People often open issues about how they're unable to `npm install electron`. Usually it's a network issue. This PR adds a distilled version of the installation advice we often repeat on repos like
[electron-quick-start](https://github.com/electron/electron-quick-start/issues) and [electron-prebuilt](https://github.com/electron-userland/electron-prebuilt/issues). 

This gives us something to link to so we don't have to keep repeating ourselves.