### PR TITLE
add app.isPackaged

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -428,11 +428,6 @@ app.relaunch({args: process.argv.slice(1).concat(['--relaunch'])})
 app.exit(0)
 ```
 
-### `app.isPackaged()`
-
-Returns `Boolean` - `true` if the app is packaged, `false` otherwise. For many apps,
-this function can be used to distinguish development and production environments.
-
 ### `app.isReady()`
 
 Returns `Boolean` - `true` if Electron has finished initializing, `false` otherwise.
@@ -1110,6 +1105,13 @@ Sets the application's [dock menu][dock-menu].
 * `image` ([NativeImage](native-image.md) | String)
 
 Sets the `image` associated with this dock icon.
+
+## Properties
+
+### `app.isPackaged`
+
+`true` if the app is packaged, `false` otherwise. For many apps, this property 
+can be used to distinguish development and production environments.
 
 [dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103
 [tasks]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -428,6 +428,11 @@ app.relaunch({args: process.argv.slice(1).concat(['--relaunch'])})
 app.exit(0)
 ```
 
+### `app.isPackaged()`
+
+Returns `Boolean` - `true` if the app is packaged, `false` otherwise. For many apps,
+this function can be used to distinguish development and production environments.
+
 ### `app.isReady()`
 
 Returns `Boolean` - `true` if Electron has finished initializing, `false` otherwise.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1110,8 +1110,7 @@ Sets the `image` associated with this dock icon.
 
 ### `app.isPackaged`
 
-`true` if the app is packaged, `false` otherwise. For many apps, this property 
-can be used to distinguish development and production environments.
+A `Boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.
 
 [dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103
 [tasks]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -42,7 +42,11 @@ Object.assign(app, {
 })
 
 app.isPackaged = () => {
-  return ['app', 'app.asar'].some(p => fs.existsSync(path.join(process.resourcesPath, p)))
+  const execFile = path.basename(process.execPath)
+  if (process.platform === 'win32') {
+    return execFile === 'electron.exe'
+  }
+  return execFile === 'electron'
 }
 
 if (process.platform === 'darwin') {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const bindings = process.atomBinding('app')
+const path = require('path')
+const fs = require('fs')
 const {app, App} = bindings
 
 // Only one app object permitted.
@@ -38,6 +40,10 @@ Object.assign(app, {
     }
   }
 })
+
+app.isPackaged = () => {
+  return ['app', 'app.asar'].some(p => fs.existsSync(path.join(process.resourcesPath, p)))
+}
 
 if (process.platform === 'darwin') {
   app.dock = {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -41,7 +41,7 @@ Object.assign(app, {
 })
 
 app.isPackaged = (() => {
-  const execFile = path.basename(process.execPath)
+  const execFile = path.basename(process.execPath).toLowerCase()
   if (process.platform === 'win32') {
     return execFile !== 'electron.exe'
   }

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -41,13 +41,13 @@ Object.assign(app, {
   }
 })
 
-app.isPackaged = () => {
+app.isPackaged = (() => {
   const execFile = path.basename(process.execPath)
   if (process.platform === 'win32') {
-    return execFile === 'electron.exe'
+    return execFile !== 'electron.exe'
   }
-  return execFile === 'electron'
-}
+  return execFile !== 'electron'
+})()
 
 if (process.platform === 'darwin') {
   app.dock = {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -2,7 +2,6 @@
 
 const bindings = process.atomBinding('app')
 const path = require('path')
-const fs = require('fs')
 const {app, App} = bindings
 
 // Only one app object permitted.

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -113,6 +113,12 @@ describe('app module', () => {
     })
   })
 
+  describe('app.isPackaged()', () => {
+    it('should be false durings tests', () => {
+      assert.equal(app.isPackaged(), false)
+    })
+  })
+
   describe('app.isInApplicationsFolder()', () => {
     before(function () {
       if (process.platform !== 'darwin') {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -113,9 +113,9 @@ describe('app module', () => {
     })
   })
 
-  describe('app.isPackaged()', () => {
+  describe('app.isPackaged', () => {
     it('should be false durings tests', () => {
-      assert.equal(app.isPackaged(), false)
+      assert.equal(app.isPackaged, false)
     })
   })
 


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/7714.

First pass at adding an `isPackaged()` method to `app` in order to distinguish between development and production.

Todo:
- [x] specs
- [x] docs

/cc @zeke 