### PR TITLE
Tiny fix: String comparison for remote node warning

### DIFF
--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -129,7 +129,9 @@ if (nodeIntegration === 'true') {
     }
   }
 
-  if (/(https?)|(ftp):/.test(window.location.protocol)) {
+  if (window.location.protocol === 'https:' ||
+      window.location.protocol === 'http:' ||
+      window.location.protocol === 'ftp:') {
     let warning = 'This renderer process has Node.js integration enabled '
     warning += 'and attempted to load remote content. This exposes users of this app to severe '
     warning += 'security risks.\n'


### PR DESCRIPTION
A little performance optimization for @alespergl :wink:

