### PR TITLE
Case insensitive blacklist

### DIFF
--- a/atom/app/command_line_args.cc
+++ b/atom/app/command_line_args.cc
@@ -1388,8 +1388,8 @@ bool IsBlacklistedArg(const base::CommandLine::CharType* arg) {
     a += prefix_length;
     std::string switch_name =
         base::ToLowerASCII(base::StringPiece(a, strcspn(a, "=")));
-    return std::lower_bound(std::begin(kBlacklist), std::end(kBlacklist),
-                            switch_name);
+    return std::binary_search(std::begin(kBlacklist), std::end(kBlacklist),
+                              switch_name);
   }
 
   return false;

--- a/atom/app/command_line_args.cc
+++ b/atom/app/command_line_args.cc
@@ -1405,9 +1405,9 @@ bool CheckCommandLineArguments(int argc, base::CommandLine::CharType** argv) {
                           return base::StringPiece(a) < base::StringPiece(b);
                         }))
       << "The kBlacklist must be in sorted order";
-  DCHECK_NE(std::binary_search(std::begin(kBlacklist), std::end(kBlacklist),
-                      base::StringPiece("inspect"));
-      << "Do not forget to add Node command line flags to kBlacklist";
+  DCHECK(std::binary_search(std::begin(kBlacklist), std::end(kBlacklist),
+                            base::StringPiece("inspect")))
+      << "Remember to add Node command line flags to kBlacklist";
 
   const base::CommandLine::StringType dashdash(2, '-');
   bool block_blacklisted_args = false;

--- a/atom/app/command_line_args.cc
+++ b/atom/app/command_line_args.cc
@@ -1388,11 +1388,8 @@ bool IsBlacklistedArg(const base::CommandLine::CharType* arg) {
     a += prefix_length;
     std::string switch_name =
         base::ToLowerASCII(base::StringPiece(a, strcspn(a, "=")));
-    auto* iter = std::lower_bound(std::begin(kBlacklist), std::end(kBlacklist),
-                                  switch_name);
-    if (iter != std::end(kBlacklist) && switch_name == *iter) {
-      return true;
-    }
+    return std::lower_bound(std::begin(kBlacklist), std::end(kBlacklist),
+                            switch_name);
   }
 
   return false;
@@ -1408,9 +1405,8 @@ bool CheckCommandLineArguments(int argc, base::CommandLine::CharType** argv) {
                           return base::StringPiece(a) < base::StringPiece(b);
                         }))
       << "The kBlacklist must be in sorted order";
-  DCHECK_NE(std::find(std::begin(kBlacklist), std::end(kBlacklist),
-                      base::StringPiece("inspect")),
-            std::end(kBlacklist))
+  DCHECK_NE(std::binary_search(std::begin(kBlacklist), std::end(kBlacklist),
+                      base::StringPiece("inspect"));
       << "Do not forget to add Node command line flags to kBlacklist";
 
   const base::CommandLine::StringType dashdash(2, '-');

--- a/atom/app/command_line_args.cc
+++ b/atom/app/command_line_args.cc
@@ -38,24 +38,20 @@ bool IsUrlArg(const base::CommandLine::CharType* arg) {
   return false;
 }
 
-// The blacklist of command line switches, must be sorted.
-// Created with:
-//     find ./ -name "*switches.cc" \
-//       | xargs grep -P --no-filename "\"\S+\";" \
-//       | perl -pe 's|^.*?"(\S+)";|  "$1",|' \
-//       | sort | uniq
-// then manually insert following switches into the list:
-//     "inspect",
-//     "inspect-brk",
-// finally write a small piece of code to print out the sorted list since
-// the "sort" tool may use differnt rules from C++ STL.
-//     std::vector<std::string> sorted(std::begin(kBlacklist),
-//                                     std::end(kBlacklist));
-//     std::sort(sorted.begin(), sorted.end());
-//     FILE* f = fopen("testlist2", "w+");
-//     for (auto& i : sorted)
-//       fprintf(f, "\"%s\",\n", i.c_str());
-//     fclose(f);
+/*
+ * The blacklist of command line switches, must be sorted.
+ * Update the list by pasting the following command into bash
+ * in libchromiumcontent/src/:
+
+   (find ./ -name "*switches.cc" | \
+      xargs grep -P --no-filename "\"\S+\";" | \
+      perl -pe 's|^.*?"(\S+)";|  "$1",|'; \
+      echo '  "inspect",'; \
+      echo '  "inspect-brk",') | \
+    LANG=C sort | \
+    uniq > blacklist-switches.txt
+
+ */
 const char* kBlacklist[] = {
   "/prefetch:1",
   "/prefetch:2",

--- a/atom/app/command_line_args.cc
+++ b/atom/app/command_line_args.cc
@@ -1390,7 +1390,8 @@ bool IsBlacklistedArg(const base::CommandLine::CharType* arg) {
 
   if (prefix_length > 0) {
     a += prefix_length;
-    std::string switch_name(a, strcspn(a, "="));
+    std::string switch_name =
+        base::ToLowerASCII(base::StringPiece(a, strcspn(a, "=")));
     auto* iter = std::lower_bound(std::begin(kBlacklist), std::end(kBlacklist),
                                   switch_name);
     if (iter != std::end(kBlacklist) && switch_name == *iter) {


### PR DESCRIPTION
* Applies Sam's case-insensitive blacklist patch.

* Uses std::binary_search as discussed in #11726 with @zcbenz and @alespergl 

* Make a blacklist recipe that can be copied and pasted from the code comments into a shell