### PR TITLE
Cleanup obsolete code

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -9,6 +9,7 @@
 #if defined(OS_WIN)
 #include <windows.h>  // windows.h must be included first
 
+#include <atlbase.h>  // ensures that ATL statics like `_AtlWinModule` are initialized (it's an issue in static debug build)
 #include <shellapi.h>
 #include <shellscalingapi.h>
 #include <tchar.h>

--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -17,7 +17,7 @@
 #include "base/values.h"
 
 #if defined(OS_WIN)
-#include "atom/node/osfhandle.h"
+#include <io.h>
 #endif
 
 namespace asar {
@@ -118,7 +118,7 @@ Archive::Archive(const base::FilePath& path)
     : path_(path),
       file_(path_, base::File::FLAG_OPEN | base::File::FLAG_READ),
 #if defined(OS_WIN)
-      fd_(node::open_osfhandle(
+      fd_(_open_osfhandle(
               reinterpret_cast<intptr_t>(file_.GetPlatformFile()), 0)),
 #elif defined(OS_POSIX)
       fd_(file_.GetPlatformFile()),
@@ -131,7 +131,7 @@ Archive::Archive(const base::FilePath& path)
 Archive::~Archive() {
 #if defined(OS_WIN)
   if (fd_ != -1) {
-    node::close(fd_);
+    _close(fd_);
     // Don't close the handle since we already closed the fd.
     file_.TakePlatformFile();
   }

--- a/atom/node/osfhandle.cc
+++ b/atom/node/osfhandle.cc
@@ -4,8 +4,6 @@
 
 #include "osfhandle.h"
 
-#include <io.h>
-
 #if !defined(DEBUG)
 #define U_I18N_IMPLEMENTATION
 #define U_COMMON_IMPLEMENTATION
@@ -31,14 +29,6 @@
 #include "v8-inspector.h"
 
 namespace node {
-
-int open_osfhandle(intptr_t osfhandle, int flags) {
-  return _open_osfhandle(osfhandle, flags);
-}
-
-int close(int fd) {
-  return _close(fd);
-}
 
 void ReferenceSymbols() {
   // Following symbols are used by electron.exe but got stripped by compiler,

--- a/atom/node/osfhandle.h
+++ b/atom/node/osfhandle.h
@@ -5,21 +5,7 @@
 #ifndef ATOM_NODE_OSFHANDLE_H_
 #define ATOM_NODE_OSFHANDLE_H_
 
-#include <windows.h>
-
 namespace node {
-
-// The _open_osfhandle and _close functions on Windows are provided by the
-// Visual C++ library, so the fd returned by them can only be used in the
-// same instance of VC++ library.
-// However Electron is linking with VC++ library statically, so electron.exe
-// shares a different instance of VC++ library with node.exe. This results
-// in fd created in electron.exe not usable in node.dll, so we have to ensure
-// we always create fd in one instance of VC++ library.
-// Followings wrappers are compiled in node.dll, and all code in electron.exe
-// should call these wrappers instead of calling _open_osfhandle directly.
-__declspec(dllexport) int open_osfhandle(intptr_t osfhandle, int flags);
-__declspec(dllexport) int close(int fd);
 
 // A trick to force referencing symbols.
 __declspec(dllexport) void ReferenceSymbols();


### PR DESCRIPTION
As we've switched to dynamic CRT on Windows, the function wrappers exposed from `node.dll` are no longer necessary. This PR removes the wrappers.

Also, I noticed that when the static build is built in debug mode, it crashes because some ATL static objects don't get initialized. I included the `atlbase.h` header which ensures that the initialization happens correctly.