### PR TITLE
Backport fixes to 1.6

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -200,7 +200,10 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
 void WebFrame::InsertText(const std::string& text) {
   web_frame_->frameWidget()
             ->getActiveWebInputMethodController()
-            ->commitText(blink::WebString::fromUTF8(text), 0);
+            ->commitText(blink::WebString::fromUTF8(text),
+                         blink::WebVector<blink::WebCompositionUnderline>(),
+                         blink::WebRange(),
+                         0);
 }
 
 void WebFrame::InsertCSS(const std::string& css) {

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -135,7 +135,12 @@ void AtomRendererClient::WillReleaseScriptContext(
     node_bindings_->set_uv_env(nullptr);
 
   // Destroy the node environment.
-  node::FreeEnvironment(env);
+  // This is disabled because pending async tasks may still use the environment
+  // and would cause crashes later. Node does not seem to clear all async tasks
+  // when the environment is destroyed.
+  // node::FreeEnvironment(env);
+
+  // AtomBindings is tracking node environments.
   atom_bindings_->EnvironmentDestroyed(env);
 }
 

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    '3b6f80921d5ae1426bbccb3cec840ca2f646621c'
+    'f3e99add3753f82f9ce02788144b9ea9cd6367d8'
 
 PLATFORM = {
   'cygwin': 'win32',

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    'e2ec6935fbf034207d5ad00fa905a4b2cdd60bb7'
+    '3b6f80921d5ae1426bbccb3cec840ca2f646621c'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
This PR backports the following fixes to the 1.6 release line.

- https://github.com/electron/libchromiumcontent/pull/310 - linux appIndicator submenu fix 
- https://github.com/electron/libchromiumcontent/pull/323 - accented letter input resulting double letters in webview 
- https://github.com/electron/electron/pull/10099 - Leak the Node environment when context is released 

🍒