### PR TITLE
Update electron-download to version 4.1.0

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -12,7 +12,7 @@
   "types": "electron.d.ts",
   "dependencies": {
     "@types/node": "^8.0.24",
-    "electron-download": "^3.0.1",
+    "electron-download": "^4.1.0",
     "extract-zip": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Respects the OS cache location and be able to set he cache location by setting the environment variable `ELECTRON_CACHE`.