### PR TITLE
Expose events (EventEmitter) to sandboxed renderer

### DIFF
--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -25,6 +25,7 @@ const fs = require('fs')
 const preloadModules = new Map([
   ['child_process', require('child_process')],
   ['electron', electron],
+  ['events', events],
   ['fs', fs],
   ['os', require('os')],
   ['path', require('path')],


### PR DESCRIPTION
The events module containing the EventEmitter class is JavaScript only code, which is safe to be exposed to sandboxed renderers. It's also potentially very useful if the client code needs to inherit the EventEmitter.