### PR TITLE
Fixed potential crash in Win32 notifications.

### DIFF
--- a/brightray/browser/win/win32_desktop_notifications/desktop_notification_controller.cc
+++ b/brightray/browser/win/win32_desktop_notifications/desktop_notification_controller.cc
@@ -325,6 +325,7 @@ HWND DesktopNotificationController::GetToast(
     const NotificationData* data) const {
     auto it = find_if(instances_.cbegin(), instances_.cend(),
         [data](auto&& inst) {
+            if (!inst.hwnd) return false;
             auto toast = Toast::Get(inst.hwnd);
             return data == toast->GetNotification().get();
         });


### PR DESCRIPTION
There's a potential crash when iterating over toast instances where a null pointer is dereferenced in case an instance's HWND has already been destroyed.

This is a backport candidate to previous releases which have Windows 7 notifications.