### PR TITLE
fix: Don't crash on `setApplicationMenu(null)`

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -133,7 +133,7 @@ Menu.sendActionToFirstResponder = bindings.sendActionToFirstResponder
 
 // set application menu with a preexisting menu
 Menu.setApplicationMenu = function (menu) {
-  if (!(!menu || menu.constructor === Menu)) {
+  if (menu && menu.constructor !== Menu)) {
     throw new TypeError('Invalid menu')
   }
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -133,7 +133,7 @@ Menu.sendActionToFirstResponder = bindings.sendActionToFirstResponder
 
 // set application menu with a preexisting menu
 Menu.setApplicationMenu = function (menu) {
-  if (!(menu || menu.constructor === Menu)) {
+  if (!(!menu || menu.constructor === Menu)) {
     throw new TypeError('Invalid menu')
   }
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -133,7 +133,7 @@ Menu.sendActionToFirstResponder = bindings.sendActionToFirstResponder
 
 // set application menu with a preexisting menu
 Menu.setApplicationMenu = function (menu) {
-  if (menu && menu.constructor !== Menu)) {
+  if (menu && menu.constructor !== Menu) {
     throw new TypeError('Invalid menu')
   }
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -291,15 +291,22 @@ describe('Menu module', () => {
   })
 
   describe('Menu.setApplicationMenu', () => {
-    const menu = Menu.buildFromTemplate([
-      {
-        label: '1'
-      }, {
-        label: '2'
-      }
-    ])
-    Menu.setApplicationMenu(menu)
-    assert.notEqual(Menu.getApplicationMenu(), null)
+    it('sets a menu', () => {
+      const menu = Menu.buildFromTemplate([
+        {
+          label: '1'
+        }, {
+          label: '2'
+        }
+      ])
+      Menu.setApplicationMenu(menu)
+      assert.notEqual(Menu.getApplicationMenu(), null)
+    })
+
+    it('unsets a menu with null', () => {
+      Menu.setApplicationMenu(null)
+      assert.equal(Menu.getApplicationMenu(), null)
+    })
   })
 
   describe('MenuItem.click', () => {


### PR DESCRIPTION
We found a little bug that snuck in during the ES6 transition. This PR ensures that calling `setApplicationMenu(null)` (which removes the current menu) doesn't crash.

Also: A spec!

Fixes #11052