### PR TITLE
add changed-files-only mode to cpplint

### DIFF
--- a/atom/node/osfhandle.cc
+++ b/atom/node/osfhandle.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "osfhandle.h"
+#include "atom/node/osfhandle.h"
 
 #if !defined(DEBUG)
 #define U_I18N_IMPLEMENTATION
@@ -23,10 +23,10 @@
 #include "third_party/icu/source/i18n/unicode/ucsdet.h"
 #include "third_party/icu/source/i18n/unicode/ulocdata.h"
 #include "third_party/icu/source/i18n/unicode/uregex.h"
-#include "third_party/icu/source/i18n/unicode/uspoof.h"
 #include "third_party/icu/source/i18n/unicode/usearch.h"
-#include "v8-profiler.h"
-#include "v8-inspector.h"
+#include "third_party/icu/source/i18n/unicode/uspoof.h"
+#include "v8/include/v8-inspector.h"
+#include "v8/include/v8-profiler.h"
 
 namespace node {
 

--- a/atom/node/osfhandle.cc
+++ b/atom/node/osfhandle.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "atom/node/osfhandle.h"
+#include "osfhandle.h"
 
 #if !defined(DEBUG)
 #define U_I18N_IMPLEMENTATION
@@ -23,10 +23,10 @@
 #include "third_party/icu/source/i18n/unicode/ucsdet.h"
 #include "third_party/icu/source/i18n/unicode/ulocdata.h"
 #include "third_party/icu/source/i18n/unicode/uregex.h"
-#include "third_party/icu/source/i18n/unicode/usearch.h"
 #include "third_party/icu/source/i18n/unicode/uspoof.h"
-#include "v8/include/v8-inspector.h"
-#include "v8/include/v8-profiler.h"
+#include "third_party/icu/source/i18n/unicode/usearch.h"
+#include "v8-profiler.h"
+#include "v8-inspector.h"
 
 namespace node {
 

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -20,6 +20,7 @@ IGNORE_FILES = [
   os.path.join('atom', 'common', 'api', 'api_messages.h'),
   os.path.join('atom', 'common', 'common_message_generator.cc'),
   os.path.join('atom', 'common', 'common_message_generator.h'),
+  os.path.join('atom', 'node', 'osfhandle.cc'),
   os.path.join('brightray', 'browser', 'mac',
                'bry_inspectable_web_contents_view.h'),
   os.path.join('brightray', 'browser', 'mac', 'event_dispatching_window.h'),

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -71,17 +71,17 @@ def main():
     enable_verbose_mode()
 
   os.chdir(SOURCE_ROOT)
-  files = list_files('atom',
+  files = find_files('atom',
                      ['app', 'browser', 'common', 'renderer', 'utility'],
                      ['*.cc', '*.h'])
-  files += list_files('brightray', ['browser', 'common'], ['*.cc', '*.h'])
+  files += find_files('brightray', ['browser', 'common'], ['*.cc', '*.h'])
   files -= set(IGNORE_FILES)
   if args.only_changed:
-    files &= get_changed_files()
+    files &= find_changed_files()
   call_cpplint(list(files))
 
 
-def list_files(parent, directories, filters):
+def find_files(parent, directories, filters):
   matches = set()
   for directory in directories:
     for root, _, filenames, in os.walk(os.path.join(parent, directory)):
@@ -91,7 +91,7 @@ def list_files(parent, directories, filters):
   return matches
 
 
-def get_changed_files():
+def find_changed_files():
   return set(execute(['git', 'diff', '--name-only']).splitlines())
 
 

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -89,7 +89,7 @@ def find_files(roots, test):
 
 
 def is_cpp_file(filename):
-      return filename.endswith('.cc') or filename.endswith('.h')
+  return filename.endswith('.cc') or filename.endswith('.h')
 
 
 def find_changed_files():

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -70,14 +70,12 @@ def main():
   if args.verbose:
     enable_verbose_mode()
 
-  ignore = set(IGNORE_FILES)
-
   os.chdir(SOURCE_ROOT)
   files = list_files('atom',
                      ['app', 'browser', 'common', 'renderer', 'utility'],
                      ['*.cc', '*.h'])
   files += list_files('brightray', ['browser', 'common'], ['*.cc', '*.h'])
-  files -= ignore
+  files -= set(IGNORE_FILES)
   if args.only_changed:
     files &= get_changed_files()
   call_cpplint(list(files))

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -7,36 +7,31 @@ import sys
 from lib.config import enable_verbose_mode
 from lib.util import execute
 
-IGNORE_FILES = [
-  os.path.join('atom', 'browser', 'mac', 'atom_application.h'),
-  os.path.join('atom', 'browser', 'mac', 'atom_application_delegate.h'),
-  os.path.join('atom', 'browser', 'resources', 'win', 'resource.h'),
-  os.path.join('atom', 'browser', 'ui', 'cocoa', 'atom_menu_controller.h'),
-  os.path.join('atom', 'browser', 'ui', 'cocoa', 'atom_touch_bar.h'),
-  os.path.join('atom', 'browser', 'ui', 'cocoa',
-               'touch_bar_forward_declarations.h'),
-  os.path.join('atom', 'browser', 'ui', 'cocoa', 'NSColor+Hex.h'),
-  os.path.join('atom', 'browser', 'ui', 'cocoa', 'NSString+ANSI.h'),
-  os.path.join('atom', 'common', 'api', 'api_messages.h'),
-  os.path.join('atom', 'common', 'common_message_generator.cc'),
-  os.path.join('atom', 'common', 'common_message_generator.h'),
-  os.path.join('atom', 'node', 'osfhandle.cc'),
-  os.path.join('brightray', 'browser', 'mac',
-               'bry_inspectable_web_contents_view.h'),
-  os.path.join('brightray', 'browser', 'mac', 'event_dispatching_window.h'),
-  os.path.join('brightray', 'browser', 'mac',
-               'notification_center_delegate.h'),
-  os.path.join('brightray', 'browser', 'win', 'notification_presenter_win7.h'),
-  os.path.join('brightray', 'browser', 'win', 'win32_desktop_notifications',
-               'common.h'),
-  os.path.join('brightray', 'browser', 'win', 'win32_desktop_notifications',
-               'desktop_notification_controller.cc'),
-  os.path.join('brightray', 'browser', 'win', 'win32_desktop_notifications',
-               'desktop_notification_controller.h'),
-  os.path.join('brightray', 'browser', 'win', 'win32_desktop_notifications',
-               'toast.h'),
-  os.path.join('brightray', 'browser', 'win', 'win32_notification.h')
-]
+IGNORE_FILES = set(os.path.join(*components) for components in [
+  ['atom', 'browser', 'mac', 'atom_application.h'],
+  ['atom', 'browser', 'mac', 'atom_application_delegate.h'],
+  ['atom', 'browser', 'resources', 'win', 'resource.h'],
+  ['atom', 'browser', 'ui', 'cocoa', 'atom_menu_controller.h'],
+  ['atom', 'browser', 'ui', 'cocoa', 'atom_touch_bar.h'],
+  ['atom', 'browser', 'ui', 'cocoa', 'touch_bar_forward_declarations.h'],
+  ['atom', 'browser', 'ui', 'cocoa', 'NSColor+Hex.h'],
+  ['atom', 'browser', 'ui', 'cocoa', 'NSString+ANSI.h'],
+  ['atom', 'common', 'api', 'api_messages.h'],
+  ['atom', 'common', 'common_message_generator.cc'],
+  ['atom', 'common', 'common_message_generator.h'],
+  ['atom', 'node', 'osfhandle.cc'],
+  ['brightray', 'browser', 'mac', 'bry_inspectable_web_contents_view.h'],
+  ['brightray', 'browser', 'mac', 'event_dispatching_window.h'],
+  ['brightray', 'browser', 'mac', 'notification_center_delegate.h'],
+  ['brightray', 'browser', 'win', 'notification_presenter_win7.h'],
+  ['brightray', 'browser', 'win', 'win32_desktop_notifications', 'common.h'],
+  ['brightray', 'browser', 'win', 'win32_desktop_notifications',
+   'desktop_notification_controller.cc'],
+  ['brightray', 'browser', 'win', 'win32_desktop_notifications',
+   'desktop_notification_controller.h'],
+  ['brightray', 'browser', 'win', 'win32_desktop_notifications', 'toast.h'],
+  ['brightray', 'browser', 'win', 'win32_notification.h']
+])
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
@@ -72,10 +67,10 @@ def main():
 
   os.chdir(SOURCE_ROOT)
   files = find_files(['atom', 'brightray'], is_cpp_file)
-  files -= set(IGNORE_FILES)
+  files -= IGNORE_FILES
   if args.only_changed:
     files &= find_changed_files()
-  call_cpplint(list(files))
+  call_cpplint(files)
 
 
 def find_files(roots, test):
@@ -100,7 +95,7 @@ def find_changed_files():
 def call_cpplint(files):
   if files:
     cpplint = cpplint_path()
-    execute([sys.executable, cpplint] + files)
+    execute([sys.executable, cpplint] + list(files))
 
 
 def cpplint_path():

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -79,12 +79,7 @@ def main():
   files = list_files('atom',
                      ['app', 'browser', 'common', 'renderer', 'utility'],
                      ['*.cc', '*.h'])
-  files -= ignore
-  if args.only_changed:
-    files &= changed_files
-  call_cpplint(list(files))
-
-  files = list_files('brightray', ['browser', 'common'], ['*.cc', '*.h'])
+  files += list_files('brightray', ['browser', 'common'], ['*.cc', '*.h'])
   files -= ignore
   if args.only_changed:
     files &= changed_files

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import fnmatch
 import os
 import sys
 
@@ -83,7 +82,7 @@ def find_files(roots, test):
   for root in roots:
     for parent, _, children, in os.walk(root):
       for child in children:
-        filename = os.path.join(parent,child)
+        filename = os.path.join(parent, child)
         if test(filename):
           matches.add(filename)
   return matches

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -67,9 +67,6 @@ def main():
     print("[INFO] Skipping cpplint, dependencies has not been bootstrapped")
     return
 
-  if args.only_changed:
-    changed_files = get_changed_files()
-
   if args.verbose:
     enable_verbose_mode()
 
@@ -82,7 +79,7 @@ def main():
   files += list_files('brightray', ['browser', 'common'], ['*.cc', '*.h'])
   files -= ignore
   if args.only_changed:
-    files &= changed_files
+    files &= get_changed_files()
   call_cpplint(list(files))
 
 

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -73,22 +73,27 @@ def main():
   os.chdir(SOURCE_ROOT)
   files = find_files('atom',
                      ['app', 'browser', 'common', 'renderer', 'utility'],
-                     ['*.cc', '*.h'])
-  files += find_files('brightray', ['browser', 'common'], ['*.cc', '*.h'])
+                     is_cpp_file)
+  files |= find_files('brightray', ['browser', 'common'], is_cpp_file)
   files -= set(IGNORE_FILES)
   if args.only_changed:
     files &= find_changed_files()
   call_cpplint(list(files))
 
 
-def find_files(parent, directories, filters):
+def find_files(root, directories, test):
   matches = set()
   for directory in directories:
-    for root, _, filenames, in os.walk(os.path.join(parent, directory)):
-      for f in filters:
-        for filename in fnmatch.filter(filenames, f):
-          matches.add(os.path.join(root, filename))
+    for parent, _, children, in os.walk(os.path.join(root, directory)):
+      for child in children:
+        filename = os.path.join(parent,child)
+        if test(filename):
+          matches.add(filename)
   return matches
+
+
+def is_cpp_file(filename):
+      return filename.endswith('.cc') or filename.endswith('.h')
 
 
 def find_changed_files():

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -71,20 +71,17 @@ def main():
     enable_verbose_mode()
 
   os.chdir(SOURCE_ROOT)
-  files = find_files('atom',
-                     ['app', 'browser', 'common', 'renderer', 'utility'],
-                     is_cpp_file)
-  files |= find_files('brightray', ['browser', 'common'], is_cpp_file)
+  files = find_files(['atom', 'brightray'], is_cpp_file)
   files -= set(IGNORE_FILES)
   if args.only_changed:
     files &= find_changed_files()
   call_cpplint(list(files))
 
 
-def find_files(root, directories, test):
+def find_files(roots, test):
   matches = set()
-  for directory in directories:
-    for parent, _, children, in os.walk(os.path.join(root, directory)):
+  for root in roots:
+    for parent, _, children, in os.walk(root):
       for child in children:
         filename = os.path.join(parent,child)
         if test(filename):


### PR DESCRIPTION
`scripts/cpplint.py` currently runs on our entire codebase, which is perfect for CI but slow for a human who wants to check a few changes they just made pre-commit. This PR adds a command-line option to run only on changed files, making it faster to use during iterative development.

It also adds a 'verbose' mode to handle for the use case of having perfect files the first time through *cough* such that cpplint returns no output. With verbose mode, you know something did indeed get checked :)

These two new flags are for human use and don't affect CI.

Sample use from command line: `./scripts/cpplint.py -cv`