### PR TITLE
Refactor NativeWindow (Part 12): Do not use custom content view on macOS

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -12,14 +12,22 @@
 
 #include "atom/browser/native_window.h"
 #include "base/mac/scoped_nsobject.h"
+#include "ui/views/controls/native/native_view_host.h"
 
 @class AtomNSWindow;
 @class AtomNSWindowDelegate;
 @class AtomPreviewItem;
 @class AtomTouchBar;
+@class CustomWindowButtonView;
 @class FullSizeContentView;
 
+namespace views {
+class NativeViewHost;
+}
+
 namespace atom {
+
+class RootViewMac;
 
 class NativeWindowMac : public NativeWindow {
  public:
@@ -136,6 +144,7 @@ class NativeWindowMac : public NativeWindow {
   };
   TitleBarStyle title_bar_style() const { return title_bar_style_; }
 
+  views::View* content_view() { return content_view_; }
   AtomPreviewItem* preview_item() const { return preview_item_.get(); }
   AtomTouchBar* touch_bar() const { return touch_bar_.get(); }
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
@@ -145,6 +154,7 @@ class NativeWindowMac : public NativeWindow {
  protected:
   // views::WidgetDelegate:
   bool CanResize() const override;
+  views::View* GetContentsView() override;
 
  private:
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
@@ -157,6 +167,7 @@ class NativeWindowMac : public NativeWindow {
   base::scoped_nsobject<AtomNSWindowDelegate> window_delegate_;
   base::scoped_nsobject<AtomPreviewItem> preview_item_;
   base::scoped_nsobject<AtomTouchBar> touch_bar_;
+  base::scoped_nsobject<CustomWindowButtonView> buttons_view_;
 
   // Event monitor for scroll wheel event.
   id wheel_event_monitor_;
@@ -164,8 +175,11 @@ class NativeWindowMac : public NativeWindow {
   // The view that will fill the whole frameless window.
   base::scoped_nsobject<FullSizeContentView> container_view_;
 
-  // The content view passed by SetContentView, weak ref.
-  NSView* content_view_;
+  // The view that fills the client area.
+  std::unique_ptr<RootViewMac> root_view_;
+
+  // The content view, managed by widget_.
+  views::NativeViewHost* content_view_;
 
   bool is_kiosk_;
   bool was_fullscreen_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -244,7 +244,9 @@ void ViewDidMoveToSuperview(NSView* self, SEL _cmd) {
     // [BridgedContentView viewDidMoveToSuperview];
     auto original = reinterpret_cast<decltype(&ViewDidMoveToSuperview)>(
         original_view_did_move_to_superview);
-    return original(self, _cmd);
+    if (original)
+      original(self, _cmd);
+    return;
   }
   [self setFrame:[[self superview] bounds]];
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -232,7 +232,6 @@ void SetFrameSize(NSView* self, SEL _cmd, NSSize size) {
   // For frameless window, resize the view to cover full window.
   if ([self superview])
     size = [[self superview] bounds].size;
-  // [super setFrameSize:size];
   auto super_impl = reinterpret_cast<decltype(&SetFrameSize)>(
       [[self superclass] instanceMethodForSelector:_cmd]);
   super_impl(self, _cmd, size);
@@ -332,11 +331,10 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   params.bounds = bounds;
   params.delegate = this;
   params.type = views::Widget::InitParams::TYPE_WINDOW;
-  params.native_widget = new AtomNativeWidgetMac(styleMask, widget());
+  params.native_widget = new AtomNativeWidgetMac(this, styleMask, widget());
   widget()->Init(params);
   window_ = static_cast<AtomNSWindow*>(widget()->GetNativeWindow());
 
-  [window_ setShell:this];
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
 
   window_delegate_.reset([[AtomNSWindowDelegate alloc] initWithShell:this]);
@@ -714,7 +712,7 @@ void NativeWindowMac::SetContentSizeConstraints(
     // will result in actual content size being larger.
     if (!has_frame()) {
       NSRect frame = NSMakeRect(0, 0, size.width(), size.height());
-      NSRect content = [window_ contentRectForFrameRect:frame];
+      NSRect content = [window_ originalContentRectForFrameRect:frame];
       return content.size;
     } else {
       return NSMakeSize(size.width(), size.height());

--- a/atom/browser/ui/cocoa/atom_native_widget_mac.h
+++ b/atom/browser/ui/cocoa/atom_native_widget_mac.h
@@ -9,9 +9,12 @@
 
 namespace atom {
 
+class NativeWindowMac;
+
 class AtomNativeWidgetMac : public views::NativeWidgetMac {
  public:
-  AtomNativeWidgetMac(NSUInteger style_mask,
+  AtomNativeWidgetMac(NativeWindowMac* shell,
+                      NSUInteger style_mask,
                       views::internal::NativeWidgetDelegate* delegate);
   ~AtomNativeWidgetMac() override;
 
@@ -21,6 +24,7 @@ class AtomNativeWidgetMac : public views::NativeWidgetMac {
       const views::Widget::InitParams& params) override;
 
  private:
+  NativeWindowMac* shell_;
   NSUInteger style_mask_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomNativeWidgetMac);

--- a/atom/browser/ui/cocoa/atom_native_widget_mac.mm
+++ b/atom/browser/ui/cocoa/atom_native_widget_mac.mm
@@ -5,25 +5,23 @@
 #include "atom/browser/ui/cocoa/atom_native_widget_mac.h"
 
 #include "atom/browser/ui/cocoa/atom_ns_window.h"
-#include "ui/base/cocoa/window_size_constants.h"
 
 namespace atom {
 
 AtomNativeWidgetMac::AtomNativeWidgetMac(
+    NativeWindowMac* shell,
     NSUInteger style_mask,
     views::internal::NativeWidgetDelegate* delegate)
     : views::NativeWidgetMac(delegate),
+      shell_(shell),
       style_mask_(style_mask) {}
 
 AtomNativeWidgetMac::~AtomNativeWidgetMac() {}
 
 NativeWidgetMacNSWindow* AtomNativeWidgetMac::CreateNSWindow(
     const views::Widget::InitParams& params) {
-  return [[[AtomNSWindow alloc]
-      initWithContentRect:ui::kWindowSizeDeterminedLater
-                styleMask:style_mask_
-                  backing:NSBackingStoreBuffered
-                    defer:YES] autorelease];
+  return [[[AtomNSWindow alloc] initWithShell:shell_ styleMask:style_mask_]
+      autorelease];
 }
 
 }  // namespace atom

--- a/atom/browser/ui/cocoa/atom_ns_window.h
+++ b/atom/browser/ui/cocoa/atom_ns_window.h
@@ -36,8 +36,9 @@ class ScopedDisableResize {
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
 @property NSPoint windowButtonsOffset;
-@property (nonatomic, retain) NSView* vibrantView;
+@property(nonatomic, retain) NSView* vibrantView;
 - (void)setShell:(atom::NativeWindowMac*)shell;
+- (atom::NativeWindowMac*)shell;
 - (void)enableWindowButtonsOffset;
 - (void)toggleFullScreenMode:(id)sender;
 @end

--- a/atom/browser/ui/cocoa/atom_ns_window.h
+++ b/atom/browser/ui/cocoa/atom_ns_window.h
@@ -37,8 +37,10 @@ class ScopedDisableResize {
 @property BOOL disableKeyOrMainWindow;
 @property NSPoint windowButtonsOffset;
 @property(nonatomic, retain) NSView* vibrantView;
-- (void)setShell:(atom::NativeWindowMac*)shell;
+- (id)initWithShell:(atom::NativeWindowMac*)shell
+          styleMask:(NSUInteger)styleMask;
 - (atom::NativeWindowMac*)shell;
+- (NSRect)originalContentRectForFrameRect:(NSRect)frameRect;
 - (void)enableWindowButtonsOffset;
 - (void)toggleFullScreenMode:(id)sender;
 @end

--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -7,6 +7,7 @@
 #include "atom/browser/native_window_mac.h"
 #include "atom/browser/ui/cocoa/atom_preview_item.h"
 #include "atom/browser/ui/cocoa/atom_touch_bar.h"
+#include "ui/base/cocoa/window_size_constants.h"
 
 namespace atom {
 
@@ -23,12 +24,23 @@ bool ScopedDisableResize::disable_resize_ = false;
 @synthesize windowButtonsOffset;
 @synthesize vibrantView;
 
-- (void)setShell:(atom::NativeWindowMac*)shell {
-  shell_ = shell;
+- (id)initWithShell:(atom::NativeWindowMac*)shell
+          styleMask:(NSUInteger)styleMask {
+  if ((self = [super initWithContentRect:ui::kWindowSizeDeterminedLater
+                               styleMask:styleMask
+                                 backing:NSBackingStoreBuffered
+                                   defer:YES])) {
+    shell_ = shell;
+  }
+  return self;
 }
 
 - (atom::NativeWindowMac*)shell {
   return shell_;
+}
+
+- (NSRect)originalContentRectForFrameRect:(NSRect)frameRect {
+  return [super contentRectForFrameRect:frameRect];
 }
 
 - (NSTouchBar*)makeTouchBar API_AVAILABLE(macosx(10.12.2)) {
@@ -50,6 +62,13 @@ bool ScopedDisableResize::disable_resize_ = false;
   } else if (event.deltaX == 1.0) {
     shell_->NotifyWindowSwipe("left");
   }
+}
+
+- (NSRect)contentRectForFrameRect:(NSRect)frameRect {
+  if (shell_->has_frame())
+    return [super contentRectForFrameRect:frameRect];
+  else
+    return frameRect;
 }
 
 - (NSRect)constrainFrameRect:(NSRect)frameRect toScreen:(NSScreen*)screen {

--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -27,6 +27,10 @@ bool ScopedDisableResize::disable_resize_ = false;
   shell_ = shell;
 }
 
+- (atom::NativeWindowMac*)shell {
+  return shell_;
+}
+
 - (NSTouchBar*)makeTouchBar API_AVAILABLE(macosx(10.12.2)) {
   if (shell_->touch_bar())
     return [shell_->touch_bar() makeTouchBar];

--- a/atom/browser/ui/cocoa/root_view_mac.h
+++ b/atom/browser/ui/cocoa/root_view_mac.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_UI_COCOA_ROOT_VIEW_MAC_H_
+#define ATOM_BROWSER_UI_COCOA_ROOT_VIEW_MAC_H_
+
+#include "ui/views/view.h"
+
+namespace atom {
+
+class NativeWindow;
+
+class RootViewMac : public views::View {
+ public:
+  explicit RootViewMac(NativeWindow* window);
+  ~RootViewMac() override;
+
+  // views::View:
+  void Layout() override;
+  gfx::Size GetMinimumSize() const override;
+  gfx::Size GetMaximumSize() const override;
+
+ private:
+  // Parent window, weak ref.
+  NativeWindow* window_;
+
+  DISALLOW_COPY_AND_ASSIGN(RootViewMac);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_UI_COCOA_ROOT_VIEW_MAC_H_

--- a/atom/browser/ui/cocoa/root_view_mac.mm
+++ b/atom/browser/ui/cocoa/root_view_mac.mm
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/ui/cocoa/root_view_mac.h"
+
+#include "atom/browser/native_window_mac.h"
+
+namespace atom {
+
+RootViewMac::RootViewMac(NativeWindow* window) : window_(window) {
+  set_owned_by_client();
+}
+
+RootViewMac::~RootViewMac() {}
+
+void RootViewMac::Layout() {
+  views::View* content_view =
+      static_cast<NativeWindowMac*>(window_)->content_view();
+  if (!content_view)  // Not ready yet.
+    return;
+
+  content_view->SetBoundsRect(gfx::Rect(gfx::Point(), size()));
+}
+
+gfx::Size RootViewMac::GetMinimumSize() const {
+  return window_->GetMinimumSize();
+}
+
+gfx::Size RootViewMac::GetMaximumSize() const {
+  return window_->GetMaximumSize();
+}
+
+}  // namespace atom

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -330,6 +330,8 @@
       'atom/browser/ui/cocoa/atom_touch_bar.mm',
       'atom/browser/ui/cocoa/views_delegate_mac.h',
       'atom/browser/ui/cocoa/views_delegate_mac.mm',
+      'atom/browser/ui/cocoa/root_view_mac.mm',
+      'atom/browser/ui/cocoa/root_view_mac.h',
       'atom/browser/ui/cocoa/touch_bar_forward_declarations.h',
       'atom/browser/ui/drag_util_mac.mm',
       'atom/browser/ui/drag_util_views.cc',


### PR DESCRIPTION
Remove our custom content view on macOS, and rely on `views::Widget` to provide everything needed for layout.

This PR would allow us to display arbitrary `views::View` on macOS.