### PR TITLE
Update to use Squirrel.Mac that supports CDN releases

### DIFF
--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -99,10 +99,8 @@ void AutoUpdater::OnWindowAllClosed() {
   QuitAndInstall();
 }
 
-void AutoUpdater::SetFeedURL(const std::string& url, mate::Arguments* args) {
-  auto_updater::AutoUpdater::HeaderMap headers;
-  args->GetNext(&headers);
-  auto_updater::AutoUpdater::SetFeedURL(url, headers);
+void AutoUpdater::SetFeedURL(mate::Arguments* args) {
+  auto_updater::AutoUpdater::SetFeedURL(args);
 }
 
 void AutoUpdater::QuitAndInstall() {

--- a/atom/browser/api/atom_api_auto_updater.h
+++ b/atom/browser/api/atom_api_auto_updater.h
@@ -47,7 +47,7 @@ class AutoUpdater : public mate::EventEmitter<AutoUpdater>,
 
  private:
   std::string GetFeedURL();
-  void SetFeedURL(const std::string& url, mate::Arguments* args);
+  void SetFeedURL(mate::Arguments* args);
   void QuitAndInstall();
 
   DISALLOW_COPY_AND_ASSIGN(AutoUpdater);

--- a/atom/browser/auto_updater.cc
+++ b/atom/browser/auto_updater.cc
@@ -21,8 +21,7 @@ std::string AutoUpdater::GetFeedURL() {
   return "";
 }
 
-void AutoUpdater::SetFeedURL(const std::string& url,
-                             const HeaderMap& requestHeaders) {
+void AutoUpdater::SetFeedURL(mate::Arguments* args) {
 }
 
 void AutoUpdater::CheckForUpdates() {

--- a/atom/browser/auto_updater.h
+++ b/atom/browser/auto_updater.h
@@ -10,6 +10,7 @@
 
 #include "base/macros.h"
 #include "build/build_config.h"
+#include "native_mate/arguments.h"
 
 namespace base {
 class Time;
@@ -53,8 +54,7 @@ class AutoUpdater {
   static void SetDelegate(Delegate* delegate);
 
   static std::string GetFeedURL();
-  static void SetFeedURL(const std::string& url,
-                         const HeaderMap& requestHeaders);
+  static void SetFeedURL(mate::Arguments* args);
   static void CheckForUpdates();
   static void QuitAndInstall();
 

--- a/atom/browser/auto_updater_mac.mm
+++ b/atom/browser/auto_updater_mac.mm
@@ -48,7 +48,7 @@ void AutoUpdater::SetFeedURL(mate::Arguments* args) {
       args->ThrowError("Expected options object to contain a 'url' string property in setFeedUrl call");
       return;
     }
-    opts.Get("requestHeaders", &requestHeaders);
+    opts.Get("headers", &requestHeaders);
     opts.Get("serverType", &serverType);
     if (serverType != "default" && serverType != "json") {
       args->ThrowError("Expected serverType to be 'default' or 'json'");

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -88,10 +88,13 @@ On Windows only `releaseName` is available.
 
 The `autoUpdater` object has the following methods:
 
-### `autoUpdater.setFeedURL(url[, requestHeaders])`
+### `autoUpdater.setFeedURL(options)`
 
-* `url` String
-* `requestHeaders` Object (optional) _macOS_ - HTTP request headers.
+* `options` Object
+  * `url` String
+  * `requestHeaders` Object (optional) _macOS_ - HTTP request headers.
+  * `serverType` String (optional) _macOS_ - Either `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
+    README for more information.
 
 Sets the `url` and initialize the auto updater.
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -92,7 +92,7 @@ The `autoUpdater` object has the following methods:
 
 * `options` Object
   * `url` String
-  * `requestHeaders` Object (optional) _macOS_ - HTTP request headers.
+  * `headers` Object (optional) _macOS_ - HTTP request headers.
   * `serverType` String (optional) _macOS_ - Either `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
     README for more information.
 

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -19,12 +19,16 @@ class AutoUpdater extends EventEmitter {
 
   setFeedURL (options) {
     let updateURL
-    if (typeof options === 'string') {
+    if (typeof options === 'object') {
+      if (typeof options.url === 'string') {
+        updateURL = options.url
+      } else {
+        throw new Error('Expected options object to contain a \'url\' string property in setFeedUrl call')
+      }
+    } else if (typeof options === 'string') {
       updateURL = options
-    } else if (typeof options === 'object' && typeof options.url === 'string') {
-      updateURL = options.url
     } else {
-      throw new Error('Expected options.url to be a string but none was provided')
+      throw new Error('Expected an options object with a \'url\' property to be provided')
     }
     this.updateURL = updateURL
   }

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -17,7 +17,15 @@ class AutoUpdater extends EventEmitter {
     return this.updateURL
   }
 
-  setFeedURL (updateURL, headers) {
+  setFeedURL (options) {
+    let updateURL
+    if (typeof options === 'string') {
+      updateURL = options
+    } else if (typeof options === 'object' && typeof options.url === 'string') {
+      updateURL = options.url
+    } else {
+      throw new Error('Expected options.url to be a string but none was provided')
+    }
     this.updateURL = updateURL
   }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.4",
-    "electron-typescript-definitions": "^1.3.0",
+    "electron-typescript-definitions": "1.3.1",
     "github": "^9.2.0",
     "husky": "^0.14.3",
     "minimist": "^1.2.0",

--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -8,7 +8,7 @@ from lib.config import get_target_arch
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v1.2.2'
+VERSION = 'v1.3.0'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/electron/electron-frameworks/releases' \
                  '/download/' + VERSION

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -29,6 +29,25 @@ describe('autoUpdater module', function () {
     })
   })
 
+  describe('getFeedURL', function () {
+    it('returns a falsey value by default', function () {
+      assert.ok(!autoUpdater.getFeedURL())
+    })
+
+    it('correctly fetches the previously set FeedURL', function (done) {
+      if (process.platform !== 'win32') {
+        // FIXME(alexeykuzmin): Skip the test.
+        // this.skip()
+        return done()
+      }
+
+      const updateURL = 'https://fake-update.electron.io'
+      autoUpdater.setFeedURL(updateURL)
+      assert.equal(autoUpdater.getFeedURL(), updateURL)
+      done()
+    })
+  })
+
   describe('setFeedURL', function () {
     describe('on Mac or Windows', () => {
       const noThrow = (fn) => {
@@ -103,25 +122,6 @@ describe('autoUpdater module', function () {
           isServerTypeError
         )
       })
-    })
-  })
-
-  describe('getFeedURL', function () {
-    it('returns a falsey value by default', function () {
-      assert.ok(!autoUpdater.getFeedURL())
-    })
-
-    it('correctly fetches the previously set FeedURL', function (done) {
-      if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
-      }
-
-      const updateURL = 'https://fake-update.electron.io'
-      autoUpdater.setFeedURL(updateURL)
-      assert.equal(autoUpdater.getFeedURL(), updateURL)
-      done()
     })
   })
 

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -30,7 +30,45 @@ describe('autoUpdater module', function () {
   })
 
   describe('setFeedURL', function () {
+    describe('on Mac or Windows', () => {
+      const noThrow = (fn) => {
+        try { fn() } catch (err) {}
+      }
+
+      before(function () {
+        if (process.platform !== 'win32' && process.platform !== 'darwin') {
+          this.skip()
+        }
+      })
+
+      it('sets url successfully using old (url, headers) syntax', () => {
+        noThrow(() => autoUpdater.setFeedURL('http://electronjs.org', { header: 'val' }))
+        assert.equal(autoUpdater.getFeedURL(), 'http://electronjs.org')
+      })
+
+      it('throws if no url is provided when using the old style', () => {
+        assert.throws(
+          () => autoUpdater.setFeedURL(),
+          err => err.message.includes('Expected an options object with a \'url\' property to be provided') // eslint-disable-line
+        )
+      })
+
+      it('sets url successfully using new ({ url }) syntax', () => {
+        noThrow(() => autoUpdater.setFeedURL({ url: 'http://mymagicurl.local' }))
+        assert.equal(autoUpdater.getFeedURL(), 'http://mymagicurl.local')
+      })
+
+      it('throws if no url is provided when using the new style', () => {
+        assert.throws(
+          () => autoUpdater.setFeedURL({ noUrl: 'lol' }),
+          err => err.message.includes('Expected options object to contain a \'url\' string property in setFeedUrl call') // eslint-disable-line
+        )
+      })
+    })
+
     describe('on Mac', function () {
+      const isServerTypeError = (err) => err.message.includes('Expected serverType to be \'default\' or \'json\'')
+
       before(function () {
         if (process.platform !== 'darwin') {
           this.skip()
@@ -43,6 +81,27 @@ describe('autoUpdater module', function () {
           done()
         })
         autoUpdater.setFeedURL('')
+      })
+
+      it('does not throw if default is the serverType', () => {
+        assert.doesNotThrow(
+          () => autoUpdater.setFeedURL({ url: '', serverType: 'default' }),
+          isServerTypeError
+        )
+      })
+
+      it('does not throw if json is the serverType', () => {
+        assert.doesNotThrow(
+          () => autoUpdater.setFeedURL({ url: '', serverType: 'default' }),
+          isServerTypeError
+        )
+      })
+
+      it('does throw if an unknown string is the serverType', () => {
+        assert.throws(
+          () => autoUpdater.setFeedURL({ url: '', serverType: 'weow' }),
+          isServerTypeError
+        )
       })
     })
   })


### PR DESCRIPTION
This doesn't actually include the Squirrel.Mac version bump, that needs to happen in `electron-frameworks` first 👍 

This PR is backwards compatible with the old way of calling `setFeedURL` so no impact on existing consumers.  The new object based API is just to allow easier expansion in the future, adding a long list of args just gets annoying especially when multiple are optional.