### PR TITLE
add warning when addTabbedWindow is called on self

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -1084,7 +1084,9 @@ void BrowserWindow::ToggleTabBar() {
 
 void BrowserWindow::AddTabbedWindow(NativeWindow* window,
   mate::Arguments* args) {
-  window_->AddTabbedWindow(window, args);
+  const bool windowAdded = window_->AddTabbedWindow(window);
+  if (!windowAdded)
+    args->ThrowError("AddTabbedWindow cannot be called by a window on itself");
 }
 
 void BrowserWindow::SetVibrancy(mate::Arguments* args) {

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -1082,7 +1082,8 @@ void BrowserWindow::ToggleTabBar() {
   window_->ToggleTabBar();
 }
 
-void BrowserWindow::AddTabbedWindow(NativeWindow* window, mate::Arguments* args) {
+void BrowserWindow::AddTabbedWindow(NativeWindow* window,
+  mate::Arguments* args) {
   window_->AddTabbedWindow(window, args);
 }
 

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -1082,8 +1082,13 @@ void BrowserWindow::ToggleTabBar() {
   window_->ToggleTabBar();
 }
 
-void BrowserWindow::AddTabbedWindow(NativeWindow* window) {
-  window_->AddTabbedWindow(window);
+void BrowserWindow::AddTabbedWindow(mate::Arguments* args) {
+  NativeWindow* window;
+  if (!args->GetNext(&window)) {
+    args->ThrowError("Insert good error message here");
+    return;
+  }
+  window_->AddTabbedWindow(window, args);
 }
 
 void BrowserWindow::SetVibrancy(mate::Arguments* args) {

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -1082,12 +1082,7 @@ void BrowserWindow::ToggleTabBar() {
   window_->ToggleTabBar();
 }
 
-void BrowserWindow::AddTabbedWindow(mate::Arguments* args) {
-  NativeWindow* window;
-  if (!args->GetNext(&window)) {
-    args->ThrowError("Insert good error message here");
-    return;
-  }
+void BrowserWindow::AddTabbedWindow(NativeWindow* window, mate::Arguments* args) {
   window_->AddTabbedWindow(window, args);
 }
 

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -1083,10 +1083,10 @@ void BrowserWindow::ToggleTabBar() {
 }
 
 void BrowserWindow::AddTabbedWindow(NativeWindow* window,
-  mate::Arguments* args) {
+                                    mate::Arguments* args) {
   const bool windowAdded = window_->AddTabbedWindow(window);
   if (!windowAdded)
-    args->ThrowError("AddTabbedWindow cannot be called by a window on itself");
+    args->ThrowError("AddTabbedWindow cannot be called by a window on itself.");
 }
 
 void BrowserWindow::SetVibrancy(mate::Arguments* args) {

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -243,7 +243,7 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void MergeAllWindows();
   void MoveTabToNewWindow();
   void ToggleTabBar();
-  void AddTabbedWindow(NativeWindow* window);
+  void AddTabbedWindow(mate::Arguments* args);
 
   void SetVibrancy(mate::Arguments* args);
   void SetTouchBar(const std::vector<mate::PersistentDictionary>& items);

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -243,7 +243,7 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void MergeAllWindows();
   void MoveTabToNewWindow();
   void ToggleTabBar();
-  void AddTabbedWindow(mate::Arguments* args);
+  void AddTabbedWindow(NativeWindow* window, mate::Arguments* args);
 
   void SetVibrancy(mate::Arguments* args);
   void SetTouchBar(const std::vector<mate::PersistentDictionary>& items);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -336,8 +336,8 @@ void NativeWindow::MoveTabToNewWindow() {
 void NativeWindow::ToggleTabBar() {
 }
 
-void NativeWindow::AddTabbedWindow(NativeWindow* window,
-  mate::Arguments* args) {
+bool NativeWindow::AddTabbedWindow(NativeWindow* window) {
+  return true;  // for non-Mac platforms
 }
 
 void NativeWindow::SetVibrancy(const std::string& filename) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -336,7 +336,8 @@ void NativeWindow::MoveTabToNewWindow() {
 void NativeWindow::ToggleTabBar() {
 }
 
-void NativeWindow::AddTabbedWindow(NativeWindow* window, mate::Arguments* args) {
+void NativeWindow::AddTabbedWindow(NativeWindow* window,
+  mate::Arguments* args) {
 }
 
 void NativeWindow::SetVibrancy(const std::string& filename) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -336,7 +336,7 @@ void NativeWindow::MoveTabToNewWindow() {
 void NativeWindow::ToggleTabBar() {
 }
 
-void NativeWindow::AddTabbedWindow(NativeWindow* window) {
+void NativeWindow::AddTabbedWindow(NativeWindow* window, mate::Arguments* args) {
 }
 
 void NativeWindow::SetVibrancy(const std::string& filename) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -192,7 +192,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void MergeAllWindows();
   virtual void MoveTabToNewWindow();
   virtual void ToggleTabBar();
-  virtual void AddTabbedWindow(NativeWindow* window, mate::Arguments* args);
+  virtual bool AddTabbedWindow(NativeWindow* window);
 
   // Webview APIs.
   virtual void FocusOnWebView();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -192,7 +192,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void MergeAllWindows();
   virtual void MoveTabToNewWindow();
   virtual void ToggleTabBar();
-  virtual void AddTabbedWindow(NativeWindow* window);
+  virtual void AddTabbedWindow(NativeWindow* window, mate::Arguments* args);
 
   // Webview APIs.
   virtual void FocusOnWebView();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -109,7 +109,7 @@ class NativeWindowMac : public NativeWindow {
   void MergeAllWindows() override;
   void MoveTabToNewWindow() override;
   void ToggleTabBar() override;
-  void AddTabbedWindow(NativeWindow* window) override;
+  void AddTabbedWindow(NativeWindow* window, mate::Arguments* args) override;
 
   void SetVibrancy(const std::string& type) override;
   void SetTouchBar(

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -109,7 +109,7 @@ class NativeWindowMac : public NativeWindow {
   void MergeAllWindows() override;
   void MoveTabToNewWindow() override;
   void ToggleTabBar() override;
-  void AddTabbedWindow(NativeWindow* window, mate::Arguments* args) override;
+  bool AddTabbedWindow(NativeWindow* window) override;
 
   void SetVibrancy(const std::string& type) override;
   void SetTouchBar(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -918,7 +918,6 @@ NativeWindowMac::NativeWindowMac(
   }
 
   if (transparent()) {
-    NSLog(@"Setting transparent");
     // Setting the background color to clear will also hide the shadow.
     [window_ setBackgroundColor:[NSColor clearColor]];
   }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -918,6 +918,7 @@ NativeWindowMac::NativeWindowMac(
   }
 
   if (transparent()) {
+    NSLog(@"Setting transparent");
     // Setting the background color to clear will also hide the shadow.
     [window_ setBackgroundColor:[NSColor clearColor]];
   }
@@ -1671,9 +1672,9 @@ void NativeWindowMac::ToggleTabBar() {
   }
 }
 
-void NativeWindowMac::AddTabbedWindow(NativeWindow* window) {
+void NativeWindowMac::AddTabbedWindow(NativeWindow* window, mate::Arguments* args) {
   if (window_.get() == window->GetNativeWindow()) {
-    NSLog(@"Error: AddTabbedWindow cannot be called by a window on itself.");
+    args->ThrowError("AddTabbedWindow cannot be called by a window on itself");
   } else {
     if ([window_ respondsToSelector:@selector(addTabbedWindow:ordered:)]) {
       [window_ addTabbedWindow:window->GetNativeWindow() ordered:NSWindowAbove];

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1672,8 +1672,12 @@ void NativeWindowMac::ToggleTabBar() {
 }
 
 void NativeWindowMac::AddTabbedWindow(NativeWindow* window) {
-  if ([window_ respondsToSelector:@selector(addTabbedWindow:ordered:)]) {
-    [window_ addTabbedWindow:window->GetNativeWindow() ordered:NSWindowAbove];
+  if (window_.get() == window->GetNativeWindow()) {
+    NSLog(@"Error: AddTabbedWindow cannot be called by a window on itself.");
+  } else {
+    if ([window_ respondsToSelector:@selector(addTabbedWindow:ordered:)]) {
+      [window_ addTabbedWindow:window->GetNativeWindow() ordered:NSWindowAbove];
+    }
   }
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1672,14 +1672,14 @@ void NativeWindowMac::ToggleTabBar() {
   }
 }
 
-void NativeWindowMac::AddTabbedWindow(NativeWindow* window, mate::Arguments* args) {
+bool NativeWindowMac::AddTabbedWindow(NativeWindow* window) {
   if (window_.get() == window->GetNativeWindow()) {
-    args->ThrowError("AddTabbedWindow cannot be called by a window on itself");
+    return false;
   } else {
-    if ([window_ respondsToSelector:@selector(addTabbedWindow:ordered:)]) {
+    if ([window_ respondsToSelector:@selector(addTabbedWindow:ordered:)])
       [window_ addTabbedWindow:window->GetNativeWindow() ordered:NSWindowAbove];
-    }
   }
+  return true;
 }
 
 void NativeWindowMac::SetRenderWidgetHostOpaque(bool opaque) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -733,6 +733,12 @@ describe('BrowserWindow module', () => {
         done()
       })
     })
+
+    it('throws when called on itself', () => {
+      assert.throws(() => {
+        w.addTabbedWindow(w)
+      }, /AddTabbedWindow cannot be called by a window on itself./)
+    })
   })
 
   describe('BrowserWindow.setVibrancy(type)', () => {


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/12046.

Per [documentation](https://developer.apple.com/documentation/appkit/nswindow/1855947-addtabbedwindow?language=objc), you can't add a tabbed window with the same window; you need to create a new one. When you add a new window, you need to pass in a value for `NSWindowOrderingMode`, which can be only `NSWindowAbove`, `NSWindowBelow`, or `NSWindowOut`. As you can't set a window above or below itself, this will crash it. 

This PR catches attempts to do the above and instead outputs an error explaining that it must be called on a new window.

/cc @bpasero @MarshallOfSound 