### PR TITLE
Add optional verbose switch '-v' to build script.

### DIFF
--- a/script/build.py
+++ b/script/build.py
@@ -66,7 +66,6 @@ def parse_args():
   parser.add_argument('-v', '--verbose',
                       action='store_true',
                       default=False,
-                      #dest='only_changed',
                       help='Verbose output')
   parser.add_argument('-t', '--target',
                       help='Build specified target',

--- a/script/build.py
+++ b/script/build.py
@@ -28,10 +28,15 @@ def main():
   # Update the VS build env.
   import_vs_env(get_target_arch())
 
-  ninja_exec = os.path.join('vendor', 'depot_tools', 'ninja')
-  if sys.platform == 'win32':
-    ninja_exec += '.exe'
-  ninja = [ninja_exec]
+  # decide which ninja executable to use
+  ninja_path = args.ninja_path
+  if not ninja_path:
+    ninja_path = os.path.join('vendor', 'depot_tools', 'ninja')
+    if sys.platform == 'win32':
+      ninja_path += '.exe'
+
+  # decide how to invoke ninja
+  ninja = [ninja_path]
   if is_verbose_mode():
     ninja.append('-v')
 
@@ -78,6 +83,9 @@ def parse_args():
                         '-d --debug_libchromiumcontent.'
                       ),
                       action='store_true', default=False)
+  parser.add_argument('--ninja-path',
+                      help='Path of ninja command to use.',
+                      required=False)
   return parser.parse_args()
 
 


### PR DESCRIPTION
This PR was requested by no-one and blocks nothing, but it does what it says on the tin.

If you want to see ninja's build commands so that you can look at each argument as a clue to why your build isn't behaving the way you thought it would, this is the patch for you.