### PR TITLE
First optional parameter is an overload for d.ts

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -39,9 +39,32 @@ session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback
 
 The following methods are available on instances of `WebRequest`:
 
-#### `webRequest.onBeforeRequest([filter, ]listener)`
+#### `webRequest.onBeforeRequest(listener)`
 
-* `filter` Object
+* `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `resourceType` String
+    * `timestamp` Double
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `response` Object
+      * `cancel` Boolean (optional)
+      * `redirectURL` String (optional) - The original request is prevented from
+        being sent or completed and is instead redirected to the given URL.
+
+The `listener` will be called with `listener(details, callback)` when a request
+is about to occur.
+
+The `uploadData` is an array of `UploadData` objects.
+
+The `callback` has to be called with an `response` object.
+
+#### `webRequest.onBeforeRequest(filter, listener)`
+
+* `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the 
         requests that do not match the URL patterns.
 * `listener` Function


### PR DESCRIPTION
Docs are used for generation of `d.ts`. Typescript likes optional parameters on the tail, and a signature with optional first parameter should be changed to overloading (?) multiple definitions. In this case, there should be two of them.

It may look uglier, cause we are repeating docs. May be we need some convention for cases like these? Or, may be, d.ts generation utility should work around first parameters, marked as optional. In later case, fix is trivial addition of `(optional)` for the first argument. Does utility handle first optional parameter, turning it into several definitions? I assumed not, but I may be wrong :) .

By the way `webRequest.onHeadersReceived([filter, ]listener)` and others need change like this.