### PR TITLE
:apple: Stricter macOS kiosk mode

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -175,8 +175,6 @@ class NativeWindowMac : public NativeWindow,
 
   bool is_kiosk_;
 
-  bool was_fullscreen_;
-
   bool zoom_to_page_width_;
 
   bool fullscreen_window_title_;


### PR DESCRIPTION
Changed from [NSWindow toggleFullScreen:] to [NSView enterFullScreenMode:withOptions:] when enabling kiosk mode since it resolves a lot of kiosk mode related issues such as menu bar, dock and applications on other displays being visible.

Example issues that are solved are: #8426 and #1054

**Special note:** Worth mentioning is that this kiosk mode is so aggressive that it will not even allow dialogs to show - showing dialogs will practically cause the computer to hang, because you will not be able to interact with the application when the dialog is alive, and you cannot interact with the dialog since the application is running in strict full screen.

So this is a decision if it is worth a tighter kiosk mode with the con that dialogs does not work as intended.

Examples on a multi-screen setup:

**Before changes:**
![before_kiosk_changes](https://user-images.githubusercontent.com/302151/28669329-2c731a7a-72d4-11e7-83f8-66768332db86.png)

**After changes:**
![after_kiosk_changes](https://user-images.githubusercontent.com/302151/28669333-30582b4e-72d4-11e7-9c40-1daa78110e35.png)



