### PR TITLE
Update libchromiumcontent to fix crash in Node

### DIFF
--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -94,6 +94,8 @@
         'defines': [
           # Needed by gin:
           'V8_USE_EXTERNAL_STARTUP_DATA',
+          # Special configuration for node:
+          'V8_PROMISE_INTERNAL_FIELD_COUNT=1',
           # From skia_for_chromium_defines.gypi:
           'SK_SUPPORT_LEGACY_GETTOPDEVICE',
           'SK_SUPPORT_LEGACY_BITMAP_CONFIG',


### PR DESCRIPTION
Update libchromiumcontent for https://github.com/electron/libchromiumcontent/pull/363.

Close https://github.com/electron/electron/issues/10571.