### PR TITLE
Turn off visual zoom by default

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -211,6 +211,8 @@ void AtomBrowserClient::OverrideWebkitPrefs(content::RenderViewHost* host,
   prefs->webgl1_enabled = true;
   prefs->webgl2_enabled = true;
   prefs->allow_running_insecure_content = false;
+  prefs->default_minimum_page_scale_factor = 1.f;
+  prefs->default_maximum_page_scale_factor = 1.f;
 
   // Custom preferences of guest page.
   auto* web_contents = content::WebContents::FromRenderViewHost(host);


### PR DESCRIPTION
Ref #12631

Visual zoom can be re-enabled by `webContents.setVisualZoomLevelLimits(1, 3)` (see [web_preferences.cc](https://cs.chromium.org/chromium/src/content/public/common/web_preferences.cc?l=215-224&rcl=d6d671bb399031d59bf8cb6716715a37bef420f4) for more details on how the defaults are currently set).