### PR TITLE
fix dev tools window interfering with mouse forward

### DIFF
--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -160,8 +160,12 @@ bool NativeWindowViews::PreHandleMSG(
       if (LOWORD(w_param) == WM_CREATE) {
         // Because of reasons regarding legacy drivers and stuff, a window that
         // matches the client area is created and used internally by Chromium.
-        // This is used when forwarding mouse messages.
-        legacy_window_ = reinterpret_cast<HWND>(l_param);
+        // This is used when forwarding mouse messages. We only cache the first
+        // occurrence (the webview window) because dev tools also cause this
+        // message to be sent.
+        if (!legacy_window_) {
+          legacy_window_ = reinterpret_cast<HWND>(l_param);
+        }
       }
       return false;
     }


### PR DESCRIPTION
Fixes a bug with mouse forwarding that was brought to my attention in https://github.com/electron/electron/issues/1335. The problem was that the dev tools window interfered with the tracking of the webview window handle, causing mouse moves to be forwarded to that window instead. This means that once forwarding began, it never returned.

Note that there is still an issue with docked dev tools, because if your application is in a state where it's ignoring mouse input, you can't interact with them. This happens because the entire window ignores input, and is thus a side-effect of the original mouse ignore implementation. Since I came across it, I figured I'll mention it in case somebody wonders in the future.