### PR TITLE
Feature/simple fullscreen mode

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -603,6 +603,14 @@ void Window::SetSkipTaskbar(bool skip) {
   window_->SetSkipTaskbar(skip);
 }
 
+void Window::SetSimpleFullScreen(bool simple_fullscreen) {
+  window_->SetSimpleFullScreen(simple_fullscreen);
+}
+
+bool Window::IsSimpleFullScreen() {
+  return window_->IsSimpleFullScreen();
+}
+
 void Window::SetKiosk(bool kiosk) {
   window_->SetKiosk(kiosk);
 }
@@ -1018,6 +1026,8 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getTitle", &Window::GetTitle)
       .SetMethod("flashFrame", &Window::FlashFrame)
       .SetMethod("setSkipTaskbar", &Window::SetSkipTaskbar)
+      .SetMethod("setSimpleFullScreen", &Window::SetSimpleFullScreen)
+      .SetMethod("isSimpleFullScreen", &Window::IsSimpleFullScreen)
       .SetMethod("setKiosk", &Window::SetKiosk)
       .SetMethod("isKiosk", &Window::IsKiosk)
       .SetMethod("setBackgroundColor", &Window::SetBackgroundColor)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -154,6 +154,8 @@ class Window : public mate::TrackableObject<Window>,
   std::string GetTitle();
   void FlashFrame(bool flash);
   void SetSkipTaskbar(bool skip);
+  void SetSimpleFullScreen(bool simple_fullscreen);
+  bool IsSimpleFullScreen();
   void SetKiosk(bool kiosk);
   bool IsKiosk();
   void SetBackgroundColor(const std::string& color_name);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -134,6 +134,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetTitle() = 0;
   virtual void FlashFrame(bool flash) = 0;
   virtual void SetSkipTaskbar(bool skip) = 0;
+  virtual void SetSimpleFullScreen(bool simple_fullscreen) = 0;
+  virtual bool IsSimpleFullScreen() = 0;
   virtual void SetKiosk(bool kiosk) = 0;
   virtual bool IsKiosk() = 0;
   virtual void SetBackgroundColor(const std::string& color_name) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -76,6 +76,8 @@ class NativeWindowMac : public NativeWindow,
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;
   void SetSkipTaskbar(bool skip) override;
+  void SetSimpleFullScreen(bool simple_fullscreen) override;
+  bool IsSimpleFullScreen() override;
   void SetKiosk(bool kiosk) override;
   bool IsKiosk() override;
   void SetBackgroundColor(const std::string& color_name) override;
@@ -135,6 +137,8 @@ class NativeWindowMac : public NativeWindow,
 
   bool fullscreen_window_title() const { return fullscreen_window_title_; }
 
+  bool simple_fullscreen() const { return simple_fullscreen_; }
+
  protected:
   // Return a vector of non-draggable regions that fill a window of size
   // |width| by |height|, but leave gaps where the window should be draggable.
@@ -188,6 +192,19 @@ class NativeWindowMac : public NativeWindow,
 
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_;
+
+  // Simple (pre-Lion) Fullscreen Settings
+  bool simple_fullscreen_;
+  bool is_simple_fullscreen_;
+  bool was_maximized_;
+  bool was_minimizable_;
+  bool was_maximizable_;
+  bool was_resizable_;
+  bool was_movable_;
+  NSRect original_frame_;
+
+  // The presentation options before entering simple fullscreen mode.
+  NSApplicationPresentationOptions simple_fullscreen_options_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -196,12 +196,10 @@ class NativeWindowMac : public NativeWindow,
   // Simple (pre-Lion) Fullscreen Settings
   bool simple_fullscreen_;
   bool is_simple_fullscreen_;
-  bool was_maximized_;
-  bool was_minimizable_;
   bool was_maximizable_;
-  bool was_resizable_;
   bool was_movable_;
   NSRect original_frame_;
+  NSUInteger simple_fullscreen_mask_;
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -137,7 +137,7 @@ class NativeWindowMac : public NativeWindow,
 
   bool fullscreen_window_title() const { return fullscreen_window_title_; }
 
-  bool simple_fullscreen() const { return simple_fullscreen_; }
+  bool simple_fullscreen() const { return always_simple_fullscreen_; }
 
  protected:
   // Return a vector of non-draggable regions that fill a window of size
@@ -194,7 +194,7 @@ class NativeWindowMac : public NativeWindow,
   TitleBarStyle title_bar_style_;
 
   // Simple (pre-Lion) Fullscreen Settings
-  bool simple_fullscreen_;
+  bool always_simple_fullscreen_;
   bool is_simple_fullscreen_;
   bool was_maximizable_;
   bool was_movable_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -827,7 +827,7 @@ NativeWindowMac::NativeWindowMac(
       fullscreen_window_title_(false),
       attention_request_id_(0),
       title_bar_style_(NORMAL),
-      simple_fullscreen_(false),
+      always_simple_fullscreen_(false),
       is_simple_fullscreen_(false) {
   int width = 800, height = 600;
   options.Get(options::kWidth, &width);
@@ -974,7 +974,7 @@ NativeWindowMac::NativeWindowMac(
 
   options.Get(options::kFullscreenWindowTitle, &fullscreen_window_title_);
 
-  options.Get(options::kSimpleFullScreen, &simple_fullscreen_);
+  options.Get(options::kSimpleFullScreen, &always_simple_fullscreen_);
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -754,6 +754,14 @@ void NativeWindowViews::SetSkipTaskbar(bool skip) {
 #endif
 }
 
+void NativeWindowViews::SetSimpleFullScreen(bool simple_fullscreen) {
+  SetFullScreen(simple_fullscreen);
+}
+
+bool NativeWindowViews::IsSimpleFullScreen() {
+  return IsFullscreen();
+}
+
 void NativeWindowViews::SetKiosk(bool kiosk) {
   SetFullScreen(kiosk);
 }

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -96,6 +96,8 @@ class NativeWindowViews : public NativeWindow,
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;
   void SetSkipTaskbar(bool skip) override;
+  void SetSimpleFullScreen(bool simple_fullscreen) override;
+  bool IsSimpleFullScreen() override;
   void SetKiosk(bool kiosk) override;
   bool IsKiosk() override;
   void SetBackgroundColor(const std::string& color_name) override;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -36,6 +36,8 @@ const char kSkipTaskbar[] = "skipTaskbar";
 // http://www.opera.com/support/mastering/kiosk/
 const char kKiosk[] = "kiosk";
 
+const char kSimpleFullScreen[] = "simpleFullscreen";
+
 // Make windows stays on the top of all other windows.
 const char kAlwaysOnTop[] = "alwaysOnTop";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -31,6 +31,7 @@ extern const char kClosable[];
 extern const char kFullscreen[];
 extern const char kSkipTaskbar[];
 extern const char kKiosk[];
+extern const char kSimpleFullScreen[];
 extern const char kAlwaysOnTop[];
 extern const char kAcceptFirstMouse[];
 extern const char kUseContentSize[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -771,11 +771,13 @@ Returns `Boolean` - Whether the window is in fullscreen mode.
 
 * `flag` Boolean
 
-Sets whether the window should be in simple fullscreen mode.
+Enters or leaves simple fullscreen mode.
+
+Simple fullscreen mode emulates the native fullscreen behavior found in versions of Mac OS X prior to Lion (10.7).
 
 #### `win.isSimpleFullScreen()` _macOS_
 
-Returns `Boolean` - Whether the window is in simple fullscreen mode.
+Returns `Boolean` - Whether the window is in simple (pre-Lion) fullscreen mode.
 
 #### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -176,6 +176,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `fullscreenable` Boolean (optional) - Whether the window can be put into fullscreen
     mode. On macOS, also whether the maximize/zoom button should toggle full
     screen mode or maximize window. Default is `true`.
+  * `simpleFullscreen` Boolean (optional) - Use pre-Lion fullscreen on macOS. Default is `false`.
   * `skipTaskbar` Boolean (optional) - Whether to show the window in taskbar. Default is
     `false`.
   * `kiosk` Boolean (optional) - The kiosk mode. Default is `false`.
@@ -765,6 +766,16 @@ Sets whether the window should be in fullscreen mode.
 #### `win.isFullScreen()`
 
 Returns `Boolean` - Whether the window is in fullscreen mode.
+
+#### `win.setSimpleFullScreen(flag)` _macOS_
+
+* `flag` Boolean
+
+Sets whether the window should be in simple fullscreen mode.
+
+#### `win.isSimpleFullScreen()` _macOS_
+
+Returns `Boolean` - Whether the window is in simple fullscreen mode.
 
 #### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_
 


### PR DESCRIPTION
Modern implementations of macOS utilize desktop spaces to implement fullscreen functionality, which presents a less-than-ideal interaction for users who use multiple monitors (and prefer to keep those monitors within the same space), or prefer to have more control over their ability to multitask while using a fullscreen application.

Prior to the release of Lion, fullscreen functionality on Mac OS X acted similarly to the current fullscreen functionality on Windows and Linux. This PR provides functionality to simulate that same style of pre-Lion fullscreen on macOS for Electron applications.

**Full Disclosure: This is my first attempt at writing Objective-C... ever... so _any_ feedback would be greatly appreciated!** 😄

### Usage

Simple fullscreen support can be enabled by passing `simpleFullscreen: true` to the `BrowserWindow` constructor which, when enabled, will override the default macOS fullscreen functionality with the new simple fullscreen functionality.

Additionally, two new methods (`setSimpleFullScreen()` and `isFullScreen()`) have been added for more granular usability.

### Demonstration

Here is a short animation that demonstrates what simple fullscreen support looks like (pay attention to the window, as it stays on the current space rather than moving to a new one, which is the default functionality).

![](https://user-images.githubusercontent.com/920019/29246939-75df5668-7fc4-11e7-9d7e-63e8dd923c73.gif)

### Background

Because popular desktop applications like Sublime Text 3, MacVim, and iTerm2 provide support for pre-Lion fullscreen, this particular feature has been requested many times over in several popular open source Electron projects (including the Electron core itself):

- Electron Core Feature Request - https://github.com/electron/electron/issues/8218
- Visual Studio Code Feature Request - https://github.com/Microsoft/vscode/issues/5344
- Hyper Feature Request - https://github.com/zeit/hyper/issues/526
- Atom Feature Request - https://github.com/atom/atom/issues/967 