### PR TITLE
Removals come >=1 major release after deprecation.

### DIFF
--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -3,7 +3,7 @@
 The following list includes the APIs that will be removed in Electron 2.0.
 
 There is no timetable for when this release will occur but deprecation
-warnings will be added at least 90 days beforehand.
+warnings will be added at least [one major version](electron-versioning.md#semver) beforehand.
 
 ## `app`
 


### PR DESCRIPTION
Backporting https://github.com/electron/electron/pull/12155 to 2-0-x.