### PR TITLE
Added session-created event documentation

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -356,6 +356,23 @@ assistive technologies, such as screen readers, are enabled or disabled.
 See https://www.chromium.org/developers/design-documents/accessibility for more
 details.
 
+### Event: 'session-created'
+
+Returns:
+
+* `event` Event
+* `session` [Session](session.md)
+
+Emitted when Electron has created a new `session`.
+
+```javascript
+const {app} = require('electron')
+
+app.on('session-created', (event, session) => {
+  console.log(session)  
+})
+```
+
 ## Methods
 
 The `app` object has the following methods:


### PR DESCRIPTION
The event 'session-created' doesn't seem to be a part of the documentation. 

The event is emitted at https://github.com/electron/electron/blob/1c0ea0286ed7f8fb9075d1a6c03c758c72e965b8/lib/browser/api/session.js#L21
