### PR TITLE
Give user access to the URL that is attempting to be openExternal'ed

### DIFF
--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -105,7 +105,7 @@ int AtomPermissionManager::RequestPermission(
       nullptr,
       response_callback);
 }
-    
+
 int AtomPermissionManager::RequestPermissionWithDetails(
     content::PermissionType permission,
     content::RenderFrameHost* render_frame_host,
@@ -173,7 +173,8 @@ int AtomPermissionManager::RequestPermissionsWithDetails(
         base::Bind(&AtomPermissionManager::OnPermissionResponse,
                    base::Unretained(this), request_id, i);
     if (details == nullptr) {
-      request_handler_.Run(web_contents, permission, callback, base::DictionaryValue());
+      request_handler_.Run(web_contents, permission, callback,
+                           base::DictionaryValue());
     } else {
       request_handler_.Run(web_contents, permission, callback, *details);
     }

--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -97,11 +97,28 @@ int AtomPermissionManager::RequestPermission(
     const GURL& requesting_origin,
     bool user_gesture,
     const StatusCallback& response_callback) {
-  return RequestPermissions(
+  return RequestPermissionWithDetails(
+      permission,
+      render_frame_host,
+      requesting_origin,
+      user_gesture,
+      nullptr,
+      response_callback);
+}
+    
+int AtomPermissionManager::RequestPermissionWithDetails(
+    content::PermissionType permission,
+    content::RenderFrameHost* render_frame_host,
+    const GURL& requesting_origin,
+    bool user_gesture,
+    const base::DictionaryValue* details,
+    const StatusCallback& response_callback) {
+  return RequestPermissionsWithDetails(
       std::vector<content::PermissionType>(1, permission),
       render_frame_host,
       requesting_origin,
       user_gesture,
+      details,
       base::Bind(&PermissionRequestResponseCallbackWrapper, response_callback));
 }
 
@@ -110,6 +127,18 @@ int AtomPermissionManager::RequestPermissions(
     content::RenderFrameHost* render_frame_host,
     const GURL& requesting_origin,
     bool user_gesture,
+    const StatusesCallback& response_callback) {
+  return RequestPermissionsWithDetails(
+    permissions, render_frame_host, requesting_origin,
+    user_gesture, nullptr, response_callback);
+}
+
+int AtomPermissionManager::RequestPermissionsWithDetails(
+    const std::vector<content::PermissionType>& permissions,
+    content::RenderFrameHost* render_frame_host,
+    const GURL& requesting_origin,
+    bool user_gesture,
+    const base::DictionaryValue* details,
     const StatusesCallback& response_callback) {
   if (permissions.empty()) {
     response_callback.Run(std::vector<blink::mojom::PermissionStatus>());
@@ -143,7 +172,11 @@ int AtomPermissionManager::RequestPermissions(
     const auto callback =
         base::Bind(&AtomPermissionManager::OnPermissionResponse,
                    base::Unretained(this), request_id, i);
-    request_handler_.Run(web_contents, permission, callback);
+    if (details == nullptr) {
+      request_handler_.Run(web_contents, permission, callback, base::DictionaryValue());
+    } else {
+      request_handler_.Run(web_contents, permission, callback, *details);
+    }
   }
 
   return request_id;

--- a/atom/browser/atom_permission_manager.h
+++ b/atom/browser/atom_permission_manager.h
@@ -10,6 +10,7 @@
 
 #include "base/callback.h"
 #include "base/id_map.h"
+#include "base/values.h"
 #include "content/public/browser/permission_manager.h"
 
 namespace content {
@@ -30,7 +31,8 @@ class AtomPermissionManager : public content::PermissionManager {
   using RequestHandler =
       base::Callback<void(content::WebContents*,
                           content::PermissionType,
-                          const StatusCallback&)>;
+                          const StatusCallback&,
+                          const base::DictionaryValue&)>;
 
   // Handler to dispatch permission requests in JS.
   void SetPermissionRequestHandler(const RequestHandler& handler);
@@ -43,6 +45,13 @@ class AtomPermissionManager : public content::PermissionManager {
       bool user_gesture,
       const base::Callback<void(blink::mojom::PermissionStatus)>& callback)
       override;
+  int RequestPermissionWithDetails(
+      content::PermissionType permission,
+      content::RenderFrameHost* render_frame_host,
+      const GURL& requesting_origin,
+      bool user_gesture,
+      const base::DictionaryValue* details,
+      const base::Callback<void(blink::mojom::PermissionStatus)>& callback);
   int RequestPermissions(
       const std::vector<content::PermissionType>& permissions,
       content::RenderFrameHost* render_frame_host,
@@ -51,6 +60,14 @@ class AtomPermissionManager : public content::PermissionManager {
       const base::Callback<void(
           const std::vector<blink::mojom::PermissionStatus>&)>& callback)
       override;
+  int RequestPermissionsWithDetails(
+      const std::vector<content::PermissionType>& permissions,
+      content::RenderFrameHost* render_frame_host,
+      const GURL& requesting_origin,
+      bool user_gesture,
+      const base::DictionaryValue* details,
+      const base::Callback<void(
+          const std::vector<blink::mojom::PermissionStatus>&)>& callback);
 
  protected:
   void OnPermissionResponse(int request_id,

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -61,7 +61,8 @@ void HandleExternalProtocolInUI(
 
   GURL escaped_url(net::EscapeExternalHandlerValue(url.spec()));
   auto callback = base::Bind(&OnOpenExternal, escaped_url);
-  permission_helper->RequestOpenExternalPermission(callback, has_user_gesture, url);
+  permission_helper->RequestOpenExternalPermission(callback, has_user_gesture,
+                                                   url);
 }
 
 void OnPdfResourceIntercepted(

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -61,7 +61,7 @@ void HandleExternalProtocolInUI(
 
   GURL escaped_url(net::EscapeExternalHandlerValue(url.spec()));
   auto callback = base::Bind(&OnOpenExternal, escaped_url);
-  permission_helper->RequestOpenExternalPermission(callback, has_user_gesture);
+  permission_helper->RequestOpenExternalPermission(callback, has_user_gesture, url);
 }
 
 void OnPdfResourceIntercepted(

--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -69,8 +69,8 @@ void WebContentsPermissionHelper::RequestPermissionWithDetails(
       web_contents_->GetBrowserContext()->GetPermissionManager());
   auto origin = web_contents_->GetLastCommittedURL();
   permission_manager->RequestPermissionWithDetails(
-    permission, rfh, origin, false, details,
-    base::Bind(&OnPermissionResponse, callback));
+      permission, rfh, origin, false, details,
+      base::Bind(&OnPermissionResponse, callback));
 }
 
 void WebContentsPermissionHelper::RequestFullscreenPermission(
@@ -106,8 +106,7 @@ void WebContentsPermissionHelper::RequestOpenExternalPermission(
     bool user_gesture,
     const GURL& url) {
   base::DictionaryValue details;
-  details.SetString("scheme", url.scheme());
-  details.SetString("url", url.spec());
+  details.SetString("externalURL", url.spec());
   RequestPermissionWithDetails(
       static_cast<content::PermissionType>(PermissionType::OPEN_EXTERNAL),
       callback, user_gesture, &details);

--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -55,13 +55,6 @@ WebContentsPermissionHelper::~WebContentsPermissionHelper() {
 void WebContentsPermissionHelper::RequestPermission(
     content::PermissionType permission,
     const base::Callback<void(bool)>& callback,
-    bool user_gesture) {
-  RequestPermissionWithDetails(permission, callback, user_gesture, nullptr);
-}
-
-void WebContentsPermissionHelper::RequestPermissionWithDetails(
-    content::PermissionType permission,
-    const base::Callback<void(bool)>& callback,
     bool user_gesture,
     const base::DictionaryValue* details) {
   auto rfh = web_contents_->GetMainFrame();
@@ -107,7 +100,7 @@ void WebContentsPermissionHelper::RequestOpenExternalPermission(
     const GURL& url) {
   base::DictionaryValue details;
   details.SetString("externalURL", url.spec());
-  RequestPermissionWithDetails(
+  RequestPermission(
       static_cast<content::PermissionType>(PermissionType::OPEN_EXTERNAL),
       callback, user_gesture, &details);
 }

--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -58,7 +58,7 @@ void WebContentsPermissionHelper::RequestPermission(
     bool user_gesture) {
   RequestPermissionWithDetails(permission, callback, user_gesture, nullptr);
 }
-    
+
 void WebContentsPermissionHelper::RequestPermissionWithDetails(
     content::PermissionType permission,
     const base::Callback<void(bool)>& callback,

--- a/atom/browser/web_contents_permission_helper.h
+++ b/atom/browser/web_contents_permission_helper.h
@@ -43,12 +43,8 @@ class WebContentsPermissionHelper
   void RequestPermission(
       content::PermissionType permission,
       const base::Callback<void(bool)>& callback,
-      bool user_gesture = false);
-  void RequestPermissionWithDetails(
-      content::PermissionType permission,
-      const base::Callback<void(bool)>& callback,
-      bool user_gesture,
-      const base::DictionaryValue* details);
+      bool user_gesture = false,
+      const base::DictionaryValue* details = nullptr);
 
   content::WebContents* web_contents_;
 

--- a/atom/browser/web_contents_permission_helper.h
+++ b/atom/browser/web_contents_permission_helper.h
@@ -33,7 +33,8 @@ class WebContentsPermissionHelper
   void RequestPointerLockPermission(bool user_gesture);
   void RequestOpenExternalPermission(
       const base::Callback<void(bool)>& callback,
-      bool user_gesture);
+      bool user_gesture,
+      const GURL& url);
 
  private:
   explicit WebContentsPermissionHelper(content::WebContents* web_contents);
@@ -43,6 +44,11 @@ class WebContentsPermissionHelper
       content::PermissionType permission,
       const base::Callback<void(bool)>& callback,
       bool user_gesture = false);
+  void RequestPermissionWithDetails(
+    content::PermissionType permission,
+    const base::Callback<void(bool)>& callback,
+    bool user_gesture,
+    const base::DictionaryValue* details);
 
   content::WebContents* web_contents_;
 

--- a/atom/browser/web_contents_permission_helper.h
+++ b/atom/browser/web_contents_permission_helper.h
@@ -45,10 +45,10 @@ class WebContentsPermissionHelper
       const base::Callback<void(bool)>& callback,
       bool user_gesture = false);
   void RequestPermissionWithDetails(
-    content::PermissionType permission,
-    const base::Callback<void(bool)>& callback,
-    bool user_gesture,
-    const base::DictionaryValue* details);
+      content::PermissionType permission,
+      const base::Callback<void(bool)>& callback,
+      bool user_gesture,
+      const base::DictionaryValue* details);
 
   content::WebContents* web_contents_;
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -293,6 +293,9 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
     'pointerLock', 'fullscreen', 'openExternal'.
   * `callback` Function
     * `permissionGranted` Boolean - Allow or deny the permission.
+  * `details` Object - Some properties are only available on certain permission types.
+    * `url` String - The url of the `openExternal` request.
+    * `scheme` String - The protocol scheme of the `openExternal` request.
 
 Sets the handler which can be used to respond to permission requests for the `session`.
 Calling `callback(true)` will allow the permission and `callback(false)` will reject it.

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -294,8 +294,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
   * `callback` Function
     * `permissionGranted` Boolean - Allow or deny the permission.
   * `details` Object - Some properties are only available on certain permission types.
-    * `url` String - The url of the `openExternal` request.
-    * `scheme` String - The protocol scheme of the `openExternal` request.
+    * `externalURL` String - The url of the `openExternal` request.
 
 Sets the handler which can be used to respond to permission requests for the `session`.
 Calling `callback(true)` will allow the permission and `callback(false)` will reject it.


### PR DESCRIPTION
Fixes #11075

This adds a `details` parameter to the permission request callback that when the request is an `openExternal` request provides the scheme and url of the request.  This can allow users to whitelist certain schemes and such.

/cc @gerges 