### PR TITLE
Fixed guide about `Notification` module

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -10,13 +10,14 @@ you want to show Notifications in the main process please check out the
 [Notification](../api/notification.md) module.
 
 ```javascript
-let myNotification = new Notification('Title', {
+const myNotification = new Notification({
+  title: 'This Is the Title',
   body: 'Lorem Ipsum Dolor Sit Amet'
 })
 
-myNotification.onclick = () => {
+myNotification.on('click', () => {
   console.log('Notification clicked')
-}
+})
 ```
 
 While code and user experience across operating systems are similar, there

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -10,6 +10,8 @@ you want to show Notifications in the main process please check out the
 [Notification](../api/notification.md) module.
 
 ```javascript
+const {Notification} = require('electron')
+
 const myNotification = new Notification({
   title: 'This Is the Title',
   body: 'Lorem Ipsum Dolor Sit Amet'


### PR DESCRIPTION
This is a very important fix: As stated [here](https://electron.atom.io/docs/api/notification/) the current example is not correct.