### PR TITLE
Fix transparency

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -276,6 +276,9 @@ content::ServiceWorkerContext* GetServiceWorkerContext(
 void OnCapturePageDone(const base::Callback<void(const gfx::Image&)>& callback,
                        const SkBitmap& bitmap,
                        content::ReadbackResponse response) {
+  // Hack to enable transparency in captured image
+  // TODO(nitsakh) Remove hack once fixed in chromium
+  const_cast<SkBitmap&>(bitmap).setAlphaType(kPremul_SkAlphaType);
   callback.Run(gfx::Image::CreateFrom1xBitmap(bitmap));
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -442,6 +442,29 @@ describe('BrowserWindow module', () => {
         done()
       })
     })
+
+    it('preserves transparency', (done) => {
+      w.close()
+      const width = 400
+      const height = 400
+      w = new BrowserWindow({
+        show: false,
+        width: width,
+        height: height,
+        transparent: true
+      })
+      w.loadURL('data:text/html,<html><body background-color: rgba(255,255,255,0)></body></html>')
+      w.once('ready-to-show', () => {
+        w.show()
+        w.capturePage((image) => {
+          let imgBuffer = image.toPNG()
+          // Check 25th byte in the PNG
+          // Values can be 0,2,3,4, or 6. We want 6, which is RGB + Alpha
+          assert.equal(imgBuffer[25], 6)
+          done()
+        })
+      })
+    })
   })
 
   describe('BrowserWindow.setSize(width, height)', () => {


### PR DESCRIPTION
This fixes #12308.

With the latest chromium, the problem is consistent, i.e. the unscaled capture PNG also did not have transparency. The real fix for this would be to fix it in chromium, `DelegatedFrameHost::CopyFromCompositingSurface` by specifying the result format as `RGBA_BITMAP`. Currently, the result format is `RGBA_TEXTURE`, which causes the issue.
However, chromium is currently making changes and the breaking code path will be going away completely soon (https://bugs.chromium.org/p/chromium/issues/detail?id=759310).
So, for the time being, lets do a hack to preserve the transparency.(thanks to @brenca for this one)

The test creates a browser window with transparent background and captures that into a PNG.
We check the PNG header to make sure that the alpha channel is present in the PNG.