### PR TITLE
Linux named notifications - 2-0-0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   electron-linux-arm:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: arm
     resource_class: 2xlarge
@@ -106,7 +106,7 @@ jobs:
               docker run --rm --privileged multiarch/qemu-user-static:register --reset
               docker run -it \
               --mount type=bind,source=/tmp/workspace,target=/tmp/workspace \
-              --rm electronbuilds/electronarm7:0.0.4 > version.txt
+              --rm electronbuilds/electronarm7:0.0.5 > version.txt
               cat version.txt
               if grep -q `script/get-version.py` version.txt; then
                 echo "Versions match"
@@ -119,7 +119,7 @@ jobs:
             fi
   electron-linux-arm64:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: arm64
     resource_class: 2xlarge
@@ -199,7 +199,7 @@ jobs:
               docker run --rm --privileged multiarch/qemu-user-static:register --reset
               docker run -it \
               --mount type=bind,source=/tmp/workspace,target=/tmp/workspace \
-              --rm electronbuilds/electronarm64:0.0.5 > version.txt
+              --rm electronbuilds/electronarm64:0.0.6 > version.txt
               cat version.txt
               if grep -q `script/get-version.py` version.txt; then
                 echo "Versions match"
@@ -296,7 +296,7 @@ jobs:
              fi
   electron-linux-mips64el:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: mips64el
     resource_class: xlarge
@@ -354,7 +354,7 @@ jobs:
 
   electron-linux-x64:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.6
         environment:
           TARGET_ARCH: x64
           DISPLAY: ':99.0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get install -y wget
 # Install python-dbusmock
 RUN apt-get install -y python-dbusmock
 
+# Install libnotify
+RUN apt-get install -y libnotify-bin
+
 # Add xvfb init script
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y\
  libgnome-keyring-dev \
  libgtk-3-0 \
  libgtk-3-dev \
+ libnotify-bin \
  libnotify-dev \
  libnss3 \
  libnss3-dev \

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y\
  libgnome-keyring-dev \
  libgtk-3-0 \
  libgtk-3-dev \
+ libnotify-bin \
  libnotify-dev \
  libnss3 \
  libnss3-dev \

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -12,6 +12,9 @@ RUN apt-get install -y wget
 # Install python-dbusmock
 RUN apt-get install -y python-dbusmock
 
+# Install libnotify
+RUN apt-get install -y libnotify-bin
+
 # Add xvfb init script
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -108,14 +108,13 @@ void Browser::SetVersion(const std::string& version) {
 }
 
 std::string Browser::GetName() const {
-  std::string ret = name_override_;
+  std::string ret = brightray::GetOverriddenApplicationName();
   if (ret.empty())
     ret = GetExecutableFileProductName();
   return ret;
 }
 
 void Browser::SetName(const std::string& name) {
-  name_override_ = name;
   brightray::OverrideApplicationName(name);
 }
 

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -273,8 +273,6 @@ class Browser : public WindowListObserver {
   // The browser is being shutdown.
   bool is_shutdown_;
 
-  std::string name_override_;
-
   int badge_count_ = 0;
 
 #if defined(OS_MACOSX)

--- a/atom/common/linux/application_info.cc
+++ b/atom/common/linux/application_info.cc
@@ -18,10 +18,15 @@
 namespace {
 
 GDesktopAppInfo* get_desktop_app_info() {
+  GDesktopAppInfo * ret = nullptr;
+
   std::unique_ptr<base::Environment> env(base::Environment::Create());
   const std::string desktop_id = libgtkui::GetDesktopName(env.get());
-  return desktop_id.empty() ? nullptr
-                            : g_desktop_app_info_new(desktop_id.c_str());
+  const char * libcc_default_id = "chromium-browser.desktop";
+  if (!desktop_id.empty() && (desktop_id != libcc_default_id))
+    ret = g_desktop_app_info_new(desktop_id.c_str());
+
+  return ret;
 }
 
 }  // namespace

--- a/atom/common/linux/application_info.cc
+++ b/atom/common/linux/application_info.cc
@@ -13,6 +13,7 @@
 #include "atom/common/atom_version.h"
 #include "base/environment.h"
 #include "base/logging.h"
+#include "brightray/common/platform_util.h"
 #include "chrome/browser/ui/libgtkui/gtk_util.h"
 
 namespace {
@@ -20,10 +21,8 @@ namespace {
 GDesktopAppInfo* get_desktop_app_info() {
   GDesktopAppInfo * ret = nullptr;
 
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
-  const std::string desktop_id = libgtkui::GetDesktopName(env.get());
-  const char * libcc_default_id = "chromium-browser.desktop";
-  if (!desktop_id.empty() && (desktop_id != libcc_default_id))
+  std::string desktop_id;
+  if (brightray::platform_util::GetDesktopName(&desktop_id))
     ret = g_desktop_app_info_new(desktop_id.c_str());
 
   return ret;

--- a/brightray/browser/linux/libnotify_notification.cc
+++ b/brightray/browser/linux/libnotify_notification.cc
@@ -8,13 +8,13 @@
 #include <string>
 #include <vector>
 
-#include "base/environment.h"
 #include "base/files/file_enumerator.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/notification_delegate.h"
 #include "brightray/common/application_info.h"
+#include "brightray/common/platform_util.h"
 #include "chrome/browser/ui/libgtkui/gtk_util.h"
 #include "chrome/browser/ui/libgtkui/skia_utils_gtk.h"
 #include "third_party/skia/include/core/SkBitmap.h"
@@ -130,9 +130,8 @@ void LibnotifyNotification::Show(const NotificationOptions& options) {
 
   // Send the desktop name to identify the application
   // The desktop-entry is the part before the .desktop
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
-  std::string desktop_id = libgtkui::GetDesktopName(env.get());
-  if (!desktop_id.empty()) {
+  std::string desktop_id;
+  if (platform_util::GetDesktopName(&desktop_id)) {
     const std::string suffix{".desktop"};
     if (base::EndsWith(desktop_id, suffix,
                        base::CompareCase::INSENSITIVE_ASCII)) {

--- a/brightray/common/application_info.cc
+++ b/brightray/common/application_info.cc
@@ -7,8 +7,9 @@ namespace {
 std::string g_overridden_application_name;
 std::string g_overridden_application_version;
 
-}
+}  // namespace
 
+// name
 void OverrideApplicationName(const std::string& name) {
   g_overridden_application_name = name;
 }
@@ -16,6 +17,7 @@ std::string GetOverriddenApplicationName() {
   return g_overridden_application_name;
 }
 
+// version
 void OverrideApplicationVersion(const std::string& version) {
   g_overridden_application_version = version;
 }

--- a/brightray/common/application_info_win.cc
+++ b/brightray/common/application_info_win.cc
@@ -47,10 +47,7 @@ PCWSTR GetRawAppUserModelID() {
     if (SUCCEEDED(GetCurrentProcessExplicitAppUserModelID(&current_app_id))) {
       g_app_user_model_id = current_app_id;
     } else {
-      std::string name = GetOverriddenApplicationName();
-      if (name.empty()) {
-        name = GetApplicationName();
-      }
+      std::string name = GetApplicationName();
       base::string16 generated_app_id = base::ReplaceStringPlaceholders(
         kAppUserModelIDFormat, base::UTF8ToUTF16(name), nullptr);
       SetAppUserModelID(generated_app_id);

--- a/brightray/common/platform_util.h
+++ b/brightray/common/platform_util.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef BRIGHTRAY_COMMON_PLATFORM_UTIL_H_
+#define BRIGHTRAY_COMMON_PLATFORM_UTIL_H_
+
+#include <string>
+
+namespace brightray {
+
+namespace platform_util {
+
+#if defined(OS_LINUX)
+// Returns a success flag.
+// Unlike libgtkui, does *not* use "chromium-browser.desktop" as a fallback.
+bool GetDesktopName(std::string* setme);
+#endif
+
+}  // namespace platform_util
+
+}  // namespace brightray
+
+#endif  // BRIGHTRAY_COMMON_PLATFORM_UTIL_H_

--- a/brightray/common/platform_util_linux.cc
+++ b/brightray/common/platform_util_linux.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "brightray/common/platform_util.h"
+
+#include "base/environment.h"
+#include "chrome/browser/ui/libgtkui/gtk_util.h"
+
+namespace brightray {
+
+namespace platform_util {
+
+bool GetDesktopName(std::string* setme) {
+  bool found = false;
+
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  std::string desktop_id = libgtkui::GetDesktopName(env.get());
+  constexpr char const* libcc_default_id = "chromium-browser.desktop";
+  if (!desktop_id.empty() && (desktop_id != libcc_default_id)) {
+    *setme = desktop_id;
+    found = true;
+  }
+
+  return found;
+}
+
+}  // namespace platform_util
+
+}  // namespace brightray

--- a/brightray/filenames.gypi
+++ b/brightray/filenames.gypi
@@ -124,6 +124,8 @@
       'common/main_delegate_mac.mm',
       'common/switches.cc',
       'common/switches.h',
+      'common/platform_util_linux.cc',
+      'common/platform_util.h',
     ],
   },
 }

--- a/script/lib/dbus_mock.py
+++ b/script/lib/dbus_mock.py
@@ -1,13 +1,22 @@
+from config import is_verbose_mode
 from dbusmock import DBusTestCase
 
 import atexit
+import os
+import sys
+
 
 def cleanup():
     DBusTestCase.stop_dbus(DBusTestCase.system_bus_pid)
+    DBusTestCase.stop_dbus(DBusTestCase.session_bus_pid)
 
 
 atexit.register(cleanup)
+
+dbusmock_log = sys.stdout if is_verbose_mode() else open(os.devnull, 'w')
+
 DBusTestCase.start_system_bus()
-# create a mock for "org.freedesktop.login1" using python-dbusmock
-# preconfigured template
-(logind_mock, logind) = DBusTestCase.spawn_server_template('logind')
+DBusTestCase.spawn_server_template('logind', None, dbusmock_log)
+
+DBusTestCase.start_session_bus()
+DBusTestCase.spawn_server_template('notification_daemon', None, dbusmock_log)

--- a/script/test.py
+++ b/script/test.py
@@ -38,6 +38,7 @@ def main():
 
   if args.verbose:
     enable_verbose_mode()
+    os.environ['ELECTRON_ENABLE_LOGGING'] = '1'
 
   spec_modules = os.path.join(SOURCE_ROOT, 'spec', 'node_modules')
   if args.rebuild_native_modules or not os.path.isdir(spec_modules):

--- a/spec/api-notification-dbus-spec.js
+++ b/spec/api-notification-dbus-spec.js
@@ -1,0 +1,122 @@
+// For these tests we use a fake DBus daemon to verify libnotify interaction
+// with the session bus. This requires python-dbusmock to be installed and
+// running at $DBUS_SESSION_BUS_ADDRESS.
+//
+// script/test.py spawns dbusmock, which sets DBUS_SESSION_BUS_ADDRESS.
+//
+// See https://pypi.python.org/pypi/python-dbusmock to read about dbusmock.
+
+const assert = require('assert')
+const dbus = require('dbus-native')
+const Promise = require('bluebird')
+
+const {remote} = require('electron')
+const {app} = remote.require('electron')
+
+const skip = process.platform !== 'linux' ||
+             process.arch === 'ia32' ||
+             !process.env.DBUS_SESSION_BUS_ADDRESS;
+
+(skip ? describe.skip : describe)('Notification module (dbus)', () => {
+  let mock, Notification, getCalls, reset
+  const realAppName = app.getName()
+  const realAppVersion = app.getVersion()
+  const appName = 'api-notification-dbus-spec'
+  const serviceName = 'org.freedesktop.Notifications'
+
+  before(async () => {
+    // init app
+    app.setName(appName)
+    app.setDesktopName(appName + '.desktop')
+    // init dbus
+    const path = '/org/freedesktop/Notifications'
+    const iface = 'org.freedesktop.DBus.Mock'
+    const bus = dbus.sessionBus()
+    console.log('session bus: ' + process.env.DBUS_SESSION_BUS_ADDRESS)
+    const service = bus.getService(serviceName)
+    const getInterface = Promise.promisify(service.getInterface, {context: service})
+    mock = await getInterface(path, iface)
+    getCalls = Promise.promisify(mock.GetCalls, {context: mock})
+    reset = Promise.promisify(mock.Reset, {context: mock})
+  })
+
+  after(async () => {
+    // cleanup dbus
+    await reset()
+    // cleanup app
+    app.setName(realAppName)
+    app.setVersion(realAppVersion)
+  })
+
+  describe('Notification module using ' + serviceName, () => {
+    function onMethodCalled (done) {
+      function cb (name) {
+        console.log('onMethodCalled: ' + name)
+        if (name === 'Notify') {
+          mock.removeListener('MethodCalled', cb)
+          console.log('done')
+          done()
+        }
+      }
+      return cb
+    }
+
+    function unmarshalDBusNotifyHints (dbusHints) {
+      let o = {}
+      for (let hint of dbusHints) {
+        let key = hint[0]
+        let value = hint[1][1][0]
+        o[key] = value
+      }
+      return o
+    }
+
+    function unmarshalDBusNotifyArgs (dbusArgs) {
+      return {
+        app_name: dbusArgs[0][1][0],
+        replaces_id: dbusArgs[1][1][0],
+        app_icon: dbusArgs[2][1][0],
+        title: dbusArgs[3][1][0],
+        body: dbusArgs[4][1][0],
+        actions: dbusArgs[5][1][0],
+        hints: unmarshalDBusNotifyHints(dbusArgs[6][1][0])
+      }
+    }
+
+    before((done) => {
+      mock.on('MethodCalled', onMethodCalled(done))
+      // lazy load Notification after we listen to MethodCalled mock signal
+      Notification = require('electron').remote.Notification
+      const n = new Notification({
+        title: 'title',
+        subtitle: 'subtitle',
+        body: 'body',
+        replyPlaceholder: 'replyPlaceholder',
+        sound: 'sound',
+        closeButtonText: 'closeButtonText'
+      })
+      n.show()
+    })
+
+    it('should call ' + serviceName + ' to show notifications', async () => {
+      const calls = await getCalls()
+      assert(calls.length >= 1)
+      let lastCall = calls[calls.length - 1]
+      let methodName = lastCall[1]
+      assert.equal(methodName, 'Notify')
+      let args = unmarshalDBusNotifyArgs(lastCall[2])
+      assert.deepEqual(args, {
+        app_name: appName,
+        replaces_id: 0,
+        app_icon: '',
+        title: 'title',
+        body: 'body',
+        actions: [],
+        hints: {
+          'append': 'true',
+          'desktop-entry': appName
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
Cherry-picks the three sections of the linux notification cleanup:
5f48f91d948db9cca3266b324dabf8f26f9768bd bumps the docker images for libnotify in CI tests
86af20ded062598fbc71244fd180e3e608954ba6 is the main fix
dd2c2660b91647acd97d1ed109e540888a055328 handles an edge case and eliminates duplicate code