### PR TITLE
Refactor NativeWindow (Part 5): Add NativeWindow::SetContentView

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -150,9 +150,9 @@ void BrowserWindow::Init(v8::Isolate* isolate,
 
   // Creates BrowserWindow.
   window_.reset(NativeWindow::Create(
-      web_contents->managed_web_contents(),
       options,
       parent.IsEmpty() ? nullptr : parent->window_.get()));
+  window_->SetContentView(web_contents->managed_web_contents());
   web_contents->SetOwnerWindow(window_.get());
 
   // Tell the content module to initialize renderer widget with transparent

--- a/atom/browser/common_web_contents_delegate_views.cc
+++ b/atom/browser/common_web_contents_delegate_views.cc
@@ -38,7 +38,7 @@ void CommonWebContentsDelegate::ShowAutofillPopup(
 
   auto* window = static_cast<NativeWindowViews*>(owner_window());
   autofill_popup_->CreateView(
-      frame_host, offscreen, window->web_view(), bounds);
+      frame_host, offscreen, window->content_view(), bounds);
   autofill_popup_->SetItems(values, labels);
 }
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -131,6 +131,12 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   if (options.Get(options::kKiosk, &kiosk) && kiosk) {
     SetKiosk(kiosk);
   }
+#if defined(OS_MACOSX)
+  std::string type;
+  if (options.Get(options::kVibrancyType, &type)) {
+    SetVibrancy(type);
+  }
+#endif
   std::string color;
   if (options.Get(options::kBackgroundColor, &color)) {
     SetBackgroundColor(ParseHexColor(color));

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -12,17 +12,14 @@
 #include "atom/browser/window_list.h"
 #include "atom/common/color_util.h"
 #include "atom/common/options_switches.h"
-#include "brightray/browser/inspectable_web_contents.h"
 #include "native_mate/dictionary.h"
 
 DEFINE_WEB_CONTENTS_USER_DATA_KEY(atom::NativeWindowRelay);
 
 namespace atom {
 
-NativeWindow::NativeWindow(
-    brightray::InspectableWebContents* inspectable_web_contents,
-    const mate::Dictionary& options,
-    NativeWindow* parent)
+NativeWindow::NativeWindow(const mate::Dictionary& options,
+                           NativeWindow* parent)
     : has_frame_(true),
       transparent_(false),
       enable_larger_than_screen_(false),

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -11,13 +11,11 @@
 #include <vector>
 
 #include "atom/browser/native_window_observer.h"
-#include "atom/browser/ui/atom_menu_model.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/supports_user_data.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "extensions/browser/app_window/size_constraints.h"
-#include "native_mate/persistent_dictionary.h"
 
 class SkRegion;
 
@@ -39,10 +37,12 @@ class Size;
 
 namespace mate {
 class Dictionary;
+class PersistentDictionary;
 }
 
 namespace atom {
 
+class AtomMenuModel;
 class NativeBrowserView;
 
 struct DraggableRegion;
@@ -272,8 +272,7 @@ class NativeWindow : public base::SupportsUserData {
   bool is_modal() const { return is_modal_; }
 
  protected:
-  NativeWindow(brightray::InspectableWebContents* inspectable_web_contents,
-               const mate::Dictionary& options,
+  NativeWindow(const mate::Dictionary& options,
                NativeWindow* parent);
 
   void set_browser_view(NativeBrowserView* browser_view) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -53,12 +53,13 @@ class NativeWindow : public base::SupportsUserData {
 
   // Create window with existing WebContents, the caller is responsible for
   // managing the window's live.
-  static NativeWindow* Create(
-      brightray::InspectableWebContents* inspectable_web_contents,
-      const mate::Dictionary& options,
-      NativeWindow* parent = nullptr);
+  static NativeWindow* Create(const mate::Dictionary& options,
+                              NativeWindow* parent = nullptr);
 
   void InitFromOptions(const mate::Dictionary& options);
+
+  virtual void SetContentView(
+      brightray::InspectableWebContents* web_contents) = 0;
 
   virtual void Close() = 0;
   virtual void CloseImmediately() = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -141,8 +141,6 @@ class NativeWindowMac : public NativeWindow {
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void ShowWindowButton(NSWindowButton button);
 
-  void InstallView(NSView* view);
-
   void SetForwardMouseMessages(bool forward);
 
   base::scoped_nsobject<AtomNSWindow> window_;
@@ -152,7 +150,10 @@ class NativeWindowMac : public NativeWindow {
   id wheel_event_monitor_;
 
   // The view that will fill the whole frameless window.
-  base::scoped_nsobject<FullSizeContentView> content_view_;
+  base::scoped_nsobject<FullSizeContentView> container_view_;
+
+  // The content view passed by SetContentView, weak ref.
+  NSView* content_view_;
 
   bool is_kiosk_;
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -21,12 +21,12 @@ namespace atom {
 
 class NativeWindowMac : public NativeWindow {
  public:
-  NativeWindowMac(brightray::InspectableWebContents* inspectable_web_contents,
-                  const mate::Dictionary& options,
+  NativeWindowMac(const mate::Dictionary& options,
                   NativeWindow* parent);
   ~NativeWindowMac() override;
 
   // NativeWindow:
+  void SetContentView(brightray::InspectableWebContents* web_contents) override;
   void Close() override;
   void CloseImmediately() override;
   void Focus(bool focus) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -970,11 +970,6 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
       return event;
   }];
 
-  std::string type;
-  if (options.Get(options::kVibrancyType, &type)) {
-    SetVibrancy(type);
-  }
-
   // Set maximizable state last to ensure zoom button does not get reset
   // by calls to other APIs.
   SetMaximizable(maximizable);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -986,9 +986,15 @@ NativeWindowMac::~NativeWindowMac() {
 
 void NativeWindowMac::SetContentView(
     brightray::InspectableWebContents* web_contents) {
-  // TODO(zcbenz): Uninstall view first.
-  // TODO(zcbenz): Handle vibrancy.
-  // TODO(zcbenz): Handle draggable regions.
+  // We might have vibrantView added to the contentView.
+  NSArray* subviews = [[window_ contentView] subviews];
+  if ([subviews count] == ([window_ vibrantView] != nil ? 2 : 1)) {
+    // The vibrantView is always bellow the web view.
+    NSView* content_view = static_cast<NSView*>(
+        [subviews objectAtIndex:([subviews count] - 1)]);
+    [content_view removeFromSuperview];
+  }
+
   NSView* view = web_contents->GetView()->GetNativeView();
   [view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
   InstallView(web_contents->GetView()->GetNativeView());

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1708,7 +1708,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     return;
   }
 
-  background_color_before_vibrancy_.reset([window_ backgroundColor]);
+  background_color_before_vibrancy_.reset([[window_ backgroundColor] retain]);
   transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
   ui::GpuSwitchingManager::SetTransparent(true);
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -780,7 +780,7 @@ NativeWindowMac::NativeWindowMac(
     brightray::InspectableWebContents* web_contents,
     const mate::Dictionary& options,
     NativeWindow* parent)
-    : NativeWindow(web_contents, options, parent),
+    : NativeWindow(options, parent),
       is_kiosk_(false),
       was_fullscreen_(false),
       zoom_to_page_width_(false),

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -124,7 +124,7 @@ NativeWindowViews::NativeWindowViews(
     NativeWindow* parent)
     : NativeWindow(options, parent),
       window_(new views::Widget),
-      web_view_(web_contents->GetView()->GetView()),
+      content_view_(web_contents->GetView()->GetView()),
       focused_view_(web_contents->GetView()->GetWebView()),
       menu_bar_autohide_(false),
       menu_bar_visible_(false),
@@ -266,7 +266,7 @@ NativeWindowViews::NativeWindowViews(
     SetWindowType(GetAcceleratedWidget(), window_type);
 #endif
 
-  AddChildView(web_view_);
+  AddChildView(content_view_);
 
 #if defined(OS_WIN)
   if (!has_frame()) {
@@ -544,7 +544,7 @@ gfx::Rect NativeWindowViews::GetBounds() {
 }
 
 gfx::Rect NativeWindowViews::GetContentBounds() {
-  return web_view_->GetBoundsInScreen();
+  return content_view_->GetBoundsInScreen();
 }
 
 gfx::Size NativeWindowViews::GetContentSize() {
@@ -553,7 +553,7 @@ gfx::Size NativeWindowViews::GetContentSize() {
     return NativeWindow::GetContentSize();
 #endif
 
-  return web_view_->size();
+  return content_view_->size();
 }
 
 void NativeWindowViews::SetContentSizeConstraints(
@@ -934,7 +934,7 @@ void NativeWindowViews::SetMenu(AtomMenuModel* menu_model) {
 
 void NativeWindowViews::SetBrowserView(NativeBrowserView* view) {
   if (browser_view()) {
-    web_view_->RemoveChildView(
+    content_view_->RemoveChildView(
         browser_view()->GetInspectableWebContentsView()->GetView());
     set_browser_view(nullptr);
   }
@@ -946,7 +946,7 @@ void NativeWindowViews::SetBrowserView(NativeBrowserView* view) {
   // Add as child of the main web view to avoid (0, 0) origin from overlapping
   // with menu bar.
   set_browser_view(view);
-  web_view_->AddChildView(view->GetInspectableWebContentsView()->GetView());
+  content_view_->AddChildView(view->GetInspectableWebContentsView()->GetView());
 }
 
 void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
@@ -1346,6 +1346,9 @@ void NativeWindowViews::HandleKeyboardEvent(
 }
 
 void NativeWindowViews::Layout() {
+  if (!content_view_)  // Not ready yet.
+    return;
+
   const auto size = GetContentsBounds().size();
   const auto menu_bar_bounds =
       menu_bar_visible_ ? gfx::Rect(0, 0, size.width(), kMenuBarHeight)
@@ -1354,11 +1357,9 @@ void NativeWindowViews::Layout() {
     menu_bar_->SetBoundsRect(menu_bar_bounds);
   }
 
-  if (web_view_) {
-    web_view_->SetBoundsRect(
-        gfx::Rect(0, menu_bar_bounds.height(), size.width(),
-                  size.height() - menu_bar_bounds.height()));
-  }
+  content_view_->SetBoundsRect(
+      gfx::Rect(0, menu_bar_bounds.height(), size.width(),
+                size.height() - menu_bar_bounds.height()));
 }
 
 gfx::Size NativeWindowViews::GetMinimumSize() const {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -122,7 +122,7 @@ NativeWindowViews::NativeWindowViews(
     brightray::InspectableWebContents* web_contents,
     const mate::Dictionary& options,
     NativeWindow* parent)
-    : NativeWindow(web_contents, options, parent),
+    : NativeWindow(options, parent),
       window_(new views::Widget),
       web_view_(web_contents->GetView()->GetView()),
       focused_view_(web_contents->GetView()->GetWebView()),

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -46,12 +46,12 @@ class NativeWindowViews : public NativeWindow,
                           public views::WidgetDelegateView,
                           public views::WidgetObserver {
  public:
-  NativeWindowViews(brightray::InspectableWebContents* inspectable_web_contents,
-                    const mate::Dictionary& options,
+  NativeWindowViews(const mate::Dictionary& options,
                     NativeWindow* parent);
   ~NativeWindowViews() override;
 
   // NativeWindow:
+  void SetContentView(brightray::InspectableWebContents* web_contents) override;
   void Close() override;
   void CloseImmediately() override;
   void Focus(bool focus) override;
@@ -61,6 +61,7 @@ class NativeWindowViews : public NativeWindow,
   void Hide() override;
   bool IsVisible() override;
   bool IsEnabled() override;
+  void SetEnabled(bool enable) override;
   void Maximize() override;
   void Unmaximize() override;
   bool IsMaximized() override;
@@ -138,8 +139,6 @@ class NativeWindowViews : public NativeWindow,
 #elif defined(USE_X11)
   void SetIcon(const gfx::ImageSkia& icon);
 #endif
-
-  void SetEnabled(bool enable) override;
 
   views::Widget* widget() const { return window_.get(); }
   views::View* content_view() const { return content_view_; }

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -142,7 +142,7 @@ class NativeWindowViews : public NativeWindow,
   void SetEnabled(bool enable) override;
 
   views::Widget* widget() const { return window_.get(); }
-  views::View* web_view() const { return web_view_; }
+  views::View* content_view() const { return content_view_; }
   SkRegion* draggable_region() const { return draggable_region_.get(); }
 
 #if defined(OS_WIN)
@@ -209,7 +209,7 @@ class NativeWindowViews : public NativeWindow,
   ui::WindowShowState GetRestoredState();
 
   std::unique_ptr<views::Widget> window_;
-  views::View* web_view_;  // Managed by inspectable_web_contents_.
+  views::View* content_view_;  // Weak ref.
   views::View* focused_view_;  // The view should be focused by default.
 
   std::unique_ptr<MenuBar> menu_bar_;

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -16,6 +16,7 @@
 #include "chrome/browser/ui/libgtkui/gtk_signal.h"
 #include "chrome/browser/ui/libgtkui/gtk_util.h"
 #include "chrome/browser/ui/libgtkui/skia_utils_gtk.h"
+#include "ui/gfx/image/image_skia.h"
 #include "ui/views/widget/desktop_aura/x11_desktop_handler.h"
 
 #define ANSI_FOREGROUND_RED "\x1b[31m"

--- a/atom/browser/ui/message_box_mac.mm
+++ b/atom/browser/ui/message_box_mac.mm
@@ -11,6 +11,7 @@
 #include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
 #include "skia/ext/skia_utils_mac.h"
+#include "ui/gfx/image/image_skia.h"
 
 @interface ModalDelegate : NSObject {
  @private

--- a/atom/browser/ui/message_box_win.cc
+++ b/atom/browser/ui/message_box_win.cc
@@ -21,6 +21,7 @@
 #include "base/win/scoped_gdi_object.h"
 #include "content/public/browser/browser_thread.h"
 #include "ui/gfx/icon_util.h"
+#include "ui/gfx/image/image_skia.h"
 
 namespace atom {
 


### PR DESCRIPTION
Do not pass `web_contents` to `NativeWindow` via constructor, instead add a `SetContentView` method that can take views after the window has been created. This allows us to use arbitrary view as `NativeWindow`'s content view in future.