### PR TITLE
Fixes hexColorDWORDToRGBA for transparent colors

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <iomanip>
+
 #include "atom/browser/api/atom_api_system_preferences.h"
 
 #include "atom/common/color_util.h"
@@ -26,10 +28,10 @@ bool SystemPreferences::IsAeroGlassEnabled() {
 }
 
 std::string hexColorDWORDToRGBA(DWORD color) {
+  DWORD rgba = color << 8 | color >> 24;
   std::ostringstream stream;
-  stream << std::hex << color;
-  std::string hexColor = stream.str();
-  return hexColor.substr(2) + hexColor.substr(0, 2);
+  stream << std::hex << std::setw(8) << std::setfill('0') << rgba;
+  return stream.str();
 }
 
 std::string SystemPreferences::GetAccentColor() {


### PR DESCRIPTION
Fixes issue #11556 

Uses 0-padding and a set width 8 characters of ensure that RGBA hexadecimal colors string representations are unambiguous.

e.g. (A: 00, R: 0, G: 0, B: 255) is now unambiguously printed as `0000FF00`, not `FF00`.

Replaces janky string substring and concatenation based ARGB -> RGBA shifting logic with bitwise operations to fix several bugs.

The previous code resulted in colors with low-alpha or R-channel values being printed incorrectly. For example, previously

(A: 0, R: 0, G: 160, B: 0) (ARGB: 0x0000A000) would be rendered as RGBA `00A0` which is not correct. Meanwhile, (A: 0, R: 0, G: 0, B: 0) would not render at all in RGBA leading to an exception. Please review the previous code's use of string operations to understand why.
  