### PR TITLE
Parent's visibility trumps inherited 'show' option

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -52,10 +52,7 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     // if parent's visibility is available, that overrides 'show' flag (#12125)
     const win = BrowserWindow.fromWebContents(embedder.webContents)
     if (win != null) {
-      const show = win.isVisible()
-      if (typeof show === 'boolean') {
-        parentOptions = {...embedder.browserWindowOptions, show}
-      }
+      parentOptions = {...embedder.browserWindowOptions, show: win.isVisible()}
     }
 
     // Inherit the original options if it is a BrowserWindow.

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -47,8 +47,19 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     options.webPreferences = {}
   }
   if (embedder.browserWindowOptions != null) {
+    let parentOptions = {...embedder.browserWindowOptions}
+
+    // if parent's visibility is available, that overrides 'show' flag (#12125)
+    const win = BrowserWindow.fromWebContents(embedder.webContents)
+    if (win != null) {
+      const show = win.isVisible()
+      if (typeof show === 'boolean') {
+        parentOptions.show = show
+      }
+    }
+
     // Inherit the original options if it is a BrowserWindow.
-    mergeOptions(options, embedder.browserWindowOptions)
+    mergeOptions(options, parentOptions)
   } else {
     // Or only inherit webPreferences if it is a webview.
     mergeOptions(options.webPreferences, embedder.getWebPreferences())

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -47,14 +47,14 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     options.webPreferences = {}
   }
   if (embedder.browserWindowOptions != null) {
-    let parentOptions = {...embedder.browserWindowOptions}
+    let parentOptions = embedder.browserWindowOptions
 
     // if parent's visibility is available, that overrides 'show' flag (#12125)
     const win = BrowserWindow.fromWebContents(embedder.webContents)
     if (win != null) {
       const show = win.isVisible()
       if (typeof show === 'boolean') {
-        parentOptions.show = show
+        parentOptions = {...embedder.browserWindowOptions, show: show}
       }
     }
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -54,7 +54,7 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     if (win != null) {
       const show = win.isVisible()
       if (typeof show === 'boolean') {
-        parentOptions = {...embedder.browserWindowOptions, show: show}
+        parentOptions = {...embedder.browserWindowOptions, show}
       }
     }
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -223,9 +223,9 @@ describe('chromium feature', () => {
       b = window.open(`file://${fixtures}/pages/window-open-size.html`, '', 'show=no')
     })
 
-    for (const show in [true, false]) {
+    for (const show of [true, false]) {
       it(`inherits parent visibility over parent {show=${show}} option`, (done) => {
-        let w = new BrowserWindow({show: show})
+        const w = new BrowserWindow({show})
 
         // toggle visibility
         if (show) {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -223,6 +223,26 @@ describe('chromium feature', () => {
       b = window.open(`file://${fixtures}/pages/window-open-size.html`, '', 'show=no')
     })
 
+    for (const show in [true, false]) {
+      it(`inherits parent visibility over parent {show=${show}} option`, (done) => {
+        let w = new BrowserWindow({show: show})
+
+        // toggle visibility
+        if (show) {
+          w.hide()
+        } else {
+          w.show()
+        }
+
+        w.webContents.once('new-window', (e, url, frameName, disposition, options) => {
+          assert.equal(options.show, w.isVisible())
+          w.close()
+          done()
+        })
+        w.loadURL(`file://${fixtures}/pages/window-open.html`)
+      })
+    }
+
     it('disables node integration when it is disabled on the parent window', (done) => {
       let b
       listener = (event) => {


### PR DESCRIPTION
The fix works but needs a spec.

Fixes #12125.