### PR TITLE
Fix AttributeError: 'dict' object has no attribute 'required'

### DIFF
--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -64,8 +64,8 @@ def download_files(url, files):
   directory = tempfile.mkdtemp(prefix='electron-tmp')
   result = []
   for optional_f in files:
-    required = optional_f.required
-    f = optional_f.filename
+    required = optional_f['required']
+    f = optional_f['filename']
     try:
       result.append(download(f, url + f, os.path.join(directory, f)))
     except Exception:


### PR DESCRIPTION
When I ran the 2.0.0-beta.4 release, the release process failed with the following error:
`    required = optional_f.required
AttributeError: 'dict' object has no attribute 'required'`
This PR fixes that error.
It appears that this was caused by @MarshallOfSound's changes in #12217.

(cherry picked from commit 71c3483f552e485895c3a00ae9e2729f286a1736)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->