### PR TITLE
Fix transparent windows losing transparency when devtools detaches

### DIFF
--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -167,9 +167,7 @@ void RendererClientBase::RenderViewCreated(content::RenderView* render_view) {
   if (cmd->HasSwitch(switches::kGuestInstanceID)) {  // webview.
     web_frame_widget->SetBaseBackgroundColor(SK_ColorTRANSPARENT);
   } else {  // normal window.
-    // If backgroundColor is specified then use it.
     std::string name = cmd->GetSwitchValueASCII(switches::kBackgroundColor);
-    // Otherwise use white background.
     SkColor color = name.empty() ? SK_ColorTRANSPARENT : ParseHexColor(name);
     web_frame_widget->SetBaseBackgroundColor(color);
   }

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -170,7 +170,7 @@ void RendererClientBase::RenderViewCreated(content::RenderView* render_view) {
     // If backgroundColor is specified then use it.
     std::string name = cmd->GetSwitchValueASCII(switches::kBackgroundColor);
     // Otherwise use white background.
-    SkColor color = name.empty() ? SK_ColorWHITE : ParseHexColor(name);
+    SkColor color = name.empty() ? SK_ColorTRANSPARENT : ParseHexColor(name);
     web_frame_widget->SetBaseBackgroundColor(color);
   }
 }


### PR DESCRIPTION
Fixes #11833 

[Related chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=800285&can=1&q=devtools%20transparent%20white&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified). This might be a permament fix, since before we relied on the [`SetBaseBackgroundColorOverride`](https://cs.chromium.org/chromium/src/content/renderer/render_view_impl.cc?q=setbackgroundcoloroverride&dr=C&l=2092) that was called by [`SetBackgroundOpaque`](https://cs.chromium.org/chromium/src/content/browser/renderer_host/render_widget_host_impl.cc?type=cs&l=2429), which is now gonna be cleared when the devtools is detached.