### PR TITLE
Remove "async" flag from the `menu.popup()` options

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -67,9 +67,6 @@ The `menu` object has the following instance methods:
     Must be declared if `y` is declared.
   * `y` Number (optional) - Default is the current mouse cursor position.
     Must be declared if `x` is declared.
-  * `async` Boolean (optional) - Set to `true` to have this method return
-    immediately called, `false` to return after the menu has been selected
-    or closed. Defaults to `false`.
   * `positioningItem` Number (optional) _macOS_ - The index of the menu item to
     be positioned under the mouse cursor at the specified coordinates. Default
     is -1.


### PR DESCRIPTION
All menus have become async after the Chromium 61 upgrade.
Fixes #11242.

@zeke, should I do anything else besides updating that menu.md file?