### PR TITLE
Enable testing with python-dbusmock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   electron-linux-arm:
     docker:
-      - image: electronbuilds/electron:0.0.3
+      - image: electronbuilds/electron:0.0.4
         environment:
           TARGET_ARCH: arm
     resource_class: 2xlarge
@@ -60,7 +60,7 @@ jobs:
              fi
   electron-linux-arm64:
     docker:
-      - image: electronbuilds/electron:0.0.3
+      - image: electronbuilds/electron:0.0.4
         environment:
           TARGET_ARCH: arm64
     resource_class: 2xlarge
@@ -117,7 +117,7 @@ jobs:
              fi
   electron-linux-ia32:
     docker:
-      - image: electronbuilds/electron:0.0.3
+      - image: electronbuilds/electron:0.0.4
         environment:
           TARGET_ARCH: ia32
     resource_class: xlarge
@@ -174,7 +174,7 @@ jobs:
              fi
   electron-linux-mips64el:
     docker:
-      - image: electronbuilds/electron:0.0.3
+      - image: electronbuilds/electron:0.0.4
         environment:
           TARGET_ARCH: mips64el
     resource_class: xlarge
@@ -232,7 +232,7 @@ jobs:
 
   electron-linux-x64:
     docker:
-      - image: electronbuilds/electron:0.0.3
+      - image: electronbuilds/electron:0.0.4
         environment:
           TARGET_ARCH: x64
           DISPLAY: ':99.0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,13 @@ RUN chmod a+rwx /home
 
 # Install node.js
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get update && apt-get install -y --force-yes nodejs
+RUN apt-get update && apt-get install -y nodejs
 
 # Install wget used by crash reporter
-RUN apt-get install -y --force-yes  wget
+RUN apt-get install -y wget
+
+# Install python-dbusmock
+RUN apt-get install -y python-dbusmock
 
 # Add xvfb init script
 ADD tools/xvfb-init.sh /etc/init.d/xvfb

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -4,10 +4,13 @@ USER root
 
 # Install node.js
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get update && apt-get install -y --force-yes nodejs
+RUN apt-get update && apt-get install -y nodejs
 
 # Install wget used by crash reporter
-RUN apt-get install -y --force-yes  wget
+RUN apt-get install -y wget
+
+# Install python-dbusmock
+RUN apt-get install -y python-dbusmock
 
 # Add xvfb init script
 ADD tools/xvfb-init.sh /etc/init.d/xvfb


### PR DESCRIPTION
This is a followup to #11306 which enables testing of the powerMonitor events on CircleCI.