### PR TITLE
Document BrowserView.{destroy,isDestroyed}

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -73,6 +73,16 @@ A `Integer` representing the unique ID of the view.
 
 Objects created with `new BrowserView` have the following instance methods:
 
+#### `view.destroy()`
+
+Force closing the view, the `unload` and `beforeunload` events won't be emitted
+for the web page. After you're done with a view, call this function in order to
+free memory and other resources as soon as possible.
+
+#### `view.isDestroyed()`
+
+Returns `Boolean` - Whether the view is destroyed.
+
 #### `view.setAutoResize(options)` _Experimental_
 
 * `options` Object

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -30,6 +30,22 @@ describe('BrowserView module', () => {
     return closeWindow(w).then(() => { w = null })
   })
 
+  describe('BrowserView.destroy()', () => {
+    it('does not throw', () => {
+      view = new BrowserView()
+      view.destroy()
+    })
+  })
+
+  describe('BrowserView.isDestroyed()', () => {
+    it('returns correct value', () => {
+      view = new BrowserView()
+      assert.ok(!view.isDestroyed())
+      view.destroy()
+      assert.ok(view.isDestroyed())
+    })
+  })
+
   describe('BrowserView.setBackgroundColor()', () => {
     it('does not throw for valid args', () => {
       view = new BrowserView()


### PR DESCRIPTION
This fixes #10096.

Note that we haven't addressed [this comment](https://github.com/electron/electron/issues/10096#issuecomment-320163081) yet. I'll do that in a separate PR.