### PR TITLE
Change macos app termination process

### DIFF
--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -4,6 +4,7 @@
 
 #import "atom/browser/mac/atom_application.h"
 
+#import "atom/browser/mac/atom_application_delegate.h"
 #include "atom/browser/mac/dict_util.h"
 #include "atom/browser/browser.h"
 #include "base/auto_reset.h"
@@ -25,6 +26,11 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 
 + (AtomApplication*)sharedApplication {
   return (AtomApplication*)[super sharedApplication];
+}
+
+- (void)terminate:(id)sender {
+  AtomApplicationDelegate* atomDelegate = (AtomApplicationDelegate*) [NSApp delegate];
+  [atomDelegate tryToTerminateApp:self];
 }
 
 - (BOOL)isHandlingSendEvent {

--- a/atom/browser/mac/atom_application_delegate.h
+++ b/atom/browser/mac/atom_application_delegate.h
@@ -11,6 +11,8 @@
   base::scoped_nsobject<AtomMenuController> menu_controller_;
 }
 
+- (void)tryToTerminateApp:(NSApplication*)app;
+
 // Sets the menu that will be returned in "applicationDockMenu:".
 - (void)setApplicationDockMenu:(atom::AtomMenuModel*)model;
 

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -87,15 +87,11 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
   return atom::Browser::Get()->OpenFile(filename_str) ? YES : NO;
 }
 
-- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*)sender {
-  atom::Browser* browser = atom::Browser::Get();
-  if (browser->is_quiting()) {
-    return NSTerminateNow;
-  } else {
-    // System started termination.
-    atom::Browser::Get()->Quit();
-    return NSTerminateCancel;
-  }
+// We simply try to close the browser, which in turn will try to close the windows.
+// Termination can proceed if all windows are closed or window close can be cancelled
+// which will abort termination.
+- (void)tryToTerminateApp:(NSApplication*)app {
+  atom::Browser::Get()->Quit();
 }
 
 - (BOOL)applicationShouldHandleReopen:(NSApplication*)theApplication

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -158,7 +158,7 @@ describe('app module', () => {
       })
     })
 
-    it('exits gracefully on macos', (done) => {
+    it('exits gracefully on macos', function (done) {
       if (process.platform !== 'darwin') {
         this.skip()
       }

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -160,7 +160,7 @@ describe('app module', () => {
 
     it('exits gracefully on macos', (done) => {
       if (process.platform !== 'darwin') {
-          this.skip()
+        this.skip()
       }
       const appPath = path.join(__dirname, 'fixtures', 'api', 'singleton')
       const electronPath = remote.getGlobal('process').execPath

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -157,6 +157,24 @@ describe('app module', () => {
         done()
       })
     })
+
+    it('exits gracefully on macos', (done) => {
+      if (process.platform !== 'darwin') {
+          this.skip()
+      }
+      const appPath = path.join(__dirname, 'fixtures', 'api', 'singleton')
+      const electronPath = remote.getGlobal('process').execPath
+      appProcess = ChildProcess.spawn(electronPath, [appPath])
+      appProcess.stdout.once('data', () => {
+        // The apple script will try to terminate the app
+        // If there's an error terminating the app, then it will print to stderr
+        ChildProcess.exec('osascript -e \'quit app "Electron"\'', (err, stdout, stderr) => {
+          assert(!err)
+          assert(!stderr.trim())
+          done()
+        })
+      })
+    })
   })
 
   describe('app.makeSingleInstance', () => {


### PR DESCRIPTION
#230 happens because `applicationShouldTerminate` returns `NSTerminateCancel`. One of the ways to fix that would have been returning `NSTerminateLater` as was suggested in one of the responses the #230. However, the app will switch to `NSModalPanelRunLoopMode` and will wait for `replyToApplicationShouldTerminate` being called.
The chrome message loop however, does not end and there's possibility of abruptly terminating the app, causing loss of data.
The approach taken in this PR, is by implementing application `terminate` instead of `applicationShouldTerminate` delegate method. Terminate will try to close the browser windows, and chrome message loop will proceed to termination. If browser windows are not closed (user cancelled through the popup), then termination will halt and the app will keep running. [Chrome seems to follow a similar approach.]