### PR TITLE
Don't drag fullscreen window

### DIFF
--- a/atom/browser/native_browser_view_mac.mm
+++ b/atom/browser/native_browser_view_mac.mm
@@ -47,7 +47,7 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
     return;
   }
 
-  if (([self.window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask) {
+  if (self.window.styleMask & NSFullScreenWindowMask) {
     return;
   }
 
@@ -60,7 +60,7 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
     return;
   }
 
-  if (([self.window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask) {
+  if (self.window.styleMask & NSFullScreenWindowMask) {
     return;
   }
 

--- a/atom/browser/native_browser_view_mac.mm
+++ b/atom/browser/native_browser_view_mac.mm
@@ -47,12 +47,20 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
     return;
   }
 
+  if (([self.window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask) {
+    return;
+  }
+
   self.initialLocation = [event locationInWindow];
 }
 
 - (void)mouseDragged:(NSEvent *)theEvent
 {
   if ([self.window respondsToSelector:@selector(performWindowDragWithEvent)]) {
+    return;
+  }
+
+  if (([self.window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask) {
     return;
   }
 


### PR DESCRIPTION
When using `webkit-app-region: drag` together with BrowserViews, one is able to move the window even when in fullscreen mode. Trippy, right?

The reason is that we're moving the window manually on older versions of macOS that do not support the native `performWindowDragWithEvent`. This PR adds a quick check if we're in fullscreen mode - which cancels a move when in fullscreen mode.