### PR TITLE
feature: Add `BrowserWindow.fromBrowserView()`

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -580,6 +580,12 @@ Returns `BrowserWindow` - The window that is focused in this application, otherw
 
 Returns `BrowserWindow` - The window that owns the given `webContents`.
 
+#### `BrowserWindow.fromBrowserView(browserView)`
+
+* `browserView` [BrowserView](browser-view.md)
+
+Returns `BrowserWindow | null` - The window that owns the given `browserView`. If the given view is not attached to any window, returns `null`.
+
 #### `BrowserWindow.fromId(id)`
 
 * `id` Integer

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -144,6 +144,12 @@ BrowserWindow.fromWebContents = (webContents) => {
   }
 }
 
+BrowserWindow.fromBrowserView = (browserView) => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (window.getBrowserView() === browserView) return window
+  }
+}
+
 BrowserWindow.fromDevToolsWebContents = (webContents) => {
   for (const window of BrowserWindow.getAllWindows()) {
     const {devToolsWebContents} = window

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -148,6 +148,8 @@ BrowserWindow.fromBrowserView = (browserView) => {
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.getBrowserView() === browserView) return window
   }
+
+  return null
 }
 
 BrowserWindow.fromDevToolsWebContents = (webContents) => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -818,6 +818,10 @@ describe('BrowserWindow module', () => {
     it('returns the window with the browserView', () => {
       assert.equal(BrowserWindow.fromBrowserView(bv).id, w.id)
     })
+
+    it('returns undefined if not attached', () => {
+      w.setBrowserView(null)
+      assert.equal(BrowserWindow.fromBrowserView(bv), undefined)
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -9,7 +9,7 @@ const http = require('http')
 const {closeWindow} = require('./window-helpers')
 
 const {ipcRenderer, remote, screen} = require('electron')
-const {app, ipcMain, BrowserWindow, protocol, webContents} = remote
+const {app, ipcMain, BrowserWindow, BrowserView, protocol, webContents} = remote
 
 const isCI = remote.getGlobal('isCi')
 const nativeModulesEnabled = remote.getGlobal('nativeModulesEnabled')
@@ -799,6 +799,25 @@ describe('BrowserWindow module', () => {
         done()
       })
       w.webContents.openDevTools()
+    })
+  })
+
+  describe('BrowserWindow.fromBrowserView(browserView)', () => {
+    let bv = null
+
+    beforeEach(() => {
+      bv = new BrowserView()
+      w.setBrowserView(bv)
+    })
+
+    afterEach(() => {
+      w.setBrowserView(null)
+      bv.destroy()
+    })
+
+    it('returns the window with the browserView', () => {
+      assert.equal(BrowserWindow.fromBrowserView(bv).id, w.id)
+    })
     })
   })
 


### PR DESCRIPTION
It's currently not clear how one would access the current window from within a `browserView`. This makes that a little bit easier. I put this API onto `BrowserWindow` to mimic the similar `BrowserWindow.fromWebContents`, but we could move the API if people felt strongly that it should live somewhere else.

• `BrowserWindow.fromBrowserView(browserView)` API
• Tests
•  Docs