### PR TITLE
Update electron.atom.io -> electronjs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Electron Logo](https://electron.atom.io/images/electron-logo.svg)](https://electron.atom.io/)
+[![Electron Logo](https://electronjs.org/images/electron-logo.svg)](https://electronjs.org)
 
 [![Travis Build Status](https://travis-ci.org/electron/electron.svg?branch=master)](https://travis-ci.org/electron/electron)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/bc56v83355fi3369/branch/master?svg=true)](https://ci.appveyor.com/project/electron-bot/electron/branch/master)
@@ -11,7 +11,7 @@ View these docs in other languages at [electron/electron-i18n](https://github.co
 The Electron framework lets you write cross-platform desktop applications
 using JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and
 [Chromium](http://www.chromium.org) and is used by the [Atom
-editor](https://github.com/atom/atom) and many other [apps](https://electron.atom.io/apps).
+editor](https://github.com/atom/atom) and many other [apps](https://electronjs.org/apps).
 
 Follow [@ElectronJS](https://twitter.com/electronjs) on Twitter for important
 announcements.
@@ -33,10 +33,10 @@ npm install electron --save-dev --save-exact
 
 The `--save-exact` flag is recommended as Electron does not follow semantic
 versioning. For info on how to manage Electron versions in your apps, see
-[Electron versioning](https://electron.atom.io/docs/tutorial/electron-versioning/).
+[Electron versioning](https://electronjs.org/docs/tutorial/electron-versioning).
 
 For more installation options and troubleshooting tips, see
-[installation](https://electron.atom.io/docs/tutorial/installation/).
+[installation](https://electronjs.org/docs/tutorial/installation).
 
 ## Quick Start
 
@@ -53,9 +53,9 @@ npm start
 
 ## Resources for Learning Electron
 
-- [electron.atom.io/docs](http://electron.atom.io/docs) - all of Electron's documentation
+- [electronjs.org/docs](https://electronjs.org/docs) - all of Electron's documentation
 - [electron/electron-quick-start](https://github.com/electron/electron-quick-start) - a very basic starter Electron app
-- [electron.atom.io/community/#boilerplates](http://electron.atom.io/community/#boilerplates) - sample starter apps created by the community
+- [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) - sample starter apps created by the community
 - [electron/simple-samples](https://github.com/electron/simple-samples) - small applications with ideas for taking them further
 - [electron/electron-api-demos](https://github.com/electron/electron-api-demos) - an Electron app that teaches you how to use Electron
 - [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps) - small demo apps for the various Electron APIs

--- a/default_app/index.html
+++ b/default_app/index.html
@@ -204,7 +204,7 @@
 
     <nav>
       <div class="linkcol">
-        <a class="hero-link" href="https://electron.atom.io/blog">
+        <a class="hero-link" href="https://electronjs.org/blog">
           <span class="octicon hero-octicon octicon-gist" aria-hidden="true"></span>
           <h4>Blog</h4>
         </a>
@@ -216,7 +216,7 @@
         </a>
       </div>
       <div class="linkcol">
-        <a class="hero-link" href="https://electron.atom.io/docs">
+        <a class="hero-link" href="https://electronjs.org/docs">
           <span class="octicon hero-octicon octicon-gear" aria-hidden="true"></span>
           <h4>Docs</h4>
         </a>

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -138,7 +138,7 @@ app.once('ready', () => {
         {
           label: 'Learn More',
           click () {
-            shell.openExternal('https://electron.atom.io')
+            shell.openExternal('https://electronjs.org')
           }
         },
         {

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -30,7 +30,7 @@ let view = new BrowserView({
 })
 win.setBrowserView(view)
 view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
-view.webContents.loadURL('https://electron.atom.io')
+view.webContents.loadURL('https://electronjs.org')
 ```
 
 ### `new BrowserView([options])` _Experimental_

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -103,7 +103,7 @@ clipboard.
 
 ```js
 clipboard.write({
-  text: 'https://electron.atom.io',
+  text: 'https://electronjs.org',
   bookmark: 'Electron Homepage'
 })
 ```

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -167,7 +167,7 @@ const template = [
     submenu: [
       {
         label: 'Learn More',
-        click () { require('electron').shell.openExternal('https://electron.atom.io') }
+        click () { require('electron').shell.openExternal('https://electronjs.org') }
       }
     ]
   }

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -177,7 +177,7 @@ Web security is enabled by default.
 
 ```html
 <webview src="https://github.com" partition="persist:github"></webview>
-<webview src="https://electron.atom.io" partition="electron"></webview>
+<webview src="https://electronjs.org" partition="electron"></webview>
 ```
 
 Sets the session used by the page. If `partition` starts with `persist:`, the

--- a/docs/tutorial/about.md
+++ b/docs/tutorial/about.md
@@ -1,10 +1,10 @@
 # About Electron
 
-[Electron](https://electron.atom.io) is an open source library developed by GitHub for building cross-platform desktop applications with HTML, CSS, and JavaScript. Electron accomplishes this by combining [Chromium](https://www.chromium.org/Home) and [Node.js](https://nodejs.org) into a single runtime and apps can be packaged for Mac, Windows, and Linux.
+[Electron](https://electronjs.org) is an open source library developed by GitHub for building cross-platform desktop applications with HTML, CSS, and JavaScript. Electron accomplishes this by combining [Chromium](https://www.chromium.org/Home) and [Node.js](https://nodejs.org) into a single runtime and apps can be packaged for Mac, Windows, and Linux.
 
 Electron began in 2013 as the framework on which [Atom](https://atom.io), GitHub's hackable text editor, would be built. The two were open sourced in the Spring of 2014.
 
-It has since become a popular tool used by open source developers, startups, and established companies. [See who is building on Electron](https://electron.atom.io/apps/).
+It has since become a popular tool used by open source developers, startups, and established companies. [See who is building on Electron](https://electronjs.org/apps).
 
 Read on to learn more about the contributors and releases of Electron or get started building with Electron in the [Quick Start Guide](quick-start.md).
 
@@ -27,13 +27,13 @@ In Electron, Node.js and Chromium share a single V8 instance—usually the versi
 
 ### Versioning
 
-Due to the hard dependency on Node.js and Chromium, Electron is in a tricky versioning position and [does not follow `semver`](http://semver.org). You should therefore always reference a specific version of Electron. [Read more about Electron's versioning](https://electron.atom.io/docs/tutorial/electron-versioning/) or see the [versions currently in use](https://electron.atom.io/#electron-versions).
+Due to the hard dependency on Node.js and Chromium, Electron is in a tricky versioning position and [does not follow `semver`](http://semver.org). You should therefore always reference a specific version of Electron. [Read more about Electron's versioning](https://electronjs.org/docs/tutorial/electron-versioning) or see the [versions currently in use](https://electronjs.org/#electron-versions).
 
 ### LTS
 
 Long term support of older versions of Electron does not currently exist. If your current version of Electron works for you, you can stay on it for as long as you'd like. If you want to make use of new features as they come in you should upgrade to a newer version.
 
-A major update came with version `v1.0.0`. If you're not yet using this version, you should [read more about the `v1.0.0` changes](https://electron.atom.io/blog/2016/05/11/electron-1-0).
+A major update came with version `v1.0.0`. If you're not yet using this version, you should [read more about the `v1.0.0` changes](https://electronjs.org/blog/electron-1-0).
 
 ## Core Philosophy
 
@@ -41,7 +41,7 @@ In order to keep Electron small (file size) and sustainable (the spread of depen
 
 For instance, Electron uses just the rendering library from Chromium rather than all of Chromium. This makes it easier to upgrade Chromium but also means some browser features found in Google Chrome do not exist in Electron.
 
-New features added to Electron should primarily be native APIs. If a feature can be its own Node.js module, it probably should be. See the [Electron tools built by the community](https://electron.atom.io/community).
+New features added to Electron should primarily be native APIs. If a feature can be its own Node.js module, it probably should be. See the [Electron tools built by the community](https://electronjs.org/community).
 
 ## History
 
@@ -52,6 +52,6 @@ Below are milestones in Electron's history.
 | **April 2013**| [Atom Shell is started](https://github.com/electron/electron/commit/6ef8875b1e93787fa9759f602e7880f28e8e6b45).|
 | **May 2014** | [Atom Shell is open sourced](http://blog.atom.io/2014/05/06/atom-is-now-open-source.html). |
 | **April 2015** | [Atom Shell is re-named Electron](https://github.com/electron/electron/pull/1389). |
-| **May 2016** | [Electron releases `v1.0.0`](https://electron.atom.io/blog/2016/05/11/electron-1-0).|
-| **May 2016** | [Electron apps compatible with Mac App Store](https://electron.atom.io/docs/tutorial/mac-app-store-submission-guide).|
-| **August 2016** | [Windows Store support for Electron apps](https://electron.atom.io/docs/tutorial/windows-store-guide).|
+| **May 2016** | [Electron releases `v1.0.0`](https://electronjs.org/blog/electron-1-0).|
+| **May 2016** | [Electron apps compatible with Mac App Store](https://electronjs.org/docs/tutorial/mac-app-store-submission-guide).|
+| **August 2016** | [Windows Store support for Electron apps](https://electronjs.org/docs/tutorial/windows-store-guide).|

--- a/docs/tutorial/accessibility.md
+++ b/docs/tutorial/accessibility.md
@@ -6,7 +6,7 @@ Making accessible applications is important and we're happy to introduce new fun
 
 Accessibility concerns in Electron applications are similar to those of websites because they're both ultimately HTML. With Electron apps, however, you can't use the online resources for accessibility audits because your app doesn't have a URL to point the auditor to.
 
-These new features bring those auditing tools to your Electron app. You can choose to add audits to your tests with Spectron or use them within DevTools with Devtron. Read on for a summary of the tools or checkout our [accessibility documentation](https://electron.atom.io/docs/tutorial/accessibility) for more information.
+These new features bring those auditing tools to your Electron app. You can choose to add audits to your tests with Spectron or use them within DevTools with Devtron. Read on for a summary of the tools or checkout our [accessibility documentation](https://electronjs.org/docs/tutorial/accessibility) for more information.
 
 ## Spectron
 
@@ -30,7 +30,7 @@ In Devtron, there is a new accessibility tab which will allow you to audit a pag
 
 Both of these tools are using the [Accessibility Developer Tools](https://github.com/GoogleChrome/accessibility-developer-tools) library built by Google for Chrome. You can learn more about the accessibility audit rules this library uses on that [repository's wiki](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules).
 
-If you know of other great accessibility tools for Electron, add them to the [accessibility documentation](https://electron.atom.io/docs/tutorial/accessibility) with a pull request.
+If you know of other great accessibility tools for Electron, add them to the [accessibility documentation](https://electronjs.org/docs/tutorial/accessibility) with a pull request.
 
 ## Enabling Accessibility
 

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -11,7 +11,7 @@ npm install electron --save-dev
 ```
 
 See the 
-[Electron versioning doc](https://electron.atom.io/docs/tutorial/electron-versioning/)
+[Electron versioning doc](https://electronjs.org/docs/tutorial/electron-versioning)
 for info on how to manage Electron versions in your apps.
 
 ## Global Installation

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -244,7 +244,7 @@ $ npm start
 ```
 
 For more example apps, see the
-[list of boilerplates](https://electron.atom.io/community/#boilerplates)
+[list of boilerplates](https://electronjs.org/community#boilerplates)
 created by the awesome electron community.
 
 [share-data]: ../faq.md#how-to-share-data-between-web-pages

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -135,7 +135,7 @@ if (nodeIntegration === 'true') {
     let warning = 'This renderer process has Node.js integration enabled '
     warning += 'and attempted to load remote content. This exposes users of this app to severe '
     warning += 'security risks.\n'
-    warning += 'For more information and help, consult https://electron.atom.io/docs/tutorial/security/'
+    warning += 'For more information and help, consult https://electronjs.org/docs/tutorial/security'
 
     console.warn('%cElectron Security Warning', 'font-weight: bold;', warning)
   }

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -45,10 +45,10 @@ describe('clipboard module', () => {
     it('returns title and url', () => {
       if (process.platform === 'linux') return
 
-      clipboard.writeBookmark('a title', 'https://electron.atom.io')
+      clipboard.writeBookmark('a title', 'https://electronjs.org')
       assert.deepEqual(clipboard.readBookmark(), {
         title: 'a title',
-        url: 'https://electron.atom.io'
+        url: 'https://electronjs.org'
       })
 
       clipboard.writeText('no bookmark')


### PR DESCRIPTION
Update electron.atom.io -> electronjs.org to reduce redirects and speed navigation.