### PR TITLE
add formula to setZoomLevel doc

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -831,7 +831,8 @@ Sends a request to get current zoom factor, the `callback` will be called with
 
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
-limits of 300% and 50% of original size, respectively.
+limits of 300% and 50% of original size, respectively. The formula for this is
+`scale := 1.2 ^ level`.
 
 #### `contents.getZoomLevel(callback)`
 


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/11869.

Adds formula for `contents.setZoomLevel(level)` to `web-contents.md` for clarification.

/cc @MarshallOfSound 