### PR TITLE
Disable chromium's redraw locking on Windows when DWM is disabled

### DIFF
--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -25,4 +25,11 @@ bool AtomDesktopWindowTreeHostWin::PreHandleMSG(
   return delegate_->PreHandleMSG(message, w_param, l_param, result);
 }
 
+bool AtomDesktopWindowTreeHostWin::HasNativeFrame() const {
+  // Since we never use chromium's titlebar implementation, we can just say
+  // that we use a native titlebar. This will disable the repaint locking when
+  // DWM composition is disabled.
+  return true;
+}
+
 }  // namespace atom

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
@@ -27,6 +27,7 @@ class AtomDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin {
  protected:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
+  bool HasNativeFrame() const override;
 
  private:
   MessageHandlerDelegate* delegate_;  // weak ref


### PR DESCRIPTION
Depends on electron/libchromiumcontent#503