### PR TITLE
show file filter name for accessory view of file dialog

### DIFF
--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -16,17 +16,17 @@
 
 @interface PopUpButtonHandler : NSObject
 @property (nonatomic, strong) NSSavePanel *savePanel;
-@property (nonatomic, strong) NSArray *fileTypes;
-- (instancetype)initWithPanel:(NSSavePanel *)panel andTypes:(NSArray *)types;
+@property (nonatomic, strong) NSArray *fileTypesList;
+- (instancetype)initWithPanel:(NSSavePanel *)panel andTypesList:(NSArray *)typesList;
 - (void)selectFormat:(id)sender;
 @end
 
 @implementation PopUpButtonHandler
-- (instancetype)initWithPanel:(NSSavePanel *)panel andTypes:(NSArray *)types {
+- (instancetype)initWithPanel:(NSSavePanel *)panel andTypesList:(NSArray *)typesList {
   self = [super init];
   if (self) {
     _savePanel = panel;
-    _fileTypes = types;
+    _fileTypesList = typesList;
   }
   return self;
 }
@@ -34,13 +34,16 @@
 - (void)selectFormat:(id)sender {
   NSPopUpButton *button = (NSPopUpButton *)sender;
   NSInteger selectedItemIndex = [button indexOfSelectedItem];
-  NSString *nameFieldString = [[self savePanel] nameFieldStringValue];
-  NSString *trimmedNameFieldString = [nameFieldString stringByDeletingPathExtension];
-  NSString *extension = [[self fileTypes] objectAtIndex: selectedItemIndex];
+  NSArray *list = [self fileTypesList];
+  NSArray *fileTypes = [list objectAtIndex:selectedItemIndex];
 
-  NSString *nameFieldStringWithExt = [NSString stringWithFormat:@"%@.%@", trimmedNameFieldString, extension];
-  [[self savePanel] setNameFieldStringValue:nameFieldStringWithExt];
-  [[self savePanel] setAllowedFileTypes:@[extension]];
+  // If we meet a '*' file extension, we allow all the file types and no
+  // need to set the specified file types.
+  if ([fileTypes count] == 0 || [fileTypes containsObject:@"*"]) {
+    [[self savePanel] setAllowedFileTypes:nil];
+  } else {
+    [[self savePanel] setAllowedFileTypes:fileTypes];
+  }
 }
 @end
 
@@ -48,35 +51,39 @@ namespace file_dialog {
 
 namespace {
 
-static PopUpButtonHandler *popUpButtonHandler;
-
 void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
-  NSMutableSet* file_type_set = [NSMutableSet set];
-  for (size_t i = 0; i < filters.size(); ++i) {
-    const Filter& filter = filters[i];
-    for (size_t j = 0; j < filter.second.size(); ++j) {
-      // If we meet a '*' file extension, we allow all the file types and no
-      // need to set the specified file types.
+  NSMutableArray* file_types_list = [NSMutableArray array];
+  NSMutableArray* filter_names = [NSMutableArray array];
 
-      if (filter.second[j] == "*") {
-        [dialog setAllowsOtherFileTypes:YES];
-        return;
-      }
-      base::ScopedCFTypeRef<CFStringRef> ext_cf(
-          base::SysUTF8ToCFStringRef(filter.second[j]));
+  // Create array to keep file types and their name.
+  for (size_t i = 0; i < filters.size(); ++i) {
+    NSMutableSet* file_type_set = [NSMutableSet set];
+    const Filter& filter = filters[i];
+    base::ScopedCFTypeRef<CFStringRef> name_cf(base::SysUTF8ToCFStringRef(filter.first));
+    [filter_names addObject:base::mac::CFToNSCast(name_cf.get())];
+    for (size_t j = 0; j < filter.second.size(); ++j) {
+      base::ScopedCFTypeRef<CFStringRef> ext_cf(base::SysUTF8ToCFStringRef(filter.second[j]));
       [file_type_set addObject:base::mac::CFToNSCast(ext_cf.get())];
     }
+    [file_types_list addObject:[file_type_set allObjects]];
   }
 
   // Passing empty array to setAllowedFileTypes will cause exception.
   NSArray* file_types = nil;
-  if ([file_type_set count])
-    file_types = [file_type_set allObjects];
-
+  NSUInteger count = [file_types_list count];
+  if (count > 0) {
+    file_types = [[file_types_list objectAtIndex:0] allObjects];
+    // If we meet a '*' file extension, we allow all the file types and no
+    // need to set the specified file types.
+    if ([file_types count] == 0 || [file_types containsObject:@"*"]) {
+      file_types = nil;
+    }
+  }
   [dialog setAllowedFileTypes:file_types];
 
-  if (!popUpButtonHandler)
-    popUpButtonHandler = [[PopUpButtonHandler alloc] initWithPanel:dialog andTypes:file_types];
+  if (count <= 1) {
+    return; // don't add file format picker
+  }
 
   // add file format picker
   NSView  *accessoryView = [[NSView alloc] initWithFrame:NSMakeRect(0.0, 0.0, 200, 32.0)];
@@ -89,7 +96,8 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   [label setDrawsBackground:NO];
 
   NSPopUpButton *popupButton = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(50.0, 2, 140, 22.0) pullsDown:NO];
-  [popupButton addItemsWithTitles:file_types];
+  PopUpButtonHandler *popUpButtonHandler = [[PopUpButtonHandler alloc] initWithPanel:dialog andTypesList:[file_types_list copy]];
+  [popupButton addItemsWithTitles:[filter_names copy]];
   [popupButton setTarget:popUpButtonHandler];
   [popupButton setAction:@selector(selectFormat:)];
 

--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -15,36 +15,56 @@
 #include "base/strings/sys_string_conversions.h"
 
 @interface PopUpButtonHandler : NSObject
-@property (nonatomic, strong) NSSavePanel *savePanel;
-@property (nonatomic, strong) NSArray *fileTypesList;
-- (instancetype)initWithPanel:(NSSavePanel *)panel andTypesList:(NSArray *)typesList;
+
+@property(nonatomic, assign) NSSavePanel* savePanel;
+@property(nonatomic, strong) NSArray* fileTypesList;
+
+- (instancetype)initWithPanel:(NSSavePanel*)panel
+                 andTypesList:(NSArray*)typesList;
 - (void)selectFormat:(id)sender;
+
 @end
 
 @implementation PopUpButtonHandler
-- (instancetype)initWithPanel:(NSSavePanel *)panel andTypesList:(NSArray *)typesList {
+
+- (instancetype)initWithPanel:(NSSavePanel*)panel
+                 andTypesList:(NSArray*)typesList {
   self = [super init];
   if (self) {
-    _savePanel = panel;
-    _fileTypesList = typesList;
+    [self setSavePanel:panel];
+    [self setFileTypesList:typesList];
   }
   return self;
 }
 
 - (void)selectFormat:(id)sender {
-  NSPopUpButton *button = (NSPopUpButton *)sender;
+  NSPopUpButton* button = (NSPopUpButton*)sender;
   NSInteger selectedItemIndex = [button indexOfSelectedItem];
-  NSArray *list = [self fileTypesList];
-  NSArray *fileTypes = [list objectAtIndex:selectedItemIndex];
+  NSArray* list = [self fileTypesList];
+  NSArray* fileTypes = [list objectAtIndex:selectedItemIndex];
 
   // If we meet a '*' file extension, we allow all the file types and no
   // need to set the specified file types.
-  if ([fileTypes count] == 0 || [fileTypes containsObject:@"*"]) {
+  if ([fileTypes count] == 0 || [fileTypes containsObject:@"*"])
     [[self savePanel] setAllowedFileTypes:nil];
-  } else {
+  else
     [[self savePanel] setAllowedFileTypes:fileTypes];
-  }
 }
+
+@end
+
+// Manages the PopUpButtonHandler.
+@interface AtomAccessoryView : NSView
+@end
+
+@implementation AtomAccessoryView
+
+- (void)dealloc {
+  auto* popupButton = static_cast<NSPopUpButton*>([[self subviews] objectAtIndex: 1]);
+  [[popupButton target] release];
+  [super dealloc];
+}
+
 @end
 
 namespace file_dialog {
@@ -56,13 +76,13 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   NSMutableArray* filter_names = [NSMutableArray array];
 
   // Create array to keep file types and their name.
-  for (size_t i = 0; i < filters.size(); ++i) {
+  for (const Filter& filter : filters) {
     NSMutableSet* file_type_set = [NSMutableSet set];
-    const Filter& filter = filters[i];
-    base::ScopedCFTypeRef<CFStringRef> name_cf(base::SysUTF8ToCFStringRef(filter.first));
+    base::ScopedCFTypeRef<CFStringRef> name_cf(
+        base::SysUTF8ToCFStringRef(filter.first));
     [filter_names addObject:base::mac::CFToNSCast(name_cf.get())];
-    for (size_t j = 0; j < filter.second.size(); ++j) {
-      base::ScopedCFTypeRef<CFStringRef> ext_cf(base::SysUTF8ToCFStringRef(filter.second[j]));
+    for (const std::string& ext : filter.second) {
+      base::ScopedCFTypeRef<CFStringRef> ext_cf(base::SysUTF8ToCFStringRef(ext));
       [file_type_set addObject:base::mac::CFToNSCast(ext_cf.get())];
     }
     [file_types_list addObject:[file_type_set allObjects]];
@@ -75,19 +95,19 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
     file_types = [[file_types_list objectAtIndex:0] allObjects];
     // If we meet a '*' file extension, we allow all the file types and no
     // need to set the specified file types.
-    if ([file_types count] == 0 || [file_types containsObject:@"*"]) {
+    if ([file_types count] == 0 || [file_types containsObject:@"*"])
       file_types = nil;
-    }
   }
   [dialog setAllowedFileTypes:file_types];
 
-  if (count <= 1) {
-    return; // don't add file format picker
-  }
+  if (count <= 1)
+    return;  // don't add file format picker
 
-  // add file format picker
-  NSView  *accessoryView = [[NSView alloc] initWithFrame:NSMakeRect(0.0, 0.0, 200, 32.0)];
-  NSTextField *label = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 60, 22)];
+  // Add file format picker.
+  AtomAccessoryView* accessoryView =
+      [[AtomAccessoryView alloc] initWithFrame:NSMakeRect(0.0, 0.0, 200, 32.0)];
+  NSTextField* label =
+      [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 60, 22)];
 
   [label setEditable:NO];
   [label setStringValue:@"Format:"];
@@ -95,16 +115,18 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   [label setBezeled:NO];
   [label setDrawsBackground:NO];
 
-  NSPopUpButton *popupButton = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(50.0, 2, 140, 22.0) pullsDown:NO];
-  PopUpButtonHandler *popUpButtonHandler = [[PopUpButtonHandler alloc] initWithPanel:dialog andTypesList:[file_types_list copy]];
-  [popupButton addItemsWithTitles:[filter_names copy]];
+  NSPopUpButton* popupButton = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(50.0, 2, 140, 22.0)
+                                                          pullsDown:NO];
+  PopUpButtonHandler* popUpButtonHandler = [[PopUpButtonHandler alloc] initWithPanel:dialog
+                                                                        andTypesList:file_types_list];
+  [popupButton addItemsWithTitles:filter_names];
   [popupButton setTarget:popUpButtonHandler];
   [popupButton setAction:@selector(selectFormat:)];
 
-  [accessoryView addSubview:label];
-  [accessoryView addSubview:popupButton];
+  [accessoryView addSubview:[label autorelease]];
+  [accessoryView addSubview:[popupButton autorelease]];
 
-  [dialog setAccessoryView:accessoryView];
+  [dialog setAccessoryView:[accessoryView autorelease]];
 }
 
 void SetupDialog(NSSavePanel* dialog,
@@ -126,6 +148,7 @@ void SetupDialog(NSSavePanel* dialog,
   NSString* default_dir = nil;
   NSString* default_filename = nil;
   if (!settings.default_path.empty()) {
+    base::ThreadRestrictions::ScopedAllowIO allow_io;
     if (base::DirectoryExists(settings.default_path)) {
       default_dir = base::SysUTF8ToNSString(settings.default_path.value());
     } else {


### PR DESCRIPTION
This PR would improve format picker of macOS file fialog.

- Respect filters option of `dialog.showOpenDialog()` and `dialog.showSaveDialog()`. (#10335)
- Show "All Files" for `<input>` apart from "accept" attribute. (#11456 and the original problem of #9745)

![format_filter](https://user-images.githubusercontent.com/1412057/36383858-ccf89066-15d0-11e8-9e6d-9233d52d79f8.png)

```javascript
dialog.showSaveDialog({
  filters: [
    {name: 'Images', extensions: ['jpg', 'png', 'gif']},
    {name: 'Movies', extensions: ['mkv', 'avi', 'mp4']},
    {name: 'Custom File Type', extensions: ['as']},
    {name: 'All Files', extensions: ['*']}
  ]
});
```

Unfortunately I could not find a way to automate tests.