### PR TITLE
[2.0.x] Preload doesn't load in sandboxed render if preload path contains special chars

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -15,6 +15,7 @@
 #include "atom/renderer/api/atom_api_renderer_ipc.h"
 #include "atom/renderer/atom_render_frame_observer.h"
 #include "base/command_line.h"
+#include "base/files/file_path.h"
 #include "chrome/renderer/printing/print_web_view_helper.h"
 #include "content/public/renderer/render_frame.h"
 #include "native_mate/dictionary.h"
@@ -152,9 +153,9 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
     return;
 
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  std::string preload_script = command_line->GetSwitchValueASCII(
+  base::FilePath preload_script_path = command_line->GetSwitchValuePath(
       switches::kPreloadScript);
-  if (preload_script.empty())
+  if (preload_script_path.empty())
     return;
 
   auto isolate = context->GetIsolate();
@@ -180,7 +181,7 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   AddRenderBindings(isolate, binding);
   v8::Local<v8::Value> args[] = {
     binding,
-    mate::ConvertToV8(isolate, preload_script)
+    mate::ConvertToV8(isolate, preload_script_path.value())
   };
   // Execute the function with proper arguments
   ignore_result(func->Call(context, v8::Null(isolate), 2, args));

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1197,7 +1197,24 @@ describe('BrowserWindow module', () => {
         w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
       })
 
-      it('exposes "exit" event to preload script', (done) => {
+      it('exposes ipcRenderer to preload script (path has special chars)', function (done) {
+        const preloadSpecialChars = path.join(fixtures, 'module', 'preload-sandboxæø åü.js')
+        ipcMain.once('answer', function (event, test) {
+          assert.equal(test, 'preload')
+          done()
+        })
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true,
+            preload: preloadSpecialChars
+          }
+        })
+        w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
+      })
+
+      it('exposes "exit" event to preload script', function (done) {
         w.destroy()
         w = new BrowserWindow({
           show: false,

--- a/spec/fixtures/module/preload-sandboxæø åü.js
+++ b/spec/fixtures/module/preload-sandboxæø åü.js
@@ -1,0 +1,6 @@
+(function () {
+  window.require = require
+  if (location.protocol === 'file:') {
+    window.test = 'preload'
+  }
+})()


### PR DESCRIPTION
Backports #12037.

/cc @juturu, @miniak 