### PR TITLE
[RFC] New API: powerMonitor "shutdown" event

### DIFF
--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -92,10 +92,6 @@ using atom::api::PowerMonitor;
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
-#if defined(OS_MACOSX)
-  base::PowerMonitorDeviceSource::AllocateSystemIOPorts();
-#endif
-
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("powerMonitor", PowerMonitor::Create(isolate));

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -24,6 +24,14 @@ PowerMonitor::~PowerMonitor() {
   base::PowerMonitor::Get()->RemoveObserver(this);
 }
 
+void PowerMonitor::BlockShutdown(mate::Arguments* args) {
+  atom::PowerObserver::BlockShutdown();
+}
+
+void PowerMonitor::UnblockShutdown(mate::Arguments* args) {
+  atom::PowerObserver::UnblockShutdown();
+}
+
 void PowerMonitor::OnPowerStateChange(bool on_battery_power) {
   if (on_battery_power)
     Emit("on-battery");
@@ -37,6 +45,10 @@ void PowerMonitor::OnSuspend() {
 
 void PowerMonitor::OnResume() {
   Emit("resume");
+}
+
+bool PowerMonitor::OnShutdown() {
+  return Emit("shutdown");
 }
 
 // static
@@ -55,6 +67,9 @@ v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
 void PowerMonitor::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "PowerMonitor"));
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+      .SetMethod("blockShutdown", &PowerMonitor::BlockShutdown)
+      .SetMethod("unblockShutdown", &PowerMonitor::UnblockShutdown);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -24,14 +24,6 @@ PowerMonitor::~PowerMonitor() {
   base::PowerMonitor::Get()->RemoveObserver(this);
 }
 
-void PowerMonitor::BlockShutdown(mate::Arguments* args) {
-  atom::PowerObserver::BlockShutdown();
-}
-
-void PowerMonitor::UnblockShutdown(mate::Arguments* args) {
-  atom::PowerObserver::UnblockShutdown();
-}
-
 void PowerMonitor::OnPowerStateChange(bool on_battery_power) {
   if (on_battery_power)
     Emit("on-battery");
@@ -47,9 +39,11 @@ void PowerMonitor::OnResume() {
   Emit("resume");
 }
 
+#if defined(OS_LINUX)
 bool PowerMonitor::OnShutdown() {
   return Emit("shutdown");
 }
+#endif
 
 // static
 v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
@@ -67,9 +61,11 @@ v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
 void PowerMonitor::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "PowerMonitor"));
+#if defined(OS_LINUX)
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("blockShutdown", &PowerMonitor::BlockShutdown)
       .SetMethod("unblockShutdown", &PowerMonitor::UnblockShutdown);
+#endif
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -18,8 +18,10 @@ namespace api {
 PowerMonitor::PowerMonitor(v8::Isolate* isolate) {
 #if defined(OS_LINUX)
   SetShutdownHandler(base::Bind(&PowerMonitor::ShouldShutdown,
-                                // Passed to base class, no need for weak ptr.
                                 base::Unretained(this)));
+#elif defined(OS_MACOSX)
+  Browser::Get()->SetShutdownHandler(base::Bind(&PowerMonitor::ShouldShutdown,
+                                                base::Unretained(this)));
 #endif
   base::PowerMonitor::Get()->AddObserver(this);
   Init(isolate);
@@ -30,7 +32,7 @@ PowerMonitor::~PowerMonitor() {
 }
 
 bool PowerMonitor::ShouldShutdown() {
-  return Emit("shutdown");
+  return !Emit("shutdown");
 }
 
 #if defined(OS_LINUX)

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -26,16 +26,15 @@ class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
   explicit PowerMonitor(v8::Isolate* isolate);
   ~PowerMonitor() override;
 
-  void BlockShutdown(mate::Arguments* args);
-  void UnblockShutdown(mate::Arguments* args);
-
   // base::PowerObserver implementations:
   void OnPowerStateChange(bool on_battery_power) override;
   void OnSuspend() override;
   void OnResume() override;
 
+#if defined(OS_LINUX)
   // atom::PowerObserver
   bool OnShutdown() override;
+#endif
 
  private:
   DISALLOW_COPY_AND_ASSIGN(PowerMonitor);

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -26,10 +26,16 @@ class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
   explicit PowerMonitor(v8::Isolate* isolate);
   ~PowerMonitor() override;
 
+  void BlockShutdown(mate::Arguments* args);
+  void UnblockShutdown(mate::Arguments* args);
+
   // base::PowerObserver implementations:
   void OnPowerStateChange(bool on_battery_power) override;
   void OnSuspend() override;
   void OnResume() override;
+
+  // atom::PowerObserver
+  bool OnShutdown() override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(PowerMonitor);

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -26,15 +26,19 @@ class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
   explicit PowerMonitor(v8::Isolate* isolate);
   ~PowerMonitor() override;
 
+  // Called by native calles.
+  bool ShouldShutdown();
+
+#if defined(OS_LINUX)
+  // Private JS APIs.
+  void BlockShutdown();
+  void UnblockShutdown();
+#endif
+
   // base::PowerObserver implementations:
   void OnPowerStateChange(bool on_battery_power) override;
   void OnSuspend() override;
   void OnResume() override;
-
-#if defined(OS_LINUX)
-  // atom::PowerObserver
-  bool OnShutdown() override;
-#endif
 
  private:
   DISALLOW_COPY_AND_ASSIGN(PowerMonitor);

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -105,6 +105,9 @@ class Browser : public WindowListObserver {
   LoginItemSettings GetLoginItemSettings(const LoginItemSettings& options);
 
 #if defined(OS_MACOSX)
+  // Set the handler which decides whether to shutdown.
+  void SetShutdownHandler(base::Callback<bool()> handler);
+
   // Hide the application.
   void Hide();
 

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -21,6 +21,10 @@
 
 namespace atom {
 
+void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
+  [[AtomApplication sharedApplication] setShutdownHandler:std::move(handler)];
+}
+
 void Browser::Focus() {
   [[AtomApplication sharedApplication] activateIgnoringOtherApps:YES];
 }

--- a/atom/browser/lib/power_observer.h
+++ b/atom/browser/lib/power_observer.h
@@ -18,19 +18,7 @@ namespace atom {
 #if defined(OS_LINUX)
 typedef PowerObserverLinux PowerObserver;
 #else
-class PowerObserver : public base::PowerObserver {
- public:
-  PowerObserver() {}
-  void BlockShutdown() {}
-  void UnblockShutdown() {}
-  // Notification that the system is rebooting or shutting down. If the
-  // implementation returns true, the PowerObserver instance should try to delay
-  // OS shutdown so the application can perform cleanup before exiting.
-  virtual bool OnShutdown() { return false; }
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(PowerObserver);
-};
+typedef base::PowerObserver PowerObserver;
 #endif  // defined(OS_LINUX)
 
 }  // namespace atom

--- a/atom/browser/lib/power_observer.h
+++ b/atom/browser/lib/power_observer.h
@@ -18,7 +18,19 @@ namespace atom {
 #if defined(OS_LINUX)
 typedef PowerObserverLinux PowerObserver;
 #else
-typedef base::PowerObserver PowerObserver;
+class PowerObserver : public base::PowerObserver {
+ public:
+  PowerObserver() {}
+  void BlockShutdown() {}
+  void UnblockShutdown() {}
+  // Notification that the system is rebooting or shutting down. If the
+  // implementation returns true, the PowerObserver instance should try to delay
+  // OS shutdown so the application can perform cleanup before exiting.
+  virtual bool OnShutdown() { return false; }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(PowerObserver);
+};
 #endif  // defined(OS_LINUX)
 
 }  // namespace atom

--- a/atom/browser/lib/power_observer_linux.cc
+++ b/atom/browser/lib/power_observer_linux.cc
@@ -148,7 +148,7 @@ void PowerObserverLinux::OnPrepareForShutdown(dbus::Signal* signal) {
     return;
   }
   if (shutting_down) {
-    if (!should_shutdown_ || !should_shutdown_.Run()) {
+    if (!should_shutdown_ || should_shutdown_.Run()) {
       // The user didn't try to prevent shutdown. Release the lock and allow the
       // shutdown to continue normally.
       shutdown_lock_.reset();

--- a/atom/browser/lib/power_observer_linux.cc
+++ b/atom/browser/lib/power_observer_linux.cc
@@ -122,12 +122,12 @@ void PowerObserverLinux::OnInhibitResponse(base::ScopedFD* scoped_fd,
 
 void PowerObserverLinux::OnPrepareForSleep(dbus::Signal* signal) {
   dbus::MessageReader reader(signal);
-  bool status;
-  if (!reader.PopBool(&status)) {
+  bool suspending;
+  if (!reader.PopBool(&suspending)) {
     LOG(ERROR) << "Invalid signal: " << signal->ToString();
     return;
   }
-  if (status) {
+  if (suspending) {
     OnSuspend();
     sleep_lock_.reset();
   } else {
@@ -138,12 +138,12 @@ void PowerObserverLinux::OnPrepareForSleep(dbus::Signal* signal) {
 
 void PowerObserverLinux::OnPrepareForShutdown(dbus::Signal* signal) {
   dbus::MessageReader reader(signal);
-  bool status;
-  if (!reader.PopBool(&status)) {
+  bool shutting_down;
+  if (!reader.PopBool(&shutting_down)) {
     LOG(ERROR) << "Invalid signal: " << signal->ToString();
     return;
   }
-  if (status) {
+  if (shutting_down) {
     if (!OnShutdown()) {
       // The user didn't try to prevent shutdown. Release the lock and allow the
       // shutdown to continue normally.

--- a/atom/browser/lib/power_observer_linux.h
+++ b/atom/browser/lib/power_observer_linux.h
@@ -39,6 +39,7 @@ class PowerObserverLinux : public base::PowerObserver {
   scoped_refptr<dbus::ObjectProxy> logind_;
   std::string lock_owner_name_;
   base::ScopedFD sleep_lock_;
+  base::ScopedFD shutdown_lock_;
   base::WeakPtrFactory<PowerObserverLinux> weak_ptr_factory_;
   DISALLOW_COPY_AND_ASSIGN(PowerObserverLinux);
 };

--- a/atom/browser/lib/power_observer_linux.h
+++ b/atom/browser/lib/power_observer_linux.h
@@ -20,12 +20,13 @@ class PowerObserverLinux : public base::PowerObserver {
  public:
   PowerObserverLinux();
 
+  void BlockSleep();
+  void UnblockSleep();
   void BlockShutdown();
   void UnblockShutdown();
   virtual bool OnShutdown() { return false; }
 
  private:
-  void TakeSleepLock();
   void OnLoginServiceAvailable(bool available);
   void OnInhibitResponse(base::ScopedFD* scoped_fd, dbus::Response* response);
   void OnPrepareForSleep(dbus::Signal* signal);

--- a/atom/browser/lib/power_observer_linux.h
+++ b/atom/browser/lib/power_observer_linux.h
@@ -26,7 +26,7 @@ class PowerObserverLinux : public base::PowerObserver {
   void BlockShutdown();
   void UnblockShutdown();
 
-  virtual bool OnShutdown() { return false; }
+  void SetShutdownHandler(base::Callback<bool()> should_shutdown);
 
  private:
   void OnLoginServiceAvailable(bool available);
@@ -36,6 +36,8 @@ class PowerObserverLinux : public base::PowerObserver {
   void OnSignalConnected(const std::string& interface,
                          const std::string& signal,
                          bool success);
+
+  base::Callback<bool()> should_shutdown_;
 
   scoped_refptr<dbus::Bus> bus_;
   scoped_refptr<dbus::ObjectProxy> logind_;

--- a/atom/browser/lib/power_observer_linux.h
+++ b/atom/browser/lib/power_observer_linux.h
@@ -20,11 +20,16 @@ class PowerObserverLinux : public base::PowerObserver {
  public:
   PowerObserverLinux();
 
+  void BlockShutdown();
+  void UnblockShutdown();
+  virtual bool OnShutdown() { return false; }
+
  private:
   void TakeSleepLock();
   void OnLoginServiceAvailable(bool available);
   void OnInhibitResponse(base::ScopedFD* scoped_fd, dbus::Response* response);
   void OnPrepareForSleep(dbus::Signal* signal);
+  void OnPrepareForShutdown(dbus::Signal* signal);
   void OnSignalConnected(const std::string& interface,
                          const std::string& signal,
                          bool success);

--- a/atom/browser/lib/power_observer_linux.h
+++ b/atom/browser/lib/power_observer_linux.h
@@ -20,10 +20,12 @@ class PowerObserverLinux : public base::PowerObserver {
  public:
   PowerObserverLinux();
 
+ protected:
   void BlockSleep();
   void UnblockSleep();
   void BlockShutdown();
   void UnblockShutdown();
+
   virtual bool OnShutdown() { return false; }
 
  private:
@@ -41,6 +43,7 @@ class PowerObserverLinux : public base::PowerObserver {
   base::ScopedFD sleep_lock_;
   base::ScopedFD shutdown_lock_;
   base::WeakPtrFactory<PowerObserverLinux> weak_ptr_factory_;
+
   DISALLOW_COPY_AND_ASSIGN(PowerObserverLinux);
 };
 

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -2,8 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#import "base/mac/scoped_sending_event.h"
-#import "base/mac/scoped_nsobject.h"
+#include "base/callback.h"
+#include "base/mac/scoped_sending_event.h"
+#include "base/mac/scoped_nsobject.h"
 
 @interface AtomApplication : NSApplication<CrAppProtocol,
                                            CrAppControlProtocol,
@@ -13,9 +14,12 @@
   base::scoped_nsobject<NSUserActivity> currentActivity_;
   NSCondition* handoffLock_;
   BOOL updateReceived_;
+  base::Callback<bool()> shouldShutdown_;
 }
 
 + (AtomApplication*)sharedApplication;
+
+- (void)setShutdownHandler:(base::Callback<bool()>)handler;
 
 // CrAppProtocol:
 - (BOOL)isHandlingSendEvent;

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -31,8 +31,11 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 - (void)terminate:(id)sender {
   if (shouldShutdown_ && !shouldShutdown_.Run())
     return;  // User will call Quit later.
-  AtomApplicationDelegate* atomDelegate = (AtomApplicationDelegate*) [NSApp delegate];
-  [atomDelegate tryToTerminateApp:self];
+
+  // We simply try to close the browser, which in turn will try to close the
+  // windows. Termination can proceed if all windows are closed or window close
+  // can be cancelled which will abort termination.
+  atom::Browser::Get()->Quit();
 }
 
 - (void)setShutdownHandler:(base::Callback<bool()>)handler {

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -29,8 +29,14 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 }
 
 - (void)terminate:(id)sender {
+  if (shouldShutdown_ && !shouldShutdown_.Run())
+    return;  // User will call Quit later.
   AtomApplicationDelegate* atomDelegate = (AtomApplicationDelegate*) [NSApp delegate];
   [atomDelegate tryToTerminateApp:self];
+}
+
+- (void)setShutdownHandler:(base::Callback<bool()>)handler {
+  shouldShutdown_ = std::move(handler);
 }
 
 - (BOOL)isHandlingSendEvent {

--- a/atom/browser/mac/atom_application_delegate.h
+++ b/atom/browser/mac/atom_application_delegate.h
@@ -11,8 +11,6 @@
   base::scoped_nsobject<AtomMenuController> menu_controller_;
 }
 
-- (void)tryToTerminateApp:(NSApplication*)app;
-
 // Sets the menu that will be returned in "applicationDockMenu:".
 - (void)setApplicationDockMenu:(atom::AtomMenuModel*)model;
 

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -87,13 +87,6 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
   return atom::Browser::Get()->OpenFile(filename_str) ? YES : NO;
 }
 
-// We simply try to close the browser, which in turn will try to close the windows.
-// Termination can proceed if all windows are closed or window close can be cancelled
-// which will abort termination.
-- (void)tryToTerminateApp:(NSApplication*)app {
-  atom::Browser::Get()->Quit();
-}
-
 - (BOOL)applicationShouldHandleReopen:(NSApplication*)theApplication
                     hasVisibleWindows:(BOOL)flag {
   atom::Browser* browser = atom::Browser::Get();

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -39,3 +39,10 @@ Emitted when the system changes to AC power.
 ### Event: 'on-battery' _Windows_
 
 Emitted when system changes to battery power.
+
+### Event: 'shutdown' _Linux_
+
+Emitted when the system is about to reboot or shut down. If the event handler
+invokes `e.preventDefault()`, Electron will attempt to delay system shutdown in
+order for the app to exit cleanly. If `e.preventDefault()` is called, the app
+should exit as soon as possible by calling something like `app.quit()`.

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -40,7 +40,7 @@ Emitted when the system changes to AC power.
 
 Emitted when system changes to battery power.
 
-### Event: 'shutdown' _Linux_
+### Event: 'shutdown' _Linux_ _macOS_
 
 Emitted when the system is about to reboot or shut down. If the event handler
 invokes `e.preventDefault()`, Electron will attempt to delay system shutdown in

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -5,16 +5,19 @@ const {powerMonitor, PowerMonitor} = process.atomBinding('power_monitor')
 Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
 EventEmitter.call(powerMonitor)
 
-powerMonitor.on('newListener', (event) => {
-  if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
-    powerMonitor.blockShutdown()
-  }
-})
+// On Linux we need to call blockShutdown() to subscribe to shutdown event.
+if (process.platform === 'linux') {
+  powerMonitor.on('newListener', (event) => {
+    if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
+      powerMonitor.blockShutdown()
+    }
+  })
 
-powerMonitor.on('removeListener', (event) => {
-  if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
-    powerMonitor.unblockShutdown()
-  }
-})
+  powerMonitor.on('removeListener', (event) => {
+    if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
+      powerMonitor.unblockShutdown()
+    }
+  })
+}
 
 module.exports = powerMonitor

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -5,4 +5,16 @@ const {powerMonitor, PowerMonitor} = process.atomBinding('power_monitor')
 Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
 EventEmitter.call(powerMonitor)
 
+powerMonitor.on('newListener', (event) => {
+  if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
+    powerMonitor.blockShutdown()
+  }
+})
+
+powerMonitor.on('removeListener', (event) => {
+  if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
+    powerMonitor.unblockShutdown()
+  }
+})
+
 module.exports = powerMonitor


### PR DESCRIPTION
In this PR I add a new event to `powerMonitor`. Usage is very simple:

```js
powerMonitor.on('shutdown', (e) => {
  e.preventDefault()  // This will delay OS shutdown as much as possible
  someAppSpecificCleanup().then(() => {
    app.quit() // exit, this must be called ASAP!
  })
})
```

This is useful for any application that needs to ensure its state is saved correctly when the computer shuts down.

Currently only works on Linux, though I imagine windows/osx have similar APIs that could be used (I know I have seen Windows notification that some apps are delaying shutdown)