### PR TITLE
Fix crashes due to using Debug version of libc++

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -291,6 +291,8 @@ v8::Local<v8::Value> NativeImage::ToBitmap(mate::Arguments* args) {
 v8::Local<v8::Value> NativeImage::ToJPEG(v8::Isolate* isolate, int quality) {
   std::vector<unsigned char> output;
   gfx::JPEG1xEncodedDataFromImage(image_, quality, &output);
+  if (output.empty())
+    return node::Buffer::New(isolate, 0).ToLocalChecked();
   return node::Buffer::Copy(
       isolate,
       reinterpret_cast<const char*>(&output.front()),

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -268,11 +268,10 @@ v8::Local<v8::Value> NativeImage::ToPNG(mate::Arguments* args) {
 
   const SkBitmap bitmap =
       image_.AsImageSkia().GetRepresentation(scale_factor).sk_bitmap();
-  std::unique_ptr<std::vector<unsigned char>> encoded(
-      new std::vector<unsigned char>());
-  gfx::PNGCodec::EncodeBGRASkBitmap(bitmap, false, encoded.get());
-  const char* data = reinterpret_cast<char*>(encoded->data());
-  size_t size = encoded->size();
+  std::vector<unsigned char> encoded;
+  gfx::PNGCodec::EncodeBGRASkBitmap(bitmap, false, &encoded);
+  const char* data = reinterpret_cast<char*>(encoded.data());
+  size_t size = encoded.size();
   return node::Buffer::Copy(args->isolate(), data, size).ToLocalChecked();
 }
 

--- a/atom/common/native_mate_converters/callback.h
+++ b/atom/common/native_mate_converters/callback.h
@@ -56,7 +56,8 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args { ConvertToV8(isolate, raw)... };
-    v8::Local<v8::Value> ret(holder->Call(holder, args.size(), &args.front()));
+    v8::Local<v8::Value> ret(holder->Call(
+        holder, args.size(), args.empty() ? nullptr : &args.front()));
     return handle_scope.Escape(ret);
   }
 };
@@ -76,7 +77,8 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args { ConvertToV8(isolate, raw)... };
-    holder->Call(holder, args.size(), &args.front());
+    holder->Call(
+        holder, args.size(), args.empty() ? nullptr : &args.front());
   }
 };
 
@@ -97,8 +99,8 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args { ConvertToV8(isolate, raw)... };
     v8::Local<v8::Value> result;
-    auto maybe_result =
-        holder->Call(context, holder, args.size(), &args.front());
+    auto maybe_result = holder->Call(
+        context, holder, args.size(), args.empty() ? nullptr : &args.front());
     if (maybe_result.ToLocal(&result))
       Converter<ReturnType>::FromV8(isolate, result, &ret);
     return ret;

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -62,16 +62,17 @@
   if (query.invert) mocha.invert();
 
   // Read all test files.
-  var walker = require('walkdir').walk(require('path').dirname(__dirname), {
+  var walker = require('walkdir').walk(path.dirname(__dirname), {
     no_recurse: true
   });
 
   walker.on('file', function(file) {
-    if (/-spec\.js$/.test(file))
+    if (/-spec\.js$/.test(file) && !file.includes('api-crash-reporter-spec.js'))
       mocha.addFile(file);
   });
 
   walker.on('end', function() {
+    mocha.addFile(path.resolve(__dirname, '..', 'api-crash-reporter-spec.js'))
     var runner = mocha.run(function() {
       if (isCi && runner.hasOnly) {
         try {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -141,6 +141,10 @@ app.on('ready', function () {
     })
     if (chosen === 0) window.destroy()
   })
+  window.webContents.on('crashed', function () {
+    console.error('Renderer process crashed')
+    process.exit(1)
+  })
 
   // For session's download test, listen 'will-download' event in browser, and
   // reply the result to renderer for verifying


### PR DESCRIPTION
Saw it when running tests on Linux:

```
Objects involved in the operation:
sequence "this" @ 0x0x7ffce7459758 {
}
Received signal 6
#0 0x7f7cd6955afb base::debug::StackTrace::StackTrace()
#1 0x7f7cd695106c base::debug::StackTrace::StackTrace()
#2 0x7f7cd695560f <unknown>
#3 0x7f7cbfe8bcb0 <unknown>
#4 0x7f7cb992a035 gsignal
#5 0x7f7cb992d79b abort
#6 0x7f7cba2265ad __gnu_debug::_Error_formatter::_M_error()
#7 0x000000fc6195 std::__debug::vector<>::front()
#8 0x000000fc22e8 atom::api::NativeImage::ToJPEG()
#9 0x000000fcba34 _ZN4base8internal13FunctorTraitsIMN4atom3api11NativeImageEFN2v85LocalINS5_5ValueEEEPNS5_7IsolateEiEvE6InvokeIPS4_JSA_iEEES8_SC_OT_DpOT0_
#10 0x000000fcb95b _ZN4base8internal12InvokeHelperILb0EN2v85LocalINS2_5ValueEEEE8MakeItSoIRKMN4atom3api11NativeImageEFS5_PNS2_7IsolateEiEJPSA_SC_iEEES5_OT_DpOT0_
#11 0x000000fcb8d0 _ZN4base8internal7InvokerINS0_9BindStateIMN4atom3api11NativeImageEFN2v85LocalINS6_5ValueEEEPNS6_7IsolateEiEJEEEFS9_PS5_SB_iEE7RunImplIRKSD_RKSt5tupleIJEEJEEES9_OT_OT0_NS_13IndexSequenceIJXspT1_EEEEOSF_OSB_Oi
#12 0x000000fcb7d3 _ZN4base8internal7InvokerINS0_9BindStateIMN4atom3api11NativeImageEFN2v85LocalINS6_5ValueEEEPNS6_7IsolateEiEJEEEFS9_PS5_SB_iEE3RunEPNS0_13BindStateBaseEOSF_OSB_Oi
#13 0x000000fcb68f base::internal::RunMixin<>::Run()
#14 0x000000fcb4b4 _ZN4mate8internal7InvokerINS0_13IndicesHolderIJLm0ELm1ELm2EEEEJPN4atom3api11NativeImageEPN2v87IsolateEiEE18DispatchToCallbackINS8_5LocalINS8_5ValueEEEEEvN4base8CallbackIFT_S7_SA_iELNSG_8internal8CopyModeE1ELNSK_10RepeatModeE1EEE
#15 0x000000fcb298 mate::internal::Dispatcher<>::DispatchToCallback()
#16 0x7f7ce4cddf6b <unknown>
#17 0x7f7ce4d9e7ff <unknown>
#18 0x7f7ce4d9d59c <unknown>
#19 0x35634c684204 <unknown>
  r8: 00007f7ce6f44980  r9: 00007ffce7459258 r10: 0000000000000008 r11: 0000000000000202
 r12: 00007ffce74594e0 r13: 0000000000000000 r14: 0000000000000001 r15: 0000000000000000
  di: 0000000000005607  si: 0000000000005607  bp: 0000000000000001  bx: 00007ffce74594a8
  dx: 0000000000000006  ax: 0000000000000000  cx: ffffffffffffffff  sp: 00007ffce74592a8
  ip: 00007f7cb992a035 efl: 0000000000000202 cgf: 0000000000000033 erf: 0000000000000007
 trp: 000000000000000e msk: 0000000000000000 cr2: 00007f12f232a700
[end of stack trace]
```