### PR TITLE
Add API to set arbitrary WebContents as devtools

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -896,9 +896,10 @@ void WebContents::DevToolsOpened() {
       "DevToolsAPI.setInspectedTabId", &tab_id, nullptr, nullptr);
 
   // Inherit owner window in devtools.
-  if (owner_window())
-    handle->SetOwnerWindow(managed_web_contents()->GetDevToolsWebContents(),
-                           owner_window());
+  auto* devtools = managed_web_contents()->GetDevToolsWebContents();
+  if (owner_window() &&
+      !devtools->GetUserData(NativeWindowRelay::UserDataKey()))
+    handle->SetOwnerWindow(devtools, owner_window());
 
   Emit("devtools-opened");
 }
@@ -1808,6 +1809,11 @@ void WebContents::SetEmbedder(const WebContents* embedder) {
   }
 }
 
+void WebContents::SetDevToolsWebContents(const WebContents* devtools) {
+  if (managed_web_contents())
+    managed_web_contents()->SetDevToolsWebContents(devtools->web_contents());
+}
+
 v8::Local<v8::Value> WebContents::GetNativeView() const {
   gfx::NativeView ptr = web_contents()->GetNativeView();
   auto buffer = node::Buffer::Copy(
@@ -1929,6 +1935,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("copyImageAt", &WebContents::CopyImageAt)
       .SetMethod("capturePage", &WebContents::CapturePage)
       .SetMethod("setEmbedder", &WebContents::SetEmbedder)
+      .SetMethod("setDevToolsWebContents", &WebContents::SetDevToolsWebContents)
       .SetMethod("getNativeView", &WebContents::GetNativeView)
       .SetMethod("setWebRTCIPHandlingPolicy",
                  &WebContents::SetWebRTCIPHandlingPolicy)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -895,10 +895,10 @@ void WebContents::DevToolsOpened() {
   managed_web_contents()->CallClientFunction(
       "DevToolsAPI.setInspectedTabId", &tab_id, nullptr, nullptr);
 
-  // Inherit owner window in devtools.
+  // Inherit owner window in devtools when it doesn't have one.
   auto* devtools = managed_web_contents()->GetDevToolsWebContents();
-  if (owner_window() &&
-      !devtools->GetUserData(NativeWindowRelay::UserDataKey()))
+  bool has_window = devtools->GetUserData(NativeWindowRelay::UserDataKey());
+  if (owner_window() && !has_window)
     handle->SetOwnerWindow(devtools, owner_window());
 
   Emit("devtools-opened");
@@ -1179,7 +1179,8 @@ void WebContents::OpenDevTools(mate::Arguments* args) {
   std::string state;
   if (type_ == WEB_VIEW || !owner_window()) {
     state = "detach";
-  } else if (args && args->Length() == 1) {
+  }
+  if (args && args->Length() == 1) {
     bool detach = false;
     mate::Dictionary options;
     if (args->GetNext(&options)) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -126,6 +126,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   void SetEmbedder(const WebContents* embedder);
+  void SetDevToolsWebContents(const WebContents* devtools);
   v8::Local<v8::Value> GetNativeView() const;
 
   // Print current page as PDF.

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -391,6 +391,10 @@ class NativeWindowRelay :
   explicit NativeWindowRelay(base::WeakPtr<NativeWindow> window)
     : key(UserDataKey()), window(window) {}
 
+  static void* UserDataKey() {
+    return content::WebContentsUserData<NativeWindowRelay>::UserDataKey();
+  }
+
   void* key;
   base::WeakPtr<NativeWindow> window;
 

--- a/brightray/browser/inspectable_web_contents.h
+++ b/brightray/browser/inspectable_web_contents.h
@@ -37,6 +37,7 @@ class InspectableWebContents {
   virtual void SetDelegate(InspectableWebContentsDelegate* delegate) = 0;
   virtual InspectableWebContentsDelegate* GetDelegate() const = 0;
 
+  virtual void SetDevToolsWebContents(content::WebContents* devtools) = 0;
   virtual void SetDockState(const std::string& state) = 0;
   virtual void ShowDevTools() = 0;
   virtual void CloseDevTools() = 0;

--- a/brightray/browser/inspectable_web_contents_impl.h
+++ b/brightray/browser/inspectable_web_contents_impl.h
@@ -48,6 +48,7 @@ class InspectableWebContentsImpl :
 
   void SetDelegate(InspectableWebContentsDelegate* delegate) override;
   InspectableWebContentsDelegate* GetDelegate() const override;
+  void SetDevToolsWebContents(content::WebContents* devtools) override;
   void SetDockState(const std::string& state) override;
   void ShowDevTools() override;
   void CloseDevTools() override;
@@ -192,7 +193,13 @@ class InspectableWebContentsImpl :
   PrefService* pref_service_;  // weak reference.
 
   std::unique_ptr<content::WebContents> web_contents_;
-  std::unique_ptr<content::WebContents> devtools_web_contents_;
+
+  // The default devtools created by this class when we don't have an external
+  // one assigned by SetDevToolsWebContents.
+  std::unique_ptr<content::WebContents> managed_devtools_web_contents_;
+  // The external devtools assigned by SetDevToolsWebContents.
+  content::WebContents* external_devtools_web_contents_ = nullptr;
+
   std::unique_ptr<InspectableWebContentsView> view_;
 
   using ExtensionsAPIs = std::map<std::string, std::string>;

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1131,7 +1131,7 @@ app.once('ready', () => {
   devtools = new BrowserWindow({show: false})
   devtools.show()
   win.webContents.setDevToolsWebContents(devtools.webContents)
-  win.webContents.openDevTools()
+  win.webContents.openDevTools({mode: 'detach'})
 })
 ```
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1074,6 +1074,67 @@ win.webContents.on('devtools-opened', () => {
 
 Removes the specified path from DevTools workspace.
 
+#### `contents.setDevToolsWebContents(devToolsWebContents)`
+
+* `devToolsWebContents` WebContents
+
+Uses the `devToolsWebContents` as the target `WebContents` to show devtools.
+
+The `devToolsWebContents` must not have done any navigation, and it should not
+be used for other purposes after the call.
+
+By default Electron manages the devtools by creating an internal `WebContents`
+with native view, which developers have very limited control of. With the
+`setDevToolsWebContents` method, developers can use any `WebContents` to show
+the devtools in it, including `BrowserWindow`, `BrowserView` and `<webview>`
+tag.
+
+An example of showing devtools in a `<webview>` tag:
+
+```html
+<html>
+<head>
+  <style type="text/css">
+    * { margin: 0; }
+    #browser { height: 70%; }
+    #devtools { height: 30%; }
+  </style>
+</head>
+<body>
+  <webview id="browser" src="https://github.com"></webview>
+  <webview id="devtools"></webview>
+  <script>
+    const browserView = document.getElementById('browser')
+    const devtoolsView = document.getElementById('devtools')
+    browserView.addEventListener('dom-ready', () => {
+      const browser = browserView.getWebContents()
+      browser.setDevToolsWebContents(devtoolsView.getWebContents())
+      browser.openDevTools()
+    })
+  </script>
+</body>
+</html>
+```
+
+An example of showing devtools in a `BrowserWindow`:
+
+```js
+const {app, BrowserWindow} = require('electron')
+
+let win = null
+let devtools = null
+
+app.once('ready', () => {
+  win = new BrowserWindow()
+  win.loadURL('https://github.com')
+  win.show()
+  devtools = new BrowserWindow({show: false})
+  devtools.show()
+  win.webContents.setDevToolsWebContents(devtools.webContents)
+  win.webContents.openDevTools()
+})
+```
+
 #### `contents.openDevTools([options])`
 
 * `options` Object (optional)

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1089,6 +1089,9 @@ with native view, which developers have very limited control of. With the
 the devtools in it, including `BrowserWindow`, `BrowserView` and `<webview>`
 tag.
 
+Note that closing the devtools does not destory the `devToolsWebContents`, it
+is caller's responsibility to destroy `devToolsWebContents`.
+
 An example of showing devtools in a `<webview>` tag:
 
 ```html

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1126,10 +1126,8 @@ let devtools = null
 
 app.once('ready', () => {
   win = new BrowserWindow()
+  devtools = new BrowserWindow()
   win.loadURL('https://github.com')
-  win.show()
-  devtools = new BrowserWindow({show: false})
-  devtools.show()
   win.webContents.setDevToolsWebContents(devtools.webContents)
   win.webContents.openDevTools({mode: 'detach'})
 })

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1144,6 +1144,9 @@ app.once('ready', () => {
 
 Opens the devtools.
 
+When `contents` is a `<webview>` tag, the `mode` would be `detach` by default,
+explicitly passing an empty `mode` can force using last used dock state.
+
 #### `contents.closeDevTools()`
 
 Closes the devtools.

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -230,7 +230,7 @@ class SrcAttribute extends WebViewAttribute {
   }
 
   parse () {
-    if (!this.webViewImpl.elementAttached || !this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_PARTITION].validPartitionId || !this.getValue()) {
+    if (!this.webViewImpl.elementAttached || !this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_PARTITION].validPartitionId) {
       return
     }
     if (this.webViewImpl.guestInstanceId == null) {
@@ -238,6 +238,9 @@ class SrcAttribute extends WebViewAttribute {
         this.webViewImpl.beforeFirstNavigation = false
         this.webViewImpl.createGuest()
       }
+      return
+    }
+    if (!this.getValue()) {
       return
     }
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -92,6 +92,22 @@ describe('webContents module', () => {
     })
   })
 
+  describe('setDevToolsWebCotnents() API', () => {
+    it('sets arbitry webContents as devtools', (done) => {
+      let devtools = new BrowserWindow({show: false})
+      devtools.webContents.once('dom-ready', () => {
+        assert.ok(devtools.getURL().startsWith('chrome-devtools://devtools'))
+        devtools.webContents.executeJavaScript('InspectorFrontendHost.constructor.name', (name) => {
+          assert.ok(name, 'InspectorFrontendHostImpl')
+          devtools.destroy()
+          done()
+        })
+      })
+      w.webContents.setDevToolsWebContents(devtools.webContents)
+      w.webContents.openDevTools()
+    })
+  })
+
   describe('isFocused() API', () => {
     it('returns false when the window is hidden', () => {
       BrowserWindow.getAllWindows().forEach((window) => {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -655,6 +655,30 @@ describe('<webview> tag', function () {
     })
   })
 
+  describe('setDevToolsWebCotnents() API', () => {
+    it('sets webContents of webview as devtools', (done) => {
+      const webview2 = new WebView()
+      webview2.addEventListener('did-attach', () => {
+        webview2.addEventListener('dom-ready', () => {
+          const devtools = webview2.getWebContents()
+          assert.ok(devtools.getURL().startsWith('chrome-devtools://devtools'))
+          devtools.executeJavaScript('InspectorFrontendHost.constructor.name', (name) => {
+            assert.ok(name, 'InspectorFrontendHostImpl')
+            document.body.removeChild(webview2)
+            done()
+          })
+        })
+        webview.addEventListener('dom-ready', () => {
+          webview.getWebContents().setDevToolsWebContents(webview2.getWebContents())
+          webview.getWebContents().openDevTools()
+        })
+        webview.src = 'about:blank'
+        document.body.appendChild(webview)
+      })
+      document.body.appendChild(webview2)
+    })
+  })
+
   describe('devtools-opened event', () => {
     it('should fire when webview.openDevTools() is called', (done) => {
       const listener = () => {


### PR DESCRIPTION
Close #3177.

### `contents.setDevToolsWebContents(devToolsWebContents)`

* `devToolsWebContents` WebContents

Uses the `devToolsWebContents` as the target `WebContents` to show devtools.

The `devToolsWebContents` must not have done any navigation, and it should not
be used for other purposes after the call.

By default Electron manages the devtools by creating an internal `WebContents`
with native view, which developers have very limited control of. With the
`setDevToolsWebContents` method, developers can use any `WebContents` to show
the devtools in it, including `BrowserWindow`, `BrowserView` and `<webview>`
tag.

An example of showing devtools in a `<webview>` tag:

```html
<html>
<head>
  <style type="text/css">
    * { margin: 0; }
    #browser { height: 70%; }
    #devtools { height: 30%; }
  </style>
</head>
<body>
  <webview id="browser" src="https://github.com"></webview>
  <webview id="devtools"></webview>
  <script>
    const browserView = document.getElementById('browser')
    const devtoolsView = document.getElementById('devtools')
    browserView.addEventListener('dom-ready', () => {
      const browser = browserView.getWebContents()
      browser.setDevToolsWebContents(devtoolsView.getWebContents())
      browser.openDevTools()
    })
  </script>
</body>
</html>
```

An example of showing devtools in a `BrowserWindow`:

```js
const {app, BrowserWindow} = require('electron')

let win = null
let devtools = null

app.once('ready', () => {
  win = new BrowserWindow()
  win.loadURL('https://github.com')
  win.show()
  devtools = new BrowserWindow({show: false})
  devtools.show()
  win.webContents.setDevToolsWebContents(devtools.webContents)
  win.webContents.openDevTools({mode: 'detach'})
})
```

![screen shot 2017-12-01 at 11 59 10](https://user-images.githubusercontent.com/639601/33466097-21e7fd72-d68f-11e7-9cab-8b6eed624f1d.png)
