### PR TITLE
Fix 'BrowserWindow module window states resizable state works for a frameless window'

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -309,9 +309,11 @@ NativeWindowViews::NativeWindowViews(
     // we should check whether setting it in InitParams can work.
     window_->set_frame_type(views::Widget::FrameType::FRAME_TYPE_FORCE_NATIVE);
     window_->FrameTypeChanged();
+#if defined(OS_WIN)
     // thickFrame also works for normal window.
     if (!thick_frame_)
       FlipWindowStyle(GetAcceleratedWidget(), false, WS_THICKFRAME);
+#endif
   }
 
   gfx::Size size = bounds.size();
@@ -580,11 +582,15 @@ gfx::Size NativeWindowViews::GetContentSize() {
 void NativeWindowViews::SetContentSizeConstraints(
     const extensions::SizeConstraints& size_constraints) {
   NativeWindow::SetContentSizeConstraints(size_constraints);
+#if defined(OS_WIN)
   // Changing size constraints would force adding the WS_THICKFRAME style, so
   // do nothing if thickFrame is false.
+  if (!thick_frame_)
+    return;
+#endif
   // widget_delegate() is only available after Init() is called, we make use of
   // this to determine whether native widget has initialized.
-  if (thick_frame_ && window_ && window_->widget_delegate())
+  if (window_ && window_->widget_delegate())
     window_->OnSizeConstraintsChanged();
 #if defined(USE_X11)
   if (resizable_)

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -304,11 +304,14 @@ NativeWindowViews::NativeWindowViews(
   ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
 #endif
 
-  // TODO(zcbenz): This was used to force using native frame on Windows 2003, we
-  // should check whether setting it in InitParams can work.
   if (has_frame()) {
+    // TODO(zcbenz): This was used to force using native frame on Windows 2003,
+    // we should check whether setting it in InitParams can work.
     window_->set_frame_type(views::Widget::FrameType::FRAME_TYPE_FORCE_NATIVE);
     window_->FrameTypeChanged();
+    // thickFrame also works for normal window.
+    if (!thick_frame_)
+      FlipWindowStyle(GetAcceleratedWidget(), false, WS_THICKFRAME);
   }
 
   gfx::Size size = bounds.size();
@@ -577,9 +580,11 @@ gfx::Size NativeWindowViews::GetContentSize() {
 void NativeWindowViews::SetContentSizeConstraints(
     const extensions::SizeConstraints& size_constraints) {
   NativeWindow::SetContentSizeConstraints(size_constraints);
+  // Changing size constraints would force adding the WS_THICKFRAME style, so
+  // do nothing if thickFrame is false.
   // widget_delegate() is only available after Init() is called, we make use of
   // this to determine whether native widget has initialized.
-  if (window_ && window_->widget_delegate())
+  if (thick_frame_ && window_ && window_->widget_delegate())
     window_->OnSizeConstraintsChanged();
 #if defined(USE_X11)
   if (resizable_)
@@ -589,7 +594,7 @@ void NativeWindowViews::SetContentSizeConstraints(
 
 void NativeWindowViews::SetResizable(bool resizable) {
 #if defined(OS_WIN)
-  if (has_frame())
+  if (has_frame() && thick_frame_)
     FlipWindowStyle(GetAcceleratedWidget(), resizable, WS_THICKFRAME);
 #elif defined(USE_X11)
   if (resizable != resizable_) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1962,7 +1962,7 @@ describe('BrowserWindow module', function () {
         assert.equal(w.isResizable(), true)
       })
 
-      xit('works for a frameless window', () => {
+      it('works for a frameless window', () => {
         w.destroy()
         w = new BrowserWindow({show: false, frame: false})
         assert.equal(w.isResizable(), true)


### PR DESCRIPTION
It was disabled during Chromium 59 upgrade, see #9946.