### PR TITLE
Removed tracking area for tray to prevent mouse leave race condition crash

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -33,6 +33,7 @@ const CGFloat kVerticalTitleMargin = 2;
   base::scoped_nsobject<NSString> title_;
   base::scoped_nsobject<NSMutableAttributedString> attributedTitle_;
   base::scoped_nsobject<NSStatusItem> statusItem_;
+  NSTrackingArea *trackingArea_;
 }
 
 @end  // @interface StatusItemView
@@ -61,12 +62,12 @@ const CGFloat kVerticalTitleMargin = 2;
     [self updateDimensions];
 
     // Add NSTrackingArea for listening to mouseEnter, mouseExit, and mouseMove events
-    auto trackingArea = [[[NSTrackingArea alloc]
+    trackingArea_ = [[[NSTrackingArea alloc]
         initWithRect:[self bounds]
              options:NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingActiveAlways
                owner:self
             userInfo:nil] autorelease];
-    [self addTrackingArea:trackingArea];
+    [self addTrackingArea:trackingArea_];
   }
   return self;
 }
@@ -78,6 +79,8 @@ const CGFloat kVerticalTitleMargin = 2;
 }
 
 - (void)removeItem {
+  // Turn off tracking events to prevent crash
+  [self removeTrackingArea:trackingArea_];
   [[NSStatusBar systemStatusBar] removeStatusItem:statusItem_];
   statusItem_.reset();
 }
@@ -399,8 +402,9 @@ TrayIconCocoa::TrayIconCocoa() : menu_model_(nullptr) {
 
 TrayIconCocoa::~TrayIconCocoa() {
   [status_item_view_ removeItem];
-  if (menu_model_)
+  if (menu_model_){
     menu_model_->RemoveObserver(this);
+  }
 }
 
 void TrayIconCocoa::SetImage(const gfx::Image& image) {

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -402,9 +402,8 @@ TrayIconCocoa::TrayIconCocoa() : menu_model_(nullptr) {
 
 TrayIconCocoa::~TrayIconCocoa() {
   [status_item_view_ removeItem];
-  if (menu_model_){
+  if (menu_model_)
     menu_model_->RemoveObserver(this);
-  }
 }
 
 void TrayIconCocoa::SetImage(const gfx::Image& image) {

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -33,7 +33,7 @@ const CGFloat kVerticalTitleMargin = 2;
   base::scoped_nsobject<NSString> title_;
   base::scoped_nsobject<NSMutableAttributedString> attributedTitle_;
   base::scoped_nsobject<NSStatusItem> statusItem_;
-  NSTrackingArea *trackingArea_;
+  base::scoped_nsobject<NSTrackingArea> trackingArea_;
 }
 
 @end  // @interface StatusItemView
@@ -62,11 +62,11 @@ const CGFloat kVerticalTitleMargin = 2;
     [self updateDimensions];
 
     // Add NSTrackingArea for listening to mouseEnter, mouseExit, and mouseMove events
-    trackingArea_ = [[[NSTrackingArea alloc]
+    trackingArea_.reset([[NSTrackingArea alloc]
         initWithRect:[self bounds]
              options:NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingActiveAlways
                owner:self
-            userInfo:nil] autorelease];
+            userInfo:nil]);
     [self addTrackingArea:trackingArea_];
   }
   return self;
@@ -80,7 +80,10 @@ const CGFloat kVerticalTitleMargin = 2;
 
 - (void)removeItem {
   // Turn off tracking events to prevent crash
-  [self removeTrackingArea:trackingArea_];
+  if (trackingArea_) {
+    [self removeTrackingArea:trackingArea_];
+    trackingArea_.reset();
+  }
   [[NSStatusBar systemStatusBar] removeStatusItem:statusItem_];
   statusItem_.reset();
 }


### PR DESCRIPTION
When the tray icon is destroyed, sometimes a `mouseExited` event is triggered late, causing a crash. This is fixed by explicitly removing the tracking area when removing the tray icon.