### PR TITLE
remove app.getAppMemoryInfo

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1266,7 +1266,6 @@ void App::BuildPrototype(
       .SetMethod("startAccessingSecurityScopedResource",
                  &App::StartAccessingSecurityScopedResource)
       #endif
-      .SetMethod("getAppMemoryInfo", &App::GetAppMetrics);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1256,7 +1256,6 @@ void App::BuildPrototype(
       .SetMethod("getFileIcon", &App::GetFileIcon)
       .SetMethod("getAppMetrics", &App::GetAppMetrics)
       .SetMethod("getGPUFeatureStatus", &App::GetGPUFeatureStatus)
-      .SetMethod("enableMixedSandbox", &App::EnableMixedSandbox)
       // TODO(juturu): Remove in 2.0, deprecate before then with warnings
       #if defined(OS_MACOSX)
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
@@ -1266,6 +1265,7 @@ void App::BuildPrototype(
       .SetMethod("startAccessingSecurityScopedResource",
                  &App::StartAccessingSecurityScopedResource)
       #endif
+      .SetMethod("enableMixedSandbox", &App::EnableMixedSandbox);
 }
 
 }  // namespace api

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -844,11 +844,6 @@ disables that behaviour.
 
 This method can only be called before app is ready.
 
-### `app.getAppMemoryInfo()` _Deprecated_
-
-Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
-**Note:** This method is deprecated, use `app.getAppMetrics()` instead.
-
 ### `app.getAppMetrics()`
 
 Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.


### PR DESCRIPTION
remove `app.getAppMemoryInfo` in favor of `app.getAppMetrics` per [2.0 Breaking Changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)

```js
// Deprecated
app.getAppMemoryInfo()
// Replace with
app.getAppMetrics()
```

/cc @ckerr 