### PR TITLE
Backport macOS IME backspace fix for 1.6.x

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -9,7 +9,7 @@ import sys
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = os.getenv('LIBCHROMIUMCONTENT_COMMIT') or \
-    'f3e99add3753f82f9ce02788144b9ea9cd6367d8'
+    'a46563ffdf1c3867ecfd19e10d5cf4f0c9f59bca'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
Fix the issue (#9173) of Backspace can not erase the last one character during Japanese IME conversion (macOS) for 1.6.x

