### PR TITLE
deprecate autoSubmit in favor of uploadToServer

### DIFF
--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -4,7 +4,7 @@ const {spawn} = require('child_process')
 const os = require('os')
 const path = require('path')
 const electron = require('electron')
-const {app} = process.type === 'browser' ? electron : electron.remote
+const {app, deprecate} = process.type === 'browser' ? electron : electron.remote
 const binding = process.atomBinding('crash_reporter')
 
 class CrashReporter {
@@ -20,7 +20,15 @@ class CrashReporter {
       uploadToServer
     } = options
 
-    if (uploadToServer == null) uploadToServer = true
+    if (uploadToServer == null) {
+      if (options.autoSubmit) {
+        deprecate.warn('autoSubmit', 'uploadToServer')
+        uploadToServer = options.autoSubmit
+      } else {
+        uploadToServer = true
+      }
+    }
+
     if (ignoreSystemCrashHandler == null) ignoreSystemCrashHandler = false
     if (extra == null) extra = {}
 


### PR DESCRIPTION
Reverts removal of `autoSubmit` param and instead displays a deprecation warning when it's used.

/cc @ckerr 
