### PR TITLE
fix: lint is a devDependency, not a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "electron-typescript-definitions": "^1.3.2",
     "github": "^9.2.0",
     "husky": "^0.14.3",
+    "lint": "^1.1.2",
     "minimist": "^1.2.0",
     "nugget": "^2.0.1",
     "remark-cli": "^4.0.0",
@@ -77,8 +78,5 @@
   "author": "Electron Community",
   "keywords": [
     "electron"
-  ],
-  "dependencies": {
-    "lint": "^1.1.2"
-  }
+  ]
 }


### PR DESCRIPTION
This was introduced as a dependency in a4db8e1c551388c78457bfb2179d23abea579a66 but it should really be a devDependency.