### PR TITLE
Parse --grep and --invert for mocha

### DIFF
--- a/script/test.py
+++ b/script/test.py
@@ -81,8 +81,13 @@ def parse_args():
                       help='Run tests in CI mode',
                       action='store_true',
                       required=False)
-  parser.add_argument('-g',
-                      help='Filter',
+  parser.add_argument('-g', '--grep',
+                      help='Only run tests matching <pattern>',
+                      metavar='pattern',
+                      required=False)
+  parser.add_argument('-i', '--invert',
+                      help='Inverts --grep matches',
+                      action='store_true',
                       required=False)
   parser.add_argument('-v', '--verbose',
                       action='store_true',


### PR DESCRIPTION
This regressed when I added the argument parser to `script/test.py` in #9589 