### PR TITLE
fix: Correctly detect insecure resources

### DIFF
--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -111,7 +111,7 @@ module.exports = {
 
     const resources = window.performance
       .getEntriesByType('resource')
-      .filter(({ name }) => /^(http|ftp):?/gi.test(name || ''))
+      .filter(({ name }) => /^(http|ftp):/gi.test(name || ''))
       .map(({ name }) => `- ${name}`)
       .join('\n')
 


### PR DESCRIPTION
In the current 2.0.0 beta, we're incorrectly marking secure resources as insecure. This tiny change fixes that.