### PR TITLE
Update the external binaries version

### DIFF
--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -8,7 +8,7 @@ from lib.config import get_target_arch
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v1.2.0'
+VERSION = 'v1.2.1'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/electron/electron-frameworks/releases' \
                  '/download/' + VERSION


### PR DESCRIPTION
Update to [1.2.1](https://github.com/electron/electron-frameworks/releases/tag/v1.2.1).

This is to update to Squirrel.Mac [0.3.1](https://github.com/Squirrel/Squirrel.Mac/releases/tag/0.3.1) which 🙏 I believe 🙏 fixes long-standing issues around update permissions and non-admin users.