### PR TITLE
Ensure DesktopCapturers are destroyed when no longer needed.

### DIFF
--- a/chromium_src/chrome/browser/media/desktop_media_list_observer.h
+++ b/chromium_src/chrome/browser/media/desktop_media_list_observer.h
@@ -14,6 +14,9 @@ class DesktopMediaListObserver {
   virtual void OnSourceMoved(int old_index, int new_index) = 0;
   virtual void OnSourceNameChanged(int index) = 0;
   virtual void OnSourceThumbnailChanged(int index) = 0;
+
+  // Return false to stop refreshing. The associated |DesktopMediaList| should
+  // no longer be used.
   virtual bool OnRefreshFinished() = 0;
 
  protected:

--- a/chromium_src/chrome/browser/media/native_desktop_media_list.cc
+++ b/chromium_src/chrome/browser/media/native_desktop_media_list.cc
@@ -368,5 +368,8 @@ void NativeDesktopMediaList::OnRefreshFinished() {
         base::Bind(&NativeDesktopMediaList::Refresh,
                    weak_factory_.GetWeakPtr()),
         update_period_);
+  } else {
+    // Destroy the capturers.
+    worker_.reset();
   }
 }


### PR DESCRIPTION
After an app calls `desktopCapturer.getSources` on macOS, the screen sharing icon will appear on the lock screen until the app is closed:
<img width="242" alt="mac-lock-screen-icon" src="https://user-images.githubusercontent.com/920663/29093453-c23efa2e-7c3e-11e7-8562-d635ab9c5f75.png">

This happens because we currently never destroy the desktop capturers that are created upon `getSources`. This change has `NativeDesktopMediaList` destroy them when its user indicates it is finished by returning `false` from `OnRefreshFinished`.

To see this occur, run the demo app in this repo on macOS:
https://github.com/ajmacd/desktop-capturer-demo

and check the lock screen after capturing the screen once. The screen share icon will be present until the app is killed. By replacing Electron with one built from this PR, the screen share icon is no longer present.
  