### PR TITLE
[WIP] add deprecations for toPng and toJpeg

### DIFF
--- a/lib/common/api/native-image.js
+++ b/lib/common/api/native-image.js
@@ -1,1 +1,20 @@
-module.exports = process.atomBinding('native_image')
+const {deprecate} = require('electron')
+const nativeImage = process.atomBinding('native_image')
+
+// TODO(codebytere): remove in 3.0
+nativeImage.prototype.toJpeg = function () {
+  if (!process.noDeprecations) {
+    deprecate.warn('nativeImage.toJpeg()', 'nativeImage.toJPEG()')
+  }
+  return nativeImage.toJPEG()
+}
+
+// TODO(codebytere): remove in 3.0
+nativeImage.prototype.toPng = function () {
+  if (!process.noDeprecations) {
+    deprecate.warn('nativeImage.toPng()', 'nativeImage.toPNG()')
+  }
+  return nativeImage.toPNG()
+}
+
+module.exports = nativeImage


### PR DESCRIPTION
Adds deprecations for `nativeImage.toJpeg()'` and `nativeImage.toPng()`. Since we're calling the updated methods on the native side, there's no need to revert the changes on the native side.