### PR TITLE
disable flaky app.importCertificate and select-client-certificate tests

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -434,7 +434,7 @@ describe('app module', function () {
     })
   })
 
-  describe('select-client-certificate event', function () {
+  xdescribe('select-client-certificate event', function () {
     let w = null
 
     beforeEach(function () {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -236,7 +236,7 @@ describe('app module', function () {
     })
   })
 
-  describe('app.importCertificate', function () {
+  xdescribe('app.importCertificate', function () {
     if (process.platform !== 'linux') return
 
     this.timeout(120000)


### PR DESCRIPTION
It seems these tests keep getting turned on and off. Not sure of the history here but we want to get a new 1.7 release out and this is blocking.

https://github.com/electron/electron/commit/68e0fbfd60bbc2fe8a33694f118555922c9c5b5a#diff-6428a7ecb6a3a2831eae23aee7efeac5
https://github.com/electron/electron/commit/a7cb89aeb54dca1e97c419fef0448d049f86f565#diff-6428a7ecb6a3a2831eae23aee7efeac5
https://github.com/electron/electron/commit/5ccae79ea725b945815d222a79c1d963aefd1280#diff-6428a7ecb6a3a2831eae23aee7efeac5

cc @zcbenz 