### PR TITLE
Move locale doc to command line switches

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -530,12 +530,6 @@ Returns `String` - The current application locale. Possible return values are do
 
 **Note:** On Windows you have to call it after the `ready` events gets emitted.
 
-### `app.setLocale(locale)`
-
-* `locale` String
-
-Set the locale of the app (must be called before the `ready` event).
-
 ### `app.addRecentDocument(path)` _macOS_ _Windows_
 
 * `path` String

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -28,6 +28,10 @@ Disables the disk cache for HTTP requests.
 
 Disable HTTP/2 and SPDY/3.1 protocols.
 
+## --lang
+
+Set a custom locale.
+
 ## --inspect=`port` and --inspect-brk=`port`
 
 Debug-related flags, see the [Debugging the Main Process][debugging-main-process] guide for details.

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -112,25 +112,6 @@ describe('app module', () => {
     })
   })
 
-  describe('app.setLocale()', () => {
-    const testLocale = (locale, result, done) => {
-      const appPath = path.join(__dirname, 'fixtures', 'api', 'locale-check')
-      const electronPath = remote.getGlobal('process').execPath
-      let output = ''
-      let appProcess = ChildProcess.spawn(electronPath, [appPath, `--lang=${locale}`])
-
-      appProcess.stdout.on('data', (data) => { output += data })
-      appProcess.stdout.on('end', () => {
-        output = output.replace(/(\r\n|\n|\r)/gm, '')
-        assert.equal(output, result)
-        done()
-      })
-    }
-
-    it('should set the locale', (done) => testLocale('fr', 'fr', done))
-    it('should not set an invalid locale', (done) => testLocale('asdfkl', 'en-US', done))
-  })
-
   describe('app.isInApplicationsFolder()', () => {
     before(function () {
       if (process.platform !== 'darwin') {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -4,10 +4,11 @@ const http = require('http')
 const path = require('path')
 const ws = require('ws')
 const url = require('url')
+const ChildProcess = require('child_process')
 const {ipcRenderer, remote} = require('electron')
 const {closeWindow} = require('./window-helpers')
 
-const {app, BrowserWindow, ipcMain, protocol, session, webContents, ChildProcess} = remote
+const {app, BrowserWindow, ipcMain, protocol, session, webContents} = remote
 
 const isCI = remote.getGlobal('isCi')
 
@@ -26,7 +27,7 @@ describe('chromium feature', () => {
     listener = null
   })
 
-  describe('command line switches', () => {
+  describe.only('command line switches', () => {
     describe('--lang switch', () => {
       const testLocale = (locale, result, done) => {
         const appPath = path.join(__dirname, 'fixtures', 'api', 'locale-check')

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -27,7 +27,7 @@ describe('chromium feature', () => {
     listener = null
   })
 
-  describe.only('command line switches', () => {
+  describe('command line switches', () => {
     describe('--lang switch', () => {
       const testLocale = (locale, result, done) => {
         const appPath = path.join(__dirname, 'fixtures', 'api', 'locale-check')


### PR DESCRIPTION
Moves locale documentation to [command_line_switches](https://github.com/electron/electron/blob/master/docs/api/chrome-command-line-switches.md) and move test to `chromium_spec.js`

/cc @deepak1556 