### PR TITLE
Enable more debug info for electron-linux-ia32

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,7 @@ jobs:
         environment:
           TARGET_ARCH: ia32
           DISPLAY: ':99.0'
+          ELECTRON_ENABLE_LOGGING: 'true'
     resource_class: xlarge
     steps:
       - checkout
@@ -271,6 +272,10 @@ jobs:
              else
                 echo 'Skipping verify ffmpeg on release build'
              fi
+      - store_test_results:
+          path: junit
+      - store_artifacts:
+          path: junit
   electron-linux-mips64el:
     docker:
       - image: electronbuilds/electron:0.0.4


### PR DESCRIPTION
This would enable us to get more information from the flaky interruption of electron-linux-ia32 tests.

```
Exited with code 1
```