### PR TITLE
deprecate boolean highlightMode param

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -39,6 +39,16 @@ struct Converter<atom::TrayIcon::HighlightMode> {
         return true;
       }
     }
+
+    bool highlight;
+    if (ConvertFromV8(isolate, val, &highlight)) {
+      if (highlight)
+        *out = atom::TrayIcon::HighlightMode::SELECTION;
+      else
+        *out = atom::TrayIcon::HighlightMode::NEVER;
+      return true;
+    }
+
     return false;
   }
 };

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -5,7 +5,7 @@ const {Tray} = process.atomBinding('tray')
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
 
 Tray.prototype.setHighlightMode = function (param) {
-  if (typeof param === 'boolean') {
+  if (!process.noDeprecations && typeof param === 'boolean') {
     if (param) {
       deprecate.warn('tray.setHighlightMode(true)', `tray.setHighlightMode("on")`)
     } else {

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -1,6 +1,18 @@
 const {EventEmitter} = require('events')
+const {deprecate} = require('electron')
 const {Tray} = process.atomBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
+
+Tray.prototype.setHighlightMode = function (param) {
+  if (typeof param === 'boolean') {
+    if (param) {
+      deprecate.warn('tray.setHighlightMode(true)', `tray.setHighlightMode("on")`)
+    } else {
+      deprecate.warn('tray.setHighlightMode(false)', `tray.setHighlightMode("off")`)
+    }
+  }
+  return this.setHighlightMode(param)
+}
 
 module.exports = Tray

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -4,6 +4,7 @@ const {Tray} = process.atomBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
 
+// TODO(codebytere): remove in 3.0
 const nativeSetHighlightMode = Tray.prototype.setHighlightMode
 Tray.prototype.setHighlightMode = function (param) {
   if (!process.noDeprecations && typeof param === 'boolean') {

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -4,6 +4,7 @@ const {Tray} = process.atomBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
 
+const nativeSetHighlightMode = Tray.prototype.setHighlightMode
 Tray.prototype.setHighlightMode = function (param) {
   if (!process.noDeprecations && typeof param === 'boolean') {
     if (param) {
@@ -12,7 +13,7 @@ Tray.prototype.setHighlightMode = function (param) {
       deprecate.warn('tray.setHighlightMode(false)', `tray.setHighlightMode("off")`)
     }
   }
-  return this.setHighlightMode(param)
+  return nativeSetHighlightMode.call(this, param)
 }
 
 module.exports = Tray


### PR DESCRIPTION
Reverts https://github.com/electron/electron/pull/11981 and adds deprecation warning to `tray.setHighlightMode(param)`

/cc @ckerr 