### PR TITLE
Support standard property/methods of 'location'

### DIFF
--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -57,14 +57,29 @@ const removeProxy = (guestId) => {
 function BrowserWindowProxy (ipcRenderer, guestId) {
   this.closed = false
 
+  function loadURL (url) {
+    url = resolveURL(url)
+    return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', guestId, 'loadURL', url)
+  }
+
   defineProperty(this, 'location', {
     get: function () {
-      return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', guestId, 'getURL')
+      let url = ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', guestId, 'getURL')
+
+      var locationObj = require('url').parse(url)
+
+      defineProperty(locationObj, 'href', {
+        set: function (url) {
+          loadURL(url)
+        },
+        get: function () {
+          return url
+        }
+      })
+
+      return locationObj
     },
-    set: function (url) {
-      url = resolveURL(url)
-      return ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', guestId, 'loadURL', url)
-    }
+    set: loadURL
   })
 
   ipcRenderer.once(`ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_${guestId}`, () => {
@@ -106,7 +121,7 @@ const getHistoryOperation = function (ipcRenderer, ...args) {
   return ipcRenderer.sendSync('ELECTRON_SYNC_NAVIGATION_CONTROLLER', ...args)
 }
 
-module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNativeWindowOpen) => {
+module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage) => {
   if (guestInstanceId == null) {
     // Override default window.close.
     window.close = function () {
@@ -114,22 +129,16 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNative
     }
   }
 
-  if (!usesNativeWindowOpen) {
-    // Make the browser window or guest view emit "new-window" event.
-    window.open = function (url, frameName, features) {
-      if (url != null && url !== '') {
-        url = resolveURL(url)
-      }
-      const guestId = ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, toString(frameName), toString(features))
-      if (guestId != null) {
-        return getOrCreateProxy(ipcRenderer, guestId)
-      } else {
-        return null
-      }
+  // Make the browser window or guest view emit "new-window" event.
+  window.open = function (url, frameName, features) {
+    if (url != null && url !== '') {
+      url = resolveURL(url)
     }
-
-    if (openerId != null) {
-      window.opener = getOrCreateProxy(ipcRenderer, openerId)
+    const guestId = ipcRenderer.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, toString(frameName), toString(features))
+    if (guestId != null) {
+      return getOrCreateProxy(ipcRenderer, guestId)
+    } else {
+      return null
     }
   }
 
@@ -144,6 +153,10 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNative
   // But we do not support prompt().
   window.prompt = function () {
     throw new Error('prompt() is and will not be supported.')
+  }
+
+  if (openerId != null) {
+    window.opener = getOrCreateProxy(ipcRenderer, openerId)
   }
 
   ipcRenderer.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId, message, sourceOrigin) {
@@ -175,35 +188,27 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNative
     }
   })
 
-  if (guestInstanceId != null) {
-    // Webview `document.visibilityState` tracks window visibility (and ignores
-    // the actual <webview> element visibility) for backwards compatibility.
-    // See discussion in #9178.
-    //
-    // Note that this results in duplicate visibilitychange events (since
-    // Chromium also fires them) and potentially incorrect visibility change.
-    // We should reconsider this decision for Electron 2.0.
-    let cachedVisibilityState = hiddenPage ? 'hidden' : 'visible'
+  // The initial visibilityState.
+  let cachedVisibilityState = hiddenPage ? 'hidden' : 'visible'
 
-    // Subscribe to visibilityState changes.
-    ipcRenderer.on('ELECTRON_GUEST_INSTANCE_VISIBILITY_CHANGE', function (event, visibilityState) {
-      if (cachedVisibilityState !== visibilityState) {
-        cachedVisibilityState = visibilityState
-        document.dispatchEvent(new Event('visibilitychange'))
-      }
-    })
+  // Subscribe to visibilityState changes.
+  ipcRenderer.on('ELECTRON_RENDERER_WINDOW_VISIBILITY_CHANGE', function (event, visibilityState) {
+    if (cachedVisibilityState !== visibilityState) {
+      cachedVisibilityState = visibilityState
+      document.dispatchEvent(new Event('visibilitychange'))
+    }
+  })
 
-    // Make document.hidden and document.visibilityState return the correct value.
-    defineProperty(document, 'hidden', {
-      get: function () {
-        return cachedVisibilityState !== 'visible'
-      }
-    })
+  // Make document.hidden and document.visibilityState return the correct value.
+  defineProperty(document, 'hidden', {
+    get: function () {
+      return cachedVisibilityState !== 'visible'
+    }
+  })
 
-    defineProperty(document, 'visibilityState', {
-      get: function () {
-        return cachedVisibilityState
-      }
-    })
-  }
+  defineProperty(document, 'visibilityState', {
+    get: function () {
+      return cachedVisibilityState
+    }
+  })
 }

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -354,12 +354,45 @@ describe('chromium feature', function () {
       b = window.open(targetURL)
     })
 
+    it('defines a window.location.href getter', function (done) {
+      var b, targetURL
+      if (process.platform === 'win32') {
+        targetURL = 'file:///' + fixtures.replace(/\\/g, '/') + '/pages/base-page.html'
+      } else {
+        targetURL = 'file://' + fixtures + '/pages/base-page.html'
+      }
+      app.once('browser-window-created', (event, window) => {
+        window.webContents.once('did-finish-load', () => {
+          assert.equal(b.location.href, targetURL)
+          b.close()
+          done()
+        })
+      })
+      b = window.open(targetURL)
+    })
+
     it('defines a window.location setter', function (done) {
       let b
       app.once('browser-window-created', (event, {webContents}) => {
         webContents.once('did-finish-load', function () {
           // When it loads, redirect
           b.location = 'file://' + fixtures + '/pages/base-page.html'
+          webContents.once('did-finish-load', function () {
+            // After our second redirect, cleanup and callback
+            b.close()
+            done()
+          })
+        })
+      })
+      // Load a page that definitely won't redirect
+      b = window.open('about:blank')
+    })
+    it('defines a window.location.href setter', function (done) {
+      let b
+      app.once('browser-window-created', (event, {webContents}) => {
+        webContents.once('did-finish-load', function () {
+          // When it loads, redirect
+          b.location.href = 'file://' + fixtures + '/pages/base-page.html'
           webContents.once('did-finish-load', function () {
             // After our second redirect, cleanup and callback
             b.close()


### PR DESCRIPTION
support location api property: host/href/protocol/search/path/hash
```
var win = window.open('http://www.github.com');
//...
console.log(win.location.host);
//...
win.location.href = 'https://www.google.com'
```
