### PR TITLE
Fix non-draggable regions on macOS

### DIFF
--- a/atom/browser/api/atom_api_browser_window_mac.mm
+++ b/atom/browser/api/atom_api_browser_window_mac.mm
@@ -85,7 +85,7 @@ void BrowserWindow::UpdateDraggableRegions(
     system_drag_exclude_areas.push_back(
         gfx::Rect(0, 0, webViewWidth, webViewHeight));
   } else {
-    CalculateNonDraggableRegions(
+    system_drag_exclude_areas = CalculateNonDraggableRegions(
         DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);
   }
 


### PR DESCRIPTION
This was a regression in 503b0ba1.