### PR TITLE
Check menu.popup options are an object

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -47,6 +47,9 @@ Menu.prototype._init = function () {
 }
 
 Menu.prototype.popup = function (options) {
+  if (options == null || typeof options !== 'object') {
+    throw new TypeError('Options must be an object')
+  }
   let {window, x, y, positioningItem, callback} = options
 
   // no callback passed

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -309,6 +309,12 @@ describe('Menu module', () => {
       return closeWindow(w).then(() => { w = null })
     })
 
+    it.only('throws an error if options is not an object', () => {
+      assert.throws(() => {
+        menu.popup()
+      }, /Options must be an object/)
+    })
+
     it('should emit menu-will-show event', (done) => {
       menu.on('menu-will-show', () => { done() })
       menu.popup({window: w})

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -309,7 +309,7 @@ describe('Menu module', () => {
       return closeWindow(w).then(() => { w = null })
     })
 
-    it.only('throws an error if options is not an object', () => {
+    it('throws an error if options is not an object', () => {
       assert.throws(() => {
         menu.popup()
       }, /Options must be an object/)


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/12324.

We need to check that options passed to `menu.popup` are an object so that confusing errors like 
> cannot destructure property `window` of `undefined` or `null`

don't occur. 


/cc @ckerr 