### PR TITLE
Add menu item order control

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -304,14 +304,14 @@ browser windows.
 
 You can make use of `before`, `after`, `beforeGroupContaining`, `afterGroupContaining` and `id` to control how the item will be placed when building a menu with `Menu.buildFromTemplate`.
 
-* `before` - Inserts this item before the item with the specified label.. If the
+* `before` - Inserts this item before the item with the specified label. If the
   referenced item doesn't exist the item will be inserted at the end of
   the menu. Also implies that the menu item in question should be placed in the same “group” as the item.
 * `after` - Inserts this item after the item with the specified label. If the
   referenced item doesn't exist the item will be inserted at the end of
   the menu. Also implies that the menu item in question should be placed in the same “group” as the item.
 * `beforeGroupContaining` - Provides a means for a single context menu to declare
-  the placement of their containing group after the containing group of the item with the specified label.
+  the placement of their containing group before the containing group of the item with the specified label.
 * `afterGroupContaining` - Provides a means for a single context menu to declare
   the placement of their containing group after the containing group of the item with the specified label.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -302,20 +302,20 @@ browser windows.
 
 ## Menu Item Position
 
-You can make use of `before/after`, `beforeGroupContaining/afterGroupContaining` and `id` to control how the item will be placed when building a menu with `Menu.buildFromTemplate`.
+You can make use of `before`, `after`, `beforeGroupContaining`, `afterGroupContaining` and `id` to control how the item will be placed when building a menu with `Menu.buildFromTemplate`.
 
-* `before` - Inserts this item before the label referenced item. If the
+* `before` - Inserts this item before the item with the specified label.. If the
   referenced item doesn't exist the item will be inserted at the end of
-  the menu. Also implies that the menu item in question should be placed in the same “group” as the item
-* `after` - Inserts this item after the label referenced item. If the
+  the menu. Also implies that the menu item in question should be placed in the same “group” as the item.
+* `after` - Inserts this item after the item with the specified label. If the
   referenced item doesn't exist the item will be inserted at the end of
-  the menu. Also implies that the menu item in question should be placed in the same “group” as the item
+  the menu. Also implies that the menu item in question should be placed in the same “group” as the item.
 * `beforeGroupContaining` - Provides a means for a single context menu to declare
-  the placement of their containing group after to the containing group of the label specified item.
-* `afterGroupContaining` Provides a means for a single context menu to declare
-  the placement of their containing group before the containing group of the label specified item.
+  the placement of their containing group after the containing group of the item with the specified label.
+* `afterGroupContaining` - Provides a means for a single context menu to declare
+  the placement of their containing group after the containing group of the item with the specified label.
 
-By default, items will be inserted in the order they exist in the template unless one of the specified positioning keywords is utilized. 
+By default, items will be inserted in the order they exist in the template unless one of the specified positioning keywords is used.
 
 ### Examples
 
@@ -323,11 +323,10 @@ Template:
 
 ```javascript
 [
-  {label: '4', id: '4'},
-  {label: '5', id: '5'},
-  {label: '1', id: '1', position: 'before=4'},
-  {label: '2', id: '2'},
-  {label: '3', id: '3'}
+  { id: '1', label: 'one'},
+  { id: '2', label: 'two' }
+  { id: '3', label: 'three' },
+  { id: '4', label: 'four' }
 ]
 ```
 
@@ -338,19 +337,39 @@ Menu:
 - 2
 - 3
 - 4
-- 5
 ```
 
 Template:
 
 ```javascript
 [
-  {label: 'a', position: 'endof=letters'},
-  {label: '1', position: 'endof=numbers'},
-  {label: 'b', position: 'endof=letters'},
-  {label: '2', position: 'endof=numbers'},
-  {label: 'c', position: 'endof=letters'},
-  {label: '3', position: 'endof=numbers'}
+  { id: '1', label: 'one'},
+  { type: 'separator' },
+  { id: '3', label: 'three', beforeGroupContaining: ['1'] },
+  { id: '4', label: 'four', afterGroupContaining: ['2'] },
+  { type: 'separator' },
+  { id: '2', label: 'two' }
+]
+```
+
+Menu:
+
+```sh
+- 3
+- 4
+- ---
+- 1
+- ---
+- 2
+```
+
+Template:
+
+```javascript
+[
+  { id: '1', label: 'one', after: ['3'] },
+  { id: '2', label: 'two', before: ['1'] },
+  { id: '3', label: 'three' }
 ]
 ```
 
@@ -358,13 +377,9 @@ Menu:
 
 ```sh
 - ---
-- a
-- b
-- c
-- ---
-- 1
-- 2
 - 3
+- 2
+- 1
 ```
 
 [AboutInformationPropertyListFiles]: https://developer.apple.com/library/ios/documentation/general/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -323,8 +323,8 @@ Template:
 
 ```javascript
 [
-  { id: '1', label: 'one'},
-  { id: '2', label: 'two' }
+  { id: '1', label: 'one' },
+  { id: '2', label: 'two' },
   { id: '3', label: 'three' },
   { id: '4', label: 'four' }
 ]
@@ -343,7 +343,7 @@ Template:
 
 ```javascript
 [
-  { id: '1', label: 'one'},
+  { id: '1', label: 'one' },
   { type: 'separator' },
   { id: '3', label: 'three', beforeGroupContaining: ['1'] },
   { id: '4', label: 'four', afterGroupContaining: ['2'] },

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -302,27 +302,20 @@ browser windows.
 
 ## Menu Item Position
 
-You can make use of `position` and `id` to control how the item will be placed
-when building a menu with `Menu.buildFromTemplate`.
+You can make use of `before/after`, `beforeGroupContaining/afterGroupContaining` and `id` to control how the item will be placed when building a menu with `Menu.buildFromTemplate`.
 
-The `position` attribute of `MenuItem` has the form `[placement]=[id]`, where
-`placement` is one of `before`, `after`, or `endof` and `id` is the unique ID of
-an existing item in the menu:
-
-* `before` - Inserts this item before the id referenced item. If the
+* `before` - Inserts this item before the label referenced item. If the
   referenced item doesn't exist the item will be inserted at the end of
-  the menu.
-* `after` - Inserts this item after id referenced item. If the referenced
-  item doesn't exist the item will be inserted at the end of the menu.
-* `endof` - Inserts this item at the end of the logical group containing
-  the id referenced item (groups are created by separator items). If
-  the referenced item doesn't exist, a new separator group is created with
-  the given id and this item is inserted after that separator.
+  the menu. Also implies that the menu item in question should be placed in the same “group” as the item
+* `after` - Inserts this item after the label referenced item. If the
+  referenced item doesn't exist the item will be inserted at the end of
+  the menu. Also implies that the menu item in question should be placed in the same “group” as the item
+* `beforeGroupContaining` - Provides a means for a single context menu to declare
+  the placement of their containing group after to the containing group of the label specified item.
+* `afterGroupContaining` Provides a means for a single context menu to declare
+  the placement of their containing group before the containing group of the label specified item.
 
-When an item is positioned, all un-positioned items are inserted after
-it until a new item is positioned. So if you want to position a group of
-menu items in the same location you only need to specify a position for
-the first item.
+By default, items will be inserted in the order they exist in the template unless one of the specified positioning keywords is utilized. 
 
 ### Examples
 

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -23,6 +23,7 @@
       'lib/browser/api/in-app-purchase.js',
       'lib/browser/api/menu-item-roles.js',
       'lib/browser/api/menu-item.js',
+      'lib/browser/api/menu-utils.js',
       'lib/browser/api/menu.js',
       'lib/browser/api/module-list.js',
       'lib/browser/api/navigation-controller.js',

--- a/lib/browser/api/menu-utils.js
+++ b/lib/browser/api/menu-utils.js
@@ -1,28 +1,27 @@
 function splitArray (arr, predicate) {
-  let lastArr = []
-  const multiArr = [lastArr]
-  arr.forEach(item => {
+  const result = arr.reduce((multi, item) => {
+    const current = multi[multi.length - 1]
     if (predicate(item)) {
-      if (lastArr.length > 0) {
-        lastArr = []
-        multiArr.push(lastArr)
-      }
+      if (current.length > 0) multi.push([])
     } else {
-      lastArr.push(item)
+      current.push(item)
     }
-  })
-  return multiArr
+    return multi
+  }, [[]])
+
+  if (result[result.length - 1].length === 0) {
+    return result.slice(0, result.length - 1)
+  }
+  return result
 }
 
 function joinArrays (arrays, joiner) {
-  const joinedArr = []
-  arrays.forEach((arr, i) => {
-    if (i > 0 && arr.length > 0) {
-      joinedArr.push(joiner)
+  return arrays.reduce((joined, arr, i) => {
+    if (i > 0 && arr.length) {
+      joined.push(joiner)
     }
-    joinedArr.push(...arr)
-  })
-  return joinedArr
+    return joined.concat(arr)
+  }, [])
 }
 
 function pushOntoMultiMap (map, key, value) {

--- a/lib/browser/api/menu-utils.js
+++ b/lib/browser/api/menu-utils.js
@@ -32,12 +32,12 @@ function pushOntoMultiMap (map, key, value) {
   map.get(key).push(value)
 }
 
-function indexOfGroupContainingLabel (groups, label, ignoreGroup) {
+function indexOfGroupContainingID (groups, id, ignoreGroup) {
   return groups.findIndex(
     candidateGroup =>
       candidateGroup !== ignoreGroup &&
       candidateGroup.some(
-        candidateItem => candidateItem.label === label
+        candidateItem => candidateItem.id === id
       )
   )
 }
@@ -48,14 +48,14 @@ function sortTopologically (originalOrder, edgesById) {
   const sorted = []
   const marked = new Set()
 
-  const visit = (id) => {
-    if (marked.has(id)) return
-    marked.add(id)
-    const edges = edgesById.get(id)
+  const visit = (mark) => {
+    if (marked.has(mark)) return
+    marked.add(mark)
+    const edges = edgesById.get(mark)
     if (edges != null) {
       edges.forEach(visit)
     }
-    sorted.push(id)
+    sorted.push(mark)
   }
 
   originalOrder.forEach(visit)
@@ -66,9 +66,9 @@ function attemptToMergeAGroup (groups) {
   for (let i = 0; i < groups.length; i++) {
     const group = groups[i]
     for (const item of group) {
-      const toLabels = [...(item.before || []), ...(item.after || [])]
-      for (const label of toLabels) {
-        const index = indexOfGroupContainingLabel(groups, label, group)
+      const toIDs = [...(item.before || []), ...(item.after || [])]
+      for (const id of toIDs) {
+        const index = indexOfGroupContainingID(groups, id, group)
         if (index === -1) continue
         const mergeTarget = groups[index]
 
@@ -92,20 +92,20 @@ function mergeGroups (groups) {
 function sortItemsInGroup (group) {
   const originalOrder = group.map((node, i) => i)
   const edges = new Map()
-  const labelToIndex = new Map(group.map((item, i) => [item.label, i]))
+  const idToIndex = new Map(group.map((item, i) => [item.id, i]))
 
   group.forEach((item, i) => {
     if (item.before) {
-      item.before.forEach(toLabel => {
-        const to = labelToIndex.get(toLabel)
+      item.before.forEach(toID => {
+        const to = idToIndex.get(toID)
         if (to != null) {
           pushOntoMultiMap(edges, to, i)
         }
       })
     }
     if (item.after) {
-      item.after.forEach(toLabel => {
-        const to = labelToIndex.get(toLabel)
+      item.after.forEach(toID => {
+        const to = idToIndex.get(toID)
         if (to != null) {
           pushOntoMultiMap(edges, i, to)
         }
@@ -121,8 +121,8 @@ function findEdgesInGroup (groups, i, edges) {
   const group = groups[i]
   for (const item of group) {
     if (item.beforeGroupContaining) {
-      for (const label of item.beforeGroupContaining) {
-        const to = indexOfGroupContainingLabel(groups, label, group)
+      for (const id of item.beforeGroupContaining) {
+        const to = indexOfGroupContainingID(groups, id, group)
         if (to !== -1) {
           pushOntoMultiMap(edges, to, i)
           return
@@ -130,8 +130,8 @@ function findEdgesInGroup (groups, i, edges) {
       }
     }
     if (item.afterGroupContaining) {
-      for (const label of item.afterGroupContaining) {
-        const to = indexOfGroupContainingLabel(groups, label, group)
+      for (const id of item.afterGroupContaining) {
+        const to = indexOfGroupContainingID(groups, id, group)
         if (to !== -1) {
           pushOntoMultiMap(edges, i, to)
           return
@@ -163,7 +163,6 @@ function sortMenuItems (menuItems) {
   const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
 
   const joined = joinArrays(sortedGroups, { type: 'separator' })
-  console.log(joined)
   return joined
 }
 

--- a/lib/browser/api/menu-utils.js
+++ b/lib/browser/api/menu-utils.js
@@ -25,7 +25,7 @@ function joinArrays (arrays, joiner) {
   return joinedArr
 }
 
-const pushOntoMultiMap = (map, key, value) => {
+function pushOntoMultiMap (map, key, value) {
   if (!map.has(key)) {
     map.set(key, [])
   }
@@ -34,9 +34,9 @@ const pushOntoMultiMap = (map, key, value) => {
 
 function indexOfGroupContainingLabel (groups, label, ignoreGroup) {
   return groups.findIndex(
-    candiateGroup =>
-      candiateGroup !== ignoreGroup &&
-      candiateGroup.some(
+    candidateGroup =>
+      candidateGroup !== ignoreGroup &&
+      candidateGroup.some(
         candidateItem => candidateItem.label === label
       )
   )
@@ -48,7 +48,7 @@ function sortTopologically (originalOrder, edgesById) {
   const sorted = []
   const marked = new Set()
 
-  function visit (id) {
+  const visit = (id) => {
     if (marked.has(id)) return
     marked.add(id)
     const edges = edgesById.get(id)
@@ -71,7 +71,7 @@ function attemptToMergeAGroup (groups) {
         const index = indexOfGroupContainingLabel(groups, label, group)
         if (index === -1) continue
         const mergeTarget = groups[index]
-        // Merge with group containing `label`
+
         mergeTarget.push(...group)
         groups.splice(i, 1)
         return true
@@ -81,12 +81,10 @@ function attemptToMergeAGroup (groups) {
   return false
 }
 
-// Merge groups based on before/after positions
-// Mutates both the array of groups, and the individual group arrays.
 function mergeGroups (groups) {
-  let mergedAGroup = true
-  while (mergedAGroup) {
-    mergedAGroup = attemptToMergeAGroup(groups)
+  let merged = true
+  while (merged) {
+    merged = attemptToMergeAGroup(groups)
   }
   return groups
 }
@@ -116,7 +114,6 @@ function sortItemsInGroup (group) {
   })
 
   const sortedNodes = sortTopologically(originalOrder, edges)
-
   return sortedNodes.map(i => group[i])
 }
 
@@ -164,7 +161,10 @@ function sortMenuItems (menuItems) {
   const mergedGroups = mergeGroups(groups)
   const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
   const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
-  return joinArrays(sortedGroups, { type: 'separator' })
+
+  const joined = joinArrays(sortedGroups, { type: 'separator' })
+  console.log(joined)
+  return joined
 }
 
 module.exports = {sortMenuItems}

--- a/lib/browser/api/menu-utils.js
+++ b/lib/browser/api/menu-utils.js
@@ -1,0 +1,177 @@
+function splitArray (arr, predicate) {
+  let lastArr = []
+  const multiArr = [lastArr]
+  arr.forEach(item => {
+    if (predicate(item)) {
+      if (lastArr.length > 0) {
+        lastArr = []
+        multiArr.push(lastArr)
+      }
+    } else {
+      lastArr.push(item)
+    }
+  })
+  return multiArr
+}
+
+function joinArrays (arrays, joiner) {
+  const joinedArr = []
+  arrays.forEach((arr, i) => {
+    if (i > 0 && arr.length > 0) {
+      joinedArr.push(joiner)
+    }
+    joinedArr.push(...arr)
+  })
+  return joinedArr
+}
+
+const pushOntoMultiMap = (map, key, value) => {
+  if (!map.has(key)) {
+    map.set(key, [])
+  }
+  map.get(key).push(value)
+}
+
+function indexOfGroupContainingCommand (groups, command, ignoreGroup) {
+  return groups.findIndex(
+    candiateGroup =>
+      candiateGroup !== ignoreGroup &&
+      candiateGroup.some(
+        candidateItem => candidateItem.command === command
+      )
+  )
+}
+
+// Sort nodes topologically using a depth-first approach. Encountered cycles
+// are broken.
+function sortTopologically (originalOrder, edgesById) {
+  const sorted = []
+  const marked = new Set()
+
+  function visit (id) {
+    if (marked.has(id)) return
+    marked.add(id)
+    const edges = edgesById.get(id)
+    if (edges != null) {
+      edges.forEach(visit)
+    }
+    sorted.push(id)
+  }
+
+  originalOrder.forEach(visit)
+  return sorted
+}
+
+function attemptToMergeAGroup (groups) {
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i]
+    for (const item of group) {
+      const toCommands = [...(item.before || []), ...(item.after || [])]
+      for (const command of toCommands) {
+        const index = indexOfGroupContainingCommand(groups, command, group)
+        if (index === -1) continue
+        const mergeTarget = groups[index]
+        // Merge with group containing `command`
+        mergeTarget.push(...group)
+        groups.splice(i, 1)
+        return true
+      }
+    }
+  }
+  return false
+}
+
+// Merge groups based on before/after positions
+// Mutates both the array of groups, and the individual group arrays.
+function mergeGroups (groups) {
+  let mergedAGroup = true
+  while (mergedAGroup) {
+    mergedAGroup = attemptToMergeAGroup(groups)
+  }
+  return groups
+}
+
+function sortItemsInGroup (group) {
+  const originalOrder = group.map((node, i) => i)
+  const edges = new Map()
+  const commandToIndex = new Map(group.map((item, i) => [item.command, i]))
+
+  group.forEach((item, i) => {
+    if (item.before) {
+      item.before.forEach(toCommand => {
+        const to = commandToIndex.get(toCommand)
+        if (to != null) {
+          pushOntoMultiMap(edges, to, i)
+        }
+      })
+    }
+    if (item.after) {
+      item.after.forEach(toCommand => {
+        const to = commandToIndex.get(toCommand)
+        if (to != null) {
+          pushOntoMultiMap(edges, i, to)
+        }
+      })
+    }
+  })
+
+  const sortedNodes = sortTopologically(originalOrder, edges)
+
+  return sortedNodes.map(i => group[i])
+}
+
+function findEdgesInGroup (groups, i, edges) {
+  const group = groups[i]
+  for (const item of group) {
+    if (item.beforeGroupContaining) {
+      for (const command of item.beforeGroupContaining) {
+        const to = indexOfGroupContainingCommand(groups, command, group)
+        if (to !== -1) {
+          pushOntoMultiMap(edges, to, i)
+          return
+        }
+      }
+    }
+    if (item.afterGroupContaining) {
+      for (const command of item.afterGroupContaining) {
+        const to = indexOfGroupContainingCommand(groups, command, group)
+        if (to !== -1) {
+          pushOntoMultiMap(edges, i, to)
+          return
+        }
+      }
+    }
+  }
+}
+
+function sortGroups (groups) {
+  const originalOrder = groups.map((item, i) => i)
+  const edges = new Map()
+
+  for (let i = 0; i < groups.length; i++) {
+    findEdgesInGroup(groups, i, edges)
+  }
+
+  const sortedGroupIndexes = sortTopologically(originalOrder, edges)
+  return sortedGroupIndexes.map(i => groups[i])
+}
+
+function isSeparator (item) {
+  return item.type === 'separator'
+}
+
+function sortMenuItems (menuItems) {
+  // Split the items into their implicit groups based upon separators.
+  const groups = splitArray(menuItems, isSeparator)
+  // Merge groups that contain before/after references to eachother.
+  const mergedGroups = mergeGroups(groups)
+  // Sort each individual group internally.
+  const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
+  // Sort the groups based upon their beforeGroupContaining/afterGroupContaining
+  // references.
+  const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
+  // Join the groups back
+  return joinArrays(sortedGroups, { type: 'separator' })
+}
+
+module.exports = {sortMenuItems}

--- a/lib/browser/api/menu-utils.js
+++ b/lib/browser/api/menu-utils.js
@@ -32,12 +32,12 @@ const pushOntoMultiMap = (map, key, value) => {
   map.get(key).push(value)
 }
 
-function indexOfGroupContainingCommand (groups, command, ignoreGroup) {
+function indexOfGroupContainingLabel (groups, label, ignoreGroup) {
   return groups.findIndex(
     candiateGroup =>
       candiateGroup !== ignoreGroup &&
       candiateGroup.some(
-        candidateItem => candidateItem.command === command
+        candidateItem => candidateItem.label === label
       )
   )
 }
@@ -66,12 +66,12 @@ function attemptToMergeAGroup (groups) {
   for (let i = 0; i < groups.length; i++) {
     const group = groups[i]
     for (const item of group) {
-      const toCommands = [...(item.before || []), ...(item.after || [])]
-      for (const command of toCommands) {
-        const index = indexOfGroupContainingCommand(groups, command, group)
+      const toLabels = [...(item.before || []), ...(item.after || [])]
+      for (const label of toLabels) {
+        const index = indexOfGroupContainingLabel(groups, label, group)
         if (index === -1) continue
         const mergeTarget = groups[index]
-        // Merge with group containing `command`
+        // Merge with group containing `label`
         mergeTarget.push(...group)
         groups.splice(i, 1)
         return true
@@ -94,20 +94,20 @@ function mergeGroups (groups) {
 function sortItemsInGroup (group) {
   const originalOrder = group.map((node, i) => i)
   const edges = new Map()
-  const commandToIndex = new Map(group.map((item, i) => [item.command, i]))
+  const labelToIndex = new Map(group.map((item, i) => [item.label, i]))
 
   group.forEach((item, i) => {
     if (item.before) {
-      item.before.forEach(toCommand => {
-        const to = commandToIndex.get(toCommand)
+      item.before.forEach(toLabel => {
+        const to = labelToIndex.get(toLabel)
         if (to != null) {
           pushOntoMultiMap(edges, to, i)
         }
       })
     }
     if (item.after) {
-      item.after.forEach(toCommand => {
-        const to = commandToIndex.get(toCommand)
+      item.after.forEach(toLabel => {
+        const to = labelToIndex.get(toLabel)
         if (to != null) {
           pushOntoMultiMap(edges, i, to)
         }
@@ -124,8 +124,8 @@ function findEdgesInGroup (groups, i, edges) {
   const group = groups[i]
   for (const item of group) {
     if (item.beforeGroupContaining) {
-      for (const command of item.beforeGroupContaining) {
-        const to = indexOfGroupContainingCommand(groups, command, group)
+      for (const label of item.beforeGroupContaining) {
+        const to = indexOfGroupContainingLabel(groups, label, group)
         if (to !== -1) {
           pushOntoMultiMap(edges, to, i)
           return
@@ -133,8 +133,8 @@ function findEdgesInGroup (groups, i, edges) {
       }
     }
     if (item.afterGroupContaining) {
-      for (const command of item.afterGroupContaining) {
-        const to = indexOfGroupContainingCommand(groups, command, group)
+      for (const label of item.afterGroupContaining) {
+        const to = indexOfGroupContainingLabel(groups, label, group)
         if (to !== -1) {
           pushOntoMultiMap(edges, i, to)
           return
@@ -156,21 +156,14 @@ function sortGroups (groups) {
   return sortedGroupIndexes.map(i => groups[i])
 }
 
-function isSeparator (item) {
-  return item.type === 'separator'
-}
-
 function sortMenuItems (menuItems) {
+  const isSeparator = (item) => item.type === 'separator'
+
   // Split the items into their implicit groups based upon separators.
   const groups = splitArray(menuItems, isSeparator)
-  // Merge groups that contain before/after references to eachother.
   const mergedGroups = mergeGroups(groups)
-  // Sort each individual group internally.
   const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
-  // Sort the groups based upon their beforeGroupContaining/afterGroupContaining
-  // references.
   const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
-  // Join the groups back
   return joinArrays(sortedGroups, { type: 'separator' })
 }
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -177,7 +177,8 @@ Menu.buildFromTemplate = function (template) {
 /* Helper Functions */
 
 function sortTemplate (template) {
-  const sorted = sortMenuItems(template)
+  const initialSort = template.sort((a, b) => a.id - b.id)
+  const sorted = sortMenuItems(initialSort)
   for (let id in sorted) {
     const item = sorted[id]
     if (Array.isArray(item.submenu)) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -178,7 +178,7 @@ Menu.buildFromTemplate = function (template) {
 
 function sortTemplate (template) {
   const sorted = sortMenuItems(template)
-  for (let id in template) {
+  for (let id in sorted) {
     const item = sorted[id]
     if (Array.isArray(item.submenu)) {
       item.submenu = sortTemplate(item.submenu)
@@ -202,45 +202,6 @@ function generateGroupId (items, pos) {
   }
   groupIdIndex += 1
   return groupIdIndex
-}
-
-function indexOfItemById (items, id) {
-  const foundItem = items.find(item => item.id === id) || -1
-  return items.indexOf(foundItem)
-}
-
-function indexToInsertByPosition (items, position) {
-  if (!position) return items.length
-
-  const [query, id] = position.split('=') // parse query and id from position
-  const idx = indexOfItemById(items, id) // calculate initial index of item
-
-  // warn if query doesn't exist
-  if (idx === -1 && query !== 'endof') {
-    console.warn(`Item with id ${id} is not found`)
-    return items.length
-  }
-
-  // compute new index based on query
-  const queries = {
-    after: (index) => {
-      index += 1
-      return index
-    },
-    endof: (index) => {
-      if (index === -1) {
-        items.push({id, type: 'separator'})
-        index = items.length - 1
-      }
-
-      index += 1
-      while (index < items.length && items[index].type !== 'separator') index += 1
-      return index
-    }
-  }
-
-  // return new index if needed, or original indexOfItemById
-  return (query in queries) ? queries[query](idx) : idx
 }
 
 function removeExtraSeparators (items) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -1,6 +1,8 @@
 'use strict'
 
+<<<<<<< HEAD
 const {TopLevelWindow, MenuItem, webContents} = require('electron')
+const {sortMenuItems} = require('./menu-utils')
 const EventEmitter = require('events').EventEmitter
 const v8Util = process.atomBinding('v8_util')
 const bindings = process.atomBinding('menu')
@@ -174,6 +176,17 @@ Menu.buildFromTemplate = function (template) {
 
 /* Helper Functions */
 
+function sortTemplate (template) {
+  const sorted = sortMenuItems(template)
+  for (let id in template) {
+    const item = sorted[id]
+    if (Array.isArray(item.submenu)) {
+      item.submenu = sortTemplate(item.submenu)
+    }
+  }
+  return sorted
+}
+
 // Search between separators to find a radio menu item and return its group id
 function generateGroupId (items, pos) {
   if (pos > 0) {
@@ -276,186 +289,6 @@ function insertItemByType (item, pos) {
     }
   }
   types[item.type]()
-}
-
-function sortTemplate (template) {
-  const sorted = sortMenuItems(template)
-  for (let id in template) {
-    const item = sorted[id]
-    if (Array.isArray(item.submenu)) {
-      item.submenu = sortTemplate(item.submenu)
-    }
-  }
-  return sorted
-}
-
-function splitArray (arr, predicate) {
-  let lastArr = []
-  const multiArr = [lastArr]
-  arr.forEach(item => {
-    if (predicate(item)) {
-      if (lastArr.length > 0) {
-        lastArr = []
-        multiArr.push(lastArr)
-      }
-    } else {
-      lastArr.push(item)
-    }
-  })
-  return multiArr
-}
-
-function joinArrays (arrays, joiner) {
-  const joinedArr = []
-  arrays.forEach((arr, i) => {
-    if (i > 0 && arr.length > 0) {
-      joinedArr.push(joiner)
-    }
-    joinedArr.push(...arr)
-  })
-  return joinedArr
-}
-
-const pushOntoMultiMap = (map, key, value) => {
-  if (!map.has(key)) {
-    map.set(key, [])
-  }
-  map.get(key).push(value)
-}
-
-function indexOfGroupContainingLabel (groups, label, ignoreGroup) {
-  return groups.findIndex(
-    candiateGroup =>
-      candiateGroup !== ignoreGroup &&
-      candiateGroup.some(
-        candidateItem => candidateItem.label === label
-      )
-  )
-}
-
-// Sort nodes topologically using a depth-first approach. Encountered cycles
-// are broken.
-function sortTopologically (originalOrder, edgesById) {
-  const sorted = []
-  const marked = new Set()
-
-  function visit (id) {
-    if (marked.has(id)) return
-    marked.add(id)
-    const edges = edgesById.get(id)
-    if (edges != null) {
-      edges.forEach(visit)
-    }
-    sorted.push(id)
-  }
-
-  originalOrder.forEach(visit)
-  return sorted
-}
-
-function attemptToMergeAGroup (groups) {
-  for (let i = 0; i < groups.length; i++) {
-    const group = groups[i]
-    for (const item of group) {
-      const toLabels = [...(item.before || []), ...(item.after || [])]
-      for (const label of toLabels) {
-        const index = indexOfGroupContainingLabel(groups, label, group)
-        if (index === -1) continue
-        const mergeTarget = groups[index]
-        // Merge with group containing `command`
-        mergeTarget.push(...group)
-        groups.splice(i, 1)
-        return true
-      }
-    }
-  }
-  return false
-}
-
-// Merge groups based on before/after positions
-// Mutates both the array of groups, and the individual group arrays.
-function mergeGroups (groups) {
-  let mergedAGroup = true
-  while (mergedAGroup) {
-    mergedAGroup = attemptToMergeAGroup(groups)
-  }
-  return groups
-}
-
-function sortItemsInGroup (group) {
-  const originalOrder = group.map((node, i) => i)
-  const edges = new Map()
-  const labelToIndex = new Map(group.map((item, i) => [item.label, i]))
-
-  group.forEach((item, i) => {
-    if (item.before) {
-      item.before.forEach(toLabel => {
-        const to = labelToIndex.get(toLabel)
-        if (to != null) {
-          pushOntoMultiMap(edges, to, i)
-        }
-      })
-    }
-    if (item.after) {
-      item.after.forEach(toLabel => {
-        const to = labelToIndex.get(toLabel)
-        if (to != null) {
-          pushOntoMultiMap(edges, i, to)
-        }
-      })
-    }
-  })
-
-  const sortedNodes = sortTopologically(originalOrder, edges)
-
-  return sortedNodes.map(i => group[i])
-}
-
-function findEdgesInGroup (groups, i, edges) {
-  const group = groups[i]
-  for (const item of group) {
-    if (item.beforeGroupContaining) {
-      for (const label of item.beforeGroupContaining) {
-        const to = indexOfGroupContainingLabel(groups, label, group)
-        if (to !== -1) {
-          pushOntoMultiMap(edges, to, i)
-          return
-        }
-      }
-    }
-    if (item.afterGroupContaining) {
-      for (const label of item.afterGroupContaining) {
-        const to = indexOfGroupContainingLabel(groups, label, group)
-        if (to !== -1) {
-          pushOntoMultiMap(edges, i, to)
-          return
-        }
-      }
-    }
-  }
-}
-
-function sortGroups (groups) {
-  const originalOrder = groups.map((item, i) => i)
-  const edges = new Map()
-
-  for (let i = 0; i < groups.length; i++) {
-    findEdgesInGroup(groups, i, edges)
-  }
-
-  const sortedGroupIndexes = sortTopologically(originalOrder, edges)
-  return sortedGroupIndexes.map(i => groups[i])
-}
-
-function sortMenuItems (menuItems) {
-  const isSeparator = (item) => item.type === 'separator'
-
-  // Split the items into their implicit groups based upon separators.
-  const groups = splitArray(menuItems, isSeparator)
-  const mergedGroups = mergeGroups(groups)
-  const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
-  const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
-  return joinArrays(sortedGroups, { type: 'separator' })
 }
 
 module.exports = Menu

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -160,18 +160,9 @@ Menu.buildFromTemplate = function (template) {
 
   const menu = new Menu()
   const filtered = removeExtraSeparators(template)
+  const sorted = sortTemplate(filtered)
 
-  const positioned = []
-  let idx = 0
-
-  // sort template by position
-  filtered.forEach(item => {
-    idx = (item.position) ? indexToInsertByPosition(positioned, item.position) : idx += 1
-    positioned.splice(idx, 0, item)
-  })
-
-  // add each item from positioned menu to application menu
-  positioned.forEach((item) => {
+  sorted.forEach((item) => {
     if (typeof item !== 'object') {
       throw new TypeError('Invalid template for MenuItem')
     }
@@ -285,6 +276,193 @@ function insertItemByType (item, pos) {
     }
   }
   types[item.type]()
+}
+
+function sortTemplate (template) {
+  const sorted = sortMenuItems(template)
+  for (let id in template) {
+    const item = sorted[id]
+    if (Array.isArray(item.submenu)) {
+      item.submenu = sortTemplate(item.submenu)
+    }
+  }
+  return sorted
+}
+
+function splitArray (arr, predicate) {
+  let lastArr = []
+  const multiArr = [lastArr]
+  arr.forEach(item => {
+    if (predicate(item)) {
+      if (lastArr.length > 0) {
+        lastArr = []
+        multiArr.push(lastArr)
+      }
+    } else {
+      lastArr.push(item)
+    }
+  })
+  return multiArr
+}
+
+function joinArrays (arrays, joiner) {
+  const joinedArr = []
+  arrays.forEach((arr, i) => {
+    if (i > 0 && arr.length > 0) {
+      joinedArr.push(joiner)
+    }
+    joinedArr.push(...arr)
+  })
+  return joinedArr
+}
+
+const pushOntoMultiMap = (map, key, value) => {
+  if (!map.has(key)) {
+    map.set(key, [])
+  }
+  map.get(key).push(value)
+}
+
+function indexOfGroupContainingCommand (groups, command, ignoreGroup) {
+  return groups.findIndex(
+    candiateGroup =>
+      candiateGroup !== ignoreGroup &&
+      candiateGroup.some(
+        candidateItem => candidateItem.command === command
+      )
+  )
+}
+
+// Sort nodes topologically using a depth-first approach. Encountered cycles
+// are broken.
+function sortTopologically (originalOrder, edgesById) {
+  const sorted = []
+  const marked = new Set()
+
+  function visit (id) {
+    if (marked.has(id)) return
+    marked.add(id)
+    const edges = edgesById.get(id)
+    if (edges != null) {
+      edges.forEach(visit)
+    }
+    sorted.push(id)
+  }
+
+  originalOrder.forEach(visit)
+  return sorted
+}
+
+function attemptToMergeAGroup (groups) {
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i]
+    for (const item of group) {
+      const toCommands = [...(item.before || []), ...(item.after || [])]
+      for (const command of toCommands) {
+        const index = indexOfGroupContainingCommand(groups, command, group)
+        if (index === -1) continue
+        const mergeTarget = groups[index]
+        // Merge with group containing `command`
+        mergeTarget.push(...group)
+        groups.splice(i, 1)
+        return true
+      }
+    }
+  }
+  return false
+}
+
+// Merge groups based on before/after positions
+// Mutates both the array of groups, and the individual group arrays.
+function mergeGroups (groups) {
+  let mergedAGroup = true
+  while (mergedAGroup) {
+    mergedAGroup = attemptToMergeAGroup(groups)
+  }
+  return groups
+}
+
+function sortItemsInGroup (group) {
+  const originalOrder = group.map((node, i) => i)
+  const edges = new Map()
+  const commandToIndex = new Map(group.map((item, i) => [item.command, i]))
+
+  group.forEach((item, i) => {
+    if (item.before) {
+      item.before.forEach(toCommand => {
+        const to = commandToIndex.get(toCommand)
+        if (to != null) {
+          pushOntoMultiMap(edges, to, i)
+        }
+      })
+    }
+    if (item.after) {
+      item.after.forEach(toCommand => {
+        const to = commandToIndex.get(toCommand)
+        if (to != null) {
+          pushOntoMultiMap(edges, i, to)
+        }
+      })
+    }
+  })
+
+  const sortedNodes = sortTopologically(originalOrder, edges)
+
+  return sortedNodes.map(i => group[i])
+}
+
+function findEdgesInGroup (groups, i, edges) {
+  const group = groups[i]
+  for (const item of group) {
+    if (item.beforeGroupContaining) {
+      for (const command of item.beforeGroupContaining) {
+        const to = indexOfGroupContainingCommand(groups, command, group)
+        if (to !== -1) {
+          pushOntoMultiMap(edges, to, i)
+          return
+        }
+      }
+    }
+    if (item.afterGroupContaining) {
+      for (const command of item.afterGroupContaining) {
+        const to = indexOfGroupContainingCommand(groups, command, group)
+        if (to !== -1) {
+          pushOntoMultiMap(edges, i, to)
+          return
+        }
+      }
+    }
+  }
+}
+
+function sortGroups (groups) {
+  const originalOrder = groups.map((item, i) => i)
+  const edges = new Map()
+
+  for (let i = 0; i < groups.length; i++) {
+    findEdgesInGroup(groups, i, edges)
+  }
+
+  const sortedGroupIndexes = sortTopologically(originalOrder, edges)
+  return sortedGroupIndexes.map(i => groups[i])
+}
+
+function isSeparator (item) {
+  return item.type === 'separator'
+}
+
+function sortMenuItems (menuItems) {
+  // Split the items into their implicit groups based upon separators.
+  const groups = splitArray(menuItems, isSeparator)
+  // Merge groups that contain before/after references to eachother.
+  const mergedGroups = mergeGroups(groups)
+  // Sort each individual group internally.
+  const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
+  // Sort the groups based upon their beforeGroupContaining/afterGroupContaining
+  // references.
+  const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
+  // Join the groups back
+  return joinArrays(sortedGroups, { type: 'separator' })
 }
 
 module.exports = Menu

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -323,12 +323,12 @@ const pushOntoMultiMap = (map, key, value) => {
   map.get(key).push(value)
 }
 
-function indexOfGroupContainingCommand (groups, command, ignoreGroup) {
+function indexOfGroupContainingLabel (groups, label, ignoreGroup) {
   return groups.findIndex(
     candiateGroup =>
       candiateGroup !== ignoreGroup &&
       candiateGroup.some(
-        candidateItem => candidateItem.command === command
+        candidateItem => candidateItem.label === label
       )
   )
 }
@@ -357,9 +357,9 @@ function attemptToMergeAGroup (groups) {
   for (let i = 0; i < groups.length; i++) {
     const group = groups[i]
     for (const item of group) {
-      const toCommands = [...(item.before || []), ...(item.after || [])]
-      for (const command of toCommands) {
-        const index = indexOfGroupContainingCommand(groups, command, group)
+      const toLabels = [...(item.before || []), ...(item.after || [])]
+      for (const label of toLabels) {
+        const index = indexOfGroupContainingLabel(groups, label, group)
         if (index === -1) continue
         const mergeTarget = groups[index]
         // Merge with group containing `command`
@@ -385,20 +385,20 @@ function mergeGroups (groups) {
 function sortItemsInGroup (group) {
   const originalOrder = group.map((node, i) => i)
   const edges = new Map()
-  const commandToIndex = new Map(group.map((item, i) => [item.command, i]))
+  const labelToIndex = new Map(group.map((item, i) => [item.label, i]))
 
   group.forEach((item, i) => {
     if (item.before) {
-      item.before.forEach(toCommand => {
-        const to = commandToIndex.get(toCommand)
+      item.before.forEach(toLabel => {
+        const to = labelToIndex.get(toLabel)
         if (to != null) {
           pushOntoMultiMap(edges, to, i)
         }
       })
     }
     if (item.after) {
-      item.after.forEach(toCommand => {
-        const to = commandToIndex.get(toCommand)
+      item.after.forEach(toLabel => {
+        const to = labelToIndex.get(toLabel)
         if (to != null) {
           pushOntoMultiMap(edges, i, to)
         }
@@ -415,8 +415,8 @@ function findEdgesInGroup (groups, i, edges) {
   const group = groups[i]
   for (const item of group) {
     if (item.beforeGroupContaining) {
-      for (const command of item.beforeGroupContaining) {
-        const to = indexOfGroupContainingCommand(groups, command, group)
+      for (const label of item.beforeGroupContaining) {
+        const to = indexOfGroupContainingLabel(groups, label, group)
         if (to !== -1) {
           pushOntoMultiMap(edges, to, i)
           return
@@ -424,8 +424,8 @@ function findEdgesInGroup (groups, i, edges) {
       }
     }
     if (item.afterGroupContaining) {
-      for (const command of item.afterGroupContaining) {
-        const to = indexOfGroupContainingCommand(groups, command, group)
+      for (const label of item.afterGroupContaining) {
+        const to = indexOfGroupContainingLabel(groups, label, group)
         if (to !== -1) {
           pushOntoMultiMap(edges, i, to)
           return
@@ -447,21 +447,14 @@ function sortGroups (groups) {
   return sortedGroupIndexes.map(i => groups[i])
 }
 
-function isSeparator (item) {
-  return item.type === 'separator'
-}
-
 function sortMenuItems (menuItems) {
+  const isSeparator = (item) => item.type === 'separator'
+
   // Split the items into their implicit groups based upon separators.
   const groups = splitArray(menuItems, isSeparator)
-  // Merge groups that contain before/after references to eachother.
   const mergedGroups = mergeGroups(groups)
-  // Sort each individual group internally.
   const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
-  // Sort the groups based upon their beforeGroupContaining/afterGroupContaining
-  // references.
   const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
-  // Join the groups back
   return joinArrays(sortedGroups, { type: 'separator' })
 }
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -177,8 +177,7 @@ Menu.buildFromTemplate = function (template) {
 /* Helper Functions */
 
 function sortTemplate (template) {
-  const initialSort = template.sort((a, b) => a.id - b.id)
-  const sorted = sortMenuItems(initialSort)
+  const sorted = sortMenuItems(template)
   for (let id in sorted) {
     const item = sorted[id]
     if (Array.isArray(item.submenu)) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -1,6 +1,5 @@
 'use strict'
 
-<<<<<<< HEAD
 const {TopLevelWindow, MenuItem, webContents} = require('electron')
 const {sortMenuItems} = require('./menu-utils')
 const EventEmitter = require('events').EventEmitter

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -90,6 +90,27 @@ describe.only('Menu module', () => {
           ]
           assert.deepEqual(sortMenuItems(items), expected)
         })
+
+        it('only respects the first matching [before|after]GroupContaining rule in a given group', () => {
+          const items = [
+            { label: 'one' },
+            { type: 'separator' },
+            { label: 'three', beforeGroupContaining: ['one'] },
+            { label: 'four', afterGroupContaining: ['two'] },
+            { type: 'separator' },
+            { label: 'two' }
+          ]
+
+          const expected = [
+            { label: 'three', beforeGroupContaining: ['one'] },
+            { label: 'four', afterGroupContaining: ['two'] },
+            { type: 'separator' },
+            { label: 'one' },
+            { type: 'separator' },
+            { label: 'two' }
+          ]
+          assert.deepEqual(sortMenuItems(items), expected)
+        })
       })
 
       describe('moves an item to a different group by merging groups', () => {
@@ -235,57 +256,10 @@ describe.only('Menu module', () => {
             after: ['1']
           }
         ])
+
         assert.equal(menu.items[0].label, '1')
         assert.equal(menu.items[1].label, '2')
         assert.equal(menu.items[2].label, '3')
-      })
-
-      it('should position at endof existing separator groups', () => {
-        const menu = Menu.buildFromTemplate([
-          {
-            label: 'first',
-            id: 'first'
-          }, {
-            type: 'separator',
-            id: 'numbers'
-          }, {
-            label: 'a',
-            id: 'a',
-            position: 'endof=letters'
-          }, {
-            type: 'separator',
-            id: 'letters'
-          }, {
-            label: '1',
-            id: '1',
-            position: 'endof=numbers'
-          }, {
-            label: 'b',
-            id: 'b',
-            position: 'endof=letters'
-          }, {
-            label: '2',
-            id: '2',
-            position: 'endof=numbers'
-          }, {
-            label: 'c',
-            id: 'c',
-            position: 'endof=letters'
-          }, {
-            label: '3',
-            id: '3',
-            position: 'endof=numbers'
-          }
-        ])
-
-        assert.equal(menu.items[1].id, 'numbers')
-        assert.equal(menu.items[2].label, '1')
-        assert.equal(menu.items[3].label, '2')
-        assert.equal(menu.items[4].label, '3')
-        assert.equal(menu.items[5].id, 'letters')
-        assert.equal(menu.items[6].label, 'a')
-        assert.equal(menu.items[7].label, 'b')
-        assert.equal(menu.items[8].label, 'c')
       })
 
       it('should filter excess menu separators', () => {
@@ -330,95 +304,6 @@ describe.only('Menu module', () => {
         assert.equal(menuTwo.items[0].label, 'a')
         assert.equal(menuTwo.items[1].label, 'b')
         assert.equal(menuTwo.items[2].label, 'c')
-      })
-
-      it('should create separator group if endof does not reference existing separator group', () => {
-        const menu = Menu.buildFromTemplate([
-          {
-            label: 'a',
-            id: 'a',
-            position: 'endof=letters'
-          }, {
-            label: '1',
-            id: '1',
-            position: 'endof=numbers'
-          }, {
-            label: 'b',
-            id: 'b',
-            position: 'endof=letters'
-          }, {
-            label: '2',
-            id: '2',
-            position: 'endof=numbers'
-          }, {
-            label: 'c',
-            id: 'c',
-            position: 'endof=letters'
-          }, {
-            label: '3',
-            id: '3',
-            position: 'endof=numbers'
-          }
-        ])
-        assert.equal(menu.items[0].id, 'letters')
-        assert.equal(menu.items[1].label, 'a')
-        assert.equal(menu.items[2].label, 'b')
-        assert.equal(menu.items[3].label, 'c')
-        assert.equal(menu.items[4].id, 'numbers')
-        assert.equal(menu.items[5].label, '1')
-        assert.equal(menu.items[6].label, '2')
-        assert.equal(menu.items[7].label, '3')
-      })
-
-      it('resolves cycles by ignoring things that conflict', () => {
-        const items = [
-          {
-            label: 'two',
-            afterGroupContaining: ['one']
-          },
-          { type: 'separator' },
-          {
-            label: 'one',
-            afterGroupContaining: ['two']
-          }
-        ]
-
-        const expected = [
-          {
-            label: 'one',
-            afterGroupContaining: ['two']
-          },
-          { type: 'separator' },
-          {
-            label: 'two',
-            afterGroupContaining: ['one']
-          }
-        ]
-
-        assert.deepEqual(sortMenuItems(items), expected)
-      })
-
-
-
-      it('only respects the first matching [before|after]GroupContaining rule in a given group', () => {
-        const items = [
-          { label: 'one' },
-          { type: 'separator' },
-          { label: 'three', beforeGroupContaining: ['one'] },
-          { label: 'four', afterGroupContaining: ['two'] },
-          { type: 'separator' },
-          { label: 'two' }
-        ]
-
-        const expected = [
-          { label: 'three', beforeGroupContaining: ['one'] },
-          { label: 'four', afterGroupContaining: ['two'] },
-          { type: 'separator' },
-          { label: 'one' },
-          { type: 'separator' },
-          { label: 'two' }
-        ]
-        assert.deepEqual(sortMenuItems(items), expected)
       })
 
       it('should continue inserting items at next index when no specifier is present', () => {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -242,7 +242,7 @@ describe.only('Menu module', () => {
         assert.equal(menu.items[2].label, '3')
       })
 
-      it('should position after existing item', () => {
+      it.only('should position after existing item', () => {
         const menu = Menu.buildFromTemplate([
           {
             label: '1',
@@ -306,7 +306,7 @@ describe.only('Menu module', () => {
         assert.equal(menuTwo.items[2].label, 'c')
       })
 
-      it('should continue inserting items at next index when no specifier is present', () => {
+      it.only('should continue inserting items at next index when no specifier is present', () => {
         const menu = Menu.buildFromTemplate([
           {
             label: '4',
@@ -326,6 +326,7 @@ describe.only('Menu module', () => {
             id: '3'
           }
         ])
+
         assert.equal(menu.items[0].label, '1')
         assert.equal(menu.items[1].label, '2')
         assert.equal(menu.items[2].label, '3')

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -5,7 +5,7 @@ const {BrowserWindow, Menu, MenuItem} = remote
 const {sortMenuItems} = require('../lib/browser/api/menu-utils')
 const {closeWindow} = require('./window-helpers')
 
-describe.only('Menu module', () => {
+describe('Menu module', () => {
   describe('Menu.buildFromTemplate', () => {
     it('should be able to attach extra fields', () => {
       const menu = Menu.buildFromTemplate([
@@ -242,7 +242,7 @@ describe.only('Menu module', () => {
         assert.equal(menu.items[2].label, '3')
       })
 
-      it.only('should position after existing item', () => {
+      it('should position after existing item', () => {
         const menu = Menu.buildFromTemplate([
           {
             label: '1',
@@ -306,7 +306,7 @@ describe.only('Menu module', () => {
         assert.equal(menuTwo.items[2].label, 'c')
       })
 
-      it.only('should continue inserting items at next index when no specifier is present', () => {
+      it('should continue inserting items at next index when no specifier is present', () => {
         const menu = Menu.buildFromTemplate([
           {
             label: '4',

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -38,77 +38,146 @@ describe('Menu module', () => {
       })
     })
 
-    describe('Menu.buildFromTemplate', () => {
+    describe('Menu sorting and building', () => {
       describe('sorts groups', () => {
         it('does a simple sort', () => {
           const items = [
-            { label: 'two', afterGroupContaining: ['one'] },
+            {
+              label: 'two',
+              id: '2',
+              afterGroupContaining: ['1'] },
             { type: 'separator' },
-            { label: 'one' }
+            {
+              id: '1',
+              label: 'one'
+            }
           ]
 
           const expected = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'two', afterGroupContaining: ['one'] }
+            {
+              id: '2',
+              label: 'two',
+              afterGroupContaining: ['1']
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it('resolves cycles by ignoring things that conflict', () => {
           const items = [
-            { label: 'two', afterGroupContaining: ['one'] },
+            {
+              id: '2',
+              label: 'two',
+              afterGroupContaining: ['1']
+            },
             { type: 'separator' },
-            { label: 'one', afterGroupContaining: ['two'] }
+            {
+              id: '1',
+              label: 'one',
+              afterGroupContaining: ['2']
+            }
           ]
 
           const expected = [
-            { label: 'one', afterGroupContaining: ['two'] },
+            {
+              id: '1',
+              label: 'one',
+              afterGroupContaining: ['2']
+            },
             { type: 'separator' },
-            { label: 'two', afterGroupContaining: ['one'] }
+            {
+              id: '2',
+              label: 'two',
+              afterGroupContaining: ['1']
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it('ignores references to commands that do not exist', () => {
           const items = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
             {
+              id: '2',
               label: 'two',
               afterGroupContaining: ['does-not-exist']
             }
           ]
 
           const expected = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
             {
+              id: '2',
               label: 'two',
               afterGroupContaining: ['does-not-exist']
             }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it('only respects the first matching [before|after]GroupContaining rule in a given group', () => {
           const items = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'three', beforeGroupContaining: ['one'] },
-            { label: 'four', afterGroupContaining: ['two'] },
+            {
+              id: '3',
+              label: 'three',
+              beforeGroupContaining: ['1']
+            },
+            {
+              id: '4',
+              label: 'four',
+              afterGroupContaining: ['2']
+            },
             { type: 'separator' },
-            { label: 'two' }
+            {
+              id: '2',
+              label: 'two'
+            }
           ]
 
           const expected = [
-            { label: 'three', beforeGroupContaining: ['one'] },
-            { label: 'four', afterGroupContaining: ['two'] },
+            {
+              id: '3',
+              label: 'three',
+              beforeGroupContaining: ['1']
+            },
+            {
+              id: '4',
+              label: 'four',
+              afterGroupContaining: ['2']
+            },
             { type: 'separator' },
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'two' }
+            {
+              id: '2',
+              label: 'two'
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
       })
@@ -116,109 +185,255 @@ describe('Menu module', () => {
       describe('moves an item to a different group by merging groups', () => {
         it('can move a group of one item', () => {
           const items = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'two' },
+            {
+              id: '2',
+              label: 'two'
+            },
             { type: 'separator' },
-            { label: 'three', after: ['one'] },
+            {
+              id: '3',
+              label: 'three',
+              after: ['1']
+            },
             { type: 'separator' }
           ]
 
           const expected = [
-            { label: 'one' },
-            { label: 'three', after: ['one'] },
+            {
+              id: '1',
+              label: 'one'
+            },
+            {
+              id: '3',
+              label: 'three',
+              after: ['1']
+            },
             { type: 'separator' },
-            { label: 'two' }
+            {
+              id: '2',
+              label: 'two'
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it("moves all items in the moving item's group", () => {
           const items = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'two' },
+            {
+              id: '2',
+              label: 'two'
+            },
             { type: 'separator' },
-            { label: 'three', after: ['one'] },
-            { label: 'four' },
+            {
+              id: '3',
+              label: 'three',
+              after: ['1']
+            },
+            {
+              id: '4',
+              label: 'four'
+            },
             { type: 'separator' }
           ]
 
           const expected = [
-            { label: 'one' },
-            { label: 'three', after: ['one'] },
-            { label: 'four' },
+            {
+              id: '1',
+              label: 'one'
+            },
+            {
+              id: '3',
+              label: 'three',
+              after: ['1']
+            },
+            {
+              id: '4',
+              label: 'four'
+            },
             { type: 'separator' },
-            { label: 'two' }
+            {
+              id: '2',
+              label: 'two'
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it("ignores positions relative to commands that don't exist", () => {
           const items = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'two' },
+            {
+              id: '2',
+              label: 'two'
+            },
             { type: 'separator' },
-            { label: 'three', after: ['does-not-exist'] },
-            { label: 'four', after: ['one'] },
+            {
+              id: '3',
+              label: 'three',
+              after: ['does-not-exist']
+            },
+            {
+              id: '4',
+              label: 'four',
+              after: ['1']
+            },
             { type: 'separator' }
           ]
 
           const expected = [
-            { label: 'one' },
-            { label: 'three', after: ['does-not-exist'] },
-            { label: 'four', after: ['one'] },
+            {
+              id: '1',
+              label: 'one'
+            },
+            {
+              id: '3',
+              label: 'three',
+              after: ['does-not-exist']
+            },
+            {
+              id: '4',
+              label: 'four',
+              after: ['1']
+            },
             { type: 'separator' },
-            { label: 'two' }
+            {
+              id: '2',
+              label: 'two'
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it('can handle recursive group merging', () => {
           const items = [
-            { label: 'one', after: ['three'] },
-            { label: 'two', before: ['one'] },
-            { label: 'three' }
+            {
+              id: '1',
+              label: 'one',
+              after: ['3']
+            },
+            {
+              id: '2',
+              label: 'two',
+              before: ['1']
+            },
+            {
+              id: '3',
+              label: 'three'
+            }
           ]
 
           const expected = [
-            { label: 'three' },
-            { label: 'two', before: ['one'] },
-            { label: 'one', after: ['three'] }
+            {
+              id: '3',
+              label: 'three'
+            },
+            {
+              id: '2',
+              label: 'two',
+              before: ['1']
+            },
+            {
+              id: '1',
+              label: 'one',
+              after: ['3']
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it('can merge multiple groups when given a list of before/after commands', () => {
           const items = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'two' },
+            {
+              id: '2',
+              label: 'two'
+            },
             { type: 'separator' },
-            { label: 'three', after: ['one', 'two'] }
+            {
+              id: '3',
+              label: 'three',
+              after: ['1', '2']
+            }
           ]
+
           const expected = [
-            { label: 'two' },
-            { label: 'one' },
-            { label: 'three', after: ['one', 'two'] }
+            {
+              id: '2',
+              label: 'two'
+            },
+            {
+              id: '1',
+              label: 'one'
+            },
+            {
+              id: '3',
+              label: 'three',
+              after: ['1', '2']
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
 
         it('can merge multiple groups based on both before/after commands', () => {
           const items = [
-            { label: 'one' },
+            {
+              id: '1',
+              label: 'one'
+            },
             { type: 'separator' },
-            { label: 'two' },
+            {
+              id: '2',
+              label: 'two'
+            },
             { type: 'separator' },
-            { label: 'three', after: ['one'], before: ['two'] }
+            {
+              id: '3',
+              label: 'three',
+              after: ['1'],
+              before: ['2']
+            }
           ]
+
           const expected = [
-            { label: 'one' },
-            { label: 'three', after: ['one'], before: ['two'] },
-            { label: 'two' }
+            {
+              id: '1',
+              label: 'one'
+            },
+            {
+              id: '3',
+              label: 'three',
+              after: ['1'],
+              before: ['2']
+            },
+            {
+              id: '2',
+              label: 'two'
+            }
           ]
+
           assert.deepEqual(sortMenuItems(items), expected)
         })
       })
@@ -226,40 +441,42 @@ describe('Menu module', () => {
       it('should position before existing item', () => {
         const menu = Menu.buildFromTemplate([
           {
-            label: '2',
-            id: '2'
+            id: '2',
+            label: 'two'
           }, {
-            label: '3',
-            id: '3'
+            id: '3',
+            label: 'three'
           }, {
-            label: '1',
             id: '1',
+            label: 'one',
             before: ['2']
           }
         ])
-        assert.equal(menu.items[0].label, '1')
-        assert.equal(menu.items[1].label, '2')
-        assert.equal(menu.items[2].label, '3')
+
+        assert.equal(menu.items[0].label, 'one')
+        assert.equal(menu.items[1].label, 'two')
+        assert.equal(menu.items[2].label, 'three')
       })
 
       it('should position after existing item', () => {
         const menu = Menu.buildFromTemplate([
           {
-            label: '1',
-            id: '1'
-          }, {
-            label: '3',
-            id: '3'
-          }, {
-            label: '2',
             id: '2',
+            label: 'two',
             after: ['1']
+          },
+          {
+            id: '1',
+            label: 'one'
+          }, {
+            id: '3',
+            label: 'three'
           }
         ])
 
-        assert.equal(menu.items[0].label, '1')
-        assert.equal(menu.items[1].label, '2')
-        assert.equal(menu.items[2].label, '3')
+        assert.equal(menu.items[0].label, 'one')
+        assert.equal(menu.items[1].label, 'two')
+        assert.equal(menu.items[2].label, 'three')
       })
 
       it('should filter excess menu separators', () => {
@@ -309,29 +526,29 @@ describe('Menu module', () => {
       it('should continue inserting items at next index when no specifier is present', () => {
         const menu = Menu.buildFromTemplate([
           {
-            label: '4',
-            id: '4'
+            id: '2',
+            label: 'two'
           }, {
-            label: '5',
-            id: '5'
+            id: '3',
+            label: 'three'
           }, {
-            label: '1',
+            id: '4',
+            label: 'four'
+          }, {
+            id: '5',
+            label: 'five'
+          }, {
             id: '1',
-            before: ['4']
-          }, {
-            label: '2',
-            id: '2'
-          }, {
-            label: '3',
-            id: '3'
+            label: 'one',
+            before: ['2']
           }
         ])
 
-        assert.equal(menu.items[0].label, '1')
-        assert.equal(menu.items[1].label, '2')
-        assert.equal(menu.items[2].label, '3')
-        assert.equal(menu.items[3].label, '4')
-        assert.equal(menu.items[4].label, '5')
+        assert.equal(menu.items[0].label, 'one')
+        assert.equal(menu.items[1].label, 'two')
+        assert.equal(menu.items[2].label, 'three')
+        assert.equal(menu.items[3].label, 'four')
+        assert.equal(menu.items[4].label, 'five')
       })
     })
   })

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -38,6 +38,116 @@ describe.only('Menu module', () => {
       })
     })
 
+    describe('Moves an item to a different group by merging groups', () => {
+      it('can move a group of one item', () => {
+        const items = [
+          { label: 'one' },
+          { type: 'separator' },
+          { label: 'two' },
+          { type: 'separator' },
+          { label: 'three', after: ['one'] },
+          { type: 'separator' }
+        ]
+
+        const expected = [
+          { label: 'one' },
+          { label: 'three', after: ['one'] },
+          { type: 'separator' },
+          { label: 'two' }
+        ]
+        assert.deepEqual(sortMenuItems(items), expected)
+      })
+
+      it("moves all items in the moving item's group", () => {
+        const items = [
+          { label: 'one' },
+          { type: 'separator' },
+          { label: 'two' },
+          { type: 'separator' },
+          { label: 'three', after: ['one'] },
+          { label: 'four' },
+          { type: 'separator' }
+        ]
+
+        const expected = [
+          { label: 'one' },
+          { label: 'three', after: ['one'] },
+          { label: 'four' },
+          { type: 'separator' },
+          { label: 'two' }
+        ]
+        assert.deepEqual(sortMenuItems(items), expected)
+      })
+
+      it("ignores positions relative to commands that don't exist", () => {
+        const items = [
+          { label: 'one' },
+          { type: 'separator' },
+          { label: 'two' },
+          { type: 'separator' },
+          { label: 'three', after: ['does-not-exist'] },
+          { label: 'four', after: ['one'] },
+          { type: 'separator' }
+        ]
+
+        const expected = [
+          { label: 'one' },
+          { label: 'three', after: ['does-not-exist'] },
+          { label: 'four', after: ['one'] },
+          { type: 'separator' },
+          { label: 'two' }
+        ]
+        assert.deepEqual(sortMenuItems(items), expected)
+      })
+
+      it('can handle recursive group merging', () => {
+        const items = [
+          { label: 'one', after: ['three'] },
+          { label: 'two', before: ['one'] },
+          { label: 'three' }
+        ]
+
+        const expected = [
+          { label: 'three' },
+          { label: 'two', before: ['one'] },
+          { label: 'one', after: ['three'] }
+        ]
+        assert.deepEqual(sortMenuItems(items), expected)
+      })
+
+      it('can merge multiple groups when given a list of before/after commands', () => {
+        const items = [
+          { label: 'one' },
+          { type: 'separator' },
+          { label: 'two' },
+          { type: 'separator' },
+          { label: 'three', after: ['one', 'two'] }
+        ]
+        const expected = [
+          { label: 'two' },
+          { label: 'one' },
+          { label: 'three', after: ['one', 'two'] }
+        ]
+        assert.deepEqual(sortMenuItems(items), expected)
+      })
+
+      it('can merge multiple groups based on both before/after commands', () => {
+        const items = [
+          { label: 'one' },
+          { type: 'separator' },
+          { label: 'two' },
+          { type: 'separator' },
+          { label: 'three', after: ['one'], before: ['two'] }
+        ]
+        const expected = [
+          { label: 'one' },
+          { label: 'three', after: ['one'], before: ['two'] },
+          { label: 'two' }
+        ]
+        assert.deepEqual(sortMenuItems(items), expected)
+      })
+    })
+
     describe('Menu.buildFromTemplate should reorder based on item position specifiers', () => {
       it('should position before existing item', () => {
         const menu = Menu.buildFromTemplate([


### PR DESCRIPTION
This PR reworks the way that we approach menu item ordering by porting an approximation of the solution devised in `atom/atom` with https://github.com/atom/atom/pull/16661 to Electron.

Fixes https://github.com/electron/electron/issues/11668.

To-Do:
- [x] Fix two failing tests
- [x] Documentation

This PR would hopefully be a breaking change in `3-0-x`.