### PR TITLE
fix: Incorrect warnings in webviews

### DIFF
--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -84,7 +84,7 @@ const getWebPreferences = function () {
     }
 
     const { remote } = require('electron')
-    webPreferences = remote.getCurrentWindow().webContents.getWebPreferences()
+    webPreferences = remote.getCurrentWebContents()
     return webPreferences
   } catch (error) {
     return null

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -84,7 +84,7 @@ const getWebPreferences = function () {
     }
 
     const { remote } = require('electron')
-    webPreferences = remote.getCurrentWebContents()
+    webPreferences = remote.getCurrentWebContents().getWebPreferences()
     return webPreferences
   } catch (error) {
     return null


### PR DESCRIPTION
This PR fixes incorrect security warnings in `webContents` that aren't the current window's `webContents`. It is unclear to me why I didn't just call `getCurrentWebContents()` to begin with.

Closes https://github.com/electron/electron/issues/12200