### PR TITLE
Explicitly disable executable stack

### DIFF
--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -291,6 +291,7 @@
             'ldflags': [
               '-flto=thin',
               '-fuse-ld=lld',  # Chromium Clang uses lld for doing LTO
+              '-Wl,--icf=all',
               '-Wl,--lto-O0',  # this could be removed in future; see https://codereview.chromium.org/2939923004
               '-Wl,-mllvm,-function-sections',
               '-Wl,-mllvm,-data-sections',

--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -138,6 +138,9 @@
               '-D__STRICT_ANSI__',
               '-fno-rtti',
             ],
+            'ldflags': [
+              '-Wl,-z,noexecstack',
+            ],
           }],  # OS=="linux"
           ['OS=="mac"', {
             'defines': [


### PR DESCRIPTION
Executable stack is already (implicitly) not required by the current master build, but this PR makes it explicit and avoids regression in case some new raw assembly code is introduced which is not properly marked for non-executable stack.

As a bonus, I added `--icf=all` to reduce binary size on supported architectures.