### PR TITLE
Use same screen capturer settings for thumbnails as getUserMedia

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -13,6 +13,7 @@ using base::PlatformThreadRef;
 #include "native_mate/dictionary.h"
 #include "third_party/webrtc/modules/desktop_capture/desktop_capture_options.h"
 #include "third_party/webrtc/modules/desktop_capture/desktop_capturer.h"
+#include "content/public/browser/desktop_capture.h"
 
 #include "atom/common/node_includes.h"
 
@@ -49,18 +50,7 @@ DesktopCapturer::~DesktopCapturer() {
 void DesktopCapturer::StartHandling(bool capture_window,
                                     bool capture_screen,
                                     const gfx::Size& thumbnail_size) {
-  webrtc::DesktopCaptureOptions options =
-      webrtc::DesktopCaptureOptions::CreateDefault();
-
-#if defined(OS_WIN)
-  // On windows, desktop effects (e.g. Aero) will be disabled when the Desktop
-  // capture API is active by default.
-  // We keep the desktop effects in most times. Howerver, the screen still
-  // fickers when the API is capturing the window due to limitation of current
-  // implemetation. This is a known and wontFix issue in webrtc (see:
-  // http://code.google.com/p/webrtc/issues/detail?id=3373)
-  options.set_disable_effects(false);
-#endif
+  webrtc::DesktopCaptureOptions options = content::CreateDesktopCaptureOptions();
 
   std::unique_ptr<webrtc::DesktopCapturer> screen_capturer(
       capture_screen ? webrtc::DesktopCapturer::CreateScreenCapturer(options)

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -10,10 +10,10 @@ using base::PlatformThreadRef;
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/media/desktop_media_list.h"
+#include "content/public/browser/desktop_capture.h"
 #include "native_mate/dictionary.h"
 #include "third_party/webrtc/modules/desktop_capture/desktop_capture_options.h"
 #include "third_party/webrtc/modules/desktop_capture/desktop_capturer.h"
-#include "content/public/browser/desktop_capture.h"
 
 #include "atom/common/node_includes.h"
 
@@ -50,7 +50,8 @@ DesktopCapturer::~DesktopCapturer() {
 void DesktopCapturer::StartHandling(bool capture_window,
                                     bool capture_screen,
                                     const gfx::Size& thumbnail_size) {
-  webrtc::DesktopCaptureOptions options = content::CreateDesktopCaptureOptions();
+  webrtc::DesktopCaptureOptions options =
+    content::CreateDesktopCaptureOptions();
 
   std::unique_ptr<webrtc::DesktopCapturer> screen_capturer(
       capture_screen ? webrtc::DesktopCapturer::CreateScreenCapturer(options)


### PR DESCRIPTION
Fixes #9933 (and its duplicates #10513, #11609)
 
Following along from http://crrev.com/2961193002: ensure the
screen thumbnail capturers initialize with the same settings as the screen capturer
from a getUserMedia call. Otherwise, there is no guarantee that the
sources on Windows will match. As a result, this change switches the default capturer for thumbnails on Windows from GDI to the newer DirectX capturer. It maintains GDI as a fallback in the event of failure.

**A caveat:** there is still a bug that causes Chrome and atom::api::DesktopCapturer to end up with different screen capture sources. If you try to capture thumbnails while already capturing a screen from getUserMedia, it seems that DXGIDuplicatorController gets double initialized, DXGI output duplication fails (because you're explicitly not allowed to duplicate the same monitor twice), and the thumbnail capturer will fallback to the old GDI capturer (and thus, different source IDs). I'm still looking into why the statically initialized DXGIDuplicatorController doesn't end up being reused, but my guess is that it's happening in a different process. Any thoughts on next steps there would be welcome.

**Testing:**
Windows 10: Tested with various monitor setups and adapters.
Mac (High Sierra): Quick smoke test that screen sharing still works.
