### PR TITLE
Fix crash when releasing a script context that never had node injected

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -122,6 +122,8 @@ void AtomRendererClient::DidCreateScriptContext(
 void AtomRendererClient::WillReleaseScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {
+  if (injected_frames_.find(render_frame) == injected_frames_.end())
+    return;
   injected_frames_.erase(render_frame);
 
   node::Environment* env = node::Environment::GetCurrent(context);


### PR DESCRIPTION
This was causing a renderer to sometimes crash in the test `BrowserWindow module "webPreferences" option nativeWindowOpen option opens window from <iframe> tags`. The test wasn't failing because the crash occurred when tearing down the window.