### PR TITLE
Refactor NativeWindow (Part 11): NativeWindowViews should not be a View

### DIFF
--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -9,9 +9,7 @@
 
 #include <set>
 #include <string>
-#include <vector>
 
-#include "atom/browser/ui/accelerator_util.h"
 #include "ui/views/widget/widget_observer.h"
 
 #if defined(OS_WIN)
@@ -27,7 +25,7 @@ class UnhandledKeyboardEventHandler;
 namespace atom {
 
 class GlobalMenuBarX11;
-class MenuBar;
+class RootView;
 class WindowStateWatcher;
 
 #if defined(OS_WIN)
@@ -40,7 +38,6 @@ class NativeWindowViews : public NativeWindow,
 #if defined(OS_WIN)
                           public MessageHandlerDelegate,
 #endif
-                          public views::View,
                           public views::WidgetObserver {
  public:
   NativeWindowViews(const mate::Dictionary& options, NativeWindow* parent);
@@ -195,25 +192,13 @@ class NativeWindowViews : public NativeWindow,
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) override;
 
-  // views::View:
-  void Layout() override;
-  gfx::Size GetMinimumSize() const override;
-  gfx::Size GetMaximumSize() const override;
-  bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
-
-  // Register accelerators supported by the menu model.
-  void RegisterAccelerators(AtomMenuModel* menu_model);
-
   // Returns the restore state for the window.
   ui::WindowShowState GetRestoredState();
 
+  std::unique_ptr<RootView> root_view_;
+
   views::View* content_view_;  // Weak ref.
   views::View* focused_view_;  // The view should be focused by default.
-
-  std::unique_ptr<MenuBar> menu_bar_;
-  bool menu_bar_autohide_;
-  bool menu_bar_visible_;
-  bool menu_bar_alt_pressed_;
 
   // The "resizable" flag on Linux is implemented by setting size constraints,
   // we need to make sure size constraints are restored when window becomes
@@ -280,9 +265,6 @@ class NativeWindowViews : public NativeWindow,
 
   // Handles unhandled keyboard messages coming back from the renderer process.
   std::unique_ptr<views::UnhandledKeyboardEventHandler> keyboard_event_handler_;
-
-  // Map from accelerator to menu item's command id.
-  accelerator_util::AcceleratorTable accelerator_table_;
 
   // For custom drag, the whole window is non-draggable and the draggable region
   // has to been explicitly provided.

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -1,0 +1,197 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/ui/views/root_view.h"
+
+#include "atom/browser/native_window_views.h"
+#include "atom/browser/ui/views/menu_bar.h"
+#include "content/public/browser/native_web_keyboard_event.h"
+
+namespace atom {
+
+namespace {
+
+// The menu bar height in pixels.
+#if defined(OS_WIN)
+const int kMenuBarHeight = 20;
+#else
+const int kMenuBarHeight = 25;
+#endif
+
+bool IsAltKey(const content::NativeWebKeyboardEvent& event) {
+  return event.windows_key_code == ui::VKEY_MENU;
+}
+
+bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
+  typedef content::NativeWebKeyboardEvent::Modifiers Modifiers;
+  int modifiers = event.GetModifiers();
+  modifiers &= ~Modifiers::kNumLockOn;
+  modifiers &= ~Modifiers::kCapsLockOn;
+  return (modifiers == Modifiers::kAltKey) ||
+         (modifiers == (Modifiers::kAltKey | Modifiers::kIsLeft)) ||
+         (modifiers == (Modifiers::kAltKey | Modifiers::kIsRight));
+}
+
+}  // namespace
+
+RootView::RootView(NativeWindow* window) : window_(window) {
+  set_owned_by_client();
+}
+
+RootView::~RootView() {}
+
+void RootView::SetMenu(AtomMenuModel* menu_model) {
+  if (menu_model == nullptr) {
+    // Remove accelerators
+    accelerator_table_.clear();
+    GetFocusManager()->UnregisterAccelerators(this);
+    // and menu bar.
+    SetMenuBarVisibility(false);
+    menu_bar_.reset();
+    return;
+  }
+
+  RegisterAccelerators(menu_model);
+
+  // Do not show menu bar in frameless window.
+  if (!window_->has_frame())
+    return;
+
+  if (!menu_bar_) {
+    menu_bar_.reset(new MenuBar(this));
+    menu_bar_->set_owned_by_client();
+    if (!menu_bar_autohide_)
+      SetMenuBarVisibility(true);
+  }
+
+  menu_bar_->SetMenu(menu_model);
+  Layout();
+}
+
+bool RootView::HasMenu() const {
+  return !!menu_bar_;
+}
+
+int RootView::GetMenuBarHeight() const {
+  return kMenuBarHeight;
+}
+
+void RootView::SetAutoHideMenuBar(bool auto_hide) {
+  menu_bar_autohide_ = auto_hide;
+}
+
+bool RootView::IsMenuBarAutoHide() const {
+  return menu_bar_autohide_;
+}
+
+void RootView::SetMenuBarVisibility(bool visible) {
+  if (!menu_bar_ || menu_bar_visible_ == visible)
+    return;
+
+  // Always show the accelerator when the auto-hide menu bar shows.
+  if (menu_bar_autohide_)
+    menu_bar_->SetAcceleratorVisibility(visible);
+
+  menu_bar_visible_ = visible;
+  if (visible) {
+    DCHECK_EQ(child_count(), 1);
+    AddChildView(menu_bar_.get());
+  } else {
+    DCHECK_EQ(child_count(), 2);
+    RemoveChildView(menu_bar_.get());
+  }
+
+  Layout();
+}
+
+bool RootView::IsMenuBarVisible() const {
+  return menu_bar_visible_;
+}
+
+void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
+  if (!menu_bar_)
+    return;
+
+  // Show accelerator when "Alt" is pressed.
+  if (menu_bar_visible_ && IsAltKey(event))
+    menu_bar_->SetAcceleratorVisibility(event.GetType() ==
+                                        blink::WebInputEvent::kRawKeyDown);
+
+  // Show the submenu when "Alt+Key" is pressed.
+  if (event.GetType() == blink::WebInputEvent::kRawKeyDown &&
+      !IsAltKey(event) && IsAltModifier(event)) {
+    if (!menu_bar_visible_ &&
+        (menu_bar_->HasAccelerator(event.windows_key_code)))
+      SetMenuBarVisibility(true);
+    menu_bar_->ActivateAccelerator(event.windows_key_code);
+    return;
+  }
+
+  if (!menu_bar_autohide_)
+    return;
+
+  // Toggle the menu bar only when a single Alt is released.
+  if (event.GetType() == blink::WebInputEvent::kRawKeyDown && IsAltKey(event)) {
+    // When a single Alt is pressed:
+    menu_bar_alt_pressed_ = true;
+  } else if (event.GetType() == blink::WebInputEvent::kKeyUp &&
+             IsAltKey(event) && menu_bar_alt_pressed_) {
+    // When a single Alt is released right after a Alt is pressed:
+    menu_bar_alt_pressed_ = false;
+    SetMenuBarVisibility(!menu_bar_visible_);
+  } else {
+    // When any other keys except single Alt have been pressed/released:
+    menu_bar_alt_pressed_ = false;
+  }
+}
+
+void RootView::ResetAltState() {
+  menu_bar_alt_pressed_ = false;
+}
+
+void RootView::Layout() {
+  views::View* content_view =
+      static_cast<NativeWindowViews*>(window_)->content_view();
+  if (!content_view)  // Not ready yet.
+    return;
+
+  const auto menu_bar_bounds =
+      menu_bar_visible_ ? gfx::Rect(0, 0, size().width(), kMenuBarHeight)
+                        : gfx::Rect();
+  if (menu_bar_)
+    menu_bar_->SetBoundsRect(menu_bar_bounds);
+
+  content_view->SetBoundsRect(
+      gfx::Rect(0, menu_bar_bounds.height(), size().width(),
+                size().height() - menu_bar_bounds.height()));
+}
+
+gfx::Size RootView::GetMinimumSize() const {
+  return window_->GetMinimumSize();
+}
+
+gfx::Size RootView::GetMaximumSize() const {
+  return window_->GetMaximumSize();
+}
+
+bool RootView::AcceleratorPressed(const ui::Accelerator& accelerator) {
+  return accelerator_util::TriggerAcceleratorTableCommand(&accelerator_table_,
+                                                          accelerator);
+}
+
+void RootView::RegisterAccelerators(AtomMenuModel* menu_model) {
+  // Clear previous accelerators.
+  views::FocusManager* focus_manager = GetFocusManager();
+  accelerator_table_.clear();
+  focus_manager->UnregisterAccelerators(this);
+
+  // Register accelerators with focus manager.
+  accelerator_util::GenerateAcceleratorTable(&accelerator_table_, menu_model);
+  for (const auto& iter : accelerator_table_) {
+    focus_manager->RegisterAccelerator(
+        iter.first, ui::AcceleratorManager::kNormalPriority, this);
+  }
+}
+
+}  // namespace atom

--- a/atom/browser/ui/views/root_view.h
+++ b/atom/browser/ui/views/root_view.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_UI_VIEWS_ROOT_VIEW_H_
+#define ATOM_BROWSER_UI_VIEWS_ROOT_VIEW_H_
+
+#include <memory>
+
+#include "atom/browser/ui/accelerator_util.h"
+#include "ui/views/view.h"
+
+namespace content {
+struct NativeWebKeyboardEvent;
+}
+
+namespace atom {
+
+class AtomMenuModel;
+class MenuBar;
+class NativeWindow;
+
+class RootView : public views::View {
+ public:
+  explicit RootView(NativeWindow* window);
+  ~RootView() override;
+
+  void SetMenu(AtomMenuModel* menu_model);
+  bool HasMenu() const;
+  int GetMenuBarHeight() const;
+  void SetAutoHideMenuBar(bool auto_hide);
+  bool IsMenuBarAutoHide() const;
+  void SetMenuBarVisibility(bool visible);
+  bool IsMenuBarVisible() const;
+  void HandleKeyEvent(const content::NativeWebKeyboardEvent& event);
+  void ResetAltState();
+
+  // views::View:
+  void Layout() override;
+  gfx::Size GetMinimumSize() const override;
+  gfx::Size GetMaximumSize() const override;
+  bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
+
+ private:
+  // Register accelerators supported by the menu model.
+  void RegisterAccelerators(AtomMenuModel* menu_model);
+
+  // Parent window, weak ref.
+  NativeWindow* window_;
+
+  // Menu bar.
+  std::unique_ptr<MenuBar> menu_bar_;
+  bool menu_bar_autohide_ = false;
+  bool menu_bar_visible_ = false;
+  bool menu_bar_alt_pressed_ = false;
+
+  // Map from accelerator to menu item's command id.
+  accelerator_util::AcceleratorTable accelerator_table_;
+
+  DISALLOW_COPY_AND_ASSIGN(RootView);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_UI_VIEWS_ROOT_VIEW_H_

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -368,6 +368,8 @@
       'atom/browser/ui/views/menu_model_adapter.h',
       'atom/browser/ui/views/native_frame_view.cc',
       'atom/browser/ui/views/native_frame_view.h',
+      'atom/browser/ui/views/root_view.cc',
+      'atom/browser/ui/views/root_view.h',
       'atom/browser/ui/views/submenu_button.cc',
       'atom/browser/ui/views/submenu_button.h',
       'atom/browser/ui/views/win_frame_view.cc',


### PR DESCRIPTION
Do not make `NativeWindowViews` inherit from `views::View`, and move view related code into a new class.

With this PR the `NativeWindowViews` implement would be more similar to `NativeWindowMac`, and it also decouples the management of `MenuBar` from `NativeWindowViews`.