### PR TITLE
Make MenuItem roles camelCase-compatible

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -54,19 +54,19 @@ The `role` property can have following values:
 * `cut`
 * `copy`
 * `paste`
-* `pasteandmatchstyle`
-* `selectall`
+* `pasteAndMatchStyle`
+* `selectAll`
 * `delete`
 * `minimize` - Minimize current window.
 * `close` - Close current window.
 * `quit`- Quit the application.
 * `reload` - Reload the current window.
-* `forcereload` - Reload the current window ignoring the cache.
-* `toggledevtools` - Toggle developer tools in the current window.
-* `togglefullscreen`- Toggle full screen mode on the current window.
-* `resetzoom` - Reset the focused page's zoom level to the original size.
-* `zoomin` - Zoom in the focused page by 10%.
-* `zoomout` - Zoom out the focused page by 10%.
+* `forceReload` - Reload the current window ignoring the cache.
+* `toggleDevTools` - Toggle developer tools in the current window.
+* `toggleFullScreen`- Toggle full screen mode on the current window.
+* `resetZoom` - Reset the focused page's zoom level to the original size.
+* `zoomIn` - Zoom in the focused page by 10%.
+* `zoomOut` - Zoom out the focused page by 10%.
 * `editMenu` - Whole default "Edit" menu (Undo, Copy, etc.).
 * `windowMenu` - Whole default "Window" menu (Minimize, Close, etc.).
 
@@ -74,25 +74,26 @@ The following additional roles are available on _macOS_:
 
 * `about` - Map to the `orderFrontStandardAboutPanel` action.
 * `hide` - Map to the `hide` action.
-* `hideothers` - Map to the `hideOtherApplications` action.
+* `hideOthers` - Map to the `hideOtherApplications` action.
 * `unhide` - Map to the `unhideAllApplications` action.
-* `startspeaking` - Map to the `startSpeaking` action.
-* `stopspeaking` - Map to the `stopSpeaking` action.
+* `startSpeaking` - Map to the `startSpeaking` action.
+* `stopSpeaking` - Map to the `stopSpeaking` action.
 * `front` - Map to the `arrangeInFront` action.
 * `zoom` - Map to the `performZoom` action.
-* `toggletabbar` - Map to the `toggleTabBar` action.
-* `selectnexttab` - Map to the `selectNextTab` action.
-* `selectprevioustab` - Map to the `selectPreviousTab` action.
-* `mergeallwindows` - Map to the `mergeAllWindows` action.
-* `movetabtonewwindow` - Map to the `moveTabToNewWindow` action.
+* `toggleTabBar` - Map to the `toggleTabBar` action.
+* `selectNextTab` - Map to the `selectNextTab` action.
+* `selectPreviousTab` - Map to the `selectPreviousTab` action.
+* `mergeAllWindows` - Map to the `mergeAllWindows` action.
+* `moveTabToNewWindow` - Map to the `moveTabToNewWindow` action.
 * `window` - The submenu is a "Window" menu.
 * `help` - The submenu is a "Help" menu.
 * `services` - The submenu is a "Services" menu.
-* `recentdocuments` - The submenu is an "Open Recent" menu.
-* `clearrecentdocuments` - Map to the `clearRecentDocuments` action.
+* `recentDocuments` - The submenu is an "Open Recent" menu.
+* `clearRecentDocuments` - Map to the `clearRecentDocuments` action.
 
 When specifying a `role` on macOS, `label` and `accelerator` are the only
 options that will affect the menu item. All other options will be ignored.
+Lowercase `role`, e.g. `toggledevtools`, is still supported.
 
 ### Instance Properties
 

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -162,7 +162,7 @@ const roles = {
     }
   },
   // Edit submenu (should fit both Mac & Windows)
-  editMenu: {
+  editmenu: {
     label: 'Edit',
     submenu: [
       {
@@ -185,7 +185,7 @@ const roles = {
       },
 
       process.platform === 'darwin' ? {
-        role: 'pasteandmatchstyle'
+        role: 'pasteAndMatchStyle'
       } : null,
 
       {
@@ -197,13 +197,13 @@ const roles = {
       } : null,
 
       {
-        role: 'selectall'
+        role: 'selectAll'
       }
     ]
   },
 
   // Window submenu should be used for Mac only
-  windowMenu: {
+  windowmenu: {
     label: 'Window',
     submenu: [
       {

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -11,8 +11,9 @@ const MenuItem = function (options) {
   for (let key in options) {
     if (!(key in this)) this[key] = options[key]
   }
-  if (typeof this.role === 'string' || this.role instanceof String)
+  if (typeof this.role === 'string' || this.role instanceof String) {
     this.role = this.role.toLowerCase()
+  }
   this.submenu = this.submenu || roles.getDefaultSubmenu(this.role)
   if (this.submenu != null && this.submenu.constructor !== Menu) {
     this.submenu = Menu.buildFromTemplate(this.submenu)

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -11,6 +11,8 @@ const MenuItem = function (options) {
   for (let key in options) {
     if (!(key in this)) this[key] = options[key]
   }
+  if (typeof this.role === 'string' || this.role instanceof String)
+    this.role = this.role.toLowerCase()
   this.submenu = this.submenu || roles.getDefaultSubmenu(this.role)
   if (this.submenu != null && this.submenu.constructor !== Menu) {
     this.submenu = Menu.buildFromTemplate(this.submenu)

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -94,13 +94,13 @@ const getEditMenuItems = function () {
       role: 'paste'
     },
     {
-      role: 'pasteandmatchstyle'
+      role: 'pasteAndMatchStyle'
     },
     {
       role: 'delete'
     },
     {
-      role: 'selectall'
+      role: 'selectAll'
     }
   ]
 }

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -591,15 +591,15 @@ describe('Menu module', () => {
       assert.equal(item.submenu.items[5].role, 'paste')
 
       if (process.platform === 'darwin') {
-        assert.equal(item.submenu.items[6].role, 'pasteandmatchstyle')
+        assert.equal(item.submenu.items[6].role, 'pasteAndMatchStyle')
         assert.equal(item.submenu.items[7].role, 'delete')
-        assert.equal(item.submenu.items[8].role, 'selectall')
+        assert.equal(item.submenu.items[8].role, 'selectAll')
       }
 
       if (process.platform === 'win32') {
         assert.equal(item.submenu.items[6].role, 'delete')
         assert.equal(item.submenu.items[7].type, 'separator')
-        assert.equal(item.submenu.items[8].role, 'selectall')
+        assert.equal(item.submenu.items[8].role, 'selectAll')
       }
     })
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -591,15 +591,15 @@ describe('Menu module', () => {
       assert.equal(item.submenu.items[5].role, 'paste')
 
       if (process.platform === 'darwin') {
-        assert.equal(item.submenu.items[6].role, 'pasteAndMatchStyle')
+        assert.equal(item.submenu.items[6].role, 'pasteandmatchstyle')
         assert.equal(item.submenu.items[7].role, 'delete')
-        assert.equal(item.submenu.items[8].role, 'selectAll')
+        assert.equal(item.submenu.items[8].role, 'selectall')
       }
 
       if (process.platform === 'win32') {
         assert.equal(item.submenu.items[6].role, 'delete')
         assert.equal(item.submenu.items[7].type, 'separator')
-        assert.equal(item.submenu.items[8].role, 'selectAll')
+        assert.equal(item.submenu.items[8].role, 'selectall')
       }
     })
 


### PR DESCRIPTION
Migrating MenuItem roles to be in camelCase while keeping backward lowercase compatibility.

Closes #10372
CC: @zeke