### PR TITLE
Add and document menu events

### DIFF
--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -153,6 +153,14 @@ bool Menu::IsVisibleAt(int index) const {
   return model_->IsVisibleAt(index);
 }
 
+void Menu::OnMenuWillClose() {
+  Emit("menu-will-close");
+}
+
+void Menu::OnMenuWillShow() {
+  Emit("menu-will-show");
+}
+
 // static
 void Menu::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::FunctionTemplate> prototype) {

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -23,9 +23,13 @@ Menu::Menu(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
     : model_(new AtomMenuModel(this)),
       parent_(nullptr) {
   InitWith(isolate, wrapper);
+  model_->AddObserver(this);
 }
 
 Menu::~Menu() {
+  if (model_) {
+    model_->RemoveObserver(this);
+  }
 }
 
 void Menu::AfterInit(v8::Isolate* isolate) {

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -60,6 +60,10 @@ class Menu : public mate::TrackableObject<Menu>,
   std::unique_ptr<AtomMenuModel> model_;
   Menu* parent_;
 
+  // Observable:
+  void OnMenuWillClose() override;
+  void OnMenuWillShow() override;
+
  private:
   void InsertItemAt(int index, int command_id, const base::string16& label);
   void InsertSeparatorAt(int index);

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -18,7 +18,8 @@ namespace atom {
 namespace api {
 
 class Menu : public mate::TrackableObject<Menu>,
-             public AtomMenuModel::Delegate {
+              public AtomMenuModel::Delegate,
+              public AtomMenuModel::Observer {
  public:
   static mate::WrappableBase* New(mate::Arguments* args);
 

--- a/atom/browser/ui/atom_menu_model.cc
+++ b/atom/browser/ui/atom_menu_model.cc
@@ -42,8 +42,16 @@ bool AtomMenuModel::GetAcceleratorAtWithParams(
 
 void AtomMenuModel::MenuWillClose() {
   ui::SimpleMenuModel::MenuWillClose();
-  for (Observer& observer : observers_)
-    observer.MenuWillClose();
+  for (Observer& observer : observers_) {
+    observer.OnMenuWillClose();
+  }
+}
+
+void AtomMenuModel::MenuWillShow() {
+  ui::SimpleMenuModel::MenuWillShow();
+  for (Observer& observer : observers_) {
+    observer.OnMenuWillShow();
+  }
 }
 
 AtomMenuModel* AtomMenuModel::GetSubmenuModelAt(int index) {

--- a/atom/browser/ui/atom_menu_model.h
+++ b/atom/browser/ui/atom_menu_model.h
@@ -36,8 +36,11 @@ class AtomMenuModel : public ui::SimpleMenuModel {
    public:
     virtual ~Observer() {}
 
+    // Notifies the menu will open.
+    virtual void OnMenuWillShow() {}
+
     // Notifies the menu has been closed.
-    virtual void MenuWillClose() {}
+    virtual void OnMenuWillClose() {}
   };
 
   explicit AtomMenuModel(Delegate* delegate);
@@ -54,6 +57,7 @@ class AtomMenuModel : public ui::SimpleMenuModel {
 
   // ui::SimpleMenuModel:
   void MenuWillClose() override;
+  void MenuWillShow() override;
 
   using SimpleMenuModel::GetSubmenuModelAt;
   AtomMenuModel* GetSubmenuModelAt(int index);

--- a/atom/browser/ui/tray_icon_cocoa.h
+++ b/atom/browser/ui/tray_icon_cocoa.h
@@ -35,7 +35,7 @@ class TrayIconCocoa : public TrayIcon,
 
  protected:
   // AtomMenuModel::Observer:
-  void MenuWillClose() override;
+  void OnMenuWillClose() override;
 
  private:
   // Atom custom view for NSStatusItem.

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -461,7 +461,7 @@ gfx::Rect TrayIconCocoa::GetBounds() {
   return bounds;
 }
 
-void TrayIconCocoa::MenuWillClose() {
+void TrayIconCocoa::OnMenuWillClose() {
   [status_item_view_ setNeedsDisplay:YES];
 }
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -120,7 +120,7 @@ Returns:
 
 * `event` Event
 
-Emitted when a popup is close either manually or with `menu.closePopup()`
+Emitted when a popup is closed either manually or with `menu.closePopup()`.
 
 ### Instance Properties
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -99,6 +99,29 @@ Returns `MenuItem` the item with the specified `id`
 
 Inserts the `menuItem` to the `pos` position of the menu.
 
+### Instance Events
+
+Objects created with `new Menu` emit the following events:
+
+**Note:** Some events are only available on specific operating systems and are
+labeled as such.
+
+#### Event: 'menu-will-show' _macOS_
+
+Returns:
+
+* `event` Event
+
+Emitted when `menu.popup()` is called.
+
+#### Event: 'menu-will-close' _macOS_
+
+Returns:
+
+* `event` Event
+
+Emitted when a popup is close either manually or with `menu.closePopup()`
+
 ### Instance Properties
 
 `menu` objects also have the following properties:

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -106,7 +106,7 @@ Objects created with `new Menu` emit the following events:
 **Note:** Some events are only available on specific operating systems and are
 labeled as such.
 
-#### Event: 'menu-will-show' _macOS_
+#### Event: 'menu-will-show'
 
 Returns:
 
@@ -114,7 +114,7 @@ Returns:
 
 Emitted when `menu.popup()` is called.
 
-#### Event: 'menu-will-close' _macOS_
+#### Event: 'menu-will-close'
 
 Returns:
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -261,7 +261,7 @@ describe('Menu module', () => {
     })
   })
 
-  describe.only('Menu.popup', () => {
+  describe('Menu.popup', () => {
     let w = null
     let menu
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -284,6 +284,17 @@ describe('Menu module', () => {
       return closeWindow(w).then(() => { w = null })
     })
 
+    it('should emit menu-will-show event', (done) => {
+      menu.popup(w)
+      menu.on('menu-will-show', () => { done() })
+    })
+
+    it('should emit menu-will-close event', (done) => {
+      menu.popup(w)
+      menu.closePopup()
+      menu.on('menu-will-close', () => { done() })
+    })
+
     it('returns immediately', () => {
       const { browserWindow, x, y } = menu.popup(w, {x: 100, y: 101})
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -261,7 +261,7 @@ describe('Menu module', () => {
     })
   })
 
-  describe('Menu.popup', () => {
+  describe.only('Menu.popup', () => {
     let w = null
     let menu
 
@@ -285,14 +285,14 @@ describe('Menu module', () => {
     })
 
     it('should emit menu-will-show event', (done) => {
-      menu.popup(w)
       menu.on('menu-will-show', () => { done() })
+      menu.popup(w)
     })
 
     it('should emit menu-will-close event', (done) => {
+      menu.on('menu-will-close', () => { done() })
       menu.popup(w)
       menu.closePopup()
-      menu.on('menu-will-close', () => { done() })
     })
 
     it('returns immediately', () => {


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/8999 by adding event emission for `menu-will-show` and `menu-will-close`.

To-Do:
- [x] document new menu events 
- [x] add (passing) specs

/cc @MarshallOfSound