### PR TITLE
fix: Don't call idleWakeupsPerSecond on Windows

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1073,8 +1073,17 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
     cpu_dict.Set("percentCPUUsage",
         process_metric.second->metrics->GetPlatformIndependentCPUUsage()
         / processor_count);
+
+#if !defined(OS_WIN)
     cpu_dict.Set("idleWakeupsPerSecond",
         process_metric.second->metrics->GetIdleWakeupsPerSecond());
+#else
+    // Chrome's underlying process_metrics.cc will throw a non-fatal warning
+    // that this method isn't implemented on Windows, so set it to 0 instead
+    // of calling it
+    cpu_dict.Set("idleWakeupsPerSecond", 0);
+#endif
+
     pid_dict.Set("cpu", cpu_dict);
     pid_dict.Set("pid", process_metric.second->pid);
     pid_dict.Set("type",


### PR DESCRIPTION
On Windows, the system doesn't keep track of idle wakeups the same way Unix does - so Chromium throws a nasty `NOTIMPLEMENTED()` every single time we call `getAppMetrics()` on Windows. Nothing crashes, but it pollutes the log with lines like these:

```
[1288:1003/084000.939:ERROR:process_metrics.cc(99)] NOT IMPLEMENTED
```

This PR makes sure that we don't even attempt this not implemented call. Instead, we return 0, keeping the current behavior around.

We've done this before for the explicit call (https://github.com/electron/electron/pull/10680), but missed this one.