### PR TITLE
Add Isolated World API

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -253,9 +253,9 @@ void WebFrame::ExecuteJavaScript(const base::string16& code,
 }
 
 void WebFrame::ExecuteJavaScriptInIsolatedWorld(
-  int world_id,
-  const std::vector<mate::Dictionary>& scripts,
-  mate::Arguments* args) {
+    int world_id,
+    const std::vector<mate::Dictionary>& scripts,
+    mate::Arguments* args) {
   std::vector<blink::WebScriptSource> sources;
 
   for (const auto& script : scripts) {
@@ -279,7 +279,7 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(
   args->GetNext(&has_user_gesture);
 
   blink::WebLocalFrame::ScriptExecutionType scriptExecutionType =
-    blink::WebLocalFrame::kSynchronous;
+      blink::WebLocalFrame::kSynchronous;
   args->GetNext(&scriptExecutionType);
 
   ScriptExecutionCallback::CompletionCallback completion_callback;
@@ -292,23 +292,26 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(
       scriptExecutionType, callback.release());
 }
 
-void WebFrame::SetIsolatedWorldSecurityOrigin(int world_id,
-  const std::string& origin_url) {
-    web_frame_->SetIsolatedWorldSecurityOrigin(
+void WebFrame::SetIsolatedWorldSecurityOrigin(
+    int world_id,
+    const std::string& origin_url) {
+  web_frame_->SetIsolatedWorldSecurityOrigin(
       world_id,
       blink::WebSecurityOrigin::CreateFromString(
-        blink::WebString::FromUTF8(origin_url)));
+          blink::WebString::FromUTF8(origin_url)));
 }
 
-void WebFrame::SetIsolatedWorldContentSecurityPolicy(int world_id,
-  const std::string& security_policy) {
+void WebFrame::SetIsolatedWorldContentSecurityPolicy(
+    int world_id,
+    const std::string& security_policy) {
   web_frame_->SetIsolatedWorldContentSecurityPolicy(
-    world_id, blink::WebString::FromUTF8(security_policy));
+      world_id, blink::WebString::FromUTF8(security_policy));
 }
 
-void WebFrame::SetIsolatedWorldHumanReadableName(int world_id,
-  const std::string& name) {
-    web_frame_->SetIsolatedWorldHumanReadableName(
+void WebFrame::SetIsolatedWorldHumanReadableName(
+    int world_id,
+    const std::string& name) {
+  web_frame_->SetIsolatedWorldHumanReadableName(
       world_id, blink::WebString::FromUTF8(name));
 }
 

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -274,6 +274,13 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(int world_id,
       scriptExecutionType, callback.release());
 }
 
+void WebFrame::SetIsolatedWorldContentSecurityPolicy(int world_id,
+  const std::string& security_policy) {
+  web_frame_->SetIsolatedWorldContentSecurityPolicy(
+    world_id,
+    blink::WebString::FromUTF8(security_policy));
+}
+
 // static
 mate::Handle<WebFrame> WebFrame::Create(v8::Isolate* isolate) {
   return mate::CreateHandle(isolate, new WebFrame(isolate));
@@ -324,7 +331,9 @@ void WebFrame::BuildPrototype(
       .SetMethod("insertCSS", &WebFrame::InsertCSS)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)
       .SetMethod("executeJavaScriptInIsolatedWorld",
-        &WebFrame::ExecuteJavaScriptInIsolatedWorld)
+                 &WebFrame::ExecuteJavaScriptInIsolatedWorld)
+      .SetMethod("setIsolatedWorldContentSecurityPolicy",
+                 &WebFrame::SetIsolatedWorldContentSecurityPolicy)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
       .SetMethod("clearCache", &WebFrame::ClearCache)
       // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -277,8 +277,13 @@ void WebFrame::ExecuteJavaScriptInIsolatedWorld(int world_id,
 void WebFrame::SetIsolatedWorldContentSecurityPolicy(int world_id,
   const std::string& security_policy) {
   web_frame_->SetIsolatedWorldContentSecurityPolicy(
-    world_id,
-    blink::WebString::FromUTF8(security_policy));
+    world_id, blink::WebString::FromUTF8(security_policy));
+}
+
+void WebFrame::SetIsolatedWorldHumanReadableName(int world_id,
+  const std::string& name) {
+    web_frame_->SetIsolatedWorldHumanReadableName(
+      world_id, blink::WebString::FromUTF8(name));
 }
 
 // static
@@ -334,6 +339,8 @@ void WebFrame::BuildPrototype(
                  &WebFrame::ExecuteJavaScriptInIsolatedWorld)
       .SetMethod("setIsolatedWorldContentSecurityPolicy",
                  &WebFrame::SetIsolatedWorldContentSecurityPolicy)
+      .SetMethod("setIsolatedWorldHumanReadableName",
+                 &WebFrame::SetIsolatedWorldHumanReadableName)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
       .SetMethod("clearCache", &WebFrame::ClearCache)
       // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -19,6 +19,7 @@ class WebLocalFrame;
 }
 
 namespace mate {
+class Dictionary;
 class Arguments;
 }
 
@@ -72,15 +73,19 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   void InsertText(const std::string& text);
   void InsertCSS(const std::string& css);
 
-  // Excecuting scripts.
+  // Executing scripts.
   void ExecuteJavaScript(const base::string16& code, mate::Arguments* args);
-  void ExecuteJavaScriptInIsolatedWorld(int world_id,
-                                        const base::string16& code,
-                                        mate::Arguments* args);
+  void ExecuteJavaScriptInIsolatedWorld(
+      int world_id,
+      const std::vector<mate::Dictionary>& scripts,
+      mate::Arguments* args);
 
-  void SetIsolatedWorldContentSecurityPolicy(int world_id,
-                                             const std::string& security_policy);
-
+  // Isolated world related methods
+  void SetIsolatedWorldSecurityOrigin(int world_id,
+                                      const std::string& origin_url);
+  void SetIsolatedWorldContentSecurityPolicy(
+      int world_id,
+      const std::string& security_policy);
   void SetIsolatedWorldHumanReadableName(int world_id,
                                          const std::string& name);
 

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -81,6 +81,9 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   void SetIsolatedWorldContentSecurityPolicy(int world_id,
                                              const std::string& security_policy);
 
+  void SetIsolatedWorldHumanReadableName(int world_id,
+                                         const std::string& name);
+
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);
   void ClearCache(v8::Isolate* isolate);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "atom/renderer/guest_view_container.h"
 #include "native_mate/handle.h"
@@ -73,6 +74,9 @@ class WebFrame : public mate::Wrappable<WebFrame> {
 
   // Excecuting scripts.
   void ExecuteJavaScript(const base::string16& code, mate::Arguments* args);
+  void ExecuteJavaScriptInIsolatedWorld(int world_id,
+                                        const base::string16& code,
+                                        mate::Arguments* args);
 
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -78,6 +78,9 @@ class WebFrame : public mate::Wrappable<WebFrame> {
                                         const base::string16& code,
                                         mate::Arguments* args);
 
+  void SetIsolatedWorldContentSecurityPolicy(int world_id,
+                                             const std::string& security_policy);
+
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);
   void ClearCache(v8::Isolate* isolate);

--- a/docs/api/structures/web-source.md
+++ b/docs/api/structures/web-source.md
@@ -1,0 +1,5 @@
+# WebSource Object
+
+* `code` String
+* `url` String (optional)
+* `startLine` Integer (optional) - Default is 1.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -145,6 +145,37 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
+### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])`
+
+* `worldId` Integer
+* `scripts` [WebSource[]](structures/web-source.md)
+* `userGesture` Boolean (optional) - Default is `false`.
+* `callback` Function (optional) - Called after script has been executed.
+  * `result` Any
+
+Work like `executeJavaScript` but evaluates `scripts` in isolated context.
+
+### `webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp)`
+
+* `worldId` Integer
+* `csp` String
+
+Set the content security policy of the isolated world.
+
+### `webFrame.setIsolatedWorldHumanReadableName(worldId, name)`
+
+* `worldId` Integer
+* `name` String
+
+Set the name of the isolated world. Useful in devtools.
+
+### `webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin)`
+
+* `worldId` Integer
+* `securityOrigin` String
+
+Set the security origin of the isolated world.
+
 ### `webFrame.getResourceUsage()`
 
 Returns `Object`:


### PR DESCRIPTION
_Following #10404 and #9494_

**Background**

For extension's content scripts injection, Chromium relies on "isolated world".

> Content scripts execute in a special environment called an isolated world. They have access to the DOM of the page they are injected into, but not to any JavaScript variables or functions created by the page. It looks to each content script as if there is no other JavaScript executing on the page it is running on. The same is true in reverse: JavaScript running on the page cannot call any functions or access any variables defined by content scripts.

In Electron, the current implementation relies on `vm.runInThisContext` that does not have the same isolation properties.

**Objective**

This PR wants to add the necessary APIs to deal with isolated world and use it in content scripts injection.

**Done**

- Add `webframe.executeJavaScriptInIsolatedWorld`
- Add `webframe.setIsolatedWorldContentSecurityPolicy`
- Add `webframe.setIsolatedWorldHumanReadableName`
- Add `webframe.setIsolatedWorldSecurityOrigin`

**Todo**

- [x] Add documentation
- [x] Use plain JS object with optional properties instead of `code` and `url` parameters in `executeJavaScriptInIsolatedWorld` for map with [WebScriptSource](https://cs.chromium.org/chromium/src/third_party/WebKit/public/web/WebScriptSource.h?q=WebScriptSource&dr=CSs&l=31) functionalities 
- [x] Allow an array of WebScriptSource as parameter in `executeJavaScriptInIsolatedWorld`

**Need help**

For the last two todo, due to my poor skills with C++, I can't easily implement features. Any help is welcome  ❤️ 

_Thanks to @alexstrat for the perfect exploration, analyses and first implementation 👌_