### PR TITLE
Revert "PrinterInfo options object causes TypeScript error"

### DIFF
--- a/docs/api/structures/printer-info.md
+++ b/docs/api/structures/printer-info.md
@@ -4,7 +4,6 @@
 * `description` String
 * `status` Number
 * `isDefault` Boolean
-* `options` Object - Additional fields
 
 ## Example
 


### PR DESCRIPTION
Reverts electron/electron#9603

When I run `npm run lint` (or more specifically `npm run lint-docs`) on master, I get a failure:

```
Error: Ruh roh, "Options" is already declared
    at Object.keys.sort.forEach (/Users/z/Desktop/electron/node_modules/electron-typescript-definitions/lib/dynamic-param-interfaces.js:77:17)
    at Array.forEach (<anonymous>)
    at Object.flushParamInterfaces (/Users/z/Desktop/electron/node_modules/electron-typescript-definitions/lib/dynamic-param-interfaces.js:70:142)
    at module.exports (/Users/z/Desktop/electron/node_modules/electron-typescript-definitions/index.js:69:19)
    at apiPromise.then.then.API (/Users/z/Desktop/electron/node_modules/electron-typescript-definitions/cli.js:56:18)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
    at Function.Module.runMain (module.js:611:11)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:598:3
```

I don't think this was actually fixed. Given that there are green PRs opened since this was merged, I'm inclined to believe that the linter may not be running on CI.

cc @MarshallOfSound 