### PR TITLE
Revert "Merge pull request #10250 from electron/remove-preinstall-no-op"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lint-api-docs-js": "standard-markdown docs && standard-markdown docs-translations",
     "create-api-json": "electron-docs-linter docs --outfile=out/electron-api.json --version=$npm_package_version",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=out/electron-api.json --out=out/electron.d.ts",
+    "preinstall": "node -e 'process.exit(0)'",
     "publish-to-npm": "node ./script/publish-to-npm.js",
     "prepack": "check-for-leaks",
     "prepush": "check-for-leaks",


### PR DESCRIPTION
Check [Travis builds](https://travis-ci.org/electron/electron/builds/263625304) in #10250, exactly this happens on a user's machine when they run `./script/bootstrap.py`.

```
$ ./script/bootstrap.py

> electron@1.7.6 install /Volumes/Transcend/Projects/electron
> node-gyp rebuild

gyp: binding.gyp not found (cwd: /Volumes/Transcend/Projects/electron) while trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:336:16)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Darwin 16.7.0
gyp ERR! command "/usr/local/Cellar/node@6/6.11.0/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Volumes/Transcend/Projects/electron
gyp ERR! node -v v6.11.0
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! electron@1.7.6 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the electron@1.7.6 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/alkuzmin/.npm/_logs/2017-08-14T18_23_04_816Z-debug.log

Traceback (most recent call last):
  File "./script/bootstrap.py", line 250, in <module>
    sys.exit(main())
  File "./script/bootstrap.py", line 54, in main
    update_node_modules('.')
  File "/Volumes/Transcend/Projects/electron/script/lib/util.py", line 289, in update_node_modules
    execute_stdout(args, env)
  File "/Volumes/Transcend/Projects/electron/script/lib/util.py", line 186, in execute_stdout
    execute(argv, env)
  File "/Volumes/Transcend/Projects/electron/script/lib/util.py", line 174, in execute
    raise e
subprocess.CalledProcessError: Command '['npm', 'install']' returned non-zero exit status 1
```