### PR TITLE
remove support for crashReporter autoSubmit

### DIFF
--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -20,7 +20,6 @@ class CrashReporter {
       uploadToServer
     } = options
 
-    if (uploadToServer == null) uploadToServer = options.autoSubmit
     if (uploadToServer == null) uploadToServer = true
     if (ignoreSystemCrashHandler == null) ignoreSystemCrashHandler = false
     if (extra == null) extra = {}


### PR DESCRIPTION
Remove support for `autosubmit` as a `crashReporter` parameter per [2.0 Breaking Changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)

```
// Removed
  crashReporter.start({
    companyName: 'Crashly',
    submitURL: 'https://crash.server.com',
    autoSubmit: true
  })
  // Replace with
  crashReporter.start({
    companyName: 'Crashly',
    submitURL: 'https://crash.server.com',
    uploadToServer: true
  })
```

/cc @ckerr 