### PR TITLE
Suppress the destroy() spec on all platforms

### DIFF
--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -589,13 +589,9 @@ describe('webContents module', function () {
     })
   })
 
-  describe('destroy()', () => {
-    // Destroying webContents in its event listener is going to crash when
-    // Electron is built in Debug mode.
-    if (process.platform !== 'darwin') {
-      return
-    }
-
+  // Destroying webContents in its event listener is going to crash when
+  // Electron is built in Debug mode.
+  xdescribe('destroy()', () => {
     let server
 
     before(function (done) {


### PR DESCRIPTION
It is also crashing on mac, but just not as frequent as other platforms.