### PR TITLE
Workaround for Windows DPI issues

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -118,7 +118,7 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
     SetPosition(gfx::Point(x, y));
 
-#if DEFINED(OS_WIN)
+#if defined(OS_WIN)
     // Dirty, dirty workaround for
     // https://github.com/electron/electron/issues/10862
     // Somehow, we need to call `SetBounds` twice to get

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -118,7 +118,7 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
     SetPosition(gfx::Point(x, y));
 
-#if DEFINEED(OS_WIN)
+#if DEFINED(OS_WIN)
     // Dirty, dirty workaround for
     // https://github.com/electron/electron/issues/10862
     // Somehow, we need to call `SetBounds` twice to get

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -119,7 +119,7 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
     SetPosition(gfx::Point(x, y));
 
 #if defined(OS_WIN)
-    // Dirty, dirty workaround for
+    // FIXME(felixrieseberg): Dirty, dirty workaround for
     // https://github.com/electron/electron/issues/10862
     // Somehow, we need to call `SetBounds` twice to get
     // usable results. The root cause is still unknown.

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -117,6 +117,14 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   bool center;
   if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
     SetPosition(gfx::Point(x, y));
+
+#if DEFINEED(OS_WIN)
+    // Dirty, dirty workaround for
+    // https://github.com/electron/electron/issues/10862
+    // Somehow, we need to call `SetBounds` twice to get
+    // usable results. The root cause is still unknown.
+    SetPosition(gfx::Point(x, y));
+#endif
   } else if (options.Get(options::kCenter, &center) && center) {
     Center();
   }


### PR DESCRIPTION
This isn't really a solution, this is more a workaround in case we can't find any real solution. 

On Windows, multiple screens with different scaling factors result in the _first_ call to `setBounds` being incorrect. Subsequent calls will place the window correctly. This dirty fix simply does that.

Ref https://github.com/electron/electron/issues/10862