### PR TITLE
no longer support bool param for setHighlightMode

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -39,18 +39,6 @@ struct Converter<atom::TrayIcon::HighlightMode> {
         return true;
       }
     }
-
-    // Support old boolean parameter
-    // TODO(kevinsawicki): Remove in 2.0, deprecate before then with warnings
-    bool highlight;
-    if (ConvertFromV8(isolate, val, &highlight)) {
-      if (highlight)
-        *out = atom::TrayIcon::HighlightMode::SELECTION;
-      else
-        *out = atom::TrayIcon::HighlightMode::NEVER;
-      return true;
-    }
-
     return false;
   }
 };


### PR DESCRIPTION
What it says on the tin, per [2.0 Breaking Changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)

```js
// Deprecated
tray.setHighlightMode(true)
// Replace with
tray.setHighlightMode('on')
  
// Deprecated
tray.setHighlightMode(false)
// Replace with
tray.setHighlightMode('off')
```