### PR TITLE
Fix dark mode tray highlighting bug

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -98,7 +98,7 @@ const CGFloat kVerticalTitleMargin = 2;
 
   // Draw the system bar background.
   [statusItem_ drawStatusBarBackgroundInRect:self.bounds
-                               withHighlight:[self isHighlighted]];
+                               withHighlight:[self shouldHighlight]];
 
   // Determine which image to use.
   NSImage* image = image_.get();


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/12366.

Previously, we only checked `[self shouldHighlight]` when calling `drawStatusBarBackgroundInRect` in `drawRect`; a PR accidentally changed it to checking both `[self shouldHighlight]` and `[self isDarkMode]` when updating to a helper method. 

This fixes that while leaving all other checks against highlighting in dark mode in place.

/cc @ckerr 