### PR TITLE
Warn if loading remote content with nodeIntegration

### DIFF
--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -129,6 +129,15 @@ if (nodeIntegration === 'true') {
     }
   }
 
+  if (/(https?)|(ftp):/.test(window.location.protocol)) {
+    let warning =  'This renderer process has Node.js integration enabled '
+        warning += 'and attempted to load remote content. This exposes users of this app to severe '
+        warning += 'security risks.\n'
+        warning += 'For more information and help, consult https://electron.atom.io/docs/tutorial/security/'
+
+    console.warn('%cElectron Security Warning', 'font-weight: bold;', warning)
+  }
+
   // Redirect window.onerror to uncaughtException.
   window.onerror = function (message, filename, lineno, colno, error) {
     if (global.process.listeners('uncaughtException').length > 0) {

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -130,10 +130,10 @@ if (nodeIntegration === 'true') {
   }
 
   if (/(https?)|(ftp):/.test(window.location.protocol)) {
-    let warning =  'This renderer process has Node.js integration enabled '
-        warning += 'and attempted to load remote content. This exposes users of this app to severe '
-        warning += 'security risks.\n'
-        warning += 'For more information and help, consult https://electron.atom.io/docs/tutorial/security/'
+    let warning = 'This renderer process has Node.js integration enabled '
+    warning += 'and attempted to load remote content. This exposes users of this app to severe '
+    warning += 'security risks.\n'
+    warning += 'For more information and help, consult https://electron.atom.io/docs/tutorial/security/'
 
     console.warn('%cElectron Security Warning', 'font-weight: bold;', warning)
   }


### PR DESCRIPTION
I'm concerned about more and more users loading remote content with `nodeIntegration` enabled. To make sure that developers are educated, I'd like to add the following warning:

![screen shot 2017-10-06 at 1 02 41 pm](https://user-images.githubusercontent.com/1426799/31296353-d59f0a42-aa96-11e7-9027-dbafad372f11.png)
