### PR TITLE
Add a callback option to `webContents.print`

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1269,13 +1269,21 @@ bool WebContents::IsAudioMuted() {
 
 void WebContents::Print(mate::Arguments* args) {
   PrintSettings settings = { false, false, base::string16() };
-  if (args->Length() == 1 && !args->GetNext(&settings)) {
+  if (args->Length() >= 1 && !args->GetNext(&settings)) {
     args->ThrowError();
     return;
   }
-
-  printing::PrintViewManagerBasic::FromWebContents(web_contents())->
-      PrintNow(web_contents()->GetMainFrame(),
+  auto print_view_manager_basic_ptr =
+      printing::PrintViewManagerBasic::FromWebContents(web_contents());
+  if (args->Length() == 2) {
+    base::Callback<void(bool)> callback;
+    if (!args->GetNext(&callback)) {
+      args->ThrowError();
+      return;
+    }
+    print_view_manager_basic_ptr->SetCallback(callback);
+  }
+  print_view_manager_basic_ptr->PrintNow(web_contents()->GetMainFrame(),
                settings.silent,
                settings.print_background,
                settings.device_name);

--- a/chromium_src/chrome/browser/printing/print_view_manager_base.cc
+++ b/chromium_src/chrome/browser/printing/print_view_manager_base.cc
@@ -377,9 +377,12 @@ void PrintViewManagerBase::DisconnectFromCurrentPrintJob() {
 }
 
 void PrintViewManagerBase::PrintingDone(bool success) {
-  if (!print_job_.get())
-    return;
-  Send(new PrintMsg_PrintingDone(routing_id(), success));
+  if (print_job_.get()) {
+    Send(new PrintMsg_PrintingDone(routing_id(), success));
+  }
+  if (!callback.is_null()) {
+    callback.Run(success && print_job_);
+  }
 }
 
 void PrintViewManagerBase::TerminatePrintJob(bool cancel) {

--- a/chromium_src/chrome/browser/printing/print_view_manager_base.h
+++ b/chromium_src/chrome/browser/printing/print_view_manager_base.h
@@ -5,6 +5,9 @@
 #ifndef CHROME_BROWSER_PRINTING_PRINT_VIEW_MANAGER_BASE_H_
 #define CHROME_BROWSER_PRINTING_PRINT_VIEW_MANAGER_BASE_H_
 
+#include <memory>
+
+#include "base/callback.h"
 #include "base/memory/ref_counted.h"
 #include "components/prefs/pref_member.h"
 #include "base/strings/string16.h"
@@ -46,6 +49,10 @@ class PrintViewManagerBase : public content::NotificationObserver,
 
   // PrintedPagesSource implementation.
   virtual base::string16 RenderSourceName() override;
+
+  void SetCallback(const base::Callback<void(bool)>& cb) {
+    callback = cb;
+  };
 
  protected:
   explicit PrintViewManagerBase(content::WebContents* web_contents);
@@ -158,6 +165,8 @@ class PrintViewManagerBase : public content::NotificationObserver,
   bool printing_enabled_;
 
   scoped_refptr<printing::PrintQueriesQueue> queue_;
+
+  base::Callback<void(bool)> callback;
 
   DISALLOW_COPY_AND_ASSIGN(PrintViewManagerBase);
 };

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -950,13 +950,15 @@ Get the system printer list.
 
 Returns [`PrinterInfo[]`](structures/printer-info.md)
 
-#### `contents.print([options])`
+#### `contents.print([options], [callback])`
 
 * `options` Object (optional)
   * `silent` Boolean (optional) - Don't ask user for print settings. Default is `false`.
   * `printBackground` Boolean (optional) - Also prints the background color and image of
     the web page. Default is `false`.
   * `deviceName` String (optional) - Set the printer device name to use. Default is `''`.
+* `callback` Function (optional)
+  * success` Boolean - Indicates success of the print call.
 
 Prints window's web page. When `silent` is set to `true`, Electron will pick
 the system's default printer if `deviceName` is empty and the default settings


### PR DESCRIPTION
The `webContents.print` is async but does not support a callback.
And see #9712 