### PR TITLE
add mouse-move event and click event position for tray

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -86,7 +86,9 @@ mate::WrappableBase* Tray::New(mate::Handle<NativeImage> image,
   return new Tray(args->isolate(), args->GetThis(), image);
 }
 
-void Tray::OnClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) {
+void Tray::OnClicked(const gfx::Rect& bounds,
+                     const gfx::Point& location,
+                     int modifiers) {
   EmitWithFlags("click", modifiers, bounds, location);
 }
 

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -86,8 +86,8 @@ mate::WrappableBase* Tray::New(mate::Handle<NativeImage> image,
   return new Tray(args->isolate(), args->GetThis(), image);
 }
 
-void Tray::OnClicked(const gfx::Rect& bounds, int modifiers) {
-  EmitWithFlags("click", modifiers, bounds);
+void Tray::OnClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) {
+  EmitWithFlags("click", modifiers, bounds, location);
 }
 
 void Tray::OnDoubleClicked(const gfx::Rect& bounds, int modifiers) {
@@ -128,6 +128,10 @@ void Tray::OnMouseEntered(const gfx::Point& location, int modifiers) {
 
 void Tray::OnMouseExited(const gfx::Point& location, int modifiers) {
   EmitWithFlags("mouse-leave", modifiers, location);
+}
+
+void Tray::OnMouseMoved(const gfx::Point& location, int modifiers) {
+  EmitWithFlags("mouse-move", modifiers, location);
 }
 
 void Tray::OnDragEntered() {

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -47,7 +47,9 @@ class Tray : public mate::TrackableObject<Tray>,
   ~Tray() override;
 
   // TrayIconObserver:
-  void OnClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) override;
+  void OnClicked(const gfx::Rect& bounds,
+                 const gfx::Point& location,
+                 int modifiers) override;
   void OnDoubleClicked(const gfx::Rect& bounds, int modifiers) override;
   void OnRightClicked(const gfx::Rect& bounds, int modifiers) override;
   void OnBalloonShow() override;

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -47,7 +47,7 @@ class Tray : public mate::TrackableObject<Tray>,
   ~Tray() override;
 
   // TrayIconObserver:
-  void OnClicked(const gfx::Rect& bounds, int modifiers) override;
+  void OnClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) override;
   void OnDoubleClicked(const gfx::Rect& bounds, int modifiers) override;
   void OnRightClicked(const gfx::Rect& bounds, int modifiers) override;
   void OnBalloonShow() override;
@@ -61,6 +61,7 @@ class Tray : public mate::TrackableObject<Tray>,
   void OnDragEnded() override;
   void OnMouseEntered(const gfx::Point& location, int modifiers) override;
   void OnMouseExited(const gfx::Point& location, int modifiers) override;
+  void OnMouseMoved(const gfx::Point& location, int modifiers) override;
 
   void SetImage(v8::Isolate* isolate, mate::Handle<NativeImage> image);
   void SetPressedImage(v8::Isolate* isolate, mate::Handle<NativeImage> image);

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -34,7 +34,9 @@ gfx::Rect TrayIcon::GetBounds() {
   return gfx::Rect();
 }
 
-void TrayIcon::NotifyClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) {
+void TrayIcon::NotifyClicked(const gfx::Rect& bounds,
+                             const gfx::Point& location,
+                             int modifiers) {
   for (TrayIconObserver& observer : observers_)
     observer.OnClicked(bounds, location, modifiers);
 }

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -34,9 +34,9 @@ gfx::Rect TrayIcon::GetBounds() {
   return gfx::Rect();
 }
 
-void TrayIcon::NotifyClicked(const gfx::Rect& bounds, int modifiers) {
+void TrayIcon::NotifyClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) {
   for (TrayIconObserver& observer : observers_)
-    observer.OnClicked(bounds, modifiers);
+    observer.OnClicked(bounds, location, modifiers);
 }
 
 void TrayIcon::NotifyDoubleClicked(const gfx::Rect& bounds, int modifiers) {
@@ -87,6 +87,11 @@ void TrayIcon::NotifyMouseEntered(const gfx::Point& location, int modifiers) {
 void TrayIcon::NotifyMouseExited(const gfx::Point& location, int modifiers) {
   for (TrayIconObserver& observer : observers_)
     observer.OnMouseExited(location, modifiers);
+}
+
+void TrayIcon::NotifyMouseMoved(const gfx::Point& location, int modifiers) {
+  for (TrayIconObserver& observer : observers_)
+    observer.OnMouseMoved(location, modifiers);
 }
 
 void TrayIcon::NotifyDragEntered() {

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -70,7 +70,7 @@ class TrayIcon {
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
 
-  void NotifyClicked(const gfx::Rect& = gfx::Rect(), int modifiers = 0);
+  void NotifyClicked(const gfx::Rect& = gfx::Rect(), const gfx::Point& location = gfx::Point(), int modifiers = 0);
   void NotifyDoubleClicked(const gfx::Rect& = gfx::Rect(), int modifiers = 0);
   void NotifyBalloonShow();
   void NotifyBalloonClicked();
@@ -86,6 +86,8 @@ class TrayIcon {
   void NotifyMouseEntered(const gfx::Point& location = gfx::Point(),
                           int modifiers = 0);
   void NotifyMouseExited(const gfx::Point& location = gfx::Point(),
+                         int modifiers = 0);
+  void NotifyMouseMoved(const gfx::Point& location = gfx::Point(),
                          int modifiers = 0);
 
  protected:

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -70,7 +70,9 @@ class TrayIcon {
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
 
-  void NotifyClicked(const gfx::Rect& = gfx::Rect(), const gfx::Point& location = gfx::Point(), int modifiers = 0);
+  void NotifyClicked(const gfx::Rect& = gfx::Rect(),
+                     const gfx::Point& location = gfx::Point(),
+                     int modifiers = 0);
   void NotifyDoubleClicked(const gfx::Rect& = gfx::Rect(), int modifiers = 0);
   void NotifyBalloonShow();
   void NotifyBalloonClicked();

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -249,7 +249,7 @@ const CGFloat kVerticalTitleMargin = 2;
   if (event.clickCount == 1)
     trayIcon_->NotifyClicked(
         gfx::ScreenRectFromNSRect(event.window.frame),
-		gfx::ScreenPointFromNSPoint([event locationInWindow]),
+        gfx::ScreenPointFromNSPoint([event locationInWindow]),
         ui::EventFlagsFromModifiers([event modifierFlags]));
 
   // Double click event.

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -57,10 +57,10 @@ const CGFloat kVerticalTitleMargin = 2;
     // Finalize setup by sizing our views
     [self updateDimensions];
 
-    // Add NSTrackingArea for listening to mouseEnter and mouseExit events
+    // Add NSTrackingArea for listening to mouseEnter, mouseExit, and mouseMove events
     auto trackingArea = [[[NSTrackingArea alloc]
         initWithRect:[self bounds]
-             options:NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways
+             options:NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingActiveAlways
                owner:self
             userInfo:nil] autorelease];
     [self addTrackingArea:trackingArea];
@@ -249,6 +249,7 @@ const CGFloat kVerticalTitleMargin = 2;
   if (event.clickCount == 1)
     trayIcon_->NotifyClicked(
         gfx::ScreenRectFromNSRect(event.window.frame),
+		gfx::ScreenPointFromNSPoint([event locationInWindow]),
         ui::EventFlagsFromModifiers([event modifierFlags]));
 
   // Double click event.
@@ -303,6 +304,12 @@ const CGFloat kVerticalTitleMargin = 2;
 
 - (void)mouseEntered:(NSEvent*)event {
   trayIcon_->NotifyMouseEntered(
+      gfx::ScreenPointFromNSPoint([event locationInWindow]),
+      ui::EventFlagsFromModifiers([event modifierFlags]));
+}
+
+- (void)mouseMoved:(NSEvent*)event {
+  trayIcon_->NotifyMouseMoved(
       gfx::ScreenPointFromNSPoint([event locationInWindow]),
       ui::EventFlagsFromModifiers([event modifierFlags]));
 }

--- a/atom/browser/ui/tray_icon_observer.h
+++ b/atom/browser/ui/tray_icon_observer.h
@@ -17,7 +17,7 @@ namespace atom {
 
 class TrayIconObserver {
  public:
-  virtual void OnClicked(const gfx::Rect& bounds, int modifiers) {}
+  virtual void OnClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) {}
   virtual void OnDoubleClicked(const gfx::Rect& bounds, int modifiers) {}
   virtual void OnBalloonShow() {}
   virtual void OnBalloonClicked() {}
@@ -31,6 +31,7 @@ class TrayIconObserver {
   virtual void OnDragEnded() {}
   virtual void OnMouseEntered(const gfx::Point& location, int modifiers) {}
   virtual void OnMouseExited(const gfx::Point& location, int modifiers) {}
+  virtual void OnMouseMoved(const gfx::Point& location, int modifiers) {}
 
  protected:
   virtual ~TrayIconObserver() {}

--- a/atom/browser/ui/tray_icon_observer.h
+++ b/atom/browser/ui/tray_icon_observer.h
@@ -17,7 +17,9 @@ namespace atom {
 
 class TrayIconObserver {
  public:
-  virtual void OnClicked(const gfx::Rect& bounds, const gfx::Point& location, int modifiers) {}
+  virtual void OnClicked(const gfx::Rect& bounds,
+                         const gfx::Point& location,
+                         int modifiers) {}
   virtual void OnDoubleClicked(const gfx::Rect& bounds, int modifiers) {}
   virtual void OnBalloonShow() {}
   virtual void OnBalloonClicked() {}

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -55,7 +55,9 @@ void NotifyIcon::HandleClickEvent(int modifiers,
     if (double_button_click)  // double left click
       NotifyDoubleClicked(bounds, modifiers);
     else  // single left click
-      NotifyClicked(bounds, modifiers);
+      NotifyClicked(bounds,
+                    display::Screen::GetScreen()->GetCursorScreenPoint(),
+                    modifiers);
     return;
   } else if (!double_button_click) {  // single right click
     if (menu_model_)

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -76,6 +76,7 @@ The `Tray` module emits the following events:
   * `ctrlKey` Boolean
   * `metaKey` Boolean
 * `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon
+* `position` [Point](structures/point.md) - The position of the event
 
 Emitted when the tray icon is clicked.
 
@@ -165,6 +166,17 @@ Emitted when the mouse enters the tray icon.
 * `position` [Point](structures/point.md) - The position of the event
 
 Emitted when the mouse exits the tray icon.
+
+#### Event: 'mouse-move' _macOS_
+
+* `event` Event
+  * `altKey` Boolean
+  * `shiftKey` Boolean
+  * `ctrlKey` Boolean
+  * `metaKey` Boolean
+* `position` [Point](structures/point.md) - The position of the event
+
+Emitted when the mouse moves in the tray icon.
 
 ### Instance Methods
 


### PR DESCRIPTION
Similar to #9760 - Adds API for listening to mouse-move events for Tray. Also adds position for the Tray click event. This allows for more precise hover states and click events on the tray icon.