### PR TITLE
feat(webframe): export set cache capacity interface

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -368,6 +368,15 @@ void WebFrame::ClearCache(v8::Isolate* isolate) {
     base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL);
 }
 
+void WebFrame::SetCacheCapacity(v8::Isolate* isolate, int capacity) {
+  if (capacity > 0) {
+    blink::WebCache::SetCapacity(capacity);
+  } else {
+    isolate->ThrowException(v8::Exception::TypeError(
+        mate::StringToV8(isolate, "Invalid cache capacity")));
+  }
+}
+
 // static
 void WebFrame::BuildPrototype(
     v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
@@ -408,6 +417,7 @@ void WebFrame::BuildPrototype(
                  &WebFrame::SetIsolatedWorldHumanReadableName)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
       .SetMethod("clearCache", &WebFrame::ClearCache)
+      .SetMethod("setCacheCapacity", &WebFrame::SetCacheCapacity)
       // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
       .SetMethod("setZoomLevelLimits", &WebFrame::SetVisualZoomLevelLimits);
 }

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -92,6 +92,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   // Resource related methods
   blink::WebCache::ResourceTypeStats GetResourceUsage(v8::Isolate* isolate);
   void ClearCache(v8::Isolate* isolate);
+  void SetCacheCapacity(v8::Isolate* isolate, int capacity);
 
   std::unique_ptr<SpellCheckClient> spell_check_client_;
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -221,4 +221,13 @@ in your app has occurred that makes you think your page is actually using less
 memory (i.e. you have navigated from a super heavy page to a mostly empty one,
 and intend to stay there).
 
+### `webFrame.setCacheCapacity(capacity)`
+
+* `capacity` Integer
+
+Set the capacity of resource cache for the renderer process in bytes
+
+Note if current cached resource size is larger than newly specified capacity, Electron
+will schedule to prune cached resources until it reaches below new capacity.
+
 [spellchecker]: https://github.com/atom/node-spellchecker

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -225,7 +225,7 @@ and intend to stay there).
 
 * `capacity` Integer
 
-Set the capacity of resource cache for the renderer process in bytes
+Attemp to set the capacity of resource cache for the renderer process in bytes
 
 Note if current cached resource size is larger than newly specified capacity, Electron
 will schedule to prune cached resources until it reaches below new capacity.

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -139,4 +139,10 @@ describe('webFrame module', function () {
       webFrame.setLayoutZoomLevelLimits(0, 25)
     })
   })
+
+  it('supports setting cache capacity', function () {
+    assert.doesNotThrow(function () {
+      webFrame.setCacheCapacity(1024)
+    })
+  })
 })


### PR DESCRIPTION
Reopening https://github.com/electron/electron/pull/11731, sorry that I've incorrectly rebased PR and it rewrotes huge commit history incorrectly - had close and reopened new one instead.

This PR exposes interface `WebCache::SetCapacity` to `webFrame`. 

Per chromium's description `Sets the capacities of the resource cache, evicting objects as necessary.`, it allows fine-grained control over to resource cache size for given web frame to enable more aggresive, or loosened cache eviction strategy.

Looking for issues I couldn't able to lookup if this is intentionally non-exposed interface to webFrame, if so feel freely close as needed.