### PR TITLE
Cleanup the static methods of WebContentsPreferences

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -118,11 +118,10 @@ BrowserWindow::BrowserWindow(v8::Isolate* isolate,
         WebContentsPreferences::FromWebContents(web_contents->web_contents());
     base::DictionaryValue web_preferences_dict;
     if (mate::ConvertFromV8(isolate, web_preferences.GetHandle(),
-                        &web_preferences_dict)) {
-      existing_preferences->web_preferences()->Clear();
+                            &web_preferences_dict)) {
+      existing_preferences->dict()->Clear();
       existing_preferences->Merge(web_preferences_dict);
     }
-
   } else {
     // Creates the WebContents used by BrowserWindow.
     web_contents = WebContents::Create(isolate, web_preferences);

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -115,7 +115,7 @@ BrowserWindow::BrowserWindow(v8::Isolate* isolate,
     // These preferences will be used when the webContent launches new
     // render processes.
     auto* existing_preferences =
-        WebContentsPreferences::FromWebContents(web_contents->web_contents());
+        WebContentsPreferences::From(web_contents->web_contents());
     base::DictionaryValue web_preferences_dict;
     if (mate::ConvertFromV8(isolate, web_preferences.GetHandle(),
                             &web_preferences_dict)) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1125,8 +1125,8 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
     WebContentsPreferences* web_preferences =
         WebContentsPreferences::FromWebContents(web_contents());
     std::string color_name;
-    if (web_preferences->web_preferences()->GetString(options::kBackgroundColor,
-                                                      &color_name)) {
+    if (web_preferences->dict()->GetString(options::kBackgroundColor,
+                                           &color_name)) {
       view->SetBackgroundColor(ParseHexColor(color_name));
     } else {
       view->SetBackgroundColor(SK_ColorTRANSPARENT);
@@ -1844,7 +1844,7 @@ v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
       WebContentsPreferences::FromWebContents(web_contents());
   if (!web_preferences)
     return v8::Null(isolate);
-  return mate::ConvertToV8(isolate, *web_preferences->web_preferences());
+  return mate::ConvertToV8(isolate, *web_preferences->dict());
 }
 
 v8::Local<v8::Value> WebContents::GetLastWebPreferences(v8::Isolate* isolate) {
@@ -1852,7 +1852,7 @@ v8::Local<v8::Value> WebContents::GetLastWebPreferences(v8::Isolate* isolate) {
       WebContentsPreferences::FromWebContents(web_contents());
   if (!web_preferences)
     return v8::Null(isolate);
-  return mate::ConvertToV8(isolate, *web_preferences->last_web_preferences());
+  return mate::ConvertToV8(isolate, *web_preferences->last_dict());
 }
 
 v8::Local<v8::Value> WebContents::GetOwnerBrowserWindow() {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1122,8 +1122,7 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   // created after loading a page.
   const auto view = web_contents()->GetRenderWidgetHostView();
   if (view) {
-    WebContentsPreferences* web_preferences =
-        WebContentsPreferences::FromWebContents(web_contents());
+    auto* web_preferences = WebContentsPreferences::From(web_contents());
     std::string color_name;
     if (web_preferences->dict()->GetString(options::kBackgroundColor,
                                            &color_name)) {
@@ -1840,8 +1839,7 @@ void WebContents::OnGetZoomLevel(content::RenderFrameHost* rfh,
 }
 
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
-  WebContentsPreferences* web_preferences =
-      WebContentsPreferences::FromWebContents(web_contents());
+  auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (!web_preferences)
     return v8::Null(isolate);
   return mate::ConvertToV8(isolate, *web_preferences->dict());

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -34,7 +34,7 @@ void AddGuest(int guest_instance_id,
         ->SetDefaultZoomFactor(zoom_factor);
   }
 
-  WebContentsPreferences::FromWebContents(guest_web_contents)->Merge(options);
+  WebContentsPreferences::From(guest_web_contents)->Merge(options);
 }
 
 void RemoveGuest(content::WebContents* embedder, int guest_instance_id) {

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -238,7 +238,7 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
   auto* web_preferences = web_contents ?
       WebContentsPreferences::FromWebContents(web_contents) : nullptr;
   if (web_preferences &&
-      web_preferences->web_preferences()->GetString("affinity", &affinity) &&
+      web_preferences->dict()->GetString("affinity", &affinity) &&
       !affinity.empty()) {
     affinity = base::ToLowerASCII(affinity);
     auto iter = site_per_affinities.find(affinity);

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -173,17 +173,14 @@ void AtomBrowserClient::RenderProcessWillLaunch(
   host->AddFilter(
       new WidevineCdmMessageFilter(process_id, host->GetBrowserContext()));
 
-  content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);
-  ProcessPreferences process_prefs;
-  process_prefs.sandbox =
-      WebContentsPreferences::IsPreferenceEnabled("sandbox", web_contents);
-  process_prefs.native_window_open =
-      WebContentsPreferences::IsPreferenceEnabled("nativeWindowOpen",
-                                                  web_contents);
-  process_prefs.disable_popups =
-      WebContentsPreferences::IsPreferenceEnabled("disablePopups",
-                                                  web_contents);
-  AddProcessPreferences(host->GetID(), process_prefs);
+  ProcessPreferences prefs;
+  auto* web_preferences = WebContentsPreferences::From(process_id);
+  if (web_preferences) {
+    prefs.sandbox = web_preferences->IsEnabled("sandbox");
+    prefs.native_window_open = web_preferences->IsEnabled("nativeWindowOpen");
+    prefs.disable_popups = web_preferences->IsEnabled("disablePopups");
+  }
+  AddProcessPreferences(host->GetID(), prefs);
   // ensure the ProcessPreferences is removed later
   host->AddObserver(this);
 }

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -174,7 +174,8 @@ void AtomBrowserClient::RenderProcessWillLaunch(
       new WidevineCdmMessageFilter(process_id, host->GetBrowserContext()));
 
   ProcessPreferences prefs;
-  auto* web_preferences = WebContentsPreferences::From(process_id);
+  auto* web_preferences = WebContentsPreferences::From(
+      GetWebContentsFromProcessID(process_id));
   if (web_preferences) {
     prefs.sandbox = web_preferences->IsEnabled("sandbox");
     prefs.native_window_open = web_preferences->IsEnabled("nativeWindowOpen");

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -208,8 +208,10 @@ void AtomBrowserClient::OverrideWebkitPrefs(
   prefs->allow_running_insecure_content = false;
 
   // Custom preferences of guest page.
-  auto web_contents = content::WebContents::FromRenderViewHost(host);
-  WebContentsPreferences::OverrideWebkitPrefs(web_contents, prefs);
+  auto* web_contents = content::WebContents::FromRenderViewHost(host);
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
+  if (web_preferences)
+    web_preferences->OverrideWebkitPrefs(prefs);
 }
 
 void AtomBrowserClient::OverrideSiteInstanceForNavigation(
@@ -319,8 +321,9 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
 
   content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);
   if (web_contents) {
-    WebContentsPreferences::AppendExtraCommandLineSwitches(
-        web_contents, command_line);
+    auto* web_preferences = WebContentsPreferences::From(web_contents);
+    if (web_preferences)
+      web_preferences->AppendCommandLineSwitches(command_line);
     SessionPreferences::AppendExtraCommandLineSwitches(
         web_contents->GetBrowserContext(), command_line);
 

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -235,8 +235,7 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
   // Do we have an affinity site to manage ?
   std::string affinity;
   auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
-  auto* web_preferences = web_contents ?
-      WebContentsPreferences::FromWebContents(web_contents) : nullptr;
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
   if (web_preferences &&
       web_preferences->dict()->GetString("affinity", &affinity) &&
       !affinity.empty()) {

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -118,15 +118,16 @@ class AtomBrowserClient : public brightray::BrowserClient,
                            int exit_code) override;
 
  private:
-  bool ShouldCreateNewSiteInstance(content::RenderFrameHost* render_frame_host,
-                                   content::BrowserContext* browser_context,
-                                   content::SiteInstance* current_instance,
-                                   const GURL& dest_url);
   struct ProcessPreferences {
     bool sandbox = false;
     bool native_window_open = false;
     bool disable_popups = false;
   };
+
+  bool ShouldCreateNewSiteInstance(content::RenderFrameHost* render_frame_host,
+                                   content::BrowserContext* browser_context,
+                                   content::SiteInstance* current_instance,
+                                   const GURL& dest_url);
   void AddProcessPreferences(int process_id, ProcessPreferences prefs);
   void RemoveProcessPreferences(int process_id);
   bool IsProcessObserved(int process_id);

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -55,13 +55,13 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
 
   origin_counts_[origin]++;
 
-  std::string checkbox_string;
-  if (origin_counts_[origin] > 1 &&
-      WebContentsPreferences::IsPreferenceEnabled("safeDialogs",
-                                                  web_contents)) {
-    if (!WebContentsPreferences::GetString("safeDialogsMessage",
-                                           &checkbox_string, web_contents)) {
-      checkbox_string = "Prevent this app from creating additional dialogs";
+  std::string checkbox;
+  if (origin_counts_[origin] > 1) {
+    auto* web_preferences = WebContentsPreferences::From(web_contents);
+    if (web_preferences &&
+        web_preferences->IsEnabled("safeDialogs") &&
+        !web_preferences->dict()->GetString("safeDialogsMessage", &checkbox)) {
+      checkbox = "Prevent this app from creating additional dialogs";
     }
   }
 
@@ -70,7 +70,7 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
       relay ? relay->window.get() : nullptr,
       atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, -1, 0,
       atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
-      base::UTF16ToUTF8(message_text), "", checkbox_string,
+      base::UTF16ToUTF8(message_text), "", checkbox,
       false, gfx::ImageSkia(),
       base::Bind(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
                  base::Unretained(this),

--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "atom/browser/atom_browser_client.h"
 #include "atom/browser/web_contents_preferences.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/permission_type.h"
@@ -19,11 +20,12 @@ namespace atom {
 namespace {
 
 bool WebContentsDestroyed(int process_id) {
-  auto contents =
-      WebContentsPreferences::GetWebContentsFromProcessID(process_id);
-  if (!contents)
+  content::WebContents* web_contents =
+      static_cast<AtomBrowserClient*>(AtomBrowserClient::Get())->
+          GetWebContentsFromProcessID(process_id);
+  if (!web_contents)
     return true;
-  return contents->IsBeingDestroyed();
+  return web_contents->IsBeingDestroyed();
 }
 
 void PermissionRequestResponseCallbackWrapper(

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -80,9 +80,10 @@ void OnPdfResourceIntercepted(
   if (!web_contents)
     return;
 
-  if (!WebContentsPreferences::IsPreferenceEnabled("plugins", web_contents)) {
-    auto browser_context = web_contents->GetBrowserContext();
-    auto download_manager =
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
+  if (!web_preferences || !web_preferences->IsEnabled("plugins")) {
+    auto* browser_context = web_contents->GetBrowserContext();
+    auto* download_manager =
         content::BrowserContext::GetDownloadManager(browser_context);
 
     download_manager->DownloadUrl(

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1373,7 +1373,7 @@ void NativeWindowViews::ShowAutofillPopup(
   auto* web_contents_preferences =
       WebContentsPreferences::FromWebContents(web_contents);
   if (web_contents_preferences) {
-    const auto* web_preferences = web_contents_preferences->web_preferences();
+    const auto* web_preferences = web_contents_preferences->dict();
 
     web_preferences->GetBoolean("offscreen", &is_offsceen);
     int guest_instance_id = 0;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1370,14 +1370,12 @@ void NativeWindowViews::ShowAutofillPopup(
   bool is_offsceen = false;
   bool is_embedder_offscreen = false;
 
-  auto* web_contents_preferences =
-      WebContentsPreferences::FromWebContents(web_contents);
-  if (web_contents_preferences) {
-    const auto* web_preferences = web_contents_preferences->dict();
-
-    web_preferences->GetBoolean("offscreen", &is_offsceen);
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
+  if (web_preferences) {
+    web_preferences->dict()->GetBoolean("offscreen", &is_offsceen);
     int guest_instance_id = 0;
-    web_preferences->GetInteger(options::kGuestInstanceID, &guest_instance_id);
+    web_preferences->dict()->GetInteger(options::kGuestInstanceID,
+                                        &guest_instance_id);
 
     if (guest_instance_id) {
       auto manager = WebViewManager::GetWebViewManager(web_contents);

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1378,12 +1378,13 @@ void NativeWindowViews::ShowAutofillPopup(
                                         &guest_instance_id);
 
     if (guest_instance_id) {
-      auto manager = WebViewManager::GetWebViewManager(web_contents);
+      auto* manager = WebViewManager::GetWebViewManager(web_contents);
       if (manager) {
-        auto embedder = manager->GetEmbedder(guest_instance_id);
+        auto* embedder = manager->GetEmbedder(guest_instance_id);
         if (embedder) {
-          is_embedder_offscreen = WebContentsPreferences::IsPreferenceEnabled(
-              "offscreen", embedder);
+          auto* embedder_prefs = WebContentsPreferences::From(embedder);
+          is_embedder_offscreen = embedder_prefs &&
+                                  embedder_prefs->IsEnabled("offscreen");
         }
       }
     }

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -120,11 +120,6 @@ WebContentsPreferences* WebContentsPreferences::From(
   return FromWebContents(web_contents);
 }
 
-// static
-WebContentsPreferences* WebContentsPreferences::From(int process_id) {
-  return From(GetWebContentsFromProcessID(process_id));
-}
-
 void WebContentsPreferences::AppendCommandLineSwitches(
     base::CommandLine* command_line) {
   bool b;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -71,7 +71,7 @@ WebContentsPreferences::WebContentsPreferences(
   #endif
   SetDefaultBoolIfUndefined("offscreen", false);
 
-  last_dict_.MergeDictionary(&web_preferences_);
+  last_dict_ = std::move(*dict_.CreateDeepCopy());
 }
 
 WebContentsPreferences::~WebContentsPreferences() {
@@ -256,8 +256,7 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents
   // we can fetch the options used to initally configure the WebContents
-  last_dict_.Clear();
-  last_dict_.MergeDictionary(&dict_);
+  last_dict_ = std::move(*dict_.CreateDeepCopy());
 }
 
 void WebContentsPreferences::OverrideWebkitPrefs(

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -106,6 +106,14 @@ content::WebContents* WebContentsPreferences::GetWebContentsFromProcessID(
 }
 
 // static
+WebContentsPreferences* WebContentsPreferences::From(
+    content::WebContents* web_contents) {
+  if (!web_contents)
+    return nullptr;
+  return FromWebContents(web_contents);
+}
+
+// static
 void WebContentsPreferences::AppendExtraCommandLineSwitches(
     content::WebContents* web_contents, base::CommandLine* command_line) {
   WebContentsPreferences* self = FromWebContents(web_contents);

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -45,7 +45,7 @@ WebContentsPreferences::WebContentsPreferences(
   copied.Delete("isGuest");
   copied.Delete("session");
 
-  mate::ConvertFromV8(isolate, copied.GetHandle(), &web_preferences_);
+  mate::ConvertFromV8(isolate, copied.GetHandle(), &dict_);
   web_contents->SetUserData(UserDataKey(), base::WrapUnique(this));
 
   instances_.push_back(this);
@@ -70,7 +70,8 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kScrollBounce, false);
   #endif
   SetDefaultBoolIfUndefined("offscreen", false);
-  last_web_preferences_.MergeDictionary(&web_preferences_);
+
+  last_dict_.MergeDictionary(&web_preferences_);
 }
 
 WebContentsPreferences::~WebContentsPreferences() {
@@ -90,7 +91,7 @@ bool WebContentsPreferences::SetDefaultBoolIfUndefined(const std::string key,
 }
 
 void WebContentsPreferences::Merge(const base::DictionaryValue& extend) {
-  web_preferences_.MergeDictionary(&extend);
+  dict_.MergeDictionary(&extend);
 }
 
 // static
@@ -111,13 +112,13 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   if (!self)
     return;
 
-  base::DictionaryValue& web_preferences = self->web_preferences_;
+  base::DictionaryValue& web_preferences = self->dict_;
 
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents
   // we can fetch the options used to initally configure the WebContents
-  self->last_web_preferences_.Clear();
-  self->last_web_preferences_.MergeDictionary(&web_preferences);
+  self->last_dict_.Clear();
+  self->last_dict_.MergeDictionary(&web_preferences);
 
   bool b;
   // Check if plugins are enabled.
@@ -274,7 +275,7 @@ bool WebContentsPreferences::IsPreferenceEnabled(
   if (!self)
     return false;
 
-  base::DictionaryValue& web_preferences = self->web_preferences_;
+  base::DictionaryValue& web_preferences = self->dict_;
   bool bool_value = false;
   web_preferences.GetBoolean(attribute_name, &bool_value);
   return bool_value;
@@ -288,24 +289,30 @@ void WebContentsPreferences::OverrideWebkitPrefs(
     return;
 
   bool b;
-  if (self->web_preferences_.GetBoolean("javascript", &b))
+  if (self->dict_.GetBoolean("javascript", &b))
     prefs->javascript_enabled = b;
-  if (self->web_preferences_.GetBoolean("images", &b))
+  if (self->dict_.GetBoolean("images", &b))
     prefs->images_enabled = b;
-  if (self->web_preferences_.GetBoolean("textAreasAreResizable", &b))
+  if (self->dict_.GetBoolean("textAreasAreResizable", &b))
     prefs->text_areas_are_resizable = b;
+<<<<<<< HEAD
   if (self->web_preferences_.GetBoolean("webgl", &b)) {
     prefs->webgl1_enabled = b;
     prefs->webgl2_enabled = b;
   }
   if (self->web_preferences_.GetBoolean("webSecurity", &b)) {
+=======
+  if (self->dict_.GetBoolean("webgl", &b))
+    prefs->experimental_webgl_enabled = b;
+  if (self->dict_.GetBoolean("webSecurity", &b)) {
+>>>>>>> web_prefrences() => dict()
     prefs->web_security_enabled = b;
     prefs->allow_running_insecure_content = !b;
   }
-  if (self->web_preferences_.GetBoolean("allowRunningInsecureContent", &b))
+  if (self->dict_.GetBoolean("allowRunningInsecureContent", &b))
     prefs->allow_running_insecure_content = b;
   const base::DictionaryValue* fonts = nullptr;
-  if (self->web_preferences_.GetDictionary("defaultFontFamily", &fonts)) {
+  if (self->dict_.GetDictionary("defaultFontFamily", &fonts)) {
     base::string16 font;
     if (fonts->GetString("standard", &font))
       prefs->standard_font_family_map[content::kCommonScript] = font;
@@ -328,18 +335,18 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   if (self->GetInteger("minimumFontSize", &size))
     prefs->minimum_font_size = size;
   std::string encoding;
-  if (self->web_preferences_.GetString("defaultEncoding", &encoding))
+  if (self->dict_.GetString("defaultEncoding", &encoding))
     prefs->default_encoding = encoding;
 }
 
 bool WebContentsPreferences::GetInteger(const std::string& attributeName,
                                         int* intValue) {
   // if it is already an integer, no conversion needed
-  if (web_preferences_.GetInteger(attributeName, intValue))
+  if (dict_.GetInteger(attributeName, intValue))
     return true;
 
   base::string16 stringValue;
-  if (web_preferences_.GetString(attributeName, &stringValue))
+  if (dict_.GetString(attributeName, &stringValue))
     return base::StringToInt(stringValue, intValue);
 
   return false;
@@ -351,7 +358,7 @@ bool WebContentsPreferences::GetString(const std::string& attribute_name,
   WebContentsPreferences* self = FromWebContents(web_contents);
   if (!self)
     return false;
-  return self->web_preferences()->GetString(attribute_name, string_value);
+  return self->dict()->GetString(attribute_name, string_value);
 }
 
 }  // namespace atom

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -33,6 +33,9 @@ class WebContentsPreferences
   // FIXME(zcbenz): This method does not belong here.
   static content::WebContents* GetWebContentsFromProcessID(int process_id);
 
+  // Get self from WebContents.
+  static WebContentsPreferences* From(content::WebContents* web_contents);
+
   // Append command paramters according to |web_contents|'s preferences.
   static void AppendExtraCommandLineSwitches(
       content::WebContents* web_contents, base::CommandLine* command_line);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -31,8 +31,6 @@ class WebContentsPreferences
  public:
   // Get self from WebContents.
   static WebContentsPreferences* From(content::WebContents* web_contents);
-  // Get self from procese ID.
-  static WebContentsPreferences* From(int process_id);
 
   WebContentsPreferences(content::WebContents* web_contents,
                          const mate::Dictionary& web_preferences);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -34,14 +34,6 @@ class WebContentsPreferences
   // Get self from procese ID.
   static WebContentsPreferences* From(int process_id);
 
-  // Append command paramters according to |web_contents|'s preferences.
-  static void AppendExtraCommandLineSwitches(
-      content::WebContents* web_contents, base::CommandLine* command_line);
-
-  // Modify the WebPreferences according to |web_contents|'s preferences.
-  static void OverrideWebkitPrefs(
-      content::WebContents* web_contents, content::WebPreferences* prefs);
-
   WebContentsPreferences(content::WebContents* web_contents,
                          const mate::Dictionary& web_preferences);
   ~WebContentsPreferences() override;
@@ -51,6 +43,12 @@ class WebContentsPreferences
 
   // $.extend(|web_preferences|, |new_web_preferences|).
   void Merge(const base::DictionaryValue& new_web_preferences);
+
+  // Append command paramters according to preferences.
+  void AppendCommandLineSwitches(base::CommandLine* command_line);
+
+  // Modify the WebPreferences according to preferences.
+  void OverrideWebkitPrefs(content::WebPreferences* prefs);
 
   // Returns the web preferences.
   base::DictionaryValue* dict() { return &dict_; }

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -35,17 +35,12 @@ class WebContentsPreferences
 
   // Get self from WebContents.
   static WebContentsPreferences* From(content::WebContents* web_contents);
+  // Get self from procese ID.
+  static WebContentsPreferences* From(int process_id);
 
   // Append command paramters according to |web_contents|'s preferences.
   static void AppendExtraCommandLineSwitches(
       content::WebContents* web_contents, base::CommandLine* command_line);
-
-  static bool IsPreferenceEnabled(const std::string& attribute_name,
-                                  content::WebContents* web_contents);
-
-  static bool GetString(const std::string& attribute_name,
-                        std::string* string_value,
-                        content::WebContents* web_contents);
 
   // Modify the WebPreferences according to |web_contents|'s preferences.
   static void OverrideWebkitPrefs(
@@ -54,6 +49,9 @@ class WebContentsPreferences
   WebContentsPreferences(content::WebContents* web_contents,
                          const mate::Dictionary& web_preferences);
   ~WebContentsPreferences() override;
+
+  // A simple way to know whether a Boolean property is enabled.
+  bool IsEnabled(const base::StringPiece& name, bool default_value = false);
 
   // $.extend(|web_preferences|, |new_web_preferences|).
   void Merge(const base::DictionaryValue& new_web_preferences);
@@ -67,10 +65,10 @@ class WebContentsPreferences
   friend class content::WebContentsUserData<WebContentsPreferences>;
 
   // Set preference value to given bool if user did not provide value
-  bool SetDefaultBoolIfUndefined(const std::string key, bool val);
+  bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);
 
   // Get preferences value as integer possibly coercing it from a string
-  bool GetInteger(const std::string& attributeName, int* intValue);
+  bool GetInteger(const base::StringPiece& attribute_name, int* val);
 
   static std::vector<WebContentsPreferences*> instances_;
 

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -29,10 +29,6 @@ namespace atom {
 class WebContentsPreferences
     : public content::WebContentsUserData<WebContentsPreferences> {
  public:
-  // Get WebContents according to process ID.
-  // FIXME(zcbenz): This method does not belong here.
-  static content::WebContents* GetWebContentsFromProcessID(int process_id);
-
   // Get self from WebContents.
   static WebContentsPreferences* From(content::WebContents* web_contents);
   // Get self from procese ID.
@@ -63,6 +59,10 @@ class WebContentsPreferences
 
  private:
   friend class content::WebContentsUserData<WebContentsPreferences>;
+  friend class AtomBrowserClient;
+
+  // Get WebContents according to process ID.
+  static content::WebContents* GetWebContentsFromProcessID(int process_id);
 
   // Set preference value to given bool if user did not provide value
   bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -52,14 +52,13 @@ class WebContentsPreferences
                          const mate::Dictionary& web_preferences);
   ~WebContentsPreferences() override;
 
-  // $.extend(|web_preferences_|, |new_web_preferences|).
+  // $.extend(|web_preferences|, |new_web_preferences|).
   void Merge(const base::DictionaryValue& new_web_preferences);
 
   // Returns the web preferences.
-  base::DictionaryValue* web_preferences() { return &web_preferences_; }
-  base::DictionaryValue* last_web_preferences() {
-    return &last_web_preferences_;
-  }
+  base::DictionaryValue* dict() { return &dict_; }
+  const base::DictionaryValue* dict() const { return &dict_; }
+  base::DictionaryValue* last_dict() { return &last_dict_; }
 
  private:
   friend class content::WebContentsUserData<WebContentsPreferences>;
@@ -73,8 +72,9 @@ class WebContentsPreferences
   static std::vector<WebContentsPreferences*> instances_;
 
   content::WebContents* web_contents_;
-  base::DictionaryValue web_preferences_;
-  base::DictionaryValue last_web_preferences_;
+
+  base::DictionaryValue dict_;
+  base::DictionaryValue last_dict_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContentsPreferences);
 };


### PR DESCRIPTION
This PR cleanups the `WebContentsPreferences` class so the usage of this class is uniformed, and we won't be using different ways to do the same things.