### PR TITLE
Fix 'electron-versioning' link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install electron --save-dev --save-exact
 
 The `--save-exact` flag is recommended as Electron does not follow semantic
 versioning. For info on how to manage Electron versions in your apps, see
-[Electron versioning](docs/tutorial/versioning.md).
+[Electron versioning](docs/tutorial/electron-versioning.md).
 
 For more installation options and troubleshooting tips, see
 [installation](docs/tutorial/installation.md).


### PR DESCRIPTION
"Electron versioning"'s link is broken.