### PR TITLE
Fix for issue #10697

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -286,12 +286,13 @@ WebContents::WebContents(v8::Isolate* isolate,
       request_id_(0),
       background_throttling_(true),
       enable_devtools_(true) {
+  const mate::Dictionary options = mate::Dictionary::CreateEmpty(isolate);
   if (type == REMOTE) {
     web_contents->SetUserAgentOverride(GetBrowserContext()->GetUserAgent());
     Init(isolate);
     AttachAsUserData(web_contents);
+    InitZoomController(web_contents, options);
   } else {
-    const mate::Dictionary options = mate::Dictionary::CreateEmpty(isolate);
     auto session = Session::CreateFrom(isolate, GetBrowserContext());
     session_.Reset(isolate, session.ToV8());
     InitWithSessionAndOptions(isolate, web_contents, session, options);
@@ -392,6 +393,15 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
   InitWithSessionAndOptions(isolate, web_contents, session, options);
 }
 
+void WebContents::InitZoomController(content::WebContents* web_contents,
+                                     const mate::Dictionary& options) {
+  WebContentsZoomController::CreateForWebContents(web_contents);
+  zoom_controller_ = WebContentsZoomController::FromWebContents(web_contents);
+  double zoom_factor;
+  if (options.Get(options::kZoomFactor, &zoom_factor))
+    zoom_controller_->SetDefaultZoomFactor(zoom_factor);
+}
+
 void WebContents::InitWithSessionAndOptions(v8::Isolate* isolate,
                                             content::WebContents *web_contents,
                                             mate::Handle<api::Session> session,
@@ -409,11 +419,7 @@ void WebContents::InitWithSessionAndOptions(v8::Isolate* isolate,
   // Initialize security state client.
   SecurityStateTabHelper::CreateForWebContents(web_contents);
   // Initialize zoom controller.
-  WebContentsZoomController::CreateForWebContents(web_contents);
-  zoom_controller_ = WebContentsZoomController::FromWebContents(web_contents);
-  double zoom_factor;
-  if (options.Get(options::kZoomFactor, &zoom_factor))
-    zoom_controller_->SetDefaultZoomFactor(zoom_factor);
+  InitZoomController(web_contents, options);
 
   web_contents->SetUserAgentOverride(GetBrowserContext()->GetUserAgent());
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -385,6 +385,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // get the zoom level.
   void OnGetZoomLevel(IPC::Message* reply_msg);
 
+  void InitZoomController(content::WebContents* web_contents,
+                          const mate::Dictionary& options);
+
   v8::Global<v8::Value> session_;
   v8::Global<v8::Value> devtools_web_contents_;
   v8::Global<v8::Value> debugger_;


### PR DESCRIPTION
This PR is to fix the crash described in the issue #10697.
The root cause is  zoom_controller_ is not initialized for dev tools.