### PR TITLE
infra: Upgrade to StandardJS 10

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -306,7 +306,6 @@ function startRepl () {
   if (process.platform === 'win32') {
     console.error('Electron REPL not currently supported on Windows')
     process.exit(1)
-    return
   }
 
   const repl = require('repl')

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -28,7 +28,7 @@ var spawnUpdate = function (args, detached, callback) {
     // Process spawned, different args:   Return with error
     // No process spawned:                Spawn new process
     if (spawnedProcess && !isSameArgs(args)) {
-      return callback('AutoUpdater process with arguments ' + args + ' is already running')
+      return callback(`AutoUpdater process with arguments ${args} is already running`)
     } else if (!spawnedProcess) {
       spawnedProcess = spawn(updateExe, args, {
         detached: detached
@@ -68,7 +68,7 @@ var spawnUpdate = function (args, detached, callback) {
 
     // Process terminated with error.
     if (code !== 0) {
-      return callback('Command failed: ' + (signal != null ? signal : code) + '\n' + stderr)
+      return callback(`Command failed: ${signal != null ? signal : code}\n${stderr}`)
     }
 
     // Success.
@@ -93,7 +93,7 @@ exports.checkForUpdate = function (updateURL, callback) {
       json = stdout.trim().split('\n').pop()
       update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === 'function' ? ref1.pop() : void 0 : void 0 : void 0
     } catch (jsonError) {
-      return callback('Invalid result:\n' + stdout)
+      return callback(`Invalid result:\n${stdout}`)
     }
     return callback(null, update)
   })

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -28,6 +28,8 @@ var spawnUpdate = function (args, detached, callback) {
     // Process spawned, different args:   Return with error
     // No process spawned:                Spawn new process
     if (spawnedProcess && !isSameArgs(args)) {
+      // Disabled for backwards compatibility:
+      // eslint-disable-next-line standard/no-callback-literal
       return callback(`AutoUpdater process with arguments ${args} is already running`)
     } else if (!spawnedProcess) {
       spawnedProcess = spawn(updateExe, args, {
@@ -68,6 +70,8 @@ var spawnUpdate = function (args, detached, callback) {
 
     // Process terminated with error.
     if (code !== 0) {
+      // Disabled for backwards compatibility:
+      // eslint-disable-next-line standard/no-callback-literal
       return callback(`Command failed: ${signal != null ? signal : code}\n${stderr}`)
     }
 
@@ -93,6 +97,8 @@ exports.checkForUpdate = function (updateURL, callback) {
       json = stdout.trim().split('\n').pop()
       update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === 'function' ? ref1.pop() : void 0 : void 0 : void 0
     } catch (jsonError) {
+      // Disabled for backwards compatibility:
+      // eslint-disable-next-line standard/no-callback-literal
       return callback(`Invalid result:\n${stdout}`)
     }
     return callback(null, update)

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -79,7 +79,6 @@ class IncomingMessage extends Readable {
     this.shouldPush = true
     this._pushInternalData()
   }
-
 }
 
 URLRequest.prototype._emitRequestEvent = function (isAsync, ...rest) {
@@ -103,7 +102,6 @@ URLRequest.prototype._emitResponseEvent = function (isAsync, ...rest) {
 }
 
 class ClientRequest extends EventEmitter {
-
   constructor (options, callback) {
     super()
 
@@ -354,7 +352,6 @@ class ClientRequest extends EventEmitter {
   abort () {
     this.urlRequest.cancel()
   }
-
 }
 
 function writeAfterEndNT (self, error, callback) {

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -26,6 +26,8 @@ Session.prototype.setCertificateVerifyProc = function (verifyProc) {
     // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
     this._setCertificateVerifyProc(({hostname, certificate, verificationResult}, cb) => {
       verifyProc(hostname, certificate, (result) => {
+        // Disabled due to false positive in StandardJS
+        // eslint-disable-next-line standard/no-callback-literal
         cb(result ? 0 : -2)
       })
     })

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -6,6 +6,7 @@ const {app, ipcMain, session, NavigationController} = electron
 
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
+// eslint-disable-next-line
 session
 
 let nextId = 0

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -311,6 +311,8 @@ const chromeExtensionHandler = function (request, callback) {
 
   const page = backgroundPages[parsed.hostname]
   if (page && parsed.path === `/${page.name}`) {
+    // Disabled due to false positive in StandardJS
+    // eslint-disable-next-line standard/no-callback-literal
     return callback({
       mimeType: 'text/html',
       data: page.html
@@ -319,6 +321,8 @@ const chromeExtensionHandler = function (request, callback) {
 
   fs.readFile(path.join(manifest.srcDirectory, parsed.path), function (err, content) {
     if (err) {
+      // Disabled due to false positive in StandardJS
+      // eslint-disable-next-line standard/no-callback-literal
       return callback(-6)  // FILE_NOT_FOUND
     } else {
       return callback(content)

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -367,6 +367,8 @@
         return invalidArchiveError(asarPath, callback)
       }
       process.nextTick(function () {
+        // Disabled due to false positive in StandardJS
+        // eslint-disable-next-line standard/no-callback-literal
         callback(archive.stat(filePath) !== false)
       })
     }

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -482,7 +482,7 @@
       }
       if (info.size === 0) {
         return process.nextTick(function () {
-          callback(null, encoding ? '' : new Buffer(0))
+          callback(null, encoding ? '' : Buffer.alloc(0))
         })
       }
       if (info.unpacked) {
@@ -490,7 +490,7 @@
         return fs.readFile(realPath, options, callback)
       }
 
-      const buffer = new Buffer(info.size)
+      const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
       if (!(fd >= 0)) {
         return notFoundError(asarPath, filePath, callback)
@@ -519,7 +519,7 @@
         if (options) {
           return ''
         } else {
-          return new Buffer(0)
+          return Buffer.alloc(0)
         }
       }
       if (info.unpacked) {
@@ -538,7 +538,7 @@
         throw new TypeError('Bad arguments')
       }
       const {encoding} = options
-      const buffer = new Buffer(info.size)
+      const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
       if (!(fd >= 0)) {
         notFoundError(asarPath, filePath)
@@ -611,7 +611,7 @@
           encoding: 'utf8'
         })
       }
-      const buffer = new Buffer(info.size)
+      const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
       if (!(fd >= 0)) {
         return

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -147,6 +147,8 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
     executeScript (tabId, details, callback) {
       const requestId = ++nextId
       ipcRenderer.once(`CHROME_TABS_EXECUTESCRIPT_RESULT_${requestId}`, (event, result) => {
+        // Disabled due to false positive in StandardJS
+        // eslint-disable-next-line standard/no-callback-literal
         callback([event.result])
       })
       ipcRenderer.send('CHROME_TABS_EXECUTESCRIPT', requestId, tabId, extensionId, details)

--- a/lib/renderer/extensions/storage.js
+++ b/lib/renderer/extensions/storage.js
@@ -51,6 +51,8 @@ const getStorage = (storageType, extensionId, cb) => {
     if (data !== null) {
       cb(JSON.parse(data))
     } else {
+      // Disabled due to false positive in StandardJS
+      // eslint-disable-next-line standard/no-callback-literal
       cb({})
     }
   })
@@ -82,6 +84,9 @@ const getStorageManager = (storageType, extensionId) => {
             }
             break
         }
+
+        // Disabled due to false positive in StandardJS
+        // eslint-disable-next-line standard/no-callback-literal
         if (keys.length === 0) return callback({})
 
         let items = {}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "remark-cli": "^4.0.0",
     "remark-preset-lint-markdown-style-guide": "^2.1.1",
     "request": "^2.68.0",
-    "standard": "^8.4.0",
+    "standard": "^10.0.0",
     "standard-markdown": "^4.0.0",
     "sumchecker": "^2.0.2",
     "temp": "^0.8.3"

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -31,7 +31,7 @@ async function makeRequest (requestOptions, parseResponse) {
         } else {
           console.log('Error: ', `(status ${res.statusCode})`, err || res.body, requestOptions)
         }
-        reject()
+        reject(err)
       }
     })
   })

--- a/script/merge-release.js
+++ b/script/merge-release.js
@@ -31,7 +31,7 @@ async function checkoutBranch (branchName) {
   console.log(`Checking out ${branchName}.`)
   let errorMessage = `Error checking out branch ${branchName}:`
   let successMessage = `Successfully checked out branch ${branchName}.`
-  return await callGit(['checkout', branchName], errorMessage, successMessage)
+  return callGit(['checkout', branchName], errorMessage, successMessage)
 }
 
 async function commitMerge () {
@@ -39,7 +39,7 @@ async function commitMerge () {
   let errorMessage = `Error committing merge:`
   let successMessage = `Successfully committed the merge for v${pkg.version}`
   let gitArgs = ['commit', '-m', `v${pkg.version}`]
-  return await callGit(gitArgs, errorMessage, successMessage)
+  return callGit(gitArgs, errorMessage, successMessage)
 }
 
 async function mergeReleaseIntoBranch (branchName) {
@@ -67,14 +67,14 @@ async function pushBranch (branchName) {
   let pushArgs = ['push', 'origin', branchName]
   let errorMessage = `Could not push branch ${branchName} due to an error:`
   let successMessage = `Successfully pushed branch ${branchName}.`
-  return await callGit(pushArgs, errorMessage, successMessage)
+  return callGit(pushArgs, errorMessage, successMessage)
 }
 
 async function pull () {
   console.log(`Performing a git pull`)
   let errorMessage = `Could not pull due to an error:`
   let successMessage = `Successfully performed a git pull`
-  return await callGit(['pull'], errorMessage, successMessage)
+  return callGit(['pull'], errorMessage, successMessage)
 }
 
 async function rebase (targetBranch) {
@@ -82,7 +82,7 @@ async function rebase (targetBranch) {
   let errorMessage = `Could not rebase due to an error:`
   let successMessage = `Successfully rebased release branch from ` +
     `${targetBranch}`
-  return await callGit(['rebase', targetBranch], errorMessage, successMessage)
+  return callGit(['rebase', targetBranch], errorMessage, successMessage)
 }
 
 async function mergeRelease () {

--- a/script/release.js
+++ b/script/release.js
@@ -213,7 +213,7 @@ async function uploadShasumFile (filePath, fileName, release) {
     filePath,
     name: fileName
   }
-  return await github.repos.uploadAsset(githubOpts)
+  return github.repos.uploadAsset(githubOpts)
     .catch(err => {
       console.log(`${fail} Error uploading ${filePath} to GitHub:`, err)
       process.exit(1)
@@ -248,7 +248,7 @@ async function publishRelease (release) {
     tag_name: release.tag_name,
     draft: false
   }
-  return await github.repos.editRelease(githubOpts)
+  return github.repos.editRelease(githubOpts)
     .catch(err => {
       console.log(`${fail} Error publishing release:`, err)
       process.exit(1)
@@ -445,7 +445,7 @@ async function cleanupReleaseBranch () {
   await callGit(['branch', '-D', 'release'], errorMessage, successMessage)
   errorMessage = `Could not delete remote release branch.`
   successMessage = `Successfully deleted remote release branch.`
-  return await callGit(['push', 'origin', ':release'], errorMessage, successMessage)
+  return callGit(['push', 'origin', ':release'], errorMessage, successMessage)
 }
 
 async function callGit (args, errorMessage, successMessage) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -27,7 +27,7 @@ describe('BrowserWindow module', () => {
     postData = [
       {
         type: 'rawData',
-        bytes: new Buffer('username=test&file=')
+        bytes: Buffer.from('username=test&file=')
       },
       {
         type: 'file',
@@ -270,7 +270,7 @@ describe('BrowserWindow module', () => {
         assert.equal(isMainFrame, true)
         done()
       })
-      const data = new Buffer(2 * 1024 * 1024).toString('base64')
+      const data = Buffer.alloc(2 * 1024 * 1024).toString('base64')
       w.loadURL(`data:image/png;base64,${data}`)
     })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -153,7 +153,7 @@ describe('BrowserWindow module', () => {
       ]
       const responseEvent = 'window-webContents-destroyed'
 
-      function* genNavigationEvent () {
+      function * genNavigationEvent () {
         let eventOptions = null
         while ((eventOptions = events.shift()) && events.length) {
           let w = new BrowserWindow({show: false})
@@ -1056,6 +1056,8 @@ describe('BrowserWindow module', () => {
       // http protocol to simulate accessing another domain. This is required
       // because the code paths for cross domain popups is different.
       function crossDomainHandler (request, callback) {
+        // Disabled due to false positive in StandardJS
+        // eslint-disable-next-line standard/no-callback-literal
         callback({
           mimeType: 'text/html',
           data: `<html><body><h1>${request.url}</h1></body></html>`
@@ -3025,6 +3027,8 @@ const isScaleFactorRounding = () => {
 function serveFileFromProtocol (protocolName, filePath) {
   return new Promise((resolve, reject) => {
     protocol.registerBufferProtocol(protocolName, (request, callback) => {
+      // Disabled due to false positive in StandardJS
+      // eslint-disable-next-line standard/no-callback-literal
       callback({
         mimeType: 'text/html',
         data: fs.readFileSync(filePath)

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -145,7 +145,7 @@ describe('ipc module', () => {
 
   describe('remote.createFunctionWithReturnValue', () => {
     it('should be called in browser synchronously', () => {
-      const buf = new Buffer('test')
+      const buf = Buffer.from('test')
       const call = remote.require(path.join(fixtures, 'module', 'call.js'))
       const result = call.call(remote.createFunctionWithReturnValue(buf))
       assert.equal(result.constructor.name, 'Buffer')
@@ -239,7 +239,7 @@ describe('ipc module', () => {
     const printName = remote.require(print)
 
     it('keeps its constructor name for objects', () => {
-      const buf = new Buffer('test')
+      const buf = Buffer.from('test')
       assert.equal(printName.print(buf), 'Buffer')
     })
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -195,6 +195,7 @@ describe('ipc module', () => {
       const foo = remote.require(path.join(fixtures, 'module', 'error-properties.js'))
 
       assert.throws(() => {
+        // eslint-disable-next-line
         foo.bar
       }, /getting error/)
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint-disable no-unused-expressions */
+
 const {expect} = require('chai')
 const {nativeImage} = require('electron')
 const path = require('path')

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -6,6 +6,9 @@ const url = require('url')
 const {net} = remote
 const {session} = remote
 
+/* The whole net API doesn't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 function randomBuffer (size, start, end) {
   start = start || 0
   end = end || 255
@@ -855,6 +858,8 @@ describe('net module', () => {
         (details, callback) => {
           if (details.url === `${server.url}${requestUrl}`) {
             requestIsIntercepted = true
+            // Disabled due to false positive in StandardJS
+            // eslint-disable-next-line standard/no-callback-literal
             callback({
               redirectURL: `${server.url}${redirectUrl}`
             })
@@ -907,6 +912,8 @@ describe('net module', () => {
       customSession.webRequest.onBeforeRequest((details, callback) => {
         if (details.url === `${server.url}${requestUrl}`) {
           requestIsIntercepted = true
+          // Disabled due to false positive in StandardJS
+          // eslint-disable-next-line standard/no-callback-literal
           callback({
             redirectURL: `${server.url}${redirectUrl}`
           })
@@ -1154,6 +1161,8 @@ describe('net module', () => {
           url: `${server.url}${requestUrl}`,
           session: 1
         })
+
+        // eslint-disable-next-line
         urlRequest
       } catch (exception) {
         done()
@@ -1223,6 +1232,8 @@ describe('net module', () => {
           url: `${server.url}${requestUrl}`,
           partition: 1
         })
+
+        // eslint-disable-next-line
         urlRequest
       } catch (exception) {
         done()

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -10,6 +10,9 @@ const {BrowserWindow, ipcMain, protocol, session, webContents} = remote
 // and use Stream instances created in the browser process.
 const stream = remote.require('stream')
 
+/* The whole protocol API doesn't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 describe('protocol module', () => {
   const protocolName = 'sp'
   const text = 'valar morghulis'

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -28,7 +28,7 @@ describe('protocol module', () => {
     const body = stream.PassThrough()
 
     async function sendChunks () {
-      let buf = new Buffer(data)
+      let buf = Buffer.from(data)
       for (;;) {
         body.push(buf.slice(0, chunkSize))
         buf = buf.slice(chunkSize)
@@ -204,7 +204,7 @@ describe('protocol module', () => {
   })
 
   describe('protocol.registerBufferProtocol', () => {
-    const buffer = new Buffer(text)
+    const buffer = Buffer.from(text)
     it('sends Buffer as response', (done) => {
       const handler = (request, callback) => callback(buffer)
       protocol.registerBufferProtocol(protocolName, handler, (error) => {
@@ -767,7 +767,7 @@ describe('protocol module', () => {
 
   describe('protocol.interceptBufferProtocol', () => {
     it('can intercept http protocol', (done) => {
-      const handler = (request, callback) => callback(new Buffer(text))
+      const handler = (request, callback) => callback(Buffer.from(text))
       protocol.interceptBufferProtocol('http', handler, (error) => {
         if (error) return done(error)
         $.ajax({

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -10,6 +10,9 @@ const {closeWindow} = require('./window-helpers')
 const {ipcRenderer, remote} = require('electron')
 const {ipcMain, session, BrowserWindow, net} = remote
 
+/* The whole session API doesn't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 describe('session module', () => {
   let fixtures = path.resolve(__dirname, 'fixtures')
   let w = null

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -242,7 +242,7 @@ describe('session module', () => {
     })
 
     it('can cancel default download behavior', (done) => {
-      const mockFile = new Buffer(1024)
+      const mockFile = Buffer.alloc(1024)
       const contentDisposition = 'inline; filename="mockFile.txt"'
       const downloadServer = http.createServer((req, res) => {
         res.writeHead(200, {
@@ -271,7 +271,7 @@ describe('session module', () => {
   })
 
   describe('DownloadItem', () => {
-    const mockPDF = new Buffer(1024 * 1024 * 5)
+    const mockPDF = Buffer.alloc(1024 * 1024 * 5)
     let contentDisposition = 'inline; filename="mock.pdf"'
     const downloadFilePath = path.join(fixtures, 'mock.pdf')
     const downloadServer = http.createServer((req, res) => {

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -10,6 +10,9 @@ const {BrowserWindow, webContents, ipcMain, session} = remote
 
 const isCi = remote.getGlobal('isCi')
 
+/* The whole webContents API doesn't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 describe('webContents module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures')
   let w
@@ -634,7 +637,7 @@ describe('webContents module', () => {
       ]
       const responseEvent = 'webcontents-destroyed'
 
-      function* genNavigationEvent () {
+      function * genNavigationEvent () {
         let eventOptions = null
         while ((eventOptions = events.shift()) && events.length) {
           eventOptions.responseEvent = responseEvent

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -4,6 +4,9 @@ const {closeWindow} = require('./window-helpers')
 const {remote, webFrame} = require('electron')
 const {BrowserWindow, protocol, ipcMain} = remote
 
+/* Most of the APIs here don't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 describe('webFrame module', function () {
   var fixtures = path.resolve(__dirname, 'fixtures')
   var w = null

--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -4,6 +4,9 @@ const qs = require('querystring')
 const remote = require('electron').remote
 const session = remote.session
 
+/* The whole webRequest API doesn't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 describe('webRequest module', () => {
   const ses = session.defaultSession
   const server = http.createServer((req, res) => {

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -15,7 +15,7 @@ describe('asar package', function () {
 
   describe('node api', function () {
     it('supports paths specified as a Buffer', function () {
-      var file = new Buffer(path.join(fixtures, 'asar', 'a.asar', 'file1'))
+      var file = Buffer.from(path.join(fixtures, 'asar', 'a.asar', 'file1'))
       assert.equal(fs.existsSync(file), true)
     })
 
@@ -491,7 +491,7 @@ describe('asar package', function () {
           file = ref2[j]
           p = path.join(fixtures, 'asar', 'a.asar', file)
           fd = fs.openSync(p, 'r')
-          buffer = new Buffer(6)
+          buffer = Buffer.alloc(6)
           fs.readSync(fd, buffer, 0, 6, 0)
           assert.equal(String(buffer).trim(), 'file1')
           fs.closeSync(fd)
@@ -512,7 +512,7 @@ describe('asar package', function () {
         var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         fs.open(p, 'r', function (err, fd) {
           assert.equal(err, null)
-          var buffer = new Buffer(6)
+          var buffer = Buffer.alloc(6)
           fs.read(fd, buffer, 0, 6, 0, function (err) {
             assert.equal(err, null)
             assert.equal(String(buffer).trim(), 'file1')

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -11,6 +11,9 @@ const {app, BrowserWindow, ipcMain, protocol, session, webContents} = remote
 
 const isCI = remote.getGlobal('isCi')
 
+/* Most of the APIs here don't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 describe('chromium feature', () => {
   const fixtures = path.resolve(__dirname, 'fixtures')
   let listener = null

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -274,7 +274,7 @@ describe('node feature', () => {
     it('can be created from WebKit external string', () => {
       const p = document.createElement('p')
       p.innerText = '闲云潭影日悠悠，物换星移几度秋'
-      const b = new Buffer(p.innerText)
+      const b = Buffer.from(p.innerText)
       assert.equal(b.toString(), '闲云潭影日悠悠，物换星移几度秋')
       assert.equal(Buffer.byteLength(p.innerText), 45)
     })
@@ -282,15 +282,15 @@ describe('node feature', () => {
     it('correctly parses external one-byte UTF8 string', () => {
       const p = document.createElement('p')
       p.innerText = 'Jøhänñéß'
-      const b = new Buffer(p.innerText)
+      const b = Buffer.from(p.innerText)
       assert.equal(b.toString(), 'Jøhänñéß')
       assert.equal(Buffer.byteLength(p.innerText), 13)
     })
 
     it('does not crash when creating large Buffers', () => {
-      let buffer = new Buffer(new Array(4096).join(' '))
+      let buffer = Buffer.from(new Array(4096).join(' '))
       assert.equal(buffer.length, 4095)
-      buffer = new Buffer(new Array(4097).join(' '))
+      buffer = Buffer.from(new Array(4097).join(' '))
       assert.equal(buffer.length, 4096)
     })
   })

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -298,6 +298,7 @@ describe('node feature', () => {
   describe('process.stdout', () => {
     it('does not throw an exception when accessed', () => {
       assert.doesNotThrow(() => {
+        // eslint-disable-next-line
         process.stdout
       })
     })
@@ -332,7 +333,7 @@ describe('node feature', () => {
   describe('process.stdin', () => {
     it('does not throw an exception when accessed', () => {
       assert.doesNotThrow(() => {
-        process.stdin
+        process.stdin // eslint-disable-line
       })
     })
 

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -32,9 +32,11 @@ app.commandLine.appendSwitch('disable-renderer-backgrounding')
 // Accessing stdout in the main process will result in the process.stdout
 // throwing UnknownSystemError in renderer process sometimes. This line makes
 // sure we can reproduce it in renderer process.
+// eslint-disable-next-line
 process.stdout
 
 // Access console to reproduce #3482.
+// eslint-disable-next-line
 console
 
 ipcMain.on('message', function (event, ...args) {
@@ -378,6 +380,8 @@ const suspendListeners = (emitter, eventName, callback) => {
     listeners.forEach((listener) => {
       emitter.on(eventName, listener)
     })
+
+    // eslint-disable-next-line standard/no-callback-literal
     callback(...args)
   })
 }

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -9,6 +9,9 @@ const {closeWindow} = require('./window-helpers')
 const isCI = remote.getGlobal('isCi')
 const nativeModulesEnabled = remote.getGlobal('nativeModulesEnabled')
 
+/* Most of the APIs here don't use standard callbacks */
+/* eslint-disable standard/no-callback-literal */
+
 describe('<webview> tag', function () {
   this.timeout(3 * 60 * 1000)
 
@@ -1423,7 +1426,7 @@ describe('<webview> tag', function () {
         })
 
         webview.style.display = 'none'
-        webview.offsetHeight
+        webview.offsetHeight // eslint-disable-line
         webview.style.display = 'block'
       })
       webview.src = `file://${fixtures}/pages/a.html`
@@ -1442,7 +1445,7 @@ describe('<webview> tag', function () {
         })
 
         webview.style.display = 'none'
-        webview.offsetHeight
+        webview.offsetHeight  // eslint-disable-line
         webview.style.display = 'block'
       })
       webview.src = `file://${fixtures}/pages/a.html`


### PR DESCRIPTION
We're currently using `standard` v8, but v10 is what's current. Before the changes become too big for us to easily merge them, I upgraded our codebase to v10.

⚠️ Conveniently, this PR doesn't touch any of the files in the Chromium 61 Upgrade PR. They can both be merged on top of each other without any conflicts.

### Non-style changes
`new Buffer()` is deprecated in Node core. I replaced the few use cases with the official Node recommendation (`Buffer.from()` and `Buffer.alloc()`). This should have no impact on the logic, but goes beyond a mere style-change.

### Style changes
The only notable new rule is `standard/no-callback-literal`, which forces us to use callbacks in the style of `callback(new Error('message')` instead of `callback('message')`. That'd be a breaking change - and most of our callbacks don't even have an error argument. That's a bit unfortunate, but without dwelling on this for too long, I disabled this rule where appropriate. If we want to change all our callbacks into one uniform format, we can always do so in Electron v2!

### Errors before this PR

#### Non-spec:

<details>

```
/electron/default_app/main.js:309:5: Unreachable code.
/electron/default_app/main.js:309:5: Unnecessary return statement.
/electron/lib/browser/api/auto-updater/squirrel-update-win.js:31:14: Unexpected literal in error position of callback.
/electron/lib/browser/api/auto-updater/squirrel-update-win.js:71:14: Unexpected literal in error position of callback.
/electron/lib/browser/api/auto-updater/squirrel-update-win.js:96:14: Unexpected literal in error position of callback.
/electron/lib/browser/api/net.js:83:1: Block must not be padded by blank lines.
/electron/lib/browser/api/net.js:105:42: Block must not be padded by blank lines.
/electron/lib/browser/api/net.js:358:1: Block must not be padded by blank lines.
/electron/lib/browser/api/session.js:29:9: Unexpected literal in error position of callback.
/electron/lib/browser/api/web-contents.js:9:1: Expected an assignment or function call and instead saw an expression.
/electron/lib/browser/chrome-extension.js:314:12: Unexpected literal in error position of callback.
/electron/lib/browser/chrome-extension.js:322:14: Unexpected literal in error position of callback.
/electron/lib/common/asar.js:370:9: Unexpected literal in error position of callback.
/electron/lib/common/asar.js:485:42: 'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/lib/common/asar.js:493:22: 'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/lib/common/asar.js:522:18: 'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/lib/common/asar.js:541:22: 'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/lib/common/asar.js:614:22: 'new buffer.Buffer()' was deprecated since v6. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/lib/renderer/chrome-api.js:150:9: Unexpected literal in error position of callback.
/electron/lib/renderer/extensions/storage.js:54:7: Unexpected literal in error position of callback.
/electron/lib/renderer/extensions/storage.js:85:39: Unexpected literal in error position of callback.
/electron/script/ci-release-build.js:34:9: Expected the Promise rejection reason to be an Error.
/electron/script/merge-release.js:34:10: Redundant use of `await` on a return value.
/electron/script/merge-release.js:42:10: Redundant use of `await` on a return value.
/electron/script/merge-release.js:70:10: Redundant use of `await` on a return value.
/electron/script/merge-release.js:77:10: Redundant use of `await` on a return value.
/electron/script/merge-release.js:85:10: Redundant use of `await` on a return value.
/electron/script/release.js:216:10: Redundant use of `await` on a return value.
/electron/script/release.js:251:10: Redundant use of `await` on a return value.
/electron/script/release.js:448:10: Redundant use of `await` on a return value.
```

</details>

#### Spec:

<details>

```
/electron/spec/api-browser-window-spec.js:30:16: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-browser-window-spec.js:156:15: Missing space before *.
/electron/spec/api-browser-window-spec.js:273:20: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-browser-window-spec.js:1059:9: Unexpected literal in error position of callback.
/electron/spec/api-browser-window-spec.js:3028:7: Unexpected literal in error position of callback.
/electron/spec/api-ipc-spec.js:148:19: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-ipc-spec.js:198:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-ipc-spec.js:242:19: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-native-image-spec.js:112:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:113:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:114:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:115:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:116:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:117:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:118:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:121:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:136:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:215:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:250:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:281:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:288:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:295:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:326:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:356:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:367:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:426:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:472:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-native-image-spec.js:507:7: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-net-spec.js:858:13: Unexpected literal in error position of callback.
/electron/spec/api-net-spec.js:862:13: Unexpected literal in error position of callback.
/electron/spec/api-net-spec.js:910:11: Unexpected literal in error position of callback.
/electron/spec/api-net-spec.js:914:11: Unexpected literal in error position of callback.
/electron/spec/api-net-spec.js:1157:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-net-spec.js:1190:11: Unexpected literal in error position of callback.
/electron/spec/api-net-spec.js:1194:11: Unexpected literal in error position of callback.
/electron/spec/api-net-spec.js:1226:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/api-protocol-spec.js:31:17: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-protocol-spec.js:170:9: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:207:20: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-protocol-spec.js:243:9: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:321:46: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:396:48: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:413:46: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:461:48: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:497:46: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:516:46: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:541:46: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:564:9: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:726:9: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:749:9: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:770:55: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-protocol-spec.js:855:9: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:858:9: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:920:13: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:1014:11: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:1032:46: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:1043:46: Unexpected literal in error position of callback.
/electron/spec/api-protocol-spec.js:1054:46: Unexpected literal in error position of callback.
/electron/spec/api-session-spec.js:245:24: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-session-spec.js:274:21: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/api-session-spec.js:404:7: Unexpected literal in error position of callback.
/electron/spec/api-session-spec.js:500:11: Unexpected literal in error position of callback.
/electron/spec/api-session-spec.js:548:9: Unexpected literal in error position of callback.
/electron/spec/api-session-spec.js:562:11: Unexpected literal in error position of callback.
/electron/spec/api-session-spec.js:575:11: Unexpected literal in error position of callback.
/electron/spec/api-session-spec.js:600:9: Unexpected literal in error position of callback.
/electron/spec/api-session-spec.js:715:13: Unexpected literal in error position of callback.
/electron/spec/api-web-contents-spec.js:357:9: Unexpected literal in error position of callback.
/electron/spec/api-web-contents-spec.js:437:9: Unexpected literal in error position of callback.
/electron/spec/api-web-contents-spec.js:637:15: Missing space before *.
/electron/spec/api-web-frame-spec.js:114:9: Unexpected literal in error position of callback.
/electron/spec/api-web-frame-spec.js:121:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:44:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:62:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:87:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:110:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:124:11: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:126:11: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:149:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:166:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:183:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:226:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:242:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:257:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:273:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:288:9: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:338:11: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:340:11: Unexpected literal in error position of callback.
/electron/spec/api-web-request-spec.js:390:9: Unexpected literal in error position of callback.
/electron/spec/asar-spec.js:18:18: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/asar-spec.js:494:20: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/asar-spec.js:515:24: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/chromium-spec.js:145:9: Unexpected literal in error position of callback.
/electron/spec/chromium-spec.js:454:9: Unexpected literal in error position of callback.
/electron/spec/chromium-spec.js:807:11: Unexpected literal in error position of callback.
/electron/spec/node-spec.js:277:17: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/node-spec.js:285:17: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/node-spec.js:291:20: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/node-spec.js:293:16: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
/electron/spec/node-spec.js:301:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/node-spec.js:335:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/static/main.js:35:1: Expected an assignment or function call and instead saw an expression.
/electron/spec/static/main.js:38:1: Expected an assignment or function call and instead saw an expression.
/electron/spec/static/main.js:381:5: Unexpected literal in error position of callback.
/electron/spec/webview-spec.js:977:20: Unexpected literal in error position of callback.
/electron/spec/webview-spec.js:981:11: Unexpected literal in error position of callback.
/electron/spec/webview-spec.js:1061:30: Unexpected literal in error position of callback.
/electron/spec/webview-spec.js:1426:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/webview-spec.js:1445:9: Expected an assignment or function call and instead saw an expression.
/electron/spec/webview-spec.js:1615:9: Unexpected literal in error position of callback.
```
</details>