### PR TITLE
Fixed Mac build when enable_run_as_node==false

### DIFF
--- a/atom/app/atom_library_main.h
+++ b/atom/app/atom_library_main.h
@@ -12,8 +12,10 @@ extern "C" {
 __attribute__((visibility("default")))
 int AtomMain(int argc, char* argv[]);
 
+#ifdef ENABLE_RUN_AS_NODE
 __attribute__((visibility("default")))
 int AtomInitializeICUandStartNode(int argc, char *argv[]);
+#endif
 }
 #endif  // OS_MACOSX
 

--- a/atom/app/atom_library_main.mm
+++ b/atom/app/atom_library_main.mm
@@ -14,7 +14,6 @@
 #include "brightray/common/mac/main_application_bundle.h"
 #include "content/public/app/content_main.h"
 
-#if defined(OS_MACOSX)
 int AtomMain(int argc, char* argv[]) {
   atom::AtomMainDelegate delegate;
   content::ContentMainParams params(&delegate);
@@ -24,6 +23,7 @@ int AtomMain(int argc, char* argv[]) {
   return content::ContentMain(params);
 }
 
+#ifdef ENABLE_RUN_AS_NODE
 int AtomInitializeICUandStartNode(int argc, char *argv[]) {
   base::AtExitManager atexit_manager;
   base::mac::ScopedNSAutoreleasePool pool;
@@ -35,4 +35,4 @@ int AtomInitializeICUandStartNode(int argc, char *argv[]) {
   base::i18n::InitializeICU();
   return atom::NodeMain(argc, argv);
 }
-#endif  // OS_MACOSX
+#endif

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -42,6 +42,7 @@ namespace {
 const auto kRunAsNode = "ELECTRON_RUN_AS_NODE";
 #endif
 
+#if defined(ENABLE_RUN_AS_NODE) || defined(OS_WIN)
 bool IsEnvSet(const char* name) {
 #if defined(OS_WIN)
   size_t required_size;
@@ -52,6 +53,7 @@ bool IsEnvSet(const char* name) {
   return indicator && indicator[0] != '\0';
 #endif
 }
+#endif
 
 }  // namespace
 


### PR DESCRIPTION
The build fails on macOS when `enable_run_as_node` is turned off.