### PR TITLE
Fix macos Full Screen Toggle menu item label

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -732,7 +732,7 @@ enum {
     [super performClose:sender];
 }
 
-- (void)toggleFullScreen:(id)sender {
+- (void)toggleFullScreenMode:(id)sender {
   if (shell_->simple_fullscreen())
     shell_->SetSimpleFullScreen(!shell_->IsSimpleFullScreen());
   else
@@ -1178,7 +1178,7 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
   if (fullscreen == IsFullscreen())
     return;
 
-  [window_ toggleFullScreen:nil];
+  [window_ toggleFullScreenMode:nil];
 }
 
 bool NativeWindowMac::IsFullscreen() const {

--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -41,7 +41,10 @@ Role kRolesMap[] = {
   { @selector(performClose:), "close" },
   { @selector(performZoom:), "zoom" },
   { @selector(terminate:), "quit" },
-  { @selector(toggleFullScreen:), "togglefullscreen" },
+  // ↓ is intentionally not `toggleFullScreen`. The macOS full screen menu item behaves weird.
+  // If we use `toggleFullScreen`, then the menu item will use the default label, and not take
+  // the one provided.
+  { @selector(toggleFullScreenMode:), "togglefullscreen" },
   { @selector(toggleTabBar:), "toggletabbar" },
   { @selector(selectNextTab:), "selectnexttab" },
   { @selector(selectPreviousTab:), "selectprevioustab" },


### PR DESCRIPTION
Fix for issue  #11571 and probably #10575 as well.

The Full screen menu item on the mac is special and behaves unexpected.
I think macOS checks if we have an implementation for `toggleFullScreen` and then uses the default menu item label for it. This PR instead maps the `togglefullscreen` role to a different named method, so as to not confuse the OS, and enable changing the menu item label.