### PR TITLE
Exit gracefully on linux

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -159,6 +159,10 @@ describe('app module', () => {
     })
 
     it('exits gracefully', function (done) {
+      if (!['darwin', 'linux'].includes(process.platform)) {
+        this.skip()
+      }
+
       const electronPath = remote.getGlobal('process').execPath
       const appPath = path.join(__dirname, 'fixtures', 'api', 'singleton')
       appProcess = ChildProcess.spawn(electronPath, [appPath])

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -167,8 +167,9 @@ describe('app module', () => {
       // After that, ask it to exit gracefully and confirm that it does.
       appProcess.stdout.on('data', (data) => appProcess.kill())
       appProcess.on('exit', (code, sig) => {
-        assert.equal(code, 0)
-        assert.equal(sig, null)
+        let message = ['code:', code, 'sig:', sig].join('\n')
+        assert.equal(code, 0, message)
+        assert.equal(sig, null, message)
         done()
       })
     })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -163,8 +163,8 @@ describe('app module', () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'singleton')
       appProcess = ChildProcess.spawn(electronPath, [appPath])
 
-      // singleton will send us greeting data to let us know it's running.
-      // when we receive that, test that it exits cleanly when asked to close
+      // Singleton will send us greeting data to let us know it's running.
+      // After that, ask it to exit gracefully and confirm that it does.
       appProcess.stdout.on('data', (data) => appProcess.kill())
       appProcess.on('exit', (code, sig) => {
         assert.equal(code, 0)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -159,10 +159,6 @@ describe('app module', () => {
     })
 
     it('exits gracefully', function (done) {
-      if (!['darwin', 'linux'].includes(process.platform)) {
-        this.skip()
-      }
-
       const electronPath = remote.getGlobal('process').execPath
       const appPath = path.join(__dirname, 'fixtures', 'api', 'singleton')
       appProcess = ChildProcess.spawn(electronPath, [appPath])

--- a/spec/fixtures/api/singleton/main.js
+++ b/spec/fixtures/api/singleton/main.js
@@ -1,6 +1,8 @@
 const {app} = require('electron')
 
-console.log('started')  // ping parent
+app.once('ready', () => {
+  console.log('started')  // ping parent
+})
 
 const shouldExit = app.makeSingleInstance(() => {
   process.nextTick(() => app.exit(0))


### PR DESCRIPTION
1. Fixes #12050 which was caused by a timing issue. The singleton fixture was reporting its readiness before app had emitted a 'ready' signal. At times, this could cause the parent test harness to run its tests before the child Electron process had finished starting its event loop.

2. Rewrites the `exit_gracefully_on_macos()` test to run on other platforms too.

This code is ready for review but is a WIP in the sense that I need confirmation from CI about the portability of the rewritten test.
