### PR TITLE
Fix context menu for sandbox devtools

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -20,6 +20,7 @@
 #include "chrome/renderer/printing/print_web_view_helper.h"
 #include "content/public/renderer/render_frame.h"
 #include "native_mate/dictionary.h"
+#include "third_party/WebKit/public/web/WebDocument.h"
 #include "third_party/WebKit/public/web/WebKit.h"
 
 #include "atom/common/node_includes.h"
@@ -31,6 +32,11 @@ namespace {
 
 const std::string kIpcKey = "ipcNative";
 const std::string kModuleCacheKey = "native-module-cache";
+
+bool IsDevTools(content::RenderFrame* render_frame) {
+  return render_frame->GetWebFrame()->GetDocument().Url()
+        .ProtocolIs("chrome-devtools");
+}
 
 v8::Local<v8::Object> GetModuleCache(v8::Isolate* isolate) {
   mate::Dictionary global(isolate, isolate->GetCurrentContext()->Global());
@@ -151,15 +157,14 @@ void AtomSandboxedRendererClient::RenderViewCreated(
 void AtomSandboxedRendererClient::DidCreateScriptContext(
     v8::Handle<v8::Context> context, content::RenderFrame* render_frame) {
 
-  // Only allow preload for the main frame
-  if (!render_frame->IsMainFrame())
+  // Only allow preload for the main frame or
+  // For devtools we still want to run the preload_bundle script
+  if (!render_frame->IsMainFrame() && !IsDevTools(render_frame))
     return;
 
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   base::FilePath preload_script_path = command_line->GetSwitchValuePath(
       switches::kPreloadScript);
-  if (preload_script_path.empty())
-    return;
 
   auto isolate = context->GetIsolate();
   v8::HandleScope handle_scope(isolate);

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -32,8 +32,6 @@ const preloadModules = new Map([
   ['timers', require('timers')]
 ])
 
-const preloadSrc = fs.readFileSync(preloadPath).toString()
-
 // Pass different process object to the preload script(which should not have
 // access to things like `process.atomBinding`).
 const preloadProcess = new events.EventEmitter()
@@ -55,6 +53,11 @@ function preloadRequire (module) {
   throw new Error('module not found')
 }
 
+if (window.location.protocol === 'chrome-devtools:') {
+  // Override some inspector APIs.
+  require('../renderer/inspector')
+}
+
 // Wrap the script into a function executed in global scope. It won't have
 // access to the current scope, so we'll expose a few objects as arguments:
 //
@@ -74,13 +77,16 @@ function preloadRequire (module) {
 // and any `require('electron')` calls in `preload.js` will work as expected
 // since browserify won't try to include `electron` in the bundle, falling back
 // to the `preloadRequire` function above.
-const preloadWrapperSrc = `(function(require, process, Buffer, global, setImmediate) {
-${preloadSrc}
-})`
+if (preloadPath) {
+  const preloadSrc = fs.readFileSync(preloadPath).toString()
+  const preloadWrapperSrc = `(function(require, process, Buffer, global, setImmediate) {
+  ${preloadSrc}
+  })`
 
-// eval in window scope:
-// http://www.ecma-international.org/ecma-262/5.1/#sec-10.4.2
-const geval = eval
-const preloadFn = geval(preloadWrapperSrc)
-const {setImmediate} = require('timers')
-preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate)
+  // eval in window scope:
+  // http://www.ecma-international.org/ecma-262/5.1/#sec-10.4.2
+  const geval = eval
+  const preloadFn = geval(preloadWrapperSrc)
+  const {setImmediate} = require('timers')
+  preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate)
+}


### PR DESCRIPTION
This PR fixes #10398.
The init script did not override the inspector APIs for sandbox mode, like the non sandbox mode. This adds that.
This also allows this init script to run for dev tools window.