### PR TITLE
Fix avoid the same method used many times

### DIFF
--- a/lib/renderer/extensions/event.js
+++ b/lib/renderer/extensions/event.js
@@ -8,10 +8,7 @@ class Event {
   }
 
   removeListener (callback) {
-    const index = this.listeners.indexOf(callback)
-    if (index !== -1) {
-      this.listeners.splice(index, 1)
-    }
+    this.listeners = this.listeners.filter((item) => item !== callback)
   }
 
   emit (...args) {


### PR DESCRIPTION
```javascript
const callback = () => { }

const event = new Event()

event.addListener(callback)
event.addListener(callback)
event.removeListener(callback)

// Before
// event.listeners = [callback]

// Now
// event.listeners = []
```