### PR TITLE
 Use Node's V8Platform instead of gin's

### DIFF
--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -58,7 +58,7 @@ int NodeMain(int argc, char *argv[]) {
 
     // Enable support for v8 inspector.
     NodeDebugger node_debugger(env);
-    node_debugger.Start();
+    node_debugger.Start(gin_env.platform());
 
     mate::Dictionary process(gin_env.isolate(), env->process_object());
 #if defined(OS_WIN)

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -137,7 +137,7 @@ void AtomBrowserMainParts::PostEarlyInitialization() {
 
   // Enable support for v8 inspector
   node_debugger_.reset(new NodeDebugger(env));
-  node_debugger_->Start();
+  node_debugger_->Start(js_env_->platform());
 
   // Add Electron extended APIs.
   atom_bindings_->BindTo(js_env_->isolate(), env->process_object());

--- a/atom/browser/javascript_environment.h
+++ b/atom/browser/javascript_environment.h
@@ -10,6 +10,7 @@
 
 namespace node {
 class Environment;
+class NodePlatform;
 }
 
 namespace atom {
@@ -29,6 +30,9 @@ class JavascriptEnvironment {
 
  private:
   bool Initialize();
+
+  // Leaked on exit.
+  node::NodePlatform* platform_;
 
   bool initialized_;
   gin::IsolateHolder isolate_holder_;

--- a/atom/browser/javascript_environment.h
+++ b/atom/browser/javascript_environment.h
@@ -23,6 +23,7 @@ class JavascriptEnvironment {
   void OnMessageLoopCreated();
   void OnMessageLoopDestroying();
 
+  node::NodePlatform* platform() const { return platform_; }
   v8::Isolate* isolate() const { return isolate_; }
   v8::Local<v8::Context> context() const {
     return v8::Local<v8::Context>::New(isolate_, context_);

--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -14,15 +14,13 @@
 namespace atom {
 
 NodeDebugger::NodeDebugger(node::Environment* env)
-    : env_(env), platform_(nullptr) {
+    : env_(env) {
 }
 
 NodeDebugger::~NodeDebugger() {
-  if (platform_)
-    FreePlatform(platform_);
 }
 
-void NodeDebugger::Start() {
+void NodeDebugger::Start(node::NodePlatform* platform) {
   auto inspector = env_->inspector_agent();
   if (inspector == nullptr)
     return;
@@ -37,13 +35,6 @@ void NodeDebugger::Start() {
   }
 
   if (options.inspector_enabled()) {
-    // Use custom platform since the gin platform does not work correctly
-    // with node's inspector agent. We use the default thread pool size
-    // specified by node.cc
-    platform_ = node::CreatePlatform(
-        /* thread_pool_size */ 4, env_->event_loop(),
-        /* tracing_controller */ nullptr);
-
     // Set process._debugWaitConnect if --inspect-brk was specified to stop
     // the debugger on the first line
     if (options.wait_for_connect()) {
@@ -51,7 +42,7 @@ void NodeDebugger::Start() {
       process.Set("_breakFirstLine", true);
     }
 
-    inspector->Start(platform_, nullptr, options);
+    inspector->Start(platform, nullptr, options);
   }
 }
 

--- a/atom/browser/node_debugger.h
+++ b/atom/browser/node_debugger.h
@@ -20,11 +20,10 @@ class NodeDebugger {
   explicit NodeDebugger(node::Environment* env);
   ~NodeDebugger();
 
-  void Start();
+  void Start(node::NodePlatform* platform);
 
  private:
   node::Environment* env_;
-  node::NodePlatform* platform_;
 
   DISALLOW_COPY_AND_ASSIGN(NodeDebugger);
 };


### PR DESCRIPTION
The default V8 platform of gin relies on Chromium's message loop, which has not been initialized when Node.js is loaded.

This PR should be able to fix the startup hang on Windows x64.

/cc @alexeykuzmin The commits are picked up from the Chrome62 branch and will cause conflicts.