### PR TITLE
Fix network delegate race condition

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -441,14 +441,15 @@ void DownloadIdCallback(content::DownloadManager* download_manager,
 }
 
 void SetDevToolsNetworkEmulationClientIdInIO(
-    brightray::URLRequestContextGetter* context_getter,
+    brightray::URLRequestContextGetter* url_request_context_getter,
     const std::string& client_id) {
-  if (!context_getter)
+  if (!url_request_context_getter)
     return;
-  auto network_delegate =
-      static_cast<AtomNetworkDelegate*>(context_getter->network_delegate());
-  if (network_delegate)
-    network_delegate->SetDevToolsNetworkEmulationClientId(client_id);
+  net::URLRequestContext* context =
+      url_request_context_getter->GetURLRequestContext();
+  AtomNetworkDelegate* network_delegate =
+      static_cast<AtomNetworkDelegate*>(context->network_delegate());
+  network_delegate->SetDevToolsNetworkEmulationClientId(client_id);
 }
 
 }  // namespace

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -227,22 +227,22 @@ AtomNetworkDelegate::~AtomNetworkDelegate() {
 
 void AtomNetworkDelegate::SetSimpleListenerInIO(
     SimpleEvent type,
-    const URLPatterns& patterns,
-    const SimpleListener& callback) {
+    URLPatterns patterns,
+    SimpleListener callback) {
   if (callback.is_null())
     simple_listeners_.erase(type);
   else
-    simple_listeners_[type] = { patterns, callback };
+    simple_listeners_[type] = { std::move(patterns), std::move(callback) };
 }
 
 void AtomNetworkDelegate::SetResponseListenerInIO(
     ResponseEvent type,
-    const URLPatterns& patterns,
-    const ResponseListener& callback) {
+    URLPatterns patterns,
+    ResponseListener callback) {
   if (callback.is_null())
     response_listeners_.erase(type);
   else
-    response_listeners_[type] = { patterns, callback };
+    response_listeners_[type] = { std::move(patterns), std::move(callback) };
 }
 
 void AtomNetworkDelegate::SetDevToolsNetworkEmulationClientId(

--- a/atom/browser/net/atom_network_delegate.h
+++ b/atom/browser/net/atom_network_delegate.h
@@ -62,11 +62,11 @@ class AtomNetworkDelegate : public brightray::NetworkDelegate {
   ~AtomNetworkDelegate() override;
 
   void SetSimpleListenerInIO(SimpleEvent type,
-                             const URLPatterns& patterns,
-                             const SimpleListener& callback);
+                             URLPatterns patterns,
+                             SimpleListener callback);
   void SetResponseListenerInIO(ResponseEvent type,
-                               const URLPatterns& patterns,
-                               const ResponseListener& callback);
+                               URLPatterns patterns,
+                               ResponseListener callback);
 
   void SetDevToolsNetworkEmulationClientId(const std::string& client_id);
 

--- a/brightray/browser/url_request_context_getter.h
+++ b/brightray/browser/url_request_context_getter.h
@@ -84,11 +84,6 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
 
   net::HostResolver* host_resolver();
   net::URLRequestJobFactory* job_factory() const { return job_factory_; }
-  net::NetworkDelegate* network_delegate() const {
-    if (url_request_context_)
-      return url_request_context_->network_delegate();
-    return nullptr;
-  }
 
  private:
   Delegate* delegate_;


### PR DESCRIPTION
This fix the race condition when getting network delegate in UI thread, should be able to close #12029.

The network delegate is created in IO thread lazily, we should never try to get it in UI thread.

