### PR TITLE
Rollback debug mode changes

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -34,7 +34,7 @@
 
 namespace {
 
-const auto kRunAsNode = "ELECTRON_RUN_AS_NODE";
+const char* kRunAsNode = "ELECTRON_RUN_AS_NODE";
 
 bool IsEnvSet(const char* name) {
 #if defined(OS_WIN)
@@ -56,29 +56,6 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
 
   bool run_as_node = IsEnvSet(kRunAsNode);
 
-#ifdef _DEBUG
-  // Don't display assert dialog boxes in CI test runs
-  static const auto kCI = "ELECTRON_CI";
-  bool is_ci = IsEnvSet(kCI);
-  if (!is_ci) {
-    for (int i = 0; i < argc; ++i) {
-      if (!_wcsicmp(wargv[i], L"--ci")) {
-        is_ci = true;
-        _putenv_s(kCI, "1");  // set flag for child processes
-        break;
-      }
-    }
-  }
-  if (is_ci) {
-    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
-
-    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
-
-    _set_error_mode(_OUT_TO_STDERR);
-  }
-#endif
 
   // Make sure the output is printed to console.
   if (run_as_node || !IsEnvSet("ELECTRON_NO_ATTACH_CONSOLE"))

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -216,7 +216,7 @@ void AtomSandboxedRendererClient::InvokeIpcCallback(
   auto callback_value = binding->Get(callback_key);
   DCHECK(callback_value->IsFunction());  // set by sandboxed_renderer/init.js
   auto callback = v8::Handle<v8::Function>::Cast(callback_value);
-  ignore_result(callback->Call(context, binding, args.size(), args.data()));
+  ignore_result(callback->Call(context, binding, args.size(), &args[0]));
 }
 
 }  // namespace atom

--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -92,6 +92,8 @@
       'Common_Base': {
         'abstract': 1,
         'defines': [
+          # We are using Release version libchromiumcontent:
+          'NDEBUG',
           # Needed by gin:
           'V8_USE_EXTERNAL_STARTUP_DATA',
           # From skia_for_chromium_defines.gypi:
@@ -187,7 +189,6 @@
           # Use this instead of "NDEBUG" to determine whether we are in
           # Debug build, because "NDEBUG" is already used by Chromium.
           'DEBUG',
-          '_DEBUG',
           # Require when using libchromiumcontent.
           'COMPONENT_BUILD',
           'GURL_DLL',
@@ -197,32 +198,15 @@
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': '3',  # /MDd (debug DLL)
+            'RuntimeLibrary': '2',  # /MD (nondebug DLL)
             'Optimization': '0',  # 0 = /Od
             # See http://msdn.microsoft.com/en-us/library/8wtf2dfz(VS.71).aspx
             'BasicRuntimeChecks': '3',  # 3 = all checks enabled, 0 = off
           },
-          'VCLinkerTool': {
-            'OptimizeReferences': 2, # /OPT:REF
-            'EnableCOMDATFolding': 2, # /OPT:ICF
-          },
         },
-        'conditions': [
-          ['OS=="linux" and target_arch=="x64"', {
-            'defines': [
-              '_GLIBCXX_DEBUG',
-            ],
-            'cflags': [
-              '-g',
-            ],
-          }],  # OS=="linux"
-        ],
       },  # Debug_Base
       'Release_Base': {
         'abstract': 1,
-        'defines': [
-          'NDEBUG',
-        ],
         'msvs_settings': {
           'VCCLCompilerTool': {
             'RuntimeLibrary': '2',  # /MD (nondebug DLL)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -405,7 +405,7 @@ describe('app module', function () {
     })
   })
 
-  xdescribe('select-client-certificate event', function () {
+  describe('select-client-certificate event', function () {
     let w = null
 
     beforeEach(function () {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -208,7 +208,7 @@ describe('app module', function () {
     })
   })
 
-  xdescribe('app.importCertificate', function () {
+  describe('app.importCertificate', function () {
     if (process.platform !== 'linux') return
 
     var w = null

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -63,7 +63,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request(`${server.url}${requestUrl}`)
@@ -89,7 +89,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -120,7 +120,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request(`${server.url}${requestUrl}`)
@@ -157,7 +157,7 @@ describe('net module', function () {
             })
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -197,7 +197,7 @@ describe('net module', function () {
             })
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -252,7 +252,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -333,7 +333,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -420,7 +420,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -459,7 +459,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -500,7 +500,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -545,7 +545,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       customSession.cookies.set({
@@ -582,6 +582,7 @@ describe('net module', function () {
     it('should be able to abort an HTTP request before first write', function (done) {
       const requestUrl = '/requestUrl'
       server.on('request', function (request, response) {
+        response.end()
         assert.fail('Unexpected request event')
       })
 
@@ -625,7 +626,7 @@ describe('net module', function () {
             cancelRequest()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -678,7 +679,7 @@ describe('net module', function () {
             })
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -729,7 +730,7 @@ describe('net module', function () {
             response.write(randomString(kOneKiloByte))
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -794,7 +795,7 @@ describe('net module', function () {
             cancelRequest()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -844,15 +845,12 @@ describe('net module', function () {
       let requestIsRedirected = false
       server.on('request', function (request, response) {
         switch (request.url) {
-          case requestUrl:
-            assert.fail(`Unexpected url: ${request.url}`)
-            break
           case redirectUrl:
             requestIsRedirected = true
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -895,15 +893,12 @@ describe('net module', function () {
       let requestIsRedirected = false
       server.on('request', function (request, response) {
         switch (request.url) {
-          case requestUrl:
-            assert.fail(`Unexpected url: ${request.url}`)
-            break
           case redirectUrl:
             requestIsRedirected = true
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -994,7 +989,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -1026,7 +1021,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -1053,7 +1048,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -1089,7 +1084,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -1130,7 +1125,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -1180,15 +1175,12 @@ describe('net module', function () {
       let requestIsRedirected = false
       server.on('request', function (request, response) {
         switch (request.url) {
-          case requestUrl:
-            assert.fail(`Unexpected url: ${request.url}`)
-            break
           case redirectUrl:
             requestIsRedirected = true
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -1262,7 +1254,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -1315,7 +1307,7 @@ describe('net module', function () {
             })
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
 
@@ -1347,7 +1339,7 @@ describe('net module', function () {
             request.socket.destroy()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       let requestErrorEventEmitted = false
@@ -1378,7 +1370,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       const urlRequest = net.request({
@@ -1442,7 +1434,7 @@ describe('net module', function () {
             })
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       ipcRenderer.once('api-net-spec-done', function () {
@@ -1487,7 +1479,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       let requestCloseEventEmitted = false
@@ -1563,7 +1555,7 @@ describe('net module', function () {
             })
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       ipcRenderer.once('api-net-spec-done', function () {
@@ -1601,7 +1593,7 @@ describe('net module', function () {
             response.end()
             break
           default:
-            assert.fail(`Unexpected url: ${request.url}`)
+            handleUnexpectedURL(request, response)
         }
       })
       ipcRenderer.once('api-net-spec-done', function () {
@@ -1628,3 +1620,9 @@ describe('net module', function () {
     })
   })
 })
+
+function handleUnexpectedURL (request, response) {
+  response.statusCode = '500'
+  response.end()
+  assert.fail(`Unexpected URL: ${request.url}`)
+}

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -590,12 +590,6 @@ describe('webContents module', function () {
   })
 
   describe('destroy()', () => {
-    // Destroying webContents in its event listener is going to crash when
-    // Electron is built in Debug mode.
-    if (process.platform !== 'darwin') {
-      return
-    }
-
     let server
 
     before(function (done) {


### PR DESCRIPTION
Given that #10203 still didn't fix the issue of Linux CI builds failing, this PR simply rolls back the debug mode changes made.