### PR TITLE
Add logic to support automatic releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,29 @@ jobs:
                 echo 'Skipping upload distribution because build is not for release'
              fi
       - run:
+          name: Optionally finish release
+          shell: /bin/sh
+          command: |
+            if [ "$ELECTRON_RELEASE" == "1" ] && [ "$AUTO_RELEASE" == "true" ]; then
+              curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+              export NVM_DIR="$HOME/.nvm"
+              [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+              nvm install 8
+              nvm use 8
+              node script/release.js --automaticRelease
+              releaseExitCode=$?
+              if [ $? -eq 0 ]; then
+                echo 'Release successful, now publishing to npm'
+                echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
+                nvm use system
+                npm run publish
+              else
+                echo 'Release is not complete, skipping publish for now.'
+              fi
+            else
+              echo 'Skipping release check'
+            fi
+      - run:
           name: Zip out directory
           command: |
             if [ "$ELECTRON_RELEASE" != "1" ]; then

--- a/script/release.js
+++ b/script/release.js
@@ -148,7 +148,11 @@ function s3UrlsForVersion (version) {
 function checkVersion () {
   console.log(`Verifying that app version matches package version ${pkgVersion}.`)
   let startScript = path.join(__dirname, 'start.py')
-  let appVersion = runScript(startScript, ['--version']).trim()
+  let scriptArgs = ['--version']
+  if (args.automaticRelease) {
+    scriptArgs.unshift('-R')
+  }
+  let appVersion = runScript(startScript, scriptArgs).trim()
   check((pkgVersion.indexOf(appVersion) === 0), `App version ${appVersion} matches ` +
     `package version ${pkgVersion}.`, true)
 }


### PR DESCRIPTION
This PR allows us to run automatic beta releases.  The idea is that some process (at this point probably a Jenkins job) will kick off the release.

This required the following changes:
1. prepare-release.js and ci-release-build.js have been changed to include an "automaticRelease" option.  This option gets passed along to all of the release builds.  Additionally the release notes that are automatically generated by prepare-release.js have been cleaned up to be more readable.

2. As part of our release build, CI will now check to see if it is running an automatica release.  If so, once it is done building its release files, it will run the release script to check if the release is ready to go.  If it is, it will auto publish the release in GitHub and NPM.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->