### PR TITLE
remove no-op preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lint-api-docs-js": "standard-markdown docs && standard-markdown docs-translations",
     "create-api-json": "electron-docs-linter docs --outfile=out/electron-api.json --version=$npm_package_version",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=out/electron-api.json --out=out/electron.d.ts",
-    "preinstall": "node -e 'process.exit(0)'",
     "publish-to-npm": "node ./script/publish-to-npm.js",
     "prepack": "check-for-leaks",
     "prepush": "check-for-leaks",


### PR DESCRIPTION
Apparently this script was needed for old versions of npm. It is presumably safe to remove it now.

cc @MylesBorins @vanessayuenn @malept 