### PR TITLE
Newer CI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   electron-linux-arm:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: arm
     resource_class: 2xlarge
@@ -83,7 +83,7 @@ jobs:
               docker run --rm --privileged multiarch/qemu-user-static:register --reset
               docker run -it \
               --mount type=bind,source=/tmp/workspace,target=/tmp/workspace \
-              --rm electronbuilds/electronarm7:0.0.4 > version.txt
+              --rm electronbuilds/electronarm7:0.0.5 > version.txt
               cat version.txt
               if grep -q `script/get-version.py` version.txt; then
                 echo "Versions match"
@@ -96,7 +96,7 @@ jobs:
             fi
   electron-linux-arm64:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: arm64
     resource_class: 2xlarge
@@ -176,7 +176,7 @@ jobs:
               docker run --rm --privileged multiarch/qemu-user-static:register --reset
               docker run -it \
               --mount type=bind,source=/tmp/workspace,target=/tmp/workspace \
-              --rm electronbuilds/electronarm64:0.0.5 > version.txt
+              --rm electronbuilds/electronarm64:0.0.6 > version.txt
               cat version.txt
               if grep -q `script/get-version.py` version.txt; then
                 echo "Versions match"
@@ -273,7 +273,7 @@ jobs:
              fi
   electron-linux-mips64el:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: mips64el
     resource_class: xlarge
@@ -331,7 +331,7 @@ jobs:
 
   electron-linux-x64:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: x64
           DISPLAY: ':99.0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get install -y wget
 # Install python-dbusmock
 RUN apt-get install -y python-dbusmock
 
+# Install libnotify
+RUN apt-get install -y libnotify-bin
+
 # Add xvfb init script
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y\
  libgnome-keyring-dev \
  libgtk-3-0 \
  libgtk-3-dev \
+ libnotify-bin \
  libnotify-dev \
  libnss3 \
  libnss3-dev \

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y\
  libgnome-keyring-dev \
  libgtk-3-0 \
  libgtk-3-dev \
+ libnotify-bin \
  libnotify-dev \
  libnss3 \
  libnss3-dev \

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -12,6 +12,9 @@ RUN apt-get install -y wget
 # Install python-dbusmock
 RUN apt-get install -y python-dbusmock
 
+# Install libnotify
+RUN apt-get install -y libnotify-bin
+
 # Add xvfb init script
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb


### PR DESCRIPTION
Bumps version numbers and updates Dockerfiles.

The `linux-appname` branch is kind of a clustermess and this is an incremental step to landing it more cleanly.

`linux-appname` needed CI to add libnotify, which poked the Dockerfiles and bumped the electronbuilds/electron* versions in circleci -- but because the branch has been gathering dust for a bit, `master` has diverged a bit. This PR is to reconcile those differences and make `master` safe for `linux-appname`.

Submitting this as a separate patch because CI has been so janky with that PR that I'm taking this in smaller steps: I don't know if the problems are in my specs (likely), or in landing the tests and CI changes at the same time (possible?). So I'm going to land one at a time.