### PR TITLE
security.md: Reformat security recommendation checklist

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -69,20 +69,18 @@ either `process.env` or the `window` object.
 This is not bulletproof, but at the least, you should follow these steps to
 improve the security of your application.
 
-1) [Only load secure content](#only-load-secure-content)
-2) [Disable the Node.js integration in all renderers that display remote content](#disable-node.js-integration-for-remote-content)
-3) [Enable context isolation in all renderers that display remote content](#enable-context-isolation-for-remote-content)
-4) [Use `ses.setPermissionRequestHandler()` in all sessions that load remote content](#handle-session-permission-requests-from-remote-content)
-5) [Do not disable `webSecurity`](#do-not-disable-websecurity)
-6) [Define a `Content-Security-Policy`](#define-a-content-security-policy)
-  and use restrictive rules (i.e. `script-src 'self'`)
-7) [Override and disable `eval`](#override-and-disable-eval)
-, which allows strings to be executed as code.
-8) [Do not set `allowRunningInsecureContent` to `true`](#do-not-set-allowRunningInsecureContent-to-true)
-9) [Do not enable experimental features](#do-not-enable-experimental-features)
-10) [Do not use `blinkFeatures`](#do-not-use-blinkfeatures)
-11) [WebViews: Do not use `allowpopups`](#do-not-use-allowpopups)
-12) [WebViews: Verify the options and params of all `<webview>` tags](#verify-webview-options-before-creation)
+1. [Only load secure content](#only-load-secure-content)
+2. [Disable the Node.js integration in all renderers that display remote content](#disable-node.js-integration-for-remote-content)
+3. [Enable context isolation in all renderers that display remote content](#enable-context-isolation-for-remote-content)
+4. [Use `ses.setPermissionRequestHandler()` in all sessions that load remote content](#handle-session-permission-requests-from-remote-content)
+5. [Do not disable `webSecurity`](#do-not-disable-websecurity)
+6. [Define a `Content-Security-Policy`](#define-a-content-security-policy) and use restrictive rules (i.e. `script-src 'self'`)
+7. [Override and disable `eval`](#override-and-disable-eval), which allows strings to be executed as code.
+8. [Do not set `allowRunningInsecureContent` to `true`](#do-not-set-allowRunningInsecureContent-to-true)
+9. [Do not enable experimental features](#do-not-enable-experimental-features)
+10. [Do not use `blinkFeatures`](#do-not-use-blinkfeatures)
+11. [WebViews: Do not use `allowpopups`](#do-not-use-allowpopups)
+12. [WebViews: Verify the options and params of all `<webview>` tags](#verify-webview-options-before-creation)
 
 
 ## 1) Only Load Secure Content


### PR DESCRIPTION
The current list [being rendered](https://electronjs.org/docs/tutorial/security#checklist-security-recommendations) doesn't look so good:

![image](https://user-images.githubusercontent.com/630613/36397072-b0001a80-15c9-11e8-8620-a8fb62460463.png)

This PR aims to make it look better (**note**: I have not validated how this will be rendered on the actual `electronjs.org` web site, so shooting a bit in the dark here.) Lists are usually easier on the reader if split on multiple lines.