### PR TITLE
Update testing docs to reflect --grep syntax

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -37,8 +37,8 @@ its own `package.json` and that its dependencies are therefore not defined
 in the top-level `package.json`.
 
 To run only specific tests matching a pattern, run `npm run test --
--g=PATTERN`, replacing the `PATTERN` with a regex that matches the test suites
-you would like to run. As an example: If you want to run only IPC suites, you
+-g=PATTERN`, replacing the `PATTERN` with a regex that matches the tests
+you would like to run. As an example: If you want to run only IPC tests, you
 would run `npm run test -- -g ipc`.
 
 [standard-addons]: https://standardjs.com/#are-there-text-editor-plugins

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -36,9 +36,9 @@ app (surprise!) that can be found in the `spec` folder. Note that it has
 its own `package.json` and that its dependencies are therefore not defined
 in the top-level `package.json`.
 
-To run only a selected number of tests, run `npm run test -match=NAME`,
-replacing the `NAME` with the file name of the test suite you would like
-to run. As an example: If you want to run only IPC suites, you would run
-`npm run test -match=ipc`.
+To run only specific tests matching a pattern, run `npm run test --
+-g=PATTERN`, replacing the `PATTERN` with a regex that matches the test suites
+you would like to run. As an example: If you want to run only IPC suites, you
+would run `npm run test -- -g ipc`.
 
 [standard-addons]: https://standardjs.com/#are-there-text-editor-plugins


### PR DESCRIPTION
Looks like the -match syntax is no longer supported.