### PR TITLE
Update desktop-capturer.md documentation

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -28,7 +28,12 @@ desktopCapturer.getSources({types: ['window', 'screen']}, (error, sources) => {
             maxHeight: 720
           }
         }
-      }, handleStream, handleError)
+      })
+      .then(function(stream) {
+        handleStream(stream)
+      }).catch(function(e) {
+        handleError(e)
+      })
       return
     }
   }


### PR DESCRIPTION
The code as documented here does not work anymore.

`navigator.mediaDevices.getUserMedia` API has been updated to return a Promise object.
[https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)

