### PR TITLE
Revert "Fix window.opener being null when nativeWindowOpen is used"

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -100,14 +100,13 @@ bool AtomBrowserClient::ShouldCreateNewSiteInstance(
 
   int process_id = current_instance->GetProcess()->GetID();
   if (!IsRendererSandboxed(process_id)) {
-    auto web_contents =
-        content::WebContents::FromRenderFrameHost(render_frame_host);
-    if (!WebContentsPreferences::UsesNativeWindowOpen(web_contents)) {
+    if (!RendererUsesNativeWindowOpen(process_id)) {
       // non-sandboxed renderers without native window.open should always create
       // a new SiteInstance
       return true;
     }
-
+    auto web_contents =
+        content::WebContents::FromRenderFrameHost(render_frame_host);
     if (!ChildWebContentsTracker::IsChildWebContents(web_contents)) {
       // Root WebContents should always create new process to make sure
       // native addons are loaded correctly after reload / navigation.
@@ -115,17 +114,6 @@ bool AtomBrowserClient::ShouldCreateNewSiteInstance(
       //  reuse process to allow synchronous cross-window scripting.)
       return true;
     }
-
-    // In a non-sandboxed renderer with native window open we should
-    // reuse the same site to allow cross-window scripting.  We do
-    // not need to check urls / domains as native window open logic
-    // handles cross site scripting protection.
-    //
-    // NOTE: We know that nativeWindowOpen is enabled at this point
-    // because we check if it is NOT enabled above this point.  We
-    // will only reach this return if sandbox is disabled but
-    // nativeWindowOpen is enabled.
-    return false;
   }
 
   // Create new a SiteInstance if navigating to a different site.


### PR DESCRIPTION
Reverts electron/electron#9961

@MarshallOfSound The change is reliably causing following tests to fail:

```
not ok 125 BrowserWindow module "webPreferences" option nativeWindowOpen option should inherit the nativeWindowOpen setting in opened windows
  Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at C:\e\workspace\electron-win-ia32\spec\node_modules\mocha\lib\runnable.js:232:19
not ok 126 BrowserWindow module "webPreferences" option nativeWindowOpen option should open windows with the options configured via new-window event listeners
  Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at C:\e\workspace\electron-win-ia32\spec\node_modules\mocha\lib\runnable.js:232:19
not ok 127 BrowserWindow module "webPreferences" option nativeWindowOpen option retains the original web preferences when window.location is changed to a new origin
  Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at C:\e\workspace\electron-win-ia32\spec\node_modules\mocha\lib\runnable.js:232:19
```

I haven't figured out why, but I'm reverting it for now to avoid blocking new releases.