### PR TITLE
net: change mime type deduction in Change URLRequestAsarJob (#12319)

### DIFF
--- a/atom/browser/net/asar/url_request_asar_job.cc
+++ b/atom/browser/net/asar/url_request_asar_job.cc
@@ -241,10 +241,21 @@ void URLRequestAsarJob::FetchMetaInfo(const base::FilePath& file_path,
       meta_info->is_directory = file_info.is_directory;
     }
   }
-  // On Windows GetMimeTypeFromFile() goes to the registry. Thus it should be
-  // done in WorkerPool.
-  meta_info->mime_type_result =
-      net::GetMimeTypeFromFile(file_path, &meta_info->mime_type);
+
+  // We use GetWellKnownMimeTypeFromExtension() to ensure that configurations
+  // that may have been set by other programs on a user's machine don't affect
+  // the mime type returned (in particular, JS should always be
+  // (application/javascript). See https://crbug.com/797712. Using an accurate
+  // mime type is necessary at least for modules and sw, which enforce strict
+  // mime type requirements.
+  // TODO(deepak1556): Revert this when sw support is removed for file scheme.
+  base::FilePath::StringType file_extension = file_path.Extension();
+  if (file_extension.empty()) {
+    meta_info->mime_type_result = false;
+  } else {
+    meta_info->mime_type_result = net::GetWellKnownMimeTypeFromExtension(
+        file_extension.substr(1), &meta_info->mime_type);
+  }
 }
 
 void URLRequestAsarJob::DidFetchMetaInfo(const FileMetaInfo* meta_info) {


### PR DESCRIPTION
Backport https://github.com/electron/electron/commit/792837bd7184db318e2f00e9630a40e5dd83928f from `master` becauase the "serviceWorker should register for file scheme" flake appears in 2-0-x PRs as well. [example](https://windows-ci.electronjs.org/project/AppVeyor/electron/build/1.0.3588/job/l3x9rdy05hhmd3w7) 

Fixes #12173 for 2-0-x.