### PR TITLE
fix: Fix `menu.popup()` bugs

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -53,7 +53,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   }
 
   // menu.popup({})
-  if (window && window.constructor !== BrowserWindow) {
+  if (window != null && window.constructor === Object) {
     opts = window
   // menu.popup(window, {})
   } else if (x && typeof x === 'object') {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -56,8 +56,7 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   }
 
   // menu.popup({})
-  if (window && typeof window === 'object' && window.constructor &&
-      window.constructor.name !== 'BrowserWindow') {
+  if (typeof window === 'object' && window.constructor !== BrowserWindow) {
     opts = window
   // menu.popup(window, {})
   } else if (x && typeof x === 'object') {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -63,10 +63,10 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   }
 
   // set defaults
-  if (typeof x !== 'number') newX = -1
-  if (typeof y !== 'number') newY = -1
-  if (typeof positioningItem !== 'number') newPosition = -1
   if (!window) newWindow = BrowserWindow.getFocusedWindow()
+  if (typeof newX !== 'number') newX = -1
+  if (typeof newY !== 'number') newY = -1
+  if (typeof newPosition !== 'number') newPosition = -1
 
   this.popupAt(newWindow, newX, newY, newPosition)
 }

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -48,11 +48,8 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   let opts
 
   // menu.popup(x, y, positioningItem)
-  if (!window) {
-    // shift over values
-    if (typeof window !== 'object' || window.constructor !== BrowserWindow) {
-      [newPosition, newY, newX, newWindow] = [y, x, window, null]
-    }
+  if (window && typeof window !== 'object' || window.constructor !== BrowserWindow) {
+    [newPosition, newY, newX, newWindow] = [y, x, window, null]
   }
 
   // menu.popup({})

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -86,6 +86,8 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   }
 
   this.popupAt(newWindow, newX, newY, newPosition)
+
+  return { browserWindow: newWindow, x: newX, y: newY, position: newPosition }
 }
 
 Menu.prototype.closePopup = function (window) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -63,10 +63,23 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   }
 
   // set defaults
-  if (!window) newWindow = BrowserWindow.getFocusedWindow()
   if (typeof newX !== 'number') newX = -1
   if (typeof newY !== 'number') newY = -1
   if (typeof newPosition !== 'number') newPosition = -1
+  if (!newWindow || (newWindow && newWindow.constructor !== BrowserWindow)) {
+    newWindow = BrowserWindow.getFocusedWindow()
+
+    // No window focused?
+    if (!newWindow) {
+      const browserWindows = BrowserWindow.getAllWindows()
+
+      if (browserWindows && browserWindows.length > 0) {
+        newWindow = browserWindows[0]
+      } else {
+        throw new Error(`Cannot open Menu without a BrowserWindow present`)
+      }
+    }
+  }
 
   this.popupAt(newWindow, newX, newY, newPosition)
 }

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -45,6 +45,7 @@ Menu.prototype._init = function () {
 
 Menu.prototype.popup = function (window, x, y, positioningItem) {
   let [newX, newY, newPosition, newWindow] = [x, y, positioningItem, window]
+  let opts
 
   // menu.popup(x, y, positioningItem)
   if (!window) {
@@ -54,9 +55,16 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     }
   }
 
+  // menu.popup({})
+  if (window && typeof window === 'object' && window.constructor &&
+      window.constructor.name !== 'BrowserWindow') {
+    opts = window
   // menu.popup(window, {})
-  if (x && typeof x === 'object') {
-    const opts = x
+  } else if (x && typeof x === 'object') {
+    opts = x
+  }
+
+  if (opts) {
     newX = opts.x
     newY = opts.y
     newPosition = opts.positioningItem

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -48,12 +48,12 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   let opts
 
   // menu.popup(x, y, positioningItem)
-  if (window && typeof window !== 'object' || window.constructor !== BrowserWindow) {
+  if (window != null && !(window instanceof BrowserWindow)) {
     [newPosition, newY, newX, newWindow] = [y, x, window, null]
   }
 
   // menu.popup({})
-  if (typeof window === 'object' && window.constructor !== BrowserWindow) {
+  if (window && window.constructor !== BrowserWindow) {
     opts = window
   // menu.popup(window, {})
   } else if (x && typeof x === 'object') {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -283,41 +283,41 @@ describe('Menu module', () => {
     })
 
     it('returns immediately', () => {
-      const { browserWindow, x, y } = menu.popup(w, {x: 100, y: 100})
+      const { browserWindow, x, y } = menu.popup(w, {x: 100, y: 101})
 
       assert.equal(browserWindow, w)
       assert.equal(x, 100)
-      assert.equal(y, 100)
+      assert.equal(y, 101)
 
       menu.closePopup(w)
     })
 
     it('works without a given BrowserWindow and options', () => {
-      const { browserWindow, x, y } = menu.popup({x: 100, y: 100})
+      const { browserWindow, x, y } = menu.popup({x: 100, y: 101})
 
       assert.equal(browserWindow.constructor.name, 'BrowserWindow')
       assert.equal(x, 100)
-      assert.equal(y, 100)
+      assert.equal(y, 101)
 
       menu.closePopup()
     })
 
     it('works without a given BrowserWindow', () => {
-      const { browserWindow, x, y } = menu.popup(100, 100)
+      const { browserWindow, x, y } = menu.popup(100, 101)
 
       assert.equal(browserWindow.constructor.name, 'BrowserWindow')
       assert.equal(x, 100)
-      assert.equal(y, 100)
+      assert.equal(y, 101)
 
       menu.closePopup()
     })
 
     it('works with a given BrowserWindow and no options', () => {
-      const { browserWindow, x, y } = menu.popup(w, 100, 100)
+      const { browserWindow, x, y } = menu.popup(w, 100, 101)
 
       assert.equal(browserWindow, w)
       assert.equal(x, 100)
-      assert.equal(y, 100)
+      assert.equal(y, 101)
 
       menu.closePopup(w)
     })

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -283,18 +283,43 @@ describe('Menu module', () => {
     })
 
     it('returns immediately', () => {
-      menu.popup(w, {x: 100, y: 100})
+      const { browserWindow, x, y } = menu.popup(w, {x: 100, y: 100})
+
+      assert.equal(browserWindow, w)
+      assert.equal(x, 100)
+      assert.equal(y, 100)
+
       menu.closePopup(w)
     })
 
     it('works without a given BrowserWindow and options', () => {
-      menu.popup({x: 100, y: 100})
+      const { browserWindow, x, y } = menu.popup({x: 100, y: 100})
+
+      assert.equal(browserWindow.constructor.name, 'BrowserWindow')
+      assert.equal(x, 100)
+      assert.equal(y, 100)
+
       menu.closePopup()
     })
 
     it('works without a given BrowserWindow', () => {
-      menu.popup(100, 100)
+      const { browserWindow, x, y } = menu.popup(100, 100)
+
+      assert.equal(browserWindow.constructor.name, 'BrowserWindow')
+      assert.equal(x, 100)
+      assert.equal(y, 100)
+
       menu.closePopup()
+    })
+
+    it('works with a given BrowserWindow and no options', () => {
+      const { browserWindow, x, y } = menu.popup(w, 100, 100)
+
+      assert.equal(browserWindow, w)
+      assert.equal(x, 100)
+      assert.equal(y, 100)
+
+      menu.closePopup(w)
     })
   })
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -283,8 +283,18 @@ describe('Menu module', () => {
     })
 
     it('returns immediately', () => {
-      menu.popup(w, {x: 100, y: 100, async: true})
+      menu.popup(w, {x: 100, y: 100})
       menu.closePopup(w)
+    })
+
+    it('works without a given BrowserWindow and options', () => {
+      menu.popup({x: 100, y: 100})
+      menu.closePopup()
+    })
+
+    it('works without a given BrowserWindow', () => {
+      menu.popup(100, 100)
+      menu.closePopup()
     })
   })
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -312,6 +312,16 @@ describe('Menu module', () => {
       menu.closePopup()
     })
 
+    it('works without a given BrowserWindow and 0 options', () => {
+      const { browserWindow, x, y } = menu.popup(0, 1)
+
+      assert.equal(browserWindow.constructor.name, 'BrowserWindow')
+      assert.equal(x, 0)
+      assert.equal(y, 1)
+
+      menu.closePopup()
+    })
+
     it('works with a given BrowserWindow and no options', () => {
       const { browserWindow, x, y } = menu.popup(w, 100, 101)
 


### PR DESCRIPTION
This PR does three things:

• Calling `menu.popup({})` used to be okay, but broke in the last beta. This fixes that.
• We assigned defaults incorrectly, overriding user input 😱 
• Tests!

Closes https://github.com/electron/electron/issues/11376