### PR TITLE
docs: change getBlobData return type from Blob to Buffer

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -356,8 +356,6 @@ Returns `String` - The user agent for this session.
 * `callback` Function
   * `result` Buffer - Blob data.
 
-Returns `Buffer` - The blob data associated with the `identifier`.
-
 #### `ses.createInterruptedDownload(options)`
 
 * `options` Object

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -356,7 +356,7 @@ Returns `String` - The user agent for this session.
 * `callback` Function
   * `result` Buffer - Blob data.
 
-Returns `Blob` - The blob data associated with the `identifier`.
+Returns `Buffer` - The blob data associated with the `identifier`.
 
 #### `ses.createInterruptedDownload(options)`
 


### PR DESCRIPTION
Noticed during failed compiles that the electron.d.ts getBlobData( ) return type `Blob` was not found.  A small oversight in documenting the API docs which are used to generate electron.d.ts.

To play around with this workflow, you can change the API documentation then `npm run create-typescript-definitions`
#