### PR TITLE
Increase timeout for inAppPurchase test

### DIFF
--- a/spec/api-in-app-purchase-spec.js
+++ b/spec/api-in-app-purchase-spec.js
@@ -4,8 +4,10 @@ const assert = require('assert')
 
 const {remote} = require('electron')
 
-describe('inAppPurchase module', () => {
+describe('inAppPurchase module', function () {
   if (process.platform !== 'darwin') return
+
+  this.timeout(3 * 60 * 1000)
 
   const {inAppPurchase} = remote
 


### PR DESCRIPTION
It seems that macOS in our CI sometimes got stuck when handling payments, hopefully increasing timeout could solve the flaky test.

Refs https://github.com/electron/electron/issues/12314.