### PR TITLE
Chromium 63 - upgrade to Node v9.7.0

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <string>
 
+#include "atom/common/api/locker.h"
 #include "atom/common/atom_version.h"
 #include "atom/common/chrome_version.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
@@ -97,8 +98,11 @@ void AtomBindings::OnCallNextTick(uv_async_t* handle) {
   for (std::list<node::Environment*>::const_iterator it =
            self->pending_next_ticks_.begin();
        it != self->pending_next_ticks_.end(); ++it) {
+    node::Environment* env = *it;
+    mate::Locker locker(env->isolate());
+    v8::Context::Scope context_scope(env->context());
     node::InternalCallbackScope scope(
-        *it,
+        env,
         v8::Local<v8::Object>(),
         {0, 0},
         node::InternalCallbackScope::kAllowEmptyResource);

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -103,11 +103,11 @@ void AtomBindings::OnCallNextTick(uv_async_t* handle) {
     if (callback_scope.in_makecallback())
       continue;
     node::Environment::TickInfo* tick_info = env->tick_info();
-    if (tick_info->length() == 0)
+    if (!tick_info->has_scheduled())
       env->isolate()->RunMicrotasks();
     v8::Local<v8::Object> process = env->process_object();
-    if (tick_info->length() == 0)
-      tick_info->set_index(0);
+    if (!tick_info->has_scheduled())
+      return;
     env->tick_callback_function()->Call(process, 0, nullptr).IsEmpty();
   }
 

--- a/atom/common/node_includes.h
+++ b/atom/common/node_includes.h
@@ -6,7 +6,7 @@
 #define ATOM_COMMON_NODE_INCLUDES_H_
 
 #include "base/logging.h"
-#include "v8-platform.h"
+#include "v8-platform.h" // NOLINT
 
 // Include common headers for using node APIs.
 

--- a/common.gypi
+++ b/common.gypi
@@ -44,7 +44,7 @@
     'uv_library': 'static_library',
     'uv_parent_path': 'vendor/node/deps/uv',
     'uv_use_dtrace': 'false',
-    'V8_BASE': '',
+    'v8_base': '',
     'v8_postmortem_support': 'false',
     'v8_enable_i18n_support': 'false',
     'v8_enable_inspector': '1',
@@ -52,7 +52,7 @@
   # Settings to compile node under Windows.
   'target_defaults': {
     'target_conditions': [
-      ['_target_name in ["libuv", "http_parser", "openssl", "openssl-cli", "cares", "node", "zlib", "nghttp2"]', {
+      ['_target_name in ["libuv", "http_parser", "openssl", "openssl-cli", "cares", "node_lib", "zlib", "nghttp2"]', {
         'msvs_disabled_warnings': [
           4003,  # not enough actual parameters for macro 'V'
           4013,  # 'free' undefined; assuming extern returning int
@@ -136,7 +136,7 @@
           }],
         ],
       }],
-      ['_target_name=="node"', {
+      ['_target_name=="node_lib"', {
         'include_dirs': [
           '<(libchromiumcontent_src_dir)',
           '<(libchromiumcontent_src_dir)/third_party/icu/source/common',
@@ -245,7 +245,7 @@
           }],  # OS=="win"
         ],
       }],
-      ['OS=="linux" and _toolset=="target" and _target_name in ["dump_syms", "node"]', {
+      ['OS=="linux" and _toolset=="target" and _target_name in ["dump_syms", "node_lib"]', {
         'conditions': [
           ['libchromiumcontent_component==0', {
             'libraries': [

--- a/common.gypi
+++ b/common.gypi
@@ -61,6 +61,7 @@
           4055,  # 'type cast' : from data pointer 'void *' to function pointer
           4057,  # 'function' : 'volatile LONG *' differs in indirection to slightly different base types from 'unsigned long *'
           4065,  # switch statement contains 'default' but no 'case' labels
+          4129,  # unrecognized character escape sequence
           4189,  #
           4131,  # uses old-style declarator
           4133,  # incompatible types
@@ -74,6 +75,7 @@
           4232,  # address of dllimport 'free' is not static, identity not guaranteed
           4291,  # no matching operator delete found
           4295,  # array is too small to include a terminating null character
+          4309,  # 'static_cast': truncation of constant value
           4311,  # 'type cast': pointer truncation from 'void *const ' to 'unsigned long'
           4389,  # '==' : signed/unsigned mismatch
           4456,  # declaration of 'm' hides previous local declaration

--- a/common.gypi
+++ b/common.gypi
@@ -19,7 +19,7 @@
     'openssl_fips': '',
     'openssl_no_asm': 1,
     'use_openssl_def': 0,
-    'OPENSSL_PRODUCT': 'libopenssl.a',
+    'openssl_product': 'libopenssl.a',
     'node_release_urlbase': 'https://atom.io/download/electron',
     'node_byteorder': '<!(node <(DEPTH)/tools/get-endianness.js)',
     'node_target_type': 'shared_library',

--- a/electron.gyp
+++ b/electron.gyp
@@ -245,7 +245,7 @@
         'atom_js2c',
         'vendor/pdf_viewer/pdf_viewer.gyp:pdf_viewer',
         'brightray/brightray.gyp:brightray',
-        'vendor/node/node.gyp:node',
+        'vendor/node/node.gyp:node_lib',
       ],
       'defines': [
         # We need to access internal implementations of Node.


### PR DESCRIPTION
Upgrade [Chromium 63](https://github.com/electron/electron/pull/11459) to Node `v9.7.0` 

/cc @deepak1556 