### PR TITLE
Fix getFocusedWindow return type

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -587,7 +587,7 @@ Returns `BrowserWindow[]` - An array of all opened browser windows.
 
 #### `BrowserWindow.getFocusedWindow()`
 
-Returns `BrowserWindow` - The window that is focused in this application, otherwise returns `null`.
+Returns `BrowserWindow | null` - The window that is focused in this application, otherwise returns `null`.
 
 #### `BrowserWindow.fromWebContents(webContents)`
 


### PR DESCRIPTION
For the generated TypeScript definition to be correct, getFocusedWindow's type needs to indicate that it can return null.