### PR TITLE
Force uv loop cleanup

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -140,7 +140,7 @@ NodeBindings::~NodeBindings() {
       if (!uv_run(uv_loop_, UV_RUN_DEFAULT))
         break;
 
-    DCHECK_EQ(uv_loop_alive(uv_loop_), 0);
+    DCHECK_EQ(!uv_loop_alive(uv_loop_));
     uv_loop_close(uv_loop_);
   }
 }

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -135,6 +135,7 @@ NodeBindings::~NodeBindings() {
       if (!uv_run(uv_loop_, UV_RUN_DEFAULT))
         break;
 
+    DCHECK(uv_loop_alive(uv_loop_) == 0);
     uv_loop_delete(uv_loop_);
   }
 }

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -81,7 +81,7 @@ void stop_and_close_uv_loop(uv_loop_t* loop) {
     if (!uv_run(loop, UV_RUN_DEFAULT))
       break;
 
-  DCHECK_EQ(!uv_loop_alive(loop));
+  DCHECK(!uv_loop_alive(loop));
   uv_loop_close(loop);
 }
 

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -135,7 +135,7 @@ NodeBindings::~NodeBindings() {
     }, nullptr);
 
     // Run the loop to let it finish all the closing handles
-    // NB: after uv_close(), uv_run(UV_RUN_DEFAULT) returns 0 when that's done
+    // NB: after uv_stop(), uv_run(UV_RUN_DEFAULT) returns 0 when that's done
     for (;;)
       if (!uv_run(uv_loop_, UV_RUN_DEFAULT))
         break;

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -140,7 +140,7 @@ NodeBindings::~NodeBindings() {
       if (!uv_run(uv_loop_, UV_RUN_DEFAULT))
         break;
 
-    DCHECK(uv_loop_alive(uv_loop_) == 0);
+    DCHECK_EQ(uv_loop_alive(uv_loop_), 0);
     uv_loop_close(uv_loop_);
   }
 }

--- a/atom/common/node_bindings.h
+++ b/atom/common/node_bindings.h
@@ -85,6 +85,9 @@ class NodeBindings {
   // Whether the libuv loop has ended.
   bool embed_closed_;
 
+  // Loop used when constructed in WORKER mode
+  uv_loop_t worker_loop_;
+
   // Dummy handle to make uv's loop not quit.
   uv_async_t dummy_uv_handle_;
 


### PR DESCRIPTION
This PR tries to ensure that a Worker's event loop has no pending business before the loop is closed. It does this by
 1. calling `uv_stop()` on the loop
 2. walking the event loop to close() all active handles
 3. calling [`uv_loop_run(UV_RUN_DEFAULT)`](http://docs.libuv.org/en/v1.x/loop.html#c.uv_run) so that pending handles can be disposed of properly

This is related to #11243

In addition, since `uv_loop_new()` and `uv_loop_destroy()` are deprecated API, this patch replaces those with `uv_loop_init()` and `uv_loop_close()`