### PR TITLE
Fix crash in custom protocols caused by bad callback exec

### DIFF
--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -258,7 +258,9 @@ void URLRequestFetchJob::OnURLFetchComplete(const net::URLFetcher* source) {
       HeadersCompleted();
       return;
     }
-    ReadRawDataComplete(0);
+    if (request_->status().is_io_pending()) {
+      ReadRawDataComplete(0);
+    }
   } else {
     NotifyStartError(fetcher_->GetStatus());
   }


### PR DESCRIPTION
I'm proposing this solution to the crash bug that we've been experiencing in Beaker when using custom protocols.

History:

 - There was a PR by @deepak1556 to solve this: https://github.com/electron/electron/pull/9358. That got reverted due to a regression (https://github.com/electron/electron/issues/9587).
 - Robo's suggested cause was "Race between destruction of source and sink buffers caused UAF crash." I wasn't able to confirm or disprove that (I'm still pretty new at this codebase).
 - This is the function in the chromium source that crashes:

```cpp
// url_request_job.cc
void URLRequestJob::ReadRawDataComplete(int result) {
  DCHECK(request_->status().is_io_pending());
  DCHECK_NE(ERR_IO_PENDING, result);

  // The headers should be complete before reads complete
  DCHECK(has_handled_response_);

  GatherRawReadStats(result);

  // Notify SourceStream.
  DCHECK(!read_raw_callback_.is_null());

  base::ResetAndReturn(&read_raw_callback_).Run(result);
  // |this| may be destroyed at this point.
}
```
 - It's being called by `URLRequestFetchJob::OnURLFetchComplete()` in electron. Through logging, I found that the crashes only occurred when `ReadRawDataComplete()` was called when `request_->status().is_io_pending() == false`.
 - Based on my read of `URLRequestJob`, I **believe** `ReadRawDataComplete()` only needs to be called if an async `ReadRawData()` is still in progress. I think the crash is occurring because there's no async read in progress, and `ReadRawDataComplete()` is blindly calling `read_raw_callback_` when it's a null reference. (However, because `read_raw_callback_` is private and I dont know how to do custom libchromiumcontent builds yet, I couldn't check its value to confirm that.)
 - The DCHECK against `is_io_pending()` at the top of `ReadRawDataComplete()` seems to confirm the check I'm doing.

Test case: https://github.com/pfrazee/electron-bug-video-stream-crash

```
git clone https://github.com/pfrazee/electron-bug-video-stream-crash
npm install
npm start
```

Closes https://github.com/electron/electron/issues/9342. (Related: https://github.com/electron/electron/issues/8871 https://github.com/electron/electron/issues/9635)