### PR TITLE
Fix flaky security-warnings test

### DIFF
--- a/spec/security-warnings-spec.js
+++ b/spec/security-warnings-spec.js
@@ -54,9 +54,8 @@ describe('security warnings', () => {
   })
 
   afterEach(() => {
-    closeWindow(w).then(() => { w = null })
-
     useCsp = true
+    return closeWindow(w).then(() => { w = null })
   })
 
   it('should warn about Node.js integration with remote content', (done) => {


### PR DESCRIPTION
```
security warnings "after each" hook - "after each" hook
/home/builduser/project/spec/security-warnings-spec.js
lessAssertionError [ERR_ASSERTION]: false == true
    at w.webContents.on (/home/builduser/project/spec/security-warnings-spec.js:81:7)
    at CallbacksRegistry.apply (/home/builduser/project/out/D/resources/electron.asar/common/api/callbacks-registry.js:47:25)
    at EventEmitter.ipcRenderer.on (/home/builduser/project/out/D/resources/electron.asar/renderer/api/remote.js:270:21)
    at EventEmitter.emit (events.js:127:13)
```