### PR TITLE
Add native arm/arm64 mksnapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@
 /vendor/llvm/
 /vendor/npm/
 /vendor/python_26/
+/vendor/native_mksnapshot
+/vendor/LICENSES.chromium.html
 node_modules/
 SHASUMS256.txt
 **/package-lock.json

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -40,6 +40,9 @@ def main():
   if args.target_arch == 'mips64el':
     download_mips64el_toolchain()
 
+  if args.target_arch.startswith('arm'):
+    download_native_mksnapshot(args.target_arch)
+
   # Redirect to use local libchromiumcontent build.
   if args.build_release_libcc or args.build_debug_libcc:
     build_libchromiumcontent(args.verbose, args.target_arch,
@@ -216,6 +219,15 @@ def download_mips64el_toolchain():
     subprocess.check_call(['tar', '-xf', tar_name, '-C', VENDOR_DIR])
     os.remove(tar_name)
 
+def download_native_mksnapshot(arch):
+  if not os.path.exists(os.path.join(VENDOR_DIR,
+                                     'native_mksnapshot')):
+    tar_name = 'native-mksnapshot.tar.bz2'
+    url = '{0}/linux/{1}/{2}/{3}'.format(BASE_URL, arch,
+           get_libchromiumcontent_commit(), tar_name)
+    download(tar_name, url, os.path.join(SOURCE_ROOT, tar_name))
+    subprocess.call(['tar', '-jxf', tar_name, '-C', VENDOR_DIR])
+    os.remove(tar_name)
 
 def create_chrome_version_h():
   version_file = os.path.join(VENDOR_DIR, 'libchromiumcontent', 'VERSION')

--- a/script/upload.py
+++ b/script/upload.py
@@ -85,12 +85,16 @@ def main():
   upload_electron(github, release, os.path.join(DIST_DIR, ffmpeg),
                   args.upload_to_s3)
 
-  # Upload chromedriver and mksnapshot for minor version update.
-  if parse_version(args.version)[2] == '0':
-    chromedriver = get_zip_name('chromedriver', ELECTRON_VERSION)
-    upload_electron(github, release, os.path.join(DIST_DIR, chromedriver),
-                    args.upload_to_s3)
-    mksnapshot = get_zip_name('mksnapshot', ELECTRON_VERSION)
+  chromedriver = get_zip_name('chromedriver', ELECTRON_VERSION)
+  upload_electron(github, release, os.path.join(DIST_DIR, chromedriver),
+                  args.upload_to_s3)
+  mksnapshot = get_zip_name('mksnapshot', ELECTRON_VERSION)
+  upload_electron(github, release, os.path.join(DIST_DIR, mksnapshot),
+                args.upload_to_s3)
+
+  if get_target_arch().startswith('arm'):
+    # Upload the x64 binary for arm/arm64 mksnapshot
+    mksnapshot = get_zip_name('mksnapshot', ELECTRON_VERSION, 'x64')
     upload_electron(github, release, os.path.join(DIST_DIR, mksnapshot),
                     args.upload_to_s3)
 


### PR DESCRIPTION
This PR adds the native arm and arm64 mksnapshot binaries to our releases.

Additionally, every release will now have mksnapshot and chromedriver binaries included in the release assets.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->