### PR TITLE
Link to the new docs translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,7 @@ const child = proc.spawn(electron)
 
 ## Documentation Translations
 
-- [Brazilian Portuguese](https://github.com/electron/electron/tree/master/docs-translations/pt-BR)
-- [Korean](https://github.com/electron/electron/tree/master/docs-translations/ko-KR)
-- [Japanese](https://github.com/electron/electron/tree/master/docs-translations/jp)
-- [Spanish](https://github.com/electron/electron/tree/master/docs-translations/es)
-- [Simplified Chinese](https://github.com/electron/electron/tree/master/docs-translations/zh-CN)
-- [Traditional Chinese](https://github.com/electron/electron/tree/master/docs-translations/zh-TW)
-- [Turkish](https://github.com/electron/electron/tree/master/docs-translations/tr-TR)
-- [Thai](https://github.com/electron/electron/tree/master/docs-translations/th-TH)
-- [Ukrainian](https://github.com/electron/electron/tree/master/docs-translations/uk-UA)
-- [Russian](https://github.com/electron/electron/tree/master/docs-translations/ru-RU)
-- [French](https://github.com/electron/electron/tree/master/docs-translations/fr-FR)
-- [Indonesian](https://github.com/electron/electron/tree/master/docs-translations/id)
+Find documentation translations in [electron/electron-18n](https://github.com/electron/electron-i18n).
 
 ## Community
 


### PR DESCRIPTION
After the `/docs-translations` deprecation in #11039, here is an updated README with a link to the [electron/electron-i18n](https://github.com/electron/electron-i18n) repository.
I replaced the old links with a very simple line, maybe we should add more informations to it.

/cc @zeke @electron/i18n 