### PR TITLE
fix: menu.popup should handle options correctly in 1.8.x

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -44,20 +44,23 @@ Menu.prototype._init = function () {
 }
 
 Menu.prototype.popup = function (window, x, y, positioningItem) {
-  let asyncPopup
+  let asyncPopup, opts
   let [newX, newY, newPosition, newWindow] = [x, y, positioningItem, window]
 
   // menu.popup(x, y, positioningItem)
-  if (!window) {
-    // shift over values
-    if (typeof window !== 'object' || window.constructor !== BrowserWindow) {
-      [newPosition, newY, newX, newWindow] = [y, x, window, null]
-    }
+  if (window != null && !(window instanceof BrowserWindow)) {
+    [newPosition, newY, newX, newWindow] = [y, x, window, null]
   }
 
+  // menu.popup({})
+  if (window != null && window.constructor === Object) {
+    opts = window
   // menu.popup(window, {})
-  if (x && typeof x === 'object') {
-    const opts = x
+  } else if (x && typeof x === 'object') {
+    opts = x
+  }
+
+  if (opts) {
     newX = opts.x
     newY = opts.y
     newPosition = opts.positioningItem
@@ -65,13 +68,28 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
   }
 
   // set defaults
-  if (typeof x !== 'number') newX = -1
-  if (typeof y !== 'number') newY = -1
-  if (typeof positioningItem !== 'number') newPosition = -1
-  if (!window) newWindow = BrowserWindow.getFocusedWindow()
+  if (typeof newX !== 'number') newX = -1
+  if (typeof newY !== 'number') newY = -1
+  if (typeof newPosition !== 'number') newPosition = -1
   if (typeof asyncPopup !== 'boolean') asyncPopup = false
+  if (!newWindow || (newWindow && newWindow.constructor !== BrowserWindow)) {
+    newWindow = BrowserWindow.getFocusedWindow()
+
+    // No window focused?
+    if (!newWindow) {
+      const browserWindows = BrowserWindow.getAllWindows()
+
+      if (browserWindows && browserWindows.length > 0) {
+        newWindow = browserWindows[0]
+      } else {
+        throw new Error(`Cannot open Menu without a BrowserWindow present`)
+      }
+    }
+  }
 
   this.popupAt(newWindow, newX, newY, newPosition, asyncPopup)
+
+  return { browserWindow: newWindow, x: newX, y: newY, position: newPosition, async: asyncPopup }
 }
 
 Menu.prototype.closePopup = function (window) {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -279,14 +279,26 @@ describe('Menu module', () => {
     })
 
     afterEach(() => {
+      menu.closePopup()
+      menu.closePopup(w)
       return closeWindow(w).then(() => { w = null })
     })
 
-    describe('when called with async: true', () => {
-      it('returns immediately', () => {
-        menu.popup(w, {x: 100, y: 100, async: true})
-        menu.closePopup(w)
-      })
+    it('returns immediately', () => {
+      const { browserWindow, x, y, async } = menu.popup(w, {x: 100, y: 101, async: true})
+
+      assert.equal(browserWindow, w)
+      assert.equal(x, 100)
+      assert.equal(y, 101)
+      assert.equal(async, true)
+    })
+
+    it('works without a given BrowserWindow and options', () => {
+      const { browserWindow, x, y } = menu.popup({x: 100, y: 101, async: true})
+
+      assert.equal(browserWindow.constructor.name, 'BrowserWindow')
+      assert.equal(x, 100)
+      assert.equal(y, 101)
     })
   })
 


### PR DESCRIPTION
Backports https://github.com/electron/electron/pull/11385

Refs https://github.com/electron/electron/issues/11376

I skipped some of the tests from the original PR that would default to the sync menu in this branch.