### PR TITLE
fix: fs.readFile: make options optional

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -464,6 +464,10 @@
         options = {
           encoding: options
         }
+      } else if (options === null || options === undefined) {
+        options = {
+          encoding: null
+        }
       } else if (!util.isObject(options)) {
         throw new TypeError('Bad arguments')
       }


### PR DESCRIPTION
Node documents `options` in `fs.readFile`/`fs.writeFile` operations as optional. We have done so for almost all operations, but made a mistake in `fs.readFile` - if you don't pass options, you'll get a `TypeError` that shouldn't be there.

This tiny PR fixes that.

Closes https://github.com/electron/electron/issues/11182