### PR TITLE
add development README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,7 @@ dependencies, and tools contained in the `electron/electron` repository.
 
 See [Coding Style](https://electronjs.org/docs/development/coding-style) for information about which standards Electron adheres to in different parts of its codebase.
 
+## Further Reading
+
+For more in-depth guides on developing Electron, see 
+[/docs/development](/docs/development/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,22 +152,4 @@ These individual tutorials expand on topics discussed in the guide above.
 
 ## Development
 
-* [Coding Style](development/coding-style.md)
-* [Using clang-format on C++ Code](development/clang-format.md)
-* [Testing](development/testing.md)
-* [Source Code Directory Structure](development/source-code-directory-structure.md)
-* [Technical Differences to NW.js (formerly node-webkit)](development/atom-shell-vs-node-webkit.md)
-* [Build System Overview](development/build-system-overview.md)
-* [Build Instructions (macOS)](development/build-instructions-osx.md)
-* [Build Instructions (Windows)](development/build-instructions-windows.md)
-* [Build Instructions (Linux)](development/build-instructions-linux.md)
-* [Debug Instructions (macOS)](development/debugging-instructions-macos.md)
-* [Debug Instructions (Windows)](development/debug-instructions-windows.md)
-* [Setting Up Symbol Server in debugger](development/setting-up-symbol-server.md)
-* [Documentation Styleguide](styleguide.md)
-* [Contributing to Electron](../CONTRIBUTING.md)
-* [Issues](development/issues.md)
-* [Pull Requests](development/pull-requests.md)
-* [Upgrading Chromium](development/upgrading-chromium.md)
-* [Chromium Development](development/chromium-development.md)
-* [V8 Development](development/v8-development.md)
+See [development/README.md](development/README.md)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,28 @@
+# Developing Electron
+
+These guides are intended for people working on the Electron project itself. 
+For guides on Electron app development, see 
+[/docs/README.md](../README.md#guides-and-tutorials).
+
+* [Code of Conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing to Electron](../../CONTRIBUTING.md)
+* [Issues](issues.md)
+* [Pull Requests](pull-requests.md)
+* [Documentation Styleguide](styleguide.md)
+* [Source Code Directory Structure](source-code-directory-structure.md)
+* [Coding Style](coding-style.md)
+* [Using clang-format on C++ Code](clang-format.md)
+* [Build System Overview](build-system-overview.md)
+* [Build Instructions (macOS)](build-instructions-osx.md)
+* [Build Instructions (Windows)](build-instructions-windows.md)
+* [Build Instructions (Linux)](build-instructions-linux.md)
+* [Chromium Development](chromium-development.md)
+* [V8 Development](v8-development.md)
+* [Testing](testing.md)
+* [Debugging on Windows](debug-instructions-windows.md)
+* [Debugging on macOS](debugging-instructions-macos.md)
+* [Setting Up Symbol Server in Debugger](setting-up-symbol-server.md)
+* [Upgrading Chromium](upgrading-chromium.md)
+* [Upgrading Crashpad](upgrading-crashpad.md)
+* [Upgrading Node](upgrading-node.md)
+* [Releasing](releasing.md)


### PR DESCRIPTION
Following in the footsteps of #11416 and #11966, this pull request adds a README to docs/development with a logically ordered table of contents. Since github.com's file browser automatically displays README when viewing a directory, this will make crash-landings into /docs/development more welcoming. We can also parse this new table of contents and display it as a navigational element on the website.

cc @ckerr 