### PR TITLE
Fix dockMenu not being referenced in JavaScript

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -10,6 +10,8 @@ const electron = require('electron')
 const {deprecate, Menu} = electron
 const {EventEmitter} = require('events')
 
+let dockMenu = null
+
 // App is an EventEmitter.
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 EventEmitter.call(app)
@@ -49,7 +51,13 @@ if (process.platform === 'darwin') {
     hide: bindings.dockHide,
     show: bindings.dockShow,
     isVisible: bindings.dockIsVisible,
-    setMenu: bindings.dockSetMenu,
+    setMenu (menu) {
+      dockMenu = menu
+      bindings.dockSetMenu(menu)
+    },
+    getMenu () {
+      return dockMenu
+    },
     setIcon: bindings.dockSetIcon
   }
 }

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -7,7 +7,7 @@ const path = require('path')
 const {ipcRenderer, remote} = require('electron')
 const {closeWindow} = require('./window-helpers')
 
-const {app, BrowserWindow, ipcMain} = remote
+const {app, BrowserWindow, Menu, ipcMain} = remote
 
 const isCI = remote.getGlobal('isCi')
 
@@ -879,6 +879,20 @@ describe('app module', () => {
       assert.throws(() => {
         app.disableDomainBlockingFor3DAPIs()
       }, /before app is ready/)
+    })
+  })
+
+  describe('dock.setMenu', () => {
+    before(function () {
+      if (process.platform !== 'darwin') {
+        this.skip()
+      }
+    })
+
+    it('keeps references to the menu', () => {
+      app.dock.setMenu(new Menu())
+      const v8Util = process.atomBinding('v8_util')
+      v8Util.requestGarbageCollectionForTesting()
     })
   })
 })


### PR DESCRIPTION
This was not a problem until https://github.com/electron/electron/pull/11967 fixed the memory leak of menus.

Close https://github.com/electron/electron/issues/12002.