### PR TITLE
Allow CI testing on arm64 hardware

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,63 @@
+FROM arm64v8/ubuntu:16.04
+
+RUN groupadd --gid 1000 builduser \
+  && useradd --uid 1000 --gid builduser --shell /bin/bash --create-home builduser
+
+RUN groupadd --gid 114 jenkins \
+  && useradd --uid 110 --gid jenkins --shell /bin/bash --create-home jenkins
+
+# Set up TEMP directory
+ENV TEMP=/tmp
+RUN chmod a+rwx /tmp
+
+RUN apt-get update && apt-get install -y\
+ bison \
+ build-essential \
+ clang \
+ curl \
+ gperf \
+ git \
+ libasound2 \
+ libasound2-dev \
+ libcap-dev \
+ libcups2-dev \
+ libdbus-1-dev \
+ libgconf-2-4 \
+ libgconf2-dev \
+ libgnome-keyring-dev \
+ libgtk2.0-0 \
+ libgtk2.0-dev \
+ libgtk-3-0 \
+ libgtk-3-dev \
+ libnotify-dev \
+ libnss3 \
+ libnss3-dev \
+ libx11-xcb-dev \
+ libxss1 \
+ libxtst-dev \
+ libxtst6 \
+ lsb-release \
+ locales \
+ ninja \
+ python-setuptools \
+ python-pip \
+ python-dbusmock \
+ wget \
+ xvfb
+
+# Install node.js
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get update && apt-get install -y nodejs
+
+# Install crcmod
+RUN pip install -U crcmod
+
+ADD tools/xvfb-init.sh /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb
+
+# Install ninja in /usr/local
+RUN cd /usr/local && git clone https://github.com/martine/ninja.git -b v1.5.3
+RUN cd /usr/local/ninja && ./configure.py --bootstrap
+
+USER builduser
+WORKDIR /home/builduser

--- a/Jenkinsfile.arm64
+++ b/Jenkinsfile.arm64
@@ -1,0 +1,35 @@
+pipeline {
+  agent {
+    docker {
+      image 'electronbuilds/arm64v8:0.0.1'
+      args '--privileged'
+    }
+  }
+  environment {
+    TARGET_ARCH='arm64'
+    DISPLAY=':99.0'
+  }
+  stages {
+    stage('Bootstrap') {
+      steps {
+        sh 'script/bootstrap.py -v --dev --target_arch=$TARGET_ARCH'
+      }
+    }
+    stage('Build') {
+      steps {
+        sh 'script/build.py -c D --ninja-path /usr/local/ninja/ninja'
+      }
+    }
+    stage('Test') {
+      steps {
+        sh '/etc/init.d/xvfb start'
+        sh 'script/test.py --ci'
+      }
+    }
+  }
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/brightray/brightray.gyp
+++ b/brightray/brightray.gyp
@@ -161,7 +161,6 @@
                   '-ldl',
                   '-lresolv',
                   '-lfontconfig',
-                  '-lfreetype',
                   '-lexpat',
                 ],
               },
@@ -170,14 +169,6 @@
               'link_settings': {
                 'libraries!': [
                   '<(libchromiumcontent_dir)/libdesktop_capture_differ_sse2.a',
-                ],
-              },
-            }],
-            # On ARM64 libchromiumcontent always links to system libfreetype
-            ['target_arch=="arm64"', {
-              'link_settings': {
-                'libraries': [
-                  '-lfreetype',
                 ],
               },
             }],

--- a/script/update-clang.sh
+++ b/script/update-clang.sh
@@ -24,6 +24,7 @@ STAMP_FILE="${LLVM_DIR}/../llvm-build/cr_build_revision"
 LLVM_REPO_URL=${LLVM_URL:-https://llvm.org/svn/llvm-project}
 
 CDS_URL=https://commondatastorage.googleapis.com/chromium-browser-clang
+S3_URL=https://s3.amazonaws.com/gh-contractor-zcbenz/clang
 
 
 # Die if any command dies, error on undefined variable expansions.
@@ -49,7 +50,12 @@ CDS_FILE="clang-${PACKAGE_VERSION}.tgz"
 CDS_OUT_DIR=$(mktemp -d -t clang_download.XXXXXX)
 CDS_OUTPUT="${CDS_OUT_DIR}/${CDS_FILE}"
 if [ "${OS}" = "Linux" ]; then
-  CDS_FULL_URL="${CDS_URL}/Linux_x64/${CDS_FILE}"
+  ARCH="$(uname -m)"
+  if [ "${ARCH}" = "aarch64" ]; then
+    CDS_FULL_URL="${S3_URL}/arm64/${CDS_FILE}"
+  else
+    CDS_FULL_URL="${CDS_URL}/Linux_x64/${CDS_FILE}"
+  fi
 elif [ "${OS}" = "Darwin" ]; then
   CDS_FULL_URL="${CDS_URL}/Mac/${CDS_FILE}"
 fi

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -33,7 +33,8 @@ describe('modules support', () => {
     // https://github.com/electron/electron/issues/11274
     xdescribe('ffi', () => {
       before(function () {
-        if (!nativeModulesEnabled || process.platform === 'win32') {
+        if (!nativeModulesEnabled || process.platform === 'win32' ||
+            process.arch === 'arm64') {
           this.skip()
         }
       })


### PR DESCRIPTION
This PR adds the capability of building/testing our arm64 build on arm64 hardware.

There are a couple changes needed to do this:
1. There isn't a prebuilt ninja binary available for arm64 so the docker image that is used includes a built from source ninja binary.  Because the ninja binary isn't in the location it usually is, I added a parameter `ninja-path` to build.py to specify the location of the ninja binary.

2. There isn't a prebuilt clang binary available for arm64, so I created a prebuilt binary for arm64 and updated script/update-clang.sh to pull the prebuilt binary from our s3 bucket.

3. There is a new CI machine, https://arm64-ci.electronjs.org that I have provisioned for running our CI on actual arm64 hardware (in this case a 96 core arm64 machine that has 2 Cavium ThunderX ARMv8 SoC's).
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->