### PR TITLE
Fix: Do not block main process for async dialog

### DIFF
--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -283,8 +283,9 @@ void ShowOpenDialog(const DialogSettings& settings,
 
   if (!settings.parent_window || !settings.parent_window->GetNativeWindow() ||
       settings.force_detached) {
-    int chosen = [dialog runModal];
-    OpenDialogCompletion(chosen, dialog, settings, callback);
+    [dialog beginWithCompletionHandler:^(NSInteger chosen) {
+      OpenDialogCompletion(chosen, dialog, settings, callback);
+    }];
   } else {
     NSWindow* window = settings.parent_window->GetNativeWindow();
     [dialog beginSheetModalForWindow:window
@@ -343,8 +344,9 @@ void ShowSaveDialog(const DialogSettings& settings,
 
   if (!settings.parent_window || !settings.parent_window->GetNativeWindow() ||
       settings.force_detached) {
-    int chosen = [dialog runModal];
-    SaveDialogCompletion(chosen, dialog, settings, callback);
+    [dialog beginWithCompletionHandler:^(NSInteger chosen) {
+      SaveDialogCompletion(chosen, dialog, settings, callback);
+    }];
   } else {
     NSWindow* window = settings.parent_window->GetNativeWindow();
     [dialog beginSheetModalForWindow:window


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Reported in https://github.com/electron/electron/issues/12368: Although the current API seems async `electron.dialog.show{Open,Save}Dialog()` with `callback` provided, it runs on a blocking call to macOS AppKit.

Doc ref:

> If a callback is passed, the API call will be asynchronous and the result will be passed via callback(filenames).
