### PR TITLE
Refactor NativeWindow (Part 9): Use views::Widget on macOS

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -23,7 +23,8 @@
 
 namespace atom {
 
-class NativeWindowMac : public NativeWindow {
+class NativeWindowMac : public NativeWindow,
+                        public views::WidgetDelegate {
  public:
   NativeWindowMac(const mate::Dictionary& options, NativeWindow* parent);
   ~NativeWindowMac() override;
@@ -144,18 +145,24 @@ class NativeWindowMac : public NativeWindow {
   bool fullscreen_window_title() const { return fullscreen_window_title_; }
   bool simple_fullscreen() const { return always_simple_fullscreen_; }
 
+ protected:
+  // views::WidgetDelegate:
+  void DeleteDelegate() override;
+  views::Widget* GetWidget() override;
+  const views::Widget* GetWidget() const override;
+
  private:
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void ShowWindowButton(NSWindowButton button);
 
   void SetForwardMouseMessages(bool forward);
 
-  base::scoped_nsobject<AtomNSWindow> window_;
+  std::unique_ptr<views::Widget> widget_;
+  AtomNSWindow* window_;  // Weak ref, managed by widget_.
+
   base::scoped_nsobject<AtomNSWindowDelegate> window_delegate_;
   base::scoped_nsobject<AtomPreviewItem> preview_item_;
   base::scoped_nsobject<AtomTouchBar> touch_bar_;
-
-  std::unique_ptr<views::Widget> widget_;
 
   // Event monitor for scroll wheel event.
   id wheel_event_monitor_;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -147,7 +147,6 @@ class NativeWindowMac : public NativeWindow,
 
  protected:
   // views::WidgetDelegate:
-  void DeleteDelegate() override;
   views::Widget* GetWidget() override;
   const views::Widget* GetWidget() const override;
   bool CanResize() const override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -150,6 +150,7 @@ class NativeWindowMac : public NativeWindow,
   void DeleteDelegate() override;
   views::Widget* GetWidget() override;
   const views::Widget* GetWidget() const override;
+  bool CanResize() const override;
 
  private:
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
@@ -174,12 +175,10 @@ class NativeWindowMac : public NativeWindow,
   NSView* content_view_;
 
   bool is_kiosk_;
-
   bool was_fullscreen_;
-
   bool zoom_to_page_width_;
-
   bool fullscreen_window_title_;
+  bool resizable_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1305,9 +1305,6 @@ gfx::Rect NativeWindowMac::WindowBoundsToContentBounds(
   }
 }
 
-void NativeWindowMac::DeleteDelegate() {
-}
-
 views::Widget* NativeWindowMac::GetWidget() {
   return widget_.get();
 }

--- a/atom/browser/ui/cocoa/atom_native_widget_mac.h
+++ b/atom/browser/ui/cocoa/atom_native_widget_mac.h
@@ -11,7 +11,8 @@ namespace atom {
 
 class AtomNativeWidgetMac : public views::NativeWidgetMac {
  public:
-  explicit AtomNativeWidgetMac(views::internal::NativeWidgetDelegate* delegate);
+  AtomNativeWidgetMac(NSUInteger style_mask,
+                      views::internal::NativeWidgetDelegate* delegate);
   ~AtomNativeWidgetMac() override;
 
  protected:
@@ -20,6 +21,8 @@ class AtomNativeWidgetMac : public views::NativeWidgetMac {
       const views::Widget::InitParams& params) override;
 
  private:
+  NSUInteger style_mask_;
+
   DISALLOW_COPY_AND_ASSIGN(AtomNativeWidgetMac);
 };
 

--- a/atom/browser/ui/cocoa/atom_native_widget_mac.mm
+++ b/atom/browser/ui/cocoa/atom_native_widget_mac.mm
@@ -4,17 +4,26 @@
 
 #include "atom/browser/ui/cocoa/atom_native_widget_mac.h"
 
+#include "atom/browser/ui/cocoa/atom_ns_window.h"
+#include "ui/base/cocoa/window_size_constants.h"
+
 namespace atom {
 
 AtomNativeWidgetMac::AtomNativeWidgetMac(
+    NSUInteger style_mask,
     views::internal::NativeWidgetDelegate* delegate)
-    : views::NativeWidgetMac(delegate) {}
+    : views::NativeWidgetMac(delegate),
+      style_mask_(style_mask) {}
 
 AtomNativeWidgetMac::~AtomNativeWidgetMac() {}
 
 NativeWidgetMacNSWindow* AtomNativeWidgetMac::CreateNSWindow(
     const views::Widget::InitParams& params) {
-  return views::NativeWidgetMac::CreateNSWindow(params);
+  return [[[AtomNSWindow alloc]
+      initWithContentRect:ui::kWindowSizeDeterminedLater
+                styleMask:style_mask_
+                  backing:NSBackingStoreBuffered
+                    defer:YES] autorelease];
 }
 
 }  // namespace atom

--- a/atom/browser/ui/cocoa/atom_ns_window.h
+++ b/atom/browser/ui/cocoa/atom_ns_window.h
@@ -26,7 +26,7 @@ class ScopedDisableResize {
 
 }  // namespace atom
 
-@interface AtomNSWindow : EventDispatchingWindow {
+@interface AtomNSWindow : NativeWidgetMacNSWindow {
  @private
   atom::NativeWindowMac* shell_;
   CGFloat windowButtonsInterButtonSpacing_;

--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.h
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.h
@@ -13,9 +13,9 @@ namespace atom {
 class NativeWindowMac;
 }
 
-@interface AtomNSWindowDelegate : NSObject<NSWindowDelegate,
-                                           NSTouchBarDelegate,
-                                           QLPreviewPanelDataSource> {
+@interface AtomNSWindowDelegate :
+    ViewsNSWindowDelegate<NSTouchBarDelegate,
+                          QLPreviewPanelDataSource> {
  @private
   atom::NativeWindowMac* shell_;
   bool is_zooming_;

--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -116,10 +116,12 @@
 }
 
 - (void)windowDidResize:(NSNotification*)notification {
+  [super windowDidResize:notification];
   shell_->NotifyWindowResize();
 }
 
 - (void)windowDidMove:(NSNotification*)notification {
+  [super windowDidMove:notification];
   // TODO(zcbenz): Remove the alias after figuring out a proper
   // way to dispatch move.
   shell_->NotifyWindowMove();
@@ -135,10 +137,12 @@
 }
 
 - (void)windowDidMiniaturize:(NSNotification*)notification {
+  [super windowDidMiniaturize:notification];
   shell_->NotifyWindowMinimize();
 }
 
 - (void)windowDidDeminiaturize:(NSNotification*)notification {
+  [super windowDidDeminiaturize:notification];
   [shell_->GetNativeWindow() setLevel:level_];
   shell_->NotifyWindowRestore();
 }

--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -9,11 +9,21 @@
 #include "atom/browser/ui/cocoa/atom_preview_item.h"
 #include "atom/browser/ui/cocoa/atom_touch_bar.h"
 #include "base/mac/mac_util.h"
+#include "ui/views/widget/native_widget_mac.h"
 
 @implementation AtomNSWindowDelegate
 
 - (id)initWithShell:(atom::NativeWindowMac*)shell {
-  if ((self = [super init])) {
+  // The views library assumes the window delegate must be an instance of
+  // ViewsNSWindowDelegate, since we don't have a way to override the creation
+  // of NSWindowDelegate, we have to dynamically replace the window delegate
+  // on the fly.
+  // TODO(zcbenz): Add interface in NativeWidgetMac to allow overriding creating
+  // window delegate.
+  views::BridgedNativeWidget* bridget_view =
+      views::NativeWidgetMac::GetBridgeForNativeWindow(
+          shell->GetNativeWindow());
+  if ((self = [super initWithBridgedNativeWidget:bridget_view])) {
     shell_ = shell;
     is_zooming_ = false;
     level_ = [shell_->GetNativeWindow() level];

--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -20,10 +20,10 @@
   // on the fly.
   // TODO(zcbenz): Add interface in NativeWidgetMac to allow overriding creating
   // window delegate.
-  views::BridgedNativeWidget* bridget_view =
+  views::BridgedNativeWidget* bridged_view =
       views::NativeWidgetMac::GetBridgeForNativeWindow(
           shell->GetNativeWindow());
-  if ((self = [super initWithBridgedNativeWidget:bridget_view])) {
+  if ((self = [super initWithBridgedNativeWidget:bridged_view])) {
     shell_ = shell;
     is_zooming_ = false;
     level_ = [shell_->GetNativeWindow() level];

--- a/atom/browser/ui/cocoa/views_delegate_mac.mm
+++ b/atom/browser/ui/cocoa/views_delegate_mac.mm
@@ -16,8 +16,7 @@ ViewsDelegateMac::~ViewsDelegateMac() {}
 void ViewsDelegateMac::OnBeforeWidgetInit(
     views::Widget::InitParams* params,
     views::internal::NativeWidgetDelegate* delegate) {
-  if (!params->native_widget)
-    params->native_widget = new views::NativeWidgetMac(delegate);
+  DCHECK(params->native_widget);
 }
 
 ui::ContextFactory* ViewsDelegateMac::GetContextFactory() {


### PR DESCRIPTION
This PR uses `views::Widget` to replace current manual creation of `NSWindow`, it would allow us to put arbitrary `views::View` inside `TopLevelWindow` on macOS.

To make the migration graceful, I'm still using our own logics for managing window's styles and states, so this change should have minimal affects on window's behaviors. But it can still cause quirks and regressions since Chromium is adding a lot of custom logics to `NSWindow` in `views::Widget`, please let me know if you noticed any quirk after this change.