### PR TITLE
Fix broken links

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -133,7 +133,7 @@ Some popular `key` and `type`s are:
 ### `systemPreferences.setUserDefault(key, type, value)` _macOS_
 
 * `key` String
-* `type` String - See [`getUserDefault`][#systempreferencesgetuserdefaultkey-type-macos].
+* `type` String - See [`getUserDefault`](#systempreferencesgetuserdefaultkey-type-macos).
 * `value` String
 
 Set the value of `key` in `NSUserDefaults`.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -8,7 +8,7 @@ all ship apps with fewer bugs.
 
 This repository comes with linting rules for both JavaScript and C++ –
 as well as unit and integration tests. To learn more about Electron's
-coding style, please see the [coding-style(coding-style.md) document.
+coding style, please see the [coding-style](coding-style.md) document.
 
 ## Linting
 To ensure that your JavaScript is in compliance with the Electron coding

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -46,3 +46,4 @@ of `app` module will be emitted for it.
 [dock-menu-image]: https://cloud.githubusercontent.com/assets/639601/5069610/2aa80758-6e97-11e4-8cfb-c1a414a10774.png
 [addrecentdocument]: ../api/app.md#appaddrecentdocumentpath-macos-windows
 [clearrecentdocuments]: ../api/app.md#appclearrecentdocuments-macos-windows
+[app-registration]: https://msdn.microsoft.com/en-us/library/cc144104(VS.85).aspx


### PR DESCRIPTION
There's also a broken one in [/docs/tutorial/recent-documents.md](https://github.com/electron/electron/blob/master/docs/tutorial/recent-documents.md#windows-notes), but I'm not sure what that should link to. Feel free to add to this PR.