### PR TITLE
Backport #10293 (notification-sounds)

### DIFF
--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -67,6 +67,7 @@ Notification::Notification(v8::Isolate* isolate,
     opts.Get("replyPlaceholder", &reply_placeholder_);
     opts.Get("hasReply", &has_reply_);
     opts.Get("actions", &actions_);
+    opts.Get("sound", &sound_);
   }
 }
 
@@ -113,6 +114,10 @@ std::vector<brightray::NotificationAction> Notification::GetActions() const {
   return actions_;
 }
 
+base::string16 Notification::GetSound() const {
+  return sound_;
+}
+
 // Setters
 void Notification::SetTitle(const base::string16& new_title) {
   title_ = new_title;
@@ -141,6 +146,10 @@ void Notification::SetHasReply(bool new_has_reply) {
 void Notification::SetActions(
   const std::vector<brightray::NotificationAction>& actions) {
   actions_ = actions;
+}
+
+void Notification::SetSound(const base::string16& new_sound) {
+  sound_ = new_sound;
 }
 
 void Notification::NotificationAction(int index) {
@@ -181,6 +190,7 @@ void Notification::Show() {
       options.has_reply = has_reply_;
       options.reply_placeholder = reply_placeholder_;
       options.actions = actions_;
+      options.sound = sound_;
       notification_->Show(options);
     }
   }
@@ -207,7 +217,9 @@ void Notification::BuildPrototype(v8::Isolate* isolate,
       .SetProperty("hasReply", &Notification::GetHasReply,
                    &Notification::SetHasReply)
       .SetProperty("actions", &Notification::GetActions,
-                   &Notification::SetActions);
+                   &Notification::SetActions)
+      .SetProperty("sound", &Notification::GetSound,
+                   &Notification::SetSound);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_notification.h
+++ b/atom/browser/api/atom_api_notification.h
@@ -54,6 +54,7 @@ class Notification : public mate::TrackableObject<Notification>,
   base::string16 GetReplyPlaceholder() const;
   bool GetHasReply() const;
   std::vector<brightray::NotificationAction> GetActions() const;
+  base::string16 GetSound() const;
 
   // Prop Setters
   void SetTitle(const base::string16& new_title);
@@ -63,6 +64,7 @@ class Notification : public mate::TrackableObject<Notification>,
   void SetReplyPlaceholder(const base::string16& new_reply_placeholder);
   void SetHasReply(bool new_has_reply);
   void SetActions(const std::vector<brightray::NotificationAction>& actions);
+  void SetSound(const base::string16& sound);
 
  private:
   base::string16 title_;
@@ -75,6 +77,7 @@ class Notification : public mate::TrackableObject<Notification>,
   base::string16 reply_placeholder_;
   bool has_reply_ = false;
   std::vector<brightray::NotificationAction> actions_;
+  base::string16 sound_;
 
   brightray::NotificationPresenter* presenter_;
 

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -39,6 +39,8 @@ void CocoaNotification::Show(const NotificationOptions& options) {
 
   if (options.silent) {
     [notification_ setSoundName:nil];
+  } else if (options.sound != nil) {
+    [notification_ setSoundName:base::SysUTF16ToNSString(options.sound)];
   } else {
     [notification_ setSoundName:NSUserNotificationDefaultSoundName];
   }

--- a/brightray/browser/notification.h
+++ b/brightray/browser/notification.h
@@ -33,6 +33,7 @@ struct NotificationOptions {
   bool silent;
   bool has_reply;
   base::string16 reply_placeholder;
+  base::string16 sound;
   std::vector<NotificationAction> actions;
 };
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -37,6 +37,7 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
   * `icon` [NativeImage](native-image.md) - (optional) An icon to use in the notification
   * `hasReply` Boolean - (optional) Whether or not to add an inline reply option to the notification.  _macOS_
   * `replyPlaceholder` String - (optional) The placeholder to write in the inline reply input field. _macOS_
+  * `sound` String - (optional) The name of the sound file to play when the notification is shown. _macOS_
   * `actions` [NotificationAction[]](structures/notification-action.md) - (optional) Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
 
 
@@ -102,3 +103,18 @@ Immediately shows the notification to the user, please note this means unlike th
 HTML5 Notification implementation, simply instantiating a `new Notification` does
 not immediately show it to the user, you need to call this method before the OS
 will display it.
+
+### Playing Sounds
+
+On macOS, you can specify the name of the sound you'd like to play when the
+notification is shown. Any of the default sounds (under System Preferences >
+Sound) can be used, in addition to custom sound files. Be sure that the sound
+file is copied under the app bundle (e.g., `YourApp.app/Contents/Resources`),
+or one of the following locations:
+
+* `~/Library/Sounds`
+* `/Library/Sounds`
+* `/Network/Library/Sounds`
+* `/System/Library/Sounds`
+
+See the [`NSSound`](https://developer.apple.com/documentation/appkit/nssound) docs for more information.


### PR DESCRIPTION
This PR backports #10293, adding support for `sound` to macOS notifications.

The cherry-pick had zero conflicts and the feature still works fine 🍒

cc @jkleinsc @CharlieHess