### PR TITLE
Don't be quiet on default loglevel

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -29,7 +29,7 @@ download({
   arch: process.env.npm_config_arch,
   strictSSL: process.env.npm_config_strict_ssl === 'true',
   force: process.env.force_no_cache === 'true',
-  quiet: process.env.npm_config_loglevel === 'silent'
+  quiet: process.env.npm_config_loglevel === 'silent' || process.env.CI
 }, extractFile)
 
 // unzips and makes path.txt point at the correct executable

--- a/npm/install.js
+++ b/npm/install.js
@@ -29,7 +29,7 @@ download({
   arch: process.env.npm_config_arch,
   strictSSL: process.env.npm_config_strict_ssl === 'true',
   force: process.env.force_no_cache === 'true',
-  quiet: ['info', 'verbose', 'silly', 'http'].indexOf(process.env.npm_config_loglevel) === -1
+  quiet: process.env.npm_config_loglevel === 'silent'
 }, extractFile)
 
 // unzips and makes path.txt point at the correct executable


### PR DESCRIPTION
Currently, users don't see any indiciation for the download progress of electron. That's especially confusing to newcomers with less-than-stellar internet connections, because neither npm nor Node are telling them that anything is happening. That's bad.

At the same time, the reasoning for the original PR was to ensure that automated build environment logs aren't polluted with tons of progress bar updates. This new solution hides the progress bar in two cases:

 * `npm`'s loglevel is set to `silent`
 *  A `CI` environment variable is set (Automatically set on [Travis](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables),  [AppVeyor](https://www.appveyor.com/docs/environment-variables/), [CircleCI](https://circleci.com/docs/1.0/environment-variables/), [GitLab](https://docs.gitlab.com/ee/ci/variables/), and probably every other CI provider, too)

Closes https://github.com/electron/electron/issues/10747