### PR TITLE
Remove atom-shell process name

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -71,9 +71,6 @@ void AtomBindings::BindTo(v8::Isolate* isolate,
     // TODO(kevinsawicki): Make read-only in 2.0 to match node
     versions.Set(ATOM_PROJECT_NAME, ATOM_VERSION_STRING);
     versions.Set("chrome", CHROME_VERSION_STRING);
-
-    // TODO(kevinsawicki): Remove in 2.0
-    versions.Set("atom-shell", ATOM_VERSION_STRING);
   }
 }
 


### PR DESCRIPTION
Remove `atom-shell` process name per [2.0 Breaking Changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)

```js
  // Deprecated
  process.versions['atom-shell']
  // Replace with
  process.versions.electron
```