### PR TITLE
Fix content scripts matches

### DIFF
--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -26,9 +26,7 @@ const runContentScript = function (extensionId, url, code) {
 // Run injected scripts.
 // https://developer.chrome.com/extensions/content_scripts
 const injectContentScript = function (extensionId, script) {
-  for (const match of script.matches) {
-    if (!matchesPattern(match)) return
-  }
+  if (!script.matches.some(matchesPattern)) return
 
   for (const {url, code} of script.js) {
     const fire = runContentScript.bind(window, extensionId, url, code)


### PR DESCRIPTION
Script was injected only if the current URL matched the first item of `content_scripts[].matchs` ignoring the following items