### PR TITLE
revert to more graceful template structure check

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -154,7 +154,7 @@ Menu.setApplicationMenu = function (menu) {
 }
 
 Menu.buildFromTemplate = function (template) {
-  if (!(template instanceof Array)) {
+  if (!Array.isArray(template)) {
     throw new TypeError('Invalid template for Menu')
   }
 


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/12698.

Reverts to more graceful check of menu template:
```js
  if (!Array.isArray(template)) {
    throw new TypeError('Invalid template for Menu')
  }
```

as opposed to:
```js
  if (!(template instanceof Array) {
    throw new TypeError('Invalid template for Menu')
  }
```

/cc @MarshallOfSound 