### PR TITLE
feat: Accept additional notification actions

### DIFF
--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -28,8 +28,8 @@ class CocoaNotification : public Notification {
 
   void NotificationDisplayed();
   void NotificationReplied(const std::string& reply);
-  void NotificationButtonClicked();
-  void NotificationAdditionalActionClicked(NSUserNotificationAction* action);
+  void NotificationActivated();
+  void NotificationActivated(NSUserNotificationAction* action);
 
   NSUserNotification* notification() const { return notification_; }
 

--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -7,9 +7,9 @@
 
 #import <Foundation/Foundation.h>
 
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 #include "base/mac/scoped_nsobject.h"
 #include "brightray/browser/notification.h"

--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 #include "base/mac/scoped_nsobject.h"
 #include "brightray/browser/notification.h"
@@ -28,6 +29,7 @@ class CocoaNotification : public Notification {
   void NotificationDisplayed();
   void NotificationReplied(const std::string& reply);
   void NotificationButtonClicked();
+  void NotificationAdditionalActionClicked(NSUserNotificationAction* action);
 
   NSUserNotification* notification() const { return notification_; }
 
@@ -35,7 +37,8 @@ class CocoaNotification : public Notification {
   void LogAction(const char* action);
 
   base::scoped_nsobject<NSUserNotification> notification_;
-  int action_index_;
+  std::map<std::string, unsigned> additional_action_indices_;
+  unsigned action_index_;
 
   DISALLOW_COPY_AND_ASSIGN(CocoaNotification);
 };

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -59,13 +59,30 @@ void CocoaNotification::Show(const NotificationOptions& options) {
   [notification_ setHasActionButton:false];
 
   int i = 0;
+  action_index_ = UINT_MAX;
+  NSMutableArray* additionalActions = [[[NSMutableArray alloc] init] autorelease];
   for (const auto& action : options.actions) {
     if (action.type == base::ASCIIToUTF16("button")) {
-      [notification_ setHasActionButton:true];
-      [notification_ setActionButtonTitle:base::SysUTF16ToNSString(action.text)];
-      action_index_ = i;
+      if (action_index_ == UINT_MAX) {
+        // First button observed is the displayed action
+        [notification_ setHasActionButton:true];
+        [notification_ setActionButtonTitle:base::SysUTF16ToNSString(action.text)];
+        action_index_ = i;
+      } else {
+        // All of the rest are appended to the list of additional actions
+        NSString* actionIdentifier = [NSString stringWithFormat:@"%@Action%d", identifier, i];
+        NSUserNotificationAction* notificationAction =
+          [NSUserNotificationAction actionWithIdentifier:actionIdentifier
+                                                   title:base::SysUTF16ToNSString(action.text)];
+        [additionalActions addObject:notificationAction];
+        additional_action_indices_.insert(std::make_pair(base::SysNSStringToUTF8(actionIdentifier), i));
+      }
     }
     i++;
+  }
+  if ([additionalActions count] > 0 &&
+      [notification_ respondsToSelector:@selector(setAdditionalActions:)]) {
+    [notification_ setAdditionalActions:additionalActions]; // Requires macOS 10.10
   }
 
   if (options.has_reply) {
@@ -104,6 +121,23 @@ void CocoaNotification::NotificationReplied(const std::string& reply) {
 void CocoaNotification::NotificationButtonClicked() {
   if (delegate())
     delegate()->NotificationAction(action_index_);
+
+  this->LogAction("button clicked");
+}
+
+void CocoaNotification::NotificationAdditionalActionClicked(NSUserNotificationAction* action) {
+  if (delegate()) {
+    unsigned index = action_index_;
+    std::string identifier = base::SysNSStringToUTF8(action.identifier);
+    for (const auto& it : additional_action_indices_) {
+      if (it.first == identifier) {
+        index = it.second;
+        break;
+      }
+    }
+
+    delegate()->NotificationAction(index);
+  }
 
   this->LogAction("button clicked");
 }

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -48,10 +48,10 @@ void CocoaNotification::Show(const NotificationOptions& options) {
 
   if (options.silent) {
     [notification_ setSoundName:nil];
-  } else if (options.sound != nil) {
-    [notification_ setSoundName:base::SysUTF16ToNSString(options.sound)];
-  } else {
+  } else if (options.sound.empty()) {
     [notification_ setSoundName:NSUserNotificationDefaultSoundName];
+  } else {
+    [notification_ setSoundName:base::SysUTF16ToNSString(options.sound)];
   }
 
   [notification_ setHasActionButton:false];

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -41,8 +41,7 @@ void CocoaNotification::Show(const NotificationOptions& options) {
     LOG(INFO) << "Notification created (" << [identifier UTF8String] << ")";
   }
 
-  if ([notification_ respondsToSelector:@selector(setContentImage:)] &&
-      !options.icon.drawsNothing()) {
+  if (!options.icon.drawsNothing()) {
     NSImage* image = skia::SkBitmapToNSImageWithColorSpace(
         options.icon, base::mac::GetGenericRGBColorSpace());
     [notification_ setContentImage:image];

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -116,14 +116,14 @@ void CocoaNotification::NotificationReplied(const std::string& reply) {
   this->LogAction("replied to");
 }
 
-void CocoaNotification::NotificationButtonClicked() {
+void CocoaNotification::NotificationActivated() {
   if (delegate())
     delegate()->NotificationAction(action_index_);
 
   this->LogAction("button clicked");
 }
 
-void CocoaNotification::NotificationAdditionalActionClicked(NSUserNotificationAction* action) {
+void CocoaNotification::NotificationActivated(NSUserNotificationAction* action) {
   if (delegate()) {
     unsigned index = action_index_;
     std::string identifier = base::SysNSStringToUTF8(action.identifier);

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -29,13 +29,12 @@ CocoaNotification::~CocoaNotification() {
 void CocoaNotification::Show(const NotificationOptions& options) {
   notification_.reset([[NSUserNotification alloc] init]);
 
-  NSString* identifier = [NSString stringWithFormat:@"%s%d", "ElectronNotification", g_identifier_];
+  NSString* identifier = [NSString stringWithFormat:@"ElectronNotification%d", g_identifier_++];
 
   [notification_ setTitle:base::SysUTF16ToNSString(options.title)];
   [notification_ setSubtitle:base::SysUTF16ToNSString(options.subtitle)];
   [notification_ setInformativeText:base::SysUTF16ToNSString(options.msg)];
   [notification_ setIdentifier:identifier];
-  g_identifier_++;
 
   if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
     LOG(INFO) << "Notification created (" << [identifier UTF8String] << ")";

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -38,11 +38,11 @@
     if (notif.activationType == NSUserNotificationActivationTypeContentsClicked) {
       notification->NotificationClicked();
     } else if (notif.activationType == NSUserNotificationActivationTypeActionButtonClicked) {
-      notification->NotificationButtonClicked();
+      notification->NotificationActivated();
     } else if (notif.activationType == NSUserNotificationActivationTypeReplied) {
       notification->NotificationReplied([notif.response.string UTF8String]);
     } else if (notif.activationType == NSUserNotificationActivationTypeAdditionalActionClicked) {
-      notification->NotificationAdditionalActionClicked([notif additionalActivationAction]);
+      notification->NotificationActivated([notif additionalActivationAction]);
     }
   }
 }

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -34,12 +34,15 @@
   }
 
   if (notification) {
-    if (notif.activationType == NSUserNotificationActivationTypeReplied) {
-      notification->NotificationReplied([notif.response.string UTF8String]);
+    // Ref: https://developer.apple.com/documentation/foundation/nsusernotificationactivationtype?language=objc
+    if (notif.activationType == NSUserNotificationActivationTypeContentsClicked) {
+      notification->NotificationClicked();
     } else if (notif.activationType == NSUserNotificationActivationTypeActionButtonClicked) {
       notification->NotificationButtonClicked();
-    } else if (notif.activationType == NSUserNotificationActivationTypeContentsClicked) {
-      notification->NotificationClicked();
+    } else if (notif.activationType == NSUserNotificationActivationTypeReplied) {
+      notification->NotificationReplied([notif.response.string UTF8String]);
+    } else if (notif.activationType == NSUserNotificationActivationTypeAdditionalActionClicked) {
+      notification->NotificationAdditionalActionClicked([notif additionalActivationAction]);
     }
   }
 }

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -15,6 +15,6 @@ In order for extra notification buttons to work on macOS your app must meet the
 following criteria.
 
 * App is signed
-* App has it's `NSUserNotificationAlertStyle` set to `alert` in the `info.plist`.
+* App has it's `NSUserNotificationAlertStyle` set to `alert` in the `Info.plist`.
 
 If either of these requirements are not met the button simply won't appear.

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -7,7 +7,7 @@
 
 | Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
 |-------------|------------------|-----------------|----------------|-------------|
-| `button`    | macOS            | Used as the label for the button | "Show" | Maximum of one button, if multiple are provided only the last is used.  This action is also incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
+| `button`    | macOS            | Used as the label for the button | "Show" | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any of such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
 
 ### Button support on macOS
 

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -7,7 +7,7 @@
 
 | Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
 |-------------|------------------|-----------------|----------------|-------------|
-| `button`    | macOS            | Used as the label for the button | "Show" (if first of such `button`, otherwise empty) | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any of such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
+| `button`    | macOS            | Used as the label for the button | "Show" (or a localized string by system default if first of such `button`, otherwise empty) | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any of such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
 
 ### Button support on macOS
 

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -7,7 +7,7 @@
 
 | Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
 |-------------|------------------|-----------------|----------------|-------------|
-| `button`    | macOS            | Used as the label for the button | "Show" (or a localized string by system default if first of such `button`, otherwise empty) | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any of such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
+| `button`    | macOS            | Used as the label for the button | "Show" (or a localized string by system default if first of such `button`, otherwise empty) | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
 
 ### Button support on macOS
 

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -7,7 +7,7 @@
 
 | Action Type | Platform Support | Usage of `text` | Default `text` | Limitations |
 |-------------|------------------|-----------------|----------------|-------------|
-| `button`    | macOS            | Used as the label for the button | "Show" | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any of such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
+| `button`    | macOS            | Used as the label for the button | "Show" (if first of such `button`, otherwise empty) | Only the first one is used. If multiple are provided, those beyond the first will be listed as additional actions (displayed when mouse active over the action button). Any of such action also is incompatible with `hasReply` and will be ignored if `hasReply` is `true`. |
 
 ### Button support on macOS
 


### PR DESCRIPTION
🍎 For macOS 10.9 and above: The first action with type `button` seen will be displayed on the notification, the rest listed as additional actions (shown when holding down on the primary action button).

With the following config:

- `NSUserNotificationAlertStyle` set to `alert` in `Info.plist` of the app bundle
- Probably check if alerts are enabled for the app in System Preferences (not only banners)

Using the following script:

```javascript
// This doesn't produce a window...
// But should be enough to produce a native notification
const electron = require('electron')
electron.app.on('ready', function (event) {

  let n = new electron.Notification({
    title: 'Notification',
    actions: [
      {type: 'button', text: 'First'}, // This will be displayed as the action button
      {type: 'button', text: 'Second'}, // The following listed if mouse held down
      {type: 'button', text: 'Third'},
    ],
  })

  n.on('action', function (event, index) {
    console.log(index) // Should tell the index of the button activated
  })

  n.show()

})
```

Screenshot:

![preview](https://user-images.githubusercontent.com/3168941/34972557-23d17bba-fa37-11e7-94d7-b9b6fcea32c4.png)

---

Should partially address for macOS: https://github.com/electron/electron/issues/4424