### PR TITLE
Use real shared library names for symbol files

### DIFF
--- a/tools/posix/generate_breakpad_symbols.py
+++ b/tools/posix/generate_breakpad_symbols.py
@@ -117,7 +117,7 @@ def GetSharedLibraryDependenciesLinux(binary):
   for line in ldd.splitlines():
     m = lib_re.match(line)
     if m:
-      result.append(m.group(1))
+      result.append(os.path.realpath(m.group(1)))
   return result
 
 


### PR DESCRIPTION
The names of symbol files on Linux are based on the names of the `.so` files found by `ldd` as dependencies. Usually these are just symlinks and the actual binaries loaded into the process are named differently, e.g. `libstdc++.so.6` resolves to `libstdc++.so.6.0.24`. When the symlink name is used for the symbol file name, the symbol file will not be matched with the real file name when symbolicating a crash dump. Therefore the real name needs to be used for naming the symbol file.