### PR TITLE
win: Correctly close popup menu

### DIFF
--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -108,7 +108,12 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
 }
 
 void MenuMac::ClosePopupAt(int32_t window_id) {
-  popup_controllers_.erase(window_id);
+  auto it = popup_controllers_.find(window_id);
+  if (it != popup_controllers_.end()) {
+    popup_controllers_.erase(it);
+  } else if (window_id == -1) {
+    popup_controllers_.clear();
+  }
 }
 
 // static

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -25,6 +25,8 @@ class MenuViews : public Menu {
   void ClosePopupAt(int32_t window_id) override;
 
  private:
+  void OnClosed(int32_t window_id);
+
   // window ID -> open context menu
   std::map<int32_t, std::unique_ptr<views::MenuRunner>> menu_runners_;
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -94,10 +94,13 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
 }
 
 Menu.prototype.closePopup = function (window) {
-  if (!window || window.constructor !== BrowserWindow) {
-    window = BrowserWindow.getFocusedWindow()
+  if (window && window.constructor !== BrowserWindow) {
+    this.closePopupAt(window.id)
+  } else {
+    // Passing -1 (invalid) would make closePopupAt close the all menu runners
+    // belong to this menu.
+    this.closePopupAt(-1)
   }
-  if (window) this.closePopupAt(window.id)
 }
 
 Menu.prototype.getMenuItemById = function (id) {


### PR DESCRIPTION
The close callback passed to MenuRunner should only do cleanup job, e.g. erase the runner from map. While the ClosePopupAt API should only cancel the menu, and let the close callback do cleanup job. Merging the two jobs together would crash under edge cases.

This PR also fixes the problem that closing a popup menu without focused window does not work.

This should fix the Windows CI failure.