### PR TITLE
Fix findInPage() documentation for correcting type definition

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -896,10 +896,10 @@ Inserts `text` to the focused element.
     uppercase letter followed by a lowercase or non-letter.
     Accepts several other intra-word matches, defaults to `false`.
 
-Starts a request to find all matches for the `text` in the web page and returns
-an `Integer` representing the request id used for the request. The result of
-the request can be obtained by subscribing to
-[`found-in-page`](web-contents.md#event-found-in-page) event.
+Returns `Integer` - The request id used for the request.
+
+Starts a request to find all matches for the `text` in the web page. The result of the request
+can be obtained by subscribing to [`found-in-page`](web-contents.md#event-found-in-page) event.
 
 #### `contents.stopFindInPage(action)`
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -520,9 +520,10 @@ Inserts `text` to the focused element.
     uppercase letter followed by a lowercase or non-letter.
     Accepts several other intra-word matches, defaults to `false`.
 
-Starts a request to find all matches for the `text` in the web page and returns an `Integer`
-representing the request id used for the request. The result of the request can be
-obtained by subscribing to [`found-in-page`](webview-tag.md#event-found-in-page) event.
+Returns `Integer` - The request id used for the request.
+
+Starts a request to find all matches for the `text` in the web page. The result of the request
+can be obtained by subscribing to [`found-in-page`](webview-tag.md#event-found-in-page) event.
 
 ### `<webview>.stopFindInPage(action)`
 


### PR DESCRIPTION
I found that return type of `webContents.findInPage()` and `webview.findInPage()` are `void` in `electron.d.ts` (electron v1.7.8).

But from document, they should return `number` which represents request ID. Although I'm not sure how the documents are converted into type definitions, return types don't seem to be recognized from the document correctly. I fixed documents to correct the return types.
