### PR TITLE
Improve in-app purchase for MacOS

### DIFF
--- a/atom/browser/api/atom_api_in_app_purchase.cc
+++ b/atom/browser/api/atom_api_in_app_purchase.cc
@@ -45,26 +45,24 @@ struct Converter<in_app_purchase::Transaction> {
   }
 };
 
-
 template <>
 struct Converter<in_app_purchase::Product> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const in_app_purchase::Product& val) {
-  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
-  dict.SetHidden("simple", true);
-  dict.Set("productIdentifier", val.productIdentifier);
-  dict.Set("localizedDescription", val.localizedDescription);
-  dict.Set("localizedTitle", val.localizedTitle);
-  dict.Set("contentVersion", val.localizedTitle);
-  dict.Set("contentLengths", val.contentLengths);
-  
-  // Pricing Information
-  dict.Set("price", val.price);
-  dict.Set("formattedPrice", val.formattedPrice);
+    mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+    dict.SetHidden("simple", true);
+    dict.Set("productIdentifier", val.productIdentifier);
+    dict.Set("localizedDescription", val.localizedDescription);
+    dict.Set("localizedTitle", val.localizedTitle);
+    dict.Set("contentVersion", val.localizedTitle);
+    dict.Set("contentLengths", val.contentLengths);
 
-  // Downloadable Content Information
-  dict.Set("isDownloadable", val.downloadable);
+    // Pricing Information
+    dict.Set("price", val.price);
+    dict.Set("formattedPrice", val.formattedPrice);
 
+    // Downloadable Content Information
+    dict.Set("isDownloadable", val.downloadable);
 
     return dict.GetHandle();
   }
@@ -90,8 +88,10 @@ void InAppPurchase::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("canMakePayments", &in_app_purchase::CanMakePayments)
       .SetMethod("getReceiptURL", &in_app_purchase::GetReceiptURL)
       .SetMethod("purchaseProduct", &InAppPurchase::PurchaseProduct)
-      .SetMethod("finishAllTransactions", &in_app_purchase::FinishAllTransactions)
-      .SetMethod("finishTransactionByDate", &in_app_purchase::FinishTransactionByDate)
+      .SetMethod("finishAllTransactions",
+                 &in_app_purchase::FinishAllTransactions)
+      .SetMethod("finishTransactionByDate",
+                 &in_app_purchase::FinishTransactionByDate)
       .SetMethod("getProducts", &in_app_purchase::GetProducts);
 }
 
@@ -99,8 +99,7 @@ InAppPurchase::InAppPurchase(v8::Isolate* isolate) {
   Init(isolate);
 }
 
-InAppPurchase::~InAppPurchase() {
-}
+InAppPurchase::~InAppPurchase() {}
 
 void InAppPurchase::PurchaseProduct(const std::string& product_id,
                                     mate::Arguments* args) {

--- a/atom/browser/api/atom_api_in_app_purchase.cc
+++ b/atom/browser/api/atom_api_in_app_purchase.cc
@@ -99,7 +99,8 @@ InAppPurchase::InAppPurchase(v8::Isolate* isolate) {
   Init(isolate);
 }
 
-InAppPurchase::~InAppPurchase() {}
+InAppPurchase::~InAppPurchase() {
+}
 
 void InAppPurchase::PurchaseProduct(const std::string& product_id,
                                     mate::Arguments* args) {
@@ -139,4 +140,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_in_app_purchase, Initialize);
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_in_app_purchase, Initialize)

--- a/atom/browser/api/atom_api_in_app_purchase.cc
+++ b/atom/browser/api/atom_api_in_app_purchase.cc
@@ -45,6 +45,31 @@ struct Converter<in_app_purchase::Transaction> {
   }
 };
 
+
+template <>
+struct Converter<in_app_purchase::Product> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const in_app_purchase::Product& val) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
+  dict.Set("productIdentifier", val.productIdentifier);
+  dict.Set("localizedDescription", val.localizedDescription);
+  dict.Set("localizedTitle", val.localizedTitle);
+  dict.Set("contentVersion", val.localizedTitle);
+  dict.Set("contentLengths", val.contentLengths);
+  
+  // Pricing Information
+  dict.Set("price", val.price);
+  dict.Set("formattedPrice", val.formattedPrice);
+
+  // Downloadable Content Information
+  dict.Set("isDownloadable", val.downloadable);
+
+
+    return dict.GetHandle();
+  }
+};
+
 }  // namespace mate
 
 namespace atom {
@@ -64,7 +89,10 @@ void InAppPurchase::BuildPrototype(v8::Isolate* isolate,
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("canMakePayments", &in_app_purchase::CanMakePayments)
       .SetMethod("getReceiptURL", &in_app_purchase::GetReceiptURL)
-      .SetMethod("purchaseProduct", &InAppPurchase::PurchaseProduct);
+      .SetMethod("purchaseProduct", &InAppPurchase::PurchaseProduct)
+      .SetMethod("finishAllTransactions", &in_app_purchase::FinishAllTransactions)
+      .SetMethod("finishTransactionByDate", &in_app_purchase::FinishTransactionByDate)
+      .SetMethod("getProducts", &in_app_purchase::GetProducts);
 }
 
 InAppPurchase::InAppPurchase(v8::Isolate* isolate) {
@@ -112,4 +140,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_in_app_purchase, Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_in_app_purchase, Initialize);

--- a/atom/browser/api/atom_api_in_app_purchase.h
+++ b/atom/browser/api/atom_api_in_app_purchase.h
@@ -11,6 +11,7 @@
 #include "atom/browser/api/event_emitter.h"
 #include "atom/browser/mac/in_app_purchase.h"
 #include "atom/browser/mac/in_app_purchase_observer.h"
+#include "atom/browser/mac/in_app_purchase_product.h"
 #include "native_mate/handle.h"
 
 namespace atom {

--- a/atom/browser/api/atom_api_in_app_purchase.h
+++ b/atom/browser/api/atom_api_in_app_purchase.h
@@ -18,8 +18,8 @@ namespace atom {
 
 namespace api {
 
-class InAppPurchase: public mate::EventEmitter<InAppPurchase>,
-                     public in_app_purchase::TransactionObserver {
+class InAppPurchase : public mate::EventEmitter<InAppPurchase>,
+                      public in_app_purchase::TransactionObserver {
  public:
   static mate::Handle<InAppPurchase> Create(v8::Isolate* isolate);
 

--- a/atom/browser/mac/in_app_purchase.h
+++ b/atom/browser/mac/in_app_purchase.h
@@ -9,7 +9,6 @@
 
 #include "base/callback.h"
 
-
 namespace in_app_purchase {
 
 // --------------------------- Typedefs ---------------------------

--- a/atom/browser/mac/in_app_purchase.h
+++ b/atom/browser/mac/in_app_purchase.h
@@ -9,6 +9,7 @@
 
 #include "base/callback.h"
 
+
 namespace in_app_purchase {
 
 // --------------------------- Typedefs ---------------------------
@@ -18,6 +19,10 @@ typedef base::Callback<void(bool isProductValid)> InAppPurchaseCallback;
 // --------------------------- Functions ---------------------------
 
 bool CanMakePayments(void);
+
+void FinishAllTransactions(void);
+
+void FinishTransactionByDate(const std::string& date);
 
 std::string GetReceiptURL(void);
 

--- a/atom/browser/mac/in_app_purchase.mm
+++ b/atom/browser/mac/in_app_purchase.mm
@@ -11,7 +11,6 @@
 #import <CommonCrypto/CommonCrypto.h>
 #import <StoreKit/StoreKit.h>
 
-
 // ============================================================================
 //                             InAppPurchase
 // ============================================================================
@@ -51,7 +50,6 @@
   return self;
 }
 
-
 /**
  * Start the in-app purchase process.
  *
@@ -69,8 +67,6 @@
   productsRequest.delegate = self;
   [productsRequest start];
 }
-
-
 
 /**
  * Process product informations and start the payment.
@@ -141,14 +137,13 @@ bool CanMakePayments() {
 }
 
 void FinishAllTransactions() {
-  for (SKPaymentTransaction *transaction in SKPaymentQueue.defaultQueue.transactions) {
-      [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-    }
+  for (SKPaymentTransaction* transaction in SKPaymentQueue.defaultQueue
+           .transactions) {
+    [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+  }
 }
 
 void FinishTransactionByDate(const std::string& date) {
-
-
   // Create the date formatter.
   NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
   NSLocale* enUSPOSIXLocale =
@@ -157,13 +152,16 @@ void FinishTransactionByDate(const std::string& date) {
   [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
 
   // Remove the transaction.
-  NSString * transactionDate = base::SysUTF8ToNSString(date);
+  NSString* transactionDate = base::SysUTF8ToNSString(date);
 
-   for (SKPaymentTransaction *transaction in SKPaymentQueue.defaultQueue.transactions) {
-      if ([transactionDate isEqualToString:[dateFormatter stringFromDate:transaction.transactionDate]]) {
-        [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-      }
+  for (SKPaymentTransaction* transaction in SKPaymentQueue.defaultQueue
+           .transactions) {
+    if ([transactionDate
+            isEqualToString:[dateFormatter
+                                stringFromDate:transaction.transactionDate]]) {
+      [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
     }
+  }
 }
 
 std::string GetReceiptURL() {

--- a/atom/browser/mac/in_app_purchase.mm
+++ b/atom/browser/mac/in_app_purchase.mm
@@ -11,6 +11,7 @@
 #import <CommonCrypto/CommonCrypto.h>
 #import <StoreKit/StoreKit.h>
 
+
 // ============================================================================
 //                             InAppPurchase
 // ============================================================================
@@ -50,6 +51,7 @@
   return self;
 }
 
+
 /**
  * Start the in-app purchase process.
  *
@@ -67,6 +69,8 @@
   productsRequest.delegate = self;
   [productsRequest start];
 }
+
+
 
 /**
  * Process product informations and start the payment.
@@ -134,6 +138,32 @@ namespace in_app_purchase {
 
 bool CanMakePayments() {
   return [SKPaymentQueue canMakePayments];
+}
+
+void FinishAllTransactions() {
+  for (SKPaymentTransaction *transaction in SKPaymentQueue.defaultQueue.transactions) {
+      [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+    }
+}
+
+void FinishTransactionByDate(const std::string& date) {
+
+
+  // Create the date formatter.
+  NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
+  NSLocale* enUSPOSIXLocale =
+      [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+  [dateFormatter setLocale:enUSPOSIXLocale];
+  [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
+
+  // Remove the transaction.
+  NSString * transactionDate = base::SysUTF8ToNSString(date);
+
+   for (SKPaymentTransaction *transaction in SKPaymentQueue.defaultQueue.transactions) {
+      if ([transactionDate isEqualToString:[dateFormatter stringFromDate:transaction.transactionDate]]) {
+        [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+      }
+    }
 }
 
 std::string GetReceiptURL() {

--- a/atom/browser/mac/in_app_purchase_observer.h
+++ b/atom/browser/mac/in_app_purchase_observer.h
@@ -13,7 +13,7 @@
 
 #if defined(__OBJC__)
 @class InAppTransactionObserver;
-#else   // __OBJC__
+#else  // __OBJC__
 class InAppTransactionObserver;
 #endif  // __OBJC__
 

--- a/atom/browser/mac/in_app_purchase_observer.h
+++ b/atom/browser/mac/in_app_purchase_observer.h
@@ -13,7 +13,7 @@
 
 #if defined(__OBJC__)
 @class InAppTransactionObserver;
-#else  // __OBJC__
+#else   // __OBJC__
 class InAppTransactionObserver;
 #endif  // __OBJC__
 

--- a/atom/browser/mac/in_app_purchase_observer.mm
+++ b/atom/browser/mac/in_app_purchase_observer.mm
@@ -17,9 +17,8 @@
 
 namespace {
 
-using InAppTransactionCallback =
-    base::RepeatingCallback<
-        void(const std::vector<in_app_purchase::Transaction>&)>;
+using InAppTransactionCallback = base::RepeatingCallback<void(
+    const std::vector<in_app_purchase::Transaction>&)>;
 
 }  // namespace
 
@@ -72,8 +71,8 @@ using InAppTransactionCallback =
   }
 
   // Send the callback to the browser thread.
-  content::BrowserThread::PostTask(
-      content::BrowserThread::UI, FROM_HERE, base::Bind(callback_, converted));
+  content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,
+                                   base::Bind(callback_, converted));
 }
 
 /**
@@ -141,9 +140,9 @@ using InAppTransactionCallback =
   }
 
   if (transaction.transactionState < 5) {
-    transactionStruct.transactionState = [[@[
-        @"purchasing", @"purchased", @"failed", @"restored", @"deferred"
-    ] objectAtIndex:transaction.transactionState] UTF8String];
+    transactionStruct.transactionState =
+        [[@[ @"purchasing", @"purchased", @"failed", @"restored", @"deferred" ]
+            objectAtIndex:transaction.transactionState] UTF8String];
   }
 
   if (transaction.payment != nil) {
@@ -177,8 +176,8 @@ namespace in_app_purchase {
 
 TransactionObserver::TransactionObserver() : weak_ptr_factory_(this) {
   obeserver_ = [[InAppTransactionObserver alloc]
-     initWithCallback:base::Bind(&TransactionObserver::OnTransactionsUpdated,
-                                 weak_ptr_factory_.GetWeakPtr())];
+      initWithCallback:base::Bind(&TransactionObserver::OnTransactionsUpdated,
+                                  weak_ptr_factory_.GetWeakPtr())];
 }
 
 TransactionObserver::~TransactionObserver() {

--- a/atom/browser/mac/in_app_purchase_product.h
+++ b/atom/browser/mac/in_app_purchase_product.h
@@ -10,9 +10,7 @@
 
 #include "base/callback.h"
 
-
 namespace in_app_purchase {
-
 
 // --------------------------- Structures ---------------------------
 
@@ -21,25 +19,25 @@ struct Product {
   std::string productIdentifier = "";
 
   // Product Attributes
-  std::string   localizedDescription     = "";
-  std::string   localizedTitle           = "";
-  std::string   contentVersion           = "";
+  std::string localizedDescription = "";
+  std::string localizedTitle = "";
+  std::string contentVersion = "";
   std::vector<long long> contentLengths;
 
   // Pricing Information
-  double price                     = 0.0;
-  std::string    formattedPrice    = "";
+  double price = 0.0;
+  std::string formattedPrice = "";
 
   // Downloadable Content Information
-  bool          downloadable                    = false;
+  bool downloadable = false;
 };
 
 // --------------------------- Typedefs ---------------------------
 
-typedef base::Callback<void(const std::vector<in_app_purchase::Product>&)> InAppPurchaseProductsCallback;
+typedef base::Callback<void(const std::vector<in_app_purchase::Product>&)>
+    InAppPurchaseProductsCallback;
 
 // --------------------------- Functions ---------------------------
-
 
 void GetProducts(const std::vector<std::string>& productIDs,
                  const InAppPurchaseProductsCallback& callback);

--- a/atom/browser/mac/in_app_purchase_product.h
+++ b/atom/browser/mac/in_app_purchase_product.h
@@ -16,17 +16,17 @@ namespace in_app_purchase {
 
 struct Product {
   // Product Identifier
-  std::string productIdentifier = "";
+  std::string productIdentifier;
 
   // Product Attributes
-  std::string localizedDescription = "";
-  std::string localizedTitle = "";
-  std::string contentVersion = "";
+  std::string localizedDescription;
+  std::string localizedTitle;
+  std::string contentVersion;
   std::vector<uint32_t> contentLengths;
 
   // Pricing Information
   double price = 0.0;
-  std::string formattedPrice = "";
+  std::string formattedPrice;
 
   // Downloadable Content Information
   bool downloadable = false;

--- a/atom/browser/mac/in_app_purchase_product.h
+++ b/atom/browser/mac/in_app_purchase_product.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2018 Amaplex Software, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_MAC_IN_APP_PURCHASE_PRODUCT_H_
+#define ATOM_BROWSER_MAC_IN_APP_PURCHASE_PRODUCT_H_
+
+#include <string>
+#include <vector>
+
+#include "base/callback.h"
+
+
+namespace in_app_purchase {
+
+
+// --------------------------- Structures ---------------------------
+
+struct Product {
+  // Product Identifier
+  std::string productIdentifier = "";
+
+  // Product Attributes
+  std::string   localizedDescription     = "";
+  std::string   localizedTitle           = "";
+  std::string   contentVersion           = "";
+  std::vector<long long> contentLengths;
+
+  // Pricing Information
+  double price                     = 0.0;
+  std::string    formattedPrice    = "";
+
+  // Downloadable Content Information
+  bool          downloadable                    = false;
+};
+
+// --------------------------- Typedefs ---------------------------
+
+typedef base::Callback<void(const std::vector<in_app_purchase::Product>&)> InAppPurchaseProductsCallback;
+
+// --------------------------- Functions ---------------------------
+
+
+void GetProducts(const std::vector<std::string>& productIDs,
+                 const InAppPurchaseProductsCallback& callback);
+
+}  // namespace in_app_purchase
+
+#endif  // ATOM_BROWSER_MAC_IN_APP_PURCHASE_PRODUCT_H_

--- a/atom/browser/mac/in_app_purchase_product.h
+++ b/atom/browser/mac/in_app_purchase_product.h
@@ -22,7 +22,7 @@ struct Product {
   std::string localizedDescription = "";
   std::string localizedTitle = "";
   std::string contentVersion = "";
-  std::vector<long long> contentLengths;
+  std::vector<uint32_t> contentLengths;
 
   // Pricing Information
   double price = 0.0;

--- a/atom/browser/mac/in_app_purchase_product.mm
+++ b/atom/browser/mac/in_app_purchase_product.mm
@@ -1,0 +1,185 @@
+// Copyright (c) 2017 Amaplex Software, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/mac/in_app_purchase_product.h"
+
+#include "base/bind.h"
+#include "base/strings/sys_string_conversions.h"
+#include "content/public/browser/browser_thread.h"
+
+
+#import <StoreKit/StoreKit.h>
+
+
+// ============================================================================
+//                             InAppPurchaseProduct
+// ============================================================================
+
+// --------------------------------- Interface --------------------------------
+
+
+@interface InAppPurchaseProduct : NSObject<SKProductsRequestDelegate> {
+ @private
+  in_app_purchase::InAppPurchaseProductsCallback callback_;
+}
+
+- (id)initWithCallback:(const in_app_purchase::InAppPurchaseProductsCallback&)callback;
+
+@end
+
+// ------------------------------- Implementation -----------------------------
+
+@implementation InAppPurchaseProduct
+
+/**
+ * Init with a callback.
+ *
+ * @param callback - The callback that will be called to return the products.
+ */
+- (id)initWithCallback:(const in_app_purchase::InAppPurchaseProductsCallback&)callback {
+  if ((self = [super init])) {
+    callback_ = callback;
+  }
+
+  return self;
+}
+
+/**
+ * Return products.
+ *
+ * @param productIDs - The products' id to fetch.
+ */
+- (void)getProducts:(NSSet *)productIDs {
+
+  SKProductsRequest* productsRequest;
+  productsRequest = [[SKProductsRequest alloc]
+      initWithProductIdentifiers:productIDs];
+
+  productsRequest.delegate = self;
+  [productsRequest start];
+}
+
+/**
+ * @see SKProductsRequestDelegate
+ */
+- (void)productsRequest:(SKProductsRequest*)request
+     didReceiveResponse:(SKProductsResponse*)response {
+
+  // Release request object.
+  [request release];
+
+  // Get the products.
+  NSArray* products = response.products;
+
+  // Convert the products.
+  std::vector<in_app_purchase::Product> converted;
+  converted.reserve([products count]);
+  
+  for (SKProduct* product in products) {
+    converted.push_back([self skProductToStruct:product]);
+  }
+
+  // Send the callback to the browser thread.
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE, base::Bind(callback_, converted));
+
+  [self release];
+}
+
+/**
+ * Format local price.
+ *
+ * @param price - The price to format.
+ * @param priceLocal - The local format.
+ */
+- (NSString*)formatPrice:(NSDecimalNumber*)price withLocal:(NSLocale*)priceLocal
+{
+    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+
+    [numberFormatter setFormatterBehavior:NSNumberFormatterBehavior10_4];
+    [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
+    [numberFormatter setLocale:priceLocal];
+    
+    return [numberFormatter stringFromNumber:price];
+}
+
+
+/**
+ * Convert a skProduct object to Product structure.
+ *
+ * @param product - The SKProduct object to convert.
+ */
+- (in_app_purchase::Product)skProductToStruct:(SKProduct*)product {
+  in_app_purchase::Product productStruct;
+
+  // Product Identifier
+  if (product.productIdentifier != nil) {
+    productStruct.productIdentifier = [product.productIdentifier UTF8String];
+  }
+
+  // Product Attributes
+  if (product.localizedDescription != nil) {
+    productStruct.localizedDescription = [product.localizedDescription UTF8String];
+  }
+  if (product.localizedTitle != nil) {
+    productStruct.localizedTitle = [product.localizedTitle UTF8String];
+  }
+  if (product.contentVersion != nil) {
+    productStruct.contentVersion = [product.contentVersion UTF8String];
+  }
+  if (product.contentLengths != nil) {
+  
+    productStruct.contentLengths.reserve([product.contentLengths count]);
+
+    for (NSNumber * contentLength in product.contentLengths) {
+        productStruct.contentLengths.push_back([contentLength longLongValue]);
+    }
+  }
+  
+  // Pricing Information
+  if (product.price != nil) {
+    productStruct.price = [product.price doubleValue];
+
+    if (product.priceLocale != nil){
+        productStruct.formattedPrice = [[self formatPrice:product.price withLocal:product.priceLocale] UTF8String];
+    }
+
+  }
+
+
+  // Downloadable Content Information
+  if (product.downloadable == true) {
+    productStruct.downloadable = true;
+  }
+
+
+  return productStruct;
+}
+
+
+@end
+
+
+// ============================================================================
+//                             C++ in_app_purchase
+// ============================================================================
+
+namespace in_app_purchase {
+
+void GetProducts(const std::vector<std::string>& productIDs,
+                 const InAppPurchaseProductsCallback& callback) {
+  auto * iapProduct = [[InAppPurchaseProduct alloc] initWithCallback:callback];
+
+  // Convert the products' id to NSSet.
+  NSMutableSet * productsIDSet = [NSMutableSet setWithCapacity:productIDs.size()];
+  
+  for (auto &productID : productIDs) {  
+    [productsIDSet addObject:base::SysUTF8ToNSString(productID)];
+  }
+
+  // Fetch the products.
+  [iapProduct getProducts:productsIDSet];
+}
+
+}  // namespace in_app_purchase

--- a/atom/browser/mac/in_app_purchase_product.mm
+++ b/atom/browser/mac/in_app_purchase_product.mm
@@ -8,9 +8,7 @@
 #include "base/strings/sys_string_conversions.h"
 #include "content/public/browser/browser_thread.h"
 
-
 #import <StoreKit/StoreKit.h>
-
 
 // ============================================================================
 //                             InAppPurchaseProduct
@@ -18,13 +16,13 @@
 
 // --------------------------------- Interface --------------------------------
 
-
 @interface InAppPurchaseProduct : NSObject<SKProductsRequestDelegate> {
  @private
   in_app_purchase::InAppPurchaseProductsCallback callback_;
 }
 
-- (id)initWithCallback:(const in_app_purchase::InAppPurchaseProductsCallback&)callback;
+- (id)initWithCallback:
+    (const in_app_purchase::InAppPurchaseProductsCallback&)callback;
 
 @end
 
@@ -37,7 +35,8 @@
  *
  * @param callback - The callback that will be called to return the products.
  */
-- (id)initWithCallback:(const in_app_purchase::InAppPurchaseProductsCallback&)callback {
+- (id)initWithCallback:
+    (const in_app_purchase::InAppPurchaseProductsCallback&)callback {
   if ((self = [super init])) {
     callback_ = callback;
   }
@@ -50,11 +49,10 @@
  *
  * @param productIDs - The products' id to fetch.
  */
-- (void)getProducts:(NSSet *)productIDs {
-
+- (void)getProducts:(NSSet*)productIDs {
   SKProductsRequest* productsRequest;
-  productsRequest = [[SKProductsRequest alloc]
-      initWithProductIdentifiers:productIDs];
+  productsRequest =
+      [[SKProductsRequest alloc] initWithProductIdentifiers:productIDs];
 
   productsRequest.delegate = self;
   [productsRequest start];
@@ -65,7 +63,6 @@
  */
 - (void)productsRequest:(SKProductsRequest*)request
      didReceiveResponse:(SKProductsResponse*)response {
-
   // Release request object.
   [request release];
 
@@ -75,14 +72,14 @@
   // Convert the products.
   std::vector<in_app_purchase::Product> converted;
   converted.reserve([products count]);
-  
+
   for (SKProduct* product in products) {
     converted.push_back([self skProductToStruct:product]);
   }
 
   // Send the callback to the browser thread.
-  content::BrowserThread::PostTask(
-      content::BrowserThread::UI, FROM_HERE, base::Bind(callback_, converted));
+  content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,
+                                   base::Bind(callback_, converted));
 
   [self release];
 }
@@ -93,17 +90,16 @@
  * @param price - The price to format.
  * @param priceLocal - The local format.
  */
-- (NSString*)formatPrice:(NSDecimalNumber*)price withLocal:(NSLocale*)priceLocal
-{
-    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+- (NSString*)formatPrice:(NSDecimalNumber*)price
+               withLocal:(NSLocale*)priceLocal {
+  NSNumberFormatter* numberFormatter = [[NSNumberFormatter alloc] init];
 
-    [numberFormatter setFormatterBehavior:NSNumberFormatterBehavior10_4];
-    [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
-    [numberFormatter setLocale:priceLocal];
-    
-    return [numberFormatter stringFromNumber:price];
+  [numberFormatter setFormatterBehavior:NSNumberFormatterBehavior10_4];
+  [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
+  [numberFormatter setLocale:priceLocal];
+
+  return [numberFormatter stringFromNumber:price];
 }
-
 
 /**
  * Convert a skProduct object to Product structure.
@@ -120,7 +116,8 @@
 
   // Product Attributes
   if (product.localizedDescription != nil) {
-    productStruct.localizedDescription = [product.localizedDescription UTF8String];
+    productStruct.localizedDescription =
+        [product.localizedDescription UTF8String];
   }
   if (product.localizedTitle != nil) {
     productStruct.localizedTitle = [product.localizedTitle UTF8String];
@@ -129,37 +126,33 @@
     productStruct.contentVersion = [product.contentVersion UTF8String];
   }
   if (product.contentLengths != nil) {
-  
     productStruct.contentLengths.reserve([product.contentLengths count]);
 
-    for (NSNumber * contentLength in product.contentLengths) {
-        productStruct.contentLengths.push_back([contentLength longLongValue]);
+    for (NSNumber* contentLength in product.contentLengths) {
+      productStruct.contentLengths.push_back([contentLength longLongValue]);
     }
   }
-  
+
   // Pricing Information
   if (product.price != nil) {
     productStruct.price = [product.price doubleValue];
 
-    if (product.priceLocale != nil){
-        productStruct.formattedPrice = [[self formatPrice:product.price withLocal:product.priceLocale] UTF8String];
+    if (product.priceLocale != nil) {
+      productStruct.formattedPrice =
+          [[self formatPrice:product.price withLocal:product.priceLocale]
+              UTF8String];
     }
-
   }
-
 
   // Downloadable Content Information
   if (product.downloadable == true) {
     productStruct.downloadable = true;
   }
 
-
   return productStruct;
 }
 
-
 @end
-
 
 // ============================================================================
 //                             C++ in_app_purchase
@@ -169,12 +162,13 @@ namespace in_app_purchase {
 
 void GetProducts(const std::vector<std::string>& productIDs,
                  const InAppPurchaseProductsCallback& callback) {
-  auto * iapProduct = [[InAppPurchaseProduct alloc] initWithCallback:callback];
+  auto* iapProduct = [[InAppPurchaseProduct alloc] initWithCallback:callback];
 
   // Convert the products' id to NSSet.
-  NSMutableSet * productsIDSet = [NSMutableSet setWithCapacity:productIDs.size()];
-  
-  for (auto &productID : productIDs) {  
+  NSMutableSet* productsIDSet =
+      [NSMutableSet setWithCapacity:productIDs.size()];
+
+  for (auto& productID : productIDs) {
     [productsIDSet addObject:base::SysUTF8ToNSString(productID)];
   }
 

--- a/docs/api/in-app-purchase.md
+++ b/docs/api/in-app-purchase.md
@@ -24,7 +24,7 @@ The `inAppPurchase` module has the following methods:
 
 ### `inAppPurchase.purchaseProduct(productID, quantity, callback)`
 
-* `productID` String - The identifiers of the product to purchase. (the identifier of `com.example.app.product1` is `product1`).
+* `productID` String - The identifiers of the product to purchase. (The identifier of `com.example.app.product1` is `product1`).
 * `quantity` Integer (optional) - The number of items the user wants to purchase.
 * `callback` Function (optional) - The callback called when the payment is added to the PaymentQueue.
     * `isProductValid` Boolean - Determine if the product is valid and added to the payment queue.

--- a/docs/api/in-app-purchase.md
+++ b/docs/api/in-app-purchase.md
@@ -21,14 +21,23 @@ Returns:
 
 The `inAppPurchase` module has the following methods:
 
+
 ### `inAppPurchase.purchaseProduct(productID, quantity, callback)`
 
-* `productID` String - The id of the product to purchase. (the id of `com.example.app.product1` is `product1`).
+* `productID` String - The identifiers of the product to purchase. (the identifier of `com.example.app.product1` is `product1`).
 * `quantity` Integer (optional) - The number of items the user wants to purchase.
 * `callback` Function (optional) - The callback called when the payment is added to the PaymentQueue.
-* `isProductValid` Boolean - Determine if the product is valid and added to the payment queue.
+    * `isProductValid` Boolean - Determine if the product is valid and added to the payment queue.
 
 You should listen for the `transactions-updated` event as soon as possible and certainly before you call `purchaseProduct`.
+
+### `inAppPurchase.getProducts(productIDs, callback)`
+
+* `productIDs` String[] - The identifiers of the products to get.
+* `callback` Function - The callback called with the products or an empty array if the products don't exist.
+    * `products` Product[] - Array of [`Product`](structures/product) objects
+
+Retrieves the product descriptions.
 
 ### `inAppPurchase.canMakePayments()`
 
@@ -37,3 +46,15 @@ Returns `true` if the user can make a payment and `false` otherwise.
 ### `inAppPurchase.getReceiptURL()`
 
 Returns `String`, the path to the receipt.
+
+
+### `inAppPurchase.finishAllTransactions()`
+
+Completes all pending transactions.
+
+
+### `inAppPurchase.finishTransactionByDate(date)`
+
+* `date` String - The ISO formatted date of the transaction to finish.
+
+Completes the pending transactions corresponding to the date.

--- a/docs/api/structures/product.md
+++ b/docs/api/structures/product.md
@@ -1,0 +1,10 @@
+# Product Object
+
+* `productIdentifier` String - The string that identifies the product to the Apple App Store.
+* `localizedDescription` String - A description of the product.
+* `localizedTitle` String - The name of the product.
+* `contentVersion` String - A string that identifies the version of the content.
+* `contentLengths` Number[] - The total size of the content, in bytes.
+* `price` Number - The cost of the product in the local currency.
+* `formattedPrice` String - The locale formatted price of the product.
+* `downloadable` Boolean - A Boolean value that indicates whether the App Store has downloadable content for this product.

--- a/docs/api/structures/transaction.md
+++ b/docs/api/structures/transaction.md
@@ -1,11 +1,11 @@
 # Transaction Object
 
-* `transactionIdentifier` String
-* `transactionDate` String
-* `originalTransactionIdentifier` String
+* `transactionIdentifier` String - A string that uniquely identifies a successful payment transaction.
+* `transactionDate` String - The date the transaction was added to the App Store’s payment queue.
+* `originalTransactionIdentifier` String - The identifier of the restored transaction by the App Store.
 * `transactionState` String - The transaction sate (`"purchasing"`, `"purchased"`, `"failed"`, `"restored"`, or `"deferred"`)
-* `errorCode` Integer
-* `errorMessage` String
+* `errorCode` Integer - The error code if an error occurred while processing the transaction.
+* `errorMessage` String - The error message if an error occurred while processing the transaction.
 * `payment` Object
-  * `productIdentifier` String
-  * `quantity` Integer
+  * `productIdentifier` String - The identifier of the purchased product.
+  * `quantity` Integer  - The quantity purchased.

--- a/docs/tutorial/in-app-purchases.md
+++ b/docs/tutorial/in-app-purchases.md
@@ -1,9 +1,9 @@
-# In App Purchase (macOS)
+# In-App Purchase (macOS)
 
 ## Preparing
 
 ### Paid Applications Agreement
-If it is not already done, you’ll need to sign the Paid Applications Agreement and set up your banking and tax information with iTunes Connect. 
+If it's not already done, you’ll need to sign the Paid Applications Agreement and set up your banking and tax information in iTunes Connect. 
 
 [iTunes Connect Developer Help: Agreements, tax, and banking overview](https://help.apple.com/itunes-connect/developer/#/devb6df5ee51)
 
@@ -15,7 +15,7 @@ Then, you'll need to configure your in-app purchases in iTunes Connect, and incl
 
 ### Change the CFBundleIdentifier
 
-To test In App Purchase in developement with Electron you'll have to change the `CFBundleIdentifier` in `node_modules/electron/dist/Electron.app/Contents/Info.plist`. You have to replace `com.github.electron` by the budle identifier of the application you created with iTunes Connect.
+To test In-App Purchase in developement with Electron you'll have to change the `CFBundleIdentifier` in `node_modules/electron/dist/Electron.app/Contents/Info.plist`. You have to replace `com.github.electron` by the budle identifier of the application you created with iTunes Connect.
 
 ```
 <key>CFBundleIdentifier</key>
@@ -25,10 +25,10 @@ To test In App Purchase in developement with Electron you'll have to change the 
 
 ## Code example
 
-Here is an example that shows how tu use In App Purchase in Electron. You'll have to replace the product ids by the identifiers of the products created with iTunes Connect (the identifier of `com.example.app.product1` is `product1`). Note that you have to listen to the `transactions-updated` event as soon as possible in your app.
+Here is an example that shows how tu use In-App Purchase in Electron. You'll have to replace the product ids by the identifiers of the products created with iTunes Connect (the identifier of `com.example.app.product1` is `product1`). Note that you have to listen to the `transactions-updated` event as soon as possible in your app.
 
 
-```
+```javascript
 const { inAppPurchase } = require('electron').remote
 const PRODUCT_IDS = ['id1', 'id2']
 

--- a/docs/tutorial/in-app-purchases.md
+++ b/docs/tutorial/in-app-purchases.md
@@ -3,7 +3,7 @@
 ## Preparing
 
 ### Paid Applications Agreement
-If it's not already done, you’ll need to sign the Paid Applications Agreement and set up your banking and tax information in iTunes Connect. 
+If you haven't already, you’ll need to sign the Paid Applications Agreement and set up your banking and tax information in iTunes Connect. 
 
 [iTunes Connect Developer Help: Agreements, tax, and banking overview](https://help.apple.com/itunes-connect/developer/#/devb6df5ee51)
 
@@ -15,7 +15,7 @@ Then, you'll need to configure your in-app purchases in iTunes Connect, and incl
 
 ### Change the CFBundleIdentifier
 
-To test In-App Purchase in developement with Electron you'll have to change the `CFBundleIdentifier` in `node_modules/electron/dist/Electron.app/Contents/Info.plist`. You have to replace `com.github.electron` by the budle identifier of the application you created with iTunes Connect.
+To test In-App Purchase in development with Electron you'll have to change the `CFBundleIdentifier` in `node_modules/electron/dist/Electron.app/Contents/Info.plist`. You have to replace `com.github.electron` by the bundle identifier of the application you created with iTunes Connect.
 
 ```xml
 <key>CFBundleIdentifier</key>
@@ -25,7 +25,7 @@ To test In-App Purchase in developement with Electron you'll have to change the 
 
 ## Code example
 
-Here is an example that shows how tu use In-App Purchase in Electron. You'll have to replace the product ids by the identifiers of the products created with iTunes Connect (the identifier of `com.example.app.product1` is `product1`). Note that you have to listen to the `transactions-updated` event as soon as possible in your app.
+Here is an example that shows how to use In-App Purchases in Electron. You'll have to replace the product ids by the identifiers of the products created with iTunes Connect (the identifier of `com.example.app.product1` is `product1`). Note that you have to listen to the `transactions-updated` event as soon as possible in your app.
 
 
 ```javascript
@@ -94,7 +94,7 @@ if (!inAppPurchase.canMakePayments()) {
   console.log('The user is not allowed to make in-app purchase.')
 }
 
-// Retrieve and display the product informations.
+// Retrieve and display the product descriptions.
 inAppPurchase.getProducts(PRODUCT_IDS, (products) => {
   // Check the parameters.
   if (!Array.isArray(products) || products.length <= 0) {

--- a/docs/tutorial/in-app-purchases.md
+++ b/docs/tutorial/in-app-purchases.md
@@ -17,7 +17,7 @@ Then, you'll need to configure your in-app purchases in iTunes Connect, and incl
 
 To test In-App Purchase in developement with Electron you'll have to change the `CFBundleIdentifier` in `node_modules/electron/dist/Electron.app/Contents/Info.plist`. You have to replace `com.github.electron` by the budle identifier of the application you created with iTunes Connect.
 
-```
+```xml
 <key>CFBundleIdentifier</key>
 <string>com.example.app</string>
 ```
@@ -122,5 +122,4 @@ inAppPurchase.getProducts(PRODUCT_IDS, (products) => {
     console.log('The payment has been added to the payment queue.')
   })
 })
-
 ```

--- a/docs/tutorial/in-app-purchases.md
+++ b/docs/tutorial/in-app-purchases.md
@@ -1,0 +1,126 @@
+# In App Purchase (macOS)
+
+## Preparing
+
+### Paid Applications Agreement
+If it is not already done, you’ll need to sign the Paid Applications Agreement and set up your banking and tax information with iTunes Connect. 
+
+[iTunes Connect Developer Help: Agreements, tax, and banking overview](https://help.apple.com/itunes-connect/developer/#/devb6df5ee51)
+
+### Create Your In-App Purchases
+Then, you'll need to configure your in-app purchases in iTunes Connect, and include details such as name, pricing, and description that highlights the features and functionality of your in-app purchase.
+
+[iTunes Connect Developer Help: Create an in-app purchase](https://help.apple.com/itunes-connect/developer/#/devae49fb316)
+
+
+### Change the CFBundleIdentifier
+
+To test In App Purchase in developement with Electron you'll have to change the `CFBundleIdentifier` in `node_modules/electron/dist/Electron.app/Contents/Info.plist`. You have to replace `com.github.electron` by the budle identifier of the application you created with iTunes Connect.
+
+```
+<key>CFBundleIdentifier</key>
+<string>com.example.app</string>
+```
+
+
+## Code example
+
+Here is an example that shows how tu use In App Purchase in Electron. You'll have to replace the product ids by the identifiers of the products created with iTunes Connect (the identifier of `com.example.app.product1` is `product1`). Note that you have to listen to the `transactions-updated` event as soon as possible in your app.
+
+
+```
+const { inAppPurchase } = require('electron').remote
+const PRODUCT_IDS = ['id1', 'id2']
+
+// Listen for transactions as soon as possible.
+inAppPurchase.on('transactions-updated', (event, transactions) => {
+  if (!Array.isArray(transactions)) {
+    return
+  }
+
+  // Check each transaction.
+  transactions.forEach(function (transaction) {
+    var payment = transaction.payment
+
+    switch (transaction.transactionState) {
+      case 'purchasing':
+        console.log(`Purchasing ${payment.productIdentifier}...`)
+        break
+      case 'purchased':
+
+        console.log(`${payment.productIdentifier} purchased.`)
+
+        // Get the receipt url.
+        let receiptURL = inAppPurchase.getReceiptURL()
+
+        console.log(`Receipt URL: ${receiptURL}`)
+
+        // Submit the receipt file to the server and check if it is valid.
+        // @see https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html
+        // ...
+        // If the receipt is valid, the product is purchased
+        // ...
+
+        // Finish the transaction.
+        inAppPurchase.finishTransactionByDate(transaction.transactionDate)
+
+        break
+      case 'failed':
+
+        console.log(`Failed to purchase ${payment.productIdentifier}.`)
+
+        // Finish the transaction.
+        inAppPurchase.finishTransactionByDate(transaction.transactionDate)
+
+        break
+      case 'restored':
+
+        console.log(`The purchase of ${payment.productIdentifier} has been restored.`)
+
+        break
+      case 'deferred':
+
+        console.log(`The purchase of ${payment.productIdentifier} has been deferred.`)
+
+        break
+      default:
+        break
+    }
+  })
+})
+
+// Check if the user is allowed to make in-app purchase.
+if (!inAppPurchase.canMakePayments()) {
+  console.log('The user is not allowed to make in-app purchase.')
+}
+
+// Retrieve and display the product informations.
+inAppPurchase.getProducts(PRODUCT_IDS, (products) => {
+  // Check the parameters.
+  if (!Array.isArray(products) || products.length <= 0) {
+    console.log('Unable to retrieve the product informations.')
+    return
+  }
+
+  // Display the name and price of each product.
+  products.forEach((product) => {
+    console.log(`The price of ${product.localizedTitle} is ${product.formattedPrice}.`)
+  })
+
+  // Ask the user which product he/she wants to purchase.
+  // ...
+  let selectedProduct = products[0]
+  let selectedQuantity = 1
+
+  // Purchase the selected product.
+  inAppPurchase.purchaseProduct(selectedProduct.productIdentifier, selectedQuantity, (isProductValid) => {
+    if (!isProductValid) {
+      console.log('The product is not valid.')
+      return
+    }
+
+    console.log('The payment has been added to the payment queue.')
+  })
+})
+
+```

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -240,6 +240,8 @@
       'atom/browser/mac/in_app_purchase.mm',
       'atom/browser/mac/in_app_purchase_observer.h',
       'atom/browser/mac/in_app_purchase_observer.mm',
+      'atom/browser/mac/in_app_purchase_product.h',
+      'atom/browser/mac/in_app_purchase_product.mm',
       'atom/browser/native_browser_view.cc',
       'atom/browser/native_browser_view.h',
       'atom/browser/native_browser_view_mac.h',

--- a/spec/api-in-app-purchase-spec.js
+++ b/spec/api-in-app-purchase-spec.js
@@ -15,6 +15,14 @@ describe('inAppPurchase module', function () {
     inAppPurchase.canMakePayments()
   })
 
+  it('finishAllTransactions() does not throw', () => {
+    inAppPurchase.finishAllTransactions()
+  })
+
+  it('finishTransactionByDate() does not throw', () => {
+    inAppPurchase.finishTransactionByDate(new Date().toISOString())
+  })
+
   it('getReceiptURL() returns receipt URL', () => {
     assert.ok(inAppPurchase.getReceiptURL().endsWith('_MASReceipt/receipt'))
   })
@@ -29,6 +37,13 @@ describe('inAppPurchase module', function () {
   it('purchaseProduct() accepts optional arguments', (done) => {
     inAppPurchase.purchaseProduct('non-exist', () => {
       inAppPurchase.purchaseProduct('non-exist', 1)
+      done()
+    })
+  })
+
+  it('getProducts() return an empty list when getting invalid product', (done) => {
+    inAppPurchase.getProducts(['non-exist'], (products) => {
+      assert.ok(products.length === 0)
       done()
     })
   })

--- a/spec/api-in-app-purchase-spec.js
+++ b/spec/api-in-app-purchase-spec.js
@@ -41,7 +41,7 @@ describe('inAppPurchase module', function () {
     })
   })
 
-  it('getProducts() return an empty list when getting invalid product', (done) => {
+  it('getProducts() returns an empty list when getting invalid product', (done) => {
     inAppPurchase.getProducts(['non-exist'], (products) => {
       assert.ok(products.length === 0)
       done()


### PR DESCRIPTION
This pull request adds multiple improvements of the In-App Purchase module for MacOS (see #11292).

1. It is now possible to get product descriptions (name, price, etc.) directly from the App Store.
2. It is now possible to finish transactions.
3. The documentation has been improved.
4. I have added a tutorial that shows how to use the In-App Purchase module. 

Let me know if you see modifications to do.