### PR TITLE
Fixes electron/electron#12147

### DIFF
--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -21,11 +21,6 @@ var NavigationController = (function () {
     this.webContents = webContents
     this.clearHistory()
 
-    // webContents may have already navigated to a page.
-    if (this.webContents._getURL()) {
-      this.currentIndex++
-      this.history.push(this.webContents._getURL())
-    }
     this.webContents.on('navigation-entry-commited', (event, url, inPage, replaceEntry) => {
       if (this.inPageIndex > -1 && !inPage) {
         // Navigated to a new page, clear in-page mark.
@@ -106,6 +101,12 @@ var NavigationController = (function () {
     this.currentIndex = -1
     this.pendingIndex = -1
     this.inPageIndex = -1
+
+    // webContents may have already navigated to a page.
+    if (this.webContents._getURL()) {
+      this.currentIndex++
+      this.history.push(this.webContents._getURL())
+    }
   }
 
   NavigationController.prototype.goBack = function () {


### PR DESCRIPTION
When calling `clearHistory()` from an external caller, it does not correctly check and rebuild the navigation stack with the active URL, as it does during construction.

This clearHistory issue would also cause bugs in similar functions: getURL, canGoToIndex, canGoBack.

Afaict, there are no existing automated tests for the navigation-controller. I verified this change by performing the steps described in the issue and verifying the expected outcome. I did not verify any other case that did not call `clearHistory`, as the object is logically identical.