### PR TITLE
docs: Document Python TLS requirements

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -7,6 +7,19 @@ Follow the guidelines below for building Electron on Linux.
 * At least 25GB disk space and 8GB RAM.
 * Python 2.7.x. Some distributions like CentOS 6.x still use Python 2.6.x
   so you may need to check your Python version with `python -V`.
+
+  Please also ensure that your system and Python version support at least TLS 1.2.
+  For a quick test, run the following script:
+
+  ```sh
+  $ python ./script/check-tls.py
+  ```
+
+  If the script returns that your configuration is using an outdated security
+  protocol, use your system's package manager to update Python to the latest
+  version in the 2.7.x branch. Alternatively, visit https://www.python.org/downloads/
+  for detailed instructions.
+
 * Node.js. There are various ways to install Node. You can download
   source code from [nodejs.org](https://nodejs.org) and compile it.
   Doing so permits installing Node on your own home directory as a standard user.

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -7,8 +7,26 @@ Follow the guidelines below for building Electron on macOS.
 * macOS >= 10.11.6
 * [Xcode](https://developer.apple.com/technologies/tools/) >= 8.2.1
 * [node.js](https://nodejs.org) (external)
+* Python 2.7 with support for TLS 1.2
 
-If you are using the Python downloaded by Homebrew, you also need to install
+## Python
+
+Please also ensure that your system and Python version support at least TLS 1.2.
+This depends on both your version of macOS and Python. For a quick test, run:
+
+```sh
+$ python ./script/check-tls.py
+```
+
+If the script returns that your configuration is using an outdated security
+protocol, you can either update macOS to High Sierra or install a new version
+of Python 2.7.x. To upgrade Python, use [Homebrew](https://brew.sh/):
+
+```sh
+$ brew install python@2 && brew link python@2 --force
+```
+
+If you are using Python as provided by Homebrew, you also need to install
 the following Python modules:
 
 * [pyobjc](https://pythonhosted.org/pyobjc/install.html)

--- a/script/check-tls.py
+++ b/script/check-tls.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import json
+import urllib2
+import sys
+
+def main():
+  tls = json.load(urllib2.urlopen('https://www.howsmyssl.com/a/check'))['tls_version']
+
+  if sys.platform == "linux" or sys.platform == "linux2":
+    tutorial = "./docs/development/build-instructions-linux.md"
+  elif sys.platform == "darwin":
+    tutorial = "./docs/development/build-instructions-osx.md"
+  elif sys.platform == "win32":
+    tutorial = "./docs/development/build-instructions-windows.md"
+  else:
+    tutorial = "build instructions for your operation system in ./docs/development/"
+
+  if tls == "TLS 1.2":
+    print "Your system/python combination is using an outdated security protocol and will not"
+    print "be able to compile Electron. Please see " + tutorial + "."
+    print "for instructions on how to update Python."
+    sys.exit(1)
+  else:
+    print "Your Python is using " + tls + ", which is sufficient for building Electron."
+    sys.exit(0)
+
+if __name__ == '__main__':
+  main()

--- a/script/check-tls.py
+++ b/script/check-tls.py
@@ -16,7 +16,7 @@ def main():
   else:
     tutorial = "build instructions for your operation system in ./docs/development/"
 
-  if tls == "TLS 1.2":
+  if tls == "TLS 1.0":
     print "Your system/python combination is using an outdated security protocol and will not"
     print "be able to compile Electron. Please see " + tutorial + "."
     print "for instructions on how to update Python."


### PR DESCRIPTION
This PR provides a simple test script that confirms for people whether or not they need to update Python as well as documentation for how to do so. 

Just recommending to update Python for all users is a bit of overkill - users on High Sierra are fine even with an older version of Python, Linux users _may_ be fine with whatever version they have, and Windows users are (as far as I can tell) fine no matter what.

So, new script:

```sh
$ python .\script\check-tls.py
$ Your Python is using TLS 1.2, which is sufficient for building Electron.
```

If things don't look good:

```sh
$ python .\script\check-tls.py
Your system/python combination is using an outdated security protocol and will not
be able to compile Electron. Please see ./docs/development/build-instructions-osx.md.
```

Closes https://github.com/electron/electron/issues/12079