### PR TITLE
feat(#10699): Add Menu#popup positioningItem opt for Linux & Windows

### DIFF
--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -42,6 +42,12 @@ void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
 
   int flags = MenuRunner::CONTEXT_MENU | MenuRunner::HAS_MNEMONICS;
 
+  // Show the entire menu by default, or just a submenu if specified.
+  AtomMenuModel* menu = model();
+  if (positioning_item >= 0 && positioning_item < menu->GetItemCount()) {
+    menu = menu->GetSubmenuModelAt(positioning_item);
+  }
+
   // Don't emit unresponsive event when showing menu.
   atom::UnresponsiveSuppressor suppressor;
 
@@ -50,7 +56,7 @@ void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
   auto close_callback = base::Bind(
       &MenuViews::OnClosed, weak_factory_.GetWeakPtr(), window_id);
   menu_runners_[window_id] = std::unique_ptr<MenuRunner>(new MenuRunner(
-      model(), flags, close_callback));
+      menu, flags, close_callback));
   menu_runners_[window_id]->RunMenuAt(
       static_cast<NativeWindowViews*>(window->window())->widget(),
       NULL,

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -67,7 +67,7 @@ The `menu` object has the following instance methods:
     Must be declared if `y` is declared.
   * `y` Number (optional) - Default is the current mouse cursor position.
     Must be declared if `x` is declared.
-  * `positioningItem` Number (optional) _macOS_ - The index of the menu item to
+  * `positioningItem` Number (optional) - The index of the menu item to
     be positioned under the mouse cursor at the specified coordinates. Default
     is -1.
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -293,11 +293,12 @@ describe('Menu module', () => {
     })
 
     it('works without a given BrowserWindow and options', () => {
-      const { browserWindow, x, y } = menu.popup({x: 100, y: 101})
+      const { browserWindow, x, y, position } = menu.popup({ x: 100, y: 101, positioningItem: 1 })
 
       assert.equal(browserWindow.constructor.name, 'BrowserWindow')
       assert.equal(x, 100)
       assert.equal(y, 101)
+      assert.equal(position, 1)
     })
 
     it('works without a given BrowserWindow', () => {


### PR DESCRIPTION
Addresses: https://github.com/electron/electron/issues/10699

Tested on Linux Mint but don't have access to a Windows box. Would someone be able to verify that this works on Windows as well, please?