### PR TITLE
fix: Documentation: Add link to App User Model Id

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -87,3 +87,4 @@ Specification][notification-spec], including Cinnamon, Enlightenment, Unity,
 GNOME, KDE.
 
 [notification-spec]: https://developer.gnome.org/notification-spec/
+[app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx


### PR DESCRIPTION
Another tiny one-line fix I came across in our documentation.