### PR TITLE
Fix Broken README.md

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -18,5 +18,5 @@ If you just came here to learn about Electron, check out the
 
 [first-app]: ./first-app.md
 [processes]: ./application-architecture.md#main-and-renderer-processes
-[readme]: ../README.md
+[readme]: ../../README.md
 


### PR DESCRIPTION
Fix Broken Link at below url. When click  "official guides." go to 404 page. 

https://electronjs.org/docs/tutorial/quick-start

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->