### PR TITLE
notifications: send the desktop file name with the notification

### DIFF
--- a/brightray/browser/linux/libnotify_notification.cc
+++ b/brightray/browser/linux/libnotify_notification.cc
@@ -6,11 +6,13 @@
 
 #include <vector>
 
+#include "base/environment.h"
 #include "base/files/file_enumerator.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/notification_delegate.h"
 #include "brightray/common/application_info.h"
+#include "chrome/browser/ui/libgtkui/gtk_util.h"
 #include "chrome/browser/ui/libgtkui/skia_utils_gtk.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 
@@ -124,6 +126,20 @@ void LibnotifyNotification::Show(const NotificationOptions& options) {
   } else if (HasCapability("x-canonical-append")) {
     libnotify_loader_.notify_notification_set_hint_string(
         notification_, "x-canonical-append", "true");
+  }
+
+  // Send the desktop name to identify the application
+  // The desktop-entry is the part before the .desktop
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  std::string desktop_id = libgtkui::GetDesktopName(env.get());
+  if (!desktop_id.empty()) {
+    std::size_t last_pos = desktop_id.find_last_of(".desktop");
+    if (last_pos != std::string::npos) {
+      desktop_id = desktop_id.substr(0, last_pos);
+    }
+
+    libnotify_loader_.notify_notification_set_hint_string(
+        notification_, "desktop-entry", desktop_id.c_str());
   }
 
   GError* error = nullptr;


### PR DESCRIPTION
I sadly haven't tested it.
It should allow any linux desktop environment to be able to know where the notification comes from and be able to categorize it in the settings and even be able to fine-tune per-app settings (play sound/show popup/keep in notification center).
How to test:
Build a linux app using notifications and test that the notification entry is present in the notification settings of the distribution (for example GNOME Control Center)