### PR TITLE
Add LICENSE to npm publish

### DIFF
--- a/script/publish-to-npm.js
+++ b/script/publish-to-npm.js
@@ -21,7 +21,8 @@ const files = [
   'index.js',
   'install.js',
   'package.json',
-  'README.md'
+  'README.md',
+  'LICENSE'
 ]
 
 const jsonFields = [
@@ -49,9 +50,10 @@ new Promise((resolve, reject) => {
   tempDir = dirPath
   // copy files from `/npm` to temp directory
   files.forEach((name) => {
+    const noThirdSegment = name === 'README.md' || 'LICENSE'
     fs.writeFileSync(
       path.join(tempDir, name),
-      fs.readFileSync(path.join(__dirname, '..', name === 'README.md' ? '' : 'npm', name))
+      fs.readFileSync(path.join(__dirname, '..', noThirdSegment ? '' : 'npm', name))
     )
   })
   // copy from root package.json to temp/package.json


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/11703 by adding the` LICENSE` to npm when a new version is published. 

/cc @jkleinsc 