### PR TITLE
W/A for Narrator not working with electron on Win10

### DIFF
--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -102,15 +102,17 @@ bool NativeWindowViews::PreHandleMSG(
     case WM_GETOBJECT: {
       if (checked_for_a11y_support_) return false;
 
-      const DWORD obj_id = static_cast<DWORD>(l_param);
+      const DWORD obj_id = static_cast<DWORD>(static_cast<DWORD_PTR>(l_param));
 
-      if (obj_id != OBJID_CLIENT) {
+      const DWORD OBJID_WIN10_CLIENT = 0xFFFFFFE7;
+
+      if (obj_id != OBJID_CLIENT && obj_id != OBJID_WIN10_CLIENT) {
         return false;
       }
 
-      if (!IsScreenReaderActive()) {
-        return false;
-      }
+      //if (!IsScreenReaderActive()) {
+      //  return false;
+      //}
 
       checked_for_a11y_support_ = true;
 


### PR DESCRIPTION
#10507 fix for this issue

This fixes the narrator not working properly on win10, atm. i don't have win7 platform to cross check

steps to reproduce:
1. run electron.exe
2. Win+U
3. Turn on narrator
4. Focus Electron window
5. Tab through available elements
Current behavior:
Nothing is read out.

Expected behavior:
Every tabbed element is red out

