### PR TITLE
add setAsDefaultProtocolClient for Linux

### DIFF
--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -23,7 +23,6 @@
 namespace atom {
 
 const char kXdgSettings[] = "xdg-settings";
-const char kXdgSettingsDefaultBrowser[] = "default-web-browser";
 const char kXdgSettingsDefaultSchemeHandler[] = "default-url-scheme-handler";
 
 bool LaunchXdgUtility(const std::vector<std::string>& argv, int* exit_code) {

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -86,7 +86,6 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
 
 bool Browser::IsDefaultProtocolClient(const std::string& protocol,
                                       mate::Arguments* args) {
-  base::ThreadRestrictions::AssertIOAllowed();
   std::unique_ptr<base::Environment> env(base::Environment::Create());
 
   if (protocol.empty()) return false;

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -4,14 +4,14 @@
 
 #include "atom/browser/browser.h"
 
-#include <stdlib.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 #include "atom/browser/native_window.h"
 #include "atom/browser/window_list.h"
 #include "atom/common/atom_version.h"
-#include "base/environment.h"
 #include "base/command_line.h"
+#include "base/environment.h"
 #include "base/process/launch.h"
 #include "brightray/common/application_info.h"
 
@@ -22,7 +22,48 @@
 
 namespace atom {
 
-bool SetDefaultWebClient(const std::string& protocol);
+const char kXdgSettings[] = "xdg-settings";
+const char kXdgSettingsDefaultBrowser[] = "default-web-browser";
+const char kXdgSettingsDefaultSchemeHandler[] = "default-url-scheme-handler";
+
+bool LaunchXdgUtility(const std::vector<std::string>& argv, int* exit_code) {
+  *exit_code = EXIT_FAILURE;
+  int devnull = open("/dev/null", O_RDONLY);
+  if (devnull < 0) return false;
+
+  base::LaunchOptions options;
+
+  base::FileHandleMappingVector remap;
+  remap.push_back(std::make_pair(devnull, STDIN_FILENO));
+  options.fds_to_remap = &remap;
+
+  base::Process process = base::LaunchProcess(argv, options);
+  close(devnull);
+
+  if (!process.IsValid())return false;
+  return process.WaitForExit(exit_code);
+}
+
+bool SetDefaultWebClient(const std::string& protocol) {
+#if defined(OS_CHROMEOS)
+  return true;
+#else
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+
+  std::vector<std::string> argv;
+  argv.push_back(kXdgSettings);
+  argv.push_back("set");
+  if (!protocol.empty()) {
+    argv.push_back(kXdgSettingsDefaultSchemeHandler);
+    argv.push_back(protocol);
+  }
+  argv.push_back(libgtkui::GetDesktopName(env.get()));
+
+  int exit_code;
+  bool ran_ok = LaunchXdgUtility(argv, &exit_code);
+  return ran_ok && exit_code == EXIT_SUCCESS;
+#endif
+}
 
 void Browser::Focus() {
   // Focus on the first visible window.
@@ -43,18 +84,11 @@ void Browser::ClearRecentDocuments() {
 void Browser::SetAppUserModelID(const base::string16& name) {
 }
 
-const char kXdgSettings[] = "xdg-settings";
-const char kXdgSettingsDefaultBrowser[] = "default-web-browser";
-const char kXdgSettingsDefaultSchemeHandler[] = "default-url-scheme-handler";
-
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
                                          mate::Arguments* args) {
   return SetDefaultWebClient(protocol);
 }
 
-// TODO(codebytere): handle/replace GetChromeVersionOfScript
-// https://portland.freedesktop.org/doc/xdg-settings.html
-// https://cs.chromium.org/chromium/src/chrome/browser/shell_integration_linux.cc?sq=package:chromium&l=78
 bool Browser::IsDefaultProtocolClient(const std::string& protocol,
                                         mate::Arguments* args) {
   #if defined(OS_CHROMEOS)
@@ -67,9 +101,7 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
     std::vector<std::string> argv;
     argv.push_back(kXdgSettings);
     argv.push_back("check");
-    if (protocol.empty()) {
-      argv.push_back(kXdgSettingsDefaultBrowser);
-    } else {
+    if (!protocol.empty()) {
       argv.push_back(kXdgSettingsDefaultSchemeHandler);
       argv.push_back(protocol);
     }
@@ -89,7 +121,7 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
   #endif
 }
 
-// TODO(codebytere): implement method with xdgsettings
+// Todo implement 
 bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
                                             mate::Arguments* args) {
   return false;
@@ -123,48 +155,6 @@ std::string Browser::GetExecutableFileProductName() const {
 
 bool Browser::IsUnityRunning() {
   return unity::IsRunning();
-}
-
-/* Helper Functions */
-
-bool LaunchXdgUtility(const std::vector<std::string>& argv, int* exit_code) {
-  *exit_code = EXIT_FAILURE;
-  int devnull = open("/dev/null", O_RDONLY);
-  if (devnull < 0)
-    return false;
-
-  base::LaunchOptions options;
-  base::FileHandleMappingVector remap = *(options.fds_to_remap);
-  remap.push_back(std::make_pair(devnull, STDIN_FILENO));
-  base::Process process = base::LaunchProcess(argv, options);
-  close(devnull);
-  if (!process.IsValid())
-    return false;
-  return process.WaitForExit(exit_code);
-}
-
-bool SetDefaultWebClient(const std::string& protocol) {
-#if defined(OS_CHROMEOS)
-  return true;
-#else
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
-
-  std::vector<std::string> argv;
-  argv.push_back(kXdgSettings);
-  argv.push_back("set");
-  if (protocol.empty()) {
-    argv.push_back(kXdgSettingsDefaultBrowser);
-  } else {
-    argv.push_back(kXdgSettingsDefaultSchemeHandler);
-    argv.push_back(protocol);
-  }
-  argv.push_back(libgtkui::GetDesktopName(env.get()));
-
-  int exit_code;
-  bool ran_ok = LaunchXdgUtility(argv, &exit_code);
-
-  return ran_ok && exit_code == EXIT_SUCCESS;
-#endif
 }
 
 }  // namespace atom

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -121,7 +121,7 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
   #endif
 }
 
-// Todo implement 
+// Todo implement
 bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
                                             mate::Arguments* args) {
   return false;

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -10,7 +10,11 @@
 #include "atom/browser/window_list.h"
 #include "atom/common/atom_version.h"
 #include "brightray/common/application_info.h"
+
+#if defined(USE_X11)
+#include "chrome/browser/ui/libgtkui/gtk_util.h"
 #include "chrome/browser/ui/libgtkui/unity_service.h"
+#endif
 
 namespace atom {
 
@@ -33,18 +37,88 @@ void Browser::ClearRecentDocuments() {
 void Browser::SetAppUserModelID(const base::string16& name) {
 }
 
-bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
-                                            mate::Arguments* args) {
-  return false;
-}
+const char kXdgSettings[] = "xdg-settings";
+const char kXdgSettingsDefaultBrowser[] = "default-web-browser";
+const char kXdgSettingsDefaultSchemeHandler[] = "default-url-scheme-handler";
 
+// TODO(codebytere): handle/replace GetChromeVersionOfScript
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
                                          mate::Arguments* args) {
-  return false;
+  #if defined(OS_CHROMEOS)
+    return true;
+  #else
+    std::unique_ptr<base::Environment> env(base::Environment::Create());
+
+    std::vector<std::string> argv;
+    argv.push_back(kXdgSettings);
+    argv.push_back("set");
+    if (protocol.empty()) {
+     argv.push_back(kXdgSettingsDefaultBrowser);
+    } else {
+     argv.push_back(kXdgSettingsDefaultSchemeHandler);
+     argv.push_back(protocol);
+    }
+    argv.push_back(libgtkui::GetDesktopName(env.get()));
+
+    int exit_code;
+    bool ran_ok = LaunchXdgUtility(argv, &exit_code);
+    if (ran_ok && exit_code == EXIT_XDG_SETTINGS_SYNTAX_ERROR) {
+     if (GetChromeVersionOfScript(kXdgSettings, &argv[0])) {
+       ran_ok = LaunchXdgUtility(argv, &exit_code);
+     }
+    }
+
+    return ran_ok && exit_code == EXIT_SUCCESS;
+  #endif
 }
 
+// TODO(codebytere): handle/replace GetChromeVersionOfScript
 bool Browser::IsDefaultProtocolClient(const std::string& protocol,
                                       mate::Arguments* args) {
+  #if defined(OS_CHROMEOS)
+    return UNKNOWN_DEFAULT;
+  #else
+    base::ThreadRestrictions::AssertIOAllowed();
+
+    std::unique_ptr<base::Environment> env(base::Environment::Create());
+
+    std::vector<std::string> argv;
+    argv.push_back(kXdgSettings);
+    argv.push_back("check");
+    if (protocol.empty()) {
+      argv.push_back(kXdgSettingsDefaultBrowser);
+    } else {
+      argv.push_back(kXdgSettingsDefaultSchemeHandler);
+      argv.push_back(protocol);
+    }
+    argv.push_back(shell_integration_linux::GetDesktopName(env.get()));
+
+    std::string reply;
+    int success_code;
+    bool ran_ok = base::GetAppOutputWithExitCode(base::CommandLine(argv),
+    &reply, &success_code);
+    if (ran_ok && success_code == EXIT_XDG_SETTINGS_SYNTAX_ERROR) {
+      if (GetChromeVersionOfScript(kXdgSettings, &argv[0])) {
+        ran_ok = base::GetAppOutputWithExitCode(base::CommandLine(argv), &reply,
+                                                &success_code);
+      }
+    }
+
+    if (!ran_ok || success_code != EXIT_SUCCESS) {
+      // xdg-settings failed: we can't determine or set the default browser.
+      return UNKNOWN_DEFAULT;
+    }
+
+    // Allow any reply that starts with "yes".
+    return base::StartsWith(reply, "yes", base::CompareCase::SENSITIVE)
+               ? IS_DEFAULT
+               : NOT_DEFAULT;
+  #endif
+}
+
+// TODO(codebytere): implement method with xdgsettings
+bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
+                                            mate::Arguments* args) {
   return false;
 }
 


### PR DESCRIPTION
Tracking progress for implementation of https://github.com/electron/electron/issues/6440

**Todo:**
- [x] Replace `GetChromeVersionOfScript` in `SetAsDefaultProtocolClient` and `IsDefaultProtocolClient` appropriately