### PR TITLE
Allow CI testing on arm64 hardware for 1-8-x

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,63 @@
+FROM arm64v8/ubuntu:16.04
+
+RUN groupadd --gid 1000 builduser \
+  && useradd --uid 1000 --gid builduser --shell /bin/bash --create-home builduser
+
+RUN groupadd --gid 114 jenkins \
+  && useradd --uid 110 --gid jenkins --shell /bin/bash --create-home jenkins
+
+# Set up TEMP directory
+ENV TEMP=/tmp
+RUN chmod a+rwx /tmp
+
+RUN apt-get update && apt-get install -y\
+ bison \
+ build-essential \
+ clang \
+ curl \
+ gperf \
+ git \
+ libasound2 \
+ libasound2-dev \
+ libcap-dev \
+ libcups2-dev \
+ libdbus-1-dev \
+ libgconf-2-4 \
+ libgconf2-dev \
+ libgnome-keyring-dev \
+ libgtk2.0-0 \
+ libgtk2.0-dev \
+ libgtk-3-0 \
+ libgtk-3-dev \
+ libnotify-dev \
+ libnss3 \
+ libnss3-dev \
+ libx11-xcb-dev \
+ libxss1 \
+ libxtst-dev \
+ libxtst6 \
+ lsb-release \
+ locales \
+ ninja \
+ python-setuptools \
+ python-pip \
+ python-dbusmock \
+ wget \
+ xvfb
+
+# Install node.js
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get update && apt-get install -y nodejs
+
+# Install crcmod
+RUN pip install -U crcmod
+
+ADD tools/xvfb-init.sh /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb
+
+# Install ninja in /usr/local
+RUN cd /usr/local && git clone https://github.com/martine/ninja.git -b v1.5.3
+RUN cd /usr/local/ninja && ./configure.py --bootstrap
+
+USER builduser
+WORKDIR /home/builduser

--- a/Jenkinsfile.arm64
+++ b/Jenkinsfile.arm64
@@ -1,0 +1,35 @@
+pipeline {
+  agent {
+    docker {
+      image 'electronbuilds/arm64v8:0.0.1'
+      args '--privileged'
+    }
+  }
+  environment {
+    TARGET_ARCH='arm64'
+    DISPLAY=':99.0'
+  }
+  stages {
+    stage('Bootstrap') {
+      steps {
+        sh 'script/bootstrap.py -v --dev --target_arch=$TARGET_ARCH'
+      }
+    }
+    stage('Build') {
+      steps {
+        sh 'script/build.py -c D --ninja-path /usr/local/ninja/ninja'
+      }
+    }
+    stage('Test') {
+      steps {
+        sh '/etc/init.d/xvfb start'
+        sh 'script/test.py --ci'
+      }
+    }
+  }
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/script/build.py
+++ b/script/build.py
@@ -28,6 +28,8 @@ def main():
     ninja += '.exe'
 
   args = parse_args()
+  if args.ninja_path:
+    ninja = args.ninja_path
   if args.libcc:
     if ('D' not in args.configuration
         or not os.path.exists(GCLIENT_DONE)
@@ -67,6 +69,9 @@ def parse_args():
                         '-d --debug_libchromiumcontent.'
                       ),
                       action='store_true', default=False)
+  parser.add_argument('--ninja-path',
+                      help='Path of ninja command to use.',
+                      required=False)
   return parser.parse_args()
 
 

--- a/script/update-clang.sh
+++ b/script/update-clang.sh
@@ -24,6 +24,7 @@ STAMP_FILE="${LLVM_DIR}/../llvm-build/cr_build_revision"
 LLVM_REPO_URL=${LLVM_URL:-https://llvm.org/svn/llvm-project}
 
 CDS_URL=https://commondatastorage.googleapis.com/chromium-browser-clang
+S3_URL=https://s3.amazonaws.com/gh-contractor-zcbenz/clang
 
 
 # Die if any command dies, error on undefined variable expansions.
@@ -52,8 +53,14 @@ mkdir -p "${LLVM_BUILD_DIR}"
 CDS_FILES=("clang-${PACKAGE_VERSION}.tgz")
 CDS_OUT_DIR=$(mktemp -d -t clang_download.XXXXXX)
 if [ "${OS}" = "Linux" ]; then
-  CDS_FILES+=("llvmgold-${PACKAGE_VERSION}.tgz")
-  CDS_SUBDIR="Linux_x64"
+  ARCH="$(uname -m)"
+  if [ "${ARCH}" = "aarch64" ]; then
+    CDS_URL="${S3_URL}"
+    CDS_SUBDIR="arm64"
+  else
+    CDS_FILES+=("llvmgold-${PACKAGE_VERSION}.tgz")
+    CDS_SUBDIR="Linux_x64"
+  fi
 elif [ "${OS}" = "Darwin" ]; then
   CDS_SUBDIR="Mac"
 fi

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -30,7 +30,8 @@ describe('modules support', () => {
 
     describe('ffi', () => {
       before(function () {
-        if (!nativeModulesEnabled || process.platform === 'win32') {
+        if (!nativeModulesEnabled || process.platform === 'win32' ||
+            process.arch === 'arm64') {
           this.skip()
         }
       })


### PR DESCRIPTION
Backports #12080 to 1-8-x.

(cherry picked from commit 73394d335af879c59bd0590cf18f8539cfa8124a)

This PR is ready to go as all tests pass on 1-8-x with the exception of ffi which isn't currently supported on arm64: https://github.com/node-ffi/node-ffi/issues/393
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->