### PR TITLE
Move to using Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,44 @@
+pipeline {
+  agent none
+  stages {
+    stage('Build') {
+      parallel {
+        stage('electron-osx-x64') {
+            agent {
+              label 'osx'
+            }
+            steps {
+              sh 'script/bootstrap.py --target_arch=x64 --dev'
+              sh 'npm run lint'
+              sh 'script/build.py -c D'
+              sh 'script/test.py --ci --rebuild_native_modules'
+            }
+            post {
+              always {
+                cleanWs()
+              }
+            }
+        }
+        stage('electron-mas-x64') {
+          agent {
+            label 'osx'
+          }
+          environment {
+            MAS_BUILD = '1'
+          }
+          steps {
+            sh 'script/bootstrap.py --target_arch=x64 --dev'
+            sh 'npm run lint'
+            sh 'script/build.py -c D'
+            sh 'script/test.py --ci --rebuild_native_modules'
+          }
+          post {
+            always {
+              cleanWs()
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change will allow us to use a Jenkins pipeline to do builds in Jenkins.  This will finally give us the capability of rerunning builds on demand in Jenkins.

This intentionally only runs debug/test builds as we are going to move to running release builds on demand instead of looking for a "bump" commit.