### PR TITLE
Enable "document.visibilityState/hidden" tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,44 @@
+pipeline {
+  agent none
+  stages {
+    stage('Build') {
+      parallel {
+        stage('electron-osx-x64') {
+            agent {
+              label 'osx'
+            }
+            steps {
+              sh 'script/bootstrap.py --target_arch=x64 --dev'
+              sh 'npm run lint'
+              sh 'script/build.py -c D'
+              sh 'script/test.py --ci --rebuild_native_modules'
+            }
+            post {
+              always {
+                cleanWs()
+              }
+            }
+        }
+        stage('electron-mas-x64') {
+          agent {
+            label 'osx'
+          }
+          environment {
+            MAS_BUILD = '1'
+          }
+          steps {
+            sh 'script/bootstrap.py --target_arch=x64 --dev'
+            sh 'npm run lint'
+            sh 'script/build.py -c D'
+            sh 'script/test.py --ci --rebuild_native_modules'
+          }
+          post {
+            always {
+              cleanWs()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1528,9 +1528,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  // FIXME(alexeykuzmin): Temporary disabled to unblock master.
-  // https://github.com/electron/electron/issues/10988
-  xdescribe('document.visibilityState/hidden', () => {
+  describe('document.visibilityState/hidden', () => {
     beforeEach(() => { w.destroy() })
 
     function onVisibilityChange (callback) {


### PR DESCRIPTION
The tests were disabled in #10989, task to enable them – #10988.

_There is no fix for now, the tests are simply enabled. They are expected to fail on Mac._