### PR TITLE
🍎 Fix SetVisibleOnAllWorkspaces to show app over Fullscreen apps too

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1623,7 +1623,7 @@ void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
 }
 
 void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible) {
-  SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
+  SetCollectionBehavior(visible, (NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorFullScreenAuxiliary));
 }
 
 bool NativeWindowMac::IsVisibleOnAllWorkspaces() {


### PR DESCRIPTION
Tested on OS: Mac OS X 10.12.6

`browserWindow.setVisibleOnAllWorkspaces(boolean)` was not able to show app over Fullscreen app's workspaces. This commit fixes the function to do so. The change is inspired from [Helium](http://heliumfloats.com/) app's [code](https://github.com/JadenGeller/Helium/blob/b35a416376dee7184f788e6ae5736f19890d3ddc/Helium/Helium/HeliumPanelController.swift#L122).