### PR TITLE
Use task scheduler for app.getFileIcon API

### DIFF
--- a/chromium_src/chrome/browser/icon_loader.h
+++ b/chromium_src/chrome/browser/icon_loader.h
@@ -82,8 +82,6 @@ class IconLoader {
 
   IconSize icon_size_;
 
-  std::unique_ptr<gfx::Image> image_;
-
   IconLoadedCallback callback_;
 
   DISALLOW_COPY_AND_ASSIGN(IconLoader);

--- a/chromium_src/chrome/browser/icon_loader.h
+++ b/chromium_src/chrome/browser/icon_loader.h
@@ -12,6 +12,7 @@
 #include "base/files/file_path.h"
 #include "base/macros.h"
 #include "base/single_thread_task_runner.h"
+#include "base/task_scheduler/task_traits.h"
 #include "build/build_config.h"
 #include "content/public/browser/browser_thread.h"
 #include "ui/gfx/image/image.h"
@@ -66,12 +67,18 @@ class IconLoader {
   // Given a file path, get the group for the given file.
   static IconGroup GroupForFilepath(const base::FilePath& file_path);
 
-  // The thread ReadIcon() should be called on.
-  static content::BrowserThread::ID ReadIconThreadID();
+  // The TaskRunner that ReadIcon() must be called on.
+  static scoped_refptr<base::TaskRunner> GetReadIconTaskRunner();
 
   void ReadGroup();
-  void OnReadGroup();
   void ReadIcon();
+
+  // The traits of the tasks posted by this class. These operations may block,
+  // because they are fetching icons from the disk, yet the result will be seen
+  // by the user so they should be prioritized accordingly.
+  static constexpr base::TaskTraits traits() {
+    return {base::MayBlock(), base::TaskPriority::USER_VISIBLE};
+  }
 
   // The task runner object of the thread in which we notify the delegate.
   scoped_refptr<base::SingleThreadTaskRunner> target_task_runner_;

--- a/chromium_src/chrome/browser/icon_loader_auralinux.cc
+++ b/chromium_src/chrome/browser/icon_loader_auralinux.cc
@@ -5,6 +5,7 @@
 #include "chrome/browser/icon_loader.h"
 
 #include "base/bind.h"
+#include "base/memory/ptr_util.h"
 #include "base/message_loop/message_loop.h"
 #include "base/nix/mime_util_xdg.h"
 #include "ui/views/linux_ui/linux_ui.h"
@@ -38,14 +39,17 @@ void IconLoader::ReadIcon() {
       NOTREACHED();
   }
 
+  std::unique_ptr<gfx::Image> image;
+
   views::LinuxUI* ui = views::LinuxUI::instance();
   if (ui) {
-    gfx::Image image = ui->GetIconForContentType(group_, size_pixels);
-    if (!image.IsEmpty())
-      image_.reset(new gfx::Image(image));
+    image = base::MakeUnique<gfx::Image>(
+        ui->GetIconForContentType(group_, size_pixels));
+    if (image->IsEmpty())
+      image = nullptr;
   }
 
   target_task_runner_->PostTask(
-      FROM_HERE, base::Bind(callback_, base::Passed(&image_), group_));
+      FROM_HERE, base::Bind(callback_, base::Passed(&image), group_));
   delete this;
 }

--- a/chromium_src/chrome/browser/icon_loader_auralinux.cc
+++ b/chromium_src/chrome/browser/icon_loader_auralinux.cc
@@ -17,10 +17,11 @@ IconLoader::IconGroup IconLoader::GroupForFilepath(
 }
 
 // static
-content::BrowserThread::ID IconLoader::ReadIconThreadID() {
+scoped_refptr<base::TaskRunner> IconLoader::GetReadIconTaskRunner() {
   // ReadIcon() calls into views::LinuxUI and GTK2 code, so it must be on the UI
   // thread.
-  return content::BrowserThread::UI;
+  return content::BrowserThread::GetTaskRunnerForThread(
+    content::BrowserThread::UI);
 }
 
 void IconLoader::ReadIcon() {
@@ -50,6 +51,6 @@ void IconLoader::ReadIcon() {
   }
 
   target_task_runner_->PostTask(
-      FROM_HERE, base::Bind(callback_, base::Passed(&image), group_));
+      FROM_HERE, base::BindOnce(callback_, base::Passed(&image), group_));
   delete this;
 }

--- a/chromium_src/chrome/browser/icon_loader_mac.mm
+++ b/chromium_src/chrome/browser/icon_loader_mac.mm
@@ -11,6 +11,7 @@
 #include "base/memory/ptr_util.h"
 #include "base/message_loop/message_loop.h"
 #include "base/strings/sys_string_conversions.h"
+#include "base/task_scheduler/post_task.h"
 #include "base/threading/thread.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/image/image_skia_util_mac.h"
@@ -22,8 +23,9 @@ IconLoader::IconGroup IconLoader::GroupForFilepath(
 }
 
 // static
-content::BrowserThread::ID IconLoader::ReadIconThreadID() {
-  return content::BrowserThread::FILE;
+scoped_refptr<base::TaskRunner> IconLoader::GetReadIconTaskRunner() {
+  // NSWorkspace is thread-safe.
+  return base::CreateTaskRunnerWithTraits(traits());
 }
 
 void IconLoader::ReadIcon() {

--- a/chromium_src/chrome/browser/icon_loader_mac.mm
+++ b/chromium_src/chrome/browser/icon_loader_mac.mm
@@ -8,6 +8,7 @@
 
 #include "base/bind.h"
 #include "base/files/file_path.h"
+#include "base/memory/ptr_util.h"
 #include "base/message_loop/message_loop.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/threading/thread.h"
@@ -30,9 +31,11 @@ void IconLoader::ReadIcon() {
   NSWorkspace* workspace = [NSWorkspace sharedWorkspace];
   NSImage* icon = [workspace iconForFileType:group];
 
+  std::unique_ptr<gfx::Image> image;
+
   if (icon_size_ == ALL) {
     // The NSImage already has all sizes.
-    image_.reset(new gfx::Image([icon retain]));
+    image = base::MakeUnique<gfx::Image>([icon retain]);
   } else {
     NSSize size = NSZeroSize;
     switch (icon_size_) {
@@ -48,11 +51,11 @@ void IconLoader::ReadIcon() {
     gfx::ImageSkia image_skia(gfx::ImageSkiaFromResizedNSImage(icon, size));
     if (!image_skia.isNull()) {
       image_skia.MakeThreadSafe();
-      image_.reset(new gfx::Image(image_skia));
+      image = base::MakeUnique<gfx::Image>(image_skia);
     }
   }
 
   target_task_runner_->PostTask(
-      FROM_HERE, base::Bind(callback_, base::Passed(&image_), group_));
+      FROM_HERE, base::Bind(callback_, base::Passed(&image), group_));
   delete this;
 }

--- a/chromium_src/chrome/browser/icon_loader_win.cc
+++ b/chromium_src/chrome/browser/icon_loader_win.cc
@@ -8,6 +8,7 @@
 #include <shellapi.h>
 
 #include "base/bind.h"
+#include "base/memory/ptr_util.h"
 #include "base/message_loop/message_loop.h"
 #include "base/threading/thread.h"
 #include "third_party/skia/include/core/SkBitmap.h"
@@ -49,7 +50,7 @@ void IconLoader::ReadIcon() {
       NOTREACHED();
   }
 
-  image_.reset();
+  std::unique_ptr<gfx::Image> image;
 
   SHFILEINFO file_info = { 0 };
   if (SHGetFileInfo(group_.c_str(), FILE_ATTRIBUTE_NORMAL, &file_info,
@@ -61,12 +62,12 @@ void IconLoader::ReadIcon() {
       gfx::ImageSkia image_skia(gfx::ImageSkiaRep(*bitmap,
                                                   display::win::GetDPIScale()));
       image_skia.MakeThreadSafe();
-      image_.reset(new gfx::Image(image_skia));
+      image = base::MakeUnique<gfx::Image>(image_skia);
       DestroyIcon(file_info.hIcon);
     }
   }
 
   target_task_runner_->PostTask(
-      FROM_HERE, base::Bind(callback_, base::Passed(&image_), group_));
+      FROM_HERE, base::Bind(callback_, base::Passed(&image), group_));
   delete this;
 }

--- a/chromium_src/chrome/browser/icon_loader_win.cc
+++ b/chromium_src/chrome/browser/icon_loader_win.cc
@@ -10,6 +10,7 @@
 #include "base/bind.h"
 #include "base/memory/ptr_util.h"
 #include "base/message_loop/message_loop.h"
+#include "base/task_scheduler/post_task.h"
 #include "base/threading/thread.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/display/win/dpi.h"
@@ -30,8 +31,10 @@ IconLoader::IconGroup IconLoader::GroupForFilepath(
 }
 
 // static
-content::BrowserThread::ID IconLoader::ReadIconThreadID() {
-  return content::BrowserThread::FILE;
+scoped_refptr<base::TaskRunner> IconLoader::GetReadIconTaskRunner() {
+  // Technically speaking, only a thread with COM is needed, not one that has
+  // a COM STA. However, this is what is available for now.
+  return base::CreateCOMSTATaskRunnerWithTraits(traits());
 }
 
 void IconLoader::ReadIcon() {


### PR DESCRIPTION
This updates icon loader to be closer to upstream Chromium state of things.

Related Chromium review entries:
https://codereview.chromium.org/2709683002
https://codereview.chromium.org/2953633002