### PR TITLE
add welcome probots

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -2,19 +2,23 @@
 
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: |
-  👋 Thanks for opening your first issue here! If you're reporting a 🐞 bug, please make sure you include steps to reproduce it. We get a lot of issues on this repo, so please be patient, and we will get back to you as soon as we can.
+  👋 Thanks for opening your first issue here! If you're reporting a 🐞 bug, please make sure you include steps to reproduce it. We get a lot of issues on this repo, so please be patient and we will get back to you as soon as we can.
   
   To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md#submitting-issues).
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 
 # Comment to be posted to on PRs from first time contributors in your repository
-newPRWelcomeComment: "Thanks for opening this pull request! Here is a list of things that will help get it across the finish line:
+newPRWelcomeComment: |
+  💖 Thanks for opening this pull request! 💖
+  
+  Here is a list of things that will help get it across the finish line:
   - Follow the JavaScript, C++, and Python [coding style](https://github.com/electron/electron/blob/master/docs/development/coding-style.md).
   - Run `npm run lint` locally to catch formatting errors earlier.
   - Document any user-facing changes you've made following the [documentation styleguide](https://github.com/electron/electron/blob/master/docs/styleguide.md).
   - Include tests when adding/changing behavior.
-  - Include screenshots and animated GIFs whenever possible."
+  - Include screenshots and animated GIFs whenever possible.
+  We get a lot of pull requests on this repo, so please be patient and we will get back to you as soon as we can.
 
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,25 @@
+# Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
+
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: |
+  👋 Thanks for opening your first issue here! If you're reporting a 🐞 bug, please make sure you include steps to reproduce it. We get a lot of issues on this repo, so please be patient, and we will get back to you as soon as we can.
+  
+  To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md#submitting-issues).
+
+# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
+
+# Comment to be posted to on PRs from first time contributors in your repository
+newPRWelcomeComment: "Thanks for opening this pull request! Here is a list of things that will help get it across the finish line:
+  - Follow the JavaScript, C++, and Python [coding style](https://github.com/electron/electron/blob/master/docs/development/coding-style.md).
+  - Run `npm run lint` locally to catch formatting errors earlier.
+  - Document any user-facing changes you've made following the [documentation styleguide](https://github.com/electron/electron/blob/master/docs/styleguide.md).
+  - Include tests when adding/changing behavior.
+  - Include screenshots and animated GIFs whenever possible."
+
+# Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
+
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: >
+  Congrats on merging your first pull request! 🎉🎉🎉
+
+# It is recommend to include as many gifs and emojis as possiblec


### PR DESCRIPTION
This PR adds the config file needed for [the probot plugin](https://github.com/behaviorbot/welcome) that would welcome users to the Electron repo. 
✨ @hiimbex @bkeepers
🍐 @zeke 

Screenshot here shows the message for someone opening their first issue:
![image](https://user-images.githubusercontent.com/6842965/29380619-5a172438-8294-11e7-9ac3-581ac2f186fa.png)
