### PR TITLE
Add "app.whenReady()"

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -432,6 +432,12 @@ app.exit(0)
 
 Returns `Boolean` - `true` if Electron has finished initializing, `false` otherwise.
 
+### `app.whenReady()`
+
+Returns `Promise` - fulfilled when Electron is initialized.
+May be used as a convenient alternative to checking `app.isReady()`
+and subscribing to the `ready` event if the app is not ready yet.
+
 ### `app.focus()`
 
 On Linux, focuses on the first visible window. On macOS, makes the application

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -11,12 +11,30 @@ const {deprecate, Menu} = electron
 const {EventEmitter} = require('events')
 
 let dockMenu = null
+let readyPromise = null
 
 // App is an EventEmitter.
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 EventEmitter.call(app)
 
 Object.assign(app, {
+  whenReady () {
+    if (readyPromise !== null) {
+      return readyPromise
+    }
+
+    if (app.isReady()) {
+      readyPromise = Promise.resolve()
+    } else {
+      readyPromise = new Promise(resolve => {
+        // XXX(alexeykuzmin): Explicitly ignore any data
+        // passed to the event handler to avoid memory leaks.
+        app.once('ready', () => resolve())
+      })
+    }
+
+    return readyPromise
+  },
   setApplicationMenu (menu) {
     return Menu.setApplicationMenu(menu)
   },

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -1,4 +1,6 @@
 const assert = require('assert')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
 const ChildProcess = require('child_process')
 const https = require('https')
 const net = require('net')
@@ -7,9 +9,12 @@ const path = require('path')
 const {ipcRenderer, remote} = require('electron')
 const {closeWindow} = require('./window-helpers')
 
+const {expect} = chai
 const {app, BrowserWindow, Menu, ipcMain} = remote
 
 const isCI = remote.getGlobal('isCi')
+
+chai.use(chaiAsPromised)
 
 describe('electron module', () => {
   it('does not expose internal modules to require', () => {
@@ -901,6 +906,17 @@ describe('app module', () => {
       app.dock.setMenu(new Menu())
       const v8Util = process.atomBinding('v8_util')
       v8Util.requestGarbageCollectionForTesting()
+    })
+  })
+
+  describe('whenReady', () => {
+    it('returns a Promise', () => {
+      expect(app.whenReady()).to.be.an.instanceOf(Promise)
+    })
+
+    it('becomes fulfilled if the app is already ready', () => {
+      assert(app.isReady())
+      return expect(app.whenReady()).to.be.eventually.fulfilled
     })
   })
 })

--- a/spec/package.json
+++ b/spec/package.json
@@ -7,6 +7,7 @@
     "basic-auth": "^1.0.4",
     "bluebird": "^3.5.1",
     "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "coffee-script": "1.12.7",
     "dbus-native": "^0.2.3",
     "graceful-fs": "^4.1.9",


### PR DESCRIPTION
`app.ready` getter that would return a `Promise` didn't look very well aligned with the rest on the Electron API, so I've decided to go with the `app.whenReady()` method instead.

Closes #9561.
/cc @sindresorhus 