### PR TITLE
Small devtools fixes

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1369,22 +1369,26 @@ void NativeWindowViews::ShowAutofillPopup(
     const gfx::RectF& bounds,
     const std::vector<base::string16>& values,
     const std::vector<base::string16>& labels) {
-  const auto* web_preferences =
-      WebContentsPreferences::FromWebContents(web_contents)->web_preferences();
-
   bool is_offsceen = false;
-  web_preferences->GetBoolean("offscreen", &is_offsceen);
-  int guest_instance_id = 0;
-  web_preferences->GetInteger(options::kGuestInstanceID, &guest_instance_id);
-
   bool is_embedder_offscreen = false;
-  if (guest_instance_id) {
-    auto manager = WebViewManager::GetWebViewManager(web_contents);
-    if (manager) {
-      auto embedder = manager->GetEmbedder(guest_instance_id);
-      if (embedder) {
-        is_embedder_offscreen = WebContentsPreferences::IsPreferenceEnabled(
-            "offscreen", embedder);
+
+  auto* web_contents_preferences =
+      WebContentsPreferences::FromWebContents(web_contents);
+  if (web_contents_preferences) {
+    const auto* web_preferences = web_contents_preferences->web_preferences();
+
+    web_preferences->GetBoolean("offscreen", &is_offsceen);
+    int guest_instance_id = 0;
+    web_preferences->GetInteger(options::kGuestInstanceID, &guest_instance_id);
+
+    if (guest_instance_id) {
+      auto manager = WebViewManager::GetWebViewManager(web_contents);
+      if (manager) {
+        auto embedder = manager->GetEmbedder(guest_instance_id);
+        if (embedder) {
+          is_embedder_offscreen = WebContentsPreferences::IsPreferenceEnabled(
+              "offscreen", embedder);
+        }
       }
     }
   }

--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -31,6 +31,7 @@
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_widget_host_view.h"
 #include "content/public/common/user_agent.h"
 #include "ipc/ipc_channel.h"
 #include "net/http/http_response_headers.h"
@@ -337,6 +338,14 @@ void InspectableWebContentsImpl::CloseDevTools() {
     }
     embedder_message_dispatcher_.reset();
     web_contents_->Focus();
+
+    // Restore background color of the page since closing devtools changes the
+    // color to the default white. TODO(brenca): remove this once this fix is
+    // not necessary
+    const auto view = web_contents_->GetRenderWidgetHostView();
+    if (view) {
+      view->SetBackgroundColor(view->background_color());
+    }
   }
 }
 

--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -31,7 +31,6 @@
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
-#include "content/public/browser/render_widget_host_view.h"
 #include "content/public/common/user_agent.h"
 #include "ipc/ipc_channel.h"
 #include "net/http/http_response_headers.h"
@@ -338,14 +337,6 @@ void InspectableWebContentsImpl::CloseDevTools() {
     }
     embedder_message_dispatcher_.reset();
     web_contents_->Focus();
-
-    // Restore background color of the page since closing devtools changes the
-    // color to the default white. TODO(brenca): remove this once this fix is
-    // not necessary
-    const auto view = web_contents_->GetRenderWidgetHostView();
-    if (view) {
-      view->SetBackgroundColor(view->background_color());
-    }
   }
 }
 


### PR DESCRIPTION
- Fixed a crash accidentally introduced during the merging of my latest OSR pr by @zcbenz (the `devtools`'s `web_contents` doesn't have a `WebContentsPreferences` object apparently).
- Fixed a bug where if you closed the `devtools` which was in a detached state (only seen this on 1.8.x), the window's background would be set to white. This might be a bug deeper down in chromium code, I'll try to find out where it was introduced, and send a bug report. In the meantime, I've added a workaround that sets the background of the `RenderWidgetHostView` to the background it believes it has.