### PR TITLE
Fix a bunch of chromium-style errors

### DIFF
--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -135,7 +135,7 @@ void ComputeBuiltInPlugins(std::vector<content::PepperPluginInfo>* plugins) {
 void ConvertStringWithSeparatorToVector(std::vector<std::string>* vec,
                                         const char* separator,
                                         const char* cmd_switch) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   auto string_with_separator = command_line->GetSwitchValueASCII(cmd_switch);
   if (!string_with_separator.empty())
     *vec = base::SplitString(string_with_separator, separator,
@@ -146,7 +146,7 @@ void ConvertStringWithSeparatorToVector(std::vector<std::string>* vec,
 
 void AddPepperFlashFromCommandLine(
     std::vector<content::PepperPluginInfo>* plugins) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   base::FilePath flash_path =
       command_line->GetSwitchValuePath(switches::kPpapiFlashPath);
   if (flash_path.empty())
@@ -161,7 +161,7 @@ void AddPepperFlashFromCommandLine(
 #if defined(WIDEVINE_CDM_AVAILABLE) && BUILDFLAG(ENABLE_LIBRARY_CDMS)
 void AddWidevineCdmFromCommandLine(
     std::vector<content::PepperPluginInfo>* plugins) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   base::FilePath widevine_cdm_path =
       command_line->GetSwitchValuePath(switches::kWidevineCdmPath);
   if (widevine_cdm_path.empty())

--- a/atom/app/atom_content_client.h
+++ b/atom/app/atom_content_client.h
@@ -16,7 +16,7 @@ namespace atom {
 class AtomContentClient : public brightray::ContentClient {
  public:
   AtomContentClient();
-  virtual ~AtomContentClient();
+  ~AtomContentClient() override;
 
  protected:
   // content::ContentClient:

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -39,7 +39,7 @@
 namespace {
 
 #ifdef ENABLE_RUN_AS_NODE
-const auto kRunAsNode = "ELECTRON_RUN_AS_NODE";
+const char kRunAsNode[] = "ELECTRON_RUN_AS_NODE";
 #endif
 
 #if defined(ENABLE_RUN_AS_NODE) || defined(OS_WIN)

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -61,7 +61,7 @@ AtomMainDelegate::AtomMainDelegate() {}
 AtomMainDelegate::~AtomMainDelegate() {}
 
 bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
 
   logging::LoggingSettings settings;
 #if defined(OS_WIN)
@@ -129,7 +129,7 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 void AtomMainDelegate::PreSandboxStartup() {
   brightray::MainDelegate::PreSandboxStartup();
 
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   std::string process_type =
       command_line->GetSwitchValueASCII(::switches::kProcessType);
 

--- a/atom/app/atom_main_delegate.h
+++ b/atom/app/atom_main_delegate.h
@@ -15,7 +15,7 @@ namespace atom {
 class AtomMainDelegate : public brightray::MainDelegate {
  public:
   AtomMainDelegate();
-  ~AtomMainDelegate();
+  ~AtomMainDelegate() override;
 
  protected:
   // content::ContentMainDelegate:

--- a/atom/app/command_line_args.cc
+++ b/atom/app/command_line_args.cc
@@ -17,7 +17,7 @@ bool IsUrlArg(const base::CommandLine::CharType* arg) {
   // the first character must be a letter for this to be a URL
   auto c = *arg;
   if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')) {
-    for (auto p = arg + 1; *p; ++p) {
+    for (auto* p = arg + 1; *p; ++p) {
       c = *p;
 
       // colon indicates that the argument starts with a URI scheme
@@ -1377,7 +1377,7 @@ bool IsBlacklistedArg(const base::CommandLine::CharType* arg) {
   static const char* prefixes[] = {"--", "-", "/"};
 
   int prefix_length = 0;
-  for (auto& prefix : prefixes) {
+  for (auto*& prefix : prefixes) {
     if (base::StartsWith(a, prefix, base::CompareCase::SENSITIVE)) {
       prefix_length = strlen(prefix);
       break;

--- a/atom/app/uv_task_runner.h
+++ b/atom/app/uv_task_runner.h
@@ -18,7 +18,6 @@ namespace atom {
 class UvTaskRunner : public base::SingleThreadTaskRunner {
  public:
   explicit UvTaskRunner(uv_loop_t* loop);
-  ~UvTaskRunner() override;
 
   // base::SingleThreadTaskRunner:
   bool PostDelayedTask(const base::Location& from_here,
@@ -30,6 +29,7 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
                                   base::TimeDelta delay) override;
 
  private:
+  ~UvTaskRunner() override;
   static void OnTimeout(uv_timer_t* timer);
   static void OnClose(uv_handle_t* handle);
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -927,12 +927,12 @@ void App::DisableDomainBlockingFor3DAPIs(mate::Arguments* args) {
 }
 
 bool App::IsAccessibilitySupportEnabled() {
-  auto ax_state = content::BrowserAccessibilityState::GetInstance();
+  auto* ax_state = content::BrowserAccessibilityState::GetInstance();
   return ax_state->IsAccessibleBrowser();
 }
 
 void App::SetAccessibilitySupportEnabled(bool enabled) {
-  auto ax_state = content::BrowserAccessibilityState::GetInstance();
+  auto* ax_state = content::BrowserAccessibilityState::GetInstance();
   if (enabled) {
     ax_state->OnScreenReaderDetected();
   } else {
@@ -1054,7 +1054,7 @@ void App::GetFileIcon(const base::FilePath& path, mate::Arguments* args) {
     return;
   }
 
-  auto icon_manager = g_browser_process->GetIconManager();
+  auto* icon_manager = g_browser_process->GetIconManager();
   gfx::Image* icon =
       icon_manager->LookupIconFromFilepath(normalized_path, icon_size);
   if (icon) {
@@ -1132,7 +1132,7 @@ void App::EnableMixedSandbox(mate::Arguments* args) {
     return;
   }
 
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(::switches::kNoSandbox)) {
 #if defined(OS_WIN)
     const base::CommandLine::CharType* noSandboxArg = L"--no-sandbox";
@@ -1263,7 +1263,7 @@ void App::BuildPrototype(v8::Isolate* isolate,
 namespace {
 
 void AppendSwitch(const std::string& switch_string, mate::Arguments* args) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
 
   if (base::EndsWith(switch_string, "-path",
                      base::CompareCase::INSENSITIVE_ASCII) ||
@@ -1301,7 +1301,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("App", atom::api::App::GetConstructor(isolate)->GetFunction());

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -349,6 +349,16 @@ struct Converter<content::CertificateRequestResultType> {
 
 namespace atom {
 
+ProcessMetric::ProcessMetric(int type,
+    base::ProcessId pid,
+    std::unique_ptr<base::ProcessMetrics> metrics) {
+  this->type = type;
+  this->pid = pid;
+  this->metrics = std::move(metrics);
+}
+
+ProcessMetric::~ProcessMetric() = default;
+
 namespace api {
 
 namespace {

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -52,11 +52,8 @@ struct ProcessMetric {
 
   ProcessMetric(int type,
                 base::ProcessId pid,
-                std::unique_ptr<base::ProcessMetrics> metrics) {
-    this->type = type;
-    this->pid = pid;
-    this->metrics = std::move(metrics);
-  }
+                std::unique_ptr<base::ProcessMetrics> metrics);
+  ~ProcessMetric();
 };
 
 namespace api {

--- a/atom/browser/api/atom_api_auto_updater.h
+++ b/atom/browser/api/atom_api_auto_updater.h
@@ -34,7 +34,7 @@ class AutoUpdater : public mate::EventEmitter<AutoUpdater>,
   void OnError(const std::string& error) override;
   void OnError(const std::string& message,
                const int code,
-               const std::string& domain);
+               const std::string& domain) override;
   void OnCheckingForUpdate() override;
   void OnUpdateAvailable() override;
   void OnUpdateNotAvailable() override;

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -135,7 +135,7 @@ void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {
 
   // When there is a non-empty first paint, resize the RenderWidget to force
   // Chromium to draw.
-  const auto view = web_contents()->GetRenderWidgetHostView();
+  auto* const view = web_contents()->GetRenderWidgetHostView();
   view->Show();
   view->SetSize(window()->GetContentSize());
 
@@ -408,7 +408,7 @@ void BrowserWindow::BuildPrototype(v8::Isolate* isolate,
 // static
 v8::Local<v8::Value> BrowserWindow::From(v8::Isolate* isolate,
                                          NativeWindow* native_window) {
-  auto existing = TrackableObject::FromWrappedClass(isolate, native_window);
+  auto* existing = TrackableObject::FromWrappedClass(isolate, native_window);
   if (existing)
     return existing->GetWrapper();
   else

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -250,7 +250,7 @@ Cookies::~Cookies() {}
 void Cookies::Get(const base::DictionaryValue& filter,
                   const GetCallback& callback) {
   std::unique_ptr<base::DictionaryValue> copied(filter.CreateDeepCopy());
-  auto getter = browser_context_->GetRequestContext();
+  auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
       base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter), Passed(&copied),
@@ -260,7 +260,7 @@ void Cookies::Get(const base::DictionaryValue& filter,
 void Cookies::Remove(const GURL& url,
                      const std::string& name,
                      const base::Closure& callback) {
-  auto getter = browser_context_->GetRequestContext();
+  auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
       base::BindOnce(RemoveCookieOnIOThread, base::RetainedRef(getter), url,
@@ -270,7 +270,7 @@ void Cookies::Remove(const GURL& url,
 void Cookies::Set(const base::DictionaryValue& details,
                   const SetCallback& callback) {
   std::unique_ptr<base::DictionaryValue> copied(details.CreateDeepCopy());
-  auto getter = browser_context_->GetRequestContext();
+  auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
       base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), Passed(&copied),
@@ -278,7 +278,7 @@ void Cookies::Set(const base::DictionaryValue& details,
 }
 
 void Cookies::FlushStore(const base::Closure& callback) {
-  auto getter = browser_context_->GetRequestContext();
+  auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
       base::BindOnce(FlushCookieStoreOnIOThread, base::RetainedRef(getter),

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -207,7 +207,7 @@ void DownloadItem::BuildPrototype(v8::Isolate* isolate,
 // static
 mate::Handle<DownloadItem> DownloadItem::Create(v8::Isolate* isolate,
                                                 content::DownloadItem* item) {
-  auto existing = TrackableObject::FromWrappedClass(isolate, item);
+  auto* existing = TrackableObject::FromWrappedClass(isolate, item);
   if (existing)
     return mate::CreateHandle(isolate, static_cast<DownloadItem*>(existing));
 

--- a/atom/browser/api/atom_api_download_item.h
+++ b/atom/browser/api/atom_api_download_item.h
@@ -50,7 +50,7 @@ class DownloadItem : public mate::TrackableObject<DownloadItem>,
 
  protected:
   DownloadItem(v8::Isolate* isolate, content::DownloadItem* download_item);
-  ~DownloadItem();
+  ~DownloadItem() override;
 
   // Override content::DownloadItem::Observer methods
   void OnDownloadUpdated(content::DownloadItem* download) override;

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -21,6 +21,7 @@ namespace api {
 class MenuMac : public Menu {
  protected:
   MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
+  ~MenuMac() override;
 
   void PopupAt(TopLevelWindow* window,
                int x,

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -21,23 +21,22 @@ namespace atom {
 namespace api {
 
 MenuMac::MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
-    : Menu(isolate, wrapper),
-      weak_factory_(this) {
-}
+    : Menu(isolate, wrapper), weak_factory_(this) {}
 
 MenuMac::~MenuMac() = default;
 
 void MenuMac::PopupAt(TopLevelWindow* window,
-                      int x, int y, int positioning_item,
+                      int x,
+                      int y,
+                      int positioning_item,
                       const base::Closure& callback) {
   NativeWindow* native_window = window->window();
   if (!native_window)
     return;
 
   auto popup = base::Bind(&MenuMac::PopupOnUI, weak_factory_.GetWeakPtr(),
-                          native_window->GetWeakPtr(),
-                          window->weak_map_id(), x, y,
-                          positioning_item, callback);
+                          native_window->GetWeakPtr(), window->weak_map_id(), x,
+                          y, positioning_item, callback);
   BrowserThread::PostTask(BrowserThread::UI, FROM_HERE, popup);
 }
 
@@ -53,9 +52,9 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
 
   auto close_callback = base::Bind(
       &MenuMac::OnClosed, weak_factory_.GetWeakPtr(), window_id, callback);
-  popup_controllers_[window_id] = base::scoped_nsobject<AtomMenuController>(
-      [[AtomMenuController alloc] initWithModel:model()
-                          useDefaultAccelerator:NO]);
+  popup_controllers_[window_id] = base::scoped_nsobject<AtomMenuController>([
+      [AtomMenuController alloc] initWithModel:model()
+                         useDefaultAccelerator:NO]);
   NSMenu* menu = [popup_controllers_[window_id] menu];
   NSView* view = [nswindow contentView];
 
@@ -130,9 +129,9 @@ void MenuMac::OnClosed(int32_t window_id, base::Closure callback) {
 // static
 void Menu::SetApplicationMenu(Menu* base_menu) {
   MenuMac* menu = static_cast<MenuMac*>(base_menu);
-  base::scoped_nsobject<AtomMenuController> menu_controller(
-      [[AtomMenuController alloc] initWithModel:menu->model_.get()
-                          useDefaultAccelerator:YES]);
+  base::scoped_nsobject<AtomMenuController> menu_controller([
+      [AtomMenuController alloc] initWithModel:menu->model_.get()
+                         useDefaultAccelerator:YES]);
   [NSApp setMainMenu:[menu_controller menu]];
 
   // Ensure the menu_controller_ is destroyed after main menu is set.

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -25,6 +25,8 @@ MenuMac::MenuMac(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
       weak_factory_(this) {
 }
 
+MenuMac::~MenuMac() = default;
+
 void MenuMac::PopupAt(TopLevelWindow* window,
                       int x, int y, int positioning_item,
                       const base::Closure& callback) {

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -17,6 +17,8 @@ namespace api {
 MenuViews::MenuViews(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
     : Menu(isolate, wrapper), weak_factory_(this) {}
 
+MenuViews::~MenuViews() = default;
+
 void MenuViews::PopupAt(TopLevelWindow* window,
                         int x,
                         int y,

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -19,6 +19,7 @@ namespace api {
 class MenuViews : public Menu {
  public:
   MenuViews(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
+  ~MenuViews() override;
 
  protected:
   void PopupAt(TopLevelWindow* window,

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -83,7 +83,7 @@ void Protocol::UnregisterProtocol(const std::string& scheme,
                                   mate::Arguments* args) {
   CompletionCallback callback;
   args->GetNext(&callback);
-  auto getter = browser_context_->GetRequestContext();
+  auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTaskAndReplyWithResult(
       content::BrowserThread::IO, FROM_HERE,
       base::BindOnce(&Protocol::UnregisterProtocolInIO,
@@ -95,7 +95,7 @@ void Protocol::UnregisterProtocol(const std::string& scheme,
 Protocol::ProtocolError Protocol::UnregisterProtocolInIO(
     scoped_refptr<brightray::URLRequestContextGetter> request_context_getter,
     const std::string& scheme) {
-  auto job_factory = static_cast<AtomURLRequestJobFactory*>(
+  auto* job_factory = static_cast<AtomURLRequestJobFactory*>(
       request_context_getter->job_factory());
   if (!job_factory->HasProtocolHandler(scheme))
     return PROTOCOL_NOT_REGISTERED;
@@ -105,7 +105,7 @@ Protocol::ProtocolError Protocol::UnregisterProtocolInIO(
 
 void Protocol::IsProtocolHandled(const std::string& scheme,
                                  const BooleanCallback& callback) {
-  auto getter = browser_context_->GetRequestContext();
+  auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTaskAndReplyWithResult(
       content::BrowserThread::IO, FROM_HERE,
       base::Bind(&Protocol::IsProtocolHandledInIO, base::RetainedRef(getter),
@@ -124,7 +124,7 @@ void Protocol::UninterceptProtocol(const std::string& scheme,
                                    mate::Arguments* args) {
   CompletionCallback callback;
   args->GetNext(&callback);
-  auto getter = browser_context_->GetRequestContext();
+  auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTaskAndReplyWithResult(
       content::BrowserThread::IO, FROM_HERE,
       base::BindOnce(&Protocol::UninterceptProtocolInIO,

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -100,7 +100,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
                         mate::Arguments* args) {
     CompletionCallback callback;
     args->GetNext(&callback);
-    auto getter = browser_context_->GetRequestContext();
+    auto* getter = browser_context_->GetRequestContext();
     content::BrowserThread::PostTaskAndReplyWithResult(
         content::BrowserThread::IO, FROM_HERE,
         base::BindOnce(&Protocol::RegisterProtocolInIO<RequestJob>,
@@ -113,7 +113,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
       v8::Isolate* isolate,
       const std::string& scheme,
       const Handler& handler) {
-    auto job_factory = static_cast<AtomURLRequestJobFactory*>(
+    auto* job_factory = static_cast<AtomURLRequestJobFactory*>(
         request_context_getter->job_factory());
     if (job_factory->IsHandledProtocol(scheme))
       return PROTOCOL_REGISTERED;
@@ -146,7 +146,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
                          mate::Arguments* args) {
     CompletionCallback callback;
     args->GetNext(&callback);
-    auto getter = browser_context_->GetRequestContext();
+    auto* getter = browser_context_->GetRequestContext();
     content::BrowserThread::PostTaskAndReplyWithResult(
         content::BrowserThread::IO, FROM_HERE,
         base::BindOnce(&Protocol::InterceptProtocolInIO<RequestJob>,
@@ -159,7 +159,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
       v8::Isolate* isolate,
       const std::string& scheme,
       const Handler& handler) {
-    auto job_factory = static_cast<AtomURLRequestJobFactory*>(
+    auto* job_factory = static_cast<AtomURLRequestJobFactory*>(
         request_context_getter->job_factory());
     if (!job_factory->IsHandledProtocol(scheme))
       return PROTOCOL_NOT_REGISTERED;

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -47,7 +47,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
 
  protected:
   Protocol(v8::Isolate* isolate, AtomBrowserContext* browser_context);
-  ~Protocol();
+  ~Protocol() override;
 
  private:
   // Possible errors.

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -91,7 +91,7 @@ class Session : public mate::TrackableObject<Session>,
 
  protected:
   Session(v8::Isolate* isolate, AtomBrowserContext* browser_context);
-  ~Session();
+  ~Session() override;
 
   // content::DownloadManager::Observer:
   void OnDownloadCreated(content::DownloadManager* manager,

--- a/atom/browser/api/atom_api_url_request.cc
+++ b/atom/browser/api/atom_api_url_request.cc
@@ -38,7 +38,7 @@ struct Converter<scoped_refptr<const net::IOBufferWithSize>> {
       *out = nullptr;
       return true;
     }
-    auto data = node::Buffer::Data(val);
+    auto* data = node::Buffer::Data(val);
     if (!data) {
       // This is an error as size is positive but data is null.
       return false;
@@ -138,7 +138,7 @@ URLRequest::~URLRequest() {
 
 // static
 mate::WrappableBase* URLRequest::New(mate::Arguments* args) {
-  auto isolate = args->isolate();
+  auto* isolate = args->isolate();
   v8::Local<v8::Object> options;
   args->GetNext(&options);
   mate::Dictionary dict(isolate, options);
@@ -157,8 +157,8 @@ mate::WrappableBase* URLRequest::New(mate::Arguments* args) {
     // Use the default session if not specified.
     session = Session::FromPartition(isolate, "");
   }
-  auto browser_context = session->browser_context();
-  auto api_url_request = new URLRequest(args->isolate(), args->GetThis());
+  auto* browser_context = session->browser_context();
+  auto* api_url_request = new URLRequest(args->isolate(), args->GetThis());
   auto atom_url_request = AtomURLRequest::Create(
       browser_context, method, url, redirect_policy, api_url_request);
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -275,12 +275,12 @@ namespace {
 
 content::ServiceWorkerContext* GetServiceWorkerContext(
     const content::WebContents* web_contents) {
-  auto context = web_contents->GetBrowserContext();
-  auto site_instance = web_contents->GetSiteInstance();
+  auto* context = web_contents->GetBrowserContext();
+  auto* site_instance = web_contents->GetSiteInstance();
   if (!context || !site_instance)
     return nullptr;
 
-  auto storage_partition =
+  auto* storage_partition =
       content::BrowserContext::GetStoragePartition(context, site_instance);
   if (!storage_partition)
     return nullptr;
@@ -486,7 +486,7 @@ void WebContents::InitWithSessionAndOptions(v8::Isolate* isolate,
     NativeWindow* owner_window = nullptr;
     if (embedder_) {
       // New WebContents's owner_window is the embedder's owner_window.
-      auto relay =
+      auto* relay =
           NativeWindowRelay::FromWebContents(embedder_->web_contents());
       if (relay)
         owner_window = relay->window.get();
@@ -675,7 +675,7 @@ content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
 
 void WebContents::EnterFullscreenModeForTab(content::WebContents* source,
                                             const GURL& origin) {
-  auto permission_helper = WebContentsPermissionHelper::FromWebContents(source);
+  auto* permission_helper = WebContentsPermissionHelper::FromWebContents(source);
   auto callback = base::Bind(&WebContents::OnEnterFullscreenModeForTab,
                              base::Unretained(this), source, origin);
   permission_helper->RequestFullscreenPermission(callback);
@@ -754,7 +754,7 @@ void WebContents::RequestMediaAccessPermission(
     content::WebContents* web_contents,
     const content::MediaStreamRequest& request,
     const content::MediaResponseCallback& callback) {
-  auto permission_helper =
+  auto* permission_helper =
       WebContentsPermissionHelper::FromWebContents(web_contents);
   permission_helper->RequestMediaAccessPermission(request, callback);
 }
@@ -762,7 +762,7 @@ void WebContents::RequestMediaAccessPermission(
 void WebContents::RequestToLockMouse(content::WebContents* web_contents,
                                      bool user_gesture,
                                      bool last_unlocked_by_target) {
-  auto permission_helper =
+  auto* permission_helper =
       WebContentsPermissionHelper::FromWebContents(web_contents);
   permission_helper->RequestPointerLockPermission(user_gesture);
 }
@@ -789,7 +789,7 @@ void WebContents::BeforeUnloadFired(const base::TimeTicks& proceed_time) {
 }
 
 void WebContents::RenderViewCreated(content::RenderViewHost* render_view_host) {
-  const auto impl = content::RenderWidgetHostImpl::FromID(
+  auto* const impl = content::RenderWidgetHostImpl::FromID(
       render_view_host->GetProcess()->GetID(),
       render_view_host->GetRoutingID());
   if (impl)
@@ -807,7 +807,7 @@ void WebContents::RenderProcessGone(base::TerminationStatus status) {
 void WebContents::PluginCrashed(const base::FilePath& plugin_path,
                                 base::ProcessId plugin_pid) {
   content::WebPluginInfo info;
-  auto plugin_service = content::PluginService::GetInstance();
+  auto* plugin_service = content::PluginService::GetInstance();
   plugin_service->GetPluginInfoByPath(plugin_path, &info);
   Emit("plugin-crashed", info.name, info.version);
 }
@@ -1129,7 +1129,7 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   // Set the background color of RenderWidgetHostView.
   // We have to call it right after LoadURL because the RenderViewHost is only
   // created after loading a page.
-  const auto view = web_contents()->GetRenderWidgetHostView();
+  auto* const view = web_contents()->GetRenderWidgetHostView();
   if (view) {
     auto* web_preferences = WebContentsPreferences::From(web_contents());
     std::string color_name;
@@ -1143,8 +1143,8 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
 }
 
 void WebContents::DownloadURL(const GURL& url) {
-  auto browser_context = web_contents()->GetBrowserContext();
-  auto download_manager =
+  auto* browser_context = web_contents()->GetBrowserContext();
+  auto* download_manager =
       content::BrowserContext::GetDownloadManager(browser_context);
 
   download_manager->DownloadUrl(
@@ -1223,7 +1223,7 @@ std::string WebContents::GetUserAgent() {
 bool WebContents::SavePage(const base::FilePath& full_file_path,
                            const content::SavePageType& save_type,
                            const SavePageHandler::SavePageCallback& callback) {
-  auto handler = new SavePageHandler(web_contents(), callback);
+  auto* handler = new SavePageHandler(web_contents(), callback);
   return handler->Handle(full_file_path, save_type);
 }
 
@@ -1280,9 +1280,9 @@ void WebContents::EnableDeviceEmulation(
   if (type_ == REMOTE)
     return;
 
-  auto frame_host = web_contents()->GetMainFrame();
+  auto* frame_host = web_contents()->GetMainFrame();
   if (frame_host) {
-    auto widget_host =
+    auto* widget_host =
         frame_host ? frame_host->GetView()->GetRenderWidgetHost() : nullptr;
     if (!widget_host)
       return;
@@ -1295,9 +1295,9 @@ void WebContents::DisableDeviceEmulation() {
   if (type_ == REMOTE)
     return;
 
-  auto frame_host = web_contents()->GetMainFrame();
+  auto* frame_host = web_contents()->GetMainFrame();
   if (frame_host) {
-    auto widget_host =
+    auto* widget_host =
         frame_host ? frame_host->GetView()->GetRenderWidgetHost() : nullptr;
     if (!widget_host)
       return;
@@ -1343,7 +1343,7 @@ void WebContents::InspectServiceWorker() {
 }
 
 void WebContents::HasServiceWorker(const base::Callback<void(bool)>& callback) {
-  auto context = GetServiceWorkerContext(web_contents());
+  auto* context = GetServiceWorkerContext(web_contents());
   if (!context)
     return;
 
@@ -1358,7 +1358,7 @@ void WebContents::HasServiceWorker(const base::Callback<void(bool)>& callback) {
     }
   };
 
-  auto wrapped_callback = new WrappedCallback(callback);
+  auto* wrapped_callback = new WrappedCallback(callback);
 
   context->CheckHasServiceWorker(
       web_contents()->GetLastCommittedURL(), GURL::EmptyGURL(),
@@ -1367,7 +1367,7 @@ void WebContents::HasServiceWorker(const base::Callback<void(bool)>& callback) {
 
 void WebContents::UnregisterServiceWorker(
     const base::Callback<void(bool)>& callback) {
-  auto context = GetServiceWorkerContext(web_contents());
+  auto* context = GetServiceWorkerContext(web_contents());
   if (!context)
     return;
 
@@ -1393,7 +1393,7 @@ void WebContents::Print(mate::Arguments* args) {
     args->ThrowError();
     return;
   }
-  auto print_view_manager_basic_ptr =
+  auto* print_view_manager_basic_ptr =
       printing::PrintViewManagerBasic::FromWebContents(web_contents());
   if (args->Length() == 2) {
     base::Callback<void(bool)> callback;
@@ -1505,14 +1505,14 @@ void WebContents::StopFindInPage(content::StopFindAction action) {
 
 void WebContents::ShowDefinitionForSelection() {
 #if defined(OS_MACOSX)
-  const auto view = web_contents()->GetRenderWidgetHostView();
+  auto* const view = web_contents()->GetRenderWidgetHostView();
   if (view)
     view->ShowDefinitionForSelection();
 #endif
 }
 
 void WebContents::CopyImageAt(int x, int y) {
-  const auto host = web_contents()->GetMainFrame();
+  auto* const host = web_contents()->GetMainFrame();
   if (host)
     host->CopyImageAt(x, y);
 }
@@ -1544,7 +1544,7 @@ void WebContents::TabTraverse(bool reverse) {
 bool WebContents::SendIPCMessage(bool all_frames,
                                  const base::string16& channel,
                                  const base::ListValue& args) {
-  auto frame_host = web_contents()->GetMainFrame();
+  auto* frame_host = web_contents()->GetMainFrame();
   if (frame_host) {
     return frame_host->Send(new AtomFrameMsg_Message(
         frame_host->GetRoutingID(), all_frames, channel, args));
@@ -1554,7 +1554,7 @@ bool WebContents::SendIPCMessage(bool all_frames,
 
 void WebContents::SendInputEvent(v8::Isolate* isolate,
                                  v8::Local<v8::Value> input_event) {
-  const auto view = static_cast<content::RenderWidgetHostViewBase*>(
+  auto* const view = static_cast<content::RenderWidgetHostViewBase*>(
       web_contents()->GetRenderWidgetHostView());
   if (!view)
     return;
@@ -1597,7 +1597,7 @@ void WebContents::BeginFrameSubscription(mate::Arguments* args) {
     return;
   }
 
-  const auto view = web_contents()->GetRenderWidgetHostView();
+  auto* const view = web_contents()->GetRenderWidgetHostView();
   if (view) {
     std::unique_ptr<FrameSubscriber> frame_subscriber(
         new FrameSubscriber(isolate(), view, callback, only_dirty));
@@ -1606,7 +1606,7 @@ void WebContents::BeginFrameSubscription(mate::Arguments* args) {
 }
 
 void WebContents::EndFrameSubscription() {
-  const auto view = web_contents()->GetRenderWidgetHostView();
+  auto* const view = web_contents()->GetRenderWidgetHostView();
   if (view)
     view->EndFrameSubscription();
 }
@@ -1659,7 +1659,7 @@ void WebContents::CapturePage(mate::Arguments* args) {
     return;
   }
 
-  const auto view = web_contents()->GetRenderWidgetHostView();
+  auto* const view = web_contents()->GetRenderWidgetHostView();
   if (!view) {
     callback.Run(gfx::Image());
     return;
@@ -1787,7 +1787,7 @@ void WebContents::Invalidate() {
       osr_rwhv->Invalidate();
 #endif
   } else {
-    const auto window = owner_window();
+    auto* const window = owner_window();
     if (window)
       window->Invalidate();
   }
@@ -1795,7 +1795,7 @@ void WebContents::Invalidate() {
 
 gfx::Size WebContents::GetSizeForNewRenderView(content::WebContents* wc) const {
   if (IsOffScreen() && wc == web_contents()) {
-    auto relay = NativeWindowRelay::FromWebContents(web_contents());
+    auto* relay = NativeWindowRelay::FromWebContents(web_contents());
     if (relay) {
       return relay->window->GetSize();
     }
@@ -1877,7 +1877,7 @@ content::WebContents* WebContents::HostWebContents() {
 void WebContents::SetEmbedder(const WebContents* embedder) {
   if (embedder) {
     NativeWindow* owner_window = nullptr;
-    auto relay = NativeWindowRelay::FromWebContents(embedder->web_contents());
+    auto* relay = NativeWindowRelay::FromWebContents(embedder->web_contents());
     if (relay) {
       owner_window = relay->window.get();
     }
@@ -2054,7 +2054,7 @@ mate::Handle<WebContents> WebContents::CreateFrom(
     v8::Isolate* isolate,
     content::WebContents* web_contents) {
   // We have an existing WebContents object in JS.
-  auto existing = TrackableObject::FromWrappedClass(isolate, web_contents);
+  auto* existing = TrackableObject::FromWrappedClass(isolate, web_contents);
   if (existing)
     return mate::CreateHandle(isolate, static_cast<WebContents*>(existing));
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -675,7 +675,8 @@ content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
 
 void WebContents::EnterFullscreenModeForTab(content::WebContents* source,
                                             const GURL& origin) {
-  auto* permission_helper = WebContentsPermissionHelper::FromWebContents(source);
+  auto* permission_helper =
+      WebContentsPermissionHelper::FromWebContents(source);
   auto callback = base::Bind(&WebContents::OnEnterFullscreenModeForTab,
                              base::Unretained(this), source, origin);
   permission_helper->RequestFullscreenPermission(callback);

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -262,7 +262,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
               content::WebContents* web_contents,
               Type type);
   WebContents(v8::Isolate* isolate, const mate::Dictionary& options);
-  ~WebContents();
+  ~WebContents() override;
 
   void InitWithSessionAndOptions(v8::Isolate* isolate,
                                  content::WebContents* web_contents,

--- a/atom/browser/api/atom_api_web_contents_mac.mm
+++ b/atom/browser/api/atom_api_web_contents_mac.mm
@@ -11,7 +11,7 @@ namespace atom {
 namespace api {
 
 bool WebContents::IsFocused() const {
-  auto view = web_contents()->GetRenderWidgetHostView();
+  auto* view = web_contents()->GetRenderWidgetHostView();
   if (!view) return false;
 
   if (GetType() != BACKGROUND_PAGE) {

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -23,7 +23,7 @@ void AddGuest(int guest_instance_id,
               content::WebContents* embedder,
               content::WebContents* guest_web_contents,
               const base::DictionaryValue& options) {
-  auto manager = atom::WebViewManager::GetWebViewManager(embedder);
+  auto* manager = atom::WebViewManager::GetWebViewManager(embedder);
   if (manager)
     manager->AddGuest(guest_instance_id, element_instance_id, embedder,
                       guest_web_contents);
@@ -38,7 +38,7 @@ void AddGuest(int guest_instance_id,
 }
 
 void RemoveGuest(content::WebContents* embedder, int guest_instance_id) {
-  auto manager = atom::WebViewManager::GetWebViewManager(embedder);
+  auto* manager = atom::WebViewManager::GetWebViewManager(embedder);
   if (manager)
     manager->RemoveGuest(guest_instance_id);
 }

--- a/atom/browser/api/event_subscriber.cc
+++ b/atom/browser/api/event_subscriber.cc
@@ -75,7 +75,7 @@ void EventSubscriberBase::On(const std::string& event_name) {
   v8::HandleScope handle_scope(isolate_);
   auto fn_template = g_cached_template.Get(isolate_);
   auto event = mate::StringToV8(isolate_, event_name);
-  auto js_handler_data = new JSHandlerData(isolate_, this);
+  auto* js_handler_data = new JSHandlerData(isolate_, this);
   v8::Local<v8::Value> fn = internal::BindFunctionWith(
       isolate_, isolate_->GetCurrentContext(), fn_template->GetFunction(),
       js_handler_data->handle_.Get(isolate_), event);

--- a/atom/browser/api/frame_subscriber.cc
+++ b/atom/browser/api/frame_subscriber.cc
@@ -87,8 +87,8 @@ void FrameSubscriber::OnFrameDelivered(const FrameCaptureCallback& callback,
   auto local_buffer = buffer.ToLocalChecked();
 
   {
-    auto source = static_cast<const unsigned char*>(bitmap.getPixels());
-    auto target = node::Buffer::Data(local_buffer);
+    auto* source = static_cast<const unsigned char*>(bitmap.getPixels());
+    auto* target = node::Buffer::Data(local_buffer);
 
     for (int y = 0; y < bitmap.height(); ++y) {
       memcpy(target, source, rgb_row_size);

--- a/atom/browser/api/frame_subscriber.cc
+++ b/atom/browser/api/frame_subscriber.cc
@@ -27,6 +27,8 @@ FrameSubscriber::FrameSubscriber(v8::Isolate* isolate,
       source_id_for_copy_request_(base::UnguessableToken::Create()),
       weak_factory_(this) {}
 
+FrameSubscriber::~FrameSubscriber() = default;
+
 bool FrameSubscriber::ShouldCaptureFrame(
     const gfx::Rect& dirty_rect,
     base::TimeTicks present_time,

--- a/atom/browser/api/frame_subscriber.h
+++ b/atom/browser/api/frame_subscriber.h
@@ -27,6 +27,7 @@ class FrameSubscriber : public content::RenderWidgetHostViewFrameSubscriber {
                   content::RenderWidgetHostView* view,
                   const FrameCaptureCallback& callback,
                   bool only_dirty);
+  ~FrameSubscriber() override;
 
   bool ShouldCaptureFrame(const gfx::Rect& damage_rect,
                           base::TimeTicks present_time,

--- a/atom/browser/api/save_page_handler.cc
+++ b/atom/browser/api/save_page_handler.cc
@@ -30,7 +30,7 @@ void SavePageHandler::OnDownloadCreated(content::DownloadManager* manager,
 
 bool SavePageHandler::Handle(const base::FilePath& full_path,
                              const content::SavePageType& save_type) {
-  auto download_manager = content::BrowserContext::GetDownloadManager(
+  auto* download_manager = content::BrowserContext::GetDownloadManager(
       web_contents_->GetBrowserContext());
   download_manager->AddObserver(this);
   // Chromium will create a 'foo_files' directory under the directory of saving

--- a/atom/browser/api/save_page_handler.h
+++ b/atom/browser/api/save_page_handler.h
@@ -32,7 +32,7 @@ class SavePageHandler : public content::DownloadManager::Observer,
 
   SavePageHandler(content::WebContents* web_contents,
                   const SavePageCallback& callback);
-  ~SavePageHandler();
+  ~SavePageHandler() override;
 
   bool Handle(const base::FilePath& full_path,
               const content::SavePageType& save_type);

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -54,7 +54,8 @@ void TrackableObjectBase::AttachAsUserData(base::SupportsUserData* wrapped) {
 int32_t TrackableObjectBase::GetIDFromWrappedClass(
     base::SupportsUserData* wrapped) {
   if (wrapped) {
-    auto id = static_cast<IDUserData*>(wrapped->GetUserData(kTrackedObjectKey));
+    auto* id = static_cast<IDUserData*>(
+        wrapped->GetUserData(kTrackedObjectKey));
     if (id)
       return *id;
   }

--- a/atom/browser/atom_access_token_store.h
+++ b/atom/browser/atom_access_token_store.h
@@ -12,7 +12,6 @@ namespace atom {
 class AtomAccessTokenStore : public device::AccessTokenStore {
  public:
   AtomAccessTokenStore() = default;
-  ~AtomAccessTokenStore() = default;
 
   // device::AccessTokenStore:
   void LoadAccessTokens(const LoadAccessTokensCallback& callback) override {}
@@ -20,6 +19,7 @@ class AtomAccessTokenStore : public device::AccessTokenStore {
                        const base::string16& access_token) override {}
 
  private:
+  ~AtomAccessTokenStore() override = default;
   DISALLOW_COPY_AND_ASSIGN(AtomAccessTokenStore);
 };
 

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -120,7 +120,7 @@ bool AtomBrowserClient::ShouldCreateNewSiteInstance(
       // a new SiteInstance
       return true;
     }
-    auto web_contents =
+    auto* web_contents =
         content::WebContents::FromRenderFrameHost(render_frame_host);
     if (!ChildWebContentsTracker::IsChildWebContents(web_contents)) {
       // Root WebContents should always create new process to make sure
@@ -252,7 +252,7 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
       site_per_affinities[affinity] = candidate_instance;
       *new_instance = candidate_instance;
       // Remember the original web contents for the pending renderer process.
-      auto pending_process = candidate_instance->GetProcess();
+      auto* pending_process = candidate_instance->GetProcess();
       pending_processes_[pending_process->GetID()] = web_contents;
     }
   } else {
@@ -272,7 +272,7 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
 
     *new_instance = candidate_instance;
     // Remember the original web contents for the pending renderer process.
-    auto pending_process = candidate_instance->GetProcess();
+    auto* pending_process = candidate_instance->GetProcess();
     pending_processes_[pending_process->GetID()] = web_contents;
   }
 }
@@ -343,8 +343,8 @@ void AtomBrowserClient::DidCreatePpapiPlugin(content::BrowserPpapiHost* host) {
 void AtomBrowserClient::GetGeolocationRequestContext(
     base::OnceCallback<void(scoped_refptr<net::URLRequestContextGetter>)>
         callback) {
-  auto io_thread = AtomBrowserMainParts::Get()->io_thread();
-  auto context = io_thread->GetRequestContext();
+  auto* io_thread = AtomBrowserMainParts::Get()->io_thread();
+  auto* context = io_thread->GetRequestContext();
   base::ThreadTaskRunnerHandle::Get()->PostTask(
       FROM_HERE,
       base::BindOnce(std::move(callback), base::RetainedRef(context)));
@@ -483,7 +483,7 @@ void AtomBrowserClient::WebNotificationAllowed(
     callback.Run(false, false);
     return;
   }
-  auto permission_helper =
+  auto* permission_helper =
       WebContentsPermissionHelper::FromWebContents(web_contents);
   if (!permission_helper) {
     callback.Run(false, false);

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -31,7 +31,7 @@ class AtomBrowserClient : public brightray::BrowserClient,
                           public content::RenderProcessHostObserver {
  public:
   AtomBrowserClient();
-  virtual ~AtomBrowserClient();
+  ~AtomBrowserClient() override;
 
   using Delegate = content::ContentBrowserClient;
   void set_delegate(Delegate* delegate) { delegate_ = delegate; }

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -150,7 +150,7 @@ AtomBrowserContext::CreateURLRequestJobFactory(
       url::kWssScheme,
       base::WrapUnique(new HttpProtocolHandler(url::kWssScheme)));
 
-  auto host_resolver =
+  auto* host_resolver =
       url_request_context_getter()->GetURLRequestContext()->host_resolver();
   job_factory->SetProtocolHandler(
       url::kFtpScheme, net::FtpProtocolHandler::Create(host_resolver));
@@ -171,7 +171,7 @@ AtomBrowserContext::CreateHttpCacheBackendFactory(
 content::DownloadManagerDelegate*
 AtomBrowserContext::GetDownloadManagerDelegate() {
   if (!download_manager_delegate_.get()) {
-    auto download_manager = content::BrowserContext::GetDownloadManager(this);
+    auto* download_manager = content::BrowserContext::GetDownloadManager(this);
     download_manager_delegate_.reset(
         new AtomDownloadManagerDelegate(download_manager));
   }

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -28,7 +28,7 @@ class BridgeTaskRunner;
 class AtomBrowserMainParts : public brightray::BrowserMainParts {
  public:
   AtomBrowserMainParts();
-  virtual ~AtomBrowserMainParts();
+  ~AtomBrowserMainParts() override;
 
   static AtomBrowserMainParts* Get();
 

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -78,13 +78,13 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
     const base::FilePath& default_path) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  auto item = download_manager_->GetDownload(download_id);
+  auto* item = download_manager_->GetDownload(download_id);
   if (!item)
     return;
 
   NativeWindow* window = nullptr;
   content::WebContents* web_contents = item->GetWebContents();
-  auto relay =
+  auto* relay =
       web_contents ? NativeWindowRelay::FromWebContents(web_contents) : nullptr;
   if (relay)
     window = relay->window.get();

--- a/atom/browser/atom_download_manager_delegate.h
+++ b/atom/browser/atom_download_manager_delegate.h
@@ -22,7 +22,7 @@ class AtomDownloadManagerDelegate : public content::DownloadManagerDelegate {
       base::Callback<void(const base::FilePath&)>;
 
   explicit AtomDownloadManagerDelegate(content::DownloadManager* manager);
-  virtual ~AtomDownloadManagerDelegate();
+  ~AtomDownloadManagerDelegate() override;
 
   void OnDownloadPathGenerated(uint32_t download_id,
                                const content::DownloadTargetCallback& callback,

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -28,6 +28,7 @@ constexpr int kUserWantsNoMoreDialogs = -1;
 AtomJavaScriptDialogManager::AtomJavaScriptDialogManager(
     api::WebContents* api_web_contents)
     : api_web_contents_(api_web_contents) {}
+AtomJavaScriptDialogManager::~AtomJavaScriptDialogManager() = default;
 
 void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     content::WebContents* web_contents,

--- a/atom/browser/atom_javascript_dialog_manager.h
+++ b/atom/browser/atom_javascript_dialog_manager.h
@@ -19,6 +19,7 @@ class WebContents;
 class AtomJavaScriptDialogManager : public content::JavaScriptDialogManager {
  public:
   explicit AtomJavaScriptDialogManager(api::WebContents* api_web_contents);
+  ~AtomJavaScriptDialogManager() override;
 
   // content::JavaScriptDialogManager implementations.
   void RunJavaScriptDialog(content::WebContents* web_contents,

--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -76,7 +76,7 @@ void AtomPermissionManager::SetPermissionRequestHandler(
   if (handler.is_null() && !pending_requests_.IsEmpty()) {
     for (PendingRequestsMap::const_iterator iter(&pending_requests_);
          !iter.IsAtEnd(); iter.Advance()) {
-      auto request = iter.GetCurrentValue();
+      auto* request = iter.GetCurrentValue();
       if (!WebContentsDestroyed(request->render_process_id()))
         request->RunCallback();
     }
@@ -146,7 +146,7 @@ int AtomPermissionManager::RequestPermissionsWithDetails(
     return kNoPendingOperation;
   }
 
-  auto web_contents =
+  auto* web_contents =
       content::WebContents::FromRenderFrameHost(render_frame_host);
   int request_id = pending_requests_.Add(std::make_unique<PendingRequest>(
       render_frame_host, permissions, response_callback));
@@ -175,7 +175,7 @@ void AtomPermissionManager::OnPermissionResponse(
     int request_id,
     int permission_id,
     blink::mojom::PermissionStatus status) {
-  auto pending_request = pending_requests_.Lookup(request_id);
+  auto* pending_request = pending_requests_.Lookup(request_id);
   if (!pending_request)
     return;
 
@@ -187,7 +187,7 @@ void AtomPermissionManager::OnPermissionResponse(
 }
 
 void AtomPermissionManager::CancelPermissionRequest(int request_id) {
-  auto pending_request = pending_requests_.Lookup(request_id);
+  auto* pending_request = pending_requests_.Lookup(request_id);
   if (!pending_request)
     return;
 

--- a/atom/browser/atom_quota_permission_context.h
+++ b/atom/browser/atom_quota_permission_context.h
@@ -14,7 +14,6 @@ class AtomQuotaPermissionContext : public content::QuotaPermissionContext {
   typedef content::QuotaPermissionContext::QuotaPermissionResponse response;
 
   AtomQuotaPermissionContext();
-  virtual ~AtomQuotaPermissionContext();
 
   // content::QuotaPermissionContext:
   void RequestQuotaPermission(const content::StorageQuotaParams& params,
@@ -22,6 +21,8 @@ class AtomQuotaPermissionContext : public content::QuotaPermissionContext {
                               const PermissionCallback& callback) override;
 
  private:
+  ~AtomQuotaPermissionContext() override;
+
   DISALLOW_COPY_AND_ASSIGN(AtomQuotaPermissionContext);
 };
 

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -57,7 +57,7 @@ void HandleExternalProtocolInUI(
   if (!web_contents)
     return;
 
-  auto permission_helper =
+  auto* permission_helper =
       WebContentsPermissionHelper::FromWebContents(web_contents);
   if (!permission_helper)
     return;

--- a/atom/browser/atom_speech_recognition_manager_delegate.h
+++ b/atom/browser/atom_speech_recognition_manager_delegate.h
@@ -18,7 +18,7 @@ class AtomSpeechRecognitionManagerDelegate
       public content::SpeechRecognitionEventListener {
  public:
   AtomSpeechRecognitionManagerDelegate();
-  virtual ~AtomSpeechRecognitionManagerDelegate();
+  ~AtomSpeechRecognitionManagerDelegate() override;
 
   // content::SpeechRecognitionEventListener:
   void OnRecognitionStart(int session_id) override;

--- a/atom/browser/atom_web_ui_controller_factory.h
+++ b/atom/browser/atom_web_ui_controller_factory.h
@@ -16,7 +16,7 @@ class AtomWebUIControllerFactory : public content::WebUIControllerFactory {
   static AtomWebUIControllerFactory* GetInstance();
 
   AtomWebUIControllerFactory();
-  virtual ~AtomWebUIControllerFactory();
+  ~AtomWebUIControllerFactory() override;
 
   // content::WebUIControllerFactory:
   content::WebUI::TypeID GetWebUIType(content::BrowserContext* browser_context,

--- a/atom/browser/bridge_task_runner.cc
+++ b/atom/browser/bridge_task_runner.cc
@@ -8,6 +8,9 @@
 
 namespace atom {
 
+BridgeTaskRunner::BridgeTaskRunner() = default;
+BridgeTaskRunner::~BridgeTaskRunner() = default;
+
 void BridgeTaskRunner::MessageLoopIsReady() {
   auto* message_loop = base::MessageLoop::current();
   CHECK(message_loop);

--- a/atom/browser/bridge_task_runner.cc
+++ b/atom/browser/bridge_task_runner.cc
@@ -9,7 +9,7 @@
 namespace atom {
 
 void BridgeTaskRunner::MessageLoopIsReady() {
-  auto message_loop = base::MessageLoop::current();
+  auto* message_loop = base::MessageLoop::current();
   CHECK(message_loop);
   for (TaskPair& task : tasks_) {
     message_loop->task_runner()->PostDelayedTask(
@@ -24,7 +24,7 @@ void BridgeTaskRunner::MessageLoopIsReady() {
 bool BridgeTaskRunner::PostDelayedTask(const base::Location& from_here,
                                        base::OnceClosure task,
                                        base::TimeDelta delay) {
-  auto message_loop = base::MessageLoop::current();
+  auto* message_loop = base::MessageLoop::current();
   if (!message_loop) {
     tasks_.push_back(std::make_tuple(from_here, std::move(task), delay));
     return true;
@@ -35,7 +35,7 @@ bool BridgeTaskRunner::PostDelayedTask(const base::Location& from_here,
 }
 
 bool BridgeTaskRunner::RunsTasksInCurrentSequence() const {
-  auto message_loop = base::MessageLoop::current();
+  auto* message_loop = base::MessageLoop::current();
   if (!message_loop)
     return true;
 
@@ -46,7 +46,7 @@ bool BridgeTaskRunner::PostNonNestableDelayedTask(
     const base::Location& from_here,
     base::OnceClosure task,
     base::TimeDelta delay) {
-  auto message_loop = base::MessageLoop::current();
+  auto* message_loop = base::MessageLoop::current();
   if (!message_loop) {
     non_nestable_tasks_.push_back(
         std::make_tuple(from_here, std::move(task), delay));

--- a/atom/browser/bridge_task_runner.h
+++ b/atom/browser/bridge_task_runner.h
@@ -19,7 +19,6 @@ namespace atom {
 class BridgeTaskRunner : public base::SingleThreadTaskRunner {
  public:
   BridgeTaskRunner() {}
-  ~BridgeTaskRunner() override {}
 
   // Called when message loop is ready.
   void MessageLoopIsReady();
@@ -36,6 +35,8 @@ class BridgeTaskRunner : public base::SingleThreadTaskRunner {
  private:
   using TaskPair =
       std::tuple<base::Location, base::OnceClosure, base::TimeDelta>;
+  ~BridgeTaskRunner() override {}
+
   std::vector<TaskPair> tasks_;
   std::vector<TaskPair> non_nestable_tasks_;
 

--- a/atom/browser/bridge_task_runner.h
+++ b/atom/browser/bridge_task_runner.h
@@ -18,7 +18,7 @@ namespace atom {
 // otherwise delay the work until message loop is ready.
 class BridgeTaskRunner : public base::SingleThreadTaskRunner {
  public:
-  BridgeTaskRunner() {}
+  BridgeTaskRunner();
 
   // Called when message loop is ready.
   void MessageLoopIsReady();
@@ -35,7 +35,7 @@ class BridgeTaskRunner : public base::SingleThreadTaskRunner {
  private:
   using TaskPair =
       std::tuple<base::Location, base::OnceClosure, base::TimeDelta>;
-  ~BridgeTaskRunner() override {}
+  ~BridgeTaskRunner() override;
 
   std::vector<TaskPair> tasks_;
   std::vector<TaskPair> non_nestable_tasks_;

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -21,6 +21,11 @@
 
 namespace atom {
 
+Browser::LoginItemSettings::LoginItemSettings() = default;
+Browser::LoginItemSettings::~LoginItemSettings() = default;
+Browser::LoginItemSettings::LoginItemSettings(
+    const LoginItemSettings& other) = default;
+
 Browser::Browser()
     : is_quiting_(false),
       is_exiting_(false),

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -38,7 +38,7 @@ class LoginHandler;
 class Browser : public WindowListObserver {
  public:
   Browser();
-  ~Browser();
+  ~Browser() override;
 
   static Browser* Get();
 

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -100,6 +100,10 @@ class Browser : public WindowListObserver {
     bool opened_as_hidden = false;
     base::string16 path;
     std::vector<base::string16> args;
+
+    LoginItemSettings();
+    ~LoginItemSettings();
+    LoginItemSettings(const LoginItemSettings&);
   };
   void SetLoginItemSettings(LoginItemSettings settings);
   LoginItemSettings GetLoginItemSettings(const LoginItemSettings& options);

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -145,9 +145,13 @@ void Browser::SetUserActivity(const std::string& type,
 }
 
 std::string Browser::GetCurrentActivityType() {
-  NSUserActivity* userActivity =
-      [[AtomApplication sharedApplication] getCurrentActivity];
-  return base::SysNSStringToUTF8(userActivity.activityType);
+  if (@available(macOS 10.10, *)) {
+    NSUserActivity* userActivity =
+        [[AtomApplication sharedApplication] getCurrentActivity];
+    return base::SysNSStringToUTF8(userActivity.activityType);
+  } else {
+    return std::string();
+  }
 }
 
 void Browser::InvalidateCurrentActivity() {

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -256,7 +256,7 @@ std::string Browser::DockGetBadgeText() {
 }
 
 void Browser::DockHide() {
-  for (const auto& window : WindowList::GetWindows())
+  for (auto* const& window : WindowList::GetWindows())
     [window->GetNativeWindow() setCanHide:NO];
 
   ProcessSerialNumber psn = { 0, kCurrentProcess };

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -57,7 +57,7 @@ struct FileSystem {
 
 std::string RegisterFileSystem(content::WebContents* web_contents,
                                const base::FilePath& path) {
-  auto isolated_context = storage::IsolatedContext::GetInstance();
+  auto* isolated_context = storage::IsolatedContext::GetInstance();
   std::string root_name(kRootName);
   std::string file_system_id = isolated_context->RegisterFileSystemForPath(
       storage::kFileSystemTypeNativeLocal, std::string(), path, &root_name);
@@ -113,13 +113,13 @@ void AppendToFile(const base::FilePath& path, const std::string& content) {
 }
 
 PrefService* GetPrefService(content::WebContents* web_contents) {
-  auto context = web_contents->GetBrowserContext();
+  auto* context = web_contents->GetBrowserContext();
   return static_cast<atom::AtomBrowserContext*>(context)->prefs();
 }
 
 std::set<std::string> GetAddedFileSystemPaths(
     content::WebContents* web_contents) {
-  auto pref_service = GetPrefService(web_contents);
+  auto* pref_service = GetPrefService(web_contents);
   const base::DictionaryValue* file_system_paths_value =
       pref_service->GetDictionary(prefs::kDevToolsFileSystemPaths);
   std::set<std::string> result;
@@ -176,7 +176,7 @@ void CommonWebContentsDelegate::SetOwnerWindow(
     NativeWindow* owner_window) {
   owner_window_ = owner_window ? owner_window->GetWeakPtr() : nullptr;
   auto relay = std::make_unique<NativeWindowRelay>(owner_window_);
-  auto relay_key = relay->key;
+  auto* relay_key = relay->key;
   if (owner_window) {
 #if defined(TOOLKIT_VIEWS)
     autofill_popup_.reset(new AutofillPopup());
@@ -383,7 +383,7 @@ void CommonWebContentsDelegate::DevToolsAddFileSystem(
   std::unique_ptr<base::DictionaryValue> file_system_value(
       CreateFileSystemValue(file_system));
 
-  auto pref_service = GetPrefService(GetDevToolsWebContents());
+  auto* pref_service = GetPrefService(GetDevToolsWebContents());
   DictionaryPrefUpdate update(pref_service, prefs::kDevToolsFileSystemPaths);
   update.Get()->SetWithoutPathExpansion(path.AsUTF8Unsafe(),
                                         std::make_unique<base::Value>());
@@ -401,7 +401,7 @@ void CommonWebContentsDelegate::DevToolsRemoveFileSystem(
   storage::IsolatedContext::GetInstance()->RevokeFileSystemByPath(
       file_system_path);
 
-  auto pref_service = GetPrefService(GetDevToolsWebContents());
+  auto* pref_service = GetPrefService(GetDevToolsWebContents());
   DictionaryPrefUpdate update(pref_service, prefs::kDevToolsFileSystemPaths);
   update.Get()->RemoveWithoutPathExpansion(path, nullptr);
 

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -33,7 +33,7 @@ class CommonWebContentsDelegate
       public brightray::InspectableWebContentsViewDelegate {
  public:
   CommonWebContentsDelegate();
-  virtual ~CommonWebContentsDelegate();
+  ~CommonWebContentsDelegate() override;
 
   // Creates a InspectableWebContents object and takes onwership of
   // |web_contents|.

--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -29,6 +29,8 @@ JavascriptEnvironment::JavascriptEnvironment()
       context_(isolate_, v8::Context::New(isolate_)),
       context_scope_(v8::Local<v8::Context>::New(isolate_, context_)) {}
 
+JavascriptEnvironment::~JavascriptEnvironment() = default;
+
 void JavascriptEnvironment::OnMessageLoopCreated() {
   isolate_holder_.AddRunMicrotasksObserver();
 }

--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -38,7 +38,7 @@ void JavascriptEnvironment::OnMessageLoopDestroying() {
 }
 
 bool JavascriptEnvironment::Initialize() {
-  auto cmd = base::CommandLine::ForCurrentProcess();
+  auto* cmd = base::CommandLine::ForCurrentProcess();
 
   // --js-flags.
   std::string js_flags = cmd->GetSwitchValueASCII(switches::kJavaScriptFlags);

--- a/atom/browser/javascript_environment.h
+++ b/atom/browser/javascript_environment.h
@@ -19,6 +19,7 @@ namespace atom {
 class JavascriptEnvironment {
  public:
   JavascriptEnvironment();
+  ~JavascriptEnvironment();
 
   void OnMessageLoopCreated();
   void OnMessageLoopDestroying();

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -11,7 +11,7 @@
                                             NSUserActivityDelegate> {
  @private
   BOOL handlingSendEvent_;
-  base::scoped_nsobject<NSUserActivity> currentActivity_;
+  base::scoped_nsobject<NSUserActivity> currentActivity_ API_AVAILABLE(macosx(10.10));
   NSCondition* handoffLock_;
   BOOL updateReceived_;
   base::Callback<bool()> shouldShutdown_;
@@ -27,7 +27,7 @@
 // CrAppControlProtocol:
 - (void)setHandlingSendEvent:(BOOL)handlingSendEvent;
 
-- (NSUserActivity*)getCurrentActivity;
+- (NSUserActivity*)getCurrentActivity API_AVAILABLE(macosx(10.10));
 - (void)setCurrentActivity:(NSString*)type
               withUserInfo:(NSDictionary*)userInfo
             withWebpageURL:(NSURL*)webpageURL;

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -165,7 +165,7 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 }
 
 - (void)updateAccessibilityEnabled:(BOOL)enabled {
-  auto ax_state = content::BrowserAccessibilityState::GetInstance();
+  auto* ax_state = content::BrowserAccessibilityState::GetInstance();
 
   if (enabled) {
     ax_state->OnScreenReaderDetected();

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -58,13 +58,15 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 - (void)setCurrentActivity:(NSString*)type
               withUserInfo:(NSDictionary*)userInfo
             withWebpageURL:(NSURL*)webpageURL {
-  currentActivity_ = base::scoped_nsobject<NSUserActivity>(
-      [[NSUserActivity alloc] initWithActivityType:type]);
-  [currentActivity_ setUserInfo:userInfo];
-  [currentActivity_ setWebpageURL:webpageURL];
-  [currentActivity_ setDelegate:self];
-  [currentActivity_ becomeCurrent];
-  [currentActivity_ setNeedsSave:YES];
+  if (@available(macOS 10.10, *)) {
+    currentActivity_ = base::scoped_nsobject<NSUserActivity>(
+        [[NSUserActivity alloc] initWithActivityType:type]);
+    [currentActivity_ setUserInfo:userInfo];
+    [currentActivity_ setWebpageURL:webpageURL];
+    [currentActivity_ setDelegate:self];
+    [currentActivity_ becomeCurrent];
+    [currentActivity_ setNeedsSave:YES];
+  }
 }
 
 - (NSUserActivity*)getCurrentActivity {
@@ -90,7 +92,7 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   [handoffLock_ unlock];
 }
 
-- (void)userActivityWillSave:(NSUserActivity *)userActivity {
+- (void)userActivityWillSave:(NSUserActivity *)userActivity API_AVAILABLE(macosx(10.10)) {
   __block BOOL shouldWait = NO;
   dispatch_sync_main(^{
     std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
@@ -114,7 +116,7 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   [userActivity setNeedsSave:YES];
 }
 
-- (void)userActivityWasContinued:(NSUserActivity *)userActivity {
+- (void)userActivityWasContinued:(NSUserActivity *)userActivity API_AVAILABLE(macosx(10.10)) {
   dispatch_async(dispatch_get_main_queue(), ^{
     std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
     std::unique_ptr<base::DictionaryValue> user_info =

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -96,7 +96,8 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 
 -  (BOOL)application:(NSApplication*)sender
 continueUserActivity:(NSUserActivity*)userActivity
-  restorationHandler:(void (^)(NSArray*restorableObjects))restorationHandler {
+  restorationHandler:(void (^)(NSArray*restorableObjects))restorationHandler
+  API_AVAILABLE(macosx(10.10)) {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
   std::unique_ptr<base::DictionaryValue> user_info =
     atom::NSDictionaryToDictionaryValue(userActivity.userInfo);

--- a/atom/browser/mac/in_app_purchase_observer.h
+++ b/atom/browser/mac/in_app_purchase_observer.h
@@ -34,6 +34,10 @@ struct Transaction {
   std::string errorMessage = "";
   std::string transactionState = "";
   Payment payment;
+
+  Transaction();
+  Transaction(const Transaction&);
+  ~Transaction();
 };
 
 // --------------------------- Classes ---------------------------

--- a/atom/browser/mac/in_app_purchase_observer.mm
+++ b/atom/browser/mac/in_app_purchase_observer.mm
@@ -174,6 +174,10 @@ using InAppTransactionCallback = base::RepeatingCallback<void(
 
 namespace in_app_purchase {
 
+Transaction::Transaction() = default;
+Transaction::Transaction(const Transaction&) = default;
+Transaction::~Transaction() = default;
+
 TransactionObserver::TransactionObserver() : weak_ptr_factory_(this) {
   obeserver_ = [[InAppTransactionObserver alloc]
       initWithCallback:base::Bind(&TransactionObserver::OnTransactionsUpdated,

--- a/atom/browser/mac/in_app_purchase_product.h
+++ b/atom/browser/mac/in_app_purchase_product.h
@@ -30,6 +30,10 @@ struct Product {
 
   // Downloadable Content Information
   bool downloadable = false;
+
+  Product(const Product&);
+  Product();
+  ~Product();
 };
 
 // --------------------------- Typedefs ---------------------------

--- a/atom/browser/mac/in_app_purchase_product.mm
+++ b/atom/browser/mac/in_app_purchase_product.mm
@@ -160,6 +160,10 @@
 
 namespace in_app_purchase {
 
+Product::Product() = default;
+Product::Product(const Product&) = default;
+Product::~Product() = default;
+
 void GetProducts(const std::vector<std::string>& productIDs,
                  const InAppPurchaseProductsCallback& callback) {
   auto* iapProduct = [[InAppPurchaseProduct alloc] initWithCallback:callback];

--- a/atom/browser/native_browser_view_mac.mm
+++ b/atom/browser/native_browser_view_mac.mm
@@ -50,7 +50,9 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
         postNotificationName:NSWindowWillMoveNotification
                       object:self];
 
-    [self.window performWindowDragWithEvent:event];
+    if (@available(macOS 10.11, *)) {
+      [self.window performWindowDragWithEvent:event];
+    }
     return;
   }
 

--- a/atom/browser/native_browser_view_mac.mm
+++ b/atom/browser/native_browser_view_mac.mm
@@ -25,6 +25,8 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
 
 @implementation DragRegionView
 
+@synthesize initialLocation;
+
 - (BOOL)mouseDownCanMoveWindow
 {
   return NO;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -155,6 +155,10 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
     Show();
 }
 
+bool NativeWindow::IsClosed() const {
+  return is_closed_;
+}
+
 void NativeWindow::SetSize(const gfx::Size& size, bool animate) {
   SetBounds(gfx::Rect(GetPosition(), size), animate);
 }

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -505,4 +505,9 @@ void NativeWindow::NotifyWindowMessage(UINT message,
 }
 #endif
 
+NativeWindowRelay::NativeWindowRelay(base::WeakPtr<NativeWindow> window)
+  : key(UserDataKey()), window(window) {}
+
+NativeWindowRelay::~NativeWindowRelay() = default;
+
 }  // namespace atom

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -323,8 +323,8 @@ class NativeWindow : public base::SupportsUserData {
 class NativeWindowRelay
     : public content::WebContentsUserData<NativeWindowRelay> {
  public:
-  explicit NativeWindowRelay(base::WeakPtr<NativeWindow> window)
-      : key(UserDataKey()), window(window) {}
+  explicit NativeWindowRelay(base::WeakPtr<NativeWindow> window);
+  ~NativeWindowRelay() override;
 
   static void* UserDataKey() {
     return content::WebContentsUserData<NativeWindowRelay>::UserDataKey();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -63,7 +63,7 @@ class NativeWindow : public base::SupportsUserData {
 
   virtual void Close() = 0;
   virtual void CloseImmediately() = 0;
-  virtual bool IsClosed() const { return is_closed_; }
+  virtual bool IsClosed() const;
   virtual void Focus(bool focus) = 0;
   virtual bool IsFocused() = 0;
   virtual void Show() = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -119,8 +119,8 @@ class NativeWindowMac : public NativeWindow {
   void RefreshTouchBarItem(const std::string& item_id) override;
   void SetEscapeTouchBarItem(const mate::PersistentDictionary& item) override;
 
-  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const;
-  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const;
+  gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
+  gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
 
   // Set the attribute of NSWindow while work around a bug of zoom button.
   void SetStyleMask(bool on, NSUInteger flag);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -314,59 +314,60 @@ bool ScopedDisableResize::disable_resize_ = false;
   shell_->SetResizable(true);
   // Hide the native toolbar before entering fullscreen, so there is no visual
   // artifacts.
-  if (base::mac::IsAtLeastOS10_10() &&
-      shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
-    NSWindow* window = shell_->GetNativeWindow();
-    [window setToolbar:nil];
+  if (@available(macOS 10.10, *)) {
+    if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+      NSWindow* window = shell_->GetNativeWindow();
+      [window setToolbar:nil];
+    }
   }
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
   shell_->NotifyWindowEnterFullScreen();
 
-  // For frameless window we don't show set title for normal mode since the
-  // titlebar is expected to be empty, but after entering fullscreen mode we
-  // have to set one, because title bar is visible here.
-  NSWindow* window = shell_->GetNativeWindow();
-  if ((shell_->transparent() || !shell_->has_frame()) &&
-      base::mac::IsAtLeastOS10_10() &&
-      // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
+  if (@available(macOS 10.10, *)) {
+    // For frameless window we don't show set title for normal mode since the
+    // titlebar is expected to be empty, but after entering fullscreen mode we
+    // have to set one, because title bar is visible here.
+    NSWindow* window = shell_->GetNativeWindow();
+    if ((shell_->transparent() || !shell_->has_frame()) &&
+        // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
+        // fullscreen mode.
+        // Show title if fullscreen_window_title flag is set
+        (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+         shell_->fullscreen_window_title())) {
+      [window setTitleVisibility:NSWindowTitleVisible];
+    }
+
+    // Restore the native toolbar immediately after entering fullscreen, if we do
+    // this before leaving fullscreen, traffic light buttons will be jumping.
+    if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+      base::scoped_nsobject<NSToolbar> toolbar(
+          [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
+      [toolbar setShowsBaselineSeparator:NO];
+      [window setToolbar:toolbar];
+
+      // Set window style to hide the toolbar, otherwise the toolbar will show in
       // fullscreen mode.
-      // Show title if fullscreen_window_title flag is set
-      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
-       shell_->fullscreen_window_title())) {
-    [window setTitleVisibility:NSWindowTitleVisible];
-  }
-
-  // Restore the native toolbar immediately after entering fullscreen, if we do
-  // this before leaving fullscreen, traffic light buttons will be jumping.
-  if (base::mac::IsAtLeastOS10_10() &&
-      shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
-    base::scoped_nsobject<NSToolbar> toolbar(
-        [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
-    [toolbar setShowsBaselineSeparator:NO];
-    [window setToolbar:toolbar];
-
-    // Set window style to hide the toolbar, otherwise the toolbar will show in
-    // fullscreen mode.
-    shell_->SetStyleMask(true, NSFullSizeContentViewWindowMask);
+      shell_->SetStyleMask(true, NSFullSizeContentViewWindowMask);
+    }
   }
 }
 
 - (void)windowWillExitFullScreen:(NSNotification*)notification {
-  // Restore the titlebar visibility.
-  NSWindow* window = shell_->GetNativeWindow();
-  if ((shell_->transparent() || !shell_->has_frame()) &&
-      base::mac::IsAtLeastOS10_10() &&
-      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
-       shell_->fullscreen_window_title())) {
-    [window setTitleVisibility:NSWindowTitleHidden];
-  }
+  if (@available(macOS 10.10, *)) {
+    // Restore the titlebar visibility.
+    NSWindow* window = shell_->GetNativeWindow();
+    if ((shell_->transparent() || !shell_->has_frame()) &&
+        (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+         shell_->fullscreen_window_title())) {
+      [window setTitleVisibility:NSWindowTitleHidden];
+    }
 
-  // Turn off the style for toolbar.
-  if (base::mac::IsAtLeastOS10_10() &&
-      shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
-    shell_->SetStyleMask(false, NSFullSizeContentViewWindowMask);
+    // Turn off the style for toolbar.
+    if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+      shell_->SetStyleMask(false, NSFullSizeContentViewWindowMask);
+    }
   }
 }
 
@@ -487,7 +488,8 @@ enum {
   enable_larger_than_screen_ = enable;
 }
 
-- (void)resetTouchBar:(const std::vector<mate::PersistentDictionary>&)settings {
+- (void)resetTouchBar:(const std::vector<mate::PersistentDictionary>&)settings
+  API_AVAILABLE(macosx(10.12.2)) {
   if (![self respondsToSelector:@selector(touchBar)]) return;
 
   atom_touch_bar_.reset([[AtomTouchBar alloc] initWithDelegate:self
@@ -496,12 +498,13 @@ enum {
   self.touchBar = nil;
 }
 
-- (void)refreshTouchBarItem:(const std::string&)item_id {
+- (void)refreshTouchBarItem:(const std::string&)item_id
+  API_AVAILABLE(macosx(10.12.2)) {
   if (atom_touch_bar_ && self.touchBar)
     [atom_touch_bar_ refreshTouchBarItem:self.touchBar id:item_id];
 }
 
-- (NSTouchBar*)makeTouchBar {
+- (NSTouchBar*)makeTouchBar API_AVAILABLE(macosx(10.12.2)) {
   if (atom_touch_bar_)
     return [atom_touch_bar_ makeTouchBar];
   else
@@ -509,14 +512,15 @@ enum {
 }
 
 - (NSTouchBarItem*)touchBar:(NSTouchBar*)touchBar
-      makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier {
+      makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier API_AVAILABLE(macosx(10.12.2)) {
   if (touchBar && atom_touch_bar_)
     return [atom_touch_bar_ makeItemForIdentifier:identifier];
   else
     return nil;
 }
 
-- (void)setEscapeTouchBarItem:(const mate::PersistentDictionary&)item {
+- (void)setEscapeTouchBarItem:(const mate::PersistentDictionary&)item
+  API_AVAILABLE(macosx(10.12.2)) {
   if (atom_touch_bar_ && self.touchBar)
     [atom_touch_bar_ setEscapeTouchBarItem:item forTouchBar:self.touchBar];
 }
@@ -828,10 +832,11 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   }
 
   NSUInteger styleMask = NSTitledWindowMask;
-  if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER &&
-      base::mac::IsAtLeastOS10_10() &&
-      (!useStandardWindow || transparent() || !has_frame())) {
-    styleMask = NSFullSizeContentViewWindowMask;
+  if (@available(macOS 10.10, *)) {
+    if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER &&
+        (!useStandardWindow || transparent() || !has_frame())) {
+      styleMask = NSFullSizeContentViewWindowMask;
+    }
   }
   if (minimizable) {
     styleMask |= NSMiniaturizableWindowMask;
@@ -885,7 +890,7 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
     [window_ setDisableKeyOrMainWindow:YES];
 
   if (transparent() || !has_frame()) {
-    if (base::mac::IsAtLeastOS10_10()) {
+    if (@available(macOS 10.10, *)) {
       // Don't show title bar.
       [window_ setTitlebarAppearsTransparent:YES];
       [window_ setTitleVisibility:NSWindowTitleHidden];
@@ -897,11 +902,11 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   // Create a tab only if tabbing identifier is specified and window has
   // a native title bar.
   if (tabbingIdentifier.empty() || transparent() || !has_frame()) {
-    if ([window_ respondsToSelector:@selector(tabbingMode)]) {
+    if (@available(macOS 10.12, *)) {
       [window_ setTabbingMode:NSWindowTabbingModeDisallowed];
     }
   } else {
-    if ([window_ respondsToSelector:@selector(tabbingIdentifier)]) {
+    if (@available(macOS 10.12, *)) {
       [window_ setTabbingIdentifier:base::SysUTF8ToNSString(tabbingIdentifier)];
     }
   }
@@ -911,14 +916,14 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
 
   // Hide the title bar background
   if (title_bar_style_ != NORMAL) {
-    if (base::mac::IsAtLeastOS10_10()) {
+    if (@available(macOS 10.10, *)) {
       [window_ setTitlebarAppearsTransparent:YES];
     }
   }
 
   // Hide the title bar.
   if (title_bar_style_ == HIDDEN_INSET) {
-    if (base::mac::IsAtLeastOS10_10()) {
+    if (@available(macOS 10.10, *)) {
       base::scoped_nsobject<NSToolbar> toolbar(
           [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
       [toolbar setShowsBaselineSeparator:NO];
@@ -1650,31 +1655,31 @@ void NativeWindowMac::SetAutoHideCursor(bool auto_hide) {
 }
 
 void NativeWindowMac::SelectPreviousTab() {
-  if ([window_ respondsToSelector:@selector(selectPreviousTab:)]) {
+  if (@available(macOS 10.12, *)) {
     [window_ selectPreviousTab:nil];
   }
 }
 
 void NativeWindowMac::SelectNextTab() {
-  if ([window_ respondsToSelector:@selector(selectNextTab:)]) {
+  if (@available(macOS 10.12, *)) {
     [window_ selectNextTab:nil];
   }
 }
 
 void NativeWindowMac::MergeAllWindows() {
-  if ([window_ respondsToSelector:@selector(mergeAllWindows:)]) {
+  if (@available(macOS 10.12, *)) {
     [window_ mergeAllWindows:nil];
   }
 }
 
 void NativeWindowMac::MoveTabToNewWindow() {
-  if ([window_ respondsToSelector:@selector(moveTabToNewWindow:)]) {
+  if (@available(macOS 10.12, *)) {
     [window_ moveTabToNewWindow:nil];
   }
 }
 
 void NativeWindowMac::ToggleTabBar() {
-  if ([window_ respondsToSelector:@selector(toggleTabBar:)]) {
+  if (@available(macOS 10.12, *)) {
     [window_ toggleTabBar:nil];
   }
 }
@@ -1683,91 +1688,91 @@ bool NativeWindowMac::AddTabbedWindow(NativeWindow* window) {
   if (window_.get() == window->GetNativeWindow()) {
     return false;
   } else {
-    if ([window_ respondsToSelector:@selector(addTabbedWindow:ordered:)])
+    if (@available(macOS 10.12, *))
       [window_ addTabbedWindow:window->GetNativeWindow() ordered:NSWindowAbove];
   }
   return true;
 }
 
 void NativeWindowMac::SetVibrancy(const std::string& type) {
-  if (!base::mac::IsAtLeastOS10_10()) return;
+  if (@available(macOS 10.10, *)) {
+    NSView* vibrant_view = [window_ vibrantView];
 
-  NSView* vibrant_view = [window_ vibrantView];
+    if (type.empty()) {
+      if (background_color_before_vibrancy_) {
+        [window_ setBackgroundColor:background_color_before_vibrancy_];
+        [window_ setTitlebarAppearsTransparent:transparency_before_vibrancy_];
+      }
+      if (vibrant_view == nil) return;
 
-  if (type.empty()) {
-    if (background_color_before_vibrancy_) {
-      [window_ setBackgroundColor:background_color_before_vibrancy_];
-      [window_ setTitlebarAppearsTransparent:transparency_before_vibrancy_];
+      [vibrant_view removeFromSuperview];
+      [window_ setVibrantView:nil];
+      ui::GpuSwitchingManager::SetTransparent(transparent());
+
+      return;
     }
-    if (vibrant_view == nil) return;
 
-    [vibrant_view removeFromSuperview];
-    [window_ setVibrantView:nil];
-    ui::GpuSwitchingManager::SetTransparent(transparent());
+    background_color_before_vibrancy_.reset([[window_ backgroundColor] retain]);
+    transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
+    ui::GpuSwitchingManager::SetTransparent(true);
 
-    return;
-  }
-
-  background_color_before_vibrancy_.reset([[window_ backgroundColor] retain]);
-  transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
-  ui::GpuSwitchingManager::SetTransparent(true);
-
-  if (title_bar_style_ != NORMAL) {
-    [window_ setTitlebarAppearsTransparent:YES];
-    [window_ setBackgroundColor:[NSColor clearColor]];
-  }
-
-  NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
-  if (effect_view == nil) {
-    effect_view = [[[NSVisualEffectView alloc]
-        initWithFrame: [[window_ contentView] bounds]] autorelease];
-    [window_ setVibrantView:(NSView*)effect_view];
-
-    [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-    [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
-    [effect_view setState:NSVisualEffectStateActive];
-    [[window_ contentView] addSubview:effect_view
-                           positioned:NSWindowBelow
-                           relativeTo:nil];
-  }
-
-  NSVisualEffectMaterial vibrancyType = NSVisualEffectMaterialLight;
-
-  if (type == "appearance-based") {
-    vibrancyType = NSVisualEffectMaterialAppearanceBased;
-  } else if (type == "light") {
-    vibrancyType = NSVisualEffectMaterialLight;
-  } else if (type == "dark") {
-    vibrancyType = NSVisualEffectMaterialDark;
-  } else if (type == "titlebar") {
-    vibrancyType = NSVisualEffectMaterialTitlebar;
-  }
-
-  if (base::mac::IsAtLeastOS10_11()) {
-    // TODO(kevinsawicki): Use NSVisualEffectMaterial* constants directly once
-    // they are available in the minimum SDK version
-    if (type == "selection") {
-      // NSVisualEffectMaterialSelection
-      vibrancyType = static_cast<NSVisualEffectMaterial>(4);
-    } else if (type == "menu") {
-      // NSVisualEffectMaterialMenu
-      vibrancyType = static_cast<NSVisualEffectMaterial>(5);
-    } else if (type == "popover") {
-      // NSVisualEffectMaterialPopover
-      vibrancyType = static_cast<NSVisualEffectMaterial>(6);
-    } else if (type == "sidebar") {
-      // NSVisualEffectMaterialSidebar
-      vibrancyType = static_cast<NSVisualEffectMaterial>(7);
-    } else if (type == "medium-light") {
-      // NSVisualEffectMaterialMediumLight
-      vibrancyType = static_cast<NSVisualEffectMaterial>(8);
-    } else if (type == "ultra-dark") {
-      // NSVisualEffectMaterialUltraDark
-      vibrancyType = static_cast<NSVisualEffectMaterial>(9);
+    if (title_bar_style_ != NORMAL) {
+      [window_ setTitlebarAppearsTransparent:YES];
+      [window_ setBackgroundColor:[NSColor clearColor]];
     }
-  }
 
-  [effect_view setMaterial:vibrancyType];
+    NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
+    if (effect_view == nil) {
+      effect_view = [[[NSVisualEffectView alloc]
+          initWithFrame: [[window_ contentView] bounds]] autorelease];
+      [window_ setVibrantView:(NSView*)effect_view];
+
+      [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+      [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
+      [effect_view setState:NSVisualEffectStateActive];
+      [[window_ contentView] addSubview:effect_view
+                             positioned:NSWindowBelow
+                             relativeTo:nil];
+    }
+
+    NSVisualEffectMaterial vibrancyType = NSVisualEffectMaterialLight;
+
+    if (type == "appearance-based") {
+      vibrancyType = NSVisualEffectMaterialAppearanceBased;
+    } else if (type == "light") {
+      vibrancyType = NSVisualEffectMaterialLight;
+    } else if (type == "dark") {
+      vibrancyType = NSVisualEffectMaterialDark;
+    } else if (type == "titlebar") {
+      vibrancyType = NSVisualEffectMaterialTitlebar;
+    }
+
+    if (@available(macOS 10.11, *)) {
+      // TODO(kevinsawicki): Use NSVisualEffectMaterial* constants directly once
+      // they are available in the minimum SDK version
+      if (type == "selection") {
+        // NSVisualEffectMaterialSelection
+        vibrancyType = static_cast<NSVisualEffectMaterial>(4);
+      } else if (type == "menu") {
+        // NSVisualEffectMaterialMenu
+        vibrancyType = static_cast<NSVisualEffectMaterial>(5);
+      } else if (type == "popover") {
+        // NSVisualEffectMaterialPopover
+        vibrancyType = static_cast<NSVisualEffectMaterial>(6);
+      } else if (type == "sidebar") {
+        // NSVisualEffectMaterialSidebar
+        vibrancyType = static_cast<NSVisualEffectMaterial>(7);
+      } else if (type == "medium-light") {
+        // NSVisualEffectMaterialMediumLight
+        vibrancyType = static_cast<NSVisualEffectMaterial>(8);
+      } else if (type == "ultra-dark") {
+        // NSVisualEffectMaterialUltraDark
+        vibrancyType = static_cast<NSVisualEffectMaterial>(9);
+      }
+    }
+
+    [effect_view setMaterial:vibrancyType];
+  }
 }
 
 void NativeWindowMac::SetTouchBar(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -425,6 +425,9 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 @implementation AtomPreviewItem
 
+@synthesize previewItemURL;
+@synthesize previewItemTitle;
+
 - (id)initWithURL:(NSURL*)url title:(NSString*)title {
   self = [super init];
   if (self) {
@@ -479,6 +482,13 @@ enum {
 @end
 
 @implementation AtomNSWindow
+
+@synthesize acceptsFirstMouse;
+@synthesize disableAutoHideCursor;
+@synthesize disableKeyOrMainWindow;
+@synthesize windowButtonsOffset;
+@synthesize quickLookItem;
+@synthesize vibrantView;
 
 - (void)setShell:(atom::NativeWindowMac*)shell {
   shell_ = shell;

--- a/atom/browser/net/asar/asar_protocol_handler.h
+++ b/atom/browser/net/asar/asar_protocol_handler.h
@@ -18,7 +18,7 @@ class AsarProtocolHandler : public net::URLRequestJobFactory::ProtocolHandler {
  public:
   explicit AsarProtocolHandler(
       const scoped_refptr<base::TaskRunner>& file_task_runner);
-  virtual ~AsarProtocolHandler();
+  ~AsarProtocolHandler() override;
 
   // net::URLRequestJobFactory::ProtocolHandler:
   net::URLRequestJob* MaybeCreateJob(

--- a/atom/browser/net/asar/url_request_asar_job.h
+++ b/atom/browser/net/asar/url_request_asar_job.h
@@ -42,7 +42,7 @@ class URLRequestAsarJob : public net::URLRequestJob {
                   const base::FilePath& file_path);
 
  protected:
-  virtual ~URLRequestAsarJob();
+  ~URLRequestAsarJob() override;
 
   void InitializeAsarJob(const scoped_refptr<base::TaskRunner> file_task_runner,
                          std::shared_ptr<Archive> archive,

--- a/atom/browser/net/atom_cert_verifier.cc
+++ b/atom/browser/net/atom_cert_verifier.cc
@@ -19,6 +19,10 @@ using content::BrowserThread;
 
 namespace atom {
 
+VerifyRequestParams::VerifyRequestParams() = default;
+VerifyRequestParams::~VerifyRequestParams() = default;
+VerifyRequestParams::VerifyRequestParams(const VerifyRequestParams&) = default;
+
 namespace {
 
 class Response : public base::LinkNode<Response> {

--- a/atom/browser/net/atom_cert_verifier.h
+++ b/atom/browser/net/atom_cert_verifier.h
@@ -31,7 +31,7 @@ struct VerifyRequestParams {
 class AtomCertVerifier : public net::CertVerifier {
  public:
   explicit AtomCertVerifier(brightray::RequireCTDelegate* ct_delegate);
-  virtual ~AtomCertVerifier();
+  ~AtomCertVerifier() override;
 
   using VerifyProc = base::Callback<void(const VerifyRequestParams& request,
                                          const net::CompletionCallback&)>;

--- a/atom/browser/net/atom_cert_verifier.h
+++ b/atom/browser/net/atom_cert_verifier.h
@@ -26,6 +26,10 @@ struct VerifyRequestParams {
   std::string default_result;
   int error_code;
   scoped_refptr<net::X509Certificate> certificate;
+
+  VerifyRequestParams();
+  VerifyRequestParams(const VerifyRequestParams&);
+  ~VerifyRequestParams();
 };
 
 class AtomCertVerifier : public net::CertVerifier {

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -197,7 +197,7 @@ void ReadFromResponseObject(const base::DictionaryValue& response,
   if (!response.GetString("statusLine", &status_line))
     status_line = container.second;
   if (response.GetDictionary("responseHeaders", &dict)) {
-    auto headers = container.first;
+    auto* headers = container.first;
     *headers = new net::HttpResponseHeaders("");
     (*headers)->ReplaceStatusLine(status_line);
     for (base::DictionaryValue::Iterator it(*dict); !it.IsAtEnd();

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -217,6 +217,18 @@ void ReadFromResponseObject(const base::DictionaryValue& response,
 
 }  // namespace
 
+AtomNetworkDelegate::SimpleListenerInfo::SimpleListenerInfo(
+    URLPatterns patterns_,
+    SimpleListener listener_): url_patterns(patterns_), listener(listener_) {}
+AtomNetworkDelegate::SimpleListenerInfo::SimpleListenerInfo() = default;
+AtomNetworkDelegate::SimpleListenerInfo::~SimpleListenerInfo() = default;
+
+AtomNetworkDelegate::ResponseListenerInfo::ResponseListenerInfo(
+    URLPatterns patterns_,
+    ResponseListener listener_): url_patterns(patterns_), listener(listener_) {}
+AtomNetworkDelegate::ResponseListenerInfo::ResponseListenerInfo() = default;
+AtomNetworkDelegate::ResponseListenerInfo::~ResponseListenerInfo() = default;
+
 AtomNetworkDelegate::AtomNetworkDelegate() {}
 
 AtomNetworkDelegate::~AtomNetworkDelegate() {}

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -219,13 +219,15 @@ void ReadFromResponseObject(const base::DictionaryValue& response,
 
 AtomNetworkDelegate::SimpleListenerInfo::SimpleListenerInfo(
     URLPatterns patterns_,
-    SimpleListener listener_): url_patterns(patterns_), listener(listener_) {}
+    SimpleListener listener_)
+    : url_patterns(patterns_), listener(listener_) {}
 AtomNetworkDelegate::SimpleListenerInfo::SimpleListenerInfo() = default;
 AtomNetworkDelegate::SimpleListenerInfo::~SimpleListenerInfo() = default;
 
 AtomNetworkDelegate::ResponseListenerInfo::ResponseListenerInfo(
     URLPatterns patterns_,
-    ResponseListener listener_): url_patterns(patterns_), listener(listener_) {}
+    ResponseListener listener_)
+    : url_patterns(patterns_), listener(listener_) {}
 AtomNetworkDelegate::ResponseListenerInfo::ResponseListenerInfo() = default;
 AtomNetworkDelegate::ResponseListenerInfo::~ResponseListenerInfo() = default;
 

--- a/atom/browser/net/atom_network_delegate.h
+++ b/atom/browser/net/atom_network_delegate.h
@@ -51,11 +51,19 @@ class AtomNetworkDelegate : public brightray::NetworkDelegate {
   struct SimpleListenerInfo {
     URLPatterns url_patterns;
     SimpleListener listener;
+
+    SimpleListenerInfo(URLPatterns, SimpleListener);
+    SimpleListenerInfo();
+    ~SimpleListenerInfo();
   };
 
   struct ResponseListenerInfo {
     URLPatterns url_patterns;
     ResponseListener listener;
+
+    ResponseListenerInfo(URLPatterns, ResponseListener);
+    ResponseListenerInfo();
+    ~ResponseListenerInfo();
   };
 
   AtomNetworkDelegate();

--- a/atom/browser/net/atom_url_request.cc
+++ b/atom/browser/net/atom_url_request.cc
@@ -105,7 +105,7 @@ void AtomURLRequest::DoInitialize(
   redirect_policy_ = redirect_policy;
   request_context_getter_ = request_context_getter;
   request_context_getter_->AddObserver(this);
-  auto context = request_context_getter_->GetURLRequestContext();
+  auto* context = request_context_getter_->GetURLRequestContext();
   if (!context) {
     // Called after shutdown.
     DoCancelWithError("Cannot start a request after shutdown.", true);
@@ -238,14 +238,14 @@ void AtomURLRequest::DoWriteBuffer(
     if (buffer) {
       // Handling potential empty buffers.
       using internal::UploadOwnedIOBufferElementReader;
-      auto element_reader =
+      auto* element_reader =
           UploadOwnedIOBufferElementReader::CreateWithBuffer(std::move(buffer));
       upload_element_readers_.push_back(
           std::unique_ptr<net::UploadElementReader>(element_reader));
     }
 
     if (is_last) {
-      auto elements_upload_data_stream = new net::ElementsUploadDataStream(
+      auto* elements_upload_data_stream = new net::ElementsUploadDataStream(
           std::move(upload_element_readers_), 0);
       request_->set_upload(
           std::unique_ptr<net::UploadDataStream>(elements_upload_data_stream));

--- a/atom/browser/net/atom_url_request_job_factory.h
+++ b/atom/browser/net/atom_url_request_job_factory.h
@@ -21,7 +21,7 @@ const void* DisableProtocolInterceptFlagKey();
 class AtomURLRequestJobFactory : public net::URLRequestJobFactory {
  public:
   AtomURLRequestJobFactory();
-  virtual ~AtomURLRequestJobFactory();
+  ~AtomURLRequestJobFactory() override;
 
   // Sets the ProtocolHandler for a scheme. Returns true on success, false on
   // failure (a ProtocolHandler already exists for |scheme|). On success,

--- a/atom/browser/net/http_protocol_handler.h
+++ b/atom/browser/net/http_protocol_handler.h
@@ -14,7 +14,7 @@ namespace atom {
 class HttpProtocolHandler : public net::URLRequestJobFactory::ProtocolHandler {
  public:
   explicit HttpProtocolHandler(const std::string&);
-  virtual ~HttpProtocolHandler();
+  ~HttpProtocolHandler() override;
 
   // net::URLRequestJobFactory::ProtocolHandler:
   net::URLRequestJob* MaybeCreateJob(

--- a/atom/browser/net/url_request_buffer_job.cc
+++ b/atom/browser/net/url_request_buffer_job.cc
@@ -31,6 +31,8 @@ URLRequestBufferJob::URLRequestBufferJob(net::URLRequest* request,
     : JsAsker<net::URLRequestSimpleJob>(request, network_delegate),
       status_code_(net::HTTP_NOT_IMPLEMENTED) {}
 
+URLRequestBufferJob::~URLRequestBufferJob() = default;
+
 void URLRequestBufferJob::StartAsync(std::unique_ptr<base::Value> options) {
   const base::Value* binary = nullptr;
   if (options->IsType(base::Value::Type::DICTIONARY)) {

--- a/atom/browser/net/url_request_buffer_job.h
+++ b/atom/browser/net/url_request_buffer_job.h
@@ -17,6 +17,7 @@ namespace atom {
 class URLRequestBufferJob : public JsAsker<net::URLRequestSimpleJob> {
  public:
   URLRequestBufferJob(net::URLRequest*, net::NetworkDelegate*);
+  ~URLRequestBufferJob() override;
 
   // JsAsker:
   void StartAsync(std::unique_ptr<base::Value> options) override;

--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -83,6 +83,8 @@ URLRequestFetchJob::URLRequestFetchJob(net::URLRequest* request,
       pending_buffer_size_(0),
       write_num_bytes_(0) {}
 
+URLRequestFetchJob::~URLRequestFetchJob() = default;
+
 void URLRequestFetchJob::BeforeStartInUI(v8::Isolate* isolate,
                                          v8::Local<v8::Value> value) {
   mate::Dictionary options;

--- a/atom/browser/net/url_request_fetch_job.h
+++ b/atom/browser/net/url_request_fetch_job.h
@@ -20,6 +20,7 @@ class URLRequestFetchJob : public JsAsker<net::URLRequestJob>,
                            public brightray::URLRequestContextGetter::Delegate {
  public:
   URLRequestFetchJob(net::URLRequest*, net::NetworkDelegate*);
+  ~URLRequestFetchJob() override;
 
   // Called by response writer.
   void HeadersCompleted();

--- a/atom/browser/net/url_request_stream_job.cc
+++ b/atom/browser/net/url_request_stream_job.cc
@@ -28,6 +28,8 @@ URLRequestStreamJob::URLRequestStreamJob(net::URLRequest* request,
       response_headers_(nullptr),
       weak_factory_(this) {}
 
+URLRequestStreamJob::~URLRequestStreamJob() = default;
+
 void URLRequestStreamJob::BeforeStartInUI(v8::Isolate* isolate,
                                           v8::Local<v8::Value> value) {
   if (value->IsNull() || value->IsUndefined() || !value->IsObject()) {

--- a/atom/browser/net/url_request_stream_job.h
+++ b/atom/browser/net/url_request_stream_job.h
@@ -23,6 +23,7 @@ class URLRequestStreamJob : public JsAsker<net::URLRequestJob> {
  public:
   URLRequestStreamJob(net::URLRequest* request,
                       net::NetworkDelegate* network_delegate);
+  ~URLRequestStreamJob() override;
 
   void OnData(mate::Arguments* args);
   void OnEnd(mate::Arguments* args);

--- a/atom/browser/net/url_request_string_job.cc
+++ b/atom/browser/net/url_request_string_job.cc
@@ -15,6 +15,8 @@ URLRequestStringJob::URLRequestStringJob(net::URLRequest* request,
                                          net::NetworkDelegate* network_delegate)
     : JsAsker<net::URLRequestSimpleJob>(request, network_delegate) {}
 
+URLRequestStringJob::~URLRequestStringJob() = default;
+
 void URLRequestStringJob::StartAsync(std::unique_ptr<base::Value> options) {
   if (options->IsType(base::Value::Type::DICTIONARY)) {
     base::DictionaryValue* dict =

--- a/atom/browser/net/url_request_string_job.h
+++ b/atom/browser/net/url_request_string_job.h
@@ -15,6 +15,7 @@ namespace atom {
 class URLRequestStringJob : public JsAsker<net::URLRequestSimpleJob> {
  public:
   URLRequestStringJob(net::URLRequest*, net::NetworkDelegate*);
+  ~URLRequestStringJob() override;
 
   // JsAsker:
   void StartAsync(std::unique_ptr<base::Value> options) override;

--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -18,7 +18,7 @@ NodeDebugger::NodeDebugger(node::Environment* env) : env_(env) {}
 NodeDebugger::~NodeDebugger() {}
 
 void NodeDebugger::Start(node::MultiIsolatePlatform* platform) {
-  auto inspector = env_->inspector_agent();
+  auto* inspector = env_->inspector_agent();
   if (inspector == nullptr)
     return;
 

--- a/atom/browser/render_process_preferences.h
+++ b/atom/browser/render_process_preferences.h
@@ -27,7 +27,7 @@ class RenderProcessPreferences : public content::NotificationObserver {
   // The |predicate| is used to determine whether to set preferences for a
   // render process.
   explicit RenderProcessPreferences(const Predicate& predicate);
-  virtual ~RenderProcessPreferences();
+  ~RenderProcessPreferences() override;
 
   int AddEntry(const base::DictionaryValue& entry);
   void RemoveEntry(int id);

--- a/atom/browser/ui/accelerator_util.cc
+++ b/atom/browser/ui/accelerator_util.cc
@@ -74,7 +74,7 @@ void GenerateAcceleratorTable(AcceleratorTable* table,
   for (int i = 0; i < count; ++i) {
     atom::AtomMenuModel::ItemType type = model->GetTypeAt(i);
     if (type == atom::AtomMenuModel::TYPE_SUBMENU) {
-      auto submodel = model->GetSubmenuModelAt(i);
+      auto* submodel = model->GetSubmenuModelAt(i);
       GenerateAcceleratorTable(table, submodel);
     } else {
       ui::Accelerator accelerator;

--- a/atom/browser/ui/atom_menu_model.cc
+++ b/atom/browser/ui/atom_menu_model.cc
@@ -8,6 +8,12 @@
 
 namespace atom {
 
+bool AtomMenuModel::Delegate::GetAcceleratorForCommandId(int command_id,
+    ui::Accelerator* accelerator) const {
+  return GetAcceleratorForCommandIdWithParams(
+      command_id, false, accelerator);
+}
+
 AtomMenuModel::AtomMenuModel(Delegate* delegate)
     : ui::SimpleMenuModel(delegate), delegate_(delegate) {}
 

--- a/atom/browser/ui/atom_menu_model.h
+++ b/atom/browser/ui/atom_menu_model.h
@@ -16,7 +16,7 @@ class AtomMenuModel : public ui::SimpleMenuModel {
  public:
   class Delegate : public ui::SimpleMenuModel::Delegate {
    public:
-    virtual ~Delegate() {}
+    ~Delegate() override {}
 
     virtual bool GetAcceleratorForCommandIdWithParams(
         int command_id,
@@ -44,7 +44,7 @@ class AtomMenuModel : public ui::SimpleMenuModel {
   };
 
   explicit AtomMenuModel(Delegate* delegate);
-  virtual ~AtomMenuModel();
+  ~AtomMenuModel() override;
 
   void AddObserver(Observer* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(Observer* obs) { observers_.RemoveObserver(obs); }

--- a/atom/browser/ui/atom_menu_model.h
+++ b/atom/browser/ui/atom_menu_model.h
@@ -26,10 +26,7 @@ class AtomMenuModel : public ui::SimpleMenuModel {
    private:
     // ui::SimpleMenuModel::Delegate:
     bool GetAcceleratorForCommandId(int command_id,
-                                    ui::Accelerator* accelerator) const {
-      return GetAcceleratorForCommandIdWithParams(command_id, false,
-                                                  accelerator);
-    }
+                                    ui::Accelerator* accelerator) const override;
   };
 
   class Observer {

--- a/atom/browser/ui/atom_menu_model.h
+++ b/atom/browser/ui/atom_menu_model.h
@@ -25,8 +25,9 @@ class AtomMenuModel : public ui::SimpleMenuModel {
 
    private:
     // ui::SimpleMenuModel::Delegate:
-    bool GetAcceleratorForCommandId(int command_id,
-                                    ui::Accelerator* accelerator) const override;
+    bool GetAcceleratorForCommandId(
+        int command_id,
+        ui::Accelerator* accelerator) const override;
   };
 
   class Observer {

--- a/atom/browser/ui/autofill_popup.h
+++ b/atom/browser/ui/autofill_popup.h
@@ -21,7 +21,7 @@ class AutofillPopupView;
 class AutofillPopup : public views::ViewObserver {
  public:
   AutofillPopup();
-  ~AutofillPopup();
+  ~AutofillPopup() override;
 
   void CreateView(content::RenderFrameHost* render_frame,
                   bool offscreen,

--- a/atom/browser/ui/certificate_trust_mac.mm
+++ b/atom/browser/ui/certificate_trust_mac.mm
@@ -68,7 +68,7 @@
 - (void)panelDidEnd:(NSWindow*)sheet
         returnCode:(int)returnCode
         contextInfo:(void*)contextInfo {
-  auto cert_db = net::CertDatabase::GetInstance();
+  auto* cert_db = net::CertDatabase::GetInstance();
   // This forces Chromium to reload the certificate since it might be trusted
   // now.
   cert_db->NotifyObserversCertDBChanged();
@@ -86,7 +86,7 @@ void ShowCertificateTrust(atom::NativeWindow* parent_window,
                           const scoped_refptr<net::X509Certificate>& cert,
                           const std::string& message,
                           const ShowTrustCallback& callback) {
-  auto sec_policy = SecPolicyCreateBasicX509();
+  auto* sec_policy = SecPolicyCreateBasicX509();
   auto cert_chain =
       net::x509_util::CreateSecCertificateArrayForX509Certificate(cert.get());
   SecTrustRef trust = nullptr;

--- a/atom/browser/ui/cocoa/atom_touch_bar.h
+++ b/atom/browser/ui/cocoa/atom_touch_bar.h
@@ -31,16 +31,16 @@
                 window:(atom::NativeWindow*)window
               settings:(const std::vector<mate::PersistentDictionary>&)settings;
 
-- (NSTouchBar*)makeTouchBar;
-- (NSTouchBar*)touchBarFromItemIdentifiers:(NSMutableArray*)items;
+- (NSTouchBar*)makeTouchBar API_AVAILABLE(macosx(10.12.2));
+- (NSTouchBar*)touchBarFromItemIdentifiers:(NSMutableArray*)items API_AVAILABLE(macosx(10.12.2));
 - (NSMutableArray*)identifiersFromSettings:
     (const std::vector<mate::PersistentDictionary>&)settings;
 - (void)refreshTouchBarItem:(NSTouchBar*)touchBar
-                         id:(const std::string&)item_id;
+                         id:(const std::string&)item_id API_AVAILABLE(macosx(10.12.2));
 - (void)addNonDefaultTouchBarItems:
     (const std::vector<mate::PersistentDictionary>&)items;
 - (void)setEscapeTouchBarItem:(const mate::PersistentDictionary&)item
-                  forTouchBar:(NSTouchBar*)touchBar;
+                  forTouchBar:(NSTouchBar*)touchBar API_AVAILABLE(macosx(10.12.2));
 
 - (NSString*)idFromIdentifier:(NSString*)identifier
                    withPrefix:(NSString*)prefix;
@@ -51,35 +51,36 @@
 
 // Selector actions
 - (void)buttonAction:(id)sender;
-- (void)colorPickerAction:(id)sender;
-- (void)sliderAction:(id)sender;
+- (void)colorPickerAction:(id)sender API_AVAILABLE(macosx(10.12.2));
+- (void)sliderAction:(id)sender API_AVAILABLE(macosx(10.12.2));
 
 // Helpers to create touch bar items
-- (NSTouchBarItem*)makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier;
+- (NSTouchBarItem*)makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
+  API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeButtonForID:(NSString*)id
-                    withIdentifier:(NSString*)identifier;
+                    withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeLabelForID:(NSString*)id
-                   withIdentifier:(NSString*)identifier;
+                   withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeColorPickerForID:(NSString*)id
-                         withIdentifier:(NSString*)identifier;
+                         withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeSliderForID:(NSString*)id
-                    withIdentifier:(NSString*)identifier;
+                    withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makePopoverForID:(NSString*)id
-                     withIdentifier:(NSString*)identifier;
+                     withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeGroupForID:(NSString*)id
-                   withIdentifier:(NSString*)identifier;
+                   withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
 
 // Helpers to update touch bar items
 - (void)updateButton:(NSCustomTouchBarItem*)item
-        withSettings:(const mate::PersistentDictionary&)settings;
+        withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
 - (void)updateLabel:(NSCustomTouchBarItem*)item
-       withSettings:(const mate::PersistentDictionary&)settings;
+       withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
 - (void)updateColorPicker:(NSColorPickerTouchBarItem*)item
-             withSettings:(const mate::PersistentDictionary&)settings;
+             withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
 - (void)updateSlider:(NSSliderTouchBarItem*)item
-        withSettings:(const mate::PersistentDictionary&)settings;
+        withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
 - (void)updatePopover:(NSPopoverTouchBarItem*)item
-         withSettings:(const mate::PersistentDictionary&)settings;
+         withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
 
 @end
 

--- a/atom/browser/ui/cocoa/atom_touch_bar.h
+++ b/atom/browser/ui/cocoa/atom_touch_bar.h
@@ -32,15 +32,18 @@
               settings:(const std::vector<mate::PersistentDictionary>&)settings;
 
 - (NSTouchBar*)makeTouchBar API_AVAILABLE(macosx(10.12.2));
-- (NSTouchBar*)touchBarFromItemIdentifiers:(NSMutableArray*)items API_AVAILABLE(macosx(10.12.2));
+- (NSTouchBar*)touchBarFromItemIdentifiers:(NSMutableArray*)items
+    API_AVAILABLE(macosx(10.12.2));
 - (NSMutableArray*)identifiersFromSettings:
     (const std::vector<mate::PersistentDictionary>&)settings;
 - (void)refreshTouchBarItem:(NSTouchBar*)touchBar
-                         id:(const std::string&)item_id API_AVAILABLE(macosx(10.12.2));
+                         id:(const std::string&)item_id
+    API_AVAILABLE(macosx(10.12.2));
 - (void)addNonDefaultTouchBarItems:
     (const std::vector<mate::PersistentDictionary>&)items;
 - (void)setEscapeTouchBarItem:(const mate::PersistentDictionary&)item
-                  forTouchBar:(NSTouchBar*)touchBar API_AVAILABLE(macosx(10.12.2));
+                  forTouchBar:(NSTouchBar*)touchBar
+    API_AVAILABLE(macosx(10.12.2));
 
 - (NSString*)idFromIdentifier:(NSString*)identifier
                    withPrefix:(NSString*)prefix;
@@ -56,31 +59,42 @@
 
 // Helpers to create touch bar items
 - (NSTouchBarItem*)makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
-  API_AVAILABLE(macosx(10.12.2));
+    API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeButtonForID:(NSString*)id
-                    withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
+                    withIdentifier:(NSString*)identifier
+    API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeLabelForID:(NSString*)id
-                   withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
+                   withIdentifier:(NSString*)identifier
+    API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeColorPickerForID:(NSString*)id
-                         withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
+                         withIdentifier:(NSString*)identifier
+    API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeSliderForID:(NSString*)id
-                    withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
+                    withIdentifier:(NSString*)identifier
+    API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makePopoverForID:(NSString*)id
-                     withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
+                     withIdentifier:(NSString*)identifier
+    API_AVAILABLE(macosx(10.12.2));
 - (NSTouchBarItem*)makeGroupForID:(NSString*)id
-                   withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2));
+                   withIdentifier:(NSString*)identifier
+    API_AVAILABLE(macosx(10.12.2));
 
 // Helpers to update touch bar items
 - (void)updateButton:(NSCustomTouchBarItem*)item
-        withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
+        withSettings:(const mate::PersistentDictionary&)settings
+    API_AVAILABLE(macosx(10.12.2));
 - (void)updateLabel:(NSCustomTouchBarItem*)item
-       withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
+       withSettings:(const mate::PersistentDictionary&)settings
+    API_AVAILABLE(macosx(10.12.2));
 - (void)updateColorPicker:(NSColorPickerTouchBarItem*)item
-             withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
+             withSettings:(const mate::PersistentDictionary&)settings
+    API_AVAILABLE(macosx(10.12.2));
 - (void)updateSlider:(NSSliderTouchBarItem*)item
-        withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
+        withSettings:(const mate::PersistentDictionary&)settings
+    API_AVAILABLE(macosx(10.12.2));
 - (void)updatePopover:(NSPopoverTouchBarItem*)item
-         withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2));
+         withSettings:(const mate::PersistentDictionary&)settings
+    API_AVAILABLE(macosx(10.12.2));
 
 @end
 

--- a/atom/browser/ui/cocoa/atom_touch_bar.mm
+++ b/atom/browser/ui/cocoa/atom_touch_bar.mm
@@ -51,32 +51,34 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 - (NSMutableArray*)identifiersFromSettings:(const std::vector<mate::PersistentDictionary>&)dicts {
   NSMutableArray* identifiers = [NSMutableArray array];
 
-  for (const auto& item : dicts) {
-    std::string type;
-    std::string item_id;
-    if (item.Get("type", &type) && item.Get("id", &item_id)) {
-      NSTouchBarItemIdentifier identifier = nil;
-      if (type == "spacer") {
-        std::string size;
-        item.Get("size", &size);
-        if (size == "large") {
-          identifier = NSTouchBarItemIdentifierFixedSpaceLarge;
-        } else if (size == "flexible") {
-          identifier = NSTouchBarItemIdentifierFlexibleSpace;
+  if (@available(macOS 10.12.2, *)) {
+    for (const auto& item : dicts) {
+      std::string type;
+      std::string item_id;
+      if (item.Get("type", &type) && item.Get("id", &item_id)) {
+        NSTouchBarItemIdentifier identifier = nil;
+        if (type == "spacer") {
+          std::string size;
+          item.Get("size", &size);
+          if (size == "large") {
+            identifier = NSTouchBarItemIdentifierFixedSpaceLarge;
+          } else if (size == "flexible") {
+            identifier = NSTouchBarItemIdentifierFlexibleSpace;
+          } else {
+            identifier = NSTouchBarItemIdentifierFixedSpaceSmall;
+          }
         } else {
-          identifier = NSTouchBarItemIdentifierFixedSpaceSmall;
+          identifier = [self identifierFromID:item_id type:type];
         }
-      } else {
-        identifier = [self identifierFromID:item_id type:type];
-      }
 
-      if (identifier) {
-        settings_[item_id] = item;
-        [identifiers addObject:identifier];
+        if (identifier) {
+          settings_[item_id] = item;
+          [identifiers addObject:identifier];
+        }
       }
     }
+    [identifiers addObject:NSTouchBarItemIdentifierOtherItemsProxy];
   }
-  [identifiers addObject:NSTouchBarItemIdentifierOtherItemsProxy];
 
   return identifiers;
 }
@@ -116,7 +118,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 - (void)refreshTouchBarItem:(NSTouchBar*)touchBar
                          id:(NSTouchBarItemIdentifier)identifier
                    withType:(const std::string&)item_type
-               withSettings:(const mate::PersistentDictionary&)settings {
+               withSettings:(const mate::PersistentDictionary&)settings
+               API_AVAILABLE(macosx(10.12.2)) {
   NSTouchBarItem* item = [touchBar itemForIdentifier:identifier];
   if (!item) return;
 
@@ -245,14 +248,14 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
                                          details);
 }
 
-- (void)scrubber:(NSScrubber*)scrubber didSelectItemAtIndex:(NSInteger)selectedIndex {
+- (void)scrubber:(NSScrubber*)scrubber didSelectItemAtIndex:(NSInteger)selectedIndex API_AVAILABLE(macosx(10.12.2)) {
   base::DictionaryValue details;
   details.SetInteger("selectedIndex", selectedIndex);
   details.SetString("type", "select");
   window_->NotifyTouchBarItemInteraction([scrubber.identifier UTF8String], details);
 }
 
-- (void)scrubber:(NSScrubber*)scrubber didHighlightItemAtIndex:(NSInteger)highlightedIndex {
+- (void)scrubber:(NSScrubber*)scrubber didHighlightItemAtIndex:(NSInteger)highlightedIndex API_AVAILABLE(macosx(10.12.2)) {
   base::DictionaryValue details;
   details.SetInteger("highlightedIndex", highlightedIndex);
   details.SetString("type", "highlight");
@@ -494,7 +497,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (void)updateGroup:(NSGroupTouchBarItem*)item
-    withSettings:(const mate::PersistentDictionary&)settings {
+    withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2)) {
   
   mate::PersistentDictionary child;
   if (!settings.Get("child", &child)) return;
@@ -505,7 +508,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (NSTouchBarItem*)makeSegmentedControlForID:(NSString*)id
-                              withIdentifier:(NSString*)identifier {
+                              withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2)) {
   std::string s_id([id UTF8String]);
   if (![self hasItemWithID:s_id]) return nil;
 
@@ -525,7 +528,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (void)updateSegmentedControl:(NSCustomTouchBarItem*)item
-                  withSettings:(const mate::PersistentDictionary&)settings {
+                  withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2)) {
 
   NSSegmentedControl* control = item.view;
 
@@ -582,7 +585,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (NSTouchBarItem*)makeScrubberForID:(NSString*)id
-                     withIdentifier:(NSString*)identifier {
+                     withIdentifier:(NSString*)identifier API_AVAILABLE(macosx(10.12.2)) {
   std::string s_id([id UTF8String]);
   if (![self hasItemWithID:s_id]) return nil;
 
@@ -606,7 +609,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (void)updateScrubber:(NSCustomTouchBarItem*)item
-          withSettings:(const mate::PersistentDictionary&)settings {
+          withSettings:(const mate::PersistentDictionary&)settings API_AVAILABLE(macosx(10.12.2)) {
   NSScrubber* scrubber = item.view;
 
   bool showsArrowButtons = false;
@@ -649,7 +652,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   [scrubber reloadData];
 }
 
-- (NSInteger)numberOfItemsForScrubber:(NSScrubber*)scrubber {
+- (NSInteger)numberOfItemsForScrubber:(NSScrubber*)scrubber API_AVAILABLE(macosx(10.12.2)) {
   std::string s_id([[scrubber identifier] UTF8String]);
   if (![self hasItemWithID:s_id]) return 0;
 
@@ -660,7 +663,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (NSScrubberItemView*)scrubber:(NSScrubber*)scrubber
-             viewForItemAtIndex:(NSInteger)index {
+             viewForItemAtIndex:(NSInteger)index API_AVAILABLE(macosx(10.12.2)) {
   std::string s_id([[scrubber identifier] UTF8String]);
   if (![self hasItemWithID:s_id]) return nil;
 
@@ -694,7 +697,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (NSSize)scrubber:(NSScrubber *)scrubber layout:(NSScrubberFlowLayout *)layout sizeForItemAtIndex:(NSInteger)itemIndex
-{
+API_AVAILABLE(macosx(10.12.2)) {
   NSInteger width = 50;
   NSInteger height = 30;
   NSInteger margin = 15;

--- a/atom/browser/ui/cocoa/touch_bar_forward_declarations.h
+++ b/atom/browser/ui/cocoa/touch_bar_forward_declarations.h
@@ -259,7 +259,7 @@ static const NSTouchBarItemIdentifier NSTouchBarItemIdentifierOtherItemsProxy =
 @class NSTouchBarItem;
 
 @interface NSWindow (TouchBarSDK)
-@property(strong, readonly) NSTouchBar* touchBar;
+@property(strong, readonly) NSTouchBar* touchBar API_AVAILABLE(macosx(10.12.2));
 @end
 
 #endif  // MAC_OS_X_VERSION_10_12_1

--- a/atom/browser/ui/file_dialog.h
+++ b/atom/browser/ui/file_dialog.h
@@ -64,6 +64,9 @@ struct DialogSettings {
   bool shows_tag_field = true;
   bool force_detached = false;
   bool security_scoped_bookmarks = false;
+
+  DialogSettings();
+  ~DialogSettings();
 };
 
 bool ShowOpenDialog(const DialogSettings& settings,

--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -17,6 +17,9 @@
 
 namespace file_dialog {
 
+DialogSettings::DialogSettings() = default;
+DialogSettings::~DialogSettings() = default;
+
 namespace {
 
 // Makes sure that .jpg also shows .JPG.

--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -27,6 +27,9 @@
 
 @implementation PopUpButtonHandler
 
+@synthesize savePanel;
+@synthesize fileTypesList;
+
 - (instancetype)initWithPanel:(NSSavePanel*)panel
                  andTypesList:(NSArray*)typesList {
   self = [super init];

--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -69,6 +69,9 @@
 
 namespace file_dialog {
 
+DialogSettings::DialogSettings() = default;
+DialogSettings::~DialogSettings() = default;
+
 namespace {
 
 void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {

--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -25,6 +25,9 @@
 
 namespace file_dialog {
 
+DialogSettings::DialogSettings() = default;
+DialogSettings::~DialogSettings() = default;
+
 namespace {
 
 // Distinguish directories from regular files.

--- a/atom/browser/ui/tray_icon_cocoa.h
+++ b/atom/browser/ui/tray_icon_cocoa.h
@@ -20,7 +20,7 @@ namespace atom {
 class TrayIconCocoa : public TrayIcon, public AtomMenuModel::Observer {
  public:
   TrayIconCocoa();
-  virtual ~TrayIconCocoa();
+  ~TrayIconCocoa() override;
 
   void SetImage(const gfx::Image& image) override;
   void SetPressedImage(const gfx::Image& image) override;

--- a/atom/browser/ui/views/autofill_popup_view.cc
+++ b/atom/browser/ui/views/autofill_popup_view.cc
@@ -18,6 +18,11 @@
 
 namespace atom {
 
+void AutofillPopupChildView::GetAccessibleNodeData(ui::AXNodeData* node_data) {
+  node_data->role = ui::AX_ROLE_MENU_ITEM;
+  node_data->SetName(suggestion_);
+}
+
 AutofillPopupView::AutofillPopupView(AutofillPopup* popup,
                                      views::Widget* parent_widget)
     : popup_(popup),
@@ -126,6 +131,16 @@ void AutofillPopupView::OnSuggestionsChanged() {
     return;
   }
   DoUpdateBoundsAndRedrawPopup();
+}
+
+int AutofillPopupView::GetDragOperationsForView(
+    views::View*, const gfx::Point&) {
+  return ui::DragDropTypes::DRAG_NONE;
+}
+
+bool AutofillPopupView::CanStartDragForView(
+  views::View*, const gfx::Point&, const gfx::Point&) {
+  return false;
 }
 
 void AutofillPopupView::OnSelectedRowChanged(

--- a/atom/browser/ui/views/autofill_popup_view.cc
+++ b/atom/browser/ui/views/autofill_popup_view.cc
@@ -133,13 +133,18 @@ void AutofillPopupView::OnSuggestionsChanged() {
   DoUpdateBoundsAndRedrawPopup();
 }
 
-int AutofillPopupView::GetDragOperationsForView(
-    views::View*, const gfx::Point&) {
+void AutofillPopupView::WriteDragDataForView(views::View*,
+                                             const gfx::Point&,
+                                             ui::OSExchangeData*) {}
+
+int AutofillPopupView::GetDragOperationsForView(views::View*,
+                                                const gfx::Point&) {
   return ui::DragDropTypes::DRAG_NONE;
 }
 
-bool AutofillPopupView::CanStartDragForView(
-  views::View*, const gfx::Point&, const gfx::Point&) {
+bool AutofillPopupView::CanStartDragForView(views::View*,
+                                            const gfx::Point&,
+                                            const gfx::Point&) {
   return false;
 }
 

--- a/atom/browser/ui/views/autofill_popup_view.h
+++ b/atom/browser/ui/views/autofill_popup_view.h
@@ -42,10 +42,7 @@ class AutofillPopupChildView : public views::View {
   ~AutofillPopupChildView() override {}
 
   // views::Views implementation
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override {
-    node_data->role = ui::AX_ROLE_MENU_ITEM;
-    node_data->SetName(suggestion_);
-  }
+  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
 
   base::string16 suggestion_;
 
@@ -70,15 +67,11 @@ class AutofillPopupView : public views::WidgetDelegateView,
 
   void WriteDragDataForView(views::View*,
                             const gfx::Point&,
-                            ui::OSExchangeData*) override {}
-  int GetDragOperationsForView(views::View*, const gfx::Point&) override {
-    return ui::DragDropTypes::DRAG_NONE;
-  }
+                            ui::OSExchangeData*) override;
+  int GetDragOperationsForView(views::View*, const gfx::Point&) override;
   bool CanStartDragForView(views::View*,
                            const gfx::Point&,
-                           const gfx::Point&) override {
-    return false;
-  }
+                           const gfx::Point&) override;
 
  private:
   friend class AutofillPopup;

--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -54,8 +54,8 @@ void WebContentsPermissionHelper::RequestPermission(
     const base::Callback<void(bool)>& callback,
     bool user_gesture,
     const base::DictionaryValue* details) {
-  auto rfh = web_contents_->GetMainFrame();
-  auto permission_manager = static_cast<AtomPermissionManager*>(
+  auto* rfh = web_contents_->GetMainFrame();
+  auto* permission_manager = static_cast<AtomPermissionManager*>(
       web_contents_->GetBrowserContext()->GetPermissionManager());
   auto origin = web_contents_->GetLastCommittedURL();
   permission_manager->RequestPermissionWithDetails(

--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -33,7 +33,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
   FileSelectHelper(content::RenderFrameHost* render_frame_host,
                    const content::FileChooserParams::Mode& mode)
       : render_frame_host_(render_frame_host), mode_(mode) {
-    auto web_contents =
+    auto* web_contents =
         content::WebContents::FromRenderFrameHost(render_frame_host);
     content::WebContentsObserver::Observe(web_contents);
   }
@@ -71,7 +71,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
       }
 
       if (render_frame_host_ && !paths.empty()) {
-        auto browser_context = static_cast<atom::AtomBrowserContext*>(
+        auto* browser_context = static_cast<atom::AtomBrowserContext*>(
             render_frame_host_->GetProcess()->GetBrowserContext());
         browser_context->prefs()->SetFilePath(prefs::kSelectFileLastDirectory,
                                               paths[0].DirName());

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -61,7 +61,7 @@ void WebViewGuestDelegate::SetSize(const SetSizeParams& params) {
 
   enable_auto_size &= !min_auto_size_.IsEmpty() && !max_auto_size_.IsEmpty();
 
-  auto rvh = web_contents()->GetRenderViewHost();
+  auto* rvh = web_contents()->GetRenderViewHost();
   if (enable_auto_size) {
     // Autosize is being enabled.
     rvh->EnableAutoResize(min_auto_size_, max_auto_size_);
@@ -120,7 +120,7 @@ void WebViewGuestDelegate::DidAttach(int guest_proxy_routing_id) {
 
   embedder_zoom_controller_ =
       WebContentsZoomController::FromWebContents(embedder_web_contents_);
-  auto zoom_controller = api_web_contents_->GetZoomController();
+  auto* zoom_controller = api_web_contents_->GetZoomController();
   embedder_zoom_controller_->AddObserver(this);
   zoom_controller->SetEmbedderZoomController(embedder_zoom_controller_);
 }
@@ -210,8 +210,8 @@ content::WebContents* WebViewGuestDelegate::CreateNewGuestWindow(
   guest_params.initial_size =
       embedder_web_contents_->GetContainerBounds().size();
   guest_params.context = embedder_web_contents_->GetNativeView();
-  auto guest_contents = content::WebContents::Create(guest_params);
-  auto guest_contents_impl =
+  auto* guest_contents = content::WebContents::Create(guest_params);
+  auto* guest_contents_impl =
       static_cast<content::WebContentsImpl*>(guest_contents);
   guest_contents_impl->GetView()->CreateViewForWidget(
       guest_contents->GetRenderViewHost()->GetWidget(), false);

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -23,6 +23,9 @@ const int kDefaultHeight = 300;
 
 }  // namespace
 
+SetSizeParams::SetSizeParams() = default;
+SetSizeParams::~SetSizeParams() = default;
+
 WebViewGuestDelegate::WebViewGuestDelegate()
     : embedder_zoom_controller_(nullptr),
       guest_host_(nullptr),

--- a/atom/browser/web_view_guest_delegate.h
+++ b/atom/browser/web_view_guest_delegate.h
@@ -22,8 +22,8 @@ class WebContents;
 // meaningful. This is because the normal size of the guestview is overridden
 // whenever autosizing occurs.
 struct SetSizeParams {
-  SetSizeParams() {}
-  ~SetSizeParams() {}
+  SetSizeParams();
+  ~SetSizeParams();
 
   std::unique_ptr<bool> enable_auto_size;
   std::unique_ptr<gfx::Size> min_size;

--- a/atom/browser/web_view_manager.cc
+++ b/atom/browser/web_view_manager.cc
@@ -74,9 +74,9 @@ bool WebViewManager::ForEachGuest(content::WebContents* embedder_web_contents,
 // static
 WebViewManager* WebViewManager::GetWebViewManager(
     content::WebContents* web_contents) {
-  auto context = web_contents->GetBrowserContext();
+  auto* context = web_contents->GetBrowserContext();
   if (context) {
-    auto manager = context->GetGuestManager();
+    auto* manager = context->GetGuestManager();
     return static_cast<WebViewManager*>(manager);
   } else {
     return nullptr;

--- a/atom/browser/window_list.cc
+++ b/atom/browser/window_list.cc
@@ -84,7 +84,7 @@ void WindowList::CloseAllWindows() {
 #if defined(OS_MACOSX)
   std::reverse(windows.begin(), windows.end());
 #endif
-  for (const auto& window : windows)
+  for (auto* const& window : windows)
     if (!window->IsClosed())
       window->Close();
 }
@@ -92,7 +92,7 @@ void WindowList::CloseAllWindows() {
 // static
 void WindowList::DestroyAllWindows() {
   WindowVector windows = GetInstance()->windows_;
-  for (const auto& window : windows)
+  for (auto* const& window : windows)
     window->CloseImmediately();  // e.g. Destroy()
 }
 

--- a/atom/common/api/remote_callback_freer.cc
+++ b/atom/common/api/remote_callback_freer.cc
@@ -35,7 +35,7 @@ void RemoteCallbackFreer::RunDestructor() {
       base::ASCIIToUTF16("ELECTRON_RENDERER_RELEASE_CALLBACK");
   base::ListValue args;
   args.AppendInteger(object_id_);
-  auto frame_host = web_contents()->GetMainFrame();
+  auto* frame_host = web_contents()->GetMainFrame();
   if (frame_host) {
     frame_host->Send(new AtomFrameMsg_Message(frame_host->GetRoutingID(), false,
                                               channel, args));

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -17,7 +17,7 @@
 namespace crash_reporter {
 
 CrashReporter::CrashReporter() {
-  auto cmd = base::CommandLine::ForCurrentProcess();
+  auto* cmd = base::CommandLine::ForCurrentProcess();
   is_browser_ = cmd->GetSwitchValueASCII(switches::kProcessType).empty();
 }
 
@@ -102,7 +102,7 @@ CrashReporter* CrashReporter::GetInstance() {
 #endif
 
 void CrashReporter::StartInstance(const mate::Dictionary& options) {
-  auto reporter = GetInstance();
+  auto* reporter = GetInstance();
   if (!reporter)
     return;
 

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -45,7 +45,7 @@ class CrashReporterMac : public CrashReporter {
   friend struct base::DefaultSingletonTraits<CrashReporterMac>;
 
   CrashReporterMac();
-  virtual ~CrashReporterMac();
+  ~CrashReporterMac() override;
 
   void SetUploadsEnabled(bool enable_uploads);
   void SetCrashKeyValue(const base::StringPiece& key,

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -127,7 +127,7 @@ std::map<std::string, std::string> CrashReporterMac::GetParameters() const {
     std::map<std::string, std::string> ret;
     crashpad::SimpleStringDictionary::Iterator iter(*simple_string_dictionary_);
     for(;;) {
-      const auto entry = iter.Next();
+      auto* const entry = iter.Next();
       if (!entry) break;
       ret[entry->key] = entry->value;
     }

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -114,7 +114,7 @@ std::unique_ptr<const char* []> StringVectorToArgArray(
 }
 
 base::FilePath GetResourcesPath(bool is_browser) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   base::FilePath exec_path(command_line->GetProgram());
   PathService::Get(base::FILE_EXE, &exec_path);
 

--- a/atom/common/node_bindings_mac.h
+++ b/atom/common/node_bindings_mac.h
@@ -13,7 +13,7 @@ namespace atom {
 class NodeBindingsMac : public NodeBindings {
  public:
   explicit NodeBindingsMac(BrowserEnvironment browser_env);
-  virtual ~NodeBindingsMac();
+  ~NodeBindingsMac() override;
 
   void RunMessageLoop() override;
 

--- a/atom/renderer/api/atom_api_spell_check_client.cc
+++ b/atom/renderer/api/atom_api_spell_check_client.cc
@@ -237,6 +237,8 @@ SpellCheckClient::SpellCheckScope::SpellCheckScope(
       provider_(client.provider_.NewHandle()),
       spell_check_(client.spell_check_.NewHandle()) {}
 
+SpellCheckClient::SpellCheckScope::~SpellCheckScope() = default;
+
 }  // namespace api
 
 }  // namespace atom

--- a/atom/renderer/api/atom_api_spell_check_client.h
+++ b/atom/renderer/api/atom_api_spell_check_client.h
@@ -60,6 +60,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
     v8::Local<v8::Function> spell_check_;
 
     explicit SpellCheckScope(const SpellCheckClient& client);
+    ~SpellCheckScope();
   };
 
   // Check the spelling of text.

--- a/atom/renderer/api/atom_api_spell_check_client.h
+++ b/atom/renderer/api/atom_api_spell_check_client.h
@@ -33,7 +33,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
                    bool auto_spell_correct_turned_on,
                    v8::Isolate* isolate,
                    v8::Local<v8::Object> provider);
-  virtual ~SpellCheckClient();
+  ~SpellCheckClient() override;
 
  private:
   class SpellcheckRequest;

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -95,7 +95,7 @@ class FrameSpellChecker : public content::RenderFrameVisitor {
     main_frame_ = nullptr;
   }
   bool Visit(content::RenderFrame* render_frame) override {
-    auto view = render_frame->GetRenderView();
+    auto* view = render_frame->GetRenderView();
     if (view->GetMainRenderFrame() == main_frame_ ||
         (render_frame->IsMainFrame() && render_frame == main_frame_)) {
       render_frame->GetWebFrame()->SetTextCheckClient(spell_check_client_);
@@ -173,7 +173,7 @@ v8::Local<v8::Value> WebFrame::RegisterEmbedderCustomElement(
 void WebFrame::RegisterElementResizeCallback(
     int element_instance_id,
     const GuestViewContainer::ResizeCallback& callback) {
-  auto guest_view_container = GuestViewContainer::FromID(element_instance_id);
+  auto* guest_view_container = GuestViewContainer::FromID(element_instance_id);
   if (guest_view_container)
     guest_view_container->RegisterElementResizeCallback(callback);
 }

--- a/atom/renderer/atom_autofill_agent.cc
+++ b/atom/renderer/atom_autofill_agent.cc
@@ -57,6 +57,8 @@ AutofillAgent::AutofillAgent(content::RenderFrame* frame)
   render_frame()->GetWebFrame()->SetAutofillClient(this);
 }
 
+AutofillAgent::~AutofillAgent() = default;
+
 void AutofillAgent::OnDestruct() {
   delete this;
 }

--- a/atom/renderer/atom_autofill_agent.cc
+++ b/atom/renderer/atom_autofill_agent.cc
@@ -210,7 +210,7 @@ void AutofillAgent::DoFocusChangeComplete() {
   if (focused_node_was_last_clicked_ && was_focused_before_now_) {
     ShowSuggestionsOptions options;
     options.autofill_on_empty_values = true;
-    auto input_element = ToWebInputElement(&element);
+    auto* input_element = ToWebInputElement(&element);
     if (input_element)
       ShowSuggestions(*input_element, options);
   }

--- a/atom/renderer/atom_autofill_agent.h
+++ b/atom/renderer/atom_autofill_agent.h
@@ -21,6 +21,7 @@ class AutofillAgent : public content::RenderFrameObserver,
                       public blink::WebAutofillClient {
  public:
   explicit AutofillAgent(content::RenderFrame* frame);
+  ~AutofillAgent() override;
 
   // content::RenderFrameObserver:
   void OnDestruct() override;

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -126,7 +126,7 @@ void AtomRenderFrameObserver::OnDestruct() {
 }
 
 void AtomRenderFrameObserver::CreateIsolatedWorldContext() {
-  auto frame = render_frame_->GetWebFrame();
+  auto* frame = render_frame_->GetWebFrame();
 
   // This maps to the name shown in the context combo box in the Console tab
   // of the dev tools.

--- a/atom/renderer/atom_render_view_observer.h
+++ b/atom/renderer/atom_render_view_observer.h
@@ -14,7 +14,7 @@ class AtomRenderViewObserver : public content::RenderViewObserver {
   explicit AtomRenderViewObserver(content::RenderView* render_view);
 
  protected:
-  virtual ~AtomRenderViewObserver();
+  ~AtomRenderViewObserver() override;
 
  private:
   // content::RenderViewObserver implementation.

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -23,7 +23,7 @@ class NodeBindings;
 class AtomRendererClient : public RendererClientBase {
  public:
   AtomRendererClient();
-  virtual ~AtomRendererClient();
+  ~AtomRendererClient() override;
 
   // atom::RendererClientBase:
   void DidCreateScriptContext(v8::Handle<v8::Context> context,

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -60,7 +60,7 @@ v8::Local<v8::Value> GetBinding(v8::Isolate* isolate,
     return exports;
   }
 
-  auto mod = node::get_builtin_module(module_key.c_str());
+  auto* mod = node::get_builtin_module(module_key.c_str());
 
   if (!mod) {
     char errmsg[1024];
@@ -84,7 +84,7 @@ base::CommandLine::StringVector GetArgv() {
 
 void InitializeBindings(v8::Local<v8::Object> binding,
                         v8::Local<v8::Context> context) {
-  auto isolate = context->GetIsolate();
+  auto* isolate = context->GetIsolate();
   mate::Dictionary b(isolate, binding);
   b.SetMethod("get", GetBinding);
   b.SetMethod("crash", AtomBindings::Crash);
@@ -111,7 +111,7 @@ class AtomSandboxedRenderFrameObserver : public AtomRenderFrameObserver {
     if (!frame)
       return;
 
-    auto isolate = blink::MainThreadIsolate();
+    auto* isolate = blink::MainThreadIsolate();
     v8::HandleScope handle_scope(isolate);
     auto context = frame->MainWorldScriptContext();
     v8::Context::Scope context_scope(context);
@@ -160,7 +160,7 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   base::FilePath preload_script_path =
       command_line->GetSwitchValuePath(switches::kPreloadScript);
 
-  auto isolate = context->GetIsolate();
+  auto* isolate = context->GetIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);
   // Wrap the bundle into a function that receives the binding object and the
@@ -191,7 +191,7 @@ void AtomSandboxedRendererClient::WillReleaseScriptContext(
   if (!render_frame->IsMainFrame())
     return;
 
-  auto isolate = context->GetIsolate();
+  auto* isolate = context->GetIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);
   InvokeIpcCallback(context, "onExit", std::vector<v8::Local<v8::Value>>());
@@ -201,7 +201,7 @@ void AtomSandboxedRendererClient::InvokeIpcCallback(
     v8::Handle<v8::Context> context,
     const std::string& callback_name,
     std::vector<v8::Handle<v8::Value>> args) {
-  auto isolate = context->GetIsolate();
+  auto* isolate = context->GetIsolate();
   auto binding_key = mate::ConvertToV8(isolate, kIpcKey)->ToString();
   auto private_binding_key = v8::Private::ForApi(isolate, binding_key);
   auto global_object = context->Global();

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -107,7 +107,7 @@ class AtomSandboxedRenderFrameObserver : public AtomRenderFrameObserver {
  protected:
   void EmitIPCEvent(blink::WebLocalFrame* frame,
                     const base::string16& channel,
-                    const base::ListValue& args) {
+                    const base::ListValue& args) override {
     if (!frame)
       return;
 

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -14,7 +14,7 @@ namespace atom {
 class AtomSandboxedRendererClient : public RendererClientBase {
  public:
   AtomSandboxedRendererClient();
-  virtual ~AtomSandboxedRendererClient();
+  ~AtomSandboxedRendererClient() override;
 
   void InvokeIpcCallback(v8::Handle<v8::Context> context,
                          const std::string& callback_name,

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -18,7 +18,7 @@ class PreferencesManager;
 class RendererClientBase : public content::ContentRendererClient {
  public:
   RendererClientBase();
-  virtual ~RendererClientBase();
+  ~RendererClientBase() override;
 
   virtual void DidCreateScriptContext(v8::Handle<v8::Context> context,
                                       content::RenderFrame* render_frame) = 0;

--- a/brightray/browser/browser_client.cc
+++ b/brightray/browser/browser_client.cc
@@ -58,6 +58,13 @@ BrowserClient::BrowserClient() : browser_main_parts_(nullptr) {
 
 BrowserClient::~BrowserClient() {}
 
+
+void BrowserClient::WebNotificationAllowed(
+    int render_process_id,
+    const base::Callback<void(bool, bool)>& callback) {
+  callback.Run(false, true);
+}
+
 NotificationPresenter* BrowserClient::GetNotificationPresenter() {
   if (!notification_presenter_) {
     // Create a new presenter if on OS X, Linux, or Windows 7+

--- a/brightray/browser/browser_client.h
+++ b/brightray/browser/browser_client.h
@@ -23,7 +23,7 @@ class BrowserClient : public content::ContentBrowserClient {
   static void SetApplicationLocale(const std::string& locale);
 
   BrowserClient();
-  ~BrowserClient();
+  ~BrowserClient() override;
 
   BrowserMainParts* browser_main_parts() { return browser_main_parts_; }
 

--- a/brightray/browser/browser_client.h
+++ b/brightray/browser/browser_client.h
@@ -32,9 +32,7 @@ class BrowserClient : public content::ContentBrowserClient {
   // Subclasses should override this to enable or disable WebNotification.
   virtual void WebNotificationAllowed(
       int render_process_id,
-      const base::Callback<void(bool, bool)>& callback) {
-    callback.Run(false, true);
-  }
+      const base::Callback<void(bool, bool)>& callback);
 
   // Subclasses that override this (e.g., to provide their own protocol
   // handlers) should call this implementation after doing their own work.

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -227,7 +227,7 @@ void BrowserMainParts::PreMainMessageLoopStart() {
   // Initialize ui::ResourceBundle.
   ui::ResourceBundle::InitSharedInstanceWithLocale(
       "", nullptr, ui::ResourceBundle::DO_NOT_LOAD_COMMON_RESOURCES);
-  auto cmd_line = base::CommandLine::ForCurrentProcess();
+  auto* cmd_line = base::CommandLine::ForCurrentProcess();
   if (cmd_line->HasSwitch(switches::kLang)) {
     const std::string locale = cmd_line->GetSwitchValueASCII(switches::kLang);
     const base::FilePath locale_file_path =
@@ -258,7 +258,7 @@ void BrowserMainParts::PreMainMessageLoopRun() {
       WebUIControllerFactory::GetInstance());
 
   // --remote-debugging-port
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kRemoteDebuggingPort))
     DevToolsManagerDelegate::StartHttpHandler();
 }

--- a/brightray/browser/browser_main_parts.h
+++ b/brightray/browser/browser_main_parts.h
@@ -33,7 +33,7 @@ namespace brightray {
 class BrowserMainParts : public content::BrowserMainParts {
  public:
   BrowserMainParts();
-  ~BrowserMainParts();
+  ~BrowserMainParts() override;
 
   IOThread* io_thread() const { return io_thread_.get(); }
 

--- a/brightray/browser/devtools_manager_delegate.h
+++ b/brightray/browser/devtools_manager_delegate.h
@@ -18,7 +18,7 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
   static void StartHttpHandler();
 
   DevToolsManagerDelegate();
-  virtual ~DevToolsManagerDelegate();
+  ~DevToolsManagerDelegate() override;
 
   // DevToolsManagerDelegate implementation.
   void Inspect(content::DevToolsAgentHost* agent_host) override;

--- a/brightray/browser/inspectable_web_contents.cc
+++ b/brightray/browser/inspectable_web_contents.cc
@@ -6,7 +6,7 @@ namespace brightray {
 
 InspectableWebContents* InspectableWebContents::Create(
     const content::WebContents::CreateParams& create_params) {
-  auto contents = content::WebContents::Create(create_params);
+  auto* contents = content::WebContents::Create(create_params);
   return Create(contents);
 }
 

--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -203,10 +203,10 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
       delegate_(nullptr),
       web_contents_(web_contents),
       weak_factory_(this) {
-  auto context =
+  auto* context =
       static_cast<BrowserContext*>(web_contents_->GetBrowserContext());
   pref_service_ = context->prefs();
-  auto bounds_dict = pref_service_->GetDictionary(kDevToolsBoundsPref);
+  auto* bounds_dict = pref_service_->GetDictionary(kDevToolsBoundsPref);
   if (bounds_dict) {
     DictionaryToRect(*bounds_dict, &devtools_bounds_);
     // Sometimes the devtools window is out of screen or has too small size.
@@ -719,7 +719,7 @@ bool InspectableWebContentsImpl::ShouldCreateWebContents(
 void InspectableWebContentsImpl::HandleKeyboardEvent(
     content::WebContents* source,
     const content::NativeWebKeyboardEvent& event) {
-  auto delegate = web_contents_->GetDelegate();
+  auto* delegate = web_contents_->GetDelegate();
   if (delegate)
     delegate->HandleKeyboardEvent(source, event);
 }
@@ -733,7 +733,7 @@ content::ColorChooser* InspectableWebContentsImpl::OpenColorChooser(
     content::WebContents* source,
     SkColor color,
     const std::vector<content::ColorSuggestion>& suggestions) {
-  auto delegate = web_contents_->GetDelegate();
+  auto* delegate = web_contents_->GetDelegate();
   if (delegate)
     return delegate->OpenColorChooser(source, color, suggestions);
   return nullptr;
@@ -742,7 +742,7 @@ content::ColorChooser* InspectableWebContentsImpl::OpenColorChooser(
 void InspectableWebContentsImpl::RunFileChooser(
     content::RenderFrameHost* render_frame_host,
     const content::FileChooserParams& params) {
-  auto delegate = web_contents_->GetDelegate();
+  auto* delegate = web_contents_->GetDelegate();
   if (delegate)
     delegate->RunFileChooser(render_frame_host, params);
 }
@@ -751,7 +751,7 @@ void InspectableWebContentsImpl::EnumerateDirectory(
     content::WebContents* source,
     int request_id,
     const base::FilePath& path) {
-  auto delegate = web_contents_->GetDelegate();
+  auto* delegate = web_contents_->GetDelegate();
   if (delegate)
     delegate->EnumerateDirectory(source, request_id, path);
 }

--- a/brightray/browser/inspectable_web_contents_impl.h
+++ b/brightray/browser/inspectable_web_contents_impl.h
@@ -40,7 +40,7 @@ class InspectableWebContentsImpl
   static void RegisterPrefs(PrefRegistrySimple* pref_registry);
 
   explicit InspectableWebContentsImpl(content::WebContents*);
-  virtual ~InspectableWebContentsImpl();
+  ~InspectableWebContentsImpl() override;
 
   InspectableWebContentsView* GetView() const override;
   content::WebContents* GetWebContents() const override;

--- a/brightray/browser/inspectable_web_contents_view_mac.h
+++ b/brightray/browser/inspectable_web_contents_view_mac.h
@@ -15,7 +15,7 @@ class InspectableWebContentsViewMac : public InspectableWebContentsView {
  public:
   explicit InspectableWebContentsViewMac(
       InspectableWebContentsImpl* inspectable_web_contents_impl);
-  virtual ~InspectableWebContentsViewMac();
+  ~InspectableWebContentsViewMac() override;
 
   gfx::NativeView GetNativeView() const override;
   void ShowDevTools() override;

--- a/brightray/browser/linux/libnotify_notification.cc
+++ b/brightray/browser/linux/libnotify_notification.cc
@@ -28,8 +28,8 @@ LibNotifyLoader libnotify_loader_;
 const std::set<std::string>& GetServerCapabilities() {
   static std::set<std::string> caps;
   if (caps.empty()) {
-    auto capabilities = libnotify_loader_.notify_get_server_caps();
-    for (auto l = capabilities; l != nullptr; l = l->next)
+    auto* capabilities = libnotify_loader_.notify_get_server_caps();
+    for (auto* l = capabilities; l != nullptr; l = l->next)
       caps.insert(static_cast<const char*>(l->data));
     g_list_free_full(capabilities, g_free);
   }

--- a/brightray/browser/linux/libnotify_notification.h
+++ b/brightray/browser/linux/libnotify_notification.h
@@ -18,7 +18,7 @@ class LibnotifyNotification : public Notification {
  public:
   LibnotifyNotification(NotificationDelegate* delegate,
                         NotificationPresenter* presenter);
-  virtual ~LibnotifyNotification();
+  ~LibnotifyNotification() override;
 
   static bool Initialize();
 

--- a/brightray/browser/linux/notification_presenter_linux.h
+++ b/brightray/browser/linux/notification_presenter_linux.h
@@ -13,7 +13,7 @@ namespace brightray {
 class NotificationPresenterLinux : public NotificationPresenter {
  public:
   NotificationPresenterLinux();
-  ~NotificationPresenterLinux();
+  ~NotificationPresenterLinux() override;
 
  private:
   Notification* CreateNotificationObject(

--- a/brightray/browser/mac/bry_inspectable_web_contents_view.mm
+++ b/brightray/browser/mac/bry_inspectable_web_contents_view.mm
@@ -31,7 +31,7 @@
               name:NSWindowDidBecomeMainNotification
             object:nil];
 
-  auto contents = inspectableWebContentsView_->inspectable_web_contents()->GetWebContents();
+  auto* contents = inspectableWebContentsView_->inspectable_web_contents()->GetWebContents();
   auto contentsView = contents->GetNativeView();
   [contentsView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
   [self addSubview:contentsView];
@@ -63,9 +63,9 @@
   if (visible == devtools_visible_)
     return;
 
-  auto inspectable_web_contents = inspectableWebContentsView_->inspectable_web_contents();
-  auto webContents = inspectable_web_contents->GetWebContents();
-  auto devToolsWebContents = inspectable_web_contents->GetDevToolsWebContents();
+  auto* inspectable_web_contents = inspectableWebContentsView_->inspectable_web_contents();
+  auto* webContents = inspectable_web_contents->GetWebContents();
+  auto* devToolsWebContents = inspectable_web_contents->GetDevToolsWebContents();
   auto devToolsView = devToolsWebContents->GetNativeView();
 
   if (visible && devtools_docked_) {
@@ -120,8 +120,8 @@
   // Switch to new state.
   devtools_docked_ = docked;
   if (!docked) {
-    auto inspectable_web_contents = inspectableWebContentsView_->inspectable_web_contents();
-    auto devToolsWebContents = inspectable_web_contents->GetDevToolsWebContents();
+    auto* inspectable_web_contents = inspectableWebContentsView_->inspectable_web_contents();
+    auto* devToolsWebContents = inspectable_web_contents->GetDevToolsWebContents();
     auto devToolsView = devToolsWebContents->GetNativeView();
 
     auto styleMask = NSTitledWindowMask | NSClosableWindowMask |
@@ -184,10 +184,10 @@
 }
 
 - (void)viewDidBecomeFirstResponder:(NSNotification*)notification {
-  auto inspectable_web_contents = inspectableWebContentsView_->inspectable_web_contents();
+  auto* inspectable_web_contents = inspectableWebContentsView_->inspectable_web_contents();
   if (!inspectable_web_contents)
     return;
-  auto webContents = inspectable_web_contents->GetWebContents();
+  auto* webContents = inspectable_web_contents->GetWebContents();
   auto webContentsView = webContents->GetNativeView();
 
   NSView* view = [notification object];
@@ -196,7 +196,7 @@
     return;
   }
 
-  auto devToolsWebContents = inspectable_web_contents->GetDevToolsWebContents();
+  auto* devToolsWebContents = inspectable_web_contents->GetDevToolsWebContents();
   if (!devToolsWebContents)
     return;
   auto devToolsView = devToolsWebContents->GetNativeView();

--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -20,7 +20,7 @@ class CocoaNotification : public Notification {
  public:
   CocoaNotification(NotificationDelegate* delegate,
                     NotificationPresenter* presenter);
-  ~CocoaNotification();
+  ~CocoaNotification() override;
 
   // Notification:
   void Show(const NotificationOptions& options) override;

--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -29,7 +29,8 @@ class CocoaNotification : public Notification {
   void NotificationDisplayed();
   void NotificationReplied(const std::string& reply);
   void NotificationActivated();
-  void NotificationActivated(NSUserNotificationAction* action);
+  void NotificationActivated(NSUserNotificationAction* action)
+    API_AVAILABLE(macosx(10.10));
 
   NSUserNotification* notification() const { return notification_; }
 

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -69,18 +69,22 @@ void CocoaNotification::Show(const NotificationOptions& options) {
       } else {
         // All of the rest are appended to the list of additional actions
         NSString* actionIdentifier = [NSString stringWithFormat:@"%@Action%d", identifier, i];
-        NSUserNotificationAction* notificationAction =
-          [NSUserNotificationAction actionWithIdentifier:actionIdentifier
-                                                   title:base::SysUTF16ToNSString(action.text)];
-        [additionalActions addObject:notificationAction];
-        additional_action_indices_.insert(std::make_pair(base::SysNSStringToUTF8(actionIdentifier), i));
+        if (@available(macOS 10.10, *)) {
+          NSUserNotificationAction* notificationAction =
+            [NSUserNotificationAction actionWithIdentifier:actionIdentifier
+                                                     title:base::SysUTF16ToNSString(action.text)];
+          [additionalActions addObject:notificationAction];
+          additional_action_indices_.insert(std::make_pair(base::SysNSStringToUTF8(actionIdentifier), i));
+        }
       }
     }
     i++;
   }
   if ([additionalActions count] > 0 &&
       [notification_ respondsToSelector:@selector(setAdditionalActions:)]) {
-    [notification_ setAdditionalActions:additionalActions]; // Requires macOS 10.10
+    if (@available(macOS 10.10, *)) {
+      [notification_ setAdditionalActions:additionalActions];
+    }
   }
 
   if (options.has_reply) {

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -41,8 +41,12 @@
       notification->NotificationActivated();
     } else if (notif.activationType == NSUserNotificationActivationTypeReplied) {
       notification->NotificationReplied([notif.response.string UTF8String]);
-    } else if (notif.activationType == NSUserNotificationActivationTypeAdditionalActionClicked) {
-      notification->NotificationActivated([notif additionalActivationAction]);
+    } else {
+      if (@available(macOS 10.10, *)) {
+        if (notif.activationType == NSUserNotificationActivationTypeAdditionalActionClicked) {
+          notification->NotificationActivated([notif additionalActivationAction]);
+        }
+      }
     }
   }
 }

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -20,14 +20,14 @@
 
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
         didDeliverNotification:(NSUserNotification*)notif {
-  auto notification = presenter_->GetNotification(notif);
+  auto* notification = presenter_->GetNotification(notif);
   if (notification)
     notification->NotificationDisplayed();
 }
 
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
        didActivateNotification:(NSUserNotification *)notif {
-  auto notification = presenter_->GetNotification(notif);
+  auto* notification = presenter_->GetNotification(notif);
 
   if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
     LOG(INFO) << "Notification activated (" << [notif.identifier UTF8String] << ")";

--- a/brightray/browser/mac/notification_presenter_mac.h
+++ b/brightray/browser/mac/notification_presenter_mac.h
@@ -19,7 +19,7 @@ class NotificationPresenterMac : public NotificationPresenter {
   CocoaNotification* GetNotification(NSUserNotification* notif);
 
   NotificationPresenterMac();
-  ~NotificationPresenterMac();
+  ~NotificationPresenterMac() override;
 
  private:
   Notification* CreateNotificationObject(

--- a/brightray/browser/mac/notification_presenter_mac.mm
+++ b/brightray/browser/mac/notification_presenter_mac.mm
@@ -17,7 +17,7 @@ NotificationPresenter* NotificationPresenter::Create() {
 CocoaNotification* NotificationPresenterMac::GetNotification(
     NSUserNotification* ns_notification) {
   for (Notification* notification : notifications()) {
-    auto native_notification = static_cast<CocoaNotification*>(notification);
+    auto* native_notification = static_cast<CocoaNotification*>(notification);
     if ([native_notification->notification().identifier
           isEqual:ns_notification.identifier])
       return native_notification;

--- a/brightray/browser/media/media_capture_devices_dispatcher.h
+++ b/brightray/browser/media/media_capture_devices_dispatcher.h
@@ -70,7 +70,7 @@ class MediaCaptureDevicesDispatcher : public content::MediaObserver {
   friend struct base::DefaultSingletonTraits<MediaCaptureDevicesDispatcher>;
 
   MediaCaptureDevicesDispatcher();
-  virtual ~MediaCaptureDevicesDispatcher();
+  ~MediaCaptureDevicesDispatcher() override;
 
   // Flag used by unittests to disable device enumeration.
   bool is_device_enumeration_disabled_;

--- a/brightray/browser/net_log.cc
+++ b/brightray/browser/net_log.cc
@@ -43,7 +43,7 @@ NetLog::~NetLog() {
 }
 
 void NetLog::StartLogging() {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   if (!command_line->HasSwitch(switches::kLogNetLog))
     return;
 

--- a/brightray/browser/network_delegate.cc
+++ b/brightray/browser/network_delegate.cc
@@ -23,7 +23,7 @@ const char kIgnoreConnectionsLimit[] = "ignore-connections-limit";
 }  // namespace
 
 NetworkDelegate::NetworkDelegate() {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(kIgnoreConnectionsLimit)) {
     std::string value =
         command_line->GetSwitchValueASCII(kIgnoreConnectionsLimit);

--- a/brightray/browser/network_delegate.h
+++ b/brightray/browser/network_delegate.h
@@ -15,7 +15,7 @@ namespace brightray {
 class NetworkDelegate : public net::NetworkDelegate {
  public:
   NetworkDelegate();
-  virtual ~NetworkDelegate();
+  ~NetworkDelegate() override;
 
  protected:
   int OnBeforeURLRequest(net::URLRequest* request,

--- a/brightray/browser/notification.cc
+++ b/brightray/browser/notification.cc
@@ -9,6 +9,9 @@
 
 namespace brightray {
 
+NotificationOptions::NotificationOptions() = default;
+NotificationOptions::~NotificationOptions() = default;
+
 Notification::Notification(NotificationDelegate* delegate,
                            NotificationPresenter* presenter)
     : delegate_(delegate), presenter_(presenter), weak_factory_(this) {}

--- a/brightray/browser/notification.h
+++ b/brightray/browser/notification.h
@@ -36,6 +36,9 @@ struct NotificationOptions {
   base::string16 sound;
   std::vector<NotificationAction> actions;
   base::string16 close_button_text;
+
+  NotificationOptions();
+  ~NotificationOptions();
 };
 
 class Notification {

--- a/brightray/browser/platform_notification_service.cc
+++ b/brightray/browser/platform_notification_service.cc
@@ -105,7 +105,7 @@ void PlatformNotificationService::DisplayNotification(
     const content::PlatformNotificationData& notification_data,
     const content::NotificationResources& notification_resources,
     base::Closure* cancel_callback) {
-  auto presenter = browser_client_->GetNotificationPresenter();
+  auto* presenter = browser_client_->GetNotificationPresenter();
   if (!presenter)
     return;
   NotificationDelegateImpl* delegate =

--- a/brightray/browser/url_request_context_getter.cc
+++ b/brightray/browser/url_request_context_getter.cc
@@ -27,6 +27,7 @@
 #include "net/cert/ct_log_verifier.h"
 #include "net/cert/ct_policy_enforcer.h"
 #include "net/cert/multi_log_ct_verifier.h"
+#include "net/cookies/cookie_monster.h"
 #include "net/dns/mapped_host_resolver.h"
 #include "net/http/http_auth_filter.h"
 #include "net/http/http_auth_handler_factory.h"
@@ -208,13 +209,16 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     auto cookie_path = in_memory_
                            ? base::FilePath()
                            : base_path_.Append(FILE_PATH_LITERAL("Cookies"));
-    auto cookie_config = content::CookieStoreConfig(
-        cookie_path, content::CookieStoreConfig::EPHEMERAL_SESSION_COOKIES,
-        nullptr);
-    cookie_config.cookieable_schemes = delegate_->GetCookieableSchemes();
     std::unique_ptr<net::CookieStore> cookie_store =
-        content::CreateCookieStore(cookie_config);
+        content::CreateCookieStore(content::CookieStoreConfig(
+            cookie_path, content::CookieStoreConfig::EPHEMERAL_SESSION_COOKIES,
+            nullptr));
     storage_->set_cookie_store(std::move(cookie_store));
+
+    // Set custom schemes that can accept cookies.
+    net::CookieMonster* cookie_monster =
+        static_cast<net::CookieMonster*>(url_request_context_->cookie_store());
+    cookie_monster->SetCookieableSchemes(delegate_->GetCookieableSchemes());
     // Cookie store will outlive notifier by order of declaration
     // in the header.
     cookie_change_sub_ =

--- a/brightray/browser/url_request_context_getter.cc
+++ b/brightray/browser/url_request_context_getter.cc
@@ -87,7 +87,7 @@ URLRequestContextGetter::Delegate::CreateURLRequestJobFactory(
 net::HttpCache::BackendFactory*
 URLRequestContextGetter::Delegate::CreateHttpCacheBackendFactory(
     const base::FilePath& base_path) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   int max_size = 0;
   base::StringToInt(command_line->GetSwitchValueASCII(switches::kDiskCacheSize),
                     &max_size);

--- a/brightray/browser/url_request_context_getter.cc
+++ b/brightray/browser/url_request_context_getter.cc
@@ -60,6 +60,11 @@ std::string URLRequestContextGetter::Delegate::GetUserAgent() {
   return base::EmptyString();
 }
 
+std::unique_ptr<net::NetworkDelegate>
+URLRequestContextGetter::Delegate::CreateNetworkDelegate() {
+  return nullptr;
+}
+
 std::unique_ptr<net::URLRequestJobFactory>
 URLRequestContextGetter::Delegate::CreateURLRequestJobFactory(
     content::ProtocolHandlerMap* protocol_handlers) {

--- a/brightray/browser/url_request_context_getter.h
+++ b/brightray/browser/url_request_context_getter.h
@@ -48,9 +48,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
     Delegate() {}
     virtual ~Delegate() {}
 
-    virtual std::unique_ptr<net::NetworkDelegate> CreateNetworkDelegate() {
-      return nullptr;
-    }
+    virtual std::unique_ptr<net::NetworkDelegate> CreateNetworkDelegate();
     virtual std::string GetUserAgent();
     virtual std::unique_ptr<net::URLRequestJobFactory>
     CreateURLRequestJobFactory(content::ProtocolHandlerMap* protocol_handlers);

--- a/brightray/browser/url_request_context_getter.h
+++ b/brightray/browser/url_request_context_getter.h
@@ -73,7 +73,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
       scoped_refptr<base::SingleThreadTaskRunner> io_task_runner,
       content::ProtocolHandlerMap* protocol_handlers,
       content::URLRequestInterceptorScopedVector protocol_interceptors);
-  virtual ~URLRequestContextGetter();
+  ~URLRequestContextGetter() override;
 
   // net::CookieStore::CookieChangedCallback implementation.
   void OnCookieChanged(const net::CanonicalCookie& cookie,

--- a/brightray/browser/url_request_context_getter.h
+++ b/brightray/browser/url_request_context_getter.h
@@ -73,7 +73,6 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
       scoped_refptr<base::SingleThreadTaskRunner> io_task_runner,
       content::ProtocolHandlerMap* protocol_handlers,
       content::URLRequestInterceptorScopedVector protocol_interceptors);
-  ~URLRequestContextGetter() override;
 
   // net::CookieStore::CookieChangedCallback implementation.
   void OnCookieChanged(const net::CanonicalCookie& cookie,
@@ -90,6 +89,8 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   void NotifyContextShutdownOnIO();
 
  private:
+  ~URLRequestContextGetter() override;
+
   Delegate* delegate_;
 
   NetLog* net_log_;

--- a/brightray/browser/views/inspectable_web_contents_view_views.cc
+++ b/brightray/browser/views/inspectable_web_contents_view_views.cc
@@ -30,7 +30,7 @@ class DevToolsWindowDelegate : public views::ClientView,
     if (shell->GetDelegate())
       icon_ = shell->GetDelegate()->GetDevToolsWindowIcon();
   }
-  virtual ~DevToolsWindowDelegate() {}
+  ~DevToolsWindowDelegate() override {}
 
   // views::WidgetDelegate:
   void DeleteDelegate() override { delete this; }

--- a/brightray/browser/views/inspectable_web_contents_view_views.h
+++ b/brightray/browser/views/inspectable_web_contents_view_views.h
@@ -21,7 +21,7 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
  public:
   explicit InspectableWebContentsViewViews(
       InspectableWebContentsImpl* inspectable_web_contents_impl);
-  ~InspectableWebContentsViewViews();
+  ~InspectableWebContentsViewViews() override;
 
   // InspectableWebContentsView:
   views::View* GetView() override;

--- a/brightray/browser/views/views_delegate.h
+++ b/brightray/browser/views/views_delegate.h
@@ -15,7 +15,7 @@ namespace brightray {
 class ViewsDelegate : public views::ViewsDelegate {
  public:
   ViewsDelegate();
-  virtual ~ViewsDelegate();
+  ~ViewsDelegate() override;
 
  protected:
   // views::ViewsDelegate:

--- a/brightray/browser/web_ui_controller_factory.cc
+++ b/brightray/browser/web_ui_controller_factory.cc
@@ -53,7 +53,7 @@ content::WebUIController* WebUIControllerFactory::CreateWebUIControllerForURL(
     content::WebUI* web_ui,
     const GURL& url) const {
   if (url.host() == kChromeUIDevToolsBundledHost) {
-    auto browser_context = web_ui->GetWebContents()->GetBrowserContext();
+    auto* browser_context = web_ui->GetWebContents()->GetBrowserContext();
     return new DevToolsUI(browser_context, web_ui);
   }
   return nullptr;

--- a/brightray/browser/web_ui_controller_factory.h
+++ b/brightray/browser/web_ui_controller_factory.h
@@ -23,7 +23,7 @@ class WebUIControllerFactory : public content::WebUIControllerFactory {
   static WebUIControllerFactory* GetInstance();
 
   WebUIControllerFactory();
-  virtual ~WebUIControllerFactory();
+  ~WebUIControllerFactory() override;
 
   content::WebUI::TypeID GetWebUIType(content::BrowserContext* browser_context,
                                       const GURL& url) const override;

--- a/brightray/common/content_client.h
+++ b/brightray/common/content_client.h
@@ -17,7 +17,7 @@ std::string GetBrightrayUserAgent();
 class ContentClient : public content::ContentClient {
  public:
   ContentClient();
-  ~ContentClient();
+  ~ContentClient() override;
 
  private:
   std::string GetProduct() const override;

--- a/brightray/common/main_delegate.h
+++ b/brightray/common/main_delegate.h
@@ -30,7 +30,7 @@ void LoadCommonResources();
 class MainDelegate : public content::ContentMainDelegate {
  public:
   MainDelegate();
-  ~MainDelegate();
+  ~MainDelegate() override;
 
  protected:
   // Subclasses can override this to provide their own ContentClient

--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener_mac.h
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener_mac.h
@@ -29,7 +29,7 @@ namespace extensions {
 class GlobalShortcutListenerMac : public GlobalShortcutListener {
  public:
   GlobalShortcutListenerMac();
-  virtual ~GlobalShortcutListenerMac();
+  ~GlobalShortcutListenerMac() override;
 
  private:
   typedef int KeyId;
@@ -42,11 +42,11 @@ class GlobalShortcutListenerMac : public GlobalShortcutListener {
   bool OnMediaOrVolumeKeyEvent(int key_code);
 
   // GlobalShortcutListener implementation.
-  virtual void StartListening() override;
-  virtual void StopListening() override;
-  virtual bool RegisterAcceleratorImpl(
+  void StartListening() override;
+  void StopListening() override;
+  bool RegisterAcceleratorImpl(
       const ui::Accelerator& accelerator) override;
-  virtual void UnregisterAcceleratorImpl(
+  void UnregisterAcceleratorImpl(
       const ui::Accelerator& accelerator) override;
 
   // Mac-specific functions for registering hot keys with modifiers.

--- a/chromium_src/chrome/browser/printing/print_view_manager_base.cc
+++ b/chromium_src/chrome/browser/printing/print_view_manager_base.cc
@@ -368,7 +368,7 @@ void PrintViewManagerBase::DisconnectFromCurrentPrintJob() {
 }
 
 void PrintViewManagerBase::PrintingDone(bool success) {
-  auto host = web_contents()->GetRenderViewHost();
+  auto* host = web_contents()->GetRenderViewHost();
   if (print_job_.get()) {
     if (host)
       host->Send(new PrintMsg_PrintingDone(host->GetRoutingID(), success));

--- a/chromium_src/chrome/browser/printing/print_view_manager_base.h
+++ b/chromium_src/chrome/browser/printing/print_view_manager_base.h
@@ -34,7 +34,7 @@ class PrintQueriesQueue;
 class PrintViewManagerBase : public content::NotificationObserver,
                              public content::WebContentsObserver {
  public:
-  virtual ~PrintViewManagerBase();
+  ~PrintViewManagerBase() override;
 
 #if !defined(DISABLE_BASIC_PRINTING)
   // Prints the current document immediately. Since the rendering is
@@ -70,12 +70,12 @@ class PrintViewManagerBase : public content::NotificationObserver,
 
  private:
   // content::NotificationObserver implementation.
-  virtual void Observe(int type,
-                       const content::NotificationSource& source,
-                       const content::NotificationDetails& details) override;
+  void Observe(int type,
+               const content::NotificationSource& source,
+               const content::NotificationDetails& details) override;
 
   // Cancels the print job.
-  virtual void NavigationStopped() override;
+  void NavigationStopped() override;
 
   // IPC Message handlers.
   void OnDidGetPrintedPagesCount(int cookie, int number_pages);

--- a/chromium_src/chrome/browser/printing/print_view_manager_basic.h
+++ b/chromium_src/chrome/browser/printing/print_view_manager_basic.h
@@ -19,7 +19,7 @@ class PrintViewManagerBasic
     : public PrintViewManagerBase,
       public content::WebContentsUserData<PrintViewManagerBasic> {
  public:
-  virtual ~PrintViewManagerBasic();
+  ~PrintViewManagerBasic() override;
 
 #if defined(OS_ANDROID)
   // Sets the file descriptor into which the PDF will be written.

--- a/chromium_src/chrome/browser/printing/printing_message_filter.h
+++ b/chromium_src/chrome/browser/printing/printing_message_filter.h
@@ -41,7 +41,7 @@ class PrintingMessageFilter : public content::BrowserMessageFilter {
   friend class base::DeleteHelper<PrintingMessageFilter>;
   friend class content::BrowserThread;
 
-  virtual ~PrintingMessageFilter();
+  ~PrintingMessageFilter() override;
 
   void OnDestruct() const override;
 

--- a/chromium_src/chrome/browser/process_singleton_posix.cc
+++ b/chromium_src/chrome/browser/process_singleton_posix.cc
@@ -321,7 +321,7 @@ bool DisplayProfileInUseError(const base::FilePath& lock_path,
 bool IsChromeProcess(pid_t pid) {
   base::FilePath other_chrome_path(base::GetProcessExecutablePath(pid));
 
-  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   base::FilePath exec_path(command_line->GetProgram());
   PathService::Get(base::FILE_EXE, &exec_path);
 

--- a/chromium_src/chrome/browser/renderer_host/pepper/widevine_cdm_message_filter.h
+++ b/chromium_src/chrome/browser/renderer_host/pepper/widevine_cdm_message_filter.h
@@ -24,7 +24,7 @@ class WidevineCdmMessageFilter : public content::BrowserMessageFilter {
   friend class content::BrowserThread;
   friend class base::DeleteHelper<WidevineCdmMessageFilter>;
 
-  virtual ~WidevineCdmMessageFilter();
+  ~WidevineCdmMessageFilter() override;
 
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
   // Returns whether any internal plugin supporting |mime_type| is registered

--- a/chromium_src/chrome/browser/speech/tts_controller_impl.h
+++ b/chromium_src/chrome/browser/speech/tts_controller_impl.h
@@ -29,30 +29,30 @@ class TtsControllerImpl : public TtsController {
   static TtsControllerImpl* GetInstance();
 
   // TtsController methods
-  virtual bool IsSpeaking() override;
-  virtual void SpeakOrEnqueue(Utterance* utterance) override;
-  virtual void Stop() override;
-  virtual void Pause() override;
-  virtual void Resume() override;
-  virtual void OnTtsEvent(int utterance_id,
-                          TtsEventType event_type,
-                          int char_index,
-                          const std::string& error_message) override;
-  virtual void GetVoices(content::BrowserContext* browser_context,
-                         std::vector<VoiceData>* out_voices) override;
-  virtual void VoicesChanged() override;
-  virtual void AddVoicesChangedDelegate(
+  bool IsSpeaking() override;
+  void SpeakOrEnqueue(Utterance* utterance) override;
+  void Stop() override;
+  void Pause() override;
+  void Resume() override;
+  void OnTtsEvent(int utterance_id,
+                  TtsEventType event_type,
+                  int char_index,
+                  const std::string& error_message) override;
+  void GetVoices(content::BrowserContext* browser_context,
+                 std::vector<VoiceData>* out_voices) override;
+  void VoicesChanged() override;
+  void AddVoicesChangedDelegate(
       VoicesChangedDelegate* delegate) override;
-  virtual void RemoveVoicesChangedDelegate(
+  void RemoveVoicesChangedDelegate(
       VoicesChangedDelegate* delegate) override;
-  virtual void SetTtsEngineDelegate(TtsEngineDelegate* delegate) override;
-  virtual TtsEngineDelegate* GetTtsEngineDelegate() override;
-  virtual void SetPlatformImpl(TtsPlatformImpl* platform_impl) override;
-  virtual int QueueSize() override;
+  void SetTtsEngineDelegate(TtsEngineDelegate* delegate) override;
+  TtsEngineDelegate* GetTtsEngineDelegate() override;
+  void SetPlatformImpl(TtsPlatformImpl* platform_impl) override;
+  int QueueSize() override;
 
  protected:
   TtsControllerImpl();
-  virtual ~TtsControllerImpl();
+  ~TtsControllerImpl() override;
 
  private:
   // Get the platform TTS implementation (or injected mock).

--- a/chromium_src/chrome/browser/speech/tts_mac.mm
+++ b/chromium_src/chrome/browser/speech/tts_mac.mm
@@ -49,26 +49,26 @@ class TtsPlatformImplMac;
 
 class TtsPlatformImplMac : public TtsPlatformImpl {
  public:
-  virtual bool PlatformImplAvailable() override {
+  bool PlatformImplAvailable() override {
     return true;
   }
 
-  virtual bool Speak(
+  bool Speak(
       int utterance_id,
       const std::string& utterance,
       const std::string& lang,
       const VoiceData& voice,
       const UtteranceContinuousParameters& params) override;
 
-  virtual bool StopSpeaking() override;
+  bool StopSpeaking() override;
 
-  virtual void Pause() override;
+  void Pause() override;
 
-  virtual void Resume() override;
+  void Resume() override;
 
-  virtual bool IsSpeaking() override;
+  bool IsSpeaking() override;
 
-  virtual void GetVoices(std::vector<VoiceData>* out_voices) override;
+  void GetVoices(std::vector<VoiceData>* out_voices) override;
 
   // Called by ChromeTtsDelegate when we get a callback from the
   // native speech engine.
@@ -82,7 +82,7 @@ class TtsPlatformImplMac : public TtsPlatformImpl {
 
  private:
   TtsPlatformImplMac();
-  virtual ~TtsPlatformImplMac();
+  ~TtsPlatformImplMac() override;
 
   base::scoped_nsobject<SingleUseSpeechSynthesizer> speech_synthesizer_;
   base::scoped_nsobject<ChromeTtsDelegate> delegate_;

--- a/chromium_src/chrome/browser/speech/tts_message_filter.h
+++ b/chromium_src/chrome/browser/speech/tts_message_filter.h
@@ -41,7 +41,7 @@ class TtsMessageFilter : public content::BrowserMessageFilter,
   friend class content::BrowserThread;
   friend class base::DeleteHelper<TtsMessageFilter>;
 
-  virtual ~TtsMessageFilter();
+  ~TtsMessageFilter() override;
 
   void OnInitializeVoiceList();
   void OnSpeak(const TtsUtteranceRequest& utterance);

--- a/chromium_src/chrome/browser/ui/cocoa/color_chooser_mac.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/color_chooser_mac.mm
@@ -39,14 +39,14 @@ class ColorChooserMac : public content::ColorChooser {
                                SkColor initial_color);
 
   ColorChooserMac(content::WebContents* tab, SkColor initial_color);
-  virtual ~ColorChooserMac();
+  ~ColorChooserMac() override;
 
   // Called from ColorPanelCocoa.
   void DidChooseColorInColorPanel(SkColor color);
   void DidCloseColorPabel();
 
-  virtual void End() override;
-  virtual void SetSelectedColor(SkColor color) override;
+  void End() override;
+  void SetSelectedColor(SkColor color) override;
 
  private:
   static ColorChooserMac* current_color_chooser_;

--- a/chromium_src/chrome/common/tts_utterance_request.cc
+++ b/chromium_src/chrome/common/tts_utterance_request.cc
@@ -11,6 +11,8 @@ TtsUtteranceRequest::~TtsUtteranceRequest() {}
 
 TtsVoice::TtsVoice() : local_service(true), is_default(false) {}
 
+TtsVoice::TtsVoice(const TtsVoice&) = default;
+
 TtsVoice::~TtsVoice() {}
 
 TtsUtteranceResponse::TtsUtteranceResponse() : id(0) {}

--- a/chromium_src/chrome/common/tts_utterance_request.h
+++ b/chromium_src/chrome/common/tts_utterance_request.h
@@ -25,6 +25,7 @@ struct TtsUtteranceRequest {
 
 struct TtsVoice {
   TtsVoice();
+  TtsVoice(const TtsVoice&);
   ~TtsVoice();
 
   std::string voice_uri;

--- a/chromium_src/chrome/renderer/printing/print_web_view_helper.h
+++ b/chromium_src/chrome/renderer/printing/print_web_view_helper.h
@@ -67,7 +67,7 @@ class PrintWebViewHelper
       public content::RenderFrameObserverTracker<PrintWebViewHelper> {
  public:
   explicit PrintWebViewHelper(content::RenderFrame* render_frame);
-  virtual ~PrintWebViewHelper();
+  ~PrintWebViewHelper() override;
 
   void PrintNode(const blink::WebNode& node);
 

--- a/chromium_src/chrome/renderer/tts_dispatcher.h
+++ b/chromium_src/chrome/renderer/tts_dispatcher.h
@@ -29,19 +29,19 @@ class TtsDispatcher : public blink::WebSpeechSynthesizer,
                       public content::RenderThreadObserver {
  public:
   explicit TtsDispatcher(blink::WebSpeechSynthesizerClient* client);
-  virtual ~TtsDispatcher();
+  ~TtsDispatcher() override;
 
  private:
   // RenderProcessObserver override.
-  virtual bool OnControlMessageReceived(const IPC::Message& message) override;
+  bool OnControlMessageReceived(const IPC::Message& message) override;
 
   // blink::WebSpeechSynthesizer implementation.
-  virtual void UpdateVoiceList() override;
-  virtual void Speak(
-      const blink::WebSpeechSynthesisUtterance& utterance) override;
-  virtual void Pause() override;
-  virtual void Resume() override;
-  virtual void Cancel() override;
+  void UpdateVoiceList() override;
+  void Speak(const blink::WebSpeechSynthesisUtterance& utterance)
+      override;
+  void Pause() override;
+  void Resume() override;
+  void Cancel() override;
 
   blink::WebSpeechSynthesisUtterance FindUtterance(int utterance_id);
 

--- a/electron.gyp
+++ b/electron.gyp
@@ -369,6 +369,10 @@
           'xcode_settings': {
             # ReactiveCocoa which is used by Squirrel requires using __weak.
             'CLANG_ENABLE_OBJC_WEAK': 'YES',
+            'OTHER_CFLAGS': [
+              '-Wunguarded-availability',
+              '-Wobjc-missing-property-synthesis',
+            ],
           },
         }],  # OS=="mac" and mas_build==0
         ['OS=="mac" and mas_build==1', {

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -122,6 +122,43 @@
           'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',  # -std=c++14
         },
         'target_conditions': [
+          ['_target_name in ["electron", "brightray"]', {
+            'conditions': [
+              ['OS=="mac"', {
+                'xcode_settings': {
+                  'OTHER_CFLAGS': [
+                    "-Xclang",
+                    "-load",
+                    "-Xclang",
+                    "<(source_root)/<(make_clang_dir)/lib/libFindBadConstructs.dylib",
+                    "-Xclang",
+                    "-add-plugin",
+                    "-Xclang",
+                    "find-bad-constructs",
+                    "-Xclang",
+                    "-plugin-arg-find-bad-constructs",
+                    "-Xclang",
+                    "check-auto-raw-pointer",
+                  ],
+                },
+              }, {  # OS=="mac"
+                'cflags_cc': [
+                  "-Xclang",
+                  "-load",
+                  "-Xclang",
+                  "<(source_root)/<(make_clang_dir)/lib/libFindBadConstructs.so",
+                  "-Xclang",
+                  "-add-plugin",
+                  "-Xclang",
+                  "find-bad-constructs",
+                  "-Xclang",
+                  "-plugin-arg-find-bad-constructs",
+                  "-Xclang",
+                  "check-auto-raw-pointer",
+                ],
+              }],
+            ],
+          }],
           ['OS=="mac" and _type in ["executable", "shared_library"]', {
             'xcode_settings': {
               # On some machines setting CLANG_CXX_LIBRARY doesn't work for


### PR DESCRIPTION
We're not yet running any of the chromium-style checkers on our build, but as
part of exploring porting our build system to GN, I happened across a few
places where the chromium-style clang plugins threw warnings. This fixes them.

These patches are separated out by warning type, so I recommend reading each
commit separately, rather than using the "Files Changed" tab.

See [here](https://www.chromium.org/developers/coding-style/chromium-style-checker-errors) for more information about the chromium-style checker.