### PR TITLE
Fix incorrect dependency import in example

### DIFF
--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -32,7 +32,7 @@ used:
 ```javascript
 const {app} = require('electron')
 app.on('ready', () => {
-  const {net} = require('electron')
+  const {net} = require('electron').remote
   const request = net.request('https://github.com')
   request.on('response', (response) => {
     console.log(`STATUS: ${response.statusCode}`)


### PR DESCRIPTION
[ci skip]

Electron Version: 1.7.8
OS Version: MacOS High Sierra Version 10.13.1 Beta

Was trying to import `net` module into `renderer.js`. It seems that the only attributes available from `require('electron')` are `['clipboard','crashReporter','nativeImage','shell','desktopCapturer','ipcRenderer','remote','screen','webFrame']`, none of which are `net`, which was misleading. I then found you could access built-in modules like this: https://github.com/electron/electron/blob/master/docs/api/remote.md#accessing-built-in-modules-in-the-main-process

![image](https://user-images.githubusercontent.com/19781463/32819134-8e5cfb44-c995-11e7-831a-d2e255a8fa30.png)