### PR TITLE
Fix release build of mips64el (1.8.x)

### DIFF
--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -62,9 +62,6 @@ v8::Local<v8::Value> Converter<const net::AuthChallengeInfo*>::ToV8(
 // static
 v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
     v8::Isolate* isolate, const scoped_refptr<net::X509Certificate>& val) {
-#if defined(ARCH_CPU_MIPS64EL)
-  return v8::Undefined(isolate);
-#else
   mate::Dictionary dict(isolate, v8::Object::New(isolate));
   std::string encoded_data;
   net::X509Certificate::GetPEMEncoded(
@@ -95,15 +92,11 @@ v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
   }
 
   return dict.GetHandle();
-#endif
 }
 
 bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(
     v8::Isolate* isolate, v8::Local<v8::Value> val,
     scoped_refptr<net::X509Certificate>* out) {
-#if defined(ARCH_CPU_MIPS64EL)
-  return false;
-#else
   mate::Dictionary dict;
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
@@ -130,7 +123,6 @@ bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(
   }
 
   return true;
-#endif
 }
 
 // static

--- a/brightray/brightray.gyp
+++ b/brightray/brightray.gyp
@@ -1,12 +1,10 @@
 {
   'variables': {
     # The libraries brightray will be compiled to.
-    'linux_system_libraries': 'gtk+-2.0 dbus-1 x11 x11-xcb xcb xi xcursor xdamage xrandr xcomposite xext xfixes xrender xtst xscrnsaver gconf-2.0 gmodule-2.0',
+    'linux_system_libraries': 'gtk+-2.0 dbus-1 x11 x11-xcb xcb xi xcursor xdamage xrandr xcomposite xext xfixes xrender xtst xscrnsaver gconf-2.0 gmodule-2.0 nss',
     'conditions': [
       ['target_arch=="mips64el"', {
         'linux_system_libraries': '<(linux_system_libraries) libpulse',
-      }, {
-        'linux_system_libraries': '<(linux_system_libraries) nss',
       }],
     ],
   },

--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -277,14 +277,10 @@
               # Specifically tell the linker to perform optimizations.
               # See http://lwn.net/Articles/192624/ .
               '-Wl,-O1',
+              '-Wl,--as-needed',
               '-Wl,--gc-sections',
             ],
           }],  # OS=="linux"
-          ['OS=="linux" and target_arch!="mips64el"', {
-            'ldflags': [
-              '-Wl,--as-needed',
-            ],
-          }],
           ['OS=="linux" and target_arch in ["ia32", "x64", "arm64"]', {
             'cflags': [
               '-flto',

--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -118,10 +118,16 @@
             'defines': [
               'USE_OPENSSL',
             ],
+          }, {
+            'defines': [
+              'USE_X11',
+              # "use_nss_certs" is set to 1 in libchromiumcontent.
+              'USE_NSS_CERTS',
+              'USE_NSS',  # deprecated after Chrome 45.
+            ],
           }],
           ['OS=="linux"', {
             'defines': [
-              'USE_X11',
               '_LARGEFILE_SOURCE',
               '_LARGEFILE64_SOURCE',
               '_FILE_OFFSET_BITS=64',
@@ -131,11 +137,6 @@
               '-fno-rtti',
             ],
           }],  # OS=="linux"
-          ['OS=="linux" and target_arch!="mips64el"', {
-            'defines': [
-              'USE_NSS_CERTS',
-            ],
-          }],  # OS=="linux" and target_arch!="mips64el"
           ['OS=="mac"', {
             'defines': [
               # The usage of "webrtc/modules/desktop_capture/desktop_capture_options.h"

--- a/electron.gyp
+++ b/electron.gyp
@@ -348,6 +348,7 @@
         ['OS=="linux"', {
           'sources': [
             '<@(lib_sources_linux)',
+            '<@(lib_sources_nss)',
           ],
           'link_settings': {
             'ldflags': [
@@ -370,11 +371,6 @@
             'vendor/breakpad/breakpad.gyp:breakpad_client',
           ],
         }],  # OS=="linux"
-        ['OS=="linux" and target_arch!="mips64el"', {
-          'sources': [
-            '<@(lib_sources_nss)',
-          ],
-        }],  # OS=="linux" and target_arch!="mips64el"
         ['OS=="linux" and clang==1', {
           # Required settings of using breakpad.
           'cflags_cc': [


### PR DESCRIPTION
Relies on https://github.com/electron/libchromiumcontent/pull/482.

This PR fixed the release build of mips64el with:
* Disable official build for it;
* Re-enable nss since we have backported https://github.com/electron/libchromiumcontent/pull/469.

/cc @jkleinsc 