### PR TITLE
Update docs & tests to add app.enableMixedSandbox() on linux

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1024,7 +1024,7 @@ correctly.
 
 **Note:** This will not affect `process.argv`.
 
-### `app.enableMixedSandbox()` _Experimental_ _macOS_ _Windows_
+### `app.enableMixedSandbox()` _Experimental_
 
 Enables mixed sandbox mode on the app.
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -809,13 +809,6 @@ describe('app module', () => {
     const socketPath = process.platform === 'win32' ? '\\\\.\\pipe\\electron-mixed-sandbox' : '/tmp/electron-mixed-sandbox'
 
     beforeEach(function (done) {
-      // XXX(alexeykuzmin): Calling `.skip()` inside a `before` hook
-      // doesn't affect nested `describe`s.
-      // FIXME Get these specs running on Linux
-      if (process.platform === 'linux') {
-        this.skip()
-      }
-
       fs.unlink(socketPath, () => {
         server = net.createServer()
         server.listen(socketPath)


### PR DESCRIPTION
Hi, the docs specify that `app.enableMixedSandbox()` is only available on macOS and Windows. We've done some testing here and it works in the same way on Linux.

Reading through the original pull request to add the feature it looked like the reason it was only flagged for macOS and Windows is that nobody was able to confirm if it works on Linux https://github.com/electron/electron/pull/9644#issuecomment-308526161

This PR removes the _macOS_ and _Windows_ flags in the docs and removes the `skip()` clause in the tests