### PR TITLE
Add testing for arm, arm64 and ia32 linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,46 @@ jobs:
              else
                 echo 'Skipping upload distribution because build is not for release'
              fi
+      - run:
+          name: Zip out directory
+          command: |
+            if [ "$ELECTRON_RELEASE" != "1" ]; then
+              zip -r electron.zip out/D
+            fi
+      - persist_to_workspace:
+          root: /home/builduser
+          paths:
+            - project/out
+      - store_artifacts:
+          path: electron.zip
+  electron-linux-arm-test:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Test in ARM docker container
+          command: |
+            if [ "$ELECTRON_RELEASE" != "1" ]; then
+              docker run --rm --privileged multiarch/qemu-user-static:register --reset
+              docker run -it \
+              --mount type=bind,source=/tmp/workspace,target=/tmp/workspace \
+              --rm electronbuilds/electronarm7:0.0.4 > version.txt
+              cat version.txt
+              if grep -q `script/get-version.py` version.txt; then
+                echo "Versions match"
+              else
+                echo "Versions do not match"
+                exit 1
+              fi
+              if grep -q "core dumped" version.txt; then
+                echo "Core dump detected"
+                exit 1
+              fi
+            else
+              echo "Skipping test for release build"
+            fi
   electron-linux-arm64:
     docker:
       - image: electronbuilds/electron:0.0.4
@@ -115,6 +155,46 @@ jobs:
              else
                 echo 'Skipping upload distribution because build is not for release'
              fi
+      - run:
+          name: Zip out directory
+          command: |
+            if [ "$ELECTRON_RELEASE" != "1" ]; then
+              zip -r electron.zip out/D
+            fi
+      - persist_to_workspace:
+          root: /home/builduser
+          paths:
+            - project/out
+      - store_artifacts:
+          path: electron.zip
+  electron-linux-arm64-test:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Test in ARM64 docker container
+          command: |
+            if [ "$ELECTRON_RELEASE" != "1" ]; then
+              docker run --rm --privileged multiarch/qemu-user-static:register --reset
+              docker run -it \
+              --mount type=bind,source=/tmp/workspace,target=/tmp/workspace \
+              --rm electronbuilds/electronarm64:0.0.5 > version.txt
+              cat version.txt
+              if grep -q `script/get-version.py` version.txt; then
+                echo "Versions match"
+              else
+                echo "Versions do not match"
+                exit 1
+              fi
+              if grep -q "core dumped" version.txt; then
+                echo "Core dump detected"
+                exit 1
+              fi
+            else
+              echo "Skipping test for release build"
+            fi
   electron-linux-ia32:
     docker:
       - image: electronbuilds/electron:0.0.4
@@ -123,6 +203,9 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
+      - run:
+          name: Setup for headless testing
+          command: sh -e /etc/init.d/xvfb start
       - run:
           name: Check for release
           command: |
@@ -171,6 +254,29 @@ jobs:
                 script/upload.py --upload_to_s3
              else
                 echo 'Skipping upload distribution because build is not for release'
+             fi
+      - run:
+          name: Test
+          environment:
+            MOCHA_FILE: junit/test-results.xml
+            MOCHA_REPORTER: mocha-junit-reporter
+          command: |
+             if [ "$ELECTRON_RELEASE" != "1" ]; then
+                echo 'Testing Electron debug build'
+                out/D/electron --version
+                mkdir junit
+                script/test.py --ci --rebuild_native_modules
+             else
+                echo 'Skipping testing on release build'
+             fi
+      - run:
+          name: Verify FFmpeg
+          command: |
+             if [ "$ELECTRON_RELEASE" != "1" ]; then
+                echo 'Verifying ffmpeg on debug build'
+                script/verify-ffmpeg.py
+             else
+                echo 'Skipping verify ffmpeg on release build'
              fi
   electron-linux-mips64el:
     docker:
@@ -330,12 +436,18 @@ workflows:
   build-arm:
     jobs:
       - electron-linux-arm
+      - electron-linux-arm-test:
+          requires:
+            - electron-linux-arm
   build-arm64:
     jobs:
       - electron-linux-arm64
+      - electron-linux-arm64-test:
+          requires:
+            - electron-linux-arm64
   build-ia32:
     jobs:
       - electron-linux-ia32
   build-x64:
-    jobs:
-      - electron-linux-x64
+   jobs:
+     - electron-linux-x64

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
 !tools/xvfb-init.sh
+!tools/run-electron.sh

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,35 @@
+FROM multiarch/debian-debootstrap:arm64-jessie
+
+RUN apt-get update && apt-get install -y\
+ bison \
+ build-essential \
+ clang \
+ curl \
+ gperf \
+ libasound2 \
+ libasound2-dev \
+ libcap-dev \
+ libcups2-dev \
+ libdbus-1-dev \
+ libgconf-2-4 \
+ libgconf2-dev \
+ libgnome-keyring-dev \
+ libgtk-3-0 \
+ libgtk2.0-0 \
+ libgtk2.0-dev \
+ libnotify-dev \
+ libnss3 \
+ libnss3-dev \
+ libx11-xcb-dev \
+ libxss1 \
+ libxtst-dev \
+ libxtst6 \
+ python-dbusmock \
+ wget \
+ xvfb
+
+ADD tools/xvfb-init.sh /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb
+ADD tools/run-electron.sh /run-electron.sh
+RUN chmod a+x /run-electron.sh
+CMD sh /run-electron.sh

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,0 +1,41 @@
+FROM multiarch/debian-debootstrap:armhf-jessie
+
+RUN apt-get update && apt-get install -y\
+ bison \
+ build-essential \
+ clang \
+ curl \
+ gperf \
+ libasound2 \
+ libasound2-dev \
+ libcap-dev \
+ libcups2-dev \
+ libdbus-1-dev \
+ libgconf-2-4 \
+ libgconf2-dev \
+ libgnome-keyring-dev \
+ libgtk-3-0 \
+ libgtk2.0-0 \
+ libgtk2.0-dev \
+ libnotify-dev \
+ libnss3 \
+ libnss3-dev \
+ libx11-xcb-dev \
+ libxss1 \
+ libxtst-dev \
+ libxtst6 \
+ python-dbusmock \
+ git \
+ wget \
+ xvfb
+
+# Install node.js
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get update && apt-get install -y nodejs
+
+ADD tools/xvfb-init.sh /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb
+ADD tools/run-electron.sh /run-electron.sh
+RUN chmod a+x /run-electron.sh
+
+CMD sh /run-electron.sh

--- a/script/get-version.py
+++ b/script/get-version.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+import sys
+
+from lib.util import get_electron_version
+
+def main():
+  print get_electron_version()
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/run-electron.sh
+++ b/tools/run-electron.sh
@@ -1,0 +1,4 @@
+export DISPLAY=":99.0"
+sh -e /etc/init.d/xvfb start
+cd /tmp/workspace/project/
+out/D/electron --version


### PR DESCRIPTION
This PR adds testing for our arm, arm64 and ia32 linux builds on CircleCI.

For ia32, we can simply run the tests we run for x64 because a 32 bit executable can run in the 64 bit VM.

For arm and arm64, we need to use qemu to emulate those architectures.  We are doing so by building custom docker images on top of the [multiarch/debian-debootstrap](https://github.com/multiarch/debian-debootstrap) docker images.

At this point, we can only run the executable and verify that the version is correct.  The tests also check to make sure there isn't a core dump when running the executable.  Please note that right now the arm build in master does throw a core dump, so you will see that test failing. 