### PR TITLE
Fix sandbox crash when opening a background tab

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -43,8 +43,9 @@ BrowserWindow.prototype._init = function () {
                                             userGesture, left, top, width,
                                             height) => {
     let urlFrameName = v8Util.getHiddenValue(webContents, 'url-framename')
-    if ((disposition !== 'foreground-tab' && disposition !== 'new-window') ||
-        !urlFrameName) {
+    if ((disposition !== 'foreground-tab' && disposition !== 'new-window' &&
+         disposition !== 'background-tab') || !urlFrameName) {
+      event.preventDefault()
       return
     }
 


### PR DESCRIPTION
When a link is clicked with the middle mouse button, chrome opens a window with
"background-tab" disposition. This is not currently handled in sandbox mode,
causing an api::WebContents to leak leading to eventual crash(since it has no
wrapper).

Also fix the event handler for "-add-new-contents" by having it call
`event.preventDefault()` when the window creation should be cancelled.