### PR TITLE
fix: Ensure that -r isn’t considered interactive

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -27,8 +27,7 @@ for (let i = 0; i < argv.length; i++) {
   } else if (argv[i] === '--default' || argv[i] === '-d') {
     option.default = true
     break
-  } else if (argv[i] === '--interactive' || argv[i] === '-i' ||
-    argv[i] === '-repl' || argv[i] === '-r') {
+  } else if (argv[i] === '--interactive' || argv[i] === '-i' || argv[i] === '-repl') {
     option.interactive = true
   } else if (argv[i] === '--test-type=webdriver') {
     option.webdriver = true


### PR DESCRIPTION
Starting with 1.8, we activated `interactive` mode for the `-r` parameter, which according to docs should just require a module.

I think that was just a typo that we all missed, but I'll let @codebytere confirm.

Fixes #10877 