### PR TITLE
Remove WS_EX_COMPOSITED style from window (1-8-x)

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -298,9 +298,6 @@ NativeWindowViews::NativeWindowViews(
   }
 
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
-  // Window without thick frame has to have WS_EX_COMPOSITED style.
-  if (!thick_frame_)
-    ex_style |= WS_EX_COMPOSITED;
   if (window_type == "toolbar")
     ex_style |= WS_EX_TOOLWINDOW;
   ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);


### PR DESCRIPTION
Fixes #10678 on 1.8.x, see sister PR #11704