### PR TITLE
fix formatting in linux build instructions doc

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -149,18 +149,19 @@ information may help you.
 ### Building `libchromiumcontent` locally
 
 To avoid using the prebuilt binaries of `libchromiumcontent`, you can build `libchromiumcontent` locally.  To do so, follow these steps:
-  1. Install [depot_tools](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install)
-  2. Install [additional build dependencies](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install-additional-build-dependencies)
-  3. Fetch the git submodules:
-  
-  ```bash
-  $ git submodule update --init --recursive
-  ```
-  4. Pass the `--build_release_libcc` switch to `bootstrap.py` script:
 
-  ```bash
-  $ ./script/bootstrap.py -v --build_release_libcc
-  ```
+1. Install [depot_tools](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install)
+2. Install [additional build dependencies](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install-additional-build-dependencies)
+3. Fetch the git submodules:
+  
+```bash
+$ git submodule update --init --recursive
+```
+4. Pass the `--build_release_libcc` switch to `bootstrap.py` script:
+
+```bash
+$ ./script/bootstrap.py -v --build_release_libcc
+```
 
 Note that by default the `shared_library` configuration is not built, so you can
 only build `Release` version of Electron if you use this mode:


### PR DESCRIPTION
Fixes a formatting error discovered in https://github.com/electron/electron-i18n/issues/143