### PR TITLE
Removed incorrect optional labels from tray.displayBalloon(options) docs

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -245,8 +245,8 @@ win.on('hide', () => {
 
 * `options` Object
   * `icon` ([NativeImage](native-image.md) | String) - (optional)
-  * `title` String - (optional)
-  * `content` String - (optional)
+  * `title` String
+  * `content` String
 
 Displays a tray balloon.
 


### PR DESCRIPTION
Title and content was marked as optional, but the API throw error if they are not defined. 

See: https://github.com/electron/electron/blob/master/atom/browser/api/atom_api_tray.cc#L185