### PR TITLE
Make ScrubberItem width dynamic

### DIFF
--- a/atom/browser/ui/cocoa/atom_touch_bar.h
+++ b/atom/browser/ui/cocoa/atom_touch_bar.h
@@ -17,7 +17,7 @@
 #include "native_mate/constructor.h"
 #include "native_mate/persistent_dictionary.h"
 
-@interface AtomTouchBar : NSObject<NSScrubberDelegate, NSScrubberDataSource> {
+@interface AtomTouchBar : NSObject<NSScrubberDelegate, NSScrubberDataSource, NSScrubberFlowLayoutDelegate> {
  @protected
   std::vector<mate::PersistentDictionary> ordered_settings_;
   std::map<std::string, mate::PersistentDictionary> settings_;

--- a/atom/browser/ui/cocoa/atom_touch_bar.mm
+++ b/atom/browser/ui/cocoa/atom_touch_bar.mm
@@ -667,4 +667,40 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   return itemView;
 }
 
+- (NSSize)scrubber:(NSScrubber *)scrubber layout:(NSScrubberFlowLayout *)layout sizeForItemAtIndex:(NSInteger)itemIndex
+{
+  NSInteger width = 50;
+  NSInteger height = 30;
+  NSInteger margin = 15;
+  NSSize defaultSize = NSMakeSize(width, height);
+
+  std::string s_id([[scrubber identifier] UTF8String]);
+  if (![self hasItemWithID:s_id]) return defaultSize;
+
+  mate::PersistentDictionary settings = settings_[s_id];
+  std::vector<mate::PersistentDictionary> items;
+  if (!settings.Get("items", &items)) return defaultSize;
+
+  if (itemIndex >= static_cast<NSInteger>(items.size())) return defaultSize;
+
+  mate::PersistentDictionary item = items[itemIndex];
+  std::string title;
+
+  if (item.Get("label", &title)) {
+    NSSize size = NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX);
+    NSRect textRect = [base::SysUTF8ToNSString(title) boundingRectWithSize:size
+                                          options:NSStringDrawingUsesLineFragmentOrigin |   NSStringDrawingUsesFontLeading
+                                          attributes:@{ NSFontAttributeName: [NSFont systemFontOfSize:0]}];
+
+    width = textRect.size.width + margin;
+  } else {
+    gfx::Image image;
+    if (item.Get("icon", &image)) {
+      width = image.AsNSImage().size.width;
+    }
+  }
+
+  return NSMakeSize(width, height);
+}
+
 @end


### PR DESCRIPTION
Depending on whether a ScrubberItem has text or an icon, this changeset calculates the actual width and sizes the TouchBar items accordingly. Previously, all ScrubberItems, regardless of their content, had a static width of 50px.

This commit also fixes #10539.

It simply turns this:

![1](https://user-images.githubusercontent.com/698308/32469025-177f27a8-c351-11e7-9f09-4e6ad6d8eb88.jpg)

into this:

![2](https://user-images.githubusercontent.com/698308/32469031-1d52214e-c351-11e7-995d-3484e9a7a2c2.jpg)
