### PR TITLE
Add support for indicators in Ubuntu Gnome Session

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -163,7 +163,7 @@ require('./api/protocol')
 const mainStartupScript = packageJson.main || 'index.js'
 
 // Workaround for electron/electron#5050 and electron/electron#9046
-if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7'].includes(process.env.XDG_CURRENT_DESKTOP)) {
+if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7', 'ubuntu:GNOME'].includes(process.env.XDG_CURRENT_DESKTOP)) {
   process.env.XDG_CURRENT_DESKTOP = 'Unity'
 }
 


### PR DESCRIPTION
Ubuntu is switching to Gnome in 17.10 but it's not going to be the stock Gnome session. It's going to support the existing Unity APIs. Support has already landed for application indicators and likely other APIs (Launcher,etc) will be supported soon. The Ubuntu Gnome session will have `XDG_CURRENT_DESKTOP=ubuntu:GNOME` environment variable.

Ref: https://didrocks.fr/2017/08/23/ubuntu-gnome-shell-in-artful-day-7/