### PR TITLE
refactor showSaveDialog and showOpendialog

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -23,10 +23,10 @@ console.log(dialog)
 
 The `dialog` module has the following methods:
 
-### `dialog.showOpenDialog([browserWindow, ]options[, callback])`
+### `dialog.showOpenDialog(options)`
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
+  * `browserWindow` [BrowserWindow](browser-window.md) (optional)
   * `title` String (optional)
   * `defaultPath` String (optional)
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
@@ -51,9 +51,9 @@ The `dialog` module has the following methods:
   * `message` String (optional) _macOS_ - Message to display above input
     boxes.
   * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
-* `callback` Function (optional)
-  * `filePaths` String[] - An array of file paths chosen by the user
-  * `bookmarks` String[] _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated.
+  * `callback` Function (optional)
+    * `filePaths` String[] - An array of file paths chosen by the user
+    * `bookmarks` String[] _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated.
 
 Returns `String[]`, an array of file paths chosen by the user,
 if the callback is provided it returns `undefined`.
@@ -86,10 +86,10 @@ and a directory selector, so if you set `properties` to
 `['openFile', 'openDirectory']` on these platforms, a directory selector will be
 shown.
 
-### `dialog.showSaveDialog([browserWindow, ]options[, callback])`
+### `dialog.showSaveDialog(options)`
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
+  * `browserWindow` [BrowserWindow](browser-window.md) (optional)
   * `title` String (optional)
   * `defaultPath` String (optional) - Absolute directory path, absolute file
     path, or file name to use by default.
@@ -102,9 +102,9 @@ shown.
   * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
     defaults to `true`.
   * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
-* `callback` Function (optional)
-  * `filename` String
-  * `bookmark` String _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present.
+  * `callback` Function (optional)
+    * `filename` String
+    * `bookmark` String _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present.
 
 Returns `String`, the path of the file chosen by the user,
 if a callback is provided it returns `undefined`.
@@ -117,10 +117,10 @@ The `filters` specifies an array of file types that can be displayed, see
 If a `callback` is passed, the API call will be asynchronous and the result
 will be passed via `callback(filename)`.
 
-### `dialog.showMessageBox([browserWindow, ]options[, callback])`
+### `dialog.showMessageBox(options)`
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
+  * `browserWindow` [BrowserWindow](browser-window.md) (optional)
   * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
   `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
   you set an icon using the `"icon"` option. On macOS, both `"warning"` and
@@ -155,10 +155,10 @@ will be passed via `callback(filename)`.
     untouched on Windows. For example, a button label of `Vie&w` will be
     converted to `Vie_w` on Linux and `View` on macOS and can be selected
     via `Alt-W` on Windows and Linux.
-* `callback` Function (optional)
-  * `response` Number - The index of the button that was clicked.
-  * `checkboxChecked` Boolean - The checked state of the checkbox if
-    `checkboxLabel` was set. Otherwise `false`.
+  * `callback` Function (optional)
+    * `response` Number - The index of the button that was clicked.
+    * `checkboxChecked` Boolean - The checked state of the checkbox if
+      `checkboxLabel` was set. Otherwise `false`.
 
 Returns `Integer`, the index of the clicked button, if a callback is provided
 it returns undefined.

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -70,111 +70,66 @@ const checkAppInitialized = function () {
   }
 }
 
-module.exports = {
-  showOpenDialog: function (...args) {
-    checkAppInitialized()
+const setupDialog = (type, args) => {
+  let {
+    window,
+    buttonLabel,
+    defaultPath,
+    filters,
+    properties,
+    title,
+    message,
+    securityScopedBookmarks = false,
+    callback,
+    nameFieldLabel,
+    showsTagField
+  } = args
 
-    let [window, options, callback] = parseArgs(...args)
+  if (properties == null) {
+    properties = (type === 'open') ? ['openFile'] : ['saveFile']
+  } else if (!Array.isArray(properties)) {
+    throw new TypeError('Properties must be an array')
+  }
 
-    if (options == null) {
-      options = {
-        title: 'Open',
-        properties: ['openFile']
-      }
-    }
-
-    let {buttonLabel, defaultPath, filters, properties, title, message, securityScopedBookmarks = false} = options
-
-    if (properties == null) {
-      properties = ['openFile']
-    } else if (!Array.isArray(properties)) {
-      throw new TypeError('Properties must be an array')
-    }
-
-    let dialogProperties = 0
+  let dialogProperties = 0
+  // set up dialogProperties for showOpenDialog
+  if (type === 'open') {
     for (const prop in fileDialogProperties) {
       if (properties.includes(prop)) {
         dialogProperties |= fileDialogProperties[prop]
       }
     }
+  }
 
-    if (title == null) {
-      title = ''
-    } else if (typeof title !== 'string') {
-      throw new TypeError('Title must be a string')
-    }
+  if (filters == null) filters = []
 
-    if (buttonLabel == null) {
-      buttonLabel = ''
-    } else if (typeof buttonLabel !== 'string') {
-      throw new TypeError('Button label must be a string')
-    }
+  if (title == null) {
+    title = ''
+  } else if (typeof title !== 'string') {
+    throw new TypeError('Title must be a string')
+  }
 
-    if (defaultPath == null) {
-      defaultPath = ''
-    } else if (typeof defaultPath !== 'string') {
-      throw new TypeError('Default path must be a string')
-    }
+  if (buttonLabel == null) {
+    buttonLabel = ''
+  } else if (typeof buttonLabel !== 'string') {
+    throw new TypeError('Button label must be a string')
+  }
 
-    if (filters == null) {
-      filters = []
-    }
+  if (defaultPath == null) {
+    defaultPath = ''
+  } else if (typeof defaultPath !== 'string') {
+    throw new TypeError('Default path must be a string')
+  }
 
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
-      throw new TypeError('Message must be a string')
-    }
+  if (message == null) {
+    message = ''
+  } else if (typeof message !== 'string') {
+    throw new TypeError('Message must be a string')
+  }
 
-    const wrappedCallback = typeof callback === 'function' ? function (success, result, bookmarkData) {
-      return success ? callback(result, bookmarkData) : callback()
-    } : null
-    const settings = {title, buttonLabel, defaultPath, filters, message, securityScopedBookmarks, window}
-    settings.properties = dialogProperties
-    return binding.showOpenDialog(settings, wrappedCallback)
-  },
-
-  showSaveDialog: function (...args) {
-    checkAppInitialized()
-
-    let [window, options, callback] = parseArgs(...args)
-
-    if (options == null) {
-      options = {
-        title: 'Save'
-      }
-    }
-
-    let {buttonLabel, defaultPath, filters, title, message, securityScopedBookmarks = false, nameFieldLabel, showsTagField} = options
-
-    if (title == null) {
-      title = ''
-    } else if (typeof title !== 'string') {
-      throw new TypeError('Title must be a string')
-    }
-
-    if (buttonLabel == null) {
-      buttonLabel = ''
-    } else if (typeof buttonLabel !== 'string') {
-      throw new TypeError('Button label must be a string')
-    }
-
-    if (defaultPath == null) {
-      defaultPath = ''
-    } else if (typeof defaultPath !== 'string') {
-      throw new TypeError('Default path must be a string')
-    }
-
-    if (filters == null) {
-      filters = []
-    }
-
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
-      throw new TypeError('Message must be a string')
-    }
-
+  // set up extra parameters for showSaveDialog
+  if (type === 'save') {
+    console.log(typeof nameFieldLabel)
     if (nameFieldLabel == null) {
       nameFieldLabel = ''
     } else if (typeof nameFieldLabel !== 'string') {
@@ -184,11 +139,53 @@ module.exports = {
     if (showsTagField == null) {
       showsTagField = true
     }
+  }
 
-    const wrappedCallback = typeof callback === 'function' ? function (success, result, bookmarkData) {
-      return success ? callback(result, bookmarkData) : callback()
-    } : null
-    const settings = {title, buttonLabel, defaultPath, filters, message, securityScopedBookmarks, nameFieldLabel, showsTagField, window}
+  let wrappedCallback = null
+  if (typeof callback === 'function') {
+    wrappedCallback = (success, result, bookmarkData) => success ? callback(result, bookmarkData) : callback()
+  }
+
+  let settings
+  if (type === 'open') {
+    settings = {window, buttonLabel, defaultPath, filters, properties, title, message, securityScopedBookmarks, callback}
+  } else {
+    settings = {window, buttonLabel, defaultPath, filters, properties, title, message, securityScopedBookmarks, callback, nameFieldLabel, showsTagField}
+  }
+
+  return {settings, dialogProperties, wrappedCallback}
+}
+
+module.exports = {
+  showOpenDialog: function (args) {
+    let options = args
+    checkAppInitialized()
+
+    if (options == null) {
+      options = {
+        title: 'Open',
+        properties: ['openFile']
+      }
+    }
+
+    const {settings, dialogProperties, wrappedCallback} = setupDialog('open', options)
+
+    settings.properties = dialogProperties
+    return binding.showOpenDialog(settings, wrappedCallback)
+  },
+
+  showSaveDialog: function (args) {
+    let options = args
+    checkAppInitialized()
+
+    if (options == null) {
+      options = {
+        title: 'Save'
+      }
+    }
+
+    const {settings, wrappedCallback} = setupDialog('save', options)
+
     return binding.showSaveDialog(settings, wrappedCallback)
   },
 

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -176,14 +176,16 @@ module.exports = {
       throw new TypeError('Detail must be a string')
     }
     if (typeof checkboxLabel !== 'string') {
-      throw new TypeError('checkboxLabel must be a string')
+      throw new TypeError('Checkbox label must be a string')
     }
+    if (typeof checkboxChecked !== 'boolean') {
+      throw new TypeError('Checkbox checked value must be a boolean')
+    }
+    checkboxChecked = !!checkboxChecked
 
     if (normalizeAccessKeys) {
       buttons = buttons.map(normalizeAccessKey)
     }
-
-    checkboxChecked = !!checkboxChecked
 
     // Choose a default button to get selected when dialog is cancelled.
     if (cancelId == null) {

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -15,6 +15,11 @@ const fileDialogProperties = {
   treatPackageAsDirectory: 1 << 7
 }
 
+const Type = {
+  OPEN: 'open',
+  SAVE: 'save'
+}
+
 const messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']
 
 const messageBoxOptions = {
@@ -63,18 +68,13 @@ const setupDialog = (type, {
     nameFieldLabel = '',
     showsTagField = true
   }) => {
-  const Type = {
-    OPEN: 'open',
-    SAVE: 'save'
-  }
-
   if (!Array.isArray(properties)) {
     throw new TypeError('Properties must be an array')
   }
 
   let dialogProperties = 0
   // set up dialogProperties for showOpenDialog
-  if (type === 'open') {
+  if (type === Type.OPEN) {
     for (const prop in fileDialogProperties) {
       if (properties.includes(prop)) {
         dialogProperties |= fileDialogProperties[prop]
@@ -122,33 +122,21 @@ const setupDialog = (type, {
 }
 
 module.exports = {
-  showOpenDialog: function (args) {
-    let options = args
+  showOpenDialog: function (options = {
+    title: 'Open',
+    properties: ['openFile']
+  }) {
     checkAppInitialized()
 
-    if (options == null) {
-      options = {
-        title: 'Open',
-        properties: ['openFile']
-      }
-    }
-
-    const {settings, dialogProperties, wrappedCallback} = setupDialog('open', options)
-
+    const {settings, dialogProperties, wrappedCallback} = setupDialog(Type.OPEN, options)
     settings.properties = dialogProperties
     return binding.showOpenDialog(settings, wrappedCallback)
   },
 
-  showSaveDialog: function (args) {
-    let options = args
+  showSaveDialog: function (options = {title: 'Save'}) {
     checkAppInitialized()
 
-    if (options == null) {
-      options = {title: 'Save'}
-    }
-
-    const {settings, wrappedCallback} = setupDialog('save', options)
-
+    const {settings, wrappedCallback} = setupDialog(Type.SAVE, options)
     return binding.showSaveDialog(settings, wrappedCallback)
   },
 
@@ -221,15 +209,17 @@ module.exports = {
   },
 
   showCertificateTrustDialog: function (args) {
-    let {window, options, callback} = args
-
-    if (options == null || typeof options !== 'object') {
+    if (args == null || typeof args !== 'object') {
       throw new TypeError('options must be an object')
     }
 
-    let {certificate, message} = options
+    let {window, certificate, message, callback} = args
+
     if (certificate == null || typeof certificate !== 'object') {
       throw new TypeError('certificate must be an object')
+    }
+    if (callback == null || typeof callback !== 'function') {
+      throw new TypeError('You must pass in a valid callback')
     }
 
     if (message == null) {

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -159,8 +159,8 @@ module.exports = {
     checkAppInitialized()
 
     // check type value validity
-    const messageBoxType = messageBoxTypes.indexOf(type)
-    if (messageBoxType === -1) {
+    let messageBoxType = messageBoxTypes.indexOf(type)
+    if (!messageBoxTypes.include(type)) {
       throw new TypeError('Invalid message box type')
     }
     if (!Array.isArray(buttons)) {
@@ -206,16 +206,19 @@ module.exports = {
                                   checkboxChecked, icon, window, callback)
   },
 
-  showErrorBox: function (...args) {
+  showErrorBox: (...args) => {
     return binding.showErrorBox(...args)
   },
 
-  showCertificateTrustDialog: function (args) {
-    if (args == null || typeof args !== 'object') {
+  showCertificateTrustDialog: ({
+      window,
+      certificate,
+      message = '',
+      callback
+    }) => {
+    if (arguments == null || typeof arguments !== 'object') {
       throw new TypeError('options must be an object')
     }
-
-    let {window, certificate, message, callback} = args
 
     if (certificate == null || typeof certificate !== 'object') {
       throw new TypeError('certificate must be an object')
@@ -224,9 +227,7 @@ module.exports = {
       throw new TypeError('You must pass in a valid callback')
     }
 
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
+    if (typeof message !== 'string') {
       throw new TypeError('message must be a string')
     }
 

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -145,7 +145,7 @@ module.exports = {
       buttons = [],
       cancelId,
       checkboxLabel = '',
-      checkboxChecked,
+      checkboxChecked = false,
       defaultId = -1,
       detail = '',
       icon,
@@ -181,7 +181,6 @@ module.exports = {
     if (typeof checkboxChecked !== 'boolean') {
       throw new TypeError('Checkbox checked value must be a boolean')
     }
-    checkboxChecked = !!checkboxChecked
 
     if (normalizeAccessKeys) {
       buttons = buttons.map(normalizeAccessKey)

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -21,26 +21,6 @@ const messageBoxOptions = {
   noLink: 1 << 0
 }
 
-const parseArgs = function (window, options, callback, ...args) {
-  if (window != null && window.constructor !== BrowserWindow) {
-    // Shift.
-    [callback, options, window] = [options, window, null]
-  }
-
-  if ((callback == null) && typeof options === 'function') {
-    // Shift.
-    [callback, options] = [options, null]
-  }
-
-  // Fallback to using very last argument as the callback function
-  const lastArgument = args[args.length - 1]
-  if ((callback == null) && typeof lastArgument === 'function') {
-    callback = lastArgument
-  }
-
-  return [window, options, callback]
-}
-
 const normalizeAccessKey = (text) => {
   if (typeof text !== 'string') return text
 
@@ -70,24 +50,25 @@ const checkAppInitialized = function () {
   }
 }
 
-const setupDialog = (type, args) => {
-  let {
+const setupDialog = (type, {
     window,
-    buttonLabel,
-    defaultPath,
-    filters,
-    properties,
-    title,
-    message,
+    buttonLabel = '',
+    defaultPath = '',
+    filters = [],
+    properties = ['openFile'],
+    title = '',
+    message = '',
     securityScopedBookmarks = false,
     callback,
-    nameFieldLabel,
-    showsTagField
-  } = args
+    nameFieldLabel = '',
+    showsTagField = true
+  }) => {
+  const Type = {
+    OPEN: 'open',
+    SAVE: 'save'
+  }
 
-  if (properties == null) {
-    properties = (type === 'open') ? ['openFile'] : ['saveFile']
-  } else if (!Array.isArray(properties)) {
+  if (!Array.isArray(properties)) {
     throw new TypeError('Properties must be an array')
   }
 
@@ -101,42 +82,27 @@ const setupDialog = (type, args) => {
     }
   }
 
-  if (filters == null) filters = []
-
-  if (title == null) {
-    title = ''
-  } else if (typeof title !== 'string') {
+  // check parameter types
+  if (typeof title !== 'string') {
     throw new TypeError('Title must be a string')
   }
-
-  if (buttonLabel == null) {
-    buttonLabel = ''
-  } else if (typeof buttonLabel !== 'string') {
+  if (typeof buttonLabel !== 'string') {
     throw new TypeError('Button label must be a string')
   }
-
-  if (defaultPath == null) {
-    defaultPath = ''
-  } else if (typeof defaultPath !== 'string') {
+  if (typeof defaultPath !== 'string') {
     throw new TypeError('Default path must be a string')
   }
-
-  if (message == null) {
-    message = ''
-  } else if (typeof message !== 'string') {
+  if (typeof message !== 'string') {
     throw new TypeError('Message must be a string')
   }
 
   // set up extra parameters for showSaveDialog
-  if (type === 'save') {
-    if (nameFieldLabel == null) {
-      nameFieldLabel = ''
-    } else if (typeof nameFieldLabel !== 'string') {
+  if (type === Type.SAVE) {
+    if (typeof nameFieldLabel !== 'string') {
       throw new TypeError('Name field label must be a string')
     }
-
-    if (showsTagField == null) {
-      showsTagField = true
+    if (typeof showsTagField !== 'boolean') {
+      throw new TypeError('Shows tag option must be a boolean')
     }
   }
 
@@ -146,10 +112,10 @@ const setupDialog = (type, args) => {
   }
 
   let settings
-  if (type === 'open') {
+  if (type === Type.OPEN) {
     settings = {window, buttonLabel, defaultPath, filters, properties, title, message, securityScopedBookmarks, callback}
   } else {
-    settings = {window, buttonLabel, defaultPath, filters, properties, title, message, securityScopedBookmarks, callback, nameFieldLabel, showsTagField}
+    settings = {window, buttonLabel, defaultPath, filters, title, message, securityScopedBookmarks, callback, nameFieldLabel, showsTagField}
   }
 
   return {settings, dialogProperties, wrappedCallback}
@@ -178,9 +144,7 @@ module.exports = {
     checkAppInitialized()
 
     if (options == null) {
-      options = {
-        title: 'Save'
-      }
+      options = {title: 'Save'}
     }
 
     const {settings, wrappedCallback} = setupDialog('save', options)
@@ -188,65 +152,50 @@ module.exports = {
     return binding.showSaveDialog(settings, wrappedCallback)
   },
 
-  showMessageBox: function (args) {
-    let options = args
+  showMessageBox: ({
+      window,
+      buttons = [],
+      cancelId,
+      checkboxLabel = '',
+      checkboxChecked,
+      defaultId = -1,
+      detail = '',
+      icon,
+      normalizeAccessKeys,
+      noLink,
+      message = '',
+      title = '',
+      type = 'none',
+      callback
+    }) => {
     checkAppInitialized()
 
-    if (options == null) {
-      options = {
-        type: 'none'
-      }
-    }
-
-    let {
-      window, buttons, cancelId, checkboxLabel, checkboxChecked, defaultId,
-      detail, icon, message, title, type, callback
-    } = options
-
-    if (type == null) type = 'none'
-
+    // check type value validity
     const messageBoxType = messageBoxTypes.indexOf(type)
     if (messageBoxType === -1) {
       throw new TypeError('Invalid message box type')
     }
-
-    if (buttons == null) {
-      buttons = []
-    } else if (!Array.isArray(buttons)) {
+    if (!Array.isArray(buttons)) {
       throw new TypeError('Buttons must be an array')
     }
-
-    if (options.normalizeAccessKeys) buttons = buttons.map(normalizeAccessKey)
-
-    if (title == null) {
-      title = ''
-    } else if (typeof title !== 'string') {
+    if (typeof title !== 'string') {
       throw new TypeError('Title must be a string')
     }
-
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
+    if (typeof message !== 'string') {
       throw new TypeError('Message must be a string')
     }
-
-    if (detail == null) {
-      detail = ''
-    } else if (typeof detail !== 'string') {
+    if (typeof detail !== 'string') {
       throw new TypeError('Detail must be a string')
     }
-
-    checkboxChecked = !!checkboxChecked
-
-    if (checkboxLabel == null) {
-      checkboxLabel = ''
-    } else if (typeof checkboxLabel !== 'string') {
+    if (typeof checkboxLabel !== 'string') {
       throw new TypeError('checkboxLabel must be a string')
     }
 
-    if (icon == null) icon = null
+    if (normalizeAccessKeys) {
+      buttons = buttons.map(normalizeAccessKey)
+    }
 
-    if (defaultId == null) defaultId = -1
+    checkboxChecked = !!checkboxChecked
 
     // Choose a default button to get selected when dialog is cancelled.
     if (cancelId == null) {
@@ -260,7 +209,8 @@ module.exports = {
       }
     }
 
-    const flags = options.noLink ? messageBoxOptions.noLink : 0
+    const flags = noLink ? messageBoxOptions.noLink : 0
+
     return binding.showMessageBox(messageBoxType, buttons, defaultId, cancelId,
                                   flags, title, message, detail, checkboxLabel,
                                   checkboxChecked, icon, window, callback)
@@ -270,8 +220,8 @@ module.exports = {
     return binding.showErrorBox(...args)
   },
 
-  showCertificateTrustDialog: function (...args) {
-    let [window, options, callback] = parseArgs(...args)
+  showCertificateTrustDialog: function (args) {
+    let {window, options, callback} = args
 
     if (options == null || typeof options !== 'object') {
       throw new TypeError('options must be an object')

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {app, BrowserWindow} = require('electron')
+const {app} = require('electron')
 const binding = process.atomBinding('dialog')
 const v8Util = process.atomBinding('v8_util')
 
@@ -73,7 +73,7 @@ const setupDialog = (type, {
   }
 
   let dialogProperties = 0
-  // set up dialogProperties for showOpenDialog
+  // check extra parameters for showOpenDialog
   if (type === Type.OPEN) {
     for (const prop in fileDialogProperties) {
       if (properties.includes(prop)) {
@@ -96,7 +96,7 @@ const setupDialog = (type, {
     throw new TypeError('Message must be a string')
   }
 
-  // set up extra parameters for showSaveDialog
+  // check extra parameters for showSaveDialog
   if (type === Type.SAVE) {
     if (typeof nameFieldLabel !== 'string') {
       throw new TypeError('Name field label must be a string')

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -129,7 +129,6 @@ const setupDialog = (type, args) => {
 
   // set up extra parameters for showSaveDialog
   if (type === 'save') {
-    console.log(typeof nameFieldLabel)
     if (nameFieldLabel == null) {
       nameFieldLabel = ''
     } else if (typeof nameFieldLabel !== 'string') {
@@ -189,10 +188,9 @@ module.exports = {
     return binding.showSaveDialog(settings, wrappedCallback)
   },
 
-  showMessageBox: function (...args) {
+  showMessageBox: function (args) {
+    let options = args
     checkAppInitialized()
-
-    let [window, options, callback] = parseArgs(...args)
 
     if (options == null) {
       options = {
@@ -201,13 +199,11 @@ module.exports = {
     }
 
     let {
-      buttons, cancelId, checkboxLabel, checkboxChecked, defaultId, detail,
-      icon, message, title, type
+      window, buttons, cancelId, checkboxLabel, checkboxChecked, defaultId,
+      detail, icon, message, title, type, callback
     } = options
 
-    if (type == null) {
-      type = 'none'
-    }
+    if (type == null) type = 'none'
 
     const messageBoxType = messageBoxTypes.indexOf(type)
     if (messageBoxType === -1) {
@@ -220,9 +216,7 @@ module.exports = {
       throw new TypeError('Buttons must be an array')
     }
 
-    if (options.normalizeAccessKeys) {
-      buttons = buttons.map(normalizeAccessKey)
-    }
+    if (options.normalizeAccessKeys) buttons = buttons.map(normalizeAccessKey)
 
     if (title == null) {
       title = ''
@@ -250,13 +244,9 @@ module.exports = {
       throw new TypeError('checkboxLabel must be a string')
     }
 
-    if (icon == null) {
-      icon = null
-    }
+    if (icon == null) icon = null
 
-    if (defaultId == null) {
-      defaultId = -1
-    }
+    if (defaultId == null) defaultId = -1
 
     // Choose a default button to get selected when dialog is cancelled.
     if (cancelId == null) {

--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const {dialog} = require('electron').remote
 
-describe('dialog module', () => {
+describe.only('dialog module', () => {
   describe('showOpenDialog', () => {
     it('throws errors when the options are invalid', () => {
       assert.throws(() => {
@@ -53,11 +53,11 @@ describe('dialog module', () => {
   describe('showMessageBox', () => {
     it('throws errors when the options are invalid', () => {
       assert.throws(() => {
-        dialog.showMessageBox(undefined, {type: 'not-a-valid-type'})
+        dialog.showMessageBox({type: 'not-a-valid-type'})
       }, /Invalid message box type/)
 
       assert.throws(() => {
-        dialog.showMessageBox(null, {buttons: false})
+        dialog.showMessageBox({buttons: false})
       }, /Buttons must be an array/)
 
       assert.throws(() => {
@@ -105,7 +105,7 @@ describe('dialog module', () => {
       }, /certificate must be an object/)
 
       assert.throws(() => {
-        dialog.showCertificateTrustDialog({certificate: {}, message: false})
+        dialog.showCertificateTrustDialog({certificate: {}, message: false, callback: () => {}})
       }, /message must be a string/)
     })
   })

--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const {dialog} = require('electron').remote
 
-describe.only('dialog module', () => {
+describe('dialog module', () => {
   describe('showOpenDialog', () => {
     it('throws errors when the options are invalid', () => {
       assert.throws(() => {


### PR DESCRIPTION
Hopefully closes https://github.com/electron/electron/issues/12230.

This PR refactors dialog methods and simplifies arguments so that we do not have sniff through args each time to determine what has been passed.

Todo 🚧 
- [x] showMessageBox
- [x] update docs