### PR TITLE
:penguin: Don't wait for xdg-open to exit

### DIFF
--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -75,11 +75,11 @@ bool ShowItemInFolder(const base::FilePath& full_path) {
   if (!base::DirectoryExists(dir))
     return false;
 
-  return XDGOpen(dir.value(), true);
+  return XDGOpen(dir.value(), false);
 }
 
 bool OpenItem(const base::FilePath& full_path) {
-  return XDGOpen(full_path.value(), true);
+  return XDGOpen(full_path.value(), false);
 }
 
 bool OpenExternal(const GURL& url, bool activate) {


### PR DESCRIPTION
Waiting for xdg-open to return freezes Electron application.
Some file managers (ex: Nemo) don't return until some time after they are closed, this freezes the Electron application until the process returns.
The same is true about any application that can potentially be opened with OpenItem.

Is there any reason why this was set to true initially? It was introduced in [this commit](https://github.com/sneakypete81/electron/commit/79ba8feaf8485a0c7a94e717281d1e13deff9e6c) and it seems that it was just sent to true because the author didn't have a problem with applications opened with OpenItem or ShowItemInFolder hanging. It turns out this is easily reproducible when Nemo is the default file manager or you open a item with a default application that does not return from the xdg-open call immediately. 

I have seen this in mattlyons0/Assessorator#4 and verified this PR fixes the behavior. Additionally I believe this fixes Foundry376/Mailspring#156 (although I cannot verify because I can't get it to build with a different electron version successfully).