### PR TITLE
Fix ImportError: No module named google_compute_engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ git:
 notifications:
   email: false
 
-before_install:
-  - export BOTO_CONFIG=/dev/null
-
 language: node_js
+dist: precise
+sudo: required
 node_js:
   - "4"
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ git:
 notifications:
   email: false
 
+before_install:
+  - export BOTO_CONFIG=/dev/null
+
 language: node_js
 node_js:
   - "4"


### PR DESCRIPTION
Attempt to fix ImportError: No module named google_compute_engine that is happening in Travis