### PR TITLE
🐞 #10470 - prevent from loading preload in each iframe context

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -38,7 +38,6 @@ namespace {
 const std::string kIpcKey = "ipcNative";
 const std::string kModuleCacheKey = "native-module-cache";
 
-
 v8::Local<v8::Object> GetModuleCache(v8::Isolate* isolate) {
   mate::Dictionary global(isolate, isolate->GetCurrentContext()->Global());
   v8::Local<v8::Value> cache;
@@ -155,6 +154,11 @@ void AtomSandboxedRendererClient::RenderViewCreated(
 
 void AtomSandboxedRendererClient::DidCreateScriptContext(
     v8::Handle<v8::Context> context, content::RenderFrame* render_frame) {
+
+  // Only allow preload for the main frame
+  if (!render_frame->IsMainFrame())
+    return;
+
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   std::string preload_script = command_line->GetSwitchValueASCII(
       switches::kPreloadScript);
@@ -192,6 +196,11 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
 
 void AtomSandboxedRendererClient::WillReleaseScriptContext(
     v8::Handle<v8::Context> context, content::RenderFrame* render_frame) {
+
+  // Only allow preload for the main frame
+  if (!render_frame->IsMainFrame())
+    return;
+
   auto isolate = context->GetIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);


### PR DESCRIPTION
My first MR ;-)

In sandbox mode the preload is setup in each iframe. This is not consistent with other modes.
It impacts the performance and may generate unexpected side effects as well.