### PR TITLE
Implement App-Scoped Security scoped bookmarks

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1262,6 +1262,10 @@ void App::BuildPrototype(
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
       .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
       #endif
+      #if defined(MAS_BUILD)
+      .SetMethod("startAccessingSecurityScopedResource",
+                 &App::StartAccessingSecurityScopedResource)
+      #endif
       .SetMethod("getAppMemoryInfo", &App::GetAppMetrics);
 }
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -209,6 +209,10 @@ class App : public AtomBrowserClient::Delegate,
   bool MoveToApplicationsFolder(mate::Arguments* args);
   bool IsInApplicationsFolder();
 #endif
+#if defined(MAS_BUILD)
+  base::Callback<void()> StartAccessingSecurityScopedResource(
+    mate::Arguments* args);
+#endif
 
 #if defined(OS_WIN)
   // Get the current Jump List settings.

--- a/atom/browser/api/atom_api_app_mas.mm
+++ b/atom/browser/api/atom_api_app_mas.mm
@@ -1,0 +1,59 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/api/atom_api_app.h"
+
+#import <Cocoa/Cocoa.h>
+
+#include "base/strings/sys_string_conversions.h"
+
+namespace atom {
+
+namespace api {
+
+// Callback passed to js which will stop accessing the given bookmark.
+void OnStopAccessingSecurityScopedResource(NSURL* bookmarkUrl) {
+  [bookmarkUrl stopAccessingSecurityScopedResource];
+  [bookmarkUrl release];
+}
+
+// Get base64 encoded NSData, create a bookmark for it and start accessing it.
+base::Callback<void ()> App::StartAccessingSecurityScopedResource(mate::Arguments* args) {
+  std::string data;
+  args->GetNext(&data);
+  NSString *base64str = base::SysUTF8ToNSString(data);
+  NSData *bookmarkData = [[NSData alloc] initWithBase64EncodedString: base64str options: 0];
+
+  // Create bookmarkUrl from NSData.
+  BOOL isStale = false;
+  NSError *error = nil;
+  NSURL *bookmarkUrl = [NSURL URLByResolvingBookmarkData: bookmarkData
+                                                 options: NSURLBookmarkResolutionWithSecurityScope
+                                           relativeToURL: nil
+                                     bookmarkDataIsStale: &isStale
+                                                   error: &error];
+
+  if (error != nil) {
+    NSString *err = [NSString stringWithFormat: @"NSError: %@ %@", error, [error userInfo]];
+    args->ThrowError(base::SysNSStringToUTF8(err));
+  }
+
+  if (isStale) {
+    args->ThrowError("bookmarkDataIsStale - try recreating the bookmark");
+  }
+
+  if (error == nil && isStale == false) {
+    [bookmarkUrl startAccessingSecurityScopedResource];
+  }
+
+  // Stop the NSURL from being GC'd.
+  [bookmarkUrl retain];
+
+  // Return a js callback which will close the bookmark.
+  return base::Bind(&OnStopAccessingSecurityScopedResource, bookmarkUrl);
+}
+
+} // namespace atom
+
+} // namespace api

--- a/atom/browser/api/atom_api_dialog.cc
+++ b/atom/browser/api/atom_api_dialog.cc
@@ -54,6 +54,9 @@ struct Converter<file_dialog::DialogSettings> {
     dict.Get("filters", &(out->filters));
     dict.Get("properties", &(out->properties));
     dict.Get("showsTagField", &(out->shows_tag_field));
+    #if defined(MAS_BUILD)
+    dict.Get("securityScopedBookmarks", &(out->security_scoped_bookmarks));
+    #endif
     return true;
   }
 };

--- a/atom/browser/ui/file_dialog.h
+++ b/atom/browser/ui/file_dialog.h
@@ -33,7 +33,7 @@ enum FileDialogProperty {
   FILE_DIALOG_TREAT_PACKAGE_APP_AS_DIRECTORY = 1 << 7,
 };
 
-#if defined(OS_MACOSX)
+#if defined(MAS_BUILD)
   typedef base::Callback<void(
       bool result,
       const std::vector<base::FilePath>& paths,

--- a/atom/browser/ui/file_dialog.h
+++ b/atom/browser/ui/file_dialog.h
@@ -33,11 +33,25 @@ enum FileDialogProperty {
   FILE_DIALOG_TREAT_PACKAGE_APP_AS_DIRECTORY = 1 << 7,
 };
 
-typedef base::Callback<void(
-    bool result, const std::vector<base::FilePath>& paths)> OpenDialogCallback;
+#if defined(OS_MACOSX)
+  typedef base::Callback<void(
+      bool result,
+      const std::vector<base::FilePath>& paths,
+      const std::vector<std::string>& bookmarkData)> OpenDialogCallback;
 
-typedef base::Callback<void(
-    bool result, const base::FilePath& path)> SaveDialogCallback;
+  typedef base::Callback<void(
+      bool result,
+      const base::FilePath& path,
+      const std::string& bookmarkData)> SaveDialogCallback;
+#else
+  typedef base::Callback<void(
+      bool result,
+      const std::vector<base::FilePath>& paths)> OpenDialogCallback;
+
+  typedef base::Callback<void(
+      bool result,
+      const base::FilePath& path)> SaveDialogCallback;
+#endif
 
 struct DialogSettings {
   atom::NativeWindow* parent_window = nullptr;
@@ -50,6 +64,7 @@ struct DialogSettings {
   int properties = 0;
   bool shows_tag_field = true;
   bool force_detached = false;
+  bool security_scoped_bookmarks = false;
 };
 
 bool ShowOpenDialog(const DialogSettings& settings,

--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -53,7 +53,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
 
   ~FileSelectHelper() override {}
 
-#if defined(OS_MACOSX)
+#if defined(MAS_BUILD)
   void OnOpenDialogDone(bool result, const std::vector<base::FilePath>& paths,
                         const std::vector<std::string>& bookmarks)
 #else
@@ -79,7 +79,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
     OnFilesSelected(file_info);
   }
 
-#if defined(OS_MACOSX)
+#if defined(MAS_BUILD)
   void OnSaveDialogDone(bool result, const base::FilePath& path,
                         const std::string& bookmark)
 #else

--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -53,7 +53,13 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
 
   ~FileSelectHelper() override {}
 
-  void OnOpenDialogDone(bool result, const std::vector<base::FilePath>& paths) {
+#if defined(OS_MACOSX)
+  void OnOpenDialogDone(bool result, const std::vector<base::FilePath>& paths,
+                        const std::vector<std::string>& bookmarks)
+#else
+  void OnOpenDialogDone(bool result, const std::vector<base::FilePath>& paths)
+#endif
+  {
     std::vector<content::FileChooserFileInfo> file_info;
     if (result) {
       for (auto& path : paths) {
@@ -73,7 +79,13 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
     OnFilesSelected(file_info);
   }
 
-  void OnSaveDialogDone(bool result, const base::FilePath& path) {
+#if defined(OS_MACOSX)
+  void OnSaveDialogDone(bool result, const base::FilePath& path,
+                        const std::string& bookmark)
+#else
+  void OnSaveDialogDone(bool result, const base::FilePath& path)
+#endif
+  {
     std::vector<content::FileChooserFileInfo> file_info;
     if (result) {
       content::FileChooserFileInfo info;

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -970,6 +970,23 @@ details. Disabled by default.
 Set the about panel options. This will override the values defined in the app's
 `.plist` file. See the [Apple docs][about-panel-options] for more details.
 
+### `app.startAccessingSecurityScopedResource(bookmarkData)` _macOS (mas)_
+
+* `bookmarkData` String - The base64 encoded security scoped bookmark data returned by the `dialog.showOpenDialog` or `dialog.showSaveDialog` methods.
+
+Returns `Function` - This function **must** be called once you have finished accessing the security scoped file. If you do not remember to stop accessing the bookmark, [kernel resources will be leaked](https://developer.apple.com/reference/foundation/nsurl/1417051-startaccessingsecurityscopedreso?language=objc) and your app will lose its ability to reach outside the sandbox completely, until your app is restarted.
+
+```js
+// Start accessing the file.
+const stopAccessingSecurityScopedResource = app.startAccessingSecurityScopedResource(data)
+// You can now access the file outside of the sandbox 🎉
+
+// Remember to stop accessing the file once you've finished with it.
+stopAccessingSecurityScopedResource()
+```
+
+Start accessing a security scoped resource. With this method electron applications that are packaged for the Mac App Store may reach outside their sandbox to access files chosen by the user. See [Apple's documentation](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) for a description of how this system works.
+
 ### `app.commandLine.appendSwitch(switch[, value])`
 
 * `switch` String - A command-line switch

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -50,8 +50,10 @@ The `dialog` module has the following methods:
       as a directory instead of a file.
   * `message` String (optional) _macOS_ - Message to display above input
     boxes.
+  * `securityScopedBookmarks` _masOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
 * `callback` Function (optional)
   * `filePaths` String[] - An array of file paths chosen by the user
+  * `bookmarks` String[] _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated.
 
 Returns `String[]`, an array of file paths chosen by the user,
 if the callback is provided it returns `undefined`.
@@ -99,8 +101,10 @@ shown.
     displayed in front of the filename text field.
   * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
     defaults to `true`.
+  * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
 * `callback` Function (optional)
   * `filename` String
+  * `bookmark` String _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present.
 
 Returns `String`, the path of the file chosen by the user,
 if a callback is provided it returns `undefined`.

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -739,6 +739,11 @@
           'atom/app/node_main.h',
         ],
       }],  # enable_run_as_node
+      ['mas_build==1', {
+        'lib_sources': [
+          'atom/browser/api/atom_api_app_mas.mm',
+        ],
+      }],  # mas_build==1
     ],
   },
 }

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -83,7 +83,7 @@ module.exports = {
       }
     }
 
-    let {buttonLabel, defaultPath, filters, properties, title, message} = options
+    let {buttonLabel, defaultPath, filters, properties, title, message, securityScopedBookmarks = false} = options
 
     if (properties == null) {
       properties = ['openFile']
@@ -126,10 +126,10 @@ module.exports = {
       throw new TypeError('Message must be a string')
     }
 
-    const wrappedCallback = typeof callback === 'function' ? function (success, result) {
-      return callback(success ? result : void 0)
+    const wrappedCallback = typeof callback === 'function' ? function (success, result, bookmarkData) {
+      return success ? callback(result, bookmarkData) : callback()
     } : null
-    const settings = {title, buttonLabel, defaultPath, filters, message, window}
+    const settings = {title, buttonLabel, defaultPath, filters, message, securityScopedBookmarks, window}
     settings.properties = dialogProperties
     return binding.showOpenDialog(settings, wrappedCallback)
   },
@@ -145,7 +145,7 @@ module.exports = {
       }
     }
 
-    let {buttonLabel, defaultPath, filters, title, message, nameFieldLabel, showsTagField} = options
+    let {buttonLabel, defaultPath, filters, title, message, securityScopedBookmarks = false, nameFieldLabel, showsTagField} = options
 
     if (title == null) {
       title = ''
@@ -185,10 +185,10 @@ module.exports = {
       showsTagField = true
     }
 
-    const wrappedCallback = typeof callback === 'function' ? function (success, result) {
-      return callback(success ? result : void 0)
+    const wrappedCallback = typeof callback === 'function' ? function (success, result, bookmarkData) {
+      return success ? callback(result, bookmarkData) : callback()
     } : null
-    const settings = {title, buttonLabel, defaultPath, filters, message, nameFieldLabel, showsTagField, window}
+    const settings = {title, buttonLabel, defaultPath, filters, message, securityScopedBookmarks, nameFieldLabel, showsTagField, window}
     return binding.showSaveDialog(settings, wrappedCallback)
   },
 


### PR DESCRIPTION
Fixes #10950

This PR implements [app-scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) for `mas` builds of electron.

Basically it allows electron applications that are signed and distributed via the Mac App Store to have access to files across restarts.

### Before:

```js
// Choose a file outside mas sandbox.
let filepath;
dialog.showOpenDialog(null, {}, (filepaths) => {
  // We can access the file since the user chose it with the native panel.
  filepath = filepaths[0];
  fs.readFileSync(filepath); // Works 🎉
});

// ... restart app ...

// User can no longer access file since the app was restarted.
fs.readFileSync(filepath); // Error EPERM 👎
```

### After:

```js
let filepath;
let bookmark;
dialog.showOpenDialog(null, {}, (filepaths, bookmarks) => {
  // We can access the file since the user chose it with the native panel.
  filepath = filepaths[0];
  bookmark = bookmarks[0];
  fs.readFileSync(filepath); // Works 🎉
});

// ... restart app ...

// User can use the bookmark data given to re-open the file outside the sandbox.
const stopAccessingSecurityScopedResource = app.startAccessingSecurityScopedResource(bookmark);
fs.readFileSync(filepath); // Works 🎉
stopAccessingSecurityScopedResource();
```

This should close #4637.

## Explanation

> Note that in order to test this, one must build electron for `mas` and the app must be codesigned with the entitlements `"com.apple.security.files.bookmarks.app-scope"` and `"com.apple.security.files.user-selected.read-write"` or `"com.apple.security.files.user-selected.read"`.

In order to access files outside the macOS sandbox, one must use the `PowerBox` API - which basically means one must use `NSOpenPanel` and/or `NSSavePanel` which are transparently swapped out with `PowerBox` calls when an application is sandboxed.

The way in which we can persist access to these files outside the sandbox is by using a special call on the `NSURL` instances returned by the `PowerBox` API (namely `-bookmarkDataWithOptions`). This will give us an `NSData` instance which is a special block of data (call it a "bookmark") that will allow us to access the file again when the app is re-sandboxed (after a restart).

After a restart, the application's sandbox is reset, and as such no longer has any access to files outside of the sandbox. The way in which we can use a bookmark, is to re-create an `NSURL` from it (via the `-URLByResolvingBookmarkData` initialiser) and use that `NSURL` to allow read/write access from the file.

## Changes

This PR modifies electron's `dialog` API so that these bookmarks are returned as base64 encoded strings and the user may choose where to store them. It also provides a `startAccessingSecurityScopedResource` method on `app` which will create an `NSData` instance from the base64 encoded string, and then in turn use that to create an `NSURL` which is used to open the sandbox temporarily to that file.

After the user has read/written to the file, they must call the `stopAccessingSecurityScopedResource` function (which is returned from `app.startAccessingSecurityScopedResource` in order to close the bookmark which had temporarily opened the sandbox. If they continually fail to close opened bookmarks then macOS will enforce a stricter sandbox on the application until it has restarted (basically the app will no longer be able to use these bookmarks, etc).

Things to note:

- To enable bookmarks, provide `{ securityScopedBookmarks: true }` in the `dialog` options
- The callback to `showOpenDialog` will now return both the `filenames` array and an added `bookmarks` array
    - The `bookmarks` array will be empty if the app is not bundled for `mas`
    - If there was an error obtaining the bookmark, an empty string will be returned `""`
        - Errors may be because of signing issues, incorrect entitlements, etc
    - For `showSaveDialog` the `filename` is returned along with a `bookmark` string
- In the case of `dialog.showSaveDialog` if the chosen file didn't exist then a blank one is created since a bookmark cannot be created for a non-existent file.