### PR TITLE
Close window in order from newer one on macOS

### DIFF
--- a/atom/browser/window_list.cc
+++ b/atom/browser/window_list.cc
@@ -81,6 +81,9 @@ void WindowList::RemoveObserver(WindowListObserver* observer) {
 // static
 void WindowList::CloseAllWindows() {
   WindowVector windows = GetInstance()->windows_;
+#if defined(OS_MACOSX)
+  std::reverse(windows.begin(), windows.end());
+#endif
   for (const auto& window : windows)
     if (!window->IsClosed())
       window->Close();


### PR DESCRIPTION
A parent window is not closed if a child modal window still exists on macOS.
So a child window should be closed before parent window closed.

### Reproduce code

https://github.com/syohex/electron-app-quit-issue

`npm install && npm run start`

This example shows a window and show its child modal window. And then it calls `app.quit()` after three seconds. I expect that all windows are closed by `app.quit()` but parent window is not closed.

I checked this behavior by `lldb`. `NSWindow#performClose` does nothing(also delegate methods are not called) if child modal window still exists. Taking such behavior into consideration, a child window should be closed before parent window closed. (I could not find about this behavior from `NSWindow` document)

###  Gif animations

#### Original code(A parent window is not closed)

![before](https://user-images.githubusercontent.com/554281/29759943-e52ab5a2-8bfa-11e7-855d-73b1e931f138.gif)

#### This version(Both parent and child windows are closed)

![after](https://user-images.githubusercontent.com/554281/29759726-020419fe-8bf9-11e7-88f5-110ed1ca5e71.gif)
