### PR TITLE
Skip client-certificate test for Linux (2-0-x)

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -491,6 +491,12 @@ describe('app module', () => {
   describe('select-client-certificate event', () => {
     let w = null
 
+    before(function () {
+      if (process.platform === 'linux') {
+        this.skip()
+      }
+    })
+
     beforeEach(() => {
       w = new BrowserWindow({
         show: false,


### PR DESCRIPTION
Backports https://github.com/electron/electron/pull/12189 to 2-0-x.