### PR TITLE
Disable deprecation warning of `crashReported.setExtraParameter()`

### DIFF
--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -4,7 +4,7 @@ const {spawn} = require('child_process')
 const os = require('os')
 const path = require('path')
 const electron = require('electron')
-const {app, deprecate} = process.type === 'browser' ? electron : electron.remote
+const {app} = process.type === 'browser' ? electron : electron.remote
 const binding = process.atomBinding('crash_reporter')
 
 class CrashReporter {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -106,10 +106,14 @@ class CrashReporter {
 
   // TODO(2.0) Remove
   setExtraParameter (key, value) {
-    if (!process.noDeprecations) {
-      deprecate.warn('crashReporter.setExtraParameter',
-        'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
-    }
+    // TODO(alexeykuzmin): Warning disabled since it caused
+    // a couple of Crash Reported tests to time out on Mac. Add it back.
+    // https://github.com/electron/electron/issues/11012
+
+    // if (!process.noDeprecations) {
+    //   deprecate.warn('crashReporter.setExtraParameter',
+    //     'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
+    // }
     binding.setExtraParameter(key, value)
   }
 


### PR DESCRIPTION
It caused a couple of Crash Reported tests to timeout on Mac.
Task to enable it back: https://github.com/electron/electron/issues/11012

/cc @codebytere 