### PR TITLE
Update submenu's title at replacement

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -177,6 +177,8 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
   // Repopulate with items from the submenu to be replaced
   [self moveMenuItems:recentDocumentsMenuSwap_
                    to:recentDocumentsMenu];
+  // Update the submenu's title
+  [recentDocumentsMenu setTitle:[recentDocumentsMenuSwap_ title]];
   // Replace submenu
   [item setSubmenu:recentDocumentsMenu];
 


### PR DESCRIPTION
Something a little trivial that I realized: It may be better to also update the singleton submenu's title to have the same as that of the replaced submenu.

Following https://github.com/electron/electron/pull/11166, the change introduced here updates the title of the submenu.