### PR TITLE
add more installation tips

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -59,11 +59,8 @@ You can also attempt to download Electron directly from
 [electron/electron/releases](https://github.com/electron/electron/releases) 
 if installing via `npm` is failing.
 
-If installation fails with an `EACCESS` error you may have to run it again with `sudo`:
-
-```sh
-sudo npm install electron
-```
+If installation fails with an `EACCESS` error you may need to 
+[fix your npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
 
 If the above error persists, the [unsafe-perm](https://docs.npmjs.com/misc/config#unsafe-perm) flag may need to be set to true:
 

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -33,6 +33,13 @@ If you want to change the architecture that is downloaded (e.g., `ia32` on an
 npm install --arch=ia32 electron
 ```
 
+In addition to changing the architecture, you can also specify the platform 
+(e.g., `win32`, `linux`, etc.) using the `--platform` flag:
+
+```shell
+npm install --platform=win32 electron
+```
+
 ## Proxies
 
 If you need to use an HTTP proxy you can [set these environment variables](https://github.com/request/request/tree/f0c4ec061141051988d1216c24936ad2e7d5c45d#controlling-proxy-behaviour-using-environment-variables).
@@ -45,12 +52,30 @@ installation errors.
 In almost all cases, these errors are the result of network problems and not 
 actual issues with the `electron` npm package. Errors like `ELIFECYCLE`, 
 `EAI_AGAIN`, `ECONNRESET`, and `ETIMEDOUT` are all indications of such 
-network problems.  The best resolution is to try switching networks, or 
+network problems. The best resolution is to try switching networks, or 
 just wait a bit and try installing again.
 
 You can also attempt to download Electron directly from 
 [electron/electron/releases](https://github.com/electron/electron/releases) 
 if installing via `npm` is failing.
+
+If installation fails with an `EACCESS` error you may have to run it again with `sudo`:
+
+```sh
+sudo npm install electron
+```
+
+If the above error persists, the [unsafe-perm](https://docs.npmjs.com/misc/config#unsafe-perm) flag may need to be set to true:
+
+```sh
+sudo npm install electron --unsafe-perm=true
+```
+
+On slower networks, it may be advisable to use the `--verbose` flag in order to show download progress:
+
+```sh
+npm install --verbose electron
+```
 
 If you need to force a re-download of the asset and the SHASUM file set the
 `force_no_cache` enviroment variable to `true`.


### PR DESCRIPTION
@benjibee added some helpful tips to the README in  electron-userland/electron-prebuilt#265, electron-userland/electron-prebuilt#266, and electron-userland/electron-prebuilt#267 but we didn't get to them before we [merged electron-prebuilt into this repo](https://github.com/electron/electron/pulls/10172).

This PR adds those tips to the new installation guide.