### PR TITLE
Fix disabling accelerators

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -20,7 +20,7 @@ const delegate = {
   getAcceleratorForCommandId: (menu, id, useDefaultAccelerator) => {
     const command = menu.commandsMap[id]
     if (!command) return
-    if (command.accelerator) return command.accelerator
+    if (command.accelerator != null) return command.accelerator
     if (useDefaultAccelerator) return command.getDefaultRoleAccelerator()
   },
   executeCommand: (menu, event, id) => {


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/12384.

We checked that `(command.accelerator)` instead of that `(command.accelerator != null)`; empty strings are falsy so this removed the ability to disable accelerators by setting them to `''`. This reverts that.