### PR TITLE
add moveTop API to move window z-oder to top for win32, mac

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -1289,7 +1289,7 @@ void BrowserWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setPosition", &BrowserWindow::SetPosition)
       .SetMethod("getPosition", &BrowserWindow::GetPosition)
 #if defined(OS_WIN) || defined(OS_MACOSX)
-      .SetMethod("moveTop" , BrowserWindow::MoveTop)
+      .SetMethod("moveTop" , &BrowserWindow::MoveTop)
 #endif
       .SetMethod("setTitle", &BrowserWindow::SetTitle)
       .SetMethod("getTitle", &BrowserWindow::GetTitle)

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -749,6 +749,12 @@ std::vector<int> BrowserWindow::GetPosition() {
   return result;
 }
 
+#if defined(OS_WIN) || defined(OS_MACOSX)
+void BrowserWindow::MoveTop() {
+  window_->MoveTop();
+}
+#endif
+
 void BrowserWindow::SetTitle(const std::string& title) {
   window_->SetTitle(title);
 }
@@ -1282,6 +1288,9 @@ void BrowserWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("center", &BrowserWindow::Center)
       .SetMethod("setPosition", &BrowserWindow::SetPosition)
       .SetMethod("getPosition", &BrowserWindow::GetPosition)
+#if defined(OS_WIN) || defined(OS_MACOSX)
+      .SetMethod("moveTop" , BrowserWindow::MoveTop)
+#endif
       .SetMethod("setTitle", &BrowserWindow::SetTitle)
       .SetMethod("getTitle", &BrowserWindow::GetTitle)
       .SetMethod("flashFrame", &BrowserWindow::FlashFrame)

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -159,6 +159,9 @@ class BrowserWindow : public mate::TrackableObject<BrowserWindow>,
   void SetResizable(bool resizable);
   bool IsResizable();
   void SetMovable(bool movable);
+  #if defined(OS_WIN) || defined(OS_MACOSX)
+  void MoveTop();
+  #endif
   bool IsMovable();
   void SetMinimizable(bool minimizable);
   bool IsMinimizable();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -103,6 +103,9 @@ class NativeWindow : public base::SupportsUserData {
   virtual double GetSheetOffsetX();
   virtual double GetSheetOffsetY();
   virtual void SetResizable(bool resizable) = 0;
+#if defined(OS_WIN) || defined(OS_MACOSX)
+  virtual void MoveTop() = 0;
+#endif
   virtual bool IsResizable() = 0;
   virtual void SetMovable(bool movable) = 0;
   virtual bool IsMovable() = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -50,6 +50,7 @@ class NativeWindowMac : public NativeWindow {
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
+  void MoveTop() override;
   bool IsResizable() override;
   void SetMovable(bool movable) override;
   void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size)

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1192,6 +1192,9 @@ void NativeWindowMac::SetContentSizeConstraints(
   NativeWindow::SetContentSizeConstraints(size_constraints);
 }
 
+void NativeWindowMac::MoveTop(){
+  [window_ orderWindow:NSWindowAbove relativeTo:0];
+}
 void NativeWindowMac::SetResizable(bool resizable) {
   SetStyleMask(resizable, NSResizableWindowMask);
 }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -88,7 +88,6 @@ void FlipWindowStyle(HWND handle, bool on, DWORD flag) {
 bool IsAltKey(const content::NativeWebKeyboardEvent& event) {
   return event.windows_key_code == ui::VKEY_MENU;
 }
-
 bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
   typedef content::NativeWebKeyboardEvent::Modifiers Modifiers;
   int modifiers = event.GetModifiers();
@@ -624,6 +623,16 @@ void NativeWindowViews::SetResizable(bool resizable) {
 
   resizable_ = resizable;
 }
+
+#if defined(OS_WIN)
+void NativeWindowViews::MoveTop() {
+  gfx::Point pos = GetPosition();
+  gfx::Size size = GetSize();
+  ::SetWindowPos(GetAcceleratedWidget(), HWND_TOP,
+                pos.x(), pos.y(), size.width(), size.height(),
+                SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+}
+#endif
 
 bool NativeWindowViews::IsResizable() {
 #if defined(OS_WIN)

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -77,6 +77,9 @@ class NativeWindowViews : public NativeWindow,
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
+#if defined(OS_WIN)
+  void MoveTop() override;
+#endif
   bool IsResizable() override;
   void SetMovable(bool movable) override;
   bool IsMovable() override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1007,6 +1007,10 @@ can not be focused on.
 
 Returns `Boolean` - Whether the window is always on top of other windows.
 
+#### `win.moveTop()` _macOS_ _Windows_
+
+Moves window to top(z-order) regardless of focus
+
 #### `win.center()`
 
 Moves window to the center of the screen.


### PR DESCRIPTION
Tested Window7 , 10
os: window7,10 , Mac
API: BrowserWindow.moveTop()
Desc: move window to top position without focus
Usage: notification and show message