### PR TITLE
Fix popup menu position

### DIFF
--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -33,8 +33,7 @@ void MenuViews::PopupAt(BrowserWindow* window,
   if (x == -1 || y == -1) {
     location = display::Screen::GetScreen()->GetCursorScreenPoint();
   } else {
-    views::View* view = native_window;  // the instance is also its content view
-    gfx::Point origin = view->bounds().origin();
+    gfx::Point origin = native_window->GetContentBounds().origin();
     location = gfx::Point(origin.x() + x, origin.y() + y);
   }
 


### PR DESCRIPTION
The Views implementation of popup menus calculates the menu position relative to the view's origin in non-screen coordinates. The menu however is placed on screen coordinates. Therefore the menu appears shifted away from the mouse pointer.

This change gets the origin in screen coordinates and fixes the problem.