### PR TITLE
Fix missing extension when saving a file without filters

### DIFF
--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -40,7 +40,6 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   if ([file_type_set count])
     file_types = [file_type_set allObjects];
 
-  [dialog setExtensionHidden:NO];
   [dialog setAllowedFileTypes:file_types];
 }
 
@@ -84,11 +83,14 @@ void SetupDialog(NSSavePanel* dialog,
     SetAllowedFileTypes(dialog, settings.filters);
   }
 
+  // Make sure the extension is always visible. Without this, the extension in
+  // the default filename will not be used in the saved file.
+  [dialog setExtensionHidden:NO];
+
   if (default_dir)
     [dialog setDirectoryURL:[NSURL fileURLWithPath:default_dir]];
   if (default_filename)
     [dialog setNameFieldStringValue:default_filename];
-
 }
 
 void SetupDialogForProperties(NSOpenPanel* dialog, int properties) {


### PR DESCRIPTION
Previously, when triggering the save dialog through e.g. `<a download>`
links (e.g. http://jsfiddle.net/koldev/cW7W5/), the extension was only
saved if Finder was set to show all extensions by default. We now always
display the extension to make sure that it is saved.

If we want to keep the extension hidden, we could also populate the
allowed file types array with the extension from the default filename,
but that would have interfered with how we set the filters.