### PR TITLE
fix darkmode tray highlighting on 1-8-x

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -90,7 +90,7 @@ const CGFloat kVerticalTitleMargin = 2;
   CGFloat thickness = [[statusItem_ statusBar] thickness];
 
   // Draw the system bar background.
-  [statusItem_ drawStatusBarBackgroundInRect:self.bounds withHighlight:highlight];
+  [statusItem_ drawStatusBarBackgroundInRect:self.bounds withHighlight:shouldHighlight];
 
   // Determine which image to use.
   NSImage* image = image_.get();


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/12765.

Backports https://github.com/electron/electron/pull/12395 to `1-8-x` to fix tray icon being greyed out in MacOS dark mode. 

/cc @ckerr 