### PR TITLE
prefer `sh` to `bash` in the docs

### DIFF
--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -45,7 +45,7 @@ Forces the maximum disk space to be used by the disk cache, in bytes.
 Specifies the flags passed to the Node JS engine. It has to be passed when starting
 Electron if you want to enable the `flags` in the main process.
 
-```bash
+```sh
 $ electron --js-flags="--harmony_proxies --harmony_collections" your-app
 ```
 
@@ -112,7 +112,7 @@ A comma-separated list of servers for which integrated authentication is enabled
 
 For example:
 
-```bash
+```sh
 --auth-server-whitelist='*example.com, *foobar.com, *baz'
 ```
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -7,7 +7,7 @@ are initialized earlier than the command line flags and the app's code.
 
 POSIX shell example:
 
-```bash
+```sh
 $ export ELECTRON_ENABLE_LOGGING=true
 $ electron
 ```

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -16,7 +16,7 @@ Follow the guidelines below for building Electron on Linux.
 
 On Ubuntu, install the following libraries:
 
-```bash
+```sh
 $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        libnotify-dev libgnome-keyring-dev libgconf2-dev \
                        libasound2-dev libcap-dev libcups2-dev libxtst-dev \
@@ -26,7 +26,7 @@ $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
 
 On RHEL / CentOS, install the following libraries:
 
-```bash
+```sh
 $ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
                    libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
                    cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
@@ -35,7 +35,7 @@ $ sudo yum install clang dbus-devel gtk2-devel libnotify-devel \
 
 On Fedora, install the following libraries:
 
-```bash
+```sh
 $ sudo dnf install clang dbus-devel gtk2-devel libnotify-devel \
                    libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
                    cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
@@ -47,7 +47,7 @@ managers such as pacman. Or one can compile from source code.
 
 ## Getting the Code
 
-```bash
+```sh
 $ git clone https://github.com/electron/electron
 ```
 
@@ -58,7 +58,7 @@ the build project files. You must have Python 2.7.x for the script to succeed.
 Downloading certain files can take a long time. Notice that we are using
 `ninja` to build Electron so there is no `Makefile` generated.
 
-```bash
+```sh
 $ cd electron
 $ ./script/bootstrap.py --verbose
 ```
@@ -68,14 +68,14 @@ $ ./script/bootstrap.py --verbose
 If you want to build for an `arm` target you should also install the following
 dependencies:
 
-```bash
+```sh
 $ sudo apt-get install libc6-dev-armhf-cross linux-libc-dev-armhf-cross \
                        g++-arm-linux-gnueabihf
 ```
 
 Similarly for `arm64`, install the following:
 
-```bash
+```sh
 $ sudo apt-get install libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
                        g++-aarch64-linux-gnu
 ```
@@ -83,7 +83,7 @@ $ sudo apt-get install libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
 And to cross-compile for `arm` or `ia32` targets, you should pass the
 `--target_arch` parameter to the `bootstrap.py` script:
 
-```bash
+```sh
 $ ./script/bootstrap.py -v --target_arch=arm
 ```
 
@@ -91,7 +91,7 @@ $ ./script/bootstrap.py -v --target_arch=arm
 
 If you would like to build both `Release` and `Debug` targets:
 
-```bash
+```sh
 $ ./script/build.py
 ```
 
@@ -100,7 +100,7 @@ the directory `out/R`. The file size is in excess of 1.3 gigabytes. This
 happens because the Release target binary contains debugging symbols.
 To reduce the file size, run the `create-dist.py` script:
 
-```bash
+```sh
 $ ./script/create-dist.py
 ```
 
@@ -110,7 +110,7 @@ may want to remove the 1.3+ gigabyte binary which is still in `out/R`.
 
 You can also build the `Debug` target only:
 
-```bash
+```sh
 $ ./script/build.py -c D
 ```
 
@@ -120,13 +120,13 @@ After building is done, you can find the `electron` debug binary under `out/D`.
 
 To clean the build files:
 
-```bash
+```sh
 $ npm run clean
 ```
 
 To clean only `out` and `dist` directories:
 
-```bash
+```sh
 $ npm run clean-build
 ```
 
@@ -139,7 +139,7 @@ $ npm run clean-build
 Prebuilt `clang` will try to link to `libtinfo.so.5`. Depending on the host
 architecture, symlink to appropriate `libncurses`:
 
-```bash
+```sh
 $ sudo ln -s /usr/lib/libncurses.so.5 /usr/lib/libtinfo.so.5
 ```
 
@@ -161,19 +161,19 @@ To avoid using the prebuilt binaries of `libchromiumcontent`, you can build `lib
 2. Install [additional build dependencies](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install-additional-build-dependencies)
 3. Fetch the git submodules:
   
-```bash
+```sh
 $ git submodule update --init --recursive
 ```
 4. Pass the `--build_release_libcc` switch to `bootstrap.py` script:
 
-```bash
+```sh
 $ ./script/bootstrap.py -v --build_release_libcc
 ```
 
 Note that by default the `shared_library` configuration is not built, so you can
 only build `Release` version of Electron if you use this mode:
 
-```bash
+```sh
 $ ./script/build.py -c R
 ```
 
@@ -188,7 +188,7 @@ in `<path>/bin/`.
 
 For example if you installed `clang` under `/user/local/bin/clang`:
 
-```bash
+```sh
 $ ./script/bootstrap.py -v --build_release_libcc --clang_dir /usr/local
 $ ./script/build.py -c R
 ```
@@ -201,7 +201,7 @@ variables to the ones you want.
 
 For example building with GCC toolchain:
 
-```bash
+```sh
 $ env CC=gcc CXX=g++ ./script/bootstrap.py -v --build_release_libcc --disable_clang
 $ ./script/build.py -c R
 ```

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -29,7 +29,7 @@ DMG.
 Then, assuming that the Xcode 6.4 DMG has been mounted at `/Volumes/Xcode` and
 that your Xcode 8.2.1 install is at `/Applications/Xcode.app`, run:
 
-```bash
+```sh
 cp -r /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
 ```
 
@@ -41,7 +41,7 @@ You will also need to enable Xcode to build against the 10.10 SDK:
 
 ## Getting the Code
 
-```bash
+```sh
 $ git clone https://github.com/electron/electron
 ```
 
@@ -51,7 +51,7 @@ The bootstrap script will download all necessary build dependencies and create
 the build project files. Notice that we're using [ninja](https://ninja-build.org/)
 to build Electron so there is no Xcode project generated.
 
-```bash
+```sh
 $ cd electron
 $ ./script/bootstrap.py -v
 ```
@@ -60,13 +60,13 @@ $ ./script/bootstrap.py -v
 
 Build both `Release` and `Debug` targets:
 
-```bash
+```sh
 $ ./script/build.py
 ```
 
 You can also only build the `Debug` target:
 
-```bash
+```sh
 $ ./script/build.py -c D
 ```
 
@@ -81,13 +81,13 @@ support 32bit macOS in the future.
 
 To clean the build files:
 
-```bash
+```sh
 $ npm run clean
 ```
 
 To clean only `out` and `dist` directories:
 
-```bash
+```sh
 $ npm run clean-build
 ```
 

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -88,7 +88,7 @@ $ npm run clean
 
 To clean only `out` and `dist` directories:
 
-```bash
+```sh
 $ npm run clean-build
 ```
 
@@ -114,7 +114,7 @@ Make sure you have the latest Visual Studio update installed.
 If building under Cygwin, you may see `bootstrap.py` failed with following
 error:
 
-```bash
+```sh
 Assertion failed: ((handle))->activecnt >= 0, file src\win\pipe.c, line 1430
 
 Traceback (most recent call last):

--- a/docs/development/build-system-overview.md
+++ b/docs/development/build-system-overview.md
@@ -47,7 +47,7 @@ can switch the download address to it via
 If you only want to build Electron quickly for testing or development, you
 can download just the shared library versions by passing the `--dev` parameter:
 
-```bash
+```sh
 $ ./script/bootstrap.py --dev
 $ ./script/build.py -c D
 ```
@@ -76,20 +76,20 @@ you are not affected.
 
 Test your changes conform to the project coding style using:
 
-```bash
+```sh
 $ npm run lint
 ```
 
 Test functionality using:
 
-```bash
+```sh
 $ npm test
 ```
 
 Whenever you make changes to Electron source code, you'll need to re-run the
 build before the tests:
 
-```bash
+```sh
 $ npm run build && npm test
 ```
 
@@ -117,6 +117,6 @@ details), but they will work with the release build.
 
 To run the tests with the release build use:
 
-```bash
+```sh
 $ npm test -- -R
 ```

--- a/docs/development/chromium-development.md
+++ b/docs/development/chromium-development.md
@@ -18,7 +18,7 @@ See also [V8 Development](v8-development.md)
 It is possible to debug Chromium with Electron by passing
 `--build_debug_libcc` to the bootstrap script:
 
-```bash
+```sh
 $ ./script/bootstrap.py -d --build_debug_libcc
 ```
 
@@ -29,7 +29,7 @@ libchromiumcontent and won't strip any symbols, making it ideal for debugging.
 When built like this, you can make changes to files in
 `vendor/libchromiumcontent/src` and rebuild quickly with:
 
-```bash
+```sh
 $ ./script/build.py -c D --libcc
 ```
 
@@ -37,7 +37,7 @@ When developing on linux with gdb, it is recommended to add a gdb index to speed
 up loading symbols. This doesn't need to be executed on every build, but it is
 recommended to do it at least once to index most shared libraries:
 
-```bash
+```sh
 $ ./vendor/libchromiumcontent/src/build/gdb-add-index ./out/D/electron
 ```
 
@@ -60,7 +60,7 @@ several libchromiumcontent build trees on the same machine(to work on different
 branches for example), it is recommended to set the variable to speed up the
 download of Chromium source. For example:
 
-```bash
+```sh
 $ mkdir ~/.chromium-git-cache
 $ LIBCHROMIUMCONTENT_GIT_CACHE=~/.chromium-git-cache ./script/bootstrap.py -d --build_debug_libcc
 ```
@@ -68,7 +68,7 @@ $ LIBCHROMIUMCONTENT_GIT_CACHE=~/.chromium-git-cache ./script/bootstrap.py -d --
 If the bootstrap script is interrupted while using the git cache, it will leave
 the cache locked. To remove the lock, delete the files ending in `.lock`:
 
-```bash
+```sh
 $ find ~/.chromium-git-cache/ -type f -name '*.lock' -delete
 ```
 
@@ -80,7 +80,7 @@ not work perfectly in a network.
 On Windows, SMBv2 has a directory cache that will cause problems with the git
 cache script, so it is necessary to disable it by setting the registry key
 
-```bash
+```sh
 HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Lanmanworkstation\Parameters\DirectoryCacheLifetime
 ```
 

--- a/docs/development/debugging-instructions-macos.md
+++ b/docs/development/debugging-instructions-macos.md
@@ -26,7 +26,7 @@ to enable step-through debugging with breakpoints inside Electron's source code.
 To start a debugging session, open up Terminal and start `lldb`, passing a debug
 build of Electron as a parameter.
 
-```bash
+```sh
 $ lldb ./out/D/Electron.app
 (lldb) target create "./out/D/Electron.app"
 Current executable set to './out/D/Electron.app' (x86_64).
@@ -47,20 +47,20 @@ Let's assume that you want to debug `app.setName()`, which is defined in `browse
 as `Browser::SetName()`. Set the breakpoint using the `breakpoint` command, specifying
 file and line to break on:
 
-```bash
+```sh
 (lldb) breakpoint set --file browser.cc --line 117
 Breakpoint 1: where = Electron Framework`atom::Browser::SetName(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 20 at browser.cc:118, address = 0x000000000015fdb4
 ```
 
 Then, start Electron:
 
-```bash
+```sh
 (lldb) run
 ```
 
 The app will immediately be paused, since Electron sets the app's name on launch:
 
-```bash
+```sh
 (lldb) run
 Process 25244 launched: '/Users/fr/Code/electron/out/D/Electron.app/Contents/MacOS/Electron' (x86_64)
 Process 25244 stopped
@@ -79,7 +79,7 @@ Process 25244 stopped
 To show the arguments and local variables for the current frame, run `frame variable` (or `fr v`),
 which will show you that the app is currently setting the name to "Electron".
 
-```bash
+```sh
 (lldb) frame variable
 (atom::Browser *) this = 0x0000000108b14f20
 (const string &) name = "Electron": {
@@ -91,7 +91,7 @@ To do a source level single step in the currently selected thread, execute `step
 This would take you into `name_override_.empty()`. To proceed and do a step over,
 run `next` (or `n`).
 
-```bash
+```sh
 (lldb) step
 Process 25244 stopped
 * thread #1: tid = 0x839a4c, 0x0000000100162dcc Electron Framework`atom::Browser::SetName(this=0x0000000108b14f20, name="Electron") + 44 at browser.cc:119, queue = 'com.apple.main-thread', stop reason = step in

--- a/docs/development/upgrading-chrome.md
+++ b/docs/development/upgrading-chrome.md
@@ -14,35 +14,29 @@ on each Chromium upgrade in Electron.
 
 ### Steps
 ### 1. Get the code and initialize the project:
-  ```sh
-  $ git clone git@github.com:electron/libchromiumcontent.git
-  $ cd libchromiumcontent
-  $ ./script/bootstrap -v
-  ```
-### 2. Update the Chromium snapshot
-  - Choose a version number from [OmahaProxy](https://omahaproxy.appspot.com/) and update the `VERSION` file with it
-    - This can be done manually by visiting OmahaProxy in a browser, or automatically:
-    - One-liner for the latest stable mac version: `curl -so- https://omahaproxy.appspot.com/mac > VERSION`
-    - One-liner for the latest win64 beta version: `curl -so- https://omahaproxy.appspot.com/all | grep "win64,beta" | awk -F, 'NR==1{print $3}' > VERSION`
-  - run `$ ./script/update`
-    - Time to brew some tea -- this may run for 30m or more.
-    - It will probably fail applying patches.
-
-### 3. Fix `*.patch` files in the `/patches` and `/patches-mas` folders.
-### 4. (Optional) Run a separate script to apply patches (`script/update` uses it internally):
+```sh
+$ git clone git@github.com:electron/libchromiumcontent.git
+$ cd libchromiumcontent
+$ ./script/bootstrap -v
+```
+### 2. Find the new beta/stable Chromium version from [OmahaProxy](https://omahaproxy.appspot.com/).
+### 3. Put it into the `libchromiumcontent/VERSION` file, then run `$ ./script/update`
+ - It will probably fail applying patches.
+### 4. Fix `*.patch` files in the `/patches` and `/patches-mas` folders.
+### 5. (Optional) Run a separate script to apply patches (`script/update` uses it internally):
  ```sh
  $ ./script/apply-patches
  ```
  - There is also another script `/script/patch.py` that could be more useful, check `--help` to learn how it works with `$ ./script/patch.py -h`
-### 5. Run the build when all patches can be applied without errors
+### 6. Run the build when all patches can be applied without errors
  ```sh
  $ ./script/build
  ```
  - If some patches are no longer compatible with the Chromium code, fix compilation errors.
-### 6. When build succeeds, create a `dist` for Electron
+### 7. When build succeeds, create a `dist` for Electron
  `$ ./script/create-dist  --no_zip`
  - It will create `dist/main` folder in the root of the libcc repo, you will need it to build Electron.
-### 7. (Optional) Update script contents if there are errors resultant of some files being removed or renamed. (`--no_zip` prevents script from create `dist` archives, you don't need them.)
+### 8. (Optional) Update script contents if there are errors resultant of some files being removed or renamed. (`--no_zip` prevents script from create `dist` archives, you don't need them.)
 
 
 ## Update Electron Code

--- a/docs/development/upgrading-chrome.md
+++ b/docs/development/upgrading-chrome.md
@@ -14,29 +14,35 @@ on each Chromium upgrade in Electron.
 
 ### Steps
 ### 1. Get the code and initialize the project:
-```sh
-$ git clone git@github.com:electron/libchromiumcontent.git
-$ cd libchromiumcontent
-$ ./script/bootstrap -v
-```
-### 2. Find the new beta/stable Chromium version from [OmahaProxy](https://omahaproxy.appspot.com/).
-### 3. Put it into the `libchromiumcontent/VERSION` file, then run `$ ./script/update`
- - It will probably fail applying patches.
-### 4. Fix `*.patch` files in the `/patches` and `/patches-mas` folders.
-### 5. (Optional) Run a separate script to apply patches (`script/update` uses it internally):
+  ```sh
+  $ git clone git@github.com:electron/libchromiumcontent.git
+  $ cd libchromiumcontent
+  $ ./script/bootstrap -v
+  ```
+### 2. Update the Chromium snapshot
+  - Choose a version number from [OmahaProxy](https://omahaproxy.appspot.com/) and update the `VERSION` file with it
+    - This can be done manually by visiting OmahaProxy in a browser, or automatically:
+    - One-liner for the latest stable mac version: `curl -so- https://omahaproxy.appspot.com/mac > VERSION`
+    - One-liner for the latest win64 beta version: `curl -so- https://omahaproxy.appspot.com/all | grep "win64,beta" | awk -F, 'NR==1{print $3}' > VERSION`
+  - run `$ ./script/update`
+    - Time to brew some tea -- this may run for 30m or more.
+    - It will probably fail applying patches.
+
+### 3. Fix `*.patch` files in the `/patches` and `/patches-mas` folders.
+### 4. (Optional) Run a separate script to apply patches (`script/update` uses it internally):
  ```sh
  $ ./script/apply-patches
  ```
  - There is also another script `/script/patch.py` that could be more useful, check `--help` to learn how it works with `$ ./script/patch.py -h`
-### 6. Run the build when all patches can be applied without errors
+### 5. Run the build when all patches can be applied without errors
  ```sh
  $ ./script/build
  ```
  - If some patches are no longer compatible with the Chromium code, fix compilation errors.
-### 7. When build succeeds, create a `dist` for Electron
+### 6. When build succeeds, create a `dist` for Electron
  `$ ./script/create-dist  --no_zip`
  - It will create `dist/main` folder in the root of the libcc repo, you will need it to build Electron.
-### 8. (Optional) Update script contents if there are errors resultant of some files being removed or renamed. (`--no_zip` prevents script from create `dist` archives, you don't need them.)
+### 7. (Optional) Update script contents if there are errors resultant of some files being removed or renamed. (`--no_zip` prevents script from create `dist` archives, you don't need them.)
 
 
 ## Update Electron Code

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -158,7 +158,7 @@ and then check if it is in the following form:
 If it is something like `node_modules/electron/index.js`, then you have to
 either remove the npm `electron` module, or rename it.
 
-```bash
+```sh
 npm uninstall electron
 npm uninstall -g electron
 ```

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -44,7 +44,7 @@ For API references, there are exceptions to this rule.
 
 ## Markdown rules
 
-* Use `bash` instead of `cmd` in code blocks (due to the syntax highlighter).
+* Use `sh` instead of `cmd` in code blocks (due to the syntax highlighter).
 * Lines should be wrapped at 80 columns.
 * No nesting lists more than 2 levels (due to the markdown renderer).
 * All `js` and `javascript` code blocks are linted with

--- a/docs/tutorial/application-packaging.md
+++ b/docs/tutorial/application-packaging.md
@@ -15,13 +15,13 @@ Steps to package your app into an `asar` archive:
 
 ### 1. Install the asar Utility
 
-```bash
+```sh
 $ npm install -g asar
 ```
 
 ### 2. Package with `asar pack`
 
-```bash
+```sh
 $ asar pack your-app app.asar
 ```
 
@@ -38,7 +38,7 @@ files in the filesystem.
 
 For example, suppose we have an `example.asar` archive under `/path/to`:
 
-```bash
+```sh
 $ asar list /path/to/example.asar
 /app.js
 /file.txt
@@ -174,7 +174,7 @@ To work around this, you can unpack some files creating archives by using the
 `--unpack` option, an example of excluding shared libraries of native modules
 is:
 
-```bash
+```sh
 $ asar pack app app.asar --unpack *.node
 ```
 

--- a/docs/tutorial/debugging-main-process-vscode.md
+++ b/docs/tutorial/debugging-main-process-vscode.md
@@ -2,7 +2,7 @@
 
 ### 1. Open an Electron project in VSCode.
 
-```bash
+```sh
 $ git clone git@github.com:electron/electron-quick-start.git
 $ code electron-quick-start
 ```

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -82,7 +82,7 @@ with the Bundle ID of your app.
 
 And then sign your app with the following script:
 
-```bash
+```sh
 #!/bin/bash
 
 # Name of your app.
@@ -129,7 +129,7 @@ Native modules used in your app also need to be signed. If using
 electron-osx-sign, be sure to include the path to the built binaries in the
 argument list:
 
-```bash
+```sh
 electron-osx-sign YourApp.app YourApp.app/Contents/Resources/app/node_modules/nativemodule/build/release/nativemodule
 ```
 

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -169,7 +169,7 @@ an `npm` module that contains pre-compiled versions of Electron.
 If you've installed it globally with `npm`, then you will only need to run the
 following in your app's source directory:
 
-```bash
+```sh
 electron .
 ```
 
@@ -177,19 +177,19 @@ If you've installed it locally, then run:
 
 #### macOS / Linux
 
-```bash
+```sh
 $ ./node_modules/.bin/electron .
 ```
 
 #### Windows
 
-```bash
+```sh
 $ .\node_modules\.bin\electron .
 ```
 
 #### Node v8.2.0 and later
 
-```bash
+```sh
 $ npx electron .
 ```
 
@@ -200,19 +200,19 @@ binary to execute your app directly.
 
 #### macOS
 
-```bash
+```sh
 $ ./Electron.app/Contents/MacOS/Electron your-app/
 ```
 
 #### Linux
 
-```bash
+```sh
 $ ./electron/electron your-app/
 ```
 
 #### Windows
 
-```bash
+```sh
 $ .\electron\electron.exe your-app\
 ```
 
@@ -232,7 +232,7 @@ repository.
 
 **Note**: Running this requires [Git](https://git-scm.com) and [Node.js](https://nodejs.org/en/download/) (which includes [npm](https://npmjs.org)) on your system.
 
-```bash
+```sh
 # Clone the repository
 $ git clone https://github.com/electron/electron-quick-start
 # Go into the repository

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -16,7 +16,7 @@ directly.
 
 An example of installing all dependencies for Electron:
 
-```bash
+```sh
 # Electron's version.
 export npm_config_target=1.2.3
 # The architecture of Electron, can be ia32 or x64.
@@ -41,7 +41,7 @@ of downloading headers and building native modules for your app.
 
 An example of installing `electron-rebuild` and then rebuild modules with it:
 
-```bash
+```sh
 npm install --save-dev electron-rebuild
 
 # Every time you run "npm install", run this:
@@ -57,7 +57,7 @@ If you are a developer developing a native module and want to test it against
 Electron, you might want to rebuild the module for Electron manually. You can
 use `node-gyp` directly to build for Electron:
 
-```bash
+```sh
 cd /path-to-module/
 HOME=~/.electron-gyp node-gyp rebuild --target=1.2.3 --arch=x64 --dist-url=https://atom.io/download/electron
 ```

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -14,7 +14,7 @@ From [ChromeDriver - WebDriver for Chrome][chrome-driver]:
 for Electron. It is built on top of [WebdriverIO](http://webdriver.io/) and
 has helpers to access Electron APIs in your tests and bundles ChromeDriver.
 
-```bash
+```sh
 $ npm install --save-dev spectron
 ```
 
@@ -57,7 +57,7 @@ a Node package for testing with web driver, we will use it as an example.
 
 First you need to download the `chromedriver` binary, and run it:
 
-```bash
+```sh
 $ npm install electron-chromedriver
 $ ./node_modules/.bin/chromedriver
 Starting ChromeDriver (v2.10.291558) on port 9515
@@ -68,7 +68,7 @@ Remember the port number `9515`, which will be used later
 
 ### 2. Install WebDriverJS
 
-```bash
+```sh
 $ npm install selenium-webdriver
 ```
 
@@ -114,7 +114,7 @@ driver.
 
 First you need to download the `chromedriver` binary, and run it:
 
-```bash
+```sh
 $ npm install electron-chromedriver
 $ ./node_modules/.bin/chromedriver --url-base=wd/hub --port=9515
 Starting ChromeDriver (v2.10.291558) on port 9515
@@ -125,7 +125,7 @@ Remember the port number `9515`, which will be used later
 
 ### 2. Install WebdriverIO
 
-```bash
+```sh
 $ npm install webdriverio
 ```
 


### PR DESCRIPTION
Does what it says on the tin.

Not the most complicated patch in the world, more of a since-we're-in-the-neighborhood with all the documentation work and I keep seeing `bash`, I was reminded of [this discussion](https://github.com/electron/electron/pull/11178#issuecomment-345773553) with @zeke, @vanessayuenn  and me on this topic