### PR TITLE
Fix deprecated API in tools/dump-version-info.js for 2-0-x

### DIFF
--- a/tools/dump-version-info.js
+++ b/tools/dump-version-info.js
@@ -16,7 +16,7 @@ function getDate () {
 
 function getInfoForCurrentVersion () {
   var json = {}
-  json.version = process.versions['atom-shell']
+  json.version = process.versions.electron
   json.date = getDate()
 
   var names = ['node', 'v8', 'uv', 'zlib', 'openssl', 'modules', 'chrome']


### PR DESCRIPTION
Backport of #12003 for 2-0-x.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->