### PR TITLE
Add ability to set arbitrary arguments in a renderer process

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -136,6 +136,17 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
       LOG(ERROR) << "preload url must be file:// protocol.";
   }
 
+  // Custom args for renderer process
+  base::Value* customArgs;
+  if ((web_preferences.Get(options::kCustomArgs, &customArgs))
+      && (customArgs->is_list())) {
+    for (const base::Value& customArg : customArgs->GetList()) {
+      if (customArg.is_string()) {
+        command_line->AppendArg(customArg.GetString());
+      }
+    }
+  }
+
   // Run Electron APIs and preload script in isolated world
   bool isolated;
   if (web_preferences.GetBoolean(options::kContextIsolation, &isolated) &&

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -139,6 +139,8 @@ const char kNodeIntegrationInWorker[] = "nodeIntegrationInWorker";
 // Enable the web view tag.
 const char kWebviewTag[] = "webviewTag";
 
+const char kCustomArgs[] = "additionalArguments";
+
 }  // namespace options
 
 namespace switches {

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -68,6 +68,7 @@ extern const char kBlinkFeatures[];
 extern const char kDisableBlinkFeatures[];
 extern const char kNodeIntegrationInWorker[];
 extern const char kWebviewTag[];
+extern const char kCustomArgs[];
 
 }   // namespace options
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -353,6 +353,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       script. You can use the `will-attach-webview` event on [webContents](web-contents.md)
       to strip away the `preload` script and to validate or alter the
       `<webview>`'s initial settings.
+    * `additionArguments` String[] (optional) - A list of strings that will be appended
+      to `process.argv` in the renderer process of this app.  Useful for passing small
+      bits of data down to renderer process preload scripts.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1063,6 +1063,42 @@ describe('BrowserWindow module', () => {
       })
     })
 
+    describe('"additionalArguments" option', () => {
+      it('adds extra args to process.argv in the renderer process', (done) => {
+        const preload = path.join(fixtures, 'module', 'check-arguments.js')
+        ipcMain.once('answer', (event, argv) => {
+          assert.ok(argv.includes('--my-magic-arg'))
+          done()
+        })
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            preload: preload,
+            additionalArguments: ['--my-magic-arg']
+          }
+        })
+        w.loadURL(`file://${path.join(fixtures, 'api', 'blank.html')}`)
+      })
+
+      it('adds extra value args to process.argv in the renderer process', (done) => {
+        const preload = path.join(fixtures, 'module', 'check-arguments.js')
+        ipcMain.once('answer', (event, argv) => {
+          assert.ok(argv.includes('--my-magic-arg=foo'))
+          done()
+        })
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            preload: preload,
+            additionalArguments: ['--my-magic-arg=foo']
+          }
+        })
+        w.loadURL(`file://${path.join(fixtures, 'api', 'blank.html')}`)
+      })
+    })
+
     describe('"node-integration" option', () => {
       it('disables node integration when specified to false', (done) => {
         const preload = path.join(fixtures, 'module', 'send-later.js')

--- a/spec/fixtures/module/check-arguments.js
+++ b/spec/fixtures/module/check-arguments.js
@@ -1,0 +1,4 @@
+var ipcRenderer = require('electron').ipcRenderer
+window.onload = function () {
+  ipcRenderer.send('answer', process.argv)
+}


### PR DESCRIPTION
This provides an easy way to send additional data to a renderer process preload script.  Something like `--my-app-channel=beta` for instance 😄 