### PR TITLE
Use ui:view's Activate() on Linux

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -98,21 +98,6 @@ bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
          (modifiers == (Modifiers::kAltKey | Modifiers::kIsRight));
 }
 
-#if defined(USE_X11)
-int SendClientEvent(XDisplay* display, ::Window window, const char* msg) {
-  XEvent event = {};
-  event.xclient.type = ClientMessage;
-  event.xclient.send_event = True;
-  event.xclient.message_type = XInternAtom(display, msg, False);
-  event.xclient.window = window;
-  event.xclient.format = 32;
-  XSendEvent(display, DefaultRootWindow(display), False,
-             SubstructureRedirectMask | SubstructureNotifyMask, &event);
-  XFlush(display);
-  return True;
-}
-#endif
-
 class NativeWindowClientView : public views::ClientView {
  public:
   NativeWindowClientView(views::Widget* widget,
@@ -367,15 +352,7 @@ void NativeWindowViews::Focus(bool focus) {
     return;
 
   if (focus) {
-#if defined(OS_WIN)
     window_->Activate();
-#elif defined(USE_X11)
-    // The "Activate" implementation of Chromium is not reliable on Linux.
-    ::Window window = GetAcceleratedWidget();
-    XDisplay* xdisplay = gfx::GetXDisplay();
-    SendClientEvent(xdisplay, window, "_NET_ACTIVE_WINDOW");
-    XMapRaised(xdisplay, window);
-#endif
   } else {
     window_->Deactivate();
   }


### PR DESCRIPTION
In NativeWindowViews, we started rolling our own `_NET_ACTIVE_WINDOW` event in June 2016 to raise windows because Chromium's implementation wasn't working as expected. (See commit 32b692b6)

Activate() is working for me when testing in our current version of libcc on Linux, so I wonder if this workaround is still needed?