### PR TITLE
Don't call GetIdleWakeupsPerSecond on Win

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -188,7 +188,14 @@ v8::Local<v8::Value> AtomBindings::GetCPUUsage(v8::Isolate* isolate) {
   int processor_count = base::SysInfo::NumberOfProcessors();
   dict.Set("percentCPUUsage",
            metrics_->GetPlatformIndependentCPUUsage() / processor_count);
+
+  // NB: This will throw NOTIMPLEMENTED() on Windows
+  // For backwards compatibility, we'll return 0
+#if !defined(OS_WIN)
   dict.Set("idleWakeupsPerSecond", metrics_->GetIdleWakeupsPerSecond());
+#else
+  dict.Set("idleWakeupsPerSecond", 0);
+#endif
 
   return dict.GetHandle();
 }

--- a/docs/api/structures/cpu-usage.md
+++ b/docs/api/structures/cpu-usage.md
@@ -3,4 +3,5 @@
 * `percentCPUUsage` Number - Percentage of CPU used since the last call to getCPUUsage.
   First call returns 0.
 * `idleWakeupsPerSecond` Number - The number of average idle cpu wakeups per second
-  since the last call to getCPUUsage. First call returns 0.
+  since the last call to getCPUUsage. First call returns 0. Will always return 0 on
+  Windows.


### PR DESCRIPTION
On Windows, the system doesn't keep track of idle wakeups the same way Unix does - so Chromium throws a nasty `NOTIMPLEMENTED()` every single time we call `process.getCPUUsage()` on Windows. Nothing crashes, but it pollutes the log with lines like these:

```
[1288:1003/084000.939:ERROR:process_metrics.cc(99)] NOT IMPLEMENTED
```

This PR makes sure that we don't even attempt this not implemented call. Instead, we return 0, keeping the current behavior around.