### PR TITLE
Fix checkbox state callback bug

### DIFF
--- a/atom/browser/ui/message_box_mac.mm
+++ b/atom/browser/ui/message_box_mac.mm
@@ -188,7 +188,7 @@ void ShowMessageBox(NativeWindow* parent_window,
   if (!parent_window || !parent_window->GetNativeWindow() ||
       parent_window->is_offscreen_dummy()) {
     int ret = [[alert autorelease] runModal];
-    callback.Run(ret, false);
+    callback.Run(ret, alert.suppressionButton.state == NSOnState);
   } else {
     ModalDelegate* delegate = [[ModalDelegate alloc] initWithCallback:callback
                                                              andAlert:alert


### PR DESCRIPTION
Provides a fix for https://github.com/electron/electron/issues/11389. 
When the checkbox is clicked, check checkbox state again in the callback instead of hardcoding to `false` 🙅 

/cc @poiru @brenca
