### PR TITLE
Cleanup destruction of URLRequestContextGetter

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -238,11 +238,11 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
 }  // namespace
 
 Cookies::Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context)
-    : browser_context_(browser_context),
-      request_context_getter_(browser_context->url_request_context_getter()) {
+    : browser_context_(browser_context) {
   Init(isolate);
-  cookie_change_subscription_ = browser_context->RegisterCookieChangeCallback(
+  auto subscription = browser_context->RegisterCookieChangeCallback(
       base::Bind(&Cookies::OnCookieChanged, base::Unretained(this)));
+  browser_context->set_cookie_change_subscription(std::move(subscription));
 }
 
 Cookies::~Cookies() {}
@@ -250,34 +250,38 @@ Cookies::~Cookies() {}
 void Cookies::Get(const base::DictionaryValue& filter,
                   const GetCallback& callback) {
   std::unique_ptr<base::DictionaryValue> copied(filter.CreateDeepCopy());
-  auto getter = WrapRefCounted(request_context_getter_);
+  auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(GetCookiesOnIO, getter, Passed(&copied), callback));
+      base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter), Passed(&copied),
+                     callback));
 }
 
 void Cookies::Remove(const GURL& url, const std::string& name,
                      const base::Closure& callback) {
-  auto getter = WrapRefCounted(request_context_getter_);
+  auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(RemoveCookieOnIOThread, getter, url, name, callback));
+      base::BindOnce(RemoveCookieOnIOThread, base::RetainedRef(getter), url,
+                     name, callback));
 }
 
 void Cookies::Set(const base::DictionaryValue& details,
                   const SetCallback& callback) {
   std::unique_ptr<base::DictionaryValue> copied(details.CreateDeepCopy());
-  auto getter = WrapRefCounted(request_context_getter_);
+  auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(SetCookieOnIO, getter, Passed(&copied), callback));
+      base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), Passed(&copied),
+                     callback));
 }
 
 void Cookies::FlushStore(const base::Closure& callback) {
-  auto getter = WrapRefCounted(request_context_getter_);
+  auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(FlushCookieStoreOnIOThread, getter, callback));
+      base::BindOnce(FlushCookieStoreOnIOThread, base::RetainedRef(getter),
+                     callback));
 }
 
 void Cookies::OnCookieChanged(const CookieDetails* details) {

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -58,12 +58,7 @@ class Cookies : public mate::TrackableObject<Cookies> {
   void OnCookieChanged(const CookieDetails*);
 
  private:
-  // Store a reference to ensure this class gets destroyed before the context.
   scoped_refptr<AtomBrowserContext> browser_context_;
-  std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
-      cookie_change_subscription_;
-
-  net::URLRequestContextGetter* request_context_getter_;
 
   DISALLOW_COPY_AND_ASSIGN(Cookies);
 };

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -31,15 +31,16 @@ class IDUserData : public base::SupportsUserData::Data {
 
 TrackableObjectBase::TrackableObjectBase()
     : weak_map_id_(0), weak_factory_(this) {
-  cleanup_ = RegisterDestructionCallback(GetDestroyClosure());
+  atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(
+      GetDestroyClosure());
 }
 
 TrackableObjectBase::~TrackableObjectBase() {
-  cleanup_.Run();
 }
 
-base::Closure TrackableObjectBase::GetDestroyClosure() {
-  return base::Bind(&TrackableObjectBase::Destroy, weak_factory_.GetWeakPtr());
+base::OnceClosure TrackableObjectBase::GetDestroyClosure() {
+  return base::BindOnce(&TrackableObjectBase::Destroy,
+                        weak_factory_.GetWeakPtr());
 }
 
 void TrackableObjectBase::Destroy() {
@@ -60,12 +61,6 @@ int32_t TrackableObjectBase::GetIDFromWrappedClass(
       return *id;
   }
   return 0;
-}
-
-// static
-base::Closure TrackableObjectBase::RegisterDestructionCallback(
-    const base::Closure& c) {
-  return atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(c);
 }
 
 }  // namespace mate

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -37,18 +37,13 @@ class TrackableObjectBase {
   virtual ~TrackableObjectBase();
 
   // Returns a closure that can destroy the native class.
-  base::Closure GetDestroyClosure();
-
-  // Register a callback that should be destroyed before JavaScript environment
-  // gets destroyed.
-  static base::Closure RegisterDestructionCallback(const base::Closure& c);
+  base::OnceClosure GetDestroyClosure();
 
   int32_t weak_map_id_;
 
  private:
   void Destroy();
 
-  base::Closure cleanup_;
   base::WeakPtrFactory<TrackableObjectBase> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(TrackableObjectBase);

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -59,6 +59,13 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   AtomBlobReader* GetBlobReader();
 
+  void set_cookie_change_subscription(
+      std::unique_ptr<
+          base::CallbackList<void(const CookieDetails*)>::Subscription>
+          subscription) {
+    cookie_change_subscription_.swap(subscription);
+  }
+
  protected:
   AtomBrowserContext(const std::string& partition, bool in_memory,
                      const base::DictionaryValue& options);
@@ -73,6 +80,8 @@ class AtomBrowserContext : public brightray::BrowserContext {
   bool use_cache_;
 
   base::CallbackList<void(const CookieDetails*)> cookie_change_sub_list_;
+  std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
+      cookie_change_subscription_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserContext);
 };

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -41,7 +41,7 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   // Register a callback that should be destroyed before JavaScript environment
   // gets destroyed.
   // Returns a closure that can be used to remove |callback| from the list.
-  base::Closure RegisterDestructionCallback(const base::Closure& callback);
+  void RegisterDestructionCallback(base::OnceClosure callback);
 
   Browser* browser() { return browser_.get(); }
 
@@ -89,7 +89,7 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   base::Timer gc_timer_;
 
   // List of callbacks should be executed before destroying JS env.
-  std::list<base::Closure> destructors_;
+  std::list<base::OnceClosure> destructors_;
 
   static AtomBrowserMainParts* self_;
 

--- a/atom/browser/net/atom_url_request_job_factory.cc
+++ b/atom/browser/net/atom_url_request_job_factory.cc
@@ -92,6 +92,7 @@ void AtomURLRequestJobFactory::Clear() {
   for (auto& it : protocol_handler_map_)
     delete it.second;
   protocol_handler_map_.clear();
+  original_protocols_.clear();
 }
 
 net::URLRequestJob* AtomURLRequestJobFactory::MaybeCreateJobWithProtocolHandler(

--- a/brightray/browser/url_request_context_getter.h
+++ b/brightray/browser/url_request_context_getter.h
@@ -18,6 +18,10 @@
 #include "net/url_request/url_request_context.h"
 #include "net/url_request/url_request_context_getter.h"
 
+#if DCHECK_IS_ON()
+#include "base/debug/leak_tracker.h"
+#endif
+
 namespace base {
 class MessageLoop;
 }
@@ -83,6 +87,8 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   net::HostResolver* host_resolver();
   net::URLRequestJobFactory* job_factory() const { return job_factory_; }
 
+  void NotifyContextShutdownOnIO();
+
  private:
   Delegate* delegate_;
 
@@ -92,6 +98,10 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
 
   std::string user_agent_;
+
+#if DCHECK_IS_ON()
+  base::debug::LeakTracker<URLRequestContextGetter> leak_tracker_;
+#endif
 
   std::unique_ptr<RequireCTDelegate> ct_delegate_;
   std::unique_ptr<net::ProxyConfigService> proxy_config_service_;
@@ -106,6 +116,8 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   content::URLRequestInterceptorScopedVector protocol_interceptors_;
 
   net::URLRequestJobFactory* job_factory_;  // weak ref
+
+  bool context_shutting_down_;
 
   DISALLOW_COPY_AND_ASSIGN(URLRequestContextGetter);
 };


### PR DESCRIPTION
```
 - Add Leak detector to URLRequestContextGetter in debug mode
 - Indicate shutdown of request context from Browser Context
 - Change stored references to URLRequestContextGetter in browser api modules to use BrowserContext.
 - Destroy session properties explicitly
```

With this pr the destruction is pretty much aligned as follows:

```
Destroy session -> destroy session properties (protocol, cookies, webRequest) -> destroy BrowserContext -> destory URLRequestContextGetter -> Notify Shutdown of net::URLRequestContextGetter and destroys net::URLRequestContext.

```