### PR TITLE
fix: Ensure that update.exe doesn't open up a console window

### DIFF
--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -34,6 +34,8 @@ var spawnUpdate = function (args, detached, callback) {
     } else if (!spawnedProcess) {
       spawnedProcess = spawn(updateExe, args, {
         detached: detached
+        detached: detached,
+        windowsHide: true
       })
       spawnedArgs = args || []
     }

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -8,19 +8,15 @@ const appFolder = path.dirname(process.execPath)
 // i.e. my-app/Update.exe
 const updateExe = path.resolve(appFolder, '..', 'Update.exe')
 const exeName = path.basename(process.execPath)
-var spawnedArgs = []
-var spawnedProcess
+let spawnedArgs = []
+let spawnedProcess
 
-var isSameArgs = function (args) {
-  return (args.length === spawnedArgs.length) && args.every(function (e, i) {
-    return e === spawnedArgs[i]
-  })
-}
+const isSameArgs = (args) => args.length === spawnedArgs.length && args.every((e, i) => e === spawnedArgs[i])
 
 // Spawn a command and invoke the callback when it completes with an error
 // and the output from standard out.
-var spawnUpdate = function (args, detached, callback) {
-  var error, errorEmitted, stderr, stdout
+let spawnUpdate = function (args, detached, callback) {
+  let error, errorEmitted, stderr, stdout
 
   try {
     // Ensure we don't spawn multiple squirrel processes
@@ -33,7 +29,6 @@ var spawnUpdate = function (args, detached, callback) {
       return callback(`AutoUpdater process with arguments ${args} is already running`)
     } else if (!spawnedProcess) {
       spawnedProcess = spawn(updateExe, args, {
-        detached: detached
         detached: detached,
         windowsHide: true
       })
@@ -50,17 +45,16 @@ var spawnUpdate = function (args, detached, callback) {
   }
   stdout = ''
   stderr = ''
-  spawnedProcess.stdout.on('data', function (data) {
-    stdout += data
-  })
-  spawnedProcess.stderr.on('data', function (data) {
-    stderr += data
-  })
+
+  spawnedProcess.stdout.on('data', (data) => { stdout += data })
+  spawnedProcess.stderr.on('data', (data) => { stderr += data })
+
   errorEmitted = false
-  spawnedProcess.on('error', function (error) {
+  spawnedProcess.on('error', (error) => {
     errorEmitted = true
     callback(error)
   })
+
   return spawnedProcess.on('exit', function (code, signal) {
     spawnedProcess = undefined
     spawnedArgs = []


### PR DESCRIPTION
We've received reports that _some_  users see a `Update.exe` window flash on screen whenever you run `autoUpdater` operations. That makes sense: Node allows us to explicitly ask for the window to be hidden, which we didn't do.

Also, I sprinkled some ES6 across the file - we don't need all that `var` anymore 😉 

Closes https://github.com/electron/electron/issues/11269