### PR TITLE
fix: Pass on errors thrown in `executeJavaScript`

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -112,6 +112,16 @@ const webFrameMethods = [
 ]
 const webFrameMethodsWithResult = []
 
+const errorConstructors = {
+  Error,
+  EvalError,
+  RangeError,
+  ReferenceError,
+  SyntaxError,
+  TypeError,
+  URIError
+}
+
 const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
   return new Promise((resolve, reject) => {
     this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
@@ -120,7 +130,18 @@ const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
         if (typeof callback === 'function') callback(result)
         resolve(result)
       } else {
-        reject(error)
+        if (error && error.__ELECTRON_SERIALIZED_ERROR__) {
+          let rehydratedError = error
+
+          if (errorConstructors[error.name]) {
+            rehydratedError = new errorConstructors[error.name](error.message)
+            rehydratedError.stack = error.stack
+          }
+
+          reject(rehydratedError);
+        } else {
+          reject(error)
+        }
       }
     })
   })

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -130,13 +130,9 @@ const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
         if (typeof callback === 'function') callback(result)
         resolve(result)
       } else {
-        if (error && error.__ELECTRON_SERIALIZED_ERROR__) {
-          let rehydratedError = error
-
-          if (errorConstructors[error.name]) {
-            rehydratedError = new errorConstructors[error.name](error.message)
-            rehydratedError.stack = error.stack
-          }
+        if (error.__ELECTRON_SERIALIZED_ERROR__ && errorConstructors[error.name]) {
+          const rehydratedError = new errorConstructors[error.name](error.message)
+          rehydratedError.stack = error.stack
 
           reject(rehydratedError)
         } else {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -138,7 +138,7 @@ const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
             rehydratedError.stack = error.stack
           }
 
-          reject(rehydratedError);
+          reject(rehydratedError)
         } else {
           reject(error)
         }

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -45,6 +45,17 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (ev
         event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, null, resolvedResult)
       })
       .catch((resolvedError) => {
+        if (resolvedError instanceof Error) {
+          // Errors get lost, because: JSON.stringify(new Error('Message')) === {}
+          // Take the serializable properties and construct a generic object
+          resolvedError = {
+            message: resolvedError.message,
+            stack: resolvedError.stack,
+            name: resolvedError.name,
+            __ELECTRON_SERIALIZED_ERROR__: true
+          }
+        }
+
         event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, resolvedError)
       })
   }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2514,15 +2514,15 @@ describe('BrowserWindow module', () => {
     const code = `(() => "${expected}")()`
     const asyncCode = `(() => new Promise(r => setTimeout(() => r("${expected}"), 500)))()`
     const badAsyncCode = `(() => new Promise((r, e) => setTimeout(() => e("${expectedErrorMsg}"), 500)))()`
-    const errorCodes = {
-      Error: 'Promise.reject(new Error("Wamp-wamp"))',
-      ReferenceError: 'Promise.reject(new ReferenceError("Wamp-wamp"))',
-      EvalError: 'Promise.reject(new EvalError("Wamp-wamp"))',
-      RangeError: 'Promise.reject(new RangeError("Wamp-wamp"))',
-      SyntaxError: 'Promise.reject(new SyntaxError("Wamp-wamp"))',
-      TypeError: 'Promise.reject(new TypeError("Wamp-wamp"))',
-      URIError: 'Promise.reject(new URIError("Wamp-wamp"))'
-    }
+    const errorTypes = new Set([
+      Error,
+      ReferenceError,
+      EvalError,
+      RangeError,
+      SyntaxError,
+      TypeError,
+      URIError
+    ])
 
     it('doesnt throw when no calback is provided', () => {
       const result = ipcRenderer.sendSync('executeJavaScript', code, false)
@@ -2571,11 +2571,11 @@ describe('BrowserWindow module', () => {
       })
     })
     it('rejects the returned promise with an error if an Error.prototype is thrown', async () => {
-      for (const errorKey in errorCodes) {
+      for (const error in errorTypes) {
         await new Promise((resolve) => {
-          ipcRenderer.send('executeJavaScript', errorCodes[errorKey], true)
+          ipcRenderer.send('executeJavaScript', `Promise.reject(new ${error.name}("Wamp-wamp")`, true)
           ipcRenderer.once('executeJavaScript-promise-error-name', (event, name) => {
-            assert.equal(name, errorKey)
+            assert.equal(name, error.name)
             resolve()
           })
         })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -217,6 +217,10 @@ app.on('ready', function () {
       window.webContents.send('executeJavaScript-promise-response', result)
     }).catch((error) => {
       window.webContents.send('executeJavaScript-promise-error', error)
+
+      if (error && error.name) {
+        window.webContents.send('executeJavaScript-promise-error-name', error.name)
+      }
     })
 
     if (!hasCallback) {


### PR DESCRIPTION
When you reject a Promise from a `executeJavaScript` call, we pass on the rejection. That's good! However, [if you write JavaScript as recommended by the pros](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject), you'll be rejecting with an instance of `Error`, which results in an broken result of `{}`.

The reason is simple: `Error` objects don't serialize. This is true for all of them (`ReferenceError`, `TypeError`, `URIError`, etc).

```js
const myError = new Error('Something went wrong')
JSON.stringify(myError) === '{}' // true
```

The result is this, which makes no sense to developers who haven't studied Error objects and the IPC:
```js
webContents.executeJavaScript('Promise.reject(new Error("Something went wrong"));')
  .catch((error) => {
     console.log(error) // This will log '{}'
  })
```

This PR provides a fix: Let's serialize known and common Error objects for these calls in the renderer and recreate them in the main process. Also: Tests!

With this PR:
```js
webContents.executeJavaScript('Promise.reject(new Error("Something went wrong"));')
  .catch((error) => {
     console.log(error)
     // This will now log:
     // Error: Something went wrong
     //     at <anonymous>:1:16
     //     at EventEmitter.electron.ipcRenderer.on(...
     //     ...
  })
```

Closes #11155 