### PR TITLE
Refactor NativeWindow (Part 4): Move AutofillPopup from NativeWindow to WebContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -608,6 +608,9 @@ void WebContents::MoveContents(content::WebContents* source,
 
 void WebContents::CloseContents(content::WebContents* source) {
   Emit("close");
+#if defined(TOOLKIT_VIEWS)
+  HideAutofillPopup();
+#endif
   if (managed_web_contents())
     managed_web_contents()->GetView()->SetDelegate(nullptr);
   for (ExtendedWebContentsObserver& observer : observers_)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -960,16 +960,16 @@ void WebContents::DevToolsClosed() {
   Emit("devtools-closed");
 }
 
+#if defined(TOOLKIT_VIEWS)
 void WebContents::ShowAutofillPopup(content::RenderFrameHost* frame_host,
                                     const gfx::RectF& bounds,
                                     const std::vector<base::string16>& values,
                                     const std::vector<base::string16>& labels) {
-  auto relay = NativeWindowRelay::FromWebContents(web_contents());
-  if (relay) {
-    relay->window->ShowAutofillPopup(
-        frame_host, web_contents(), bounds, values, labels);
-  }
+  bool offscreen = IsOffScreen() || (embedder_ && embedder_->IsOffScreen());
+  CommonWebContentsDelegate::ShowAutofillPopup(
+      offscreen, frame_host, bounds, values, labels);
 }
+#endif
 
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
@@ -986,15 +986,6 @@ bool WebContents::OnMessageReceived(const IPC::Message& message,
                                     content::RenderFrameHost* frame_host) {
   bool handled = true;
   FrameDispatchHelper helper = {this, frame_host};
-  auto relay = NativeWindowRelay::FromWebContents(web_contents());
-  if (relay) {
-    IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(NativeWindow, message, frame_host)
-      IPC_MESSAGE_FORWARD(AtomAutofillFrameHostMsg_HidePopup,
-                          relay->window.get(), NativeWindow::HideAutofillPopup)
-      IPC_MESSAGE_UNHANDLED(handled = false)
-    IPC_END_MESSAGE_MAP()
-  }
-
   IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(WebContents, message, frame_host)
     IPC_MESSAGE_HANDLER(AtomFrameHostMsg_Message, OnRendererMessage)
     IPC_MESSAGE_FORWARD_DELAY_REPLY(AtomFrameHostMsg_Message_Sync, &helper,
@@ -1004,7 +995,10 @@ bool WebContents::OnMessageReceived(const IPC::Message& message,
         FrameDispatchHelper::OnSetTemporaryZoomLevel)
     IPC_MESSAGE_FORWARD_DELAY_REPLY(AtomFrameHostMsg_GetZoomLevel, &helper,
                                     FrameDispatchHelper::OnGetZoomLevel)
+#if defined(TOOLKIT_VIEWS)
     IPC_MESSAGE_HANDLER(AtomAutofillFrameHostMsg_ShowPopup, ShowAutofillPopup)
+    IPC_MESSAGE_HANDLER(AtomAutofillFrameHostMsg_HidePopup, HideAutofillPopup)
+#endif
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -384,10 +384,12 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DevToolsOpened() override;
   void DevToolsClosed() override;
 
+#if defined(TOOLKIT_VIEWS)
   void ShowAutofillPopup(content::RenderFrameHost* frame_host,
                          const gfx::RectF& bounds,
                          const std::vector<base::string16>& values,
                          const std::vector<base::string16>& labels);
+#endif
 
  private:
   struct FrameDispatchHelper;

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -189,6 +189,9 @@ void CommonWebContentsDelegate::SetOwnerWindow(
   auto relay = base::MakeUnique<NativeWindowRelay>(owner_window_);
   auto relay_key = relay->key;
   if (owner_window) {
+#if defined(TOOLKIT_VIEWS)
+    autofill_popup_.reset(new AutofillPopup());
+#endif
     web_contents->SetUserData(relay_key, std::move(relay));
   } else {
     web_contents->RemoveUserData(relay_key);

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -15,6 +15,10 @@
 #include "brightray/browser/inspectable_web_contents_view_delegate.h"
 #include "content/public/browser/web_contents_delegate.h"
 
+#if defined(TOOLKIT_VIEWS)
+#include "atom/browser/ui/autofill_popup.h"
+#endif
+
 using brightray::DevToolsFileSystemIndexer;
 
 namespace atom {
@@ -86,6 +90,17 @@ class CommonWebContentsDelegate
       content::WebContents* source,
       const content::NativeWebKeyboardEvent& event) override;
 
+  // Autofill related events.
+#if defined(TOOLKIT_VIEWS)
+  void ShowAutofillPopup(
+    bool offscreen,
+    content::RenderFrameHost* frame_host,
+    const gfx::RectF& bounds,
+    const std::vector<base::string16>& values,
+    const std::vector<base::string16>& labels);
+  void HideAutofillPopup();
+#endif
+
   // brightray::InspectableWebContentsDelegate:
   void DevToolsSaveToFile(const std::string& url,
                           const std::string& content,
@@ -122,7 +137,7 @@ class CommonWebContentsDelegate
   // Callback for when DevToolsAppendToFile has completed.
   void OnDevToolsAppendToFile(const std::string& url);
 
-  //
+  // DevTools index event callbacks.
   void OnDevToolsIndexingWorkCalculated(int request_id,
                                         const std::string& file_system_path,
                                         int total_work);
@@ -150,7 +165,12 @@ class CommonWebContentsDelegate
   // Whether window is fullscreened by window api.
   bool native_fullscreen_;
 
+  // UI related helper classes.
+#if defined(TOOLKIT_VIEWS)
+  std::unique_ptr<AutofillPopup> autofill_popup_;
+#endif
   std::unique_ptr<WebDialogHelper> web_dialog_helper_;
+
   scoped_refptr<DevToolsFileSystemIndexer> devtools_file_system_indexer_;
 
   // Make sure BrowserContext is alwasys destroyed after WebContents.

--- a/atom/browser/common_web_contents_delegate_views.cc
+++ b/atom/browser/common_web_contents_delegate_views.cc
@@ -37,9 +37,9 @@ void CommonWebContentsDelegate::ShowAutofillPopup(
     return;
 
   auto* window = static_cast<NativeWindowViews*>(owner_window());
-  autofill_popup_->CreateView(frame_host, offscreen, window, bounds);
+  autofill_popup_->CreateView(
+      frame_host, offscreen, window->web_view(), bounds);
   autofill_popup_->SetItems(values, labels);
-  autofill_popup_->UpdatePopupBounds(window->GetMenuBarHeight());
 }
 
 void CommonWebContentsDelegate::HideAutofillPopup() {

--- a/atom/browser/common_web_contents_delegate_views.cc
+++ b/atom/browser/common_web_contents_delegate_views.cc
@@ -27,6 +27,25 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
     owner_window()->HandleKeyboardEvent(source, event);
 }
 
+void CommonWebContentsDelegate::ShowAutofillPopup(
+    bool offscreen,
+    content::RenderFrameHost* frame_host,
+    const gfx::RectF& bounds,
+    const std::vector<base::string16>& values,
+    const std::vector<base::string16>& labels) {
+  if (!owner_window())
+    return;
+
+  auto* window = static_cast<NativeWindowViews*>(owner_window());
+  autofill_popup_->CreateView(frame_host, offscreen, window, bounds);
+  autofill_popup_->SetItems(values, labels);
+  autofill_popup_->UpdatePopupBounds(window->GetMenuBarHeight());
+}
+
+void CommonWebContentsDelegate::HideAutofillPopup() {
+  autofill_popup_->Hide();
+}
+
 gfx::ImageSkia CommonWebContentsDelegate::GetDevToolsWindowIcon() {
   if (!owner_window())
     return gfx::ImageSkia();

--- a/atom/browser/common_web_contents_delegate_views.cc
+++ b/atom/browser/common_web_contents_delegate_views.cc
@@ -43,7 +43,8 @@ void CommonWebContentsDelegate::ShowAutofillPopup(
 }
 
 void CommonWebContentsDelegate::HideAutofillPopup() {
-  autofill_popup_->Hide();
+  if (autofill_popup_)
+    autofill_popup_->Hide();
 }
 
 gfx::ImageSkia CommonWebContentsDelegate::GetDevToolsWindowIcon() {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -215,13 +215,6 @@ class NativeWindow : public base::SupportsUserData {
   virtual void HandleKeyboardEvent(
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) {}
-  virtual void ShowAutofillPopup(
-    content::RenderFrameHost* frame_host,
-    content::WebContents* web_contents,
-    const gfx::RectF& bounds,
-    const std::vector<base::string16>& values,
-    const std::vector<base::string16>& labels) {}
-  virtual void HideAutofillPopup(content::RenderFrameHost* frame_host) {}
 
   // Public API used by platform-dependent delegates and observers to send UI
   // related notifications.

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1170,10 +1170,6 @@ void NativeWindowViews::SetEnabled(bool enable) {
 #endif
 }
 
-int NativeWindowViews::GetMenuBarHeight() const {
-  return menu_bar_visible_ ? 0 : kMenuBarHeight;
-}
-
 void NativeWindowViews::OnWidgetActivationChanged(
     views::Widget* widget, bool active) {
   if (widget != window_.get())
@@ -1377,9 +1373,6 @@ void NativeWindowViews::Layout() {
         gfx::Rect(0, menu_bar_bounds.height(), size.width(),
                   size.height() - menu_bar_bounds.height()));
   }
-
-  // if (autofill_popup_.get())
-  //   autofill_popup_->UpdatePopupBounds(GetMenuBarHeight());
 }
 
 gfx::Size NativeWindowViews::GetMinimumSize() const {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -328,8 +328,6 @@ NativeWindowViews::NativeWindowViews(
   window_->CenterWindow(size);
   Layout();
 
-  autofill_popup_.reset(new AutofillPopup(GetNativeView()));
-
 #if defined(OS_WIN)
   // Save initial window state.
   if (fullscreen)
@@ -1172,6 +1170,10 @@ void NativeWindowViews::SetEnabled(bool enable) {
 #endif
 }
 
+int NativeWindowViews::GetMenuBarHeight() const {
+  return menu_bar_visible_ ? 0 : kMenuBarHeight;
+}
+
 void NativeWindowViews::OnWidgetActivationChanged(
     views::Widget* widget, bool active) {
   if (widget != window_.get())
@@ -1361,49 +1363,6 @@ void NativeWindowViews::HandleKeyboardEvent(
   }
 }
 
-void NativeWindowViews::ShowAutofillPopup(
-    content::RenderFrameHost* frame_host,
-    content::WebContents* web_contents,
-    const gfx::RectF& bounds,
-    const std::vector<base::string16>& values,
-    const std::vector<base::string16>& labels) {
-  bool is_offsceen = false;
-  bool is_embedder_offscreen = false;
-
-  auto* web_preferences = WebContentsPreferences::From(web_contents);
-  if (web_preferences) {
-    web_preferences->dict()->GetBoolean("offscreen", &is_offsceen);
-    int guest_instance_id = 0;
-    web_preferences->dict()->GetInteger(options::kGuestInstanceID,
-                                        &guest_instance_id);
-
-    if (guest_instance_id) {
-      auto* manager = WebViewManager::GetWebViewManager(web_contents);
-      if (manager) {
-        auto* embedder = manager->GetEmbedder(guest_instance_id);
-        if (embedder) {
-          auto* embedder_prefs = WebContentsPreferences::From(embedder);
-          is_embedder_offscreen = embedder_prefs &&
-                                  embedder_prefs->IsEnabled("offscreen");
-        }
-      }
-    }
-  }
-
-  autofill_popup_->CreateView(
-      frame_host,
-      is_offsceen || is_embedder_offscreen,
-      widget(),
-      bounds);
-  autofill_popup_->SetItems(values, labels);
-  autofill_popup_->UpdatePopupBounds(menu_bar_visible_ ? 0 : kMenuBarHeight);
-}
-
-void NativeWindowViews::HideAutofillPopup(
-    content::RenderFrameHost* frame_host) {
-  autofill_popup_->Hide();
-}
-
 void NativeWindowViews::Layout() {
   const auto size = GetContentsBounds().size();
   const auto menu_bar_bounds =
@@ -1419,8 +1378,8 @@ void NativeWindowViews::Layout() {
                   size.height() - menu_bar_bounds.height()));
   }
 
-  if (autofill_popup_.get())
-    autofill_popup_->UpdatePopupBounds(menu_bar_visible_ ? 0 : kMenuBarHeight);
+  // if (autofill_popup_.get())
+  //   autofill_popup_->UpdatePopupBounds(GetMenuBarHeight());
 }
 
 gfx::Size NativeWindowViews::GetMinimumSize() const {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "atom/browser/ui/accelerator_util.h"
-#include "atom/browser/ui/autofill_popup.h"
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/views/widget/widget_observer.h"
 
@@ -139,7 +138,10 @@ class NativeWindowViews : public NativeWindow,
 
   void SetEnabled(bool enable) override;
 
+  int GetMenuBarHeight() const;
+
   views::Widget* widget() const { return window_.get(); }
+  views::View* web_view() const { return web_view_; }
   SkRegion* draggable_region() const { return draggable_region_.get(); }
 
 #if defined(OS_WIN)
@@ -192,13 +194,6 @@ class NativeWindowViews : public NativeWindow,
   void HandleKeyboardEvent(
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) override;
-  void ShowAutofillPopup(
-    content::RenderFrameHost* frame_host,
-    content::WebContents* web_contents,
-    const gfx::RectF& bounds,
-    const std::vector<base::string16>& values,
-    const std::vector<base::string16>& labels) override;
-  void HideAutofillPopup(content::RenderFrameHost* frame_host) override;
 
   // views::View:
   void Layout() override;
@@ -215,8 +210,6 @@ class NativeWindowViews : public NativeWindow,
   std::unique_ptr<views::Widget> window_;
   views::View* web_view_;  // Managed by inspectable_web_contents_.
   views::View* focused_view_;  // The view should be focused by default.
-
-  std::unique_ptr<AutofillPopup> autofill_popup_;
 
   std::unique_ptr<MenuBar> menu_bar_;
   bool menu_bar_autohide_;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -138,8 +138,6 @@ class NativeWindowViews : public NativeWindow,
 
   void SetEnabled(bool enable) override;
 
-  int GetMenuBarHeight() const;
-
   views::Widget* widget() const { return window_.get(); }
   views::View* web_view() const { return web_view_; }
   SkRegion* draggable_region() const { return draggable_region_.get(); }

--- a/atom/browser/ui/autofill_popup.h
+++ b/atom/browser/ui/autofill_popup.h
@@ -20,11 +20,13 @@ class AutofillPopupView;
 
 class AutofillPopup {
  public:
-  explicit AutofillPopup(gfx::NativeView);
+  AutofillPopup();
   ~AutofillPopup();
 
   void CreateView(content::RenderFrameHost* render_frame,
-    bool offscreen, views::Widget* widget, const gfx::RectF& bounds);
+                  bool offscreen,
+                  views::View* parent,
+                  const gfx::RectF& bounds);
   void Hide();
 
   void SetItems(const std::vector<base::string16>& values,
@@ -48,9 +50,6 @@ class AutofillPopup {
   base::string16 GetLabelAt(int i);
   int LineFromY(int y) const;
 
-  // The native view that contains this
-  gfx::NativeView container_view_;
-
   int selected_index_;
 
   // Popup location
@@ -70,10 +69,13 @@ class AutofillPopup {
 
   // For sending the accepted suggestion to the render frame that
   // asked to open the popup
-  content::RenderFrameHost* frame_host_;
+  content::RenderFrameHost* frame_host_ = nullptr;
 
   // The popup view. The lifetime is managed by the owning Widget
-  AutofillPopupView* view_;
+  AutofillPopupView* view_ = nullptr;
+
+  // The parent view that the popup view shows on. Weak ref.
+  views::View* parent_ = nullptr;
 
   DISALLOW_COPY_AND_ASSIGN(AutofillPopup);
 };

--- a/atom/browser/ui/autofill_popup.h
+++ b/atom/browser/ui/autofill_popup.h
@@ -18,7 +18,7 @@ namespace atom {
 
 class AutofillPopupView;
 
-class AutofillPopup {
+class AutofillPopup : public views::ViewObserver {
  public:
   AutofillPopup();
   ~AutofillPopup();
@@ -31,10 +31,14 @@ class AutofillPopup {
 
   void SetItems(const std::vector<base::string16>& values,
                 const std::vector<base::string16>& labels);
-  void UpdatePopupBounds(int height_compensation);
+  void UpdatePopupBounds();
 
  private:
   friend class AutofillPopupView;
+
+  // views::ViewObserver:
+  void OnViewBoundsChanged(views::View* view) override;
+  void OnViewIsDeleting(views::View* view) override;
 
   void AcceptSuggestion(int index);
 

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -148,7 +148,9 @@ void RendererClientBase::RenderThreadStarted() {
 
 void RendererClientBase::RenderFrameCreated(
     content::RenderFrame* render_frame) {
+#if defined(TOOLKIT_VIEWS)
   new AutofillAgent(render_frame);
+#endif
   new PepperHelper(render_frame);
   new ContentSettingsObserver(render_frame);
   new printing::PrintWebViewHelper(render_frame);


### PR DESCRIPTION
Currently we assume each NativeWindow can have only one WebContents showing autofill popup. This PR moves `AutofillPopup` from `NativeWindow` to `WebContents` so:

1. There is no assumption on `NativeWindow` having a `WebContents` showing autofill popup.
2. We can have multiple `WebContents` in one window showing autofill popups.
3. The `WebContents` does not need to know anything about the window.