### PR TITLE
spec: Fix the failing coffee-script test

### DIFF
--- a/spec/package.json
+++ b/spec/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "basic-auth": "^1.0.4",
     "chai": "^4.1.2",
-    "coffee-script": "^1.12.3",
+    "coffee-script": "1.12.7",
     "graceful-fs": "^4.1.9",
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.0",


### PR DESCRIPTION
The latest version of coffee-script released a few hours ago has some regression causing our test to fail. Did not look into the root cause, but this test is to ensure we don't have a regression, instead of checking the compatibility with coffee-script, so locking the version is fine.

The failing log is https://windows-ci.electronjs.org/project/AppVeyor/electron/build/1.0.1309/job/rtetst3ovldt9286, seems to be a Windows-only thing.

```
not ok 770 modules support third-party module coffee-script can be registered and used to require .coffee files
  AssertionError [ERR_ASSERTION]: Got unwanted exception.
      at innerThrows (assert.js:653:7)
      at Function.doesNotThrow (assert.js:665:3)
      at Context.it (C:\projects\electron\spec\modules-spec.js:61:16)
      at callFn (C:\projects\electron\spec\node_modules\mocha\lib\runnable.js:348:21)
      at Test.Runnable.run (C:\projects\electron\spec\node_modules\mocha\lib\runnable.js:340:7)
      at Runner.runTest (C:\projects\electron\spec\node_modules\mocha\lib\runner.js:443:10)
      at C:\projects\electron\spec\node_modules\mocha\lib\runner.js:549:12
      at next (C:\projects\electron\spec\node_modules\mocha\lib\runner.js:361:14)
      at C:\projects\electron\spec\node_modules\mocha\lib\runner.js:371:7
      at next (C:\projects\electron\spec\node_modules\mocha\lib\runner.js:295:14)
```