### PR TITLE
Add error code to session.setCertificateVerifyProc

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -212,6 +212,7 @@ struct Converter<atom::VerifyRequestParams> {
     dict.Set("hostname", val.hostname);
     dict.Set("certificate", val.certificate);
     dict.Set("verificationResult", val.default_result);
+    dict.Set("errorCode", val.error_code);
     return dict.GetHandle();
   }
 };

--- a/atom/browser/net/atom_cert_verifier.cc
+++ b/atom/browser/net/atom_cert_verifier.cc
@@ -92,6 +92,7 @@ class CertVerifierRequest : public AtomCertVerifier::Request {
     std::unique_ptr<VerifyRequestParams> request(new VerifyRequestParams());
     request->hostname = params_.hostname();
     request->default_result = net::ErrorToString(error);
+    request->error_code = error;
     request->certificate = params_.certificate();
     BrowserThread::PostTask(
         BrowserThread::UI, FROM_HERE,

--- a/atom/browser/net/atom_cert_verifier.h
+++ b/atom/browser/net/atom_cert_verifier.h
@@ -19,6 +19,7 @@ class CertVerifierRequest;
 struct VerifyRequestParams {
   std::string hostname;
   std::string default_result;
+  int error_code;
   scoped_refptr<net::X509Certificate> certificate;
 };
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -253,7 +253,8 @@ the original network configuration.
   * `request` Object
     * `hostname` String
     * `certificate` [Certificate](structures/certificate.md)
-    * `error` String - Verification result from chromium.
+    * `verificationResult` String - Verification result from chromium.
+    * `errorCode` Integer - Error code.
   * `callback` Function
     * `verificationResult` Integer - Value can be one of certificate error codes
     from [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -572,8 +572,9 @@ describe('session module', function () {
     })
 
     it('accepts the request when the callback is called with 0', function (done) {
-      session.defaultSession.setCertificateVerifyProc(function ({hostname, certificate, verificationResult}, callback) {
+      session.defaultSession.setCertificateVerifyProc(function ({hostname, certificate, verificationResult, errorCode}, callback) {
         assert(['net::ERR_CERT_AUTHORITY_INVALID', 'net::ERR_CERT_COMMON_NAME_INVALID'].includes(verificationResult), verificationResult)
+        assert([-202, -200].includes(errorCode), errorCode)
         callback(0)
       })
 


### PR DESCRIPTION
This PR adds `errorCode` value to the request object, so ppl can directly get the error code value, not just the verification result string.