### PR TITLE
Add heading for README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+# Official Guides
+
 Please make sure that you use the documents that match your Electron version.
 The version number should be a part of the page URL. If it's not, you are
 probably using the documentation of a development branch which may contain API


### PR DESCRIPTION
The electron/i18n module uses headings in each doc to separate it into sections, and it's not happy with the current headinglessness of `README`. 😄 