### PR TITLE
Add logic to retry github uploads

### DIFF
--- a/script/upload-to-github.js
+++ b/script/upload-to-github.js
@@ -13,9 +13,22 @@ let githubOpts = {
   filePath: filePath,
   name: fileName
 }
-github.repos.uploadAsset(githubOpts).then(() => {
-  process.exit()
-}).catch((err) => {
-  console.log(`Error uploading ${fileName} to GitHub:`, err)
-  process.exitCode = 1
-})
+
+let retry = true
+
+function uploadToGitHub () {
+  github.repos.uploadAsset(githubOpts).then(() => {
+    process.exit()
+  }).catch((err) => {
+    if (retry) {
+      console.log(`Error uploading ${fileName} to GitHub, will retry.  Error was:`, err)
+      retry = false
+      uploadToGitHub()
+    } else {
+      console.log(`Error retrying uploading ${fileName} to GitHub:`, err)
+      process.exitCode = 1
+    }
+  })
+}
+
+uploadToGitHub()

--- a/script/upload-to-github.js
+++ b/script/upload-to-github.js
@@ -2,6 +2,10 @@ const GitHub = require('github')
 const github = new GitHub()
 github.authenticate({type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN})
 
+if (process.argv.length < 5) {
+  console.log('Usage: upload-to-github filePath fileName releaseId')
+  process.exit(1)
+}
 let filePath = process.argv[2]
 let fileName = process.argv[3]
 let releaseId = process.argv[4]
@@ -14,15 +18,16 @@ let githubOpts = {
   name: fileName
 }
 
-let retry = true
+let retry = 0
 
 function uploadToGitHub () {
   github.repos.uploadAsset(githubOpts).then(() => {
+    console.log(`Successfully uploaded ${fileName} to GitHub.`)
     process.exit()
   }).catch((err) => {
-    if (retry) {
+    if (retry < 4) {
       console.log(`Error uploading ${fileName} to GitHub, will retry.  Error was:`, err)
-      retry = false
+      retry++
       uploadToGitHub()
     } else {
       console.log(`Error retrying uploading ${fileName} to GitHub:`, err)


### PR DESCRIPTION
When doing a release, sometimes the GitHub upload fails, so try to retry it once before bailing.