### PR TITLE
update to urllib3

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import urllib3
+import urllib2
 import os
 import zipfile
 
@@ -82,7 +82,8 @@ def download(text, url, path):
     if hasattr(ssl, '_create_unverified_context'):
       ssl._create_default_https_context = ssl._create_unverified_context
 
-    web_file = urllib3.urlopen(url)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+    web_file = urllib2.urlopen(url, context=ctx)
     file_size = int(web_file.info().getheaders("Content-Length")[0])
     downloaded_size = 0
     block_size = 128

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import urllib2
+import urllib3
 import os
 import zipfile
 
@@ -82,7 +82,7 @@ def download(text, url, path):
     if hasattr(ssl, '_create_unverified_context'):
       ssl._create_default_https_context = ssl._create_unverified_context
 
-    web_file = urllib2.urlopen(url)
+    web_file = urllib3.urlopen(url)
     file_size = int(web_file.info().getheaders("Content-Length")[0])
     downloaded_size = 0
     block_size = 128


### PR DESCRIPTION
Earlier today, GitHub [discontinued support for weak cryptographic standards](https://githubengineering.com/crypto-deprecation-notice/). This disabled `TLSv1` used by `urllib2`, so our calls to `urllib2.urlopen(url)` in `script/lib/util.py` are now failing. 

Forcing use of `TLS1.2` should remedy this issue.