### PR TITLE
Add ability to log atom ipc messages

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -21,8 +21,17 @@
 #include "base/logging.h"
 #include "chrome/common/chrome_paths.h"
 #include "content/public/common/content_switches.h"
+#include "ipc/ipc_features.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
+
+#if BUILDFLAG(IPC_MESSAGE_LOG_ENABLED)
+#define IPC_MESSAGE_MACROS_LOG_ENABLED
+#include "content/public/common/content_ipc_logging.h"
+#define IPC_LOG_TABLE_ADD_ENTRY(msg_id, logger) \
+  content::RegisterIPCLogger(msg_id, logger)
+#include "atom/common/api/api_messages.h"
+#endif
 
 namespace atom {
 

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -30,7 +30,7 @@
 #include "content/public/common/content_ipc_logging.h"
 #define IPC_LOG_TABLE_ADD_ENTRY(msg_id, logger) \
   content::RegisterIPCLogger(msg_id, logger)
-#include "atom/common/api/api_messages.h"
+#include "atom/common/common_message_generator.h"
 #endif
 
 namespace atom {


### PR DESCRIPTION
This PR adds the ability to log `Atom*` IPC messages along with chromium IPC messages. They were showing as `UNKNOWN MSG` earlier when running with the `CHROME_IPC_LOGGING=1` env variable set for debug builds. Now the right messages and data show in the logs.

Some of the messages still are unknown, not sure which ones those are. But this PR leaves fewer unknowns.