### PR TITLE
New guide for implementing updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ an issue:
 * [Testing on Headless CI Systems (Travis, Jenkins)](tutorial/testing-on-headless-ci.md)
 * [Offscreen Rendering](tutorial/offscreen-rendering.md)
 * [Keyboard Shortcuts](tutorial/keyboard-shortcuts.md)
+* [Updating Applications](tutorial/updates.md)
 
 ## Tutorials
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -6,10 +6,13 @@ Process: [Main](../glossary.md#main-process)
 
 **You can find a detailed guide about how to implement updates into your application [here](../tutorial/updates.md).**
 
-## Platform notices
+## Platform Notices
 
-Although `autoUpdater` provides a uniform API for different platforms, there are
-still some subtle differences on each platform:
+Currently, only macOS and Windows are supported. There is no built-in support
+for auto-updater on Linux, so it is recommended to use the
+distribution's package manager to update your app.
+
+In addition, there are some subtle differences on each platform:
 
 ### macOS
 
@@ -37,15 +40,6 @@ The installer generated with Squirrel will create a shortcut icon with an
 `com.squirrel.slack.Slack` and `com.squirrel.code.Code`. You have to use the
 same ID for your app with `app.setAppUserModelId` API, otherwise Windows will
 not be able to pin your app properly in task bar.
-
-Unlike Squirrel.Mac, Windows can host updates on S3 or any other static file host.
-You can read the documents of [Squirrel.Windows][squirrel-windows] to get more details
-about how Squirrel.Windows works.
-
-### Linux
-
-There is no built-in support for auto-updater on Linux, so it is recommended to
-use the distribution's package manager to update your app.
 
 ## Events
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -42,6 +42,8 @@ same ID for your app with `app.setAppUserModelId` API, otherwise Windows will
 not be able to pin your app properly in task bar.
 
 Unlike Squirrel.Mac, Windows can host updates on S3 or any other static file host.
+You can read the documents of [Squirrel.Windows][squirrel-windows] to get more details
+about how Squirrel.Windows works.
 
 ## Events
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -4,24 +4,12 @@
 
 Process: [Main](../glossary.md#main-process)
 
-The `autoUpdater` module provides an interface for the
-[Squirrel](https://github.com/Squirrel) framework.
-
-You can quickly launch a multi-platform release server for distributing your
-application by using one of these projects:
-
-- [nuts][nuts]: *A smart release server for your applications, using GitHub as a backend. Auto-updates with Squirrel (Mac & Windows)*
-- [electron-release-server][electron-release-server]: *A fully featured,
-  self-hosted release server for electron applications, compatible with
-  auto-updater*
-- [squirrel-updates-server][squirrel-updates-server]: *A simple node.js server
-  for Squirrel.Mac and Squirrel.Windows which uses GitHub releases*
-- [squirrel-release-server][squirrel-release-server]: *A simple PHP application for Squirrel.Windows which reads updates from a folder. Supports delta updates.*
+**You can find a detailed guide about how to implement updates into your application [here](../tutorial/updates.md).**
 
 ## Platform notices
 
-Though `autoUpdater` provides a uniform API for different platforms, there are
-still some subtle differences on each platform.
+Although `autoUpdater` provides a uniform API for different platforms, there are
+still some subtle differences on each platform:
 
 ### macOS
 
@@ -134,7 +122,3 @@ from the normal quit event sequence.
 [installer-lib]: https://github.com/electron/windows-installer
 [electron-forge-lib]: https://github.com/electron-userland/electron-forge
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
-[electron-release-server]: https://github.com/ArekSredzki/electron-release-server
-[squirrel-updates-server]: https://github.com/Aluxian/squirrel-updates-server
-[nuts]: https://github.com/GitbookIO/nuts
-[squirrel-release-server]: https://github.com/Arcath/squirrel-release-server

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -41,6 +41,8 @@ The installer generated with Squirrel will create a shortcut icon with an
 same ID for your app with `app.setAppUserModelId` API, otherwise Windows will
 not be able to pin your app properly in task bar.
 
+Unlike Squirrel.Mac, Windows can host updates on S3 or any other static file host.
+
 ## Events
 
 The `autoUpdater` object emits the following events:

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -29,12 +29,12 @@ software, but it works like described when using
 [Hazel](https://github.com/zeit/hazel).
 
 **Important:** Please ensure that the code below will only be executed in 
-your packaged app. You can use 
+your packaged app, and not in development. You can use 
 [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) to check for 
 the environment.
 
 ```js
-const { app, autoUpdater } = require('electron')
+const { app, autoUpdater, dialog } = require('electron')
 ```
 
 Next, construct the URL of the update server and tell 
@@ -55,20 +55,30 @@ setInterval(() => {
 }, 60000)
 ```
 
-That's all. Once [built](../tutorial/application-distribution.md), your 
-application will receive an update for each new 
+Once your application is [packaged](../tutorial/application-distribution.md), 
+it  will receive an update for each new 
 [GitHub Release](https://help.github.com/articles/creating-releases/) that you 
-create.
+publish.
 
-## Further steps
+## Applying updates
 
 Now that you've configured the basic update mechanism for your application, you 
 need to ensure that the user will get notified when there's an update. This
-can be achieved using [events](../api/auto-updater.md#events):
+can be achieved using the autoUpdater API 
+[events](../api/auto-updater.md#events):
 
 ```js
 autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
-  // Show a notification banner to the user that allows triggering the update
+  const dialogOpts = {
+    type: 'info',
+    buttons: ['Restart', 'Later'],
+    title: 'Application Update',
+    message: 'A new version has been downloaded. Restart the application to apply the updates.',
+    detail: releaseName + '\n\n' + releaseNotes
+  }
+  dialog.showMessageBox(dialogOpts, function(response) {
+    if (response === 0) autoUpdater.quitAndInstall()
+  })
 })
 ```
 

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -1,0 +1,42 @@
+# Updating Applications
+
+There are several ways to update an Electron application. The easiest and officially supported one is taking advantage of the built-in [Squirrel](https://github.com/Squirrel) framework and the [autoUpdater](../api/auto-updater.md) module that comes with it.
+
+## Deploying an Update Server
+
+To get started, you firstly need to deploy an update server (that's where the [autoUpdater](../api/auto-updater.md) module will download new updates from).
+
+Depending on your needs, you can choose from one of these:
+
+- [Hazel](https://github.com/zeit/hazel) – Pulls new releases from [GitHub Releases](https://help.github.com/articles/creating-releases/) and is **perfect for getting started**
+- [Nuts](https://github.com/GitbookIO/nuts) – Also uses [GitHub Releases](https://help.github.com/articles/creating-releases/), but caches app updates on disk
+- [electron-release-server](https://github.com/ArekSredzki/electron-release-server) – Provides you with a dashboard for handling releases
+
+## Implemeting Updates into Your App
+
+Once you've deployed your update server, continue with importing the required modules in your code (please ensure that the code below will only be executed in production - you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) for that):
+
+```js
+const { app, autoUpdater } = require('electron')
+```
+
+Next, put together the URL of the update server:
+
+```js
+const server = <your-deployment-url>
+const feed = `${server}/update/${process.platform}/${app.getVersion()}`
+```
+
+As the final step, tell [autoUpdater](../api/auto-updater.md) where to ask for updates:
+
+```js
+autoUpdater.setFeedURL(feed)
+```
+
+That's all. Once [built](../tutorial/application-distribution.md), your application will receive an update for each new [GitHub Release](https://help.github.com/articles/creating-releases/) that you create.
+
+## Further Steps
+
+Now that you've configured the basic update mechanism for your application, you need to ensure that the user will get notified when there's an update (this can be achieved using [events](../api/auto-updater.md#events)).
+
+Also make sure that potential errors are [being handled](../api/auto-updater.md#event-error).

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -9,7 +9,7 @@ To get started, you firstly need to deploy an update server (that's where the [a
 Depending on your needs, you can choose from one of these:
 
 - [Hazel](https://github.com/zeit/hazel) – Pulls new releases from [GitHub Releases](https://help.github.com/articles/creating-releases/) and is **perfect for getting started**
-- [Nuts](https://github.com/GitbookIO/nuts) – Also uses [GitHub Releases](https://help.github.com/articles/creating-releases/), but caches app updates on disk
+- [Nuts](https://github.com/GitbookIO/nuts) – Also uses [GitHub Releases](https://help.github.com/articles/creating-releases/), but caches app updates on disk and supports private repositories
 - [electron-release-server](https://github.com/ArekSredzki/electron-release-server) – Provides you with a dashboard for handling releases
 
 ## Implementing Updates into Your App

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -1,31 +1,47 @@
 # Updating Applications
 
-There are several ways to update an Electron application. The easiest and officially supported one is taking advantage of the built-in [Squirrel](https://github.com/Squirrel) framework and the [autoUpdater](../api/auto-updater.md) module that comes with it.
+There are several ways to update an Electron application. The easiest and 
+officially supported one is taking advantage of the built-in 
+[Squirrel](https://github.com/Squirrel) framework and 
+Electron's [autoUpdater](../api/auto-updater.md) module.
 
-## Deploying an Update Server
+## Deploying an update server
 
-To get started, you firstly need to deploy an update server (that's where the [autoUpdater](../api/auto-updater.md) module will download new updates from).
+To get started, you first need to deploy a server that the 
+[autoUpdater](../api/auto-updater.md) module will download new updates from.
 
 Depending on your needs, you can choose from one of these:
 
-- [Hazel](https://github.com/zeit/hazel) – Pulls new releases from [GitHub Releases](https://help.github.com/articles/creating-releases/) and is **perfect for getting started**
-- [Nuts](https://github.com/GitbookIO/nuts) – Also uses [GitHub Releases](https://help.github.com/articles/creating-releases/), but caches app updates on disk and supports private repositories
-- [electron-release-server](https://github.com/ArekSredzki/electron-release-server) – Provides you with a dashboard for handling releases
+- [Hazel](https://github.com/zeit/hazel) – Pulls new releases from 
+[GitHub Releases](https://help.github.com/articles/creating-releases/) and can 
+be deployed for free on the [Now](https://zeit.co/now) hosting platform.
+- [Nuts](https://github.com/GitbookIO/nuts) – Also uses 
+[GitHub Releases](https://help.github.com/articles/creating-releases/), 
+but caches app updates on disk and supports private repositories.
+- [electron-release-server](https://github.com/ArekSredzki/electron-release-server) – 
+Provides a dashboard for handling releases
 
-## Implementing Updates into Your App
+## Implementing updates in your app
 
-Once you've deployed your update server, continue with importing the required modules in your code (the following code might vary for different server software, but it works like described when using [Hazel](https://github.com/zeit/hazel)).
+Once you've deployed your update server, continue with importing the required 
+modules in your code. The following code might vary for different server 
+software, but it works like described when using 
+[Hazel](https://github.com/zeit/hazel).
 
-**Important:** Please ensure that the code below will only be executed in production - you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) to check for the environment).
+**Important:** Please ensure that the code below will only be executed in 
+your packaged app. You can use 
+[electron-is-dev](https://github.com/sindresorhus/electron-is-dev) to check for 
+the environment.
 
 ```js
 const { app, autoUpdater } = require('electron')
 ```
 
-Next, put together the URL of the update server and tell [autoUpdater](../api/auto-updater.md) about it:
+Next, construct the URL of the update server and tell 
+[autoUpdater](../api/auto-updater.md) about it:
 
 ```js
-const server = <your-deployment-url>
+const server = 'https://your-deployment-url.com'
 const feed = `${server}/update/${process.platform}/${app.getVersion()}`
 
 autoUpdater.setFeedURL(feed)
@@ -39,10 +55,16 @@ setInterval(() => {
 }, 60000)
 ```
 
-That's all. Once [built](../tutorial/application-distribution.md), your application will receive an update for each new [GitHub Release](https://help.github.com/articles/creating-releases/) that you create.
+That's all. Once [built](../tutorial/application-distribution.md), your 
+application will receive an update for each new 
+[GitHub Release](https://help.github.com/articles/creating-releases/) that you 
+create.
 
-## Further Steps
+## Further steps
 
-Now that you've configured the basic update mechanism for your application, you need to ensure that the user will get notified when there's an update (this can be achieved using [events](../api/auto-updater.md#events)).
+Now that you've configured the basic update mechanism for your application, you 
+need to ensure that the user will get notified when there's an update 
+(this can be achieved using [events](../api/auto-updater.md#events)).
 
-Also make sure that potential errors are [being handled](../api/auto-updater.md#event-error).
+Also make sure that potential errors are 
+[being handled](../api/auto-updater.md#event-error).

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -76,7 +76,7 @@ autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
     message: 'A new version has been downloaded. Restart the application to apply the updates.',
     detail: releaseName + '\n\n' + releaseNotes
   }
-  dialog.showMessageBox(dialogOpts, function(response) {
+  dialog.showMessageBox(dialogOpts, (response) => {
     if (response === 0) autoUpdater.quitAndInstall()
   })
 })

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -12,9 +12,10 @@ To get started, you first need to deploy a server that the
 
 Depending on your needs, you can choose from one of these:
 
-- [Hazel](https://github.com/zeit/hazel) – Pulls new releases from 
-[GitHub Releases](https://help.github.com/articles/creating-releases/) and can 
-be deployed for free on [Now](https://zeit.co/now).
+- [Hazel](https://github.com/zeit/hazel) – Simple update server for open-source 
+apps. Pulls from 
+[GitHub Releases](https://help.github.com/articles/creating-releases/) 
+and can be deployed for free on [Now](https://zeit.co/now).
 - [Nuts](https://github.com/GitbookIO/nuts) – Also uses 
 [GitHub Releases](https://help.github.com/articles/creating-releases/), 
 but caches app updates on disk and supports private repositories.
@@ -34,7 +35,7 @@ your packaged app, and not in development. You can use
 the environment.
 
 ```js
-const { app, autoUpdater, dialog } = require('electron')
+const {app, autoUpdater, dialog} = require('electron')
 ```
 
 Next, construct the URL of the update server and tell 
@@ -47,7 +48,7 @@ const feed = `${server}/update/${process.platform}/${app.getVersion()}`
 autoUpdater.setFeedURL(feed)
 ```
 
-As the final step, check for updates (the example below will check every minute):
+As the final step, check for updates. The example below will check every minute:
 
 ```js
 setInterval(() => {

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -14,7 +14,7 @@ Depending on your needs, you can choose from one of these:
 
 - [Hazel](https://github.com/zeit/hazel) – Pulls new releases from 
 [GitHub Releases](https://help.github.com/articles/creating-releases/) and can 
-be deployed for free on the [Now](https://zeit.co/now) hosting platform.
+be deployed for free on [Now](https://zeit.co/now).
 - [Nuts](https://github.com/GitbookIO/nuts) – Also uses 
 [GitHub Releases](https://help.github.com/articles/creating-releases/), 
 but caches app updates on disk and supports private repositories.

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -76,7 +76,7 @@ autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
     message: 'A new version has been downloaded. Restart the application to apply the updates.',
     detail: releaseName + '\n\n' + releaseNotes
   }
-  
+
   dialog.showMessageBox(dialogOpts, (response) => {
     if (response === 0) autoUpdater.quitAndInstall()
   })

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -63,8 +63,19 @@ create.
 ## Further steps
 
 Now that you've configured the basic update mechanism for your application, you 
-need to ensure that the user will get notified when there's an update 
-(this can be achieved using [events](../api/auto-updater.md#events)).
+need to ensure that the user will get notified when there's an update. This
+can be achieved using [events](../api/auto-updater.md#events):
 
-Also make sure that potential errors are 
-[being handled](../api/auto-updater.md#event-error).
+```js
+autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
+  // Show a notification banner to the user that allows triggering the update
+})
+```
+
+Also make sure that errors are 
+[being handled](../api/auto-updater.md#event-error). Here's an example
+for logging them to `stderr`:
+
+```js
+autoUpdater.on('error', console.error)
+```

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -12,7 +12,7 @@ Depending on your needs, you can choose from one of these:
 - [Nuts](https://github.com/GitbookIO/nuts) – Also uses [GitHub Releases](https://help.github.com/articles/creating-releases/), but caches app updates on disk
 - [electron-release-server](https://github.com/ArekSredzki/electron-release-server) – Provides you with a dashboard for handling releases
 
-## Implemeting Updates into Your App
+## Implementing Updates into Your App
 
 Once you've deployed your update server, continue with importing the required modules in your code (please ensure that the code below will only be executed in production - you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) for that):
 

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -22,17 +22,21 @@ Once you've deployed your update server, continue with importing the required mo
 const { app, autoUpdater } = require('electron')
 ```
 
-Next, put together the URL of the update server:
+Next, put together the URL of the update server and tell [autoUpdater](../api/auto-updater.md) about it:
 
 ```js
 const server = <your-deployment-url>
 const feed = `${server}/update/${process.platform}/${app.getVersion()}`
+
+autoUpdater.setFeedURL(feed)
 ```
 
-As the final step, tell [autoUpdater](../api/auto-updater.md) where to ask for updates:
+As the final step, check for updates (the example below will check every minute):
 
 ```js
-autoUpdater.setFeedURL(feed)
+setInterval(() => {
+  autoUpdater.checkForUpdates()
+}, 60000)
 ```
 
 That's all. Once [built](../tutorial/application-distribution.md), your application will receive an update for each new [GitHub Release](https://help.github.com/articles/creating-releases/) that you create.

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -14,7 +14,9 @@ Depending on your needs, you can choose from one of these:
 
 ## Implementing Updates into Your App
 
-Once you've deployed your update server, continue with importing the required modules in your code (please ensure that the code below will only be executed in production - you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) for that):
+Once you've deployed your update server, continue with importing the required modules in your code. The following code might vary for a different update server, but it works like described when using [Hazel](https://github.com/zeit/hazel).
+
+**Important:** Please ensure that the code below will only be executed in production - you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) to check for the environment).
 
 ```js
 const { app, autoUpdater } = require('electron')

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -76,6 +76,7 @@ autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
     message: 'A new version has been downloaded. Restart the application to apply the updates.',
     detail: releaseName + '\n\n' + releaseNotes
   }
+  
   dialog.showMessageBox(dialogOpts, (response) => {
     if (response === 0) autoUpdater.quitAndInstall()
   })

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -77,5 +77,8 @@ Also make sure that errors are
 for logging them to `stderr`:
 
 ```js
-autoUpdater.on('error', console.error)
+autoUpdater.on('error', message => {
+  console.error('There was a problem updating the application')
+  console.error(message)
+})
 ```

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -73,8 +73,8 @@ autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
     type: 'info',
     buttons: ['Restart', 'Later'],
     title: 'Application Update',
-    message: 'A new version has been downloaded. Restart the application to apply the updates.',
-    detail: releaseName + '\n\n' + releaseNotes
+    message: process.platform === 'win32' ? releaseNotes : releaseName,
+    detail: 'A new version has been downloaded. Restart the application to apply the updates.'
   }
 
   dialog.showMessageBox(dialogOpts, (response) => {

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -14,7 +14,7 @@ Depending on your needs, you can choose from one of these:
 
 ## Implementing Updates into Your App
 
-Once you've deployed your update server, continue with importing the required modules in your code. The following code might vary for a different update server, but it works like described when using [Hazel](https://github.com/zeit/hazel).
+Once you've deployed your update server, continue with importing the required modules in your code (the following code might vary for different server software, but it works like described when using [Hazel](https://github.com/zeit/hazel)).
 
 **Important:** Please ensure that the code below will only be executed in production - you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) to check for the environment).
 


### PR DESCRIPTION
As discusssed with @zeke on Slack, we concluded that:

- The API docs for `autoUpdater` should really only be API docs, not contain a guide
- There needs to be a guide on how to implement updates

Both of these issues are resolved with this PR.