### PR TITLE
Fix require on network share path

### DIFF
--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -141,18 +141,16 @@ if (nodeIntegration === 'true') {
 
   // Set the __filename to the path of html file if it is file: protocol.
   if (window.location.protocol === 'file:') {
-    let pathname
-    const loc = window.location
-    if (process.platform === 'win32') {
-      if (loc.pathname[0] === '/') {
-        pathname = loc.pathname.substr(1)
-      }
+    const location = window.location
+    let pathname = location.pathname
 
-      if (loc.hostname.length > 0 && globalPaths[0].startsWith('\\')) {
-        pathname = `//${loc.host}/${pathname}`
+    if (process.platform === 'win32') {
+      if (pathname[0] === '/') pathname = pathname.substr(1)
+
+      const isWindowsNetworkSharePath = location.hostname.length > 0 && globalPaths[0].startsWith('\\')
+      if (isWindowsNetworkSharePath) {
+        pathname = `//${location.host}/${pathname}`
       }
-    } else {
-      pathname = loc.pathname
     }
 
     global.__filename = path.normalize(decodeURIComponent(pathname))

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -141,7 +141,20 @@ if (nodeIntegration === 'true') {
 
   // Set the __filename to the path of html file if it is file: protocol.
   if (window.location.protocol === 'file:') {
-    var pathname = process.platform === 'win32' && window.location.pathname[0] === '/' ? window.location.pathname.substr(1) : window.location.pathname
+    let pathname
+    const loc = window.location
+    if (process.platform === 'win32') {
+      if (loc.pathname[0] === '/') {
+        pathname = loc.pathname.substr(1)
+      }
+
+      if (loc.hostname.length > 0 && globalPaths[0].startsWith('\\')) {
+        pathname = `//${loc.host}/${pathname}`
+      }
+    } else {
+      pathname = loc.pathname
+    }
+
     global.__filename = path.normalize(decodeURIComponent(pathname))
     global.__dirname = path.dirname(global.__filename)
 


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/12268.
Closes https://github.com/electron/electron/issues/3043.

This PR fixes an issue such that when an Electron executable is run through a server/network share path formatted as`\\SERVERNAME\appdir\appname.exe`, `require` runs into
> Cannot find module 

errors.

/cc @ckerr 