### PR TITLE
Modify `bump-version.py`

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -25,7 +25,7 @@ make sure there are no drafts.
 ## Bump the version
 
 Run the `bump-version` script with arguments according to your need:
-- `--bump=patch` to increment patch version, or
+- `--bump=[major|minor|patch|beta]` to increment one of the version numbers, or
 - `--stable` to indicate this is a stable version, or
 - `--version={version}` to set version number directly.
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -24,10 +24,17 @@ make sure there are no drafts.
 
 ## Bump the version
 
-Run the `bump-version` script, passing `major`, `minor`, or `patch` as an argument:
+Run the `bump-version` script with arguments according to your need:
+- `--bump=patch` to increment patch version, or
+- `--stable` to indicate this is a stable version, or
+- `--version={version}` to set version number directly.
+
+**Note**: you can use both `--bump` and `--stable` simultaneously.
+
+There is also a `dry-run` flag you can use to make sure the version number generated is correct before committing.
 
 ```sh
-npm run bump-version -- patch
+npm run bump-version -- --bump=patch --stable
 git push origin HEAD
 ```
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// maintainer note - x.y.z-ab version in package.json -> x.y.z
-var version = require('./package').version.replace(/-.*/, '')
+var version = require('./package').version
 
 var fs = require('fs')
 var os = require('os')

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -16,7 +16,8 @@ def main():
   parser = argparse.ArgumentParser(description='Bump version numbers. Must specify at least one option.')
   parser.add_argument('--version', default=None, dest='new_version', help='new version number')
   parser.add_argument('--bump', action='store', dest='bump', default=None, help='increment [major | minor | patch | beta]')
-  parser.add_argument('--stable', action='store_true', default= False, dest='stable', help='promote to stable')
+  parser.add_argument('--stable', action='store_true', default= False, dest='stable', help='promote to stable (i.e. remove `-beta.x` suffix)')
+  parser.add_argument('--dry-run', action='store_true', default= False, dest='dry_run', help='just to check that version number is correct')
 
   args = parser.parse_args()
 
@@ -43,6 +44,10 @@ def main():
 
   version = '.'.join(versions[:3])
   suffix = '' if versions[3] == '0' else '-beta.' + versions[3]
+
+  if args.dry_run:
+    print 'new version number would be: {0}\n'.format(version + suffix)
+    return 0
 
 
   with scoped_cwd(SOURCE_ROOT):

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -13,11 +13,36 @@ SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 def main():
 
-  parser = argparse.ArgumentParser(description='Bump version numbers. Must specify at least one option.')
-  parser.add_argument('--version', default=None, dest='new_version', help='new version number')
-  parser.add_argument('--bump', action='store', dest='bump', default=None, help='increment [major | minor | patch | beta]')
-  parser.add_argument('--stable', action='store_true', default= False, dest='stable', help='promote to stable (i.e. remove `-beta.x` suffix)')
-  parser.add_argument('--dry-run', action='store_true', default= False, dest='dry_run', help='just to check that version number is correct')
+  parser = argparse.ArgumentParser(
+    description='Bump version numbers. Must specify at least one option.'
+  )
+  parser.add_argument(
+    '--version', 
+    default=None, 
+    dest='new_version', 
+    help='new version number'
+  )
+  parser.add_argument(
+    '--bump', 
+    action='store', 
+    default=None, 
+    dest='bump', 
+    help='increment [major | minor | patch | beta]'
+  )
+  parser.add_argument(
+    '--stable', 
+    action='store_true', 
+    default= False, 
+    dest='stable', 
+    help='promote to stable (i.e. remove `-beta.x` suffix)'
+  )
+  parser.add_argument(
+    '--dry-run', 
+    action='store_true', 
+    default= False, 
+    dest='dry_run', 
+    help='just to check that version number is correct'
+  )
 
   args = parser.parse_args()
 

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+import argparse
 
 from lib.util import execute, get_electron_version, parse_version, scoped_cwd
 
@@ -11,28 +12,46 @@ SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 
 def main():
-  if len(sys.argv) != 2 or sys.argv[1] == '-h':
-    print 'Usage: bump-version.py [<version> | major | minor | patch]'
+
+  parser = argparse.ArgumentParser(description='Bump version numbers. Must specify at least one option.')
+  parser.add_argument('--version', default=None, dest='new_version', help='new version number')
+  parser.add_argument('--bump', action='store', dest='bump', default=None, help='increment [major | minor | patch | beta]')
+  parser.add_argument('--stable', action='store_true', default= False, dest='stable', help='promote to stable')
+
+  args = parser.parse_args()
+
+  if args.new_version == None and args.bump == None and args.stable == False:
+    parser.print_help()
     return 1
 
-  option = sys.argv[1]
-  increments = ['major', 'minor', 'patch', 'build']
-  if option in increments:
-    version = get_electron_version()
-    versions = parse_version(version.split('-')[0])
-    versions = increase_version(versions, increments.index(option))
-  else:
-    versions = parse_version(option)
+  increments = ['major', 'minor', 'patch', 'beta']
+  
+  curr_version = get_electron_version()
+  versions = parse_version(re.sub('-beta', '', curr_version))
+  
+  if args.bump in increments:
+    versions = increase_version(versions, increments.index(args.bump))
+    if versions[3] == '0':
+      # beta starts at 1
+      versions = increase_version(versions, increments.index('beta'))
+
+  if args.stable == True:
+    versions[3] = '0'
+
+  if args.new_version != None:
+    versions = parse_version(re.sub('-beta', '', args.new_version))
 
   version = '.'.join(versions[:3])
+  suffix = '' if versions[3] == '0' else '-beta.' + versions[3]
+
 
   with scoped_cwd(SOURCE_ROOT):
-    update_electron_gyp(version)
+    update_electron_gyp(version, suffix)
     update_win_rc(version, versions)
     update_version_h(versions)
     update_info_plist(version)
-    update_package_json(version)
-    tag_version(version)
+    update_package_json(version, suffix)
+    tag_version(version, suffix)
 
 
 def increase_version(versions, index):
@@ -42,14 +61,14 @@ def increase_version(versions, index):
   return versions
 
 
-def update_electron_gyp(version):
-  pattern = re.compile(" *'version%' *: *'[0-9.]+'")
+def update_electron_gyp(version, suffix):
+  pattern = re.compile(" *'version%' *: *'[0-9.]+(-beta[0-9.]*)?'")
   with open('electron.gyp', 'r') as f:
     lines = f.readlines()
 
   for i in range(0, len(lines)):
     if pattern.match(lines[i]):
-      lines[i] = "    'version%': '{0}',\n".format(version)
+      lines[i] = "    'version%': '{0}',\n".format(version + suffix)
       with open('electron.gyp', 'w') as f:
         f.write(''.join(lines))
       return
@@ -114,7 +133,7 @@ def update_info_plist(version):
     f.write(''.join(lines))
 
 
-def update_package_json(version):
+def update_package_json(version, suffix):
   package_json = 'package.json'
   with open(package_json, 'r') as f:
     lines = f.readlines()
@@ -122,15 +141,15 @@ def update_package_json(version):
   for i in range(0, len(lines)):
     line = lines[i];
     if 'version' in line:
-      lines[i] = '  "version": "{0}",\n'.format(version)
+      lines[i] = '  "version": "{0}",\n'.format(version + suffix)
       break
 
   with open(package_json, 'w') as f:
     f.write(''.join(lines))
 
 
-def tag_version(version):
-  execute(['git', 'commit', '-a', '-m', 'Bump v{0}'.format(version)])
+def tag_version(version, suffix):
+  execute(['git', 'commit', '-a', '-m', 'Bump v{0}'.format(version + suffix)])
 
 
 if __name__ == '__main__':

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -14,7 +14,12 @@ SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 def main():
 
   parser = argparse.ArgumentParser(
-    description='Bump version numbers. Must specify at least one option.'
+    description='Bump version numbers. Must specify at least one of the three options:\n'
+               +'   --bump=patch to increment patch version, or\n'
+               +'   --stable to promote current beta to stable, or\n'
+               +'   --version={version} to set version number directly\n'
+               +'Note that you can use both --bump and --stable simultaneously.',
+               formatter_class=argparse.RawTextHelpFormatter
   )
   parser.add_argument(
     '--version', 


### PR DESCRIPTION
Modify the `bump-version` script to reflect changes in naming convention as per #10336.
New usage would be:
- `npm run bump-version -- --bump=patch` to increment patch version, or
- `npm run bump-version -- --stable` to promote current beta to stable, or 
- `npm run bump-version -- --version=1.8.1-beta.1` to set version number directly.

Note:
- you can use both `--bump` and `--stable` simultaneously.
- not all the version numbers will be affected due to certain format restrictions
- this will change `process.versions.electron` as well

To do:
- [x] kick off a round of fake builds with this new naming convention to make sure nothing is broken as a result
- [x] document changes 