### PR TITLE
revert electron-download dependency to ^3.0.1

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -12,7 +12,7 @@
   "types": "electron.d.ts",
   "dependencies": {
     "@types/node": "^8.0.24",
-    "electron-download": "^4.1.0",
+    "electron-download": "^3.0.1",
     "extract-zip": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
undo last week's dependency bump as per discussion at https://github.com/electron/electron/pull/10922

dependency was bumped @ 0c9e106502018a03d25c76a068d8741463a24fed