### PR TITLE
add ability to access logs in getPath()

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -375,6 +375,8 @@ int GetPathConstant(const std::string& name) {
     return brightray::DIR_CACHE;
   else if (name == "userCache")
     return brightray::DIR_USER_CACHE;
+  else if (name == "logs")
+    return brightray::DIR_APP_LOGS;
   else if (name == "home")
     return base::DIR_HOME;
   else if (name == "temp")

--- a/brightray/browser/brightray_paths.h
+++ b/brightray/browser/brightray_paths.h
@@ -22,6 +22,7 @@ enum {
 
   DIR_USER_DATA = PATH_START,  // Directory where user data can be written.
   DIR_USER_CACHE,  // Directory where user cache can be written.
+  DIR_APP_LOGS,  // Directory where app logs live
 
 #if defined(OS_LINUX)
   DIR_APP_DATA,  // Application Data directory under the user profile.

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -89,6 +89,18 @@ void OverrideLinuxAppDataPath() {
   PathService::Override(DIR_APP_DATA, path);
 }
 
+// void OverrideWinAppLogsPath() {
+//   base::FilePath path;
+//   // should be in c:\program files\myapp\logs ?
+//   PathService::Override(DIR_APP_DATA, path);
+// }
+
+void OverrideLinuxAppLogsPath() {
+  std::string appName = GetExecutableFileProductName();
+  std::string logPath = '/var/log' + appName
+  PathService::Override(DIR_APP_DATA, base::FilePath(logPath));
+}
+
 int BrowserX11ErrorHandler(Display* d, XErrorEvent* error) {
   if (!g_in_x11_io_error_handler) {
     base::ThreadTaskRunnerHandle::Get()->PostTask(
@@ -165,6 +177,12 @@ void BrowserMainParts::PreEarlyInitialization() {
 #if defined(OS_MACOSX)
   OverrideMacAppLogsPath();
 #endif
+#if defined(OS_LINUX)
+  OverrideLinuxAppLogsPath();
+#endif
+// #if defined(OS_WIN)
+//   OverrideWinAppLogsPath();
+// #endif
 #if defined(USE_X11)
   views::LinuxUI::SetInstance(BuildGtkUi());
   OverrideLinuxAppDataPath();

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -4,6 +4,8 @@
 
 #include "brightray/browser/browser_main_parts.h"
 
+#include <string>
+
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/strings/string_number_conversions.h"
@@ -90,19 +92,21 @@ void OverrideLinuxAppDataPath() {
   PathService::Override(DIR_APP_DATA, path);
 }
 
-// void OverrideWinAppLogsPath() {
-//   base::FilePath path;
-//   // should be in c:\program files\myapp\logs ?
-//   PathService::Override(DIR_APP_DATA, path);
-// }
+void OverrideWinAppLogsPath() {
+  std::string appName = GetApplicationName();
+  std::string logPath = "%systemdrive%%homepath%\AppData\Roaming\\";
+  std::string appLogPath = logPath + appName + "\logs";
+
+  PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
+}
 
 void OverrideLinuxAppLogsPath() {
   std::string appName = GetApplicationName();
-  std::string logPath = "/var/log";
+  std::string logPath = "/var/log/";
 
   std::string appLogPath = logPath + appName;
 
-  PathService::Override(DIR_APP_LOGS base::FilePath(appLogPath));
+  PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
 }
 
 int BrowserX11ErrorHandler(Display* d, XErrorEvent* error) {
@@ -184,9 +188,9 @@ void BrowserMainParts::PreEarlyInitialization() {
 #if defined(OS_LINUX)
   OverrideLinuxAppLogsPath();
 #endif
-// #if defined(OS_WIN)
-//   OverrideWinAppLogsPath();
-// #endif
+#if defined(OS_WIN)
+  OverrideWinAppLogsPath();
+#endif
 #if defined(USE_X11)
   views::LinuxUI::SetInstance(BuildGtkUi());
   OverrideLinuxAppDataPath();

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -137,7 +137,7 @@ int BrowserX11IOErrorHandler(Display* d) {
     // Wait for the UI thread (which has a different connection to the X server)
     // to get the error. We can't call shutdown from this thread without
     // tripping an error. Doing it through a function so that we'll be able
-    // to see it in any crash dumps.back
+    // to see it in any crash dumps.
     WaitingForUIThreadToHandleIOError();
     return 0;
   }

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -5,8 +5,8 @@
 #include "brightray/browser/browser_main_parts.h"
 
 #include <stdlib.h>
-#include <string>
 #include <sys/stat.h>
+#include <string>
 
 #include "base/command_line.h"
 #include "base/feature_list.h"
@@ -107,8 +107,8 @@ void OverrideWinAppLogsPath() {
 
 void OverrideLinuxAppLogsPath() {
   std::string appName = GetApplicationName();
-  char* homePath = getenv("HOME");
-  std::string appLogPath = std:string(homePath) + "/.config/" + appName + "/logs";
+  std::string homePath = std:string(getenv("HOME"));
+  std::string appLogPath = homePath + "/.config/" + appName + "/logs";
 
   int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
 

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -11,6 +11,7 @@
 #include "brightray/browser/browser_context.h"
 #include "brightray/browser/devtools_manager_delegate.h"
 #include "brightray/browser/web_ui_controller_factory.h"
+#include "brightray/common/application_info.h"
 #include "brightray/common/main_delegate.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_switches.h"
@@ -96,9 +97,12 @@ void OverrideLinuxAppDataPath() {
 // }
 
 void OverrideLinuxAppLogsPath() {
-  std::string appName = GetExecutableFileProductName();
-  std::string logPath = '/var/log' + appName
-  PathService::Override(DIR_APP_DATA, base::FilePath(logPath));
+  std::string appName = GetApplicationName();
+  std::string logPath = "/var/log"
+
+  std::string appLogPath = logPath + appName
+
+  PathService::Override(DIR_APP_DATA, base::FilePath(appLogPath));
 }
 
 int BrowserX11ErrorHandler(Display* d, XErrorEvent* error) {

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -60,8 +60,8 @@
 
 namespace brightray {
 
-// defined in browser_main_parts_mac
 void OverrideMacAppLogsPath();
+void OverrideWinAppLogsPath();
 
 namespace {
 

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -4,6 +4,7 @@
 
 #include "brightray/browser/browser_main_parts.h"
 
+#include <stdlib.h>
 #include <string>
 
 #include "base/command_line.h"
@@ -58,6 +59,7 @@
 
 namespace brightray {
 
+// defined in browser_main_parts_mac
 void OverrideMacAppLogsPath();
 
 namespace {
@@ -94,17 +96,20 @@ void OverrideLinuxAppDataPath() {
 
 void OverrideWinAppLogsPath() {
   std::string appName = GetApplicationName();
-  std::string logPath = "%systemdrive%%homepath%\AppData\Roaming\\";
+  std::string logPath = "%HOMEDRIVE%%HOMEPATH%\AppData\Roaming\\";
   std::string appLogPath = logPath + appName + "\logs";
+
+  int status = mkdir(appLogPath, S_IRWXU | S_IRGRP | S_IROTH);
 
   PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
 }
 
 void OverrideLinuxAppLogsPath() {
   std::string appName = GetApplicationName();
-  std::string logPath = "/var/log/";
+  char* homePath = getenv("HOME");
+  std::string appLogPath = homePath + "/.config/" + appName;
 
-  std::string appLogPath = logPath + appName;
+  int status = mkdir(appLogPath, S_IRWXU | S_IRGRP | S_IROTH);
 
   PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
 }
@@ -130,7 +135,7 @@ int BrowserX11IOErrorHandler(Display* d) {
     // Wait for the UI thread (which has a different connection to the X server)
     // to get the error. We can't call shutdown from this thread without
     // tripping an error. Doing it through a function so that we'll be able
-    // to see it in any crash dumps.
+    // to see it in any crash dumps.back
     WaitingForUIThreadToHandleIOError();
     return 0;
   }

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -107,7 +107,7 @@ void OverrideWinAppLogsPath() {
 
 void OverrideLinuxAppLogsPath() {
   std::string appName = GetApplicationName();
-  std::string homePath = std:string(getenv("HOME"));
+  std::string homePath = std::string(getenv("HOME"));
   std::string appLogPath = homePath + "/.config/" + appName + "/logs";
 
   int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -97,8 +97,8 @@ void OverrideLinuxAppDataPath() {
 
 void OverrideWinAppLogsPath() {
   std::string appName = GetApplicationName();
-  std::string logPath = "%HOMEDRIVE%%HOMEPATH%\AppData\Roaming\\";
-  std::string appLogPath = logPath + appName + "\logs";
+  std::string logPath = "%HOMEDRIVE%%HOMEPATH%\\AppData\\Roaming\\";
+  std::string appLogPath = logPath + appName + "\\logs";
 
   int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
 
@@ -113,6 +113,7 @@ void OverrideLinuxAppLogsPath() {
   int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
 
   PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
+  return;
 }
 
 int BrowserX11ErrorHandler(Display* d, XErrorEvent* error) {

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -55,6 +55,8 @@
 
 namespace brightray {
 
+void OverrideMacAppLogsPath();
+
 namespace {
 
 #if defined(OS_WIN)
@@ -160,7 +162,9 @@ void BrowserMainParts::PreEarlyInitialization() {
   std::unique_ptr<base::FeatureList> feature_list(new base::FeatureList);
   feature_list->InitializeFromCommandLine("", "");
   base::FeatureList::SetInstance(std::move(feature_list));
-
+#if defined(OS_MACOSX)
+  OverrideMacAppLogsPath();
+#endif
 #if defined(USE_X11)
   views::LinuxUI::SetInstance(BuildGtkUi());
   OverrideLinuxAppDataPath();

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -98,11 +98,11 @@ void OverrideLinuxAppDataPath() {
 
 void OverrideLinuxAppLogsPath() {
   std::string appName = GetApplicationName();
-  std::string logPath = "/var/log"
+  std::string logPath = "/var/log";
 
-  std::string appLogPath = logPath + appName
+  std::string appLogPath = logPath + appName;
 
-  PathService::Override(DIR_APP_DATA, base::FilePath(appLogPath));
+  PathService::Override(DIR_APP_LOGS base::FilePath(appLogPath));
 }
 
 int BrowserX11ErrorHandler(Display* d, XErrorEvent* error) {

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include <string>
+#include <sys/stat.h>
 
 #include "base/command_line.h"
 #include "base/feature_list.h"
@@ -99,7 +100,7 @@ void OverrideWinAppLogsPath() {
   std::string logPath = "%HOMEDRIVE%%HOMEPATH%\AppData\Roaming\\";
   std::string appLogPath = logPath + appName + "\logs";
 
-  int status = mkdir(appLogPath, S_IRWXU | S_IRGRP | S_IROTH);
+  int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
 
   PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
 }
@@ -107,9 +108,9 @@ void OverrideWinAppLogsPath() {
 void OverrideLinuxAppLogsPath() {
   std::string appName = GetApplicationName();
   char* homePath = getenv("HOME");
-  std::string appLogPath = homePath + "/.config/" + appName;
+  std::string appLogPath = std:string(homePath) + "/.config/" + appName + "/logs";
 
-  int status = mkdir(appLogPath, S_IRWXU | S_IRGRP | S_IROTH);
+  int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
 
   PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
 }

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -61,7 +61,6 @@
 namespace brightray {
 
 void OverrideMacAppLogsPath();
-void OverrideWinAppLogsPath();
 
 namespace {
 

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -94,27 +94,6 @@ void OverrideLinuxAppDataPath() {
   PathService::Override(DIR_APP_DATA, path);
 }
 
-void OverrideWinAppLogsPath() {
-  std::string appName = GetApplicationName();
-  std::string logPath = "%HOMEDRIVE%%HOMEPATH%\\AppData\\Roaming\\";
-  std::string appLogPath = logPath + appName + "\\logs";
-
-  int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
-
-  PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
-}
-
-void OverrideLinuxAppLogsPath() {
-  std::string appName = GetApplicationName();
-  std::string homePath = std::string(getenv("HOME"));
-  std::string appLogPath = homePath + "/.config/" + appName + "/logs";
-
-  int status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
-
-  PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
-  return;
-}
-
 int BrowserX11ErrorHandler(Display* d, XErrorEvent* error) {
   if (!g_in_x11_io_error_handler) {
     base::ThreadTaskRunnerHandle::Get()->PostTask(
@@ -182,6 +161,28 @@ BrowserMainParts::BrowserMainParts() {
 }
 
 BrowserMainParts::~BrowserMainParts() {
+}
+
+void OverrideWinAppLogsPath() {
+  int status;
+  std::string appName = GetApplicationName();
+  std::string logPath = "%HOMEDRIVE%%HOMEPATH%\\AppData\\Roaming\\";
+  std::string appLogPath = logPath + appName + "\\logs";
+
+  status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
+
+  PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
+}
+
+void OverrideLinuxAppLogsPath() {
+  int status;
+  std::string appName = GetApplicationName();
+  std::string homePath = std::string(getenv("HOME"));
+  std::string appLogPath = homePath + "/.config/" + appName + "/logs";
+
+  status = mkdir(appLogPath.c_str(), S_IRWXU | S_IRGRP | S_IROTH);
+
+  PathService::Override(DIR_APP_LOGS, base::FilePath(appLogPath));
 }
 
 void BrowserMainParts::PreEarlyInitialization() {

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -167,9 +167,9 @@ BrowserMainParts::~BrowserMainParts() {
 #if defined(OS_WIN) || defined(OS_LINUX)
 void OverrideAppLogsPath() {
 #if defined(OS_WIN)
-  std::string app_name = GetApplicationName();
-  std::string log_path = "%HOMEDRIVE%%HOMEPATH%\\AppData\\Roaming\\";
-  std::string app_log_path = log_path + app_name + "\\logs";
+  std::wstring app_name = base::UTF8ToWide(GetApplicationName());
+  std::wstring log_path = L"%HOMEDRIVE%%HOMEPATH%\\AppData\\Roaming\\";
+  std::wstring app_log_path = log_path + app_name + L"\\logs";
 #else
   std::string app_name = GetApplicationName();
   std::string home_path = std::string(getenv("HOME"));

--- a/brightray/browser/browser_main_parts.h
+++ b/brightray/browser/browser_main_parts.h
@@ -9,6 +9,8 @@
 
 #include "base/compiler_specific.h"
 #include "base/macros.h"
+#include "base/path_service.h"
+#include "brightray/browser/brightray_paths.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "ui/views/layout/layout_provider.h"
 

--- a/brightray/browser/browser_main_parts.h
+++ b/brightray/browser/browser_main_parts.h
@@ -47,6 +47,7 @@ class BrowserMainParts : public content::BrowserMainParts {
  private:
 #if defined(OS_MACOSX)
   void InitializeMainNib();
+  void OverrideAppLogsPath();
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/brightray/browser/browser_main_parts_mac.mm
+++ b/brightray/browser/browser_main_parts_mac.mm
@@ -6,6 +6,18 @@
 
 namespace brightray {
 
+void OverrideMacAppLogsPath() {
+  base::FilePath path;
+  NSString* bundleName = [[[NSBundle mainBundle] infoDictionary]
+    objectForKey:@"CFBundleName"];
+  NSString* logsPath = [NSString stringWithFormat:@"Library/Logs/%@",bundleName];
+
+  NSString* libraryPath = [NSHomeDirectory() stringByAppendingPathComponent:logsPath];
+  std::string libPathString = std::string([libraryPath UTF8String]);
+
+  PathService::Override(DIR_APP_LOGS, base::FilePath(libPathString));
+}
+
 // Replicates NSApplicationMain, but doesn't start a run loop.
 void BrowserMainParts::InitializeMainNib() {
   auto infoDictionary = base::mac::OuterBundle().infoDictionary;

--- a/brightray/browser/browser_main_parts_mac.mm
+++ b/brightray/browser/browser_main_parts_mac.mm
@@ -6,16 +6,14 @@
 
 namespace brightray {
 
-void OverrideMacAppLogsPath() {
+void BrowserMainParts::OverrideAppLogsPath() {
   base::FilePath path;
   NSString* bundleName = [[[NSBundle mainBundle] infoDictionary]
     objectForKey:@"CFBundleName"];
   NSString* logsPath = [NSString stringWithFormat:@"Library/Logs/%@",bundleName];
-
   NSString* libraryPath = [NSHomeDirectory() stringByAppendingPathComponent:logsPath];
-  std::string libPathString = std::string([libraryPath UTF8String]);
 
-  PathService::Override(DIR_APP_LOGS, base::FilePath(libPathString));
+  PathService::Override(DIR_APP_LOGS, base::FilePath([libraryPath UTF8String]));
 }
 
 // Replicates NSApplicationMain, but doesn't start a run loop.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -458,6 +458,7 @@ You can request the following paths by the name:
 * `music` Directory for a user's music.
 * `pictures` Directory for a user's pictures.
 * `videos` Directory for a user's videos.
+* `logs` Directory for your app's log folder.
 * `pepperFlashSystemPlugin`  Full path to the system version of the Pepper Flash plugin.
 
 ### `app.getFileIcon(path[, options], callback)`


### PR DESCRIPTION
Adds the ability to get logs via `app.getPath('logs')`, implementing feature requested in https://github.com/electron/electron/issues/10118. 

- [x] MacOS
- [x] Linux
- [x] Windows

**Nota Bene:** Unlike MacOS, Linux & Windows do not create log folders until a log-worthy event happens, so this implementation lets the app developer ensure the directory exists. If anyone has an idea for an alternate way this could be dealt with please let me know!