### PR TITLE
Add sccache option to bootstrap

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -110,9 +110,8 @@ def parse_args():
                       help='The static library path of libchromiumcontent.')
   parser.add_argument('--defines', default='',
                       help='The build variables passed to gyp')
-  parser.add_argument('--sccache',
-                      help='Enables sccache support, provide the path to ' +
-                        'sccache.  E.g.  $(which sccache)')
+  parser.add_argument('--cc_wrapper',
+                      help='Sets cc_wrapper for build. E.g. $(which sccache)')
   return parser.parse_args()
 
 
@@ -123,8 +122,8 @@ def args_to_defines(args):
   if args.clang_dir:
     defines += ' make_clang_dir=' + args.clang_dir
     defines += ' clang_use_chrome_plugins=0'
-  if args.sccache is not None:
-    defines += ' sccache_path=' + args.sccache
+  if args.cc_wrapper is not None:
+    defines += ' cc_wrapper=' + args.cc_wrapper
   return defines
 
 

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -66,8 +66,6 @@ def main():
   create_chrome_version_h()
   touch_config_gypi()
   run_update(defines, args.msvs)
-  if (args.sccache):
-    inject_sscache()
 
 
 def parse_args():
@@ -112,7 +110,9 @@ def parse_args():
                       help='The static library path of libchromiumcontent.')
   parser.add_argument('--defines', default='',
                       help='The build variables passed to gyp')
-  parser.add_argument('--sccache', action='store_true', help='Enables sccache support')
+  parser.add_argument('--sccache',
+                      help='Enables sccache support, provide the path to ' +
+                        'sccache.  E.g.  $(which sccache)')
   return parser.parse_args()
 
 
@@ -123,6 +123,8 @@ def args_to_defines(args):
   if args.clang_dir:
     defines += ' make_clang_dir=' + args.clang_dir
     defines += ' clang_use_chrome_plugins=0'
+  if args.sccache is not None:
+    defines += ' sccache_path=' + args.sccache
   return defines
 
 
@@ -258,24 +260,6 @@ def run_update(defines, msvs):
     args += ['--msvs']
 
   execute_stdout(args)
-
-def sscache_repl(match):
-  return match.group()[:-1] + 'sccache $'
-
-def inject_sscache():
-  out_dir = os.path.join(SOURCE_ROOT, 'out')
-  # We explicitly don't want to do this for cc_s
-  rules_to_update = ['cc', 'cxx', 'objc', 'objcxx']
-  for component_dir in [x for x in os.listdir(out_dir) if os.path.isdir(os.path.join(out_dir, x))]:
-    ninja_file = os.path.join(out_dir, component_dir, 'build.ninja')
-    content = ''
-    with open(ninja_file, 'r') as f:
-      content = f.read()
-    for rule in rules_to_update:
-      r = re.compile('rule ' + rule + r'(\n|(\n\r))  command = \$', re.M)
-      content = r.sub(sscache_repl, content)
-    with open(ninja_file, 'w') as f:
-      f.write(content)
 
 
 def get_libchromiumcontent_commit():

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -107,7 +107,10 @@
     # Setup sccache
     ['sccache_path!=""', {
       'make_global_settings': [
-        ['CC_wrapper', '<(sccache_path)']
+        ['CC_wrapper', '<(sccache_path)'],
+        ['CXX_wrapper', '<(sccache_path)'],
+        ['CC.host_wrapper', '<(sccache_path)'],
+        ['CXX.host_wrapper', '<(sccache_path)']
       ],
     }],
     # Setup building with clang.

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -5,6 +5,9 @@
     # Set this to true when building with Clang.
     'clang%': 1,
 
+    # Set this to the absolute path to sccache when building with sccache
+    'sccache_path%': '',
+
     # Path to mips64el toolchain.
     'make_mips64_dir%': 'vendor/gcc-4.8.3-d197-n64-loongson/usr',
 
@@ -101,6 +104,12 @@
     ],
   },
   'conditions': [
+    # Setup sccache
+    ['sccache_path!=""', {
+      'make_global_settings': [
+        ['CC_wrapper', '<(sccache_path)']
+      ],
+    }],
     # Setup building with clang.
     ['clang==1', {
       'make_global_settings': [

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -6,7 +6,7 @@
     'clang%': 1,
 
     # Set this to the absolute path to sccache when building with sccache
-    'sccache_path%': '',
+    'cc_wrapper%': '',
 
     # Path to mips64el toolchain.
     'make_mips64_dir%': 'vendor/gcc-4.8.3-d197-n64-loongson/usr',
@@ -104,13 +104,13 @@
     ],
   },
   'conditions': [
-    # Setup sccache
-    ['sccache_path!=""', {
+    # Setup cc_wrapper
+    ['cc_wrapper!=""', {
       'make_global_settings': [
-        ['CC_wrapper', '<(sccache_path)'],
-        ['CXX_wrapper', '<(sccache_path)'],
-        ['CC.host_wrapper', '<(sccache_path)'],
-        ['CXX.host_wrapper', '<(sccache_path)']
+        ['CC_wrapper', '<(cc_wrapper)'],
+        ['CXX_wrapper', '<(cc_wrapper)'],
+        ['CC.host_wrapper', '<(cc_wrapper)'],
+        ['CXX.host_wrapper', '<(cc_wrapper)']
       ],
     }],
     # Setup building with clang.


### PR DESCRIPTION
~Couldn't see a CC wrapper style option for gyp so we inject the sccache commands directly into the generated ninja files.~

Turns out `CC_wrapper` is case sensitive lol 😄 