### PR TITLE
Cache libnotify server caps

### DIFF
--- a/brightray/browser/linux/libnotify_notification.cc
+++ b/brightray/browser/linux/libnotify_notification.cc
@@ -41,14 +41,7 @@ bool NotifierSupportsActions() {
   if (getenv("ELECTRON_USE_UBUNTU_NOTIFIER"))
     return false;
 
-  static bool notify_has_result = false;
-  static bool notify_result = false;
-
-  if (notify_has_result)
-    return notify_result;
-
-  notify_result = HasCapability("actions");
-  return notify_result;
+  return HasCapability("actions");
 }
 
 void log_and_clear_error(GError* error, const char* context) {

--- a/brightray/browser/linux/libnotify_notification.cc
+++ b/brightray/browser/linux/libnotify_notification.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/files/file_enumerator.h"
+#include "base/logging.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/notification_delegate.h"
@@ -60,10 +61,12 @@ bool LibnotifyNotification::Initialize() {
       !libnotify_loader_.Load("libnotify.so.5") &&
       !libnotify_loader_.Load("libnotify.so.1") &&
       !libnotify_loader_.Load("libnotify.so")) {
+    LOG(WARNING) << "Unable to find libnotify; notifications disabled";
     return false;
   }
   if (!libnotify_loader_.notify_is_initted() &&
       !libnotify_loader_.notify_init(GetApplicationName().c_str())) {
+    LOG(WARNING) << "Unable to initialize libnotify; notifications disabled";
     return false;
   }
   return true;


### PR DESCRIPTION
An offshoot of the other libnotify branch.

Before this patch, the implementation of `HasCapability()` makes a blocking round-trip dbus call every  time it's called, even though notify server capabilities are static and can be remembered & reused. This method is also called twice by `LibnotifyNotification::Show()`, there's a redundant blocking bus call before the first notification is ever shown.

In addition, `NotifierSupportsActions()` tries to cache whether or not `actions` is a supported capability; but due to a coding error, the cache flag was never set and so it also made a blocking round trip every time.

This patch caches the server capabilities.

Unrelated but also useful: this patch logs a warning if `LibnotifyNotification::Initialize()` fails. This appears to be the reason (well, one of the reasons) that the other libnotify branch is failing CI. :roll_eyes: 