### PR TITLE
Expose desktopCapturer in sandbox mode.

### DIFF
--- a/lib/sandboxed_renderer/api/exports/electron.js
+++ b/lib/sandboxed_renderer/api/exports/electron.js
@@ -32,5 +32,15 @@ Object.defineProperties(exports, {
     get: function () {
       return require('../../../common/api/is-promise')
     }
+  },
+  desktopCapturer: {
+    get: function () {
+      return require('../../../renderer/api/desktop-capturer')
+    }
+  },
+  nativeImage: {
+    get: function () {
+      return require('../../../common/api/native-image')
+    }
   }
 })


### PR DESCRIPTION
`nativeImage` is a dependency of `desktopCapturer`, so it has to be exposed as well.