### PR TITLE
[WIP] Use isolated world for content scripts injection

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -249,15 +249,10 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(int world_id,
       scriptExecutionType, callback.release());
 }
 
-v8::Local<v8::Value> WebFrame::RunInIsolatedWorldContext(
-    int world_id,
-    const base::string16& code) {
+v8::Local<v8::Value> WebFrame::GetIsolatedWorldGlobalObject(
+    int world_id) {
   auto context = web_frame_->WorldScriptContext(isolate(), world_id);
-  auto script = v8::Script::Compile(
-      mate::ConvertToV8(context->GetIsolate(), code)->ToString());
-
-  v8::MaybeLocal<v8::Value> return_value = script->Run(context);
-  return return_value.ToLocalChecked();
+  return context->Global();
 }
 
 // static
@@ -310,7 +305,7 @@ void WebFrame::BuildPrototype(
       .SetMethod("insertCSS", &WebFrame::InsertCSS)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
       .SetMethod("executeJavaScriptInIsolatedWorld", &WebFrame::ExecuteJavaScriptInIsolatedWorld)
-      .SetMethod("runInIsolatedWorldContext", &WebFrame::RunInIsolatedWorldContext)
+      .SetMethod("getIsolatedWorldGlobalObject", &WebFrame::GetIsolatedWorldGlobalObject)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
       .SetMethod("clearCache", &WebFrame::ClearCache)
       // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -236,7 +236,7 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(int world_id,
 
   std::unique_ptr<blink::WebScriptExecutionCallback> callback(
       new ScriptExecutionCallback(completion_callback));
-  // TODO do same logic as in
+  // TODO(alexstrat) do same logic as in
   // https://cs.chromium.org/chromium/src/extensions/renderer/script_injection.cc?type=cs&sq=package:chromium&l=326
   blink::WebLocalFrame::ScriptExecutionType scriptExecutionType =
       blink::WebLocalFrame::kSynchronous;
@@ -304,8 +304,10 @@ void WebFrame::BuildPrototype(
       .SetMethod("insertText", &WebFrame::InsertText)
       .SetMethod("insertCSS", &WebFrame::InsertCSS)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
-      .SetMethod("executeJavaScriptInIsolatedWorld", &WebFrame::ExecuteJavaScriptInIsolatedWorld)
-      .SetMethod("getIsolatedWorldGlobalObject", &WebFrame::GetIsolatedWorldGlobalObject)
+      .SetMethod("executeJavaScriptInIsolatedWorld",
+        &WebFrame::ExecuteJavaScriptInIsolatedWorld)
+      .SetMethod("getIsolatedWorldGlobalObject",
+        &WebFrame::GetIsolatedWorldGlobalObject)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
       .SetMethod("clearCache", &WebFrame::ClearCache)
       // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -249,12 +249,6 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(int world_id,
       scriptExecutionType, callback.release());
 }
 
-v8::Local<v8::Value> WebFrame::GetIsolatedWorldGlobalObject(
-    int world_id) {
-  auto context = web_frame_->WorldScriptContext(isolate(), world_id);
-  return context->Global();
-}
-
 // static
 mate::Handle<WebFrame> WebFrame::Create(v8::Isolate* isolate) {
   return mate::CreateHandle(isolate, new WebFrame(isolate));
@@ -306,8 +300,6 @@ void WebFrame::BuildPrototype(
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
       .SetMethod("executeJavaScriptInIsolatedWorld",
         &WebFrame::ExecuteJavaScriptInIsolatedWorld)
-      .SetMethod("getIsolatedWorldGlobalObject",
-        &WebFrame::GetIsolatedWorldGlobalObject)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
       .SetMethod("clearCache", &WebFrame::ClearCache)
       // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -249,6 +249,17 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(int world_id,
       scriptExecutionType, callback.release());
 }
 
+v8::Local<v8::Value> WebFrame::RunInIsolatedWorldContext(
+    int world_id,
+    const base::string16& code) {
+  auto context = web_frame_->WorldScriptContext(isolate(), world_id);
+  auto script = v8::Script::Compile(
+      mate::ConvertToV8(context->GetIsolate(), code)->ToString());
+
+  v8::MaybeLocal<v8::Value> return_value = script->Run(context);
+  return return_value.ToLocalChecked();
+}
+
 // static
 mate::Handle<WebFrame> WebFrame::Create(v8::Isolate* isolate) {
   return mate::CreateHandle(isolate, new WebFrame(isolate));
@@ -298,8 +309,8 @@ void WebFrame::BuildPrototype(
       .SetMethod("insertText", &WebFrame::InsertText)
       .SetMethod("insertCSS", &WebFrame::InsertCSS)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
-      .SetMethod("executeJavaScriptInIsolatedWorld",
-                 &WebFrame::ExecuteJavaScriptInIsolatedWorld)
+      .SetMethod("executeJavaScriptInIsolatedWorld", &WebFrame::ExecuteJavaScriptInIsolatedWorld)
+      .SetMethod("runInIsolatedWorldContext", &WebFrame::RunInIsolatedWorldContext)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
       .SetMethod("clearCache", &WebFrame::ClearCache)
       // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -73,6 +73,9 @@ class WebFrame : public mate::Wrappable<WebFrame> {
 
   // Excecuting scripts.
   void ExecuteJavaScript(const base::string16& code, mate::Arguments* args);
+  void ExecuteJavaScriptInIsolatedWorld(int world_id,
+                                        const base::string16& code,
+                                        mate::Arguments* args);
 
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -76,8 +76,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   void ExecuteJavaScriptInIsolatedWorld(int world_id,
                                         const base::string16& code,
                                         mate::Arguments* args);
-  v8::Local<v8::Value> RunInIsolatedWorldContext(int world_id,
-                                         const base::string16& code);
+  v8::Local<v8::Value> GetIsolatedWorldGlobalObject(int world_id);
 
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -77,7 +77,6 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   void ExecuteJavaScriptInIsolatedWorld(int world_id,
                                         const base::string16& code,
                                         mate::Arguments* args);
-  v8::Local<v8::Value> GetIsolatedWorldGlobalObject(int world_id);
 
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -76,6 +76,8 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   void ExecuteJavaScriptInIsolatedWorld(int world_id,
                                         const base::string16& code,
                                         mate::Arguments* args);
+  v8::Local<v8::Value> RunInIsolatedWorldContext(int world_id,
+                                         const base::string16& code);
 
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "atom/renderer/guest_view_container.h"
 #include "native_mate/handle.h"


### PR DESCRIPTION
_Following #9494_

### Background
For extension's content scripts injection, Chromium relies on ["isolated world"](https://developer.chrome.com/extensions/content_scripts#execution-environment).

> Content scripts execute in a special environment called an isolated world. They have access to the DOM of the page they are injected into, but not to any JavaScript variables or functions created by the page. It looks to each content script as if there is no other JavaScript executing on the page it is running on. The same is true in reverse: JavaScript running on the page cannot call any functions or access any variables defined by content scripts.

In Electron, the current implementation relies on [`vm.runInThisContext`](https://github.com/electron/electron/blob/master/lib/renderer/content-scripts-injector.js#L16-L23) that does not have the same isolation properties.

### Objective
This PR wants to add the necessary APIs to deal with isolated world and use it in content scripts injection.

### Exploration
_Picked from #9494_
Here are my findings from diving into [`ScriptInjection`](https://cs.chromium.org/chromium/src/extensions/renderer/script_injection.h?type=cs&sq=package:chromium):
- it relies on `blink::WebFrame#executeScriptInIsolatedWorld`
- however there is no way to pass an existing `V8:Context` to `executeScriptInIsolatedWorld` (I think blink is creating contexts internally). Instead, chromium is hooking into `DidCreateScriptContext` in [` Dispatcher`](https://cs.chromium.org/chromium/src/extensions/renderer/dispatcher.cc?type=cs&sq=package:chromium&l=291) that returns a `V8:Context` freshly created.
- from there and by mapping `world_id` passed in `executeScriptInIsolatedWorld` and returned in `DidCreateScriptContext`, it can manipuate the `V8:Context` to add the necessary `chrome.*` APIs to the context (how exactly?)

### Plan
I think what can be done is:
- add `webFrame.executeJavaScriptInIsolatedWorld(worldId, code, ..)` to the `webFrame` API alongside the existing `webFrame.executeJavaScript`
- have an event `'did-create-script-context'` which callback returns `worldId` and `context` (type of context representing `v8::context`?)
- but how to inject chrome apis in the `context`? Looks like [this](https://github.com/electron/electron/blob/c6918966c25144e85956b8614bd5f005ae4e642a/atom/renderer/atom_renderer_client.cc#L172-L204) can lead to ideas.
- [bonus] add `webFrame.setIsolatedWorldContentSecurityPolicy` and `setIsolatedWorldSecurityOrigin` that could be needed at some point