### PR TITLE
typographical revision in Documentation

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -377,7 +377,7 @@ returning `false` in the `beforeunload` event handler.
 
 * `exitCode` Integer (optional)
 
-Exits immediately with `exitCode`.  `exitCode` defaults to 0.
+Exits immediately with `exitCode`. `exitCode` defaults to 0.
 
 All windows will be closed immediately without asking user and the `before-quit`
 and `will-quit` events will not be emitted.
@@ -459,7 +459,7 @@ You can request the following paths by the name:
 * `pictures` Directory for a user's pictures.
 * `videos` Directory for a user's videos.
 * `logs` Directory for your app's log folder.
-* `pepperFlashSystemPlugin`  Full path to the system version of the Pepper Flash plugin.
+* `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
 
 ### `app.getFileIcon(path[, options], callback)`
 
@@ -846,12 +846,12 @@ This method can only be called before app is ready.
 
 ### `app.getAppMemoryInfo()` _Deprecated_
 
-Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
+Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
 **Note:** This method is deprecated, use `app.getAppMetrics()` instead.
 
 ### `app.getAppMetrics()`
 
-Returns [`ProcessMetric[]`](structures/process-metric.md):  Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
+Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
 
 ### `app.getGPUFeatureStatus()`
 
@@ -998,11 +998,11 @@ This method can only be called before app is ready.
 ### `app.isInApplicationsFolder()` _macOS_
 
 Returns `Boolean` - Whether the application is currently running from the
-systems Application folder.  Use in combination with `app.moveToApplicationsFolder()`
+systems Application folder. Use in combination with `app.moveToApplicationsFolder()`
 
 ### `app.moveToApplicationsFolder()` _macOS_
 
-Returns `Boolean` - Whether the move was successful.  Please note that if
+Returns `Boolean` - Whether the move was successful. Please note that if
 the move is successful your application will quit and relaunch.
 
 No confirmation dialog will be presented by default, if you wish to allow
@@ -1010,9 +1010,9 @@ the user to confirm the operation you may do so using the
 [`dialog`](dialog.md) API.
 
 **NOTE:** This method throws errors if anything other than the user causes the
-move to fail.  For instance if the user cancels the authorization dialog this
-method returns false.  If we fail to perform the copy then this method will
-throw an error.  The message in the error should be informative and tell
+move to fail. For instance if the user cancels the authorization dialog this
+method returns false. If we fail to perform the copy then this method will
+throw an error. The message in the error should be informative and tell
 you exactly what went wrong
 
 ### `app.dock.bounce([type])` _macOS_

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -385,7 +385,7 @@ and `will-quit` events will not be emitted.
 ### `app.relaunch([options])`
 
 * `options` Object (optional)
-  * `args` String[] - (optional)
+  * `args` String[] (optional)
   * `execPath` String (optional)
 
 Relaunches the app when current instance exits.

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -91,7 +91,7 @@ The `autoUpdater` object has the following methods:
 ### `autoUpdater.setFeedURL(url[, requestHeaders])`
 
 * `url` String
-* `requestHeaders` Object _macOS_ (optional) - HTTP request headers.
+* `requestHeaders` Object (optional) _macOS_ - HTTP request headers.
 
 Sets the `url` and initialize the auto updater.
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -8,7 +8,7 @@ removed in future Electron releases.
 Process: [Main](../glossary.md#main-process)
 
 A `BrowserView` can be used to embed additional web content into a
-`BrowserWindow`. It is like a child window, except that it is positioned
+[`BrowserWindow`](browser-window.md). It is like a child window, except that it is positioned
 relative to its owning window. It is meant to be an alternative to the
 `webview` tag.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1124,7 +1124,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) - (optional)
+  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Same as `webContents.loadURL(url[, options])`.

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -25,7 +25,7 @@ specified, `partition` is ignored.
   * `protocol` String (optional) - The protocol scheme in the form 'scheme:'.
 Currently supported values are 'http:' or 'https:'. Defaults to 'http:'.
   * `host` String (optional) - The server host provided as a concatenation of
-the hostname and the port number 'hostname:port'
+the hostname and the port number 'hostname:port'.
   * `hostname` String (optional) - The server host name.
   * `port` Integer (optional) - The server's listening port number.
   * `path` String (optional) - The path part of the request URL.

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -37,7 +37,7 @@ The following events are available on instances of `Cookies`:
 #### Event: 'changed'
 
 * `event` Event
-* `cookie` [Cookie](structures/cookie.md) - The cookie that was changed
+* `cookie` [Cookie](structures/cookie.md) - The cookie that was changed.
 * `cause` String - The cause of the change with one of the following values:
   * `explicit` - The cookie was changed directly by a consumer's action.
   * `overwrite` - The cookie was automatically removed due to an insert
@@ -62,7 +62,7 @@ The following methods are available on instances of `Cookies`:
     `url`. Empty implies retrieving cookies of all urls.
   * `name` String (optional) - Filters cookies by name.
   * `domain` String (optional) - Retrieves cookies whose domains match or are
-    subdomains of `domains`
+    subdomains of `domains`.
   * `path` String (optional) - Retrieves cookies whose path matches `path`.
   * `secure` Boolean (optional) - Filters cookies by their Secure property.
   * `session` Boolean (optional) - Filters out session or persistent cookies.

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -46,7 +46,7 @@ The `crashReporter` module has the following methods:
   * `extra` Object (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly. Nested objects are not
     supported and the property names and values must be less than 64 characters long.
-  * `crashesDirectory` String (optional) - Directory to store the crashreports temporarily (only used when the crash reporter is started via `process.crashReporter.start`)
+  * `crashesDirectory` String (optional) - Directory to store the crashreports temporarily (only used when the crash reporter is started via `process.crashReporter.start`).
 
 You are required to call this method before using any other `crashReporter` APIs
 and in each process (main/renderer) from which you want to collect crash reports.
@@ -109,7 +109,7 @@ the `start` method or `setUploadToServer`.
 
 ### `crashReporter.setUploadToServer(uploadToServer)` _Linux_ _macOS_
 
-* `uploadToServer` Boolean _macOS_ - Whether reports should be submitted to the server
+* `uploadToServer` Boolean _macOS_ - Whether reports should be submitted to the server.
 
 This would normally be controlled by user preferences. This has no effect if
 called before `start` is called.
@@ -142,7 +142,7 @@ a `multipart/form-data` `POST`:
 * `ver` String - The version of Electron.
 * `platform` String - e.g. 'win32'.
 * `process_type` String - e.g. 'renderer'.
-* `guid` String - e.g. '5e1286fc-da97-479e-918b-6bfb0c3d1c72'
+* `guid` String - e.g. '5e1286fc-da97-479e-918b-6bfb0c3d1c72'.
 * `_version` String - The version in `package.json`.
 * `_productName` String - The product name in the `crashReporter` `options`
   object.

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -102,7 +102,7 @@ ID.
 
 ### `crashReporter.getUploadToServer()` _Linux_ _macOS_
 
-Returns `Boolean` - Whether reports should be submitted to the server.  Set through
+Returns `Boolean` - Whether reports should be submitted to the server. Set through
 the `start` method or `setUploadToServer`.
 
 **Note:** This API can only be called from the main process.

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -44,7 +44,7 @@ The `dialog` module has the following methods:
       the path but allows non-existent paths to be returned that should be
       created by the application.
     * `noResolveAliases` _macOS_ - Disable the automatic alias (symlink) path
-      resolution.  Selected aliases will now return the alias path instead of
+      resolution. Selected aliases will now return the alias path instead of
       their target path.
     * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
       as a directory instead of a file.
@@ -175,7 +175,7 @@ will be asynchronous and the result will be passed via `callback(response)`.
 Displays a modal dialog that shows an error message.
 
 This API can be called safely before the `ready` event the `app` module emits,
-it is usually used to report errors in early stage of startup.  If called
+it is usually used to report errors in early stage of startup. If called
 before the app `ready`event on Linux, the message will be emitted to stderr,
 and no GUI dialog will appear.
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -25,7 +25,7 @@ The `dialog` module has the following methods:
 
 ### `dialog.showOpenDialog([browserWindow, ]options[, callback])`
 
-* `browserWindow` BrowserWindow (optional)
+* `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
   * `title` String (optional)
   * `defaultPath` String (optional)
@@ -38,16 +38,16 @@ The `dialog` module has the following methods:
     * `openDirectory` - Allow directories to be selected.
     * `multiSelections` - Allow multiple paths to be selected.
     * `showHiddenFiles` - Show hidden files in dialog.
-    * `createDirectory` - Allow creating new directories from dialog. _macOS_
-    * `promptToCreate` - Prompt for creation if the file path entered
+    * `createDirectory` _macOS_ - Allow creating new directories from dialog.
+    * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
       in the dialog does not exist. This does not actually create the file at
       the path but allows non-existent paths to be returned that should be
-      created by the application. _Windows_
-    * `noResolveAliases` - Disable the automatic alias (symlink) path
+      created by the application.
+    * `noResolveAliases` _macOS_ - Disable the automatic alias (symlink) path
       resolution.  Selected aliases will now return the alias path instead of
-      their target path. _macOS_
-    * `treatPackageAsDirectory` - Treat packages, such as `.app` folders,
-      as a directory instead of a file. _macOS_
+      their target path.
+    * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
+      as a directory instead of a file.
   * `message` String (optional) _macOS_ - Message to display above input
     boxes.
 * `callback` Function (optional)
@@ -77,7 +77,7 @@ The `extensions` array should contain extensions without wildcards or dots (e.g.
 `'*'` wildcard (no other wildcard is supported).
 
 If a `callback` is passed, the API call will be asynchronous and the result
-will be passed via `callback(filenames)`
+will be passed via `callback(filenames)`.
 
 **Note:** On Windows and Linux an open dialog can not be both a file selector
 and a directory selector, so if you set `properties` to
@@ -86,7 +86,7 @@ shown.
 
 ### `dialog.showSaveDialog([browserWindow, ]options[, callback])`
 
-* `browserWindow` BrowserWindow (optional)
+* `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
   * `title` String (optional)
   * `defaultPath` String (optional) - Absolute directory path, absolute file
@@ -111,11 +111,11 @@ The `filters` specifies an array of file types that can be displayed, see
 `dialog.showOpenDialog` for an example.
 
 If a `callback` is passed, the API call will be asynchronous and the result
-will be passed via `callback(filename)`
+will be passed via `callback(filename)`.
 
 ### `dialog.showMessageBox([browserWindow, ]options[, callback])`
 
-* `browserWindow` BrowserWindow (optional)
+* `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
   * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
   `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
@@ -152,7 +152,7 @@ will be passed via `callback(filename)`
     converted to `Vie_w` on Linux and `View` on macOS and can be selected
     via `Alt-W` on Windows and Linux.
 * `callback` Function (optional)
-  * `response` Number - The index of the button that was clicked
+  * `response` Number - The index of the button that was clicked.
   * `checkboxChecked` Boolean - The checked state of the checkbox if
     `checkboxLabel` was set. Otherwise `false`.
 
@@ -169,8 +169,8 @@ will be asynchronous and the result will be passed via `callback(response)`.
 
 ### `dialog.showErrorBox(title, content)`
 
-* `title` String - The title to display in the error box
-* `content` String - The text content to display in the error box
+* `title` String - The title to display in the error box.
+* `content` String - The text content to display in the error box.
 
 Displays a modal dialog that shows an error message.
 
@@ -181,7 +181,7 @@ and no GUI dialog will appear.
 
 ### `dialog.showCertificateTrustDialog([browserWindow, ]options, callback)` _macOS_ _Windows_
 
-* `browserWindow` BrowserWindow (optional)
+* `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
   * `certificate` [Certificate](structures/certificate.md) - The certificate to trust/import.
   * `message` String - The message to display to the user.
@@ -202,7 +202,7 @@ On Windows the options are more limited, due to the Win32 APIs used:
 ## Sheets
 
 On macOS, dialogs are presented as sheets attached to a window if you provide
-a `BrowserWindow` reference in the `browserWindow` parameter, or modals if no
+a [`BrowserWindow`](browser-window.md) reference in the `browserWindow` parameter, or modals if no
 window is provided.
 
 You can call `BrowserWindow.getCurrentWindow().setSheetOffset(offset)` to change

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -147,7 +147,7 @@ header.
 
 #### `downloadItem.getState()`
 
-Returns `String` - The current state.  Can be `progressing`, `completed`, `cancelled` or `interrupted`.
+Returns `String` - The current state. Can be `progressing`, `completed`, `cancelled` or `interrupted`.
 
 **Note:** The following methods are useful specifically to resume a
 `cancelled` item when session is restarted.

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -84,12 +84,12 @@ win.show()
   the user's system).
 * On Windows operating systems, transparent windows will not work when DWM is
   disabled.
-* On Linux users have to put `--enable-transparent-visuals --disable-gpu` in
+* On Linux, users have to put `--enable-transparent-visuals --disable-gpu` in
   the command line to disable GPU and allow ARGB to make transparent window,
   this is caused by an upstream bug that [alpha channel doesn't work on some
   NVidia drivers](https://code.google.com/p/chromium/issues/detail?id=369209) on
   Linux.
-* On Mac the native window shadow will not be shown on a transparent window.
+* On Mac, the native window shadow will not be shown on a transparent window.
 
 ## Click-through window
 

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -27,12 +27,12 @@ processes:
 // In main process.
 const {ipcMain} = require('electron')
 ipcMain.on('asynchronous-message', (event, arg) => {
-  console.log(arg)  // prints "ping"
+  console.log(arg) // prints "ping"
   event.sender.send('asynchronous-reply', 'pong')
 })
 
 ipcMain.on('synchronous-message', (event, arg) => {
-  console.log(arg)  // prints "ping"
+  console.log(arg) // prints "ping"
   event.returnValue = 'pong'
 })
 ```

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -7,7 +7,7 @@ Process: [Renderer](../glossary.md#renderer-process)
 The `ipcRenderer` module is an instance of the
 [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. It provides a few
 methods so you can send synchronous and asynchronous messages from the render
-process (web page) to the main process.  You can also receive replies from the
+process (web page) to the main process. You can also receive replies from the
 main process.
 
 See [ipcMain](ipc-main.md) for code examples.

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -80,7 +80,7 @@ unless you know what you are doing you should never use it.
 * `channel` String
 * `...args` any[]
 
-Sends a message to a window with `windowid` via `channel`
+Sends a message to a window with `windowid` via `channel`.
 
 ### `ipcRenderer.sendToHost(channel[, arg1][, arg2][, ...])`
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -55,7 +55,7 @@ Send a message to the main process asynchronously via `channel`, you can also
 send arbitrary arguments. Arguments will be serialized in JSON internally and
 hence no functions or prototype chain will be included.
 
-The main process handles it by listening for `channel` with `ipcMain` module.
+The main process handles it by listening for `channel` with [`ipcMain`](ipc-main.md) module.
 
 ### `ipcRenderer.sendSync(channel[, arg1][, arg2][, ...])`
 
@@ -68,7 +68,7 @@ Send a message to the main process synchronously via `channel`, you can also
 send arbitrary arguments. Arguments will be serialized in JSON internally and
 hence no functions or prototype chain will be included.
 
-The main process handles it by listening for `channel` with `ipcMain` module,
+The main process handles it by listening for `channel` with [`ipcMain`](ipc-main.md) module,
 and replies by setting `event.returnValue`.
 
 **Note:** Sending a synchronous message will block the whole renderer process,

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -12,7 +12,7 @@ See [`Menu`](menu.md) for examples.
   * `click` Function (optional) - Will be called with
     `click(menuItem, browserWindow, event)` when the menu item is clicked.
     * `menuItem` MenuItem
-    * `browserWindow` BrowserWindow
+    * `browserWindow` [BrowserWindow](browser-window.md)
     * `event` Event
   * `role` String (optional) - Define the action of the menu item, when specified the
     `click` property will be ignored. See [roles](#roles).
@@ -27,9 +27,9 @@ See [`Menu`](menu.md) for examples.
   * `visible` Boolean (optional) - If false, the menu item will be entirely hidden.
   * `checked` Boolean (optional) - Should only be specified for `checkbox` or `radio` type
     menu items.
-  * `submenu` (MenuItemConstructorOptions[] | Menu) (optional) - Should be specified for `submenu` type menu items. If
+  * `submenu` (MenuItemConstructorOptions[] | [Menu](menu.md)) (optional) - Should be specified for `submenu` type menu items. If
     `submenu` is specified, the `type: 'submenu'` can be omitted. If the value
-    is not a `Menu` then it will be automatically converted to one using
+    is not a [`Menu`](menu.md) then it will be automatically converted to one using
     `Menu.buildFromTemplate`.
   * `id` String (optional) - Unique within a single menu. If defined then it can be used
     as a reference to this item by the position attribute.
@@ -57,39 +57,39 @@ The `role` property can have following values:
 * `pasteandmatchstyle`
 * `selectall`
 * `delete`
-* `minimize` - Minimize current window
-* `close` - Close current window
-* `quit`- Quit the application
-* `reload` - Reload the current window
+* `minimize` - Minimize current window.
+* `close` - Close current window.
+* `quit`- Quit the application.
+* `reload` - Reload the current window.
 * `forcereload` - Reload the current window ignoring the cache.
-* `toggledevtools` - Toggle developer tools in the current window
-* `togglefullscreen`- Toggle full screen mode on the current window
-* `resetzoom` - Reset the focused page's zoom level to the original size
-* `zoomin` - Zoom in the focused page by 10%
-* `zoomout` - Zoom out the focused page by 10%
-* `editMenu` - Whole default "Edit" menu (Undo, Copy, etc.)
-* `windowMenu` - Whole default "Window" menu (Minimize, Close, etc.)
+* `toggledevtools` - Toggle developer tools in the current window.
+* `togglefullscreen`- Toggle full screen mode on the current window.
+* `resetzoom` - Reset the focused page's zoom level to the original size.
+* `zoomin` - Zoom in the focused page by 10%.
+* `zoomout` - Zoom out the focused page by 10%.
+* `editMenu` - Whole default "Edit" menu (Undo, Copy, etc.).
+* `windowMenu` - Whole default "Window" menu (Minimize, Close, etc.).
 
-The following additional roles are available on macOS:
+The following additional roles are available on _macOS_:
 
-* `about` - Map to the `orderFrontStandardAboutPanel` action
-* `hide` - Map to the `hide` action
-* `hideothers` - Map to the `hideOtherApplications` action
-* `unhide` - Map to the `unhideAllApplications` action
-* `startspeaking` - Map to the `startSpeaking` action
-* `stopspeaking` - Map to the `stopSpeaking` action
-* `front` - Map to the `arrangeInFront` action
-* `zoom` - Map to the `performZoom` action
-* `toggletabbar` - Map to the `toggleTabBar` action
-* `selectnexttab` - Map to the `selectNextTab` action
-* `selectprevioustab` - Map to the `selectPreviousTab` action
-* `mergeallwindows` - Map to the `mergeAllWindows` action
-* `movetabtonewwindow` - Map to the `moveTabToNewWindow` action
-* `window` - The submenu is a "Window" menu
-* `help` - The submenu is a "Help" menu
-* `services` - The submenu is a "Services" menu
-* `recentdocuments` - The submenu is an "Open Recent" menu
-* `clearrecentdocuments` - Map to the `clearRecentDocuments` action
+* `about` - Map to the `orderFrontStandardAboutPanel` action.
+* `hide` - Map to the `hide` action.
+* `hideothers` - Map to the `hideOtherApplications` action.
+* `unhide` - Map to the `unhideAllApplications` action.
+* `startspeaking` - Map to the `startSpeaking` action.
+* `stopspeaking` - Map to the `stopSpeaking` action.
+* `front` - Map to the `arrangeInFront` action.
+* `zoom` - Map to the `performZoom` action.
+* `toggletabbar` - Map to the `toggleTabBar` action.
+* `selectnexttab` - Map to the `selectNextTab` action.
+* `selectprevioustab` - Map to the `selectPreviousTab` action.
+* `mergeallwindows` - Map to the `mergeAllWindows` action.
+* `movetabtonewwindow` - Map to the `moveTabToNewWindow` action.
+* `window` - The submenu is a "Window" menu.
+* `help` - The submenu is a "Help" menu.
+* `services` - The submenu is a "Services" menu.
+* `recentdocuments` - The submenu is an "Open Recent" menu.
+* `clearrecentdocuments` - Map to the `clearRecentDocuments` action.
 
 When specifying a `role` on macOS, `label` and `accelerator` are the only
 options that will affect the menu item. All other options will be ignored.
@@ -123,8 +123,8 @@ You can add a `click` function for additional behavior.
 
 #### `menuItem.label`
 
-A `String` representing the menu items visible label
+A `String` representing the menu items visible label.
 
 #### `menuItem.click`
 
-A `Function` that is fired when the MenuItem receives a click event
+A `Function` that is fired when the MenuItem receives a click event.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -18,8 +18,8 @@ See [`Menu`](menu.md) for examples.
     `click` property will be ignored. See [roles](#roles).
   * `type` String (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
     `radio`.
-  * `label` String - (optional)
-  * `sublabel` String - (optional)
+  * `label` String (optional)
+  * `sublabel` String (optional)
   * `accelerator` [Accelerator](accelerator.md) (optional)
   * `icon` ([NativeImage](native-image.md) | String) (optional)
   * `enabled` Boolean (optional) - If false, the menu item will be greyed out and

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -61,7 +61,7 @@ The `menu` object has the following instance methods:
 
 #### `menu.popup([browserWindow, options])`
 
-* `browserWindow` BrowserWindow (optional) - Default is the focused window.
+* `browserWindow` [BrowserWindow](browser-window.md) (optional) - Default is the focused window.
 * `options` Object (optional)
   * `x` Number (optional) - Default is the current mouse cursor position.
     Must be declared if `y` is declared.
@@ -71,17 +71,17 @@ The `menu` object has the following instance methods:
     be positioned under the mouse cursor at the specified coordinates. Default
     is -1.
 
-Pops up this menu as a context menu in the `browserWindow`.
+Pops up this menu as a context menu in the [`BrowserWindow`](browser-window.md).
 
 #### `menu.closePopup([browserWindow])`
 
-* `browserWindow` BrowserWindow (optional) - Default is the focused window.
+* `browserWindow` [BrowserWindow](browser-window.md) (optional) - Default is the focused window.
 
 Closes the context menu in the `browserWindow`.
 
 #### `menu.append(menuItem)`
 
-* `menuItem` MenuItem
+* `menuItem` [MenuItem](menu-item.md)
 
 Appends the `menuItem` to the menu.
 
@@ -94,7 +94,7 @@ Returns `MenuItem` the item with the specified `id`
 #### `menu.insert(pos, menuItem)`
 
 * `pos` Integer
-* `menuItem` MenuItem
+* `menuItem` [MenuItem](menu-item.md)
 
 Inserts the `menuItem` to the `pos` position of the menu.
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -165,21 +165,21 @@ Creates a new `NativeImage` instance from `dataURL`.
 Returns `NativeImage`
 
 Creates a new `NativeImage` instance from the NSImage that maps to the
-given image name.  See [`NSImageName`](https://developer.apple.com/documentation/appkit/nsimagename?language=objc)
+given image name. See [`NSImageName`](https://developer.apple.com/documentation/appkit/nsimagename?language=objc)
 for a list of possible values.
 
 The `hslShift` is applied to the image with the following rules
 * `hsl_shift[0]` (hue): The absolute hue value for the image - 0 and 1 map
      to 0 and 360 on the hue color wheel (red).
 * `hsl_shift[1]` (saturation): A saturation shift for the image, with the
-    following key values:  
-    0 = remove all color.  
-    0.5 = leave unchanged.  
-    1 = fully saturate the image.  
+    following key values:
+    0 = remove all color.
+    0.5 = leave unchanged.
+    1 = fully saturate the image.
 * `hsl_shift[2]` (lightness): A lightness shift for the image, with the
-    following key values:  
-    0 = remove all lightness (make all pixels black).  
-    0.5 = leave unchanged.  
+    following key values:
+    0 = remove all lightness (make all pixels black).
+    0.5 = leave unchanged.
     1 = full lightness (make all pixels white).
 
 This means that `[-1, 0, 1]` will make the image completely white and
@@ -245,7 +245,7 @@ image instead of a copy, so you _must_ ensure that the associated
 
 #### `image.isEmpty()`
 
-Returns `Boolean` -  Whether the image is empty.
+Returns `Boolean` - Whether the image is empty.
 
 #### `image.getSize()`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -263,7 +263,7 @@ Returns `Boolean` - Whether the image is a template image.
 
 #### `image.crop(rect)`
 
-* `rect` [Rectangle](structures/rectangle.md) - The area of the image to crop
+* `rect` [Rectangle](structures/rectangle.md) - The area of the image to crop.
 
 Returns `NativeImage` - The cropped image.
 
@@ -271,7 +271,7 @@ Returns `NativeImage` - The cropped image.
 
 * `options` Object
   * `width` Integer (optional) - Defaults to the image's width.
-  * `height` Integer (optional) - Defaults to the image's height
+  * `height` Integer (optional) - Defaults to the image's height.
   * `quality` String (optional) - The desired quality of the resize image.
     Possible values are `good`, `better` or `best`. The default is `best`.
     These values express a desired quality/speed tradeoff. They are translated

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -31,14 +31,14 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
 
 * `options` Object
   * `title` String - A title for the notification, which will be shown at the top of the notification window when it is shown
-  * `subtitle` String - (optional) A subtitle for the notification, which will be displayed below the title. _macOS_
+  * `subtitle` String (optional) - A subtitle for the notification, which will be displayed below the title. _macOS_
   * `body` String - The body text of the notification, which will be displayed below the title or subtitle
-  * `silent` Boolean - (optional) Whether or not to emit an OS notification noise when showing the notification
-  * `icon` (String | [NativeImage](native-image.md)) - (optional) An icon to use in the notification
-  * `hasReply` Boolean - (optional) Whether or not to add an inline reply option to the notification.  _macOS_
-  * `replyPlaceholder` String - (optional) The placeholder to write in the inline reply input field. _macOS_
-  * `sound` String - (optional) The name of the sound file to play when the notification is shown. _macOS_
-  * `actions` [NotificationAction[]](structures/notification-action.md) - (optional) Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
+  * `silent` Boolean (optional) - Whether or not to emit an OS notification noise when showing the notification
+  * `icon` (String | [NativeImage](native-image.md)) (optional) - An icon to use in the notification
+  * `hasReply` Boolean (optional) - Whether or not to add an inline reply option to the notification.  _macOS_
+  * `replyPlaceholder` String (optional) - The placeholder to write in the inline reply input field. _macOS_
+  * `sound` String (optional) - The name of the sound file to play when the notification is shown. _macOS_
+  * `actions` [NotificationAction[]](structures/notification-action.md) (optional) - Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
 
 
 ### Instance Events

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -38,7 +38,7 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
   * `hasReply` Boolean (optional) _macOS_ - Whether or not to add an inline reply option to the notification.
   * `replyPlaceholder` String (optional) _macOS_ - The placeholder to write in the inline reply input field.
   * `sound` String (optional) _macOS_ - The name of the sound file to play when the notification is shown.
-  * `actions` [NotificationAction[]](structures/notification-action.md) (optional) _macOS_ - Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation.
+  * `actions` [NotificationAction[]](structures/notification-action.md) (optional) _macOS_ - Actions to add to the notification. Please read the available actions and limitations in the `NotificationAction` documentation.
 
 
 ### Instance Events

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -30,15 +30,15 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
 ### `new Notification([options])` _Experimental_
 
 * `options` Object
-  * `title` String - A title for the notification, which will be shown at the top of the notification window when it is shown
-  * `subtitle` String (optional) - A subtitle for the notification, which will be displayed below the title. _macOS_
-  * `body` String - The body text of the notification, which will be displayed below the title or subtitle
-  * `silent` Boolean (optional) - Whether or not to emit an OS notification noise when showing the notification
-  * `icon` (String | [NativeImage](native-image.md)) (optional) - An icon to use in the notification
-  * `hasReply` Boolean (optional) - Whether or not to add an inline reply option to the notification.  _macOS_
-  * `replyPlaceholder` String (optional) - The placeholder to write in the inline reply input field. _macOS_
-  * `sound` String (optional) - The name of the sound file to play when the notification is shown. _macOS_
-  * `actions` [NotificationAction[]](structures/notification-action.md) (optional) - Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
+  * `title` String - A title for the notification, which will be shown at the top of the notification window when it is shown.
+  * `subtitle` String (optional) _macOS_ - A subtitle for the notification, which will be displayed below the title.
+  * `body` String - The body text of the notification, which will be displayed below the title or subtitle.
+  * `silent` Boolean (optional) - Whether or not to emit an OS notification noise when showing the notification.
+  * `icon` (String | [NativeImage](native-image.md)) (optional) - An icon to use in the notification.
+  * `hasReply` Boolean (optional) _macOS_ - Whether or not to add an inline reply option to the notification.
+  * `replyPlaceholder` String (optional) _macOS_ - The placeholder to write in the inline reply input field.
+  * `sound` String (optional) _macOS_ - The name of the sound file to play when the notification is shown.
+  * `actions` [NotificationAction[]](structures/notification-action.md) (optional) _macOS_ - Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation.
 
 
 ### Instance Events
@@ -82,7 +82,7 @@ is closed.
 Returns:
 
 * `event` Event
-* `reply` String - The string the user entered into the inline reply field
+* `reply` String - The string the user entered into the inline reply field.
 
 Emitted when the user clicks the "Reply" button on a notification with `hasReply: true`.
 
@@ -91,7 +91,7 @@ Emitted when the user clicks the "Reply" button on a notification with `hasReply
 Returns:
 
 * `event` Event
-* `index` Number - The index of the action that was activated
+* `index` Number - The index of the action that was activated.
 
 ### Instance Methods
 

--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -23,10 +23,10 @@ The `powerSaveBlocker` module has the following methods:
 
 * `type` String - Power save blocker type.
   * `prevent-app-suspension` - Prevent the application from being suspended.
-    Keeps system active but allows screen to be turned off.  Example use cases:
+    Keeps system active but allows screen to be turned off. Example use cases:
     downloading a file or playing audio.
   * `prevent-display-sleep` - Prevent the display from going to sleep. Keeps
-    system and screen active.  Example use case: playing video.
+    system and screen active. Example use case: playing video.
 
 Returns `Integer` - The blocker ID that is assigned to this power blocker.
 

--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -28,7 +28,7 @@ The `powerSaveBlocker` module has the following methods:
   * `prevent-display-sleep` - Prevent the display from going to sleep. Keeps
     system and screen active.  Example use case: playing video.
 
-Returns `Integer` - The blocker ID that is assigned to this power blocker
+Returns `Integer` - The blocker ID that is assigned to this power blocker.
 
 Starts preventing the system from entering lower-power mode. Returns an integer
 identifying the power save blocker.

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -47,8 +47,8 @@ will disable the support for `asar` archives in Node's built-in modules.
 
 ### `process.noDeprecation`
 
-A `Boolean` that controls whether or not deprecation warnings are printed to `stderr`.  
-Setting this to `true` will silence deprecation warnings.  This property is used
+A `Boolean` that controls whether or not deprecation warnings are printed to `stderr`.
+Setting this to `true` will silence deprecation warnings. This property is used
 instead of the `--no-deprecation` command line flag.
 
 ### `process.resourcesPath`
@@ -58,20 +58,20 @@ A `String` representing the path to the resources directory.
 ### `process.throwDeprecation`
 
 A `Boolean` that controls whether or not deprecation warnings will be thrown as
-exceptions.  Setting this to `true` will throw errors for deprecations.  This
+exceptions. Setting this to `true` will throw errors for deprecations. This
 property is used instead of the `--throw-deprecation` command line flag.
 
 ### `process.traceDeprecation`
 
 A `Boolean` that controls whether or not deprecations printed to `stderr` include
- their stack trace.  Setting this to `true` will print  stack traces for deprecations.
-   This property is instead of the `--trace-deprecation` command line flag.
+ their stack trace. Setting this to `true` will print stack traces for deprecations.
+ This property is instead of the `--trace-deprecation` command line flag.
 
 ### `process.traceProcessWarnings`
 A `Boolean` that controls whether or not process warnings printed to `stderr` include
- their stack trace.  Setting this to `true` will print stack traces for process warnings
-  (including deprecations).  This property is instead of the `--trace-warnings` command
-  line flag.
+ their stack trace. Setting this to `true` will print stack traces for process warnings
+ (including deprecations). This property is instead of the `--trace-warnings` command
+ line flag.
 
 ### `process.type`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -117,7 +117,7 @@ Returns `Object`:
 * `privateBytes` Integer - The amount of memory not shared by other processes, such as
   JS heap or HTML content.
 * `sharedBytes` Integer - The amount of memory shared between processes, typically
-  memory consumed by the Electron code itself
+  memory consumed by the Electron code itself.
 
 Returns an object giving memory usage statistics about the current process. Note
 that all statistics are reported in Kilobytes.
@@ -130,10 +130,10 @@ Returns `Object`:
   system.
 * `free` Integer - The total amount of memory not being used by applications or disk
   cache.
-* `swapTotal` Integer - The total amount of swap memory in Kilobytes available to the
-  system.  _Windows_ _Linux_
-* `swapFree` Integer - The free amount of swap memory in Kilobytes available to the
-  system.  _Windows_ _Linux_
+* `swapTotal` Integer _Windows_ _Linux_ - The total amount of swap memory in Kilobytes available to the
+  system.
+* `swapFree` Integer _Windows_ _Linux_ - The free amount of swap memory in Kilobytes available to the
+  system.
 
 Returns an object giving memory usage statistics about the entire system. Note
 that all statistics are reported in Kilobytes.

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -222,7 +222,7 @@ const {protocol} = require('electron')
 const {PassThrough} = require('stream')
 
 function createStream (text) {
-  const rv = new PassThrough()  // PassThrough is also a Readable stream
+  const rv = new PassThrough() // PassThrough is also a Readable stream
   rv.push(text)
   rv.push(null)
   return rv

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -32,7 +32,7 @@ When you invoke methods of a remote object, call a remote function, or create
 a new object with the remote constructor (function), you are actually sending
 synchronous inter-process messages.
 
-In the example above, both `BrowserWindow` and `win` were remote objects and
+In the example above, both [`BrowserWindow`](browser-window.md) and `win` were remote objects and
 `new BrowserWindow` didn't create a `BrowserWindow` object in the renderer
 process. Instead, it created a `BrowserWindow` object in the main process and
 returned the corresponding remote object in the renderer process, namely the

--- a/docs/api/sandbox-option.md
+++ b/docs/api/sandbox-option.md
@@ -33,7 +33,7 @@ which has access to a subset of the electron renderer API.
 
 Another difference is that sandboxed renderers don't modify any of the default
 JavaScript APIs. Consequently, some APIs such as `window.open` will work as they
-do in chromium (i.e. they do not return a `BrowserWindowProxy`).
+do in chromium (i.e. they do not return a [`BrowserWindowProxy`](browser-window-proxy.md)).
 
 ## Example
 
@@ -51,9 +51,9 @@ app.on('ready', () => {
 })
 ```
 
-In the above code the `BrowserWindow` that was created has node.js disabled and can communicate
+In the above code the [`BrowserWindow`](browser-window.md) that was created has node.js disabled and can communicate
 only via IPC. The use of this option stops electron from creating a node.js runtime in the renderer. Also,
-within this new window `window.open` follows the native behaviour (by default electron creates a `BrowserWindow`
+within this new window `window.open` follows the native behaviour (by default electron creates a [`BrowserWindow`](browser-window.md)
 and returns a proxy to this via `window.open`).
 
 It is important to note that this option alone won't enable the OS-enforced sandbox. To enable this feature, the

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -160,7 +160,7 @@ For example:
   over to the SOCKS5 proxy `bar.com` if `foopy` is unavailable.
 * `http=foopy,direct://` - Use HTTP proxy `foopy` for http URLs, and use no
   proxy if `foopy` is unavailable.
-* `http=foopy;socks=foopy2` -  Use HTTP proxy `foopy` for http URLs, and use
+* `http=foopy;socks=foopy2` - Use HTTP proxy `foopy` for http URLs, and use
   `socks4://foopy2` for all other URLs.
 
 The `proxyBypassRules` is a comma separated list of rules described below:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -109,12 +109,12 @@ Clears the session’s HTTP cache.
 #### `ses.clearStorageData([options, callback])`
 
 * `options` Object (optional)
-  * `origin` String - (optional) Should follow `window.location.origin`’s representation
+  * `origin` String (optional) - Should follow `window.location.origin`’s representation
     `scheme://host:port`.
-  * `storages` String[] - (optional) The types of storages to clear, can contain:
+  * `storages` String[] (optional) - The types of storages to clear, can contain:
     `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`,
     `shadercache`, `websql`, `serviceworkers`
-  * `quotas` String[] - (optional) The types of quotas to clear, can contain:
+  * `quotas` String[] (optional) - The types of quotas to clear, can contain:
     `temporary`, `persistent`, `syncable`.
 * `callback` Function (optional) - Called when operation is done.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -102,7 +102,7 @@ Callback is invoked with the session's current cache size.
 
 #### `ses.clearCache(callback)`
 
-* `callback` Function - Called when operation is done
+* `callback` Function - Called when operation is done.
 
 Clears the session’s HTTP cache.
 
@@ -113,7 +113,7 @@ Clears the session’s HTTP cache.
     `scheme://host:port`.
   * `storages` String[] (optional) - The types of storages to clear, can contain:
     `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`,
-    `shadercache`, `websql`, `serviceworkers`
+    `shadercache`, `websql`, `serviceworkers`.
   * `quotas` String[] (optional) - The types of quotas to clear, can contain:
     `temporary`, `persistent`, `syncable`.
 * `callback` Function (optional) - Called when operation is done.
@@ -211,7 +211,7 @@ Resolves the proxy information for `url`. The `callback` will be called with
 
 #### `ses.setDownloadPath(path)`
 
-* `path` String - The download location
+* `path` String - The download location.
 
 Sets download saving directory. By default, the download directory will be the
 `Downloads` under the respective app folder.
@@ -292,7 +292,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
   * `permission` String - Enum of 'media', 'geolocation', 'notifications', 'midiSysex',
     'pointerLock', 'fullscreen', 'openExternal'.
   * `callback` Function
-    * `permissionGranted` Boolean - Allow or deny the permission
+    * `permissionGranted` Boolean - Allow or deny the permission.
 
 Sets the handler which can be used to respond to permission requests for the `session`.
 Calling `callback(true)` will allow the permission and `callback(false)` will reject it.
@@ -380,7 +380,7 @@ the initial state will be `interrupted`. The download will start only when the
 #### `ses.clearAuthCache(options[, callback])`
 
 * `options` ([RemovePassword](structures/remove-password.md) | [RemoveClientCertificate](structures/remove-client-certificate.md))
-* `callback` Function (optional) - Called when operation is done
+* `callback` Function (optional) - Called when operation is done.
 
 Clears the session’s HTTP authentication cache.
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -22,7 +22,7 @@ The `shell` module has the following methods:
 
 * `fullPath` String
 
-Returns `Boolean` - Whether the item was successfully shown
+Returns `Boolean` - Whether the item was successfully shown.
 
 Show the given file in a file manager. If possible, select the file.
 
@@ -36,11 +36,11 @@ Open the given file in the desktop's default manner.
 
 ### `shell.openExternal(url[, options, callback])`
 
-* `url` String - max 2081 characters on windows, or the function returns false
+* `url` String - max 2081 characters on windows, or the function returns false.
 * `options` Object (optional) _macOS_
   * `activate` Boolean - `true` to bring the opened application to the
     foreground. The default is `true`.
-* `callback` Function (optional) - If specified will perform the open asynchronously. _macOS_
+* `callback` Function (optional) _macOS_ - If specified will perform the open asynchronously.
   * `error` Error
 
 Returns `Boolean` - Whether an application was available to open the URL.
@@ -53,7 +53,7 @@ example, mailto: URLs in the user's default mail agent).
 
 * `fullPath` String
 
-Returns `Boolean` - Whether the item was successfully moved to the trash
+Returns `Boolean` - Whether the item was successfully moved to the trash.
 
 Move the given file to trash and returns a boolean status for the operation.
 
@@ -71,7 +71,7 @@ Play the beep sound.
     exist.
 * `options` [ShortcutDetails](structures/shortcut-details.md)
 
-Returns `Boolean` - Whether the shortcut was created successfully
+Returns `Boolean` - Whether the shortcut was created successfully.
 
 Creates or updates a shortcut link at `shortcutPath`.
 

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -1,7 +1,7 @@
 # NotificationAction Object
 
 * `type` String - The type of action, can be `button`.
-* `text` String - (optional) The label for the given action.
+* `text` String (optional) - The label for the given action.
 
 ## Platform / Action Support
 

--- a/docs/api/structures/scrubber-item.md
+++ b/docs/api/structures/scrubber-item.md
@@ -1,4 +1,4 @@
 # ScrubberItem Object
 
-* `label` String - (optional) The text to appear in this item
-* `icon` NativeImage - (optional) The image to appear in this item
+* `label` String (optional) - The text to appear in this item
+* `icon` NativeImage (optional) - The image to appear in this item

--- a/docs/api/structures/segmented-control-segment.md
+++ b/docs/api/structures/segmented-control-segment.md
@@ -1,5 +1,5 @@
 # SegmentedControlSegment Object
 
-* `label` String - (optional) The text to appear in this segment
-* `icon` NativeImage - (optional) The image to appear in this segment
-* `enabled` Boolean - (optional) Whether this segment is selectable. Default: true
+* `label` String (optional) - The text to appear in this segment
+* `icon` NativeImage (optional) - The image to appear in this segment
+* `enabled` Boolean (optional) - Whether this segment is selectable. Default: true

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -116,13 +116,13 @@ Returns `any` - The value of `key` in `NSUserDefaults`.
 
 Some popular `key` and `type`s are:
 
-* `AppleInterfaceStyle`:  `string`
-* `AppleAquaColorVariant`:  `integer`
-* `AppleHighlightColor`:  `string`
-* `AppleShowScrollBars`:  `string`
-* `NSNavRecentPlaces`:  `array`
-* `NSPreferredWebServices`:  `dictionary`
-* `NSUserDictionaryReplacementItems`:  `array`
+* `AppleInterfaceStyle`: `string`
+* `AppleAquaColorVariant`: `integer`
+* `AppleHighlightColor`: `string`
+* `AppleShowScrollBars`: `string`
+* `NSNavRecentPlaces`: `array`
+* `NSPreferredWebServices`: `dictionary`
+* `NSUserDictionaryReplacementItems`: `array`
 
 ### `systemPreferences.setUserDefault(key, type, value)` _macOS_
 
@@ -137,7 +137,7 @@ if they don't.
 
 Some popular `key` and `type`s are:
 
-* `ApplePressAndHoldEnabled`:  `boolean`
+* `ApplePressAndHoldEnabled`: `boolean`
 
 ### `systemPreferences.removeUserDefault(key)` _macOS_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -98,7 +98,7 @@ Removes the subscriber with `id`.
   * `userInfo` Object
 
 Same as `subscribeNotification`, but uses `NSNotificationCenter` for local defaults.
-This is necessary for events such as `NSUserDefaultsDidChangeNotification`
+This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 
 ### `systemPreferences.unsubscribeLocalNotification(id)` _macOS_
 
@@ -110,7 +110,7 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificati
 
 * `key` String
 * `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`,
-  `url`, `array`, `dictionary`
+  `url`, `array` or `dictionary`.
 
 Returns `any` - The value of `key` in `NSUserDefaults`.
 
@@ -127,7 +127,7 @@ Some popular `key` and `type`s are:
 ### `systemPreferences.setUserDefault(key, type, value)` _macOS_
 
 * `key` String
-* `type` String - See [`getUserDefault`][#systempreferencesgetuserdefaultkey-type-macos]
+* `type` String - See [`getUserDefault`][#systempreferencesgetuserdefaultkey-type-macos].
 * `value` String
 
 Set the value of `key` in `NSUserDefaults`.

--- a/docs/api/touch-bar-color-picker.md
+++ b/docs/api/touch-bar-color-picker.md
@@ -12,7 +12,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
   * `selectedColor` String (optional) - The selected hex color in the picker,
     i.e `#ABCDEF`.
   * `change` Function (optional) - Function to call when a color is selected.
-    * `color` String - The color that the user selected from the picker
+    * `color` String - The color that the user selected from the picker.
 
 ### Instance Properties
 

--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -7,11 +7,11 @@ Process: [Main](../tutorial/quick-start.md#main-process)
 ### `new TouchBarScrubber(options)` _Experimental_
 
 * `options` Object
-  * `items` [ScrubberItem[]](structures/scrubber-item.md) - An array of items to place in this scrubber
-  * `select` Function - Called when the user taps an item that was not the last tapped item
-    * `selectedIndex` Integer - The index of the item the user selected
-  * `highlight` Function - Called when the user taps any item
-    * `highlightedIndex` Integer - The index of the item the user touched
+  * `items` [ScrubberItem[]](structures/scrubber-item.md) - An array of items to place in this scrubber.
+  * `select` Function - Called when the user taps an item that was not the last tapped item.
+    * `selectedIndex` Integer - The index of the item the user selected.
+  * `highlight` Function - Called when the user taps any item.
+    * `highlightedIndex` Integer - The index of the item the user touched.
   * `selectedStyle` String - Selected item style. Defaults to `null`.
   * `overlayStyle` String - Selected overlay item style. Defaults to `null`.
   * `showArrowButtons` Boolean - Defaults to `false`.
@@ -32,9 +32,9 @@ updates the control in the touch bar. Updating deep properties inside this array
 A `String` representing the style that selected items in the scrubber should have. Updating this value immediately
 updates the control in the touch bar.  Possible values:
 
-* `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`
-* `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`
-* `null` - Actually null, not a string, removes all styles
+* `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
+* `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
+* `null` - Actually null, not a string, removes all styles.
 
 #### `touchBarScrubber.overlayStyle`
 
@@ -42,9 +42,9 @@ A `String` representing the style that selected items in the scrubber should hav
 of the scrubber item instead of being placed behind it. Updating this value immediately updates the control in the
 touch bar.  Possible values:
 
-* `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`
-* `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`
-* `null` - Actually null, not a string, removes all styles
+* `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
+* `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
+* `null` - Actually null, not a string, removes all styles.
 
 #### `touchBarScrubber.showArrowButtons`
 
@@ -56,8 +56,8 @@ immediately updates the control in the touch bar.
 A `String` representing the mode of this scrubber. Updating this value immediately
 updates the control in the touch bar. Possible values:
 
-* `fixed` - Maps to `NSScrubberModeFixed`
-* `free` - Maps to `NSScrubberModeFree`
+* `fixed` - Maps to `NSScrubberModeFixed`.
+* `free` - Maps to `NSScrubberModeFree`.
 
 #### `touchBarScrubber.continuous`
 

--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -30,7 +30,7 @@ updates the control in the touch bar. Updating deep properties inside this array
 #### `touchBarScrubber.selectedStyle`
 
 A `String` representing the style that selected items in the scrubber should have. Updating this value immediately
-updates the control in the touch bar.  Possible values:
+updates the control in the touch bar. Possible values:
 
 * `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
@@ -40,7 +40,7 @@ updates the control in the touch bar.  Possible values:
 
 A `String` representing the style that selected items in the scrubber should have. This style is overlayed on top
 of the scrubber item instead of being placed behind it. Updating this value immediately updates the control in the
-touch bar.  Possible values:
+touch bar. Possible values:
 
 * `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
@@ -49,7 +49,7 @@ touch bar.  Possible values:
 #### `touchBarScrubber.showArrowButtons`
 
 A `Boolean` representing whether to show the left / right selection arrows in this scrubber. Updating this value
-immediately updates the control in the touch bar.  
+immediately updates the control in the touch bar.
 
 #### `touchBarScrubber.mode`
 

--- a/docs/api/touch-bar-segmented-control.md
+++ b/docs/api/touch-bar-segmented-control.md
@@ -17,7 +17,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
     * `round-rect` - The control is displayed using the round rect style.
     * `textured-square` - The control is displayed using the textured square
       style.
-    * `capsule` - The control is displayed using the capsule style
+    * `capsule` - The control is displayed using the capsule style.
     * `small-square` - The control is displayed using the small square style.
     * `separated` - The segments in the control are displayed very close to each
       other but not touching.
@@ -27,7 +27,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
     * `buttons` - Make the segments act as buttons, each segment can be pressed and released but never marked as active.
   * `segments` [SegmentedControlSegment[]](structures/segmented-control-segment.md) - An array of segments to place in this control.
   * `selectedIndex` Integer (optional) - The index of the currently selected segment, will update automatically with user interaction.  When the mode is multiple it will be the last selected item.
-  * `change` Function - Called when the user selects a new segment
+  * `change` Function - Called when the user selects a new segment.
     * `selectedIndex` Integer - The index of the segment the user selected.
     * `isSelected` Boolean - Whether as a result of user selection the segment is selected or not.
 
@@ -37,15 +37,15 @@ The following properties are available on instances of `TouchBarSegmentedControl
 
 #### `touchBarSegmentedControl.segmentStyle`
 
-A `String` representing the controls current segment style.  Updating this value immediately updates the control
+A `String` representing the controls current segment style. Updating this value immediately updates the control
 in the touch bar.
 
 #### `touchBarSegmentedControl.segments`
 
 A `SegmentedControlSegment[]` array representing the segments in this control.  Updating this value immediately
-updates the control in the touch bar.  Updating deep properties inside this array **does not update the touch bar**.
+updates the control in the touch bar. Updating deep properties inside this array **does not update the touch bar**.
 
 #### `touchBarSegmentedControl.selectedIndex`
 
 An `Integer` representing the currently selected segment.  Changing this value immediately updates the control
-in the touch bar.  User interaction with the touch bar will update this value automatically.
+in the touch bar. User interaction with the touch bar will update this value automatically.

--- a/docs/api/touch-bar-segmented-control.md
+++ b/docs/api/touch-bar-segmented-control.md
@@ -26,7 +26,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
     * `multiple` - Multiple items can be selected at a time.
     * `buttons` - Make the segments act as buttons, each segment can be pressed and released but never marked as active.
   * `segments` [SegmentedControlSegment[]](structures/segmented-control-segment.md) - An array of segments to place in this control.
-  * `selectedIndex` Integer (optional) - The index of the currently selected segment, will update automatically with user interaction.  When the mode is multiple it will be the last selected item.
+  * `selectedIndex` Integer (optional) - The index of the currently selected segment, will update automatically with user interaction. When the mode is multiple it will be the last selected item.
   * `change` Function - Called when the user selects a new segment.
     * `selectedIndex` Integer - The index of the segment the user selected.
     * `isSelected` Boolean - Whether as a result of user selection the segment is selected or not.
@@ -42,10 +42,10 @@ in the touch bar.
 
 #### `touchBarSegmentedControl.segments`
 
-A `SegmentedControlSegment[]` array representing the segments in this control.  Updating this value immediately
+A `SegmentedControlSegment[]` array representing the segments in this control. Updating this value immediately
 updates the control in the touch bar. Updating deep properties inside this array **does not update the touch bar**.
 
 #### `touchBarSegmentedControl.selectedIndex`
 
-An `Integer` representing the currently selected segment.  Changing this value immediately updates the control
+An `Integer` representing the currently selected segment. Changing this value immediately updates the control
 in the touch bar. User interaction with the touch bar will update this value automatically.

--- a/docs/api/touch-bar-segmented-control.md
+++ b/docs/api/touch-bar-segmented-control.md
@@ -7,7 +7,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
 ### `new TouchBarSegmentedControl(options)` _Experimental_
 
 * `options` Object
-  * `segmentStyle` String - (optional) Style of the segments:
+  * `segmentStyle` String (optional) - Style of the segments:
     * `automatic` - Default. The appearance of the segmented control is
       automatically determined based on the type of window in which the control
       is displayed and the position within the window.
@@ -21,7 +21,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
     * `small-square` - The control is displayed using the small square style.
     * `separated` - The segments in the control are displayed very close to each
       other but not touching.
-  * `mode` String - (optional) The selection mode of the control:
+  * `mode` String (optional) - The selection mode of the control:
     * `single` - Default. One item selected at a time, selecting one deselects the previously selected item.
     * `multiple` - Multiple items can be selected at a time.
     * `buttons` - Make the segments act as buttons, each segment can be pressed and released but never marked as active.

--- a/docs/api/touch-bar-slider.md
+++ b/docs/api/touch-bar-slider.md
@@ -12,7 +12,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
   * `minValue` Integer (optional) - Minimum value.
   * `maxValue` Integer (optional) - Maximum value.
   * `change` Function (optional) - Function to call when the slider is changed.
-    * `newValue` Number - The value that the user selected on the Slider
+    * `newValue` Number - The value that the user selected on the Slider.
 
 ### Instance Properties
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -75,8 +75,8 @@ The `Tray` module emits the following events:
   * `shiftKey` Boolean
   * `ctrlKey` Boolean
   * `metaKey` Boolean
-* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon
-* `position` [Point](structures/point.md) - The position of the event
+* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon.
+* `position` [Point](structures/point.md) - The position of the event.
 
 Emitted when the tray icon is clicked.
 
@@ -87,7 +87,7 @@ Emitted when the tray icon is clicked.
   * `shiftKey` Boolean
   * `ctrlKey` Boolean
   * `metaKey` Boolean
-* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon
+* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon.
 
 Emitted when the tray icon is right clicked.
 
@@ -98,7 +98,7 @@ Emitted when the tray icon is right clicked.
   * `shiftKey` Boolean
   * `ctrlKey` Boolean
   * `metaKey` Boolean
-* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon
+* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon.
 
 Emitted when the tray icon is double clicked.
 
@@ -129,7 +129,7 @@ Emitted when dragged files are dropped in the tray icon.
 #### Event: 'drop-text' _macOS_
 
 * `event` Event
-* `text` String - the dropped text string
+* `text` String - the dropped text string.
 
 Emitted when dragged text is dropped in the tray icon.
 
@@ -152,7 +152,7 @@ Emitted when a drag operation ends on the tray or ends at another location.
   * `shiftKey` Boolean
   * `ctrlKey` Boolean
   * `metaKey` Boolean
-* `position` [Point](structures/point.md) - The position of the event
+* `position` [Point](structures/point.md) - The position of the event.
 
 Emitted when the mouse enters the tray icon.
 
@@ -163,7 +163,7 @@ Emitted when the mouse enters the tray icon.
   * `shiftKey` Boolean
   * `ctrlKey` Boolean
   * `metaKey` Boolean
-* `position` [Point](structures/point.md) - The position of the event
+* `position` [Point](structures/point.md) - The position of the event.
 
 Emitted when the mouse exits the tray icon.
 
@@ -174,7 +174,7 @@ Emitted when the mouse exits the tray icon.
   * `shiftKey` Boolean
   * `ctrlKey` Boolean
   * `metaKey` Boolean
-* `position` [Point](structures/point.md) - The position of the event
+* `position` [Point](structures/point.md) - The position of the event.
 
 Emitted when the mouse moves in the tray icon.
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -244,7 +244,7 @@ win.on('hide', () => {
 #### `tray.displayBalloon(options)` _Windows_
 
 * `options` Object
-  * `icon` ([NativeImage](native-image.md) | String) - (optional)
+  * `icon` ([NativeImage](native-image.md) | String) (optional) -
   * `title` String
   * `content` String
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -511,7 +511,7 @@ Returns:
 
 Emitted when bluetooth device needs to be selected on call to
 `navigator.bluetooth.requestDevice`. To use `navigator.bluetooth` api
-`webBluetooth` should be enabled.  If `event.preventDefault` is not called,
+`webBluetooth` should be enabled. If `event.preventDefault` is not called,
 first available device will be selected. `callback` should be called with
 `deviceId` to be selected, passing empty string to `callback` will
 cancel the request.
@@ -762,7 +762,7 @@ invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
 If the result of the executed code is a promise the callback result will be the
-resolved value of the promise.  We recommend that you use the returned Promise
+resolved value of the promise. We recommend that you use the returned Promise
 to handle code that results in a Promise.
 
 ```js
@@ -1144,7 +1144,7 @@ app.on('ready', () => {
 <body>
   <script>
     require('electron').ipcRenderer.on('ping', (event, message) => {
-      console.log(message)  // Prints 'whoooooooh!'
+      console.log(message) // Prints 'whoooooooh!'
     })
   </script>
 </body>
@@ -1334,17 +1334,17 @@ Returns `String` - Returns the WebRTC IP Handling Policy.
 #### `contents.setWebRTCIPHandlingPolicy(policy)`
 
 * `policy` String - Specify the WebRTC IP Handling Policy.
-  * `default` - Exposes user's public and local IPs.  This is the default
-  behavior.  When this policy is used, WebRTC has the right to enumerate all
+  * `default` - Exposes user's public and local IPs. This is the default
+  behavior. When this policy is used, WebRTC has the right to enumerate all
   interfaces and bind them to discover public interfaces.
   * `default_public_interface_only` - Exposes user's public IP, but does not
-  expose user's local IP.  When this policy is used, WebRTC should only use the
+  expose user's local IP. When this policy is used, WebRTC should only use the
   default route used by http. This doesn't expose any local addresses.
   * `default_public_and_private_interfaces` - Exposes user's public and local
-  IPs.  When this policy is used, WebRTC should only use the default route used
+  IPs. When this policy is used, WebRTC should only use the default route used
   by http. This also exposes the associated default private address. Default
   route is the route chosen by the OS on a multi-homed endpoint.
-  * `disable_non_proxied_udp` - Does not expose public or local IPs.  When this
+  * `disable_non_proxied_udp` - Does not expose public or local IPs. When this
   policy is used, WebRTC should only use TCP to contact peers or servers unless
   the proxy server supports UDP.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -805,7 +805,7 @@ Sends a request to get current zoom factor, the `callback` will be called with
 
 #### `contents.setZoomLevel(level)`
 
-* `level` Number - Zoom level
+* `level` Number - Zoom level.
 
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
@@ -945,7 +945,7 @@ console.log(requestId)
 
 #### `contents.capturePage([rect, ]callback)`
 
-* `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 * `callback` Function
   * `image` [NativeImage](native-image.md)
 
@@ -975,7 +975,7 @@ when the JS promise is rejected.
 
 Get the system printer list.
 
-Returns [`PrinterInfo[]`](structures/printer-info.md)
+Returns [`PrinterInfo[]`](structures/printer-info.md).
 
 #### `contents.print([options], [callback])`
 
@@ -985,7 +985,7 @@ Returns [`PrinterInfo[]`](structures/printer-info.md)
     the web page. Default is `false`.
   * `deviceName` String (optional) - Set the printer device name to use. Default is `''`.
 * `callback` Function (optional)
-  * success` Boolean - Indicates success of the print call.
+  * `success` Boolean - Indicates success of the print call.
 
 Prints window's web page. When `silent` is set to `true`, Electron will pick
 the system's default printer if `deviceName` is empty and the default settings
@@ -1120,7 +1120,7 @@ send arbitrary arguments. Arguments will be serialized in JSON internally and
 hence no functions or prototype chain will be included.
 
 The renderer process can handle the message by listening to `channel` with the
-`ipcRenderer` module.
+[`ipcRenderer`](ipc-renderer.md) module.
 
 An example of sending messages from the main process to the renderer process:
 
@@ -1155,17 +1155,17 @@ app.on('ready', () => {
 
 * `parameters` Object
   * `screenPosition` String - Specify the screen type to emulate
-      (default: `desktop`)
-    * `desktop` - Desktop screen type
-    * `mobile` - Mobile screen type
-  * `screenSize` [Size](structures/size.md) - Set the emulated screen size (screenPosition == mobile)
+      (default: `desktop`):
+    * `desktop` - Desktop screen type.
+    * `mobile` - Mobile screen type.
+  * `screenSize` [Size](structures/size.md) - Set the emulated screen size (screenPosition == mobile).
   * `viewPosition` [Point](structures/point.md) - Position the view on the screen
-      (screenPosition == mobile) (default: `{x: 0, y: 0}`)
+      (screenPosition == mobile) (default: `{x: 0, y: 0}`).
   * `deviceScaleFactor` Integer - Set the device scale factor (if zero defaults to
-      original device scale factor) (default: `0`)
+      original device scale factor) (default: `0`).
   * `viewSize` [Size](structures/size.md) - Set the emulated view size (empty means no override)
   * `scale` Float - Scale of emulated view inside available space (not in fit to
-      view mode) (default: `1`)
+      view mode) (default: `1`).
 
 Enable device emulation with the given parameters.
 
@@ -1178,14 +1178,14 @@ Disable device emulation enabled by `webContents.enableDeviceEmulation`.
 * `event` Object
   * `type` String (**required**) - The type of the event, can be `mouseDown`,
     `mouseUp`, `mouseEnter`, `mouseLeave`, `contextMenu`, `mouseWheel`,
-    `mouseMove`, `keyDown`, `keyUp`, `char`.
+    `mouseMove`, `keyDown`, `keyUp` or `char`.
   * `modifiers` String[] - An array of modifiers of the event, can
     include `shift`, `control`, `alt`, `meta`, `isKeypad`, `isAutoRepeat`,
     `leftButtonDown`, `middleButtonDown`, `rightButtonDown`, `capsLock`,
     `numLock`, `left`, `right`.
 
 Sends an input `event` to the page.
-**Note:** The `BrowserWindow` containing the contents needs to be focused for
+**Note:** The [`BrowserWindow`](browser-window.md) containing the contents needs to be focused for
 `sendInputEvent()` to work.
 
 For keyboard events, the `event` object also have following properties:
@@ -1198,7 +1198,7 @@ For mouse events, the `event` object also have following properties:
 
 * `x` Integer (**required**)
 * `y` Integer (**required**)
-* `button` String - The button pressed, can be `left`, `middle`, `right`
+* `button` String - The button pressed, can be `left`, `middle`, `right`.
 * `globalX` Integer
 * `globalY` Integer
 * `movementX` Integer
@@ -1218,7 +1218,7 @@ For the `mouseWheel` event, the `event` object also have following properties:
 
 #### `contents.beginFrameSubscription([onlyDirty ,]callback)`
 
-* `onlyDirty` Boolean (optional) - Defaults to `false`
+* `onlyDirty` Boolean (optional) - Defaults to `false`.
 * `callback` Function
   * `frameBuffer` Buffer
   * `dirtyRect` [Rectangle](structures/rectangle.md)
@@ -1349,7 +1349,7 @@ Returns `String` - Returns the WebRTC IP Handling Policy.
   the proxy server supports UDP.
 
 Setting the WebRTC IP handling policy allows you to control which IPs are
-exposed via WebRTC.  See [BrowserLeaks](https://browserleaks.com/webrtc) for
+exposed via WebRTC. See [BrowserLeaks](https://browserleaks.com/webrtc) for
 more details.
 
 #### `contents.getOSProcessId()`

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -134,7 +134,7 @@ Emitted when the document in the given frame is loaded.
 Returns:
 
 * `event` Event
-* `favicons` String[] - Array of URLs
+* `favicons` String[] - Array of URLs.
 
 Emitted when page receives favicon urls.
 
@@ -148,7 +148,7 @@ Returns:
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
   `new-window`, `save-to-disk` and `other`.
 * `options` Object - The options which will be used for creating the new
-  `BrowserWindow`.
+  [`BrowserWindow`](browser-window.md).
 * `additionalFeatures` String[] - The non-standard features (features not handled
   by Chromium or Electron) given to `window.open()`.
 
@@ -158,8 +158,8 @@ requested by `window.open` or an external link like `<a target='_blank'>`.
 By default a new `BrowserWindow` will be created for the `url`.
 
 Calling `event.preventDefault()` will prevent Electron from automatically creating a
-new `BrowserWindow`. If you call `event.preventDefault()` and manually create a new
-`BrowserWindow` then you must set `event.newGuest` to reference the new `BrowserWindow`
+new [`BrowserWindow`](browser-window.md). If you call `event.preventDefault()` and manually create a new
+[`BrowserWindow`](browser-window.md) then you must set `event.newGuest` to reference the new [`BrowserWindow`](browser-window.md)
 instance, failing to do so may result in unexpected behavior. For example:
 
 ```javascript
@@ -276,15 +276,15 @@ Emitted when `webContents` is destroyed.
 Returns:
 
 * `event` Event
-* `input` Object - Input properties
-  * `type` String - Either `keyUp` or `keyDown`
-  * `key` String - Equivalent to [KeyboardEvent.key][keyboardevent]
-  * `code` String - Equivalent to [KeyboardEvent.code][keyboardevent]
-  * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat][keyboardevent]
-  * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey][keyboardevent]
-  * `control` Boolean - Equivalent to [KeyboardEvent.controlKey][keyboardevent]
-  * `alt` Boolean - Equivalent to [KeyboardEvent.altKey][keyboardevent]
-  * `meta` Boolean - Equivalent to [KeyboardEvent.metaKey][keyboardevent]
+* `input` Object - Input properties.
+  * `type` String - Either `keyUp` or `keyDown`.
+  * `key` String - Equivalent to [KeyboardEvent.key][keyboardevent].
+  * `code` String - Equivalent to [KeyboardEvent.code][keyboardevent].
+  * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat][keyboardevent].
+  * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey][keyboardevent].
+  * `control` Boolean - Equivalent to [KeyboardEvent.controlKey][keyboardevent].
+  * `alt` Boolean - Equivalent to [KeyboardEvent.altKey][keyboardevent].
+  * `meta` Boolean - Equivalent to [KeyboardEvent.metaKey][keyboardevent].
 
 Emitted before dispatching the `keydown` and `keyup` events in the page.
 Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events
@@ -323,10 +323,10 @@ Returns:
 
 * `event` Event
 * `url` String
-* `error` String - The error code
+* `error` String - The error code.
 * `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
-  * `isTrusted` Boolean - Indicates whether the certificate can be considered trusted
+  * `isTrusted` Boolean - Indicates whether the certificate can be considered trusted.
 
 Emitted when failed to verify the `certificate` for `url`.
 
@@ -341,7 +341,7 @@ Returns:
 * `url` URL
 * `certificateList` [Certificate[]](structures/certificate.md)
 * `callback` Function
-  * `certificate` [Certificate](structures/certificate.md) - Must be a certificate from the given list
+  * `certificate` [Certificate](structures/certificate.md) - Must be a certificate from the given list.
 
 Emitted when a client certificate is requested.
 
@@ -423,10 +423,10 @@ Returns:
 
 * `event` Event
 * `type` String
-* `image` NativeImage (optional)
-* `scale` Float (optional) - scaling factor for the custom cursor
-* `size` [Size](structures/size.md) (optional) - the size of the `image`
-* `hotspot` [Point](structures/point.md) (optional) - coordinates of the custom cursor's hotspot
+* `image` [NativeImage](native-image.md) (optional)
+* `scale` Float (optional) - scaling factor for the custom cursor.
+* `size` [Size](structures/size.md) (optional) - the size of the `image`.
+* `hotspot` [Point](structures/point.md) (optional) - coordinates of the custom cursor's hotspot.
 
 Emitted when the cursor's type changes. The `type` parameter can be `default`,
 `crosshair`, `pointer`, `text`, `wait`, `help`, `e-resize`, `n-resize`,
@@ -435,10 +435,10 @@ Emitted when the cursor's type changes. The `type` parameter can be `default`,
 `row-resize`, `m-panning`, `e-panning`, `n-panning`, `ne-panning`, `nw-panning`,
 `s-panning`, `se-panning`, `sw-panning`, `w-panning`, `move`, `vertical-text`,
 `cell`, `context-menu`, `alias`, `progress`, `nodrop`, `copy`, `none`,
-`not-allowed`, `zoom-in`, `zoom-out`, `grab`, `grabbing`, `custom`.
+`not-allowed`, `zoom-in`, `zoom-out`, `grab`, `grabbing` or `custom`.
 
 If the `type` parameter is `custom`, the `image` parameter will hold the custom
-cursor image in a `NativeImage`, and `scale`, `size` and `hotspot` will hold
+cursor image in a [`NativeImage`](native-image.md), and `scale`, `size` and `hotspot` will hold
 additional information about the custom cursor.
 
 #### Event: 'context-menu'
@@ -447,8 +447,8 @@ Returns:
 
 * `event` Event
 * `params` Object
-  * `x` Integer - x coordinate
-  * `y` Integer - y coordinate
+  * `x` Integer - x coordinate.
+  * `y` Integer - y coordinate.
   * `linkURL` String - URL of the link that encloses the node the context menu
     was invoked on.
   * `linkText` String - Text associated with the link. May be an empty
@@ -475,7 +475,7 @@ Returns:
     field, the type of that field. Possible values are `none`, `plainText`,
     `password`, `other`.
   * `menuSourceType` String - Input source that invoked the context menu.
-    Can be `none`, `mouse`, `keyboard`, `touch`, `touchMenu`.
+    Can be `none`, `mouse`, `keyboard`, `touch` or `touchMenu`.
   * `mediaFlags` Object - The flags for the media element the context menu was
     invoked on.
     * `inError` Boolean - Whether the media element has crashed.
@@ -611,8 +611,8 @@ for windows with *offscreen rendering* enabled.
 * `options` Object (optional)
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
-  * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) - (optional)
+  * `extraHeaders` String (optional) - Extra headers separated by "\n".
+  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Loads the `url` in the window. The `url` must contain the protocol prefix,
@@ -906,14 +906,14 @@ Inserts `text` to the focused element.
 
 * `text` String - Content to be searched, must not be empty.
 * `options` Object (optional)
-  * `forward` Boolean - (optional) Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean - (optional) Whether the operation is first request or a follow up,
+  * `forward` Boolean (optional) - Whether to search forward or backward, defaults to `true`.
+  * `findNext` Boolean (optional) - Whether the operation is first request or a follow up,
     defaults to `false`.
-  * `matchCase` Boolean - (optional) Whether search should be case-sensitive,
+  * `matchCase` Boolean (optional) - Whether search should be case-sensitive,
     defaults to `false`.
-  * `wordStart` Boolean - (optional) Whether to look only at the start of words.
+  * `wordStart` Boolean (optional) - Whether to look only at the start of words.
     defaults to `false`.
-  * `medialCapitalAsWordStart` Boolean - (optional) When combined with `wordStart`,
+  * `medialCapitalAsWordStart` Boolean (optional) - When combined with `wordStart`,
     accepts a match in the middle of a word if the match begins with an
     uppercase letter followed by a lowercase or non-letter.
     Accepts several other intra-word matches, defaults to `false`.
@@ -999,14 +999,14 @@ Use `page-break-before: always; ` CSS style to force to print to a new page.
 #### `contents.printToPDF(options, callback)`
 
 * `options` Object
-  * `marginsType` Integer - (optional) Specifies the type of margins to use. Uses 0 for
+  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
     default margin, 1 for no margin, and 2 for minimum margin.
-  * `pageSize` String - (optional) Specify page size of the generated PDF. Can be `A3`,
+  * `pageSize` String (optional) - Specify page size of the generated PDF. Can be `A3`,
     `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
     and `width` in microns.
-  * `printBackground` Boolean - (optional) Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean - (optional) Whether to print selection only.
-  * `landscape` Boolean - (optional) `true` for landscape, `false` for portrait.
+  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
+  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
 * `callback` Function
   * `error` Error
   * `data` Buffer

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -106,11 +106,11 @@ Content Security Policy.
 
 * `scheme` String
 * `options` Object (optional)
-  * `secure` Boolean - (optional) Default true.
-  * `bypassCSP` Boolean - (optional) Default true.
-  * `allowServiceWorkers` Boolean - (optional) Default true.
-  * `supportFetchAPI` Boolean - (optional) Default true.
-  * `corsEnabled` Boolean - (optional) Default true.
+  * `secure` Boolean (optional) - Default true.
+  * `bypassCSP` Boolean (optional) - Default true.
+  * `allowServiceWorkers` Boolean (optional) - Default true.
+  * `supportFetchAPI` Boolean (optional) - Default true.
+  * `corsEnabled` Boolean (optional) - Default true.
 
 Registers the `scheme` as secure, bypasses content security policy for resources,
 allows registering ServiceWorker and supports fetch API.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -29,7 +29,7 @@ Returns `Number` - The current zoom factor.
 
 ### `webFrame.setZoomLevel(level)`
 
-* `level` Number - Zoom level
+* `level` Number - Zoom level.
 
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
@@ -66,7 +66,7 @@ Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 * `language` String
 * `autoCorrectWord` Boolean
 * `provider` Object
-  * `spellCheck` Function - Returns `Boolean`
+  * `spellCheck` Function - Returns `Boolean`.
     * `text` String
 
 Sets a provider for spell checking in input fields and text areas.

--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -41,8 +41,8 @@ The following methods are available on instances of `WebRequest`:
 
 #### `webRequest.onBeforeRequest([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
   * `details` Object
@@ -68,8 +68,8 @@ The `callback` has to be called with an `response` object.
 
 #### `webRequest.onBeforeSendHeaders([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
 
@@ -95,8 +95,8 @@ The `callback` has to be called with an `response` object.
 
 #### `webRequest.onSendHeaders([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
   * `details` Object
@@ -114,8 +114,8 @@ response are visible by the time this listener is fired.
 
 #### `webRequest.onHeadersReceived([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
 
@@ -145,8 +145,8 @@ The `callback` has to be called with an `response` object.
 
 #### `webRequest.onResponseStarted([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
   * `details` Object
@@ -168,8 +168,8 @@ and response headers are available.
 
 #### `webRequest.onBeforeRedirect([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
   * `details` Object
@@ -191,8 +191,8 @@ redirect is about to occur.
 
 #### `webRequest.onCompleted([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
   * `details` Object
@@ -212,8 +212,8 @@ completed.
 
 #### `webRequest.onErrorOccurred([filter, ]listener)`
 
-* `filter` Object - (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the 
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
   * `details` Object

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -577,7 +577,7 @@ Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([r
 
 Send an asynchronous message to renderer process via `channel`, you can also
 send arbitrary arguments. The renderer process can handle the message by
-listening to the `channel` event with the `ipcRenderer` module.
+listening to the `channel` event with the [`ipcRenderer`](ipc-renderer.md) module.
 
 See [webContents.send](web-contents.md#webcontentssendchannel-args) for
 examples.
@@ -773,7 +773,7 @@ Returns:
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
   `new-window`, `save-to-disk` and `other`.
 * `options` Object - The options which should be used for creating the new
-  `BrowserWindow`.
+  [`BrowserWindow`](browser-window.md).
 
 Fired when the guest page attempts to open a new browser window.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -564,7 +564,7 @@ Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, cal
 
 ### `<webview>.capturePage([rect, ]callback)`
 
-* `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 * `callback` Function
   * `image` [NativeImage](native-image.md)
 
@@ -600,7 +600,7 @@ zoom percent divided by 100, so 300% = 3.0.
 
 ### `<webview>.setZoomLevel(level)`
 
-* `level` Number - Zoom level
+* `level` Number - Zoom level.
 
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -309,7 +309,7 @@ webview.addEventListener('dom-ready', () => {
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) - (optional)
+  * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) (optional) -
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Loads the `url` in the webview, the `url` must contain the protocol prefix,
@@ -508,14 +508,14 @@ Inserts `text` to the focused element.
 
 * `text` String - Content to be searched, must not be empty.
 * `options` Object (optional)
-  * `forward` Boolean - (optional) Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean - (optional) Whether the operation is first request or a follow up,
+  * `forward` Boolean (optional) - Whether to search forward or backward, defaults to `true`.
+  * `findNext` Boolean (optional) - Whether the operation is first request or a follow up,
     defaults to `false`.
-  * `matchCase` Boolean - (optional) Whether search should be case-sensitive,
+  * `matchCase` Boolean (optional) - Whether search should be case-sensitive,
     defaults to `false`.
-  * `wordStart` Boolean - (optional) Whether to look only at the start of words.
+  * `wordStart` Boolean (optional) - Whether to look only at the start of words.
     defaults to `false`.
-  * `medialCapitalAsWordStart` Boolean - (optional) When combined with `wordStart`,
+  * `medialCapitalAsWordStart` Boolean (optional) - When combined with `wordStart`,
     accepts a match in the middle of a word if the match begins with an
     uppercase letter followed by a lowercase or non-letter.
     Accepts several other intra-word matches, defaults to `false`.
@@ -548,14 +548,14 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 ### `<webview>.printToPDF(options, callback)`
 
 * `options` Object
-  * `marginsType` Integer - (optional) Specifies the type of margins to use. Uses 0 for
+  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
     default margin, 1 for no margin, and 2 for minimum margin.
-  * `pageSize` String - (optional) Specify page size of the generated PDF. Can be `A3`,
+  * `pageSize` String (optional) - Specify page size of the generated PDF. Can be `A3`,
     `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
     and `width` in microns.
-  * `printBackground` Boolean - (optional) Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean - (optional) Whether to print selection only.
-  * `landscape` Boolean - (optional) `true` for landscape, `false` for portrait.
+  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
+  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
 * `callback` Function
   * `error` Error
   * `data` Buffer

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -3,7 +3,7 @@
 > Open a new window and load a URL.
 
 When `window.open` is called to create a new window in a web page, a new instance
-of `BrowserWindow` will be created for the `url` and a proxy will be returned
+of [`BrowserWindow`](browser-window.md) will be created for the `url` and a proxy will be returned
 to `window.open` to let the page have limited control over it.
 
 The proxy has limited standard functionality implemented to be

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ installation errors.
 In almost all cases, these errors are the result of network problems and not
 actual issues with the `electron` npm package. Errors like `ELIFECYCLE`,
 `EAI_AGAIN`, `ECONNRESET`, and `ETIMEDOUT` are all indications of such
-network problems.  The best resolution is to try switching networks, or
+network problems. The best resolution is to try switching networks, or
 just wait a bit and try installing again.
 
 You can also attempt to download Electron directly from

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -12,15 +12,15 @@ The ASAR format was created primarily to improve performance on Windows... TODO
 
 ### Brightray
 
-Brightray [was](https://github.com/electron-archive/brightray) a static library 
-that made [libchromiumcontent] easier to use in applications. It is now 
+Brightray [was](https://github.com/electron-archive/brightray) a static library
+that made [libchromiumcontent] easier to use in applications. It is now
 deprecated and has been merged into Electron's codebase.
 
 ### CRT
 
-The C Run-time Library (CRT) is the part of the C++ Standard Library that 
-incorporates the ISO C99 standard library. The Visual C++ libraries that 
-implement the CRT support native code development, and both mixed native and 
+The C Run-time Library (CRT) is the part of the C++ Standard Library that
+incorporates the ISO C99 standard library. The Visual C++ libraries that
+implement the CRT support native code development, and both mixed native and
 managed code, and pure managed code for .NET development.
 
 ### DMG
@@ -31,8 +31,8 @@ supports `dmg` as a build target.
 
 ### IME
 
-Input Method Editor. A program that allows users to enter characters and 
-symbols not found on their keyboard. For example, this allows users of Latin 
+Input Method Editor. A program that allows users to enter characters and
+symbols not found on their keyboard. For example, this allows users of Latin
 keyboards to input Chinese, Japanese, Korean and Indic characters.
 
 ### IPC
@@ -51,7 +51,7 @@ dependencies (e.g., Blink, [V8], etc.). Also referred to as "libcc".
 
 The main process, commonly a file named `main.js`, is the entry point to every
 Electron app. It controls the life of the app, from open to close. It also
-manages native elements such as the Menu, Menu Bar, Dock, Tray, etc.  The
+manages native elements such as the Menu, Menu Bar, Dock, Tray, etc. The
 main process is responsible for creating each new renderer process in the app.
 The full Node API is built in.
 
@@ -93,8 +93,8 @@ as a build target.
 
 ### OSR
 
-OSR (Off-screen rendering) can be used for loading heavy page in 
-background and then displaying it after (it will be much faster). 
+OSR (Off-screen rendering) can be used for loading heavy page in
+background and then displaying it after (it will be much faster).
 It allows you to render page without showing it on screen.
 
 ### process
@@ -149,10 +149,10 @@ available in "core".
 V8 is Google's open source JavaScript engine. It is written in C++ and is
 used in Google Chrome. V8 can run standalone, or can be embedded into any C++ application.
 
-Electron builds V8 as part of Chromium and then points Node to that V8 when 
+Electron builds V8 as part of Chromium and then points Node to that V8 when
 building it.
 
-V8's version numbers always correspond to those of Google Chrome. Chrome 59 
+V8's version numbers always correspond to those of Google Chrome. Chrome 59
 includes V8 5.9, Chrome 58 includes V8 5.8, etc.
 
 - [developers.google.com/v8](https://developers.google.com/v8)


### PR DESCRIPTION
hey folks, when I translate the documentation, I see a lot of sentences without dots at the end. some double spaces and things like that. A few "(optional)" wording was after the "-" and others before.
So I've fixed that 👍 