### PR TITLE
Add CircleCI for Linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+
+version: 2
+jobs:
+  electron-linux-arm:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: arm
+    steps:
+      - checkout
+      - run: script/cibuild
+
+  electron-linux-arm64:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: arm64
+    steps:
+      - checkout
+      - run: script/cibuild
+
+  electron-linux-ia32:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: ia32
+    steps:
+      - checkout
+      - run: script/cibuild
+
+  electron-linux-x64:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: x64
+    steps:
+      - checkout
+      - run: script/cibuild
+
+workflows:
+  version: 2
+  build-arm:
+    jobs:
+      - electron-linux-arm
+  build-arm64:
+    jobs:
+      - electron-linux-arm64
+  build-ia32:
+    jobs:
+      - electron-linux-ia32
+  build-x64:
+    jobs:
+      - electron-linux-x64

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -1,0 +1,17 @@
+FROM electronbuilds/libchromiumcontent:0.0.4
+
+USER root
+
+# Install node.js
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get update && apt-get install -y --force-yes nodejs
+
+# Install wget used by crash reporter
+RUN apt-get install -y --force-yes  wget
+
+# Add xvfb init script
+ADD tools/xvfb-init.sh /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb
+
+USER builduser
+WORKDIR /home/builduser


### PR DESCRIPTION
Use CircleCI for Linux builds so that they are publicly viewable.