### PR TITLE
Mouse forward functionality on Windows

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -787,6 +787,10 @@ void Window::SetAppDetails(const mate::Dictionary& options) {
       relaunch_command, relaunch_display_name,
       window_->GetAcceleratedWidget());
 }
+
+void Window::SetForwardMouseMessages(bool forward) {
+  window_->SetForwardMouseMessages(forward);
+}
 #endif
 
 #if defined(TOOLKIT_VIEWS)
@@ -1060,6 +1064,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setThumbnailClip", &Window::SetThumbnailClip)
       .SetMethod("setThumbnailToolTip", &Window::SetThumbnailToolTip)
       .SetMethod("setAppDetails", &Window::SetAppDetails)
+      .SetMethod("setForwardMouseMessages", &Window::SetForwardMouseMessages)
 #endif
 #if defined(TOOLKIT_VIEWS)
       .SetMethod("setIcon", &Window::SetIcon)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -651,8 +651,11 @@ bool Window::IsDocumentEdited() {
   return window_->IsDocumentEdited();
 }
 
-void Window::SetIgnoreMouseEvents(bool ignore) {
-  return window_->SetIgnoreMouseEvents(ignore);
+void Window::SetIgnoreMouseEvents(bool ignore, mate::Arguments* args) {
+  mate::Dictionary options;
+  bool forward = false;
+  args->GetNext(&options) && options.Get("forward", &forward);
+  return window_->SetIgnoreMouseEvents(ignore, forward);
 }
 
 void Window::SetContentProtection(bool enable) {
@@ -786,10 +789,6 @@ void Window::SetAppDetails(const mate::Dictionary& options) {
       app_id, app_icon_path, app_icon_index,
       relaunch_command, relaunch_display_name,
       window_->GetAcceleratedWidget());
-}
-
-void Window::SetForwardMouseMessages(bool forward) {
-  window_->SetForwardMouseMessages(forward);
 }
 #endif
 
@@ -1064,7 +1063,6 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setThumbnailClip", &Window::SetThumbnailClip)
       .SetMethod("setThumbnailToolTip", &Window::SetThumbnailToolTip)
       .SetMethod("setAppDetails", &Window::SetAppDetails)
-      .SetMethod("setForwardMouseMessages", &Window::SetForwardMouseMessages)
 #endif
 #if defined(TOOLKIT_VIEWS)
       .SetMethod("setIcon", &Window::SetIcon)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -166,7 +166,7 @@ class Window : public mate::TrackableObject<Window>,
   std::string GetRepresentedFilename();
   void SetDocumentEdited(bool edited);
   bool IsDocumentEdited();
-  void SetIgnoreMouseEvents(bool ignore);
+  void SetIgnoreMouseEvents(bool ignore, mate::Arguments* args);
   void SetContentProtection(bool enable);
   void SetFocusable(bool focusable);
   void SetProgressBar(double progress, mate::Arguments* args);
@@ -201,7 +201,6 @@ class Window : public mate::TrackableObject<Window>,
   bool SetThumbnailClip(const gfx::Rect& region);
   bool SetThumbnailToolTip(const std::string& tooltip);
   void SetAppDetails(const mate::Dictionary& options);
-  void SetForwardMouseMessages(bool forward);
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -201,6 +201,7 @@ class Window : public mate::TrackableObject<Window>,
   bool SetThumbnailClip(const gfx::Rect& region);
   bool SetThumbnailToolTip(const std::string& tooltip);
   void SetAppDetails(const mate::Dictionary& options);
+  void SetForwardMouseMessages(bool forward);
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -143,7 +143,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetRepresentedFilename();
   virtual void SetDocumentEdited(bool edited);
   virtual bool IsDocumentEdited();
-  virtual void SetIgnoreMouseEvents(bool ignore) = 0;
+  virtual void SetIgnoreMouseEvents(bool ignore, bool forward) = 0;
   virtual void SetContentProtection(bool enable) = 0;
   virtual void SetFocusable(bool focusable);
   virtual void SetMenu(AtomMenuModel* menu);
@@ -152,9 +152,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::NativeView GetNativeView() const = 0;
   virtual gfx::NativeWindow GetNativeWindow() const = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() const = 0;
-#if defined(OS_WIN)
-  virtual void SetForwardMouseMessages(bool forward) = 0;
-#endif
 
   // Taskbar/Dock APIs.
   enum ProgressState {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -152,6 +152,9 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::NativeView GetNativeView() const = 0;
   virtual gfx::NativeWindow GetNativeWindow() const = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() const = 0;
+#if defined(OS_WIN)
+  virtual void SetForwardMouseMessages(bool forward) = 0;
+#endif
 
   // Taskbar/Dock APIs.
   enum ProgressState {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -334,6 +334,11 @@ NativeWindowViews::NativeWindowViews(
 
 NativeWindowViews::~NativeWindowViews() {
   window_->RemoveObserver(this);
+
+#if defined(OS_WIN)
+  // Disable mouse forwarding to relinquish resources, should any be held.
+  SetForwardMouseMessages(false);
+#endif
 }
 
 void NativeWindowViews::Close() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1064,6 +1064,13 @@ void NativeWindowViews::SetEnabled(bool enable) {
 #endif
 }
 
+#if defined(OS_WIN)
+void NativeWindowViews::SetForwardMouseMessages(bool forward) {
+  forwarding_mouse_messages_ = forward;
+  SetIgnoreMouseEvents(forward);
+}
+#endif
+
 void NativeWindowViews::OnWidgetActivationChanged(
     views::Widget* widget, bool active) {
   if (widget != window_.get())

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -790,7 +790,7 @@ bool NativeWindowViews::HasShadow() {
       != wm::ShadowElevation::NONE;
 }
 
-void NativeWindowViews::SetIgnoreMouseEvents(bool ignore) {
+void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 #if defined(OS_WIN)
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
   if (ignore)
@@ -798,6 +798,13 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore) {
   else
     ex_style &= ~(WS_EX_TRANSPARENT | WS_EX_LAYERED);
   ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
+
+  // Forwarding is always disabled when not ignoring mouse messages.
+  if (!ignore) {
+    SetForwardMouseMessages(false);
+  } else {
+    SetForwardMouseMessages(forward);
+  }
 #elif defined(USE_X11)
   if (ignore) {
     XRectangle r = {0, 0, 1, 1};

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1064,13 +1064,6 @@ void NativeWindowViews::SetEnabled(bool enable) {
 #endif
 }
 
-#if defined(OS_WIN)
-void NativeWindowViews::SetForwardMouseMessages(bool forward) {
-  forwarding_mouse_messages_ = forward;
-  SetIgnoreMouseEvents(forward);
-}
-#endif
-
 void NativeWindowViews::OnWidgetActivationChanged(
     views::Widget* widget, bool active) {
   if (widget != window_.get())

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -7,7 +7,7 @@
 
 #include "atom/browser/native_window.h"
 
-#include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -102,7 +102,7 @@ class NativeWindowViews : public NativeWindow,
   void SetBackgroundColor(const std::string& color_name) override;
   void SetHasShadow(bool has_shadow) override;
   bool HasShadow() override;
-  void SetIgnoreMouseEvents(bool ignore) override;
+  void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   void SetContentProtection(bool enable) override;
   void SetFocusable(bool focusable) override;
   void SetMenu(AtomMenuModel* menu_model) override;
@@ -134,7 +134,6 @@ class NativeWindowViews : public NativeWindow,
 
 #if defined(OS_WIN)
   TaskbarHost& taskbar_host() { return taskbar_host_; }
-  void SetForwardMouseMessages(bool forward) override;
 #endif
 
  private:
@@ -171,6 +170,7 @@ class NativeWindowViews : public NativeWindow,
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
+  void SetForwardMouseMessages(bool forward);
   static LRESULT CALLBACK SubclassProc(
       HWND hwnd, UINT msg, WPARAM w_param, LPARAM l_param, UINT_PTR subclass_id,
       DWORD_PTR ref_data);

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -7,6 +7,7 @@
 
 #include "atom/browser/native_window.h"
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -133,6 +134,7 @@ class NativeWindowViews : public NativeWindow,
 
 #if defined(OS_WIN)
   TaskbarHost& taskbar_host() { return taskbar_host_; }
+  void SetForwardMouseMessages(bool forward) override;
 #endif
 
  private:
@@ -169,6 +171,8 @@ class NativeWindowViews : public NativeWindow,
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
+  static LRESULT CALLBACK SubclassProc(HWND hwnd, UINT msg, WPARAM w_param, LPARAM l_param, UINT_PTR subclass_id, DWORD_PTR ref_data);
+  static LRESULT CALLBACK MouseHookProc(int n_code, WPARAM w_param, LPARAM l_param);
 #endif
 
   // NativeWindow:
@@ -259,6 +263,11 @@ class NativeWindowViews : public NativeWindow,
   // The icons of window and taskbar.
   base::win::ScopedHICON window_icon_;
   base::win::ScopedHICON app_icon_;
+
+  // Handles to legacy windows iterated by the mouse hook
+  static std::map<HWND, NativeWindowViews*> legacy_window_map_;
+  static HHOOK mouse_hook_;
+  bool forwarding_mouse_messages_ = false;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -267,10 +267,11 @@ class NativeWindowViews : public NativeWindow,
   base::win::ScopedHICON window_icon_;
   base::win::ScopedHICON app_icon_;
 
-  // Handles to legacy windows iterated by the mouse hook
-  static std::map<HWND, NativeWindowViews*> legacy_window_map_;
+  // The set of windows currently forwarding mouse messages.
+  static std::set<NativeWindowViews*> forwarding_windows_;
   static HHOOK mouse_hook_;
   bool forwarding_mouse_messages_ = false;
+  HWND legacy_window_ = NULL;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -171,8 +171,11 @@ class NativeWindowViews : public NativeWindow,
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
-  static LRESULT CALLBACK SubclassProc(HWND hwnd, UINT msg, WPARAM w_param, LPARAM l_param, UINT_PTR subclass_id, DWORD_PTR ref_data);
-  static LRESULT CALLBACK MouseHookProc(int n_code, WPARAM w_param, LPARAM l_param);
+  static LRESULT CALLBACK SubclassProc(
+      HWND hwnd, UINT msg, WPARAM w_param, LPARAM l_param, UINT_PTR subclass_id,
+      DWORD_PTR ref_data);
+  static LRESULT CALLBACK MouseHookProc(
+      int n_code, WPARAM w_param, LPARAM l_param);
 #endif
 
   // NativeWindow:

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -165,7 +165,8 @@ bool NativeWindowViews::PreHandleMSG(
         // Chromium removes the legacy window in the future it may be fine to
         // move the logic to this very switch statement.
         HWND legacy_window = reinterpret_cast<HWND>(l_param);
-        SetWindowSubclass(legacy_window, SubclassProc, 1, reinterpret_cast<DWORD_PTR>(this));
+        SetWindowSubclass(
+            legacy_window, SubclassProc, 1, reinterpret_cast<DWORD_PTR>(this));
         if (legacy_window_map_.size() == 0) {
           mouse_hook_ = SetWindowsHookEx(WH_MOUSE_LL, MouseHookProc, NULL, 0);
         }
@@ -228,7 +229,9 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
   }
 }
 
-LRESULT CALLBACK NativeWindowViews::SubclassProc(HWND hwnd, UINT msg, WPARAM w_param, LPARAM l_param, UINT_PTR subclass_id, DWORD_PTR ref_data) {
+LRESULT CALLBACK NativeWindowViews::SubclassProc(
+    HWND hwnd, UINT msg, WPARAM w_param, LPARAM l_param, UINT_PTR subclass_id,
+    DWORD_PTR ref_data) {
   NativeWindowViews* window = reinterpret_cast<NativeWindowViews*>(ref_data);
   switch (msg) {
     case WM_MOUSELEAVE: {
@@ -260,7 +263,8 @@ LRESULT CALLBACK NativeWindowViews::SubclassProc(HWND hwnd, UINT msg, WPARAM w_p
   return DefSubclassProc(hwnd, msg, w_param, l_param);
 }
 
-LRESULT CALLBACK NativeWindowViews::MouseHookProc(int n_code, WPARAM w_param, LPARAM l_param) {
+LRESULT CALLBACK NativeWindowViews::MouseHookProc(
+    int n_code, WPARAM w_param, LPARAM l_param) {
   if (n_code < 0) {
     return CallNextHookEx(NULL, n_code, w_param, l_param);
   }
@@ -280,10 +284,10 @@ LRESULT CALLBACK NativeWindowViews::MouseHookProc(int n_code, WPARAM w_param, LP
       // just left it as is.
       RECT client_rect;
       GetClientRect(legacy.first, &client_rect);
-      POINT p = ((MSLLHOOKSTRUCT*)l_param)->pt;
+      POINT p = reinterpret_cast<MSLLHOOKSTRUCT*>(l_param)->pt;
       ScreenToClient(legacy.first, &p);
       if (PtInRect(&client_rect, p)) {
-        WPARAM w = 0; // No virtual keys pressed for our purposes
+        WPARAM w = 0;  // No virtual keys pressed for our purposes
         LPARAM l = MAKELPARAM(p.x, p.y);
         PostMessage(legacy.first, WM_MOUSEMOVE, w, l);
       }

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -224,7 +224,7 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
   if (forward && !forwarding_mouse_messages_) {
     forwarding_mouse_messages_ = true;
     forwarding_windows_.insert(this);
-    
+
     // Subclassing is used to fix some issues when forwarding mouse messages;
     // see comments in |SubclassProc|.
     SetWindowSubclass(

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -221,10 +221,8 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 }
 
 void NativeWindowViews::SetForwardMouseMessages(bool forward) {
-  forwarding_mouse_messages_ = forward;
-  SetIgnoreMouseEvents(forward);
-
-  if (forward) {
+  if (forward && !forwarding_mouse_messages_) {
+    forwarding_mouse_messages_ = true;
     forwarding_windows_.insert(this);
     
     // Subclassing is used to fix some issues when forwarding mouse messages;
@@ -235,7 +233,8 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
     if (!mouse_hook_) {
       mouse_hook_ = SetWindowsHookEx(WH_MOUSE_LL, MouseHookProc, NULL, 0);
     }
-  } else {
+  } else if (!forward && forwarding_mouse_messages_) {
+    forwarding_mouse_messages_ = false;
     forwarding_windows_.erase(this);
 
     RemoveWindowSubclass(legacy_window_, SubclassProc, 1);

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1283,9 +1283,14 @@ Returns `Boolean` - Whether the window is visible on all workspaces.
 
 **Note:** This API always returns false on Windows.
 
-#### `win.setIgnoreMouseEvents(ignore)`
+#### `win.setIgnoreMouseEvents(ignore[, options])`
 
 * `ignore` Boolean
+* `options` Object (optional)
+  * `forward` Boolean (optional) _Windows_ - If true, forwards mouse move
+    messages to Chromium, enabling mouse related events such as `mouseleave`.
+	Only used when `ignore` is true. If `ignore` is false, forwarding is always
+	disabled regardless of this value.
 
 Makes the window ignore all mouse events.
 
@@ -1355,14 +1360,6 @@ removed in future Electron releases.
 
 **Note:** The BrowserView API is currently experimental and may change or be
 removed in future Electron releases.
-
-#### `win.setForwardMouseMessages(forward)` _Windows_
-
-* `forward` Boolean
-
-Forward mouse messages to the window below this one. This is similar to
-`setIgnoreMouseEvents`, but additionally allows users to listen to events
-related to mouse movement such as `mouseleave`.
 
 [blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.json5?l=62
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1356,6 +1356,14 @@ removed in future Electron releases.
 **Note:** The BrowserView API is currently experimental and may change or be
 removed in future Electron releases.
 
+#### `win.setForwardMouseMessages(forward)` _Windows_
+
+* `forward` Boolean
+
+Forward mouse messages to the window below this one. This is similar to
+`setIgnoreMouseEvents`, but additionally allows users to listen to events
+related to mouse movement such as `mouseleave`.
+
 [blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.json5?l=62
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -103,6 +103,27 @@ let win = new BrowserWindow()
 win.setIgnoreMouseEvents(true)
 ```
 
+### Forwarding
+
+Ignoring mouse messages makes the web page oblivious to mouse movement, meaning
+that mouse movement events will not be emitted. On Windows operating systems an
+optional parameter can be used to forward mouse move messages to the web page,
+allowing events such as `mouseleave` to be emitted:
+
+```javascript
+let win = require('electron').remote.getCurrentWindow()
+let el = document.getElementById('clickThroughElement')
+el.addEventListener('mouseenter', () => {
+  win.setIgnoreMouseEvents(true, {forward: true})
+})
+el.addEventListener('mouseleave', () => {
+  win.setIgnoreMouseEvents(false)
+})
+```
+
+This makes the web page click-through when over `el`, and returns to normal
+outside it.
+
 ## Draggable region
 
 By default, the frameless window is non-draggable. Apps need to specify


### PR DESCRIPTION
For top-level windows, setting the WS_EX_LAYERED and WS_EX_TRANSPARENT as done in `setIgnoreMouseEvents` styles effectively bypasses hit tests. This works great if the entire window should ignore mouse messages, but if we want to enable and disable bypassing based on where we are in the web page we are left in the dark since the browser window doesn't get any mouse messages anymore.

This PR solves this problem by adding a method `setForwardMouseMessages` to `BrowserWindow`. A low-level mouse hook manually sends WM_MOUSEMOVE messages to the browser window if it's in a state where it's forwarding mouse messages. This is enough for Chromium to generate events when entering/leaving HTML elements even when input is otherwise routed to underlying windows. Ultimately this allows us to stop forwarding when appropriate so that we may once again interact with the browser.

As a concrete example of where this was used, I made a transparent canvas that represents a hole the web page. Inside this area the window is treated as if it never existed. Moving out of the canvas once again acknowledges the window after disabling forwarding in the `mouseleave` event of the canvas.

Off-topic:
This is my very first PR so something has likely gone awry. Any feedback, minor or major, is greatly appreciated to improve quality of future ones.