### PR TITLE
fix: Don’t use deprecated util.is* methods

### DIFF
--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -115,7 +115,7 @@ class ClientRequest extends EventEmitter {
     if (typeof options === 'string') {
       options = url.parse(options)
     } else {
-      options = Object.assign({}, options);
+      options = Object.assign({}, options)
     }
 
     const method = (options.method || 'GET').toUpperCase()

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -115,7 +115,7 @@ class ClientRequest extends EventEmitter {
     if (typeof options === 'string') {
       options = url.parse(options)
     } else {
-      options = util._extend({}, options)
+      options = Object.assign({}, options);
     }
 
     const method = (options.method || 'GET').toUpperCase()

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -2,7 +2,6 @@
 
 const url = require('url')
 const {EventEmitter} = require('events')
-const util = require('util')
 const {Readable} = require('stream')
 const {app} = require('electron')
 const {Session} = process.atomBinding('session')

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -460,7 +460,7 @@
         options = {
           encoding: null
         }
-      } else if (util.isString(options)) {
+      } else if (typeof options === 'string') {
         options = {
           encoding: options
         }
@@ -468,7 +468,7 @@
         options = {
           encoding: null
         }
-      } else if (!util.isObject(options)) {
+      } else if (typeof options !== 'object') {
         throw new TypeError('Bad arguments')
       }
       const {encoding} = options
@@ -531,11 +531,11 @@
         options = {
           encoding: null
         }
-      } else if (util.isString(options)) {
+      } else if (typeof options === 'string') {
         options = {
           encoding: options
         }
-      } else if (!util.isObject(options)) {
+      } else if (typeof options !== 'object') {
         throw new TypeError('Bad arguments')
       }
       const {encoding} = options

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -3,7 +3,6 @@
   const {Buffer} = require('buffer')
   const childProcess = require('child_process')
   const path = require('path')
-  const util = require('util')
 
   const hasProp = {}.hasOwnProperty
 


### PR DESCRIPTION
Node has [decided to deprecate all `util.is*` methods in v5, actually shipped the deprecation in v6](https://nodejs.org/api/util.html#util_deprecated_apis), and now recommends that users either use userland modules or build their own implementations.

I only found four references and decided that we don't need another module for four calls, especially if we're only checking for `string` and `object`. The replacements are identical with what Node core used to do. `isObject` technically also checks if the target is `!== null`, but we make that check in both cases higher up.

Also deprecated: `util._extend`, which we were never meant to use anyway. It's been replaced in core by `Object.assign`.

Props to @ckerr for being on the ball here.