### PR TITLE
[Docs] Add npx command for node version 8.2.0 and later in quickstart guide

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -175,7 +175,7 @@ electron .
 
 If you've installed it locally, then run:
 
-### Node v8.2.0 and later
+#### Node v8.2.0 and later
 
 ```
 $ npx electron .

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -175,6 +175,12 @@ electron .
 
 If you've installed it locally, then run:
 
+### Node v8.2.0 and later
+
+```
+$ npx electron .
+```
+
 #### macOS / Linux
 
 ```bash

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -175,12 +175,6 @@ electron .
 
 If you've installed it locally, then run:
 
-#### Node v8.2.0 and later
-
-```
-$ npx electron .
-```
-
 #### macOS / Linux
 
 ```bash
@@ -191,6 +185,12 @@ $ ./node_modules/.bin/electron .
 
 ```
 $ .\node_modules\.bin\electron .
+```
+
+#### Node v8.2.0 and later
+
+```
+$ npx electron .
 ```
 
 ### Manually Downloaded Electron Binary


### PR DESCRIPTION
Add the npx command to quickstart guide
It avoids going to the node_modules folder to execute