### PR TITLE
Add back setExtraParameter() deprecation warning

### DIFF
--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -4,7 +4,7 @@ const {spawn} = require('child_process')
 const os = require('os')
 const path = require('path')
 const electron = require('electron')
-const {app} = process.type === 'browser' ? electron : electron.remote
+const {app, deprecate} = process.type === 'browser' ? electron : electron.remote
 const binding = process.atomBinding('crash_reporter')
 
 class CrashReporter {
@@ -106,14 +106,10 @@ class CrashReporter {
 
   // TODO(2.0) Remove
   setExtraParameter (key, value) {
-    // TODO(alexeykuzmin): Warning disabled since it caused
-    // a couple of Crash Reported tests to time out on Mac. Add it back.
-    // https://github.com/electron/electron/issues/11012
-
-    // if (!process.noDeprecations) {
-    //   deprecate.warn('crashReporter.setExtraParameter',
-    //     'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
-    // }
+    if (!process.noDeprecations) {
+      deprecate.warn('crashReporter.setExtraParameter',
+        'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
+    }
     binding.setExtraParameter(key, value)
   }
 

--- a/spec/fixtures/api/crash-restart.html
+++ b/spec/fixtures/api/crash-restart.html
@@ -24,8 +24,8 @@ if (process.platform === 'win32') {
 
 setImmediate(() => {
   if (process.platform === 'darwin') {
-    crashReporter.setExtraParameter('extra2', 'extra2')
-    crashReporter.setExtraParameter('extra3', null)
+    crashReporter.addExtraParameter('extra2', 'extra2')
+    crashReporter.removeExtraParameter('extra3')
   } else {
     crashReporter.start({
       productName: 'Zombies',


### PR DESCRIPTION
This PR adds back the deprecation warning removed in https://github.com/electron/electron/pull/11013. 

/cc @alexeykuzmin 