### PR TITLE
Mouse forward on macOS

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -88,7 +88,7 @@ class NativeWindowMac : public NativeWindow {
   std::string GetRepresentedFilename() override;
   void SetDocumentEdited(bool edited) override;
   bool IsDocumentEdited() override;
-  void SetIgnoreMouseEvents(bool ignore, bool) override;
+  void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   void SetContentProtection(bool enable) override;
   void SetBrowserView(NativeBrowserView* browser_view) override;
   void SetParentWindow(NativeWindow* parent) override;
@@ -141,6 +141,8 @@ class NativeWindowMac : public NativeWindow {
   void ShowWindowButton(NSWindowButton button);
 
   void InstallView(NSView* view);
+
+  void SetForwardMouseMessages(bool forward);
 
   base::scoped_nsobject<AtomNSWindow> window_;
   base::scoped_nsobject<AtomNSWindowDelegate> window_delegate_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1482,8 +1482,14 @@ bool NativeWindowMac::IsDocumentEdited() {
   return [window_ isDocumentEdited];
 }
 
-void NativeWindowMac::SetIgnoreMouseEvents(bool ignore, bool) {
+void NativeWindowMac::SetIgnoreMouseEvents(bool ignore, bool forward) {
   [window_ setIgnoresMouseEvents:ignore];
+
+  if (!ignore) {
+    SetForwardMouseMessages(NO);
+  } else {
+    SetForwardMouseMessages(forward);
+  }
 }
 
 void NativeWindowMac::SetContentProtection(bool enable) {
@@ -1818,6 +1824,10 @@ void NativeWindowMac::InstallView(NSView* view) {
     // prevent them from doing so in a frameless app window.
     [[window_ standardWindowButton:NSWindowZoomButton] setEnabled:NO];
   }
+}
+
+void NativeWindowMac::SetForwardMouseMessages(bool forward) {
+  [window_ setAcceptsMouseMovedEvents:forward];
 }
 
 void NativeWindowMac::SetStyleMask(bool on, NSUInteger flag) {

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1378,10 +1378,10 @@ Returns `Boolean` - Whether the window is visible on all workspaces.
 
 * `ignore` Boolean
 * `options` Object (optional)
-  * `forward` Boolean (optional) _Windows_ - If true, forwards mouse move
+  * `forward` Boolean (optional) _macOS_ _Windows_ - If true, forwards mouse move
     messages to Chromium, enabling mouse related events such as `mouseleave`.
-	Only used when `ignore` is true. If `ignore` is false, forwarding is always
-	disabled regardless of this value.
+    Only used when `ignore` is true. If `ignore` is false, forwarding is always
+    disabled regardless of this value.
 
 Makes the window ignore all mouse events.
 


### PR DESCRIPTION
This enables the equivalent mouse forward functionality that already exists on Windows, but for macOS instead. I originally had my sights on using a monitor for move events similarly to the hook on Windows, but it seems that it was enough to accept mouse move events (despite otherwise ignoring mouse related events).

I tried this on a virtual machine, but I would very much like some feedback from somebody that actually uses Mac before this is merged. It seems to work as intended, although the mouse cursor does not adapt to what is beneath the window as it does on Windows. Maybe this has always been the case?

I still need to update documentation to reflect this, but I wanted to put it up here before that so that somebody else could try it out on a real Mac. I can link to a test application tomorrow.

Edit: [Here](https://github.com/andens/electron-mouse-forward-example) is a small test application. An area of the page is transparent. When entering this area, forwarding begins (click-through). When leaving the transparent area—the "I block input" box included—forwarding stops and the application becomes the target of clicks as usual.