### PR TITLE
Better OSR tests

### DIFF
--- a/atom/common/api/features.cc
+++ b/atom/common/api/features.cc
@@ -7,6 +7,14 @@
 
 namespace {
 
+bool IsOffscreenRenderingEnabled() {
+#if defined(ENABLE_OSR)
+  return true;
+#else
+  return false;
+#endif
+}
+
 bool IsPDFViewerEnabled() {
 #if defined(ENABLE_PDF_VIEWER)
   return true;
@@ -20,6 +28,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
+  dict.SetMethod("isOffscreenRenderingEnabled", &IsOffscreenRenderingEnabled);
   dict.SetMethod("isPDFViewerEnabled", &IsPDFViewerEnabled);
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -23,6 +23,10 @@ describe('BrowserWindow module', () => {
   let server
   let postData
 
+  const closeTheWindow = function () {
+    return closeWindow(w).then(() => { w = null })
+  }
+
   before((done) => {
     const filePath = path.join(fixtures, 'pages', 'a.html')
     const fileStats = fs.statSync(filePath)
@@ -84,9 +88,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  afterEach(() => {
-    return closeWindow(w).then(() => { w = null })
-  })
+  afterEach(closeTheWindow)
 
   describe('BrowserWindow constructor', () => {
     it('allows passing void 0 as the webContents', () => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -3065,7 +3065,9 @@ describe('BrowserWindow module', () => {
   describe('offscreen rendering', () => {
     beforeEach(function () {
       if (!features.isOffscreenRenderingEnabled()) {
-        return
+        // XXX(alexeykuzmin): "afterEach" hook is not called
+        // for skipped tests, we have to close the window manually.
+        return closeTheWindow().then(() => { this.skip() })
       }
 
       if (w != null) w.destroy()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -11,6 +11,8 @@ const {closeWindow} = require('./window-helpers')
 const {ipcRenderer, remote, screen} = require('electron')
 const {app, ipcMain, BrowserWindow, BrowserView, protocol, session, webContents} = remote
 
+const features = process.atomBinding('features')
+
 const isCI = remote.getGlobal('isCi')
 const nativeModulesEnabled = remote.getGlobal('nativeModulesEnabled')
 
@@ -3059,17 +3061,11 @@ describe('BrowserWindow module', () => {
   })
 
   describe('offscreen rendering', () => {
-    const isOffscreenRenderingDisabled = () => {
-      const contents = webContents.create({})
-      const disabled = typeof contents.isOffscreen !== 'function'
-      contents.destroy()
-      return disabled
-    }
+    beforeEach(function () {
+      if (!features.isOffscreenRenderingEnabled()) {
+        return
+      }
 
-    // Offscreen rendering can be disabled in the build
-    if (isOffscreenRenderingDisabled()) return
-
-    beforeEach(() => {
       if (w != null) w.destroy()
       w = new BrowserWindow({
         width: 100,


### PR DESCRIPTION
- add a `features.` method to determine of the OSR is available
- skip the tests instead of marking them as passed if the OSR is disabled