### PR TITLE
add conditional for menu.popup(window, callback)

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -58,8 +58,9 @@ Menu.prototype.popup = function (window, x, y, positioningItem) {
     callback = newPosition
   }
 
-  // menu.popup({})
-  if (window != null && window.constructor === Object) {
+  // menu.popup({}) || menu.popup(window, callback)
+  if ((window != null && window.constructor === Object) ||
+      (x && typeof x === 'function')) {
     opts = window
     callback = arguments[1]
   // menu.popup(window, {})

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -383,6 +383,11 @@ describe('Menu module', () => {
       assert.equal(y, 101)
     })
 
+    it('works with a given BrowserWindow, no options, and a callback', (done) => {
+      menu.popup(w, () => done())
+      menu.closePopup()
+    })
+
     it('calls the callback', (done) => {
       menu.popup({}, () => done())
       menu.closePopup()


### PR DESCRIPTION
Although documentation specifies `menu.popup([browserWindow, options, callback])` & that `options` are optional, if there are no options passed in then the `callback` won't fire. 

This resolves that by adding a conditional for `menu.popup(window, callback)`.

Todo:
- [x] add a spec