### PR TITLE
Disable navigating on drag/drop

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -211,6 +211,7 @@ void AtomBrowserClient::OverrideWebkitPrefs(
   prefs->webgl1_enabled = true;
   prefs->webgl2_enabled = true;
   prefs->allow_running_insecure_content = false;
+  prefs->navigate_on_drag_drop = false;
 
   // Custom preferences of guest page.
   auto* web_contents = content::WebContents::FromRenderViewHost(host);


### PR DESCRIPTION
Ref #12631

I suspect that we'll actually want an option to turn this back on before merging this, but this was surprisingly easy!