### PR TITLE
remove RegisterURLSchemeAsSecure

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -207,48 +207,6 @@ void WebFrame::RegisterURLSchemeAsBypassingCSP(const std::string& scheme) {
       WTF::String::FromUTF8(scheme.data(), scheme.length()));
 }
 
-void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
-                                             mate::Arguments* args) {
-  // TODO(deepak1556): blink::SchemeRegistry methods should be called
-  // before any renderer threads are created. Fixing this would break
-  // current api. Change it with 2.0.
-
-  // Read optional flags
-  bool secure = true;
-  bool bypassCSP = true;
-  bool allowServiceWorkers = true;
-  bool supportFetchAPI = true;
-  bool corsEnabled = true;
-  if (args->Length() == 2) {
-    mate::Dictionary options;
-    if (args->GetNext(&options)) {
-      options.Get("secure", &secure);
-      options.Get("bypassCSP", &bypassCSP);
-      options.Get("allowServiceWorkers", &allowServiceWorkers);
-      options.Get("supportFetchAPI", &supportFetchAPI);
-      options.Get("corsEnabled", &corsEnabled);
-    }
-  }
-  // Register scheme to privileged list (https, wss, data, chrome-extension)
-  WTF::String privileged_scheme(
-      WTF::String::FromUTF8(scheme.data(), scheme.length()));
-  if (bypassCSP) {
-    blink::SchemeRegistry::RegisterURLSchemeAsBypassingContentSecurityPolicy(
-        privileged_scheme);
-  }
-  if (allowServiceWorkers) {
-    blink::SchemeRegistry::RegisterURLSchemeAsAllowingServiceWorkers(
-        privileged_scheme);
-  }
-  if (supportFetchAPI) {
-    blink::SchemeRegistry::RegisterURLSchemeAsSupportingFetchAPI(
-        privileged_scheme);
-  }
-  if (corsEnabled) {
-    blink::SchemeRegistry::RegisterURLSchemeAsCORSEnabled(privileged_scheme);
-  }
-}
-
 void WebFrame::InsertText(const std::string& text) {
   web_frame_->FrameWidget()
             ->GetActiveWebInputMethodController()
@@ -381,8 +339,6 @@ void WebFrame::BuildPrototype(
       .SetMethod("setSpellCheckProvider", &WebFrame::SetSpellCheckProvider)
       .SetMethod("registerURLSchemeAsBypassingCSP",
                  &WebFrame::RegisterURLSchemeAsBypassingCSP)
-      .SetMethod("registerURLSchemeAsPrivileged",
-                 &WebFrame::RegisterURLSchemeAsPrivileged)
       .SetMethod("insertText", &WebFrame::InsertText)
       .SetMethod("insertCSS", &WebFrame::InsertCSS)
       .SetMethod("executeJavaScript", &WebFrame::ExecuteJavaScript)

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -201,12 +201,6 @@ void WebFrame::SetSpellCheckProvider(mate::Arguments* args,
   web_frame_->SetSpellCheckPanelHostClient(spell_check_client_.get());
 }
 
-void WebFrame::RegisterURLSchemeAsSecure(const std::string& scheme) {
-  // TODO(pfrazee): Remove 2.0
-  blink::SchemeRegistry::RegisterURLSchemeAsSecure(
-      WTF::String::FromUTF8(scheme.data(), scheme.length()));
-}
-
 void WebFrame::RegisterURLSchemeAsBypassingCSP(const std::string& scheme) {
   // Register scheme to bypass pages's Content Security Policy.
   blink::SchemeRegistry::RegisterURLSchemeAsBypassingContentSecurityPolicy(
@@ -238,10 +232,6 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
   // Register scheme to privileged list (https, wss, data, chrome-extension)
   WTF::String privileged_scheme(
       WTF::String::FromUTF8(scheme.data(), scheme.length()));
-  if (secure) {
-    // TODO(pfrazee): Remove 2.0
-    blink::SchemeRegistry::RegisterURLSchemeAsSecure(privileged_scheme);
-  }
   if (bypassCSP) {
     blink::SchemeRegistry::RegisterURLSchemeAsBypassingContentSecurityPolicy(
         privileged_scheme);
@@ -389,8 +379,6 @@ void WebFrame::BuildPrototype(
       .SetMethod("attachGuest", &WebFrame::AttachGuest)
       .SetMethod("detachGuest", &WebFrame::DetachGuest)
       .SetMethod("setSpellCheckProvider", &WebFrame::SetSpellCheckProvider)
-      .SetMethod("registerURLSchemeAsSecure",
-                 &WebFrame::RegisterURLSchemeAsSecure)
       .SetMethod("registerURLSchemeAsBypassingCSP",
                  &WebFrame::RegisterURLSchemeAsBypassingCSP)
       .SetMethod("registerURLSchemeAsPrivileged",

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -64,7 +64,6 @@ class WebFrame : public mate::Wrappable<WebFrame> {
                              bool auto_spell_correct_turned_on,
                              v8::Local<v8::Object> provider);
 
-  void RegisterURLSchemeAsSecure(const std::string& scheme);
   void RegisterURLSchemeAsBypassingCSP(const std::string& scheme);
   void RegisterURLSchemeAsPrivileged(const std::string& scheme,
                                      mate::Arguments* args);

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -65,8 +65,6 @@ class WebFrame : public mate::Wrappable<WebFrame> {
                              v8::Local<v8::Object> provider);
 
   void RegisterURLSchemeAsBypassingCSP(const std::string& scheme);
-  void RegisterURLSchemeAsPrivileged(const std::string& scheme,
-                                     mate::Arguments* args);
 
   // Editing.
   void InsertText(const std::string& text);

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -106,13 +106,6 @@ void RendererClientBase::RenderThreadStarted() {
   blink::SchemeRegistry::RegisterURLSchemeAsBypassingContentSecurityPolicy(
       extension_scheme);
 
-  // Parse --secure-schemes=scheme1,scheme2
-  std::vector<std::string> secure_schemes_list =
-      ParseSchemesCLISwitch(switches::kSecureSchemes);
-  for (const std::string& scheme : secure_schemes_list)
-    blink::SchemeRegistry::RegisterURLSchemeAsSecure(
-        WTF::String::FromUTF8(scheme.data(), scheme.length()));
-
   // Allow file scheme to handle service worker by default.
   // FIXME(zcbenz): Can this be moved elsewhere?
   blink::WebSecurityPolicy::RegisterURLSchemeAsAllowingServiceWorkers("file");

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -77,16 +77,6 @@ webFrame.setSpellCheckProvider('en-US', true, {
 })
 ```
 
-### `webFrame.registerURLSchemeAsSecure(scheme)`
-
-* `scheme` String
-
-Registers the `scheme` as secure scheme.
-
-Secure schemes do not trigger mixed content warnings. For example, `https` and
-`data` are secure schemes because they cannot be corrupted by active network
-attackers.
-
 ### `webFrame.registerURLSchemeAsBypassingCSP(scheme)`
 
 * `scheme` String

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -84,27 +84,6 @@ webFrame.setSpellCheckProvider('en-US', true, {
 Resources will be loaded from this `scheme` regardless of the current page's
 Content Security Policy.
 
-### `webFrame.registerURLSchemeAsPrivileged(scheme[, options])`
-
-* `scheme` String
-* `options` Object (optional)
-  * `secure` Boolean (optional) - Default true.
-  * `bypassCSP` Boolean (optional) - Default true.
-  * `allowServiceWorkers` Boolean (optional) - Default true.
-  * `supportFetchAPI` Boolean (optional) - Default true.
-  * `corsEnabled` Boolean (optional) - Default true.
-
-Registers the `scheme` as secure, bypasses content security policy for resources,
-allows registering ServiceWorker and supports fetch API.
-
-Specify an option with the value of `false` to omit it from the registration.
-An example of registering a privileged scheme, without bypassing Content Security Policy:
-
-```javascript
-const {webFrame} = require('electron')
-webFrame.registerURLSchemeAsPrivileged('foo', { bypassCSP: false })
-```
-
 ### `webFrame.insertText(text)`
 
 * `text` String


### PR DESCRIPTION
Remove `webFrame.registerURLSchemeAsSecure('app')` and `webFrame.registerURLSchemeAsPrivileged('app', {secure: true})`
per [2.0 Breaking Changes](https://electronjs.org/docs/tutorial/planned-breaking-changes)
```js
  // Deprecated
  webFrame.registerURLSchemeAsSecure('app')
  // Replace with
  protocol.registerStandardSchemes(['app'], {secure: true})

  // Deprecated
  webFrame.registerURLSchemeAsPrivileged('app', {secure: true})
  // Replace with
  protocol.registerStandardSchemes(['app'], {secure: true})
```

I'm a little less sure about this one, is there anything else that needs to happen here?