### PR TITLE
Skip client-certificate test for Linux

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -494,6 +494,12 @@ describe('app module', () => {
   describe('select-client-certificate event', () => {
     let w = null
 
+    before(function () {
+      if (process.platform === 'linux') {
+        this.skip()
+      }
+    })
+
     beforeEach(() => {
       w = new BrowserWindow({
         show: false,


### PR DESCRIPTION
When debugging the flaky client-certificate test:

```
not ok 30 app module select-client-certificate event can respond with empty certificate list
  Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

I found that no matter this test passes or not, our `SelectClientCertificate` method has never been called.

For this test Chromium also printed an error:

```
[68266:0309/025623.322714:ERROR:cert_verify_proc_nss.cc(921)] CERT_PKIXVerifyCert for 127.0.0.1 failed err=-8172
```

And according to https://cs.chromium.org/chromium/src/net/cert/cert_verify_proc_nss.cc?sq=package:chromium&l=980-996 they consider this condition as a bug of nss in Chromium, so we won't get notified on Linux.

Since this test never does its work on Linux, I think we should just disable it for Linux. The better way of actually fixing the problem requires at least upgrading nss on our CI machine, which is probably not acceptable since it is a rather fundamental dependency.