### PR TITLE
Fix differences between text and structured parts

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -87,7 +87,7 @@ module gets emitted.
     * `method` String
     * `uploadData` [UploadData[]](structures/upload-data.md)
   * `callback` Function
-    * `filePath` String (optional)
+    * `filePath` ( String | {path:string} | number | {error:any} ) (optional)
 * `completion` Function (optional)
   * `error` Error
 
@@ -121,7 +121,7 @@ treated as a standard scheme.
     * `method` String
     * `uploadData` [UploadData[]](structures/upload-data.md)
   * `callback` Function
-    * `buffer` (Buffer | [MimeTypedBuffer](structures/mime-typed-buffer.md)) (optional)
+    * `buffer` (Buffer | [MimeTypedBuffer](structures/mime-typed-buffer.md) | number) (optional)
 * `completion` Function (optional)
   * `error` Error
 
@@ -206,7 +206,7 @@ Unregisters the custom protocol of `scheme`.
 
 * `scheme` String
 * `callback` Function
-  * `error` Error
+  * `isHandled` boolean
 
 The `callback` will be called with a boolean that indicates whether there is
 already a handler for `scheme`.


### PR DESCRIPTION
#### Issue 1:
Lines 2929-2945, definition of `registerFileProtocol(...)`.
Doc lines say (as well as docs on site),
```
     *  .... To handle
     * the request, the callback should be called with either the file's path or an
     * object that has a path property, e.g. callback(filePath) or callback({path:
     * filePath}). When callback is called with nothing, a number, or an object that
     * has an error property, the request will fail with the error number you
     * specified. 
```
but definition itself is
```
    registerFileProtocol(scheme: string, handler: (request: RegisterFileProtocolRequest, callback: (filePath?: string) => void) => void, completion?: (error: Error) => void): void;
```
`callback`'s function definition has arguments `filePath?: string`, but it should also take in values that will make request fail, i.e. `filePath?: string | number | ...`

#### Issue 2:
Lines 2922-2928, definition for `registerBufferProtocol(...)`.
Doc lines say (as well as docs on site),
```
     *  ....  The usage
     * is the same with registerFileProtocol, except that the callback should be called
     * with either a Buffer object or an object that has the data, mimeType, and
     * charset properties. Example:
     */
```
but definition itself is
```
    registerBufferProtocol(scheme: string, handler: (request: RegisterBufferProtocolRequest, callback: (buffer?: Buffer | MimeTypedBuffer) => void) => void, completion?: (error: Error) => void): void;
```
misses types for `buffer` argument in `callback`, that will make request to fail. It should be at least `buffer?: Buffer | MimeTypedBuffer | number`, which I know runs properly.

By the way, it seems that an *Example:* part of the doc line is chopped off.

#### Issue 3:
Lines 2917-2921, definition for `isProtocolHandled(...)`.
Doc lines say,
```
    /**
     * The callback will be called with a boolean that indicates whether there is
     * already a handler for scheme.
     */
```
but definition itself is
```
isProtocolHandled(scheme: string, callback: (error: Error) => void): void;
```
where callback argument should be `callback: (isHandled: boolean) => void`.