### PR TITLE
Indicate that ArrayBuffer are not JSON serialized

### DIFF
--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -53,7 +53,8 @@ Removes all listeners, or those of the specified `channel`.
 
 Send a message to the main process asynchronously via `channel`, you can also
 send arbitrary arguments. Arguments will be serialized in JSON internally and
-hence no functions or prototype chain will be included.
+hence no functions or prototype chain will be included (ArrayBuffer's are
+passed directly, even if they are values inside of a JSON serialized).
 
 The main process handles it by listening for `channel` with [`ipcMain`](ipc-main.md) module.
 
@@ -66,7 +67,8 @@ Returns `any` - The value sent back by the [`ipcMain`](ipc-main.md) handler.
 
 Send a message to the main process synchronously via `channel`, you can also
 send arbitrary arguments. Arguments will be serialized in JSON internally and
-hence no functions or prototype chain will be included.
+hence no functions or prototype chain will be included (ArrayBuffer's are
+passed directly, even if they are values inside of a JSON serialized).
 
 The main process handles it by listening for `channel` with [`ipcMain`](ipc-main.md) module,
 and replies by setting `event.returnValue`.


### PR DESCRIPTION
It used to be that Buffer's where JSON serialized (2016?), like huge and ugly form for a tiniest byte array.
It is no longer the case, and docs should reflect this.