### PR TITLE
Fix context menu click callback

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -9,11 +9,14 @@
 #include "base/logging.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/strings/utf_string_conversions.h"
+#include "content/public/browser/browser_thread.h"
 #include "ui/base/accelerators/accelerator.h"
 #include "ui/base/accelerators/platform_accelerator_cocoa.h"
 #include "ui/base/l10n/l10n_util_mac.h"
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/gfx/image/image.h"
+
+using content::BrowserThread;
 
 namespace {
 
@@ -335,7 +338,11 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
   if (isMenuOpen_) {
     isMenuOpen_ = NO;
     model_->MenuWillClose();
-    closeCallback.Run();
+    // Post async task so that itemSelected runs before the close callback	
+    // deletes the controller from the map which deallocates it	
+    if (!closeCallback.is_null()) {
+      BrowserThread::PostTask(BrowserThread::UI, FROM_HERE, closeCallback);
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Fixes https://github.com/electron/electron/issues/11818

As a regression from https://github.com/electron/electron/commit/d7bc127c6065f3206284269f6b886546f4cdb91e#diff-0a6d4ddeae086b5db6034ab060fc8d94 (thanks @codebytere for debugging help!), the click handler was no longer getting called from context menu items.

My guess is that `closeCallback.Run();` suppressed `itemSelected` from getting called when menu closes too quickly -- but using the previous `PostTask` implementation queues the callback. Would appreciate any more thoughts/insights on this!