### PR TITLE
Fix frameless windows with vibrancy

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -176,6 +176,8 @@ class NativeWindowMac : public NativeWindow,
   void RegisterInputEventObserver(content::RenderViewHost* host);
   void UnregisterInputEventObserver(content::RenderViewHost* host);
 
+  void SetRenderWidgetHostOpaque(bool opaque);
+
   base::scoped_nsobject<AtomNSWindow> window_;
   base::scoped_nsobject<AtomNSWindowDelegate> window_delegate_;
 
@@ -212,6 +214,9 @@ class NativeWindowMac : public NativeWindow,
   bool was_movable_;
   NSRect original_frame_;
   NSUInteger simple_fullscreen_mask_;
+
+  base::scoped_nsobject<NSColor> background_color_before_vibrancy_;
+  bool transparency_before_vibrancy_;
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -21,7 +21,9 @@
 #include "brightray/browser/inspectable_web_contents.h"
 #include "brightray/browser/inspectable_web_contents_view.h"
 #include "brightray/browser/mac/event_dispatching_window.h"
+#include "content/browser/renderer_host/render_widget_host_impl.h"
 #include "content/public/browser/browser_accessibility_state.h"
+#include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
@@ -1682,12 +1684,31 @@ void NativeWindowMac::AddTabbedWindow(NativeWindow* window) {
   }
 }
 
+void NativeWindowMac::SetRenderWidgetHostOpaque(bool opaque) {
+  if (!web_contents()) return;
+
+  auto render_view_host = web_contents()->GetRenderViewHost();
+  if (!render_view_host) return;
+
+  content::RenderWidgetHostImpl* impl = content::RenderWidgetHostImpl::FromID(
+      render_view_host->GetProcess()->GetID(),
+      render_view_host->GetRoutingID());
+  if (!impl) return;
+
+  impl->SetBackgroundOpaque(opaque);
+}
+
 void NativeWindowMac::SetVibrancy(const std::string& type) {
   if (!base::mac::IsAtLeastOS10_10()) return;
 
   NSView* vibrant_view = [window_ vibrantView];
 
   if (type.empty()) {
+    if (background_color_before_vibrancy_) {
+      [window_ setBackgroundColor:background_color_before_vibrancy_];
+      [window_ setTitlebarAppearsTransparent:transparency_before_vibrancy_];
+    }
+    SetRenderWidgetHostOpaque(!transparent());
     if (vibrant_view == nil) return;
 
     [vibrant_view removeFromSuperview];
@@ -1695,6 +1716,13 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
     return;
   }
+
+  SetRenderWidgetHostOpaque(false);
+  background_color_before_vibrancy_.reset([window_ backgroundColor]);
+  transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
+
+  [window_ setTitlebarAppearsTransparent:YES];
+  [window_ setBackgroundColor:[NSColor clearColor]];
 
   NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
   if (effect_view == nil) {


### PR DESCRIPTION
Fixes #10521 

Tested with `setVibrancy` as well so this supports dynamically switching vibrancy still as well. 