### PR TITLE
Removing core dump check from arm tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,10 +91,6 @@ jobs:
                 echo "Versions do not match"
                 exit 1
               fi
-              if grep -q "core dumped" version.txt; then
-                echo "Core dump detected"
-                exit 1
-              fi
             else
               echo "Skipping test for release build"
             fi
@@ -186,10 +182,6 @@ jobs:
                 echo "Versions match"
               else
                 echo "Versions do not match"
-                exit 1
-              fi
-              if grep -q "core dumped" version.txt; then
-                echo "Core dump detected"
                 exit 1
               fi
             else


### PR DESCRIPTION
It appears that the arm build failing with a core dump is a false positive.  Testing the latest arm build from master on a raspberry pi 2, it does not core dump, so I am removing that check from the arm tests.