### PR TITLE
Print detailed error for serviceWorker test

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -139,7 +139,7 @@ describe('chromium feature', () => {
         if (args[0] === 'reload') {
           w.webContents.reload()
         } else if (args[0] === 'error') {
-          done(new Error(`unexpected error : ${JSON.stringify(args[1])}`))
+          done(args[1])
         } else if (args[0] === 'response') {
           assert.equal(args[1], 'Hello from serviceWorker!')
           session.defaultSession.clearStorageData({

--- a/spec/fixtures/pages/service-worker/index.html
+++ b/spec/fixtures/pages/service-worker/index.html
@@ -13,6 +13,6 @@
       ipcRenderer.send('reload');
     }
   }).catch(function(error) {
-    ipcRenderer.send('error', error);
+    ipcRenderer.send('error', `${error.message}\n${error.stack}`);
   })
 </script>


### PR DESCRIPTION
This allows us to get more information from the flaky serviceWorker test instead of `unexpected error : [object Object]`. Refs https://github.com/electron/electron/issues/12173.