### PR TITLE
Fix 'BrowserWindow module "webPreferences" option "sandbox" option can print to PDF'

### DIFF
--- a/chromium_src/chrome/browser/printing/print_job_worker.cc
+++ b/chromium_src/chrome/browser/printing/print_job_worker.cc
@@ -119,6 +119,8 @@ void PrintSettingsToJobSettings(const PrintSettings& settings,
   job_settings->SetBoolean("rasterizePDF", false);
 
   job_settings->SetInteger("dpi", settings.dpi());
+  job_settings->SetInteger("dpiHorizontal", 72);
+  job_settings->SetInteger("dpiVertical", 72);
 
   job_settings->SetBoolean(kSettingPrintToPDF, false);
   job_settings->SetBoolean(kSettingCloudPrintDialog, false);

--- a/chromium_src/chrome/common/print_messages.cc
+++ b/chromium_src/chrome/common/print_messages.cc
@@ -26,8 +26,7 @@ PrintMsg_Print_Params::PrintMsg_Print_Params()
       display_header_footer(false),
       title(),
       url(),
-      should_print_backgrounds(false),
-      device_name() {
+      should_print_backgrounds(false) {
 }
 
 PrintMsg_Print_Params::~PrintMsg_Print_Params() {}
@@ -52,7 +51,6 @@ void PrintMsg_Print_Params::Reset() {
   title = base::string16();
   url = base::string16();
   should_print_backgrounds = false;
-  device_name.clear();
 }
 
 PrintMsg_PrintPages_Params::PrintMsg_PrintPages_Params()

--- a/chromium_src/chrome/common/print_messages.h
+++ b/chromium_src/chrome/common/print_messages.h
@@ -54,7 +54,6 @@ struct PrintMsg_Print_Params {
   base::string16 title;
   base::string16 url;
   bool should_print_backgrounds;
-  base::string16 device_name;
 };
 
 struct PrintMsg_PrintPages_Params {

--- a/chromium_src/chrome/renderer/printing/print_web_view_helper.h
+++ b/chromium_src/chrome/renderer/printing/print_web_view_helper.h
@@ -78,6 +78,7 @@ class PrintWebViewHelper
     FAIL_PRINT_INIT,
     FAIL_PRINT,
     FAIL_PREVIEW,
+    INVALID_SETTINGS,
   };
 
   enum PrintPreviewErrorBuckets {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -73,6 +73,8 @@ const defaultPrintingSetting = {
   generateDraftData: true,
   fitToPageEnabled: false,
   scaleFactor: 1,
+  dpiHorizontal: 72,
+  dpiVertical: 72,
   rasterizePDF: false,
   duplex: 0,
   copies: 1,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1185,7 +1185,7 @@ describe('BrowserWindow module', function () {
         })
       })
 
-      xit('can print to PDF', function (done) {
+      it('can print to PDF', function (done) {
         w.destroy()
         w = new BrowserWindow({
           show: false,


### PR DESCRIPTION
It was disabled during Chromium 59 upgrade, see #9946.