### PR TITLE
Include backtrace i/o as a crash reporter backend option

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -24,6 +24,10 @@ following projects:
 * [socorro](https://github.com/mozilla/socorro)
 * [mini-breakpad-server](https://github.com/electron/mini-breakpad-server)
 
+Or use a 3rd party hosted solution:
+
+* [Backtrace I/O](https://backtrace.io/electron/)
+
 Crash reports are saved locally in an application-specific temp directory folder.
 For a `productName` of `YourName`, crash reports will be stored in a folder
 named `YourName Crashes` inside the temp directory. You can customize this temp


### PR DESCRIPTION
Note: I have no affiliation with this company - just thought this would be helpful for people looking for a way to get started quickly (it was for me).