### PR TITLE
Correct app-command name corresponding to APPCOMMAND_MEDIA_PLAY_PAUSE

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -243,8 +243,6 @@ void TopLevelWindow::OnWindowLeaveHtmlFullScreen() {
 }
 
 void TopLevelWindow::OnExecuteWindowsCommand(const std::string& command_name) {
-  if (command_name == "media-play-pause")
-    Emit("app-command", "media-play_pause");
   Emit("app-command", command_name);
 }
 

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -243,6 +243,8 @@ void TopLevelWindow::OnWindowLeaveHtmlFullScreen() {
 }
 
 void TopLevelWindow::OnExecuteWindowsCommand(const std::string& command_name) {
+  if (command_name == "media-play-pause")
+    Emit("app-command", "media-play_pause");
   Emit("app-command", command_name);
 }
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -142,6 +142,11 @@ HHOOK NativeWindowViews::mouse_hook_ = NULL;
 bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {
   std::string command = AppCommandToString(command_id);
   NotifyWindowExecuteWindowsCommand(command);
+
+  if (command_id == APPCOMMAND_MEDIA_PLAY_PAUSE)
+    // FIXME(htk3): Remove media-play_pause in 3.0
+    NotifyWindowExecuteWindowsCommand("media-play_pause");
+
   return false;
 }
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -44,7 +44,7 @@ const char* AppCommandToString(int command_id) {
     case APPCOMMAND_MEDIA_STOP:
       return "media-stop";
     case APPCOMMAND_MEDIA_PLAY_PAUSE:
-      return "media-play_pause";
+      return "media-play-pause";
     case APPCOMMAND_LAUNCH_MAIL:
       return "launch-mail";
     case APPCOMMAND_LAUNCH_MEDIA_SELECT:

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -23,6 +23,19 @@ let windowA = new BrowserWindow(optionsA)
 // Replace with
 let optionsB = {webPreferences: {enableBlinkFeatures: ''}}
 let windowB = new BrowserWindow(optionsB)
+
+// Deprecated
+window.on('app-command', (e, cmd) => {
+  if (cmd == 'media-play_pause') {
+    // do something
+  }
+})
+// Replace with
+window.on('app-command', (e, cmd) => {
+  if (cmd == 'media-play-pause') {
+    // do something
+  }
+})
 ```
 
 ## `clipboard`

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -26,13 +26,13 @@ let windowB = new BrowserWindow(optionsB)
 
 // Deprecated
 window.on('app-command', (e, cmd) => {
-  if (cmd == 'media-play_pause') {
+  if (cmd === 'media-play_pause') {
     // do something
   }
 })
 // Replace with
 window.on('app-command', (e, cmd) => {
-  if (cmd == 'media-play-pause') {
+  if (cmd === 'media-play-pause') {
     // do something
   }
 })


### PR DESCRIPTION
* Operating system: Windows 10 Version 1709
* Keyboard: Surface Pro 3 Type Cover, Elecom TK-GMFCM006, and Logicool K270

I tested this code:

```js
win.on('app-command', (e, cmd) => {
  dialog.showMessageBox({message: `invoked app command: ${cmd}`})
})
```

When I pressed play/pause key in my keyboard, alerted `invoked app command: media-play_pause`, not `media-play-pause`.
I think, that command must be named `media-play-pause`. Because [documentation of app-command event](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#event-app-command-windows) says "underscores are replaced with hyphens", and [any command names excluding that](https://github.com/electron/electron/blob/master/atom/browser/native_window_views_win.cc#L16-L69) are not including underscore.

This PR corrects `media-play_pause` to `media-play-pause`.