### PR TITLE
tutorial: Surround the snap version in quotes

### DIFF
--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -110,7 +110,7 @@ Let's look at an example:
 
 ```yaml
 name: myApp
-version: 2.0.0
+version: '2.0.0'
 summary: A little description for the app.
 description: |
  You know what? This app is amazing! It does all the things


### PR DESCRIPTION
The example YAML in the Snapcraft section of the tutorial contains a version number. Best practice here is to always surround the version in quotes to avoid trailing zeros being lost, ie. `version: 2.10` would end up being parsed as version "2.1".