### PR TITLE
CrashReport structure in docs does not match API output

### DIFF
--- a/docs/api/structures/crash-report.md
+++ b/docs/api/structures/crash-report.md
@@ -1,4 +1,4 @@
 # CrashReport Object
 
-* `date` String
-* `ID` Integer
+* `date` Date
+* `id` String


### PR DESCRIPTION
Electron 1.7

Docs:
```typescript
  interface CrashReport {
    date: string;
    ID: number;
  }
```
Actual output of `getLastCrashReport`:
```
{ 
  date: 2018-01-26T21:50:05.000Z,
  id: '989d0469-9eb7-4f70-ba58-3425bc6ffa3b' 
}
```