### PR TITLE
feature: Hot security tips

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -54,9 +54,20 @@ Node.js integration enabled. Instead, use only local files (packaged together
 with your application) to execute Node.js code. To display remote content, use
 the [`webview`][web-view] tag and make sure to disable the `nodeIntegration`.
 
-#### Checklist: Security Recommendations
+## Electron Security Warnings
 
-This is not bulletproof, but at the least, you should attempt the following:
+From Electron 2.0 on, developers will see warnings and recommendations printed
+to the developer console. They only show op when the binary's name is Electron,
+indicating that a developer is currently looking at the console.
+
+You can force-enable or force-disable these warnings by setting
+`ELECTRON_ENABLE_SECURITY_WARNINGS` or `ELECTRON_DISABLE_SECURITY_WARNINGS` on
+either `process.env` or the `window` object.
+
+## Checklist: Security Recommendations
+
+This is not bulletproof, but at the least, you should follow these steps to
+improve the security of your application.
 
 1) [Only load secure content](#only-load-secure-content)
 2) [Disable the Node.js integration in all renderers that display remote content](#disable-node.js-integration-for-remote-content)

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -63,6 +63,7 @@
       'lib/renderer/init.js',
       'lib/renderer/inspector.js',
       'lib/renderer/override.js',
+      'lib/renderer/security-warnings.js',
       'lib/renderer/window-setup.js',
       'lib/renderer/web-view/guest-view-internal.js',
       'lib/renderer/web-view/web-view.js',

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -36,7 +36,8 @@ const {
   warnAboutBlinkFeatures,
   warnAboutInsecureResources,
   warnAboutInsecureCSP,
-  warnAboutAllowedPopups
+  warnAboutAllowedPopups,
+  shouldLogSecurityWarnings
 } = require('./security-warnings')
 
 // Call webFrame method.
@@ -159,8 +160,6 @@ if (nodeIntegration === 'true') {
     }
   }
 
-  warnAboutNodeWithRemoteContent()
-
   // Redirect window.onerror to uncaughtException.
   window.onerror = function (message, filename, lineno, colno, error) {
     if (global.process.listeners('uncaughtException').length > 0) {
@@ -193,13 +192,19 @@ for (const preloadScript of preloadScripts) {
 
 // Warn about security issues
 window.addEventListener('load', function loadHandler () {
-  warnAboutDisabledWebSecurity()
-  warnAboutInsecureResources()
-  warnAboutInsecureContentAllowed()
-  warnAboutExperimentalFeatures()
-  warnAboutBlinkFeatures()
-  warnAboutInsecureCSP()
-  warnAboutAllowedPopups()
+  if (shouldLogSecurityWarnings()) {
+    if (nodeIntegration === 'true') {
+      warnAboutNodeWithRemoteContent()
+    }
+
+    warnAboutDisabledWebSecurity()
+    warnAboutInsecureResources()
+    warnAboutInsecureContentAllowed()
+    warnAboutExperimentalFeatures()
+    warnAboutBlinkFeatures()
+    warnAboutInsecureCSP()
+    warnAboutAllowedPopups()
+  }
 
   window.removeEventListener('load', loadHandler)
 })

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -28,6 +28,17 @@ v8Util.setHiddenValue(global, 'ipc', new events.EventEmitter())
 // Use electron module after everything is ready.
 const electron = require('electron')
 
+const {
+  warnAboutNodeWithRemoteContent,
+  warnAboutDisabledWebSecurity,
+  warnAboutInsecureContentAllowed,
+  warnAboutExperimentalFeatures,
+  warnAboutBlinkFeatures,
+  warnAboutInsecureResources,
+  warnAboutInsecureCSP,
+  warnAboutAllowedPopups
+} = require('./security-warnings')
+
 // Call webFrame method.
 electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, method, args) => {
   electron.webFrame[method](...args)
@@ -148,16 +159,7 @@ if (nodeIntegration === 'true') {
     }
   }
 
-  if (window.location.protocol === 'https:' ||
-      window.location.protocol === 'http:' ||
-      window.location.protocol === 'ftp:') {
-    let warning = 'This renderer process has Node.js integration enabled '
-    warning += 'and attempted to load remote content. This exposes users of this app to severe '
-    warning += 'security risks.\n'
-    warning += 'For more information and help, consult https://electronjs.org/docs/tutorial/security'
-
-    console.warn('%cElectron Security Warning', 'font-weight: bold;', warning)
-  }
+  warnAboutNodeWithRemoteContent()
 
   // Redirect window.onerror to uncaughtException.
   window.onerror = function (message, filename, lineno, colno, error) {
@@ -188,3 +190,16 @@ for (const preloadScript of preloadScripts) {
     console.error(error.stack || error.message)
   }
 }
+
+// Warn about security issues
+window.addEventListener('load', function loadHandler () {
+  warnAboutDisabledWebSecurity()
+  warnAboutInsecureResources()
+  warnAboutInsecureContentAllowed()
+  warnAboutExperimentalFeatures()
+  warnAboutBlinkFeatures()
+  warnAboutInsecureCSP()
+  warnAboutAllowedPopups()
+
+  window.removeEventListener('load', loadHandler)
+})

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -1,0 +1,274 @@
+let shouldLog = null
+
+/**
+ * This method checks if a security message should be logged.
+ * It does so by determining whether we're running as Electron,
+ * which indicates that a developer is currently looking at the
+ * app.
+ *
+ * @returns {boolean} - Should we log?
+ */
+const getShouldLog = function () {
+  if (shouldLog !== null) {
+    return shouldLog
+  }
+
+  const { platform, execPath, env } = process
+
+  switch (platform) {
+    case 'darwin':
+      shouldLog = execPath.endsWith('MacOS/Electron') ||
+                  execPath.includes('Electron.app/Contents/Frameworks/')
+      break
+    case 'freebsd':
+    case 'linux':
+      shouldLog = execPath.endsWith('/electron')
+      break
+    case 'win32':
+      shouldLog = execPath.endsWith('/electron.exe')
+      break
+    default:
+      shouldLog = false
+  }
+
+  if (env && env.ELECTRON_DISABLE_SECURITY_WARNINGS) {
+    shouldLog = false
+  }
+
+  return shouldLog
+}
+
+/**
+ * Check's if the current window is remote.
+ *
+ * @returns {boolean} - Is this a remote protocol?
+ */
+const getIsRemoteProtocol = function () {
+  if (window && window.location && window.location.protocol) {
+    return /^(http|ftp)s?/gi.test(window.location.protocol)
+  }
+}
+
+/**
+ * Tries to determine whether a CSP without `unsafe-eval` is set.
+ *
+ * @returns {boolean} Is a CSP with `unsafe-eval` set?
+ */
+const isUnsafeEvalEnabled = function () {
+  try {
+    //eslint-disable-next-line
+    new Function('');
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
+/**
+ * Attempts to get the current webContents. Returns null
+ * if that fails
+ *
+ * @returns {Object|null} webPreferences
+ */
+let webPreferences
+const getWebPreferences = function () {
+  try {
+    if (webPreferences) {
+      return webPreferences
+    }
+
+    const { remote } = require('electron')
+    webPreferences = remote.getCurrentWindow().webContents.getWebPreferences()
+    return webPreferences
+  } catch (error) {
+    return null
+  }
+}
+
+const moreInformation = 'For more information and help, consult ' +
+                        'https://electronjs.org/docs/tutorial/security.\n' +
+                        'This warning will not show up once the app is packaged.'
+
+module.exports = {
+  /**
+   * #1 Only load secure content
+   *
+   * Checks the loaded resources on the current page and logs a
+   * message about all resources loaded over HTTP or FTP.
+   */
+  warnAboutInsecureResources: () => {
+    if (!getShouldLog() || !window || !window.performance || !window.performance.getEntriesByType) {
+      return
+    }
+
+    const resources = window.performance
+      .getEntriesByType('resource')
+      .filter(({ name }) => /^(http|ftp):?/gi.test(name || ''))
+      .map(({ name }) => `- ${name}`)
+      .join('\n')
+
+    if (!resources || resources.length === 0) {
+      return
+    }
+
+    let warning = 'This renderer process loads resources using insecure protocols. ' +
+                  'This exposes users of this app to unnecessary security risks. ' +
+                  'Consider loading the following resources over HTTPS or FTPS. \n' +
+                  resources + '\n' +
+                  moreInformation
+
+    console.warn('%cElectron Security Warning (Insecure Resources)',
+      'font-weight: bold;', warning)
+  },
+
+  /**
+   * #2 on the checklist: Disable the Node.js integration in all renderers that
+   * display remote content
+   *
+   * Logs a warning message about Node integration.
+   */
+  warnAboutNodeWithRemoteContent: () => {
+    if (getShouldLog() && getIsRemoteProtocol()) {
+      let warning = 'This renderer process has Node.js integration enabled ' +
+                    'and attempted to load remote content. This exposes users of this app to severe ' +
+                    'security risks.\n' +
+                    moreInformation
+
+      console.warn('%cElectron Security Warning (Node.js Integration with Remote Content)',
+        'font-weight: bold;', warning)
+    }
+  },
+
+  // Currently missing since it has ramifications and is still experimental:
+  //   #3 Enable context isolation in all renderers that display remote content
+  //
+  // Currently missing since we can't easily programmatically check for those cases:
+  //   #4 Use ses.setPermissionRequestHandler() in all sessions that load remote content
+
+  /**
+   * #5 on the checklist: Do not disable websecurity
+   *
+   * Logs a warning message about disabled webSecurity.
+   */
+  warnAboutDisabledWebSecurity: () => {
+    if (getShouldLog()) {
+      const webPreferences = getWebPreferences()
+      if (!webPreferences || webPreferences.webSecurity !== false) return
+
+      let warning = 'This renderer process has "webSecurity" disabled. ' +
+                    'This exposes users of this app to severe security risks.\n' +
+                    moreInformation
+
+      console.warn('%cElectron Security Warning (Disabled webSecurity)',
+        'font-weight: bold;', warning)
+    }
+  },
+
+  /**
+   * #6 on the checklist: Define a Content-Security-Policy and use restrictive
+   * rules (i.e. script-src 'self')
+   *
+   * #7 on the checklist: Disable eval
+   *
+   * Logs a warning message about unset or insecure CSP
+   */
+  warnAboutInsecureCSP: () => {
+    if (getShouldLog() && isUnsafeEvalEnabled()) {
+      let warning = 'This renderer process has either no Content Security Policy set ' +
+                    'or a policy with "unsafe-eval" enabled. This exposes users of this ' +
+                    'app to unnecessary security risks.\n' +
+                    moreInformation
+
+      console.warn('%cElectron Security Warning (Insecure Content-Security-Policy)',
+        'font-weight: bold;', warning)
+    }
+  },
+
+  /**
+   * #8 on the checklist: Do not set allowRunningInsecureContent to true
+   *
+   * Logs a warning message about disabled webSecurity.
+   */
+  warnAboutInsecureContentAllowed: () => {
+    if (getShouldLog()) {
+      const webPreferences = getWebPreferences()
+      if (!webPreferences || !webPreferences.allowRunningInsecureContent) return
+
+      let warning = 'This renderer process has "allowRunningInsecureContent" ' +
+                    'enabled. This exposes users of this app to severe security risks.\n' +
+                    moreInformation
+
+      console.warn('%cElectron Security Warning (allowRunningInsecureContent)',
+        'font-weight: bold;', warning)
+    }
+  },
+
+  /**
+   * #8 on the checklist: Do not enable experimental features
+   *
+   * Logs a warning message about experimental features.
+   */
+  warnAboutExperimentalFeatures: () => {
+    if (getShouldLog()) {
+      const webPreferences = getWebPreferences()
+      if (!webPreferences || (!webPreferences.experimentalFeatures &&
+          !webPreferences.experimentalCanvasFeatures)) {
+        return
+      }
+
+      let warning = 'This renderer process has "experimentalFeatures" ' +
+                    'enabled. This exposes users of this app to some security risk. ' +
+                    'If you do not need this feature, you should disable it.\n' +
+                    moreInformation
+
+      console.warn('%cElectron Security Warning (experimentalFeatures)',
+        'font-weight: bold;', warning)
+    }
+  },
+
+  /**
+   * #9 on the checklist: Do not enable experimental features
+   *
+   * Logs a warning message about experimental features.
+   */
+  warnAboutBlinkFeatures: () => {
+    if (getShouldLog()) {
+      const webPreferences = getWebPreferences()
+      if (!webPreferences || !webPreferences.blinkFeatures ||
+          (webPreferences.blinkFeatures.length && webPreferences.blinkFeatures.length === 0)) {
+        return
+      }
+
+      let warning = 'This renderer process has additional "blinkFeatures" ' +
+                    'enabled. This exposes users of this app to some security risk. ' +
+                    'If you do not need this feature, you should disable it.\n' +
+                    moreInformation
+
+      console.warn('%cElectron Security Warning (blinkFeatures)',
+        'font-weight: bold;', warning)
+    }
+  },
+
+  /**
+   * #10 on the checklist: Do Not Use allowpopups
+   *
+   * Logs a warning message about allowed popups
+   */
+  warnAboutAllowedPopups: () => {
+    if (getShouldLog() && document && document.querySelectorAll) {
+      const domElements = document.querySelectorAll('[allowpopups]')
+
+      if (!domElements || domElements.length === 0) {
+        return
+      }
+
+      let warning = 'A <webview> has "allowpopups" set to true. ' +
+                    'This exposes users of this app to some security risk, since popups are just ' +
+                    'BrowserWindows. If you do not need this feature, you should disable it.\n' +
+                    moreInformation
+
+      console.warn('%cElectron Security Warning (allowpopups)',
+        'font-weight: bold;', warning)
+    }
+  }
+}

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -87,7 +87,7 @@ const getWebPreferences = function () {
   }
 }
 
-const moreInformation = 'For more information and help, consult ' +
+const moreInformation = '\nFor more information and help, consult ' +
                         'https://electronjs.org/docs/tutorial/security.\n' +
                         'This warning will not show up once the app is packaged.'
 

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -206,7 +206,7 @@ module.exports = {
   },
 
   /**
-   * #8 on the checklist: Do not enable experimental features
+   * #9 on the checklist: Do not enable experimental features
    *
    * Logs a warning message about experimental features.
    */
@@ -229,9 +229,9 @@ module.exports = {
   },
 
   /**
-   * #9 on the checklist: Do not enable experimental features
+   * #10 on the checklist: Do not use blinkFeatures
    *
-   * Logs a warning message about experimental features.
+   * Logs a warning message about blinkFeatures
    */
   warnAboutBlinkFeatures: () => {
     if (getShouldLog()) {
@@ -252,7 +252,7 @@ module.exports = {
   },
 
   /**
-   * #10 on the checklist: Do Not Use allowpopups
+   * #11 on the checklist: Do Not Use allowpopups
    *
    * Logs a warning message about allowed popups
    */
@@ -273,4 +273,7 @@ module.exports = {
         'font-weight: bold;', warning)
     }
   }
+
+  // Currently missing since we can't easily programmatically check for it:
+  //   #12WebViews: Verify the options and params of all `<webview>` tags
 }

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -25,7 +25,7 @@ const getShouldLog = function () {
       shouldLog = execPath.endsWith('/electron')
       break
     case 'win32':
-      shouldLog = execPath.endsWith('/electron.exe')
+      shouldLog = execPath.endsWith('\\electron.exe')
       break
     default:
       shouldLog = false

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -8,7 +8,7 @@ let shouldLog = null
  *
  * @returns {boolean} - Should we log?
  */
-const getShouldLog = function () {
+const shouldLogSecurityWarnings = function () {
   if (shouldLog !== null) {
     return shouldLog
   }
@@ -31,9 +31,13 @@ const getShouldLog = function () {
       shouldLog = false
   }
 
-  if (env && env.ELECTRON_DISABLE_SECURITY_WARNINGS) {
+  if ((env && env.ELECTRON_DISABLE_SECURITY_WARNINGS) ||
+      (window && window.ELECTRON_DISABLE_SECURITY_WARNINGS)) {
     shouldLog = false
-  } else if (env && env.ELECTRON_ENABLE_SECURITY_WARNINGS) {
+  }
+
+  if ((env && env.ELECTRON_ENABLE_SECURITY_WARNINGS) ||
+      (window && window.ELECTRON_ENABLE_SECURITY_WARNINGS)) {
     shouldLog = true
   }
 
@@ -92,6 +96,8 @@ const moreInformation = '\nFor more information and help, consult ' +
                         'This warning will not show up once the app is packaged.'
 
 module.exports = {
+  shouldLogSecurityWarnings,
+
   /**
    * #1 Only load secure content
    *
@@ -99,7 +105,7 @@ module.exports = {
    * message about all resources loaded over HTTP or FTP.
    */
   warnAboutInsecureResources: () => {
-    if (!getShouldLog() || !window || !window.performance || !window.performance.getEntriesByType) {
+    if (!window || !window.performance || !window.performance.getEntriesByType) {
       return
     }
 
@@ -130,7 +136,7 @@ module.exports = {
    * Logs a warning message about Node integration.
    */
   warnAboutNodeWithRemoteContent: () => {
-    if (getShouldLog() && getIsRemoteProtocol()) {
+    if (getIsRemoteProtocol()) {
       let warning = 'This renderer process has Node.js integration enabled ' +
                     'and attempted to load remote content. This exposes users of this app to severe ' +
                     'security risks.\n' +
@@ -153,17 +159,15 @@ module.exports = {
    * Logs a warning message about disabled webSecurity.
    */
   warnAboutDisabledWebSecurity: () => {
-    if (getShouldLog()) {
-      const webPreferences = getWebPreferences()
-      if (!webPreferences || webPreferences.webSecurity !== false) return
+    const webPreferences = getWebPreferences()
+    if (!webPreferences || webPreferences.webSecurity !== false) return
 
-      let warning = 'This renderer process has "webSecurity" disabled. ' +
-                    'This exposes users of this app to severe security risks.\n' +
-                    moreInformation
+    let warning = 'This renderer process has "webSecurity" disabled. ' +
+                  'This exposes users of this app to severe security risks.\n' +
+                  moreInformation
 
-      console.warn('%cElectron Security Warning (Disabled webSecurity)',
-        'font-weight: bold;', warning)
-    }
+    console.warn('%cElectron Security Warning (Disabled webSecurity)',
+      'font-weight: bold;', warning)
   },
 
   /**
@@ -175,7 +179,7 @@ module.exports = {
    * Logs a warning message about unset or insecure CSP
    */
   warnAboutInsecureCSP: () => {
-    if (getShouldLog() && isUnsafeEvalEnabled()) {
+    if (isUnsafeEvalEnabled()) {
       let warning = 'This renderer process has either no Content Security Policy set ' +
                     'or a policy with "unsafe-eval" enabled. This exposes users of this ' +
                     'app to unnecessary security risks.\n' +
@@ -192,17 +196,15 @@ module.exports = {
    * Logs a warning message about disabled webSecurity.
    */
   warnAboutInsecureContentAllowed: () => {
-    if (getShouldLog()) {
-      const webPreferences = getWebPreferences()
-      if (!webPreferences || !webPreferences.allowRunningInsecureContent) return
+    const webPreferences = getWebPreferences()
+    if (!webPreferences || !webPreferences.allowRunningInsecureContent) return
 
-      let warning = 'This renderer process has "allowRunningInsecureContent" ' +
-                    'enabled. This exposes users of this app to severe security risks.\n' +
-                    moreInformation
+    let warning = 'This renderer process has "allowRunningInsecureContent" ' +
+                  'enabled. This exposes users of this app to severe security risks.\n' +
+                  moreInformation
 
-      console.warn('%cElectron Security Warning (allowRunningInsecureContent)',
-        'font-weight: bold;', warning)
-    }
+    console.warn('%cElectron Security Warning (allowRunningInsecureContent)',
+      'font-weight: bold;', warning)
   },
 
   /**
@@ -211,21 +213,19 @@ module.exports = {
    * Logs a warning message about experimental features.
    */
   warnAboutExperimentalFeatures: () => {
-    if (getShouldLog()) {
-      const webPreferences = getWebPreferences()
-      if (!webPreferences || (!webPreferences.experimentalFeatures &&
-          !webPreferences.experimentalCanvasFeatures)) {
-        return
-      }
-
-      let warning = 'This renderer process has "experimentalFeatures" ' +
-                    'enabled. This exposes users of this app to some security risk. ' +
-                    'If you do not need this feature, you should disable it.\n' +
-                    moreInformation
-
-      console.warn('%cElectron Security Warning (experimentalFeatures)',
-        'font-weight: bold;', warning)
+    const webPreferences = getWebPreferences()
+    if (!webPreferences || (!webPreferences.experimentalFeatures &&
+        !webPreferences.experimentalCanvasFeatures)) {
+      return
     }
+
+    let warning = 'This renderer process has "experimentalFeatures" ' +
+                  'enabled. This exposes users of this app to some security risk. ' +
+                  'If you do not need this feature, you should disable it.\n' +
+                  moreInformation
+
+    console.warn('%cElectron Security Warning (experimentalFeatures)',
+      'font-weight: bold;', warning)
   },
 
   /**
@@ -234,21 +234,19 @@ module.exports = {
    * Logs a warning message about blinkFeatures
    */
   warnAboutBlinkFeatures: () => {
-    if (getShouldLog()) {
-      const webPreferences = getWebPreferences()
-      if (!webPreferences || !webPreferences.blinkFeatures ||
-          (webPreferences.blinkFeatures.length && webPreferences.blinkFeatures.length === 0)) {
-        return
-      }
-
-      let warning = 'This renderer process has additional "blinkFeatures" ' +
-                    'enabled. This exposes users of this app to some security risk. ' +
-                    'If you do not need this feature, you should disable it.\n' +
-                    moreInformation
-
-      console.warn('%cElectron Security Warning (blinkFeatures)',
-        'font-weight: bold;', warning)
+    const webPreferences = getWebPreferences()
+    if (!webPreferences || !webPreferences.blinkFeatures ||
+        (webPreferences.blinkFeatures.length && webPreferences.blinkFeatures.length === 0)) {
+      return
     }
+
+    let warning = 'This renderer process has additional "blinkFeatures" ' +
+                  'enabled. This exposes users of this app to some security risk. ' +
+                  'If you do not need this feature, you should disable it.\n' +
+                  moreInformation
+
+    console.warn('%cElectron Security Warning (blinkFeatures)',
+      'font-weight: bold;', warning)
   },
 
   /**
@@ -257,7 +255,7 @@ module.exports = {
    * Logs a warning message about allowed popups
    */
   warnAboutAllowedPopups: () => {
-    if (getShouldLog() && document && document.querySelectorAll) {
+    if (document && document.querySelectorAll) {
       const domElements = document.querySelectorAll('[allowpopups]')
 
       if (!domElements || domElements.length === 0) {

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -33,6 +33,8 @@ const getShouldLog = function () {
 
   if (env && env.ELECTRON_DISABLE_SECURITY_WARNINGS) {
     shouldLog = false
+  } else if (env && env.ELECTRON_ENABLE_SECURITY_WARNINGS) {
+    shouldLog = true
   }
 
   return shouldLog

--- a/script/test.py
+++ b/script/test.py
@@ -15,7 +15,7 @@ if sys.platform == 'linux2':
     # powerMonitor interaction with org.freedesktop.login1 service. The
     # dbus_mock module takes care of setting up the fake server with mock,
     # while also setting DBUS_SYSTEM_BUS_ADDRESS environment variable, which
-    # will be picked up by electron. 
+    # will be picked up by electron.
     try:
         import lib.dbus_mock
     except ImportError:
@@ -62,6 +62,7 @@ def main():
   try:
     if args.use_instrumented_asar:
       install_instrumented_asar_file(resources_path)
+    os.environ["ELECTRON_DISABLE_SECURITY_WARNINGS"] = "1"
     subprocess.check_call([electron, 'spec'] + sys.argv[1:])
   except subprocess.CalledProcessError as e:
     returncode = e.returncode

--- a/spec/fixtures/pages/base-page-security.html
+++ b/spec/fixtures/pages/base-page-security.html
@@ -4,7 +4,6 @@
       window.ELECTRON_ENABLE_SECURITY_WARNINGS = true
     </script>
   </head>
-  <body>
-    <webview allowpopups></webview>
-  </body>
+<body>
+</body>
 </html>

--- a/spec/fixtures/pages/insecure-resources.html
+++ b/spec/fixtures/pages/insecure-resources.html
@@ -1,10 +1,10 @@
 <html>
   <head>
+    <link rel="stylesheet" href="http://127.0.0.1:8881/save_page/test.css">
     <script type="text/javascript">
       window.ELECTRON_ENABLE_SECURITY_WARNINGS = true
     </script>
   </head>
-  <body>
-    <webview allowpopups></webview>
-  </body>
+<body>
+</body>
 </html>

--- a/spec/fixtures/pages/webview-allowpopups.html
+++ b/spec/fixtures/pages/webview-allowpopups.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<webview allowpopups></webview>
+</body>
+</html>

--- a/spec/security-warnings-spec.js
+++ b/spec/security-warnings-spec.js
@@ -3,7 +3,6 @@ const http = require('http')
 const fs = require('fs')
 const path = require('path')
 const url = require('url')
-const {execSync} = require('child_process')
 
 const {remote} = require('electron')
 const {BrowserWindow} = remote

--- a/spec/security-warnings-spec.js
+++ b/spec/security-warnings-spec.js
@@ -1,0 +1,165 @@
+const assert = require('assert')
+const http = require('http')
+const fs = require('fs')
+const path = require('path')
+const url = require('url')
+const os = require('os')
+const qs = require('querystring')
+
+const {remote} = require('electron')
+const {BrowserWindow} = remote
+
+describe('security warnings', () => {
+  let server
+  let w = null
+  let useCsp = true
+
+  before(() => {
+    server = http.createServer(function(request, response) {
+      const uri = url.parse(request.url).pathname
+      let filename = path.join(__dirname, './fixtures/pages', uri)
+
+      fs.exists(filename, (exists) => {
+        if (!exists) {
+          response.writeHead(404, { 'Content-Type': 'text/plain' })
+          response.end()
+          return
+        }
+
+        if (fs.statSync(filename).isDirectory()) {
+          filename += '/index.html'
+        }
+
+        fs.readFile(filename, 'binary', function(err, file) {
+          if (err) {
+            response.writeHead(404, { 'Content-Type': 'text/plain' })
+            response.end()
+            return
+          }
+
+          const cspHeaders = { 'Content-Security-Policy': `script-src 'self'` }
+          response.writeHead(200, useCsp ? cspHeaders : undefined)
+          response.write(file, 'binary')
+          response.end()
+        })
+      })
+    }).listen(8881)
+  })
+
+  after(() => {
+    server.close()
+    server = null
+  })
+
+  afterEach(() => {
+    if (w && w.close) w.close()
+    useCsp = true
+  })
+
+  it('should warn about Node.js integration with remote content', (done) => {
+    w = new BrowserWindow({ show: false })
+    w.webContents.on('console-message', (e, level, message) => {
+      assert(message.includes('Node.js Integration with Remote Content'))
+      done()
+    })
+
+    w.loadURL(`http://127.0.0.1:8881/base-page.html`)
+  })
+
+  it('should warn about disabled webSecurity', (done) => {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        webSecurity: false,
+        nodeIntegration: false
+      }
+    })
+    w.webContents.on('console-message', (e, level, message) => {
+      assert(message.includes('Disabled webSecurity'))
+      done()
+    })
+
+    w.loadURL(`http://127.0.0.1:8881/base-page.html`)
+  })
+
+  it('should warn about insecure Content-Security-Policy', (done) => {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        nodeIntegration: false
+      }
+    })
+
+    w.webContents.on('console-message', (e, level, message) => {
+      assert(message.includes('Insecure Content-Security-Policy'))
+      done()
+    })
+
+    useCsp = false
+    w.loadURL(`http://127.0.0.1:8881/base-page.html`)
+  })
+
+  it('should warn about allowRunningInsecureContent', (done) => {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        allowRunningInsecureContent: true,
+        nodeIntegration: false
+      }
+    })
+    w.webContents.on('console-message', (e, level, message) => {
+      assert(message.includes('allowRunningInsecureContent'))
+      done()
+    })
+
+    w.loadURL(`http://127.0.0.1:8881/base-page.html`)
+  })
+
+  it('should warn about experimentalFeatures', (done) => {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        experimentalFeatures: true,
+        nodeIntegration: false
+      }
+    })
+    w.webContents.on('console-message', (e, level, message) => {
+      assert(message.includes('experimentalFeatures'))
+      done()
+    })
+
+    w.loadURL(`http://127.0.0.1:8881/base-page.html`)
+  })
+
+  it('should warn about blinkFeatures', (done) => {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        blinkFeatures: ['my-cool-feature'],
+        nodeIntegration: false
+      }
+    })
+    w.webContents.on('console-message', (e, level, message) => {
+      assert(message.includes('blinkFeatures'))
+      done()
+    })
+
+    w.loadURL(`http://127.0.0.1:8881/base-page.html`)
+  })
+
+  it('should warn about allowpopups', (done) => {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        nodeIntegration: false
+      }
+    })
+    w.webContents.on('console-message', (e, level, message) => {
+      console.log(message)
+      assert(message.includes('allowpopups'))
+      done()
+    })
+
+    w.loadURL(`http://127.0.0.1:8881/webview-allowpopups.html`)
+  })
+})

--- a/spec/security-warnings-spec.js
+++ b/spec/security-warnings-spec.js
@@ -3,8 +3,6 @@ const http = require('http')
 const fs = require('fs')
 const path = require('path')
 const url = require('url')
-const os = require('os')
-const qs = require('querystring')
 
 const {remote} = require('electron')
 const {BrowserWindow} = remote
@@ -15,22 +13,22 @@ describe('security warnings', () => {
   let useCsp = true
 
   before(() => {
-    server = http.createServer(function(request, response) {
+    server = http.createServer((request, response) => {
       const uri = url.parse(request.url).pathname
       let filename = path.join(__dirname, './fixtures/pages', uri)
 
-      fs.exists(filename, (exists) => {
-        if (!exists) {
+      fs.stat(filename, (error, stats) => {
+        if (error) {
           response.writeHead(404, { 'Content-Type': 'text/plain' })
           response.end()
           return
         }
 
-        if (fs.statSync(filename).isDirectory()) {
+        if (stats.isDirectory()) {
           filename += '/index.html'
         }
 
-        fs.readFile(filename, 'binary', function(err, file) {
+        fs.readFile(filename, 'binary', (err, file) => {
           if (err) {
             response.writeHead(404, { 'Content-Type': 'text/plain' })
             response.end()

--- a/spec/security-warnings-spec.js
+++ b/spec/security-warnings-spec.js
@@ -78,7 +78,6 @@ describe('security warnings', () => {
       }
     })
     w.webContents.on('console-message', (e, level, message) => {
-      console.log(message)
       assert(message.includes('Disabled webSecurity'))
       done()
     })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -29,6 +29,9 @@ app.commandLine.appendSwitch('js-flags', '--expose_gc')
 app.commandLine.appendSwitch('ignore-certificate-errors')
 app.commandLine.appendSwitch('disable-renderer-backgrounding')
 
+// Disable security warnings (the security warnings test will enable them)
+process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = true
+
 // Accessing stdout in the main process will result in the process.stdout
 // throwing UnknownSystemError in renderer process sometimes. This line makes
 // sure we can reproduce it in renderer process.


### PR DESCRIPTION
Now that we have this fancy security checklist, we need to make sure that developers know that it's there.

This PR generalizes the one `Electron Security Warning` that we already have and adds new warnings for all of the checklist items that are easy to detect. **The warnings are _only_ emitted if the binary's name is `electron`, indicating strongly that a developer is looking at the console**.

The detection and subsequent logs can be force-set with the environment variables `ELECTRON_DISABLE_SECURITY_WARNINGS` and `ELECTRON_ENABLE_SECURITY_WARNINGS`. One can also set those properties on the `window` object to enable or disable them per-renderer.

If you mess up greatly, you'd see something like this:

<img width="1018" alt="screen shot 2018-02-01 at 3 02 44 pm" src="https://user-images.githubusercontent.com/1426799/35708020-f9c3d62e-0760-11e8-86ba-e114e9e831af.png">
