### PR TITLE
Fix broken fragment link in ipcMain documentation

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -96,4 +96,4 @@ Returns the `webContents` that sent the message, you can call
 `event.sender.send` to reply to the asynchronous message, see
 [webContents.send][web-contents-send] for more information.
 
-[web-contents-send]: web-contents.md#webcontentssendchannel-arg1-arg2-
+[web-contents-send]: web-contents.md#contentssendchannel-arg1-arg2-


### PR DESCRIPTION
Headings in webContents.md are changed at #6489, but fragment link to one of these in ipcMain.md is still not changed.