### PR TITLE
Refactor NativeWindow (Part 1): Remove WebContentsObserver methods

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -20,7 +20,9 @@
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
 #include "base/threading/thread_task_runner_handle.h"
+#include "content/browser/renderer_host/render_widget_host_impl.h"
 #include "content/public/browser/render_process_host.h"
+#include "content/public/browser/render_view_host.h"
 #include "content/public/common/content_switches.h"
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
@@ -175,6 +177,18 @@ BrowserWindow::~BrowserWindow() {
   // Destroy the native window in next tick because the native code might be
   // iterating all windows.
   base::ThreadTaskRunnerHandle::Get()->DeleteSoon(FROM_HERE, window_.release());
+}
+
+void BrowserWindow::RenderViewCreated(
+    content::RenderViewHost* render_view_host) {
+  if (!window_->transparent())
+    return;
+
+  content::RenderWidgetHostImpl* impl = content::RenderWidgetHostImpl::FromID(
+      render_view_host->GetProcess()->GetID(),
+      render_view_host->GetRoutingID());
+  if (impl)
+    impl->SetBackgroundOpaque(false);
 }
 
 void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -205,7 +205,8 @@ void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {
   base::ThreadTaskRunnerHandle::Get()->PostTask(
       FROM_HERE,
       base::Bind([](base::WeakPtr<BrowserWindow> self) {
-        self->Emit("ready-to-show");
+        if (self)
+          self->Emit("ready-to-show");
       }, GetWeakPtr()));
 }
 

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -136,8 +136,8 @@ void BrowserWindow::Init(v8::Isolate* isolate,
                          mate::Handle<class WebContents> web_contents) {
   web_contents_.Reset(isolate, web_contents.ToV8());
   api_web_contents_ = web_contents.get();
-  Observe(web_contents->web_contents());
   api_web_contents_->AddObserver(this);
+  Observe(api_web_contents_->web_contents());
 
   // Keep a copy of the options for later use.
   mate::Dictionary(isolate, web_contents->GetWrapper()).Set(
@@ -248,7 +248,7 @@ void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {
 void BrowserWindow::BeforeUnloadDialogCancelled() {
   WindowList::WindowCloseCancelled(window_.get());
   // Cancel unresponsive event when window close is cancelled.
-  window_unresposive_closure_.Cancel();
+  window_unresponsive_closure_.Cancel();
 }
 
 void BrowserWindow::OnRendererUnresponsive(content::RenderWidgetHost*) {
@@ -295,11 +295,11 @@ void BrowserWindow::OnCloseContents() {
   window_->CloseImmediately();
 
   // Do not sent "unresponsive" event after window is closed.
-  window_unresposive_closure_.Cancel();
+  window_unresponsive_closure_.Cancel();
 }
 
 void BrowserWindow::OnRendererResponsive() {
-  window_unresposive_closure_.Cancel();
+  window_unresponsive_closure_.Cancel();
   Emit("responsive");
 }
 
@@ -317,7 +317,7 @@ void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
   // not closed in 5s, in this way we can quickly show the unresponsive
   // dialog when the window is busy executing some script withouth waiting for
   // the unresponsive timeout.
-  if (window_unresposive_closure_.IsCancelled())
+  if (window_unresponsive_closure_.IsCancelled())
     ScheduleUnresponsiveEvent(5000);
 
   if (!web_contents())
@@ -1139,19 +1139,19 @@ void BrowserWindow::UpdateDraggableRegions(
 }
 
 void BrowserWindow::ScheduleUnresponsiveEvent(int ms) {
-  if (!window_unresposive_closure_.IsCancelled())
+  if (!window_unresponsive_closure_.IsCancelled())
     return;
 
-  window_unresposive_closure_.Reset(
+  window_unresponsive_closure_.Reset(
       base::Bind(&BrowserWindow::NotifyWindowUnresponsive, GetWeakPtr()));
   base::ThreadTaskRunnerHandle::Get()->PostDelayedTask(
       FROM_HERE,
-      window_unresposive_closure_.callback(),
+      window_unresponsive_closure_.callback(),
       base::TimeDelta::FromMilliseconds(ms));
 }
 
 void BrowserWindow::NotifyWindowUnresponsive() {
-  window_unresposive_closure_.Cancel();
+  window_unresponsive_closure_.Cancel();
   if (!window_->IsClosed() && window_->IsEnabled() &&
       !IsUnresponsiveEventSuppressed()) {
     Emit("unresponsive");

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -30,6 +30,7 @@
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/gl/gpu_switching_manager.h"
 
 #if defined(TOOLKIT_VIEWS)
 #include "atom/browser/native_window_views.h"
@@ -154,6 +155,10 @@ void BrowserWindow::Init(v8::Isolate* isolate,
       parent.IsEmpty() ? nullptr : parent->window_.get()));
   web_contents->SetOwnerWindow(window_.get());
   window_->set_is_offscreen_dummy(api_web_contents_->IsOffScreen());
+
+  // Tell the content module to initialize renderer widget with transparent
+  // mode.
+  ui::GpuSwitchingManager::SetTransparent(window_->transparent());
 
 #if defined(TOOLKIT_VIEWS)
   // Sets the window icon.

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -243,6 +243,14 @@ void BrowserWindow::WillDestroyNativeObject() {
   }
 }
 
+void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
+  // When user tries to close the window by clicking the close button, we do
+  // not close the window immediately, instead we try to close the web page
+  // first, and when the web page is closed the window will also be closed.
+  *prevent_default = true;
+  window_->RequestToClosePage();
+}
+
 void BrowserWindow::OnWindowClosed() {
   api_web_contents_->DestroyWebContents(true /* async */);
 

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -10,6 +10,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/web_contents_preferences.h"
+#include "atom/common/api/api_messages.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
@@ -208,6 +209,17 @@ void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {
         if (self)
           self->Emit("ready-to-show");
       }, GetWeakPtr()));
+}
+
+bool BrowserWindow::OnMessageReceived(const IPC::Message& message,
+                                      content::RenderFrameHost* rfh) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(BrowserWindow, message, rfh)
+    IPC_MESSAGE_HANDLER(AtomFrameHostMsg_UpdateDraggableRegions,
+                        UpdateDraggableRegions)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+  return handled;
 }
 
 void BrowserWindow::WillCloseWindow(bool* prevent_default) {
@@ -1037,6 +1049,12 @@ void BrowserWindow::RemoveFromParentChildWindows() {
   }
 
   parent->child_windows_.Remove(ID());
+}
+
+void BrowserWindow::UpdateDraggableRegions(
+    content::RenderFrameHost* rfh,
+    const std::vector<DraggableRegion>& regions) {
+  window_->UpdateDraggableRegions(regions);
 }
 
 // static

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -129,6 +129,7 @@ void BrowserWindow::Init(v8::Isolate* isolate,
                          mate::Handle<class WebContents> web_contents) {
   web_contents_.Reset(isolate, web_contents.ToV8());
   api_web_contents_ = web_contents.get();
+  Observe(web_contents->web_contents());
 
   // Keep a copy of the options for later use.
   mate::Dictionary(isolate, web_contents->GetWrapper()).Set(
@@ -303,11 +304,11 @@ void BrowserWindow::OnWindowLeaveHtmlFullScreen() {
   Emit("leave-html-full-screen");
 }
 
-void BrowserWindow::OnRendererUnresponsive() {
+void BrowserWindow::OnWindowUnresponsive() {
   Emit("unresponsive");
 }
 
-void BrowserWindow::OnRendererResponsive() {
+void BrowserWindow::OnWindowResponsive() {
   Emit("responsive");
 }
 

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -134,6 +134,7 @@ void BrowserWindow::Init(v8::Isolate* isolate,
   web_contents_.Reset(isolate, web_contents.ToV8());
   api_web_contents_ = web_contents.get();
   Observe(web_contents->web_contents());
+  api_web_contents_->AddObserver(this);
 
   // Keep a copy of the options for later use.
   mate::Dictionary(isolate, web_contents->GetWrapper()).Set(
@@ -174,6 +175,8 @@ void BrowserWindow::Init(v8::Isolate* isolate,
 BrowserWindow::~BrowserWindow() {
   if (!window_->IsClosed())
     window_->CloseContents(nullptr);
+
+  api_web_contents_->RemoveObserver(this);
 
   // Destroy the native window in next tick because the native code might be
   // iterating all windows.
@@ -220,6 +223,9 @@ bool BrowserWindow::OnMessageReceived(const IPC::Message& message,
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;
+}
+
+void BrowserWindow::OnRendererResponsive() {
 }
 
 void BrowserWindow::WillCloseWindow(bool* prevent_default) {

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -15,6 +15,7 @@
 #include "atom/browser/native_window_observer.h"
 #include "atom/common/api/atom_api_native_image.h"
 #include "atom/common/key_weak_map.h"
+#include "base/memory/weak_ptr.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "native_mate/handle.h"
 #include "native_mate/persistent_dictionary.h"
@@ -60,6 +61,9 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
                 const mate::Dictionary& options);
   ~BrowserWindow() override;
 
+  // content::WebContentsObserver:
+  void DidFirstVisuallyNonEmptyPaint() override;
+
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
   void WillDestroyNativeObject() override;
@@ -69,7 +73,6 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void OnWindowFocus() override;
   void OnWindowShow() override;
   void OnWindowHide() override;
-  void OnReadyToShow() override;
   void OnWindowMaximize() override;
   void OnWindowUnmaximize() override;
   void OnWindowMinimize() override;
@@ -98,11 +101,16 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
   #endif
 
+  base::WeakPtr<BrowserWindow> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
  private:
   void Init(v8::Isolate* isolate,
             v8::Local<v8::Object> wrapper,
             const mate::Dictionary& options,
             mate::Handle<class WebContents> web_contents);
+
   // APIs for NativeWindow.
   void Close();
   void Focus();
@@ -249,6 +257,8 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   api::WebContents* api_web_contents_;
 
   std::unique_ptr<NativeWindow> window_;
+
+  base::WeakPtrFactory<BrowserWindow> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(BrowserWindow);
 };

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -62,6 +62,7 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   ~BrowserWindow() override;
 
   // content::WebContentsObserver:
+  void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void DidFirstVisuallyNonEmptyPaint() override;
 
   // NativeWindowObserver:

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -64,6 +64,8 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   // content::WebContentsObserver:
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void DidFirstVisuallyNonEmptyPaint() override;
+  bool OnMessageReceived(const IPC::Message& message,
+                         content::RenderFrameHost* rfh) override;
 
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
@@ -243,6 +245,11 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
 
   // Remove this window from parent window's |child_windows_|.
   void RemoveFromParentChildWindows();
+
+  // Called when the window needs to update its draggable region.
+  void UpdateDraggableRegions(
+      content::RenderFrameHost* rfh,
+      const std::vector<DraggableRegion>& regions);
 
 #if defined(OS_WIN)
   typedef std::map<UINT, MessageCallback> MessageCallbackMap;

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -71,6 +71,7 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;
   void WillDestroyNativeObject() override;
+  void OnCloseButtonClicked(bool* prevent_default) override;
   void OnWindowClosed() override;
   void OnWindowEndSession() override;
   void OnWindowBlur() override;

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -10,16 +10,13 @@
 #include <string>
 #include <vector>
 
-#include "atom/browser/api/trackable_object.h"
+#include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/native_window_observer.h"
 #include "atom/common/api/atom_api_native_image.h"
 #include "atom/common/key_weak_map.h"
 #include "base/memory/weak_ptr.h"
-#include "content/public/browser/web_contents_observer.h"
-#include "native_mate/handle.h"
 #include "native_mate/persistent_dictionary.h"
-#include "ui/gfx/image/image.h"
 
 class GURL;
 
@@ -40,6 +37,7 @@ namespace api {
 
 class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
                       public content::WebContentsObserver,
+                      public ExtendedWebContentsObserver,
                       public NativeWindowObserver {
  public:
   static mate::WrappableBase* New(mate::Arguments* args);
@@ -66,6 +64,9 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void DidFirstVisuallyNonEmptyPaint() override;
   bool OnMessageReceived(const IPC::Message& message,
                          content::RenderFrameHost* rfh) override;
+
+  // ExtendedWebContentsObserver:
+  void OnRendererResponsive() override;
 
   // NativeWindowObserver:
   void WillCloseWindow(bool* prevent_default) override;

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -273,7 +273,7 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
 
   // Closure that would be called when window is unresponsive when closing,
   // it should be cancelled when we can prove that the window is responsive.
-  base::CancelableClosure window_unresposive_closure_;
+  base::CancelableClosure window_unresponsive_closure_;
 
   v8::Global<v8::Value> browser_view_;
   v8::Global<v8::Value> web_contents_;

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -15,6 +15,7 @@
 #include "atom/browser/native_window_observer.h"
 #include "atom/common/api/atom_api_native_image.h"
 #include "atom/common/key_weak_map.h"
+#include "content/public/browser/web_contents_observer.h"
 #include "native_mate/handle.h"
 #include "native_mate/persistent_dictionary.h"
 #include "ui/gfx/image/image.h"
@@ -36,9 +37,8 @@ class NativeWindow;
 
 namespace api {
 
-class WebContents;
-
 class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
+                      public content::WebContentsObserver,
                       public NativeWindowObserver {
  public:
   static mate::WrappableBase* New(mate::Arguments* args);
@@ -87,8 +87,8 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;
   void OnWindowLeaveHtmlFullScreen() override;
-  void OnRendererUnresponsive() override;
-  void OnRendererResponsive() override;
+  void OnWindowUnresponsive() override;
+  void OnWindowResponsive() override;
   void OnExecuteWindowsCommand(const std::string& command_name) override;
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -17,6 +17,7 @@
 #include "atom/common/key_weak_map.h"
 #include "base/cancelable_callback.h"
 #include "base/memory/weak_ptr.h"
+#include "content/public/browser/render_widget_host.h"
 #include "native_mate/persistent_dictionary.h"
 
 class GURL;
@@ -37,6 +38,7 @@ class NativeWindow;
 namespace api {
 
 class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
+                      public content::RenderWidgetHost::InputEventObserver,
                       public content::WebContentsObserver,
                       public ExtendedWebContentsObserver,
                       public NativeWindowObserver {
@@ -60,7 +62,12 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
                 const mate::Dictionary& options);
   ~BrowserWindow() override;
 
+  // content::RenderWidgetHost::InputEventObserver:
+  void OnInputEvent(const blink::WebInputEvent& event) override;
+
   // content::WebContentsObserver:
+  void RenderViewHostChanged(content::RenderViewHost* old_host,
+                             content::RenderViewHost* new_host) override;
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void DidFirstVisuallyNonEmptyPaint() override;
   void BeforeUnloadDialogCancelled() override;
@@ -90,7 +97,6 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void OnWindowMoved() override;
   void OnWindowScrollTouchBegin() override;
   void OnWindowScrollTouchEnd() override;
-  void OnWindowScrollTouchEdge() override;
   void OnWindowSwipe(const std::string& direction) override;
   void OnWindowSheetBegin() override;
   void OnWindowSheetEnd() override;

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -642,6 +642,8 @@ void WebContents::RendererResponsive(content::WebContents* source) {
   Emit("responsive");
   if ((type_ == BROWSER_WINDOW || type_ == OFF_SCREEN) && owner_window())
     owner_window()->RendererResponsive(source);
+  for (ExtendedWebContentsObserver& observer : observers_)
+    observer.OnRendererResponsive();
 }
 
 bool WebContents::HandleContextMenu(const content::ContextMenuParams& params) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -636,8 +636,6 @@ void WebContents::RendererUnresponsive(
     content::WebContents* source,
     const content::WebContentsUnresponsiveState& unresponsive_state) {
   Emit("unresponsive");
-  if ((type_ == BROWSER_WINDOW || type_ == OFF_SCREEN) && owner_window())
-    owner_window()->RendererUnresponsive(source);
 }
 
 void WebContents::RendererResponsive(content::WebContents* source) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -89,6 +89,11 @@
 #include "ui/aura/window.h"
 #endif
 
+#if defined(OS_LINUX) || defined(OS_WIN)
+#include "content/public/common/renderer_preferences.h"
+#include "ui/gfx/font_render_params.h"
+#endif
+
 #include "atom/common/node_includes.h"
 
 namespace {
@@ -411,6 +416,19 @@ void WebContents::InitWithSessionAndOptions(v8::Isolate* isolate,
   InitWithWebContents(web_contents, session->browser_context());
 
   managed_web_contents()->GetView()->SetDelegate(this);
+
+#if defined(OS_LINUX) || defined(OS_WIN)
+  // Update font settings.
+  auto* prefs = web_contents->GetMutableRendererPrefs();
+  CR_DEFINE_STATIC_LOCAL(const gfx::FontRenderParams, params,
+      (gfx::GetFontRenderParams(gfx::FontRenderParamsQuery(), nullptr)));
+  prefs->should_antialias_text = params.antialiasing;
+  prefs->use_subpixel_positioning = params.subpixel_positioning;
+  prefs->hinting = params.hinting;
+  prefs->use_autohinter = params.autohinter;
+  prefs->use_bitmaps = params.use_bitmaps;
+  prefs->subpixel_rendering = params.subpixel_rendering;
+#endif
 
   // Save the preferences in C++.
   new WebContentsPreferences(web_contents, options);

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -13,6 +13,7 @@
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/common_web_contents_delegate.h"
 #include "atom/browser/ui/autofill_popup.h"
+#include "base/observer_list.h"
 #include "content/common/cursors/webcursor.h"
 #include "content/public/browser/keyboard_event_processing_result.h"
 #include "content/public/browser/web_contents.h"
@@ -52,6 +53,7 @@ namespace api {
 // Certain events are only in WebContentsDelegate, provide our own Observer to
 // dispatch those events.
 class ExtendedWebContentsObserver {
+ public:
   virtual void OnRendererResponsive() {}
 };
 
@@ -237,6 +239,13 @@ class WebContents : public mate::TrackableObject<WebContents>,
   v8::Local<v8::Value> Debugger(v8::Isolate* isolate);
 
   WebContentsZoomController* GetZoomController() { return zoom_controller_; }
+
+  void AddObserver(ExtendedWebContentsObserver* obs) {
+    observers_.AddObserver(obs);
+  }
+  void RemoveObserver(ExtendedWebContentsObserver* obs) {
+    observers_.RemoveObserver(obs);
+  }
 
  protected:
   WebContents(v8::Isolate* isolate,
@@ -427,6 +436,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether to enable devtools.
   bool enable_devtools_;
+
+  // Observers of this WebContents.
+  base::ObserverList<ExtendedWebContentsObserver> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -54,6 +54,7 @@ namespace api {
 // dispatch those events.
 class ExtendedWebContentsObserver {
  public:
+  virtual void OnCloseContents() {}
   virtual void OnRendererResponsive() {}
 };
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -49,6 +49,13 @@ class WebViewGuestDelegate;
 
 namespace api {
 
+// Certain events are only in WebContentsDelegate, provide our own Observer to
+// dispatch those events.
+class ExtendedWebContentsObserver {
+  virtual void OnRendererResponsive() {}
+};
+
+// Wrapper around the content::WebContents.
 class WebContents : public mate::TrackableObject<WebContents>,
                     public CommonWebContentsDelegate,
                     public content::WebContentsObserver {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -13,7 +13,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/unresponsive_suppressor.h"
 #include "atom/browser/window_list.h"
-#include "atom/common/api/api_messages.h"
+#include "atom/common/draggable_region.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/options_switches.h"
 #include "base/files/file_util.h"
@@ -657,18 +657,6 @@ void NativeWindow::BeforeUnloadDialogCancelled() {
 
   // Cancel unresponsive event when window close is cancelled.
   window_unresposive_closure_.Cancel();
-}
-
-bool NativeWindow::OnMessageReceived(const IPC::Message& message,
-                                     content::RenderFrameHost* rfh) {
-  bool handled = true;
-  IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(NativeWindow, message, rfh)
-    IPC_MESSAGE_HANDLER(AtomFrameHostMsg_UpdateDraggableRegions,
-                        UpdateDraggableRegions)
-    IPC_MESSAGE_UNHANDLED(handled = false)
-  IPC_END_MESSAGE_MAP()
-
-  return handled;
 }
 
 void NativeWindow::ScheduleUnresponsiveEvent(int ms) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -24,7 +24,6 @@
 #include "brightray/browser/inspectable_web_contents.h"
 #include "brightray/browser/inspectable_web_contents_view.h"
 #include "components/prefs/pref_service.h"
-#include "content/browser/renderer_host/render_widget_host_impl.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/plugin_service.h"
 #include "content/public/browser/render_process_host.h"
@@ -651,18 +650,6 @@ std::unique_ptr<SkRegion> NativeWindow::DraggableRegionsToSkRegion(
         region.draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
   }
   return sk_region;
-}
-
-void NativeWindow::RenderViewCreated(
-    content::RenderViewHost* render_view_host) {
-  if (!transparent_)
-    return;
-
-  content::RenderWidgetHostImpl* impl = content::RenderWidgetHostImpl::FromID(
-      render_view_host->GetProcess()->GetID(),
-      render_view_host->GetRoutingID());
-  if (impl)
-    impl->SetBackgroundOpaque(false);
 }
 
 void NativeWindow::BeforeUnloadDialogCancelled() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -672,22 +672,6 @@ void NativeWindow::BeforeUnloadDialogCancelled() {
   window_unresposive_closure_.Cancel();
 }
 
-void NativeWindow::DidFirstVisuallyNonEmptyPaint() {
-  if (IsVisible())
-    return;
-
-  // When there is a non-empty first paint, resize the RenderWidget to force
-  // Chromium to draw.
-  const auto view = web_contents()->GetRenderWidgetHostView();
-  view->Show();
-  view->SetSize(GetContentSize());
-
-  // Emit the ReadyToShow event in next tick in case of pending drawing work.
-  base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE,
-      base::Bind(&NativeWindow::NotifyReadyToShow, GetWeakPtr()));
-}
-
 bool NativeWindow::OnMessageReceived(const IPC::Message& message,
                                      content::RenderFrameHost* rfh) {
   bool handled = true;
@@ -729,11 +713,6 @@ void NativeWindow::NotifyWindowUnresponsive() {
     for (NativeWindowObserver& observer : observers_)
       observer.OnWindowUnresponsive();
   }
-}
-
-void NativeWindow::NotifyReadyToShow() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnReadyToShow();
 }
 
 }  // namespace atom

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -39,11 +39,6 @@
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/geometry/size_conversions.h"
 
-#if defined(OS_LINUX) || defined(OS_WIN)
-#include "content/public/common/renderer_preferences.h"
-#include "ui/gfx/font_render_params.h"
-#endif
-
 DEFINE_WEB_CONTENTS_USER_DATA_KEY(atom::NativeWindowRelay);
 
 namespace atom {
@@ -71,20 +66,6 @@ NativeWindow::NativeWindow(
 
   if (parent)
     options.Get("modal", &is_modal_);
-
-#if defined(OS_LINUX) || defined(OS_WIN)
-  auto* prefs = web_contents()->GetMutableRendererPrefs();
-
-  // Update font settings.
-  CR_DEFINE_STATIC_LOCAL(const gfx::FontRenderParams, params,
-      (gfx::GetFontRenderParams(gfx::FontRenderParamsQuery(), nullptr)));
-  prefs->should_antialias_text = params.antialiasing;
-  prefs->use_subpixel_positioning = params.subpixel_positioning;
-  prefs->hinting = params.hinting;
-  prefs->use_autohinter = params.autohinter;
-  prefs->use_bitmaps = params.use_bitmaps;
-  prefs->subpixel_rendering = params.subpixel_rendering;
-#endif
 
   WindowList::AddWindow(this);
 }

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -489,7 +489,7 @@ void NativeWindow::RendererUnresponsive(content::WebContents* source) {
 void NativeWindow::RendererResponsive(content::WebContents* source) {
   window_unresposive_closure_.Cancel();
   for (NativeWindowObserver& observer : observers_)
-    observer.OnRendererResponsive();
+    observer.OnWindowResponsive();
 }
 
 void NativeWindow::NotifyWindowClosed() {
@@ -727,7 +727,7 @@ void NativeWindow::NotifyWindowUnresponsive() {
 
   if (!is_closed_ && !IsUnresponsiveEventSuppressed() && IsEnabled()) {
     for (NativeWindowObserver& observer : observers_)
-      observer.OnRendererUnresponsive();
+      observer.OnWindowUnresponsive();
   }
 }
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -530,11 +530,6 @@ void NativeWindow::NotifyWindowScrollTouchEnd() {
     observer.OnWindowScrollTouchEnd();
 }
 
-void NativeWindow::NotifyWindowScrollTouchEdge() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowScrollTouchEdge();
-}
-
 void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowSwipe(direction);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -474,17 +474,6 @@ void NativeWindow::CloseContents(content::WebContents* source) {
   window_unresposive_closure_.Cancel();
 }
 
-void NativeWindow::RendererUnresponsive(content::WebContents* source) {
-  // Schedule the unresponsive shortly later, since we may receive the
-  // responsive event soon. This could happen after the whole application had
-  // blocked for a while.
-  // Also notice that when closing this event would be ignored because we have
-  // explicitly started a close timeout counter. This is on purpose because we
-  // don't want the unresponsive event to be sent too early when user is closing
-  // the window.
-  ScheduleUnresponsiveEvent(50);
-}
-
 void NativeWindow::RendererResponsive(content::WebContents* source) {
   window_unresposive_closure_.Cancel();
   for (NativeWindowObserver& observer : observers_)
@@ -657,6 +646,17 @@ void NativeWindow::BeforeUnloadDialogCancelled() {
 
   // Cancel unresponsive event when window close is cancelled.
   window_unresposive_closure_.Cancel();
+}
+
+void NativeWindow::OnRendererUnresponsive(content::RenderWidgetHost*) {
+  // Schedule the unresponsive shortly later, since we may receive the
+  // responsive event soon. This could happen after the whole application had
+  // blocked for a while.
+  // Also notice that when closing this event would be ignored because we have
+  // explicitly started a close timeout counter. This is on purpose because we
+  // don't want the unresponsive event to be sent too early when user is closing
+  // the window.
+  ScheduleUnresponsiveEvent(50);
 }
 
 void NativeWindow::ScheduleUnresponsiveEvent(int ms) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -671,15 +671,6 @@ bool NativeWindow::OnMessageReceived(const IPC::Message& message,
   return handled;
 }
 
-void NativeWindow::UpdateDraggableRegions(
-    content::RenderFrameHost* rfh,
-    const std::vector<DraggableRegion>& regions) {
-  // Draggable region is not supported for non-frameless window.
-  if (has_frame_)
-    return;
-  draggable_region_ = DraggableRegionsToSkRegion(regions);
-}
-
 void NativeWindow::ScheduleUnresponsiveEvent(int ms) {
   if (!window_unresposive_closure_.IsCancelled())
     return;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -38,7 +38,6 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/geometry/size_conversions.h"
-#include "ui/gl/gpu_switching_manager.h"
 
 #if defined(OS_LINUX) || defined(OS_WIN)
 #include "content/public/common/renderer_preferences.h"
@@ -86,10 +85,6 @@ NativeWindow::NativeWindow(
   prefs->use_bitmaps = params.use_bitmaps;
   prefs->subpixel_rendering = params.subpixel_rendering;
 #endif
-
-  // Tell the content module to initialize renderer widget with transparent
-  // mode.
-  ui::GpuSwitchingManager::SetTransparent(transparent_);
 
   WindowList::AddWindow(this);
 }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -320,7 +320,6 @@ class NativeWindow : public base::SupportsUserData,
   // content::WebContentsObserver:
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void BeforeUnloadDialogCancelled() override;
-  void DidFirstVisuallyNonEmptyPaint() override;
   bool OnMessageReceived(const IPC::Message& message,
                          content::RenderFrameHost* rfh) override;
 
@@ -330,9 +329,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Dispatch unresponsive event to observers.
   void NotifyWindowUnresponsive();
-
-  // Dispatch ReadyToShow event to observers.
-  void NotifyReadyToShow();
 
   // Whether window has standard frame.
   bool has_frame_;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -249,6 +249,7 @@ class NativeWindow : public base::SupportsUserData,
 
   // Public API used by platform-dependent delegates and observers to send UI
   // related notifications.
+  void NotifyWindowCloseButtonClicked();
   void NotifyWindowClosed();
   void NotifyWindowEndSession();
   void NotifyWindowBlur();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -235,7 +235,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Methods called by the WebContents.
   virtual void CloseContents(content::WebContents* source);
-  virtual void RendererUnresponsive(content::WebContents* source);
   virtual void RendererResponsive(content::WebContents* source);
   virtual void HandleKeyboardEvent(
       content::WebContents*,
@@ -317,6 +316,7 @@ class NativeWindow : public base::SupportsUserData,
 
   // content::WebContentsObserver:
   void BeforeUnloadDialogCancelled() override;
+  void OnRendererUnresponsive(content::RenderWidgetHost*) override;
 
  private:
   // Schedule a notification unresponsive event.

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -216,6 +216,17 @@ class NativeWindow : public base::SupportsUserData,
                            const std::string& display_name);
   virtual void CloseFilePreview();
 
+  // Converts between content bounds and window bounds.
+  virtual gfx::Rect ContentBoundsToWindowBounds(
+      const gfx::Rect& bounds) const = 0;
+  virtual gfx::Rect WindowBoundsToContentBounds(
+      const gfx::Rect& bounds) const = 0;
+
+  // Called when the window needs to update its draggable region.
+  virtual void UpdateDraggableRegions(
+      content::RenderFrameHost* rfh,
+      const std::vector<DraggableRegion>& regions) = 0;
+
   base::WeakPtr<NativeWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
   }
@@ -287,7 +298,6 @@ class NativeWindow : public base::SupportsUserData,
   void set_has_frame(bool has_frame) { has_frame_ = has_frame; }
 
   bool transparent() const { return transparent_; }
-  SkRegion* draggable_region() const { return draggable_region_.get(); }
   bool enable_larger_than_screen() const { return enable_larger_than_screen_; }
 
   void set_is_offscreen_dummy(bool is_dummy) { is_osr_dummy_ = is_dummy; }
@@ -304,17 +314,6 @@ class NativeWindow : public base::SupportsUserData,
   // Convert draggable regions in raw format to SkRegion format. Caller is
   // responsible for deleting the returned SkRegion instance.
   std::unique_ptr<SkRegion> DraggableRegionsToSkRegion(
-      const std::vector<DraggableRegion>& regions);
-
-  // Converts between content bounds and window bounds.
-  virtual gfx::Rect ContentBoundsToWindowBounds(
-      const gfx::Rect& bounds) const = 0;
-  virtual gfx::Rect WindowBoundsToContentBounds(
-      const gfx::Rect& bounds) const = 0;
-
-  // Called when the window needs to update its draggable region.
-  virtual void UpdateDraggableRegions(
-      content::RenderFrameHost* rfh,
       const std::vector<DraggableRegion>& regions);
 
   // content::WebContentsObserver:
@@ -334,10 +333,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Whether window is transparent.
   bool transparent_;
-
-  // For custom drag, the whole window is non-draggable and the draggable region
-  // has to been explicitly provided.
-  std::unique_ptr<SkRegion> draggable_region_;  // used in custom drag.
 
   // Minimum and maximum size, stored as content size.
   extensions::SizeConstraints size_constraints_;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -318,7 +318,6 @@ class NativeWindow : public base::SupportsUserData,
       const std::vector<DraggableRegion>& regions);
 
   // content::WebContentsObserver:
-  void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void BeforeUnloadDialogCancelled() override;
   bool OnMessageReceived(const IPC::Message& message,
                          content::RenderFrameHost* rfh) override;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -13,7 +13,6 @@
 #include "atom/browser/native_window_observer.h"
 #include "atom/browser/ui/accelerator_util.h"
 #include "atom/browser/ui/atom_menu_model.h"
-#include "base/cancelable_callback.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/supports_user_data.h"
@@ -230,12 +229,7 @@ class NativeWindow : public base::SupportsUserData,
     return weak_factory_.GetWeakPtr();
   }
 
-  // Requests the WebContents to close, can be cancelled by the page.
-  virtual void RequestToClosePage();
-
   // Methods called by the WebContents.
-  virtual void CloseContents(content::WebContents* source);
-  virtual void RendererResponsive(content::WebContents* source);
   virtual void HandleKeyboardEvent(
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) {}
@@ -315,17 +309,7 @@ class NativeWindow : public base::SupportsUserData,
   std::unique_ptr<SkRegion> DraggableRegionsToSkRegion(
       const std::vector<DraggableRegion>& regions);
 
-  // content::WebContentsObserver:
-  void BeforeUnloadDialogCancelled() override;
-  void OnRendererUnresponsive(content::RenderWidgetHost*) override;
-
  private:
-  // Schedule a notification unresponsive event.
-  void ScheduleUnresponsiveEvent(int ms);
-
-  // Dispatch unresponsive event to observers.
-  void NotifyWindowUnresponsive();
-
   // Whether window has standard frame.
   bool has_frame_;
 
@@ -340,10 +324,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // The windows has been closed.
   bool is_closed_;
-
-  // Closure that would be called when window is unresponsive when closing,
-  // it should be cancelled when we can prove that the window is responsive.
-  base::CancelableClosure window_unresposive_closure_;
 
   // Used to display sheets at the appropriate horizontal and vertical offsets
   // on macOS.

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -224,7 +224,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // Called when the window needs to update its draggable region.
   virtual void UpdateDraggableRegions(
-      content::RenderFrameHost* rfh,
       const std::vector<DraggableRegion>& regions) = 0;
 
   base::WeakPtr<NativeWindow> GetWeakPtr() {
@@ -318,8 +317,6 @@ class NativeWindow : public base::SupportsUserData,
 
   // content::WebContentsObserver:
   void BeforeUnloadDialogCancelled() override;
-  bool OnMessageReceived(const IPC::Message& message,
-                         content::RenderFrameHost* rfh) override;
 
  private:
   // Schedule a notification unresponsive event.

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -259,7 +259,6 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowMoved();
   void NotifyWindowScrollTouchBegin();
   void NotifyWindowScrollTouchEnd();
-  void NotifyWindowScrollTouchEdge();
   void NotifyWindowSwipe(const std::string& direction);
   void NotifyWindowSheetBegin();
   void NotifyWindowSheetEnd();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -122,7 +122,6 @@ class NativeWindowMac : public NativeWindow,
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const;
   void UpdateDraggableRegions(
-      content::RenderFrameHost* rfh,
       const std::vector<DraggableRegion>& regions) override;
 
   // content::RenderWidgetHost::InputEventObserver:

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -119,17 +119,18 @@ class NativeWindowMac : public NativeWindow,
   void RefreshTouchBarItem(const std::string& item_id) override;
   void SetEscapeTouchBarItem(const mate::PersistentDictionary& item) override;
 
+  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const;
+  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const;
+  void UpdateDraggableRegions(
+      content::RenderFrameHost* rfh,
+      const std::vector<DraggableRegion>& regions) override;
+
   // content::RenderWidgetHost::InputEventObserver:
   void OnInputEvent(const blink::WebInputEvent& event) override;
 
   // content::WebContentsObserver:
   void RenderViewHostChanged(content::RenderViewHost* old_host,
                              content::RenderViewHost* new_host) override;
-
-  // Refresh the DraggableRegion views.
-  void UpdateDraggableRegionViews() {
-    UpdateDraggableRegionViews(draggable_regions_);
-  }
 
   // Set the attribute of NSWindow while work around a bug of zoom button.
   void SetStyleMask(bool on, NSUInteger flag);
@@ -144,10 +145,11 @@ class NativeWindowMac : public NativeWindow,
   TitleBarStyle title_bar_style() const { return title_bar_style_; }
 
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
-
   bool fullscreen_window_title() const { return fullscreen_window_title_; }
-
   bool simple_fullscreen() const { return always_simple_fullscreen_; }
+  const std::vector<DraggableRegion>& draggable_regions() const {
+    return draggable_regions_;
+  }
 
  protected:
   // Return a vector of non-draggable regions that fill a window of size
@@ -156,22 +158,11 @@ class NativeWindowMac : public NativeWindow,
       const std::vector<DraggableRegion>& regions, int width, int height);
 
  private:
-  // NativeWindow:
-  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const;
-  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const;
-  void UpdateDraggableRegions(
-      content::RenderFrameHost* rfh,
-      const std::vector<DraggableRegion>& regions) override;
-
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void ShowWindowButton(NSWindowButton button);
 
   void InstallView();
   void UninstallView();
-
-  // Install the drag view, which will cover the whole window and decides
-  // whether we can drag.
-  void UpdateDraggableRegionViews(const std::vector<DraggableRegion>& regions);
 
   void RegisterInputEventObserver(content::RenderViewHost* host);
   void UnregisterInputEventObserver(content::RenderViewHost* host);

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -12,7 +12,6 @@
 
 #include "atom/browser/native_window.h"
 #include "base/mac/scoped_nsobject.h"
-#include "content/public/browser/render_widget_host.h"
 
 @class AtomNSWindow;
 @class AtomNSWindowDelegate;
@@ -20,8 +19,7 @@
 
 namespace atom {
 
-class NativeWindowMac : public NativeWindow,
-                        public content::RenderWidgetHost::InputEventObserver {
+class NativeWindowMac : public NativeWindow {
  public:
   NativeWindowMac(brightray::InspectableWebContents* inspectable_web_contents,
                   const mate::Dictionary& options,
@@ -124,13 +122,6 @@ class NativeWindowMac : public NativeWindow,
   void UpdateDraggableRegions(
       const std::vector<DraggableRegion>& regions) override;
 
-  // content::RenderWidgetHost::InputEventObserver:
-  void OnInputEvent(const blink::WebInputEvent& event) override;
-
-  // content::WebContentsObserver:
-  void RenderViewHostChanged(content::RenderViewHost* old_host,
-                             content::RenderViewHost* new_host) override;
-
   // Set the attribute of NSWindow while work around a bug of zoom button.
   void SetStyleMask(bool on, NSUInteger flag);
   void SetCollectionBehavior(bool on, NSUInteger flag);
@@ -162,9 +153,6 @@ class NativeWindowMac : public NativeWindow,
 
   void InstallView();
   void UninstallView();
-
-  void RegisterInputEventObserver(content::RenderViewHost* host);
-  void UnregisterInputEventObserver(content::RenderViewHost* host);
 
   void SetRenderWidgetHostOpaque(bool opaque);
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -415,10 +415,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (BOOL)windowShouldClose:(id)window {
-  // When user tries to close the window by clicking the close button, we do
-  // not close the window immediately, instead we try to close the web page
-  // first, and when the web page is closed the window will also be closed.
-  shell_->RequestToClosePage();
+  shell_->NotifyWindowCloseButtonClicked();
   return NO;
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -296,7 +296,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (void)windowDidResize:(NSNotification*)notification {
-  shell_->UpdateDraggableRegions(nullptr, shell_->draggable_regions());
+  shell_->UpdateDraggableRegions(shell_->draggable_regions());
   shell_->NotifyWindowResize();
 }
 
@@ -1816,7 +1816,6 @@ gfx::Rect NativeWindowMac::WindowBoundsToContentBounds(
 }
 
 void NativeWindowMac::UpdateDraggableRegions(
-    content::RenderFrameHost* rfh,
     const std::vector<DraggableRegion>& regions) {
   if (has_frame())
     return;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1038,9 +1038,6 @@ NativeWindowMac::NativeWindowMac(
   // Set maximizable state last to ensure zoom button does not get reset
   // by calls to other APIs.
   SetMaximizable(maximizable);
-
-  RegisterInputEventObserver(
-      web_contents->GetWebContents()->GetRenderViewHost());
 }
 
 NativeWindowMac::~NativeWindowMac() {
@@ -1869,25 +1866,6 @@ void NativeWindowMac::UpdateDraggableRegions(
   [window_ setMovableByWindowBackground:YES];
 }
 
-void NativeWindowMac::OnInputEvent(const blink::WebInputEvent& event) {
-  switch (event.GetType()) {
-    case blink::WebInputEvent::kGestureScrollBegin:
-    case blink::WebInputEvent::kGestureScrollUpdate:
-    case blink::WebInputEvent::kGestureScrollEnd:
-        this->NotifyWindowScrollTouchEdge();
-      break;
-    default:
-      break;
-  }
-}
-
-void NativeWindowMac::RenderViewHostChanged(
-    content::RenderViewHost* old_host,
-    content::RenderViewHost* new_host) {
-  UnregisterInputEventObserver(old_host);
-  RegisterInputEventObserver(new_host);
-}
-
 std::vector<gfx::Rect> NativeWindowMac::CalculateNonDraggableRegions(
     const std::vector<DraggableRegion>& regions, int width, int height) {
   std::vector<gfx::Rect> result;
@@ -2014,18 +1992,6 @@ void NativeWindowMac::SetCollectionBehavior(bool on, NSUInteger flag) {
   // Change collectionBehavior will make the zoom button revert to default,
   // probably a bug of Cocoa or macOS.
   SetMaximizable(was_maximizable);
-}
-
-void NativeWindowMac::RegisterInputEventObserver(
-    content::RenderViewHost* host) {
-  if (host)
-    host->GetWidget()->AddInputEventObserver(this);
-}
-
-void NativeWindowMac::UnregisterInputEventObserver(
-    content::RenderViewHost* host) {
-  if (host)
-    host->GetWidget()->RemoveInputEventObserver(this);
 }
 
 // static

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -34,9 +34,6 @@ class NativeWindowObserver {
   // Called when the window is gonna closed.
   virtual void WillCloseWindow(bool* prevent_default) {}
 
-  // Called before the native window object is going to be destroyed.
-  virtual void WillDestroyNativeObject() {}
-
   // Called when closed button is clicked.
   virtual void OnCloseButtonClicked(bool* prevent_default) {}
 
@@ -84,12 +81,6 @@ class NativeWindowObserver {
   #if defined(OS_WIN)
   virtual void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {}
   #endif
-
-  // Called when renderer is hung.
-  virtual void OnWindowUnresponsive() {}
-
-  // Called when renderer recovers.
-  virtual void OnWindowResponsive() {}
 
   // Called on Windows when App Commands arrive (WM_APPCOMMAND)
   virtual void OnExecuteWindowsCommand(const std::string& command_name) {}

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -65,7 +65,6 @@ class NativeWindowObserver {
   virtual void OnWindowMoved() {}
   virtual void OnWindowScrollTouchBegin() {}
   virtual void OnWindowScrollTouchEnd() {}
-  virtual void OnWindowScrollTouchEdge() {}
   virtual void OnWindowSwipe(const std::string& direction) {}
   virtual void OnWindowSheetBegin() {}
   virtual void OnWindowSheetEnd() {}

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -86,10 +86,10 @@ class NativeWindowObserver {
   #endif
 
   // Called when renderer is hung.
-  virtual void OnRendererUnresponsive() {}
+  virtual void OnWindowUnresponsive() {}
 
   // Called when renderer recovers.
-  virtual void OnRendererResponsive() {}
+  virtual void OnWindowResponsive() {}
 
   // Called on Windows when App Commands arrive (WM_APPCOMMAND)
   virtual void OnExecuteWindowsCommand(const std::string& command_name) {}

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -37,6 +37,9 @@ class NativeWindowObserver {
   // Called before the native window object is going to be destroyed.
   virtual void WillDestroyNativeObject() {}
 
+  // Called when closed button is clicked.
+  virtual void OnCloseButtonClicked(bool* prevent_default) {}
+
   // Called when the window is closed.
   virtual void OnWindowClosed() {}
 

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -55,9 +55,6 @@ class NativeWindowObserver {
   // Called when window is hidden.
   virtual void OnWindowHide() {}
 
-  // Called when window is ready to show.
-  virtual void OnReadyToShow() {}
-
   // Called when window state changed.
   virtual void OnWindowMaximize() {}
   virtual void OnWindowUnmaximize() {}

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1122,7 +1122,6 @@ gfx::Rect NativeWindowViews::WindowBoundsToContentBounds(
 }
 
 void NativeWindowViews::UpdateDraggableRegions(
-    content::RenderFrameHost* rfh,
     const std::vector<DraggableRegion>& regions) {
   // Draggable region is not supported for non-frameless window.
   if (has_frame())

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -124,7 +124,8 @@ class NativeWindowClientView : public views::ClientView {
   virtual ~NativeWindowClientView() {}
 
   bool CanClose() override {
-    static_cast<NativeWindowViews*>(contents_view())->RequestToClosePage();
+    static_cast<NativeWindowViews*>(contents_view())->
+        NotifyWindowCloseButtonClicked();
     return false;
   }
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -126,6 +126,12 @@ class NativeWindowViews : public NativeWindow,
 
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
 
+  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
+  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
+  void UpdateDraggableRegions(
+      content::RenderFrameHost* rfh,
+      const std::vector<DraggableRegion>& regions) override;
+
 #if defined(OS_WIN)
   void SetIcon(HICON small_icon, HICON app_icon);
 #elif defined(USE_X11)
@@ -135,6 +141,7 @@ class NativeWindowViews : public NativeWindow,
   void SetEnabled(bool enable) override;
 
   views::Widget* widget() const { return window_.get(); }
+  SkRegion* draggable_region() const { return draggable_region_.get(); }
 
 #if defined(OS_WIN)
   TaskbarHost& taskbar_host() { return taskbar_host_; }
@@ -183,8 +190,6 @@ class NativeWindowViews : public NativeWindow,
 #endif
 
   // NativeWindow:
-  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
-  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
   void HandleKeyboardEvent(
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) override;
@@ -288,6 +293,10 @@ class NativeWindowViews : public NativeWindow,
 
   // Map from accelerator to menu item's command id.
   accelerator_util::AcceleratorTable accelerator_table_;
+
+  // For custom drag, the whole window is non-draggable and the draggable region
+  // has to been explicitly provided.
+  std::unique_ptr<SkRegion> draggable_region_;  // used in custom drag.
 
   // How many times the Disable has been called.
   int disable_count_;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -129,7 +129,6 @@ class NativeWindowViews : public NativeWindow,
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
   void UpdateDraggableRegions(
-      content::RenderFrameHost* rfh,
       const std::vector<DraggableRegion>& regions) override;
 
 #if defined(OS_WIN)

--- a/atom/browser/window_list.cc
+++ b/atom/browser/window_list.cc
@@ -93,7 +93,7 @@ void WindowList::CloseAllWindows() {
 void WindowList::DestroyAllWindows() {
   WindowVector windows = GetInstance()->windows_;
   for (const auto& window : windows)
-    window->CloseContents(nullptr);  // e.g. Destroy()
+    window->CloseImmediately();  // e.g. Destroy()
 }
 
 WindowList::WindowList() {


### PR DESCRIPTION
This PR relies on https://github.com/electron/electron/pull/12004, and should be reviewed and merged after it.

This is part of the changes to decouple `NativeWindow` from `WebContents`, so it would be possible for us to implement new APIs based on `NativeWindow`, e.g. providing APIs to create native GUI elements without using `WebContents`.

This PR moves `WebContentsObserver` methods of `NativeWindow` into `api::BrowserWindow`. Commits have been organized to make it easier to review.