### PR TITLE
Only update dbus menu when it has been changed

### DIFF
--- a/atom/browser/ui/views/global_menu_bar_x11.cc
+++ b/atom/browser/ui/views/global_menu_bar_x11.cc
@@ -165,6 +165,18 @@ void SetMenuItemID(DbusmenuMenuitem* item, int id) {
   g_object_set_data(G_OBJECT(item), "menu-id", GINT_TO_POINTER(id + 1));
 }
 
+std::string GetMenuModelStatus(AtomMenuModel* model) {
+  std::string ret;
+  for (int i = 0; i < model->GetItemCount(); ++i) {
+    int status = model->GetTypeAt(i) | (model->IsVisibleAt(i) << 30)
+                                     | (model->IsEnabledAt(i) << 29)
+                                     | (model->IsItemCheckedAt(i) << 28);
+    ret += base::StringPrintf(
+        "%s-%d\n", base::UTF16ToUTF8(model->GetLabelAt(i)).c_str(), status);
+  }
+  return ret;
+}
+
 }  // namespace
 
 GlobalMenuBarX11::GlobalMenuBarX11(NativeWindowViews* window)
@@ -308,6 +320,16 @@ void GlobalMenuBarX11::OnSubMenuShow(DbusmenuMenuitem* item) {
   AtomMenuModel* model = ModelForMenuItem(item);
   if (!model || !GetMenuItemID(item, &id))
     return;
+
+  // Do not update menu if the submenu has not been changed.
+  std::string status = GetMenuModelStatus(model);
+  char* old = static_cast<char*>(g_object_get_data(G_OBJECT(item), "status"));
+  if (old && status == old)
+    return;
+
+  // Save the new status.
+  g_object_set_data_full(G_OBJECT(item), "status", g_strdup(status.c_str()),
+                         g_free);
 
   // Clear children.
   GList *children = menuitem_take_children(item);

--- a/atom/browser/ui/views/global_menu_bar_x11.cc
+++ b/atom/browser/ui/views/global_menu_bar_x11.cc
@@ -168,11 +168,11 @@ void SetMenuItemID(DbusmenuMenuitem* item, int id) {
 std::string GetMenuModelStatus(AtomMenuModel* model) {
   std::string ret;
   for (int i = 0; i < model->GetItemCount(); ++i) {
-    int status = model->GetTypeAt(i) | (model->IsVisibleAt(i) << 30)
-                                     | (model->IsEnabledAt(i) << 29)
-                                     | (model->IsItemCheckedAt(i) << 28);
+    int status = model->GetTypeAt(i) | (model->IsVisibleAt(i) << 3)
+                                     | (model->IsEnabledAt(i) << 4)
+                                     | (model->IsItemCheckedAt(i) << 5);
     ret += base::StringPrintf(
-        "%s-%d\n", base::UTF16ToUTF8(model->GetLabelAt(i)).c_str(), status);
+        "%s-%X\n", base::UTF16ToUTF8(model->GetLabelAt(i)).c_str(), status);
   }
   return ret;
 }


### PR DESCRIPTION
The dbus menu implementaion of KDE would send the about-to-show signal whenever the menu has been changed, resulting in infinite loop on our side.

Close #8455.