### PR TITLE
fix some optional args docs

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -26,7 +26,7 @@ The `session` module has the following methods:
 ### `session.fromPartition(partition[, options])`
 
 * `partition` String
-* `options` Object
+* `options` Object (optional)
   * `cache` Boolean - Whether to enable cache.
 
 Returns `Session` - A session instance from `partition` string. When there is an existing

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -405,7 +405,7 @@ Injects CSS into the guest page.
 ### `<webview>.executeJavaScript(code, userGesture, callback)`
 
 * `code` String
-* `userGesture` Boolean - Default `false`.
+* `userGesture` Boolean (optional) - Default `false`.
 * `callback` Function (optional) - Called after script has been executed.
   * `result` Any
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -402,7 +402,7 @@ Returns `String` - The user agent for guest page.
 
 Injects CSS into the guest page.
 
-### `<webview>.executeJavaScript(code, userGesture, callback)`
+### `<webview>.executeJavaScript(code[, userGesture, callback])`
 
 * `code` String
 * `userGesture` Boolean (optional) - Default `false`.


### PR DESCRIPTION
While moving from DefinitelyTyped's `electron/index.d.ts` to official `electron.d.ts`, I found some args should be optional. Fixed them in this PR.