### PR TITLE
 deprecation for webContents.openDevTools

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -165,11 +165,12 @@ for (const method of webFrameMethodsWithResult) {
   }
 }
 
+const nativeOpenDevTools = WebContents.prototype.openDevTools
 WebContents.prototype.openDevTools = function (params) {
   if (!process.noDeprecations && params && 'detach' in params) {
     deprecate.warn('webContents.openDevTools({detach: true})', `webContents.openDevTools({mode: 'detach'})`)
   }
-  return this.openDevTools(params)
+  return nativeOpenDevTools.call(this, params)
 }
 
 // Make sure WebContents::executeJavaScript would run the code only when the

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -4,7 +4,7 @@ const {EventEmitter} = require('events')
 const electron = require('electron')
 const path = require('path')
 const url = require('url')
-const {app, ipcMain, session, NavigationController} = electron
+const {app, ipcMain, session, NavigationController, deprecate} = electron
 
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
@@ -163,6 +163,13 @@ for (const method of webFrameMethodsWithResult) {
     const actualArgs = args.slice(0, args.length - 2)
     syncWebFrameMethods.call(this, getNextId(), method, callback, ...actualArgs)
   }
+}
+
+WebContents.prototype.openDevTools = function (params) {
+  if ('detach' in params) {
+    deprecate.warn('webContents.openDevTools({detach: true})', `webContents.openDevTools({mode: 'detach'})`)
+  }
+  return this.openDevTools(params)
 }
 
 // Make sure WebContents::executeJavaScript would run the code only when the

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -166,7 +166,7 @@ for (const method of webFrameMethodsWithResult) {
 }
 
 WebContents.prototype.openDevTools = function (params) {
-  if ('detach' in params) {
+  if (!process.noDeprecations && params && 'detach' in params) {
     deprecate.warn('webContents.openDevTools({detach: true})', `webContents.openDevTools({mode: 'detach'})`)
   }
   return this.openDevTools(params)


### PR DESCRIPTION
Remove support for `{detach: true}` parameter in `webContents.openDevTools` per [2.0 Breaking Changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)

This was marked deprecated in docs, so i think we're ok to remove.

```js
// Deprecated
webContents.openDevTools({detach: true})
// Replace with
webContents.openDevTools({mode: 'detach'})
```

/cc @ckerr 