### PR TITLE
Windows 10 focus fix

### DIFF
--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -36,7 +36,23 @@ BOOL CALLBACK WindowsEnumerationHandler(HWND hwnd, LPARAM param) {
 
   GetWindowThreadProcessId(hwnd, &process_id);
   if (process_id == target_process_id) {
+    // To unlock SetForegroundWindow we need to imitate pressing the Alt key
+    // This circumvents the ForegroundLockTimeout in Windows 10
+    bool bPressed = false;
+    if((GetAsyncKeyState(VK_MENU) & 0x8000) == 0)
+    {
+        bPressed = true;
+        keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
+    }
+
+    SetForegroundWindow(hwnd);
     SetFocus(hwnd);
+
+    if(bPressed)
+    {
+        keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+    }
+
     return FALSE;
   }
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -39,8 +39,7 @@ BOOL CALLBACK WindowsEnumerationHandler(HWND hwnd, LPARAM param) {
     // To unlock SetForegroundWindow we need to imitate pressing the Alt key
     // This circumvents the ForegroundLockTimeout in Windows 10
     bool bPressed = false;
-    if((GetAsyncKeyState(VK_MENU) & 0x8000) == 0)
-    {
+    if ((GetAsyncKeyState(VK_MENU) & 0x8000) == 0) {
         bPressed = true;
         keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
     }
@@ -48,8 +47,7 @@ BOOL CALLBACK WindowsEnumerationHandler(HWND hwnd, LPARAM param) {
     SetForegroundWindow(hwnd);
     SetFocus(hwnd);
 
-    if(bPressed)
-    {
+    if (bPressed) {
         keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
     }
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -11,6 +11,7 @@
 #include <shobjidl.h>
 
 #include "atom/browser/ui/win/jump_list.h"
+#include "atom/browser/ui/win/window_util.h"
 #include "atom/common/atom_version.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/base_paths.h"
@@ -36,21 +37,7 @@ BOOL CALLBACK WindowsEnumerationHandler(HWND hwnd, LPARAM param) {
 
   GetWindowThreadProcessId(hwnd, &process_id);
   if (process_id == target_process_id) {
-    // To unlock SetForegroundWindow we need to imitate pressing the Alt key
-    // This circumvents the ForegroundLockTimeout in Windows 10
-    bool bPressed = false;
-    if ((GetAsyncKeyState(VK_MENU) & 0x8000) == 0) {
-        bPressed = true;
-        keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
-    }
-
-    SetForegroundWindow(hwnd);
-    SetFocus(hwnd);
-
-    if (bPressed) {
-        keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
-    }
-
+    window_util::ForceFocusWindow(hwnd);
     return FALSE;
   }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -371,8 +371,7 @@ void NativeWindowViews::Focus(bool focus) {
     HWND hwnd = GetAcceleratedWidget();
 
     bool bPressed = false;
-    if ((GetAsyncKeyState(VK_MENU) & 0x8000) == 0)
-    {
+    if ((GetAsyncKeyState(VK_MENU) & 0x8000) == 0) {
       bPressed = true;
       keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
     }
@@ -380,8 +379,7 @@ void NativeWindowViews::Focus(bool focus) {
     SetForegroundWindow(hwnd);
     SetFocus(hwnd);
 
-    if (bPressed)
-    {
+    if (bPressed) {
       keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
     }
 #elif defined(USE_X11)

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -366,7 +366,24 @@ void NativeWindowViews::Focus(bool focus) {
 
   if (focus) {
 #if defined(OS_WIN)
-    window_->Activate();
+    // To unlock SetForegroundWindow we need to imitate pressing the Alt key
+    // This circumvents the ForegroundLockTimeout in Windows 10
+    HWND hwnd = GetAcceleratedWidget();
+
+    bool bPressed = false;
+    if ((GetAsyncKeyState(VK_MENU) & 0x8000) == 0)
+    {
+      bPressed = true;
+      keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
+    }
+
+    SetForegroundWindow(hwnd);
+    SetFocus(hwnd);
+
+    if (bPressed)
+    {
+      keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+    }
 #elif defined(USE_X11)
     // The "Activate" implementation of Chromium is not reliable on Linux.
     ::Window window = GetAcceleratedWidget();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -51,6 +51,7 @@
 #include "atom/browser/ui/views/win_frame_view.h"
 #include "atom/browser/ui/win/atom_desktop_native_widget_aura.h"
 #include "atom/browser/ui/win/atom_desktop_window_tree_host_win.h"
+#include "atom/browser/ui/win/window_util.h"
 #include "skia/ext/skia_utils_win.h"
 #include "ui/base/win/shell.h"
 #include "ui/display/display.h"
@@ -366,22 +367,8 @@ void NativeWindowViews::Focus(bool focus) {
 
   if (focus) {
 #if defined(OS_WIN)
-    // To unlock SetForegroundWindow we need to imitate pressing the Alt key
-    // This circumvents the ForegroundLockTimeout in Windows 10
     HWND hwnd = GetAcceleratedWidget();
-
-    bool bPressed = false;
-    if ((GetAsyncKeyState(VK_MENU) & 0x8000) == 0) {
-      bPressed = true;
-      keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
-    }
-
-    SetForegroundWindow(hwnd);
-    SetFocus(hwnd);
-
-    if (bPressed) {
-      keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
-    }
+    window_util::ForceFocusWindow(hwnd);
 #elif defined(USE_X11)
     // The "Activate" implementation of Chromium is not reliable on Linux.
     ::Window window = GetAcceleratedWidget();

--- a/atom/browser/ui/win/window_util.cc
+++ b/atom/browser/ui/win/window_util.cc
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/ui/win/window_util.h"
+
+namespace window_util {
+
+void ForceFocusWindow(HWND hwnd) {
+  // To unlock SetForegroundWindow we need to imitate pressing the Alt key
+  // This circumvents the ForegroundLockTimeout in Windows 10
+  bool pressed = false;
+  if ((GetAsyncKeyState(VK_MENU) & 0x8000) == 0) {
+    pressed = true;
+    keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
+  }
+
+  SetForegroundWindow(hwnd);
+  SetFocus(hwnd);
+
+  if (pressed) {
+    keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+  }
+}
+
+}  // namespace window_util

--- a/atom/browser/ui/win/window_util.h
+++ b/atom/browser/ui/win/window_util.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2017 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_UI_WIN_WINDOW_UTIL_H_
+#define ATOM_BROWSER_UI_WIN_WINDOW_UTIL_H_
+
+#include <windows.h>
+
+namespace window_util {
+
+void ForceFocusWindow(HWND hwnd);
+
+}  // namespace window_util
+
+#endif  // ATOM_BROWSER_UI_WIN_WINDOW_UTIL_H_

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -354,6 +354,8 @@
       'atom/browser/ui/win/notify_icon.h',
       'atom/browser/ui/win/taskbar_host.cc',
       'atom/browser/ui/win/taskbar_host.h',
+      'atom/browser/ui/win/window_util.cc',
+      'atom/browser/ui/win/window_util.h',
       'atom/browser/ui/x/event_disabler.cc',
       'atom/browser/ui/x/event_disabler.h',
       'atom/browser/ui/x/window_state_watcher.cc',


### PR DESCRIPTION
I changed the focus() implementation to circumvent the ForegroundLockTimeout and allowing apps to focus without limitations in Windows 10.

This is kind of a hack since not being able to focus a window is by design in Windows 10 (see first related issue). So there is a stand point needed to be taken if the hack should be included in Electron since it is highly requested or if related issues should be closed as "Won't fix" and instead let third party modules implement this hack.

**Related issues:**
- https://github.com/electron/electron/issues/2867
- https://github.com/Microsoft/vscode/issues/35765

**Code quality issues:**
I did not know where to put the shared logic for doing this work around, so the same logic is duplicated on the application level focus and window level focus.