### PR TITLE
[Security] Use textContent instead innerHTML to remediate DOM based XSS

### DIFF
--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -5,7 +5,7 @@ const {runInThisContext} = require('vm')
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$')
+  const regexp = new RegExp(`^${pattern.replace(/\*/g, '.*')}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }
@@ -23,12 +23,30 @@ const runContentScript = function (extensionId, url, code) {
   return compiledWrapper.call(this, context.chrome)
 }
 
+const runStylesheet = function (url, code) {
+  const wrapper = `(function (code) {
+    function init() {
+      var styleElement = document.createElement('style');
+      styleElement.setAttribute('type', 'text/css');
+      styleElement.textContent = code;
+      document.head.append(styleElement);
+    }
+    document.addEventListener('DOMContentLoaded', init);
+  })`;
+  const compiledWrapper = runInThisContext(wrapper, {
+    filename: url,
+    lineOffset: 1,
+    displayErrors: true,
+  });
+  return compiledWrapper.call(this, code);
+}
+
 // Run injected scripts.
 // https://developer.chrome.com/extensions/content_scripts
 const injectContentScript = function (extensionId, script) {
   if (!script.matches.some(matchesPattern)) return
 
-  if (script.js) {
+  if (script.js.length) {
     for (const {url, code} of script.js) {
       const fire = runContentScript.bind(window, extensionId, url, code)
       if (script.runAt === 'document_start') {
@@ -41,13 +59,16 @@ const injectContentScript = function (extensionId, script) {
     }
   }
 
-  if (script.css) {
-    for (const {code} of script.css) {
-      process.once('document-end', () => {
-        var node = document.createElement('style')
-        node.innerHTML = code
-        window.document.body.appendChild(node)
-      })
+  if (script.css.length) {
+    for (const {url, code} of script.css) {
+      const fire = runStylesheet.bind(window, url, code)
+      if (script.runAt === 'document_start') {
+        process.once('document-start', fire)
+      } else if (script.runAt === 'document_end') {
+        process.once('document-end', fire)
+      } else if (script.runAt === 'document_idle') {
+        document.addEventListener('DOMContentLoaded', fire)
+      }
     }
   }
 }

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -14,7 +14,7 @@ const matchesPattern = function (pattern) {
 const runContentScript = function (extensionId, url, code) {
   const context = {}
   require('./chrome-api').injectTo(extensionId, false, context)
-  const wrapper = `(function (chrome) {\n  ${code}\n  })`
+  const wrapper = `((chrome) => {\n  ${code}\n  })`
   const compiledWrapper = runInThisContext(wrapper, {
     filename: url,
     lineOffset: 1,
@@ -24,10 +24,9 @@ const runContentScript = function (extensionId, url, code) {
 }
 
 const runStylesheet = function (url, code) {
-  const wrapper = `(function (code) {
+  const wrapper = `((code) => {
     function init() {
-      var styleElement = document.createElement('style');
-      styleElement.setAttribute('type', 'text/css');
+      const styleElement = document.createElement('style');
       styleElement.textContent = code;
       document.head.append(styleElement);
     }
@@ -46,27 +45,27 @@ const runStylesheet = function (url, code) {
 const injectContentScript = function (extensionId, script) {
   if (!script.matches.some(matchesPattern)) return
 
-  if (script.js.length) {
+  if (script.js) {
     for (const {url, code} of script.js) {
       const fire = runContentScript.bind(window, extensionId, url, code)
       if (script.runAt === 'document_start') {
         process.once('document-start', fire)
       } else if (script.runAt === 'document_end') {
         process.once('document-end', fire)
-      } else if (script.runAt === 'document_idle') {
+      } else {
         document.addEventListener('DOMContentLoaded', fire)
       }
     }
   }
 
-  if (script.css.length) {
+  if (script.css) {
     for (const {url, code} of script.css) {
       const fire = runStylesheet.bind(window, url, code)
       if (script.runAt === 'document_start') {
         process.once('document-start', fire)
       } else if (script.runAt === 'document_end') {
         process.once('document-end', fire)
-      } else if (script.runAt === 'document_idle') {
+      } else {
         document.addEventListener('DOMContentLoaded', fire)
       }
     }

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -31,13 +31,13 @@ const runStylesheet = function (url, code) {
       document.head.append(styleElement);
     }
     document.addEventListener('DOMContentLoaded', init);
-  })`;
+  })`
   const compiledWrapper = runInThisContext(wrapper, {
     filename: url,
     lineOffset: 1,
-    displayErrors: true,
-  });
-  return compiledWrapper.call(this, code);
+    displayErrors: true
+  })
+  return compiledWrapper.call(this, code)
 }
 
 // Run injected scripts.


### PR DESCRIPTION
This commit is a security improvement for https://github.com/electron/electron/pull/10076, as @javan suggested, we should use `textContent` instead. Besides, I also revise some code to improve code quality.

Ref: https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet