### PR TITLE
Allow BrowserWindows to emit `console-message` events.

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -480,7 +480,7 @@ bool WebContents::DidAddMessageToConsole(content::WebContents* source,
                                          const base::string16& message,
                                          int32_t line_no,
                                          const base::string16& source_id) {
-  if (type_ == BROWSER_WINDOW || type_ == OFF_SCREEN) {
+  if (type_ == OFF_SCREEN) {
     return false;
   } else {
     Emit("console-message", level, message, line_no, source_id);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -591,7 +591,7 @@ Returns:
 
 Emitted when a `<webview>` has been attached to this web contents.
 
-### Event: 'console-message'
+#### Event: 'console-message'
 
 Returns:
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -591,6 +591,18 @@ Returns:
 
 Emitted when a `<webview>` has been attached to this web contents.
 
+### Event: 'console-message'
+
+Returns:
+
+* `level` Integer
+* `message` String
+* `line` Integer
+* `sourceId` String
+
+Emitted when the associated window logs a console message. Will not be emitted
+for windows with *offscreen rendering* enabled.
+
 ### Instance Methods
 
 #### `contents.loadURL(url[, options])`

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -667,4 +667,14 @@ describe('webContents module', () => {
       w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'theme-color.html')}`)
     })
   })
+
+  describe('console-message event', () => {
+    it('is triggered with correct log message', (done) => {
+      w.webContents.on('console-message', (e, level, message) => {
+        assert.equal(message, 'a')
+        done()
+      })
+      w.loadURL(`file://${fixtures}/pages/a.html`)
+    })
+  })
 })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -671,8 +671,10 @@ describe('webContents module', () => {
   describe('console-message event', () => {
     it('is triggered with correct log message', (done) => {
       w.webContents.on('console-message', (e, level, message) => {
-        assert.equal(message, 'a')
-        done()
+        // Don't just assert as Chromium might emit other logs that we should ignore.
+        if (message === 'a') {
+          done()
+        }
       })
       w.loadURL(`file://${fixtures}/pages/a.html`)
     })


### PR DESCRIPTION
The Slack app has cases of BrowserWindows without an accompanying WebView/BrowserView that we'd like to capture logs from. This change permits that.