### PR TITLE
remove support for hidden-inset

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -813,8 +813,7 @@ struct Converter<atom::NativeWindowMac::TitleBarStyle> {
       return false;
     if (title_bar_style == "hidden") {
       *out = atom::NativeWindowMac::HIDDEN;
-    } else if (title_bar_style == "hidden-inset" ||  // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
-               title_bar_style == "hiddenInset") {
+    } else if (title_bar_style == "hiddenInset") {
       *out = atom::NativeWindowMac::HIDDEN_INSET;
     } else if (title_bar_style == "customButtonsOnHover") {
       *out = atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -220,7 +220,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `hidden` - Results in a hidden title bar and a full size content window, yet
       the title bar still has the standard window controls ("traffic lights") in
       the top left.
-    * `hidden-inset` - Deprecated, use `hiddenInset` instead.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
     * `customButtonsOnHover` Boolean (optional) - Draw custom close, minimize,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -927,7 +927,7 @@ describe('BrowserWindow module', () => {
         show: false,
         width: 400,
         height: 400,
-        titleBarStyle: 'hidden-inset'
+        titleBarStyle: 'hiddenInset'
       })
       const contentSize = w.getContentSize()
       assert.equal(contentSize[1], 400)


### PR DESCRIPTION
Remove support for `BrowserWindow` parameter marked for 2.0 removal per [2.0 breaking changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)

`hidden-inset` => `hiddenInset`