### PR TITLE
Migrate deprecated web-view method

### DIFF
--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -27,7 +27,7 @@ class WebViewImpl {
     // on* Event handlers.
     this.on = {}
     this.browserPluginNode = this.createBrowserPluginNode()
-    const shadowRoot = this.webviewNode.createShadowRoot()
+    const shadowRoot = this.webviewNode.attachShadow({mode: 'open'})
     shadowRoot.innerHTML = '<!DOCTYPE html><style type="text/css">:host { display: flex; }</style>'
     this.setupWebViewAttributes()
     this.setupFocusPropagation()


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/11788.

Migrates call to `createShadowRoot()` in `web-view.js` to `attachShadow(shadowRootInit)` per [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow)