### PR TITLE
Add window opacity support

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -631,6 +631,10 @@ bool Window::HasShadow() {
   return window_->HasShadow();
 }
 
+void Window::SetOpacity(const double opacity) {
+  window_->SetOpacity(opacity);
+}
+
 void Window::FocusOnWebView() {
   window_->FocusOnWebView();
 }
@@ -1056,6 +1060,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setBackgroundColor", &Window::SetBackgroundColor)
       .SetMethod("setHasShadow", &Window::SetHasShadow)
       .SetMethod("hasShadow", &Window::HasShadow)
+      .SetMethod("setOpacity", &Window::SetOpacity)
       .SetMethod("setRepresentedFilename", &Window::SetRepresentedFilename)
       .SetMethod("getRepresentedFilename", &Window::GetRepresentedFilename)
       .SetMethod("setDocumentEdited", &Window::SetDocumentEdited)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -635,6 +635,10 @@ void Window::SetOpacity(const double opacity) {
   window_->SetOpacity(opacity);
 }
 
+double Window::GetOpacity() {
+  return window_->GetOpacity();
+}
+
 void Window::FocusOnWebView() {
   window_->FocusOnWebView();
 }
@@ -1061,6 +1065,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setHasShadow", &Window::SetHasShadow)
       .SetMethod("hasShadow", &Window::HasShadow)
       .SetMethod("setOpacity", &Window::SetOpacity)
+      .SetMethod("getOpacity", &Window::GetOpacity)
       .SetMethod("setRepresentedFilename", &Window::SetRepresentedFilename)
       .SetMethod("getRepresentedFilename", &Window::GetRepresentedFilename)
       .SetMethod("setDocumentEdited", &Window::SetDocumentEdited)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -161,6 +161,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetBackgroundColor(const std::string& color_name);
   void SetHasShadow(bool has_shadow);
   bool HasShadow();
+  void SetOpacity(const double opacity);
   void FocusOnWebView();
   void BlurWebView();
   bool IsWebViewFocused();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -162,6 +162,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetHasShadow(bool has_shadow);
   bool HasShadow();
   void SetOpacity(const double opacity);
+  double GetOpacity();
   void FocusOnWebView();
   void BlurWebView();
   bool IsWebViewFocused();

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -159,6 +159,10 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   if (options.Get(options::kHasShadow, &has_shadow)) {
     SetHasShadow(has_shadow);
   }
+  double opacity;
+  if (options.Get(options::kOpacity, &opacity)) {
+    SetOpacity(opacity);
+  }
   bool top;
   if (options.Get(options::kAlwaysOnTop, &top) && top) {
     SetAlwaysOnTop(true);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -142,6 +142,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetHasShadow(bool has_shadow) = 0;
   virtual bool HasShadow() = 0;
   virtual void SetOpacity(const double opacity) = 0;
+  virtual double GetOpacity() = 0;
   virtual void SetRepresentedFilename(const std::string& filename);
   virtual std::string GetRepresentedFilename();
   virtual void SetDocumentEdited(bool edited);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -141,6 +141,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetBackgroundColor(const std::string& color_name) = 0;
   virtual void SetHasShadow(bool has_shadow) = 0;
   virtual bool HasShadow() = 0;
+  virtual void SetOpacity(const double opacity) = 0;
   virtual void SetRepresentedFilename(const std::string& filename);
   virtual std::string GetRepresentedFilename();
   virtual void SetDocumentEdited(bool edited);

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -84,6 +84,7 @@ class NativeWindowMac : public NativeWindow,
   void SetHasShadow(bool has_shadow) override;
   bool HasShadow() override;
   void SetOpacity(const double opacity) override;
+  double GetOpacity() override;
   void SetRepresentedFilename(const std::string& filename) override;
   std::string GetRepresentedFilename() override;
   void SetDocumentEdited(bool edited) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -83,6 +83,7 @@ class NativeWindowMac : public NativeWindow,
   void SetBackgroundColor(const std::string& color_name) override;
   void SetHasShadow(bool has_shadow) override;
   bool HasShadow() override;
+  void SetOpacity(const double opacity) override;
   void SetRepresentedFilename(const std::string& filename) override;
   std::string GetRepresentedFilename() override;
   void SetDocumentEdited(bool edited) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1507,6 +1507,10 @@ void NativeWindowMac::SetOpacity(const double opacity) {
   [window_ setAlphaValue:opacity];
 }
 
+double NativeWindowMac::GetOpacity() {
+  return [window_ alphaValue];
+}
+
 void NativeWindowMac::SetRepresentedFilename(const std::string& filename) {
   [window_ setRepresentedFilename:base::SysUTF8ToNSString(filename)];
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1503,6 +1503,10 @@ bool NativeWindowMac::HasShadow() {
   return [window_ hasShadow];
 }
 
+void NativeWindowMac::SetOpacity(const double opacity) {
+  [window_ setAlphaValue:opacity];
+}
+
 void NativeWindowMac::SetRepresentedFilename(const std::string& filename) {
   [window_ setRepresentedFilename:base::SysUTF8ToNSString(filename)];
 }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -816,14 +816,14 @@ bool NativeWindowViews::HasShadow() {
 
 void NativeWindowViews::SetOpacity(const double opacity) {
 #if defined(OS_WIN)
+  HWND hwnd = GetAcceleratedWidget();
   if (!layered_) {
-    LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
+    LONG ex_style = ::GetWindowLong(hwnd, GWL_EXSTYLE);
     ex_style |= WS_EX_LAYERED;
-    ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
+    ::SetWindowLong(hwnd, GWL_EXSTYLE, ex_style);
     layered_ = true;
   }
-
-  ::SetLayeredWindowAttributes(GetAcceleratedWidget(), 0, opacity * 255, LWA_ALPHA);
+  ::SetLayeredWindowAttributes(hwnd, 0, opacity * 255, LWA_ALPHA);
 #endif
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -825,6 +825,11 @@ void NativeWindowViews::SetOpacity(const double opacity) {
   }
   ::SetLayeredWindowAttributes(hwnd, 0, opacity * 255, LWA_ALPHA);
 #endif
+  opacity_ = opacity;
+}
+
+double NativeWindowViews::GetOpacity() {
+  return opacity_;
 }
 
 void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -814,6 +814,19 @@ bool NativeWindowViews::HasShadow() {
       != wm::ShadowElevation::NONE;
 }
 
+void NativeWindowViews::SetOpacity(const double opacity) {
+#if defined(OS_WIN)
+  if (!layered_) {
+    LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
+    ex_style |= WS_EX_LAYERED;
+    ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
+    layered_ = true;
+  }
+
+  ::SetLayeredWindowAttributes(GetAcceleratedWidget(), 0, opacity * 255, LWA_ALPHA);
+#endif
+}
+
 void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 #if defined(OS_WIN)
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
@@ -821,6 +834,8 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
     ex_style |= (WS_EX_TRANSPARENT | WS_EX_LAYERED);
   else
     ex_style &= ~(WS_EX_TRANSPARENT | WS_EX_LAYERED);
+  if (layered_)
+    ex_style |= WS_EX_LAYERED;
   ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
 
   // Forwarding is always disabled when not ignoring mouse messages.

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -104,6 +104,7 @@ class NativeWindowViews : public NativeWindow,
   void SetBackgroundColor(const std::string& color_name) override;
   void SetHasShadow(bool has_shadow) override;
   bool HasShadow() override;
+  void SetOpacity(const double opacity) override;
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   void SetContentProtection(bool enable) override;
   void SetFocusable(bool focusable) override;
@@ -274,6 +275,7 @@ class NativeWindowViews : public NativeWindow,
   static HHOOK mouse_hook_;
   bool forwarding_mouse_messages_ = false;
   HWND legacy_window_ = NULL;
+  bool layered_ = false;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -105,6 +105,7 @@ class NativeWindowViews : public NativeWindow,
   void SetHasShadow(bool has_shadow) override;
   bool HasShadow() override;
   void SetOpacity(const double opacity) override;
+  double GetOpacity() override;
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   void SetContentProtection(bool enable) override;
   void SetFocusable(bool focusable) override;
@@ -295,6 +296,7 @@ class NativeWindowViews : public NativeWindow,
   bool fullscreenable_;
   std::string title_;
   gfx::Size widget_size_;
+  double opacity_ = 1.0;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowViews);
 };

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -86,6 +86,9 @@ const char kBackgroundColor[] = "backgroundColor";
 // Whether the window should have a shadow.
 const char kHasShadow[] = "hasShadow";
 
+// Browser window opacity
+const char kOpacity[] = "opacity";
+
 // Whether the window can be activated.
 const char kFocusable[] = "focusable";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -48,6 +48,7 @@ extern const char kDisableAutoHideCursor[];
 extern const char kStandardWindow[];
 extern const char kBackgroundColor[];
 extern const char kHasShadow[];
+extern const char kOpacity[];
 extern const char kFocusable[];
 extern const char kWebPreferences[];
 extern const char kVibrancyType[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -205,7 +205,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     `#FFF` (white).
   * `hasShadow` Boolean (optional) - Whether window should have a shadow. This is only
     implemented on macOS. Default is `true`.
-  * `opacity` Double (optional) - Set the initial opacity of the window, between 0.0 (fully
+  * `opacity` Number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
   * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
@@ -1210,9 +1210,13 @@ On Windows and Linux always returns
 
 #### `win.setOpacity(opacity)` _Windows_ _macOS_
 
-* `opacity` Double - between 0.0 (fully transparent) and 1.0 (fully opaque)
+* `opacity` Number - between 0.0 (fully transparent) and 1.0 (fully opaque)
 
 Sets the opacity of the window. On Linux does nothing.
+
+#### `win.getOpacity()` _Windows_ _macOS_
+
+Returns `Number` - between 0.0 (fully transparent) and 1.0 (fully opaque)
 
 #### `win.setThumbarButtons(buttons)` _Windows_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -205,6 +205,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     `#FFF` (white).
   * `hasShadow` Boolean (optional) - Whether window should have a shadow. This is only
     implemented on macOS. Default is `true`.
+  * `opacity` Double (optional) - Set the initial opacity of the window, between 0.0 (fully
+    transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
   * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
   * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md).
@@ -1205,6 +1207,12 @@ Returns `Boolean` - Whether the window has a shadow.
 
 On Windows and Linux always returns
 `true`.
+
+#### `win.setOpacity(opacity)` _Windows_ _macOS_
+
+* `opacity` Double - between 0.0 (fully transparent) and 1.0 (fully opaque)
+
+Sets the opacity of the window. On Linux does nothing.
 
 #### `win.setThumbarButtons(buttons)` _Windows_
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -804,13 +804,17 @@ describe('BrowserWindow module', function () {
         height: 400,
         opacity: 0.5
       })
+      assert.equal(w.getOpacity(), 0.5)
     })
 
     it('allows setting the opacity', function () {
       assert.doesNotThrow(function () {
         w.setOpacity(0.0)
+        assert.equal(w.getOpacity(), 0.0)
         w.setOpacity(0.5)
+        assert.equal(w.getOpacity(), 0.5)
         w.setOpacity(1.0)
+        assert.equal(w.getOpacity(), 1.0)
       })
     })
   })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -795,6 +795,26 @@ describe('BrowserWindow module', function () {
     })
   })
 
+  describe('BrowserWindow.setOpacity(opacity)', function () {
+    it('make window with initial opacity', function () {
+      w.destroy()
+      w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        opacity: 0.5
+      })
+    })
+
+    it('allows setting the opacity', function () {
+      assert.doesNotThrow(function () {
+        w.setOpacity(0.0)
+        w.setOpacity(0.5)
+        w.setOpacity(1.0)
+      })
+    })
+  })
+
   describe('"useContentSize" option', function () {
     it('make window created with content size when used', function () {
       w.destroy()


### PR DESCRIPTION
This PR adds support for controlling the opacity of BrowserWindow. It makes the entire window transparent - including system window borders.

Implemented on Windows and macOS.