### PR TITLE
Document setPermissionRequestHandler(null)

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -287,7 +287,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 
 #### `ses.setPermissionRequestHandler(handler)`
 
-* `handler` Function
+* `handler` Function | null
   * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.
   * `permission` String - Enum of 'media', 'geolocation', 'notifications', 'midiSysex',
     'pointerLock', 'fullscreen', 'openExternal'.
@@ -296,6 +296,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 
 Sets the handler which can be used to respond to permission requests for the `session`.
 Calling `callback(true)` will allow the permission and `callback(false)` will reject it.
+To clear the handler, call `setPermissionRequestHandler(null)`.
 
 ```javascript
 const {session} = require('electron')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.4",
-    "electron-typescript-definitions": "^1.2.10",
+    "electron-typescript-definitions": "^1.2.11",
     "github": "^9.2.0",
     "husky": "^0.14.3",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dotenv-safe": "^4.0.4",
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
-    "electron-docs-linter": "^2.3.3",
+    "electron-docs-linter": "^2.3.4",
     "electron-typescript-definitions": "^1.2.10",
     "github": "^9.2.0",
     "husky": "^0.14.3",


### PR DESCRIPTION
We never documented how to clear a permissions request handler, leaving developers believing that we forgot to find a way to remove 'em (https://github.com/electron/electron/issues/11057).

We didn't, we just never documented it :wink:

Closes #11057