### PR TITLE
Avoid proxy handler race condition crash

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -633,12 +633,17 @@ void App::OnLogin(LoginHandler* login_handler,
                   const base::DictionaryValue& request_details) {
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
-  bool prevent_default = Emit(
-      "login",
-      WebContents::CreateFrom(isolate(), login_handler->GetWebContents()),
-      request_details,
-      login_handler->auth_info(),
-      base::Bind(&PassLoginInformation, make_scoped_refptr(login_handler)));
+  bool prevent_default = false;
+  content::WebContents* web_contents = login_handler->GetWebContents();
+  if (web_contents) {
+    prevent_default =
+        Emit("login",
+             WebContents::CreateFrom(isolate(), web_contents),
+             request_details,
+             login_handler->auth_info(),
+             base::Bind(&PassLoginInformation,
+                        make_scoped_refptr(login_handler)));
+  }
 
   // Default behavior is to always cancel the auth.
   if (!prevent_default)


### PR DESCRIPTION
#11134 seems to be a very delicate race condition. No luck making an isolated demo, but here is a working theory:

- `URLRequest` hits a proxy while running on an IO thread
- `LoginHandler` is constructed, captures `render_process_host_id_`/`render_frame_id_` [at that moment, then posts a task to the UI thread](https://github.com/electron/electron/blob/master/atom/browser/login_handler.cc#L40)
- The original process or render frame dies somehow. Maybe the Window is closed, or navigation happens. *This is the race*
- The `RequestLogin` task finally executes on the UI thread
- [`App::OnLogin`](https://github.com/electron/electron/blob/master/atom/browser/api/atom_api_app.cc#L638) calls [`LoginHandler::GetWebContents()`](https://github.com/electron/electron/blob/master/atom/browser/login_handler.cc#L64) which returns null, either because `render_process_host_id_`/`render_frame_id_` are no longer valid, or because `RenderFrameHost` can't be mapped to a `WebContents`
- `App::OnLogin` tries to [construct a wrapper](https://github.com/electron/electron/blob/4d364fa27a6fa5803a25a343e40a2fe68e27b27f/atom/browser/api/atom_api_web_contents.cc#L1968) around the null `web_contents`, and ends up [crashing here](https://github.com/electron/electron/blob/4d364fa27a6fa5803a25a343e40a2fe68e27b27f/atom/browser/api/atom_api_web_contents.cc#L291)

This seems like a plausible race, and there are [already places in the code where we convert host and frame ids into a webcontents then guard against exactly this case](https://github.com/electron/electron/blob/master/atom/browser/api/atom_api_app.cc#L662). How do people feel about handling the null `web_contents` gracefully and just cancelling the auth request? 
