### PR TITLE
remove potential deprecation and fix app close

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -336,8 +336,6 @@ if (option.file && !option.webdriver) {
   startRepl()
 } else {
   const welcomeMessage = `
-  Deprecation Warning: To render the default app, the -d or --default flags will soon need to be used.
-
   Electron ${process.versions.electron} - Build cross platform desktop apps with JavaScript, HTML, and CSS
   Usage: electron [options] [path]
 
@@ -357,5 +355,4 @@ if (option.file && !option.webdriver) {
   console.log(welcomeMessage)
   const indexPath = path.join(__dirname, '/index.html')
   loadApplicationByUrl(`file://${indexPath}`)
-  process.exit(0)
 }


### PR DESCRIPTION
per conversation with last night, move to remove deprecation warning and simply show help information alongside opening default app when `electron` is run with no args

/cc @MarshallOfSound @zeke 