### PR TITLE
[WIP] add getMenuItemById to Menu API

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -93,7 +93,7 @@ Appends the `menuItem` to the menu.
 
 * `id` String
 
-Returns the MenuItem with the specified `id`.
+Returns `MenuItem` the item with the specified `id`
 
 #### `menu.insert(pos, menuItem)`
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -89,6 +89,12 @@ Closes the context menu in the `browserWindow`.
 
 Appends the `menuItem` to the menu.
 
+#### `menu.getMenuItemById(id)`
+
+* `id` String
+
+Returns the MenuItem with the specified `id`.
+
 #### `menu.insert(pos, menuItem)`
 
 * `pos` Integer

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -190,8 +190,7 @@ Menu.prototype.closePopup = function (window) {
 }
 
 Menu.prototype.getMenuItemById = function (id) {
-  let items = this
-  if (items instanceof Menu) items = this.items
+  const items = this.items
 
   let found = items.find(item => item.id === id) || false
   for (let i = 0, length = items.length; !found && i < length; i++) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -189,6 +189,19 @@ Menu.prototype.closePopup = function (window) {
   }
 }
 
+Menu.prototype.getMenuItemById = function (items, id) {
+  if (items instanceof Menu) {
+    items = items.items;
+  }
+  let found = items.find(item => item.id === id) || false;
+  for(let i = 0, length = items.length; !found && i < length; i++) {
+    if (items[i].submenu) {
+      found = this.getMenuItemById(items[i].submenu, id);
+    }
+  }
+  return found;
+};
+
 Menu.prototype.append = function (item) {
   return this.insert(this.getItemCount(), item)
 }

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -191,16 +191,16 @@ Menu.prototype.closePopup = function (window) {
 
 Menu.prototype.getMenuItemById = function (items, id) {
   if (items instanceof Menu) {
-    items = items.items;
+    items = items.items
   }
-  let found = items.find(item => item.id === id) || false;
-  for(let i = 0, length = items.length; !found && i < length; i++) {
+  let found = items.find(item => item.id === id) || false
+  for (let i = 0, length = items.length; !found && i < length; i++) {
     if (items[i].submenu) {
-      found = this.getMenuItemById(items[i].submenu, id);
+      found = this.getMenuItemById(items[i].submenu, id)
     }
   }
-  return found;
-};
+  return found
+}
 
 Menu.prototype.append = function (item) {
   return this.insert(this.getItemCount(), item)

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -192,7 +192,7 @@ Menu.prototype.closePopup = function (window) {
 Menu.prototype.getMenuItemById = function (id) {
   const items = this.items
 
-  let found = items.find(item => item.id === id) || false
+  let found = items.find(item => item.id === id) || null
   for (let i = 0, length = items.length; !found && i < length; i++) {
     if (items[i].submenu) {
       found = items[i].submenu.getMenuItemById(id)

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -190,7 +190,7 @@ Menu.prototype.closePopup = function (window) {
 }
 
 Menu.prototype.getMenuItemById = function (id) {
-  let items = this;
+  let items = this
   if (items instanceof Menu) items = this.items
 
   let found = items.find(item => item.id === id) || false

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -189,14 +189,14 @@ Menu.prototype.closePopup = function (window) {
   }
 }
 
-Menu.prototype.getMenuItemById = function (items, id) {
-  if (items instanceof Menu) {
-    items = items.items
-  }
+Menu.prototype.getMenuItemById = function (id) {
+  let items = this;
+  if (items instanceof Menu) items = this.items
+
   let found = items.find(item => item.id === id) || false
   for (let i = 0, length = items.length; !found && i < length; i++) {
     if (items[i].submenu) {
-      found = this.getMenuItemById(items[i].submenu, id)
+      found = items[i].submenu.getMenuItemById(id)
     }
   }
   return found

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -195,6 +195,29 @@ describe('menu module', function () {
     })
   })
 
+  describe('Menu.getMenuItemById', function () {
+    it('should return the item with the given id', function () {
+      var menu = Menu.buildFromTemplate([
+        {
+          label: 'View',
+          submenu: [
+            {
+              label: 'Enter Fullscreen',
+              accelerator: 'Control+Command+F',
+              id: 'fullScreen'
+            },
+            {
+              label: 'Exit Fullscreen',
+              accelerator: 'Control+Command+F'
+            }
+          ]
+        }
+      ])
+      const fsc = menu.getMenuItemById('fullScreen')
+      assert.equal(menu.items[0].submenu.items[0], fsc)
+    })
+  })
+
   describe('Menu.insert', function () {
     it('should store item in @items by its index', function () {
       var menu = Menu.buildFromTemplate([


### PR DESCRIPTION
Adds the feature requested in https://github.com/electron/electron/issues/10440

Ability to fetch a menu items by passing in `MenuItem`s and an `id`. 

Called like: `const fsc = menu.getMenuItemById('fullScreen');`