### PR TITLE
Send document-start/end to the right context when contextIsolation=true

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -218,8 +218,9 @@ node::Environment* AtomRendererClient::GetEnvironment(
   if (injected_frames_.find(render_frame) == injected_frames_.end())
     return nullptr;
   v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
-  node::Environment* env = node::Environment::GetCurrent(
-      render_frame->GetWebFrame()->MainWorldScriptContext());
+  auto context =
+      GetContext(render_frame->GetWebFrame(), v8::Isolate::GetCurrent());
+  node::Environment* env = node::Environment::GetCurrent(context);
   if (environments_.find(env) == environments_.end())
     return nullptr;
   return env;

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -226,7 +226,7 @@ void RendererClientBase::AddSupportedKeySystems(
 
 v8::Local<v8::Context> RendererClientBase::GetContext(
     blink::WebLocalFrame* frame,
-    v8::Isolate* isolate) {
+    v8::Isolate* isolate) const {
   if (isolated_world())
     return frame->WorldScriptContext(isolate, World::ISOLATED_WORLD);
   else

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -27,11 +27,11 @@ class RendererClientBase : public content::ContentRendererClient {
   virtual void DidClearWindowObject(content::RenderFrame* render_frame);
   virtual void SetupMainWorldOverrides(v8::Handle<v8::Context> context) = 0;
 
-  bool isolated_world() { return isolated_world_; }
+  bool isolated_world() const { return isolated_world_; }
 
   // Get the context that the Electron API is running in.
   v8::Local<v8::Context> GetContext(blink::WebLocalFrame* frame,
-                                    v8::Isolate* isolate);
+                                    v8::Isolate* isolate) const;
 
  protected:
   void AddRenderBindings(v8::Isolate* isolate,


### PR DESCRIPTION
I'm not super familiar with the contextIsolation code, but this was crashing tests locally on my GN build, for reasons I'm not totally clear on. It seems like the events here ought to be going to the isolated world, though, not the main world.