### PR TITLE
move window z-order top with out focus

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -507,9 +507,12 @@ void Window::SetSheetOffset(double offsetY, mate::Arguments* args) {
   window_->SetSheetOffset(offsetX, offsetY);
 }
 
+#if defined(OS_WIN) || defined(OS_MACOSX)
 void Window::MoveTop() {
   window_->MoveTop();
 }
+#endif
+
 void Window::SetResizable(bool resizable) {
   window_->SetResizable(resizable);
 }
@@ -1056,7 +1059,9 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getMaximumSize", &Window::GetMaximumSize)
       .SetMethod("setSheetOffset", &Window::SetSheetOffset)
       .SetMethod("setResizable", &Window::SetResizable)
+#if defined(OS_WIN) || defined(OS_MACOSX)
       .SetMethod("moveTop", &Window::MoveTop)
+#endif
       .SetMethod("isResizable", &Window::IsResizable)
       .SetMethod("setMovable", &Window::SetMovable)
       .SetMethod("isMovable", &Window::IsMovable)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -507,6 +507,9 @@ void Window::SetSheetOffset(double offsetY, mate::Arguments* args) {
   window_->SetSheetOffset(offsetX, offsetY);
 }
 
+void Window::MoveTop(){
+  window_->MoveTop();
+}
 void Window::SetResizable(bool resizable) {
   window_->SetResizable(resizable);
 }
@@ -1053,6 +1056,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getMaximumSize", &Window::GetMaximumSize)
       .SetMethod("setSheetOffset", &Window::SetSheetOffset)
       .SetMethod("setResizable", &Window::SetResizable)
+      .SetMethod("moveTop", &Window::MoveTop)
       .SetMethod("isResizable", &Window::IsResizable)
       .SetMethod("setMovable", &Window::SetMovable)
       .SetMethod("isMovable", &Window::IsMovable)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -507,7 +507,7 @@ void Window::SetSheetOffset(double offsetY, mate::Arguments* args) {
   window_->SetSheetOffset(offsetX, offsetY);
 }
 
-void Window::MoveTop(){
+void Window::MoveTop() {
   window_->MoveTop();
 }
 void Window::SetResizable(bool resizable) {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -137,7 +137,9 @@ class Window : public mate::TrackableObject<Window>,
   void SetResizable(bool resizable);
   bool IsResizable();
   void SetMovable(bool movable);
+  #if defined(OS_WIN) || defined(OS_MACOSX)
   void MoveTop();
+  #endif
   bool IsMovable();
   void SetMinimizable(bool minimizable);
   bool IsMinimizable();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -137,6 +137,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetResizable(bool resizable);
   bool IsResizable();
   void SetMovable(bool movable);
+  void MoveTop();
   bool IsMovable();
   void SetMinimizable(bool minimizable);
   bool IsMinimizable();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -113,6 +113,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual double GetSheetOffsetX();
   virtual double GetSheetOffsetY();
   virtual void SetResizable(bool resizable) = 0;
+  virtual void ModeTop() = 0;
   virtual bool IsResizable() = 0;
   virtual void SetMovable(bool movable) = 0;
   virtual bool IsMovable() = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -113,7 +113,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual double GetSheetOffsetX();
   virtual double GetSheetOffsetY();
   virtual void SetResizable(bool resizable) = 0;
-  virtual void ModeTop() = 0;
+  virtual void MoveTop() = 0;
   virtual bool IsResizable() = 0;
   virtual void SetMovable(bool movable) = 0;
   virtual bool IsMovable() = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -113,7 +113,9 @@ class NativeWindow : public base::SupportsUserData,
   virtual double GetSheetOffsetX();
   virtual double GetSheetOffsetY();
   virtual void SetResizable(bool resizable) = 0;
+#if defined(OS_WIN) || defined(OS_MACOSX)
   virtual void MoveTop() = 0;
+#endif
   virtual bool IsResizable() = 0;
   virtual void SetMovable(bool movable) = 0;
   virtual bool IsMovable() = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -52,6 +52,7 @@ class NativeWindowMac : public NativeWindow,
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
+  void MoveTop() override;
   bool IsResizable() override;
   void SetMovable(bool movable) override;
   void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size)

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1253,6 +1253,9 @@ void NativeWindowMac::SetContentSizeConstraints(
   NativeWindow::SetContentSizeConstraints(size_constraints);
 }
 
+void MoveTop(){
+  [window_ orderWindow:NSWindowAbove relativeTo:0];
+}
 void NativeWindowMac::SetResizable(bool resizable) {
   SetStyleMask(resizable, NSResizableWindowMask);
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1253,7 +1253,7 @@ void NativeWindowMac::SetContentSizeConstraints(
   NativeWindow::SetContentSizeConstraints(size_constraints);
 }
 
-void MoveTop(){
+void NativeWindowMac::MoveTop(){
   [window_ orderWindow:NSWindowAbove relativeTo:0];
 }
 void NativeWindowMac::SetResizable(bool resizable) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -89,13 +89,6 @@ void FlipWindowStyle(HWND handle, bool on, DWORD flag) {
 bool IsAltKey(const content::NativeWebKeyboardEvent& event) {
   return event.windows_key_code == ui::VKEY_MENU;
 }
-void MoveTop(){
-#if defined(OS_WIN)
-  gfx::Point pos = GetPosition();
-  gfx::Size size = GetSize();
-  SetWindowPos(0 , pos.x(), pos.y(), size.width(), size.height(), SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); 
-#endif
-}
 bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
   typedef content::NativeWebKeyboardEvent::Modifiers Modifiers;
   int modifiers = event.GetModifiers();
@@ -630,7 +623,13 @@ void NativeWindowViews::SetResizable(bool resizable) {
 
   resizable_ = resizable;
 }
-
+void NativeWindowViews::MoveTop(){
+#if defined(OS_WIN)
+  gfx::Point pos = GetPosition();
+  gfx::Size size = GetSize();
+  ::SetWindowPos(GetAcceleratedWidget(), HWND_TOP , pos.x(), pos.y(), size.width(), size.height(), SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); 
+#endif
+}
 bool NativeWindowViews::IsResizable() {
 #if defined(OS_WIN)
   if (has_frame())

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -623,15 +623,17 @@ void NativeWindowViews::SetResizable(bool resizable) {
 
   resizable_ = resizable;
 }
-void NativeWindowViews::MoveTop() {
+
 #if defined(OS_WIN)
+void NativeWindowViews::MoveTop() {
   gfx::Point pos = GetPosition();
   gfx::Size size = GetSize();
   ::SetWindowPos(GetAcceleratedWidget(), HWND_TOP,
                 pos.x(), pos.y(), size.width(), size.height(),
                 SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-#endif
 }
+#endif
+
 bool NativeWindowViews::IsResizable() {
 #if defined(OS_WIN)
   if (has_frame())

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -89,7 +89,13 @@ void FlipWindowStyle(HWND handle, bool on, DWORD flag) {
 bool IsAltKey(const content::NativeWebKeyboardEvent& event) {
   return event.windows_key_code == ui::VKEY_MENU;
 }
-
+void MoveTop(){
+#if defined(OS_WIN)
+  gfx::Point pos = GetPosition();
+  gfx::Size size = GetSize();
+  SetWindowPos(0 , pos.x(), pos.y(), size.width(), size.height(), SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); 
+#endif
+}
 bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
   typedef content::NativeWebKeyboardEvent::Modifiers Modifiers;
   int modifiers = event.GetModifiers();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -623,11 +623,13 @@ void NativeWindowViews::SetResizable(bool resizable) {
 
   resizable_ = resizable;
 }
-void NativeWindowViews::MoveTop(){
+void NativeWindowViews::MoveTop() {
 #if defined(OS_WIN)
   gfx::Point pos = GetPosition();
   gfx::Size size = GetSize();
-  ::SetWindowPos(GetAcceleratedWidget(), HWND_TOP , pos.x(), pos.y(), size.width(), size.height(), SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); 
+  ::SetWindowPos(GetAcceleratedWidget(), HWND_TOP,
+                pos.x(), pos.y(), size.width(), size.height(),
+                SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
 #endif
 }
 bool NativeWindowViews::IsResizable() {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -77,6 +77,7 @@ class NativeWindowViews : public NativeWindow,
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
+  void MoveTop() override;
   bool IsResizable() override;
   void SetMovable(bool movable) override;
   bool IsMovable() override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -77,7 +77,9 @@ class NativeWindowViews : public NativeWindow,
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
+#if defined(OS_WIN)
   void MoveTop() override;
+#endif
   bool IsResizable() override;
   void SetMovable(bool movable) override;
   bool IsMovable() override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1001,7 +1001,7 @@ can not be focused on.
 
 Returns `Boolean` - Whether the window is always on top of other windows.
 
-#### `win.moveTop()`
+#### `win.moveTop()` _macOS_ _Windows_
 
 Moves window to top(z-order) regardless of focus
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1001,6 +1001,10 @@ can not be focused on.
 
 Returns `Boolean` - Whether the window is always on top of other windows.
 
+#### `win.moveTop()`
+
+Moves window to top(z-order) regardless of focus
+
 #### `win.center()`
 
 Moves window to the center of the screen.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Tested Window7 ,  10
os: window7,10 , Mac
API: BrowserWindow.moveTop()
Desc: move window to top position without focus
Usage: notification and show message

