### PR TITLE
Implement dialog (alert/confirm) blocking as a user switch after the first dialog

### DIFF
--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -36,7 +36,9 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     origin_counts_[origin] = 0;
   }
 
-  if (origin_counts_[origin] == -1) return callback.Run(false, base::string16());;
+  if (origin_counts_[origin] == -1) {
+    return callback.Run(false, base::string16());
+  }
 
   if (dialog_type != JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_ALERT &&
       dialog_type != JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_CONFIRM) {
@@ -62,8 +64,8 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
   atom::ShowMessageBox(NativeWindow::FromWebContents(web_contents),
                        atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, -1,
                        0, atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
-                       base::UTF16ToUTF8(message_text), "", checkbox_string, false,
-                       gfx::ImageSkia(),
+                       base::UTF16ToUTF8(message_text), "", checkbox_string,
+                       false, gfx::ImageSkia(),
                        base::Bind(&OnMessageBoxCallback, callback, origin,
                                   &origin_counts_));
 }

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -59,7 +59,8 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
 
   std::string checkbox_string;
   if (origin_counts_[origin] > 1 &&
-      WebContentsPreferences::IsPreferenceEnabled("safeDialogs", web_contents)) {
+      WebContentsPreferences::IsPreferenceEnabled("safeDialogs",
+                                                  web_contents)) {
     if (!WebContentsPreferences::GetString("safeDialogsMessage",
                                            &checkbox_string, web_contents)) {
       checkbox_string = "Prevent this app from creating additional dialogs";

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -17,6 +17,10 @@
 
 using content::JavaScriptDialogType;
 
+namespace {
+  constexpr int USER_WANTS_NO_MORE_DIALOGS = -1;
+}
+
 namespace atom {
 
 AtomJavaScriptDialogManager::AtomJavaScriptDialogManager(
@@ -36,7 +40,7 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     origin_counts_[origin] = 0;
   }
 
-  if (origin_counts_[origin] == -1) {
+  if (origin_counts_[origin] == USER_WANTS_NO_MORE_DIALOGS) {
     return callback.Run(false, base::string16());
   }
 
@@ -92,7 +96,7 @@ void AtomJavaScriptDialogManager::OnMessageBoxCallback(
     int code,
     bool checkbox_checked) {
   if (checkbox_checked) {
-    (*origin_counts_)[origin] = -1;
+    (*origin_counts_)[origin] = USER_WANTS_NO_MORE_DIALOGS;
   }
   callback.Run(code == 0, base::string16());
 }

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -64,13 +64,14 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
       checkbox_string = "Prevent this app from creating additional dialogs";
     }
   }
-  atom::ShowMessageBox(NativeWindow::FromWebContents(web_contents),
-                       atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, -1,
-                       0, atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
-                       base::UTF16ToUTF8(message_text), "", checkbox_string,
-                       false, gfx::ImageSkia(),
-                       base::Bind(&OnMessageBoxCallback, callback, origin,
-                                  &origin_counts_));
+  atom::ShowMessageBox(
+      NativeWindow::FromWebContents(web_contents),
+      atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, -1, 0,
+      atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
+      base::UTF16ToUTF8(message_text), "", checkbox_string,
+      false, gfx::ImageSkia(),
+      base::Bind(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
+                 base::Unretained(this), callback, origin));
 }
 
 void AtomJavaScriptDialogManager::RunBeforeUnloadDialog(
@@ -87,16 +88,13 @@ void AtomJavaScriptDialogManager::CancelDialogs(
     bool reset_state) {
 }
 
-// static
 void AtomJavaScriptDialogManager::OnMessageBoxCallback(
     const DialogClosedCallback& callback,
     const std::string& origin,
-    std::map<std::string, int>* origin_counts_,
     int code,
     bool checkbox_checked) {
-  if (checkbox_checked) {
-    (*origin_counts_)[origin] = kUserWantsNoMoreDialogs;
-  }
+  if (checkbox_checked)
+    origin_counts_[origin] = kUserWantsNoMoreDialogs;
   callback.Run(code == 0, base::string16());
 }
 

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -17,11 +17,13 @@
 
 using content::JavaScriptDialogType;
 
-namespace {
-  constexpr int USER_WANTS_NO_MORE_DIALOGS = -1;
-}
-
 namespace atom {
+
+namespace {
+
+constexpr int kUserWantsNoMoreDialogs = -1;
+
+}  // namespace
 
 AtomJavaScriptDialogManager::AtomJavaScriptDialogManager(
     api::WebContents* api_web_contents)
@@ -36,11 +38,7 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     const DialogClosedCallback& callback,
     bool* did_suppress_message) {
   const std::string origin = origin_url.GetOrigin().spec();
-  if (origin_counts_.find(origin) == origin_counts_.end()) {
-    origin_counts_[origin] = 0;
-  }
-
-  if (origin_counts_[origin] == USER_WANTS_NO_MORE_DIALOGS) {
+  if (origin_counts_[origin] == kUserWantsNoMoreDialogs) {
     return callback.Run(false, base::string16());
   }
 
@@ -97,7 +95,7 @@ void AtomJavaScriptDialogManager::OnMessageBoxCallback(
     int code,
     bool checkbox_checked) {
   if (checkbox_checked) {
-    (*origin_counts_)[origin] = USER_WANTS_NO_MORE_DIALOGS;
+    (*origin_counts_)[origin] = kUserWantsNoMoreDialogs;
   }
   callback.Run(code == 0, base::string16());
 }

--- a/atom/browser/atom_javascript_dialog_manager.h
+++ b/atom/browser/atom_javascript_dialog_manager.h
@@ -5,8 +5,8 @@
 #ifndef ATOM_BROWSER_ATOM_JAVASCRIPT_DIALOG_MANAGER_H_
 #define ATOM_BROWSER_ATOM_JAVASCRIPT_DIALOG_MANAGER_H_
 
-#include <string>
 #include <map>
+#include <string>
 
 #include "content/public/browser/javascript_dialog_manager.h"
 

--- a/atom/browser/atom_javascript_dialog_manager.h
+++ b/atom/browser/atom_javascript_dialog_manager.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_ATOM_JAVASCRIPT_DIALOG_MANAGER_H_
 
 #include <string>
+#include <map>
 
 #include "content/public/browser/javascript_dialog_manager.h"
 
@@ -37,9 +38,12 @@ class AtomJavaScriptDialogManager : public content::JavaScriptDialogManager {
 
  private:
   static void OnMessageBoxCallback(const DialogClosedCallback& callback,
+                                   const std::string& origin,
+                                   std::map<std::string, int>* origins_,
                                    int code,
                                    bool checkbox_checked);
   api::WebContents* api_web_contents_;
+  std::map<std::string, int> origin_counts_;
 };
 
 }  // namespace atom

--- a/atom/browser/atom_javascript_dialog_manager.h
+++ b/atom/browser/atom_javascript_dialog_manager.h
@@ -37,11 +37,10 @@ class AtomJavaScriptDialogManager : public content::JavaScriptDialogManager {
                      bool reset_state) override;
 
  private:
-  static void OnMessageBoxCallback(const DialogClosedCallback& callback,
-                                   const std::string& origin,
-                                   std::map<std::string, int>* origins_,
-                                   int code,
-                                   bool checkbox_checked);
+  void OnMessageBoxCallback(const DialogClosedCallback& callback,
+                            const std::string& origin,
+                            int code,
+                            bool checkbox_checked);
 
   api::WebContents* api_web_contents_;
   std::map<std::string, int> origin_counts_;

--- a/atom/browser/atom_javascript_dialog_manager.h
+++ b/atom/browser/atom_javascript_dialog_manager.h
@@ -42,6 +42,7 @@ class AtomJavaScriptDialogManager : public content::JavaScriptDialogManager {
                                    std::map<std::string, int>* origins_,
                                    int code,
                                    bool checkbox_checked);
+
   api::WebContents* api_web_contents_;
   std::map<std::string, int> origin_counts_;
 };

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -301,4 +301,13 @@ bool WebContentsPreferences::GetInteger(const std::string& attributeName,
   return false;
 }
 
+bool WebContentsPreferences::GetString(const std::string& attributeName,
+                                       std::string* stringValue,
+                                       content::WebContents* web_contents) {
+  WebContentsPreferences* self = FromWebContents(web_contents);
+  if (!self)
+    return false;
+  return self->web_preferences()->GetString(attributeName, stringValue);
+}
+
 }  // namespace atom

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -301,13 +301,13 @@ bool WebContentsPreferences::GetInteger(const std::string& attributeName,
   return false;
 }
 
-bool WebContentsPreferences::GetString(const std::string& attributeName,
-                                       std::string* stringValue,
+bool WebContentsPreferences::GetString(const std::string& attribute_name,
+                                       std::string* string_value,
                                        content::WebContents* web_contents) {
   WebContentsPreferences* self = FromWebContents(web_contents);
   if (!self)
     return false;
-  return self->web_preferences()->GetString(attributeName, stringValue);
+  return self->web_preferences()->GetString(attribute_name, string_value);
 }
 
 }  // namespace atom

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -40,6 +40,10 @@ class WebContentsPreferences
   static bool IsPreferenceEnabled(const std::string& attribute_name,
                                   content::WebContents* web_contents);
 
+  static bool GetString(const std::string& attributeName,
+                 std::string* stringValue,
+                 content::WebContents* web_contents);
+
   // Modify the WebPreferences according to |web_contents|'s preferences.
   static void OverrideWebkitPrefs(
       content::WebContents* web_contents, content::WebPreferences* prefs);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -40,9 +40,9 @@ class WebContentsPreferences
   static bool IsPreferenceEnabled(const std::string& attribute_name,
                                   content::WebContents* web_contents);
 
-  static bool GetString(const std::string& attributeName,
-                 std::string* stringValue,
-                 content::WebContents* web_contents);
+  static bool GetString(const std::string& attribute_name,
+                        std::string* string_value,
+                        content::WebContents* web_contents);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.
   static void OverrideWebkitPrefs(

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -363,9 +363,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       to `process.argv` in the renderer process of this app.  Useful for passing small
       bits of data down to renderer process preload scripts.
     * `safeDialogs` Boolean (optional) - Whether to enable browser style
-      consecutive dialog protection.
+      consecutive dialog protection. Default is `false`.
     * `safeDialogsMessage` String (optional) - The message to display when consecutive
-      dialog protection is triggered.
+      dialog protection is triggered. Default is empty string.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -362,6 +362,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `additionArguments` String[] (optional) - A list of strings that will be appended
       to `process.argv` in the renderer process of this app.  Useful for passing small
       bits of data down to renderer process preload scripts.
+    * `safeDialogs` Boolean (optional) - Whether to enable browser style
+      consecutive dialog protection.
+    * `safeDialogsMessage` String (optional) - The message to display when consecutive
+      dialog protection is triggered.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -364,8 +364,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       bits of data down to renderer process preload scripts.
     * `safeDialogs` Boolean (optional) - Whether to enable browser style
       consecutive dialog protection. Default is `false`.
-    * `safeDialogsMessage` String (optional) - The message to display when consecutive
-      dialog protection is triggered. Default is empty string.
+    * `safeDialogsMessage` String (optional) - The message to display when
+      consecutive dialog protection is triggered. If not defined the default
+      message would be used, note that currently the default message is in
+      English and not localized.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -438,39 +438,6 @@ ipcMain.on('ELECTRON_BROWSER_SEND_TO', function (event, sendToAll, webContentsId
   }
 })
 
-// Implements window.alert(message, title)
-ipcMain.on('ELECTRON_BROWSER_WINDOW_ALERT', function (event, message, title) {
-  if (message == null) message = ''
-  if (title == null) title = ''
-
-  const dialogProperties = {
-    message: `${message}`,
-    title: `${title}`,
-    buttons: ['OK']
-  }
-  event.returnValue = event.sender.isOffscreen()
-    ? electron.dialog.showMessageBox(dialogProperties)
-    : electron.dialog.showMessageBox(
-      event.sender.getOwnerBrowserWindow(), dialogProperties)
-})
-
-// Implements window.confirm(message, title)
-ipcMain.on('ELECTRON_BROWSER_WINDOW_CONFIRM', function (event, message, title) {
-  if (message == null) message = ''
-  if (title == null) title = ''
-
-  const dialogProperties = {
-    message: `${message}`,
-    title: `${title}`,
-    buttons: ['OK', 'Cancel'],
-    cancelId: 1
-  }
-  event.returnValue = !(event.sender.isOffscreen()
-    ? electron.dialog.showMessageBox(dialogProperties)
-    : electron.dialog.showMessageBox(
-      event.sender.getOwnerBrowserWindow(), dialogProperties))
-})
-
 // Implements window.close()
 ipcMain.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
   const window = event.sender.getOwnerBrowserWindow()

--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -133,14 +133,6 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNative
     }
   }
 
-  window.alert = function (message, title) {
-    ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_ALERT', toString(message), toString(title))
-  }
-
-  window.confirm = function (message, title) {
-    return ipcRenderer.sendSync('ELECTRON_BROWSER_WINDOW_CONFIRM', toString(message), toString(title))
-  }
-
   // But we do not support prompt().
   window.prompt = function () {
     throw new Error('prompt() is and will not be supported.')

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1088,10 +1088,6 @@ describe('chromium feature', () => {
       assert.throws(() => {
         window.alert({toString: null})
       }, /Cannot convert object to primitive value/)
-
-      assert.throws(() => {
-        window.alert('message', {toString: 3})
-      }, /Cannot convert object to primitive value/)
     })
   })
 
@@ -1099,10 +1095,6 @@ describe('chromium feature', () => {
     it('throws an exception when the arguments cannot be converted to strings', () => {
       assert.throws(() => {
         window.confirm({toString: null}, 'title')
-      }, /Cannot convert object to primitive value/)
-
-      assert.throws(() => {
-        window.confirm('message', {toString: 3})
       }, /Cannot convert object to primitive value/)
     })
   })


### PR DESCRIPTION
* This is to enable more browser-like behavior so that users who run third-party code
  will not be DOS'ed with alerts and confirms.  This is already handled like this
  in most major browsers so this will greatly help these developers.
* This also removes our JS implementation of `alert` and `confirm` which minimizes risk and works because we have a working `JavascriptDialogManager` now 👍 
  