### PR TITLE
Remove nativeImage deprecated methods

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -583,10 +583,7 @@ void NativeImage::BuildPrototype(
       .SetMethod("resize", &NativeImage::Resize)
       .SetMethod("crop", &NativeImage::Crop)
       .SetMethod("getAspectRatio", &NativeImage::GetAspectRatio)
-      .SetMethod("addRepresentation", &NativeImage::AddRepresentation)
-      // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
-      .SetMethod("toPng", &NativeImage::ToPNG)
-      .SetMethod("toJpeg", &NativeImage::ToJPEG);
+      .SetMethod("addRepresentation", &NativeImage::AddRepresentation);
 }
 
 }  // namespace api

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -6,7 +6,7 @@ const {expect} = require('chai')
 const {nativeImage} = require('electron')
 const path = require('path')
 
-describe('nativeImage module', () => {
+describe.only('nativeImage module', () => {
   const ImageFormat = {
     PNG: 'png',
     JPEG: 'jpeg'
@@ -162,9 +162,6 @@ describe('nativeImage module', () => {
       const imageI = nativeImage.createFromBuffer(imageA.toBitmap(),
         {width: 538, height: 190, scaleFactor: 2.0})
       expect(imageI.getSize()).to.deep.equal({width: 269, height: 95})
-
-      const imageJ = nativeImage.createFromBuffer(imageA.toPNG(), 2.0)
-      expect(imageJ.getSize()).to.deep.equal({width: 269, height: 95})
     })
   })
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -6,7 +6,7 @@ const {expect} = require('chai')
 const {nativeImage} = require('electron')
 const path = require('path')
 
-describe.only('nativeImage module', () => {
+describe('nativeImage module', () => {
   const ImageFormat = {
     PNG: 'png',
     JPEG: 'jpeg'


### PR DESCRIPTION
Remove deprecated methods in `nativeImage` per [2.0 Breaking Changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)
```js
  // Deprecated
  nativeImage.toPng()
  // Replace with
  nativeImage.toPNG()
  
  // Deprecated
  nativeImage.toJpeg()
  // Replace with
  nativeImage.toJPEG()
  
  // Deprecated
  nativeImage.createFromBuffer(buffer, 1.0)
  // Replace with
  nativeImage.createFromBuffer(buffer, {
    scaleFactor: 1.0
  })
```