### PR TITLE
Use key window event instead of main window event (macOS)

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -240,7 +240,7 @@ bool ScopedDisableResize::disable_resize_ = false;
   return frame;
 }
 
-- (void)windowDidBecomeMain:(NSNotification*)notification {
+- (void)windowDidBecomeKey:(NSNotification*)notification {
   content::WebContents* web_contents = shell_->web_contents();
   if (!web_contents)
     return;
@@ -254,7 +254,7 @@ bool ScopedDisableResize::disable_resize_ = false;
   shell_->NotifyWindowFocus();
 }
 
-- (void)windowDidResignMain:(NSNotification*)notification {
+- (void)windowDidResignKey:(NSNotification*)notification {
   content::WebContents* web_contents = shell_->web_contents();
   if (!web_contents)
     return;


### PR DESCRIPTION
`NativeWindowMac::IsFocused()` returns `[window_ isKeyWindow]` but focus event is fired on `windowDidBecomeMain`.

Fixes #9530.

See also: [Cocoa docs](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html#//apple_ref/doc/uid/20000236-128794) on key vs main windows.