### PR TITLE
use full image URL

### DIFF
--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -81,7 +81,7 @@ Alternatively, a more conservative approach is to use the
 **Note: The schedule outlined here is _aspirational_. We are not yet cutting
 releases at a weekly cadence, but we hope to get there eventually.**
 
-<img style="width:100%;margin:20px 0;" src="../images/tutorial-release-schedule.svg">
+<img style="width:100%;margin:20px 0;" src="https://cdn.rawgit.com/electron/electron/master/docs/images/tutorial-release-schedule.svg">
 
 Here are some important points to call out:
 


### PR DESCRIPTION
The electron website gets its docs from the [electron-i18n](https://github.com/electron/electron-i18n) repo, which concerns itself with text, not assets like image files. Rather than trying to preserve the image file and its relative URL across this transition, I think it would be easier to just use URL references that are guaranteed to work in any context.