### PR TITLE
remove setExtraParameter for 2.0

### DIFF
--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -31,15 +31,6 @@ struct Converter<CrashReporter::UploadReportResult> {
 
 namespace {
 
-// TODO(2.0) Remove
-void SetExtraParameter(const std::string& key, mate::Arguments* args) {
-  std::string value;
-  if (args->GetNext(&value))
-    CrashReporter::GetInstance()->AddExtraParameter(key, value);
-  else
-    CrashReporter::GetInstance()->RemoveExtraParameter(key);
-}
-
 void AddExtraParameter(const std::string& key, const std::string& value) {
   CrashReporter::GetInstance()->AddExtraParameter(key, value);
 }
@@ -57,7 +48,6 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   mate::Dictionary dict(context->GetIsolate(), exports);
   auto reporter = base::Unretained(CrashReporter::GetInstance());
   dict.SetMethod("start", base::Bind(&CrashReporter::Start, reporter));
-  dict.SetMethod("setExtraParameter", &SetExtraParameter);
   dict.SetMethod("addExtraParameter", &AddExtraParameter);
   dict.SetMethod("removeExtraParameter", &RemoveExtraParameter);
   dict.SetMethod("getParameters", &GetParameters);

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -62,7 +62,7 @@ This will start the process that will monitor and send the crash reports. Replac
 and `crashesDirectory` with appropriate values.
 
 **Note:** If you need send additional/updated `extra` parameters after your
-first call `start` you can call `setExtraParameter` on macOS or call `start`
+first call `start` you can call `addExtraParameter` on macOS or call `start`
 again with the new/updated `extra` parameters on Linux and Windows.
 
 ```js

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -104,15 +104,6 @@ class CrashReporter {
     }
   }
 
-  // TODO(2.0) Remove
-  setExtraParameter (key, value) {
-    if (!process.noDeprecations) {
-      deprecate.warn('crashReporter.setExtraParameter',
-        'crashReporter.addExtraParameter or crashReporter.removeExtraParameter')
-    }
-    binding.setExtraParameter(key, value)
-  }
-
   addExtraParameter (key, value) {
     binding.addExtraParameter(key, value)
   }

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -4,7 +4,7 @@ const {spawn} = require('child_process')
 const os = require('os')
 const path = require('path')
 const electron = require('electron')
-const {app, deprecate} = process.type === 'browser' ? electron : electron.remote
+const {app} = process.type === 'browser' ? electron : electron.remote
 const binding = process.atomBinding('crash_reporter')
 
 class CrashReporter {


### PR DESCRIPTION
We previously deprecated ` crashReporter.setExtraParameter` in favor of `crashReporter.addExtraParameter` and `crashReporter.removeExtraParameter`

This PR removes backwards compatibility for the old method in 2.0.