### PR TITLE
Improve coverage for autoupdate module

### DIFF
--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -22,27 +22,21 @@ class AutoUpdater extends EventEmitter {
   }
 
   checkForUpdates () {
-    if (!this.updateURL) {
-      return this.emitError('Update URL is not set')
-    }
-    if (!squirrelUpdate.supported()) {
-      return this.emitError('Can not find Squirrel')
-    }
+    if (!this.updateURL) return this.emitError('Update URL is not set')
+    if (!squirrelUpdate.supported()) return this.emitError('Can\'t find Squirrel')
+
     this.emit('checking-for-update')
     squirrelUpdate.checkForUpdate(this.updateURL, (error, update) => {
-      if (error != null) {
-        return this.emitError(error)
-      }
-      if (update == null) {
-        return this.emit('update-not-available')
-      }
+      if (error != null) return this.emitError(error)
+      if (update == null) return this.emit('update-not-available')
+
       this.updateAvailable = true
       this.emit('update-available')
       squirrelUpdate.update(this.updateURL, (error) => {
-        if (error != null) {
-          return this.emitError(error)
-        }
+        if (error != null) return this.emitError(error)
+
         const {releaseNotes, version} = update
+
         // Date is not available on Windows, so fake it.
         const date = new Date()
         this.emit('update-downloaded', {}, releaseNotes, version, date, this.updateURL, () => {

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -16,8 +16,6 @@ const isSameArgs = (args) => args.length === spawnedArgs.length && args.every((e
 // Spawn a command and invoke the callback when it completes with an error
 // and the output from standard out.
 let spawnUpdate = function (args, detached, callback) {
-  let error, errorEmitted, stderr, stdout
-
   try {
     // Ensure we don't spawn multiple squirrel processes
     // Process spawned, same args:        Attach events to alread running process
@@ -34,64 +32,55 @@ let spawnUpdate = function (args, detached, callback) {
       })
       spawnedArgs = args || []
     }
-  } catch (error1) {
-    error = error1
-
+  } catch (error) {
     // Shouldn't happen, but still guard it.
-    process.nextTick(function () {
-      return callback(error)
-    })
+    process.nextTick(() => callback(error))
     return
   }
-  stdout = ''
-  stderr = ''
 
+  let stdout, stderr
   spawnedProcess.stdout.on('data', (data) => { stdout += data })
   spawnedProcess.stderr.on('data', (data) => { stderr += data })
 
-  errorEmitted = false
+  let errorEmitted = false
   spawnedProcess.on('error', (error) => {
     errorEmitted = true
     callback(error)
   })
 
-  return spawnedProcess.on('exit', function (code, signal) {
+  return spawnedProcess.on('exit', (code, signal) => {
     spawnedProcess = undefined
     spawnedArgs = []
 
-    // We may have already emitted an error.
-    if (errorEmitted) {
-      return
-    }
-
+    if (errorEmitted) return
     // Process terminated with error.
     if (code !== 0) {
       // Disabled for backwards compatibility:
       // eslint-disable-next-line standard/no-callback-literal
       return callback(`Command failed: ${signal != null ? signal : code}\n${stderr}`)
     }
-
-    // Success.
     callback(null, stdout)
   })
 }
 
 // Start an instance of the installed app.
-exports.processStart = function () {
-  return spawnUpdate(['--processStartAndWait', exeName], true, function () {})
+exports.processStart = () => {
+  return spawnUpdate(['--processStartAndWait', exeName], true, () => {})
 }
 
 // Download the releases specified by the URL and write new results to stdout.
-exports.checkForUpdate = function (updateURL, callback) {
-  return spawnUpdate(['--checkForUpdate', updateURL], false, function (error, stdout) {
-    var json, ref, ref1, update
-    if (error != null) {
-      return callback(error)
-    }
+exports.checkForUpdate = (updateURL, callback) => {
+  return spawnUpdate(['--checkForUpdate', updateURL], false, (error, stdout) => {
+    if (error != null) return callback(error)
+
+    let update
     try {
-      // Last line of output is the JSON details about the releases
-      json = stdout.trim().split('\n').pop()
-      update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === 'function' ? ref1.pop() : void 0 : void 0 : void 0
+      const json = JSON.parse(stdout.trim().split('\n').pop())
+      if (json.releasesToApply !== null) {
+        if (typeof json.releasesToApply.pop === 'function') {
+          update = json.releasesToApply.pop()
+        }
+      }
     } catch (jsonError) {
       // Disabled for backwards compatibility:
       // eslint-disable-next-line standard/no-callback-literal
@@ -102,12 +91,12 @@ exports.checkForUpdate = function (updateURL, callback) {
 }
 
 // Update the application to the latest remote version specified by URL.
-exports.update = function (updateURL, callback) {
+exports.update = (updateURL, callback) => {
   return spawnUpdate(['--update', updateURL], false, callback)
 }
 
 // Is the Update.exe installed with the current application?
-exports.supported = function () {
+exports.supported = () => {
   try {
     fs.accessSync(updateExe, fs.R_OK)
     return true

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -2,62 +2,53 @@ const assert = require('assert')
 const {autoUpdater} = require('electron').remote
 const {ipcRenderer} = require('electron')
 
-describe('autoUpdater module', function () {
-  // XXX(alexeykuzmin): Calling `.skip()` in a 'before' hook
-  // doesn't affect nested 'describe's
+describe.only('autoUpdater module', () => {
   beforeEach(function () {
-    // Skip autoUpdater tests in MAS build.
     if (process.mas) {
       this.skip()
     }
   })
 
-  describe('checkForUpdates', function () {
-    it('emits an error on Windows when called the feed URL is not set', function (done) {
-      if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
-      }
+  describe('checkForUpdates', () => {
+    it('emits an error on Windows when called the feed URL is not set', (done) => {
+      if (process.platform !== 'win32') return done()
 
-      ipcRenderer.once('auto-updater-error', function (event, message) {
+      ipcRenderer.once('auto-updater-error', (event, message) => {
         assert.equal(message, 'Update URL is not set')
         done()
       })
+
       autoUpdater.setFeedURL('')
       autoUpdater.checkForUpdates()
     })
   })
 
-  describe('setFeedURL', function () {
-    describe('on Mac', function () {
+  describe('setFeedURL', () => {
+    describe('on Mac', () => {
       before(function () {
         if (process.platform !== 'darwin') {
           this.skip()
         }
       })
 
-      it('emits an error when the application is unsigned', function (done) {
-        ipcRenderer.once('auto-updater-error', function (event, message) {
+      it('emits an error when the application is unsigned', (done) => {
+        ipcRenderer.once('auto-updater-error', (event, message) => {
           assert.equal(message, 'Could not get code signature for running application')
           done()
         })
+
         autoUpdater.setFeedURL('')
       })
     })
   })
 
-  describe('getFeedURL', function () {
-    it('returns a falsey value by default', function () {
+  describe('getFeedURL', () => {
+    it('returns a falsey value by default', () => {
       assert.ok(!autoUpdater.getFeedURL())
     })
 
-    it('correctly fetches the previously set FeedURL', function (done) {
-      if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
-      }
+    it('correctly fetches the previously set FeedURL', (done) => {
+      if (process.platform !== 'win32') return done()
 
       const updateURL = 'https://fake-update.electron.io'
       autoUpdater.setFeedURL(updateURL)
@@ -66,31 +57,24 @@ describe('autoUpdater module', function () {
     })
   })
 
-  describe('quitAndInstall', function () {
-    it('emits an error on Windows when no update is available', function (done) {
-      if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
-      }
+  describe('quitAndInstall', () => {
+    it('emits an error on Windows when no update is available', (done) => {
+      if (process.platform !== 'win32') return done()
 
-      ipcRenderer.once('auto-updater-error', function (event, message) {
+      ipcRenderer.once('auto-updater-error', (event, message) => {
         assert.equal(message, 'No update available, can\'t quit and install')
         done()
       })
+
       autoUpdater.quitAndInstall()
     })
   })
 
-  describe('error event', function () {
-    it('serializes correctly over the remote module', function (done) {
-      if (process.platform === 'linux') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
-      }
+  describe('error event', () => {
+    it('serializes correctly over the remote module', (done) => {
+      if (process.platform === 'linux') return done()
 
-      autoUpdater.once('error', function (error) {
+      autoUpdater.once('error', (error) => {
         assert.equal(error instanceof Error, true)
         assert.deepEqual(Object.getOwnPropertyNames(error), ['stack', 'message', 'name'])
         done()


### PR DESCRIPTION
This PR improves coverage for the `autoupdate` module, since at present a nontrivial number of exported functions remain untested.

To-Do:
- [ ] Test event emitters (`checking-for-update`, `update-available`, `update-not-available`)
- [ ] Test `OnUpdateDownloaded()` 
- [ ] Test `OnWindowAllClosed()`
- [ ] Test `OnError()` (both)
- [ ] More integration tests 