### PR TITLE
Support Notification actions on Windows 10+

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1136,7 +1136,7 @@ void App::BuildPrototype(
 #if defined(USE_NSS_CERTS)
       .SetMethod("importCertificate", &App::ImportCertificate)
 #endif
-      .SetMethod("makeSingleInstance", &App::MakeSingleInstance)
+      .SetMethod("_makeSingleInstance", &App::MakeSingleInstance)
       .SetMethod("releaseSingleInstance", &App::ReleaseSingleInstance)
       .SetMethod("relaunch", &App::Relaunch)
       .SetMethod("isAccessibilitySupportEnabled",

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -211,7 +211,8 @@ void Notification::BuildPrototype(v8::Isolate* isolate,
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
       .SetMethod("show", &Notification::Show)
-      .SetMethod("_setWindowsProtocolHandler", &Notification::SetWindowsProtocolHandler)
+      .SetMethod("_setWindowsProtocolHandler",
+                 &Notification::SetWindowsProtocolHandler)
       .SetMethod("_emitAction", &Notification::NotificationAction)
       .SetProperty("title", &Notification::GetTitle, &Notification::SetTitle)
       .SetProperty("subtitle", &Notification::GetSubtitle,

--- a/atom/browser/api/atom_api_notification.h
+++ b/atom/browser/api/atom_api_notification.h
@@ -26,6 +26,8 @@ class Notification : public mate::TrackableObject<Notification>,
  public:
   static mate::WrappableBase* New(mate::Arguments* args);
   static bool IsSupported();
+  void SetWindowsProtocolHandler(base::string16 protocol);
+  base::string16 GetWindowsProtocolHandler();
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
@@ -75,6 +77,8 @@ class Notification : public mate::TrackableObject<Notification>,
   base::string16 reply_placeholder_;
   bool has_reply_ = false;
   std::vector<brightray::NotificationAction> actions_;
+
+  base::string16 windowsProtocol_ = L"not-used";
 
   brightray::NotificationPresenter* presenter_;
 

--- a/brightray/browser/notification.h
+++ b/brightray/browser/notification.h
@@ -21,6 +21,7 @@ class NotificationPresenter;
 struct NotificationAction {
   base::string16 type;
   base::string16 text;
+  base::string16 _protocol;
 };
 
 struct NotificationOptions {

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -9,6 +9,7 @@
 #include "brightray/browser/win/windows_toast_notification.h"
 
 #include <shlobj.h>
+#include <sstream>
 #include <vector>
 
 #include "base/strings/utf_string_conversions.h"
@@ -93,7 +94,7 @@ void WindowsToastNotification::Show(const NotificationOptions& options) {
 
   ComPtr<IXmlDocument> toast_xml;
   if (FAILED(GetToastXml(toast_manager_.Get(), options.title, options.msg,
-                         icon_path, options.silent, &toast_xml))) {
+                         icon_path, options.silent, options.actions, &toast_xml))) {
     NotificationFailed();
     return;
   }
@@ -144,6 +145,7 @@ bool WindowsToastNotification::GetToastXml(
     const std::wstring& msg,
     const std::wstring& icon_path,
     bool silent,
+    const std::vector<NotificationAction> actions,
     IXmlDocument** toast_xml) {
   ABI::Windows::UI::Notifications::ToastTemplateType template_type;
   if (title.empty() || msg.empty()) {
@@ -180,6 +182,125 @@ bool WindowsToastNotification::GetToastXml(
   if (!icon_path.empty())
     return SetXmlImage(*toast_xml, icon_path);
 
+  if (FAILED(AddActions(*toast_xml, actions)))
+    return false;
+
+  return true;
+}
+
+bool WindowsToastNotification::AddAttribute(IXmlDocument* doc, ComPtr<IXmlNamedNodeMap> attributes, std::wstring name, std::wstring value) {
+  // Create attribute
+  ComPtr<IXmlAttribute> attribute;
+  ScopedHString attr_str(name);
+  if (FAILED(doc->CreateAttribute(attr_str, &attribute)))
+    return false;
+
+  ComPtr<IXmlNode> attribute_node;
+  if (FAILED(attribute.As(&attribute_node)))
+    return false;
+  
+  // Set content attribute to value
+  ScopedHString attr_value(value);
+  if (!attr_value.success())
+    return false;
+
+  ComPtr<IXmlText> attr_text;
+  if (FAILED(doc->CreateTextNode(attr_value, &attr_text)))
+    return false;
+
+  ComPtr<IXmlNode> attr_node;
+  if (FAILED(attr_text.As(&attr_node)))
+    return false;
+
+  ComPtr<IXmlNode> child_node;
+  if (FAILED(
+          attribute_node->AppendChild(attr_node.Get(), &child_node)))
+    return false;
+
+  ComPtr<IXmlNode> attribute_pnode;
+  if (FAILED(attributes.Get()->SetNamedItem(attribute_node.Get(),
+                                                  &attribute_pnode))) {
+    return false;
+  }
+
+  return true;
+}
+
+bool WindowsToastNotification::AddActions(IXmlDocument* doc, const std::vector<NotificationAction> actions) {
+  int buttons = 0;
+  base::string16 buttonType = base::UTF8ToUTF16("button");
+  for (auto action : actions) {
+    if (action.type == buttonType) {
+      buttons++;
+    }
+  }
+  // If there are no buttons, let's stop right here
+  if (buttons == 0)
+    return true;
+
+  // Create the "actions" element container
+  ScopedHString tag(L"toast");
+  if (!tag.success())
+    return false;
+
+  ComPtr<IXmlNodeList> node_list;
+  if (FAILED(doc->GetElementsByTagName(tag, &node_list)))
+    return false;
+
+  ComPtr<IXmlNode> root;
+  if (FAILED(node_list->Item(0, &root)))
+    return false;
+
+  ComPtr<IXmlElement> actions_element;
+  ScopedHString actions_str(L"actions");
+  if (FAILED(doc->CreateElement(actions_str, &actions_element)))
+    return false;
+
+  ComPtr<IXmlNode> actions_node_tmp;
+  if (FAILED(actions_element.As(&actions_node_tmp)))
+    return false;
+
+  // Append actions node to toast xml
+  ComPtr<IXmlNode> actions_node;
+  if (FAILED(root->AppendChild(actions_node_tmp.Get(), &actions_node)))
+    return false;
+
+  for (int i = 0; i < actions.size(); i++) {
+    auto action = actions[i];
+    if (action.type == buttonType) {
+      // Create action element
+      ComPtr<IXmlElement> action_element;
+      ScopedHString action_str(L"action");
+      if (FAILED(doc->CreateElement(action_str, &action_element)))
+        return false;
+
+      ComPtr<IXmlNode> action_node_tmp;
+      if (FAILED(action_element.As(&action_node_tmp)))
+        return false;
+
+      // Append action node to actions xml
+      ComPtr<IXmlNode> action_node;
+      if (FAILED(actions_node->AppendChild(action_node_tmp.Get(), &action_node)))
+        return false;
+
+      // Get attributes
+      ComPtr<IXmlNamedNodeMap> attributes;
+      if (FAILED(action_node->get_Attributes(&attributes)))
+        return false;
+
+      if (FAILED(AddAttribute(doc, attributes, L"content", action.text)))
+        return false;
+
+      std::ostringstream index;
+      index << i;
+      if (FAILED(AddAttribute(doc, attributes, L"arguments", base::UTF8ToUTF16(base::UTF16ToUTF8(action._protocol) + "/button?id=" + index.str()))))
+        return false;
+
+      if (FAILED(AddAttribute(doc, attributes, L"activationType", L"protocol")))
+        return false;
+    }
+  }
+  
   return true;
 }
 

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -270,7 +270,7 @@ bool WindowsToastNotification::AddActions(IXmlDocument* doc,
   if (FAILED(root->AppendChild(actions_node_tmp.Get(), &actions_node)))
     return false;
 
-  for (int i = 0; i < actions.size(); i++) {
+  for (size_t i = 0; i < actions.size(); i++) {
     auto action = actions[i];
     if (action.type == buttonType) {
       // Create action element

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -9,7 +9,6 @@
 #include "brightray/browser/win/windows_toast_notification.h"
 
 #include <shlobj.h>
-#include <sstream>
 #include <vector>
 
 #include "base/strings/utf_string_conversions.h"
@@ -297,10 +296,8 @@ bool WindowsToastNotification::AddActions(IXmlDocument* doc,
       if (FAILED(AddAttribute(doc, attributes, L"content", action.text)))
         return false;
 
-      std::ostringstream index;
-      index << i;
       base::string16 launchString = base::UTF8ToUTF16(
-        base::UTF16ToUTF8(action._protocol) + "/button?id=" + index.str());
+        base::UTF16ToUTF8(action._protocol) + "/button?id=" + std::to_string(i));
 
       if (FAILED(AddAttribute(doc, attributes, L"arguments", launchString)))
         return false;

--- a/brightray/browser/win/windows_toast_notification.h
+++ b/brightray/browser/win/windows_toast_notification.h
@@ -64,7 +64,13 @@ class WindowsToastNotification : public Notification {
       const std::wstring& msg,
       const std::wstring& icon_path,
       const bool silent,
+      const std::vector<NotificationAction> actions,
       ABI::Windows::Data::Xml::Dom::IXmlDocument** toastXml);
+  bool AddAttribute(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
+                    ComPtr<ABI::Windows::Data::Xml::Dom::IXmlNamedNodeMap>
+                        attributes, std::wstring name, std::wstring value);
+  bool AddActions(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
+                  const std::vector<NotificationAction> actions);
   bool SetXmlAudioSilent(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
   bool SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                   const std::wstring& text);

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -5,6 +5,10 @@ const Module = require('module')
 const path = require('path')
 const url = require('url')
 
+// We don't set process.defaultApp if the app doesn't launch anything but shows the default HTML
+// file.  This variable is set no matter what we do as long as default_app was run
+process.defaultAppRan = true
+
 // Parse command line options.
 const argv = process.argv.slice(1)
 const option = { file: null, help: null, version: null, abi: null, webdriver: null, modules: [] }

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -671,6 +671,12 @@ app.setJumpList([
 ])
 ```
 
+### `app.isSingleInstance()`
+
+Returns `Boolean`.  Whether the app has called `makeSingleInstance` or not,
+useful for third party modules to determine if the app is running in Single
+Instance mode or not.
+
 ### `app.makeSingleInstance(callback)`
 
 * `callback` Function

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -91,7 +91,7 @@ Returns:
 
 Emitted when the user clicks the "Reply" button on a notification with `hasReply: true`.
 
-#### Event: 'action' _macOS_
+#### Event: 'action' _macOS_ _Windows_
 
 Returns:
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -27,6 +27,12 @@ The `Notification` class has the following static methods:
 
 Returns `Boolean` - Whether or not desktop notifications are supported on the current system
 
+#### `Notification.setWindowsProtocol(protocol)`
+
+Sets the URI protocol to use when setting up actions such as buttons in Notifications.  You
+only need to call this if you are using the `actions` property on Windows.  The protocol
+you provide must not be in use  **even by your own app**.
+
 ### `new Notification([options])` _Experimental_
 
 * `options` Object

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -8,6 +8,7 @@
 | Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
 |-------------|------------------|-----------------|----------------|-------------|
 | `button`    | macOS            | Used as the label for the button | "Show" | Maximum of one button, if multiple are provided only the last is used.  This action is also incomptible with `hasReply` and will be ignored if `hasReply` is `true`. |
+| `button`    | Windows 10+      | Used as the label for the button | "Show" | N/A |
 
 ### Button support on macOS
 
@@ -18,3 +19,14 @@ following criteria.
 * App has it's `NSUserNotificationAlertStyle` set to `alert` in the `info.plist`.
 
 If either of these requirements are not met the button simply won't appear.
+
+### Button support on Windows
+
+Buttons are only supported on Windows 10 and above, in order for buttons to appear
+your app must meet the following criteria.
+
+* App is running with `app.makeSingleInstance()`
+* You have called `Notification.setWindowsProtocol(protocol)` with a protocol that Electron can register to support notification actions
+
+**NOTE:** The provided protocol must **NOT** be in use by your app already,
+this protocol must be dedicated to just this API or strange things may happen.

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -73,6 +73,23 @@ app.allowNTLMCredentialsForAllDomains = function (allow) {
   }
 }
 
+let isSingleInstance = false
+app.isSingleInstance = () => isSingleInstance
+
+// Allow API's to listen for the single-instance callback without
+// asking users for it
+app.makeSingleInstance = (callback) => {
+  isSingleInstance = true
+  return app._makeSingleInstance((...args) => {
+    let prevent = false
+    const event = { preventDefault: () => { prevent = true } }
+    app.emit('single-instance', event, ...args)
+    if (!prevent) {
+      return callback(...args)
+    }
+  })
+}
+
 // Routes the events to webContents.
 const events = ['login', 'certificate-error', 'select-client-certificate']
 for (let name of events) {

--- a/lib/browser/api/notification.js
+++ b/lib/browser/api/notification.js
@@ -1,8 +1,72 @@
+const {app} = require('electron')
 const {EventEmitter} = require('events')
-const {Notification, isSupported} = process.atomBinding('notification')
+const {Notification: NativeNotification, isSupported} = process.atomBinding('notification')
+const querystring = require('querystring')
+const path = require('path')
+const url = require('url')
 
-Object.setPrototypeOf(Notification.prototype, EventEmitter.prototype)
+Object.setPrototypeOf(NativeNotification.prototype, EventEmitter.prototype)
+
+let providedProtocol
+let notificationId = 1
+const notificationMap = {}
+
+class Notification extends NativeNotification {
+  constructor (options) {
+    super(options)
+    this.id = notificationId++
+    notificationMap[this.id] = this
+    // On windows we require certain things to be true before allowing buttons
+    // * isSingleInstance() === true
+    // * protocol has been provided
+    if (process.platform === 'win32' && options.actions && options.actions.find(action => action.type === 'button')) {
+      if (!providedProtocol) {
+        throw new Error('You must call Notification.setWindowsProtocol before using button actions on Windows')
+      }
+      this._setWindowsProtocolHandler(`${providedProtocol}/${this.id}`)
+    }
+    delete this._setWindowsProtocolHandler
+  }
+}
 
 Notification.isSupported = isSupported
+Notification.fromID = (id) => notificationMap[id]
+
+// Windows magic stuff to support buttons
+Notification.setWindowsProtocol = (protocol) => {
+  if (process.platform !== 'win32' || !protocol) return
+  if (!app.isSingleInstance()) {
+    throw new Error('You must call app.makeSingleInstance before using button actions on Windows')
+  }
+  providedProtocol = `${protocol}://action`
+  app.setAsDefaultProtocolClient(protocol, process.execPath, process.defaultAppRan ? [path.resolve(__dirname, '../../../default_app.asar/index.html')] : [])
+}
+
+app.on('single-instance', (event, argv) => {
+  if (!providedProtocol) return
+  let notificationAction = argv.find(arg => arg.startsWith(providedProtocol))
+  if (!notificationAction) return
+  event.preventDefault()
+  // Let's play this safe to stop people crashing apps by sending random fakish arg strings
+  try {
+    const parsed = url.parse(notificationAction)
+    const parts = parsed.pathname.substr(1).split('/')
+    // This is unexpected
+    if (parts.length !== 2) return
+    // It's not a button so who knows what's going on
+    if (parts[1] !== 'button') return
+    const id = parseInt(parts[0], 10)
+    if (isNaN(id)) return
+    const notification = Notification.fromID(id)
+    if (!notification) return
+    const parsedQuerystring = querystring.parse(parsed.query)
+    if (typeof parsedQuerystring.id === 'undefined') return
+    const actionId = parseInt(parsedQuerystring.id, 10)
+    if (isNaN(actionId)) return
+    notification._emitAction(actionId)
+  } catch (err) {
+    // Ignore
+  }
+})
 
 module.exports = Notification


### PR DESCRIPTION
Well this is kind of hacky, but it's also a necessary evil (Windows Notification API's suck...)

Basically, users must provide a `protocol` for us to register and listen for notification activations.  This API also requires `makeSingleInstance` to have been called.