### PR TITLE
bump @types/node to 8

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,7 @@
   "main": "index.js",
   "types": "electron.d.ts",
   "dependencies": {
-    "@types/node": "^7.0.18",
+    "@types/node": "^8.0.24",
     "electron-download": "^3.0.1",
     "extract-zip": "^1.0.3"
   },


### PR DESCRIPTION
Electron 1.8 will use Node 8. https://github.com/electron/electron/pull/9992

 This PR bumps the TypeScript definition file in the `electron` npm module to match.