### PR TITLE
switch to sk_tool_utils::copy_to()

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -10,44 +10,10 @@
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPixmap.h"
+#include "third_party/skia/tools/sk_tool_utils.h"
 #include "ui/base/clipboard/scoped_clipboard_writer.h"
 
 #include "atom/common/node_includes.h"
-
-namespace {
-
-// TODO(alexeykuzmin): It is a copy of `sk_tool_utils::copy_to()`,
-// use the original function if possible, skia doesn't export it.
-bool copy_to(SkBitmap* dst, SkColorType dstColorType, const SkBitmap& src) {
-  SkPixmap srcPM;
-  if (!src.peekPixels(&srcPM)) {
-    return false;
-  }
-
-  SkBitmap tmpDst;
-  SkImageInfo dstInfo = srcPM.info().makeColorType(dstColorType);
-  if (!tmpDst.setInfo(dstInfo)) {
-    return false;
-  }
-
-  if (!tmpDst.tryAllocPixels()) {
-    return false;
-  }
-
-  SkPixmap dstPM;
-  if (!tmpDst.peekPixels(&dstPM)) {
-    return false;
-  }
-
-  if (!srcPM.readPixels(dstPM)) {
-    return false;
-  }
-
-  dst->swap(tmpDst);
-  return true;
-}
-
-}  // namespace
 
 namespace atom {
 
@@ -207,7 +173,7 @@ void Clipboard::WriteImage(const gfx::Image& image, mate::Arguments* args) {
   SkBitmap orig = image.AsBitmap();
   SkBitmap bmp;
 
-  if (copy_to(&bmp, orig.colorType(), orig)) {
+  if (sk_tool_utils::copy_to(&bmp, orig.colorType(), &orig)) {
     writer.WriteImage(bmp);
   } else {
     writer.WriteImage(orig);

--- a/common.gypi
+++ b/common.gypi
@@ -146,6 +146,8 @@
           '<(libchromiumcontent_src_dir)',
           '<(libchromiumcontent_src_dir)/third_party/icu/source/common',
           '<(libchromiumcontent_src_dir)/third_party/icu/source/i18n',
+          '<(libchromiumcontent_src_dir)/third_party/skia/include/utils',
+          '<(libchromiumcontent_src_dir)/third_party/skia/include/private',
           '<(libchromiumcontent_src_dir)/v8',
           '<(libchromiumcontent_src_dir)/v8/include',
         ],


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/11248.

This PR remove our manual implementation of `.deepCopyTo` in favor of `switch to sk_tool_utils::copy_to()` that occurred as a result of the Chromium 61 upgrade.

Currently having some issues with `include_dirs` for the `sk_tool_utils.h` imports in libcc.

/cc @alexeykuzmin 