### PR TITLE
Fix link to `official guides` in quick start page

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -14,9 +14,9 @@ two documents:
 [Main and Renderer Processes][processes].
 
 If you just came here to learn about Electron, check out the
-[official guides][readme].
+[official guides][tutorial].
 
 [first-app]: ./first-app.md
 [processes]: ./application-architecture.md#main-and-renderer-processes
-[readme]: ../README.md
+[tutorial]: ../tutorial.md
 


### PR DESCRIPTION
While browsing through the docs I found out that this link was broken. I guess it should point to the main Guides page (tutorial.md) :)