### PR TITLE
WebFrame.setVisualZoomLevelLimits sets user-agent scale constraints

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -159,6 +159,7 @@ double WebFrame::GetZoomFactor() const {
 
 void WebFrame::SetVisualZoomLevelLimits(double min_level, double max_level) {
   web_frame_->View()->SetDefaultPageScaleLimits(min_level, max_level);
+  web_frame_->View()->SetIgnoreViewportTagScaleLimits(true);
 }
 
 void WebFrame::SetLayoutZoomLevelLimits(double min_level, double max_level) {


### PR DESCRIPTION
Fixes #11216.

FWIW, this is also [how Muon does it][1].

[1]: https://github.com/brave/muon/blob/79a7e24a433e52bba09a5ce4a95ee613c5de009e/brave/renderer/extensions/web_frame_bindings.cc#L159