### PR TITLE
:apple: skip tabbing category if macOS < Sierra

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -465,7 +465,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 @end
 
-#if !defined(MAC_OS_X_VERSION_10_12)
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1012 // MAC_OS_X_VERSION_10_12
 
 enum {
   NSWindowTabbingModeDisallowed = 2

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -4,6 +4,7 @@
 
 #include "atom/browser/native_window_mac.h"
 
+#include <AvailabilityMacros.h>
 #include <Quartz/Quartz.h>
 #include <string>
 
@@ -465,7 +466,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 @end
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1012 // MAC_OS_X_VERSION_10_12
+#if !defined(AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER)
 
 enum {
   NSWindowTabbingModeDisallowed = 2
@@ -482,7 +483,7 @@ enum {
 - (IBAction)toggleTabBar:(id)sender;
 @end
 
-#endif  // MAC_OS_X_VERSION_10_12
+#endif
 
 @interface AtomNSWindow : EventDispatchingWindow<QLPreviewPanelDataSource, QLPreviewPanelDelegate, NSTouchBarDelegate> {
  @private


### PR DESCRIPTION
Previously, the macro was ensuring the` MAC_OS_X_VERSION_10_12` was not defined to decide to compile a `NSWindow` category back porting native tabs or not.

This patch ensures to compile the `NSWindow` category only if the min required version is lesser than 1012 (`MAC_OS_X_VERSION_10_12`)

fixes #10657