### PR TITLE
[Docs] Fix URLs and Paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,6 @@ an issue:
 
 * [Coding Style](development/coding-style.md)
 * [Using clang-format on C++ Code](development/clang-format.md)
-* [Testing](development/testing.md)
 * [Source Code Directory Structure](development/source-code-directory-structure.md)
 * [Technical Differences to NW.js (formerly node-webkit)](development/atom-shell-vs-node-webkit.md)
 * [Build System Overview](development/build-system-overview.md)
@@ -107,6 +106,6 @@ an issue:
 * [Debug Instructions (Windows)](development/debug-instructions-windows.md)
 * [Setting Up Symbol Server in debugger](development/setting-up-symbol-server.md)
 * [Documentation Styleguide](styleguide.md)
-* [Upgrading Chrome](development/upgrading-chrome.md)
+* [Upgrading Chromium](development/upgrading-chromium.md)
 * [Chromium Development](development/chromium-development.md)
 * [V8 Development](development/v8-development.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ an issue:
 
 * [Coding Style](development/coding-style.md)
 * [Using clang-format on C++ Code](development/clang-format.md)
+* [Testing](development/testing.md)
 * [Source Code Directory Structure](development/source-code-directory-structure.md)
 * [Technical Differences to NW.js (formerly node-webkit)](development/atom-shell-vs-node-webkit.md)
 * [Build System Overview](development/build-system-overview.md)

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1078,7 +1078,7 @@ Sets the application's [dock menu][dock-menu].
 Sets the `image` associated with this dock icon.
 
 [dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103
-[tasks]:http://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
+[tasks]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [CFBundleURLTypes]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102207-TPXREF115
 [LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/#//apple_ref/c/func/LSCopyDefaultHandlerForURLScheme

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1459,6 +1459,6 @@ removed in future Electron releases.
 [blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/runtime_enabled_features.json5?l=70
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
-[vibrancy-docs]: https://developer.apple.com/reference/appkit/nsvisualeffectview?language=objc
+[vibrancy-docs]:  https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/reference/appkit/nswindow/1664726-window_levels
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -133,7 +133,7 @@ state is `hidden` in order to minimize power consumption.
 Process: [Main](../glossary.md#main-process)
 
 `BrowserWindow` is an
-[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
+[EventEmitter](https://nodejs.org/api/events.html#events_class_events_eventemitter).
 
 It creates a new `BrowserWindow` with native properties as set by the `options`.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -343,7 +343,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       Console tab. **Note:** This option is currently experimental and may
       change or be removed in future Electron releases.
     * `nativeWindowOpen` Boolean (optional) - Whether to use native
-      `window.open()`. Defaults to `false`.  **Note:** This option is currently
+      `window.open()`. Defaults to `false`. **Note:** This option is currently
       experimental.
     * `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
       Defaults to the value of the `nodeIntegration` option. **Note:** The
@@ -1459,6 +1459,6 @@ removed in future Electron releases.
 [blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/runtime_enabled_features.json5?l=70
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
-[vibrancy-docs]:  https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
+[vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/reference/appkit/nswindow/1664726-window_levels
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -15,7 +15,7 @@ If you want to show Notifications from a renderer process you should use the [HT
 Process: [Main](../glossary.md#main-process)
 
 `Notification` is an
-[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
+[EventEmitter](https://nodejs.org/api/events.html#events_class_events_eventemitter).
 
 It creates a new `Notification` with native properties as set by the `options`.
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -195,5 +195,5 @@ process.
 The `process` object in the main process. This is the same as
 `remote.getGlobal('process')` but is cached.
 
-[rmi]: http://en.wikipedia.org/wiki/Java_remote_method_invocation
+[rmi]: https://en.wikipedia.org/wiki/Java_remote_method_invocation
 [enumerable-properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -187,7 +187,7 @@ The `proxyBypassRules` is a comma separated list of rules described below:
    Examples:
      "127.0.1", "[0:0::1]", "[::1]", "http://[::1]:99"
 
-*  `IP_LITERAL "/" PREFIX_LENGHT_IN_BITS`
+* `IP_LITERAL "/" PREFIX_LENGHT_IN_BITS`
 
    Match any URL that is to an IP literal that falls between the
    given range. IP range is specified using CIDR notation.
@@ -195,7 +195,7 @@ The `proxyBypassRules` is a comma separated list of rules described below:
    Examples:
      "192.168.1.1/16", "fefe:13::abc/33".
 
-*  `<local>`
+* `<local>`
 
    Match local addresses. The meaning of `<local>` is whether the
    host matches one of: "127.0.0.1", "::1", "localhost".

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1353,7 +1353,7 @@ Set the size of the page. This is only supported for `<webview>` guest contents.
 
 * `options` Object
   * `normal` Object (optional) - Normal size of the page. This can be used in
-    combination with the [`disableguestresize`](web-view-tag.md#disableguestresize)
+    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
     attribute to manually resize the webview guest contents.
     * `width` Integer
     * `height` Integer

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -155,12 +155,12 @@ information may help you.
 
 ### Building `libchromiumcontent` locally
 
-To avoid using the prebuilt binaries of `libchromiumcontent`, you can build `libchromiumcontent` locally.  To do so, follow these steps:
+To avoid using the prebuilt binaries of `libchromiumcontent`, you can build `libchromiumcontent` locally. To do so, follow these steps:
 
 1. Install [depot_tools](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install)
 2. Install [additional build dependencies](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install-additional-build-dependencies)
 3. Fetch the git submodules:
-  
+
 ```sh
 $ git submodule update --init --recursive
 ```
@@ -179,11 +179,11 @@ $ ./script/build.py -c R
 
 ### Using system `clang` instead of downloaded `clang` binaries
 
-By default Electron is built with prebuilt 
+By default Electron is built with prebuilt
 [`clang`](https://clang.llvm.org/get_started.html) binaries provided by the
-Chromium project. If for some reason you want to build with the `clang` 
-installed in your system, you can call `bootstrap.py` with `--clang_dir=<path>` 
-switch. By passing it the build script will assume the `clang` binaries reside 
+Chromium project. If for some reason you want to build with the `clang`
+installed in your system, you can call `bootstrap.py` with `--clang_dir=<path>`
+switch. By passing it the build script will assume the `clang` binaries reside
 in `<path>/bin/`.
 
 For example if you installed `clang` under `/user/local/bin/clang`:

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -8,7 +8,7 @@ Follow the guidelines below for building Electron on Linux.
 * Python 2.7.x. Some distributions like CentOS 6.x still use Python 2.6.x
   so you may need to check your Python version with `python -V`.
 * Node.js. There are various ways to install Node. You can download
-  source code from [nodejs.org](http://nodejs.org) and compile it.
+  source code from [nodejs.org](https://nodejs.org) and compile it.
   Doing so permits installing Node on your own home directory as a standard user.
   Or try repositories such as [NodeSource](https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories).
 * [clang](https://clang.llvm.org/get_started.html) 3.4 or later.

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -6,7 +6,7 @@ Follow the guidelines below for building Electron on macOS.
 
 * macOS >= 10.11.6
 * [Xcode](https://developer.apple.com/technologies/tools/) >= 8.2.1
-* [node.js](http://nodejs.org) (external)
+* [node.js](https://nodejs.org) (external)
 
 If you are using the Python downloaded by Homebrew, you also need to install
 the following Python modules:

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -8,7 +8,7 @@ Follow the guidelines below for building Electron on Windows.
 * Visual Studio 2015 Update 3 - [download VS 2015 Community Edition for
   free](https://www.visualstudio.com/vs/older-downloads/)
 * [Python 2.7](http://www.python.org/download/releases/2.7/)
-* [Node.js](http://nodejs.org/download/)
+* [Node.js](https://nodejs.org/download/)
 * [Git](http://git-scm.com)
 * [Debugging Tools for Windows](https://msdn.microsoft.com/en-us/library/windows/hardware/ff551063.aspx)
   if you plan on creating a full distribution since `symstore.exe` is used for
@@ -143,7 +143,7 @@ Try reinstalling 32bit Node.js.
 
 ### Error: ENOENT, stat 'C:\Users\USERNAME\AppData\Roaming\npm'
 
-Simply making that directory [should fix the problem](http://stackoverflow.com/a/25095327/102704):
+Simply making that directory [should fix the problem](https://stackoverflow.com/a/25095327/102704):
 
 ```powershell
 $ mkdir ~\AppData\Roaming\npm

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -8,7 +8,7 @@ You can run `npm run lint` to show any style issues detected by `cpplint` and
 ## C++ and Python
 
 For C++ and Python, we follow Chromium's [Coding
-Style](http://www.chromium.org/developers/coding-style). You can use
+Style](https://www.chromium.org/developers/coding-style). You can use
 [clang-format](clang-format.md) to format the C++ code automatically. There is
 also a script `script/cpplint.py` to check whether all files conform.
 
@@ -23,7 +23,7 @@ etc.
 
 ## JavaScript
 
-* Write [standard](http://npm.im/standard) JavaScript style.
+* Write [standard](https://npm.im/standard) JavaScript style.
 * File names should be concatenated with `-` instead of `_`, e.g.
   `file-name.js` rather than `file_name.js`, because in
   [github/atom](https://github.com/github/atom) module names are usually in

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -10,7 +10,7 @@ This document describes the process for releasing a new version of Electron.
 
 ## Find out what version change is needed
 Run `npm run prepare-release -- --notesOnly` to view auto generated release
-notes.  The notes generated should help you determine if this is a major, minor,
+notes. The notes generated should help you determine if this is a major, minor,
 patch, or beta version change. Read the
 [Version Change Rules](../tutorial/electron-versioning.md#semver) for more information.
 
@@ -18,7 +18,7 @@ patch, or beta version change. Read the
 The prepare release script will do the following:
 1. Check if a release is already in process and if so it will halt.
 2. Create a release branch.
-3. Bump the version number in several files.  See [this bump commit] for an example.
+3. Bump the version number in several files. See [this bump commit] for an example.
 4. Create a draft release on GitHub with auto-generated release notes.
 5. Push the release branch.
 6. Call the APIs to run the release builds.
@@ -188,7 +188,7 @@ npm run merge-release -- 1-7-x
 ## Publish the release
 
 Once the merge has finished successfully, run the `release` script
-via `npm run release` to finish the release process.  This script will do the
+via `npm run release` to finish the release process. This script will do the
 following:
 1. Build the project to validate that the correct version number is being released.
 2. Download the binaries and generate the node headers and the .lib linker used

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -57,7 +57,7 @@ To monitor the build progress, see the following pages:
 
 - [mac-ci.electronjs.org/blue/organizations/jenkins/electron-mas-x64-release/activity](https://mac-ci.electronjs.org/blue/organizations/jenkins/electron-mas-x64-release/activity) for Mac App Store
 - [mac-ci.electronjs.org/blue/organizations/jenkins/electron-osx-x64-release/activity](https://mac-ci.electronjs.org/blue/organizations/jenkins/electron-osx-x64-release/activity) for OS X
-- [circleci.com/gh/electron](https://circleci.com/gh/electron) for Linux
+- [circleci.com/gh/electron/electron](https://circleci.com/gh/electron) for Linux
 - [windows-ci.electronjs.org/project/AppVeyor/electron](https://windows-ci.electronjs.org/project/AppVeyor/electron) for Windows
 
 ## Compile release notes

--- a/docs/development/setting-up-symbol-server.md
+++ b/docs/development/setting-up-symbol-server.md
@@ -5,7 +5,7 @@ about the functions contained in executables and dynamic libraries and provide
 you with information to get clean call stacks. A Symbol Server allows the
 debugger to load the correct symbols, binaries and sources automatically without
 forcing users to download large debugging files. The server functions like
-[Microsoft's symbol server](http://support.microsoft.com/kb/311503) so the
+[Microsoft's symbol server](https://support.microsoft.com/kb/311503) so the
 documentation there can be useful.
 
 Note that because released Electron builds are heavily optimized, debugging is
@@ -38,7 +38,7 @@ or by typing the `.sympath` command. If you would like to get symbols from
 Microsoft's symbol server as well, you should list that first:
 
 ```powershell
-SRV*c:\code\symbols\*http://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
+SRV*c:\code\symbols\*https://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
 ```
 
 ## Using the symbol server in Visual Studio

--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -4,7 +4,7 @@ The source code of Electron is separated into a few parts, mostly
 following Chromium on the separation conventions.
 
 You may need to become familiar with [Chromium's multi-process
-architecture](http://dev.chromium.org/developers/design-documents/multi-process-architecture)
+architecture](https://dev.chromium.org/developers/design-documents/multi-process-architecture)
 to understand the source code better.
 
 ## Structure of Source Code

--- a/docs/development/updgrading-chrome.md
+++ b/docs/development/updgrading-chrome.md
@@ -1,0 +1,1 @@
+Moved to [upgrading-chromium.md](upgrading-chromium.md)

--- a/docs/development/upgrading-chromium.md
+++ b/docs/development/upgrading-chromium.md
@@ -107,7 +107,7 @@ Follow all the steps above to fix Electron code on all supported platforms.
 
 If there are any compilation errors related to the Crashpad, it probably means
 you need to update the fork to a newer revision. See
-[Upgrading Crashpad](https://github.com/electron/electron/tree/master/docs/development/upgrading-crashpad.md)
+[Upgrading Crashpad](upgrading-crashpad.md)
 for instructions on how to do that.
 
 
@@ -116,7 +116,7 @@ for instructions on how to do that.
 Upgrade `vendor/node` to the Node release that corresponds to the v8 version
 used in the new Chromium release. See the v8 versions in Node on
 
-See [Upgrading Node](https://github.com/electron/electron/tree/master/docs/development/upgrading-node.md)
+See [Upgrading Node](upgrading-node.md)
 for instructions on this.
 
 ## Verify ffmpeg support

--- a/docs/development/upgrading-chromium.md
+++ b/docs/development/upgrading-chromium.md
@@ -37,7 +37,7 @@ This is an overview of the steps needed to upgrade Chromium in Electron.
   - If some patches are no longer compatible with the Chromium code,
     fix compilation errors.
 6. When the build succeeds, create a `dist` for Electron
-  - `$ ./script/create-dist  --no_zip`
+  - `$ ./script/create-dist --no_zip`
     - It will create a `dist/main` folder in the libcc repo's root.
       You will need this to build Electron.
 7. (Optional) Update script contents if there are errors resulting from files

--- a/docs/development/upgrading-crashpad.md
+++ b/docs/development/upgrading-crashpad.md
@@ -19,7 +19,7 @@
     - Or view https://github.com/electron/crashpad/commits/previous-branch-name
 
 3. For each patch:
-  - In `electron-crashpad-vA.B.C.D`, cherry-pick the patch's checksum    
+  - In `electron-crashpad-vA.B.C.D`, cherry-pick the patch's checksum
     - `git cherry-pick <checksum>`
   - Resolve any conflicts
   - Make sure it builds then add, commit, and push work to electron's crashpad fork

--- a/docs/development/upgrading-crashpad.md
+++ b/docs/development/upgrading-crashpad.md
@@ -16,7 +16,7 @@
 
 2. Make a checklist of the Electron patches that need to be applied
   with `git log --oneline`
-    - Or view http://github.com/electron/crashpad/commits/previous-branch-name
+    - Or view https://github.com/electron/crashpad/commits/previous-branch-name
 
 3. For each patch:
   - In `electron-crashpad-vA.B.C.D`, cherry-pick the patch's checksum    
@@ -37,6 +37,3 @@
 6. Push changes to submodule reference
   - (From electron root) `git add vendor/crashpad`
   - `git push origin upgrade-to-chromium-62`
-
-
-

--- a/docs/development/upgrading-node.md
+++ b/docs/development/upgrading-node.md
@@ -4,7 +4,7 @@
 
 One upgrade issue is building all of Electron with a single copy
 of V8 to ensure compatability. This is important because
-upstream Node and [libchromiumcontent](upgrading-chrome.md)
+upstream Node and [libchromiumcontent](upgrading-chromium.md)
 both use their own versions of V8.
 
 Upgrading Node is much easier than upgrading libchromiumcontent,

--- a/docs/development/upgrading-node.md
+++ b/docs/development/upgrading-node.md
@@ -97,7 +97,7 @@ We need to generate a patch file from each patch applied to V8.
      - `mv test.patch patches/v8/xxx-patch_name.patch`
   - Add the patched code to the index _without_ committing:
      - `cd src/v8 && git add . && cd ../..`
-     -  We don't want to commit the changes (they're kept in the patchfiles)
+     - We don't want to commit the changes (they're kept in the patchfiles)
         but need them locally so that they don't show up in subsequent diffs
         while we iterate through more patches
   - Add the patch file to the index:

--- a/docs/tutorial/about.md
+++ b/docs/tutorial/about.md
@@ -27,7 +27,7 @@ In Electron, Node.js and Chromium share a single V8 instance—usually the versi
 
 ### Versioning
 
-As of version 2.0 Electron [follows `semver`](http://semver.org).
+As of version 2.0 Electron [follows `semver`](https://semver.org).
 For most applications, and using any recent version of npm,
 running `$ npm install electron` will do the right thing.
 
@@ -54,8 +54,8 @@ Below are milestones in Electron's history.
 | :calendar: | :tada: |
 | --- | --- |
 | **April 2013**| [Atom Shell is started](https://github.com/electron/electron/commit/6ef8875b1e93787fa9759f602e7880f28e8e6b45).|
-| **May 2014** | [Atom Shell is open sourced](http://blog.atom.io/2014/05/06/atom-is-now-open-source.html). |
+| **May 2014** | [Atom Shell is open sourced](https://blog.atom.io/2014/05/06/atom-is-now-open-source.html). |
 | **April 2015** | [Atom Shell is re-named Electron](https://github.com/electron/electron/pull/1389). |
 | **May 2016** | [Electron releases `v1.0.0`](https://electronjs.org/blog/electron-1-0).|
-| **May 2016** | [Electron apps compatible with Mac App Store](https://electronjs.org/docs/tutorial/mac-app-store-submission-guide).|
-| **August 2016** | [Windows Store support for Electron apps](https://electronjs.org/docs/tutorial/windows-store-guide).|
+| **May 2016** | [Electron apps compatible with Mac App Store](mac-app-store-submission-guide.md).|
+| **August 2016** | [Windows Store support for Electron apps](windows-store-guide.md).|

--- a/docs/tutorial/accessibility.md
+++ b/docs/tutorial/accessibility.md
@@ -1,6 +1,6 @@
 # Accessibility
 
-Making accessible applications is important and we're happy to introduce new functionality to [Devtron](https://electron.atom.io/devtron) and [Spectron](https://electron.atom.io/spectron) that gives developers the opportunity to make their apps better for everyone.
+Making accessible applications is important and we're happy to introduce new functionality to [Devtron](https://electronjs.org/devtron) and [Spectron](https://electronjs.org/spectron) that gives developers the opportunity to make their apps better for everyone.
 
 ---
 
@@ -38,7 +38,7 @@ Electron applications keep accessibility disabled by default for performance rea
 
 ### Inside Application
 
-By using [`app.setAccessibilitySupportEnabled(enabled)`](https://electron.atom.io/docs/api/app.md#appsetaccessibilitysupportenabledenabled-macos-windows), you can expose accessibility switch to users in the application preferences. User's system assistive utilities have priority over this setting and will override it.
+By using [`app.setAccessibilitySupportEnabled(enabled)`](../api/app.md#appsetaccessibilitysupportenabledenabled-macos-windows), you can expose accessibility switch to users in the application preferences. User's system assistive utilities have priority over this setting and will override it.
 
 ### Assistive Technology
 
@@ -54,7 +54,7 @@ CFStringRef kAXManualAccessibility = CFSTR("AXManualAccessibility");
     AXUIElementRef appRef = AXUIElementCreateApplication(app.processIdentifier);
     if (appRef == nil)
         return;
-    
+
     CFBooleanRef value = enable ? kCFBooleanTrue : kCFBooleanFalse;
     AXUIElementSetAttributeValue(appRef, kAXManualAccessibility, value);
     CFRelease(appRef);

--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -108,7 +108,7 @@ as quoted from MSDN:
 
 __Tasks of Internet Explorer:__
 
-![IE](https://msdn.microsoft.com/dynimg/IC420539.png)
+![IE](http://i.msdn.microsoft.com/dynimg/IC420539.png)
 
 Unlike the dock menu in macOS which is a real menu, user tasks in Windows work
 like application shortcuts such that when user clicks a task, a program will be
@@ -337,16 +337,16 @@ ipcMain.on('ondragstart', (event, filePath) => {
 })
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath-os-x-windows
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments-os-x-windows
+[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath-macos-windows
+[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments-macos-windows
 [setusertaskstasks]: ../api/app.md#appsetusertaskstasks-windows
 [setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress
-[setoverlayicon]: ../api/browser-window.md#winsetoverlayiconoverlay-description-windows-7
-[setrepresentedfilename]: ../api/browser-window.md#winsetrepresentedfilenamefilename-os-x
-[setdocumentedited]: ../api/browser-window.md#winsetdocumenteditededited-os-x
-[app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
+[setoverlayicon]: ../api/browser-window.md#winsetoverlayiconoverlay-description-windows
+[setrepresentedfilename]: ../api/browser-window.md#winsetrepresentedfilenamefilename-macos
+[setdocumentedited]: ../api/browser-window.md#winsetdocumenteditededited-macos
+[app-registration]: https://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#winsetthumbarbuttonsbuttons-windows-7
+[setthumbarbuttons]: ../api/browser-window.md#winsetthumbarbuttonsbuttons-windows
 [tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -50,7 +50,7 @@ Following Devtools Extensions are tested and guaranteed to work in Electron:
 * [jQuery Debugger](https://chrome.google.com/webstore/detail/jquery-debugger/dbhhnnnpaeobfddmlalhnehgclcmjimi)
 * [AngularJS Batarang](https://chrome.google.com/webstore/detail/angularjs-batarang/ighdmehidhipcmcojjgiloacoafjmpfk)
 * [Vue.js devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
-* [Cerebral Debugger](http://www.cerebraljs.com/documentation/the_debugger)
+* [Cerebral Debugger](https://cerebraljs.com/docs/introduction/debugger.html)
 * [Redux DevTools Extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
 * [MobX Developer Tools](https://chrome.google.com/webstore/detail/mobx-developer-tools/pfgnfdagidkfgccljigdamigbcnndkod)
 

--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -47,7 +47,7 @@ Below is a table explicitly mapping types of changes to their corresponding cate
 	* node.js major version updates
 	* Electron breaking API changes
 * **Minor Version Increments**
-	* node.js  minor version updates
+	* node.js minor version updates
 	* Electron non-breaking API changes
 * **Patch Version Increments**
 	* node.js patch version updates
@@ -71,9 +71,9 @@ Older lines will not be supported by GitHub, but other groups can take ownership
 
 # Beta Releases and Bug Fixes
 
-Developers want to know which releases are _safe_ to use. Even seemingly innocent features can introduce regressions in complex applications.  At the same time, locking to a fixed version is dangerous because you’re ignoring security patches and bug fixes that may have come out since your version. Our goal is to allow the following standard semver ranges in `package.json` :
+Developers want to know which releases are _safe_ to use. Even seemingly innocent features can introduce regressions in complex applications. At the same time, locking to a fixed version is dangerous because you’re ignoring security patches and bug fixes that may have come out since your version. Our goal is to allow the following standard semver ranges in `package.json` :
 
-* Use `~2.0.0` to  admit only stability or security related fixes to your `2.0.0` release.
+* Use `~2.0.0` to admit only stability or security related fixes to your `2.0.0` release.
 * Use `^2.0.0` to admit non-breaking _reasonably stable_ feature work as well as security and bug fixes.
 
 What’s important about the second point is that apps using `^` should still be able to expect a reasonable level of stability. To accomplish this, semver allows for a _pre-release identifier_ to indicate a particular version is not yet _safe_ or _stable_.
@@ -104,7 +104,7 @@ For each major and minor bump, you should expect too see something like the foll
 
 An example lifecycle in pictures:
 
-* A new release branch is created that includes the latest set of features. It is published as  `2.0.0-beta.1`.
+* A new release branch is created that includes the latest set of features. It is published as `2.0.0-beta.1`.
 ![](../images/versioning-sketch-3.png)
 * A bug fix comes into master that can be pack-ported to the release branch. The patch is applied, and a new beta is published as `2.0.0-beta.2`.
 ![](../images/versioning-sketch-4.png)

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -231,7 +231,7 @@ more details.
 
 ## Known issues
 
-### `shell.openItem(filePath)` 
+### `shell.openItem(filePath)`
 
 This will fail when the app is signed for distribution in the Mac App Store.
 Subscribe to [#9005](https://github.com/electron/electron/issues/9005) for updates.
@@ -248,29 +248,29 @@ submit a copy of U.S. Encryption Registration (ERN) approval.
 
 Electron uses following cryptographic algorithms:
 
-* AES - [NIST SP 800-38A](http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf), [NIST SP 800-38D](http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf), [RFC 3394](http://www.ietf.org/rfc/rfc3394.txt)
-* HMAC - [FIPS 198-1](http://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf)
+* AES - [NIST SP 800-38A](https://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf), [NIST SP 800-38D](https://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf), [RFC 3394](https://www.ietf.org/rfc/rfc3394.txt)
+* HMAC - [FIPS 198-1](https://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf)
 * ECDSA - ANS X9.62–2005
 * ECDH - ANS X9.63–2001
-* HKDF - [NIST SP 800-56C](http://csrc.nist.gov/publications/nistpubs/800-56C/SP-800-56C.pdf)
+* HKDF - [NIST SP 800-56C](https://csrc.nist.gov/publications/nistpubs/800-56C/SP-800-56C.pdf)
 * PBKDF2 - [RFC 2898](https://tools.ietf.org/html/rfc2898)
 * RSA - [RFC 3447](http://www.ietf.org/rfc/rfc3447)
-* SHA - [FIPS 180-4](http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf)
+* SHA - [FIPS 180-4](https://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf)
 * Blowfish - https://www.schneier.com/cryptography/blowfish/
 * CAST - [RFC 2144](https://tools.ietf.org/html/rfc2144), [RFC 2612](https://tools.ietf.org/html/rfc2612)
-* DES - [FIPS 46-3](http://csrc.nist.gov/publications/fips/fips46-3/fips46-3.pdf)
+* DES - [FIPS 46-3](https://csrc.nist.gov/publications/fips/fips46-3/fips46-3.pdf)
 * DH - [RFC 2631](https://tools.ietf.org/html/rfc2631)
-* DSA - [ANSI X9.30](http://webstore.ansi.org/RecordDetail.aspx?sku=ANSI+X9.30-1%3A1997)
+* DSA - [ANSI X9.30](https://webstore.ansi.org/RecordDetail.aspx?sku=ANSI+X9.30-1%3A1997)
 * EC - [SEC 1](http://www.secg.org/sec1-v2.pdf)
 * IDEA - "On the Design and Security of Block Ciphers" book by X. Lai
-* MD2 - [RFC 1319](http://tools.ietf.org/html/rfc1319)
+* MD2 - [RFC 1319](https://tools.ietf.org/html/rfc1319)
 * MD4 - [RFC 6150](https://tools.ietf.org/html/rfc6150)
 * MD5 - [RFC 1321](https://tools.ietf.org/html/rfc1321)
-* MDC2 - [ISO/IEC 10118-2](https://www.openssl.org/docs/manmaster/crypto/mdc2.html)
+* MDC2 - [ISO/IEC 10118-2](https://wiki.openssl.org/index.php/Manual:Mdc2(3))
 * RC2 - [RFC 2268](https://tools.ietf.org/html/rfc2268)
 * RC4 - [RFC 4345](https://tools.ietf.org/html/rfc4345)
 * RC5 - http://people.csail.mit.edu/rivest/Rivest-rc5rev.pdf
-* RIPEMD - [ISO/IEC 10118-3](http://webstore.ansi.org/RecordDetail.aspx?sku=ISO%2FIEC%2010118-3:2004)
+* RIPEMD - [ISO/IEC 10118-3](https://webstore.ansi.org/RecordDetail.aspx?sku=ISO%2FIEC%2010118-3:2004)
 
 On how to get the ERN approval, you can reference the article: [How to legally
 submit an app to Apple’s App Store when it uses encryption (or how to obtain an

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -1,7 +1,7 @@
 # Security, Native Capabilities, and Your Responsibility
 
 As web developers, we usually enjoy the strong security net of the browser - the
-risks associated with the code we write are relatively small.  Our websites are
+risks associated with the code we write are relatively small. Our websites are
 granted limited powers in a sandbox, and we trust that our users enjoy a browser
 built by a large team of engineers that is able to quickly respond to newly
 discovered security threats.

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -1,45 +1,45 @@
 # Updating Applications
 
-There are several ways to update an Electron application. The easiest and 
-officially supported one is taking advantage of the built-in 
-[Squirrel](https://github.com/Squirrel) framework and 
+There are several ways to update an Electron application. The easiest and
+officially supported one is taking advantage of the built-in
+[Squirrel](https://github.com/Squirrel) framework and
 Electron's [autoUpdater](../api/auto-updater.md) module.
 
 ## Deploying an update server
 
-To get started, you first need to deploy a server that the 
+To get started, you first need to deploy a server that the
 [autoUpdater](../api/auto-updater.md) module will download new updates from.
 
 Depending on your needs, you can choose from one of these:
 
 - [Hazel](https://github.com/zeit/hazel) – Update server for private or open-source apps. Can be deployed for free on [Now](https://zeit.co/now) (using a single command), pulls from [GitHub Releases](https://help.github.com/articles/creating-releases/) and leverages the power of GitHub's CDN.
-- [Nuts](https://github.com/GitbookIO/nuts) – Also uses 
-[GitHub Releases](https://help.github.com/articles/creating-releases/), 
+- [Nuts](https://github.com/GitbookIO/nuts) – Also uses
+[GitHub Releases](https://help.github.com/articles/creating-releases/),
 but caches app updates on disk and supports private repositories.
 - [electron-release-server](https://github.com/ArekSredzki/electron-release-server) – Provides a dashboard for handling releases
 - [Nucleus](https://github.com/atlassian/nucleus) – A complete update server for Electron apps maintained by Atlassian. Supports multiple applications and channels; uses a static file store to minify server cost.
 
-If your app is packaged with [electron-builder][electron-builder-lib] you can use the 
-[electron-updater] module, which does not require a server and allows for updates 
+If your app is packaged with [electron-builder][electron-builder-lib] you can use the
+[electron-updater] module, which does not require a server and allows for updates
 from S3, GitHub or any other static file host.
 
 ## Implementing updates in your app
 
-Once you've deployed your update server, continue with importing the required 
-modules in your code. The following code might vary for different server 
-software, but it works like described when using 
+Once you've deployed your update server, continue with importing the required
+modules in your code. The following code might vary for different server
+software, but it works like described when using
 [Hazel](https://github.com/zeit/hazel).
 
-**Important:** Please ensure that the code below will only be executed in 
-your packaged app, and not in development. You can use 
-[electron-is-dev](https://github.com/sindresorhus/electron-is-dev) to check for 
+**Important:** Please ensure that the code below will only be executed in
+your packaged app, and not in development. You can use
+[electron-is-dev](https://github.com/sindresorhus/electron-is-dev) to check for
 the environment.
 
 ```js
 const {app, autoUpdater, dialog} = require('electron')
 ```
 
-Next, construct the URL of the update server and tell 
+Next, construct the URL of the update server and tell
 [autoUpdater](../api/auto-updater.md) about it:
 
 ```js
@@ -57,16 +57,16 @@ setInterval(() => {
 }, 60000)
 ```
 
-Once your application is [packaged](../tutorial/application-distribution.md), 
-it  will receive an update for each new 
-[GitHub Release](https://help.github.com/articles/creating-releases/) that you 
+Once your application is [packaged](../tutorial/application-distribution.md),
+it will receive an update for each new 
+[GitHub Release](https://help.github.com/articles/creating-releases/) that you
 publish.
 
 ## Applying updates
 
-Now that you've configured the basic update mechanism for your application, you 
+Now that you've configured the basic update mechanism for your application, you
 need to ensure that the user will get notified when there's an update. This
-can be achieved using the autoUpdater API 
+can be achieved using the autoUpdater API
 [events](../api/auto-updater.md#events):
 
 ```js
@@ -85,7 +85,7 @@ autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
 })
 ```
 
-Also make sure that errors are 
+Also make sure that errors are
 [being handled](../api/auto-updater.md#event-error). Here's an example
 for logging them to `stderr`:
 

--- a/docs/tutorial/using-pepper-flash-plugin.md
+++ b/docs/tutorial/using-pepper-flash-plugin.md
@@ -63,7 +63,7 @@ the plugins yourself, its path can be received by calling
 Add `plugins` attribute to `<webview>` tag.
 
 ```html
-<webview src="http://www.adobe.com/software/flash/about/" plugins></webview>
+<webview src="https://www.adobe.com/software/flash/about/" plugins></webview>
 ```
 
 ## Troubleshooting

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -169,4 +169,4 @@ your app's folder. This eliminates the need to copy-paste your app into
 Electron's resource directory.
 
 [chrome-driver]: https://sites.google.com/a/chromium.org/chromedriver/
-[spectron]: https://electron.atom.io/spectron
+[spectron]: https://electronjs.org/spectron


### PR DESCRIPTION
# Summary
- Using HTTPS if available
- Replaced offline URLs
- Replace `electron.atom.io` >> `electronjs.org`
- Fix paths
- Removed double spaces
-----

# ~~WIP~~
I can't get an equivalent reference in:
- https://github.com/TiagoDanin-Forks/electron/blame/df26e51f3decf90d24cccea6ab1f8af19949c707/docs/development/upgrading-node.md#L55
- https://github.com/TiagoDanin-Forks/electron/blame/df26e51f3decf90d24cccea6ab1f8af19949c707/docs/api/app.md#L1080
- https://github.com/TiagoDanin-Forks/electron/blame/df26e51f3decf90d24cccea6ab1f8af19949c707/docs/tutorial/accessibility.md#L9
- https://github.com/TiagoDanin-Forks/electron/blame/df26e51f3decf90d24cccea6ab1f8af19949c707/docs/tutorial/accessibility.md#L33

Suggestions?