### PR TITLE
Add a null-pointer check before processing base::SupportsUserData::GetUserData

### DIFF
--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -6,6 +6,7 @@
 
 #include "atom/browser/atom_browser_main_parts.h"
 #include "base/bind.h"
+#include "base/memory/ptr_util.h"
 #include "base/supports_user_data.h"
 
 namespace mate {
@@ -46,16 +47,19 @@ void TrackableObjectBase::Destroy() {
 }
 
 void TrackableObjectBase::AttachAsUserData(base::SupportsUserData* wrapped) {
-  wrapped->SetUserData(kTrackedObjectKey, new IDUserData(weak_map_id_));
+  wrapped->SetUserData(kTrackedObjectKey,
+      base::MakeUnique<IDUserData>(weak_map_id_));
 }
 
 // static
-int32_t TrackableObjectBase::GetIDFromWrappedClass(base::SupportsUserData* w) {
-  auto id = static_cast<IDUserData*>(w->GetUserData(kTrackedObjectKey));
-  if (id)
-    return *id;
-  else
-    return 0;
+int32_t TrackableObjectBase::GetIDFromWrappedClass(
+    base::SupportsUserData* wrapped) {
+  if (wrapped) {
+    auto id = static_cast<IDUserData*>(wrapped->GetUserData(kTrackedObjectKey));
+    if (id)
+      return *id;
+  }
+  return 0;
 }
 
 // static

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -82,8 +82,12 @@ void ToDictionary(base::DictionaryValue* details, net::URLRequest* request) {
     int frame_id = info->GetRenderFrameID();
     auto* webContents = content::WebContents::FromRenderFrameHost(
         content::RenderFrameHost::FromID(process_id, frame_id));
-    details->SetInteger("webContentsId",
-        atom::api::WebContents::GetIDFromWrappedClass(webContents));
+    int webContentsId = atom::api::WebContents::GetIDFromWrappedClass(
+        webContents);
+
+    // webContentsId must be greater than zero
+    if (webContentsId)
+      details->SetInteger("webContentsId", webContentsId);
     details->SetString("resourceType",
         ResourceTypeToString(info->GetResourceType()));
   } else {


### PR DESCRIPTION
As https://github.com/electron/electron/pull/10429 got merged in Electron v1.8.x, I've discovered that we didn't check if `wrapped` is a valid object or not [here](https://github.com/electron/electron/blob/master/atom/browser/api/trackable_object.cc#L53-L59).
This will then cause the Electron to crash if the `wrapped` object doesn't belong to a valid memory we can touch.

In this PR, I've added a check before calling the `SupportsUserData::GetUserData` function and also modified the code of `TrackableObjectBase::AttachAsUserData` to call from SupportsUserData with `std::unique_ptr` rather than `raw-pointer` as suggested [here](https://chromium.googlesource.com/chromium/src.git/+/a86f3e33aeeb1e7d0d98319c8000ebd0a20bcabf%5E%21/#F0).

Thanks!