### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -86,9 +86,10 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   logging::SetLogItems(true, false, true, false);
 
   // Enable convient stack printing.
-  bool enable_stack_dumping = env->HasVar("ELECTRON_ENABLE_STACK_DUMPING");
 #if defined(DEBUG) && defined(OS_LINUX)
-  enable_stack_dumping = true;
+  const bool enable_stack_dumping = true;
+#endif
+  const bool enable_stack_dumping = env->HasVar("ELECTRON_ENABLE_STACK_DUMPING");
 #endif
   if (enable_stack_dumping)
     base::debug::EnableInProcessStackDumping();

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -87,9 +87,9 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 
   // Enable convient stack printing.
 #if defined(DEBUG) && defined(OS_LINUX)
-  const bool enable_stack_dumping = true;
+  bool enable_stack_dumping = true;
 #else
-  const bool enable_stack_dumping = env->HasVar("ELECTRON_ENABLE_STACK_DUMPING");
+  bool enable_stack_dumping = env->HasVar("ELECTRON_ENABLE_STACK_DUMPING");
 #endif
   if (enable_stack_dumping)
     base::debug::EnableInProcessStackDumping();

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -88,7 +88,7 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   // Enable convient stack printing.
 #if defined(DEBUG) && defined(OS_LINUX)
   const bool enable_stack_dumping = true;
-#endif
+#else
   const bool enable_stack_dumping = env->HasVar("ELECTRON_ENABLE_STACK_DUMPING");
 #endif
   if (enable_stack_dumping)

--- a/atom/browser/atom_browser_main_parts_posix.cc
+++ b/atom/browser/atom_browser_main_parts_posix.cc
@@ -119,9 +119,8 @@ void ShutdownDetector::ThreadMain() {
 
   int signal;
   size_t bytes_read = 0;
-  ssize_t ret;
   do {
-    ret = HANDLE_EINTR(
+    ssize_t ret = HANDLE_EINTR(
         read(shutdown_fd_,
              reinterpret_cast<char*>(&signal) + bytes_read,
              sizeof(signal) - bytes_read));

--- a/atom/browser/atom_web_ui_controller_factory.cc
+++ b/atom/browser/atom_web_ui_controller_factory.cc
@@ -52,7 +52,7 @@ AtomWebUIControllerFactory::CreateWebUIControllerForURL(content::WebUI* web_ui,
   if (url.host() == kPdfViewerUIHost) {
     base::StringPairs toplevel_params;
     base::SplitStringIntoKeyValuePairs(url.query(), '=', '&', &toplevel_params);
-    std::string stream_id, src;
+    std::string src;
 
     const net::UnescapeRule::Type unescape_rules =
       net::UnescapeRule::SPACES | net::UnescapeRule::PATH_SEPARATORS |

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -194,7 +194,7 @@ class AtomCopyFrameGenerator {
 
   void OnCopyFrameCaptureSuccess(
       const gfx::Rect& damage_rect,
-      std::shared_ptr<SkBitmap> bitmap) {
+      const std::shared_ptr<SkBitmap>& bitmap) {
     base::AutoLock lock(onPaintLock_);
     view_->OnPaint(damage_rect, *bitmap);
   }

--- a/brightray/browser/net/devtools_network_protocol_handler.cc
+++ b/brightray/browser/net/devtools_network_protocol_handler.cc
@@ -72,10 +72,10 @@ std::unique_ptr<base::DictionaryValue>
 CreateFailureResponse(int id, const std::string& param) {
   auto response = base::MakeUnique<base::DictionaryValue>();
   auto error_object = base::MakeUnique<base::DictionaryValue>();
-  response->Set(kError, std::move(error_object));
   error_object->SetInteger(params::kErrorCode, kErrorInvalidParams);
   error_object->SetString(params::kErrorMessage,
       base::StringPrintf("Missing or Invalid '%s' parameter", param.c_str()));
+  response->Set(kError, std::move(error_object));
   return response;
 }
 


### PR DESCRIPTION
Fix some warnings that cppcheck yielded when run on `atom/` and `brightray/`