### PR TITLE
remove setZoomLevelLimits

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -407,9 +407,7 @@ void WebFrame::BuildPrototype(
       .SetMethod("setIsolatedWorldHumanReadableName",
                  &WebFrame::SetIsolatedWorldHumanReadableName)
       .SetMethod("getResourceUsage", &WebFrame::GetResourceUsage)
-      .SetMethod("clearCache", &WebFrame::ClearCache)
-      // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
-      .SetMethod("setZoomLevelLimits", &WebFrame::SetVisualZoomLevelLimits);
+      .SetMethod("clearCache", &WebFrame::ClearCache);
 }
 
 }  // namespace api

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -842,14 +842,6 @@ limits of 300% and 50% of original size, respectively. The formula for this is
 Sends a request to get current zoom level, the `callback` will be called with
 `callback(zoomLevel)`.
 
-#### `contents.setZoomLevelLimits(minimumLevel, maximumLevel)`
-
-* `minimumLevel` Number
-* `maximumLevel` Number
-
-**Deprecated:** Call `setVisualZoomLevelLimits` instead to set the visual zoom
-level limits. This method will be removed in Electron 2.0.
-
 #### `contents.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 
 * `minimumLevel` Number

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -39,14 +39,6 @@ limits of 300% and 50% of original size, respectively.
 
 Returns `Number` - The current zoom level.
 
-### `webFrame.setZoomLevelLimits(minimumLevel, maximumLevel)`
-
-* `minimumLevel` Number
-* `maximumLevel` Number
-
-**Deprecated:** Call `setVisualZoomLevelLimits` instead to set the visual zoom
-level limits. This method will be removed in Electron 2.0.
-
 ### `webFrame.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 
 * `minimumLevel` Number

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -109,9 +109,7 @@ const webFrameMethods = [
   'insertCSS',
   'insertText',
   'setLayoutZoomLevelLimits',
-  'setVisualZoomLevelLimits',
-  // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
-  'setZoomLevelLimits'
+  'setVisualZoomLevelLimits'
 ]
 const webFrameMethodsWithResult = []
 

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -375,9 +375,7 @@ const registerWebViewElement = function () {
     'send',
     'sendInputEvent',
     'setLayoutZoomLevelLimits',
-    'setVisualZoomLevelLimits',
-    // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
-    'setZoomLevelLimits'
+    'setVisualZoomLevelLimits'
   ]
 
   // Forward proto.foo* method calls to WebViewImpl.foo*.

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -134,7 +134,6 @@ describe('webFrame module', function () {
 
   it('supports setting the visual and layout zoom level limits', function () {
     assert.doesNotThrow(function () {
-      webFrame.setZoomLevelLimits(1, 100)
       webFrame.setVisualZoomLevelLimits(1, 50)
       webFrame.setLayoutZoomLevelLimits(0, 25)
     })


### PR DESCRIPTION
Remove method marked for 2.0 removal per [2.0 breaking changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)

`setZoomLevelLimits` => `setVisualZoomLevelLimits`