### PR TITLE
correct error about will-navigate event in docs/api/web-contents.md

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -189,7 +189,7 @@ It is also not emitted for in-page navigations, such as clicking anchor links
 or updating the `window.location.hash`. Use `did-navigate-in-page` event for
 this purpose.
 
-Calling `event.preventDefault()` will prevent the navigation.
+Calling `event.preventDefault()` will NOT prevent the navigation.
 
 #### Event: 'did-navigate'
 


### PR DESCRIPTION
Someone [here](https://github.com/electron/electron/issues/1378#issuecomment-223505198) says that the documentation is wrong, and my own tests show that too.