### PR TITLE
Part I: Move from base::Bind to base::BindOnce and remove unneeded base::Passed

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -421,8 +421,8 @@ bool NotificationCallbackWrapper(
   } else {
     scoped_refptr<base::SingleThreadTaskRunner> task_runner(
         base::ThreadTaskRunnerHandle::Get());
-    task_runner->PostTask(FROM_HERE,
-                          base::Bind(base::IgnoreResult(callback), cmd, cwd));
+    task_runner->PostTask(
+        FROM_HERE, base::BindOnce(base::IgnoreResult(callback), cmd, cwd));
   }
   // ProcessSingleton needs to know whether current process is quiting.
   return !Browser::Get()->is_shutting_down();

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -141,7 +141,7 @@ void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {
 
   // Emit the ReadyToShow event in next tick in case of pending drawing work.
   base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, base::Bind(
+      FROM_HERE, base::BindOnce(
                      [](base::WeakPtr<BrowserWindow> self) {
                        if (self)
                          self->Emit("ready-to-show");

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -174,7 +174,7 @@ void RemoveCookieOnIOThread(scoped_refptr<net::URLRequestContextGetter> getter,
                             const std::string& name,
                             const base::Closure& callback) {
   GetCookieStore(getter)->DeleteCookieAsync(
-      url, name, base::Bind(RunCallbackInUI, callback));
+      url, name, base::BindOnce(RunCallbackInUI, callback));
 }
 
 // Callback of SetCookie.
@@ -187,7 +187,7 @@ void OnSetCookie(const Cookies::SetCallback& callback, bool success) {
 void FlushCookieStoreOnIOThread(
     scoped_refptr<net::URLRequestContextGetter> getter,
     const base::Closure& callback) {
-  GetCookieStore(getter)->FlushStore(base::Bind(RunCallbackInUI, callback));
+  GetCookieStore(getter)->FlushStore(base::BindOnce(RunCallbackInUI, callback));
 }
 
 // Sets cookie with |details| in IO thread.
@@ -232,7 +232,7 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
   GetCookieStore(getter)->SetCookieWithDetailsAsync(
       GURL(url), name, value, domain, path, creation_time, expiration_time,
       last_access_time, secure, http_only, net::CookieSameSite::DEFAULT_MODE,
-      net::COOKIE_PRIORITY_DEFAULT, base::Bind(OnSetCookie, callback));
+      net::COOKIE_PRIORITY_DEFAULT, base::BindOnce(OnSetCookie, callback));
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -253,8 +253,8 @@ void Cookies::Get(const base::DictionaryValue& filter,
   auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter), Passed(&copied),
-                     callback));
+      base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter),
+                     std::move(copied), callback));
 }
 
 void Cookies::Remove(const GURL& url,
@@ -273,8 +273,8 @@ void Cookies::Set(const base::DictionaryValue& details,
   auto getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), Passed(&copied),
-                     callback));
+      base::BindOnce(SetCookieOnIO, base::RetainedRef(getter),
+                     std::move(copied), callback));
 }
 
 void Cookies::FlushStore(const base::Closure& callback) {

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -244,15 +244,15 @@ class ResolveProxyHelper {
     scoped_refptr<net::URLRequestContextGetter> context_getter =
         browser_context->url_request_context_getter();
     context_getter->GetNetworkTaskRunner()->PostTask(
-        FROM_HERE, base::Bind(&ResolveProxyHelper::ResolveProxy,
-                              base::Unretained(this), context_getter, url));
+        FROM_HERE, base::BindOnce(&ResolveProxyHelper::ResolveProxy,
+                                  base::Unretained(this), context_getter, url));
   }
 
   void OnResolveProxyCompleted(int result) {
     std::string proxy;
     if (result == net::OK)
       proxy = proxy_info_.ToPacString();
-    original_thread_->PostTask(FROM_HERE, base::Bind(callback_, proxy));
+    original_thread_->PostTask(FROM_HERE, base::BindOnce(callback_, proxy));
     delete this;
   }
 
@@ -291,7 +291,7 @@ void RunCallbackInUI(const base::Callback<void()>& callback) {
 template <typename... T>
 void RunCallbackInUI(const base::Callback<void(T...)>& callback, T... result) {
   BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
-                          base::Bind(callback, result...));
+                          base::BindOnce(callback, result...));
 }
 
 // Callback of HttpCache::GetBackend.
@@ -529,9 +529,9 @@ template <Session::CacheAction action>
 void Session::DoCacheAction(const net::CompletionCallback& callback) {
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&DoCacheActionInIO,
-                 WrapRefCounted(browser_context_->GetRequestContext()), action,
-                 callback));
+      base::BindOnce(&DoCacheActionInIO,
+                     WrapRefCounted(browser_context_->GetRequestContext()),
+                     action, callback));
 }
 
 void Session::ClearStorageData(mate::Arguments* args) {
@@ -592,7 +592,7 @@ void Session::EnableNetworkEmulation(const mate::Dictionary& options) {
       devtools_network_emulation_client_id_, std::move(conditions));
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(
+      base::BindOnce(
           &SetDevToolsNetworkEmulationClientIdInIO,
           base::RetainedRef(browser_context_->url_request_context_getter()),
           devtools_network_emulation_client_id_));
@@ -604,7 +604,7 @@ void Session::DisableNetworkEmulation() {
       devtools_network_emulation_client_id_, std::move(conditions));
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(
+      base::BindOnce(
           &SetDevToolsNetworkEmulationClientIdInIO,
           base::RetainedRef(browser_context_->url_request_context_getter()),
           std::string()));
@@ -620,8 +620,9 @@ void Session::SetCertVerifyProc(v8::Local<v8::Value> val,
 
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&SetCertVerifyProcInIO,
-                 WrapRefCounted(browser_context_->GetRequestContext()), proc));
+      base::BindOnce(&SetCertVerifyProcInIO,
+                     WrapRefCounted(browser_context_->GetRequestContext()),
+                     proc));
 }
 
 void Session::SetPermissionRequestHandler(v8::Local<v8::Value> val,
@@ -642,9 +643,9 @@ void Session::ClearHostResolverCache(mate::Arguments* args) {
 
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&ClearHostResolverCacheInIO,
-                 WrapRefCounted(browser_context_->GetRequestContext()),
-                 callback));
+      base::BindOnce(&ClearHostResolverCacheInIO,
+                     WrapRefCounted(browser_context_->GetRequestContext()),
+                     callback));
 }
 
 void Session::ClearAuthCache(mate::Arguments* args) {
@@ -658,17 +659,17 @@ void Session::ClearAuthCache(mate::Arguments* args) {
 
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&ClearAuthCacheInIO,
-                 WrapRefCounted(browser_context_->GetRequestContext()), options,
-                 callback));
+      base::BindOnce(&ClearAuthCacheInIO,
+                     WrapRefCounted(browser_context_->GetRequestContext()),
+                     options, callback));
 }
 
 void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&AllowNTLMCredentialsForDomainsInIO,
-                 WrapRefCounted(browser_context_->GetRequestContext()),
-                 domains));
+      base::BindOnce(&AllowNTLMCredentialsForDomainsInIO,
+                     WrapRefCounted(browser_context_->GetRequestContext()),
+                     domains));
 }
 
 void Session::SetUserAgent(const std::string& user_agent,
@@ -682,7 +683,7 @@ void Session::SetUserAgent(const std::string& user_agent,
       browser_context_->GetRequestContext());
   getter->GetNetworkTaskRunner()->PostTask(
       FROM_HERE,
-      base::Bind(&SetUserAgentInIO, getter, accept_lang, user_agent));
+      base::BindOnce(&SetUserAgentInIO, getter, accept_lang, user_agent));
 }
 
 std::string Session::GetUserAgent() {
@@ -697,8 +698,8 @@ void Session::GetBlobData(const std::string& uuid,
   AtomBlobReader* blob_reader = browser_context()->GetBlobReader();
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&AtomBlobReader::StartReading, base::Unretained(blob_reader),
-                 uuid, callback));
+      base::BindOnce(&AtomBlobReader::StartReading,
+                     base::Unretained(blob_reader), uuid, callback));
 }
 
 void Session::CreateInterruptedDownload(const mate::Dictionary& options) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1362,7 +1362,8 @@ void WebContents::HasServiceWorker(const base::Callback<void(bool)>& callback) {
 
   context->CheckHasServiceWorker(
       web_contents()->GetLastCommittedURL(), GURL::EmptyGURL(),
-      base::Bind(&WrappedCallback::Run, base::Unretained(wrapped_callback)));
+      base::BindOnce(&WrappedCallback::Run,
+                     base::Unretained(wrapped_callback)));
 }
 
 void WebContents::UnregisterServiceWorker(

--- a/atom/browser/api/atom_api_web_request.cc
+++ b/atom/browser/api/atom_api_web_request.cc
@@ -100,9 +100,9 @@ void WebRequest::SetListener(Method method, Event type, mate::Arguments* args) {
     return;
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&CallNetworkDelegateMethod<Method, Event, Listener>,
-                 base::RetainedRef(url_request_context_getter), method, type,
-                 std::move(patterns), std::move(listener)));
+      base::BindOnce(&CallNetworkDelegateMethod<Method, Event, Listener>,
+                     base::RetainedRef(url_request_context_getter), method,
+                     type, std::move(patterns), std::move(listener)));
 }
 
 // static

--- a/atom/browser/api/event_subscriber.h
+++ b/atom/browser/api/event_subscriber.h
@@ -71,7 +71,7 @@ class EventSubscriber : internal::EventSubscriberBase {
       ptr->handler_ = nullptr;
       content::BrowserThread::PostTask(
           content::BrowserThread::UI, FROM_HERE,
-          base::Bind(
+          base::BindOnce(
               [](EventSubscriber<HandlerType>* subscriber) {
                 {
                   // It is possible that this function will execute in the UI

--- a/atom/browser/atom_blob_reader.cc
+++ b/atom/browser/atom_blob_reader.cc
@@ -61,7 +61,7 @@ void AtomBlobReader::StartReading(
   auto callback = base::Bind(&RunCallbackInUI, completion_callback);
   if (!blob_data_handle) {
     BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
-                            base::Bind(callback, nullptr, 0));
+                            base::BindOnce(callback, nullptr, 0));
     return;
   }
 
@@ -117,7 +117,7 @@ void AtomBlobReader::BlobReadHelper::DidReadBlobData(
   char* data = new char[size];
   memcpy(data, blob_data->data(), size);
   BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
-                          base::Bind(completion_callback_, data, size));
+                          base::BindOnce(completion_callback_, data, size));
   delete this;
 }
 

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -43,7 +43,7 @@ void CreateDownloadPath(
 
   base::FilePath path(default_download_path.Append(generated_name));
   content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,
-                                   base::Bind(callback, path));
+                                   base::BindOnce(callback, path));
 }
 
 }  // namespace
@@ -165,10 +165,10 @@ bool AtomDownloadManagerDelegate::DetermineDownloadTarget(
 
   content::BrowserThread::PostTask(
       content::BrowserThread::FILE, FROM_HERE,
-      base::Bind(&CreateDownloadPath, download->GetURL(),
-                 download->GetContentDisposition(),
-                 download->GetSuggestedFilename(), download->GetMimeType(),
-                 default_download_path, download_path_callback));
+      base::BindOnce(&CreateDownloadPath, download->GetURL(),
+                     download->GetContentDisposition(),
+                     download->GetSuggestedFilename(), download->GetMimeType(),
+                     default_download_path, download_path_callback));
   return true;
 }
 

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -117,9 +117,9 @@ bool AtomResourceDispatcherHostDelegate::HandleExternalProtocol(
     const GURL& url,
     content::ResourceRequestInfo* info) {
   BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
-                          base::Bind(&HandleExternalProtocolInUI, url,
-                                     info->GetWebContentsGetterForRequest(),
-                                     info->HasUserGesture()));
+                          base::BindOnce(&HandleExternalProtocolInUI, url,
+                                         info->GetWebContentsGetterForRequest(),
+                                         info->HasUserGesture()));
   return true;
 }
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -312,9 +312,10 @@ void CommonWebContentsDelegate::DevToolsSaveToFile(const std::string& url,
 
   saved_files_[url] = path;
   BrowserThread::PostTaskAndReply(
-      BrowserThread::FILE, FROM_HERE, base::Bind(&WriteToFile, path, content),
-      base::Bind(&CommonWebContentsDelegate::OnDevToolsSaveToFile,
-                 base::Unretained(this), url));
+      BrowserThread::FILE, FROM_HERE,
+      base::BindOnce(&WriteToFile, path, content),
+      base::BindOnce(&CommonWebContentsDelegate::OnDevToolsSaveToFile,
+                     base::Unretained(this), url));
 }
 
 void CommonWebContentsDelegate::DevToolsAppendToFile(
@@ -326,9 +327,9 @@ void CommonWebContentsDelegate::DevToolsAppendToFile(
 
   BrowserThread::PostTaskAndReply(
       BrowserThread::FILE, FROM_HERE,
-      base::Bind(&AppendToFile, it->second, content),
-      base::Bind(&CommonWebContentsDelegate::OnDevToolsAppendToFile,
-                 base::Unretained(this), url));
+      base::BindOnce(&AppendToFile, it->second, content),
+      base::BindOnce(&CommonWebContentsDelegate::OnDevToolsAppendToFile,
+                     base::Unretained(this), url));
 }
 
 void CommonWebContentsDelegate::DevToolsRequestFileSystems() {

--- a/atom/browser/login_handler.cc
+++ b/atom/browser/login_handler.cc
@@ -47,9 +47,9 @@ LoginHandler::LoginHandler(net::AuthChallengeInfo* auth_info,
 
   BrowserThread::PostTask(
       BrowserThread::UI, FROM_HERE,
-      base::Bind(&Browser::RequestLogin, base::Unretained(Browser::Get()),
-                 base::RetainedRef(WrapRefCounted(this)),
-                 base::Passed(&request_details)));
+      base::BindOnce(&Browser::RequestLogin, base::Unretained(Browser::Get()),
+                     base::RetainedRef(WrapRefCounted(this)),
+                     base::Passed(&request_details)));
 }
 
 LoginHandler::~LoginHandler() {}
@@ -69,7 +69,7 @@ void LoginHandler::Login(const base::string16& username,
     return;
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&LoginHandler::DoLogin, this, username, password));
+      base::BindOnce(&LoginHandler::DoLogin, this, username, password));
 }
 
 void LoginHandler::CancelAuth() {
@@ -77,7 +77,7 @@ void LoginHandler::CancelAuth() {
   if (TestAndSetAuthHandled())
     return;
   BrowserThread::PostTask(BrowserThread::IO, FROM_HERE,
-                          base::Bind(&LoginHandler::DoCancelAuth, this));
+                          base::BindOnce(&LoginHandler::DoCancelAuth, this));
 }
 
 void LoginHandler::OnRequestCancelled() {

--- a/atom/browser/login_handler.cc
+++ b/atom/browser/login_handler.cc
@@ -49,7 +49,7 @@ LoginHandler::LoginHandler(net::AuthChallengeInfo* auth_info,
       BrowserThread::UI, FROM_HERE,
       base::BindOnce(&Browser::RequestLogin, base::Unretained(Browser::Get()),
                      base::RetainedRef(WrapRefCounted(this)),
-                     base::Passed(&request_details)));
+                     std::move(request_details)));
 }
 
 LoginHandler::~LoginHandler() {}

--- a/atom/browser/net/asar/url_request_asar_job.cc
+++ b/atom/browser/net/asar/url_request_asar_job.cc
@@ -109,15 +109,15 @@ void URLRequestAsarJob::Start() {
     }
     file_task_runner_->PostTaskAndReply(
         FROM_HERE,
-        base::Bind(&URLRequestAsarJob::FetchMetaInfo, file_path_, type_,
-                   base::Unretained(meta_info)),
-        base::Bind(&URLRequestAsarJob::DidFetchMetaInfo,
-                   weak_ptr_factory_.GetWeakPtr(), base::Owned(meta_info)));
+        base::BindOnce(&URLRequestAsarJob::FetchMetaInfo, file_path_, type_,
+                       base::Unretained(meta_info)),
+        base::BindOnce(&URLRequestAsarJob::DidFetchMetaInfo,
+                       weak_ptr_factory_.GetWeakPtr(), base::Owned(meta_info)));
   } else {
     base::ThreadTaskRunnerHandle::Get()->PostTask(
-        FROM_HERE,
-        base::Bind(&URLRequestAsarJob::DidOpen, weak_ptr_factory_.GetWeakPtr(),
-                   net::ERR_FILE_NOT_FOUND));
+        FROM_HERE, base::BindOnce(&URLRequestAsarJob::DidOpen,
+                                  weak_ptr_factory_.GetWeakPtr(),
+                                  net::ERR_FILE_NOT_FOUND));
   }
 }
 

--- a/atom/browser/net/atom_cert_verifier.cc
+++ b/atom/browser/net/atom_cert_verifier.cc
@@ -96,9 +96,9 @@ class CertVerifierRequest : public AtomCertVerifier::Request {
                                         weak_ptr_factory_.GetWeakPtr());
     BrowserThread::PostTask(
         BrowserThread::UI, FROM_HERE,
-        base::Bind(&CertVerifierRequest::OnVerifyRequestInUI,
-                   cert_verifier_->verify_proc(), base::Passed(&request),
-                   response_callback));
+        base::BindOnce(&CertVerifierRequest::OnVerifyRequestInUI,
+                       cert_verifier_->verify_proc(), base::Passed(&request),
+                       response_callback));
   }
 
   static void OnVerifyRequestInUI(
@@ -112,7 +112,7 @@ class CertVerifierRequest : public AtomCertVerifier::Request {
                              int result) {
     BrowserThread::PostTask(
         BrowserThread::IO, FROM_HERE,
-        base::Bind(&CertVerifierRequest::NotifyResponseInIO, self, result));
+        base::BindOnce(&CertVerifierRequest::NotifyResponseInIO, self, result));
   }
 
   void NotifyResponseInIO(int result) {

--- a/atom/browser/net/atom_cert_verifier.cc
+++ b/atom/browser/net/atom_cert_verifier.cc
@@ -97,7 +97,7 @@ class CertVerifierRequest : public AtomCertVerifier::Request {
     BrowserThread::PostTask(
         BrowserThread::UI, FROM_HERE,
         base::BindOnce(&CertVerifierRequest::OnVerifyRequestInUI,
-                       cert_verifier_->verify_proc(), base::Passed(&request),
+                       cert_verifier_->verify_proc(), std::move(request),
                        response_callback));
   }
 

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -389,7 +389,7 @@ int AtomNetworkDelegate::HandleResponseEvent(
                  base::Unretained(this), request->identifier(), out);
   BrowserThread::PostTask(
       BrowserThread::UI, FROM_HERE,
-      base::BindOnce(RunResponseListener, info.listener, base::Passed(&details),
+      base::BindOnce(RunResponseListener, info.listener, std::move(details),
                      render_process_id, render_frame_id, response));
   return net::ERR_IO_PENDING;
 }
@@ -411,7 +411,7 @@ void AtomNetworkDelegate::HandleSimpleEvent(SimpleEvent type,
 
   BrowserThread::PostTask(
       BrowserThread::UI, FROM_HERE,
-      base::BindOnce(RunSimpleListener, info.listener, base::Passed(&details),
+      base::BindOnce(RunSimpleListener, info.listener, std::move(details),
                      render_process_id, render_frame_id));
 }
 
@@ -440,7 +440,7 @@ void AtomNetworkDelegate::OnListenerResultInUI(
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
       base::BindOnce(&AtomNetworkDelegate::OnListenerResultInIO<T>,
-                     base::Unretained(this), id, out, base::Passed(&copy)));
+                     base::Unretained(this), id, out, std::move(copy)));
 }
 
 }  // namespace atom

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -389,8 +389,8 @@ int AtomNetworkDelegate::HandleResponseEvent(
                  base::Unretained(this), request->identifier(), out);
   BrowserThread::PostTask(
       BrowserThread::UI, FROM_HERE,
-      base::Bind(RunResponseListener, info.listener, base::Passed(&details),
-                 render_process_id, render_frame_id, response));
+      base::BindOnce(RunResponseListener, info.listener, base::Passed(&details),
+                     render_process_id, render_frame_id, response));
   return net::ERR_IO_PENDING;
 }
 
@@ -411,8 +411,8 @@ void AtomNetworkDelegate::HandleSimpleEvent(SimpleEvent type,
 
   BrowserThread::PostTask(
       BrowserThread::UI, FROM_HERE,
-      base::Bind(RunSimpleListener, info.listener, base::Passed(&details),
-                 render_process_id, render_frame_id));
+      base::BindOnce(RunSimpleListener, info.listener, base::Passed(&details),
+                     render_process_id, render_frame_id));
 }
 
 template <typename T>
@@ -439,8 +439,8 @@ void AtomNetworkDelegate::OnListenerResultInUI(
   std::unique_ptr<base::DictionaryValue> copy = response.CreateDeepCopy();
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::Bind(&AtomNetworkDelegate::OnListenerResultInIO<T>,
-                 base::Unretained(this), id, out, base::Passed(&copy)));
+      base::BindOnce(&AtomNetworkDelegate::OnListenerResultInIO<T>,
+                     base::Unretained(this), id, out, base::Passed(&copy)));
 }
 
 }  // namespace atom

--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -23,7 +23,7 @@ void HandlerCallback(const BeforeStartCallback& before_start,
   v8::Local<v8::Value> value;
   if (!args->GetNext(&value)) {
     content::BrowserThread::PostTask(content::BrowserThread::IO, FROM_HERE,
-                                     base::Bind(callback, false, nullptr));
+                                     base::BindOnce(callback, false, nullptr));
     return;
   }
 
@@ -36,7 +36,7 @@ void HandlerCallback(const BeforeStartCallback& before_start,
   std::unique_ptr<base::Value> options(converter.FromV8Value(value, context));
   content::BrowserThread::PostTask(
       content::BrowserThread::IO, FROM_HERE,
-      base::Bind(callback, true, base::Passed(&options)));
+      base::BindOnce(callback, true, base::Passed(&options)));
 }
 
 }  // namespace

--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -36,7 +36,7 @@ void HandlerCallback(const BeforeStartCallback& before_start,
   std::unique_ptr<base::Value> options(converter.FromV8Value(value, context));
   content::BrowserThread::PostTask(
       content::BrowserThread::IO, FROM_HERE,
-      base::BindOnce(callback, true, base::Passed(&options)));
+      base::BindOnce(callback, true, std::move(options)));
 }
 
 }  // namespace

--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -76,7 +76,7 @@ class JsAsker : public RequestJob {
         content::BrowserThread::UI, FROM_HERE,
         base::BindOnce(
             &internal::AskForOptions, isolate_, handler_,
-            base::Passed(&request_details),
+            std::move(request_details),
             base::Bind(&JsAsker::BeforeStartInUI, weak_factory_.GetWeakPtr()),
             base::Bind(&JsAsker::OnResponse, weak_factory_.GetWeakPtr())));
   }

--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -74,7 +74,7 @@ class JsAsker : public RequestJob {
     FillRequestDetails(request_details.get(), RequestJob::request());
     content::BrowserThread::PostTask(
         content::BrowserThread::UI, FROM_HERE,
-        base::Bind(
+        base::BindOnce(
             &internal::AskForOptions, isolate_, handler_,
             base::Passed(&request_details),
             base::Bind(&JsAsker::BeforeStartInUI, weak_factory_.GetWeakPtr()),

--- a/atom/browser/net/url_request_about_job.cc
+++ b/atom/browser/net/url_request_about_job.cc
@@ -14,8 +14,8 @@ URLRequestAboutJob::URLRequestAboutJob(net::URLRequest* request,
 
 void URLRequestAboutJob::Start() {
   base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, base::Bind(&URLRequestAboutJob::StartAsync,
-                            weak_ptr_factory_.GetWeakPtr()));
+      FROM_HERE, base::BindOnce(&URLRequestAboutJob::StartAsync,
+                                weak_ptr_factory_.GetWeakPtr()));
 }
 
 void URLRequestAboutJob::Kill() {

--- a/atom/browser/net/url_request_stream_job.cc
+++ b/atom/browser/net/url_request_stream_job.cc
@@ -118,8 +118,9 @@ void URLRequestStreamJob::OnError(mate::Arguments* args) {
 int URLRequestStreamJob::ReadRawData(net::IOBuffer* dest, int dest_size) {
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
-      base::Bind(&URLRequestStreamJob::CopyMoreData, weak_factory_.GetWeakPtr(),
-                 WrapRefCounted(dest), dest_size));
+      base::BindOnce(&URLRequestStreamJob::CopyMoreData,
+                     weak_factory_.GetWeakPtr(), WrapRefCounted(dest),
+                     dest_size));
   return net::ERR_IO_PENDING;
 }
 
@@ -166,8 +167,8 @@ void URLRequestStreamJob::CopyMoreData(scoped_refptr<net::IOBuffer> io_buf,
     int status = (errored_ && !read_count) ? net::ERR_FAILED : read_count;
     content::BrowserThread::PostTask(
         content::BrowserThread::IO, FROM_HERE,
-        base::Bind(&URLRequestStreamJob::CopyMoreDataDone,
-                   weak_factory_.GetWeakPtr(), io_buf, status));
+        base::BindOnce(&URLRequestStreamJob::CopyMoreDataDone,
+                       weak_factory_.GetWeakPtr(), io_buf, status));
   }
 }
 

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -167,8 +167,8 @@ class AtomCopyFrameGenerator {
         next_frame_time_ += frame_duration_;
         content::BrowserThread::PostDelayedTask(
             content::BrowserThread::UI, FROM_HERE,
-            base::Bind(&AtomCopyFrameGenerator::OnCopyFrameCaptureSuccess,
-                       weak_ptr_factory_.GetWeakPtr(), damage_rect, bitmap),
+            base::BindOnce(&AtomCopyFrameGenerator::OnCopyFrameCaptureSuccess,
+                           weak_ptr_factory_.GetWeakPtr(), damage_rect, bitmap),
             next_frame_in);
       } else {
         next_frame_time_ = now + frame_duration_;
@@ -187,8 +187,8 @@ class AtomCopyFrameGenerator {
       // Retry with the same |damage_rect|.
       content::BrowserThread::PostTask(
           content::BrowserThread::UI, FROM_HERE,
-          base::Bind(&AtomCopyFrameGenerator::GenerateCopyFrame,
-                     weak_ptr_factory_.GetWeakPtr(), damage_rect));
+          base::BindOnce(&AtomCopyFrameGenerator::GenerateCopyFrame,
+                         weak_ptr_factory_.GetWeakPtr(), damage_rect));
     }
   }
 
@@ -1030,8 +1030,8 @@ void OffScreenRenderWidgetHostView::ReleaseResize() {
     pending_resize_ = false;
     content::BrowserThread::PostTask(
         content::BrowserThread::UI, FROM_HERE,
-        base::Bind(&OffScreenRenderWidgetHostView::WasResized,
-                   weak_ptr_factory_.GetWeakPtr()));
+        base::BindOnce(&OffScreenRenderWidgetHostView::WasResized,
+                       weak_ptr_factory_.GetWeakPtr()));
   }
 }
 
@@ -1131,8 +1131,8 @@ void OffScreenRenderWidgetHostView::ProcessMouseWheelEvent(
         // other callback.
         content::BrowserThread::PostTask(
             content::BrowserThread::UI, FROM_HERE,
-            base::Bind(&OffScreenRenderWidgetHostView::CancelWidget,
-                       popup_host_view_->weak_ptr_factory_.GetWeakPtr()));
+            base::BindOnce(&OffScreenRenderWidgetHostView::CancelWidget,
+                           popup_host_view_->weak_ptr_factory_.GetWeakPtr()));
       }
     }
   }

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -318,8 +318,8 @@ void NodeBindings::UvRunOnce() {
 
 void NodeBindings::WakeupMainThread() {
   DCHECK(task_runner_);
-  task_runner_->PostTask(FROM_HERE, base::Bind(&NodeBindings::UvRunOnce,
-                                               weak_factory_.GetWeakPtr()));
+  task_runner_->PostTask(FROM_HERE, base::BindOnce(&NodeBindings::UvRunOnce,
+                                                   weak_factory_.GetWeakPtr()));
 }
 
 void NodeBindings::WakeupEmbedThread() {

--- a/atom/renderer/atom_autofill_agent.cc
+++ b/atom/renderer/atom_autofill_agent.cc
@@ -82,8 +82,8 @@ void AutofillAgent::TextFieldDidChange(
 
   weak_ptr_factory_.InvalidateWeakPtrs();
   base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, base::Bind(&AutofillAgent::TextFieldDidChangeImpl,
-                            weak_ptr_factory_.GetWeakPtr(), element));
+      FROM_HERE, base::BindOnce(&AutofillAgent::TextFieldDidChangeImpl,
+                                weak_ptr_factory_.GetWeakPtr(), element));
 }
 
 void AutofillAgent::TextFieldDidChangeImpl(

--- a/atom/renderer/guest_view_container.cc
+++ b/atom/renderer/guest_view_container.cc
@@ -53,7 +53,7 @@ void GuestViewContainer::DidResizeElement(const gfx::Size& new_size) {
     return;
 
   base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, base::Bind(element_resize_callback_, new_size));
+      FROM_HERE, base::BindOnce(element_resize_callback_, new_size));
 }
 
 base::WeakPtr<content::BrowserPluginDelegate> GuestViewContainer::GetWeakPtr() {

--- a/brightray/browser/devtools_file_system_indexer.cc
+++ b/brightray/browser/devtools_file_system_indexer.cc
@@ -279,13 +279,14 @@ void DevToolsFileSystemIndexer::FileSystemIndexingJob::Start() {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   BrowserThread::PostTask(
       BrowserThread::FILE, FROM_HERE,
-      Bind(&FileSystemIndexingJob::CollectFilesToIndex, this));
+      BindOnce(&FileSystemIndexingJob::CollectFilesToIndex, this));
 }
 
 void DevToolsFileSystemIndexer::FileSystemIndexingJob::Stop() {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
-  BrowserThread::PostTask(BrowserThread::FILE, FROM_HERE,
-                          Bind(&FileSystemIndexingJob::StopOnFileThread, this));
+  BrowserThread::PostTask(
+      BrowserThread::FILE, FROM_HERE,
+      BindOnce(&FileSystemIndexingJob::StopOnFileThread, this));
 }
 
 void DevToolsFileSystemIndexer::FileSystemIndexingJob::StopOnFileThread() {
@@ -304,7 +305,7 @@ void DevToolsFileSystemIndexer::FileSystemIndexingJob::CollectFilesToIndex() {
   if (file_path.empty()) {
     BrowserThread::PostTask(
         BrowserThread::UI, FROM_HERE,
-        Bind(total_work_callback_, file_path_times_.size()));
+        BindOnce(total_work_callback_, file_path_times_.size()));
     indexing_it_ = file_path_times_.begin();
     IndexFiles();
     return;
@@ -318,7 +319,7 @@ void DevToolsFileSystemIndexer::FileSystemIndexingJob::CollectFilesToIndex() {
   }
   BrowserThread::PostTask(
       BrowserThread::FILE, FROM_HERE,
-      Bind(&FileSystemIndexingJob::CollectFilesToIndex, this));
+      BindOnce(&FileSystemIndexingJob::CollectFilesToIndex, this));
 }
 
 void DevToolsFileSystemIndexer::FileSystemIndexingJob::IndexFiles() {
@@ -429,7 +430,7 @@ void DevToolsFileSystemIndexer::FileSystemIndexingJob::ReportWorked() {
   if (should_send_worked_nitification) {
     last_worked_notification_time_ = current_time;
     BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
-                            Bind(worked_callback_, files_indexed_));
+                            BindOnce(worked_callback_, files_indexed_));
     files_indexed_ = 0;
   }
 }
@@ -458,8 +459,8 @@ void DevToolsFileSystemIndexer::SearchInPath(const string& file_system_path,
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   BrowserThread::PostTask(
       BrowserThread::FILE, FROM_HERE,
-      Bind(&DevToolsFileSystemIndexer::SearchInPathOnFileThread, this,
-           file_system_path, query, callback));
+      BindOnce(&DevToolsFileSystemIndexer::SearchInPathOnFileThread, this,
+               file_system_path, query, callback));
 }
 
 void DevToolsFileSystemIndexer::SearchInPathOnFileThread(
@@ -475,7 +476,8 @@ void DevToolsFileSystemIndexer::SearchInPathOnFileThread(
     if (path.IsParent(*it))
       result.push_back(it->AsUTF8Unsafe());
   }
-  BrowserThread::PostTask(BrowserThread::UI, FROM_HERE, Bind(callback, result));
+  BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
+                          BindOnce(callback, result));
 }
 
 }  // namespace brightray

--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -171,9 +171,9 @@ int ResponseWriter::Write(net::IOBuffer* buffer,
 
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
-      base::Bind(&InspectableWebContentsImpl::CallClientFunction, bindings_,
-                 "DevToolsAPI.streamWrite", base::Owned(id), base::Owned(chunk),
-                 nullptr));
+      base::BindOnce(&InspectableWebContentsImpl::CallClientFunction, bindings_,
+                     "DevToolsAPI.streamWrite", base::Owned(id),
+                     base::Owned(chunk), nullptr));
   return num_bytes;
 }
 


### PR DESCRIPTION
This PR does two things
- rewrite base::Bind to base::BindOnce
- remove base::Passed from base::BindOnce parameter

All rewrites are done using clang refactoring tool from chromium [base_bind_rewriter](https://cs.chromium.org/chromium/src/tools/clang/base_bind_rewriters/BaseBindRewriters.cpp)

Steps to build and run the tool:
```
> cd chromium_src/
> tools/clang/scripts/update.py --force-local-build --without-android --extra-tools base_bind_rewriters
> cd electron_src/
> script/build.py -t compdb // generate compilation database for the tool
> chromium_src/tools/clang/scripts/run_tool.py --tool base_bind_rewriters --tool-args=--rewriter=[TOOL_ARGS] --tool-path chromium_src/third_party/llvm-build/Release+Asserts/bin -p <path-to-generated-compdb> [TARGET PATH] > /tmp/list-of-edits.debug
> cat /tmp/list-of-edits.debug | chromium_src/tools/clang/scripts/extract_edits.py | 
 chromium_src/tools/clang/scripts/apply_edits.py -p <path-to-generated-compdb> [TARGET PATH]


TOOL_ARGS - can be one of bind_to_bind_once, remove_unneeded_passed. Refer source code for documentation on these.
TARGET PATH - Directories or file to run the tool on, ex: atom/browser/net
```

The left out changes are to be done manually in a follow up PR. Also `chromium_src` files are not touched as they are going away real soon.

Refs https://github.com/electron/electron/issues/12640 https://github.com/electron/electron/issues/12639