### PR TITLE
docs: README make versioning link relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ versioning. For info on how to manage Electron versions in your apps, see
 [Electron versioning](docs/tutorial/versioning.md).
 
 For more installation options and troubleshooting tips, see
-[installation](https://electronjs.org/docs/tutorial/installation).
+[installation](docs/tutorial/installation.md).
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install electron --save-dev --save-exact
 
 The `--save-exact` flag is recommended as Electron does not follow semantic
 versioning. For info on how to manage Electron versions in your apps, see
-[Electron versioning](https://electronjs.org/docs/tutorial/versioning).
+[Electron versioning](docs/tutorial/versioning.md).
 
 For more installation options and troubleshooting tips, see
 [installation](https://electronjs.org/docs/tutorial/installation).


### PR DESCRIPTION
I think we're making links relative within the docs, and not directly pointing to the electronjs.org website.