### PR TITLE
Fix resizable property not working when taskbar was resized

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -148,13 +148,11 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   } else {
     SetSizeConstraints(size_constraints);
   }
-#if defined(USE_X11)
+#if defined(OS_WIN) || defined(USE_X11)
   bool resizable;
   if (options.Get(options::kResizable, &resizable)) {
     SetResizable(resizable);
   }
-#endif
-#if defined(OS_WIN) || defined(USE_X11)
   bool closable;
   if (options.Get(options::kClosable, &closable)) {
     SetClosable(closable);

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -547,9 +547,9 @@ bool NativeWindowViews::IsFullscreen() const {
 }
 
 void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
-#if defined(USE_X11)
-  // On Linux the minimum and maximum size should be updated with window size
-  // when window is not resizable.
+#if defined(OS_WIN) || defined(USE_X11)
+  // On Linux and Windows the minimum and maximum size should be updated with
+  // window size when window is not resizable.
   if (!resizable_) {
     SetMaximumSize(bounds.size());
     SetMinimumSize(bounds.size());
@@ -594,17 +594,14 @@ void NativeWindowViews::SetContentSizeConstraints(
   // this to determine whether native widget has initialized.
   if (window_ && window_->widget_delegate())
     window_->OnSizeConstraintsChanged();
-#if defined(USE_X11)
+#if defined(OS_WIN) || defined(USE_X11)
   if (resizable_)
     old_size_constraints_ = size_constraints;
 #endif
 }
 
 void NativeWindowViews::SetResizable(bool resizable) {
-#if defined(OS_WIN)
-  if (has_frame() && thick_frame_)
-    FlipWindowStyle(GetAcceleratedWidget(), resizable, WS_THICKFRAME);
-#elif defined(USE_X11)
+#if defined(OS_WIN) || defined(USE_X11)
   if (resizable != resizable_) {
     // On Linux there is no "resizable" property of a window, we have to set
     // both the minimum and maximum size to the window size to achieve it.
@@ -618,6 +615,10 @@ void NativeWindowViews::SetResizable(bool resizable) {
           extensions::SizeConstraints(content_size, content_size));
     }
   }
+#endif
+#if defined(OS_WIN)
+  if (has_frame() && thick_frame_)
+    FlipWindowStyle(GetAcceleratedWidget(), resizable, WS_THICKFRAME);
 #endif
 
   resizable_ = resizable;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -228,12 +228,15 @@ class NativeWindowViews : public NativeWindow,
 
   // To disable the mouse events.
   std::unique_ptr<EventDisabler> event_disabler_;
-
+#endif
+#if defined(OS_WIN) || defined(USE_X11)
   // The "resizable" flag on Linux is implemented by setting size constraints,
   // we need to make sure size constraints are restored when window becomes
-  // resizable again.
+  // resizable again. This is also used on Windows, to keep taskbar resize
+  // events from resizing the window.
   extensions::SizeConstraints old_size_constraints_;
-#elif defined(OS_WIN)
+#endif
+#if defined(OS_WIN)
   // Weak ref.
   AtomDesktopWindowTreeHostWin* atom_desktop_window_tree_host_win_;
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -165,9 +165,6 @@ bool NativeWindowViews::PreHandleMSG(
       }
       return false;
     }
-    case WM_WINDOWPOSCHANGING: {
-      return !CanResize();
-    }
     default:
       return false;
   }

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -165,6 +165,13 @@ bool NativeWindowViews::PreHandleMSG(
       }
       return false;
     }
+    case WM_WINDOWPOSCHANGING: {
+      auto window_pos = reinterpret_cast<LPWINDOWPOS>(l_param);
+      if (window_pos->flags | SWP_FRAMECHANGED)
+        return !CanResize();
+
+      return false;
+    }
     default:
       return false;
   }

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -166,11 +166,7 @@ bool NativeWindowViews::PreHandleMSG(
       return false;
     }
     case WM_WINDOWPOSCHANGING: {
-      auto window_pos = reinterpret_cast<LPWINDOWPOS>(l_param);
-      if (window_pos->flags | SWP_FRAMECHANGED)
-        return !CanResize();
-
-      return false;
+      return !CanResize();
     }
     default:
       return false;

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2177,8 +2177,11 @@ describe('BrowserWindow module', () => {
         assert.equal(w.isMaximizable(), true)
         w.setFullScreenable(false)
         assert.equal(w.isMaximizable(), true)
+      })
+
+      it('is set to false when resizable state is set to false', () => {
         w.setResizable(false)
-        assert.equal(w.isMaximizable(), true)
+        assert.equal(w.isMaximizable(), false)
       })
     })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2178,6 +2178,11 @@ describe('BrowserWindow module', () => {
         w.setFullScreenable(false)
         assert.equal(w.isMaximizable(), true)
       })
+    })
+
+    describe('maximizable state (Windows only)', () => {
+      // Only implemented on windows.
+      if (process.platform !== 'win32') return
 
       it('is set to false when resizable state is set to false', () => {
         w.setResizable(false)


### PR DESCRIPTION
Currently, Windows can resize the `BrowserWindow` if the taskbar is resized, and the window no longer fits inside the new working area, even if resizable is set to false. This small change will prevent this from happening.