### PR TITLE
docs: specify string values for DownloadItem

### DIFF
--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -44,7 +44,7 @@ win.webContents.session.on('will-download', (event, item, webContents) => {
 Returns:
 
 * `event` Event
-* `state` String
+* `state` String - Can be `progressing` or `interrupted`.
 
 Emitted when the download has been updated and is not done.
 
@@ -58,7 +58,7 @@ The `state` can be one of following:
 Returns:
 
 * `event` Event
-* `state` String
+* `state` String - Can be `completed`, `cancelled` or `interrupted`.
 
 Emitted when the download is in a terminal state. This includes a completed
 download, a cancelled download (via `downloadItem.cancel()`), and interrupted


### PR DESCRIPTION
Explicitly list the possible string return values for the updated and done events so that the typescript declaration file can model them more accurately. At present they are represented as a string type.

Fixes : https://github.com/electron/electron-typescript-definitions/issues/71