### PR TITLE
Bump external binaries to 1.2.2

### DIFF
--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -8,7 +8,7 @@ from lib.config import get_target_arch
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v1.2.1'
+VERSION = 'v1.2.2'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/electron/electron-frameworks/releases' \
                  '/download/' + VERSION


### PR DESCRIPTION
This cherry-picks #10298 for `1-7-x`.