### PR TITLE
Remove unnecessary step from VS Code debugging instructions

### DIFF
--- a/docs/tutorial/debugging-main-process-vscode.md
+++ b/docs/tutorial/debugging-main-process-vscode.md
@@ -28,7 +28,6 @@ $ code electron-quick-start
 }
 ```
 
-**Note:** For Windows, use `"${workspaceRoot}/node_modules/.bin/electron.cmd"` for `runtimeExecutable`.
 
 ### 3. Debugging
 


### PR DESCRIPTION
VS Code automatically executes from the `windows` object on win32.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->