### PR TITLE
Fixes for autorelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,13 +64,17 @@ jobs:
           command: |
             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$AUTO_RELEASE" == "true" ]; then
               echo 'Trying to finish release'
-              node script/release.js --automaticRelease
+              node script/release.js --validateRelease --automaticRelease
               releaseExitCode=$?
               if [ $releaseExitCode -eq 0 ]; then
-                echo 'Release successful, now publishing to npm'
-                echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
-                npm run publish-to-npm
-                echo 'Release has been published to npm'
+                echo 'Release is ready to go; releasing'
+                node script/release.js--automaticRelease
+                if [ $releaseExitCode -eq 0 ]; then
+                  echo 'Release successful, now publishing to npm'
+                  echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
+                  npm run publish-to-npm
+                  echo 'Release has been published to npm'
+                fi
               else
                 echo 'Release is not complete, skipping publish for now'
               fi
@@ -176,13 +180,17 @@ jobs:
           command: |
             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$AUTO_RELEASE" == "true" ]; then
               echo 'Trying to finish release'
-              node script/release.js --automaticRelease
+              node script/release.js --validateRelease --automaticRelease
               releaseExitCode=$?
               if [ $releaseExitCode -eq 0 ]; then
-                echo 'Release successful, now publishing to npm'
-                echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
-                npm run publish-to-npm
-                echo 'Release has been published to npm'
+                echo 'Release is ready to go; releasing'
+                node script/release.js--automaticRelease
+                if [ $releaseExitCode -eq 0 ]; then
+                  echo 'Release successful, now publishing to npm'
+                  echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
+                  npm run publish-to-npm
+                  echo 'Release has been published to npm'
+                fi
               else
                 echo 'Release is not complete, skipping publish for now'
               fi
@@ -292,13 +300,17 @@ jobs:
           command: |
             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$AUTO_RELEASE" == "true" ]; then
               echo 'Trying to finish release'
-              node script/release.js --automaticRelease
+              node script/release.js --validateRelease --automaticRelease
               releaseExitCode=$?
               if [ $releaseExitCode -eq 0 ]; then
-                echo 'Release successful, now publishing to npm'
-                echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
-                npm run publish-to-npm
-                echo 'Release has been published to npm'
+                echo 'Release is ready to go; releasing'
+                node script/release.js--automaticRelease
+                if [ $releaseExitCode -eq 0 ]; then
+                  echo 'Release successful, now publishing to npm'
+                  echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
+                  npm run publish-to-npm
+                  echo 'Release has been published to npm'
+                fi
               else
                 echo 'Release is not complete, skipping publish for now'
               fi
@@ -391,13 +403,17 @@ jobs:
           command: |
             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$AUTO_RELEASE" == "true" ]; then
               echo 'Trying to finish release'
-              node script/release.js --automaticRelease
+              node script/release.js --validateRelease --automaticRelease
               releaseExitCode=$?
               if [ $releaseExitCode -eq 0 ]; then
-                echo 'Release successful, now publishing to npm'
-                echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
-                npm run publish-to-npm
-                echo 'Release has been published to npm'
+                echo 'Release is ready to go; releasing'
+                node script/release.js--automaticRelease
+                if [ $releaseExitCode -eq 0 ]; then
+                  echo 'Release successful, now publishing to npm'
+                  echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
+                  npm run publish-to-npm
+                  echo 'Release has been published to npm'
+                fi
               else
                 echo 'Release is not complete, skipping publish for now'
               fi
@@ -472,13 +488,17 @@ jobs:
           command: |
             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$AUTO_RELEASE" == "true" ]; then
               echo 'Trying to finish release'
-              node script/release.js --automaticRelease
+              node script/release.js --validateRelease --automaticRelease
               releaseExitCode=$?
               if [ $releaseExitCode -eq 0 ]; then
-                echo 'Release successful, now publishing to npm'
-                echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
-                npm run publish-to-npm
-                echo 'Release has been published to npm'
+                echo 'Release is ready to go; releasing'
+                node script/release.js--automaticRelease
+                if [ $releaseExitCode -eq 0 ]; then
+                  echo 'Release successful, now publishing to npm'
+                  echo "//registry.npmjs.org/:_authToken=$ELECTRON_NPM_TOKEN" >> ~/.npmrc
+                  npm run publish-to-npm
+                  echo 'Release has been published to npm'
+                fi
               else
                 echo 'Release is not complete, skipping publish for now'
               fi

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -22,7 +22,7 @@ const versionType = args._[0]
 assert(process.env.ELECTRON_GITHUB_TOKEN, 'ELECTRON_GITHUB_TOKEN not found in environment')
 if (!versionType && !args.notesOnly) {
   console.log(`Usage: prepare-release versionType [major | minor | patch | beta]` +
-     ` (--stable) (--notesOnly) (--automaticRelease)`)
+     ` (--stable) (--notesOnly) (--automaticRelease) (--branch)`)
   process.exit(1)
 }
 
@@ -243,7 +243,12 @@ async function prepareRelease (isBeta, notesOnly) {
     console.log(`${fail} Automatic release is only supported for beta releases`)
     process.exit(1)
   }
-  let currentBranch = await getCurrentBranch(gitDir)
+  let currentBranch
+  if (args.branch) {
+    currentBranch = args.branch
+  } else {
+    currentBranch = await getCurrentBranch(gitDir)
+  }
   if (notesOnly) {
     let releaseNotes = await getReleaseNotes(currentBranch)
     console.log(`Draft release notes are: \n${releaseNotes}`)

--- a/script/release.js
+++ b/script/release.js
@@ -183,7 +183,11 @@ function uploadNodeShasums () {
 function uploadIndexJson () {
   console.log('Uploading index.json to S3.')
   let scriptPath = path.join(__dirname, 'upload-index-json.py')
-  runScript(scriptPath, [])
+  let scriptArgs = []
+  if (args.automaticRelease) {
+    scriptArgs.push('-R')
+  }
+  runScript(scriptPath, scriptArgs)
   console.log(`${pass} Done uploading index.json to S3.`)
 }
 

--- a/script/upload-index-json.py
+++ b/script/upload-index-json.py
@@ -8,7 +8,6 @@ from lib.util import electron_gyp, execute, s3put, scoped_cwd
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-OUT_DIR     = os.path.join(SOURCE_ROOT, 'out', 'D')
 
 PROJECT_NAME = electron_gyp()['project_name%']
 PRODUCT_NAME = electron_gyp()['product_name%']
@@ -17,20 +16,25 @@ PRODUCT_NAME = electron_gyp()['product_name%']
 def main():
   # Upload the index.json.
   with scoped_cwd(SOURCE_ROOT):
+    if len(sys.argv) == 2 and sys.argv[1] == '-R':
+      config = 'R'
+    else:
+      config = 'D'
+    out_dir = os.path.join(SOURCE_ROOT, 'out', config)
     if sys.platform == 'darwin':
-      electron = os.path.join(OUT_DIR, '{0}.app'.format(PRODUCT_NAME),
+      electron = os.path.join(out_dir, '{0}.app'.format(PRODUCT_NAME),
                                 'Contents', 'MacOS', PRODUCT_NAME)
     elif sys.platform == 'win32':
-      electron = os.path.join(OUT_DIR, '{0}.exe'.format(PROJECT_NAME))
+      electron = os.path.join(out_dir, '{0}.exe'.format(PROJECT_NAME))
     else:
-      electron = os.path.join(OUT_DIR, PROJECT_NAME)
-    index_json = os.path.relpath(os.path.join(OUT_DIR, 'index.json'))
+      electron = os.path.join(out_dir, PROJECT_NAME)
+    index_json = os.path.relpath(os.path.join(out_dir, 'index.json'))
     execute([electron,
              os.path.join('tools', 'dump-version-info.js'),
              index_json])
 
     bucket, access_key, secret_key = s3_config()
-    s3put(bucket, access_key, secret_key, OUT_DIR, 'atom-shell/dist',
+    s3put(bucket, access_key, secret_key, out_dir, 'atom-shell/dist',
           [index_json])
 
 


### PR DESCRIPTION
I tried running the autorelease for 2.0.0-beta.5, but there were some issues:
1. `prepare-release.js` tries to determine the branch but the way it was doing it wasn't working when running via CI, so this PR allows us to pass in a branch name to `prepare-release.js`.
2. The automatic release was trying to run the release before validating, so this PR validates the release before trying to run release.
3. `upload-index-json.py` was hardwired to use the debug build, so this PR changes it to allow use of the release build.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->