### PR TITLE
Make run-as-node mode optional

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -38,7 +38,9 @@
 
 namespace {
 
+#ifdef ENABLE_RUN_AS_NODE
 const auto kRunAsNode = "ELECTRON_RUN_AS_NODE";
+#endif
 
 bool IsEnvSet(const char* name) {
 #if defined(OS_WIN)
@@ -89,7 +91,11 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   }
 #endif
 
+#ifdef ENABLE_RUN_AS_NODE
   bool run_as_node = IsEnvSet(kRunAsNode);
+#else
+  bool run_as_node = false;
+#endif
 
   // Make sure the output is printed to console.
   if (run_as_node || !IsEnvSet("ELECTRON_NO_ATTACH_CONSOLE"))
@@ -114,6 +120,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   });
 #endif
 
+#ifdef ENABLE_RUN_AS_NODE
   if (run_as_node) {
     std::vector<char*> argv(arguments.argc);
     std::transform(
@@ -125,7 +132,10 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     auto ret = atom::NodeMain(argv.size(), argv.data());
     std::for_each(argv.begin(), argv.end(), free);
     return ret;
-  } else if (IsEnvSet("ELECTRON_INTERNAL_CRASH_SERVICE")) {
+  }
+#endif
+
+  if (IsEnvSet("ELECTRON_INTERNAL_CRASH_SERVICE")) {
     return crash_service::Main(cmd);
   }
 
@@ -146,11 +156,13 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
 #elif defined(OS_LINUX)  // defined(OS_WIN)
 
 int main(int argc, char* argv[]) {
+#ifdef ENABLE_RUN_AS_NODE
   if (IsEnvSet(kRunAsNode)) {
     base::i18n::InitializeICU();
     base::AtExitManager atexit_manager;
     return atom::NodeMain(argc, argv);
   }
+#endif
 
   atom::AtomMainDelegate delegate;
   content::ContentMainParams params(&delegate);
@@ -163,9 +175,11 @@ int main(int argc, char* argv[]) {
 #else  // defined(OS_LINUX)
 
 int main(int argc, char* argv[]) {
+#ifdef ENABLE_RUN_AS_NODE
   if (IsEnvSet(kRunAsNode)) {
     return AtomInitializeICUandStartNode(argc, argv);
   }
+#endif
 
   return AtomMain(argc, argv);
 }

--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#ifdef ENABLE_RUN_AS_NODE
+
 #include "atom/app/node_main.h"
 
 #include "atom/app/uv_task_runner.h"
@@ -107,3 +109,5 @@ int NodeMain(int argc, char *argv[]) {
 }
 
 }  // namespace atom
+
+#endif  // ENABLE_RUN_AS_NODE

--- a/atom/app/node_main.h
+++ b/atom/app/node_main.h
@@ -5,10 +5,14 @@
 #ifndef ATOM_APP_NODE_MAIN_H_
 #define ATOM_APP_NODE_MAIN_H_
 
+#ifdef ENABLE_RUN_AS_NODE
+
 namespace atom {
 
 int NodeMain(int argc, char *argv[]);
 
 }  // namespace atom
+
+#endif  // ENABLE_RUN_AS_NODE
 
 #endif  // ATOM_APP_NODE_MAIN_H_

--- a/electron.gyp
+++ b/electron.gyp
@@ -28,6 +28,11 @@
           'ENABLE_OSR',
         ],
       }],  # enable_osr==1
+      ['enable_run_as_node', {
+        'defines': [
+          'ENABLE_RUN_AS_NODE',
+        ],
+      }],  # enable_run_as_node
     ],
   },
   'targets': [

--- a/features.gypi
+++ b/features.gypi
@@ -3,7 +3,9 @@
   'variables': {
     'variables': {
       'enable_osr%': 1,
+      'enable_run_as_node%': 1,
     },
     'enable_osr%': '<(enable_osr)',
+    'enable_run_as_node%': '<(enable_run_as_node)',
   },
 }

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -101,8 +101,6 @@
       'atom/app/atom_main_delegate_mac.mm',
       'atom/app/command_line_args.cc',
       'atom/app/command_line_args.h',
-      'atom/app/node_main.cc',
-      'atom/app/node_main.h',
       'atom/app/uv_task_runner.cc',
       'atom/app/uv_task_runner.h',
       'atom/browser/api/atom_api_app.cc',
@@ -735,6 +733,12 @@
           'atom/browser/osr/osr_view_proxy.h',
         ],
       }],  # enable_osr==1
+      ['enable_run_as_node', {
+        'lib_sources': [
+          'atom/app/node_main.cc',
+          'atom/app/node_main.h',
+        ],
+      }],  # enable_run_as_node
     ],
   },
 }


### PR DESCRIPTION
The run-as-node mode may not be generally useful for all apps. This puts it behind a build flag. By default it remains **enabled**.