### PR TITLE
🔧 Fix windows app log path

### DIFF
--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -168,8 +168,9 @@ BrowserMainParts::~BrowserMainParts() {
 void OverrideAppLogsPath() {
 #if defined(OS_WIN)
   std::wstring app_name = base::UTF8ToWide(GetApplicationName());
-  std::wstring home = _wgetenv(L"HOMEDRIVE") + "\\" +_wgetenv(L"HOMEPATH");
-  std::wstring log_path = home + L"\\AppData\\Roaming\\";
+  std::wstring home = std::wstring(_wgetenv(L"HOMEDRIVE"));
+  std::wstring drive = std::wstring(_wgetenv(L"HOMEPATH"));
+  std::wstring log_path = home + L"\\" + drive + L"\\AppData\\Roaming\\";
   std::wstring app_log_path = log_path + app_name + L"\\logs";
 #else
   std::string app_name = GetApplicationName();

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -168,7 +168,9 @@ BrowserMainParts::~BrowserMainParts() {
 void OverrideAppLogsPath() {
 #if defined(OS_WIN)
   std::wstring app_name = base::UTF8ToWide(GetApplicationName());
-  std::wstring log_path = L"%HOMEDRIVE%%HOMEPATH%\\AppData\\Roaming\\";
+  std::wstring drive = _wgetenv(L"HOMEDRIVE"));
+  std::wstring path = _wgetenv(L"HOMEPATH"));
+  std::wstring log_path = drive + "\\" + path + L"\\AppData\\Roaming\\";
   std::wstring app_log_path = log_path + app_name + L"\\logs";
 #else
   std::string app_name = GetApplicationName();

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -166,18 +166,17 @@ BrowserMainParts::~BrowserMainParts() {
 
 #if defined(OS_WIN) || defined(OS_LINUX)
 void OverrideAppLogsPath() {
+  base::FilePath path;
+  bool success = PathService::Get(brightray::DIR_APP_DATA, &path);
+  if (success) {
+    path = path.Append(base::UTF8ToWide(GetApplicationName()));
 #if defined(OS_WIN)
-  std::wstring app_name = base::UTF8ToWide(GetApplicationName());
-  std::wstring home = std::wstring(_wgetenv(L"HOMEDRIVE"));
-  std::wstring drive = std::wstring(_wgetenv(L"HOMEPATH"));
-  std::wstring log_path = home + L"\\" + drive + L"\\AppData\\Roaming\\";
-  std::wstring app_log_path = log_path + app_name + L"\\logs";
+    path = path.Append(L"logs");
 #else
-  std::string app_name = GetApplicationName();
-  std::string home_path = std::string(getenv("HOME"));
-  std::string app_log_path = home_path + "/.config/" + app_name + "/logs";
+    path = path.Append("logs");
 #endif
-  PathService::Override(DIR_APP_LOGS, base::FilePath(app_log_path));
+    PathService::Override(DIR_APP_LOGS, base::FilePath(path));
+  }
 }
 #endif
 

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -168,9 +168,8 @@ BrowserMainParts::~BrowserMainParts() {
 void OverrideAppLogsPath() {
 #if defined(OS_WIN)
   std::wstring app_name = base::UTF8ToWide(GetApplicationName());
-  std::wstring drive = _wgetenv(L"HOMEDRIVE"));
-  std::wstring path = _wgetenv(L"HOMEPATH"));
-  std::wstring log_path = drive + "\\" + path + L"\\AppData\\Roaming\\";
+  std::wstring home = _wgetenv(L"HOMEDRIVE") + "\\" +_wgetenv(L"HOMEPATH");
+  std::wstring log_path = home + L"\\AppData\\Roaming\\";
   std::wstring app_log_path = log_path + app_name + L"\\logs";
 #else
   std::string app_name = GetApplicationName();

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -167,8 +167,7 @@ BrowserMainParts::~BrowserMainParts() {
 #if defined(OS_WIN) || defined(OS_LINUX)
 void OverrideAppLogsPath() {
   base::FilePath path;
-  bool success = PathService::Get(brightray::DIR_APP_DATA, &path);
-  if (success) {
+  if (PathService::Get(brightray::DIR_APP_DATA, &path)) {
     path = path.Append(base::UTF8ToWide(GetApplicationName()));
 #if defined(OS_WIN)
     path = path.Append(L"logs");

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -168,13 +168,9 @@ BrowserMainParts::~BrowserMainParts() {
 void OverrideAppLogsPath() {
   base::FilePath path;
   if (PathService::Get(brightray::DIR_APP_DATA, &path)) {
-    path = path.Append(base::UTF8ToWide(GetApplicationName()));
-#if defined(OS_WIN)
-    path = path.Append(L"logs");
-#else
-    path = path.Append("logs");
-#endif
-    PathService::Override(DIR_APP_LOGS, base::FilePath(path));
+    path = path.Append(base::FilePath::FromUTF8Unsafe(GetApplicationName()));
+    path = path.Append(base::FilePath::FromUTF8Unsafe("logs"));
+    PathService::Override(DIR_APP_LOGS, path);
   }
 }
 #endif


### PR DESCRIPTION
https://github.com/electron/electron/issues/10910 informed me that`%HOMEPATH%` and `%HOMEDIR%` weren't correctly evaluating per https://github.com/electron/electron/blob/master/brightray/browser/browser_main_parts.cc#L171, so I switched to using _wgetenv to get windows env variables and using them to build the path instead.


/cc @MarshallOfSound 