### PR TITLE
Add Support for Pop!_OS GNOME Session

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -163,7 +163,7 @@ require('./api/protocol')
 const mainStartupScript = packageJson.main || 'index.js'
 
 // Workaround for electron/electron#5050 and electron/electron#9046
-if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7', 'ubuntu:GNOME'].includes(process.env.XDG_CURRENT_DESKTOP)) {
+if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7', 'ubuntu:GNOME', 'pop:GNOME'].includes(process.env.XDG_CURRENT_DESKTOP)) {
   process.env.XDG_CURRENT_DESKTOP = 'Unity'
 }
 


### PR DESCRIPTION
Similar to this PR: https://github.com/electron/electron/pull/10355 , Pop!_OS suffers from the same problem. Using Ubuntu AppIndicator will not show the icon currently unless the XDG_CURRENT_DESKTOP variable is modified. This commit will add support for pop so that this workaround is not needed. 

Ref: https://github.com/pop-os/pop/issues/84