### PR TITLE
chore(build): support generating compilation db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ node_modules/
 SHASUMS256.txt
 **/package-lock.json
 **/yarn.lock
+compile_commands.json
+.envrc
 
 # npm package
 /npm/dist

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -63,6 +63,13 @@ $ cd electron
 $ ./script/bootstrap.py --verbose
 ```
 
+If you are using editor supports [JSON compilation database](http://clang.llvm.org/docs/JSONCompilationDatabase.html) based
+language server, you can generate it:
+
+```sh
+$ ./script/build.py --compdb
+```
+
 ### Cross compilation
 
 If you want to build for an `arm` target you should also install the following

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -56,6 +56,13 @@ $ cd electron
 $ ./script/bootstrap.py -v
 ```
 
+If you are using editor supports [JSON compilation database](http://clang.llvm.org/docs/JSONCompilationDatabase.html) based
+language server, you can generate it:
+
+```sh
+$ ./script/build.py --compdb
+```
+
 ## Building
 
 Build both `Release` and `Debug` targets:

--- a/script/build.py
+++ b/script/build.py
@@ -56,7 +56,14 @@ def main():
   env = build_env()
   for config in args.configuration:
     build_path = os.path.join('out', config[0])
-    ret = subprocess.call(ninja + ['-C', build_path, args.target], env=env)
+    build_args = ['-C', build_path, args.target]
+    if args.compdb:
+      build_args += ['-t', 'compdb', 'cxx', 'cc']
+      compdb = open(r'compile_commands.json','w')
+      ret = subprocess.call(ninja + build_args, env=env, stdout=compdb)
+      compdb.close()
+    else:
+      ret = subprocess.call(ninja + build_args, env=env)
     if ret != 0:
       sys.exit(ret)
 
@@ -86,6 +93,12 @@ def parse_args():
   parser.add_argument('--ninja-path',
                       help='Path of ninja command to use.',
                       required=False)
+  parser.add_argument('--compdb',
+                      help=(
+                        'Generate JSON compilation database. This will not '
+                        'trigger actual build. '
+                      ),
+                      action='store_true', default=False)
   return parser.parse_args()
 
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This is chore PR to add `--compdb` flags in build script to generate JSON compilation database (http://clang.llvm.org/docs/JSONCompilationDatabase.html). 

It's bit early stage though, some of language server started to support compilation database (i.e [cquery](https://github.com/cquery-project/cquery), [vs code cpptools](https://github.com/Microsoft/vscode-cpptools/blob/master/Documentation/Getting%20started%20with%20IntelliSense%20configuration.md#1-use-compile_commandsjson-file-to-supply-includepaths-and-defines-information) and possibly some others I am not aware of) provides language features like intellisense, or others.

PR exposes `--compdb` in build script, it either generate or overwrite `compile_commands.json` when invoked. It doesn't trigger actual build if flag is supplied.

I'm not fully sure if it's acceptable to expose new flag for build script - please feel freely close if this isn't desired changes.