### PR TITLE
Refactor NativeWindow (Part 10): Share more code between NativeWindow implementations

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -13,6 +13,7 @@
 #include "atom/common/color_util.h"
 #include "atom/common/options_switches.h"
 #include "native_mate/dictionary.h"
+#include "ui/views/widget/widget.h"
 
 DEFINE_WEB_CONTENTS_USER_DATA_KEY(atom::NativeWindowRelay);
 
@@ -20,7 +21,8 @@ namespace atom {
 
 NativeWindow::NativeWindow(const mate::Dictionary& options,
                            NativeWindow* parent)
-    : has_frame_(true),
+    : widget_(new views::Widget),
+      has_frame_(true),
       transparent_(false),
       enable_larger_than_screen_(false),
       is_closed_(false),
@@ -508,6 +510,14 @@ void NativeWindow::NotifyWindowMessage(UINT message,
     observer.OnWindowMessage(message, w_param, l_param);
 }
 #endif
+
+views::Widget* NativeWindow::GetWidget() {
+  return widget();
+}
+
+const views::Widget* NativeWindow::GetWidget() const {
+  return widget();
+}
 
 NativeWindowRelay::NativeWindowRelay(base::WeakPtr<NativeWindow> window)
   : key(UserDataKey()), window(window) {}

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -16,6 +16,7 @@
 #include "base/supports_user_data.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "extensions/browser/app_window/size_constraints.h"
+#include "ui/views/widget/widget_delegate.h"
 
 class SkRegion;
 
@@ -47,7 +48,8 @@ class NativeBrowserView;
 
 struct DraggableRegion;
 
-class NativeWindow : public base::SupportsUserData {
+class NativeWindow : public base::SupportsUserData,
+                     public views::WidgetDelegate {
  public:
   ~NativeWindow() override;
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -261,6 +261,8 @@ class NativeWindow : public base::SupportsUserData,
     observers_.RemoveObserver(obs);
   }
 
+  views::Widget* widget() const { return widget_.get(); }
+
   bool has_frame() const { return has_frame_; }
   void set_has_frame(bool has_frame) { has_frame_ = has_frame; }
 
@@ -274,11 +276,17 @@ class NativeWindow : public base::SupportsUserData,
  protected:
   NativeWindow(const mate::Dictionary& options, NativeWindow* parent);
 
+  // views::WidgetDelegate:
+  views::Widget* GetWidget() override;
+  const views::Widget* GetWidget() const override;
+
   void set_browser_view(NativeBrowserView* browser_view) {
     browser_view_ = browser_view;
   }
 
  private:
+  std::unique_ptr<views::Widget> widget_;
+
   // Whether window has standard frame.
   bool has_frame_;
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -144,8 +144,6 @@ class NativeWindowMac : public NativeWindow {
 
  protected:
   // views::WidgetDelegate:
-  views::Widget* GetWidget() override;
-  const views::Widget* GetWidget() const override;
   bool CanResize() const override;
 
  private:
@@ -154,7 +152,6 @@ class NativeWindowMac : public NativeWindow {
 
   void SetForwardMouseMessages(bool forward);
 
-  std::unique_ptr<views::Widget> widget_;
   AtomNSWindow* window_;  // Weak ref, managed by widget_.
 
   base::scoped_nsobject<AtomNSWindowDelegate> window_delegate_;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -12,8 +12,6 @@
 
 #include "atom/browser/native_window.h"
 #include "base/mac/scoped_nsobject.h"
-#include "ui/views/widget/widget_delegate.h"
-#include "ui/views/widget/widget_observer.h"
 
 @class AtomNSWindow;
 @class AtomNSWindowDelegate;
@@ -23,8 +21,7 @@
 
 namespace atom {
 
-class NativeWindowMac : public NativeWindow,
-                        public views::WidgetDelegate {
+class NativeWindowMac : public NativeWindow {
  public:
   NativeWindowMac(const mate::Dictionary& options, NativeWindow* parent);
   ~NativeWindowMac() override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -308,15 +308,14 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
 
   // Create views::Widget and assign window_ with it.
   // TODO(zcbenz): Get rid of the window_ in future.
-  widget_.reset(new views::Widget());
   views::Widget::InitParams params;
   params.ownership = views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET;
   params.bounds = bounds;
   params.delegate = this;
   params.type = views::Widget::InitParams::TYPE_WINDOW;
-  params.native_widget = new AtomNativeWidgetMac(styleMask, widget_.get());
-  widget_->Init(params);
-  window_ = static_cast<AtomNSWindow*>(widget_->GetNativeWindow());
+  params.native_widget = new AtomNativeWidgetMac(styleMask, widget());
+  widget()->Init(params);
+  window_ = static_cast<AtomNSWindow*>(widget()->GetNativeWindow());
 
   [window_ setShell:this];
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
@@ -1303,14 +1302,6 @@ gfx::Rect NativeWindowMac::WindowBoundsToContentBounds(
   } else {
     return bounds;
   }
-}
-
-views::Widget* NativeWindowMac::GetWidget() {
-  return widget_.get();
-}
-
-const views::Widget* NativeWindowMac::GetWidget() const {
-  return widget_.get();
 }
 
 bool NativeWindowMac::CanResize() const {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -373,7 +373,7 @@ bool NativeWindowViews::IsFocused() {
 void NativeWindowViews::Show() {
   if (is_modal() && NativeWindow::parent() &&
       !widget()->native_widget_private()->IsVisible())
-    static_cast<NativeWindowViews*>(NativeWindow::parent())->SetEnabled(false);
+    NativeWindow::parent()->SetEnabled(false);
 
   widget()->native_widget_private()->ShowWithWindowState(GetRestoredState());
 
@@ -398,7 +398,7 @@ void NativeWindowViews::ShowInactive() {
 
 void NativeWindowViews::Hide() {
   if (is_modal() && NativeWindow::parent())
-    static_cast<NativeWindowViews*>(NativeWindow::parent())->SetEnabled(true);
+    NativeWindow::parent()->SetEnabled(true);
 
   widget()->Hide();
 
@@ -1163,10 +1163,9 @@ void NativeWindowViews::SetIcon(HICON window_icon, HICON app_icon) {
 }
 #elif defined(USE_X11)
 void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
-  views::DesktopWindowTreeHostX11* tree_host =
-      views::DesktopWindowTreeHostX11::GetHostForXID(GetAcceleratedWidget());
-  static_cast<views::DesktopWindowTreeHost*>(tree_host)->SetWindowIcons(icon,
-                                                                        icon);
+  auto* tree_host = static_cast<views::DesktopWindowTreeHost*>(
+      views::DesktopWindowTreeHostX11::GetHostForXID(GetAcceleratedWidget()));
+  tree_host->SetWindowIcons(icon, icon);
 }
 #endif
 
@@ -1224,8 +1223,7 @@ void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
 
 void NativeWindowViews::DeleteDelegate() {
   if (is_modal() && NativeWindow::parent()) {
-    NativeWindowViews* parent =
-        static_cast<NativeWindowViews*>(NativeWindow::parent());
+    auto* parent = NativeWindow::parent();
     // Enable parent window after current window gets closed.
     parent->SetEnabled(true);
     // Focus on parent window.

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -120,7 +120,6 @@ class NativeWindowClientView : public views::ClientView {
 NativeWindowViews::NativeWindowViews(const mate::Dictionary& options,
                                      NativeWindow* parent)
     : NativeWindow(options, parent),
-      widget_(new views::Widget),
       content_view_(nullptr),
       focused_view_(nullptr),
       menu_bar_autohide_(false),
@@ -1262,14 +1261,6 @@ base::string16 NativeWindowViews::GetWindowTitle() const {
 
 bool NativeWindowViews::ShouldHandleSystemCommands() const {
   return true;
-}
-
-views::Widget* NativeWindowViews::GetWidget() {
-  return widget();
-}
-
-const views::Widget* NativeWindowViews::GetWidget() const {
-  return widget();
 }
 
 views::View* NativeWindowViews::GetContentsView() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -606,14 +606,11 @@ void NativeWindowViews::SetContentSizeConstraints(
   // this to determine whether native widget has initialized.
   if (widget() && widget()->widget_delegate())
     widget()->OnSizeConstraintsChanged();
-#if defined(OS_WIN) || defined(USE_X11)
   if (resizable_)
     old_size_constraints_ = size_constraints;
-#endif
 }
 
 void NativeWindowViews::SetResizable(bool resizable) {
-#if defined(OS_WIN) || defined(USE_X11)
   if (resizable != resizable_) {
     // On Linux there is no "resizable" property of a window, we have to set
     // both the minimum and maximum size to the window size to achieve it.
@@ -627,7 +624,6 @@ void NativeWindowViews::SetResizable(bool resizable) {
           extensions::SizeConstraints(content_size, content_size));
     }
   }
-#endif
 #if defined(OS_WIN)
   if (has_frame() && thick_frame_)
     FlipWindowStyle(GetAcceleratedWidget(), resizable, WS_THICKFRAME);
@@ -650,11 +646,8 @@ bool NativeWindowViews::IsResizable() {
 #if defined(OS_WIN)
   if (has_frame())
     return ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME;
-  else
-    return CanResize();
-#else
-  return CanResize();
 #endif
+  return CanResize();
 }
 
 void NativeWindowViews::SetMovable(bool movable) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -138,6 +138,9 @@ NativeWindowViews::NativeWindowViews(const mate::Dictionary& options,
       maximizable_(true),
       minimizable_(true),
       fullscreenable_(true) {
+  // The root view is this class, it is managed by us.
+  set_owned_by_client();
+
   options.Get(options::kTitle, &title_);
   options.Get(options::kAutoHideMenuBar, &menu_bar_autohide_);
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -215,6 +215,12 @@ class NativeWindowViews : public NativeWindow,
   bool menu_bar_visible_;
   bool menu_bar_alt_pressed_;
 
+  // The "resizable" flag on Linux is implemented by setting size constraints,
+  // we need to make sure size constraints are restored when window becomes
+  // resizable again. This is also used on Windows, to keep taskbar resize
+  // events from resizing the window.
+  extensions::SizeConstraints old_size_constraints_;
+
 #if defined(USE_X11)
   std::unique_ptr<GlobalMenuBarX11> global_menu_bar_;
 
@@ -224,13 +230,7 @@ class NativeWindowViews : public NativeWindow,
   // To disable the mouse events.
   std::unique_ptr<EventDisabler> event_disabler_;
 #endif
-#if defined(OS_WIN) || defined(USE_X11)
-  // The "resizable" flag on Linux is implemented by setting size constraints,
-  // we need to make sure size constraints are restored when window becomes
-  // resizable again. This is also used on Windows, to keep taskbar resize
-  // events from resizing the window.
-  extensions::SizeConstraints old_size_constraints_;
-#endif
+
 #if defined(OS_WIN)
   // Weak ref.
   AtomDesktopWindowTreeHostWin* atom_desktop_window_tree_host_win_;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -138,7 +138,7 @@ class NativeWindowViews : public NativeWindow,
   void SetIcon(const gfx::ImageSkia& icon);
 #endif
 
-  views::Widget* widget() const { return window_.get(); }
+  views::Widget* widget() const { return widget_.get(); }
   views::View* content_view() const { return content_view_; }
   SkRegion* draggable_region() const { return draggable_region_.get(); }
 
@@ -210,7 +210,7 @@ class NativeWindowViews : public NativeWindow,
   // Returns the restore state for the window.
   ui::WindowShowState GetRestoredState();
 
-  std::unique_ptr<views::Widget> window_;
+  std::unique_ptr<views::Widget> widget_;
   views::View* content_view_;  // Weak ref.
   views::View* focused_view_;  // The view should be focused by default.
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "atom/browser/ui/accelerator_util.h"
-#include "ui/views/widget/widget_delegate.h"
 #include "ui/views/widget/widget_observer.h"
 
 #if defined(OS_WIN)
@@ -41,7 +40,7 @@ class NativeWindowViews : public NativeWindow,
 #if defined(OS_WIN)
                           public MessageHandlerDelegate,
 #endif
-                          public views::WidgetDelegateView,
+                          public views::View,
                           public views::WidgetObserver {
  public:
   NativeWindowViews(const mate::Dictionary& options, NativeWindow* parent);

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -138,7 +138,6 @@ class NativeWindowViews : public NativeWindow,
   void SetIcon(const gfx::ImageSkia& icon);
 #endif
 
-  views::Widget* widget() const { return widget_.get(); }
   views::View* content_view() const { return content_view_; }
   SkRegion* draggable_region() const { return draggable_region_.get(); }
 
@@ -160,8 +159,6 @@ class NativeWindowViews : public NativeWindow,
   bool CanMinimize() const override;
   base::string16 GetWindowTitle() const override;
   bool ShouldHandleSystemCommands() const override;
-  views::Widget* GetWidget() override;
-  const views::Widget* GetWidget() const override;
   views::View* GetContentsView() override;
   bool ShouldDescendIntoChildForEventHandling(
       gfx::NativeView child,
@@ -210,7 +207,6 @@ class NativeWindowViews : public NativeWindow,
   // Returns the restore state for the window.
   ui::WindowShowState GetRestoredState();
 
-  std::unique_ptr<views::Widget> widget_;
   views::View* content_view_;  // Weak ref.
   views::View* focused_view_;  // The view should be focused by default.
 


### PR DESCRIPTION
By using `views::Widget` on all platforms, we can now share more code between `NativeWindowMac` and `NativeWindowViews`.