### PR TITLE
Fix crash when emitting unhandled error on native EventEmitter

### DIFF
--- a/atom/common/api/event_emitter_caller.cc
+++ b/atom/common/api/event_emitter_caller.cc
@@ -20,8 +20,9 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                    v8::MicrotasksScope::kRunMicrotasks);
   // Use node::MakeCallback to call the callback, and it will also run pending
   // tasks in Node.js.
-  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, obj, method, args->size(), &args->front(),
-                            {0, 0});
+  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, obj, method,
+                                                     args->size(),
+                                                     &args->front(), {0, 0});
   if (ret.IsEmpty()) {
     return v8::Boolean::New(isolate, false);
   }

--- a/atom/common/api/event_emitter_caller.cc
+++ b/atom/common/api/event_emitter_caller.cc
@@ -26,7 +26,7 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
   // If the JS function throws an exception (doesn't return a value) the result
   // of MakeCallback will be empty and therefore ToLocal will be false, in this
   // case we need to return "false" as that indicates that the event emitter did
-  // not handle the event 
+  // not handle the event
   v8::Local<v8::Value> localRet;
   if (ret.ToLocal(&localRet)) {
     return localRet;

--- a/atom/common/api/event_emitter_caller.cc
+++ b/atom/common/api/event_emitter_caller.cc
@@ -20,8 +20,9 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                    v8::MicrotasksScope::kRunMicrotasks);
   // Use node::MakeCallback to call the callback, and it will also run pending
   // tasks in Node.js.
-  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, obj, method, args->size(), &args->front(),
-                            {0, 0});
+  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, obj, method,
+                                                     args->size(),
+                                                     &args->front(), {0, 0});
   // If the JS function throws an exception (doesn't return a value) the result
   // of MakeCallback will be empty, in this case we need to return "false" as
   // that indicates that the event emitter did not handle the event

--- a/atom/common/api/event_emitter_caller.cc
+++ b/atom/common/api/event_emitter_caller.cc
@@ -20,8 +20,12 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                    v8::MicrotasksScope::kRunMicrotasks);
   // Use node::MakeCallback to call the callback, and it will also run pending
   // tasks in Node.js.
-  return node::MakeCallback(isolate, obj, method, args->size(), &args->front(),
-                            {0, 0}).ToLocalChecked();
+  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, obj, method, args->size(), &args->front(),
+                            {0, 0});
+  if (ret.IsEmpty()) {
+    return v8::Boolean::New(isolate, false);
+  }
+  return ret.ToLocalChecked();
 }
 
 }  // namespace internal

--- a/atom/common/api/event_emitter_caller.cc
+++ b/atom/common/api/event_emitter_caller.cc
@@ -20,13 +20,22 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                    v8::MicrotasksScope::kRunMicrotasks);
   // Use node::MakeCallback to call the callback, and it will also run pending
   // tasks in Node.js.
-  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, obj, method,
-                                                     args->size(),
-                                                     &args->front(), {0, 0});
+  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, obj, method, args->size(), &args->front(),
+                            {0, 0});
+  // If the JS function throws an exception (doesn't return a value) the result
+  // of MakeCallback will be empty, in this case we need to return "false" as
+  // that indicates that the event emitter did not handle the event
   if (ret.IsEmpty()) {
     return v8::Boolean::New(isolate, false);
   }
-  return ret.ToLocalChecked();
+
+  v8::Local<v8::Value> localRet;
+  if (ret.ToLocal(&localRet)) {
+    return localRet;
+  }
+  // Should be unreachable, but the compiler complains if we don't check
+  // the result of ToLocal
+  return v8::Undefined(isolate);
 }
 
 }  // namespace internal

--- a/atom/common/api/event_emitter_caller.cc
+++ b/atom/common/api/event_emitter_caller.cc
@@ -24,19 +24,14 @@ v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
                                                      args->size(),
                                                      &args->front(), {0, 0});
   // If the JS function throws an exception (doesn't return a value) the result
-  // of MakeCallback will be empty, in this case we need to return "false" as
-  // that indicates that the event emitter did not handle the event
-  if (ret.IsEmpty()) {
-    return v8::Boolean::New(isolate, false);
-  }
-
+  // of MakeCallback will be empty and therefore ToLocal will be false, in this
+  // case we need to return "false" as that indicates that the event emitter did
+  // not handle the event 
   v8::Local<v8::Value> localRet;
   if (ret.ToLocal(&localRet)) {
     return localRet;
   }
-  // Should be unreachable, but the compiler complains if we don't check
-  // the result of ToLocal
-  return v8::Undefined(isolate);
+  return v8::Boolean::New(isolate, false);
 }
 
 }  // namespace internal


### PR DESCRIPTION
This is very similar to my original fix but is now semantically correct and I can actually explain how it fixes it 👍 

Basically the return of `node::MakeCallback` will be empty if the method threw an exception.  Turns out that any call to `emit('error')` on an `EventEmitter` that didn't have an error handler threw a synchronous error inline with the emit call (wut......).  This simply handles the empty case by claiming the method returned `false` (the event was unhandled) which is semantically correct in regards to the `EventEmitter` documentation.

See https://github.com/nodejs/node/blob/master/lib/events.js#L176 for the relevant EventEmitter code.

Fixes #10433 

/cc @bpasero 