### PR TITLE
Remove mention of SegmentedControl in description

### DIFF
--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -22,12 +22,12 @@ Process: [Main](../tutorial/quick-start.md#main-process)
 
 The following properties are available on instances of `TouchBarScrubber`:
 
-#### `touchBarSegmentedControl.items`
+#### `touchBarScrubber.items`
 
 A `ScrubberItem[]` array representing the items in this scrubber. Updating this value immediately
 updates the control in the touch bar. Updating deep properties inside this array **does not update the touch bar**.
 
-#### `touchBarSegmentedControl.selectedStyle`
+#### `touchBarScrubber.selectedStyle`
 
 A `String` representing the style that selected items in the scrubber should have. Updating this value immediately
 updates the control in the touch bar.  Possible values:
@@ -36,7 +36,7 @@ updates the control in the touch bar.  Possible values:
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`
 * `null` - Actually null, not a string, removes all styles
 
-#### `touchBarSegmentedControl.overlayStyle`
+#### `touchBarScrubber.overlayStyle`
 
 A `String` representing the style that selected items in the scrubber should have. This style is overlayed on top
 of the scrubber item instead of being placed behind it. Updating this value immediately updates the control in the
@@ -46,12 +46,12 @@ touch bar.  Possible values:
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`
 * `null` - Actually null, not a string, removes all styles
 
-#### `touchBarSegmentedControl.showArrowButtons`
+#### `touchBarScrubber.showArrowButtons`
 
 A `Boolean` representing whether to show the left / right selection arrows in this scrubber. Updating this value
 immediately updates the control in the touch bar.  
 
-#### `touchBarSegmentedControl.mode`
+#### `touchBarScrubber.mode`
 
 A `String` representing the mode of this scrubber. Updating this value immediately
 updates the control in the touch bar. Possible values:
@@ -59,7 +59,7 @@ updates the control in the touch bar. Possible values:
 * `fixed` - Maps to `NSScrubberModeFixed`
 * `free` - Maps to `NSScrubberModeFree`
 
-#### `touchBarSegmentedControl.continuous`
+#### `touchBarScrubber.continuous`
 
 A `Boolean` representing whether this scrubber is continuous or not. Updating this value immediately
 updates the control in the touch bar.


### PR DESCRIPTION
The API documentation mentioned SegmentedControl even though it's a scrubber. Just a minor docs change.