### PR TITLE
singletons that are retroactively turned into EventEmitters should ca…

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -10,7 +10,9 @@ const electron = require('electron')
 const {deprecate, Menu} = electron
 const {EventEmitter} = require('events')
 
+// App is an EventEmitter.
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
+EventEmitter.call(app)
 
 Object.assign(app, {
   setApplicationMenu (menu) {

--- a/lib/browser/api/auto-updater/auto-updater-native.js
+++ b/lib/browser/api/auto-updater/auto-updater-native.js
@@ -1,6 +1,8 @@
 const EventEmitter = require('events').EventEmitter
 const {autoUpdater, AutoUpdater} = process.atomBinding('auto_updater')
 
+// AutoUpdater is an EventEmitter.
 Object.setPrototypeOf(AutoUpdater.prototype, EventEmitter.prototype)
+EventEmitter.call(autoUpdater)
 
 module.exports = autoUpdater

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -9,7 +9,10 @@ const {Session} = process.atomBinding('session')
 const {net, Net} = process.atomBinding('net')
 const {URLRequest} = net
 
+// Net is an EventEmitter.
 Object.setPrototypeOf(Net.prototype, EventEmitter.prototype)
+EventEmitter.call(net)
+
 Object.setPrototypeOf(URLRequest.prototype, EventEmitter.prototype)
 
 const kSupportedProtocols = new Set(['http:', 'https:'])

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -1,6 +1,8 @@
 const {EventEmitter} = require('events')
 const {powerMonitor, PowerMonitor} = process.atomBinding('power_monitor')
 
+// PowerMonitor is an EventEmitter.
 Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
+EventEmitter.call(powerMonitor)
 
 module.exports = powerMonitor

--- a/lib/browser/api/screen.js
+++ b/lib/browser/api/screen.js
@@ -1,6 +1,8 @@
 const {EventEmitter} = require('events')
 const {screen, Screen} = process.atomBinding('screen')
 
+// Screen is an EventEmitter.
 Object.setPrototypeOf(Screen.prototype, EventEmitter.prototype)
+EventEmitter.call(screen)
 
 module.exports = screen

--- a/lib/browser/api/system-preferences.js
+++ b/lib/browser/api/system-preferences.js
@@ -1,6 +1,8 @@
 const {EventEmitter} = require('events')
 const {systemPreferences, SystemPreferences} = process.atomBinding('system_preferences')
 
+// SystemPreferences is an EventEmitter.
 Object.setPrototypeOf(SystemPreferences.prototype, EventEmitter.prototype)
+EventEmitter.call(systemPreferences)
 
 module.exports = systemPreferences

--- a/lib/renderer/api/web-frame.js
+++ b/lib/renderer/api/web-frame.js
@@ -5,6 +5,7 @@ const {webFrame, WebFrame} = process.atomBinding('web_frame')
 
 // WebFrame is an EventEmitter.
 Object.setPrototypeOf(WebFrame.prototype, EventEmitter.prototype)
+EventEmitter.call(webFrame)
 
 // Lots of webview would subscribe to webFrame's events.
 webFrame.setMaxListeners(0)


### PR DESCRIPTION
This follows up on a discussion that @mgc, @MarshallOfSound, and I had this week tracking down the root of the AutoUpdater error case crash.

### First try

At the end of that debugging session we'd decided to defer the singletons' instantiation until after `Object.setPrototypeOf(AutoUpdater.prototype, EventEmitter.prototype)` was called so that the newly-created AutoUpdater would have its EventEmitter parent fields initialized.

Unfortunately that's not going to work. Calling `new AutoUpdater()` in JS doesn't actually create a C++ AutoUpdater object because AutoUpdater and the other singletons don't insert a constructor into the JS bindings: (a) it's unnecessary binding code to (b) give clients the ability to create multiple instances of things designed to be singletons. So, while we _could_ add constructor bindings to make this possible, it opens up more potential problems.

### Second try

EventEmitter() defers its initialization to an `init()` helper function, and Samuel suggested that would work as well. I'm going to chalk this up to my inexperience with JS but I wasn't able to get `autoUpdater.init()` to work (and it _is_ defined a little differently from other members, ie `EventEmitter.init = function(){...}` vs. `EventEmitter.prototype.setMaxLixteners = function(){...}`) but IMO this is just as well because the approach I used is cleaner & should work even if Node [changes](https://github.com/nodejs/node/issues/10680) EventEmitter's internals.

### Third try

So after much prologue (and more digging and learning how native_mate works), we actually wind up with a pretty small & simple patch. after reparenting the singletons' prototypes, we call the parent's constructor...