### PR TITLE
Fix Scrubber touch bar item defaults

### DIFF
--- a/lib/browser/api/touch-bar.js
+++ b/lib/browser/api/touch-bar.js
@@ -292,7 +292,7 @@ TouchBar.TouchBarScrubber = class TouchBarScrubber extends TouchBarItem {
     this._addLiveProperty('overlayStyle', overlayStyle || null)
     this._addLiveProperty('showArrowButtons', showArrowButtons || false)
     this._addLiveProperty('mode', mode || 'free')
-    this._addLiveProperty('continuous', continuous || true)
+    this._addLiveProperty('continuous', typeof continuous === 'undefined' ? true : continuous)
 
     if (typeof select === 'function' || typeof highlight === 'function') {
       if (select == null) select = () => {}


### PR DESCRIPTION
Fixes #10132

`false || true === true`....

Basically `continuous` would always be a truthy value...