### PR TITLE
Use Squirrel.Windows --checkForUpdate

### DIFF
--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -29,7 +29,7 @@ class AutoUpdater extends EventEmitter {
       return this.emitError('Can not find Squirrel')
     }
     this.emit('checking-for-update')
-    squirrelUpdate.download(this.updateURL, (error, update) => {
+    squirrelUpdate.checkForUpdate(this.updateURL, (error, update) => {
       if (error != null) {
         return this.emitError(error)
       }

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -82,8 +82,8 @@ exports.processStart = function () {
 }
 
 // Download the releases specified by the URL and write new results to stdout.
-exports.download = function (updateURL, callback) {
-  return spawnUpdate(['--download', updateURL], false, function (error, stdout) {
+exports.checkForUpdate = function (updateURL, callback) {
+  return spawnUpdate(['--checkForUpdate', updateURL], false, function (error, stdout) {
     var json, ref, ref1, update
     if (error != null) {
       return callback(error)


### PR DESCRIPTION
Avoid downloading updates twice. Fix #5057.