### PR TITLE
Fixed crash on process exit on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+
+version: 2
+jobs:
+  electron-linux-arm:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: arm
+    steps:
+      - checkout
+      - run: script/cibuild
+
+  electron-linux-arm64:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: arm64
+    steps:
+      - checkout
+      - run: script/cibuild
+
+  electron-linux-ia32:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: ia32
+    steps:
+      - checkout
+      - run: script/cibuild
+
+  electron-linux-x64:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: x64
+    steps:
+      - checkout
+      - run: script/cibuild
+
+workflows:
+  version: 2
+  build-arm:
+    jobs:
+      - electron-linux-arm
+  build-arm64:
+    jobs:
+      - electron-linux-arm64
+  build-ia32:
+    jobs:
+      - electron-linux-ia32
+  build-x64:
+    jobs:
+      - electron-linux-x64

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -94,6 +94,25 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     }
   }
 
+#ifndef DEBUG
+  // Chromium has its own TLS subsystem which supports automatic destruction
+  // of thread-local data, and also depends on memory allocation routines
+  // provided by the CRT. The problem is that the auto-destruction mechanism
+  // uses a hidden feature of the OS loader which calls a callback on thread
+  // exit, but only after all loaded DLLs have been detached. Since the CRT is
+  // also a DLL, it happens that by the time Chromium's `OnThreadExit` function
+  // is called, the heap functions, though still in memory, no longer perform
+  // their duties, and when Chromium calls `free` on its buffer, it triggers
+  // an access violation error.
+  // We work around this problem by invoking Chromium's `OnThreadExit` in time
+  // from within the CRT's atexit facility, ensuring the heap functions are
+  // still active. The second invocation from the OS loader will be a no-op.
+  extern void NTAPI OnThreadExit(PVOID module, DWORD reason, PVOID reserved);
+  atexit([]() {
+    OnThreadExit(nullptr, DLL_THREAD_DETACH, nullptr);
+  });
+#endif
+
   if (run_as_node) {
     // Now that argv conversion is done, we can finally start.
     base::AtExitManager atexit_manager;


### PR DESCRIPTION
This is a fix for #10188 which was introduced by switching to dynamically linked CRT on Windows. The problem went unnoticed because it is mostly harmless other than recording the app crash in the Windows Event Log. It is desirable to merge this to master and to the 1.7 stream as well.

### Description:

Chromium has its own TLS subsystem which supports automatic destruction of thread-local data, and also depends on memory allocation routines provided by the CRT. The problem is that the auto-destruction mechanism uses a hidden feature of the OS loader which calls a callback on thread exit, but only after all loaded DLLs have been detached. Since the CRT is also a DLL, it happens that by the time Chromium's `OnThreadExit` function is called, the heap functions, though still in memory, no longer perform their duties, and when Chromium calls `free` on its buffer, it triggers an access violation error. 

The workaround is to invoke Chromium's `OnThreadExit` in time from within the CRT's atexit facility, ensuring the heap functions are still active. The second invocation from the OS loader code will be a no-op.