### PR TITLE
 Workspace notifications support on macOS

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -55,16 +55,22 @@ void SystemPreferences::BuildPrototype(
 #elif defined(OS_MACOSX)
       .SetMethod("postNotification",
                  &SystemPreferences::PostNotification)
-      .SetMethod("postLocalNotification",
-                 &SystemPreferences::PostLocalNotification)
       .SetMethod("subscribeNotification",
                  &SystemPreferences::SubscribeNotification)
       .SetMethod("unsubscribeNotification",
                  &SystemPreferences::UnsubscribeNotification)
+      .SetMethod("postLocalNotification",
+                 &SystemPreferences::PostLocalNotification)
       .SetMethod("subscribeLocalNotification",
                  &SystemPreferences::SubscribeLocalNotification)
       .SetMethod("unsubscribeLocalNotification",
                  &SystemPreferences::UnsubscribeLocalNotification)
+      .SetMethod("postWorkspaceNotification",
+                 &SystemPreferences::PostWorkspaceNotification)
+      .SetMethod("subscribeWorkspaceNotification",
+                 &SystemPreferences::SubscribeWorkspaceNotification)
+      .SetMethod("unsubscribeWorkspaceNotification",
+                 &SystemPreferences::UnsubscribeWorkspaceNotification)
       .SetMethod("registerDefaults", &SystemPreferences::RegisterDefaults)
       .SetMethod("getUserDefault", &SystemPreferences::GetUserDefault)
       .SetMethod("setUserDefault", &SystemPreferences::SetUserDefault)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -26,6 +26,14 @@ namespace atom {
 
 namespace api {
 
+#if defined(OS_MACOSX)
+enum NotificationCenterKind {
+  kNSDistributedNotificationCenter = 0,
+  kNSNotificationCenter,
+  kNSWorkspaceNotificationCenter,
+};  
+#endif
+
 class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 #if defined(OS_WIN)
     , public BrowserObserver
@@ -63,14 +71,19 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   void PostNotification(const std::string& name,
                         const base::DictionaryValue& user_info);
-  void PostLocalNotification(const std::string& name,
-                             const base::DictionaryValue& user_info);
   int SubscribeNotification(const std::string& name,
                             const NotificationCallback& callback);
   void UnsubscribeNotification(int id);
+  void PostLocalNotification(const std::string& name,
+                             const base::DictionaryValue& user_info);
   int SubscribeLocalNotification(const std::string& name,
                                  const NotificationCallback& callback);
   void UnsubscribeLocalNotification(int request_id);
+  void PostWorkspaceNotification(const std::string& name,
+                             const base::DictionaryValue& user_info);
+  int SubscribeWorkspaceNotification(const std::string& name,
+                                 const NotificationCallback& callback);
+  void UnsubscribeWorkspaceNotification(int request_id);
   v8::Local<v8::Value> GetUserDefault(const std::string& name,
                                       const std::string& type);
   void RegisterDefaults(mate::Arguments* args);
@@ -90,11 +103,11 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 #if defined(OS_MACOSX)
   void DoPostNotification(const std::string& name,
                           const base::DictionaryValue& user_info,
-                          bool is_local);
+                          NotificationCenterKind kind);
   int DoSubscribeNotification(const std::string& name,
                               const NotificationCallback& callback,
-                              bool is_local);
-  void DoUnsubscribeNotification(int request_id, bool is_local);
+                              NotificationCenterKind kind);
+  void DoUnsubscribeNotification(int request_id, NotificationCenterKind kind);
 #endif
 
  private:

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -31,7 +31,7 @@ enum NotificationCenterKind {
   kNSDistributedNotificationCenter = 0,
   kNSNotificationCenter,
   kNSWorkspaceNotificationCenter,
-};  
+};
 #endif
 
 class SystemPreferences : public mate::EventEmitter<SystemPreferences>

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -61,6 +61,14 @@ that contains the user information dictionary sent along with the notification.
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
 
+### `systemPreferences.postWorkspaceNotification(event, userInfo)` _macOS_
+
+* `event` String
+* `userInfo` Object
+
+Posts `event` as native notifications of macOS. The `userInfo` is an Object
+that contains the user information dictionary sent along with the notification.
+
 ### `systemPreferences.subscribeNotification(event, callback)` _macOS_
 
 * `event` String
@@ -84,12 +92,6 @@ example values of `event` are:
 * `AppleColorPreferencesChangedNotification`
 * `AppleShowScrollBarsSettingChanged`
 
-### `systemPreferences.unsubscribeNotification(id)` _macOS_
-
-* `id` Integer
-
-Removes the subscriber with `id`.
-
 ### `systemPreferences.subscribeLocalNotification(event, callback)` _macOS_
 
 * `event` String
@@ -100,11 +102,33 @@ Removes the subscriber with `id`.
 Same as `subscribeNotification`, but uses `NSNotificationCenter` for local defaults.
 This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 
+### `systemPreferences.subscribeWorkspaceNotification(event, callback)` _macOS_
+
+* `event` String
+* `callback` Function
+  * `event` String
+  * `userInfo` Object
+
+Same as `subscribeNotification`, but uses `NSWorkspace.sharedWorkspace.notificationCenter` for local defaults.
+This is necessary for events such as `NSWorkspaceDidActivateApplicationNotification`.
+
+### `systemPreferences.unsubscribeNotification(id)` _macOS_
+
+* `id` Integer
+
+Removes the subscriber with `id`.
+
 ### `systemPreferences.unsubscribeLocalNotification(id)` _macOS_
 
 * `id` Integer
 
 Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificationCenter`.
+
+### `systemPreferences.unsubscribeWorkspaceNotification(id)` _macOS_
+
+* `id` Integer
+
+Same as `unsubscribeNotification`, but removes the subscriber from `NSWorkspace.sharedWorkspace.notificationCenter`.
 
 ### `systemPreferences.registerDefaults(defaults)` _macOS_		
 


### PR DESCRIPTION
Electron currently does not support Workspace notification on macOS such as NSWorkspaceDidActivateApplicationNotification. As explained on [Apple website](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Workspace/Articles/WorkspaceNotifications.html), there are many uses such as :
* applications are launched and terminated
* volumes are mounted or unmounted
* the Finder performs file operations
* the Finder becomes the active application or resigns as the active application
* the user logs out or shuts down the computer
* the computer wakes from sleep.

This pull request, like the previous #6150 for local notification, allows it.