### PR TITLE
Update desktop capturer to ES6

### DIFF
--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -1,23 +1,23 @@
 'use strict'
 
-const ipcMain = require('electron').ipcMain
-const desktopCapturer = process.atomBinding('desktop_capturer').desktopCapturer
+const {ipcMain} = require('electron')
+const {desktopCapturer} = process.atomBinding('desktop_capturer')
 
-var deepEqual = function (opt1, opt2) {
-  return JSON.stringify(opt1) === JSON.stringify(opt2)
-}
+const deepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b)
 
 // A queue for holding all requests from renderer process.
-var requestsQueue = []
+let requestsQueue = []
 
-ipcMain.on('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function (event, captureWindow, captureScreen, thumbnailSize, id) {
-  var request
-  request = {
-    id: id,
+const electronSources = 'ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES'
+const capturerResult = (id) => `ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`
+
+ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize, id) => {
+  const request = {
+    id,
     options: {
-      captureWindow: captureWindow,
-      captureScreen: captureScreen,
-      thumbnailSize: thumbnailSize
+      captureWindow,
+      captureScreen,
+      thumbnailSize
     },
     webContents: event.sender
   }
@@ -28,45 +28,47 @@ ipcMain.on('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function (event, cap
 
   // If the WebContents is destroyed before receiving result, just remove the
   // reference from requestsQueue to make the module not send the result to it.
-  event.sender.once('destroyed', function () {
+  event.sender.once('destroyed', () => {
     request.webContents = null
+    return
   })
 })
 
-desktopCapturer.emit = function (event, name, sources) {
+desktopCapturer.emit = (event, name, sources) => {
   // Receiving sources result from main process, now send them back to renderer.
-  var handledRequest, i, len, ref, ref1, request, result, source, unhandledRequestsQueue
-  handledRequest = requestsQueue.shift(0)
-  result = (function () {
-    var i, len, results
-    results = []
-    for (i = 0, len = sources.length; i < len; i++) {
-      source = sources[i]
+  const handledRequest = requestsQueue.shift(0)
+  const handledWebContents = handledRequest.webContents
+  const unhandledRequestsQueue = []
+
+  const result = () => {
+    const results = []
+    sources.forEach(source => {
       results.push({
         id: source.id,
         name: source.name,
         thumbnail: source.thumbnail.toDataURL()
       })
-    }
+    })
     return results
-  })()
-  if ((ref = handledRequest.webContents) != null) {
-    ref.send('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + handledRequest.id, result)
+  }
+
+  if (handledWebContents != null) {
+    handledWebContents.send(capturerResult(handledRequest.id), result())
   }
 
   // Check the queue to see whether there is other same request. If has, handle
   // it for reducing redunplicated `desktopCaptuer.startHandling` calls.
-  unhandledRequestsQueue = []
-  for (i = 0, len = requestsQueue.length; i < len; i++) {
-    request = requestsQueue[i]
+
+  requestsQueue.forEach(request => {
+    const webContents = request.webContents
     if (deepEqual(handledRequest.options, request.options)) {
-      if ((ref1 = request.webContents) != null) {
-        ref1.send('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + request.id, result)
+      if (webContents != null) {
+        webContents.send(capturerResult(request.id), result())
       }
     } else {
       unhandledRequestsQueue.push(request)
     }
-  }
+  })
   requestsQueue = unhandledRequestsQueue
 
   // If the requestsQueue is not empty, start a new request handling.

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -30,7 +30,6 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
   // reference from requestsQueue to make the module not send the result to it.
   event.sender.once('destroyed', () => {
     request.webContents = null
-    return
   })
 })
 
@@ -48,19 +47,15 @@ desktopCapturer.emit = (event, name, sources) => {
     }
   })
 
-  if (handledWebContents != null) {
+  if (handledWebContents) {
     handledWebContents.send(capturerResult(handledRequest.id), result)
   }
 
-  // Check the queue to see whether there is other same request. If has, handle
-  // it for reducing redunplicated `desktopCaptuer.startHandling` calls.
-
+  // Check the queue to see whether there is another identical request & handle
   requestsQueue.forEach(request => {
     const webContents = request.webContents
     if (deepEqual(handledRequest.options, request.options)) {
-      if (webContents != null) {
-        webContents.send(capturerResult(request.id), result)
-      }
+      if (webContents) webContents.send(capturerResult(request.id), result)
     } else {
       unhandledRequestsQueue.push(request)
     }

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -36,24 +36,20 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
 
 desktopCapturer.emit = (event, name, sources) => {
   // Receiving sources result from main process, now send them back to renderer.
-  const handledRequest = requestsQueue.shift(0)
+  const handledRequest = requestsQueue.shift()
   const handledWebContents = handledRequest.webContents
   const unhandledRequestsQueue = []
 
-  const result = () => {
-    const results = []
-    sources.forEach(source => {
-      results.push({
-        id: source.id,
-        name: source.name,
-        thumbnail: source.thumbnail.toDataURL()
-      })
-    })
-    return results
-  }
+  const result = sources.map(source => {
+    return {
+      id: source.id,
+      name: source.name,
+      thumbnail: source.thumbnail.toDataURL()
+    }
+  })
 
   if (handledWebContents != null) {
-    handledWebContents.send(capturerResult(handledRequest.id), result())
+    handledWebContents.send(capturerResult(handledRequest.id), result)
   }
 
   // Check the queue to see whether there is other same request. If has, handle
@@ -63,7 +59,7 @@ desktopCapturer.emit = (event, name, sources) => {
     const webContents = request.webContents
     if (deepEqual(handledRequest.options, request.options)) {
       if (webContents != null) {
-        webContents.send(capturerResult(request.id), result())
+        webContents.send(capturerResult(request.id), result)
       }
     } else {
       unhandledRequestsQueue.push(request)

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -3,7 +3,10 @@ const {ipcRenderer, nativeImage} = require('electron')
 const includes = [].includes
 let currentId = 0
 
-const incrementId = () => currentId += 1
+const incrementId = () => {
+  currentId += 1
+  return currentId
+}
 
 // |options.type| can not be empty and has to include 'window' or 'screen'.
 function isValid (options) {
@@ -27,7 +30,7 @@ exports.getSources = function (options, callback) {
   ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, id)
   return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, sources) => {
     callback(null, (() => {
-      results = []
+      const results = []
       sources.forEach(source => {
         results.push({
           id: source.id,

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -1,46 +1,40 @@
-const ipcRenderer = require('electron').ipcRenderer
-const nativeImage = require('electron').nativeImage
+const {ipcRenderer, nativeImage} = require('electron')
 
-var nextId = 0
-var includes = [].includes
+const includes = [].includes
+let currentId = 0
 
-var getNextId = function () {
-  return ++nextId
-}
+const incrementId = () => currentId += 1
 
 // |options.type| can not be empty and has to include 'window' or 'screen'.
-var isValid = function (options) {
-  return ((options != null ? options.types : void 0) != null) && Array.isArray(options.types)
+function isValid (options) {
+  const types = (options != null) ? options.types : undefined
+  return (types != null) && Array.isArray(options.types)
 }
 
 exports.getSources = function (options, callback) {
-  var captureScreen, captureWindow, id
-  if (!isValid(options)) {
-    return callback(new Error('Invalid options'))
-  }
-  captureWindow = includes.call(options.types, 'window')
-  captureScreen = includes.call(options.types, 'screen')
+  if (!isValid(options)) return callback(new Error('Invalid options'))
+  const captureWindow = includes.call(options.types, 'window')
+  const captureScreen = includes.call(options.types, 'screen')
+
   if (options.thumbnailSize == null) {
     options.thumbnailSize = {
       width: 150,
       height: 150
     }
   }
-  id = getNextId()
+
+  const id = incrementId()
   ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, id)
-  return ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function (event, sources) {
-    var source
-    callback(null, (function () {
-      var i, len, results
+  return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, sources) => {
+    callback(null, (() => {
       results = []
-      for (i = 0, len = sources.length; i < len; i++) {
-        source = sources[i]
+      sources.forEach(source => {
         results.push({
           id: source.id,
           name: source.name,
           thumbnail: nativeImage.createFromDataURL(source.thumbnail)
         })
-      }
+      })
       return results
     })())
   })

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -8,10 +8,10 @@ const incrementId = () => {
   return currentId
 }
 
-// |options.type| can not be empty and has to include 'window' or 'screen'.
+// |options.types| can't be empty and must be an array
 function isValid (options) {
-  const types = (options != null) ? options.types : undefined
-  return (types != null) && Array.isArray(options.types)
+  const types = options ? options.types : undefined
+  return Array.isArray(types)
 }
 
 exports.getSources = function (options, callback) {


### PR DESCRIPTION
This PR removes unnecessary relics from original ☕️script conversion of the main and render process APIs for desktopCapturer

/cc @zeke 