### PR TITLE
Implement webview permission-request api

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -615,6 +615,22 @@ Shows pop-up dictionary that searches the selected word on the page.
 Returns [`WebContents`](web-contents.md) - The web contents associated with
 this `webview`.
 
+### `<webview>.setPermissionRequestHandler(callback)`
+
+* `callback` Function
+  * `event` Object
+    * `permission` String - Enum of 'media', 'geolocation', 'notifications', 'midiSysex', 'pointerLock', 'fullscreen', 'openExternal'.
+    * `request` Object Has an `allow` and `deny` function.
+
+Add handler for when `webview` is requested for example to go fullscreen or present a notification.
+Use `deny` to prevent default behavior. Use `allow` to accept default behavior. 
+
+You can only have one handler for each `webview`.
+
+### `<webview>.removePermissionRequestHandler()`
+
+Remove permission request handler from `webview`.
+
 ## DOM events
 
 The following DOM events are available to the `webview` tag:

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -367,7 +367,8 @@ const registerWebViewElement = function () {
     'setZoomFactor',
     'setZoomLevel',
     'getZoomLevel',
-    'getZoomFactor'
+    'getZoomFactor',
+    'setPermissionRequestHandler'
   ]
   const nonblockMethods = [
     'insertCSS',
@@ -421,6 +422,20 @@ const registerWebViewElement = function () {
   // WebContents associated with this webview.
   proto.getWebContents = function () {
     return v8Util.getHiddenValue(this, 'internal').webContents
+  }
+
+  proto.setPermissionRequestHandler = function (callback) {
+    remote.session.fromPartition(this.partition).setPermissionRequestHandler(function (webContents, permission, permissionCallback) {
+      if (webContents.getId() === this.getId()) {
+        callback({
+          permission: permission,
+          request: {
+            allow: permissionCallback.bind(null, true),
+            deny: permissionCallback.bind(null, false)
+          }
+        })
+      }
+    }.bind(this))
   }
 
   window.WebView = webFrame.registerEmbedderCustomElement('webview', {

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -368,7 +368,8 @@ const registerWebViewElement = function () {
     'setZoomLevel',
     'getZoomLevel',
     'getZoomFactor',
-    'setPermissionRequestHandler'
+    'setPermissionRequestHandler',
+    'removePermissionRequestHandler'
   ]
   const nonblockMethods = [
     'insertCSS',
@@ -436,6 +437,10 @@ const registerWebViewElement = function () {
         })
       }
     }.bind(this))
+  }
+
+  proto.removePermissionRequestHandler = function () {
+    remote.session.fromPartition(this.partition).setPermissionRequestHandler(null)
   }
 
   window.WebView = webFrame.registerEmbedderCustomElement('webview', {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1064,6 +1064,27 @@ describe('<webview> tag', function () {
     })
   })
 
+  describe('<webview>.removePermissionRequestHandler', () => {
+    it('can remove permission-request handler', (done) => {
+      webview.addEventListener('ipc-message', (e) => {
+        assert.equal(e.channel, 'message')
+        assert.deepEqual(e.args, ['granted'])
+        done()
+      })
+
+      webview.src = `file://${fixtures}/pages/permissions/notification.html`
+      webview.partition = 'permissionTest'
+      webview.setAttribute('nodeintegration', 'on')
+
+      webview.setPermissionRequestHandler((e) => {
+        setTimeout(() => { e.request.deny() }, 10)
+      })
+      webview.removePermissionRequestHandler()
+
+      document.body.appendChild(webview)
+    })
+  })
+
   describe('<webview>.getWebContents', () => {
     it('can return the webcontents associated', (done) => {
       webview.addEventListener('did-finish-load', () => {


### PR DESCRIPTION
I have implemented two new apis for the webview:
- setPermissionRequestHandler
- removePermissionRequestHandler

I implemented these because I were trying to handle a fullscreen event.
I had to dig around in the issue tracker to find that the session setPermissionRequestHandler could be used for this.

I decided to use an event object to allow and deny request because the chrome api already had an implementation of this.
https://developer.chrome.com/apps/tags/webview#event-permissionrequest

## Test instructions
I used this index.html to test blocking and allowing requests.
I also used this to remove the handler after adding it.

Test the fullscreen request by clicking on the fullscreen button.

``` html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="UTF-8">
    <title>Hello World!</title>
  </head>
  <body>
    <h1>Hello World!</h1>
    <!-- All of the Node.js APIs are available in this renderer process. -->
    We are using Node.js <script>document.write(process.versions.node)</script>,
    Chromium <script>document.write(process.versions.chrome)</script>,
    and Electron <script>document.write(process.versions.electron)</script>.

    <webview id="view" src="https://en.wikipedia.org/wiki/Cat#/media/File:Cat_poster_1.jpg" style="height: 600px;"></webview>

    <script>
      // You can also require other files to run in this process
      require('./renderer.js')

      window.onload = function () {
	      document.getElementById("view").setPermissionRequestHandler(function(e) {
		      e.request.allow();
	      })
      }
    </script>
  </body>
</html>

```