### PR TITLE
Add systemPreferences.removeUserDefault()

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -67,6 +67,7 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::UnsubscribeLocalNotification)
       .SetMethod("getUserDefault", &SystemPreferences::GetUserDefault)
       .SetMethod("setUserDefault", &SystemPreferences::SetUserDefault)
+      .SetMethod("removeUserDefault", &SystemPreferences::RemoveUserDefault)
       .SetMethod("isSwipeTrackingFromScrollEventsEnabled",
                  &SystemPreferences::IsSwipeTrackingFromScrollEventsEnabled)
 #endif

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -76,6 +76,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void SetUserDefault(const std::string& name,
                       const std::string& type,
                       mate::Arguments* args);
+  void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 #endif
   bool IsDarkMode();

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -229,6 +229,11 @@ void SystemPreferences::SetUserDefault(const std::string& name,
   }
 }
 
+void SystemPreferences::RemoveUserDefault(const std::string& name) {
+  NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+  [defaults removeObjectForKey:base::SysUTF8ToNSString(name)];
+}
+
 bool SystemPreferences::IsDarkMode() {
   NSString* mode = [[NSUserDefaults standardUserDefaults]
       stringForKey:@"AppleInterfaceStyle"];

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -112,9 +112,9 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificati
 * `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`,
   `url`, `array`, `dictionary`
 
-Returns `any` - The value of `key` in system preferences.
+Returns `any` - The value of `key` in `NSUserDefaults`.
 
-This API uses `NSUserDefaults` on macOS. Some popular `key` and `type`s are:
+Some popular `key` and `type`s are:
 
 * `AppleInterfaceStyle`:  `string`
 * `AppleAquaColorVariant`:  `integer`
@@ -130,14 +130,21 @@ This API uses `NSUserDefaults` on macOS. Some popular `key` and `type`s are:
 * `type` String - See [`getUserDefault`][#systempreferencesgetuserdefaultkey-type-macos]
 * `value` String
 
-Set the value of `key` in system preferences.
+Set the value of `key` in `NSUserDefaults`.
 
 Note that `type` should match actual type of `value`. An exception is thrown
 if they don't.
 
-This API uses `NSUserDefaults` on macOS. Some popular `key` and `type`s are:
+Some popular `key` and `type`s are:
 
 * `ApplePressAndHoldEnabled`:  `boolean`
+
+### `systemPreferences.removeUserDefault(key)` _macOS_
+
+* `key` String
+
+Removes the `key` in `NSUserDefaults`. This can be used to restore the default
+or global value of a `key` previously set with `setUserDefault`.
 
 ### `systemPreferences.isAeroGlassEnabled()` _Windows_
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -100,6 +100,23 @@ describe('systemPreferences module', function () {
     })
   })
 
+  describe('systemPreferences.setUserDefault(key, type, value)', () => {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    it('removes keys', () => {
+      const KEY = 'SystemPreferencesTest'
+      systemPreferences.setUserDefault(KEY, 'string', 'foo')
+      systemPreferences.removeUserDefault(KEY)
+      assert.equal(systemPreferences.getUserDefault(KEY, 'string'), '')
+    })
+
+    it('does not throw for missing keys', () => {
+      systemPreferences.removeUserDefault('some-missing-key')
+    })
+  })
+
   describe('systemPreferences.isInvertedColorScheme()', function () {
     it('returns a boolean', function () {
       assert.equal(typeof systemPreferences.isInvertedColorScheme(), 'boolean')


### PR DESCRIPTION
This can be used to restore the default or global value of a `key`
previously set with `setUserDefault`.