### PR TITLE
📝 Notification actions → action

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -38,7 +38,7 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
   * `hasReply` Boolean (optional) _macOS_ - Whether or not to add an inline reply option to the notification.
   * `replyPlaceholder` String (optional) _macOS_ - The placeholder to write in the inline reply input field.
   * `sound` String (optional) _macOS_ - The name of the sound file to play when the notification is shown.
-  * `actions` [NotificationAction[]](structures/notification-action.md) (optional) _macOS_ - Actions to add to the notification. Please read the available actions and limitations in the `NotificationAction` documentation.
+  * `action` [NotificationAction[]](structures/notification-action.md) (optional) _macOS_ - Actions to add to the notification. Please read the available actions and limitations in the `NotificationAction` documentation.
 
 
 ### Instance Events


### PR DESCRIPTION
Actually `action` works, not `actions`. It killed a lot of my time until I get that it's a mistake in docs. Hope it would help other developers.