### PR TITLE
Fix appname on linux

### DIFF
--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -97,17 +97,14 @@ void Browser::Shutdown() {
 }
 
 std::string Browser::GetVersion() const {
-  if (version_override_.empty()) {
-    std::string version = GetExecutableFileVersion();
-    if (!version.empty())
-      return version;
-  }
-
-  return version_override_;
+  std::string ret = brightray::GetOverriddenApplicationVersion();
+  if (ret.empty())
+    ret = GetExecutableFileVersion();
+  return ret;
 }
 
 void Browser::SetVersion(const std::string& version) {
-  version_override_ = version;
+  brightray::OverrideApplicationVersion(version);
 }
 
 std::string Browser::GetName() const {

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -108,13 +108,10 @@ void Browser::SetVersion(const std::string& version) {
 }
 
 std::string Browser::GetName() const {
-  if (name_override_.empty()) {
-    std::string name = GetExecutableFileProductName();
-    if (!name.empty())
-      return name;
-  }
-
-  return name_override_;
+  std::string ret = name_override_;
+  if (ret.empty())
+    ret = GetExecutableFileProductName();
+  return ret;
 }
 
 void Browser::SetName(const std::string& name) {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -273,7 +273,6 @@ class Browser : public WindowListObserver {
   // The browser is being shutdown.
   bool is_shutdown_;
 
-  std::string version_override_;
   std::string name_override_;
 
   int badge_count_ = 0;

--- a/atom/common/linux/application_info.cc
+++ b/atom/common/linux/application_info.cc
@@ -30,7 +30,7 @@ namespace brightray {
 
 std::string GetApplicationName() {
   // attempt #1: the string set in app.setName()
-  std::string ret = GetOverridenApplicationName();
+  std::string ret = GetOverriddenApplicationName();
 
   // attempt #2: the 'Name' entry from .desktop file's [Desktop] section
   if (ret.empty()) {

--- a/atom/common/linux/application_info.cc
+++ b/atom/common/linux/application_info.cc
@@ -2,9 +2,12 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "brightray/common/application_info.h"
+
 #include <string>
 
 #include "atom/common/atom_version.h"
+#include "base/log.h"
 
 namespace brightray {
 
@@ -13,7 +16,23 @@ std::string GetApplicationName() {
 }
 
 std::string GetApplicationVersion() {
-  return ATOM_VERSION_STRING;
+  std::string ret;
+
+  // ensure ATOM_PRODUCT_NAME and ATOM_PRODUCT_STRING match up
+  if (GetApplicationName() == ATOM_PRODUCT_NAME)
+    ret = ATOM_VERSION_STRING;
+
+  // try to use the string set in app.setVersion()
+  if (ret.empty())
+    ret = GetOverriddenApplicationVersion();
+
+  // no known version number; return some safe fallback
+  if (ret.empty()) {
+    LOG(WARNING) << "No version found. Was app.setVersion() called?";
+    ret = "0.0";
+  }
+
+  return ret;
 }
 
 }  // namespace brightray

--- a/brightray/common/application_info.cc
+++ b/brightray/common/application_info.cc
@@ -12,7 +12,7 @@ std::string g_overridden_application_version;
 void OverrideApplicationName(const std::string& name) {
   g_overriden_application_name = name;
 }
-std::string GetOverridenApplicationName() {
+std::string GetOverriddenApplicationName() {
   return g_overriden_application_name;
 }
 

--- a/brightray/common/application_info.cc
+++ b/brightray/common/application_info.cc
@@ -4,16 +4,16 @@ namespace brightray {
 
 namespace {
 
-std::string g_overriden_application_name;
+std::string g_overridden_application_name;
 std::string g_overridden_application_version;
 
 }
 
 void OverrideApplicationName(const std::string& name) {
-  g_overriden_application_name = name;
+  g_overridden_application_name = name;
 }
 std::string GetOverriddenApplicationName() {
-  return g_overriden_application_name;
+  return g_overridden_application_name;
 }
 
 void OverrideApplicationVersion(const std::string& version) {

--- a/brightray/common/application_info.cc
+++ b/brightray/common/application_info.cc
@@ -5,6 +5,7 @@ namespace brightray {
 namespace {
 
 std::string g_overriden_application_name;
+std::string g_overridden_application_version;
 
 }
 
@@ -13,6 +14,13 @@ void OverrideApplicationName(const std::string& name) {
 }
 std::string GetOverridenApplicationName() {
   return g_overriden_application_name;
+}
+
+void OverrideApplicationVersion(const std::string& version) {
+  g_overridden_application_version = version;
+}
+std::string GetOverriddenApplicationVersion() {
+  return g_overridden_application_version;
 }
 
 }  // namespace brightray

--- a/brightray/common/application_info.h
+++ b/brightray/common/application_info.h
@@ -10,7 +10,7 @@
 namespace brightray {
 
 void OverrideApplicationName(const std::string& name);
-std::string GetOverridenApplicationName();
+std::string GetOverriddenApplicationName();
 
 void OverrideApplicationVersion(const std::string& name);
 std::string GetOverriddenApplicationVersion();

--- a/brightray/common/application_info.h
+++ b/brightray/common/application_info.h
@@ -12,7 +12,7 @@ namespace brightray {
 void OverrideApplicationName(const std::string& name);
 std::string GetOverriddenApplicationName();
 
-void OverrideApplicationVersion(const std::string& name);
+void OverrideApplicationVersion(const std::string& version);
 std::string GetOverriddenApplicationVersion();
 
 std::string GetApplicationName();

--- a/brightray/common/application_info.h
+++ b/brightray/common/application_info.h
@@ -12,6 +12,9 @@ namespace brightray {
 void OverrideApplicationName(const std::string& name);
 std::string GetOverridenApplicationName();
 
+void OverrideApplicationVersion(const std::string& name);
+std::string GetOverriddenApplicationVersion();
+
 std::string GetApplicationName();
 std::string GetApplicationVersion();
 

--- a/brightray/common/application_info_win.cc
+++ b/brightray/common/application_info_win.cc
@@ -47,7 +47,7 @@ PCWSTR GetRawAppUserModelID() {
     if (SUCCEEDED(GetCurrentProcessExplicitAppUserModelID(&current_app_id))) {
       g_app_user_model_id = current_app_id;
     } else {
-      std::string name = GetOverridenApplicationName();
+      std::string name = GetOverriddenApplicationName();
       if (name.empty()) {
         name = GetApplicationName();
       }


### PR DESCRIPTION
__Rationale__

Notifications can't currently be tested in CI and the 2.0.0-beta.1 window is about to close, so this PR is a subset of the `linux-appname` branch with the API changes in `brightray/` and `atom/` (the breaking changes) but without the notification code changes, which are nonbreaking fixes that can be landed later when they are testable.

__Changes__

* Add new function `brightray::OverrideApplicationVersion()` so that version info will be in brightray's scope, and reimplement `app.setVersion()` to use it
* On Linux, implement `brightray::GetApplicationVersion()` to use the value of `app.setVersion()` if set
* On Linux, implement `brightray::GetApplicationName()` to use (1) the value of `app.setName()` if available or (2) the 'Name' entry from the app's .desktop file.
* Fix pre-existing API spelling error: s/Overriden/Overridden/ in `brightray::GetOverridenApplicationName()`