### PR TITLE
Handle empty handles

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -340,7 +340,7 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
   // Obtain the session.
   std::string partition;
   mate::Handle<api::Session> session;
-  if (options.Get("session", &session)) {
+  if (options.Get("session", &session) && !session.IsEmpty()) {
   } else if (options.Get("partition", &partition)) {
     session = Session::FromPartition(isolate, partition);
   } else {

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -101,7 +101,7 @@ Window::Window(v8::Isolate* isolate, v8::Local<v8::Object> wrapper,
   }
 #endif
 
-  if (options.Get("webContents", &web_contents)) {
+  if (options.Get("webContents", &web_contents) && !web_contents.IsEmpty()) {
     // Set webPreferences from options if using an existing webContents.
     // These preferences will be used when the webContent launches new
     // render processes.
@@ -135,7 +135,7 @@ void Window::Init(v8::Isolate* isolate,
 
   // The parent window.
   mate::Handle<Window> parent;
-  if (options.Get("parent", &parent))
+  if (options.Get("parent", &parent) && !parent.IsEmpty())
     parent_window_.Reset(isolate, parent.ToV8());
 
   // Creates BrowserWindow.
@@ -149,7 +149,7 @@ void Window::Init(v8::Isolate* isolate,
 #if defined(TOOLKIT_VIEWS)
   // Sets the window icon.
   mate::Handle<NativeImage> icon;
-  if (options.Get(options::kIcon, &icon))
+  if (options.Get(options::kIcon, &icon) && !icon.IsEmpty())
     SetIcon(icon);
 #endif
 
@@ -184,7 +184,7 @@ void Window::WillDestroyNativeObject() {
   v8::HandleScope handle_scope(isolate());
   for (v8::Local<v8::Value> value : child_windows_.Values(isolate())) {
     mate::Handle<Window> child;
-    if (mate::ConvertFromV8(isolate(), value, &child))
+    if (mate::ConvertFromV8(isolate(), value, &child) && !child.IsEmpty())
       child->window_->CloseImmediately();
   }
 }
@@ -727,7 +727,7 @@ void Window::SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   mate::Handle<Menu> menu;
   if (value->IsObject() &&
       mate::V8ToString(value->ToObject()->GetConstructorName()) == "Menu" &&
-      mate::ConvertFromV8(isolate, value, &menu)) {
+      mate::ConvertFromV8(isolate, value, &menu) && !menu.IsEmpty()) {
     menu_.Reset(isolate, menu.ToV8());
     window_->SetMenu(menu->model());
   } else if (value->IsNull()) {
@@ -847,7 +847,7 @@ void Window::SetParentWindow(v8::Local<v8::Value> value,
   }
 
   mate::Handle<Window> parent;
-  if (value->IsNull()) {
+  if (value->IsNull() || value->IsUndefined()) {
     RemoveFromParentChildWindows();
     parent_window_.Reset();
     window_->SetParentWindow(nullptr);
@@ -883,7 +883,7 @@ void Window::SetBrowserView(v8::Local<v8::Value> value) {
   ResetBrowserView();
 
   mate::Handle<BrowserView> browser_view;
-  if (value->IsNull()) {
+  if (value->IsNull() || value->IsUndefined()) {
     window_->SetBrowserView(nullptr);
   } else if (mate::ConvertFromV8(isolate(), value, &browser_view)) {
     window_->SetBrowserView(browser_view->view());
@@ -898,7 +898,8 @@ void Window::ResetBrowserView() {
   }
 
   mate::Handle<BrowserView> browser_view;
-  if (mate::ConvertFromV8(isolate(), GetBrowserView(), &browser_view)) {
+  if (mate::ConvertFromV8(isolate(), GetBrowserView(), &browser_view)
+    && !browser_view.IsEmpty()) {
     browser_view->web_contents()->SetOwnerWindow(nullptr);
   }
 
@@ -987,8 +988,10 @@ void Window::RemoveFromParentChildWindows() {
     return;
 
   mate::Handle<Window> parent;
-  if (!mate::ConvertFromV8(isolate(), GetParentWindow(), &parent))
+  if (!mate::ConvertFromV8(isolate(), GetParentWindow(), &parent)
+    || parent.IsEmpty()) {
     return;
+  }
 
   parent->child_windows_.Remove(ID());
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -91,6 +91,8 @@ describe('BrowserWindow module', () => {
       w = new BrowserWindow({
         webContents: void 0
       })
+      w.close()
+      w = null
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -86,6 +86,14 @@ describe('BrowserWindow module', () => {
     return closeWindow(w).then(() => { w = null })
   })
 
+  describe('BrowserWindow constructor', () => {
+    it('allows passing void 0 as the webContents', () => {
+      w = new BrowserWindow({
+        webContents: void 0
+      })
+    })
+  })
+
   describe('BrowserWindow.close()', () => {
     let server
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -88,11 +88,11 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow constructor', () => {
     it('allows passing void 0 as the webContents', () => {
+      w.close()
+      w = null
       w = new BrowserWindow({
         webContents: void 0
       })
-      w.close()
-      w = null
     })
   })
 


### PR DESCRIPTION
Fixes #11593

Basically just because we have a `mate::Handle` doesn't mean it actually contains anything.  In fact, a `mate::Handle` is deliberately made when the `v8::Value` is `null` or `undefined`.  I think I found all the cases where we need to do this check 👍 