### PR TITLE
Use New Versioning Strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron",
-  "version": "1.8.2-beta.2",
+  "version": "0.0.0-dev",
   "repository": "https://github.com/electron/electron",
   "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
   "devDependencies": {


### PR DESCRIPTION
For after we have a `2.0.0-beta.1` release.

The `package.json` file in master should always read `0.0.0-dev`. See https://electronjs.org/docs/tutorial/electron-versioning#versionless-master
