### PR TITLE
Use Visual Studio's vswhere to find Visual Studio

### DIFF
--- a/script/lib/env_util.py
+++ b/script/lib/env_util.py
@@ -63,9 +63,26 @@ def get_vs_env(vs_version, arch):
   """
   Returns the env object for VS building environment.
 
-  The vs_version can be strings like "2017", the arch has to
-  be one of "x86", "amd64", "arm", "x86_amd64", "x86_arm", "amd64_x86",
+  The vs_version can be strings like "[15.0,16.0)", meaning 2017, but not the next version.
+  The arch has to be one of "x86", "amd64", "arm", "x86_amd64", "x86_arm", "amd64_x86",
   "amd64_arm", e.g. the args passed to vcvarsall.bat.
   """
-  vsvarsall = "C:\\Program Files (x86)\\Microsoft Visual Studio\\{0}\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat".format(vs_version)
+
+  # vswhere can't handle spaces, like "[15.0, 16.0)" should become "[15.0,16.0)"
+  vs_version = vs_version.replace(" ", "")
+
+  # Find visual studio
+  proc = subprocess.Popen(
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe "
+    "-property installationPath "
+    "-requires Microsoft.VisualStudio.Component.VC.CoreIde "
+    "-format value "
+    "-version {0}".format(vs_version),
+    stdout=subprocess.PIPE)
+  
+  location = proc.stdout.readline().rstrip()
+
+  # Launch the process.
+  vsvarsall = "{0}\\VC\\Auxiliary\\Build\\vcvarsall.bat".format(location)
+
   return get_environment_from_batch_command([vsvarsall, arch])

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -246,7 +246,7 @@ def import_vs_env(target_arch):
     vs_arch = 'amd64_x86'
   else:
     vs_arch = 'x86_amd64'
-  env = get_vs_env('2017', vs_arch)
+  env = get_vs_env('[15.0,16.0)', vs_arch)
   os.environ.update(env)
 
 


### PR DESCRIPTION
This should find Visual Studio in such a way it doesn't matter if you have Enterprise, Professional, or Community installed, it just requires Visual Studio `[15.0,16.0)` (which is 2017), with the C++ component installed. 