### PR TITLE
add deprecation warnings for html/rtf methods

### DIFF
--- a/lib/common/api/clipboard.js
+++ b/lib/common/api/clipboard.js
@@ -2,7 +2,40 @@ if (process.platform === 'linux' && process.type === 'renderer') {
   // On Linux we could not access clipboard in renderer process.
   module.exports = require('electron').remote.clipboard
 } else {
+  const {deprecate} = require('electron')
   const clipboard = process.atomBinding('clipboard')
+
+  // TODO(codebytere): remove in 3.0
+  clipboard.readHtml = function () {
+    if (!process.noDeprecations) {
+      deprecate.warn('clipboard.readHtml', 'clipboard.readHTML')
+    }
+    return clipboard.readHTML()
+  }
+
+  // TODO(codebytere): remove in 3.0
+  clipboard.writeHtml = function () {
+    if (!process.noDeprecations) {
+      deprecate.warn('clipboard.writeHtml', 'clipboard.writeHTML')
+    }
+    return clipboard.writeHTML()
+  }
+
+  // TODO(codebytere): remove in 3.0
+  clipboard.readRtf = function () {
+    if (!process.noDeprecations) {
+      deprecate.warn('clipboard.readRtf', 'clipboard.writeRTF')
+    }
+    return clipboard.readRTF()
+  }
+
+  // TODO(codebytere): remove in 3.0
+  clipboard.writeRtf = function () {
+    if (!process.noDeprecations) {
+      deprecate.warn('clipboard.writeRtf', 'clipboard.writeRTF')
+    }
+    return clipboard.writeRTF()
+  }
 
   // Read/write to find pasteboard over IPC since only main process is notified
   // of changes


### PR DESCRIPTION
Reverts removal of supports for HTML/RTF methods in `clipboard` and adds deprecation warnings

/cc @ckerr 