### PR TITLE
feat: make shell.moveItemToTrash async by using task scheduler

### DIFF
--- a/atom/common/api/atom_api_shell.cc
+++ b/atom/common/api/atom_api_shell.cc
@@ -54,7 +54,7 @@ class MoveItemToTrashRequest {
   MoveItemToTrashRequest(v8::Isolate* isolate,
                          mate::Arguments* args,
                          const base::FilePath& file_path)
-    : isolate_(isolate), args_(args), file_path_(file_path) {};
+    : isolate_(isolate), args_(args), file_path_(file_path) {}
 
   ~MoveItemToTrashRequest();
 
@@ -67,8 +67,9 @@ class MoveItemToTrashRequest {
 
     args_->Return(resolver_.Get(isolate_)->GetPromise().As<v8::Value>());
 
-    auto callback = base::Bind(&MoveItemToTrashRequest::OnMoveItemToTrashFinished,
-                               base::Unretained(this));
+    auto callback = base::Bind(
+      &MoveItemToTrashRequest::OnMoveItemToTrashFinished,
+      base::Unretained(this));
     platform_util::MoveItemToTrash(file_path_, callback);
   }
 
@@ -78,16 +79,17 @@ class MoveItemToTrashRequest {
     v8::HandleScope handle_scope(isolate_);
 
     if (result) {
-      resolver_.Get(isolate_)->Resolve(v8::Null(isolate_));
+      resolver_.Get(isolate_)->Resolve(v8::Undefined(isolate_));
     } else {
-      printf("Rejected");
-      auto message = mate::StringToV8(isolate_, "Underlying command returned error message code");
-      resolver_.Get(isolate_)->Reject(v8::Exception::Error(message));
+      auto message = "Underlying command returned error message code";
+      auto error = v8::Exception::Error(mate::StringToV8(isolate_, message));
+      resolver_.Get(isolate_)->Reject(error);
     }
 
     resolver_.Reset();
   }
 
+ private:
   v8::Isolate* isolate_;
   mate::Arguments* args_;
   v8::Persistent<v8::Promise::Resolver> resolver_;

--- a/atom/common/api/atom_api_shell.cc
+++ b/atom/common/api/atom_api_shell.cc
@@ -43,6 +43,9 @@ struct Converter<base::win::ShortcutOperation> {
 
 namespace {
 
+typedef v8::CopyablePersistentTraits<v8::Promise::Resolver>::CopyablePersistent
+  PromiseResolverPersistent;
+
 class MoveItemToTrashRequest {
  public:
   static MoveItemToTrashRequest* Create(v8::Isolate* isolate,
@@ -92,7 +95,7 @@ class MoveItemToTrashRequest {
  private:
   v8::Isolate* isolate_;
   mate::Arguments* args_;
-  v8::CopyablePersistentTraits<v8::Promise::Resolver>::CopyablePersistent resolver_handle_;
+  PromiseResolverPersistent resolver_handle_;
   base::FilePath file_path_;
 
   DISALLOW_COPY_AND_ASSIGN(MoveItemToTrashRequest);

--- a/atom/common/api/atom_api_shell.cc
+++ b/atom/common/api/atom_api_shell.cc
@@ -70,10 +70,10 @@ class MoveItemToTrashRequest {
 
     args_->Return(resolver_handle_.Get(isolate_)->GetPromise().As<v8::Value>());
 
-    auto callback = base::Bind(
+    auto callback = base::BindOnce(
       &MoveItemToTrashRequest::OnMoveItemToTrashFinished,
       base::Unretained(this));
-    platform_util::MoveItemToTrash(file_path_, callback);
+    platform_util::MoveItemToTrash(file_path_, std::move(callback));
   }
 
   void OnMoveItemToTrashFinished(bool result) {

--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -23,6 +23,7 @@ class FilePath;
 namespace platform_util {
 
 typedef base::Callback<void(const std::string&)> OpenExternalCallback;
+typedef base::Callback<void(bool)> MoveItemToTrashCallback;
 
 // Show the given file in a file manager. If possible, select the file.
 // Must be called from the UI thread.
@@ -53,7 +54,11 @@ void OpenExternal(
     const OpenExternalCallback& callback);
 
 // Move a file to trash.
-bool MoveItemToTrash(const base::FilePath& full_path);
+bool MoveItemToTrashSync(const base::FilePath& full_path);
+
+// Async move a file to trash.
+void MoveItemToTrash(const base::FilePath& full_path,
+                     MoveItemToTrashCallback callback);
 
 void Beep();
 

--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -23,7 +23,7 @@ class FilePath;
 namespace platform_util {
 
 typedef base::Callback<void(const std::string&)> OpenExternalCallback;
-typedef base::Callback<void(bool)> MoveItemToTrashCallback;
+typedef base::OnceCallback<void(bool)> MoveItemToTrashCallback;
 
 // Show the given file in a file manager. If possible, select the file.
 // Must be called from the UI thread.

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -152,8 +152,8 @@ void MoveItemToTrash(const base::FilePath& full_path,
   base::PostTaskWithTraitsAndReplyWithResult(
     FROM_HERE,
     {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
-    base::Bind(&MoveItemToTrashSync, full_path),
-    callback);
+    base::BindOnce(&MoveItemToTrashSync, full_path),
+    std::move(callback));
 }
 
 void Beep() {

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -100,7 +100,7 @@ void OpenExternal(const GURL& url,
   callback.Run(OpenExternal(url, activate) ? "" : "Failed to open");
 }
 
-std::vector<std::string> MoveItemToTrashCommand(const base::FilePath& full_path) {
+std::vector<std::string> MoveItemToTrashArgs(const base::FilePath& full_path) {
   std::string trash;
   if (getenv(ELECTRON_TRASH) != NULL) {
     trash = getenv(ELECTRON_TRASH);
@@ -141,9 +141,9 @@ std::vector<std::string> MoveItemToTrashCommand(const base::FilePath& full_path)
 }
 
 bool MoveItemToTrashSync(const base::FilePath& full_path) {
-  auto command = MoveItemToTrashCommand(full_path);
+  auto command = MoveItemToTrashArgs(full_path);
   std::string* out = new std::string;
-  // TODO: actually pass output to reject call in case of failure
+  // TODO(YurySolovyov): actually pass output to reject call in case of failure
   return base::GetAppOutputAndError(command, out);
 }
 
@@ -153,8 +153,7 @@ void MoveItemToTrash(const base::FilePath& full_path,
     FROM_HERE,
     {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
     base::Bind(&MoveItemToTrashSync, full_path),
-    callback
-  );
+    callback);
 }
 
 void Beep() {

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -180,14 +180,14 @@ bool MoveItemToTrashSync(const base::FilePath& full_path) {
                  << " to trash";
   return status;
 }
-  
+
 void MoveItemToTrash(const base::FilePath& full_path,
                      MoveItemToTrashCallback callback) {
   base::PostTaskWithTraitsAndReplyWithResult(
     FROM_HERE,
     {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
-    base::Bind(&MoveItemToTrashSync, full_path),
-    callback);
+    base::BindOnce(&MoveItemToTrashSync, full_path),
+    std::move(callback));
 }
 
 void Beep() {

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -399,8 +399,8 @@ void MoveItemToTrash(const base::FilePath& full_path,
   base::PostTaskWithTraitsAndReplyWithResult(
     FROM_HERE,
     {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
-    base::Bind(&MoveItemToTrashSync, full_path),
-    callback);
+    base::BindOnce(&MoveItemToTrashSync, full_path),
+    std::move(callback));
 }
 
 void Beep() {

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -400,8 +400,7 @@ void MoveItemToTrash(const base::FilePath& full_path,
     FROM_HERE,
     {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
     base::Bind(&MoveItemToTrashSync, full_path),
-    callback
-  );
+    callback);
 }
 
 void Beep() {

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -53,8 +53,8 @@ example, mailto: URLs in the user's default mail agent).
 
 * `fullPath` String
 
-Returns `Promise` - Which is resolved to `undefined` in case of success or
-rejected with `Error` in case of failure.
+Returns `Promise` - Which is fulfilled in case of success or rejected with
+`Error` in case of failure.
 
 Asynchronously move the given file or directory to trash.
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -53,9 +53,18 @@ example, mailto: URLs in the user's default mail agent).
 
 * `fullPath` String
 
+Returns `Promise` - Which is resolved to `undefined` in case of success or
+rejected with `Error` in case of failure.
+
+Asynchronously move the given file or directory to trash.
+
+### `shell.moveItemToTrashSync(fullPath)`
+
+* `fullPath` String
+
 Returns `Boolean` - Whether the item was successfully moved to the trash.
 
-Move the given file to trash and returns a boolean status for the operation.
+Move the given file or directory to trash and return a boolean status for the operation.
 
 ### `shell.beep()`
 

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -117,7 +117,7 @@ describe('shell module', () => {
     })
 
     it('fails to trash file that does not exist', () => {
-      const nonExistentPath = filePath + '_does_not_exist';
+      const nonExistentPath = filePath + '_does_not_exist'
 
       const result = shell.moveItemToTrash(nonExistentPath)
       assert.equal(result, false)

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -81,8 +81,19 @@ describe('shell module', () => {
   })
 
   describe('shell.moveItemToTrash', () => {
-    const filePath = path.join(os.tmpdir(), `${Date.now()}.md`)
-    fs.writeFileSync(filePath, '# Hello')
+    let filePath
+    beforeEach(() => {
+      filePath = path.join(os.tmpdir(), `${Date.now()}.md`)
+      fs.writeFileSync(filePath, '# Hello')
+    })
+
+    afterEach(() => {
+      try {
+        fs.unlinkSync(filePath)
+      } catch (e) {
+        // Meh.
+      }
+    })
 
     it('moves file to trash asynchronously', done => {
       shell.moveItemToTrash(filePath).then(() => {
@@ -105,8 +116,19 @@ describe('shell module', () => {
   })
 
   describe('shell.moveItemToTrashSync', () => {
-    const filePath = path.join(os.tmpdir(), `${Date.now()}.md`)
-    fs.writeFileSync(filePath, '# Hello')
+    let filePath
+    beforeEach(() => {
+      filePath = path.join(os.tmpdir(), `${Date.now()}.md`)
+      fs.writeFileSync(filePath, '# Hello')
+    })
+
+    afterEach(() => {
+      try {
+        fs.unlinkSync(filePath)
+      } catch (e) {
+        // Meh.
+      }
+    })
 
     it('moves file to trash synchronously', () => {
       assert.equal(fs.existsSync(filePath), true)

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -79,4 +79,41 @@ describe('shell module', () => {
       assert.deepEqual(shell.readShortcutLink(tmpShortcut), change)
     })
   })
+
+  describe('shell.moveItemToTrash', () => {
+    const filePath = path.join(os.tmpdir(), `${Date.now()}.md`)
+    fs.writeFileSync(filePath, '# Hello')
+
+    it('moves file to trash asynchronously', done => {
+      shell.moveItemToTrash(filePath).then(() => {
+        assert.equal(fs.existsSync(filePath), false)
+        done()
+      }).catch(e => {
+        done(e)
+      })
+      assert.equal(fs.existsSync(filePath), true)
+    })
+
+    it('rejects the promise in case of error', done => {
+      shell.moveItemToTrash(filePath + '_does_not_exist').then(() => {
+        done(new Error('Should be unreachable'))
+      }).catch(e => {
+        assert.ok(e)
+        done(e)
+      })
+    })
+  })
+
+  describe('shell.moveItemToTrashSync', () => {
+    const filePath = path.join(os.tmpdir(), `${Date.now()}.md`)
+    fs.writeFileSync(filePath, '# Hello')
+
+    it('moves file to trash synchronously', () => {
+      assert.equal(fs.existsSync(filePath), true)
+
+      const result = shell.moveItemToTrash(filePath)
+      assert.equal(result, true)
+      assert.equal(fs.existsSync(filePath), false)
+    })
+  })
 })

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -115,5 +115,12 @@ describe('shell module', () => {
       assert.equal(result, true)
       assert.equal(fs.existsSync(filePath), false)
     })
+
+    it('fails to trash file that does not exist', () => {
+      const nonExistentPath = filePath + '_does_not_exist';
+
+      const result = shell.moveItemToTrash(nonExistentPath)
+      assert.equal(result, false)
+    })
   })
 })


### PR DESCRIPTION
Fixes #11555 

This might have some memory issues cause I'm still noob at manual memory management.
Looking for general feedback too.

I made some likely semver-major changes:
1. `shell.moveItemToTrash` now returns `Promise`
2. previous implementation is now `shell.moveItemToTrashSync` that still return `boolean`

TODO:
- [x] Docs update
- [x] Mac support
- [x] Use `base::bindOnce`

Need help:
- [ ] Check for memory/threading management issues
