### PR TITLE
fix: Update touch bar type documentation

### DIFF
--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -8,7 +8,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
 
 * `options` Object
   * `items` ([TouchBarButton](touch-bar-button.md) | [TouchBarColorPicker](touch-bar-color-picker.md) | [TouchBarGroup](touch-bar-group.md) | [TouchBarLabel](touch-bar-label.md) | [TouchBarPopover](touch-bar-popover.md) | [TouchBarScrubber](touch-bar-scrubber.md) | [TouchBarSegmentedControl](touch-bar-segmented-control.md) | [TouchBarSlider](touch-bar-slider.md) | [TouchBarSpacer](touch-bar-spacer.md))[]
-  * `escapeItem` ([TouchBarButton](touch-bar-button.md) | [TouchBarColorPicker](touch-bar-color-picker.md) | [TouchBarGroup](touch-bar-group.md) | [TouchBarLabel](touch-bar-label.md) | [TouchBarPopover](touch-bar-popover.md) | [TouchBarScrubber](touch-bar-scrubber.md) | [TouchBarSegmentedControl](touch-bar-segmented-control.md) | [TouchBarSlider](touch-bar-slider.md) | [TouchBarSpacer](touch-bar-spacer.md)) (optional)
+  * `escapeItem` ([TouchBarButton](touch-bar-button.md) | [TouchBarColorPicker](touch-bar-color-picker.md) | [TouchBarGroup](touch-bar-group.md) | [TouchBarLabel](touch-bar-label.md) | [TouchBarPopover](touch-bar-popover.md) | [TouchBarScrubber](touch-bar-scrubber.md) | [TouchBarSegmentedControl](touch-bar-segmented-control.md) | [TouchBarSlider](touch-bar-slider.md) | [TouchBarSpacer](touch-bar-spacer.md) | null) (optional)
 
 Creates a new touch bar with the specified items. Use
 `BrowserWindow.setTouchBar` to add the `TouchBar` to a window.

--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -26,7 +26,7 @@ The following properties are available on instances of `TouchBar`:
 
 #### `touchBar.escapeItem`
 
-The `TouchBarButton` that will replace the "esc" button on the touch bar when set.
+A `TouchBarItem` that will replace the "esc" button on the touch bar when set.
 Setting to `null` restores the default "esc" button. Changing this value
 immediately updates the escape item in the touch bar.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.4",
-    "electron-typescript-definitions": "^1.2.11",
+    "electron-typescript-definitions": "^1.3.0",
     "github": "^9.2.0",
     "husky": "^0.14.3",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Tiny change: The `escapeItem` in the touch bar constructor accepts a `null`, but our typings do not reflect that.