### PR TITLE
asar: remove patch to support graceful-fs

### DIFF
--- a/lib/common/asar_init.js
+++ b/lib/common/asar_init.js
@@ -1,20 +1,14 @@
 ;(function () {
   return function (process, require, asarSource) {
+    const source = process.binding('natives')
+
+    // Expose fs module without asar support.
+    source['original-fs'] = source.fs
+
     // Make asar.js accessible via "require".
-    process.binding('natives').ELECTRON_ASAR = asarSource
+    source.ELECTRON_ASAR = asarSource
 
     // Monkey-patch the fs module.
     require('ELECTRON_ASAR').wrapFsWithAsar(require('fs'))
-
-    // Make graceful-fs work with asar.
-    var source = process.binding('natives')
-    source['original-fs'] = source.fs
-    source['fs'] = `
-var nativeModule = new process.NativeModule('original-fs')
-nativeModule.cache()
-nativeModule.compile()
-var asar = require('ELECTRON_ASAR')
-asar.wrapFsWithAsar(nativeModule.exports)
-module.exports = nativeModule.exports`
   }
 })()


### PR DESCRIPTION
The patch is no longer needed since the implementation of the module has changed recently.

Original PR that added the patch : https://github.com/electron/electron/pull/1082