### PR TITLE
Add `hideDisabledButtons` option to BrowserWindow's `titleBarStyle`

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -128,6 +128,7 @@ class NativeWindowMac : public NativeWindow,
     HIDDEN,
     HIDDEN_INSET,
     CUSTOM_BUTTONS_ON_HOVER,
+    HIDE_DISABLED_BUTTONS,
   };
   TitleBarStyle title_bar_style() const { return title_bar_style_; }
 
@@ -180,6 +181,10 @@ class NativeWindowMac : public NativeWindow,
   bool zoom_to_page_width_;
 
   bool fullscreen_window_title_;
+
+  bool minimizable_;
+  bool maximizable_;
+  bool closable_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -220,11 +220,13 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `hidden-inset` - Deprecated, use `hiddenInset` instead.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-    * `customButtonsOnHover` Boolean (optional) - Draw custom close, minimize,
+    * `customButtonsOnHover` - Draw custom close, minimize,
       and full screen buttons on macOS frameless windows. These buttons will not
       display unless hovered over in the top left of the window. These custom
       buttons prevent issues with mouse events that occur with the standard
       window toolbar buttons. **Note:** This option is currently experimental.
+    * `hideDisabledButtons` - Results in a hidden title bar which only renders the
+      window controls that are not disabled.
   * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
     tile bar in full screen mode on macOS for all `titleBarStyle` options.
     Default is `false`.


### PR DESCRIPTION
This PR adds a new `hideDisabledButtons` option to BrowserWindow's `titleBarStyle` option.

![screenshot 2017-08-01 16 35 35](https://user-images.githubusercontent.com/119684/28915391-4b1a9654-783f-11e7-8373-e5e93a0629bc.png)

Some implementation details: Since `NativeWindowMac`'s `IsMaximizable` method checks if the maximize button is enabled (which is always the case inside `InstallView()`), I had to add three new flags to the class: `minimizable_`, `maximizable_` and `closable_` which are set to the option the user has passed to the BrowserWindow.