### PR TITLE
Fix No module named google_compute_engine error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ git:
 notifications:
   email: false
 
+before_install:
+  - export BOTO_CONFIG=/dev/null
+  
 language: node_js
 node_js:
   - "4"


### PR DESCRIPTION
This PR fixes the "No module named google_compute_engine" error on Travis