### PR TITLE
Delete `upgradeing-chrome.md`

### DIFF
--- a/docs/development/updgrading-chrome.md
+++ b/docs/development/updgrading-chrome.md
@@ -1,1 +1,0 @@
-Moved to [upgrading-chromium.md](upgrading-chromium.md)


### PR DESCRIPTION
This file is no longer needed; we've decided to remove it to unblock https://github.com/electron/electron-i18n/pull/222.