### PR TITLE
Support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,22 +89,8 @@ Find documentation translations in [electron/i18n](https://github.com/electron/i
 
 ## Community
 
-You can ask questions and interact with the community in the following
-locations:
-- [`electron`](https://discuss.atom.io/c/electron) category on the Atom
-forums
-- `#atom-shell` channel on Freenode
-- [`Atom`](https://atom-slack.herokuapp.com) channel on Slack
-- [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*
-- [`electron-br`](https://electron-br.slack.com) *(Brazilian Portuguese)*
-- [`electron-kr`](https://electron-kr.github.io/electron-kr) *(Korean)*
-- [`electron-jp`](https://electron-jp.slack.com) *(Japanese)*
-- [`electron-tr`](https://electron-tr.herokuapp.com) *(Turkish)*
-- [`electron-id`](https://electron-id.slack.com) *(Indonesia)*
-- [`electron-pl`](https://electronpl.github.io) *(Poland)*
-
-Check out [awesome-electron](https://github.com/sindresorhus/awesome-electron)
-for a community maintained list of useful example apps, tools and resources.
+Info on reporting bugs, getting help, finding third-party tools and sample apps,
+and more can be found in the [support document](docs/tutorial/support.md#finding-support).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ an issue:
   * [DevTools Extension](tutorial/devtools-extension.md)
   * [Automated Testing with a Custom Driver](tutorial/automated-testing-with-a-custom-driver.md)
 * [Application Distribution](tutorial/application-distribution.md)
-  * [Supported Platforms](tutorial/supported-platforms.md)
+  * [Supported](tutorial/supported.md)
   * [Mac App Store](tutorial/mac-app-store-submission-guide.md)
   * [Windows Store](tutorial/windows-store-guide.md)
   * [Snapcraft](tutorial/snapcraft.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ an issue:
   * [DevTools Extension](tutorial/devtools-extension.md)
   * [Automated Testing with a Custom Driver](tutorial/automated-testing-with-a-custom-driver.md)
 * [Application Distribution](tutorial/application-distribution.md)
-  * [Supported](tutorial/supported.md)
+  * [Support](tutorial/support.md)
   * [Mac App Store](tutorial/mac-app-store-submission-guide.md)
   * [Windows Store](tutorial/windows-store-guide.md)
   * [Snapcraft](tutorial/snapcraft.md)

--- a/docs/development/issues.md
+++ b/docs/development/issues.md
@@ -26,10 +26,9 @@ contribute:
 
 ## Asking for General Help
 
-Because the level of activity in the `electron/electron` repository is
-so high, questions or requests for general help using Electron should
-be directed at the [community slack channel](https://atomio.slack.com)
-or the [forum](https://discuss.atom.io/c/electron).
+["Finding Support"](../tutorial/support.md#finding-support) has a
+list of resources for getting programming help, reporting security issues,
+contributing, and more. Please use the issue tracker for bugs only!
 
 ## Submitting a Bug Report
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -12,7 +12,7 @@ you can interact with the community in these locations:
 - [`electron`](https://discuss.atom.io/c/electron) category on the Atom
 forums
 - `#atom-shell` channel on Freenode
-- [`Atom`](https://atom-slack.herokuapp.com) channel on Slack
+- [`Electron`](https://atom-slack.herokuapp.com) channel on Atom's Slack
 - [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*
 - [`electron-br`](https://electron-br.slack.com) *(Brazilian Portuguese)*
 - [`electron-kr`](https://electron-kr.github.io/electron-kr) *(Korean)*

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -1,4 +1,29 @@
-# Supported Platforms
+# Electron Support
+
+## Supported Versions
+
+The Electron maintainers support the latest three release branches.
+For example, if the latest release is 2.0.x, then the 2-0-x series
+is supported, as are the two previous release series 1-7-x and 1-8-x.
+
+When a release branch reaches the end of its support cycle,
+the series will be deprecated in NPM and a final end-of-support release
+will be made. This release will add a console warning to inform that
+an unsupported version of Electron is in use.
+
+These steps are to help app developers learn when a branch they're using
+becomes unsupported, and to avoid being intrusive to end users.
+
+If an application has exceptional circumstances and needs to stay
+on an unsupported series of Electron, developers can silence the
+end-of-support warning by omitting the final release from the app's
+`package.json` `devDependencies`. For example, since the 1-6-x series
+ended with an end-of-support 1.6.18 release, developers could choose
+to stay in the 1-6-x series without warnings with `devDependency  of
+`"electron": 1.6.0 - 1.6.17`.
+
+
+## Supported Platforms
 
 Following platforms are supported by Electron:
 
@@ -30,7 +55,7 @@ distribution includes the libraries that Electron is linked to on the building
 platform, so only Ubuntu 12.04 is guaranteed to work, but following platforms
 are also verified to be able to run the prebuilt binaries of Electron:
 
-* Ubuntu 12.04 and later
+* Ubuntu 12.04 and newer
 * Fedora 21
 * Debian 8
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -1,5 +1,21 @@
 # Electron Support
 
+## Finding Support
+
+If you have a security concern,
+please see the [security document](../../security.md).
+
+If you've found a bug in a [supported version](#supported-versions) of Electron,
+please report it with the [issue tracker](../development/issues.md).
+
+If you need programming help,
+or want to join in the discussion with other Electron developers,
+or want to find sample starter applications,
+see [these community resources](../../README.md#community).
+
+If you'd like to contribute to Electron,
+see [contributing.md](../../CONTRIBUTING.md) document.
+
 ## Supported Versions
 
 The Electron maintainers support the latest three release branches.
@@ -20,9 +36,8 @@ on an unsupported series of Electron, developers can silence the
 end-of-support warning by omitting the final release from the app's
 `package.json` `devDependencies`. For example, since the 1-6-x series
 ended with an end-of-support 1.6.18 release, developers could choose
-to stay in the 1-6-x series without warnings with `devDependency  of
+to stay in the 1-6-x series without warnings with `devDependency` of
 `"electron": 1.6.0 - 1.6.17`.
-
 
 ## Supported Platforms
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -69,9 +69,8 @@ Windows 7 and later are supported, older operating systems are not supported
 (and do not work).
 
 Both `ia32` (`x86`) and `x64` (`amd64`) binaries are provided for Windows.
-
-The Windows `ARM` binaries are not supported yet due to limited team
-resources; however, they contain no reported blockers.
+Running Electron apps on Windows for ARM devices is possible by using the
+ia32 binary.
 
 Another option for running Electron apps on Windows for `ARM` devices is
 to use the ia32 emulator that comes with Windows for ARM.

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -72,9 +72,6 @@ Both `ia32` (`x86`) and `x64` (`amd64`) binaries are provided for Windows.
 Running Electron apps on Windows for ARM devices is possible by using the
 ia32 binary.
 
-Another option for running Electron apps on Windows for `ARM` devices is
-to use the ia32 emulator that comes with Windows for ARM.
-
 ### Linux
 
 The prebuilt `ia32` (`i686`) and `x64` (`amd64`) binaries of Electron are built on

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -3,10 +3,7 @@
 ## Finding Support
 
 If you have a security concern,
-please see the [security document](../../security.md).
-
-If you've found a bug in a [supported version](#supported-versions) of Electron,
-please report it with the [issue tracker](../development/issues.md).
+please see the [security document](../../SECURITY.md).
 
 If you need programming help,
 or want to join in the discussion with other Electron developers,
@@ -14,11 +11,14 @@ or want to find sample starter applications,
 see [these community resources](../../README.md#community).
 
 If you'd like to contribute to Electron,
-see [contributing.md](../../CONTRIBUTING.md) document.
+see the [contributing document](../../CONTRIBUTING.md).
+
+If you've found a bug in a [supported version](#supported-versions) of Electron,
+please report it with the [issue tracker](../development/issues.md).
 
 ## Supported Versions
 
-The Electron maintainers support the latest three release branches.
+The latest three release branches are supported by the Electron team.
 For example, if the latest release is 2.0.x, then the 2-0-x series
 is supported, as are the two previous release series 1-7-x and 1-8-x.
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -5,16 +5,31 @@
 If you have a security concern,
 please see the [security document](../../SECURITY.md).
 
-If you need programming help,
-or want to join in the discussion with other Electron developers,
-or want to find sample starter applications,
-see [these community resources](../../README.md#community).
+If you're looking for programming help,
+for answers to questions,
+or to join in discussion with other developers who use Electron,
+you can interact with the community in these locations:
+- [`electron`](https://discuss.atom.io/c/electron) category on the Atom
+forums
+- `#atom-shell` channel on Freenode
+- [`Atom`](https://atom-slack.herokuapp.com) channel on Slack
+- [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*
+- [`electron-br`](https://electron-br.slack.com) *(Brazilian Portuguese)*
+- [`electron-kr`](https://electron-kr.github.io/electron-kr) *(Korean)*
+- [`electron-jp`](https://electron-jp.slack.com) *(Japanese)*
+- [`electron-tr`](https://electron-tr.herokuapp.com) *(Turkish)*
+- [`electron-id`](https://electron-id.slack.com) *(Indonesia)*
+- [`electron-pl`](https://electronpl.github.io) *(Poland)*
 
 If you'd like to contribute to Electron,
 see the [contributing document](../../CONTRIBUTING.md).
 
 If you've found a bug in a [supported version](#supported-versions) of Electron,
 please report it with the [issue tracker](../development/issues.md).
+
+[awesome-electron](https://github.com/sindresorhus/awesome-electron)
+is a community-maintained list of useful example apps,
+tools and resources.
 
 ## Supported Versions
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -69,7 +69,12 @@ Windows 7 and later are supported, older operating systems are not supported
 (and do not work).
 
 Both `ia32` (`x86`) and `x64` (`amd64`) binaries are provided for Windows.
-Please note, the `ARM` version of Windows is not supported for now.
+
+The Windows `ARM` binaries are not supported yet due to limited team
+resources; however, they contain no reported blockers.
+
+Another option for running Electron apps on Windows for `ARM` devices is
+to use the ia32 emulator that comes with Windows for ARM.
 
 ### Linux
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -6,13 +6,14 @@ The Electron maintainers support the latest three release branches.
 For example, if the latest release is 2.0.x, then the 2-0-x series
 is supported, as are the two previous release series 1-7-x and 1-8-x.
 
-When a release branch reaches the end of its support cycle,
-the series will be deprecated in NPM and a final end-of-support release
-will be made. This release will add a console warning to inform that
-an unsupported version of Electron is in use.
+When a release branch reaches the end of its support cycle, the series
+will be deprecated in NPM and a final end-of-support release will be
+made. This release will add a warning to inform that an unsupported
+version of Electron is in use.
 
-These steps are to help app developers learn when a branch they're using
-becomes unsupported, and to avoid being intrusive to end users.
+These steps are to help app developers learn when a branch they're
+using becomes unsupported, but without being excessively intrusive
+to end users.
 
 If an application has exceptional circumstances and needs to stay
 on an unsupported series of Electron, developers can silence the

--- a/docs/tutorial/supported-platforms.md
+++ b/docs/tutorial/supported-platforms.md
@@ -1,0 +1,1 @@
+Moved to [support.md](support.md)


### PR DESCRIPTION
Add an end-of-support policy to the public documentation.

This topic overlaps a lot with other support questions/issues, so I've repurposed `supported-platforms.md` as `support.md` and unified the discussion/linking that takes place between README.md, issues.md, support.md, and SECURITY.md.
