### PR TITLE
Use same screen capturer settings for thumbnails as getUserMedia (Chrome 59/1-8-x)

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -60,6 +60,7 @@ void DesktopCapturer::StartHandling(bool capture_window,
   // implemetation. This is a known and wontFix issue in webrtc (see:
   // http://code.google.com/p/webrtc/issues/detail?id=3373)
   options.set_disable_effects(false);
+  options.set_allow_directx_capturer(true);
 #endif
 
   std::unique_ptr<webrtc::DesktopCapturer> screen_capturer(


### PR DESCRIPTION
Same fix as #11664, but for Chrome 59 (where `content/public/browser/desktop_capture.h` doesn't exist). This relies on a ref counted DXGI controller as patched and explained here: electron/libchromiumcontent#437. Will update libcc in this PR when it merges.