### PR TITLE
feature: BrowserView.getAllViews() & BrowserView.fromWebContents()

### DIFF
--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -154,6 +154,8 @@ void Initialize(v8::Local<v8::Object> exports,
       isolate, BrowserView::GetConstructor(isolate)->GetFunction());
   browser_view.SetMethod("fromId",
                           &mate::TrackableObject<BrowserView>::FromWeakMapID);
+  browser_view.SetMethod("getAllViews",
+                          &mate::TrackableObject<BrowserView>::GetAll);
   mate::Dictionary dict(isolate, exports);
   dict.Set("BrowserView", browser_view);
 }

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -40,6 +40,10 @@ view.webContents.loadURL('https://electronjs.org')
 
 ### Static Methods
 
+#### `BrowserView.getAllViews()`
+
+Returns `BrowserView[]` - An array of all opened BrowserViews.
+
 #### `BrowserView.fromId(id)`
 
 * `id` Integer

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -44,6 +44,13 @@ view.webContents.loadURL('https://electronjs.org')
 
 Returns `BrowserView[]` - An array of all opened BrowserViews.
 
+#### `BrowserView.fromWebContents(webContents)`
+
+* `webContents` [WebContents](web-contents.md)
+
+Returns `BrowserView | null` - The BrowserView that owns the given `webContents`
+or `null` if the contents are not owned by a BrowserView.
+
 #### `BrowserView.fromId(id)`
 
 * `id` Integer

--- a/lib/browser/api/browser-view.js
+++ b/lib/browser/api/browser-view.js
@@ -7,7 +7,7 @@ Object.setPrototypeOf(BrowserView.prototype, EventEmitter.prototype)
 
 BrowserView.fromWebContents = (webContents) => {
   for (const view of BrowserView.getAllViews()) {
-    if (view.webContents.equal(webContents)) return window
+    if (view.webContents.equal(webContents)) return view
   }
 
   return null

--- a/lib/browser/api/browser-view.js
+++ b/lib/browser/api/browser-view.js
@@ -5,4 +5,12 @@ const {BrowserView} = process.atomBinding('browser_view')
 
 Object.setPrototypeOf(BrowserView.prototype, EventEmitter.prototype)
 
+BrowserView.fromWebContents = (webContents) => {
+  for (const view of BrowserView.getAllViews()) {
+    if (view.webContents.equal(webContents)) return window
+  }
+
+  return null
+}
+
 module.exports = BrowserView

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -125,4 +125,26 @@ describe('BrowserView module', () => {
       assert.equal(view2.webContents.id, view.webContents.id)
     })
   })
+
+  describe('BrowserView.fromWebContents()', () => {
+    it('returns the view with given id', () => {
+      view = new BrowserView()
+      w.setBrowserView(view)
+      assert.notEqual(view.id, null)
+      let view2 = BrowserView.fromWebContents(view.webContents)
+      assert.equal(view2.webContents.id, view.webContents.id)
+    })
+  })
+
+  describe('BrowserView.getAllViews()', () => {
+    it('returns all views', () => {
+      view = new BrowserView()
+      w.setBrowserView(view)
+      assert.notEqual(view.id, null)
+
+      const views = BrowserView.getAllViews()
+      assert.equal(views.length, 1)
+      assert.equal(views[0].webContents.id, view.webContents.id)
+    })
+  })
 })


### PR DESCRIPTION
Users used to throwing around `BrowserWindows` were limited by having less features available on the `BrowserView`. This PR brings them up to par.

- `BrowserView.getAllViews()` and `BrowserView.getFromWebContents()`, both implemented exactly like their BrowserWindow counterparts.
- Docs and tests.

Closes #https://github.com/electron/electron/issues/11132