### PR TITLE
8952 option to ignore tray double click events

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -182,6 +182,14 @@ void Tray::SetIgnoreDoubleClickEvents(bool ignore) {
 #endif
 }
 
+bool Tray::GetIgnoreDoubleClickEvents() {
+#if defined(OS_MACOSX)
+  return tray_icon_->GetIgnoreDoubleClickEvents();
+#else
+  return false;
+#endif
+}
+
 void Tray::DisplayBalloon(mate::Arguments* args,
                           const mate::Dictionary& options) {
   mate::Handle<NativeImage> icon;
@@ -232,6 +240,8 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setHighlightMode", &Tray::SetHighlightMode)
       .SetMethod("setIgnoreDoubleClickEvents",
                  &Tray::SetIgnoreDoubleClickEvents)
+      .SetMethod("getIgnoreDoubleClickEvents",
+                 &Tray::GetIgnoreDoubleClickEvents)
       .SetMethod("displayBalloon", &Tray::DisplayBalloon)
       .SetMethod("popUpContextMenu", &Tray::PopUpContextMenu)
       .SetMethod("setContextMenu", &Tray::SetContextMenu)

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -177,7 +177,9 @@ void Tray::SetHighlightMode(TrayIcon::HighlightMode mode) {
 }
 
 void Tray::SetIgnoreDoubleClickEvents(bool ignore) {
+#if defined(OS_MACOSX)
   tray_icon_->SetIgnoreDoubleClickEvents(ignore);
+#endif
 }
 
 void Tray::DisplayBalloon(mate::Arguments* args,

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -176,6 +176,10 @@ void Tray::SetHighlightMode(TrayIcon::HighlightMode mode) {
   tray_icon_->SetHighlightMode(mode);
 }
 
+void Tray::SetIgnoreDoubleClickEvents(bool ignore) {
+  tray_icon_->SetIgnoreDoubleClickEvents(ignore);
+}
+
 void Tray::DisplayBalloon(mate::Arguments* args,
                           const mate::Dictionary& options) {
   mate::Handle<NativeImage> icon;
@@ -224,6 +228,8 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setToolTip", &Tray::SetToolTip)
       .SetMethod("setTitle", &Tray::SetTitle)
       .SetMethod("setHighlightMode", &Tray::SetHighlightMode)
+      .SetMethod("setIgnoreDoubleClickEvents",
+                 &Tray::SetIgnoreDoubleClickEvents)
       .SetMethod("displayBalloon", &Tray::DisplayBalloon)
       .SetMethod("popUpContextMenu", &Tray::PopUpContextMenu)
       .SetMethod("setContextMenu", &Tray::SetContextMenu)

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -70,6 +70,7 @@ class Tray : public mate::TrackableObject<Tray>, public TrayIconObserver {
   void SetToolTip(const std::string& tool_tip);
   void SetTitle(const std::string& title);
   void SetHighlightMode(TrayIcon::HighlightMode mode);
+  void SetIgnoreDoubleClickEvents(bool ignore);
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
   void PopUpContextMenu(mate::Arguments* args);
   void SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu);

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -71,6 +71,7 @@ class Tray : public mate::TrackableObject<Tray>, public TrayIconObserver {
   void SetTitle(const std::string& title);
   void SetHighlightMode(TrayIcon::HighlightMode mode);
   void SetIgnoreDoubleClickEvents(bool ignore);
+  bool GetIgnoreDoubleClickEvents();
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
   void PopUpContextMenu(mate::Arguments* args);
   void SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu);

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -16,9 +16,6 @@ void TrayIcon::SetTitle(const std::string& title) {}
 
 void TrayIcon::SetHighlightMode(TrayIcon::HighlightMode mode) {}
 
-void TrayIcon::SetIgnoreDoubleClickEvents(bool ignore) {
-}
-
 void TrayIcon::DisplayBalloon(ImageType icon,
                               const base::string16& title,
                               const base::string16& contents) {}

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -16,6 +16,9 @@ void TrayIcon::SetTitle(const std::string& title) {}
 
 void TrayIcon::SetHighlightMode(TrayIcon::HighlightMode mode) {}
 
+void TrayIcon::SetIgnoreDoubleClickEvents(bool ignore) {
+}
+
 void TrayIcon::DisplayBalloon(ImageType icon,
                               const base::string16& title,
                               const base::string16& contents) {}

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -51,9 +51,12 @@ class TrayIcon {
   };
   virtual void SetHighlightMode(HighlightMode mode);
 
-  // Sets the flag which determines whether to ignore double click events. This
-  // only works on macOS.
-  virtual void SetIgnoreDoubleClickEvents(bool ignore);
+  // Setter and getter for the flag which determines whether to ignore double
+  // click events. These only work on macOS.
+#if defined(OS_MACOSX)
+  virtual void SetIgnoreDoubleClickEvents(bool ignore) = 0;
+  virtual bool GetIgnoreDoubleClickEvents() = 0;
+#endif
 
   // Displays a notification balloon with the specified contents.
   // Depending on the platform it might not appear by the icon tray.

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -51,6 +51,10 @@ class TrayIcon {
   };
   virtual void SetHighlightMode(HighlightMode mode);
 
+  // Sets the flag which determines whether to ignore double click events. This
+  // only works on macOS.
+  virtual void SetIgnoreDoubleClickEvents(bool ignore);
+
   // Displays a notification balloon with the specified contents.
   // Depending on the platform it might not appear by the icon tray.
   virtual void DisplayBalloon(ImageType icon,

--- a/atom/browser/ui/tray_icon_cocoa.h
+++ b/atom/browser/ui/tray_icon_cocoa.h
@@ -27,6 +27,7 @@ class TrayIconCocoa : public TrayIcon, public AtomMenuModel::Observer {
   void SetToolTip(const std::string& tool_tip) override;
   void SetTitle(const std::string& title) override;
   void SetHighlightMode(TrayIcon::HighlightMode mode) override;
+  void SetIgnoreDoubleClickEvents(bool ignore) override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;

--- a/atom/browser/ui/tray_icon_cocoa.h
+++ b/atom/browser/ui/tray_icon_cocoa.h
@@ -28,6 +28,7 @@ class TrayIconCocoa : public TrayIcon, public AtomMenuModel::Observer {
   void SetTitle(const std::string& title) override;
   void SetHighlightMode(TrayIcon::HighlightMode mode) override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
+  bool GetIgnoreDoubleClickEvents() override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -206,8 +206,12 @@ const CGFloat kVerticalTitleMargin = 2;
   [self setNeedsDisplay:YES];
 }
 
-- (void) setIgnoreDoubleClickEvents:(BOOL)ignore {
+- (void)setIgnoreDoubleClickEvents:(BOOL)ignore {
   ignoreDoubleClickEvents_ = ignore;
+}
+
+- (BOOL)getIgnoreDoubleClickEvents {
+  return ignoreDoubleClickEvents_;
 }
 
 - (void)setTitle:(NSString*)title {
@@ -448,6 +452,10 @@ void TrayIconCocoa::SetHighlightMode(TrayIcon::HighlightMode mode) {
 
 void TrayIconCocoa::SetIgnoreDoubleClickEvents(bool ignore) {
   [status_item_view_ setIgnoreDoubleClickEvents:ignore];
+}
+
+bool TrayIconCocoa::GetIgnoreDoubleClickEvents() {
+  return [status_item_view_ getIgnoreDoubleClickEvents];
 }
 
 void TrayIconCocoa::PopUpContextMenu(const gfx::Point& pos,

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -287,24 +287,16 @@ const CGFloat kVerticalTitleMargin = 2;
 
   // If we are ignoring double click events, we should ignore the `clickCount`
   // value and immediately emit a click event.
-  if (ignoreDoubleClickEvents_ == YES) {
-    trayIcon_->NotifyClicked(
-        gfx::ScreenRectFromNSRect(event.window.frame),
-        gfx::ScreenPointFromNSPoint([event locationInWindow]),
-        ui::EventFlagsFromModifiers([event modifierFlags]));
-    [self setNeedsDisplay:YES];
-    return;
-  }
-
-  // Single click event.
-  if (event.clickCount == 1)
+  BOOL shouldBeHandledAsASingleClick = (event.clickCount == 1) || ignoreDoubleClickEvents_;
+  if (shouldBeHandledAsASingleClick)
     trayIcon_->NotifyClicked(
         gfx::ScreenRectFromNSRect(event.window.frame),
         gfx::ScreenPointFromNSPoint([event locationInWindow]),
         ui::EventFlagsFromModifiers([event modifierFlags]));
 
   // Double click event.
-  if (event.clickCount == 2)
+  BOOL shouldBeHandledAsADoubleClick = (event.clickCount == 2) && !ignoreDoubleClickEvents_;
+  if (shouldBeHandledAsADoubleClick)
     trayIcon_->NotifyDoubleClicked(
         gfx::ScreenRectFromNSRect(event.window.frame),
         ui::EventFlagsFromModifiers([event modifierFlags]));

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -25,6 +25,7 @@ const CGFloat kVerticalTitleMargin = 2;
   atom::TrayIconCocoa* trayIcon_;       // weak
   AtomMenuController* menuController_;  // weak
   atom::TrayIcon::HighlightMode highlight_mode_;
+  BOOL ignoreDoubleClickEvents_;
   BOOL forceHighlight_;
   BOOL inMouseEventSequence_;
   BOOL ANSI_;
@@ -44,6 +45,7 @@ const CGFloat kVerticalTitleMargin = 2;
   image_.reset([image copy]);
   trayIcon_ = icon;
   highlight_mode_ = atom::TrayIcon::HighlightMode::SELECTION;
+  ignoreDoubleClickEvents_ = NO;
   forceHighlight_ = NO;
   inMouseEventSequence_ = NO;
 
@@ -204,6 +206,10 @@ const CGFloat kVerticalTitleMargin = 2;
   [self setNeedsDisplay:YES];
 }
 
+- (void) setIgnoreDoubleClickEvents:(BOOL)ignore {
+  ignoreDoubleClickEvents_ = ignore;
+}
+
 - (void)setTitle:(NSString*)title {
   if (title.length > 0) {
     title_.reset([title copy]);
@@ -278,6 +284,17 @@ const CGFloat kVerticalTitleMargin = 2;
   // Don't emit click events when menu is showing.
   if (menuController_)
     return;
+
+  // If we are ignoring double click events, we should ignore the `clickCount`
+  // value and immediately emit a click event.
+  if (ignoreDoubleClickEvents_ == YES) {
+    trayIcon_->NotifyClicked(
+        gfx::ScreenRectFromNSRect(event.window.frame),
+        gfx::ScreenPointFromNSPoint([event locationInWindow]),
+        ui::EventFlagsFromModifiers([event modifierFlags]));
+    [self setNeedsDisplay:YES];
+    return;
+  }
 
   // Single click event.
   if (event.clickCount == 1)
@@ -435,6 +452,10 @@ void TrayIconCocoa::SetTitle(const std::string& title) {
 
 void TrayIconCocoa::SetHighlightMode(TrayIcon::HighlightMode mode) {
   [status_item_view_ setHighlight:mode];
+}
+
+void TrayIconCocoa::SetIgnoreDoubleClickEvents(bool ignore) {
+  [status_item_view_ setIgnoreDoubleClickEvents:ignore];
 }
 
 void TrayIconCocoa::PopUpContextMenu(const gfx::Point& pos,

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -250,6 +250,10 @@ to detect every individual click of the tray icon.
 
 This value is set to false by default.
 
+### `tray.getIgnoreDoubleClickEvents()` _macOS_
+
+Returns `Boolean` - Whether double click events will be ignored.
+
 #### `tray.displayBalloon(options)` _Windows_
 
 * `options` Object

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -245,7 +245,7 @@ win.on('hide', () => {
 
 * `ignore` Boolean
 
-Sets the option to ignore double click events. Ignoring these events allow you
+Sets the option to ignore double click events. Ignoring these events allows you
 to detect every individual click of the tray icon.
 
 This value is set to false by default.

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -241,6 +241,15 @@ win.on('hide', () => {
 })
 ```
 
+#### `tray.setIgnoreDoubleClickEvents(ignore)` _macOS_
+
+* `ignore` Boolean
+
+Sets the option to ignore double click events. Ignoring these events allow you
+to detect every individual click of the tray icon.
+
+This value is set to false by default.
+
 #### `tray.displayBalloon(options)` _Windows_
 
 * `options` Object


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes [#8952](https://github.com/electron/electron/issues/8952).  Based off the conversation in the original Issue, it sounded like the agreed upon solution was to allow the application developer to ignore these double click events on macOS. This patch seems to do the trick. 