### PR TITLE
docs: clarify default auto-updater installation behavior

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -84,6 +84,9 @@ Emitted when an update has been downloaded.
 
 On Windows only `releaseName` is available.
 
+**Note:** It is not strictly necessary to handle this event. A successfully 
+downloaded update will still be applied the next time the application starts.
+
 ### Event: 'before-quit-for-update'
 
 This event is emitted after a user calls `quitAndInstall()`.
@@ -121,6 +124,10 @@ should only be called after `update-downloaded` has been emitted.
 Under the hood calling `autoUpdater.quitAndInstall()` will close all application
 windows first, and automatically call `app.quit()` after all windows have been
 closed.
+
+**Note:** It is not strictly necessary to call this function to apply an update, 
+as a successfully downloaded update will always be applied the next time the 
+application starts.
 
 **Note:** If the application is quit without calling this API after the
 `update-downloaded` event has been emitted, the application will still be

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -129,10 +129,6 @@ closed.
 as a successfully downloaded update will always be applied the next time the 
 application starts.
 
-**Note:** If the application is quit without calling this API after the
-`update-downloaded` event has been emitted, the application will still be
-replaced by the updated one on the next run.
-
 [squirrel-mac]: https://github.com/Squirrel/Squirrel.Mac
 [server-support]: https://github.com/Squirrel/Squirrel.Mac#server-support
 [squirrel-windows]: https://github.com/Squirrel/Squirrel.Windows


### PR DESCRIPTION
It has come to light in https://github.com/electron/update-electron-app/issues/22 that it's not strictly necessary to take an action upon a downloaded update, as it will be applied automatically on app restart.