### PR TITLE
Update CI to use Node.js 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   electron-linux-arm:
     docker:
-      - image: electronbuilds/electron:0.0.6
+      - image: electronbuilds/electron:0.0.7
         environment:
           TARGET_ARCH: arm
     resource_class: 2xlarge
@@ -96,7 +96,7 @@ jobs:
             fi
   electron-linux-arm64:
     docker:
-      - image: electronbuilds/electron:0.0.6
+      - image: electronbuilds/electron:0.0.7
         environment:
           TARGET_ARCH: arm64
     resource_class: 2xlarge
@@ -189,7 +189,7 @@ jobs:
             fi
   electron-linux-ia32:
     docker:
-      - image: electronbuilds/electron:0.0.4
+      - image: electronbuilds/electron:0.0.7
         environment:
           TARGET_ARCH: ia32
           DISPLAY: ':99.0'
@@ -278,7 +278,7 @@ jobs:
           path: junit
   electron-linux-mips64el:
     docker:
-      - image: electronbuilds/electron:0.0.6
+      - image: electronbuilds/electron:0.0.7
         environment:
           TARGET_ARCH: mips64el
     resource_class: xlarge
@@ -336,7 +336,7 @@ jobs:
 
   electron-linux-x64:
     docker:
-      - image: electronbuilds/electron:0.0.6
+      - image: electronbuilds/electron:0.0.7
         environment:
           TARGET_ARCH: x64
           DISPLAY: ':99.0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=/home
 RUN chmod a+rwx /home
 
 # Install node.js
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 # Install wget used by crash reporter

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y\
  xvfb
 
 # Install node.js
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 # Install crcmod

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -29,13 +29,8 @@ RUN apt-get update && apt-get install -y\
  wget \
  xvfb
 
-# Install node.js
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get update && apt-get install -y nodejs
-
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb
 ADD tools/run-electron.sh /run-electron.sh
 RUN chmod a+x /run-electron.sh
-
 CMD sh /run-electron.sh

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -3,7 +3,7 @@ FROM electronbuilds/libchromiumcontent:0.0.4
 USER root
 
 # Install node.js
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 # Install wget used by crash reporter

--- a/Jenkinsfile.arm64
+++ b/Jenkinsfile.arm64
@@ -1,13 +1,14 @@
 pipeline {
   agent {
     docker {
-      image 'electronbuilds/arm64v8:0.0.1'
+      image 'electronbuilds/arm64v8:0.0.2'
       args '--privileged'
     }
   }
   environment {
     TARGET_ARCH='arm64'
     DISPLAY=':99.0'
+    MOCHA_TIMEOUT='60000'
   }
   stages {
     stage('Bootstrap') {


### PR DESCRIPTION
This PR updates our Linux builds to use Node.js 8 instead of Node.js 6.  
This fixes the following error:
```ninja: error: '../../node_modules/ieee754/index.js', needed by 'gen/js2c/preload_bundle.js', missing and no known rule to make it```
This error was seen in #12342, #12348 and probably other PRS.  Here is a sample build containing that error:
https://circleci.com/gh/electron/electron/14417
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->