### PR TITLE
fix: Ensure that `getLastCrashReport()` is actually the last crash report

### DIFF
--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -65,6 +65,12 @@ class CrashReporter {
 
   getLastCrashReport () {
     const reports = this.getUploadedReports()
+      .sort((a, b) => {
+        const ats = (a && a.timestamp) ? new Date(a.timestamp).getTime() : 0
+        const bts = (b && b.timestamp) ? new Date(b.timestamp).getTime() : 0
+        return bts - ats
+      })
+
     return (reports.length > 0) ? reports[0] : null
   }
 

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -66,8 +66,8 @@ class CrashReporter {
   getLastCrashReport () {
     const reports = this.getUploadedReports()
       .sort((a, b) => {
-        const ats = (a && a.timestamp) ? new Date(a.timestamp).getTime() : 0
-        const bts = (b && b.timestamp) ? new Date(b.timestamp).getTime() : 0
+        const ats = (a && a.date) ? new Date(a.date).getTime() : 0
+        const bts = (b && b.date) ? new Date(b.date).getTime() : 0
         return bts - ats
       })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -259,8 +259,11 @@ describe('crashReporter module', () => {
   describe('getLastCrashReport', () => {
     it('correctly returns the most recent report', () => {
       const reports = crashReporter.getUploadedReports()
-      const lastReport = reports[0]
+      const lastReport = crashReporter.getLastCrashReport()
+
+      // In our case, the first report is actually the newest\
       assert(lastReport != null)
+      assert(lastReport === reports[0])
     })
   })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -263,15 +263,15 @@ describe('crashReporter module', () => {
 
       // Let's find the newest report
       const newestReport = reports.reduce((acc, cur) => {
-        const timestamp = new Date(cur.timestamp).getTime();
+        const timestamp = new Date(cur.date).getTime();
         return (timestamp > acc.timestamp)
           ? { report: cur, timestamp: timestamp }
           : acc
       }, { timestamp: 0 })
 
-      // In our case, the first report is actually the newest
+
       assert(lastReport != null)
-      assert(lastReport === newestReport.report)
+      assert(lastReport.date.toString() === newestReport.report.date.toString())
     })
   })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -261,9 +261,17 @@ describe('crashReporter module', () => {
       const reports = crashReporter.getUploadedReports()
       const lastReport = crashReporter.getLastCrashReport()
 
+      // Let's find the newest report
+      const newestReport = reports.reduce((acc, cur) => {
+        const timestamp = new Date(cur.timestamp).getTime();
+        return (timestamp > acc.timestamp)
+          ? { report: cur, timestamp: timestamp }
+          : acc
+      }, { timestamp: 0 })
+
       // In our case, the first report is actually the newest
       assert(lastReport != null)
-      assert(lastReport === reports[0])
+      assert(lastReport === newestReport.report)
     })
   })
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -263,12 +263,11 @@ describe('crashReporter module', () => {
 
       // Let's find the newest report
       const newestReport = reports.reduce((acc, cur) => {
-        const timestamp = new Date(cur.date).getTime();
+        const timestamp = new Date(cur.date).getTime()
         return (timestamp > acc.timestamp)
           ? { report: cur, timestamp: timestamp }
           : acc
       }, { timestamp: 0 })
-
 
       assert(lastReport != null)
       assert(lastReport.date.toString() === newestReport.report.date.toString())

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -261,7 +261,7 @@ describe('crashReporter module', () => {
       const reports = crashReporter.getUploadedReports()
       const lastReport = crashReporter.getLastCrashReport()
 
-      // In our case, the first report is actually the newest\
+      // In our case, the first report is actually the newest
       assert(lastReport != null)
       assert(lastReport === reports[0])
     })


### PR DESCRIPTION
This PR fixes https://github.com/electron/electron/issues/11749 by ensuring that `getLastCrashReport()` actually returns the last crash report (and not just a certain position in the array).

Also: A test that actually calls the method under test 😅 