### PR TITLE
Remove extra menu separators

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -184,11 +184,13 @@ Menu.buildFromTemplate = function (template) {
   }
 
   const menu = new Menu()
+  const filtered = removeExtraSeparators(template)
+
   const positioned = []
   let idx = 0
 
   // sort template by position
-  template.forEach(item => {
+  filtered.forEach(item => {
     idx = (item.position) ? indexToInsertByPosition(positioned, item.position) : idx += 1
     positioned.splice(idx, 0, item)
   })
@@ -260,6 +262,18 @@ function indexToInsertByPosition (items, position) {
 
   // return new index if needed, or original indexOfItemById
   return (query in queries) ? queries[query](idx) : idx
+}
+
+function removeExtraSeparators (template) {
+  let visiblePrev
+  const visibleItems = template.filter(el => el.visible !== false)
+
+  return visibleItems.filter((el, idx, array) => {
+    const shouldBeDeleted = !visiblePrev || idx === array.length - 1 || array[idx + 1].type === 'separator'
+    const toDelete = el.type === 'separator' && shouldBeDeleted
+    visiblePrev = toDelete ? visiblePrev : el
+    return !toDelete
+  })
 }
 
 function insertItemByType (item, pos) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -264,16 +264,15 @@ function indexToInsertByPosition (items, position) {
   return (query in queries) ? queries[query](idx) : idx
 }
 
-function removeExtraSeparators (template) {
-  let visiblePrev
-  const visibleItems = template.filter(el => el.visible !== false)
+function removeExtraSeparators (items) {
+  // remove invisible items
+  let ret = items.filter(e => e.visible !== false)
 
-  return visibleItems.filter((el, idx, array) => {
-    const meetsDeleteConditions = !visiblePrev || idx === array.length - 1 || array[idx + 1].type === 'separator'
-    const toDelete = el.type === 'separator' && meetsDeleteConditions
-    visiblePrev = toDelete ? visiblePrev : el
-    return !toDelete
-  })
+  // fold adjacent separators together
+  ret = ret.filter((e, idx, arr) => e.type !== 'separator' || idx === 0 || arr[idx - 1].type !== 'separator')
+
+  // remove edge separators
+  return ret.filter((e, idx, arr) => e.type !== 'separator' || (idx !== 0 && idx !== arr.length - 1))
 }
 
 function insertItemByType (item, pos) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -269,8 +269,8 @@ function removeExtraSeparators (template) {
   const visibleItems = template.filter(el => el.visible !== false)
 
   return visibleItems.filter((el, idx, array) => {
-    const shouldBeDeleted = !visiblePrev || idx === array.length - 1 || array[idx + 1].type === 'separator'
-    const toDelete = el.type === 'separator' && shouldBeDeleted
+    const meetsDeleteConditions = !visiblePrev || idx === array.length - 1 || array[idx + 1].type === 'separator'
+    const toDelete = el.type === 'separator' && meetsDeleteConditions
     visiblePrev = toDelete ? visiblePrev : el
     return !toDelete
   })

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -133,7 +133,7 @@ describe('Menu module', () => {
       })
 
       it('should filter excess menu separators', () => {
-        const menu = Menu.buildFromTemplate([
+        const menuOne = Menu.buildFromTemplate([
           {
             type: 'separator'
           }, {
@@ -147,10 +147,33 @@ describe('Menu module', () => {
           }
         ])
 
-        assert.equal(menu.items.length, 3)
-        assert.equal(menu.items[0].label, 'a')
-        assert.equal(menu.items[1].label, 'b')
-        assert.equal(menu.items[2].label, 'c')
+        assert.equal(menuOne.items.length, 3)
+        assert.equal(menuOne.items[0].label, 'a')
+        assert.equal(menuOne.items[1].label, 'b')
+        assert.equal(menuOne.items[2].label, 'c')
+
+        const menuTwo = Menu.buildFromTemplate([
+          {
+            type: 'separator'
+          }, {
+            type: 'separator'
+          }, {
+            label: 'a'
+          }, {
+            label: 'b'
+          }, {
+            label: 'c'
+          }, {
+            type: 'separator'
+          }, {
+            type: 'separator'
+          }
+        ])
+
+        assert.equal(menuTwo.items.length, 3)
+        assert.equal(menuTwo.items[0].label, 'a')
+        assert.equal(menuTwo.items[1].label, 'b')
+        assert.equal(menuTwo.items[2].label, 'c')
       })
 
       it('should create separator group if endof does not reference existing separator group', () => {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -87,15 +87,18 @@ describe('Menu module', () => {
       it('should position at endof existing separator groups', () => {
         const menu = Menu.buildFromTemplate([
           {
-            type: 'separator',
-            id: 'numbers'
+            label: 'first',
+            id: 'first'
           }, {
             type: 'separator',
-            id: 'letters'
+            id: 'numbers'
           }, {
             label: 'a',
             id: 'a',
             position: 'endof=letters'
+          }, {
+            type: 'separator',
+            id: 'letters'
           }, {
             label: '1',
             id: '1',
@@ -118,14 +121,36 @@ describe('Menu module', () => {
             position: 'endof=numbers'
           }
         ])
-        assert.equal(menu.items[0].id, 'numbers')
-        assert.equal(menu.items[1].label, '1')
-        assert.equal(menu.items[2].label, '2')
-        assert.equal(menu.items[3].label, '3')
-        assert.equal(menu.items[4].id, 'letters')
-        assert.equal(menu.items[5].label, 'a')
-        assert.equal(menu.items[6].label, 'b')
-        assert.equal(menu.items[7].label, 'c')
+
+        assert.equal(menu.items[1].id, 'numbers')
+        assert.equal(menu.items[2].label, '1')
+        assert.equal(menu.items[3].label, '2')
+        assert.equal(menu.items[4].label, '3')
+        assert.equal(menu.items[5].id, 'letters')
+        assert.equal(menu.items[6].label, 'a')
+        assert.equal(menu.items[7].label, 'b')
+        assert.equal(menu.items[8].label, 'c')
+      })
+
+      it('should filter excess menu separators', () => {
+        const menu = Menu.buildFromTemplate([
+          {
+            type: 'separator'
+          }, {
+            label: 'a'
+          }, {
+            label: 'b'
+          }, {
+            label: 'c'
+          }, {
+            type: 'separator'
+          }
+        ])
+
+        assert.equal(menu.items.length, 3)
+        assert.equal(menu.items[0].label, 'a')
+        assert.equal(menu.items[1].label, 'b')
+        assert.equal(menu.items[2].label, 'c')
       })
 
       it('should create separator group if endof does not reference existing separator group', () => {


### PR DESCRIPTION
Removes leading and trailing menu separators and resolves https://github.com/electron/electron/issues/5869. 

Tested manually on MacOS, Windows, and Linux

To-Do:
- [x] Add specs