### PR TITLE
Mark certain Notification options as optional

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -31,13 +31,13 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
 
 * `options` Object
   * `title` String - A title for the notification, which will be shown at the top of the notification window when it is shown
-  * `subtitle` String - A subtitle for the notification, which will be displayed below the title. _macOS_
+  * `subtitle` String - (optional) A subtitle for the notification, which will be displayed below the title. _macOS_
   * `body` String - The body text of the notification, which will be displayed below the title or subtitle
   * `silent` Boolean - (optional) Whether or not to emit an OS notification noise when showing the notification
   * `icon` [NativeImage](native-image.md) - (optional) An icon to use in the notification
   * `hasReply` Boolean - (optional) Whether or not to add an inline reply option to the notification.  _macOS_
   * `replyPlaceholder` String - (optional) The placeholder to write in the inline reply input field. _macOS_
-  * `actions` [NotificationAction[]](structures/notification-action.md) - Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
+  * `actions` [NotificationAction[]](structures/notification-action.md) - (optional) Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
 
 
 ### Instance Events


### PR DESCRIPTION
This change makes the `subtitle` and `actions` options optional to the
Notification constructor, since they are only available on macOS.