### PR TITLE
More vibrancy fixes

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -23,6 +23,7 @@
 #include "native_mate/dictionary.h"
 #include "skia/ext/skia_utils_mac.h"
 #include "ui/gfx/skia_util.h"
+#include "ui/gl/gpu_switching_manager.h"
 
 namespace {
 
@@ -1634,15 +1635,19 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
     [vibrant_view removeFromSuperview];
     [window_ setVibrantView:nil];
+    ui::GpuSwitchingManager::SetTransparent(transparent());
 
     return;
   }
 
   background_color_before_vibrancy_.reset([window_ backgroundColor]);
   transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
+  ui::GpuSwitchingManager::SetTransparent(true);
 
-  [window_ setTitlebarAppearsTransparent:YES];
-  [window_ setBackgroundColor:[NSColor clearColor]];
+  if (title_bar_style_ != NORMAL) {
+    [window_ setTitlebarAppearsTransparent:YES];
+    [window_ setBackgroundColor:[NSColor clearColor]];
+  }
 
   NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
   if (effect_view == nil) {

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -235,7 +235,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     window shadow and window animations. Default is `true`.
   * `vibrancy` String (optional) - Add a type of vibrancy effect to the window, only on
     macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
-    `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.
+    `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.  Please note that
+    using `frame: false` in combination with a vibrancy value requires that you use a
+    non-default `titleBarStyle` as well.
   * `zoomToPageWidth` Boolean (optional) - Controls the behavior on macOS when
     option-clicking the green stoplight button on the toolbar or by clicking the
     Window > Zoom menu item. If `true`, the window will grow to the preferred


### PR DESCRIPTION
This is a follow up to #11886 

* Only set title bar to transparent when vibrant with a custom titlebar
* Correctly set the transparent state of the GpuSwitcher so vibrancy works on reload
* Document case where using frame: false without custom titleBarStyle and vibrant