### PR TITLE
vendor: Update native mate to fix v8 DCHECK crash

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -332,10 +332,6 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
       request_id_(0),
       background_throttling_(true),
       enable_devtools_(true) {
-  // WebContents may need to emit events when it is garbage collected, so it
-  // has to be deleted in the first gc callback.
-  MarkHighMemoryUsage();
-
   // Read options.
   options.Get("backgroundThrottling", &background_throttling_);
 

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -223,7 +223,6 @@ NativeImage::NativeImage(v8::Isolate* isolate, const gfx::Image& image)
     isolate->AdjustAmountOfExternalAllocatedMemory(
       image_.ToImageSkia()->bitmap()->computeByteSize());
   }
-  MarkHighMemoryUsage();
 }
 
 #if defined(OS_WIN)
@@ -238,7 +237,6 @@ NativeImage::NativeImage(v8::Isolate* isolate, const base::FilePath& hicon_path)
     isolate->AdjustAmountOfExternalAllocatedMemory(
       image_.ToImageSkia()->bitmap()->computeByteSize());
   }
-  MarkHighMemoryUsage();
 }
 #endif
 


### PR DESCRIPTION
Ref https://github.com/electron/native-mate/pull/24

Fixes
```
Fatal error in ../../v8/src/global-handles.cc, line 846
Debug check failed: node_->state() == Node::NEAR_DEATH.
```

This has already been updated in 2-0-x branch.