### PR TITLE
fix: Provide full and correct version in `process.version`

### DIFF
--- a/atom/common/atom_version.h
+++ b/atom/common/atom_version.h
@@ -12,6 +12,9 @@
 
 #define ATOM_VERSION_IS_RELEASE 1
 
+#ifndef ATOM_PRE_RELEASE_VERSION
+# define ATOM_PRE_RELEASE_VERSION ""
+#endif
 
 #ifndef ATOM_TAG
 # define ATOM_TAG ""

--- a/atom/common/atom_version.h
+++ b/atom/common/atom_version.h
@@ -8,9 +8,10 @@
 #define ATOM_MAJOR_VERSION 1
 #define ATOM_MINOR_VERSION 8
 #define ATOM_PATCH_VERSION 2
-#define ATOM_LABEL_VERSION -beta.2
+#define ATOM_PRE_RELEASE_VERSION -beta.2
 
 #define ATOM_VERSION_IS_RELEASE 1
+
 
 #ifndef ATOM_TAG
 # define ATOM_TAG ""
@@ -25,13 +26,13 @@
 # define ATOM_VERSION_STRING  ATOM_STRINGIFY(ATOM_MAJOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_MINOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_PATCH_VERSION)     \
-                              ATOM_STRINGIFY(ATOM_LABEL_VERSION)     \
+                              ATOM_STRINGIFY(ATOM_PRE_RELEASE_VERSION)     \
                               ATOM_TAG
 #else
 # define ATOM_VERSION_STRING  ATOM_STRINGIFY(ATOM_MAJOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_MINOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_PATCH_VERSION)     \
-                              ATOM_STRINGIFY(ATOM_LABEL_VERSION)     \
+                              ATOM_STRINGIFY(ATOM_PRE_RELEASE_VERSION)     \
                               ATOM_TAG "-pre"
 #endif
 

--- a/atom/common/atom_version.h
+++ b/atom/common/atom_version.h
@@ -8,6 +8,7 @@
 #define ATOM_MAJOR_VERSION 1
 #define ATOM_MINOR_VERSION 8
 #define ATOM_PATCH_VERSION 2
+#define ATOM_LABEL_VERSION -beta.2
 
 #define ATOM_VERSION_IS_RELEASE 1
 
@@ -24,11 +25,13 @@
 # define ATOM_VERSION_STRING  ATOM_STRINGIFY(ATOM_MAJOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_MINOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_PATCH_VERSION)     \
+                              ATOM_STRINGIFY(ATOM_LABEL_VERSION)     \
                               ATOM_TAG
 #else
 # define ATOM_VERSION_STRING  ATOM_STRINGIFY(ATOM_MAJOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_MINOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_PATCH_VERSION)     \
+                              ATOM_STRINGIFY(ATOM_LABEL_VERSION)     \
                               ATOM_TAG "-pre"
 #endif
 

--- a/atom/common/atom_version.h
+++ b/atom/common/atom_version.h
@@ -10,14 +10,8 @@
 #define ATOM_PATCH_VERSION 2
 #define ATOM_PRE_RELEASE_VERSION -beta.2
 
-#define ATOM_VERSION_IS_RELEASE 1
-
 #ifndef ATOM_PRE_RELEASE_VERSION
 # define ATOM_PRE_RELEASE_VERSION ""
-#endif
-
-#ifndef ATOM_TAG
-# define ATOM_TAG ""
 #endif
 
 #ifndef ATOM_STRINGIFY
@@ -25,19 +19,10 @@
 #define ATOM_STRINGIFY_HELPER(n) #n
 #endif
 
-#if ATOM_VERSION_IS_RELEASE
 # define ATOM_VERSION_STRING  ATOM_STRINGIFY(ATOM_MAJOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_MINOR_VERSION) "." \
                               ATOM_STRINGIFY(ATOM_PATCH_VERSION)     \
-                              ATOM_STRINGIFY(ATOM_PRE_RELEASE_VERSION)     \
-                              ATOM_TAG
-#else
-# define ATOM_VERSION_STRING  ATOM_STRINGIFY(ATOM_MAJOR_VERSION) "." \
-                              ATOM_STRINGIFY(ATOM_MINOR_VERSION) "." \
-                              ATOM_STRINGIFY(ATOM_PATCH_VERSION)     \
-                              ATOM_STRINGIFY(ATOM_PRE_RELEASE_VERSION)     \
-                              ATOM_TAG "-pre"
-#endif
+                              ATOM_STRINGIFY(ATOM_PRE_RELEASE_VERSION)
 
 #define ATOM_VERSION "v" ATOM_VERSION_STRING
 

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -149,7 +149,11 @@ def update_version_h(versions, suffix):
       lines[i] = '#define ATOM_MAJOR_VERSION {0}\n'.format(versions[0])
       lines[i + 1] = '#define ATOM_MINOR_VERSION {0}\n'.format(versions[1])
       lines[i + 2] = '#define ATOM_PATCH_VERSION {0}\n'.format(versions[2])
-      lines[i + 3] = '#define ATOM_LABEL_VERSION {0}\n'.format(suffix)
+
+      if (suffix):
+        lines[i + 3] = '#define ATOM_PRE_RELEASE_VERSION {0}\n'.format(suffix)
+      else:
+        lines[i + 3] = '// #define ATOM_PRE_RELEASE_VERSION\n'
 
       with open(version_h, 'w') as f:
         f.write(''.join(lines))

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -85,7 +85,7 @@ def main():
   with scoped_cwd(SOURCE_ROOT):
     update_electron_gyp(version, suffix)
     update_win_rc(version, versions)
-    update_version_h(versions)
+    update_version_h(versions, suffix)
     update_info_plist(version)
     update_package_json(version, suffix)
     tag_version(version, suffix)
@@ -138,7 +138,7 @@ def update_win_rc(version, versions):
     f.write(''.join(lines))
 
 
-def update_version_h(versions):
+def update_version_h(versions, suffix):
   version_h = os.path.join('atom', 'common', 'atom_version.h')
   with open(version_h, 'r') as f:
     lines = f.readlines()
@@ -149,6 +149,7 @@ def update_version_h(versions):
       lines[i] = '#define ATOM_MAJOR_VERSION {0}\n'.format(versions[0])
       lines[i + 1] = '#define ATOM_MINOR_VERSION {0}\n'.format(versions[1])
       lines[i + 2] = '#define ATOM_PATCH_VERSION {0}\n'.format(versions[2])
+      lines[i + 3] = '#define ATOM_LABEL_VERSION {0}\n'.format(suffix)
 
       with open(version_h, 'w') as f:
         f.write(''.join(lines))

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -336,7 +336,7 @@ describe('node feature', () => {
   })
 
   it('includes the electron version in process.versions', () => {
-    assert(/^\d+\.\d+\.\d+(\S)?$/.test(process.versions.electron))
+    assert(/^\d+\.\d+\.\d+(\S*)?$/.test(process.versions.electron))
   })
 
   it('includes the chrome version in process.versions', () => {

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -336,7 +336,7 @@ describe('node feature', () => {
   })
 
   it('includes the electron version in process.versions', () => {
-    assert(/^\d+\.\d+\.\d+$/.test(process.versions.electron))
+    assert(/^\d+\.\d+\.\d+(\S)?$/.test(process.versions.electron))
   })
 
   it('includes the chrome version in process.versions', () => {


### PR DESCRIPTION
• Outputs the full and correct version from `process.version`
• Updates the `bump_version.py` script to not break it in the future

Closes https://github.com/electron/electron/issues/11101

![screen shot 2017-11-12 at 10 29 26 pm](https://user-images.githubusercontent.com/1426799/32712603-5d5e4a9e-c7fa-11e7-8a36-2618f1bf54f4.png)
