### PR TITLE
Pass preload script source to lib/sandboxed_renderer/init.js

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -429,6 +429,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void InitZoomController(content::WebContents* web_contents,
                           const mate::Dictionary& options);
 
+  void OnGetPreloadScript(content::RenderFrameHost* frame_host,
+                          IPC::Message* reply_msg);
+
   v8::Global<v8::Value> session_;
   v8::Global<v8::Value> devtools_web_contents_;
   v8::Global<v8::Value> debugger_;

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -69,3 +69,7 @@ IPC_SYNC_MESSAGE_ROUTED0_1(AtomFrameHostMsg_GetZoomLevel, double /* result */)
 IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_PDFSaveURLAs,
                     GURL /* url */,
                     content::Referrer /* referrer */)
+
+// Sent by sandboxed renderer to get the preload script.
+IPC_SYNC_MESSAGE_ROUTED0_1(AtomViewHostMsg_GetPreloadScript,
+                           std::string /* result */)

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -1,5 +1,5 @@
 /* eslint no-eval: "off" */
-/* global binding, preloadPath, Buffer */
+/* global binding, preloadPath, preloadSrc, Buffer */
 const events = require('events')
 
 process.atomBinding = require('../common/atom-binding-setup')(binding.get, 'renderer')
@@ -21,12 +21,11 @@ for (let prop of Object.keys(events.EventEmitter.prototype)) {
 Object.setPrototypeOf(process, events.EventEmitter.prototype)
 
 const electron = require('electron')
-const fs = require('fs')
 const preloadModules = new Map([
   ['child_process', require('child_process')],
   ['electron', electron],
   ['events', events],
-  ['fs', fs],
+  ['fs', require('fs')],
   ['os', require('os')],
   ['path', require('path')],
   ['url', require('url')],
@@ -81,15 +80,18 @@ if (window.location.protocol === 'chrome-devtools:') {
 // since browserify won't try to include `electron` in the bundle, falling back
 // to the `preloadRequire` function above.
 if (preloadPath) {
-  const preloadSrc = fs.readFileSync(preloadPath).toString()
-  const preloadWrapperSrc = `(function(require, process, Buffer, global, setImmediate) {
-  ${preloadSrc}
-  })`
+  if (preloadSrc) {
+    const preloadWrapperSrc = `(function(require, process, Buffer, global, setImmediate) {
+    ${preloadSrc}
+    })`
 
-  // eval in window scope:
-  // http://www.ecma-international.org/ecma-262/5.1/#sec-10.4.2
-  const geval = eval
-  const preloadFn = geval(preloadWrapperSrc)
-  const {setImmediate} = require('timers')
-  preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate)
+    // eval in window scope:
+    // http://www.ecma-international.org/ecma-262/5.1/#sec-10.4.2
+    const geval = eval
+    const preloadFn = geval(preloadWrapperSrc)
+    const {setImmediate} = require('timers')
+    preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate)
+  } else {
+    console.error('Unable to load preload script: ' + preloadPath)
+  }
 }


### PR DESCRIPTION
Don't use remote fs to load the preload script. Load it in the native code instead and pass the script source code as an argument to the init function. This would allow the preload script to work even if access to fs is disabled by filtering remote.require requests in rpc-server.js for security reasons.