### PR TITLE
:art: Refactored some files in the folder browser (not subdirectories)

### DIFF
--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -44,8 +44,8 @@ class GeoURLRequestContextGetter : public net::URLRequestContextGetter {
  private:
   friend class atom::AtomAccessTokenStore;
 
-  GeoURLRequestContextGetter() {}
-  ~GeoURLRequestContextGetter() override {}
+  GeoURLRequestContextGetter() = default;
+  ~GeoURLRequestContextGetter() override = default;
 
   std::unique_ptr<net::URLRequestContext> url_request_context_;
   DISALLOW_COPY_AND_ASSIGN(GeoURLRequestContextGetter);

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -60,10 +60,8 @@ class NoCacheBackend : public net::HttpCache::BackendFactory {
 
 std::string RemoveWhitespace(const std::string& str) {
   std::string trimmed;
-  if (base::RemoveChars(str, " ", &trimmed))
-    return trimmed;
-  else
-    return str;
+  return base::RemoveChars(str, " ", &trimmed) ?
+	  trimmed : str;
 }
 
 }  // namespace

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -233,10 +233,9 @@ scoped_refptr<AtomBrowserContext> AtomBrowserContext::From(
     const std::string& partition, bool in_memory,
     const base::DictionaryValue& options) {
   auto browser_context = brightray::BrowserContext::Get(partition, in_memory);
-  if (browser_context)
-    return static_cast<AtomBrowserContext*>(browser_context.get());
-
-  return new AtomBrowserContext(partition, in_memory, options);
+  return (browser_context) ?
+	  static_cast<AtomBrowserContext*>(browser_context.get()) :
+	  new AtomBrowserContext(partition, in_memory, options);
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -163,7 +163,8 @@ AtomBrowserContext::CreateHttpCacheBackendFactory(
     const base::FilePath& base_path) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   return (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache)) ?
-	  new NoCacheBackend : brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
+    new NoCacheBackend : 
+    brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
 }
 
 content::DownloadManagerDelegate*

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -162,7 +162,7 @@ net::HttpCache::BackendFactory*
 AtomBrowserContext::CreateHttpCacheBackendFactory(
     const base::FilePath& base_path) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache)) {
+  if (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache))
     return new NoCacheBackend;
   return brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
 }

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -164,10 +164,8 @@ net::HttpCache::BackendFactory*
 AtomBrowserContext::CreateHttpCacheBackendFactory(
     const base::FilePath& base_path) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache))
-    return new NoCacheBackend;
-  else
-    return brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
+  return (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache)) ?
+	  new NoCacheBackend : brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
 }
 
 content::DownloadManagerDelegate*

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -162,9 +162,9 @@ net::HttpCache::BackendFactory*
 AtomBrowserContext::CreateHttpCacheBackendFactory(
     const base::FilePath& base_path) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  return (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache)) ?
-    new NoCacheBackend : 
-    brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
+  if (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache)) {
+    return new NoCacheBackend;
+  return brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
 }
 
 content::DownloadManagerDelegate*

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -238,5 +238,4 @@ scoped_refptr<AtomBrowserContext> AtomBrowserContext::From(
     static_cast<AtomBrowserContext*>(browser_context.get()) :
     new AtomBrowserContext(partition, in_memory, options);
 }
-
 }  // namespace atom

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -61,7 +61,7 @@ class NoCacheBackend : public net::HttpCache::BackendFactory {
 std::string RemoveWhitespace(const std::string& str) {
   std::string trimmed;
   return base::RemoveChars(str, " ", &trimmed) ?
-	  trimmed : str;
+    trimmed : str;
 }
 
 }  // namespace

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -235,8 +235,8 @@ scoped_refptr<AtomBrowserContext> AtomBrowserContext::From(
     const base::DictionaryValue& options) {
   auto browser_context = brightray::BrowserContext::Get(partition, in_memory);
   return (browser_context) ?
-	  static_cast<AtomBrowserContext*>(browser_context.get()) :
-	  new AtomBrowserContext(partition, in_memory, options);
+    static_cast<AtomBrowserContext*>(browser_context.get()) :
+    new AtomBrowserContext(partition, in_memory, options);
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -98,7 +98,7 @@ bool AtomBrowserMainParts::SetExitCode(int code) {
 }
 
 int AtomBrowserMainParts::GetExitCode() {
-  return exit_code_ != nullptr ? *exit_code_ : 0;
+  return exit_code_ ? *exit_code_ : 0;
 }
 
 base::Closure AtomBrowserMainParts::RegisterDestructionCallback(

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -55,7 +55,6 @@ void AtomJavaScriptDialogManager::RunBeforeUnloadDialog(
     const DialogClosedCallback& callback) {
   bool default_prevented = api_web_contents_->Emit("will-prevent-unload");
   callback.Run(default_prevented, base::string16());
-  return;
 }
 
 void AtomJavaScriptDialogManager::CancelDialogs(

--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -21,9 +21,7 @@ namespace {
 bool WebContentsDestroyed(int process_id) {
   auto contents =
       WebContentsPreferences::GetWebContentsFromProcessID(process_id);
-  if (!contents)
-    return true;
-  return contents->IsBeingDestroyed();
+  return (!contents) ? true : contents->IsBeingDestroyed();
 }
 
 void PermissionRequestResponseCallbackWrapper(

--- a/atom/browser/atom_web_ui_controller_factory.cc
+++ b/atom/browser/atom_web_ui_controller_factory.cc
@@ -28,8 +28,8 @@ content::WebUI::TypeID AtomWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) const {
   return (url.host() == kPdfViewerUIHost) ?
-  	const_cast<AtomWebUIControllerFactory*>(this) :
-	content::WebUI::kNoWebUI;
+    const_cast<AtomWebUIControllerFactory*>(this) :
+    content::WebUI::kNoWebUI;
 }
 
 bool AtomWebUIControllerFactory::UseWebUIForURL(

--- a/atom/browser/atom_web_ui_controller_factory.cc
+++ b/atom/browser/atom_web_ui_controller_factory.cc
@@ -28,7 +28,7 @@ content::WebUI::TypeID AtomWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) const {
   return (url.host() == kPdfViewerUIHost) ?
-	return const_cast<AtomWebUIControllerFactory*>(this) :
+  	const_cast<AtomWebUIControllerFactory*>(this) :
 	content::WebUI::kNoWebUI;
 }
 

--- a/atom/browser/atom_web_ui_controller_factory.cc
+++ b/atom/browser/atom_web_ui_controller_factory.cc
@@ -27,11 +27,9 @@ AtomWebUIControllerFactory::~AtomWebUIControllerFactory() {}
 content::WebUI::TypeID AtomWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) const {
-  if (url.host() == kPdfViewerUIHost) {
-    return const_cast<AtomWebUIControllerFactory*>(this);
-  }
-
-  return content::WebUI::kNoWebUI;
+  return (url.host() == kPdfViewerUIHost) ?
+	return const_cast<AtomWebUIControllerFactory*>(this) :
+	content::WebUI::kNoWebUI;
 }
 
 bool AtomWebUIControllerFactory::UseWebUIForURL(

--- a/atom/browser/atom_web_ui_controller_factory.cc
+++ b/atom/browser/atom_web_ui_controller_factory.cc
@@ -63,7 +63,7 @@ AtomWebUIControllerFactory::CreateWebUIControllerForURL(content::WebUI* web_ui,
       }
     }
     if (url.has_ref()) {
-      src = src + '#' + url.ref();
+      src += '#' + url.ref();
     }
     auto browser_context = web_ui->GetWebContents()->GetBrowserContext();
     return new PdfViewerUI(browser_context, web_ui, src);

--- a/atom/browser/atom_web_ui_controller_factory.cc
+++ b/atom/browser/atom_web_ui_controller_factory.cc
@@ -63,7 +63,7 @@ AtomWebUIControllerFactory::CreateWebUIControllerForURL(content::WebUI* web_ui,
       }
     }
     if (url.has_ref()) {
-      src += '#' + url.ref();
+      src = src + '#' + url.ref();
     }
     auto browser_context = web_ui->GetWebContents()->GetBrowserContext();
     return new PdfViewerUI(browser_context, web_ui, src);

--- a/atom/browser/bridge_task_runner.cc
+++ b/atom/browser/bridge_task_runner.cc
@@ -37,7 +37,8 @@ bool BridgeTaskRunner::PostDelayedTask(
 
 bool BridgeTaskRunner::RunsTasksOnCurrentThread() const {
   auto message_loop = base::MessageLoop::current();
-  return (!message_loop) ? true : message_loop->task_runner()->RunsTasksOnCurrentThread();
+  return (!message_loop) ? 
+    true : message_loop->task_runner()->RunsTasksOnCurrentThread();
 }
 
 bool BridgeTaskRunner::PostNonNestableDelayedTask(

--- a/atom/browser/bridge_task_runner.cc
+++ b/atom/browser/bridge_task_runner.cc
@@ -37,10 +37,7 @@ bool BridgeTaskRunner::PostDelayedTask(
 
 bool BridgeTaskRunner::RunsTasksOnCurrentThread() const {
   auto message_loop = base::MessageLoop::current();
-  if (!message_loop)
-    return true;
-
-  return message_loop->task_runner()->RunsTasksOnCurrentThread();
+  return (!message_loop) ? true : message_loop->task_runner()->RunsTasksOnCurrentThread();
 }
 
 bool BridgeTaskRunner::PostNonNestableDelayedTask(

--- a/atom/browser/bridge_task_runner.cc
+++ b/atom/browser/bridge_task_runner.cc
@@ -37,7 +37,7 @@ bool BridgeTaskRunner::PostDelayedTask(
 
 bool BridgeTaskRunner::RunsTasksOnCurrentThread() const {
   auto message_loop = base::MessageLoop::current();
-  return (!message_loop) ? 
+  return (!message_loop) ?
     true : message_loop->task_runner()->RunsTasksOnCurrentThread();
 }
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -111,7 +111,7 @@ void Browser::ClearRecentDocuments() {
   CComPtr<IApplicationDestinations> destinations;
   if (FAILED(destinations.CoCreateInstance(CLSID_ApplicationDestinations,
                                            NULL, CLSCTX_INPROC_SERVER)) ||
-	  FAILED(destinations->SetAppID(GetAppUserModelID())))
+      FAILED(destinations->SetAppID(GetAppUserModelID())))
     return;
   destinations->RemoveAllDestinations();
 }

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -110,9 +110,8 @@ void Browser::AddRecentDocument(const base::FilePath& path) {
 void Browser::ClearRecentDocuments() {
   CComPtr<IApplicationDestinations> destinations;
   if (FAILED(destinations.CoCreateInstance(CLSID_ApplicationDestinations,
-                                           NULL, CLSCTX_INPROC_SERVER)))
-    return;
-  if (FAILED(destinations->SetAppID(GetAppUserModelID())))
+                                           NULL, CLSCTX_INPROC_SERVER)) ||
+	  FAILED(destinations->SetAppID(GetAppUserModelID())))
     return;
   destinations->RemoveAllDestinations();
 }

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -159,11 +159,8 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 
   base::win::RegKey key;
   base::win::RegKey commandKey;
-  if (FAILED(key.Open(root, keyPath.c_str(), KEY_ALL_ACCESS)))
-    // Key doesn't even exist, we can confirm that it is not set
-    return true;
-
-  if (FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
+  if (FAILED(key.Open(root, keyPath.c_str(), KEY_ALL_ACCESS)) ||
+	  FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
     // Key doesn't even exist, we can confirm that it is not set
     return true;
 
@@ -249,11 +246,8 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
 
   base::win::RegKey key;
   base::win::RegKey commandKey;
-  if (FAILED(key.Open(root, keyPath.c_str(), KEY_ALL_ACCESS)))
-    // Key doesn't exist, we can confirm that it is not set
-    return false;
-
-  if (FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
+  if (FAILED(key.Open(root, keyPath.c_str(), KEY_ALL_ACCESS)) ||
+	  FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
     // Key doesn't exist, we can confirm that it is not set
     return false;
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -160,7 +160,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
   base::win::RegKey key;
   base::win::RegKey commandKey;
   if (FAILED(key.Open(root, keyPath.c_str(), KEY_ALL_ACCESS)) ||
-	  FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
+      FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
     // Key doesn't even exist, we can confirm that it is not set
     return true;
 
@@ -247,7 +247,7 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
   base::win::RegKey key;
   base::win::RegKey commandKey;
   if (FAILED(key.Open(root, keyPath.c_str(), KEY_ALL_ACCESS)) ||
-	  FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
+      FAILED(commandKey.Open(root, cmdPath.c_str(), KEY_ALL_ACCESS)))
     // Key doesn't exist, we can confirm that it is not set
     return false;
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -261,11 +261,11 @@ void CommonWebContentsDelegate::EnterFullscreenModeForTab(
 
 void CommonWebContentsDelegate::ExitFullscreenModeForTab(
     content::WebContents* source) {
-  if (!owner_window_)
-    return;
-  SetHtmlApiFullscreen(false);
-  owner_window_->NotifyWindowLeaveHtmlFullScreen();
-  source->GetRenderViewHost()->GetWidget()->WasResized();
+  if (owner_window_) {
+	SetHtmlApiFullscreen(false);
+	owner_window_->NotifyWindowLeaveHtmlFullScreen();
+	source->GetRenderViewHost()->GetWidget()->WasResized();
+  }
 }
 
 bool CommonWebContentsDelegate::IsFullscreenForTabOrPending(

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -199,12 +199,12 @@ void CommonWebContentsDelegate::ResetManagedWebContents(bool async) {
 }
 
 content::WebContents* CommonWebContentsDelegate::GetWebContents() const {
-  return (web_contents) ? web_contents_->GetWebContents() : nullptr;
+  return (web_contents_) ? web_contents_->GetWebContents() : nullptr;
 }
 
 content::WebContents*
 CommonWebContentsDelegate::GetDevToolsWebContents() const {
-	return (web_contents) ? web_contents_->GetDevToolsWebContents() : nullptr;
+	return (web_contents_) ? web_contents_->GetDevToolsWebContents() : nullptr;
 }
 
 content::WebContents* CommonWebContentsDelegate::OpenURLFromTab(

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -261,7 +261,7 @@ void CommonWebContentsDelegate::EnterFullscreenModeForTab(
 
 void CommonWebContentsDelegate::ExitFullscreenModeForTab(
     content::WebContents* source) {
-  if (owner_window_) { 
+  if (owner_window_) {
     SetHtmlApiFullscreen(false);
     owner_window_->NotifyWindowLeaveHtmlFullScreen();
     source->GetRenderViewHost()->GetWidget()->WasResized();

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -253,18 +253,18 @@ void CommonWebContentsDelegate::EnumerateDirectory(content::WebContents* guest,
 void CommonWebContentsDelegate::EnterFullscreenModeForTab(
     content::WebContents* source, const GURL& origin) {
   if (owner_window_) {
-	SetHtmlApiFullscreen(true);
-	owner_window_->NotifyWindowEnterHtmlFullScreen();
-	source->GetRenderViewHost()->GetWidget()->WasResized();
+    SetHtmlApiFullscreen(true);
+    owner_window_->NotifyWindowEnterHtmlFullScreen();
+    source->GetRenderViewHost()->GetWidget()->WasResized();
   }
 }
 
 void CommonWebContentsDelegate::ExitFullscreenModeForTab(
     content::WebContents* source) {
-  if (owner_window_) {
-	SetHtmlApiFullscreen(false);
-	owner_window_->NotifyWindowLeaveHtmlFullScreen();
-	source->GetRenderViewHost()->GetWidget()->WasResized();
+  if (owner_window_) { 
+    SetHtmlApiFullscreen(false);
+    owner_window_->NotifyWindowLeaveHtmlFullScreen();
+    source->GetRenderViewHost()->GetWidget()->WasResized();
   }
 }
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -204,7 +204,7 @@ content::WebContents* CommonWebContentsDelegate::GetWebContents() const {
 
 content::WebContents*
 CommonWebContentsDelegate::GetDevToolsWebContents() const {
-	return (web_contents_) ? web_contents_->GetDevToolsWebContents() : nullptr;
+  return (web_contents_) ? web_contents_->GetDevToolsWebContents() : nullptr;
 }
 
 content::WebContents* CommonWebContentsDelegate::OpenURLFromTab(

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -199,16 +199,12 @@ void CommonWebContentsDelegate::ResetManagedWebContents(bool async) {
 }
 
 content::WebContents* CommonWebContentsDelegate::GetWebContents() const {
-  if (!web_contents_)
-    return nullptr;
-  return web_contents_->GetWebContents();
+  return (web_contents) ? web_contents_->GetWebContents() : nullptr;
 }
 
 content::WebContents*
 CommonWebContentsDelegate::GetDevToolsWebContents() const {
-  if (!web_contents_)
-    return nullptr;
-  return web_contents_->GetDevToolsWebContents();
+	return (web_contents) ? web_contents_->GetDevToolsWebContents() : nullptr;
 }
 
 content::WebContents* CommonWebContentsDelegate::OpenURLFromTab(

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -300,7 +300,6 @@ void CommonWebContentsDelegate::DevToolsSaveToFile(
       base::Value url_value(url);
       web_contents_->CallClientFunction(
           "DevToolsAPI.canceledSaveURL", &url_value, nullptr, nullptr);
-      return;
     }
   }
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -252,11 +252,11 @@ void CommonWebContentsDelegate::EnumerateDirectory(content::WebContents* guest,
 
 void CommonWebContentsDelegate::EnterFullscreenModeForTab(
     content::WebContents* source, const GURL& origin) {
-  if (!owner_window_)
-    return;
-  SetHtmlApiFullscreen(true);
-  owner_window_->NotifyWindowEnterHtmlFullScreen();
-  source->GetRenderViewHost()->GetWidget()->WasResized();
+  if (owner_window_) {
+	SetHtmlApiFullscreen(true);
+	owner_window_->NotifyWindowEnterHtmlFullScreen();
+	source->GetRenderViewHost()->GetWidget()->WasResized();
+  }
 }
 
 void CommonWebContentsDelegate::ExitFullscreenModeForTab(


### PR DESCRIPTION
I refactored some of the functions and files so they could be shorter, such as by changing conditionals and using the ternary operator where it would introduce clarity in `return` statements. I also removed unnecessary code as well. Most of these refactorings are short and sweet, so they should have little effect on the behavior of the code.