### PR TITLE
Improve OSR API (master)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1652,12 +1652,8 @@ void WebContents::StartPainting() {
     return;
 
 #if defined(ENABLE_OSR)
-  const auto* wc_impl = web_contents_impl();
-  if (!wc_impl)
-    return;
-
-  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
-      wc_impl->GetView());
+  const auto* wc_impl = static_cast<content::WebContentsImpl*>(web_contents());
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(wc_impl->GetView());
   if (osr_wcv)
     osr_wcv->SetPainting(true);
 #endif
@@ -1668,12 +1664,8 @@ void WebContents::StopPainting() {
     return;
 
 #if defined(ENABLE_OSR)
-  const auto* wc_impl = web_contents_impl();
-  if (!wc_impl)
-    return;
-
-  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
-      wc_impl->GetView());
+  const auto* wc_impl = static_cast<content::WebContentsImpl*>(web_contents());
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(wc_impl->GetView());
   if (osr_wcv)
     osr_wcv->SetPainting(false);
 #endif
@@ -1684,12 +1676,9 @@ bool WebContents::IsPainting() const {
     return false;
 
 #if defined(ENABLE_OSR)
-  const auto* wc_impl = web_contents_impl();
-  if (!wc_impl)
-    return false;
+  const auto* wc_impl = static_cast<content::WebContentsImpl*>(web_contents());
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(wc_impl->GetView());
 
-  const auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
-      wc_impl->GetView());
   return osr_wcv && osr_wcv->IsPainting();
 #else
   return false;
@@ -1701,12 +1690,9 @@ void WebContents::SetFrameRate(int frame_rate) {
     return;
 
 #if defined(ENABLE_OSR)
-  const auto* wc_impl = web_contents_impl();
-  if (!wc_impl)
-    return;
+  const auto* wc_impl = static_cast<content::WebContentsImpl*>(web_contents());
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(wc_impl->GetView());
 
-  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
-      wc_impl->GetView());
   if (osr_wcv)
     osr_wcv->SetFrameRate(frame_rate);
 #endif
@@ -1717,12 +1703,9 @@ int WebContents::GetFrameRate() const {
     return 0;
 
 #if defined(ENABLE_OSR)
-  const auto* wc_impl = web_contents_impl();
-  if (!wc_impl)
-    return 0;
+  const auto* wc_impl = static_cast<content::WebContentsImpl*>(web_contents());
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(wc_impl->GetView());
 
-  const auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
-      wc_impl->GetView());
   return osr_wcv ? osr_wcv->GetFrameRate() : 0;
 #else
   return 0;

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -378,8 +378,8 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
     options.Get("transparent", &transparent);
 
     content::WebContents::CreateParams params(session->browser_context());
-    auto* view = new OffScreenWebContentsView(
-        transparent, base::Bind(&WebContents::OnPaint, base::Unretained(this)));
+    auto* view = new OffScreenWebContentsView(transparent,
+        base::Bind(&WebContents::OnPaint, base::Unretained(this)));
     params.view = view;
     params.delegate_view = view;
 
@@ -1652,10 +1652,14 @@ void WebContents::StartPainting() {
     return;
 
 #if defined(ENABLE_OSR)
-  auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-      web_contents()->GetRenderWidgetHostView());
-  if (osr_rwhv)
-    osr_rwhv->SetPainting(true);
+  const auto* wc_impl = web_contents_impl();
+  if (!wc_impl)
+    return;
+
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
+      wc_impl->GetView());
+  if (osr_wcv)
+    osr_wcv->SetPainting(true);
 #endif
 }
 
@@ -1664,10 +1668,14 @@ void WebContents::StopPainting() {
     return;
 
 #if defined(ENABLE_OSR)
-  auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-      web_contents()->GetRenderWidgetHostView());
-  if (osr_rwhv)
-    osr_rwhv->SetPainting(false);
+  const auto* wc_impl = web_contents_impl();
+  if (!wc_impl)
+    return;
+
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
+      wc_impl->GetView());
+  if (osr_wcv)
+    osr_wcv->SetPainting(false);
 #endif
 }
 
@@ -1676,9 +1684,13 @@ bool WebContents::IsPainting() const {
     return false;
 
 #if defined(ENABLE_OSR)
-  const auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-      web_contents()->GetRenderWidgetHostView());
-  return osr_rwhv && osr_rwhv->IsPainting();
+  const auto* wc_impl = web_contents_impl();
+  if (!wc_impl)
+    return false;
+
+  const auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
+      wc_impl->GetView());
+  return osr_wcv && osr_wcv->IsPainting();
 #else
   return false;
 #endif
@@ -1689,10 +1701,14 @@ void WebContents::SetFrameRate(int frame_rate) {
     return;
 
 #if defined(ENABLE_OSR)
-  auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-      web_contents()->GetRenderWidgetHostView());
-  if (osr_rwhv)
-    osr_rwhv->SetFrameRate(frame_rate);
+  const auto* wc_impl = web_contents_impl();
+  if (!wc_impl)
+    return;
+
+  auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
+      wc_impl->GetView());
+  if (osr_wcv)
+    osr_wcv->SetFrameRate(frame_rate);
 #endif
 }
 
@@ -1701,9 +1717,13 @@ int WebContents::GetFrameRate() const {
     return 0;
 
 #if defined(ENABLE_OSR)
-  const auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-      web_contents()->GetRenderWidgetHostView());
-  return osr_rwhv ? osr_rwhv->GetFrameRate() : 0;
+  const auto* wc_impl = web_contents_impl();
+  if (!wc_impl)
+    return 0;
+
+  const auto* osr_wcv = static_cast<OffScreenWebContentsView*>(
+      wc_impl->GetView());
+  return osr_wcv ? osr_wcv->GetFrameRate() : 0;
 #else
   return 0;
 #endif

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -13,6 +13,7 @@
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/common_web_contents_delegate.h"
 #include "atom/browser/ui/autofill_popup.h"
+#include "content/browser/web_contents/web_contents_impl.h"
 #include "content/common/cursors/webcursor.h"
 #include "content/public/browser/keyboard_event_processing_result.h"
 #include "content/public/browser/web_contents.h"
@@ -371,6 +372,10 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   uint32_t GetNextRequestId() {
     return ++request_id_;
+  }
+
+  content::WebContentsImpl* web_contents_impl() const {
+    return static_cast<content::WebContentsImpl*>(web_contents());
   }
 
   // Called when we receive a CursorChange message from chromium.

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -13,7 +13,6 @@
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/common_web_contents_delegate.h"
 #include "atom/browser/ui/autofill_popup.h"
-#include "content/browser/web_contents/web_contents_impl.h"
 #include "content/common/cursors/webcursor.h"
 #include "content/public/browser/keyboard_event_processing_result.h"
 #include "content/public/browser/web_contents.h"
@@ -372,10 +371,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   uint32_t GetNextRequestId() {
     return ++request_id_;
-  }
-
-  content::WebContentsImpl* web_contents_impl() const {
-    return static_cast<content::WebContentsImpl*>(web_contents());
   }
 
   // Called when we receive a CursorChange message from chromium.

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -124,7 +124,7 @@ class AtomCopyFrameGenerator {
   }
 
   void GenerateCopyFrame(const gfx::Rect& damage_rect) {
-    if (!view_->render_widget_host())
+    if (!view_->render_widget_host() || !view_->IsPainting())
       return;
 
     std::unique_ptr<cc::CopyOutputRequest> request =

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -303,7 +303,7 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
       new ui::Compositor(context_factory_private->AllocateFrameSinkId(),
         content::GetContextFactory(), context_factory_private,
         base::ThreadTaskRunnerHandle::Get(), false));
-  compositor_->SetAcceleratedWidget(native_window_->GetAcceleratedWidget());
+  compositor_->SetAcceleratedWidget(gfx::kNullAcceleratedWidget);
   compositor_->SetRootLayer(root_layer_.get());
 #endif
   GetCompositor()->SetDelegate(this);

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -1204,7 +1204,7 @@ void OffScreenRenderWidgetHostView::SetupFrameRate(bool force) {
 
   frame_rate_threshold_us_ = 1000000 / frame_rate_;
 
-  GetCompositor()->vsync_manager()->SetAuthoritativeVSyncInterval(
+  GetCompositor()->SetAuthoritativeVSyncInterval(
       base::TimeDelta::FromMicroseconds(frame_rate_threshold_us_));
 
   if (copy_frame_generator_.get()) {

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -279,6 +279,7 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
       popup_position_(gfx::Rect()),
       hold_resize_(false),
       pending_resize_(false),
+      paint_callback_running_(false),
       renderer_compositor_frame_sink_(nullptr),
       background_color_(SkColor()),
       weak_ptr_factory_(this) {
@@ -999,7 +1000,9 @@ void OffScreenRenderWidgetHostView::OnPaint(
     }
 
     damage.Intersect(GetViewBounds());
+    paint_callback_running_ = true;
     callback_.Run(damage, bitmap);
+    paint_callback_running_ = false;
 
     for (size_t i = 0; i < damages.size(); i++) {
       CopyBitmapTo(bitmap, originals[i], damages[i]);
@@ -1147,7 +1150,7 @@ void OffScreenRenderWidgetHostView::SetPainting(bool painting) {
   painting_ = painting;
 
   if (software_output_device_) {
-    software_output_device_->SetActive(painting_, true);
+    software_output_device_->SetActive(painting_, !paint_callback_running_);
   }
 }
 

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -1167,8 +1167,8 @@ void OffScreenRenderWidgetHostView::SetFrameRate(int frame_rate) {
   } else {
     if (frame_rate <= 0)
       frame_rate = 1;
-    if (frame_rate > 60)
-      frame_rate = 60;
+    if (frame_rate > 240)
+      frame_rate = 240;
 
     frame_rate_ = frame_rate;
   }

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -255,6 +255,8 @@ class AtomBeginFrameTimer : public cc::DelayBasedTimeSourceClient {
 
 OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
     bool transparent,
+    bool painting,
+    int frame_rate,
     const OnPaintCallback& callback,
     content::RenderWidgetHost* host,
     OffScreenRenderWidgetHostView* parent_host_view,
@@ -268,12 +270,12 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
       transparent_(transparent),
       callback_(callback),
       parent_callback_(nullptr),
-      frame_rate_(60),
+      frame_rate_(frame_rate),
       frame_rate_threshold_us_(0),
       last_time_(base::Time::Now()),
       scale_factor_(kDefaultScaleFactor),
       size_(native_window->GetSize()),
-      painting_(true),
+      painting_(painting),
       is_showing_(!render_widget_host_->is_hidden()),
       is_destroyed_(false),
       popup_position_(gfx::Rect()),
@@ -738,6 +740,8 @@ content::RenderWidgetHostViewBase*
 
   return new OffScreenRenderWidgetHostView(
       transparent_,
+      true,
+      embedder_host_view->GetFrameRate(),
       callback_,
       render_widget_host,
       embedder_host_view,
@@ -929,7 +933,7 @@ bool OffScreenRenderWidgetHostView::IsAutoResizeEnabled() const {
 
 void OffScreenRenderWidgetHostView::SetNeedsBeginFrames(
     bool needs_begin_frames) {
-  SetupFrameRate(false);
+  SetupFrameRate(true);
 
   begin_frame_timer_->SetActive(needs_begin_frames);
 
@@ -1173,10 +1177,10 @@ void OffScreenRenderWidgetHostView::SetFrameRate(int frame_rate) {
     frame_rate_ = frame_rate;
   }
 
+  SetupFrameRate(true);
+
   for (auto guest_host_view : guest_host_views_)
     guest_host_view->SetFrameRate(frame_rate);
-
-  SetupFrameRate(true);
 }
 
 int OffScreenRenderWidgetHostView::GetFrameRate() const {

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -315,6 +315,8 @@ class OffScreenRenderWidgetHostView
   bool hold_resize_;
   bool pending_resize_;
 
+  bool paint_callback_running_;
+
   std::unique_ptr<ui::Layer> root_layer_;
   std::unique_ptr<ui::Compositor> compositor_;
   std::unique_ptr<content::DelegatedFrameHost> delegated_frame_host_;

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -74,6 +74,8 @@ class OffScreenRenderWidgetHostView
       public OffscreenViewProxyObserver {
  public:
   OffScreenRenderWidgetHostView(bool transparent,
+                                bool painting,
+                                int frame_rate,
                                 const OnPaintCallback& callback,
                                 content::RenderWidgetHost* render_widget_host,
                                 OffScreenRenderWidgetHostView* parent_host_view,

--- a/atom/browser/osr/osr_web_contents_view.cc
+++ b/atom/browser/osr/osr_web_contents_view.cc
@@ -15,6 +15,8 @@ namespace atom {
 OffScreenWebContentsView::OffScreenWebContentsView(
     bool transparent, const OnPaintCallback& callback)
     : transparent_(transparent),
+      painting_(true),
+      frame_rate_(60),
       callback_(callback),
       web_contents_(nullptr) {
 #if defined(OS_MACOSX)
@@ -103,6 +105,8 @@ content::RenderWidgetHostViewBase*
   auto relay = NativeWindowRelay::FromWebContents(web_contents_);
   return new OffScreenRenderWidgetHostView(
       transparent_,
+      painting_,
+      GetFrameRate(),
       callback_,
       render_widget_host,
       nullptr,
@@ -125,6 +129,8 @@ content::RenderWidgetHostViewBase*
 
   return new OffScreenRenderWidgetHostView(
       transparent_,
+      true,
+      view->GetFrameRate(),
       callback_,
       render_widget_host,
       view,
@@ -200,6 +206,42 @@ void OffScreenWebContentsView::StartDragging(
 
 void OffScreenWebContentsView::UpdateDragCursor(
     blink::WebDragOperation operation) {
+}
+
+void OffScreenWebContentsView::SetPainting(bool painting) {
+  auto* view = GetView();
+  if (view != nullptr) {
+    view->SetPainting(painting);
+  } else {
+    painting_ = painting;
+  }
+}
+
+bool OffScreenWebContentsView::IsPainting() const {
+  auto* view = GetView();
+  if (view != nullptr) {
+    return view->IsPainting();
+  } else {
+    return painting_;
+  }
+}
+
+void OffScreenWebContentsView::SetFrameRate(int frame_rate) {
+  auto* view = GetView();
+  if (view != nullptr) {
+    view->SetFrameRate(frame_rate);
+  } else {
+    frame_rate_ = frame_rate;
+  }
+}
+
+int OffScreenWebContentsView::GetFrameRate() const {
+  auto* view = GetView();
+  if (view != nullptr) {
+    return view->GetFrameRate();
+  } else {
+    return frame_rate_;
+  }
 }
 
 OffScreenRenderWidgetHostView* OffScreenWebContentsView::GetView() const {

--- a/atom/browser/osr/osr_web_contents_view.h
+++ b/atom/browser/osr/osr_web_contents_view.h
@@ -69,6 +69,11 @@ class OffScreenWebContentsView : public content::WebContentsView,
                      content::RenderWidgetHostImpl* source_rwh) override;
   void UpdateDragCursor(blink::WebDragOperation operation) override;
 
+  void SetPainting(bool painting);
+  bool IsPainting() const;
+  void SetFrameRate(int frame_rate);
+  int GetFrameRate() const;
+
  private:
 #if defined(OS_MACOSX)
   void PlatformCreate();
@@ -78,6 +83,8 @@ class OffScreenWebContentsView : public content::WebContentsView,
   OffScreenRenderWidgetHostView* GetView() const;
 
   const bool transparent_;
+  bool painting_;
+  int frame_rate_;
   OnPaintCallback callback_;
 
   // Weak refs.


### PR DESCRIPTION
This PR addresses bugs that came up in #11715 and contains some other small improvements
 - Fixes `StopPainting` not working when using GPU OSR codepath (#11715)
 - Fixes a bug where calling `StartPainting` inside the `OnPaint` callback in GPU OSR mode would try to generate another frame, essentially calling the callback recursively (#11715)
 - Switches to the `nullAcceleratedWidget` to avoid showing the GPU rendered OSR surface on the dummy window
 - Raises the maximum frame rate to 240 to prepare for modern high refresh rate displays
 - Switches to calling `SetAuthoritativeVsyncInterval` on the `Compositor` instead of it's `vsync_manager`
 - Moves the OSR related API calls to the `OffscreenWebContentsView`, because that gets created with the `WebContents`, while the `OffscreenRenderWidgetHostView` is created a bit later. This allows calls to take effect even if they are made before the first `paint` event arrives.