### PR TITLE
infra: Allow notifications debugging

### DIFF
--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -32,6 +32,8 @@ class CocoaNotification : public Notification {
   NSUserNotification* notification() const { return notification_; }
 
  private:
+  void LogAction(const char* action);
+
   base::scoped_nsobject<NSUserNotification> notification_;
   int action_index_;
 

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -38,7 +38,7 @@ void CocoaNotification::Show(const NotificationOptions& options) {
   g_identifier_++;
 
   if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
-    NSLog(@"%s (%@)", "Cocoa notification created", identifier);
+    LOG(INFO) << "Notification created (" << [identifier UTF8String] << ")";
   }
 
   if ([notification_ respondsToSelector:@selector(setContentImage:)] &&
@@ -111,7 +111,7 @@ void CocoaNotification::NotificationButtonClicked() {
 void CocoaNotification::LogAction(const char* action) {
   if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
     NSString* identifier = [notification_ valueForKey:@"identifier"];
-    NSLog(@"%s %s (%@)", "Cocoa notification", action, identifier);
+    LOG(INFO) << "Notification " << action << " (" << [identifier UTF8String] << ")";
   }
 }
 

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -105,7 +105,7 @@ void CocoaNotification::NotificationButtonClicked() {
   if (delegate())
     delegate()->NotificationAction(action_index_);
 
-  this->LogAction("clicked");
+  this->LogAction("button clicked");
 }
 
 void CocoaNotification::LogAction(const char* action) {

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -28,11 +28,18 @@ CocoaNotification::~CocoaNotification() {
 
 void CocoaNotification::Show(const NotificationOptions& options) {
   notification_.reset([[NSUserNotification alloc] init]);
+
+  NSString* identifier = [NSString stringWithFormat:@"%s%d", "ElectronNotification", g_identifier_];
+
   [notification_ setTitle:base::SysUTF16ToNSString(options.title)];
   [notification_ setSubtitle:base::SysUTF16ToNSString(options.subtitle)];
   [notification_ setInformativeText:base::SysUTF16ToNSString(options.msg)];
-  [notification_ setIdentifier:[NSString stringWithFormat:@"%s%d", "ElectronNotification", g_identifier_]];
+  [notification_ setIdentifier:identifier];
   g_identifier_++;
+
+  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+    NSLog(@"%s (%@)", "Cocoa notification created", identifier);
+  }
 
   if ([notification_ respondsToSelector:@selector(setContentImage:)] &&
       !options.icon.drawsNothing()) {
@@ -74,22 +81,38 @@ void CocoaNotification::Dismiss() {
   if (notification_)
     [NSUserNotificationCenter.defaultUserNotificationCenter
         removeDeliveredNotification:notification_];
+
   NotificationDismissed();
+
+  this->LogAction("dismissed");
 }
 
 void CocoaNotification::NotificationDisplayed() {
   if (delegate())
     delegate()->NotificationDisplayed();
+
+  this->LogAction("displayed");
 }
 
 void CocoaNotification::NotificationReplied(const std::string& reply) {
   if (delegate())
     delegate()->NotificationReplied(reply);
+
+  this->LogAction("replied to");
 }
 
 void CocoaNotification::NotificationButtonClicked() {
   if (delegate())
     delegate()->NotificationAction(action_index_);
+
+  this->LogAction("clicked");
+}
+
+void CocoaNotification::LogAction(const char* action) {
+  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+    NSString* identifier = [notification_ valueForKey:@"identifier"];
+    NSLog(@"%s %s (%@)", "Cocoa notification", action, identifier);
+  }
 }
 
 }  // namespace brightray

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -28,13 +28,18 @@
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
        didActivateNotification:(NSUserNotification *)notif {
   auto notification = presenter_->GetNotification(notif);
+
+  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+    NSLog(@"%s (%@)", "Cocoa notification activated", notif.identifier);
+  }
+
   if (notification) {
     if (notif.activationType == NSUserNotificationActivationTypeReplied) {
       notification->NotificationReplied([notif.response.string UTF8String]);
     } else if (notif.activationType == NSUserNotificationActivationTypeActionButtonClicked) {
       notification->NotificationButtonClicked();
     } else if (notif.activationType == NSUserNotificationActivationTypeContentsClicked) {
-      notification->NotificationClicked(); 
+      notification->NotificationClicked();
     }
   }
 }

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -30,7 +30,7 @@
   auto notification = presenter_->GetNotification(notif);
 
   if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
-    NSLog(@"%s (%@)", "Cocoa notification activated", notif.identifier);
+    LOG(INFO) << "Notification activated (" << [notif.identifier UTF8String] << ")";
   }
 
   if (notification) {

--- a/brightray/browser/mac/notification_presenter_mac.mm
+++ b/brightray/browser/mac/notification_presenter_mac.mm
@@ -24,7 +24,7 @@ CocoaNotification* NotificationPresenterMac::GetNotification(
   }
 
   if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
-    NSLog(@"%s \"%@\"", "Could not find cocoa notification for", ns_notification.identifier);
+    LOG(INFO) << "Could not find notification for " << [ns_notification.identifier UTF8String];
   }
 
   return nullptr;

--- a/brightray/browser/mac/notification_presenter_mac.mm
+++ b/brightray/browser/mac/notification_presenter_mac.mm
@@ -22,6 +22,11 @@ CocoaNotification* NotificationPresenterMac::GetNotification(
           isEqual:ns_notification.identifier])
       return native_notification;
   }
+
+  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+    NSLog(@"%s \"%@\"", "Could not find cocoa notification for", ns_notification.identifier);
+  }
+
   return nullptr;
 }
 

--- a/brightray/browser/win/notification_presenter_win.cc
+++ b/brightray/browser/win/notification_presenter_win.cc
@@ -13,6 +13,7 @@
 #include "base/md5.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
+#include "base/environment.h"
 #include "base/win/windows_version.h"
 #include "brightray/browser/win/notification_presenter_win7.h"
 #include "brightray/browser/win/windows_toast_notification.h"
@@ -25,6 +26,10 @@
 namespace brightray {
 
 namespace {
+
+bool IsDebuggingNotifications() {
+  return base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS");
+}
 
 bool SaveIconToPath(const SkBitmap& bitmap, const base::FilePath& path) {
   std::vector<unsigned char> png_data;
@@ -49,6 +54,11 @@ NotificationPresenter* NotificationPresenter::Create() {
       new NotificationPresenterWin);
   if (!presenter->Init())
     return nullptr;
+  
+  if (IsDebuggingNotifications()) {
+    LOG(INFO) << "Successfully created Windows notifications presenter";
+  }
+
   return presenter.release();
 }
 

--- a/brightray/browser/win/notification_presenter_win.cc
+++ b/brightray/browser/win/notification_presenter_win.cc
@@ -9,11 +9,11 @@
 #include <string>
 #include <vector>
 
+#include "base/environment.h"
 #include "base/files/file_util.h"
 #include "base/md5.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
-#include "base/environment.h"
 #include "base/win/windows_version.h"
 #include "brightray/browser/win/notification_presenter_win7.h"
 #include "brightray/browser/win/windows_toast_notification.h"
@@ -54,10 +54,9 @@ NotificationPresenter* NotificationPresenter::Create() {
       new NotificationPresenterWin);
   if (!presenter->Init())
     return nullptr;
-  
-  if (IsDebuggingNotifications()) {
+
+  if (IsDebuggingNotifications())
     LOG(INFO) << "Successfully created Windows notifications presenter";
-  }
 
   return presenter.release();
 }

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -11,6 +11,7 @@
 #include <shlobj.h>
 #include <vector>
 
+#include "base/environment.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/notification_delegate.h"
 #include "brightray/browser/win/notification_presenter_win.h"
@@ -26,6 +27,7 @@ using ABI::Windows::Data::Xml::Dom::IXmlNode;
 using ABI::Windows::Data::Xml::Dom::IXmlNodeList;
 using ABI::Windows::Data::Xml::Dom::IXmlText;
 
+
 namespace brightray {
 
 namespace {
@@ -39,6 +41,10 @@ bool GetAppUserModelId(ScopedHString* app_id) {
     app_id->Reset(base::UTF8ToUTF16(GetApplicationName()));
   }
   return app_id->success();
+}
+
+bool IsDebuggingNotifications() {
+  return base::Environment::Create()->HasVar("ELECTRON_DEBUG_NOTIFICATIONS");
 }
 
 }  // namespace
@@ -90,7 +96,7 @@ void WindowsToastNotification::Show(const NotificationOptions& options) {
   std::wstring icon_path = presenter_win->SaveIconToFilesystem(
     options.icon,
     options.icon_url);
-
+  
   ComPtr<IXmlDocument> toast_xml;
   if (FAILED(GetToastXml(toast_manager_.Get(), options.title, options.msg,
                          icon_path, options.silent, &toast_xml))) {
@@ -129,11 +135,14 @@ void WindowsToastNotification::Show(const NotificationOptions& options) {
     return;
   }
 
+  if (IsDebuggingNotifications()) LOG(INFO) << "Notification created";
+
   if (delegate())
     delegate()->NotificationDisplayed();
 }
 
 void WindowsToastNotification::Dismiss() {
+  if (IsDebuggingNotifications()) LOG(INFO) << "Hiding notification";  
   toast_notifier_->Hide(toast_notification_.Get());
 }
 
@@ -165,14 +174,20 @@ bool WindowsToastNotification::GetToastXml(
             : ABI::Windows::UI::Notifications::
                   ToastTemplateType_ToastImageAndText02;
     if (FAILED(toastManager->GetTemplateContent(template_type, toast_xml)))
+      if (IsDebuggingNotifications()) LOG(INFO) << "Fetching XML template failed";    
       return false;
     if (!SetXmlText(*toast_xml, title, msg))
+      if (IsDebuggingNotifications()) LOG(INFO) << "Setting text fields on template failed";    
       return false;
   }
 
   // Configure the toast's notification sound
   if (silent) {
     if (FAILED(SetXmlAudioSilent(*toast_xml)))
+      if (IsDebuggingNotifications()) {
+        LOG(INFO) << "Setting \"silent\" option on notification failed";  
+      }
+       
       return false;
   }
 
@@ -398,6 +413,8 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(&Notification::NotificationClicked, notification_));
+  if (IsDebuggingNotifications()) LOG(INFO) << "Notification clicked";          
+
   return S_OK;
 }
 
@@ -407,6 +424,8 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(&Notification::NotificationDismissed, notification_));
+  if (IsDebuggingNotifications()) LOG(INFO) << "Notification dismissed";                
+  
   return S_OK;
 }
 
@@ -416,6 +435,8 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(&Notification::NotificationFailed, notification_));
+  if (IsDebuggingNotifications()) LOG(INFO) << "Notification failed";                      
+
   return S_OK;
 }
 

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -27,7 +27,6 @@ using ABI::Windows::Data::Xml::Dom::IXmlNode;
 using ABI::Windows::Data::Xml::Dom::IXmlNodeList;
 using ABI::Windows::Data::Xml::Dom::IXmlText;
 
-
 namespace brightray {
 
 namespace {
@@ -96,7 +95,7 @@ void WindowsToastNotification::Show(const NotificationOptions& options) {
   std::wstring icon_path = presenter_win->SaveIconToFilesystem(
     options.icon,
     options.icon_url);
-  
+
   ComPtr<IXmlDocument> toast_xml;
   if (FAILED(GetToastXml(toast_manager_.Get(), options.title, options.msg,
                          icon_path, options.silent, &toast_xml))) {
@@ -142,7 +141,7 @@ void WindowsToastNotification::Show(const NotificationOptions& options) {
 }
 
 void WindowsToastNotification::Dismiss() {
-  if (IsDebuggingNotifications()) LOG(INFO) << "Hiding notification";  
+  if (IsDebuggingNotifications()) LOG(INFO) << "Hiding notification";
   toast_notifier_->Hide(toast_notification_.Get());
 }
 
@@ -173,22 +172,28 @@ bool WindowsToastNotification::GetToastXml(
             ? ABI::Windows::UI::Notifications::ToastTemplateType_ToastText02
             : ABI::Windows::UI::Notifications::
                   ToastTemplateType_ToastImageAndText02;
-    if (FAILED(toastManager->GetTemplateContent(template_type, toast_xml)))
-      if (IsDebuggingNotifications()) LOG(INFO) << "Fetching XML template failed";    
+    if (FAILED(toastManager->GetTemplateContent(template_type, toast_xml))) {
+      if (IsDebuggingNotifications())
+        LOG(INFO) << "Fetching XML template failed";
       return false;
-    if (!SetXmlText(*toast_xml, title, msg))
-      if (IsDebuggingNotifications()) LOG(INFO) << "Setting text fields on template failed";    
+    }
+
+    if (!SetXmlText(*toast_xml, title, msg)) {
+      if (IsDebuggingNotifications())
+        LOG(INFO) << "Setting text fields on template failed";
       return false;
+    }
   }
 
   // Configure the toast's notification sound
   if (silent) {
-    if (FAILED(SetXmlAudioSilent(*toast_xml)))
+    if (FAILED(SetXmlAudioSilent(*toast_xml))) {
       if (IsDebuggingNotifications()) {
-        LOG(INFO) << "Setting \"silent\" option on notification failed";  
+        LOG(INFO) << "Setting \"silent\" option on notification failed";
       }
-       
+
       return false;
+    }
   }
 
   // Configure the toast's image
@@ -413,7 +418,7 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(&Notification::NotificationClicked, notification_));
-  if (IsDebuggingNotifications()) LOG(INFO) << "Notification clicked";          
+  if (IsDebuggingNotifications()) LOG(INFO) << "Notification clicked";
 
   return S_OK;
 }
@@ -424,8 +429,8 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(&Notification::NotificationDismissed, notification_));
-  if (IsDebuggingNotifications()) LOG(INFO) << "Notification dismissed";                
-  
+  if (IsDebuggingNotifications()) LOG(INFO) << "Notification dismissed";
+
   return S_OK;
 }
 
@@ -435,7 +440,7 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(&Notification::NotificationFailed, notification_));
-  if (IsDebuggingNotifications()) LOG(INFO) << "Notification failed";                      
+  if (IsDebuggingNotifications()) LOG(INFO) << "Notification failed";
 
   return S_OK;
 }


### PR DESCRIPTION
We at Slack were about to switch to Electron's very own notifications for macOS, but we're seeing some trouble with notifications just silently not showing up. Debugging this is currently very difficult - we don't actually know where exactly things are going wrong – and without attaching a debugger on our customer's machines, it might continue to be difficult.

This PR adds logging statements to Electron's native notifications for macOS and Windows 10. It doesn't change any logic and _only_ starts logging if the environment variable `ELECTRON_DEBUG_NOTIFICATIONS` is set, together with the already existing `--enable-logging` parameter.

Output looks roughly like this:

```
[24035:1213/163133.070393:VERBOSE1:CONSOLE(8192)] "Main._createAppUI: 70.869873046875ms", source: chrome-devtools://devtools/bundled/inspector.js (8192)
[24035:1213/163133.372009:VERBOSE1:CONSOLE(8192)] "Main._showAppUI: 83.883056640625ms", source: chrome-devtools://devtools/bundled/inspector.js (8192)
[24035:1213/163133.380724:VERBOSE1:CONSOLE(8192)] "Main._initializeTarget: 13.277099609375ms", source: chrome-devtools://devtools/bundled/inspector.js (8192)
[24035:1213/163136.552704:INFO:cocoa_notification.mm(41)] Notification created (ElectronNotification1)
[24035:1213/163136.659964:INFO:cocoa_notification.mm(114)] Notification displayed (ElectronNotification1)
[24035:1213/163149.003999:INFO:cocoa_notification.mm(41)] Notification created (ElectronNotification2)
[24035:1213/163149.107720:INFO:cocoa_notification.mm(114)] Notification displayed (ElectronNotification2)
[24035:1213/163152.011869:INFO:notification_center_delegate.mm(33)] Notification activated (ElectronNotification2)
[24035:1213/163152.012128:INFO:cocoa_notification.mm(114)] Notification replied to (ElectronNotification2)
```