### PR TITLE
Fix crash in custom protocols caused by bad callback exec

### DIFF
--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -258,7 +258,9 @@ void URLRequestFetchJob::OnURLFetchComplete(const net::URLFetcher* source) {
       HeadersCompleted();
       return;
     }
-    ReadRawDataComplete(0);
+    if (request_->status().is_io_pending()) {
+      ReadRawDataComplete(0);
+    }
   } else {
     NotifyStartError(fetcher_->GetStatus());
   }


### PR DESCRIPTION
We got this fix merged into the 1.8.x branch with https://github.com/electron/electron/pull/10918

I wanted to make sure the fix landed in 1.7.x as well, in case I (or somebody else) cant jump to 1.8.x yet