### PR TITLE
[WIP] add @electron/core to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,14 @@
 # Everything that falls through the cracks:
 * @electron/reviewers
 
+# core
+/atom/ @electron/core
+/brightray/ @electron/core
+/chromium_src/ @electron/core
+/lib/ @electron/core
+/tools/ @electron/core
+/vendor/ @electron/core
+
 # filename patterns
 *browser_view* @electron/browserview
 *notification* @electron/notifications


### PR DESCRIPTION
Problem: It's currently possible for some pull requests to have passing status checks before they're ready to be merged.

Example: https://github.com/electron/electron/pull/11914 -- I've reviewed and approved it for docs and tests, but someone else should review the implementation. However my single review is enough to make this PR go green. There's nothing stopping the author from merging this pull request.

TODO

- [ ] See if maintainers like this idea
- [ ] Create an @electron/core team (which does not include me)


## Alternative 

Alternatively, if the CODEOWNERS change doesn't feel right for whatever reason, we could just bump the number of required reviews on the master branch:

<img width="758" alt="screen shot 2018-04-19 at 1 38 05 pm" src="https://user-images.githubusercontent.com/2289/39017503-51aa0f08-43d8-11e8-8452-0a70af5d2aa5.png">
