### PR TITLE
Avoid EventEmitter crashes

### DIFF
--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -169,10 +169,10 @@ void Notification::NotificationDisplayed() {
 }
 
 void Notification::NotificationDestroyed() {
-  Emit("close");
 }
 
 void Notification::NotificationClosed() {
+  Emit("close");
 }
 
 // Showing notifications

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -80,9 +80,10 @@ class EventEmitter : public Wrappable<T> {
     v8::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
     v8::Local<v8::Object> wrapper = GetWrapper();
-    if (wrapper.IsEmpty())
+    if (wrapper.IsEmpty()) {
       return false;
-     v8::Local<v8::Object> event = internal::CreateJSEvent(
+    }
+    v8::Local<v8::Object> event = internal::CreateJSEvent(
         isolate(), wrapper, sender, message);
     return EmitWithEvent(name, event, args...);
   }

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -79,8 +79,11 @@ class EventEmitter : public Wrappable<T> {
                       const Args&... args) {
     v8::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
-    v8::Local<v8::Object> event = internal::CreateJSEvent(
-        isolate(), GetWrapper(), sender, message);
+    v8::Local<v8::Object> wrapper = GetWrapper();
+    if (wrapper.IsEmpty())
+      return false;
+     v8::Local<v8::Object> event = internal::CreateJSEvent(
+        isolate(), wrapper, sender, message);
     return EmitWithEvent(name, event, args...);
   }
 

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -62,7 +62,10 @@ class TrackableObject : public TrackableObjectBase,
  public:
   // Mark the JS object as destroyed.
   void MarkDestroyed() {
-    Wrappable<T>::GetWrapper()->SetAlignedPointerInInternalField(0, nullptr);
+    v8::Local<v8::Object> wrapper = Wrappable<T>::GetWrapper();
+    if (!wrapper.IsEmpty()) {
+      Wrappable<T>::GetWrapper()->SetAlignedPointerInInternalField(0, nullptr);
+    }
   }
 
   bool IsDestroyed() {

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -64,7 +64,7 @@ class TrackableObject : public TrackableObjectBase,
   void MarkDestroyed() {
     v8::Local<v8::Object> wrapper = Wrappable<T>::GetWrapper();
     if (!wrapper.IsEmpty()) {
-      Wrappable<T>::GetWrapper()->SetAlignedPointerInInternalField(0, nullptr);
+      wrapper->SetAlignedPointerInInternalField(0, nullptr);
     }
   }
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -74,7 +74,7 @@ Returns:
 
 Emitted when the notification is closed by manual intervention from the user.
 
-This event is not guarunteed to be emitted in all cases where the notification
+This event is not guaranteed to be emitted in all cases where the notification
 is closed.
 
 #### Event: 'reply' _macOS_


### PR DESCRIPTION
This is an attempt to avoid #10527, in which notification events like `close` and `show` sometimes cause a crash.

First, the `close` event was a bit of a lie, as it was being dispatched somewhat randomly when the notification was GCed, not when the user actually dismissed it. Fixing this means not having to deal with emitting the event inside the destructor.

Second, it seems like there are some subtle bugs in native-mate. I'm not sure what is going on, but in reading through how Muon does things I noticed a few sensible looking changes from @bridiver: https://github.com/brave/muon/commit/58c0ec0e00d52a6c8cf31a837433b6b5eb23a8ff#diff-a31bffb28ca1eed32c06c2d6b8b53f45 https://github.com/brave/muon/pull/323

Here is an additional native-mate PR: https://github.com/electron/native-mate/pull/15