### PR TITLE
Fix nil tray title crash

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -433,7 +433,6 @@ void TrayIconCocoa::SetToolTip(const std::string& tool_tip) {
 }
 
 void TrayIconCocoa::SetTitle(const std::string& title) {
-  printf("STRING IS %s\n", title.c_str());
   [status_item_view_ setTitle:base::SysUTF8ToNSString(title)];
 }
 

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -230,8 +230,13 @@ const CGFloat kVerticalTitleMargin = 2;
     return;
   }
 
+  // check title_ being nil
+  NSString *title = @"";
+  if (title_)
+    title = title_;
+
   attributedTitle_.reset([[NSMutableAttributedString alloc]
-                             initWithString:title_
+                             initWithString:title
                                  attributes:attributes]);
 
   //NSFontAttributeName:[NSFont menuBarFontOfSize:0],
@@ -428,6 +433,7 @@ void TrayIconCocoa::SetToolTip(const std::string& tool_tip) {
 }
 
 void TrayIconCocoa::SetTitle(const std::string& title) {
+  printf("STRING IS %s\n", title.c_str());
   [status_item_view_ setTitle:base::SysUTF8ToNSString(title)];
 }
 


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/12343.

Previously, if you set the title of a Tray to an empty string, `setTitle` would crash because it would attempt to call
```
attributedTitle_.reset([[NSMutableAttributedString alloc]
                             initWithString:title
                                 attributes:attributes]);
```
with a `nil` title, likely resultant of faulty conversion.

This PR adds a check for the title being `nil`, and if it is, resets it to an empty string before calling the above `initWithTitle` method.

/cc @MarshallOfSound 