### PR TITLE
1-8-x: Fix crash when using crypto module

### DIFF
--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -293,6 +293,20 @@ describe('node feature', () => {
       buffer = new Buffer(new Array(4097).join(' '))
       assert.equal(buffer.length, 4096)
     })
+
+    it('does not crash for crypto operations', () => {
+      const crypto = require('crypto')
+      const data = 'lG9E+/g4JmRmedDAnihtBD4Dfaha/GFOjd+xUOQI05UtfVX3DjUXvrS98p7kZQwY3LNhdiFo7MY5rGft8yBuDhKuNNag9vRx/44IuClDhdQ='
+      const key = 'q90K9yBqhWZnAMCMTOJfPQ=='
+      const cipherText = '{"error_code":114,"error_message":"Tham số không hợp lệ","data":null}'
+      for (let i = 0; i < 10000; ++i) {
+        let iv = Buffer.from('0'.repeat(32), 'hex')
+        let input = Buffer.from(data, 'base64')
+        let decipher = crypto.createDecipheriv('aes-128-cbc', Buffer.from(key, 'base64'), iv)
+        let result = Buffer.concat([decipher.update(input), decipher.final()])
+        assert.equal(cipherText, result)
+      }
+    })
   })
 
   describe('process.stdout', () => {


### PR DESCRIPTION
Node.js added a few new C++ code in the crypto module, which passes some memory allocated with Node's allocator to blink, while blink then would try to free the memory with Chromium's allocator.

This is fixed by patching Node's code to use Chromium's allocator.

The patch on Node can be found at https://github.com/electron/node/commit/b6a9b918264d3e1df491cf0e2d32a1ed9686ec3f.

Close https://github.com/electron/electron/issues/11457.