### PR TITLE
Don't access unique pointer after it was moved from

### DIFF
--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -800,16 +800,21 @@ void InspectableWebContentsImpl::OnURLFetchComplete(
   DCHECK(it != pending_requests_.end());
 
   base::DictionaryValue response;
-  auto headers = base::MakeUnique<base::DictionaryValue>();
+
   net::HttpResponseHeaders* rh = source->GetResponseHeaders();
   response.SetInteger("statusCode", rh ? rh->response_code() : 200);
-  response.Set("headers", std::move(headers));
 
-  size_t iterator = 0;
-  std::string name;
-  std::string value;
-  while (rh && rh->EnumerateHeaderLines(&iterator, &name, &value))
-    headers->SetString(name, value);
+  {
+    auto headers = base::MakeUnique<base::DictionaryValue>();
+
+    size_t iterator = 0;
+    std::string name;
+    std::string value;
+    while (rh && rh->EnumerateHeaderLines(&iterator, &name, &value))
+      headers->SetString(name, value);
+
+    response.Set("headers", std::move(headers));
+  }
 
   it->second.Run(&response);
   pending_requests_.erase(it);


### PR DESCRIPTION
Fixing crash introduced by https://github.com/electron/electron/commit/2c063f93ff97cd3478f2020ab343b6249fe12546