### PR TITLE
New makeSingleInstance API

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -424,7 +424,7 @@ int GetPathConstant(const std::string& name) {
 bool NotificationCallbackWrapper(
     const base::Callback<
         void(const base::CommandLine::StringVector& command_line,
-             const base::FilePath& current_directory)> callback,
+             const base::FilePath& current_directory)>& callback,
     const base::CommandLine::StringVector& cmd,
     const base::FilePath& cwd) {
   // Make sure the callback is called after app gets ready.

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -871,7 +871,7 @@ void App::OnSecondInstance(const base::CommandLine::StringVector& cmd,
   Emit("second-instance", cmd, cwd);
 }
 
-bool App::HasSingleInstanceLock() {
+bool App::HasSingleInstanceLock() const {
   if (process_singleton_)
     return true;
   return false;

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -188,6 +188,7 @@ class App : public AtomBrowserClient::Delegate,
                         const base::FilePath& cwd);
   bool IsPrimaryInstance(mate::Arguments* args);
   bool IsSingleInstance();
+  // TODO(MarshallOfSound): Remove return value in 4.0
   bool MakeSingleInstance();
   void ReleaseSingleInstance();
   bool Relaunch(mate::Arguments* args);

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -45,12 +45,6 @@ namespace atom {
 enum class JumpListResult : int;
 #endif
 
-enum SingleInstanceState {
-  UNINITIALIZED,
-  PRIMARY,
-  SECONDARY,
-};
-
 struct ProcessMetric {
   int type;
   base::ProcessId pid;
@@ -184,13 +178,11 @@ class App : public AtomBrowserClient::Delegate,
 
   void SetDesktopName(const std::string& desktop_name);
   std::string GetLocale();
-  bool OnSecondInstance(const base::CommandLine::StringVector& cmd,
+  void OnSecondInstance(const base::CommandLine::StringVector& cmd,
                         const base::FilePath& cwd);
-  bool IsPrimaryInstance(mate::Arguments* args);
-  bool IsSingleInstance();
-  // TODO(MarshallOfSound): Remove return value in 4.0
-  bool MakeSingleInstance();
-  void ReleaseSingleInstance();
+  bool HasSingleInstanceLock();
+  bool RequestSingleInstanceLock();
+  void ReleaseSingleInstanceLock();
   bool Relaunch(mate::Arguments* args);
   void DisableHardwareAcceleration(mate::Arguments* args);
   void DisableDomainBlockingFor3DAPIs(mate::Arguments* args);
@@ -238,9 +230,6 @@ class App : public AtomBrowserClient::Delegate,
   using ProcessMetricMap =
       std::unordered_map<base::ProcessId, std::unique_ptr<atom::ProcessMetric>>;
   ProcessMetricMap app_metrics_;
-
-  SingleInstanceState single_instance_state_ =
-      SingleInstanceState::UNINITIALIZED;
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -45,6 +45,12 @@ namespace atom {
 enum class JumpListResult : int;
 #endif
 
+enum SingleInstanceState {
+  UNINITIALIZED,
+  PRIMARY,
+  SECONDARY,
+};
+
 struct ProcessMetric {
   int type;
   base::ProcessId pid;
@@ -178,8 +184,11 @@ class App : public AtomBrowserClient::Delegate,
 
   void SetDesktopName(const std::string& desktop_name);
   std::string GetLocale();
-  bool MakeSingleInstance(
-      const ProcessSingleton::NotificationCallback& callback);
+  bool OnSecondInstance(const base::CommandLine::StringVector& cmd,
+                        const base::FilePath& cwd);
+  bool IsPrimaryInstance(mate::Arguments* args);
+  bool IsSingleInstance();
+  bool MakeSingleInstance();
   void ReleaseSingleInstance();
   bool Relaunch(mate::Arguments* args);
   void DisableHardwareAcceleration(mate::Arguments* args);
@@ -228,6 +237,9 @@ class App : public AtomBrowserClient::Delegate,
   using ProcessMetricMap =
       std::unordered_map<base::ProcessId, std::unique_ptr<atom::ProcessMetric>>;
   ProcessMetricMap app_metrics_;
+
+  SingleInstanceState single_instance_state_ =
+      SingleInstanceState::UNINITIALIZED;
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -180,7 +180,7 @@ class App : public AtomBrowserClient::Delegate,
   std::string GetLocale();
   void OnSecondInstance(const base::CommandLine::StringVector& cmd,
                         const base::FilePath& cwd);
-  bool HasSingleInstanceLock();
+  bool HasSingleInstanceLock() const;
   bool RequestSingleInstanceLock();
   void ReleaseSingleInstanceLock();
   bool Relaunch(mate::Arguments* args);

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -801,12 +801,12 @@ app.on('second-instance', (commandLine, workingDirectory) => {
 })
 
 if (!gotTheLock) {
-  return app.quit()
+  app.quit()
+} else {
+  // Create myWindow, load the rest of the app, etc...
+  app.on('ready', () => {
+  })
 }
-
-// Create myWindow, load the rest of the app, etc...
-app.on('ready', () => {
-})
 ```
 
 ### `app.hasSingleInstanceLock()`

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -772,9 +772,9 @@ application successfully obtained the lock.  If it failed to obtain the lock
 you can assume that another instance of your application is already running with
 the lock and exit immediately.
 
-I.e. This methods returns `true` if your process is the primary instance of your
+I.e. This method returns `true` if your process is the primary instance of your
 application and your app should continue loading.  It returns `false` if your
-process should immediately quit as it has sent it's parameters to another
+process should immediately quit as it has sent its parameters to another
 instance that has already acquired the lock.
 
 On macOS the system enforces single instance automatically when users try to open
@@ -792,17 +792,17 @@ let myWindow = null
 
 const gotTheLock = app.requestSingleInstanceLock()
 
-app.on('second-instance', (commandLine, workingDirectory) => {
-  // Someone tried to run a second instance, we should focus our window.
-  if (myWindow) {
-    if (myWindow.isMinimized()) myWindow.restore()
-    myWindow.focus()
-  }
-})
-
 if (!gotTheLock) {
   app.quit()
 } else {
+  app.on('second-instance', (commandLine, workingDirectory) => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (myWindow) {
+      if (myWindow.isMinimized()) myWindow.restore()
+      myWindow.focus()
+    }
+  })
+
   // Create myWindow, load the rest of the app, etc...
   app.on('ready', () => {
   })
@@ -813,7 +813,7 @@ if (!gotTheLock) {
 
 Returns `Boolean`
 
-This methods returns whether or not this instance of your app is currently
+This method returns whether or not this instance of your app is currently
 holding the single instance lock.  You can request the lock with
 `app.requestSingleInstanceLock()` and release with
 `app.releaseSingleInstanceLock()`

--- a/docs/tutorial/planned-breaking-changes.md
+++ b/docs/tutorial/planned-breaking-changes.md
@@ -1,4 +1,4 @@
-# Planned Breaking API Changes
+# Planned Breaking API Changes (3.0)
 
 The following list includes the APIs that will be removed in Electron 3.0.
 
@@ -150,3 +150,33 @@ Replace with: https://atom.io/download/electron
 The `FIXME` string is used in code comments to denote things that should be
 fixed for the 3.0 release. See
 https://github.com/electron/electron/search?q=fixme
+
+# Planned Breaking API Changes (4.0)
+
+The following list includes the APIs that will be removed in Electron 4.0.
+
+There is no timetable for when this release will occur but deprecation
+warnings will be added at least [one major version](electron-versioning.md#semver) beforehand.
+
+## `app.makeSingleInstance`
+
+```js
+// Deprecated
+app.makeSingleInstance(function (argv, cwd) {
+
+})
+// Replace with
+app.requestSingleInstanceLock()
+app.on('second-instance', function (argv, cwd) {
+
+})
+```
+
+## `app.releaseSingleInstance`
+
+```js
+// Deprecated
+app.releaseSingleInstance()
+// Replace with
+app.releaseSingleInstanceLock()
+```

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -110,6 +110,12 @@ for (let name of events) {
 }
 
 // TODO(MarshallOfSound): Remove in 4.0
+app.releaseSingleInstance = () => {
+  deprecate.warn('app.releaseSingleInstance(cb)', 'app.releaseSingleInstanceLock()')
+  app.releaseSingleInstanceLock()
+}
+
+// TODO(MarshallOfSound): Remove in 4.0
 app.makeSingleInstance = (oldStyleFn) => {
   deprecate.warn('app.makeSingleInstance(cb)', 'app.requestSingleInstanceLock() and app.on(\'second-instance\', cb)')
   if (oldStyleFn && typeof oldStyleFn === 'function') {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -109,6 +109,16 @@ for (let name of events) {
   })
 }
 
+// TODO(MarshallOfSound): Remove in 4.0
+const originalMakeSingleInstance = app.makeSingleInstance.bind(app)
+app.makeSingleInstance = (cb) => {
+  if (cb && typeof cb === 'function') {
+    deprecate.warn('app.makeSingleInstance(cb)', 'app.makeSingleInstance() and app.on(\'second-instance\', cb)')
+    app.on('second-instance', (event, ...args) => cb(...args))
+  }
+  return originalMakeSingleInstance()
+}
+
 // Wrappers for native classes.
 const {DownloadItem} = process.atomBinding('download_item')
 Object.setPrototypeOf(DownloadItem.prototype, EventEmitter.prototype)

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -110,10 +110,10 @@ for (let name of events) {
 }
 
 // TODO(MarshallOfSound): Remove in 4.0
-app.makeSingleInstance = (cb) => {
+app.makeSingleInstance = (oldStyleFn) => {
   deprecate.warn('app.makeSingleInstance(cb)', 'app.requestSingleInstanceLock() and app.on(\'second-instance\', cb)')
-  if (cb && typeof cb === 'function') {
-    app.on('second-instance', (event, ...args) => cb(...args))
+  if (oldStyleFn && typeof oldStyleFn === 'function') {
+    app.on('second-instance', (event, ...args) => oldStyleFn(...args))
   }
   return !app.requestSingleInstanceLock()
 }

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -110,13 +110,12 @@ for (let name of events) {
 }
 
 // TODO(MarshallOfSound): Remove in 4.0
-const originalMakeSingleInstance = app.makeSingleInstance.bind(app)
 app.makeSingleInstance = (cb) => {
+  deprecate.warn('app.makeSingleInstance(cb)', 'app.requestSingleInstanceLock() and app.on(\'second-instance\', cb)')
   if (cb && typeof cb === 'function') {
-    deprecate.warn('app.makeSingleInstance(cb)', 'app.makeSingleInstance() and app.on(\'second-instance\', cb)')
     app.on('second-instance', (event, ...args) => cb(...args))
   }
-  return originalMakeSingleInstance()
+  return !app.requestSingleInstanceLock()
 }
 
 // Wrappers for native classes.

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -185,7 +185,29 @@ describe('app module', () => {
     })
   })
 
+  // TODO(MarshallOfSound) - Remove in 4.0.0
   describe('app.makeSingleInstance', () => {
+    it('prevents the second launch of app', function (done) {
+      this.timeout(120000)
+      const appPath = path.join(__dirname, 'fixtures', 'api', 'singleton-old')
+      // First launch should exit with 0.
+      const first = ChildProcess.spawn(remote.process.execPath, [appPath])
+      first.once('exit', (code) => {
+        assert.equal(code, 0)
+      })
+      // Start second app when received output.
+      first.stdout.once('data', () => {
+        // Second launch should exit with 1.
+        const second = ChildProcess.spawn(remote.process.execPath, [appPath])
+        second.once('exit', (code) => {
+          assert.equal(code, 1)
+          done()
+        })
+      })
+    })
+  })
+
+  describe('app.requestSingleInstanceLock', () => {
     it('prevents the second launch of app', function (done) {
       this.timeout(120000)
       const appPath = path.join(__dirname, 'fixtures', 'api', 'singleton')

--- a/spec/fixtures/api/singleton-old/main.js
+++ b/spec/fixtures/api/singleton-old/main.js
@@ -4,12 +4,10 @@ app.once('ready', () => {
   console.log('started')  // ping parent
 })
 
-const gotTheLock = app.requestSingleInstanceLock()
-
-app.on('second-instance', () => {
+const shouldExit = app.makeSingleInstance(() => {
   setImmediate(() => app.exit(0))
 })
 
-if (!gotTheLock) {
+if (shouldExit) {
   app.exit(1)
 }

--- a/spec/fixtures/api/singleton-old/package.json
+++ b/spec/fixtures/api/singleton-old/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "electron-app-singleton",
+  "main": "main.js"
+}
+

--- a/spec/fixtures/api/singleton/main.js
+++ b/spec/fixtures/api/singleton/main.js
@@ -5,7 +5,7 @@ app.once('ready', () => {
 })
 
 const shouldExit = app.makeSingleInstance(() => {
-  process.nextTick(() => app.exit(0))
+  setImmediate(() => app.exit(0))
 })
 
 if (shouldExit) {


### PR DESCRIPTION
Closes #12752

New usage is below

```javascript
const {app} = require('electron')
let myWindow = null

const gotTheLock = app.requestSingleInstanceLock()

app.on('second-instance', (commandLine, workingDirectory) => {
  // Someone tried to run a second instance, we should focus our window.
  if (myWindow) {
    if (myWindow.isMinimized()) myWindow.restore()
    myWindow.focus()
  }
})

if (!gotTheLock) {
  return app.quit()
}

// Create myWindow, load the rest of the app, etc...
app.on('ready', () => {
})
```

**IMPORTANT:** This is **not** a breaking change, the old syntax still works but is deprecated and should be removed in `4.0.0`