### PR TITLE
Redirect dead link in docs

### DIFF
--- a/docs/development/atom-shell-vs-node-webkit.md
+++ b/docs/development/atom-shell-vs-node-webkit.md
@@ -43,7 +43,7 @@ If you are an experienced NW.js user, you should be familiar with the
 concept of Node context and web context. These concepts were invented because
 of how NW.js was implemented.
 
-By using the [multi-context](http://strongloop.com/strongblog/whats-new-node-js-v0-12-multiple-context-execution/)
+By using the [multi-context](https://github.com/nodejs/node-v0.x-archive/commit/756b622)
 feature of Node, Electron doesn't introduce a new JavaScript context in web
 pages.
 


### PR DESCRIPTION
The link previous link exists in the wayback machine (http://web.archive.org/web/20151030063902/https://strongloop.com/strongblog/whats-new-node-js-v0-12-multiple-context-execution/), however on the live page the link is dead. This is the commit message for node that summarizes it well, but maybe the better option is just to remove the link entirely.