### PR TITLE
Ensure that the touchbar's esape item can be set before setting it

### DIFF
--- a/atom/browser/ui/cocoa/atom_touch_bar.mm
+++ b/atom/browser/ui/cocoa/atom_touch_bar.mm
@@ -143,6 +143,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (void)setEscapeTouchBarItem:(const mate::PersistentDictionary&)item forTouchBar:(NSTouchBar*)touchBar {
+  if (![touchBar respondsToSelector:@selector(escapeKeyReplacementItemIdentifier)]) return;
   std::string type;
   std::string item_id;
   NSTouchBarItemIdentifier identifier = nil;


### PR DESCRIPTION
Fixes #10442 