### PR TITLE
Add missing dependency to Linux build instructions

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -21,7 +21,7 @@ $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        libnotify-dev libgnome-keyring-dev libgconf2-dev \
                        libasound2-dev libcap-dev libcups2-dev libxtst-dev \
                        libxss1 libnss3-dev gcc-multilib g++-multilib curl \
-                       gperf bison
+                       gperf bison icnsutils graphicsmagick
 ```
 
 On RHEL / CentOS, install the following libraries:


### PR DESCRIPTION
I was getting the following error when trying to build `Error: Exit code: ENOENT. spawn icns2png ENOENT`
This solution was proposed here: https://github.com/SimulatedGREG/electron-vue/issues/130#issuecomment-331993257