### PR TITLE
Improvements to release process

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -164,7 +164,7 @@ This release is published to [npm](https://www.npmjs.com/package/electron) under
 1. Uncheck the `prerelease` checkbox if you're publishing a stable release; leave it checked for beta releases.
 1. Click 'Save draft'. **Do not click 'Publish release'!**
 1. Wait for all builds to pass before proceeding.
-1. You can run `npm run release --validateRelease` to verify that all of the
+1. You can run `npm run release -- --validateRelease` to verify that all of the
 required files have been created for the release.
 
 ## Merge temporary branch

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -199,7 +199,7 @@ function runRelease (targetBranch, options) {
 module.exports = runRelease
 
 if (require.main === module) {
-  const args = require('minimist')(process.argv.slice(2))
+  const args = require('minimist')(process.argv.slice(2), { boolean: 'ghRelease' })
   const targetBranch = args._[0]
   if (args._.length < 1) {
     console.log(`Trigger CI to build release builds of electron.


### PR DESCRIPTION
After running through the release process, there were a couple of issues that cropped up.  This PR adds the following:
1. Prompt user to verify version before version is created.
2. Fix validateRelease instructions and usage.
3. Fix ci-release-build so that you don't have to pass in --ghRelease=true; just --ghRelease will work.