### PR TITLE
summarize semantic commit requirements

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -12,29 +12,26 @@ newIssueWelcomeComment: |
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
 
-  We use [semantic commit messages](https://conventionalcommits.org/) to streamline the Electron release process. Before 
-  your pull request can be merged, you must **update your pull request title** 
-  to start with a semantic prefix, OR prefix at least one of your commit messages.
+  We use 
+  [semantic commit messages](https://github.com/electron/electron/blob/semantic-first-pr/docs/development/pull-requests.md#commit-message-guidelines) 
+  to streamline the release process. Before your pull request can be merged, you 
+  should **update your pull request title** to start with a semantic prefix, 
+  OR prefix at least one of your commit messages.
 
-  Common prefixes:
+  Examples of commit messages with semantic prefixes:
 
-  - fix: A bug fix
-  - feat: A new feature
-  - docs: Documentation changes
-  - test: Adding missing tests or correcting existing tests
-  - build: Changes that affect the build system
-  - ci: Changes to our CI configuration files and scripts
-  - perf: A code change that improves performance
-  - refactor: A code change that neither fixes a bug nor adds a feature
-  - style: Changes that do not affect the meaning of the code (linting)
+  - `fix: don't overwrite prevent_default if default wasn't prevented`
+  - `feat: add app.isPackaged() method`
+  - `docs: app.isDefaultProtocolClient is now available on Linux` 
 
-  Here is a list of things that will help get your PR across the finish line:
+  Things that will help get your PR across the finish line:
 
   - Follow the JavaScript, C++, and Python [coding style](https://github.com/electron/electron/blob/master/docs/development/coding-style.md).
   - Run `npm run lint` locally to catch formatting errors earlier.
   - Document any user-facing changes you've made following the [documentation styleguide](https://github.com/electron/electron/blob/master/docs/styleguide.md).
   - Include tests when adding/changing behavior.
   - Include screenshots and animated GIFs whenever possible.
+  
   We get a lot of pull requests on this repo, so please be patient and we will get back to you as soon as we can.
 
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -12,9 +12,24 @@ newIssueWelcomeComment: |
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
 
-  ![typing cat](https://user-images.githubusercontent.com/2289/36400158-2c7c589e-1584-11e8-81c7-bd34fd3c392b.gif)
+  We use [semantic commit messages](https://conventionalcommits.org/) to streamline the Electron release process. Before 
+  your pull request can be merged, you must **update your pull request title** 
+  to start with a semantic prefix, OR prefix at least one of your commit messages.
 
-  Here is a list of things that will help get it across the finish line:
+  Common prefixes:
+
+  - fix: A bug fix
+  - feat: A new feature
+  - docs: Documentation changes
+  - test: Adding missing tests or correcting existing tests
+  - build: Changes that affect the build system
+  - ci: Changes to our CI configuration files and scripts
+  - perf: A code change that improves performance
+  - refactor: A code change that neither fixes a bug nor adds a feature
+  - style: Changes that do not affect the meaning of the code (linting)
+
+  Here is a list of things that will help get your PR across the finish line:
+
   - Follow the JavaScript, C++, and Python [coding style](https://github.com/electron/electron/blob/master/docs/development/coding-style.md).
   - Run `npm run lint` locally to catch formatting errors earlier.
   - Document any user-facing changes you've made following the [documentation styleguide](https://github.com/electron/electron/blob/master/docs/styleguide.md).

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -110,6 +110,16 @@ Common prefixes:
   - refactor: A code change that neither fixes a bug nor adds a feature
   - style: Changes that do not affect the meaning of the code (linting)
 
+Other things to keep in mind when writing a commit message:
+
+1. The first line should:
+   - contain a short description of the change (preferably 50 characters or less,
+     and no more than 72 characters)
+   - be entirely in lowercase with the exception of proper nouns, acronyms, and
+   the words that refer to code, like function/variable names
+2. Keep the second line blank.
+3. Wrap all other lines at 72 columns.
+
 #### Breaking Changes
 
 A commit that has the text `BREAKING CHANGE:` at the beginning of its optional 

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -83,24 +83,42 @@ Note that multiple commits often get squashed when they are landed.
 
 #### Commit message guidelines
 
-A good commit message should describe what changed and why.
+A good commit message should describe what changed and why. The Electron project
+uses [semantic commit messages](https://conventionalcommits.org/) to streamline 
+the release process.
 
-1. The first line should:
-   - contain a short description of the change (preferably 50 characters or less,
-     and no more than 72 characters)
-   - be entirely in lowercase with the exception of proper nouns, acronyms, and
-   the words that refer to code, like function/variable names
+Before a pull request can be merged, it should include at least one semantic 
+commit message, though it's not necessary for all commits in the pull request 
+to be semantic. Alternatively, you can **update your pull request title**  to 
+start with a semantic prefix.
 
-   Examples:
-   - `updated osx build documentation for new sdk`
-   - `fixed typos in atom_api_menu.h`
+Examples of commit messages with semantic prefixes:
 
+- `fix: don't overwrite prevent_default if default wasn't prevented`
+- `feat: add app.isPackaged() method`
+- `docs: app.isDefaultProtocolClient is now available on Linux` 
 
-2. Keep the second line blank.
-3. Wrap all other lines at 72 columns.
+Common prefixes:
 
-See [this article](https://chris.beams.io/posts/git-commit/) for more examples
-of how to write good git commit messages.
+  - fix: A bug fix
+  - feat: A new feature
+  - docs: Documentation changes
+  - test: Adding missing tests or correcting existing tests
+  - build: Changes that affect the build system
+  - ci: Changes to our CI configuration files and scripts
+  - perf: A code change that improves performance
+  - refactor: A code change that neither fixes a bug nor adds a feature
+  - style: Changes that do not affect the meaning of the code (linting)
+
+#### Breaking Changes
+
+A commit that has the text `BREAKING CHANGE:` at the beginning of its optional 
+body or footer section introduces a breaking API change (correlating with Major 
+in semantic versioning). A breaking change can be part of commits of any type. 
+e.g., a `fix:`, `feat:` & `chore:` types would all be valid, in addition to any 
+other type.
+
+See [conventionalcommits.org](https://conventionalcommits.org) for more details.
 
 ### Step 6: Rebase
 


### PR DESCRIPTION
This PR represents a first step toward a "conventional commits" requirement on electron/electron.

Rather than requiring every single commit message to follow a convention, the approach here is to require **at least one semantic commit message in the PR, or a semantic PR title**.

We've been using the https://github.com/apps/semantic-pull-request probot app on electron/i18n for a few weeks, and it's worked well. If a PR is ready to go but doesn't yet meet the semantic requirements, a maintainer can change the PR title to get checks passing, then merge.

Feedback welcome!

TODO:

- [x] Document semantic commit requirements in CONTRIBUTING (so we can link to them)
- [x] Add example commit messages
- [x] Change "must" to something more polite.