### PR TITLE
Deprecate screen.getMenuBarHeight (2.0.x)

### DIFF
--- a/atom/browser/api/atom_api_screen_mac.mm
+++ b/atom/browser/api/atom_api_screen_mac.mm
@@ -9,6 +9,7 @@ namespace atom {
 
 namespace api {
 
+//TODO(codebytere): deprecated; remove in 3.0
 int Screen::getMenuBarHeight() {
   return [[NSApp mainMenu] menuBarHeight];
 }

--- a/lib/browser/api/screen.js
+++ b/lib/browser/api/screen.js
@@ -1,8 +1,17 @@
 const {EventEmitter} = require('events')
+const {deprecate} = require('electron')
 const {screen, Screen} = process.atomBinding('screen')
 
 // Screen is an EventEmitter.
 Object.setPrototypeOf(Screen.prototype, EventEmitter.prototype)
 EventEmitter.call(screen)
+
+const nativeFn = screen.getMenuBarHeight
+screen.getMenuBarHeight = function () {
+  if (!process.noDeprecations) {
+    deprecate.warn('screen.getMenuBarHeight', 'screen.getPrimaryDisplay().workArea')
+  }
+  return nativeFn.call(this)
+}
 
 module.exports = screen

--- a/spec/api-screen-spec.js
+++ b/spec/api-screen-spec.js
@@ -18,17 +18,4 @@ describe('screen module', () => {
       assert(display.size.height > 0)
     })
   })
-
-  describe('screen.getMenuBarHeight()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
-    it('returns an integer', () => {
-      const screenHeight = screen.getMenuBarHeight()
-      assert.equal(typeof screenHeight, 'number')
-    })
-  })
 })


### PR DESCRIPTION
Backports https://github.com/electron/electron/pull/12135 to `2-0-x`

/cc @ckerr 