### PR TITLE
Ensure that a document has been created before sending IPC messages

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -282,6 +282,27 @@ void OnCapturePageDone(const base::Callback<void(const gfx::Image&)>& callback,
 
 }  // namespace
 
+struct WebContents::FrameDispatchHelper {
+  WebContents* api_web_contents;
+  content::RenderFrameHost* rfh;
+
+  bool Send(IPC::Message* msg) { return rfh->Send(msg); }
+
+  void OnSetTemporaryZoomLevel(double level, IPC::Message* reply_msg) {
+    api_web_contents->OnSetTemporaryZoomLevel(rfh, level, reply_msg);
+  }
+
+  void OnGetZoomLevel(IPC::Message* reply_msg) {
+    api_web_contents->OnGetZoomLevel(rfh, reply_msg);
+  }
+
+  void OnRendererMessageSync(const base::string16& channel,
+                             const base::ListValue& args,
+                             IPC::Message* message) {
+    api_web_contents->OnRendererMessageSync(rfh, channel, args, message);
+  }
+};
+
 WebContents::WebContents(v8::Isolate* isolate,
                          content::WebContents* web_contents,
                          Type type)
@@ -942,13 +963,6 @@ void WebContents::ShowAutofillPopup(content::RenderFrameHost* frame_host,
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(WebContents, message)
-    IPC_MESSAGE_HANDLER(AtomViewHostMsg_Message, OnRendererMessage)
-    IPC_MESSAGE_HANDLER_DELAY_REPLY(AtomViewHostMsg_Message_Sync,
-                                    OnRendererMessageSync)
-    IPC_MESSAGE_HANDLER_DELAY_REPLY(AtomViewHostMsg_SetTemporaryZoomLevel,
-                                    OnSetTemporaryZoomLevel)
-    IPC_MESSAGE_HANDLER_DELAY_REPLY(AtomViewHostMsg_GetZoomLevel,
-                                    OnGetZoomLevel)
     IPC_MESSAGE_HANDLER_CODE(ViewHostMsg_SetCursor, OnCursorChange,
       handled = false)
     IPC_MESSAGE_UNHANDLED(handled = false)
@@ -958,17 +972,28 @@ bool WebContents::OnMessageReceived(const IPC::Message& message) {
 }
 
 bool WebContents::OnMessageReceived(const IPC::Message& message,
-    content::RenderFrameHost* frame_host) {
+                                    content::RenderFrameHost* frame_host) {
   bool handled = true;
+  FrameDispatchHelper helper = {this, frame_host};
   auto relay = NativeWindowRelay::FromWebContents(web_contents());
-  if (!relay)
-    return false;
+  if (relay) {
+    IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(NativeWindow, message, frame_host)
+      IPC_MESSAGE_FORWARD(AtomAutofillFrameHostMsg_HidePopup,
+                          relay->window.get(), NativeWindow::HideAutofillPopup)
+      IPC_MESSAGE_UNHANDLED(handled = false)
+    IPC_END_MESSAGE_MAP()
+  }
+
   IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(WebContents, message, frame_host)
+    IPC_MESSAGE_HANDLER(AtomFrameHostMsg_Message, OnRendererMessage)
+    IPC_MESSAGE_FORWARD_DELAY_REPLY(AtomFrameHostMsg_Message_Sync, &helper,
+                                    FrameDispatchHelper::OnRendererMessageSync)
+    IPC_MESSAGE_FORWARD_DELAY_REPLY(
+        AtomFrameHostMsg_SetTemporaryZoomLevel, &helper,
+        FrameDispatchHelper::OnSetTemporaryZoomLevel)
+    IPC_MESSAGE_FORWARD_DELAY_REPLY(AtomFrameHostMsg_GetZoomLevel, &helper,
+                                    FrameDispatchHelper::OnGetZoomLevel)
     IPC_MESSAGE_HANDLER(AtomAutofillFrameHostMsg_ShowPopup, ShowAutofillPopup)
-  IPC_END_MESSAGE_MAP()
-  IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(NativeWindow, message, frame_host)
-    IPC_MESSAGE_FORWARD(AtomAutofillFrameHostMsg_HidePopup,
-      relay->window.get(), NativeWindow::HideAutofillPopup)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -1487,7 +1512,12 @@ void WebContents::TabTraverse(bool reverse) {
 bool WebContents::SendIPCMessage(bool all_frames,
                                  const base::string16& channel,
                                  const base::ListValue& args) {
-  return Send(new AtomViewMsg_Message(routing_id(), all_frames, channel, args));
+  auto frame_host = web_contents()->GetMainFrame();
+  if (frame_host) {
+    return frame_host->Send(new AtomFrameMsg_Message(
+        frame_host->GetRoutingID(), all_frames, channel, args));
+  }
+  return false;
 }
 
 void WebContents::SendInputEvent(v8::Isolate* isolate,
@@ -1771,17 +1801,20 @@ double WebContents::GetZoomFactor() {
   return content::ZoomLevelToZoomFactor(level);
 }
 
-void WebContents::OnSetTemporaryZoomLevel(double level,
+void WebContents::OnSetTemporaryZoomLevel(content::RenderFrameHost* rfh,
+                                          double level,
                                           IPC::Message* reply_msg) {
   zoom_controller_->SetTemporaryZoomLevel(level);
   double new_level = zoom_controller_->GetZoomLevel();
-  AtomViewHostMsg_SetTemporaryZoomLevel::WriteReplyParams(reply_msg, new_level);
-  Send(reply_msg);
+  AtomFrameHostMsg_SetTemporaryZoomLevel::WriteReplyParams(reply_msg,
+                                                           new_level);
+  rfh->Send(reply_msg);
 }
 
-void WebContents::OnGetZoomLevel(IPC::Message* reply_msg) {
-  AtomViewHostMsg_GetZoomLevel::WriteReplyParams(reply_msg, GetZoomLevel());
-  Send(reply_msg);
+void WebContents::OnGetZoomLevel(content::RenderFrameHost* rfh,
+                                 IPC::Message* reply_msg) {
+  AtomFrameHostMsg_GetZoomLevel::WriteReplyParams(reply_msg, GetZoomLevel());
+  rfh->Send(reply_msg);
 }
 
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
@@ -1974,17 +2007,19 @@ AtomBrowserContext* WebContents::GetBrowserContext() const {
   return static_cast<AtomBrowserContext*>(web_contents()->GetBrowserContext());
 }
 
-void WebContents::OnRendererMessage(const base::string16& channel,
+void WebContents::OnRendererMessage(content::RenderFrameHost* frame_host,
+                                    const base::string16& channel,
                                     const base::ListValue& args) {
   // webContents.emit(channel, new Event(), args...);
   Emit(base::UTF16ToUTF8(channel), args);
 }
 
-void WebContents::OnRendererMessageSync(const base::string16& channel,
+void WebContents::OnRendererMessageSync(content::RenderFrameHost* frame_host,
+                                        const base::string16& channel,
                                         const base::ListValue& args,
                                         IPC::Message* message) {
   // webContents.emit(channel, new Event(sender, message), args...);
-  EmitWithSender(base::UTF16ToUTF8(channel), web_contents(), message, args);
+  EmitWithSender(base::UTF16ToUTF8(channel), frame_host, message, args);
 }
 
 // static

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -383,6 +383,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
                          const std::vector<base::string16>& labels);
 
  private:
+  struct FrameDispatchHelper;
   AtomBrowserContext* GetBrowserContext() const;
 
   uint32_t GetNextRequestId() {
@@ -393,21 +394,26 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void OnCursorChange(const content::WebCursor& cursor);
 
   // Called when received a message from renderer.
-  void OnRendererMessage(const base::string16& channel,
+  void OnRendererMessage(content::RenderFrameHost* frame_host,
+                         const base::string16& channel,
                          const base::ListValue& args);
 
   // Called when received a synchronous message from renderer.
-  void OnRendererMessageSync(const base::string16& channel,
+  void OnRendererMessageSync(content::RenderFrameHost* frame_host,
+                             const base::string16& channel,
                              const base::ListValue& args,
                              IPC::Message* message);
 
   // Called when received a synchronous message from renderer to
   // set temporary zoom level.
-  void OnSetTemporaryZoomLevel(double level, IPC::Message* reply_msg);
+  void OnSetTemporaryZoomLevel(content::RenderFrameHost* frame_host,
+                               double level,
+                               IPC::Message* reply_msg);
 
   // Called when received a synchronous message from renderer to
   // get the zoom level.
-  void OnGetZoomLevel(IPC::Message* reply_msg);
+  void OnGetZoomLevel(content::RenderFrameHost* frame_host,
+                      IPC::Message* reply_msg);
 
   void InitZoomController(content::WebContents* web_contents,
                           const mate::Dictionary& options);

--- a/atom/browser/api/event.cc
+++ b/atom/browser/api/event.cc
@@ -6,6 +6,7 @@
 
 #include "atom/common/api/api_messages.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "native_mate/object_template_builder.h"
 
@@ -20,17 +21,32 @@ Event::Event(v8::Isolate* isolate)
 Event::~Event() {
 }
 
-void Event::SetSenderAndMessage(content::WebContents* sender,
+void Event::SetSenderAndMessage(content::RenderFrameHost* sender,
                                 IPC::Message* message) {
   DCHECK(!sender_);
   DCHECK(!message_);
   sender_ = sender;
   message_ = message;
 
-  Observe(sender);
+  Observe(content::WebContents::FromRenderFrameHost(sender));
 }
 
-void Event::WebContentsDestroyed() {
+void Event::RenderFrameDeleted(content::RenderFrameHost* rfh) {
+  if (sender_ != rfh)
+    return;
+  sender_ = nullptr;
+  message_ = nullptr;
+}
+
+void Event::RenderFrameHostChanged(content::RenderFrameHost* old_rfh,
+                                   content::RenderFrameHost* new_rfh) {
+  if (sender_ && sender_ == old_rfh)
+    sender_ = new_rfh;
+}
+
+void Event::FrameDeleted(content::RenderFrameHost* rfh) {
+  if (sender_ != rfh)
+    return;
   sender_ = nullptr;
   message_ = nullptr;
 }
@@ -44,7 +60,7 @@ bool Event::SendReply(const base::string16& json) {
   if (message_ == nullptr || sender_ == nullptr)
     return false;
 
-  AtomViewHostMsg_Message_Sync::WriteReplyParams(message_, json);
+  AtomFrameHostMsg_Message_Sync::WriteReplyParams(message_, json);
   bool success = sender_->Send(message_);
   message_ = nullptr;
   sender_ = nullptr;

--- a/atom/browser/api/event.h
+++ b/atom/browser/api/event.h
@@ -24,7 +24,8 @@ class Event : public Wrappable<Event>,
                              v8::Local<v8::FunctionTemplate> prototype);
 
   // Pass the sender and message to be replied.
-  void SetSenderAndMessage(content::WebContents* sender, IPC::Message* message);
+  void SetSenderAndMessage(content::RenderFrameHost* sender,
+                           IPC::Message* message);
 
   // event.PreventDefault().
   void PreventDefault(v8::Isolate* isolate);
@@ -37,11 +38,14 @@ class Event : public Wrappable<Event>,
   ~Event() override;
 
   // content::WebContentsObserver implementations:
-  void WebContentsDestroyed() override;
+  void RenderFrameDeleted(content::RenderFrameHost* rfh) override;
+  void RenderFrameHostChanged(content::RenderFrameHost* old_rfh,
+                              content::RenderFrameHost* new_rfh) override;
+  void FrameDeleted(content::RenderFrameHost* rfh) override;
 
  private:
   // Replyer for the synchronous messages.
-  content::WebContents* sender_;
+  content::RenderFrameHost* sender_;
   IPC::Message* message_;
 
   DISALLOW_COPY_AND_ASSIGN(Event);

--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -39,11 +39,10 @@ v8::Local<v8::Object> CreateEventObject(v8::Isolate* isolate) {
 
 namespace internal {
 
-v8::Local<v8::Object> CreateJSEvent(
-    v8::Isolate* isolate,
-    v8::Local<v8::Object> object,
-    content::WebContents* sender,
-    IPC::Message* message) {
+v8::Local<v8::Object> CreateJSEvent(v8::Isolate* isolate,
+                                    v8::Local<v8::Object> object,
+                                    content::RenderFrameHost* sender,
+                                    IPC::Message* message) {
   v8::Local<v8::Object> event;
   bool use_native_event = sender && message;
 

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -11,7 +11,7 @@
 #include "native_mate/wrappable.h"
 
 namespace content {
-class WebContents;
+class RenderFrameHost;
 }
 
 namespace IPC {
@@ -24,7 +24,7 @@ namespace internal {
 
 v8::Local<v8::Object> CreateJSEvent(v8::Isolate* isolate,
                                     v8::Local<v8::Object> object,
-                                    content::WebContents* sender,
+                                    content::RenderFrameHost* sender,
                                     IPC::Message* message);
 v8::Local<v8::Object> CreateCustomEvent(
     v8::Isolate* isolate,
@@ -74,9 +74,9 @@ class EventEmitter : public Wrappable<T> {
   }
 
   // this.emit(name, new Event(sender, message), args...);
-  template<typename... Args>
+  template <typename... Args>
   bool EmitWithSender(const base::StringPiece& name,
-                      content::WebContents* sender,
+                      content::RenderFrameHost* sender,
                       IPC::Message* message,
                       const Args&... args) {
     v8::Locker locker(isolate());

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -24,16 +24,16 @@ IPC_STRUCT_TRAITS_BEGIN(atom::DraggableRegion)
   IPC_STRUCT_TRAITS_MEMBER(bounds)
 IPC_STRUCT_TRAITS_END()
 
-IPC_MESSAGE_ROUTED2(AtomViewHostMsg_Message,
+IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_Message,
                     base::string16 /* channel */,
                     base::ListValue /* arguments */)
 
-IPC_SYNC_MESSAGE_ROUTED2_1(AtomViewHostMsg_Message_Sync,
+IPC_SYNC_MESSAGE_ROUTED2_1(AtomFrameHostMsg_Message_Sync,
                            base::string16 /* channel */,
                            base::ListValue /* arguments */,
                            base::string16 /* result (in JSON) */)
 
-IPC_MESSAGE_ROUTED3(AtomViewMsg_Message,
+IPC_MESSAGE_ROUTED3(AtomFrameMsg_Message,
                     bool /* send_to_all */,
                     base::string16 /* channel */,
                     base::ListValue /* arguments */)
@@ -58,12 +58,12 @@ IPC_MESSAGE_ROUTED1(AtomFrameHostMsg_UpdateDraggableRegions,
 IPC_MESSAGE_CONTROL1(AtomMsg_UpdatePreferences, base::ListValue)
 
 // Sent by renderer to set the temporary zoom level.
-IPC_SYNC_MESSAGE_ROUTED1_1(AtomViewHostMsg_SetTemporaryZoomLevel,
+IPC_SYNC_MESSAGE_ROUTED1_1(AtomFrameHostMsg_SetTemporaryZoomLevel,
                            double /* zoom level */,
                            double /* result */)
 
 // Sent by renderer to get the zoom level.
-IPC_SYNC_MESSAGE_ROUTED0_1(AtomViewHostMsg_GetZoomLevel, double /* result */)
+IPC_SYNC_MESSAGE_ROUTED0_1(AtomFrameHostMsg_GetZoomLevel, double /* result */)
 
 // Brings up SaveAs... dialog to save specified URL.
 IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_PDFSaveURLAs,

--- a/atom/common/api/remote_callback_freer.cc
+++ b/atom/common/api/remote_callback_freer.cc
@@ -7,6 +7,8 @@
 #include "atom/common/api/api_messages.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
 
 namespace atom {
 
@@ -35,7 +37,11 @@ void RemoteCallbackFreer::RunDestructor() {
       base::ASCIIToUTF16("ELECTRON_RENDERER_RELEASE_CALLBACK");
   base::ListValue args;
   args.AppendInteger(object_id_);
-  Send(new AtomViewMsg_Message(routing_id(), false, channel, args));
+  auto frame_host = web_contents()->GetMainFrame();
+  if (frame_host) {
+    frame_host->Send(new AtomFrameMsg_Message(frame_host->GetRoutingID(), false,
+                                              channel, args));
+  }
 
   Observe(nullptr);
 }

--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -7,43 +7,38 @@
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
-#include "content/public/renderer/render_view.h"
+#include "content/public/renderer/render_frame.h"
 #include "native_mate/dictionary.h"
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebView.h"
 
-using content::RenderView;
+using content::RenderFrame;
 using blink::WebLocalFrame;
-using blink::WebView;
 
 namespace atom {
 
 namespace api {
 
-RenderView* GetCurrentRenderView() {
+RenderFrame* GetCurrentRenderFrame() {
   WebLocalFrame* frame = WebLocalFrame::FrameForCurrentContext();
   if (!frame)
     return nullptr;
 
-  WebView* view = frame->View();
-  if (!view)
-    return nullptr;  // can happen during closing.
-
-  return RenderView::FromWebView(view);
+  return RenderFrame::FromWebFrame(frame);
 }
 
 void Send(mate::Arguments* args,
           const base::string16& channel,
           const base::ListValue& arguments) {
-  RenderView* render_view = GetCurrentRenderView();
-  if (render_view == nullptr)
+  RenderFrame* render_frame = GetCurrentRenderFrame();
+  if (render_frame == nullptr)
     return;
 
-  bool success = render_view->Send(new AtomViewHostMsg_Message(
-      render_view->GetRoutingID(), channel, arguments));
+  bool success = render_frame->Send(new AtomFrameHostMsg_Message(
+      render_frame->GetRoutingID(), channel, arguments));
 
   if (!success)
-    args->ThrowError("Unable to send AtomViewHostMsg_Message");
+    args->ThrowError("Unable to send AtomFrameHostMsg_Message");
 }
 
 base::string16 SendSync(mate::Arguments* args,
@@ -51,16 +46,16 @@ base::string16 SendSync(mate::Arguments* args,
                         const base::ListValue& arguments) {
   base::string16 json;
 
-  RenderView* render_view = GetCurrentRenderView();
-  if (render_view == nullptr)
+  RenderFrame* render_frame = GetCurrentRenderFrame();
+  if (render_frame == nullptr)
     return json;
 
-  IPC::SyncMessage* message = new AtomViewHostMsg_Message_Sync(
-      render_view->GetRoutingID(), channel, arguments, &json);
-  bool success = render_view->Send(message);
+  IPC::SyncMessage* message = new AtomFrameHostMsg_Message_Sync(
+      render_frame->GetRoutingID(), channel, arguments, &json);
+  bool success = render_frame->Send(message);
 
   if (!success)
-    args->ThrowError("Unable to send AtomViewHostMsg_Message_Sync");
+    args->ThrowError("Unable to send AtomFrameHostMsg_Message_Sync");
 
   return json;
 }

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -132,19 +132,19 @@ void WebFrame::SetName(const std::string& name) {
 
 double WebFrame::SetZoomLevel(double level) {
   double result = 0.0;
-  content::RenderView* render_view =
-      content::RenderView::FromWebView(web_frame_->View());
-  render_view->Send(new AtomViewHostMsg_SetTemporaryZoomLevel(
-      render_view->GetRoutingID(), level, &result));
+  content::RenderFrame* render_frame =
+      content::RenderFrame::FromWebFrame(web_frame_);
+  render_frame->Send(new AtomFrameHostMsg_SetTemporaryZoomLevel(
+      render_frame->GetRoutingID(), level, &result));
   return result;
 }
 
 double WebFrame::GetZoomLevel() const {
   double result = 0.0;
-  content::RenderView* render_view =
-      content::RenderView::FromWebView(web_frame_->View());
-  render_view->Send(
-      new AtomViewHostMsg_GetZoomLevel(render_view->GetRoutingID(), &result));
+  content::RenderFrame* render_frame =
+      content::RenderFrame::FromWebFrame(web_frame_);
+  render_frame->Send(
+      new AtomFrameHostMsg_GetZoomLevel(render_frame->GetRoutingID(), &result));
   return result;
 }
 

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -6,25 +6,68 @@
 
 #include <vector>
 
+#include "atom/common/native_mate_converters/string16_converter.h"
+
 #include "atom/common/api/api_messages.h"
+#include "atom/common/api/event_emitter_caller.h"
+#include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
+#include "atom/renderer/atom_renderer_client.h"
+#include "base/command_line.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_view.h"
+#include "native_mate/dictionary.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
 #include "third_party/WebKit/public/web/WebDraggableRegion.h"
+#include "third_party/WebKit/public/web/WebElement.h"
+#include "third_party/WebKit/public/web/WebFrame.h"
+#include "third_party/WebKit/public/web/WebKit.h"
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebScriptSource.h"
+#include "third_party/WebKit/public/web/WebView.h"
 
 namespace atom {
+
+bool GetIPCObject(v8::Isolate* isolate,
+                  v8::Local<v8::Context> context,
+                  v8::Local<v8::Object>* ipc) {
+  v8::Local<v8::String> key = mate::StringToV8(isolate, "ipc");
+  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  v8::Local<v8::Object> global_object = context->Global();
+  v8::Local<v8::Value> value;
+  if (!global_object->GetPrivate(context, privateKey).ToLocal(&value))
+    return false;
+  if (value.IsEmpty() || !value->IsObject())
+    return false;
+  *ipc = value->ToObject();
+  return true;
+}
+
+std::vector<v8::Local<v8::Value>> ListValueToVector(
+    v8::Isolate* isolate,
+    const base::ListValue& list) {
+  v8::Local<v8::Value> array = mate::ConvertToV8(isolate, list);
+  std::vector<v8::Local<v8::Value>> result;
+  mate::ConvertFromV8(isolate, array, &result);
+  return result;
+}
 
 AtomRenderFrameObserver::AtomRenderFrameObserver(
     content::RenderFrame* frame,
     RendererClientBase* renderer_client)
   : content::RenderFrameObserver(frame),
     render_frame_(frame),
-    renderer_client_(renderer_client) {}
+    renderer_client_(renderer_client),
+    document_created_(false) {}
 
 void AtomRenderFrameObserver::DidClearWindowObject() {
   renderer_client_->DidClearWindowObject(render_frame_);
+}
+
+void AtomRenderFrameObserver::DidCreateDocumentElement() {
+  document_created_ = true;
 }
 
 void AtomRenderFrameObserver::DidCreateScriptContext(
@@ -97,6 +140,80 @@ bool AtomRenderFrameObserver::ShouldNotifyClient(int world_id) {
     return IsIsolatedWorld(world_id);
   else
     return IsMainWorld(world_id);
+}
+
+bool AtomRenderFrameObserver::OnMessageReceived(const IPC::Message& message) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(AtomRenderFrameObserver, message)
+    IPC_MESSAGE_HANDLER(AtomViewMsg_Message, OnBrowserMessage)
+    IPC_MESSAGE_HANDLER(AtomViewMsg_Offscreen, OnOffscreen)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+
+  return handled;
+}
+
+void AtomRenderFrameObserver::OnOffscreen() {
+  blink::WebView::SetUseExternalPopupMenus(false);
+}
+
+void AtomRenderFrameObserver::OnBrowserMessage(bool send_to_all,
+                                              const base::string16& channel,
+                                              const base::ListValue& args) {
+  // Don't handle browser messages before document element is created.
+  // When we receive a message from the browser, we try to transfer it
+  // to a web page, and when we do that Blink creates an empty
+  // document element if it hasn't been created yet, and it makes our init
+  // script to run while `window.location` is still "about:blank".
+  if (!document_created_)
+    return;
+
+  if (!render_frame()->GetRenderView()->GetWebView())
+    return;
+
+  blink::WebFrame* frame = render_frame()->GetRenderView()->GetWebView()->MainFrame();
+  if (!frame || !frame->IsWebLocalFrame())
+    return;
+
+  EmitIPCEvent(frame->ToWebLocalFrame(), channel, args);
+
+  // Also send the message to all sub-frames.
+  if (send_to_all) {
+    for (blink::WebFrame* child = frame->FirstChild(); child;
+         child = child->NextSibling())
+      if (child->IsWebLocalFrame()) {
+        EmitIPCEvent(child->ToWebLocalFrame(), channel, args);
+      }
+  }
+}
+
+void AtomRenderFrameObserver::EmitIPCEvent(blink::WebLocalFrame* frame,
+                                          const base::string16& channel,
+                                          const base::ListValue& args) {
+  if (!frame)
+    return;
+
+  v8::Isolate* isolate = blink::MainThreadIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Local<v8::Context> context = renderer_client_->GetContext(frame, isolate);
+  v8::Context::Scope context_scope(context);
+
+  // Only emit IPC event for context with node integration.
+  node::Environment* env = node::Environment::GetCurrent(context);
+  if (!env)
+    return;
+
+  v8::Local<v8::Object> ipc;
+  if (GetIPCObject(isolate, context, &ipc)) {
+    TRACE_EVENT0("devtools.timeline", "FunctionCall");
+    auto args_vector = ListValueToVector(isolate, args);
+    // Insert the Event object, event.sender is ipc.
+    mate::Dictionary event = mate::Dictionary::CreateEmpty(isolate);
+    event.Set("sender", ipc);
+    args_vector.insert(args_vector.begin(), event.GetHandle());
+    mate::EmitEvent(isolate, ipc, channel, args_vector);
+  }
 }
 
 }  // namespace atom

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -171,7 +171,8 @@ void AtomRenderFrameObserver::OnBrowserMessage(bool send_to_all,
   if (!render_frame()->GetRenderView()->GetWebView())
     return;
 
-  blink::WebFrame* frame = render_frame()->GetRenderView()->GetWebView()->MainFrame();
+  blink::WebFrame* frame =
+    render_frame()->GetRenderView()->GetWebView()->MainFrame();
   if (!frame || !frame->IsWebLocalFrame())
     return;
 

--- a/atom/renderer/atom_render_frame_observer.h
+++ b/atom/renderer/atom_render_frame_observer.h
@@ -6,6 +6,7 @@
 #define ATOM_RENDERER_ATOM_RENDER_FRAME_OBSERVER_H_
 
 #include "atom/renderer/renderer_client_base.h"
+#include "base/values.h"
 #include "content/public/renderer/render_frame_observer.h"
 
 namespace atom {
@@ -31,15 +32,28 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
   void WillReleaseScriptContext(v8::Local<v8::Context> context,
                                 int world_id) override;
   void OnDestruct() override;
+  bool OnMessageReceived(const IPC::Message& message) override;
+  void DidCreateDocumentElement() override;
+
+ protected:
+  virtual void EmitIPCEvent(blink::WebLocalFrame* frame,
+                            const base::string16& channel,
+                            const base::ListValue& args);
 
  private:
   bool ShouldNotifyClient(int world_id);
   void CreateIsolatedWorldContext();
   bool IsMainWorld(int world_id);
   bool IsIsolatedWorld(int world_id);
+  void OnBrowserMessage(bool send_to_all,
+                        const base::string16& channel,
+                        const base::ListValue& args);
+
+  void OnOffscreen();
 
   content::RenderFrame* render_frame_;
   RendererClientBase* renderer_client_;
+  bool document_created_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomRenderFrameObserver);
 };

--- a/atom/renderer/atom_render_frame_observer.h
+++ b/atom/renderer/atom_render_frame_observer.h
@@ -6,8 +6,13 @@
 #define ATOM_RENDERER_ATOM_RENDER_FRAME_OBSERVER_H_
 
 #include "atom/renderer/renderer_client_base.h"
-#include "base/values.h"
+#include "base/strings/string16.h"
 #include "content/public/renderer/render_frame_observer.h"
+#include "third_party/WebKit/public/web/WebLocalFrame.h"
+
+namespace base {
+class ListValue;
+}
 
 namespace atom {
 
@@ -48,8 +53,6 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
   void OnBrowserMessage(bool send_to_all,
                         const base::string16& channel,
                         const base::ListValue& args);
-
-  void OnOffscreen();
 
   content::RenderFrame* render_frame_;
   RendererClientBase* renderer_client_;

--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -4,62 +4,34 @@
 
 #include "atom/renderer/atom_render_view_observer.h"
 
-#include <string>
-#include <vector>
-
-// Put this before event_emitter_caller.h to have string16 support.
-#include "atom/common/native_mate_converters/string16_converter.h"
-
 #include "atom/common/api/api_messages.h"
-#include "atom/common/api/event_emitter_caller.h"
-#include "atom/common/native_mate_converters/value_converter.h"
-#include "atom/common/node_includes.h"
-#include "atom/renderer/atom_renderer_client.h"
-#include "base/command_line.h"
-#include "base/strings/string_number_conversions.h"
-#include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_view.h"
 #include "ipc/ipc_message_macros.h"
-#include "native_mate/dictionary.h"
-#include "net/base/net_module.h"
-#include "net/grit/net_resources.h"
-#include "third_party/WebKit/public/web/WebDocument.h"
-#include "third_party/WebKit/public/web/WebElement.h"
-#include "third_party/WebKit/public/web/WebFrame.h"
-#include "third_party/WebKit/public/web/WebKit.h"
-#include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebView.h"
-#include "ui/base/resource/resource_bundle.h"
 
 namespace atom {
 
-namespace {
+AtomRenderViewObserver::AtomRenderViewObserver(content::RenderView* render_view)
+    : content::RenderViewObserver(render_view) {}
 
-base::StringPiece NetResourceProvider(int key) {
-  if (key == IDR_DIR_HEADER_HTML) {
-    base::StringPiece html_data =
-        ui::ResourceBundle::GetSharedInstance().GetRawDataResource(
-            IDR_DIR_HEADER_HTML);
-    return html_data;
-  }
-  return base::StringPiece();
-}
+AtomRenderViewObserver::~AtomRenderViewObserver() {}
 
-}  // namespace
+bool AtomRenderViewObserver::OnMessageReceived(const IPC::Message& message) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(AtomRenderViewObserver, message)
+    IPC_MESSAGE_HANDLER(AtomViewMsg_Offscreen, OnOffscreen)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
 
-AtomRenderViewObserver::AtomRenderViewObserver(
-    content::RenderView* render_view,
-    AtomRendererClient* renderer_client)
-    : content::RenderViewObserver(render_view) {
-  // Initialise resource for directory listing.
-  net::NetModule::SetResourceProvider(NetResourceProvider);
-}
-
-AtomRenderViewObserver::~AtomRenderViewObserver() {
+  return handled;
 }
 
 void AtomRenderViewObserver::OnDestruct() {
   delete this;
+}
+
+void AtomRenderViewObserver::OnOffscreen() {
+  blink::WebView::SetUseExternalPopupMenus(false);
 }
 
 }  // namespace atom

--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -35,30 +35,6 @@ namespace atom {
 
 namespace {
 
-bool GetIPCObject(v8::Isolate* isolate,
-                  v8::Local<v8::Context> context,
-                  v8::Local<v8::Object>* ipc) {
-  v8::Local<v8::String> key = mate::StringToV8(isolate, "ipc");
-  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
-  v8::Local<v8::Object> global_object = context->Global();
-  v8::Local<v8::Value> value;
-  if (!global_object->GetPrivate(context, privateKey).ToLocal(&value))
-    return false;
-  if (value.IsEmpty() || !value->IsObject())
-    return false;
-  *ipc = value->ToObject();
-  return true;
-}
-
-std::vector<v8::Local<v8::Value>> ListValueToVector(
-    v8::Isolate* isolate,
-    const base::ListValue& list) {
-  v8::Local<v8::Value> array = mate::ConvertToV8(isolate, list);
-  std::vector<v8::Local<v8::Value>> result;
-  mate::ConvertFromV8(isolate, array, &result);
-  return result;
-}
-
 base::StringPiece NetResourceProvider(int key) {
   if (key == IDR_DIR_HEADER_HTML) {
     base::StringPiece html_data =
@@ -74,8 +50,7 @@ base::StringPiece NetResourceProvider(int key) {
 AtomRenderViewObserver::AtomRenderViewObserver(
     content::RenderView* render_view,
     AtomRendererClient* renderer_client)
-    : content::RenderViewObserver(render_view),
-      renderer_client_(renderer_client) {
+    : content::RenderViewObserver(render_view) {
   // Initialise resource for directory listing.
   net::NetModule::SetResourceProvider(NetResourceProvider);
 }
@@ -83,85 +58,8 @@ AtomRenderViewObserver::AtomRenderViewObserver(
 AtomRenderViewObserver::~AtomRenderViewObserver() {
 }
 
-void AtomRenderViewObserver::EmitIPCEvent(blink::WebLocalFrame* frame,
-                                          const base::string16& channel,
-                                          const base::ListValue& args) {
-  if (!frame)
-    return;
-
-  v8::Isolate* isolate = blink::MainThreadIsolate();
-  v8::HandleScope handle_scope(isolate);
-
-  v8::Local<v8::Context> context = renderer_client_->GetContext(frame, isolate);
-  v8::Context::Scope context_scope(context);
-
-  // Only emit IPC event for context with node integration.
-  node::Environment* env = node::Environment::GetCurrent(context);
-  if (!env)
-    return;
-
-  v8::Local<v8::Object> ipc;
-  if (GetIPCObject(isolate, context, &ipc)) {
-    TRACE_EVENT0("devtools.timeline", "FunctionCall");
-    auto args_vector = ListValueToVector(isolate, args);
-    // Insert the Event object, event.sender is ipc.
-    mate::Dictionary event = mate::Dictionary::CreateEmpty(isolate);
-    event.Set("sender", ipc);
-    args_vector.insert(args_vector.begin(), event.GetHandle());
-    mate::EmitEvent(isolate, ipc, channel, args_vector);
-  }
-}
-
-bool AtomRenderViewObserver::OnMessageReceived(const IPC::Message& message) {
-  bool handled = true;
-  IPC_BEGIN_MESSAGE_MAP(AtomRenderViewObserver, message)
-    IPC_MESSAGE_HANDLER(AtomViewMsg_Message, OnBrowserMessage)
-    IPC_MESSAGE_HANDLER(AtomViewMsg_Offscreen, OnOffscreen)
-    IPC_MESSAGE_UNHANDLED(handled = false)
-  IPC_END_MESSAGE_MAP()
-
-  return handled;
-}
-
 void AtomRenderViewObserver::OnDestruct() {
   delete this;
-}
-
-void AtomRenderViewObserver::OnBrowserMessage(bool send_to_all,
-                                              const base::string16& channel,
-                                              const base::ListValue& args) {
-  if (!render_view()->GetWebView())
-    return;
-
-  blink::WebFrame* frame = render_view()->GetWebView()->MainFrame();
-  if (!frame || !frame->IsWebLocalFrame())
-    return;
-
-  // Don't handle browser messages before document element is created.
-  // When we receive a message from the browser, we try to transfer it
-  // to a web page, and when we do that Blink creates an empty
-  // document element if it hasn't been created yet, and it makes our init
-  // script to run while `window.location` is still "about:blank".
-  blink::WebDocument document = frame->ToWebLocalFrame()->GetDocument();
-  blink::WebElement html_element = document.DocumentElement();
-  if (html_element.IsNull()) {
-    return;
-  }
-
-  EmitIPCEvent(frame->ToWebLocalFrame(), channel, args);
-
-  // Also send the message to all sub-frames.
-  if (send_to_all) {
-    for (blink::WebFrame* child = frame->FirstChild(); child;
-         child = child->NextSibling())
-      if (child->IsWebLocalFrame()) {
-        EmitIPCEvent(child->ToWebLocalFrame(), channel, args);
-      }
-  }
-}
-
-void AtomRenderViewObserver::OnOffscreen() {
-  blink::WebView::SetUseExternalPopupMenus(false);
 }
 
 }  // namespace atom

--- a/atom/renderer/atom_render_view_observer.h
+++ b/atom/renderer/atom_render_view_observer.h
@@ -5,28 +5,23 @@
 #ifndef ATOM_RENDERER_ATOM_RENDER_VIEW_OBSERVER_H_
 #define ATOM_RENDERER_ATOM_RENDER_VIEW_OBSERVER_H_
 
-#include "base/strings/string16.h"
 #include "content/public/renderer/render_view_observer.h"
-#include "third_party/WebKit/public/web/WebLocalFrame.h"
-
-namespace base {
-class ListValue;
-}
 
 namespace atom {
 
-class AtomRendererClient;
-
 class AtomRenderViewObserver : public content::RenderViewObserver {
  public:
-  explicit AtomRenderViewObserver(content::RenderView* render_view,
-                                  AtomRendererClient* renderer_client);
+  explicit AtomRenderViewObserver(content::RenderView* render_view);
 
  protected:
   virtual ~AtomRenderViewObserver();
 
  private:
+  // content::RenderViewObserver implementation.
+  bool OnMessageReceived(const IPC::Message& message) override;
   void OnDestruct() override;
+
+  void OnOffscreen();
 
   DISALLOW_COPY_AND_ASSIGN(AtomRenderViewObserver);
 };

--- a/atom/renderer/atom_render_view_observer.h
+++ b/atom/renderer/atom_render_view_observer.h
@@ -25,22 +25,8 @@ class AtomRenderViewObserver : public content::RenderViewObserver {
  protected:
   virtual ~AtomRenderViewObserver();
 
-  virtual void EmitIPCEvent(blink::WebLocalFrame* frame,
-                            const base::string16& channel,
-                            const base::ListValue& args);
-
  private:
-  // content::RenderViewObserver implementation.
-  bool OnMessageReceived(const IPC::Message& message) override;
   void OnDestruct() override;
-
-  void OnBrowserMessage(bool send_to_all,
-                        const base::string16& channel,
-                        const base::ListValue& args);
-
-  void OnOffscreen();
-
-  AtomRendererClient* renderer_client_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomRenderViewObserver);
 };

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -15,7 +15,6 @@
 #include "atom/common/options_switches.h"
 #include "atom/renderer/api/atom_api_renderer_ipc.h"
 #include "atom/renderer/atom_render_frame_observer.h"
-#include "atom/renderer/atom_render_view_observer.h"
 #include "atom/renderer/web_worker_observer.h"
 #include "base/command_line.h"
 #include "content/public/renderer/render_frame.h"
@@ -54,11 +53,11 @@ void AtomRendererClient::RenderThreadStarted() {
 
 void AtomRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {
+  new AtomRenderFrameObserver(render_frame, this);
   RendererClientBase::RenderFrameCreated(render_frame);
 }
 
 void AtomRendererClient::RenderViewCreated(content::RenderView* render_view) {
-  new AtomRenderViewObserver(render_view, this);
   RendererClientBase::RenderViewCreated(render_view);
 }
 

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -14,21 +14,13 @@
 #include "atom/common/node_bindings.h"
 #include "atom/common/options_switches.h"
 #include "atom/renderer/api/atom_api_renderer_ipc.h"
-#include "atom/renderer/atom_render_view_observer.h"
+#include "atom/renderer/atom_render_frame_observer.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "chrome/renderer/printing/print_web_view_helper.h"
 #include "content/public/renderer/render_frame.h"
-#include "content/public/renderer/render_view.h"
-#include "content/public/renderer/render_view_observer.h"
-#include "ipc/ipc_message_macros.h"
-#include "native_mate/converter.h"
 #include "native_mate/dictionary.h"
-#include "third_party/WebKit/public/web/WebFrame.h"
 #include "third_party/WebKit/public/web/WebKit.h"
-#include "third_party/WebKit/public/web/WebLocalFrame.h"
-#include "third_party/WebKit/public/web/WebScriptSource.h"
-#include "third_party/WebKit/public/web/WebView.h"
 
 #include "atom/common/node_includes.h"
 #include "atom_natives.h"  // NOLINT: This file is generated with js2c
@@ -97,18 +89,17 @@ void InitializeBindings(v8::Local<v8::Object> binding,
   b.SetMethod("getSystemMemoryInfo", &AtomBindings::GetSystemMemoryInfo);
 }
 
-class AtomSandboxedRenderViewObserver : public AtomRenderViewObserver {
+class AtomSandboxedRenderFrameObserver : public AtomRenderFrameObserver {
  public:
-  AtomSandboxedRenderViewObserver(content::RenderView* render_view,
-                                  AtomSandboxedRendererClient* renderer_client)
-    : AtomRenderViewObserver(render_view, nullptr),
-    v8_converter_(new atom::V8ValueConverter),
-    renderer_client_(renderer_client) {
-      v8_converter_->SetDisableNode(true);
-    }
+  AtomSandboxedRenderFrameObserver(content::RenderFrame* render_frame,
+                                   AtomSandboxedRendererClient* renderer_client)
+      : AtomRenderFrameObserver(render_frame, renderer_client),
+        v8_converter_(new atom::V8ValueConverter),
+        renderer_client_(renderer_client) {
+    v8_converter_->SetDisableNode(true);
+  }
 
  protected:
-  // TODO(MarshallOfSound): This needs to be `AtomRenderFrameObserver`
   void EmitIPCEvent(blink::WebLocalFrame* frame,
                     const base::string16& channel,
                     const base::ListValue& args) {
@@ -132,7 +123,7 @@ class AtomSandboxedRenderViewObserver : public AtomRenderViewObserver {
  private:
   std::unique_ptr<atom::V8ValueConverter> v8_converter_;
   AtomSandboxedRendererClient* renderer_client_;
-  DISALLOW_COPY_AND_ASSIGN(AtomSandboxedRenderViewObserver);
+  DISALLOW_COPY_AND_ASSIGN(AtomSandboxedRenderFrameObserver);
 };
 
 }  // namespace
@@ -148,12 +139,12 @@ AtomSandboxedRendererClient::~AtomSandboxedRendererClient() {
 
 void AtomSandboxedRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {
+  new AtomSandboxedRenderFrameObserver(render_frame, this);
   RendererClientBase::RenderFrameCreated(render_frame);
 }
 
 void AtomSandboxedRendererClient::RenderViewCreated(
     content::RenderView* render_view) {
-  new AtomSandboxedRenderViewObserver(render_view, this);
   RendererClientBase::RenderViewCreated(render_view);
 }
 

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -108,9 +108,10 @@ class AtomSandboxedRenderViewObserver : public AtomRenderViewObserver {
     }
 
  protected:
+  // TODO(MarshallOfSound): This needs to be `AtomRenderFrameObserver`
   void EmitIPCEvent(blink::WebLocalFrame* frame,
                     const base::string16& channel,
-                    const base::ListValue& args) override {
+                    const base::ListValue& args) {
     if (!frame)
       return;
 

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -13,6 +13,7 @@
 #include "atom/common/options_switches.h"
 #include "atom/renderer/atom_autofill_agent.h"
 #include "atom/renderer/atom_render_frame_observer.h"
+#include "atom/renderer/atom_render_view_observer.h"
 #include "atom/renderer/content_settings_observer.h"
 #include "atom/renderer/guest_view_container.h"
 #include "atom/renderer/preferences_manager.h"
@@ -26,13 +27,13 @@
 #include "content/public/common/content_constants.h"
 #include "content/public/renderer/render_view.h"
 #include "native_mate/dictionary.h"
+#include "third_party/WebKit/Source/platform/weborigin/SchemeRegistry.h"
 #include "third_party/WebKit/public/web/WebCustomElement.h"
 #include "third_party/WebKit/public/web/WebFrameWidget.h"
 #include "third_party/WebKit/public/web/WebKit.h"
 #include "third_party/WebKit/public/web/WebPluginParams.h"
 #include "third_party/WebKit/public/web/WebScriptSource.h"
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
-#include "third_party/WebKit/Source/platform/weborigin/SchemeRegistry.h"
 
 #if defined(OS_MACOSX)
 #include "base/mac/mac_util.h"
@@ -144,7 +145,6 @@ void RendererClientBase::RenderThreadStarted() {
 
 void RendererClientBase::RenderFrameCreated(
     content::RenderFrame* render_frame) {
-  new AtomRenderFrameObserver(render_frame, this);
   new AutofillAgent(render_frame);
   new PepperHelper(render_frame);
   new ContentSettingsObserver(render_frame);
@@ -159,6 +159,7 @@ void RendererClientBase::RenderFrameCreated(
 }
 
 void RendererClientBase::RenderViewCreated(content::RenderView* render_view) {
+  new AtomRenderViewObserver(render_view);
   blink::WebFrameWidget* web_frame_widget = render_view->GetWebFrameWidget();
   if (!web_frame_widget)
     return;

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -28,7 +28,7 @@
 #include "content/public/renderer/render_view.h"
 #include "native_mate/dictionary.h"
 #include "third_party/WebKit/Source/platform/weborigin/SchemeRegistry.h"
-#include "third_party/WebKit/public/web/WebCustomElement.h"
+#include "third_party/WebKit/public/web/WebCustomElement.h"  // NOLINT(build/include_alpha)
 #include "third_party/WebKit/public/web/WebFrameWidget.h"
 #include "third_party/WebKit/public/web/WebKit.h"
 #include "third_party/WebKit/public/web/WebPluginParams.h"


### PR DESCRIPTION
* Reverts 370476c4affc56ed9799068187b1e8fd5d1beb0a in favor of moving the previous logic to the new RenderFrameObserver instead of RenderViewObserver

Fixes #12045

🎉 