### PR TITLE
Fix menubar toggle alt key detection on focus

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1187,6 +1187,8 @@ void NativeWindowViews::OnWidgetActivationChanged(
   // Hide menu bar when window is blured.
   if (!active && menu_bar_autohide_ && menu_bar_visible_)
     SetMenuBarVisibility(false);
+
+  menu_bar_alt_pressed_ = false;
 }
 
 void NativeWindowViews::OnWidgetBoundsChanged(


### PR DESCRIPTION
Reset alt keypress flag on window blur so switching window via
Alt+* desktop / window manager keybindings can't incedentally trigger
annoying menubar toggles.

This issue is a recurring complaint among some Atom and Vscode editor users. Especially in Vscode where you can't remap the Alt key.
(https://github.com/Microsoft/vscode/issues/35010, https://github.com/Microsoft/vscode/issues/41070, https://github.com/atom/atom/issues/6037)

A description of the problem was given in PR #3218 but no fix made.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->