### PR TITLE
Stop overwriting prevent_default if default wasn't prevented

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -551,11 +551,15 @@ App::~App() {
 }
 
 void App::OnBeforeQuit(bool* prevent_default) {
-  *prevent_default = Emit("before-quit");
+  if (Emit("before-quit")) {
+    *prevent_default = true;
+  }
 }
 
 void App::OnWillQuit(bool* prevent_default) {
-  *prevent_default = Emit("will-quit");
+  if (Emit("will-quit")) {
+    *prevent_default = true;
+  }
 }
 
 void App::OnWindowAllClosed() {
@@ -573,7 +577,9 @@ void App::OnQuit() {
 }
 
 void App::OnOpenFile(bool* prevent_default, const std::string& file_path) {
-  *prevent_default = Emit("open-file", file_path);
+  if (Emit("open-file", file_path)) {
+    *prevent_default = true;
+  }
 }
 
 void App::OnOpenURL(const std::string& url) {
@@ -611,7 +617,9 @@ void App::OnAccessibilitySupportChanged() {
 #if defined(OS_MACOSX)
 void App::OnWillContinueUserActivity(bool* prevent_default,
                                      const std::string& type) {
-  *prevent_default = Emit("will-continue-activity", type);
+  if (Emit("will-continue-activity", type)) {
+    *prevent_default = true;
+  }
 }
 
 void App::OnDidFailToContinueUserActivity(const std::string& type,
@@ -622,7 +630,9 @@ void App::OnDidFailToContinueUserActivity(const std::string& type,
 void App::OnContinueUserActivity(bool* prevent_default,
                                  const std::string& type,
                                  const base::DictionaryValue& user_info) {
-  *prevent_default = Emit("continue-activity", type, user_info);
+  if (Emit("continue-activity", type, user_info)) {
+    *prevent_default = true;
+  }
 }
 
 void App::OnUserActivityWasContinued(const std::string& type,
@@ -633,7 +643,9 @@ void App::OnUserActivityWasContinued(const std::string& type,
 void App::OnUpdateUserActivityState(bool* prevent_default,
                                     const std::string& type,
                                     const base::DictionaryValue& user_info) {
-  *prevent_default = Emit("update-activity-state", type, user_info);
+  if (Emit("update-activity-state", type, user_info)) {
+    *prevent_default = true;
+  }
 }
 
 void App::OnNewWindowForTab() {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -135,7 +135,9 @@ void TopLevelWindow::InitWith(v8::Isolate* isolate,
 }
 
 void TopLevelWindow::WillCloseWindow(bool* prevent_default) {
-  *prevent_default = Emit("close");
+  if (Emit("close")) {
+    *prevent_default = true;
+  }
 }
 
 void TopLevelWindow::OnWindowClosed() {


### PR DESCRIPTION
This didn't actually cause any issues because there is only one listener
for the affected methods right now. Should we have added more, the last
called observer would have overwritten `prevent_default`. Lets only set
it when necessary to avoid this footgun in the future.