### PR TITLE
Emit console-message in OSR mode

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -481,12 +481,8 @@ bool WebContents::DidAddMessageToConsole(content::WebContents* source,
                                          const base::string16& message,
                                          int32_t line_no,
                                          const base::string16& source_id) {
-  if (type_ == OFF_SCREEN) {
-    return false;
-  } else {
-    Emit("console-message", level, message, line_no, source_id);
-    return true;
-  }
+  Emit("console-message", level, message, line_no, source_id);
+  return true;
 }
 
 void WebContents::OnCreateWindow(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -481,8 +481,7 @@ bool WebContents::DidAddMessageToConsole(content::WebContents* source,
                                          const base::string16& message,
                                          int32_t line_no,
                                          const base::string16& source_id) {
-  Emit("console-message", level, message, line_no, source_id);
-  return true;
+  return Emit("console-message", level, message, line_no, source_id);
 }
 
 void WebContents::OnCreateWindow(


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/11919.

This removes the check such that `console-message` can be fired even when rendering in offscreen.