### PR TITLE
Fix a codeblock markup

### DIFF
--- a/docs/development/upgrading-node.md
+++ b/docs/development/upgrading-node.md
@@ -105,7 +105,7 @@ We need to generate a patch file from each patch applied to V8.
      - `git commit patches/v8/`
 8. Update `patches/v8/README.md` with references to all new patches that have been added so that the next person will know which need to be removed.
 9. Update Electron's submodule references:
-   - ```sh
+   ```sh
    cd electron/vendor/node
    electron/vendor/node$ git fetch
    electron/vendor/node$ git checkout electron-node-vA.B.C


### PR DESCRIPTION
[upgrading-node.md](https://github.com/electron/electron/blob/master/docs/development/upgrading-node.md) doesn't look good now. It also fails `npm run lint-docs`.

**Now**
<img width="946" alt="screen shot 2017-11-25 at 00 58 25" src="https://user-images.githubusercontent.com/607250/33225643-d554f20c-d17b-11e7-9b59-3e0541374d81.png">

**Should be**
<img width="944" alt="screen shot 2017-11-25 at 13 02 29" src="https://user-images.githubusercontent.com/607250/33230299-f5af721a-d1e0-11e7-8e94-b71eb4cc7108.png">


/cc @codebytere, @ckerr 