### PR TITLE
Handle in-app-purchase less fatally on non-Darwin

### DIFF
--- a/lib/browser/api/in-app-purchase.js
+++ b/lib/browser/api/in-app-purchase.js
@@ -1,14 +1,20 @@
 'use strict'
 
-if (process.platform !== 'darwin') {
-  throw new Error('The inAppPurchase module can only be used on macOS')
+if (process.platform === 'darwin') {
+  const {EventEmitter} = require('events')
+  const {inAppPurchase, InAppPurchase} = process.atomBinding('in_app_purchase')
+
+  // inAppPurchase is an EventEmitter.
+  Object.setPrototypeOf(InAppPurchase.prototype, EventEmitter.prototype)
+  EventEmitter.call(inAppPurchase)
+
+  module.exports = inAppPurchase
+} else {
+  module.exports = {
+    purchaseProduct: (productID, quantity, callback) => {
+      throw new Error('The inAppPurchase module can only be used on macOS')
+    },
+    canMakePayments: () => false,
+    getReceiptURL: () => ''
+  }
 }
-
-const {EventEmitter} = require('events')
-const {inAppPurchase, InAppPurchase} = process.atomBinding('in_app_purchase')
-
-// inAppPurchase is an EventEmitter.
-Object.setPrototypeOf(InAppPurchase.prototype, EventEmitter.prototype)
-EventEmitter.call(inAppPurchase)
-
-module.exports = inAppPurchase


### PR DESCRIPTION
Fixes #12311

Right now it throws a new error when the file is even `require()d`, but this isn't ideal as there are cases where everything is mass-required, such as Spectron.

Instead, we should throw an error on non-Darwin environments only when the IAP methods are invoked.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->