### PR TITLE
Fix app.getGPUFeatureStatus in app.md

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -789,7 +789,7 @@ Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMet
 
 Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
 
-### `app.getGpuFeatureStatus()`
+### `app.getGPUFeatureStatus()`
 
 Returns [`GPUFeatureStatus`](structures/gpu-feature-status.md) - The Graphics Feature Status from `chrome://gpu/`.
 


### PR DESCRIPTION
`getGPUFeatureStatus` is incorrectly documented as `getGpuFeatureStatus`, therefore electron.d.ts contains an incorrect method signature.

in atom/browser/api/atom_api_app.cc
```
      .SetMethod("getGPUFeatureStatus", &App::GetGPUFeatureStatus)
```