### PR TITLE
Browser-process notifications: Ensure correct icon on Windows

### DIFF
--- a/brightray/browser/win/notification_presenter_win.cc
+++ b/brightray/browser/win/notification_presenter_win.cc
@@ -12,6 +12,7 @@
 #include "base/files/file_util.h"
 #include "base/md5.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/time/time.h"
 #include "base/win/windows_version.h"
 #include "brightray/browser/win/notification_presenter_win7.h"
 #include "brightray/browser/win/windows_toast_notification.h"
@@ -64,7 +65,15 @@ bool NotificationPresenterWin::Init() {
 
 base::string16 NotificationPresenterWin::SaveIconToFilesystem(
     const SkBitmap& icon, const GURL& origin) {
-  std::string filename = base::MD5String(origin.spec()) + ".png";
+  std::string filename;
+
+  if (origin.is_valid()) {
+    filename = base::MD5String(origin.spec()) + ".png";
+  } else {
+    base::TimeTicks now = base::TimeTicks::Now();
+    filename = std::to_string(now.ToInternalValue()) + ".png";
+  }
+
   base::FilePath path = temp_dir_.GetPath().Append(base::UTF8ToUTF16(filename));
   if (base::PathExists(path))
     return path.value();


### PR DESCRIPTION
The browser-process notifications are either missing or reusing images from the last notification. The reason is simple: In [atom_api_notification, we set the](base::TimeTicks::Now()) `icon_url` to `GURL()`, but in the notification presenter, [we assume an okay and unique path](https://github.com/electron/electron/blob/master/brightray/browser/win/notification_presenter_win.cc#L68-L73).

This PR ensures that our "download icon" logic handles non-valid or empty URLs, using a timestamp as an alternative. The timestamp is guaranteed to be increasing.

Closes #10610