### PR TITLE
DO NOT MERGE: Add googletest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "vendor/libchromiumcontent"]
 	path = vendor/libchromiumcontent
 	url = https://github.com/electron/libchromiumcontent
+[submodule "vendor/googletest"]
+	path = vendor/googletest
+	url = git@github.com:google/googletest.git

--- a/electron.gyp
+++ b/electron.gyp
@@ -219,6 +219,25 @@
           ],
         }],  # OS=="linux"
       ],
+    },
+    {
+      'target_name': 'electron-xtest',
+      'type': 'executable',
+      'dependencies': [
+        '<(project_name)_lib'
+      ],
+      'sources': [
+        'test/test-runner.cpp'
+      ],
+      'include_dirs': [
+        'vendor/googletest/googletest/include',
+        'vendor/googletest/googlemock/include',
+        '.'
+      ],
+      'libraries': [
+        'googlemock/gtest/libgtest.a',
+        'googlemock/libgmock.a'
+      ],      
     },  # target <(project_name)
     {
       'target_name': '<(project_name)_lib',

--- a/test/test-runner.cpp
+++ b/test/test-runner.cpp
@@ -1,0 +1,112 @@
+#include <string>
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "atom/utility/atom_content_utility_client.h"
+
+using std::string;
+
+namespace {
+  
+/*
+  Classes with virtual functions can be mocked  
+
+  Example:
+*/
+class Turtle {
+public:
+  virtual ~Turtle() {}
+  virtual void PenUp() = 0;
+  virtual void PenDown() = 0;
+  virtual void Forward(int distance) = 0;
+  virtual void Turn(int degrees) = 0;
+  virtual void GoTo(int x, int y) = 0;
+  virtual int GetX() const = 0;
+  virtual int GetY() const = 0;
+};
+
+class MockTurtle : public Turtle {
+public:
+  MOCK_METHOD0(PenUp, void());
+  MOCK_METHOD0(PenDown, void());
+  MOCK_METHOD1(Forward, void(int distance));
+  MOCK_METHOD1(Turn, void(int degrees));
+  MOCK_METHOD2(GoTo, void(int x, int y));
+  MOCK_CONST_METHOD0(GetX, int());
+  MOCK_CONST_METHOD0(GetY, int());
+};
+
+TEST(MockTurtle, Test) {
+  using ::testing::AtLeast;
+
+  MockTurtle turtle;
+  EXPECT_CALL(turtle, PenDown()).Times(AtLeast(1));
+
+  turtle.PenDown();
+}
+
+/*
+  Let's test a class with a fixture
+*/
+
+// Let's test this class
+class Foo {
+public:
+    int Add(int i, int j) {
+        return i + j;
+    }
+};
+
+// The fixture for testing class Foo.
+class FooTest : public ::testing::Test {
+ protected:
+  // You can remove any or all of the following functions if its body
+  // is empty.
+
+  FooTest() {
+    // You can do set-up work for each test here.
+  }
+
+  virtual ~FooTest() {
+    // You can do clean-up work that doesn't throw exceptions here.
+  }
+
+  // If the constructor and destructor are not enough for setting up
+  // and cleaning up each test, you can define the following methods:
+
+  virtual void SetUp() {
+    // Code here will be called immediately after the constructor (right
+    // before each test).
+  }
+
+  virtual void TearDown() {
+    // Code here will be called immediately after each test (right
+    // before the destructor).
+  }
+
+  // Objects declared here can be used by all tests in the test case for Foo.
+
+  Foo foo1;
+  Foo foo2;
+};
+
+// Tests that the Foo::Add() method works
+TEST_F(FooTest, MethodAdd) {
+  EXPECT_EQ(2, foo1.Add(1, 1));
+  EXPECT_EQ(0, foo2.Add(-1, 1));
+}
+
+/*
+  Let's try testing something from atom namespace
+*/
+
+TEST(AtomContentUtilityClient, Create) {
+  atom::AtomContentUtilityClient acuc;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest
+++ b/unittest
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+process.on('unhandledRejection', err => {
+    throw err
+})
+
+const fs = require('fs')
+const { spawn } = require('child_process')
+
+class Task {
+    constructor(fn) {
+        this.fn = fn
+    }
+    async run() {
+        const bash = spawn('bash', [], {stdio: 'pipe'})
+
+        bash.on('error', err => {
+            throw err
+        })
+        bash.stdout.pipe(process.stdout)
+        bash.stderr.pipe(process.stderr)
+        
+        bash.stdin.write('set -e\n')
+        
+        function shell([string]) {
+            console.log(`> ${string}`)
+            bash.stdin.write(string)
+            bash.stdin.write('\n')
+        }
+    
+        const done = new Promise((pass, fail) => {
+            bash.on('exit', (code, sig) => {
+                if (code || sig) {
+                    fail(`Process exited ${code||sig}`)
+                } else {
+                    pass()
+                }
+            })
+        })
+    
+        await this.fn(shell)
+    
+        bash.stdin.end()
+    
+        await done
+    }
+}
+
+function task(fn) {
+    return new Task(fn)
+}
+
+function stamp(filename, fn) {
+    return function (...args) {
+        return new Promise((pass, fail) => {
+            fs.exists(filename, async (exists) => {
+                if (exists) {
+                    console.log('Skipping: STAMP exists')
+                    return pass()
+                } else {
+                    await fn(...args)
+                    fs.writeFile(filename, Date.now(), (err) => {
+                        if (err) return fail(err)
+                        else return pass()
+                    })
+                }
+            })
+        })
+    }
+}
+
+// ------------------
+
+// I created a little build tool
+// I'm sorry ¯＼(º_o)/¯
+
+const libgtest_prep = task(stamp('.googletest-prep', async (shell) => {
+    await shell`mkdir -p out/R`
+    await shell`cd out/R`
+    await shell`cmake ../../vendor/googletest/`
+}))
+
+const libgtest = task(stamp('.googletest-make', async (shell) => {
+    await libgtest_prep.run()
+
+    await shell`cd out/R`
+    await shell`make`
+}))
+
+const testExecGyp = task(async shell => {
+    await libgtest.run()
+
+    await shell`python vendor/gyp/gyp_main.py -f ninja --depth . electron.gyp -Icommon.gypi -Dlibchromiumcontent_component=0 -Dtarget_arch=x64 -Dhost_arch=x64 -Dlibrary=static_library -Dmas_build=0 -R electron-xtest`
+})
+
+const testExec = task(async shell => {
+    await testExecGyp.run()
+
+    await shell`./vendor/depot_tools/ninja -C out/R`
+    await shell`install_name_tool -change  /usr/local/lib/libnode.dylib $(pwd)/out/R/libnode.dylib out/R/electron-xtest.app/Contents/MacOS/electron-xtest`
+    await shell`install_name_tool -change  @rpath/libffmpeg.dylib $(pwd)/vendor/download/libchromiumcontent/ffmpeg/libffmpeg.dylib out/R/electron-xtest.app/Contents/MacOS/electron-xtest`
+})
+
+const test = task(async shell => {
+    await testExec.run()
+
+    await shell`./out/R/electron-xtest.app/Contents/MacOS/electron-xtest`
+})
+
+// ------------------
+
+test.run()


### PR DESCRIPTION
 We want to have the ability to add c++ unit tests. This is my first attempt at adding [googletest](https://github.com/google/googletest), which is used in Chromium and a few other projects to run c++ unit tests.

I won't feel bad if this never gets merged, but I wanted to prove out a few things:

1. get basic googletest working 🏁 
2. add a build target to *gyp* 🎯 
3. allow tests to link against the static lib 📚 
4. get google mocks working 🍖 

I didn't want to add more hacks to the build scripts. We don't really have a great task runner yet. I just created my own quickly in js (no frameworks). You still need to run `script/bootstrap -v` before running `./unittest`. I don't care what we use in the end. I'm not sure what the best practice is for building sub-targets when the build systems are different under the hood, e.g. *googletest* uses CMake.

A more practical list of what it would take to merge this:

- [ ] windows build
- [ ] mac build
- [ ] linux build
- [ ] run tests against shared build

*LOOKING FOR A DISCUSSION TEAM* 😁 