### PR TITLE
:memo: Fix mixed content warning [ci skip]

### DIFF
--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -108,7 +108,7 @@ as quoted from MSDN:
 
 __Tasks of Internet Explorer:__
 
-![IE](http://i.msdn.microsoft.com/dynimg/IC420539.png)
+![IE](https://msdn.microsoft.com/dynimg/IC420539.png)
 
 Unlike the dock menu in macOS which is a real menu, user tasks in Windows work
 like application shortcuts such that when user clicks a task, a program will be


### PR DESCRIPTION
While browsing the docs I git a mixed content warning on https://electronjs.org/docs/tutorial/desktop-environment-integration:

> `Mixed Content: The page at 'https://electronjs.org/docs/tutorial/desktop-environment-integration' was loaded over HTTPS, but requested an insecure image 'http://i.msdn.microsoft.com/dynimg/IC420539.png'. This content should also be served over HTTPS.`

I replaced the insecure request with a secure one.