### PR TITLE
Refactor NativeWindow (Part 3):  Remove is_offscreen_dummy from NativeWindow

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -154,7 +154,6 @@ void BrowserWindow::Init(v8::Isolate* isolate,
       options,
       parent.IsEmpty() ? nullptr : parent->window_.get()));
   web_contents->SetOwnerWindow(window_.get());
-  window_->set_is_offscreen_dummy(api_web_contents_->IsOffScreen());
 
   // Tell the content module to initialize renderer widget with transparent
   // mode.

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -10,6 +10,7 @@
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/ui/file_dialog.h"
+#include "atom/browser/web_contents_preferences.h"
 #include "base/bind.h"
 #include "base/files/file_util.h"
 #include "chrome/common/pref_names.h"
@@ -89,12 +90,15 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
   if (relay)
     window = relay->window.get();
 
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
+  bool offscreen = !web_preferences || web_preferences->IsEnabled("offscreen");
+
   base::FilePath path;
   GetItemSavePath(item, &path);
   // Show save dialog if save path was not set already on item
   file_dialog::DialogSettings settings;
   settings.parent_window = window;
-  settings.force_detached = window->is_offscreen_dummy();
+  settings.force_detached = offscreen;
   settings.title = item->GetURL().spec();
   settings.default_path = default_path;
   if (path.empty() && file_dialog::ShowSaveDialog(settings, &path)) {

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -141,6 +141,7 @@ class CommonWebContentsDelegate
   // The window that this WebContents belongs to.
   base::WeakPtr<NativeWindow> owner_window_;
 
+  bool offscreen_;
   bool ignore_menu_shortcuts_;
 
   // Whether window is fullscreened by HTML5 api.

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -32,7 +32,6 @@ NativeWindow::NativeWindow(
       aspect_ratio_(0.0),
       parent_(parent),
       is_modal_(false),
-      is_osr_dummy_(false),
       browser_view_(nullptr),
       weak_factory_(this) {
   options.Get(options::kFrame, &has_frame_);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -271,9 +271,6 @@ class NativeWindow : public base::SupportsUserData {
   bool transparent() const { return transparent_; }
   bool enable_larger_than_screen() const { return enable_larger_than_screen_; }
 
-  void set_is_offscreen_dummy(bool is_dummy) { is_osr_dummy_ = is_dummy; }
-  bool is_offscreen_dummy() const { return is_osr_dummy_; }
-
   NativeBrowserView* browser_view() const { return browser_view_; }
   NativeWindow* parent() const { return parent_; }
   bool is_modal() const { return is_modal_; }
@@ -318,9 +315,6 @@ class NativeWindow : public base::SupportsUserData {
 
   // Is this a modal window.
   bool is_modal_;
-
-  // Is this a dummy window for an offscreen WebContents.
-  bool is_osr_dummy_;
 
   // The browser view layer.
   NativeBrowserView* browser_view_;

--- a/atom/browser/ui/message_box_mac.mm
+++ b/atom/browser/ui/message_box_mac.mm
@@ -146,8 +146,7 @@ int ShowMessageBox(NativeWindow* parent_window,
 
   // Use runModal for synchronous alert without parent, since we don't have a
   // window to wait for.
-  if (!parent_window || !parent_window->GetNativeWindow() ||
-      parent_window->is_offscreen_dummy())
+  if (!parent_window)
     return [[alert autorelease] runModal];
 
   int ret_code = -1;
@@ -185,8 +184,7 @@ void ShowMessageBox(NativeWindow* parent_window,
 
   // Use runModal for synchronous alert without parent, since we don't have a
   // window to wait for.
-  if (!parent_window || !parent_window->GetNativeWindow() ||
-      parent_window->is_offscreen_dummy()) {
+  if (!parent_window) {
     int ret = [[alert autorelease] runModal];
     callback.Run(ret, alert.suppressionButton.state == NSOnState);
   } else {


### PR DESCRIPTION
The offscreen state is a thing of WebContents, `NativeWindow` should not assume it has a WebContents in it.