### PR TITLE
fix heading levels for class docs

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -1,4 +1,4 @@
-# Class: BrowserView
+## Class: BrowserView
 
 > Create and control views.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -1,4 +1,5 @@
-# Class: Menu
+## Class: Menu
+
 
 > Create native application menus and context menus.
 

--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -1,4 +1,4 @@
-# Class: TouchBar
+## Class: TouchBar
 
 > Create TouchBar layouts for native macOS applications
 


### PR DESCRIPTION
This updates some of the API docs to use the HTML heading levels expected by electron-docs-linter.

Ideally these files would be starting at H1 instead of H2, but there are historical reasons for this. There are a handful of files that define a Module and a Class of the same name, like `session.md` and `native-image.md`

https://github.com/electron/electron-docs-linter/pull/77 explains the challenge:

> To allow these APIs to coexist in this way, the Class definitions still use an H2 heading, even when they are atop their own document. If we want to switch to all files starting with an H1 heading, we'll need to figure out a way to separate the session module from the Session class. Obviously they can't have the same filename, so we'd have to do something like session.md and session-class.md... I'm open to ideas about how to do that.