### PR TITLE
fix floating reference glib warning

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -57,7 +57,7 @@ void GetMenuBarColor(SkColor* enabled,
   *highlight = GetStyleContextFgColor(sc, GTK_STATE_FLAG_SELECTED);
   *hover = GetStyleContextFgColor(sc, GTK_STATE_FLAG_PRELIGHT);
   *background = GetStyleContextBgColor(sc, GTK_STATE_FLAG_NORMAL);
-  g_object_unref(G_OBJECT(menu_bar));
+  gtk_widget_destroy(GTK_WIDGET(menu_bar));
 }
 
 #endif  // USE_X11


### PR DESCRIPTION
Fix an issue that I introduced earlier this week with #11879. 

A temporary floating menubar widget is destroyed incorrectly, causing this console warning:

```text
(electron:28689): Gtk-WARNING **:
A floating object was finalized. This means that someone
called g_object_unref() on an object that had only a floating
reference; the initial floating reference is not owned by anyone
and must be removed with g_object_ref_sink().
```

The warning can be silenced by replacing the `g_object_unref()` call with `gtk_widget_destroy()`.