### PR TITLE
Update 3 (of Visual Studio 2017) is leftover from 2015

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -5,7 +5,7 @@ Follow the guidelines below for building Electron on Windows.
 ## Prerequisites
 
 * Windows 7 / Server 2008 R2 or higher
-* Visual Studio 2017 Update 3 - [download VS 2017 Community Edition for
+* Visual Studio 2017 - [download VS 2017 Community Edition for
   free](https://www.visualstudio.com/vs/)
 * [Python 2.7](http://www.python.org/download/releases/2.7/)
 * [Node.js](https://nodejs.org/download/)


### PR DESCRIPTION
does not apply to 2017
it's not clear to me that it's possible to download a non current version of vs2017
but if a specific version is required the directions should explain how to get it

