### PR TITLE
Fixed passing of exception to the system crash handler

### DIFF
--- a/atom/common/crash_reporter/crash_reporter_win.cc
+++ b/atom/common/crash_reporter/crash_reporter_win.cc
@@ -209,7 +209,10 @@ void CrashReporterWin::SetUploadParameters() {
 int CrashReporterWin::CrashForException(EXCEPTION_POINTERS* info) {
   if (breakpad_) {
     breakpad_->WriteMinidumpForException(info);
-    TerminateProcessWithoutDump();
+    if (skip_system_crash_handler_)
+      TerminateProcessWithoutDump();
+    else
+      RaiseFailFastException(info->ExceptionRecord, info->ContextRecord, 0);
   }
   return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -229,7 +232,7 @@ bool CrashReporterWin::MinidumpCallback(const wchar_t* dump_path,
                                         MDRawAssertionInfo* assertion,
                                         bool succeeded) {
   CrashReporterWin* self = static_cast<CrashReporterWin*>(context);
-  if (succeeded && !self->skip_system_crash_handler_)
+  if (succeeded && self->skip_system_crash_handler_)
     return true;
   else
     return false;


### PR DESCRIPTION
On Windows, when the Electron crash handler is enabled, the internal `skip_system_crash_handler_` flag does not work. I.e. when the flag is cleared and the process crashes, the exception is handled by Breakpad and the process terminates.

This change passes the exception to the system handler (on both ia32 and x64) which invokes the default crash dialog box.