### PR TITLE
Leak the Node environment when context is released

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -132,7 +132,12 @@ void AtomRendererClient::WillReleaseScriptContext(
     node_bindings_->set_uv_env(nullptr);
 
   // Destroy the node environment.
-  node::FreeEnvironment(env);
+  // This is disabled because pending async tasks may still use the environment
+  // and would cause crashes later. Node does not seem to clear all async tasks
+  // when the environment is destroyed.
+  // node::FreeEnvironment(env);
+
+  // AtomBindings is tracking node environments.
   atom_bindings_->EnvironmentDestroyed(env);
 }
 


### PR DESCRIPTION
This reverts the change of #8811.

So when the Node environment is destroyed, there are still libuv async tasks running that may reuse that Node environment, even though Node should have cleared all libuv handles. It might caused by Node missing some corner cases, but even if Node has covered all cases on its side, it is still possible that some native modules just assume Node environments can live forever.

Close #9538, close #9303.