### PR TITLE
Preload doesn't load in sandboxed render if preload path contains special chars

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -17,7 +17,6 @@
 #include "atom/renderer/atom_render_view_observer.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
-#include "base/files/file_util.h"
 #include "chrome/renderer/printing/print_web_view_helper.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_view.h"

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -16,6 +16,8 @@
 #include "atom/renderer/api/atom_api_renderer_ipc.h"
 #include "atom/renderer/atom_render_view_observer.h"
 #include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "chrome/renderer/printing/print_web_view_helper.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_view.h"
@@ -163,9 +165,12 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
     return;
 
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  std::string preload_script = command_line->GetSwitchValueASCII(
+  base::FilePath preload_script_path = command_line->GetSwitchValuePath(
       switches::kPreloadScript);
-  if (preload_script.empty())
+  if (preload_script_path.empty())
+    return;
+
+  if (!base::PathExists(preload_script_path))
     return;
 
   auto isolate = context->GetIsolate();
@@ -191,7 +196,7 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   AddRenderBindings(isolate, binding);
   v8::Local<v8::Value> args[] = {
     binding,
-    mate::ConvertToV8(isolate, preload_script)
+    mate::ConvertToV8(isolate, preload_script_path.value())
   };
   // Execute the function with proper arguments
   ignore_result(func->Call(context, v8::Null(isolate), 2, args));

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -170,9 +170,6 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   if (preload_script_path.empty())
     return;
 
-  if (!base::PathExists(preload_script_path))
-    return;
-
   auto isolate = context->GetIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1186,7 +1186,24 @@ describe('BrowserWindow module', () => {
         w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
       })
 
-      it('exposes "exit" event to preload script', (done) => {
+      it('exposes ipcRenderer to preload script (path has special chars)', function (done) {
+        const preloadSpecialChars = path.join(fixtures, 'module', 'preload-sandboxæø åü.js')
+        ipcMain.once('answer', function (event, test) {
+          assert.equal(test, 'preload')
+          done()
+        })
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true,
+            preload: preloadSpecialChars
+          }
+        })
+        w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
+      })
+
+      it('exposes "exit" event to preload script', function (done) {
         w.destroy()
         w = new BrowserWindow({
           show: false,

--- a/spec/fixtures/module/preload-sandboxæø åü.js
+++ b/spec/fixtures/module/preload-sandboxæø åü.js
@@ -1,0 +1,15 @@
+(function () {
+  const {setImmediate} = require('timers')
+  const {ipcRenderer} = require('electron')
+  window.ipcRenderer = ipcRenderer
+  window.setImmediate = setImmediate
+  window.require = require
+  if (location.protocol === 'file:') {
+    window.test = 'preload'
+    window.process = process
+  } else if (location.href !== 'about:blank') {
+    addEventListener('DOMContentLoaded', () => {
+      ipcRenderer.send('child-loaded', window.opener == null, document.body.innerHTML)
+    }, false)
+  }
+})()

--- a/spec/fixtures/module/preload-sandboxæø åü.js
+++ b/spec/fixtures/module/preload-sandboxæø åü.js
@@ -1,15 +1,5 @@
 (function () {
-  const {setImmediate} = require('timers')
-  const {ipcRenderer} = require('electron')
-  window.ipcRenderer = ipcRenderer
-  window.setImmediate = setImmediate
-  window.require = require
   if (location.protocol === 'file:') {
     window.test = 'preload'
-    window.process = process
-  } else if (location.href !== 'about:blank') {
-    addEventListener('DOMContentLoaded', () => {
-      ipcRenderer.send('child-loaded', window.opener == null, document.body.innerHTML)
-    }, false)
   }
 })()

--- a/spec/fixtures/module/preload-sandboxæø åü.js
+++ b/spec/fixtures/module/preload-sandboxæø åü.js
@@ -1,4 +1,5 @@
 (function () {
+  window.require = require
   if (location.protocol === 'file:') {
     window.test = 'preload'
   }


### PR DESCRIPTION
If preload file path contains special chars, load of preload in sandboxed renderer doesn't trigger.