### PR TITLE
Deprecations come >=1 major release before removal

### DIFF
--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -3,7 +3,7 @@
 The following list includes the APIs that will be removed in Electron 3.0.
 
 There is no timetable for when this release will occur but deprecation
-warnings will be added at least [one major version](electron-versioning#semver) beforehand.
+warnings will be added at least [one major version](electron-versioning.md#semver) beforehand.
 
 ## `app`
 

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -3,7 +3,7 @@
 The following list includes the APIs that will be removed in Electron 3.0.
 
 There is no timetable for when this release will occur but deprecation
-warnings will be added at least 90 days beforehand.
+warnings will be added at least [one major version](electron-versioning#semver) beforehand.
 
 ## `app`
 


### PR DESCRIPTION
This updates the "90 day guarantee" to a "one major release guarantee" to fit better with semver.