### PR TITLE
browser: fix crash when using getWebPreferences api with devtools webContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1787,6 +1787,8 @@ void WebContents::OnGetZoomLevel(IPC::Message* reply_msg) {
 v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
   WebContentsPreferences* web_preferences =
       WebContentsPreferences::FromWebContents(web_contents());
+  if (!web_preferences)
+    return v8::Null(isolate);
   return mate::ConvertToV8(isolate, *web_preferences->web_preferences());
 }
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -116,6 +116,16 @@ describe('webContents module', () => {
     })
   })
 
+  describe('getWebPreferences() API', () => {
+    it('should not crash when called for devTools webContents', (done) => {
+      w.webContents.openDevTools()
+      w.webContents.once('devtools-opened', () => {
+        assert(!w.devToolsWebContents.getWebPreferences())
+        done()
+      })
+    })
+  })
+
   describe('before-input-event event', () => {
     it('can prevent document keyboard events', (done) => {
       w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'key-events.html')}`)


### PR DESCRIPTION
Ref https://github.com/electron/electron/pull/12245

/cc @codebytere 