### PR TITLE
Fix copying files on npm-publish

### DIFF
--- a/script/publish-to-npm.js
+++ b/script/publish-to-npm.js
@@ -50,7 +50,7 @@ new Promise((resolve, reject) => {
   tempDir = dirPath
   // copy files from `/npm` to temp directory
   files.forEach((name) => {
-    const noThirdSegment = name === 'README.md' || 'LICENSE'
+    const noThirdSegment = name === 'README.md' || name === 'LICENSE'
     fs.writeFileSync(
       path.join(tempDir, name),
       fs.readFileSync(path.join(__dirname, '..', noThirdSegment ? '' : 'npm', name))


### PR DESCRIPTION
I found this on the last 1.8 release.  Files were not being properly copied because check for license was missing condition.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->