### PR TITLE
Enable easy rebuild of native modules for unreleased electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "remark-cli": "^4.0.0",
     "remark-preset-lint-markdown-style-guide": "^2.1.1",
     "request": "^2.68.0",
+    "serve": "^6.5.3",
     "standard": "^10.0.0",
     "standard-markdown": "^4.0.0",
     "sumchecker": "^2.0.2",

--- a/script/serve-node-headers.py
+++ b/script/serve-node-headers.py
@@ -26,7 +26,7 @@ def main():
 
   # Launch server
   script_path = os.path.join(SOURCE_ROOT, 'node_modules', 'serve', 'bin', 'serve.js')
-  server = Popen(['node', script_path, '--port=4321'], stdout=PIPE, cwd=DIST_DIR)
+  server = Popen(['node', script_path, '--port=' + args.port], stdout=PIPE, cwd=DIST_DIR)
   def cleanup():
     server.kill()
   atexit.register(cleanup)
@@ -36,16 +36,18 @@ def main():
   # Generate Checksums
   script_path = os.path.join(SOURCE_ROOT, 'script', 'upload-node-checksums.py')
   execute_stdout([sys.executable, script_path, '--version', args.version,
-                  '--dist-url', 'http://localhost:4321',
+                  '--dist-url', 'http://localhost:' + args.port,
                   '--target-dir', header_dir])
 
-  print("Point your npm config at 'http://localhost:4321'")
+  print("Point your npm config at 'http://localhost:" + args.port + "'")
   server.wait()
 
 def parse_args():
   parser = argparse.ArgumentParser(description='create node header tarballs')
   parser.add_argument('-v', '--version', help='Specify the version',
                       required=True)
+  parser.add_argument('-p', '--port', help='Specify port to run local server',
+                      default='4321')
   return parser.parse_args()
 
 if __name__ == '__main__':

--- a/script/serve-node-headers.py
+++ b/script/serve-node-headers.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import argparse
+import atexit
+import os
+import shutil
+import sys
+import tarfile
+import time
+
+from subprocess import Popen, PIPE
+from lib.util import execute_stdout
+
+SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+DIST_DIR    = os.path.join(SOURCE_ROOT, 'dist')
+
+
+def main():
+  args = parse_args()
+  header_dir = os.path.join(DIST_DIR, args.version)
+
+  # Generate Headers
+  script_path = os.path.join(SOURCE_ROOT, 'script', 'create-node-headers.py')
+  execute_stdout([sys.executable, script_path, '--version', args.version,
+                  '--directory', header_dir])
+
+  # Launch server
+  script_path = os.path.join(SOURCE_ROOT, 'node_modules', 'serve', 'bin', 'serve.js')
+  server = Popen(['node', script_path, '--port=4321'], stdout=PIPE, cwd=DIST_DIR)
+  def cleanup():
+    server.kill()
+  atexit.register(cleanup)
+
+  time.sleep(1)
+
+  # Generate Checksums
+  script_path = os.path.join(SOURCE_ROOT, 'script', 'upload-node-checksums.py')
+  execute_stdout([sys.executable, script_path, '--version', args.version,
+                  '--dist-url', 'http://localhost:4321',
+                  '--target-dir', header_dir])
+
+  print("Point your npm config at 'http://localhost:4321'")
+  server.wait()
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='create node header tarballs')
+  parser.add_argument('-v', '--version', help='Specify the version',
+                      required=True)
+  return parser.parse_args()
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/script/serve-node-headers.py
+++ b/script/serve-node-headers.py
@@ -25,8 +25,10 @@ def main():
                   '--directory', header_dir])
 
   # Launch server
-  script_path = os.path.join(SOURCE_ROOT, 'node_modules', 'serve', 'bin', 'serve.js')
-  server = Popen(['node', script_path, '--port=' + args.port], stdout=PIPE, cwd=DIST_DIR)
+  script_path = os.path.join(SOURCE_ROOT, 'node_modules', 'serve', 'bin',
+                            'serve.js')
+  server = Popen(['node', script_path, '--port=' + args.port], stdout=PIPE,
+                 cwd=DIST_DIR)
   def cleanup():
     server.kill()
   atexit.register(cleanup)

--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -48,26 +48,26 @@ def parse_args():
                       required=False)
   return parser.parse_args()
 
-
 def get_files_list(version):
   return [
-    ['node-{0}.tar.gz'.format(version), True],
-    ['iojs-{0}.tar.gz'.format(version), True],
-    ['iojs-{0}-headers.tar.gz'.format(version), True],
-    ['node.lib', False],
-    ['x64/node.lib', False],
-    ['win-x86/iojs.lib', False],
-    ['win-x64/iojs.lib', False]
+    { "filename": 'node-{0}.tar.gz'.format(version), "required": True },
+    { "filename": 'iojs-{0}.tar.gz'.format(version), "required": True },
+    { "filename": 'iojs-{0}-headers.tar.gz'.format(version), "required": True },
+    { "filename": 'node.lib', "required": False },
+    { "filename": 'x64/node.lib', "required": False },
+    { "filename": 'win-x86/iojs.lib', "required": False },
+    { "filename": 'win-x64/iojs.lib', "required": False }
   ]
 
 
 def download_files(url, files):
   directory = tempfile.mkdtemp(prefix='electron-tmp')
   result = []
-  for f in files:
-    required = f[1]
+  for optional_f in files:
+    required = optional_f.required
+    f = optional_f.filename
     try:
-      result.append(download(f[0], url + f[0], os.path.join(directory, f[0])))
+      result.append(download(f, url + f, os.path.join(directory, f)))
     except Exception:
       if required:
         raise

--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
+import errno
 import hashlib
 import os
+import shutil
 import tempfile
 
 from lib.config import s3_config
@@ -14,17 +16,23 @@ DIST_URL = 'https://atom.io/download/electron/'
 
 def main():
   args = parse_args()
+  dist_url = args.dist_url
+  if dist_url[len(dist_url) - 1] != "/":
+    dist_url += "/"
 
-  url = DIST_URL + args.version + '/'
+  url = dist_url + args.version + '/'
   directory, files = download_files(url, get_files_list(args.version))
   checksums = [
     create_checksum('sha1', directory, 'SHASUMS.txt', files),
     create_checksum('sha256', directory, 'SHASUMS256.txt', files)
   ]
 
-  bucket, access_key, secret_key = s3_config()
-  s3put(bucket, access_key, secret_key, directory,
-        'atom-shell/dist/{0}'.format(args.version), checksums)
+  if args.target_dir is None:
+    bucket, access_key, secret_key = s3_config()
+    s3put(bucket, access_key, secret_key, directory,
+          'atom-shell/dist/{0}'.format(args.version), checksums)
+  else:
+    copy_files(checksums, args.target_dir)
 
   rm_rf(directory)
 
@@ -33,27 +41,37 @@ def parse_args():
   parser = argparse.ArgumentParser(description='upload sumsha file')
   parser.add_argument('-v', '--version', help='Specify the version',
                       required=True)
+  parser.add_argument('-u', '--dist-url', help='Specify the dist url for downloading',
+                      required=False, default=DIST_URL)
+  parser.add_argument('-t', '--target-dir', help='Specify target dir of checksums',
+                      required=False)
   return parser.parse_args()
 
 
 def get_files_list(version):
   return [
-    'node-{0}.tar.gz'.format(version),
-    'iojs-{0}.tar.gz'.format(version),
-    'iojs-{0}-headers.tar.gz'.format(version),
-    'node.lib',
-    'x64/node.lib',
-    'win-x86/iojs.lib',
-    'win-x64/iojs.lib',
+    ['node-{0}.tar.gz'.format(version), True],
+    ['iojs-{0}.tar.gz'.format(version), True],
+    ['iojs-{0}-headers.tar.gz'.format(version), True],
+    ['node.lib', False],
+    ['x64/node.lib', False],
+    ['win-x86/iojs.lib', False],
+    ['win-x64/iojs.lib', False]
   ]
 
 
 def download_files(url, files):
   directory = tempfile.mkdtemp(prefix='electron-tmp')
-  return directory, [
-    download(f, url + f, os.path.join(directory, f))
-    for f in files
-  ]
+  result = []
+  for f in files:
+    required = f[1]
+    try:
+      result.append(download(f[0], url + f[0], os.path.join(directory, f[0])))
+    except:
+      if required:
+        raise
+
+  return directory, result
 
 
 def create_checksum(algorithm, directory, filename, files):
@@ -68,6 +86,19 @@ def create_checksum(algorithm, directory, filename, files):
   with open(checksum_file, 'w') as f:
     f.write('\n'.join(lines) + '\n')
   return checksum_file
+
+def copy_files(source_files, output_dir):
+  for source_file in source_files:
+    output_path = os.path.join(output_dir, os.path.basename(source_file))
+    safe_mkdir(os.path.dirname(output_path))
+    shutil.copy2(source_file, output_path)
+
+def safe_mkdir(path):
+  try:
+    os.makedirs(path)
+  except OSError as e:
+    if e.errno != errno.EEXIST:
+      raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes when developing locally (as I found this morning) you want to rebuild native modules
against an unreleased version of Electron (in this case local master).  This PR adds a simple
script to launch a local HTTP server that generates and hosts the required header and checksum
files to rebuild modules.  So far only tested on macOS but should work on all OS's

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->