### PR TITLE
Add brightray to src code structure

### DIFF
--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -9,7 +9,7 @@ to understand the source code better.
 
 ## Structure of Source Code
 
-```
+```diff
 Electron
 ├── atom/ - C++ source code.
 |   ├── app/ - System entry code.

--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -9,7 +9,7 @@ to understand the source code better.
 
 ## Structure of Source Code
 
-```sh
+```
 Electron
 ├── atom/ - C++ source code.
 |   ├── app/ - System entry code.
@@ -30,6 +30,7 @@ Electron
 |       loop into Chromium's message loop.
 |       └── api/ - The implementation of common APIs, and foundations of
 |           Electron's built-in modules.
+├── brightray/ - Thin shim over libcc that makes it easier to use.
 ├── chromium_src/ - Source code copied from Chromium. See below.
 ├── default_app/ - The default page to show when Electron is started without
 |   providing an app.
@@ -49,15 +50,15 @@ Electron
 
 ## `/chromium_src`
 
-The files in `/chromium_src` tend to be pieces of Chromium that aren't part of 
-the content layer. For example to implement Pepper API, we need some wiring 
-similar to what official Chrome does. We could have built the relevant 
-sources as a part of [libcc](../glossary.md#libchromiumcontent) but most 
-often we don't require all the features (some tend to be proprietary, 
-analytics stuff) so we just took parts of the code. These could have easily 
-been patches in libcc, but at the time when these were written the goal of 
-libcc was to maintain very minimal patches and chromium_src changes tend to be 
-big ones. Also, note that these patches can never be upstreamed unlike other 
+The files in `/chromium_src` tend to be pieces of Chromium that aren't part of
+the content layer. For example to implement Pepper API, we need some wiring
+similar to what official Chrome does. We could have built the relevant
+sources as a part of [libcc](../glossary.md#libchromiumcontent) but most
+often we don't require all the features (some tend to be proprietary,
+analytics stuff) so we just took parts of the code. These could have easily
+been patches in libcc, but at the time when these were written the goal of
+libcc was to maintain very minimal patches and chromium_src changes tend to be
+big ones. Also, note that these patches can never be upstreamed unlike other
 libcc patches we maintain now.
 
 ## Structure of Other Directories


### PR DESCRIPTION
Looking at the [doc](https://electronjs.org/docs/development/source-code-directory-structure), it seems brightray is missing from the source code structure diagram; this PR remedies that. 