### PR TITLE
Fix test BrowserWindow.addTabbedWindow()

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -718,7 +718,7 @@ describe('BrowserWindow module', () => {
 
       assert.equal(BrowserWindow.getAllWindows().length, 3) // Test window + w + tabbedWindow
 
-      closeWindow(tabbedWindow, {assertSingleWindow: false}).then(function () {
+      closeWindow(tabbedWindow, {assertSingleWindow: false}).then(() => {
         assert.equal(BrowserWindow.getAllWindows().length, 2) // Test window + w
         done()
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -703,8 +703,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  // FIXME(alexeykuzmin): Fails on Mac.
-  xdescribe('BrowserWindow.addTabbedWindow()', () => {
+  describe('BrowserWindow.addTabbedWindow()', () => {
     before(function () {
       if (process.platform !== 'darwin') {
         this.skip()
@@ -716,7 +715,13 @@ describe('BrowserWindow module', () => {
       assert.doesNotThrow(() => {
         w.addTabbedWindow(tabbedWindow)
       })
-      closeWindow(tabbedWindow).then(done)
+
+      assert.equal(BrowserWindow.getAllWindows().length, 3) // Test window + w + tabbedWindow
+
+      closeWindow(tabbedWindow, {assertSingleWindow: false}).then(function () {
+        assert.equal(BrowserWindow.getAllWindows().length, 2) // Test window + w
+        done()
+      })
     })
   })
 


### PR DESCRIPTION
Test was failing because close window was expecting a single window. Fixed and added additional asserts.