### PR TITLE
add new event to auto-updater

### DIFF
--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -104,6 +104,8 @@ void AutoUpdater::SetFeedURL(mate::Arguments* args) {
 }
 
 void AutoUpdater::QuitAndInstall() {
+  Emit("before-quit-for-update");
+
   // If we don't have any window then quitAndInstall immediately.
   if (WindowList::IsEmpty()) {
     auto_updater::AutoUpdater::QuitAndInstall();

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -86,7 +86,9 @@ On Windows only `releaseName` is available.
 
 ### Event: 'before-quit-for-update'
 
-Emitted when `quitAndInstall()` is called. 
+This event is emitted after a user calls `quitAndInstall()`.
+
+When this API is called, the `before-quit` event is not emitted before all windows are closed. As a result you should listen to this event if you wish to perform actions before the windows are closed while a process is quitting, as well as listening to `before-quit`.
 
 ## Methods
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -84,6 +84,10 @@ Emitted when an update has been downloaded.
 
 On Windows only `releaseName` is available.
 
+### Event: 'before-quit-for-update'
+
+Emitted when `quitAndInstall()` is called. 
+
 ## Methods
 
 The `autoUpdater` object has the following methods:


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/8293. 

Adds a `before-quit-for-update` that's emitted when `quitAndInstall` is called in AutoUpdater.

/cc @MarshallOfSound 