### PR TITLE
Don't inherit isBrowserView preference

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -25,6 +25,7 @@ const mergeOptions = function (child, parent, visited) {
 
   visited.add(parent)
   for (const key in parent) {
+    if (key === 'isBrowserView') continue
     if (!hasProp.call(parent, key)) continue
     if (key in child) continue
 


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/11790.

Make it such that `isBrowserView` is non-inheritable to prevent child windows from being unable to be closed. 

/cc @MarshallOfSound 

