### PR TITLE
Add systemPreferences.registerDefaults()

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -65,6 +65,7 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::SubscribeLocalNotification)
       .SetMethod("unsubscribeLocalNotification",
                  &SystemPreferences::UnsubscribeLocalNotification)
+      .SetMethod("registerDefaults", &SystemPreferences::RegisterDefaults)
       .SetMethod("getUserDefault", &SystemPreferences::GetUserDefault)
       .SetMethod("setUserDefault", &SystemPreferences::SetUserDefault)
       .SetMethod("removeUserDefault", &SystemPreferences::RemoveUserDefault)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -73,6 +73,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void UnsubscribeLocalNotification(int request_id);
   v8::Local<v8::Value> GetUserDefault(const std::string& name,
                                       const std::string& type);
+  void registerDefaults(const base::DictionaryValue& defaults);
   void SetUserDefault(const std::string& name,
                       const std::string& type,
                       mate::Arguments* args);

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -73,7 +73,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void UnsubscribeLocalNotification(int request_id);
   v8::Local<v8::Value> GetUserDefault(const std::string& name,
                                       const std::string& type);
-  void registerDefaults(const base::DictionaryValue& defaults);
+  void RegisterDefaults(const base::DictionaryValue& defaults);
   void SetUserDefault(const std::string& name,
                       const std::string& type,
                       mate::Arguments* args);

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -73,7 +73,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void UnsubscribeLocalNotification(int request_id);
   v8::Local<v8::Value> GetUserDefault(const std::string& name,
                                       const std::string& type);
-  void RegisterDefaults(const base::DictionaryValue& defaults);
+  void RegisterDefaults(mate::Arguments* args);
   void SetUserDefault(const std::string& name,
                       const std::string& type,
                       mate::Arguments* args);

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -144,6 +144,24 @@ v8::Local<v8::Value> SystemPreferences::GetUserDefault(
   }
 }
 
+void SystemPreferences::RegisterDefaults(const base::DictionaryValue& defaults) {
+  NSString *userDefaultsValuesPath;
+    NSDictionary *userDefaultsValuesDict;
+    NSDictionary *initialValuesDict;
+    NSArray *resettableUserDefaultsKeys;
+
+    userDefaultsValuesPath=[[NSBundle mainBundle] pathForResource:@"UserDefaults"
+                               ofType:@"plist"];
+    userDefaultsValuesDict=[NSDictionary dictionaryWithContentsOfFile:userDefaultsValuesPath];
+
+    [[NSUserDefaults standardUserDefaults] registerDefaults:userDefaultsValuesDict];
+
+    resettableUserDefaultsKeys=[NSArray arrayWithObjects:@"Value1",@"Value2",@"Value3",nil];
+    initialValuesDict=[userDefaultsValuesDict dictionaryWithValuesForKeys:resettableUserDefaultsKeys];
+
+    [[NSUserDefaultsController sharedUserDefaultsController] setInitialValues:initialValuesDict];
+}
+
 void SystemPreferences::SetUserDefault(const std::string& name,
                                        const std::string& type,
                                        mate::Arguments* args) {

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -146,13 +146,13 @@ v8::Local<v8::Value> SystemPreferences::GetUserDefault(
 
 void SystemPreferences::RegisterDefaults(mate::Arguments* args) {
   base::DictionaryValue value;
-  if (!args->GetNext(&value)) {
-    args->ThrowError("Unable to parse userDefaults dict");
-    return;
-  }
-
-  if (NSDictionary* dict = DictionaryValueToNSDictionary(value)) {
+  args->GetNext(&value);
+  
+  @try {
+    NSDictionary* dict = DictionaryValueToNSDictionary(value);
     [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
+  } @catch (NSException* exception) {
+    args->ThrowError("Invalid userDefault data provided");
   }
 }
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -150,7 +150,6 @@ void SystemPreferences::RegisterDefaults(mate::Arguments* args) {
   if(!args->GetNext(&value)) {
     args->ThrowError("Invalid userDefault data provided");
   } else {
-    args->GetNext(&value);
     @try {
       NSDictionary* dict = DictionaryValueToNSDictionary(value);
       [[NSUserDefaults standardUserDefaults] registerDefaults:dict];

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -146,13 +146,17 @@ v8::Local<v8::Value> SystemPreferences::GetUserDefault(
 
 void SystemPreferences::RegisterDefaults(mate::Arguments* args) {
   base::DictionaryValue value;
-  args->GetNext(&value);
   
-  @try {
-    NSDictionary* dict = DictionaryValueToNSDictionary(value);
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
-  } @catch (NSException* exception) {
+  if(!args->GetNext(&value)) {
     args->ThrowError("Invalid userDefault data provided");
+  } else {
+    args->GetNext(&value);
+    @try {
+      NSDictionary* dict = DictionaryValueToNSDictionary(value);
+      [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
+    } @catch (NSException* exception) {
+      args->ThrowError("Invalid userDefault data provided");
+    }
   }
 }
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -144,11 +144,15 @@ v8::Local<v8::Value> SystemPreferences::GetUserDefault(
   }
 }
 
-void SystemPreferences::RegisterDefaults(const base::DictionaryValue& defaults) {
-  if (NSDictionary* defaultsDict = DictionaryValueToNSDictionary(defaults)) {
-    [[NSUserDefaults standardUserDefaults] registerDefaults:defaultsDict];
-  } else {
-    defaults->ThrowError("Unable to parse userDefaults");
+void SystemPreferences::RegisterDefaults(mate::Arguments* args) {
+  base::DictionaryValue value;
+  if (!args->GetNext(&value)) {
+    args->ThrowError("Unable to parse userDefaults dict");
+    return;
+  }
+
+  if (NSDictionary* dict = DictionaryValueToNSDictionary(value)) {
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
   }
 }
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -145,21 +145,11 @@ v8::Local<v8::Value> SystemPreferences::GetUserDefault(
 }
 
 void SystemPreferences::RegisterDefaults(const base::DictionaryValue& defaults) {
-  NSString *userDefaultsValuesPath;
-    NSDictionary *userDefaultsValuesDict;
-    NSDictionary *initialValuesDict;
-    NSArray *resettableUserDefaultsKeys;
-
-    userDefaultsValuesPath=[[NSBundle mainBundle] pathForResource:@"UserDefaults"
-                               ofType:@"plist"];
-    userDefaultsValuesDict=[NSDictionary dictionaryWithContentsOfFile:userDefaultsValuesPath];
-
-    [[NSUserDefaults standardUserDefaults] registerDefaults:userDefaultsValuesDict];
-
-    resettableUserDefaultsKeys=[NSArray arrayWithObjects:@"Value1",@"Value2",@"Value3",nil];
-    initialValuesDict=[userDefaultsValuesDict dictionaryWithValuesForKeys:resettableUserDefaultsKeys];
-
-    [[NSUserDefaultsController sharedUserDefaultsController] setInitialValues:initialValuesDict];
+  if (NSDictionary* defaultsDict = DictionaryValueToNSDictionary(defaults)) {
+    [[NSUserDefaults standardUserDefaults] registerDefaults:defaultsDict];
+  } else {
+    defaults->ThrowError("Unable to parse userDefaults");
+  }
 }
 
 void SystemPreferences::SetUserDefault(const std::string& name,

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -106,6 +106,15 @@ This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 
 Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificationCenter`.
 
+### `systemPreferences.registerDefaults(defaults)` _macOS_
+
+* `defaults`: a dictionary of (`key: value`) user defaults
+  * `key` - must be of type `string`
+  * `value` - can be of type `string`, `boolean`, `integer`, `float`, `double`,
+    `url`, `array` or `dictionary`.
+
+Allows for registering of your application's preference defaults in `NSUserDefaults`.
+
 ### `systemPreferences.getUserDefault(key, type)` _macOS_
 
 * `key` String

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -108,10 +108,10 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificati
 
 ### `systemPreferences.registerDefaults(defaults)` _macOS_
 
-* `defaults`: a dictionary of (`key: value`) user defaults
-  * `key` - must be of type `string`
-  * `value` - can be of type `string`, `boolean`, `integer`, `float`, `double`,
-    `url`, `array` or `dictionary`.
+* `defaults` Object - a dictionary of (`key: value`) user defaults
+  * `key` String - must be of type `string`
+  * `value` Object - object of type `string`, `boolean`, `integer`, `float`, `double`,
+    `url`, `array`, or `dictionary`.
 
 Allows for registering of your application's preference defaults in `NSUserDefaults`.
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -109,8 +109,8 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificati
 ### `systemPreferences.registerDefaults(defaults)` _macOS_
 
 * `defaults` Object - a dictionary of (`key: value`) user defaults
-  * `key` String - must be of type `string`
-  * `value` Object - object of type `string`, `boolean`, `integer`, `float`, `double`,
+  * `key` String
+  * `value` (String | Boolean | Number) - object of type `string`, `boolean`, `integer`, `float`, `double`,
     `url`, `array`, or `dictionary`.
 
 Allows for registering of your application's preference defaults in `NSUserDefaults`.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -110,7 +110,7 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificati
 
 * `defaults` Object - a dictionary of (`key: value`) user defaults
   * `key` String
-  * `value` (String | Boolean | Int | Float | Double | Array | Dictionary)
+  * `value` Any
 
 Add the specified defaults to your application's `NSUserDefaults`.
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -110,10 +110,9 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificati
 
 * `defaults` Object - a dictionary of (`key: value`) user defaults
   * `key` String
-  * `value` (String | Boolean | Number) - object of type `string`, `boolean`, `integer`, `float`, `double`,
-    `url`, `array`, or `dictionary`.
+  * `value` (String | Boolean | Int | Float | Double | Array | Dictionary)
 
-Allows for registering of your application's preference defaults in `NSUserDefaults`.
+Add the specified defaults to your application's `NSUserDefaults`.
 
 ### `systemPreferences.getUserDefault(key, type)` _macOS_
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -35,32 +35,44 @@ describe('systemPreferences module', () => {
     })
   })
 
-  describe('systemPreferences.registerDefaults(defaults)', () => {
+  describe.only('systemPreferences.registerDefaults(defaults)', () => {
     before(function () {
       if (process.platform !== 'darwin') this.skip()
     })
 
     it('registers defaults', () => {
-      const userDefaults = {
+      const defaultsDict = {
         'one': 'ONE',
-        'two': 'TWO',
-        'three': 'THREE'
+        'two': 2,
+        'three': [1, 2, 3]
       }
 
-      systemPreferences.registerDefaults(userDefaults)
+      const defaultsMap = [
+        { key: 'one', type: 'string', value: 'ONE' },
+        { key: 'two', value: 2, type: 'integer' },
+        { key: 'three', value: [1, 2, 3], type: 'array' }
+      ]
 
-      for (const [key, expectedValue] of Object.entries(userDefaults)) {
-        const actualValue = systemPreferences.getUserDefault(key, 'string')
-        assert.equal(actualValue, expectedValue)
+      systemPreferences.registerDefaults(defaultsDict)
+
+      for (const def of defaultsMap) {
+        const [key, expectedValue, type] = [def.key, def.value, def.type]
+        const actualValue = systemPreferences.getUserDefault(key, type)
+        assert.deepEqual(actualValue, expectedValue)
       }
     })
 
     it('throws when bad defaults are passed', () => {
       const badDefaults1 = { 'one': null }
+      //const badDefaults1 = { 'one': null }
 
       assert.throws(() => {
         systemPreferences.registerDefaults(badDefaults1)
       }, 'Invalid userDefault data provided')
+      //
+      // assert.throws(() => {
+      //   systemPreferences.registerDefaults(badDefaults1)
+      // }, 'Invalid userDefault data provided')
     })
   })
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -35,18 +35,20 @@ describe('systemPreferences module', () => {
     })
   })
 
-  describe.only('systemPreferences.registerDefaults(defaults)', () => {
+  describe('systemPreferences.registerDefaults(defaults)', () => {
     before(function () {
       if (process.platform !== 'darwin') this.skip()
     })
 
     it('registers defaults', () => {
+      // to pass into registerDefaults
       const defaultsDict = {
         'one': 'ONE',
         'two': 2,
         'three': [1, 2, 3]
       }
 
+      // to test type
       const defaultsMap = [
         { key: 'one', type: 'string', value: 'ONE' },
         { key: 'two', value: 2, type: 'integer' },
@@ -63,16 +65,21 @@ describe('systemPreferences module', () => {
     })
 
     it('throws when bad defaults are passed', () => {
-      const badDefaults1 = { 'one': null }
-      //const badDefaults1 = { 'one': null }
+      const badDefaults1 = { 'one': null } // catches null values
+      const badDefaults2 = 1 // argument must be a dictionary
+      const badDefaults3 = null // argument can't be null
 
       assert.throws(() => {
         systemPreferences.registerDefaults(badDefaults1)
       }, 'Invalid userDefault data provided')
-      //
-      // assert.throws(() => {
-      //   systemPreferences.registerDefaults(badDefaults1)
-      // }, 'Invalid userDefault data provided')
+
+      assert.throws(() => {
+        systemPreferences.registerDefaults(badDefaults2)
+      }, 'Invalid userDefault data provided')
+
+      assert.throws(() => {
+        systemPreferences.registerDefaults(badDefaults3)
+      }, 'Invalid userDefault data provided')
     })
   })
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -36,6 +36,10 @@ describe('systemPreferences module', () => {
   })
 
   describe('systemPreferences.registerDefaults(defaults)', () => {
+    before(function () {
+      if (process.platform !== 'darwin') this.skip()
+    })
+
     it('registers defaults', () => {
       const userDefaults = {
         'one': 'onee',
@@ -49,6 +53,14 @@ describe('systemPreferences module', () => {
 
       const val = systemPreferences.getUserDefault('two', 'string')
       assert.equal(val, 'twoo')
+    })
+
+    it('throws when bad defaults are passed', () => {
+      const userDefaults = 1
+
+      assert.throws(() => {
+        systemPreferences.setUserDefault(userDefaults)
+      }, `Unable to parse userDefaults dict`)
     })
   })
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -41,45 +41,35 @@ describe('systemPreferences module', () => {
     })
 
     it('registers defaults', () => {
-      // to pass into registerDefaults
-      const defaultsDict = {
-        'one': 'ONE',
-        'two': 2,
-        'three': [1, 2, 3]
-      }
-
-      // to test type
       const defaultsMap = [
         { key: 'one', type: 'string', value: 'ONE' },
         { key: 'two', value: 2, type: 'integer' },
         { key: 'three', value: [1, 2, 3], type: 'array' }
       ]
 
+      const defaultsDict = {}
+      defaultsMap.forEach(row => { defaultsDict[row.key] = row.value })
+
       systemPreferences.registerDefaults(defaultsDict)
 
-      for (const def of defaultsMap) {
-        const [key, expectedValue, type] = [def.key, def.value, def.type]
+      for (const userDefault of defaultsMap) {
+        const { key, value: expectedValue, type } = userDefault
         const actualValue = systemPreferences.getUserDefault(key, type)
         assert.deepEqual(actualValue, expectedValue)
       }
     })
 
     it('throws when bad defaults are passed', () => {
-      const badDefaults1 = { 'one': null } // catches null values
-      const badDefaults2 = 1 // argument must be a dictionary
-      const badDefaults3 = null // argument can't be null
-
-      assert.throws(() => {
-        systemPreferences.registerDefaults(badDefaults1)
-      }, 'Invalid userDefault data provided')
-
-      assert.throws(() => {
-        systemPreferences.registerDefaults(badDefaults2)
-      }, 'Invalid userDefault data provided')
-
-      assert.throws(() => {
-        systemPreferences.registerDefaults(badDefaults3)
-      }, 'Invalid userDefault data provided')
+      for (const badDefaults of [
+        { 'one': null },  // catches null values
+        1,  // argument must be a dictionary
+        null, // argument can't be null
+        new Date() // shouldn't be able to pass date object
+      ]) {
+        assert.throws(() => {
+          systemPreferences.registerDefaults(badDefaults)
+        }, 'Invalid userDefault data provided')
+      }
     })
   })
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -42,25 +42,25 @@ describe('systemPreferences module', () => {
 
     it('registers defaults', () => {
       const userDefaults = {
-        'one': 'onee',
-        'two': 'twoo',
-        'three': 'threee',
-        'four': 'fourr',
-        'five': 'fivee'
+        'one': 'ONE',
+        'two': 'TWO',
+        'three': 'THREE'
       }
 
       systemPreferences.registerDefaults(userDefaults)
 
-      const val = systemPreferences.getUserDefault('two', 'string')
-      assert.equal(val, 'twoo')
+      for (const [key, expectedValue] of Object.entries(userDefaults)) {
+        const actualValue = systemPreferences.getUserDefault(key, 'string')
+        assert.equal(actualValue, expectedValue)
+      }
     })
 
     it('throws when bad defaults are passed', () => {
-      const userDefaults = 1
+      const badDefaults1 = { 'one': null }
 
       assert.throws(() => {
-        systemPreferences.setUserDefault(userDefaults)
-      }, `Unable to parse userDefaults dict`)
+        systemPreferences.registerDefaults(badDefaults1)
+      }, 'Invalid userDefault data provided')
     })
   })
 

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -35,6 +35,23 @@ describe('systemPreferences module', () => {
     })
   })
 
+  describe('systemPreferences.registerDefaults(defaults)', () => {
+    it('registers defaults', () => {
+      const userDefaults = {
+        'one': 'onee',
+        'two': 'twoo',
+        'three': 'threee',
+        'four': 'fourr',
+        'five': 'fivee'
+      }
+
+      systemPreferences.registerDefaults(userDefaults)
+
+      const val = systemPreferences.getUserDefault('two', 'string')
+      assert.equal(val, 'twoo')
+    })
+  })
+
   describe('systemPreferences.getUserDefault(key, type)', () => {
     before(function () {
       if (process.platform !== 'darwin') {


### PR DESCRIPTION
Implements feature requested in https://github.com/electron/electron/issues/11305.

To-Do:
- [x] Add test for `systemPreferences.registerDefaults()` success
- [x] Add test for `systemPreferences.registerDefaults()` failure 
- [x] Update `systemPreferences` docs