### PR TITLE
Add to deprecations spec

### DIFF
--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -11,20 +11,21 @@ const deprecate = function (oldName, newName, fn) {
 }
 
 // The method is renamed.
-deprecate.rename = (object, oldName, newName) => {
-  console.log('we are here')
+// nota bene: newName should already exist and
+// oldName is being injected for compatibility with old code
+deprecate.alias = function (object, deprecatedName, existingName) {
   let warned = false
   const newMethod = function () {
     if (!(warned || process.noDeprecation)) {
       warned = true
-      deprecate.warn(oldName, newName)
+      deprecate.warn(deprecatedName, existingName)
     }
-    return this[newName].apply(this, arguments)
+    return this[existingName].apply(this, arguments)
   }
   if (typeof object === 'function') {
-    object.prototype[oldName] = newMethod
+    object.prototype[deprecatedName] = newMethod
   } else {
-    object[oldName] = newMethod
+    object[deprecatedName] = newMethod
   }
 }
 

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -10,9 +10,7 @@ const deprecate = function (oldName, newName, fn) {
   }
 }
 
-// The method is renamed.
-// nota bene: newName should already exist and
-// oldName is being injected for compatibility with old code
+// The method is aliases and the old method is retained for backwards compat
 deprecate.alias = function (object, deprecatedName, existingName) {
   let warned = false
   const newMethod = function () {
@@ -27,50 +25,6 @@ deprecate.alias = function (object, deprecatedName, existingName) {
   } else {
     object[deprecatedName] = newMethod
   }
-}
-
-// Forward the method to member.
-deprecate.member = (object, method, member) => {
-  let warned = false
-  object.prototype[method] = function () {
-    if (!(warned || process.noDeprecation)) {
-      warned = true
-      deprecate.warn(method, `${member}.${method}`)
-    }
-    return this[member][method].apply(this[member], arguments)
-  }
-}
-
-// Deprecate a property.
-deprecate.property = (object, property, method) => {
-  return Object.defineProperty(object, property, {
-    get: function () {
-      let warned = false
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.warn(`${property} property`, `${method} method`)
-      }
-      return this[method]()
-    }
-  })
-}
-
-// Deprecate an event.
-deprecate.event = (emitter, oldName, newName, fn) => {
-  let warned = false
-  return emitter.on(newName, function (...args) {
-    if (this.listenerCount(oldName) > 0) {
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.warn(`'${oldName}' event`, `'${newName}' event`)
-      }
-      if (fn != null) {
-        fn.apply(this, arguments)
-      } else {
-        this.emit.apply(this, [oldName].concat(args))
-      }
-    }
-  })
 }
 
 deprecate.warn = (oldName, newName) => {
@@ -97,5 +51,52 @@ deprecate.setHandler = (handler) => {
 }
 
 deprecate.getHandler = () => deprecationHandler
+
+// None of the below methods are used, and so will be commented
+// out until such time that they are needed to be used and tested.
+
+// // Forward the method to member.
+// deprecate.member = (object, method, member) => {
+//   let warned = false
+//   object.prototype[method] = function () {
+//     if (!(warned || process.noDeprecation)) {
+//       warned = true
+//       deprecate.warn(method, `${member}.${method}`)
+//     }
+//     return this[member][method].apply(this[member], arguments)
+//   }
+// }
+//
+// // Deprecate a property.
+// deprecate.property = (object, property, method) => {
+//   return Object.defineProperty(object, property, {
+//     get: function () {
+//       let warned = false
+//       if (!(warned || process.noDeprecation)) {
+//         warned = true
+//         deprecate.warn(`${property} property`, `${method} method`)
+//       }
+//       return this[method]()
+//     }
+//   })
+// }
+//
+// // Deprecate an event.
+// deprecate.event = (emitter, oldName, newName, fn) => {
+//   let warned = false
+//   return emitter.on(newName, function (...args) {
+//     if (this.listenerCount(oldName) > 0) {
+//       if (!(warned || process.noDeprecation)) {
+//         warned = true
+//         deprecate.warn(`'${oldName}' event`, `'${newName}' event`)
+//       }
+//       if (fn != null) {
+//         fn.apply(this, arguments)
+//       } else {
+//         this.emit.apply(this, [oldName].concat(args))
+//       }
+//     }
+//   })
+// }
 
 module.exports = deprecate

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -11,7 +11,8 @@ const deprecate = function (oldName, newName, fn) {
 }
 
 // The method is renamed.
-deprecate.rename = function (object, oldName, newName) {
+deprecate.rename = (object, oldName, newName) => {
+  console.log('we are here')
   let warned = false
   const newMethod = function () {
     if (!(warned || process.noDeprecation)) {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -1,7 +1,6 @@
 // Deprecate a method.
 const deprecate = function (oldName, newName, fn) {
-  var warned
-  warned = false
+  let warned = false
   return function () {
     if (!(warned || process.noDeprecation)) {
       warned = true
@@ -13,9 +12,8 @@ const deprecate = function (oldName, newName, fn) {
 
 // The method is renamed.
 deprecate.rename = function (object, oldName, newName) {
-  var newMethod, warned
-  warned = false
-  newMethod = function () {
+  let warned = false
+  const newMethod = function () {
     if (!(warned || process.noDeprecation)) {
       warned = true
       deprecate.warn(oldName, newName)
@@ -30,27 +28,25 @@ deprecate.rename = function (object, oldName, newName) {
 }
 
 // Forward the method to member.
-deprecate.member = function (object, method, member) {
-  var warned
-  warned = false
+deprecate.member = (object, method, member) => {
+  let warned = false
   object.prototype[method] = function () {
     if (!(warned || process.noDeprecation)) {
       warned = true
-      deprecate.warn(method, member + '.' + method)
+      deprecate.warn(method, `${member}.${method}`)
     }
     return this[member][method].apply(this[member], arguments)
   }
 }
 
 // Deprecate a property.
-deprecate.property = function (object, property, method) {
+deprecate.property = (object, property, method) => {
   return Object.defineProperty(object, property, {
     get: function () {
-      var warned
-      warned = false
+      let warned = false
       if (!(warned || process.noDeprecation)) {
         warned = true
-        deprecate.warn(property + ' property', method + ' method')
+        deprecate.warn(`${property} property`, `${method} method`)
       }
       return this[method]()
     }
@@ -58,14 +54,13 @@ deprecate.property = function (object, property, method) {
 }
 
 // Deprecate an event.
-deprecate.event = function (emitter, oldName, newName, fn) {
-  var warned = false
+deprecate.event = (emitter, oldName, newName, fn) => {
+  let warned = false
   return emitter.on(newName, function (...args) {
-    // there is listeners for old API.
     if (this.listenerCount(oldName) > 0) {
       if (!(warned || process.noDeprecation)) {
         warned = true
-        deprecate.warn("'" + oldName + "' event", "'" + newName + "' event")
+        deprecate.warn(`'${oldName}' event`, `'${newName}' event`)
       }
       if (fn != null) {
         fn.apply(this, arguments)
@@ -76,15 +71,14 @@ deprecate.event = function (emitter, oldName, newName, fn) {
   })
 }
 
-// Print deprecation warning.
-deprecate.warn = function (oldName, newName) {
-  return deprecate.log(oldName + ' is deprecated. Use ' + newName + ' instead.')
+deprecate.warn = (oldName, newName) => {
+  return deprecate.log(`'${oldName}' is deprecated. Use '${newName}' instead.`)
 }
 
-var deprecationHandler = null
+let deprecationHandler = null
 
 // Print deprecation message.
-deprecate.log = function (message) {
+deprecate.log = (message) => {
   if (typeof deprecationHandler === 'function') {
     deprecationHandler(message)
   } else if (process.throwDeprecation) {
@@ -92,16 +86,14 @@ deprecate.log = function (message) {
   } else if (process.traceDeprecation) {
     return console.trace(message)
   } else {
-    return console.warn('(electron) ' + message)
+    return console.warn(`(electron) ${message}`)
   }
 }
 
-deprecate.setHandler = function (handler) {
+deprecate.setHandler = (handler) => {
   deprecationHandler = handler
 }
 
-deprecate.getHandler = function () {
-  return deprecationHandler
-}
+deprecate.getHandler = () => deprecationHandler
 
 module.exports = deprecate

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -7,44 +7,44 @@ describe.only('deprecations', () => {
     process.throwDeprecation = true
   })
 
-  it('allows a deprecation handler function to be specified', () => {
-    const messages = []
+  // it('allows a deprecation handler function to be specified', () => {
+  //   const messages = []
+  //
+  //   deprecations.setHandler((message) => {
+  //     messages.push(message)
+  //   })
+  //
+  //   deprecate.log('this is deprecated')
+  //   assert.deepEqual(messages, ['this is deprecated'])
+  // })
+  //
+  // it('returns a deprecation handler after one is set', () => {
+  //   const messages = []
+  //
+  //   deprecations.setHandler((message) => {
+  //     messages.push(message)
+  //   })
+  //
+  //   deprecate.log('this is deprecated')
+  //   assert(typeof deprecations.getHandler() === 'function')
+  // })
+  //
+  // it('returns a deprecation warning', () => {
+  //   const messages = []
+  //
+  //   deprecations.setHandler((message) => {
+  //     messages.push(message)
+  //   })
+  //
+  //   deprecate.warn('old', 'new')
+  //   assert.deepEqual(messages, [`'old' is deprecated. Use 'new' instead.`])
+  // })
 
-    deprecations.setHandler((message) => {
-      messages.push(message)
-    })
-
-    deprecate.log('this is deprecated')
-    assert.deepEqual(messages, ['this is deprecated'])
-  })
-
-  it('returns a deprecation handler after one is set', () => {
-    const messages = []
-
-    deprecations.setHandler((message) => {
-      messages.push(message)
-    })
-
-    deprecate.log('this is deprecated')
-    assert(typeof deprecations.getHandler() === 'function')
-  })
-
-  it('returns a deprecation warning', () => {
-    const messages = []
-
-    deprecations.setHandler((message) => {
-      messages.push(message)
-    })
-
-    deprecate.warn('old', 'new')
-    assert.deepEqual(messages, [`'old' is deprecated. Use 'new' instead.`])
-  })
-
-  it('throws an exception if no deprecation handler is specified', () => {
-    assert.throws(() => {
-      deprecate.log('this is deprecated')
-    }, /this is deprecated/)
-  })
+  // it('throws an exception if no deprecation handler is specified', () => {
+  //   assert.throws(() => {
+  //     deprecate.log('this is deprecated')
+  //   }, /this is deprecated/)
+  // })
 
   // it('deprecates a property', () => {
   //   deprecate.property(object, property, method)
@@ -60,8 +60,8 @@ describe.only('deprecations', () => {
 
   it('renames a method', () => {
     assert(typeof ipcRenderer.sendSync === 'function')
+    assert(typeof ipcRenderer.sendChannelSync === 'undefined')
     deprecate.rename(ipcRenderer, 'sendSync', 'sendChannelSync')
-    assert(typeof ipcRenderer.sendSync === 'undefined')
-    // assert(typeof ipcRenderer.sendChannelSync === 'function')
+    assert(typeof ipcRenderer.sendChannelSync === 'function')
   })
 })

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const {deprecations, deprecate, ipcRenderer} = require('electron')
+const {deprecations, deprecate, nativeImage} = require('electron')
 
 describe.only('deprecations', () => {
   beforeEach(() => {
@@ -7,44 +7,53 @@ describe.only('deprecations', () => {
     process.throwDeprecation = true
   })
 
-  // it('allows a deprecation handler function to be specified', () => {
-  //   const messages = []
-  //
-  //   deprecations.setHandler((message) => {
-  //     messages.push(message)
-  //   })
-  //
-  //   deprecate.log('this is deprecated')
-  //   assert.deepEqual(messages, ['this is deprecated'])
-  // })
-  //
-  // it('returns a deprecation handler after one is set', () => {
-  //   const messages = []
-  //
-  //   deprecations.setHandler((message) => {
-  //     messages.push(message)
-  //   })
-  //
-  //   deprecate.log('this is deprecated')
-  //   assert(typeof deprecations.getHandler() === 'function')
-  // })
-  //
-  // it('returns a deprecation warning', () => {
-  //   const messages = []
-  //
-  //   deprecations.setHandler((message) => {
-  //     messages.push(message)
-  //   })
-  //
-  //   deprecate.warn('old', 'new')
-  //   assert.deepEqual(messages, [`'old' is deprecated. Use 'new' instead.`])
-  // })
+  it('allows a deprecation handler function to be specified', () => {
+    const messages = []
 
-  // it('throws an exception if no deprecation handler is specified', () => {
-  //   assert.throws(() => {
-  //     deprecate.log('this is deprecated')
-  //   }, /this is deprecated/)
-  // })
+    deprecations.setHandler((message) => {
+      messages.push(message)
+    })
+
+    deprecate.log('this is deprecated')
+    assert.deepEqual(messages, ['this is deprecated'])
+  })
+
+  it('returns a deprecation handler after one is set', () => {
+    const messages = []
+
+    deprecations.setHandler((message) => {
+      messages.push(message)
+    })
+
+    deprecate.log('this is deprecated')
+    assert(typeof deprecations.getHandler() === 'function')
+  })
+
+  it('returns a deprecation warning', () => {
+    const messages = []
+
+    deprecations.setHandler((message) => {
+      messages.push(message)
+    })
+
+    deprecate.warn('old', 'new')
+    assert.deepEqual(messages, [`'old' is deprecated. Use 'new' instead.`])
+  })
+
+  it('renames a method', () => {
+    assert.equal(typeof nativeImage.createFromDataUrl, 'undefined')
+    assert.equal(typeof nativeImage.createFromDataURL, 'function')
+
+    deprecate.alias(nativeImage, 'createFromDataUrl', 'createFromDataURL')
+
+    assert.equal(typeof nativeImage.createFromDataUrl, 'function')
+  })
+
+  it('throws an exception if no deprecation handler is specified', () => {
+    assert.throws(() => {
+      deprecate.log('this is deprecated')
+    }, /this is deprecated/)
+  })
 
   // it('deprecates a property', () => {
   //   deprecate.property(object, property, method)
@@ -57,11 +66,4 @@ describe.only('deprecations', () => {
   // it('forwards a method to member', () => {
   //   deprecate.member(object, method, member)
   // })
-
-  it('renames a method', () => {
-    assert(typeof ipcRenderer.sendSync === 'function')
-    assert(typeof ipcRenderer.sendChannelSync === 'undefined')
-    deprecate.rename(ipcRenderer, 'sendSync', 'sendChannelSync')
-    assert(typeof ipcRenderer.sendChannelSync === 'function')
-  })
 })

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
-const {deprecations, deprecate} = require('electron')
+const {deprecations, deprecate, ipcRenderer} = require('electron')
 
-describe('deprecations', () => {
+describe.only('deprecations', () => {
   beforeEach(() => {
     deprecations.setHandler(null)
     process.throwDeprecation = true
@@ -18,9 +18,50 @@ describe('deprecations', () => {
     assert.deepEqual(messages, ['this is deprecated'])
   })
 
+  it('returns a deprecation handler after one is set', () => {
+    const messages = []
+
+    deprecations.setHandler((message) => {
+      messages.push(message)
+    })
+
+    deprecate.log('this is deprecated')
+    assert(typeof deprecations.getHandler() === 'function')
+  })
+
+  it('returns a deprecation warning', () => {
+    const messages = []
+
+    deprecations.setHandler((message) => {
+      messages.push(message)
+    })
+
+    deprecate.warn('old', 'new')
+    assert.deepEqual(messages, [`'old' is deprecated. Use 'new' instead.`])
+  })
+
   it('throws an exception if no deprecation handler is specified', () => {
     assert.throws(() => {
       deprecate.log('this is deprecated')
     }, /this is deprecated/)
+  })
+
+  // it('deprecates a property', () => {
+  //   deprecate.property(object, property, method)
+  // })
+  //
+  // it('deprecates an event', () => {
+  //   deprecate.event(emitter, oldName, newName, fn)
+  // })
+  //
+  // it('forwards a method to member', () => {
+  //   deprecate.member(object, method, member)
+  // })
+
+  it('renames a method', () => {
+    assert(typeof ipcRenderer.sendSync === 'function')
+    deprecate.rename(ipcRenderer, 'sendSync', 'sendChannelSync')
+    assert(typeof ipcRenderer.sendSync === 'undefined')
+    // assert(typeof ipcRenderer.sendChannelSync === 'function')
   })
 })

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const {deprecations, deprecate, nativeImage} = require('electron')
 
-describe.only('deprecations', () => {
+describe('deprecations', () => {
   beforeEach(() => {
     deprecations.setHandler(null)
     process.throwDeprecation = true
@@ -54,16 +54,4 @@ describe.only('deprecations', () => {
       deprecate.log('this is deprecated')
     }, /this is deprecated/)
   })
-
-  // it('deprecates a property', () => {
-  //   deprecate.property(object, property, method)
-  // })
-  //
-  // it('deprecates an event', () => {
-  //   deprecate.event(emitter, oldName, newName, fn)
-  // })
-  //
-  // it('forwards a method to member', () => {
-  //   deprecate.member(object, method, member)
-  // })
 })


### PR DESCRIPTION
Improve coverage in `common/deprecate.js`
This module also appears to be copied over from another project, so there are several implemented methods which we do not use or reference anywhere. I've commented them out.

To Do:
- [x] `deprecate.rename`
- [x] `deprecate.warn`
