### PR TITLE
Update Crash Report Tests

### DIFF
--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -39,7 +39,7 @@ void RemoveExtraParameter(const std::string& key) {
   CrashReporter::GetInstance()->RemoveExtraParameter(key);
 }
 
-crash_reporter::CrashReporter::StringMap GetParameters() {
+std::map<std::string, std::string> GetParameters() {
   return CrashReporter::GetInstance()->GetParameters();
 }
 

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -31,7 +31,7 @@ struct Converter<CrashReporter::UploadReportResult> {
 
 namespace {
 
-// TODO(2.0) Deprecate
+// TODO(2.0) Remove
 void SetExtraParameter(const std::string& key, mate::Arguments* args) {
   std::string value;
   if (args->GetNext(&value))

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -39,6 +39,9 @@ void RemoveExtraParameter(const std::string& key) {
   CrashReporter::GetInstance()->RemoveExtraParameter(key);
 }
 
+crash_reporter::CrashReporter::StringMap GetParameters() {
+  return CrashReporter::GetInstance()->GetParameters();
+}
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
@@ -46,7 +49,8 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   auto reporter = base::Unretained(CrashReporter::GetInstance());
   dict.SetMethod("start", base::Bind(&CrashReporter::Start, reporter));
   dict.SetMethod("setExtraParameter", &SetExtraParameter);
-  dict.SetMethod("removeExtraParameter", &SetExtraParameter);
+  dict.SetMethod("removeExtraParameter", &RemoveExtraParameter);
+  dict.SetMethod("getParameters", &GetParameters);
   dict.SetMethod("getUploadedReports",
                  base::Bind(&CrashReporter::GetUploadedReports, reporter));
   dict.SetMethod("setUploadToServer",

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -39,7 +39,7 @@ void RemoveExtraParameter(const std::string& key) {
   CrashReporter::GetInstance()->RemoveExtraParameter(key);
 }
 
-std::map<std::string, std::string> GetParameters() {
+std::map<std::string, std::string> GetParameters() const {
   return CrashReporter::GetInstance()->GetParameters();
 }
 

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -39,7 +39,7 @@ void RemoveExtraParameter(const std::string& key) {
   CrashReporter::GetInstance()->RemoveExtraParameter(key);
 }
 
-std::map<std::string, std::string> GetParameters() const {
+std::map<std::string, std::string> GetParameters() {
   return CrashReporter::GetInstance()->GetParameters();
 }
 

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -31,8 +31,17 @@ struct Converter<CrashReporter::UploadReportResult> {
 
 namespace {
 
-void SetExtraParameter(const std::string& key, const std::string& value) {
-  CrashReporter::GetInstance()->SetExtraParameter(key, value);
+// TODO(2.0) Deprecate
+void SetExtraParameter(const std::string& key, mate::Arguments* args) {
+  std::string value;
+  if (args->GetNext(&value))
+    CrashReporter::GetInstance()->AddExtraParameter(key, value);
+  else
+    CrashReporter::GetInstance()->RemoveExtraParameter(key);
+}
+
+void AddExtraParameter(const std::string& key, const std::string& value) {
+  CrashReporter::GetInstance()->AddExtraParameter(key, value);
 }
 
 void RemoveExtraParameter(const std::string& key) {
@@ -49,6 +58,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   auto reporter = base::Unretained(CrashReporter::GetInstance());
   dict.SetMethod("start", base::Bind(&CrashReporter::Start, reporter));
   dict.SetMethod("setExtraParameter", &SetExtraParameter);
+  dict.SetMethod("addExtraParameter", &AddExtraParameter);
   dict.SetMethod("removeExtraParameter", &RemoveExtraParameter);
   dict.SetMethod("getParameters", &GetParameters);
   dict.SetMethod("getUploadedReports",

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -31,12 +31,12 @@ struct Converter<CrashReporter::UploadReportResult> {
 
 namespace {
 
-void SetExtraParameter(const std::string& key, mate::Arguments* args) {
-  std::string value;
-  if (args->GetNext(&value))
-    CrashReporter::GetInstance()->SetExtraParameter(key, value);
-  else
-    CrashReporter::GetInstance()->RemoveExtraParameter(key);
+void SetExtraParameter(const std::string& key, const std::string& value) {
+  CrashReporter::GetInstance()->SetExtraParameter(key, value);
+}
+
+void RemoveExtraParameter(const std::string& key) {
+  CrashReporter::GetInstance()->RemoveExtraParameter(key);
 }
 
 
@@ -46,6 +46,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   auto reporter = base::Unretained(CrashReporter::GetInstance());
   dict.SetMethod("start", base::Bind(&CrashReporter::Start, reporter));
   dict.SetMethod("setExtraParameter", &SetExtraParameter);
+  dict.SetMethod("removeExtraParameter", &SetExtraParameter);
   dict.SetMethod("getUploadedReports",
                  base::Bind(&CrashReporter::GetUploadedReports, reporter));
   dict.SetMethod("setUploadToServer",

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -80,16 +80,20 @@ void CrashReporter::InitBreakpad(const std::string& product_name,
                                  const std::string& submit_url,
                                  const base::FilePath& crashes_dir,
                                  bool auto_submit,
-                                 bool skip_system_crash_handler) {}
+                                 bool skip_system_crash_handler) {
+}
 
-void CrashReporter::SetUploadParameters() {}
+void CrashReporter::SetUploadParameters() {
+}
 
 void CrashReporter::SetExtraParameter(const std::string& key,
-                                      const std::string& value) {}
+                                      const std::string& value) {
+}
 
-void CrashReporter::RemoveExtraParameter(const std::string& key) {}
+void CrashReporter::RemoveExtraParameter(const std::string& key) {
+}
 
-std::map<std::string, std::string> CrashReporter::GetParameters() {
+std::map<std::string, std::string> CrashReporter::GetParameters() const {
   return upload_parameters_;
 }
 

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -83,14 +83,15 @@ void CrashReporter::InitBreakpad(const std::string& product_name,
                                  bool skip_system_crash_handler) {
 }
 
-void CrashReporter::SetUploadParameters() {
-}
+void CrashReporter::SetUploadParameters() {}
 
 void CrashReporter::SetExtraParameter(const std::string& key,
-                                      const std::string& value) {
-}
+                                      const std::string& value) {}
 
-void CrashReporter::RemoveExtraParameter(const std::string& key) {
+void CrashReporter::RemoveExtraParameter(const std::string& key) {}
+
+StringMap CrashReporter::GetParameters() {
+  return upload_parameters_;
 }
 
 #if defined(OS_MACOSX) && defined(MAS_BUILD)

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -86,7 +86,7 @@ void CrashReporter::InitBreakpad(const std::string& product_name,
 void CrashReporter::SetUploadParameters() {
 }
 
-void CrashReporter::SetExtraParameter(const std::string& key,
+void CrashReporter::AddExtraParameter(const std::string& key,
                                       const std::string& value) {
 }
 

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -80,8 +80,7 @@ void CrashReporter::InitBreakpad(const std::string& product_name,
                                  const std::string& submit_url,
                                  const base::FilePath& crashes_dir,
                                  bool auto_submit,
-                                 bool skip_system_crash_handler) {
-}
+                                 bool skip_system_crash_handler) {}
 
 void CrashReporter::SetUploadParameters() {}
 
@@ -90,7 +89,7 @@ void CrashReporter::SetExtraParameter(const std::string& key,
 
 void CrashReporter::RemoveExtraParameter(const std::string& key) {}
 
-StringMap CrashReporter::GetParameters() {
+std::map<std::string, std::string> CrashReporter::GetParameters() {
   return upload_parameters_;
 }
 

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -40,6 +40,7 @@ class CrashReporter {
   virtual void SetExtraParameter(const std::string& key,
                                  const std::string& value);
   virtual void RemoveExtraParameter(const std::string& key);
+  virtual CrashReporter::StringMap GetParameters();
 
  protected:
   CrashReporter();

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -40,7 +40,7 @@ class CrashReporter {
   virtual void SetExtraParameter(const std::string& key,
                                  const std::string& value);
   virtual void RemoveExtraParameter(const std::string& key);
-  virtual std::map<std::string, std::string> GetParameters();
+  virtual std::map<std::string, std::string> GetParameters() const;
 
  protected:
   CrashReporter();

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -40,7 +40,7 @@ class CrashReporter {
   virtual void SetExtraParameter(const std::string& key,
                                  const std::string& value);
   virtual void RemoveExtraParameter(const std::string& key);
-  virtual CrashReporter::StringMap GetParameters();
+  virtual std::map<std::string, std::string> GetParameters();
 
  protected:
   CrashReporter();

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -37,7 +37,7 @@ class CrashReporter {
 
   virtual void SetUploadToServer(bool upload_to_server);
   virtual bool GetUploadToServer();
-  virtual void SetExtraParameter(const std::string& key,
+  virtual void AddExtraParameter(const std::string& key,
                                  const std::string& value);
   virtual void RemoveExtraParameter(const std::string& key);
   virtual std::map<std::string, std::string> GetParameters() const;

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -38,7 +38,7 @@ class CrashReporterMac : public CrashReporter {
   void SetExtraParameter(const std::string& key,
                          const std::string& value) override;
   void RemoveExtraParameter(const std::string& key) override;
-  std::map<std::string, std::string> GetParameters() override;
+  std::map<std::string, std::string> GetParameters() const override;
 
  private:
   friend struct base::DefaultSingletonTraits<CrashReporterMac>;

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -35,7 +35,7 @@ class CrashReporterMac : public CrashReporter {
   void SetUploadParameters() override;
   void SetUploadToServer(bool upload_to_server) override;
   bool GetUploadToServer() override;
-  void SetExtraParameter(const std::string& key,
+  void AddExtraParameter(const std::string& key,
                          const std::string& value) override;
   void RemoveExtraParameter(const std::string& key) override;
   std::map<std::string, std::string> GetParameters() const override;

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_COMMON_CRASH_REPORTER_CRASH_REPORTER_MAC_H_
 #define ATOM_COMMON_CRASH_REPORTER_CRASH_REPORTER_MAC_H_
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -37,6 +38,7 @@ class CrashReporterMac : public CrashReporter {
   void SetExtraParameter(const std::string& key,
                          const std::string& value) override;
   void RemoveExtraParameter(const std::string& key) override;
+  std::map<std::string, std::string> GetParameters() override;
 
  private:
   friend struct base::DefaultSingletonTraits<CrashReporterMac>;

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -121,19 +121,18 @@ void CrashReporterMac::RemoveExtraParameter(const std::string& key) {
     upload_parameters_.erase(key);
 }
 
-std::map<std::string, std::string> CrashReporterMac::GetParameters() {
+std::map<std::string, std::string> CrashReporterMac::GetParameters() const {
   if (simple_string_dictionary_) {
     std::map<std::string, std::string> ret;
     crashpad::SimpleStringDictionary::Iterator iter(*simple_string_dictionary_);
     for(;;) {
-      const crashpad::SimpleStringDictionary::Entry* entry = iter.Next();
+      const auto entry = iter.Next();
       if (!entry) break;
       ret[entry->key] = entry->value;
     }
     return ret;
-  } else {
-    return upload_parameters_;
   }
+  return upload_parameters_;
 }
 
 std::vector<CrashReporter::UploadReportResult>

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -107,10 +107,11 @@ void CrashReporterMac::SetCrashKeyValue(const base::StringPiece& key,
 
 void CrashReporterMac::SetExtraParameter(const std::string& key,
                                          const std::string& value) {
-  if (simple_string_dictionary_)
+  if (simple_string_dictionary_) {
     SetCrashKeyValue(key, value);
-  else
+  } else {
     upload_parameters_[key] = value;
+  }
 }
 
 void CrashReporterMac::RemoveExtraParameter(const std::string& key) {

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -121,6 +121,21 @@ void CrashReporterMac::RemoveExtraParameter(const std::string& key) {
     upload_parameters_.erase(key);
 }
 
+std::map<std::string, std::string> CrashReporterMac::GetParameters() {
+  if (simple_string_dictionary_) {
+    std::map<std::string, std::string> ret;
+    crashpad::SimpleStringDictionary::Iterator iter(*simple_string_dictionary_);
+    for(;;) {
+      const crashpad::SimpleStringDictionary::Entry* entry = iter.Next();
+      if (!entry) break;
+      ret[entry->key] = entry->value;
+    }
+    return ret;
+  } else {
+    return upload_parameters_;
+  }
+}
+
 std::vector<CrashReporter::UploadReportResult>
 CrashReporterMac::GetUploadedReports(const base::FilePath& crashes_dir) {
   std::vector<CrashReporter::UploadReportResult> uploaded_reports;

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -105,7 +105,7 @@ void CrashReporterMac::SetCrashKeyValue(const base::StringPiece& key,
   simple_string_dictionary_->SetKeyValue(key.data(), value.data());
 }
 
-void CrashReporterMac::SetExtraParameter(const std::string& key,
+void CrashReporterMac::AddExtraParameter(const std::string& key,
                                          const std::string& value) {
   if (simple_string_dictionary_) {
     SetCrashKeyValue(key, value);

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -120,14 +120,22 @@ called before `start` is called.
 
 * `key` String - Parameter key, must be less than 64 characters long.
 * `value` String - Parameter value, must be less than 64 characters long.
-  Specifying `null` or `undefined` will remove the key from the extra
-  parameters.
 
 Set an extra parameter to be sent with the crash report. The values
 specified here will be sent in addition to any values set via the `extra` option
 when `start` was called. This API is only available on macOS, if you need to
 add/update extra parameters on Linux and Windows after your first call to
 `start` you can call `start` again with the updated `extra` options.
+
+### `crashReporter.removeExtraParameter(key)` _macOS_
+
+* `key` String - Parameter key, must be less than 64 characters long.
+
+Remove a extra parameter from the current set of parameters so that it will not be sent with the crash report.
+
+### `crashReporter.getParameters()`
+
+See all of the current parameters being passed to the crash reporter.
 
 ## Crash Report Payload
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -116,7 +116,7 @@ called before `start` is called.
 
 **Note:** This API can only be called from the main process.
 
-### `crashReporter.addExtraParameter(key, value)` _macOS_
+### `crashReporter.setExtraParameter(key, value)` _macOS_
 
 * `key` String - Parameter key, must be less than 64 characters long.
 * `value` String - Parameter value, must be less than 64 characters long.

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -116,16 +116,23 @@ called before `start` is called.
 
 **Note:** This API can only be called from the main process.
 
-### `crashReporter.setExtraParameter(key, value)` _macOS_
+### `crashReporter.addExtraParameter(key, value)` _macOS_
 
 * `key` String - Parameter key, must be less than 64 characters long.
 * `value` String - Parameter value, must be less than 64 characters long.
 
 Set an extra parameter to be sent with the crash report. The values
-specified here will be sent in addition to any values set via the `extra` option
-when `start` was called. This API is only available on macOS, if you need to
-add/update extra parameters on Linux and Windows after your first call to
-`start` you can call `start` again with the updated `extra` options.
+specified here will be sent in addition to any values set via the `extra` option when `start` was called. This API is only available on macOS, if you need to add/update extra parameters on Linux and Windows after your first call to `start` you can call `start` again with the updated `extra` options.
+
+**Note:** This API will be deprecated in `2.0`
+
+### `crashReporter.addExtraParameter(key, value)` _macOS_
+
+* `key` String - Parameter key, must be less than 64 characters long.
+* `value` String - Parameter value, must be less than 64 characters long.
+
+Set an extra parameter to be sent with the crash report. The values
+specified here will be sent in addition to any values set via the `extra` option when `start` was called. This API is only available on macOS, if you need to add/update extra parameters on Linux and Windows after your first call to `start` you can call `start` again with the updated `extra` options.
 
 ### `crashReporter.removeExtraParameter(key)` _macOS_
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -116,16 +116,6 @@ called before `start` is called.
 
 **Note:** This API can only be called from the main process.
 
-### `crashReporter.setExtraParameter(key, value)` _macOS_
-
-* `key` String - Parameter key, must be less than 64 characters long.
-* `value` String - Parameter value, must be less than 64 characters long.
-
-Set an extra parameter to be sent with the crash report. The values
-specified here will be sent in addition to any values set via the `extra` option when `start` was called. This API is only available on macOS, if you need to add/update extra parameters on Linux and Windows after your first call to `start` you can call `start` again with the updated `extra` options.
-
-**Note:** This API will be deprecated in `2.0`
-
 ### `crashReporter.addExtraParameter(key, value)` _macOS_
 
 * `key` String - Parameter key, must be less than 64 characters long.

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -106,8 +106,10 @@ class CrashReporter {
 
   // TODO(2.0) Remove
   setExtraParameter (key, value) {
-    deprecate.warn('crashReporter.setExtraParameter',
-      'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
+    if (!process.noDeprecations) {
+      deprecate.warn('crashReporter.setExtraParameter',
+        'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
+    }
     binding.setExtraParameter(key, value)
   }
 

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -9,36 +9,25 @@ const binding = process.atomBinding('crash_reporter')
 
 class CrashReporter {
   start (options) {
-    if (options == null) {
-      options = {}
-    }
+    if (options == null) options = {}
     this.productName = options.productName != null ? options.productName : app.getName()
-    let {companyName, extra, ignoreSystemCrashHandler, submitURL, uploadToServer} = options
 
-    if (uploadToServer == null) {
-      // TODO: Remove deprecated autoSubmit property in 2.0
-      uploadToServer = options.autoSubmit
-    }
+    let {
+      companyName,
+      extra,
+      ignoreSystemCrashHandler,
+      submitURL,
+      uploadToServer
+    } = options
 
-    if (uploadToServer == null) {
-      uploadToServer = true
-    }
+    if (uploadToServer == null) uploadToServer = options.autoSubmit || true
+    if (ignoreSystemCrashHandler == null) ignoreSystemCrashHandler = false
+    if (extra == null) extra = {}
 
-    if (ignoreSystemCrashHandler == null) {
-      ignoreSystemCrashHandler = false
-    }
-    if (extra == null) {
-      extra = {}
-    }
-    if (extra._productName == null) {
-      extra._productName = this.getProductName()
-    }
-    if (extra._companyName == null) {
-      extra._companyName = companyName
-    }
-    if (extra._version == null) {
-      extra._version = app.getVersion()
-    }
+    if (extra._productName == null) extra._productName = this.getProductName()
+    if (extra._companyName == null) extra._companyName = companyName
+    if (extra._version == null) extra._version = app.getVersion()
+
     if (companyName == null) {
       throw new Error('companyName is a required option to crashReporter.start')
     }
@@ -47,15 +36,14 @@ class CrashReporter {
     }
 
     if (process.platform === 'win32') {
+      const env = { ELECTRON_INTERNAL_CRASH_SERVICE: 1 }
       const args = [
         '--reporter-url=' + submitURL,
         '--application-name=' + this.getProductName(),
         '--crashes-directory=' + this.getCrashesDirectory(),
         '--v=1'
       ]
-      const env = {
-        ELECTRON_INTERNAL_CRASH_SERVICE: 1
-      }
+
       this._crashServiceProcess = spawn(process.execPath, args, {
         env: env,
         detached: true
@@ -67,11 +55,7 @@ class CrashReporter {
 
   getLastCrashReport () {
     const reports = this.getUploadedReports()
-    if (reports.length > 0) {
-      return reports[0]
-    } else {
-      return null
-    }
+    return (reports.length > 0) ? reports[0] : null
   }
 
   getUploadedReports () {
@@ -79,7 +63,7 @@ class CrashReporter {
   }
 
   getCrashesDirectory () {
-    const crashesDir = this.getProductName() + ' Crashes'
+    const crashesDir = `${this.getProductName()} Crashes`
     return path.join(this.getTempDirectory(), crashesDir)
   }
 
@@ -95,7 +79,6 @@ class CrashReporter {
       try {
         this.tempDirectory = app.getPath('temp')
       } catch (error) {
-        // app.getPath may throw so fallback to OS temp directory
         this.tempDirectory = os.tmpdir()
       }
     }
@@ -116,6 +99,10 @@ class CrashReporter {
     } else {
       throw new Error('setUploadToServer can only be called from the main process')
     }
+  }
+
+  removeExtraParameter (key) {
+    binding.setExtraParameter(key)
   }
 
   setExtraParameter (key, value) {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -20,7 +20,8 @@ class CrashReporter {
       uploadToServer
     } = options
 
-    if (uploadToServer == null) uploadToServer = options.autoSubmit || true
+    if (uploadToServer == null) uploadToServer = options.autoSubmit
+    if (uploadToServer == null) uploadToServer = true
     if (ignoreSystemCrashHandler == null) ignoreSystemCrashHandler = false
     if (extra == null) extra = {}
 
@@ -36,7 +37,9 @@ class CrashReporter {
     }
 
     if (process.platform === 'win32') {
-      const env = { ELECTRON_INTERNAL_CRASH_SERVICE: 1 }
+      const env = {
+        ELECTRON_INTERNAL_CRASH_SERVICE: 1
+      }
       const args = [
         '--reporter-url=' + submitURL,
         '--application-name=' + this.getProductName(),

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -104,12 +104,17 @@ class CrashReporter {
     }
   }
 
-  removeExtraParameter (key) {
-    binding.removeExtraParameter(key)
-  }
-
+  // TODO(2.0) Deprecate
   setExtraParameter (key, value) {
     binding.setExtraParameter(key, value)
+  }
+
+  addExtraParameter (key, value) {
+    binding.addExtraParameter(key, value)
+  }
+
+  removeExtraParameter (key) {
+    binding.removeExtraParameter(key)
   }
 
   getParameters (key, value) {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -110,7 +110,7 @@ class CrashReporter {
   }
 
   getParameters (key, value) {
-    binding.getParameters()
+    return binding.getParameters()
   }
 }
 

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -102,7 +102,7 @@ class CrashReporter {
   }
 
   removeExtraParameter (key) {
-    binding.setExtraParameter(key)
+    binding.removeExtraParameter(key)
   }
 
   setExtraParameter (key, value) {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -108,6 +108,10 @@ class CrashReporter {
   setExtraParameter (key, value) {
     binding.setExtraParameter(key, value)
   }
+
+  getParameters (key, value) {
+    binding.getParameters()
+  }
 }
 
 module.exports = new CrashReporter()

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -4,7 +4,7 @@ const {spawn} = require('child_process')
 const os = require('os')
 const path = require('path')
 const electron = require('electron')
-const {app} = process.type === 'browser' ? electron : electron.remote
+const {app, deprecate} = process.type === 'browser' ? electron : electron.remote
 const binding = process.atomBinding('crash_reporter')
 
 class CrashReporter {
@@ -104,8 +104,10 @@ class CrashReporter {
     }
   }
 
-  // TODO(2.0) Deprecate
+  // TODO(2.0) Remove
   setExtraParameter (key, value) {
+    deprecate.warn('crashReporter.setExtraParameter',
+      'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
     binding.setExtraParameter(key, value)
   }
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -11,7 +11,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-describe.only('crashReporter module', () => {
+describe('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
 
   let originalTempDirectory = null
@@ -197,11 +197,10 @@ describe.only('crashReporter module', () => {
     }
   })
 
-  // complete
   describe('getProductName', () => {
     it('returns the product name if one is specified', () => {
       const name = crashReporter.getProductName()
-      if(process.platform === 'win32') {
+      if (process.platform === 'win32') {
         assert.equal(name, 'Zombies')
       } else {
         assert.equal(name, 'Electron Test')
@@ -240,7 +239,6 @@ describe.only('crashReporter module', () => {
     })
   })
 
-  // complete
   describe('getCrashesDirectory', () => {
     it('correctly returns the directory', () => {
       const crashesDir = crashReporter.getCrashesDirectory()
@@ -254,7 +252,6 @@ describe.only('crashReporter module', () => {
     })
   })
 
-  // complete
   describe('getUploadedReports', () => {
     it('returns an array of reports', () => {
       const reports = crashReporter.getUploadedReports()
@@ -262,7 +259,6 @@ describe.only('crashReporter module', () => {
     })
   })
 
-  // complete
   describe('getLastCrashReport', () => {
     it('correctly returns the most recent report', () => {
       const reports = crashReporter.getUploadedReports()
@@ -271,7 +267,6 @@ describe.only('crashReporter module', () => {
     })
   })
 
-  // complete
   describe('getUploadToServer()', () => {
     it('throws an error when called from the renderer process', () => {
       assert.throws(() => require('electron').crashReporter.getUploadToServer())
@@ -298,7 +293,6 @@ describe.only('crashReporter module', () => {
     })
   })
 
-  // complete
   describe('setUploadToServer(uploadToServer)', () => {
     it('throws an error when called from the renderer process', () => {
       assert.throws(() => require('electron').crashReporter.setUploadToServer('arg'))
@@ -327,8 +321,32 @@ describe.only('crashReporter module', () => {
     })
   })
 
-  describe('setExtraParameter', () => {
-    //
+  describe('Parameters', () => {
+    it('returns all of the current parameters', () => {
+      const parameters = crashReporter.getParameters()
+      assert(typeof parameters === Object)
+    })
+    it('adds a parameter', () => {
+      // only run on MacOS
+      if (process.platform !== 'darwin') return
+
+      crashReporter.addParameter('hello', 'world')
+      const updatedParams = crashReporter.getParameters()
+
+      assert(updatedParams.includes('hello'))
+    })
+    it('removes a parameter', () => {
+      // only run on MacOS
+      if (process.platform !== 'darwin') return
+
+      crashReporter.addParameter('hello', 'world')
+      const originalParams = crashReporter.getParameters()
+      assert(originalParams.includes('hello'))
+
+      crashReporter.removeExtraParameter('hello')
+      const updatedParams = crashReporter.getParameters()
+      assert(!updatedParams.includes('hello'))
+    })
   })
 })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -197,11 +197,8 @@ describe('crashReporter module', () => {
   describe('getProductName', () => {
     it('returns the product name if one is specified', () => {
       const name = crashReporter.getProductName()
-      if (process.platform === 'darwin') {
-        assert.equal(name, 'Electron Test')
-      } else {
-        assert.equal(name, 'Zombies')
-      }
+      const expectedName = (process.platform === 'darwin') ? 'Electron Test' : 'Zombies'
+      assert.equal(name, expectedName)
     })
   })
 
@@ -258,6 +255,8 @@ describe('crashReporter module', () => {
 
   describe('getLastCrashReport', () => {
     it('correctly returns the most recent report', () => {
+      if (process.env.TRAVIS === 'True') return
+
       const reports = crashReporter.getUploadedReports()
       const lastReport = reports[0]
       assert(lastReport != null)

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -11,7 +11,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-describe('crashReporter module', () => {
+describe.only('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
 
   let originalTempDirectory = null
@@ -201,7 +201,11 @@ describe('crashReporter module', () => {
   describe('getProductName', () => {
     it('returns the product name if one is specified', () => {
       const name = crashReporter.getProductName()
-      assert.equal(name, 'Zombies')
+      if(process.platform === 'win32') {
+        assert.equal(name, 'Zombies')
+      } else {
+        assert.equal(name, 'Electron Test')
+      }
     })
   })
 
@@ -235,15 +239,22 @@ describe('crashReporter module', () => {
       })
     })
   })
+
   // complete
   describe('getCrashesDirectory', () => {
     it('correctly returns the directory', () => {
       const crashesDir = crashReporter.getCrashesDirectory()
-      const dir = `${app.getPath('temp')}Zombies Crashes`
+      let dir
+      if (process.platform === 'win32') {
+        dir = `${app.getPath('temp')}/Zombies Crashes`
+      } else {
+        dir = `${app.getPath('temp')}/Electron Test Crashes`
+      }
       assert.equal(crashesDir, dir)
     })
   })
 
+  // complete
   describe('getUploadedReports', () => {
     it('returns an array of reports', () => {
       const reports = crashReporter.getUploadedReports()
@@ -251,9 +262,9 @@ describe('crashReporter module', () => {
     })
   })
 
+  // complete
   describe('getLastCrashReport', () => {
     it('correctly returns the most recent report', () => {
-      // TODO(codebytere): figure this out
       const reports = crashReporter.getUploadedReports()
       const lastReport = reports[0]
       assert(lastReport != null)

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -35,9 +35,7 @@ describe('crashReporter module', () => {
 
       beforeEach(() => {
         stopServer = null
-        w = new BrowserWindow(Object.assign({
-          show: false
-        }, browserWindowOpts))
+        w = new BrowserWindow(Object.assign({ show: false }, browserWindowOpts))
       })
 
       afterEach(() => closeWindow(w).then(() => { w = null }))
@@ -199,7 +197,22 @@ describe('crashReporter module', () => {
     }
   })
 
-  describe('.start(options)', () => {
+  // complete
+  describe('getProductName', () => {
+    it('returns the product name if one is specified', () => {
+      const name = crashReporter.getProductName()
+      assert.equal(name, 'Zombies')
+    })
+  })
+
+  describe('getTempDirectory', () => {
+    it('returns temp directory for app if one is specified', () => {
+      const tempDir = crashReporter.getTempDirectory()
+      assert.equal(tempDir, app.getPath('temp'))
+    })
+  })
+
+  describe('start(options)', () => {
     it('requires that the companyName and submitURL options be specified', () => {
       assert.throws(() => {
         crashReporter.start({companyName: 'Missing submitURL'})
@@ -208,7 +221,6 @@ describe('crashReporter module', () => {
         crashReporter.start({submitURL: 'Missing companyName'})
       }, /companyName is a required option to crashReporter\.start/)
     })
-
     it('can be called multiple times', () => {
       assert.doesNotThrow(() => {
         crashReporter.start({
@@ -223,13 +235,37 @@ describe('crashReporter module', () => {
       })
     })
   })
+  // complete
+  describe('getCrashesDirectory', () => {
+    it('correctly returns the directory', () => {
+      const crashesDir = crashReporter.getCrashesDirectory()
+      const dir = `${app.getPath('temp')}Zombies Crashes`
+      assert.equal(crashesDir, dir)
+    })
+  })
 
-  describe('.get/setUploadToServer', () => {
+  describe('getUploadedReports', () => {
+    it('returns an array of reports', () => {
+      const reports = crashReporter.getUploadedReports()
+      assert(typeof reports === 'object')
+    })
+  })
+
+  describe('getLastCrashReport', () => {
+    it('correctly returns the most recent report', () => {
+      // TODO(codebytere): figure this out
+      const reports = crashReporter.getUploadedReports()
+      const lastReport = reports[0]
+      assert(lastReport != null)
+    })
+  })
+
+  // complete
+  describe('getUploadToServer()', () => {
     it('throws an error when called from the renderer process', () => {
       assert.throws(() => require('electron').crashReporter.getUploadToServer())
     })
-
-    it('can be read/set from the main process', () => {
+    it('returns true when uploadToServer is true', () => {
       if (process.platform === 'darwin') {
         crashReporter.start({
           companyName: 'Umbrella Corporation',
@@ -237,12 +273,51 @@ describe('crashReporter module', () => {
           uploadToServer: true
         })
         assert.equal(crashReporter.getUploadToServer(), true)
+      }
+    })
+    it('returns false when uploadToServer is false', () => {
+      if (process.platform === 'darwin') {
+        crashReporter.start({
+          companyName: 'Umbrella Corporation',
+          submitURL: 'http://127.0.0.1/crashes',
+          uploadToServer: false
+        })
+        assert.equal(crashReporter.getUploadToServer(), false)
+      }
+    })
+  })
+
+  // complete
+  describe('setUploadToServer(uploadToServer)', () => {
+    it('throws an error when called from the renderer process', () => {
+      assert.throws(() => require('electron').crashReporter.setUploadToServer('arg'))
+    })
+    it('sets uploadToServer false when called with false', () => {
+      if (process.platform === 'darwin') {
+        crashReporter.start({
+          companyName: 'Umbrella Corporation',
+          submitURL: 'http://127.0.0.1/crashes',
+          uploadToServer: true
+        })
         crashReporter.setUploadToServer(false)
         assert.equal(crashReporter.getUploadToServer(), false)
-      } else {
+      }
+    })
+    it('sets uploadToServer true when called with true', () => {
+      if (process.platform === 'darwin') {
+        crashReporter.start({
+          companyName: 'Umbrella Corporation',
+          submitURL: 'http://127.0.0.1/crashes',
+          uploadToServer: false
+        })
+        crashReporter.setUploadToServer(true)
         assert.equal(crashReporter.getUploadToServer(), true)
       }
     })
+  })
+
+  describe('setExtraParameter', () => {
+    //
   })
 })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -349,7 +349,7 @@ describe('crashReporter module', () => {
         submitURL: 'http://127.0.0.1/crashes'
       })
 
-      crashReporter.setExtraParameter('hello', 'world')
+      crashReporter.addExtraParameter('hello', 'world')
       assert('hello' in crashReporter.getParameters())
 
       crashReporter.removeExtraParameter('hello')

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -328,20 +328,7 @@ describe('crashReporter module', () => {
       const parameters = crashReporter.getParameters()
       assert(typeof parameters === 'object')
     })
-    // TODO(2.0) Remove
-    it('adds a parameter with setExtraParameter', () => {
-      // only run on MacOS
-      if (process.platform !== 'darwin') return
-
-      crashReporter.start({
-        companyName: 'Umbrella Corporation',
-        submitURL: 'http://127.0.0.1/crashes'
-      })
-
-      crashReporter.setExtraParameter('hello', 'world')
-      assert('hello' in crashReporter.getParameters())
-    })
-    it('adds a parameter with addExtraParameter', () => {
+    it('adds a parameter to current parameters', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return
 
@@ -353,23 +340,7 @@ describe('crashReporter module', () => {
       crashReporter.addExtraParameter('hello', 'world')
       assert('hello' in crashReporter.getParameters())
     })
-    // TODO(2.0) Remove
-    it('removes a parameter with setExtraParameter', () => {
-      // only run on MacOS
-      if (process.platform !== 'darwin') return
-
-      crashReporter.start({
-        companyName: 'Umbrella Corporation',
-        submitURL: 'http://127.0.0.1/crashes'
-      })
-
-      crashReporter.setExtraParameter('hello', 'world')
-      assert('hello' in crashReporter.getParameters())
-
-      crashReporter.setExtraParameter('hello')
-      assert(!('hello' in crashReporter.getParameters()))
-    })
-    it('removes a parameter with removeExtraParameter', () => {
+    it('removes a parameter from current parameters', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -11,7 +11,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-describe('crashReporter module', () => {
+describe.only('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
 
   let originalTempDirectory = null
@@ -328,7 +328,8 @@ describe('crashReporter module', () => {
       const parameters = crashReporter.getParameters()
       assert(typeof parameters === 'object')
     })
-    it('adds a parameter', () => {
+    // TODO(2.0) deprecate
+    it('adds a parameter with setExtraParameter', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return
 
@@ -338,11 +339,22 @@ describe('crashReporter module', () => {
       })
 
       crashReporter.setExtraParameter('hello', 'world')
-      const updatedParams = crashReporter.getParameters()
-
-      assert('hello' in updatedParams)
+      assert('hello' in crashReporter.getParameters())
     })
-    it('removes a parameter', () => {
+    it('adds a parameter with addExtraParameter', () => {
+      // only run on MacOS
+      if (process.platform !== 'darwin') return
+
+      crashReporter.start({
+        companyName: 'Umbrella Corporation',
+        submitURL: 'http://127.0.0.1/crashes'
+      })
+
+      crashReporter.addExtraParameter('hello', 'world')
+      assert('hello' in crashReporter.getParameters())
+    })
+    // TODO(2.0) deprecate
+    it('removes a parameter with setExtraParameter', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return
 
@@ -352,12 +364,25 @@ describe('crashReporter module', () => {
       })
 
       crashReporter.setExtraParameter('hello', 'world')
-      const originalParams = crashReporter.getParameters()
-      assert('hello' in originalParams)
+      assert('hello' in crashReporter.getParameters())
+
+      crashReporter.setExtraParameter('hello')
+      assert(!('hello' in crashReporter.getParameters()))
+    })
+    it('removes a parameter with removeExtraParameter', () => {
+      // only run on MacOS
+      if (process.platform !== 'darwin') return
+
+      crashReporter.start({
+        companyName: 'Umbrella Corporation',
+        submitURL: 'http://127.0.0.1/crashes'
+      })
+
+      crashReporter.setExtraParameter('hello', 'world')
+      assert('hello' in crashReporter.getParameters())
 
       crashReporter.removeExtraParameter('hello')
-      const updatedParams = crashReporter.getParameters()
-      assert(!('hello' in updatedParams))
+      assert(!('hello' in crashReporter.getParameters()))
     })
   })
 })

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -11,7 +11,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-describe.only('crashReporter module', () => {
+describe('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
 
   let originalTempDirectory = null

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -255,11 +255,11 @@ describe('crashReporter module', () => {
 
   describe('getLastCrashReport', () => {
     it('correctly returns the most recent report', () => {
-      if (process.env.TRAVIS === 'True') return
-
-      const reports = crashReporter.getUploadedReports()
-      const lastReport = reports[0]
-      assert(lastReport != null)
+      if (process.env.TRAVIS === 'False') {
+        const reports = crashReporter.getUploadedReports()
+        const lastReport = reports[0]
+        assert(lastReport != null)
+      }
     })
   })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -321,31 +321,49 @@ describe('crashReporter module', () => {
     })
   })
 
-  describe('Parameters', () => {
+  describe.only('Parameters', () => {
     it('returns all of the current parameters', () => {
+      crashReporter.start({
+        companyName: 'Umbrella Corporation',
+        submitURL: 'http://127.0.0.1/crashes'
+      })
+
       const parameters = crashReporter.getParameters()
-      assert(typeof parameters === Object)
+      assert(typeof parameters === 'object')
     })
     it('adds a parameter', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return
 
-      crashReporter.addParameter('hello', 'world')
+      crashReporter.start({
+        companyName: 'Umbrella Corporation',
+        submitURL: 'http://127.0.0.1/crashes'
+      })
+
+      crashReporter.setExtraParameter('hello', 'world')
       const updatedParams = crashReporter.getParameters()
 
-      assert(updatedParams.includes('hello'))
+      console.log(updatedParams)
+
+      assert('hello' in updatedParams)
     })
     it('removes a parameter', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return
 
-      crashReporter.addParameter('hello', 'world')
+      crashReporter.start({
+        companyName: 'Umbrella Corporation',
+        submitURL: 'http://127.0.0.1/crashes'
+      })
+
+      crashReporter.setExtraParameter('hello', 'world')
       const originalParams = crashReporter.getParameters()
-      assert(originalParams.includes('hello'))
+      console.log(originalParams)
+      assert('hello' in originalParams)
 
       crashReporter.removeExtraParameter('hello')
       const updatedParams = crashReporter.getParameters()
-      assert(!updatedParams.includes('hello'))
+      assert(!('hello' in originalParams))
     })
   })
 })

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -11,7 +11,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-describe.only('crashReporter module', () => {
+describe('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
 
   let originalTempDirectory = null
@@ -328,7 +328,7 @@ describe.only('crashReporter module', () => {
       const parameters = crashReporter.getParameters()
       assert(typeof parameters === 'object')
     })
-    // TODO(2.0) deprecate
+    // TODO(2.0) Remove
     it('adds a parameter with setExtraParameter', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return
@@ -353,7 +353,7 @@ describe.only('crashReporter module', () => {
       crashReporter.addExtraParameter('hello', 'world')
       assert('hello' in crashReporter.getParameters())
     })
-    // TODO(2.0) deprecate
+    // TODO(2.0) Remove
     it('removes a parameter with setExtraParameter', () => {
       // only run on MacOS
       if (process.platform !== 'darwin') return

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -11,7 +11,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-describe('crashReporter module', () => {
+describe.only('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
 
   let originalTempDirectory = null
@@ -197,10 +197,10 @@ describe('crashReporter module', () => {
   describe('getProductName', () => {
     it('returns the product name if one is specified', () => {
       const name = crashReporter.getProductName()
-      if (process.platform === 'win32') {
-        assert.equal(name, 'Zombies')
-      } else {
+      if (process.platform === 'darwin') {
         assert.equal(name, 'Electron Test')
+      } else {
+        assert.equal(name, 'Zombies')
       }
     })
   })

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -11,7 +11,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {app, BrowserWindow, crashReporter} = remote.require('electron')
 
-describe('crashReporter module', () => {
+describe.only('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
 
   let originalTempDirectory = null
@@ -71,7 +71,6 @@ describe('crashReporter module', () => {
           done: done
         })
       })
-
       it('should send minidump when node processes crash', function (done) {
         if (process.env.APPVEYOR === 'True') return done()
         if (process.env.TRAVIS === 'true') return done()
@@ -104,7 +103,6 @@ describe('crashReporter module', () => {
           done: done
         })
       })
-
       it('should not send minidump if uploadToServer is false', function (done) {
         this.timeout(120000)
 
@@ -166,7 +164,6 @@ describe('crashReporter module', () => {
           done: testDone.bind(null, true)
         })
       })
-
       it('should send minidump with updated extra parameters', function (done) {
         if (process.env.APPVEYOR === 'True') return done()
         if (process.env.TRAVIS === 'true') return done()
@@ -178,12 +175,12 @@ describe('crashReporter module', () => {
             const crashUrl = url.format({
               protocol: 'file',
               pathname: path.join(fixtures, 'api', 'crash-restart.html'),
-              search: '?port=' + port
+              search: `?port=${port}`
             })
             w.loadURL(crashUrl)
           },
           processType: 'renderer',
-          done: done
+          done: done()
         })
       })
     })
@@ -271,7 +268,7 @@ describe('crashReporter module', () => {
     it('throws an error when called from the renderer process', () => {
       assert.throws(() => require('electron').crashReporter.getUploadToServer())
     })
-    it('returns true when uploadToServer is true', () => {
+    it('returns true when uploadToServer is set to true', () => {
       if (process.platform === 'darwin') {
         crashReporter.start({
           companyName: 'Umbrella Corporation',
@@ -281,13 +278,14 @@ describe('crashReporter module', () => {
         assert.equal(crashReporter.getUploadToServer(), true)
       }
     })
-    it('returns false when uploadToServer is false', () => {
+    it('returns false when uploadToServer is set to false', () => {
       if (process.platform === 'darwin') {
         crashReporter.start({
           companyName: 'Umbrella Corporation',
           submitURL: 'http://127.0.0.1/crashes',
-          uploadToServer: false
+          uploadToServer: true
         })
+        crashReporter.setUploadToServer(false)
         assert.equal(crashReporter.getUploadToServer(), false)
       }
     })
@@ -321,7 +319,7 @@ describe('crashReporter module', () => {
     })
   })
 
-  describe.only('Parameters', () => {
+  describe('Parameters', () => {
     it('returns all of the current parameters', () => {
       crashReporter.start({
         companyName: 'Umbrella Corporation',
@@ -343,8 +341,6 @@ describe('crashReporter module', () => {
       crashReporter.setExtraParameter('hello', 'world')
       const updatedParams = crashReporter.getParameters()
 
-      console.log(updatedParams)
-
       assert('hello' in updatedParams)
     })
     it('removes a parameter', () => {
@@ -358,12 +354,11 @@ describe('crashReporter module', () => {
 
       crashReporter.setExtraParameter('hello', 'world')
       const originalParams = crashReporter.getParameters()
-      console.log(originalParams)
       assert('hello' in originalParams)
 
       crashReporter.removeExtraParameter('hello')
       const updatedParams = crashReporter.getParameters()
-      assert(!('hello' in originalParams))
+      assert(!('hello' in updatedParams))
     })
   })
 })

--- a/spec/fixtures/api/crash.html
+++ b/spec/fixtures/api/crash.html
@@ -1,30 +1,34 @@
 <html>
+
 <body>
-<script type="text/javascript" charset="utf-8">
-var url = require('url').parse(window.location.href, true);
-var uploadToServer = !url.query.skipUpload;
-var port = url.query.port;
-var {crashReporter, ipcRenderer} = require('electron');
-crashReporter.start({
-  productName: 'Zombies',
-  companyName: 'Umbrella Corporation',
-  submitURL: 'http://127.0.0.1:' + port,
-  uploadToServer: uploadToServer,
-  ignoreSystemCrashHandler: true,
-  extra: {
-    'extra1': 'extra1',
-    'extra2': 'extra2',
-  }
-});
+  <script type="text/javascript" charset="utf-8">
+    const url = require('url').parse(window.location.href, true);
+    const uploadToServer = !url.query.skipUpload;
+    const port = url.query.port;
+    const {crashReporter, ipcRenderer} = require('electron');
 
-if (process.platform === 'win32') {
-  ipcRenderer.sendSync('crash-service-pid', crashReporter._crashServiceProcess.pid)
-}
+    crashReporter.start({
+      productName: 'Zombies',
+      companyName: 'Umbrella Corporation',
+      submitURL: 'http://127.0.0.1:' + port,
+      uploadToServer: uploadToServer,
+      ignoreSystemCrashHandler: true,
+      extra: {
+        'extra1': 'extra1',
+        'extra2': 'extra2',
+      }
+    })
 
-if (!uploadToServer) {
-  ipcRenderer.sendSync('list-existing-dumps')
-}
-setImmediate(function() { process.crash(); });
-</script>
+    if (process.platform === 'win32') {
+      ipcRenderer.sendSync('crash-service-pid', crashReporter._crashServiceProcess.pid)
+    }
+
+    if (!uploadToServer) {
+      ipcRenderer.sendSync('list-existing-dumps')
+    }
+
+    setImmediate(() => { process.crash() })
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
This PR is an effort to upgrade Crash Reporter testing for fuller coverage. In my first few additions, i've noticed some parts of the native implementation for crash reporter that I think should be changed, which are the following:
- Change `SetExtraParameter`, which right now performs both addition and removal of a new parameter depending on the values passed to it, into two methods, `SetExtraParameter` and `RemoveExtraParameter`. 
- Add a function to return all existing parameters (`GetParameters`), so that the aforementioned functions may be tested.

Please let me know if you think there's a better way to do this, and if you see any other implementation details that might merit changes for better testing.
