### PR TITLE
Set duration for Windows 7 notifications based on Control Panel

### DIFF
--- a/brightray/browser/win/win32_desktop_notifications/toast.cc
+++ b/brightray/browser/win/win32_desktop_notifications/toast.cc
@@ -641,7 +641,12 @@ void DesktopNotificationController::Toast::CancelDismiss() {
 }
 
 void DesktopNotificationController::Toast::ScheduleDismissal() {
-    SetTimer(hwnd_, TimerID_AutoDismiss, 4000, nullptr);
+    ULONG duration;
+    auto result = SystemParametersInfo(SPI_GETMESSAGEDURATION, 0, &duration, 0);
+    if (result == FALSE) {
+        duration = 5;
+    }
+    SetTimer(hwnd_, TimerID_AutoDismiss, duration * 1000, nullptr);
 }
 
 void DesktopNotificationController::Toast::ResetContents() {


### PR DESCRIPTION
[Control Panel] -> [Ease of Access] -> [Make it easier to focus on tasks] -> [Adjust time limits and flashing visuals] can set the duration to show a balloon. In this PR, desktop notifications would follow the setting as well. So users can set the desired duration (default value is 5 seconds).