### PR TITLE
feat(NativeWindowMac): addTabbedWindow

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -938,6 +938,10 @@ void Window::ToggleTabBar() {
   window_->ToggleTabBar();
 }
 
+void Window::AddTabbedWindow(NativeWindow* window) {
+  window_->AddTabbedWindow(window);
+}
+
 void Window::SetVibrancy(mate::Arguments* args) {
   std::string type;
 
@@ -1085,6 +1089,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("selectNextTab", &Window::SelectNextTab)
       .SetMethod("moveTabToNewWindow", &Window::MoveTabToNewWindow)
       .SetMethod("toggleTabBar", &Window::ToggleTabBar)
+      .SetMethod("addTabbedWindow", &Window::AddTabbedWindow)
 #endif
       .SetMethod("setVibrancy", &Window::SetVibrancy)
       .SetMethod("_setTouchBarItems", &Window::SetTouchBar)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -219,6 +219,7 @@ class Window : public mate::TrackableObject<Window>,
   void MergeAllWindows();
   void MoveTabToNewWindow();
   void ToggleTabBar();
+  void AddTabbedWindow(NativeWindow* window);
 
   void SetVibrancy(mate::Arguments* args);
   void SetTouchBar(const std::vector<mate::PersistentDictionary>& items);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -351,6 +351,9 @@ void NativeWindow::MoveTabToNewWindow() {
 void NativeWindow::ToggleTabBar() {
 }
 
+void NativeWindow::AddTabbedWindow(NativeWindow* window) {
+}
+
 void NativeWindow::SetVibrancy(const std::string& filename) {
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -190,6 +190,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void MergeAllWindows();
   virtual void MoveTabToNewWindow();
   virtual void ToggleTabBar();
+  virtual void AddTabbedWindow(NativeWindow* window);
 
   // Webview APIs.
   virtual void FocusOnWebView();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -108,6 +108,7 @@ class NativeWindowMac : public NativeWindow,
   void MergeAllWindows() override;
   void MoveTabToNewWindow() override;
   void ToggleTabBar() override;
+  void AddTabbedWindow(NativeWindow* window) override;
 
   void SetVibrancy(const std::string& type) override;
   void SetTouchBar(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -474,6 +474,7 @@ enum {
 @interface NSWindow (SierraSDK)
 - (void)setTabbingMode:(NSInteger)mode;
 - (void)setTabbingIdentifier:(NSString*)identifier;
+- (void)addTabbedWindow:(NSWindow*)window ordered:(NSWindowOrderingMode)ordered;
 - (IBAction)selectPreviousTab:(id)sender;
 - (IBAction)selectNextTab:(id)sender;
 - (IBAction)mergeAllWindows:(id)sender;
@@ -1646,6 +1647,12 @@ void NativeWindowMac::MoveTabToNewWindow() {
 void NativeWindowMac::ToggleTabBar() {
   if ([window_ respondsToSelector:@selector(toggleTabBar:)]) {
     [window_ toggleTabBar:nil];
+  }
+}
+
+void NativeWindowMac::AddTabbedWindow(NativeWindow* window) {
+  if ([window_ respondsToSelector:@selector(addTabbedWindow:ordered:)]) {
+    [window_ addTabbedWindow:window->GetNativeWindow() ordered:NSWindowAbove];
   }
 }
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1401,6 +1401,22 @@ there is more than one tab in the current window.
 Toggles the visibility of the tab bar if native tabs are enabled and
 there is only one tab in the current window.
 
+#### `win.addTabbedWindow(browserWindow)` _macOS_
+
+* `browserWindow` BrowserWindow
+
+Adds a window as a tab on this window, after the tab for the window instance.
+
+```js
+// in main.js
+
+BrowserWindow.getFocusedWindow().addTabbedWindow(new BrowserWindow({}))
+
+// in renderer.js
+
+remote.getCurrentWindow().addTabbedWindow(new BrowserWindow({}))
+```
+
 #### `win.setVibrancy(type)` _macOS_
 
 * `type` String - Can be `appearance-based`, `light`, `dark`, `titlebar`,

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1407,16 +1407,6 @@ there is only one tab in the current window.
 
 Adds a window as a tab on this window, after the tab for the window instance.
 
-```js
-// in main.js
-
-BrowserWindow.getFocusedWindow().addTabbedWindow(new BrowserWindow({}))
-
-// in renderer.js
-
-remote.getCurrentWindow().addTabbedWindow(new BrowserWindow({}))
-```
-
 #### `win.setVibrancy(type)` _macOS_
 
 * `type` String - Can be `appearance-based`, `light`, `dark`, `titlebar`,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -709,6 +709,18 @@ describe('BrowserWindow module', function () {
     })
   })
 
+  describe('BrowserWindow.addTabbedWindow()', function () {
+    it('does not throw', function () {
+      if (process.platform !== 'darwin') {
+        return
+      }
+
+      assert.doesNotThrow(() => {
+        w.addTabbedWindow(new BrowserWindow({}))
+      })
+    })
+  })
+
   describe('BrowserWindow.setVibrancy(type)', function () {
     it('allows setting, changing, and removing the vibrancy', function () {
       assert.doesNotThrow(function () {


### PR DESCRIPTION
Add support for the [`NSWindow addTabbedWindow`][nsw] method on MacOSX

This plays nicely with the changes from #9052 and #9725

Usage samples available in [this commit][c] in my fork of`electron-quick-start`

[nsw]: https://developer.apple.com/documentation/appkit/nswindow/1855947-addtabbedwindow
[c]: https://github.com/danielma/electron-quick-start/commit/79f06591dff0bf71530f5a2205b906dc11327d0c

Fixes #9094 