### PR TITLE
Fix invisible menu items no longer triggering

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -240,14 +240,19 @@ function indexToInsertByPosition (items, position) {
 }
 
 function removeExtraSeparators (items) {
-  // remove invisible items
-  let ret = items.filter(e => e.visible !== false)
-
   // fold adjacent separators together
-  ret = ret.filter((e, idx, arr) => e.type !== 'separator' || idx === 0 || arr[idx - 1].type !== 'separator')
+  let ret = items.filter((e, idx, arr) => {
+    if (e.visible === false) return true
+    return e.type !== 'separator' || idx === 0 || arr[idx - 1].type !== 'separator'
+  })
 
   // remove edge separators
-  return ret.filter((e, idx, arr) => e.type !== 'separator' || (idx !== 0 && idx !== arr.length - 1))
+  ret = ret.filter((e, idx, arr) => {
+    if (e.visible === false) return true
+    return e.type !== 'separator' || (idx !== 0 && idx !== arr.length - 1)
+  })
+
+  return ret
 }
 
 function insertItemByType (item, pos) {


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/12025.

Change `removeExtraSeparators(items)` such that it no longer filters out invisible menu separators, preventing their accelerators from working. 

/cc @zeke 