### PR TITLE
Migrate base::Bind to base::BindOnce and base::BindRepeating

### DIFF
--- a/atom/browser/api/atom_api_app_mas.mm
+++ b/atom/browser/api/atom_api_app_mas.mm
@@ -51,7 +51,7 @@ base::Callback<void ()> App::StartAccessingSecurityScopedResource(mate::Argument
   [bookmarkUrl retain];
 
   // Return a js callback which will close the bookmark.
-  return base::Bind(&OnStopAccessingSecurityScopedResource, bookmarkUrl);
+  return base::BindOnce(&OnStopAccessingSecurityScopedResource, bookmarkUrl);
 }
 
 } // namespace atom

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -16,12 +16,12 @@
 
 namespace mate {
 
-template<>
+template <>
 struct Converter<base::Time> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const base::Time& val) {
-    v8::MaybeLocal<v8::Value> date = v8::Date::New(
-        isolate->GetCurrentContext(), val.ToJsTime());
+    v8::MaybeLocal<v8::Value> date =
+        v8::Date::New(isolate->GetCurrentContext(), val.ToJsTime());
     if (date.IsEmpty())
       return v8::Null(isolate);
     else
@@ -49,21 +49,20 @@ void AutoUpdater::OnError(const std::string& message) {
   v8::HandleScope handle_scope(isolate());
   auto error = v8::Exception::Error(mate::StringToV8(isolate(), message));
   mate::EmitEvent(
-      isolate(),
-      GetWrapper(),
-      "error",
+      isolate(), GetWrapper(), "error",
       error->ToObject(isolate()->GetCurrentContext()).ToLocalChecked(),
       // Message is also emitted to keep compatibility with old code.
       message);
 }
 
 void AutoUpdater::OnError(const std::string& message,
-                          const int code, const std::string& domain) {
+                          const int code,
+                          const std::string& domain) {
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   auto error = v8::Exception::Error(mate::StringToV8(isolate(), message));
-  auto errorObject = error->ToObject(
-    isolate()->GetCurrentContext()).ToLocalChecked();
+  auto errorObject =
+      error->ToObject(isolate()->GetCurrentContext()).ToLocalChecked();
 
   // add two new params for better error handling
   errorObject->Set(mate::StringToV8(isolate(), "code"),
@@ -92,7 +91,8 @@ void AutoUpdater::OnUpdateDownloaded(const std::string& release_notes,
                                      const std::string& url) {
   Emit("update-downloaded", release_notes, release_name, release_date, url,
        // Keep compatibility with old APIs.
-       base::Bind(&AutoUpdater::QuitAndInstall, base::Unretained(this)));
+       base::BindRepeating(&AutoUpdater::QuitAndInstall,
+                           base::Unretained(this)));
 }
 
 void AutoUpdater::OnWindowAllClosed() {
@@ -123,8 +123,8 @@ mate::Handle<AutoUpdater> AutoUpdater::Create(v8::Isolate* isolate) {
 }
 
 // static
-void AutoUpdater::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+void AutoUpdater::BuildPrototype(v8::Isolate* isolate,
+                                 v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "AutoUpdater"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("checkForUpdates", &auto_updater::AutoUpdater::CheckForUpdates)
@@ -137,13 +137,14 @@ void AutoUpdater::BuildPrototype(
 
 }  // namespace atom
 
-
 namespace {
 
 using atom::api::AutoUpdater;
 
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("autoUpdater", AutoUpdater::Create(isolate));

--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -148,7 +148,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  BrowserView::SetConstructor(isolate, base::Bind(&BrowserView::New));
+  BrowserView::SetConstructor(isolate, base::BindRepeating(&BrowserView::New));
 
   mate::Dictionary browser_view(
       isolate, BrowserView::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -48,7 +48,7 @@ scoped_refptr<TracingController::TraceDataEndpoint> GetTraceDataEndpoint(
     LOG(ERROR) << "Creating temporary file failed";
 
   return TracingController::CreateFileEndpoint(result_file_path,
-                                           base::Bind(callback,
+                                           base::BindRepeating(callback,
                                                       result_file_path));
 }
 
@@ -62,12 +62,12 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   auto controller = base::Unretained(TracingController::GetInstance());
   mate::Dictionary dict(context->GetIsolate(), exports);
-  dict.SetMethod("getCategories", base::Bind(
+  dict.SetMethod("getCategories", base::BindRepeating(
       &TracingController::GetCategories, controller));
-  dict.SetMethod("startRecording", base::Bind(
+  dict.SetMethod("startRecording", base::BindRepeating(
       &TracingController::StartTracing, controller));
   dict.SetMethod("stopRecording", &StopRecording);
-  dict.SetMethod("getTraceBufferUsage", base::Bind(
+  dict.SetMethod("getTraceBufferUsage", base::BindRepeating(
       &TracingController::GetTraceBufferUsage, controller));
 }
 

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -24,7 +24,7 @@ using content::BrowserThread;
 
 namespace mate {
 
-template<>
+template <>
 struct Converter<atom::api::Cookies::Error> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    atom::api::Cookies::Error val) {
@@ -35,7 +35,7 @@ struct Converter<atom::api::Cookies::Error> {
   }
 };
 
-template<>
+template <>
 struct Converter<net::CanonicalCookie> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const net::CanonicalCookie& val) {
@@ -54,7 +54,7 @@ struct Converter<net::CanonicalCookie> {
   }
 };
 
-template<>
+template <>
 struct Converter<net::CookieStore::ChangeCause> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const net::CookieStore::ChangeCause& val) {
@@ -147,7 +147,7 @@ void FilterCookies(std::unique_ptr<base::DictionaryValue> filter,
     if (MatchesCookie(filter.get(), cookie))
       result.push_back(cookie);
   }
-  RunCallbackInUI(base::Bind(callback, Cookies::SUCCESS, result));
+  RunCallbackInUI(base::BindRepeating(callback, Cookies::SUCCESS, result));
 }
 
 // Receives cookies matching |filter| in IO thread.
@@ -158,35 +158,37 @@ void GetCookiesOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
   filter->GetString("url", &url);
 
   auto filtered_callback =
-      base::Bind(FilterCookies, base::Passed(&filter), callback);
+      base::BindRepeating(FilterCookies, base::Passed(&filter), callback);
 
   // Empty url will match all url cookies.
   if (url.empty())
     GetCookieStore(getter)->GetAllCookiesAsync(filtered_callback);
   else
     GetCookieStore(getter)->GetAllCookiesForURLAsync(GURL(url),
-        filtered_callback);
+                                                     filtered_callback);
 }
 
 // Removes cookie with |url| and |name| in IO thread.
 void RemoveCookieOnIOThread(scoped_refptr<net::URLRequestContextGetter> getter,
-                            const GURL& url, const std::string& name,
+                            const GURL& url,
+                            const std::string& name,
                             const base::Closure& callback) {
   GetCookieStore(getter)->DeleteCookieAsync(
-      url, name, base::Bind(RunCallbackInUI, callback));
+      url, name, base::BindRepeating(RunCallbackInUI, callback));
 }
 
 // Callback of SetCookie.
 void OnSetCookie(const Cookies::SetCallback& callback, bool success) {
-  RunCallbackInUI(
-      base::Bind(callback, success ? Cookies::SUCCESS : Cookies::FAILED));
+  RunCallbackInUI(base::BindRepeating(
+      callback, success ? Cookies::SUCCESS : Cookies::FAILED));
 }
 
 // Flushes cookie store in IO thread.
 void FlushCookieStoreOnIOThread(
     scoped_refptr<net::URLRequestContextGetter> getter,
     const base::Closure& callback) {
-  GetCookieStore(getter)->FlushStore(base::Bind(RunCallbackInUI, callback));
+  GetCookieStore(getter)->FlushStore(
+      base::BindRepeating(RunCallbackInUI, callback));
 }
 
 // Sets cookie with |details| in IO thread.
@@ -209,30 +211,29 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
 
   base::Time creation_time;
   if (details->GetDouble("creationDate", &creation_date)) {
-    creation_time = (creation_date == 0) ?
-        base::Time::UnixEpoch() :
-        base::Time::FromDoubleT(creation_date);
+    creation_time = (creation_date == 0)
+                        ? base::Time::UnixEpoch()
+                        : base::Time::FromDoubleT(creation_date);
   }
 
   base::Time expiration_time;
   if (details->GetDouble("expirationDate", &expiration_date)) {
-    expiration_time = (expiration_date == 0) ?
-        base::Time::UnixEpoch() :
-        base::Time::FromDoubleT(expiration_date);
+    expiration_time = (expiration_date == 0)
+                          ? base::Time::UnixEpoch()
+                          : base::Time::FromDoubleT(expiration_date);
   }
 
   base::Time last_access_time;
   if (details->GetDouble("lastAccessDate", &last_access_date)) {
-    last_access_time = (last_access_date == 0) ?
-        base::Time::UnixEpoch() :
-        base::Time::FromDoubleT(last_access_date);
+    last_access_time = (last_access_date == 0)
+                           ? base::Time::UnixEpoch()
+                           : base::Time::FromDoubleT(last_access_date);
   }
 
   GetCookieStore(getter)->SetCookieWithDetailsAsync(
-      GURL(url), name, value, domain, path, creation_time,
-      expiration_time, last_access_time, secure, http_only,
-      net::CookieSameSite::DEFAULT_MODE, net::COOKIE_PRIORITY_DEFAULT,
-      base::Bind(OnSetCookie, callback));
+      GURL(url), name, value, domain, path, creation_time, expiration_time,
+      last_access_time, secure, http_only, net::CookieSameSite::DEFAULT_MODE,
+      net::COOKIE_PRIORITY_DEFAULT, base::BindRepeating(OnSetCookie, callback));
 }
 
 }  // namespace
@@ -241,7 +242,7 @@ Cookies::Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context)
     : browser_context_(browser_context) {
   Init(isolate);
   auto subscription = browser_context->RegisterCookieChangeCallback(
-      base::Bind(&Cookies::OnCookieChanged, base::Unretained(this)));
+      base::BindRepeating(&Cookies::OnCookieChanged, base::Unretained(this)));
   browser_context->set_cookie_change_subscription(std::move(subscription));
 }
 
@@ -257,7 +258,8 @@ void Cookies::Get(const base::DictionaryValue& filter,
                      callback));
 }
 
-void Cookies::Remove(const GURL& url, const std::string& name,
+void Cookies::Remove(const GURL& url,
+                     const std::string& name,
                      const base::Closure& callback) {
   auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
@@ -288,11 +290,9 @@ void Cookies::OnCookieChanged(const CookieDetails* details) {
   Emit("changed", *(details->cookie), details->cause, details->removed);
 }
 
-
 // static
-mate::Handle<Cookies> Cookies::Create(
-    v8::Isolate* isolate,
-    AtomBrowserContext* browser_context) {
+mate::Handle<Cookies> Cookies::Create(v8::Isolate* isolate,
+                                      AtomBrowserContext* browser_context) {
   return mate::CreateHandle(isolate, new Cookies(isolate, browser_context));
 }
 

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -215,7 +215,7 @@ using atom::api::Menu;
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Menu::SetConstructor(isolate, base::Bind(&Menu::New));
+  Menu::SetConstructor(isolate, base::BindRepeating(&Menu::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("Menu", Menu::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -34,7 +34,7 @@ void MenuMac::PopupAt(BrowserWindow* window,
   if (!native_window)
     return;
 
-  auto popup = base::Bind(&MenuMac::PopupOnUI, weak_factory_.GetWeakPtr(),
+  auto popup = base::BindRepeating(&MenuMac::PopupOnUI, weak_factory_.GetWeakPtr(),
                           native_window->GetWeakPtr(),
                           window->weak_map_id(), x, y,
                           positioning_item, callback);
@@ -51,7 +51,7 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
     return;
   NSWindow* nswindow = native_window->GetNativeWindow();
 
-  auto close_callback = base::Bind(
+  auto close_callback = base::BindRepeating(
       &MenuMac::OnClosed, weak_factory_.GetWeakPtr(), window_id, callback);
   popup_controllers_[window_id] = base::scoped_nsobject<AtomMenuController>(
       [[AtomMenuController alloc] initWithModel:model()

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -44,7 +44,7 @@ void MenuViews::PopupAt(BrowserWindow* window,
 
   // Show the menu.
   int32_t window_id = window->weak_map_id();
-  auto close_callback = base::Bind(
+  auto close_callback = base::BindRepeating(
       &MenuViews::OnClosed, weak_factory_.GetWeakPtr(), window_id, callback);
   menu_runners_[window_id] = std::unique_ptr<MenuRunner>(new MenuRunner(
       model(), flags, close_callback));

--- a/atom/browser/api/atom_api_net.cc
+++ b/atom/browser/api/atom_api_net.cc
@@ -49,7 +49,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
 
-  URLRequest::SetConstructor(isolate, base::Bind(URLRequest::New));
+  URLRequest::SetConstructor(isolate, base::BindRepeating(URLRequest::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("net", Net::Create(isolate));

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -259,7 +259,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Notification::SetConstructor(isolate, base::Bind(&Notification::New));
+  Notification::SetConstructor(isolate, base::BindRepeating(&Notification::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("Notification",

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -20,10 +20,11 @@
 #include "atom/common/node_includes.h"
 
 namespace mate {
-template<>
+template <>
 struct Converter<brightray::NotificationAction> {
-  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
-                      brightray::NotificationAction* out) {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     brightray::NotificationAction* out) {
     mate::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
@@ -36,7 +37,7 @@ struct Converter<brightray::NotificationAction> {
   }
 
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                    brightray::NotificationAction val) {
+                                   brightray::NotificationAction val) {
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
     dict.Set("text", val.text);
     dict.Set("type", val.type);
@@ -155,7 +156,7 @@ void Notification::SetSound(const base::string16& new_sound) {
 }
 
 void Notification::SetActions(
-  const std::vector<brightray::NotificationAction>& actions) {
+    const std::vector<brightray::NotificationAction>& actions) {
   actions_ = actions;
 }
 
@@ -179,8 +180,7 @@ void Notification::NotificationDisplayed() {
   Emit("show");
 }
 
-void Notification::NotificationDestroyed() {
-}
+void Notification::NotificationDestroyed() {}
 
 void Notification::NotificationClosed() {
   Emit("close");
@@ -232,14 +232,12 @@ void Notification::BuildPrototype(v8::Isolate* isolate,
       .SetProperty("subtitle", &Notification::GetSubtitle,
                    &Notification::SetSubtitle)
       .SetProperty("body", &Notification::GetBody, &Notification::SetBody)
-      .SetProperty("silent", &Notification::GetSilent,
-                   &Notification::SetSilent)
+      .SetProperty("silent", &Notification::GetSilent, &Notification::SetSilent)
       .SetProperty("hasReply", &Notification::GetHasReply,
                    &Notification::SetHasReply)
       .SetProperty("replyPlaceholder", &Notification::GetReplyPlaceholder,
                    &Notification::SetReplyPlaceholder)
-      .SetProperty("sound", &Notification::GetSound,
-                   &Notification::SetSound)
+      .SetProperty("sound", &Notification::GetSound, &Notification::SetSound)
       .SetProperty("actions", &Notification::GetActions,
                    &Notification::SetActions)
       .SetProperty("closeButtonText", &Notification::GetCloseButtonText,
@@ -259,7 +257,8 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Notification::SetConstructor(isolate, base::BindRepeating(&Notification::New));
+  Notification::SetConstructor(isolate,
+                               base::BindRepeating(&Notification::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("Notification",

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -13,7 +13,7 @@
 #include "atom/common/node_includes.h"
 
 namespace mate {
-template<>
+template <>
 struct Converter<ui::IdleState> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const ui::IdleState& in) {
@@ -38,11 +38,11 @@ namespace api {
 
 PowerMonitor::PowerMonitor(v8::Isolate* isolate) {
 #if defined(OS_LINUX)
-  SetShutdownHandler(base::Bind(&PowerMonitor::ShouldShutdown,
-                                base::Unretained(this)));
+  SetShutdownHandler(base::BindRepeating(&PowerMonitor::ShouldShutdown,
+                                         base::Unretained(this)));
 #elif defined(OS_MACOSX)
-  Browser::Get()->SetShutdownHandler(base::Bind(&PowerMonitor::ShouldShutdown,
-                                                base::Unretained(this)));
+  Browser::Get()->SetShutdownHandler(base::BindRepeating(
+      &PowerMonitor::ShouldShutdown, base::Unretained(this)));
 #endif
   base::PowerMonitor::Get()->AddObserver(this);
   Init(isolate);
@@ -87,9 +87,8 @@ void PowerMonitor::QuerySystemIdleState(v8::Isolate* isolate,
   if (idle_threshold > 0) {
     ui::CalculateIdleState(idle_threshold, callback);
   } else {
-    isolate->ThrowException(v8::Exception::TypeError(
-        mate::StringToV8(isolate,
-          "Invalid idle threshold, must be greater than 0")));
+    isolate->ThrowException(v8::Exception::TypeError(mate::StringToV8(
+        isolate, "Invalid idle threshold, must be greater than 0")));
   }
 }
 
@@ -110,31 +109,32 @@ v8::Local<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
 }
 
 // static
-void PowerMonitor::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+void PowerMonitor::BuildPrototype(v8::Isolate* isolate,
+                                  v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "PowerMonitor"));
 
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
-        .MakeDestroyable()
+      .MakeDestroyable()
 #if defined(OS_LINUX)
-        .SetMethod("blockShutdown", &PowerMonitor::BlockShutdown)
-        .SetMethod("unblockShutdown", &PowerMonitor::UnblockShutdown)
+      .SetMethod("blockShutdown", &PowerMonitor::BlockShutdown)
+      .SetMethod("unblockShutdown", &PowerMonitor::UnblockShutdown)
 #endif
-        .SetMethod("querySystemIdleState", &PowerMonitor::QuerySystemIdleState)
-        .SetMethod("querySystemIdleTime", &PowerMonitor::QuerySystemIdleTime);
+      .SetMethod("querySystemIdleState", &PowerMonitor::QuerySystemIdleState)
+      .SetMethod("querySystemIdleTime", &PowerMonitor::QuerySystemIdleTime);
 }
 
 }  // namespace api
 
 }  // namespace atom
 
-
 namespace {
 
 using atom::api::PowerMonitor;
 
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("powerMonitor", PowerMonitor::Create(isolate));

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -63,7 +63,7 @@ void RegisterStandardSchemes(const std::vector<std::string>& schemes,
       atom::switches::kStandardSchemes, base::JoinString(schemes, ","));
   if (secure) {
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-      atom::switches::kSecureSchemes, base::JoinString(schemes, ","));
+        atom::switches::kSecureSchemes, base::JoinString(schemes, ","));
   }
 }
 
@@ -72,16 +72,15 @@ Protocol::Protocol(v8::Isolate* isolate, AtomBrowserContext* browser_context)
   Init(isolate);
 }
 
-Protocol::~Protocol() {
-}
+Protocol::~Protocol() {}
 
 void Protocol::RegisterServiceWorkerSchemes(
     const std::vector<std::string>& schemes) {
   atom::AtomBrowserClient::SetCustomServiceWorkerSchemes(schemes);
 }
 
-void Protocol::UnregisterProtocol(
-    const std::string& scheme, mate::Arguments* args) {
+void Protocol::UnregisterProtocol(const std::string& scheme,
+                                  mate::Arguments* args) {
   CompletionCallback callback;
   args->GetNext(&callback);
   auto getter = browser_context_->GetRequestContext();
@@ -109,8 +108,8 @@ void Protocol::IsProtocolHandled(const std::string& scheme,
   auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTaskAndReplyWithResult(
       content::BrowserThread::IO, FROM_HERE,
-      base::Bind(&Protocol::IsProtocolHandledInIO, base::RetainedRef(getter),
-                 scheme),
+      base::BindRepeating(&Protocol::IsProtocolHandledInIO,
+                          base::RetainedRef(getter), scheme),
       callback);
 }
 
@@ -121,8 +120,8 @@ bool Protocol::IsProtocolHandledInIO(
   return request_context_getter->job_factory()->IsHandledProtocol(scheme);
 }
 
-void Protocol::UninterceptProtocol(
-    const std::string& scheme, mate::Arguments* args) {
+void Protocol::UninterceptProtocol(const std::string& scheme,
+                                   mate::Arguments* args) {
   CompletionCallback callback;
   args->GetNext(&callback);
   auto getter = browser_context_->GetRequestContext();
@@ -138,12 +137,14 @@ Protocol::ProtocolError Protocol::UninterceptProtocolInIO(
     scoped_refptr<brightray::URLRequestContextGetter> request_context_getter,
     const std::string& scheme) {
   return static_cast<AtomURLRequestJobFactory*>(
-      request_context_getter->job_factory())->UninterceptProtocol(scheme) ?
-          PROTOCOL_OK : PROTOCOL_NOT_INTERCEPTED;
+             request_context_getter->job_factory())
+                 ->UninterceptProtocol(scheme)
+             ? PROTOCOL_OK
+             : PROTOCOL_NOT_INTERCEPTED;
 }
 
-void Protocol::OnIOCompleted(
-    const CompletionCallback& callback, ProtocolError error) {
+void Protocol::OnIOCompleted(const CompletionCallback& callback,
+                             ProtocolError error) {
   // The completion callback is optional.
   if (callback.is_null())
     return;
@@ -161,24 +162,30 @@ void Protocol::OnIOCompleted(
 
 std::string Protocol::ErrorCodeToString(ProtocolError error) {
   switch (error) {
-    case PROTOCOL_FAIL: return "Failed to manipulate protocol factory";
-    case PROTOCOL_REGISTERED: return "The scheme has been registered";
-    case PROTOCOL_NOT_REGISTERED: return "The scheme has not been registered";
-    case PROTOCOL_INTERCEPTED: return "The scheme has been intercepted";
-    case PROTOCOL_NOT_INTERCEPTED: return "The scheme has not been intercepted";
-    default: return "Unexpected error";
+    case PROTOCOL_FAIL:
+      return "Failed to manipulate protocol factory";
+    case PROTOCOL_REGISTERED:
+      return "The scheme has been registered";
+    case PROTOCOL_NOT_REGISTERED:
+      return "The scheme has not been registered";
+    case PROTOCOL_INTERCEPTED:
+      return "The scheme has been intercepted";
+    case PROTOCOL_NOT_INTERCEPTED:
+      return "The scheme has not been intercepted";
+    default:
+      return "Unexpected error";
   }
 }
 
 // static
-mate::Handle<Protocol> Protocol::Create(
-    v8::Isolate* isolate, AtomBrowserContext* browser_context) {
+mate::Handle<Protocol> Protocol::Create(v8::Isolate* isolate,
+                                        AtomBrowserContext* browser_context) {
   return mate::CreateHandle(isolate, new Protocol(isolate, browser_context));
 }
 
 // static
-void Protocol::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+void Protocol::BuildPrototype(v8::Isolate* isolate,
+                              v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "Protocol"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("registerServiceWorkerSchemes",
@@ -214,19 +221,22 @@ void Protocol::BuildPrototype(
 
 namespace {
 
-void RegisterStandardSchemes(
-    const std::vector<std::string>& schemes, mate::Arguments* args) {
+void RegisterStandardSchemes(const std::vector<std::string>& schemes,
+                             mate::Arguments* args) {
   if (atom::Browser::Get()->is_ready()) {
-    args->ThrowError("protocol.registerStandardSchemes should be called before "
-                     "app is ready");
+    args->ThrowError(
+        "protocol.registerStandardSchemes should be called before "
+        "app is ready");
     return;
   }
 
   atom::api::RegisterStandardSchemes(schemes, args);
 }
 
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.SetMethod("registerStandardSchemes", &RegisterStandardSchemes);

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -21,8 +21,8 @@ namespace {
 
 bool IsWebContents(v8::Isolate* isolate, content::RenderProcessHost* process) {
   content::WebContents* web_contents =
-      static_cast<AtomBrowserClient*>(AtomBrowserClient::Get())->
-          GetWebContentsFromProcessID(process->GetID());
+      static_cast<AtomBrowserClient*>(AtomBrowserClient::Get())
+          ->GetWebContentsFromProcessID(process->GetID());
   if (!web_contents)
     return false;
 
@@ -41,8 +41,7 @@ RenderProcessPreferences::RenderProcessPreferences(
   Init(isolate);
 }
 
-RenderProcessPreferences::~RenderProcessPreferences() {
-}
+RenderProcessPreferences::~RenderProcessPreferences() {}
 
 int RenderProcessPreferences::AddEntry(const base::DictionaryValue& entry) {
   return preferences_.AddEntry(entry);
@@ -54,7 +53,8 @@ void RenderProcessPreferences::RemoveEntry(int id) {
 
 // static
 void RenderProcessPreferences::BuildPrototype(
-    v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> prototype) {
+    v8::Isolate* isolate,
+    v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(
       mate::StringToV8(isolate, "RenderProcessPreferences"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
@@ -66,9 +66,8 @@ void RenderProcessPreferences::BuildPrototype(
 mate::Handle<RenderProcessPreferences>
 RenderProcessPreferences::ForAllWebContents(v8::Isolate* isolate) {
   return mate::CreateHandle(
-      isolate,
-      new RenderProcessPreferences(isolate,
-                                   base::Bind(&IsWebContents, isolate)));
+      isolate, new RenderProcessPreferences(
+                   isolate, base::BindRepeating(&IsWebContents, isolate)));
 }
 
 }  // namespace api
@@ -77,8 +76,10 @@ RenderProcessPreferences::ForAllWebContents(v8::Isolate* isolate) {
 
 namespace {
 
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("forAllWebContents",
                  &atom::api::RenderProcessPreferences::ForAllWebContents);

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -34,9 +34,10 @@
 #if defined(OS_WIN)
 namespace mate {
 
-template<>
+template <>
 struct Converter<atom::TaskbarHost::ThumbarButton> {
-  static bool FromV8(v8::Isolate* isolate, v8::Handle<v8::Value> val,
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Handle<v8::Value> val,
                      atom::TaskbarHost::ThumbarButton* out) {
     mate::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
@@ -82,16 +83,14 @@ TopLevelWindow::TopLevelWindow(v8::Isolate* isolate,
   mate::Dictionary web_preferences;
   bool offscreen;
   if (options.Get(options::kWebPreferences, &web_preferences) &&
-      web_preferences.Get("offscreen", &offscreen) &&
-      offscreen) {
+      web_preferences.Get("offscreen", &offscreen) && offscreen) {
     const_cast<mate::Dictionary&>(options).Set(options::kFrame, false);
   }
 #endif
 
   // Creates NativeWindow.
   window_.reset(NativeWindow::Create(
-      options,
-      parent.IsEmpty() ? nullptr : parent->window_.get()));
+      options, parent.IsEmpty() ? nullptr : parent->window_.get()));
   window_->AddObserver(this);
 
 #if defined(TOOLKIT_VIEWS)
@@ -227,8 +226,9 @@ void TopLevelWindow::OnExecuteWindowsCommand(const std::string& command_name) {
   Emit("app-command", command_name);
 }
 
-void TopLevelWindow::OnTouchBarItemResult(const std::string& item_id,
-                                  const base::DictionaryValue& details) {
+void TopLevelWindow::OnTouchBarItemResult(
+    const std::string& item_id,
+    const base::DictionaryValue& details) {
   Emit("-touch-bar-interaction", item_id, details);
 }
 
@@ -238,8 +238,8 @@ void TopLevelWindow::OnNewWindowForTab() {
 
 #if defined(OS_WIN)
 void TopLevelWindow::OnWindowMessage(UINT message,
-                                    WPARAM w_param,
-                                    LPARAM l_param) {
+                                     WPARAM w_param,
+                                     LPARAM l_param) {
   if (IsWindowMessageHooked(message)) {
     messages_callback_map_[message].Run(
         ToBuffer(isolate(), static_cast<void*>(&w_param), sizeof(WPARAM)),
@@ -334,7 +334,7 @@ gfx::Rect TopLevelWindow::GetBounds() {
 }
 
 void TopLevelWindow::SetContentBounds(const gfx::Rect& bounds,
-                                     mate::Arguments* args) {
+                                      mate::Arguments* args) {
   bool animate = false;
   args->GetNext(&animate);
   window_->SetContentBounds(bounds, animate);
@@ -358,8 +358,9 @@ std::vector<int> TopLevelWindow::GetSize() {
   return result;
 }
 
-void TopLevelWindow::SetContentSize(int width, int height,
-                                   mate::Arguments* args) {
+void TopLevelWindow::SetContentSize(int width,
+                                    int height,
+                                    mate::Arguments* args) {
   bool animate = false;
   args->GetNext(&animate);
   window_->SetContentSize(gfx::Size(width, height), animate);
@@ -580,16 +581,15 @@ void TopLevelWindow::SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   mate::Handle<Menu> menu;
   if (value->IsObject() &&
       mate::V8ToString(value->ToObject()->GetConstructorName()) == "Menu" &&
-      mate::ConvertFromV8(isolate, value, &menu) &&
-      !menu.IsEmpty()) {
+      mate::ConvertFromV8(isolate, value, &menu) && !menu.IsEmpty()) {
     menu_.Reset(isolate, menu.ToV8());
     window_->SetMenu(menu->model());
   } else if (value->IsNull()) {
     menu_.Reset();
     window_->SetMenu(nullptr);
   } else {
-    isolate->ThrowException(v8::Exception::TypeError(
-        mate::StringToV8(isolate, "Invalid Menu")));
+    isolate->ThrowException(
+        v8::Exception::TypeError(mate::StringToV8(isolate, "Invalid Menu")));
   }
 }
 
@@ -789,19 +789,19 @@ bool TopLevelWindow::SetThumbarButtons(mate::Arguments* args) {
 #if defined(TOOLKIT_VIEWS)
 void TopLevelWindow::SetIcon(mate::Handle<NativeImage> icon) {
 #if defined(OS_WIN)
-  static_cast<NativeWindowViews*>(window_.get())->SetIcon(
-      icon->GetHICON(GetSystemMetrics(SM_CXSMICON)),
-      icon->GetHICON(GetSystemMetrics(SM_CXICON)));
+  static_cast<NativeWindowViews*>(window_.get())
+      ->SetIcon(icon->GetHICON(GetSystemMetrics(SM_CXSMICON)),
+                icon->GetHICON(GetSystemMetrics(SM_CXICON)));
 #elif defined(USE_X11)
-  static_cast<NativeWindowViews*>(window_.get())->SetIcon(
-      icon->image().AsImageSkia());
+  static_cast<NativeWindowViews*>(window_.get())
+      ->SetIcon(icon->image().AsImageSkia());
 #endif
 }
 #endif
 
 #if defined(OS_WIN)
 bool TopLevelWindow::HookWindowMessage(UINT message,
-                               const MessageCallback& callback) {
+                                       const MessageCallback& callback) {
   messages_callback_map_[message] = callback;
   return true;
 }
@@ -846,10 +846,9 @@ void TopLevelWindow::SetAppDetails(const mate::Dictionary& options) {
   options.Get("relaunchCommand", &relaunch_command);
   options.Get("relaunchDisplayName", &relaunch_display_name);
 
-  ui::win::SetAppDetailsForWindow(
-      app_id, app_icon_path, app_icon_index,
-      relaunch_command, relaunch_display_name,
-      window_->GetAcceleratedWidget());
+  ui::win::SetAppDetailsForWindow(app_id, app_icon_path, app_icon_index,
+                                  relaunch_command, relaunch_display_name,
+                                  window_->GetAcceleratedWidget());
 }
 #endif
 
@@ -906,7 +905,7 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("hide", &TopLevelWindow::Hide)
       .SetMethod("isVisible", &TopLevelWindow::IsVisible)
       .SetMethod("isEnabled", &TopLevelWindow::IsEnabled)
-      .SetMethod("setEnabled", & TopLevelWindow::SetEnabled)
+      .SetMethod("setEnabled", &TopLevelWindow::SetEnabled)
       .SetMethod("maximize", &TopLevelWindow::Maximize)
       .SetMethod("unmaximize", &TopLevelWindow::Unmaximize)
       .SetMethod("isMaximized", &TopLevelWindow::IsMaximized)
@@ -932,7 +931,7 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isResizable", &TopLevelWindow::IsResizable)
       .SetMethod("setMovable", &TopLevelWindow::SetMovable)
 #if defined(OS_WIN) || defined(OS_MACOSX)
-      .SetMethod("moveTop" , &TopLevelWindow::MoveTop)
+      .SetMethod("moveTop", &TopLevelWindow::MoveTop)
 #endif
       .SetMethod("isMovable", &TopLevelWindow::IsMovable)
       .SetMethod("setMinimizable", &TopLevelWindow::SetMinimizable)
@@ -1036,10 +1035,13 @@ namespace {
 
 using atom::api::TopLevelWindow;
 
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  TopLevelWindow::SetConstructor(isolate, base::Bind(&TopLevelWindow::New));
+  TopLevelWindow::SetConstructor(isolate,
+                                 base::BindRepeating(&TopLevelWindow::New));
 
   mate::Dictionary constructor(
       isolate, TopLevelWindow::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -242,7 +242,7 @@ using atom::api::Tray;
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Tray::SetConstructor(isolate, base::Bind(&Tray::New));
+  Tray::SetConstructor(isolate, base::BindRepeating(&Tray::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("Tray", Tray::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_url_request.cc
+++ b/atom/browser/api/atom_api_url_request.cc
@@ -350,7 +350,8 @@ void URLRequest::OnAuthenticationRequired(
   }
 
   Emit("login", auth_info.get(),
-       base::Bind(&AtomURLRequest::PassLoginInformation, atom_request_));
+       base::BindRepeating(&AtomURLRequest::PassLoginInformation,
+                           atom_request_));
 }
 
 void URLRequest::OnResponseStarted(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -108,7 +108,7 @@ struct PrintSettings {
 
 namespace mate {
 
-template<>
+template <>
 struct Converter<atom::SetSizeParams> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
@@ -130,9 +130,10 @@ struct Converter<atom::SetSizeParams> {
   }
 };
 
-template<>
+template <>
 struct Converter<PrintSettings> {
-  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
                      PrintSettings* out) {
     mate::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
@@ -144,7 +145,7 @@ struct Converter<PrintSettings> {
   }
 };
 
-template<>
+template <>
 struct Converter<printing::PrinterBasicInfo> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const printing::PrinterBasicInfo& val) {
@@ -158,7 +159,7 @@ struct Converter<printing::PrinterBasicInfo> {
   }
 };
 
-template<>
+template <>
 struct Converter<WindowOpenDisposition> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    WindowOpenDisposition val) {
@@ -187,9 +188,10 @@ struct Converter<WindowOpenDisposition> {
   }
 };
 
-template<>
+template <>
 struct Converter<content::SavePageType> {
-  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
                      content::SavePageType* out) {
     std::string save_type;
     if (!ConvertFromV8(isolate, val, &save_type))
@@ -208,25 +210,39 @@ struct Converter<content::SavePageType> {
   }
 };
 
-template<>
+template <>
 struct Converter<atom::api::WebContents::Type> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    atom::api::WebContents::Type val) {
     using Type = atom::api::WebContents::Type;
     std::string type = "";
     switch (val) {
-      case Type::BACKGROUND_PAGE: type = "backgroundPage"; break;
-      case Type::BROWSER_WINDOW: type = "window"; break;
-      case Type::BROWSER_VIEW: type = "browserView"; break;
-      case Type::REMOTE: type = "remote"; break;
-      case Type::WEB_VIEW: type = "webview"; break;
-      case Type::OFF_SCREEN: type = "offscreen"; break;
-      default: break;
+      case Type::BACKGROUND_PAGE:
+        type = "backgroundPage";
+        break;
+      case Type::BROWSER_WINDOW:
+        type = "window";
+        break;
+      case Type::BROWSER_VIEW:
+        type = "browserView";
+        break;
+      case Type::REMOTE:
+        type = "remote";
+        break;
+      case Type::WEB_VIEW:
+        type = "webview";
+        break;
+      case Type::OFF_SCREEN:
+        type = "offscreen";
+        break;
+      default:
+        break;
     }
     return mate::ConvertToV8(isolate, type);
   }
 
-  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
                      atom::api::WebContents::Type* out) {
     using Type = atom::api::WebContents::Type;
     std::string type;
@@ -250,7 +266,6 @@ struct Converter<atom::api::WebContents::Type> {
 };
 
 }  // namespace mate
-
 
 namespace atom {
 
@@ -377,17 +392,18 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
   content::WebContents* web_contents;
   if (IsGuest()) {
     scoped_refptr<content::SiteInstance> site_instance =
-        content::SiteInstance::CreateForURL(
-            session->browser_context(), GURL("chrome-guest://fake-host"));
-    content::WebContents::CreateParams params(
-        session->browser_context(), site_instance);
+        content::SiteInstance::CreateForURL(session->browser_context(),
+                                            GURL("chrome-guest://fake-host"));
+    content::WebContents::CreateParams params(session->browser_context(),
+                                              site_instance);
     guest_delegate_.reset(new WebViewGuestDelegate);
     params.guest_delegate = guest_delegate_.get();
 
 #if defined(ENABLE_OSR)
     if (embedder_ && embedder_->IsOffScreen()) {
-      auto* view = new OffScreenWebContentsView(false,
-          base::Bind(&WebContents::OnPaint, base::Unretained(this)));
+      auto* view = new OffScreenWebContentsView(
+          false,
+          base::BindRepeating(&WebContents::OnPaint, base::Unretained(this)));
       params.view = view;
       params.delegate_view = view;
 
@@ -403,8 +419,9 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
     options.Get("transparent", &transparent);
 
     content::WebContents::CreateParams params(session->browser_context());
-    auto* view = new OffScreenWebContentsView(transparent,
-        base::Bind(&WebContents::OnPaint, base::Unretained(this)));
+    auto* view = new OffScreenWebContentsView(
+        transparent,
+        base::BindRepeating(&WebContents::OnPaint, base::Unretained(this)));
     params.view = view;
     params.delegate_view = view;
 
@@ -429,7 +446,7 @@ void WebContents::InitZoomController(content::WebContents* web_contents,
 }
 
 void WebContents::InitWithSessionAndOptions(v8::Isolate* isolate,
-                                            content::WebContents *web_contents,
+                                            content::WebContents* web_contents,
                                             mate::Handle<api::Session> session,
                                             const mate::Dictionary& options) {
   Observe(web_contents);
@@ -442,7 +459,8 @@ void WebContents::InitWithSessionAndOptions(v8::Isolate* isolate,
 
 #if defined(OS_LINUX) || defined(OS_WIN)
   // Update font settings.
-  CR_DEFINE_STATIC_LOCAL(const gfx::FontRenderParams, params,
+  CR_DEFINE_STATIC_LOCAL(
+      const gfx::FontRenderParams, params,
       (gfx::GetFontRenderParams(gfx::FontRenderParamsQuery(), nullptr)));
   prefs->should_antialias_text = params.antialiasing;
   prefs->use_subpixel_positioning = params.subpixel_positioning;
@@ -541,13 +559,12 @@ void WebContents::OnCreateWindow(
     Emit("new-window", target_url, frame_name, disposition, features);
 }
 
-void WebContents::WebContentsCreated(
-    content::WebContents* source_contents,
-    int opener_render_process_id,
-    int opener_render_frame_id,
-    const std::string& frame_name,
-    const GURL& target_url,
-    content::WebContents* new_contents) {
+void WebContents::WebContentsCreated(content::WebContents* source_contents,
+                                     int opener_render_process_id,
+                                     int opener_render_frame_id,
+                                     const std::string& frame_name,
+                                     const GURL& target_url,
+                                     content::WebContents* new_contents) {
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   auto api_web_contents = CreateFrom(isolate(), new_contents, BROWSER_WINDOW);
@@ -565,8 +582,8 @@ void WebContents::AddNewContents(content::WebContents* source,
   v8::HandleScope handle_scope(isolate());
   auto api_web_contents = CreateFrom(isolate(), new_contents);
   if (Emit("-add-new-contents", api_web_contents, disposition, user_gesture,
-      initial_rect.x(), initial_rect.y(), initial_rect.width(),
-      initial_rect.height())) {
+           initial_rect.x(), initial_rect.y(), initial_rect.width(),
+           initial_rect.height())) {
     api_web_contents->DestroyWebContents(true /* async */);
   }
 }
@@ -660,10 +677,9 @@ content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
 
 void WebContents::EnterFullscreenModeForTab(content::WebContents* source,
                                             const GURL& origin) {
-  auto permission_helper =
-      WebContentsPermissionHelper::FromWebContents(source);
-  auto callback = base::Bind(&WebContents::OnEnterFullscreenModeForTab,
-                             base::Unretained(this), source, origin);
+  auto permission_helper = WebContentsPermissionHelper::FromWebContents(source);
+  auto callback = base::BindRepeating(&WebContents::OnEnterFullscreenModeForTab,
+                                      base::Unretained(this), source, origin);
   permission_helper->RequestFullscreenPermission(callback);
 }
 
@@ -695,10 +711,10 @@ void WebContents::RendererResponsive(content::WebContents* source) {
 
 bool WebContents::HandleContextMenu(const content::ContextMenuParams& params) {
   if (params.custom_context.is_pepper_menu) {
-    Emit("pepper-context-menu",
-         std::make_pair(params, web_contents()),
-         base::Bind(&content::WebContents::NotifyContextMenuClosed,
-                    base::Unretained(web_contents()), params.custom_context));
+    Emit("pepper-context-menu", std::make_pair(params, web_contents()),
+         base::BindRepeating(&content::WebContents::NotifyContextMenuClosed,
+                             base::Unretained(web_contents()),
+                             params.custom_context));
   } else {
     Emit("context-menu", std::make_pair(params, web_contents()));
   }
@@ -731,10 +747,9 @@ void WebContents::FindReply(content::WebContents* web_contents,
   Emit("found-in-page", result);
 }
 
-bool WebContents::CheckMediaAccessPermission(
-    content::WebContents* web_contents,
-    const GURL& security_origin,
-    content::MediaStreamType type) {
+bool WebContents::CheckMediaAccessPermission(content::WebContents* web_contents,
+                                             const GURL& security_origin,
+                                             content::MediaStreamType type) {
   return true;
 }
 
@@ -747,10 +762,9 @@ void WebContents::RequestMediaAccessPermission(
   permission_helper->RequestMediaAccessPermission(request, callback);
 }
 
-void WebContents::RequestToLockMouse(
-    content::WebContents* web_contents,
-    bool user_gesture,
-    bool last_unlocked_by_target) {
+void WebContents::RequestToLockMouse(content::WebContents* web_contents,
+                                     bool user_gesture,
+                                     bool last_unlocked_by_target) {
   auto permission_helper =
       WebContentsPermissionHelper::FromWebContents(web_contents);
   permission_helper->RequestPointerLockPermission(user_gesture);
@@ -764,8 +778,7 @@ std::unique_ptr<content::BluetoothChooser> WebContents::RunBluetoothChooser(
   return std::move(bluetooth_chooser);
 }
 
-content::JavaScriptDialogManager*
-WebContents::GetJavaScriptDialogManager(
+content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(
     content::WebContents* source) {
   if (!dialog_manager_)
     dialog_manager_.reset(new AtomJavaScriptDialogManager(this));
@@ -861,26 +874,17 @@ void WebContents::DidGetResourceResponseStart(
       (details.resource_type == content::RESOURCE_TYPE_MAIN_FRAME ||
        details.resource_type == content::RESOURCE_TYPE_SUB_FRAME))
     return;
-  Emit("did-get-response-details",
-       details.socket_address.IsEmpty(),
-       details.url,
-       details.original_url,
-       details.http_response_code,
-       details.method,
-       details.referrer,
-       details.headers.get(),
+  Emit("did-get-response-details", details.socket_address.IsEmpty(),
+       details.url, details.original_url, details.http_response_code,
+       details.method, details.referrer, details.headers.get(),
        ResourceTypeToString(details.resource_type));
 }
 
 void WebContents::DidGetRedirectForResourceRequest(
     const content::ResourceRedirectDetails& details) {
-  Emit("did-get-redirect-request",
-       details.url,
-       details.new_url,
+  Emit("did-get-redirect-request", details.url, details.new_url,
        (details.resource_type == content::RESOURCE_TYPE_MAIN_FRAME),
-       details.http_response_code,
-       details.method,
-       details.referrer,
+       details.http_response_code, details.method, details.referrer,
        details.headers.get());
 }
 
@@ -953,8 +957,8 @@ void WebContents::DevToolsOpened() {
 
   // Set inspected tabID.
   base::Value tab_id(ID());
-  managed_web_contents()->CallClientFunction(
-      "DevToolsAPI.setInspectedTabId", &tab_id, nullptr, nullptr);
+  managed_web_contents()->CallClientFunction("DevToolsAPI.setInspectedTabId",
+                                             &tab_id, nullptr, nullptr);
 
   // Inherit owner window in devtools when it doesn't have one.
   auto* devtools = managed_web_contents()->GetDevToolsWebContents();
@@ -979,8 +983,8 @@ void WebContents::ShowAutofillPopup(content::RenderFrameHost* frame_host,
                                     const std::vector<base::string16>& values,
                                     const std::vector<base::string16>& labels) {
   bool offscreen = IsOffScreen() || (embedder_ && embedder_->IsOffScreen());
-  CommonWebContentsDelegate::ShowAutofillPopup(
-      offscreen, frame_host, bounds, values, labels);
+  CommonWebContentsDelegate::ShowAutofillPopup(offscreen, frame_host, bounds,
+                                               values, labels);
 }
 #endif
 
@@ -1041,8 +1045,7 @@ void WebContents::WebContentsDestroyed() {
   Emit("destroyed");
 
   // Destroy the native class in next tick.
-  base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, GetDestroyClosure());
+  base::ThreadTaskRunnerHandle::Get()->PostTask(FROM_HERE, GetDestroyClosure());
 }
 
 void WebContents::NavigationEntryCommitted(
@@ -1082,11 +1085,9 @@ bool WebContents::Equal(const WebContents* web_contents) const {
 
 void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   if (!url.is_valid() || url.spec().size() > url::kMaxURLChars) {
-    Emit("did-fail-load",
-         static_cast<int>(net::ERR_INVALID_URL),
+    Emit("did-fail-load", static_cast<int>(net::ERR_INVALID_URL),
          net::ErrorToShortString(net::ERR_INVALID_URL),
-         url.possibly_invalid_spec(),
-         true);
+         url.possibly_invalid_spec(), true);
     return;
   }
 
@@ -1147,7 +1148,7 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
 void WebContents::DownloadURL(const GURL& url) {
   auto browser_context = web_contents()->GetBrowserContext();
   auto download_manager =
-    content::BrowserContext::GetDownloadManager(browser_context);
+      content::BrowserContext::GetDownloadManager(browser_context);
 
   download_manager->DownloadUrl(
       content::DownloadUrlParameters::CreateForWebContentsMainFrame(
@@ -1194,8 +1195,7 @@ void WebContents::GoToOffset(int offset) {
 }
 
 const std::string WebContents::GetWebRTCIPHandlingPolicy() const {
-  return web_contents()->
-    GetMutableRendererPrefs()->webrtc_ip_handling_policy;
+  return web_contents()->GetMutableRendererPrefs()->webrtc_ip_handling_policy;
 }
 
 void WebContents::SetWebRTCIPHandlingPolicy(
@@ -1203,7 +1203,7 @@ void WebContents::SetWebRTCIPHandlingPolicy(
   if (GetWebRTCIPHandlingPolicy() == webrtc_ip_handling_policy)
     return;
   web_contents()->GetMutableRendererPrefs()->webrtc_ip_handling_policy =
-    webrtc_ip_handling_policy;
+      webrtc_ip_handling_policy;
 
   content::RenderViewHost* host = web_contents()->GetRenderViewHost();
   if (host)
@@ -1345,8 +1345,7 @@ void WebContents::InspectServiceWorker() {
   }
 }
 
-void WebContents::HasServiceWorker(
-    const base::Callback<void(bool)>& callback) {
+void WebContents::HasServiceWorker(const base::Callback<void(bool)>& callback) {
   auto context = GetServiceWorkerContext(web_contents());
   if (!context)
     return;
@@ -1366,7 +1365,8 @@ void WebContents::HasServiceWorker(
 
   context->CheckHasServiceWorker(
       web_contents()->GetLastCommittedURL(), GURL::EmptyGURL(),
-      base::Bind(&WrappedCallback::Run, base::Unretained(wrapped_callback)));
+      base::BindRepeating(&WrappedCallback::Run,
+                          base::Unretained(wrapped_callback)));
 }
 
 void WebContents::UnregisterServiceWorker(
@@ -1392,7 +1392,7 @@ bool WebContents::IsAudioMuted() {
 }
 
 void WebContents::Print(mate::Arguments* args) {
-  PrintSettings settings = { false, false, base::string16() };
+  PrintSettings settings = {false, false, base::string16()};
   if (args->Length() >= 1 && !args->GetNext(&settings)) {
     args->ThrowError();
     return;
@@ -1407,10 +1407,9 @@ void WebContents::Print(mate::Arguments* args) {
     }
     print_view_manager_basic_ptr->SetCallback(callback);
   }
-  print_view_manager_basic_ptr->PrintNow(web_contents()->GetMainFrame(),
-               settings.silent,
-               settings.print_background,
-               settings.device_name);
+  print_view_manager_basic_ptr->PrintNow(
+      web_contents()->GetMainFrame(), settings.silent,
+      settings.print_background, settings.device_name);
 }
 
 std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {
@@ -1423,8 +1422,8 @@ std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {
 
 void WebContents::PrintToPDF(const base::DictionaryValue& setting,
                              const PrintToPDFCallback& callback) {
-  printing::PrintPreviewMessageHandler::FromWebContents(web_contents())->
-      PrintToPDF(setting, callback);
+  printing::PrintPreviewMessageHandler::FromWebContents(web_contents())
+      ->PrintToPDF(setting, callback);
 }
 
 void WebContents::AddWorkSpace(mate::Arguments* args,
@@ -1529,7 +1528,8 @@ void WebContents::Focus() {
 #if !defined(OS_MACOSX)
 bool WebContents::IsFocused() const {
   auto view = web_contents()->GetRenderWidgetHostView();
-  if (!view) return false;
+  if (!view)
+    return false;
 
   if (GetType() != BACKGROUND_PAGE) {
     auto window = web_contents()->GetNativeView()->GetToplevelWindow();
@@ -1559,12 +1559,12 @@ bool WebContents::SendIPCMessage(bool all_frames,
 void WebContents::SendInputEvent(v8::Isolate* isolate,
                                  v8::Local<v8::Value> input_event) {
   const auto view = static_cast<content::RenderWidgetHostViewBase*>(
-    web_contents()->GetRenderWidgetHostView());
+      web_contents()->GetRenderWidgetHostView());
   if (!view)
     return;
 
-  blink::WebInputEvent::Type type = mate::GetWebInputEventType(isolate,
-      input_event);
+  blink::WebInputEvent::Type type =
+      mate::GetWebInputEventType(isolate, input_event);
   if (blink::WebInputEvent::IsMouseEventType(type)) {
     blink::WebMouseEvent mouse_event;
     if (mate::ConvertFromV8(isolate, input_event, &mouse_event)) {
@@ -1574,8 +1574,7 @@ void WebContents::SendInputEvent(v8::Isolate* isolate,
   } else if (blink::WebInputEvent::IsKeyboardEventType(type)) {
     content::NativeWebKeyboardEvent keyboard_event(
         blink::WebKeyboardEvent::kRawKeyDown,
-        blink::WebInputEvent::kNoModifiers,
-        ui::EventTimeForNow());
+        blink::WebInputEvent::kNoModifiers, ui::EventTimeForNow());
     if (mate::ConvertFromV8(isolate, input_event, &keyboard_event)) {
       view->ProcessKeyboardEvent(keyboard_event, ui::LatencyInfo());
       return;
@@ -1588,8 +1587,8 @@ void WebContents::SendInputEvent(v8::Isolate* isolate,
     }
   }
 
-  isolate->ThrowException(v8::Exception::Error(mate::StringToV8(
-      isolate, "Invalid event object")));
+  isolate->ThrowException(
+      v8::Exception::Error(mate::StringToV8(isolate, "Invalid event object")));
 }
 
 void WebContents::BeginFrameSubscription(mate::Arguments* args) {
@@ -1604,8 +1603,8 @@ void WebContents::BeginFrameSubscription(mate::Arguments* args) {
 
   const auto view = web_contents()->GetRenderWidgetHostView();
   if (view) {
-    std::unique_ptr<FrameSubscriber> frame_subscriber(new FrameSubscriber(
-        isolate(), view, callback, only_dirty));
+    std::unique_ptr<FrameSubscriber> frame_subscriber(
+        new FrameSubscriber(isolate(), view, callback, only_dirty));
     view->BeginFrameSubscription(std::move(frame_subscriber));
   }
 }
@@ -1658,8 +1657,8 @@ void WebContents::CapturePage(mate::Arguments* args) {
   base::Callback<void(const gfx::Image&)> callback;
 
   if (!(args->Length() == 1 && args->GetNext(&callback)) &&
-      !(args->Length() == 2 && args->GetNext(&rect)
-                            && args->GetNext(&callback))) {
+      !(args->Length() == 2 && args->GetNext(&rect) &&
+        args->GetNext(&callback))) {
     args->ThrowError();
     return;
   }
@@ -1671,23 +1670,22 @@ void WebContents::CapturePage(mate::Arguments* args) {
   }
 
   // Capture full page if user doesn't specify a |rect|.
-  const gfx::Size view_size = rect.IsEmpty() ? view->GetViewBounds().size() :
-                                               rect.size();
+  const gfx::Size view_size =
+      rect.IsEmpty() ? view->GetViewBounds().size() : rect.size();
 
   // By default, the requested bitmap size is the view size in screen
   // coordinates.  However, if there's more pixel detail available on the
   // current system, increase the requested bitmap size to capture it all.
   gfx::Size bitmap_size = view_size;
   const gfx::NativeView native_view = view->GetNativeView();
-  const float scale =
-      display::Screen::GetScreen()->GetDisplayNearestView(native_view)
-      .device_scale_factor();
+  const float scale = display::Screen::GetScreen()
+                          ->GetDisplayNearestView(native_view)
+                          .device_scale_factor();
   if (scale > 1.0f)
     bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
 
-  view->CopyFromSurface(gfx::Rect(rect.origin(), view_size),
-                        bitmap_size,
-                        base::Bind(&OnCapturePageDone, callback),
+  view->CopyFromSurface(gfx::Rect(rect.origin(), view_size), bitmap_size,
+                        base::BindRepeating(&OnCapturePageDone, callback),
                         kBGRA_8888_SkColorType);
 }
 
@@ -1697,10 +1695,10 @@ void WebContents::OnCursorChange(const content::WebCursor& cursor) {
 
   if (cursor.IsCustom()) {
     Emit("cursor-changed", CursorTypeToString(info),
-      gfx::Image::CreateFrom1xBitmap(info.custom_image),
-      info.image_scale_factor,
-      gfx::Size(info.custom_image.width(), info.custom_image.height()),
-      info.hotspot);
+         gfx::Image::CreateFrom1xBitmap(info.custom_image),
+         info.image_scale_factor,
+         gfx::Size(info.custom_image.width(), info.custom_image.height()),
+         info.hotspot);
   } else {
     Emit("cursor-changed", CursorTypeToString(info));
   }
@@ -1788,7 +1786,7 @@ void WebContents::Invalidate() {
   if (IsOffScreen()) {
 #if defined(ENABLE_OSR)
     auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(
-      web_contents()->GetRenderWidgetHostView());
+        web_contents()->GetRenderWidgetHostView());
     if (osr_rwhv)
       osr_rwhv->Invalidate();
 #endif
@@ -1799,8 +1797,7 @@ void WebContents::Invalidate() {
   }
 }
 
-gfx::Size WebContents::GetSizeForNewRenderView(
-    content::WebContents* wc) const {
+gfx::Size WebContents::GetSizeForNewRenderView(content::WebContents* wc) const {
   if (IsOffScreen() && wc == web_contents()) {
     auto relay = NativeWindowRelay::FromWebContents(web_contents());
     if (relay) {
@@ -1907,8 +1904,8 @@ void WebContents::SetDevToolsWebContents(const WebContents* devtools) {
 
 v8::Local<v8::Value> WebContents::GetNativeView() const {
   gfx::NativeView ptr = web_contents()->GetNativeView();
-  auto buffer = node::Buffer::Copy(
-      isolate(), reinterpret_cast<char*>(&ptr), sizeof(gfx::NativeView));
+  auto buffer = node::Buffer::Copy(isolate(), reinterpret_cast<char*>(&ptr),
+                                   sizeof(gfx::NativeView));
   if (buffer.IsEmpty())
     return v8::Null(isolate());
   else
@@ -1932,8 +1929,7 @@ v8::Local<v8::Value> WebContents::Debugger(v8::Isolate* isolate) {
 
 void WebContents::GrantOriginAccess(const GURL& url) {
   content::ChildProcessSecurityPolicy::GetInstance()->GrantOrigin(
-      web_contents()->GetMainFrame()->GetProcess()->GetID(),
-      url::Origin(url));
+      web_contents()->GetMainFrame()->GetProcess()->GetID(), url::Origin(url));
 }
 
 // static
@@ -1969,8 +1965,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("disableDeviceEmulation", &WebContents::DisableDeviceEmulation)
       .SetMethod("toggleDevTools", &WebContents::ToggleDevTools)
       .SetMethod("inspectElement", &WebContents::InspectElement)
-      .SetMethod("setIgnoreMenuShortcuts",
-                 &WebContents::SetIgnoreMenuShortcuts)
+      .SetMethod("setIgnoreMenuShortcuts", &WebContents::SetIgnoreMenuShortcuts)
       .SetMethod("setAudioMuted", &WebContents::SetAudioMuted)
       .SetMethod("isAudioMuted", &WebContents::IsAudioMuted)
       .SetMethod("undo", &WebContents::Undo)
@@ -2060,27 +2055,30 @@ void WebContents::OnRendererMessageSync(content::RenderFrameHost* frame_host,
 
 // static
 mate::Handle<WebContents> WebContents::CreateFrom(
-    v8::Isolate* isolate, content::WebContents* web_contents) {
+    v8::Isolate* isolate,
+    content::WebContents* web_contents) {
   // We have an existing WebContents object in JS.
   auto existing = TrackableObject::FromWrappedClass(isolate, web_contents);
   if (existing)
     return mate::CreateHandle(isolate, static_cast<WebContents*>(existing));
 
   // Otherwise create a new WebContents wrapper object.
-  return mate::CreateHandle(isolate, new WebContents(isolate, web_contents,
-        REMOTE));
+  return mate::CreateHandle(isolate,
+                            new WebContents(isolate, web_contents, REMOTE));
 }
 
 mate::Handle<WebContents> WebContents::CreateFrom(
-    v8::Isolate* isolate, content::WebContents* web_contents, Type type) {
+    v8::Isolate* isolate,
+    content::WebContents* web_contents,
+    Type type) {
   // Otherwise create a new WebContents wrapper object.
-  return mate::CreateHandle(isolate, new WebContents(isolate, web_contents,
-        type));
+  return mate::CreateHandle(isolate,
+                            new WebContents(isolate, web_contents, type));
 }
 
 // static
-mate::Handle<WebContents> WebContents::Create(
-    v8::Isolate* isolate, const mate::Dictionary& options) {
+mate::Handle<WebContents> WebContents::Create(v8::Isolate* isolate,
+                                              const mate::Dictionary& options) {
   return mate::CreateHandle(isolate, new WebContents(isolate, options));
 }
 
@@ -2092,8 +2090,10 @@ namespace {
 
 using atom::api::WebContents;
 
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("WebContents", WebContents::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_web_request.cc
+++ b/atom/browser/api/atom_api_web_request.cc
@@ -100,7 +100,7 @@ void WebRequest::SetListener(Method method, Event type, mate::Arguments* args) {
     return;
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&CallNetworkDelegateMethod<Method, Event, Listener>,
+      base::BindOnce(&CallNetworkDelegateMethod<Method, Event, Listener>,
                  base::RetainedRef(url_request_context_getter),
                  method, type, std::move(patterns), std::move(listener)));
 }

--- a/atom/browser/api/event_subscriber.h
+++ b/atom/browser/api/event_subscriber.h
@@ -71,7 +71,7 @@ class EventSubscriber : internal::EventSubscriberBase {
       ptr->handler_ = nullptr;
       content::BrowserThread::PostTask(
           content::BrowserThread::UI, FROM_HERE,
-          base::Bind(
+          base::BindOnce(
               [](EventSubscriber<HandlerType>* subscriber) {
                 {
                   // It is possible that this function will execute in the UI

--- a/atom/browser/api/frame_subscriber.cc
+++ b/atom/browser/api/frame_subscriber.cc
@@ -57,7 +57,7 @@ bool FrameSubscriber::ShouldCaptureFrame(
   view_->CopyFromSurface(
       rect,
       rect.size(),
-      base::Bind(&FrameSubscriber::OnFrameDelivered,
+      base::BindRepeating(&FrameSubscriber::OnFrameDelivered,
                  weak_factory_.GetWeakPtr(), callback_, rect),
       kBGRA_8888_SkColorType);
 

--- a/atom/browser/api/frame_subscriber.cc
+++ b/atom/browser/api/frame_subscriber.cc
@@ -25,8 +25,7 @@ FrameSubscriber::FrameSubscriber(v8::Isolate* isolate,
       callback_(callback),
       only_dirty_(only_dirty),
       source_id_for_copy_request_(base::UnguessableToken::Create()),
-      weak_factory_(this) {
-}
+      weak_factory_(this) {}
 
 bool FrameSubscriber::ShouldCaptureFrame(
     const gfx::Rect& dirty_rect,
@@ -46,19 +45,18 @@ bool FrameSubscriber::ShouldCaptureFrame(
   gfx::Size view_size = rect.size();
   gfx::Size bitmap_size = view_size;
   gfx::NativeView native_view = view_->GetNativeView();
-  const float scale =
-      display::Screen::GetScreen()->GetDisplayNearestView(native_view)
-      .device_scale_factor();
+  const float scale = display::Screen::GetScreen()
+                          ->GetDisplayNearestView(native_view)
+                          .device_scale_factor();
   if (scale > 1.0f)
     bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
 
   rect = gfx::Rect(rect.origin(), bitmap_size);
 
   view_->CopyFromSurface(
-      rect,
-      rect.size(),
+      rect, rect.size(),
       base::BindRepeating(&FrameSubscriber::OnFrameDelivered,
-                 weak_factory_.GetWeakPtr(), callback_, rect),
+                          weak_factory_.GetWeakPtr(), callback_, rect),
       kBGRA_8888_SkColorType);
 
   return false;

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -90,8 +90,7 @@ void AtomBrowserClient::SetCustomServiceWorkerSchemes(
 
 AtomBrowserClient::AtomBrowserClient() : delegate_(nullptr) {}
 
-AtomBrowserClient::~AtomBrowserClient() {
-}
+AtomBrowserClient::~AtomBrowserClient() {}
 
 content::WebContents* AtomBrowserClient::GetWebContentsFromProcessID(
     int process_id) {
@@ -138,7 +137,8 @@ bool AtomBrowserClient::ShouldCreateNewSiteInstance(
 }
 
 void AtomBrowserClient::AddProcessPreferences(
-    int process_id, AtomBrowserClient::ProcessPreferences prefs) {
+    int process_id,
+    AtomBrowserClient::ProcessPreferences prefs) {
   process_preferences_[process_id] = prefs;
 }
 
@@ -178,8 +178,8 @@ void AtomBrowserClient::RenderProcessWillLaunch(
       new WidevineCdmMessageFilter(process_id, host->GetBrowserContext()));
 
   ProcessPreferences prefs;
-  auto* web_preferences = WebContentsPreferences::From(
-      GetWebContentsFromProcessID(process_id));
+  auto* web_preferences =
+      WebContentsPreferences::From(GetWebContentsFromProcessID(process_id));
   if (web_preferences) {
     prefs.sandbox = web_preferences->IsEnabled("sandbox");
     prefs.native_window_open = web_preferences->IsEnabled("nativeWindowOpen");
@@ -191,12 +191,12 @@ void AtomBrowserClient::RenderProcessWillLaunch(
 }
 
 content::SpeechRecognitionManagerDelegate*
-    AtomBrowserClient::CreateSpeechRecognitionManagerDelegate() {
+AtomBrowserClient::CreateSpeechRecognitionManagerDelegate() {
   return new AtomSpeechRecognitionManagerDelegate;
 }
 
-void AtomBrowserClient::OverrideWebkitPrefs(
-    content::RenderViewHost* host, content::WebPreferences* prefs) {
+void AtomBrowserClient::OverrideWebkitPrefs(content::RenderViewHost* host,
+                                            content::WebPreferences* prefs) {
   prefs->javascript_enabled = true;
   prefs->web_security_enabled = true;
   prefs->plugins_enabled = true;
@@ -295,14 +295,12 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
     return;
 
   // Copy following switches to child process.
-  static const char* const kCommonSwitchNames[] = {
-    switches::kStandardSchemes,
-    switches::kEnableSandbox,
-    switches::kSecureSchemes
-  };
-  command_line->CopySwitchesFrom(
-      *base::CommandLine::ForCurrentProcess(),
-      kCommonSwitchNames, arraysize(kCommonSwitchNames));
+  static const char* const kCommonSwitchNames[] = {switches::kStandardSchemes,
+                                                   switches::kEnableSandbox,
+                                                   switches::kSecureSchemes};
+  command_line->CopySwitchesFrom(*base::CommandLine::ForCurrentProcess(),
+                                 kCommonSwitchNames,
+                                 arraysize(kCommonSwitchNames));
 
   // The registered service worker schemes.
   if (!g_custom_service_worker_schemes.empty())
@@ -331,15 +329,13 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
     SessionPreferences::AppendExtraCommandLineSwitches(
         web_contents->GetBrowserContext(), command_line);
 
-    auto context_id = atom::api::WebContents::GetIDForContents(
-      web_contents);
+    auto context_id = atom::api::WebContents::GetIDForContents(web_contents);
     command_line->AppendSwitchASCII(switches::kContextId,
-      base::IntToString(context_id));
+                                    base::IntToString(context_id));
   }
 }
 
-void AtomBrowserClient::DidCreatePpapiPlugin(
-    content::BrowserPpapiHost* host) {
+void AtomBrowserClient::DidCreatePpapiPlugin(content::BrowserPpapiHost* host) {
   host->GetPpapiHost()->AddHostFactoryFilter(
       base::WrapUnique(new chrome::ChromeBrowserPepperHostFactory(host)));
 }
@@ -363,7 +359,7 @@ std::string AtomBrowserClient::GetGeolocationApiKey() {
 }
 
 content::QuotaPermissionContext*
-    AtomBrowserClient::CreateQuotaPermissionContext() {
+AtomBrowserClient::CreateQuotaPermissionContext() {
   return new AtomQuotaPermissionContext;
 }
 
@@ -379,9 +375,8 @@ void AtomBrowserClient::AllowCertificateError(
         callback) {
   if (delegate_) {
     delegate_->AllowCertificateError(
-        web_contents, cert_error, ssl_info, request_url,
-        resource_type, strict_enforcement,
-        expired_previous_decision, callback);
+        web_contents, cert_error, ssl_info, request_url, resource_type,
+        strict_enforcement, expired_previous_decision, callback);
   }
 }
 
@@ -455,8 +450,7 @@ void AtomBrowserClient::GetAdditionalAllowedSchemesForFileSystem(
     std::vector<std::string>* additional_schemes) {
   auto schemes_list = api::GetStandardSchemes();
   if (!schemes_list.empty())
-    additional_schemes->insert(additional_schemes->end(),
-                               schemes_list.begin(),
+    additional_schemes->insert(additional_schemes->end(), schemes_list.begin(),
                                schemes_list.end());
   additional_schemes->push_back(content::kChromeDevToolsScheme);
 }
@@ -466,7 +460,7 @@ void AtomBrowserClient::SiteInstanceDeleting(
   // We are storing weak_ptr, is it fundamental to maintain the map up-to-date
   // when an instance is destroyed.
   for (auto iter = site_per_affinities.begin();
-      iter != site_per_affinities.end(); ++iter) {
+       iter != site_per_affinities.end(); ++iter) {
     if (iter->second == site_instance) {
       site_per_affinities.erase(iter);
       break;
@@ -496,7 +490,7 @@ void AtomBrowserClient::WebNotificationAllowed(
     return;
   }
   permission_helper->RequestWebNotificationPermission(
-      base::Bind(callback, web_contents->IsAudioMuted()));
+      base::BindRepeating(callback, web_contents->IsAudioMuted()));
 }
 
 void AtomBrowserClient::RenderProcessHostDestroyed(

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -56,7 +56,7 @@ class AtomGeolocationDelegate : public device::GeolocationDelegate {
   DISALLOW_COPY_AND_ASSIGN(AtomGeolocationDelegate);
 };
 
-template<typename T>
+template <typename T>
 void Erase(T* container, typename T::iterator iter) {
   container->erase(iter);
 }
@@ -76,8 +76,8 @@ AtomBrowserMainParts::AtomBrowserMainParts()
   DCHECK(!self_) << "Cannot have two AtomBrowserMainParts";
   self_ = this;
   // Register extension scheme as web safe scheme.
-  content::ChildProcessSecurityPolicy::GetInstance()->
-      RegisterWebSafeScheme("chrome-extension");
+  content::ChildProcessSecurityPolicy::GetInstance()->RegisterWebSafeScheme(
+      "chrome-extension");
 }
 
 AtomBrowserMainParts::~AtomBrowserMainParts() {
@@ -85,10 +85,11 @@ AtomBrowserMainParts::~AtomBrowserMainParts() {
   // Leak the JavascriptEnvironment on exit.
   // This is to work around the bug that V8 would be waiting for background
   // tasks to finish on exit, while somehow it waits forever in Electron, more
-  // about this can be found at https://github.com/electron/electron/issues/4767.
-  // On the other handle there is actually no need to gracefully shutdown V8
-  // on exit in the main process, we already ensured all necessary resources get
-  // cleaned up, and it would make quitting faster.
+  // about this can be found at
+  // https://github.com/electron/electron/issues/4767. On the other handle there
+  // is actually no need to gracefully shutdown V8 on exit in the main process,
+  // we already ensured all necessary resources get cleaned up, and it would
+  // make quitting faster.
   ignore_result(js_env_.release());
 }
 
@@ -163,9 +164,9 @@ int AtomBrowserMainParts::PreCreateThreads() {
         brightray::BrowserClient::Get()->GetApplicationLocale());
   }
 
-  #if defined(OS_MACOSX)
-    ui::InitIdleMonitor();
-  #endif
+#if defined(OS_MACOSX)
+  ui::InitIdleMonitor();
+#endif
 
   return result;
 }
@@ -183,10 +184,9 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
 #endif
 
   // Start idle gc.
-  gc_timer_.Start(
-      FROM_HERE, base::TimeDelta::FromMinutes(1),
-      base::Bind(&v8::Isolate::LowMemoryNotification,
-                 base::Unretained(js_env_->isolate())));
+  gc_timer_.Start(FROM_HERE, base::TimeDelta::FromMinutes(1),
+                  base::BindRepeating(&v8::Isolate::LowMemoryNotification,
+                                      base::Unretained(js_env_->isolate())));
 
 #if defined(ENABLE_PDF_VIEWER)
   content::WebUIControllerFactory::RegisterFactory(

--- a/atom/browser/atom_browser_main_parts_posix.cc
+++ b/atom/browser/atom_browser_main_parts_posix.cc
@@ -137,7 +137,7 @@ void ShutdownDetector::ThreadMain() {
   } while (bytes_read < sizeof(signal));
   VLOG(1) << "Handling shutdown for signal " << signal << ".";
   base::Closure task =
-      base::Bind(&Browser::Quit, base::Unretained(Browser::Get()));
+      base::BindRepeating(&Browser::Quit, base::Unretained(Browser::Get()));
 
   if (!BrowserThread::PostTask(BrowserThread::UI, FROM_HERE, task)) {
     // Without a UI thread to post the exit task to, there aren't many

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -57,8 +57,7 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
 
   auto* web_preferences = WebContentsPreferences::From(web_contents);
   std::string checkbox;
-  if (origin_counts_[origin] > 1 &&
-      web_preferences &&
+  if (origin_counts_[origin] > 1 && web_preferences &&
       web_preferences->IsEnabled("safeDialogs") &&
       !web_preferences->dict()->GetString("safeDialogsMessage", &checkbox)) {
     checkbox = "Prevent this app from creating additional dialogs";
@@ -73,15 +72,12 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
   }
 
   atom::ShowMessageBox(
-      window,
-      atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, -1, 0,
+      window, atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, -1, 0,
       atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
-      base::UTF16ToUTF8(message_text), "", checkbox,
-      false, gfx::ImageSkia(),
-      base::Bind(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
-                 base::Unretained(this),
-                 base::Passed(std::move(callback)),
-                 origin));
+      base::UTF16ToUTF8(message_text), "", checkbox, false, gfx::ImageSkia(),
+      base::BindRepeating(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
+                          base::Unretained(this),
+                          base::Passed(std::move(callback)), origin));
 }
 
 void AtomJavaScriptDialogManager::RunBeforeUnloadDialog(
@@ -95,8 +91,7 @@ void AtomJavaScriptDialogManager::RunBeforeUnloadDialog(
 
 void AtomJavaScriptDialogManager::CancelDialogs(
     content::WebContents* web_contents,
-    bool reset_state) {
-}
+    bool reset_state) {}
 
 void AtomJavaScriptDialogManager::OnMessageBoxCallback(
     DialogClosedCallback callback,

--- a/atom/common/native_mate_converters/callback.h
+++ b/atom/common/native_mate_converters/callback.h
@@ -107,7 +107,7 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
 };
 
 // Helper to pass a C++ funtion to JavaScript.
-using Translater = base::Callback<void(Arguments* args)>;
+using Translater = base::RepeatingCallback<void(Arguments* args)>;
 v8::Local<v8::Value> CreateFunctionFromTranslater(v8::Isolate* isolate,
                                                   const Translater& translater);
 v8::Local<v8::Value> BindFunctionWith(v8::Isolate* isolate,


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/12639.

This PR migrates instances of `base::Bind` to `base::BindOnce` and `base::BindRepeating`.

To-Do:
- [x] add new converters for  `base::OnceCallback` and `base::RepeatingCallback`
- [ ] convert all callbacks exposed as event parameters or methods to js land as `base::BindRepeating`
- [ ] convert `base::Bind` to `base::BindOnce` for callbacks passed between threads

/cc @MarshallOfSound @alexeykuzmin @deepak1556 