### PR TITLE
GN build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 /brightray/brightray.v12.suo
 /brightray/brightray.vcxproj*
 /brightray/brightray.xcodeproj/
-/build/
 /dist/
 /external_binaries/
 /out/

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,515 @@
+import("//build/config/locales.gni")
+import("//tools/grit/repack.gni")
+import("build/asar.gni")
+import("build/npm.gni")
+
+if (is_mac) {
+  import("//build/config/mac/rules.gni")
+  import("//third_party/icu/config.gni")
+  import("//v8/gni/v8.gni")
+}
+
+declare_args() {
+  electron_project_name = "electron"
+  electron_product_name = "Electron"
+  electron_company_name = "GitHub, Inc"
+  electron_company_abbr = "github"
+  electron_version = "0.0.0-dev"
+
+  enable_run_as_node = true
+  enable_osr = true
+}
+
+filenames_gypi = exec_script(
+  "//build/gypi_to_gn.py",
+  [
+    rebase_path("filenames.gypi"),
+    "--replace=<(SHARED_INTERMEDIATE_DIR)=$target_gen_dir",
+  ],
+  "scope",
+  [ "filenames.gypi" ]
+)
+
+config("branding") {
+  defines = [
+    "ATOM_PRODUCT_NAME=\"$electron_product_name\"",
+    "ATOM_PROJECT_NAME=\"$electron_project_name\"",
+  ]
+}
+
+config("features") {
+  defines = []
+  if (enable_run_as_node) {
+    defines += [ "ENABLE_RUN_AS_NODE=1" ]
+  }
+  if (enable_osr) {
+    defines += [ "ENABLE_OSR=1" ]
+  }
+}
+
+config("native_mate_config") {
+  include_dirs = [
+    "//third_party/native_mate",
+  ]
+  cflags_cc = [
+    "-Wno-deprecated-declarations",
+  ]
+  cflags_objcc = cflags_cc
+}
+
+source_set("native_mate") {
+  deps = [
+    "//base",
+    "//net",
+    "//v8:v8_headers",
+    "build/node",
+  ]
+  public_configs = [ ":native_mate_config" ]
+  sources = [
+    "//third_party/native_mate/native_mate/arguments.cc",
+    "//third_party/native_mate/native_mate/arguments.h",
+    "//third_party/native_mate/native_mate/compat.h",
+    "//third_party/native_mate/native_mate/constructor.h",
+    "//third_party/native_mate/native_mate/converter.cc",
+    "//third_party/native_mate/native_mate/converter.h",
+    "//third_party/native_mate/native_mate/dictionary.cc",
+    "//third_party/native_mate/native_mate/dictionary.h",
+    "//third_party/native_mate/native_mate/function_template.cc",
+    "//third_party/native_mate/native_mate/function_template.h",
+    "//third_party/native_mate/native_mate/handle.h",
+    "//third_party/native_mate/native_mate/object_template_builder.cc",
+    "//third_party/native_mate/native_mate/object_template_builder.h",
+    "//third_party/native_mate/native_mate/persistent_dictionary.cc",
+    "//third_party/native_mate/native_mate/persistent_dictionary.h",
+    "//third_party/native_mate/native_mate/scoped_persistent.h",
+    "//third_party/native_mate/native_mate/wrappable.cc",
+    "//third_party/native_mate/native_mate/wrappable.h",
+    "//third_party/native_mate/native_mate/wrappable_base.h",
+  ]
+}
+
+npm_action("atom_browserify_sandbox") {
+  deps = [ ":atom_js2c_copy" ]
+
+  sandbox_args = [
+    "lib/sandboxed_renderer/init.js",
+    "-r", "./lib/sandboxed_renderer/api/exports/electron.js:electron",
+    "-r", "./lib/sandboxed_renderer/api/exports/fs.js:fs",
+    "-r", "./lib/sandboxed_renderer/api/exports/os.js:os",
+    "-r", "./lib/sandboxed_renderer/api/exports/path.js:path",
+    "-r", "./lib/sandboxed_renderer/api/exports/child_process.js:child_process",
+  ]
+
+  inputs = [
+    "lib/sandboxed_renderer/init.js",
+    "lib/sandboxed_renderer/api/exports/electron.js",
+    "lib/sandboxed_renderer/api/exports/fs.js",
+    "lib/sandboxed_renderer/api/exports/os.js",
+    "lib/sandboxed_renderer/api/exports/path.js",
+    "lib/sandboxed_renderer/api/exports/child_process.js",
+  ]
+  outputs = [ "$target_gen_dir/js2c/preload_bundle.js" ]
+
+  script = "browserify"
+  args = sandbox_args + [
+    "-o", rebase_path(outputs[0])
+  ]
+}
+
+npm_action("atom_browserify_isolated") {
+  deps = [ ":atom_js2c_copy" ]
+
+  inputs = [ "lib/isolated_renderer/init.js" ]
+  outputs = [ "$target_gen_dir/js2c/isolated_bundle.js" ]
+
+  script = "browserify"
+  args = inputs + [
+    "-o", rebase_path(outputs[0])
+  ]
+}
+
+copy("atom_js2c_copy") {
+  sources = [
+    "lib/common/asar.js",
+    "lib/common/asar_init.js",
+  ]
+  outputs = [ "$target_gen_dir/js2c/{{source_file_part}}" ]
+}
+
+action("atom_js2c") {
+  deps = [
+    ":atom_js2c_copy",
+    ":atom_browserify_sandbox",
+    ":atom_browserify_isolated",
+  ]
+
+  js2c_sources = filenames_gypi.js2c_sources
+
+  browserify_sources = [
+    "$target_gen_dir/js2c/isolated_bundle.js",
+    "$target_gen_dir/js2c/preload_bundle.js",
+  ]
+
+  inputs = js2c_sources + browserify_sources
+
+  outputs = [ "$target_gen_dir/atom_natives.h" ]
+
+  script = "tools/js2c.py"
+  args = [
+    rebase_path("//third_party/electron_node")
+  ] + rebase_path(outputs, root_build_dir) + [
+    rebase_path("$target_gen_dir/js2c", root_build_dir)
+  ]
+}
+
+asar("js2asar") {
+  sources = filenames_gypi.js_sources
+  outputs = [ "$root_out_dir/electron.asar" ]
+  root = "lib"
+}
+
+asar("app2asar") {
+  sources = filenames_gypi.default_app_sources
+  outputs = [ "$root_out_dir/default_app.asar" ]
+  root = "default_app"
+}
+
+group("electron") {
+  deps = [ ":electron_lib" ]
+}
+
+static_library("electron_lib") {
+  configs += [
+    "//v8:external_startup_data",
+  ]
+  public_configs = [
+    ":branding",
+    ":features",
+  ]
+  deps = [
+    "//chrome/common:constants",
+    "//components/cdm/renderer",
+    "//components/network_session_configurator/common",
+    "//components/prefs",
+    "//components/printing/common",
+    "//components/security_state/content",
+    "//content/public/browser",
+    "//device/geolocation",
+    "//gin",
+    "//net:net_resources",
+    "//ppapi/host",
+    "//ppapi/proxy",
+    "//ppapi/shared_impl",
+    "//printing",
+    "//services/device/wake_lock/power_save_blocker", # TODO: this requires a visibility patch to chromium src
+    "//skia",
+    "//third_party/WebKit/public:blink",
+    "//third_party/boringssl",
+    "//third_party/crashpad/crashpad/client",
+    "//third_party/leveldatabase",
+    "//third_party/libyuv",
+    "//third_party/webrtc/modules/desktop_capture",
+    "//third_party/webrtc/modules/desktop_capture:primitives",
+    "//ui/events:dom_keycode_converter",
+    "//ui/views",
+    "//v8",
+    ":atom_js2c",
+    ":native_mate",
+    "brightray",
+    "build/node",
+  ]
+  if (is_mac) {
+    deps += [
+      "//ui/accelerated_widget_mac",
+      "//base/allocator:features",
+    ]
+  }
+  defines = [
+    # This is defined in skia/skia_common.gypi.
+    "SK_SUPPORT_LEGACY_GETTOPDEVICE",
+    # Disable warnings for g_settings_list_schemas.
+    "GLIB_DISABLE_DEPRECATION_WARNINGS",
+
+    # Import V8 symbols from shared library (node.dll / libnode.so)
+    "USING_V8_SHARED",
+    "USING_V8_PLATFORM_SHARED",
+    "USING_V8_BASE_SHARED",
+
+    # Enables SkBitmap size 64 operations
+    #"SK_SUPPORT_LEGACY_SAFESIZE64", # doesn't seem to be needed to build?
+  ]
+  include_dirs = [
+    "chromium_src",
+    ".",
+    "$target_gen_dir",
+    # TODO(nornagon): replace usage of SchemeRegistry by an actually exported
+    # API of blink, then delete this include dir.
+    "//third_party/WebKit/Source",
+    # NOTE(nornagon): other chromium files use the full path to include
+    # crashpad; this is just here for compatibility between GN and GYP, so that
+    # the #includes can be agnostic about where crashpad is vendored.
+    "//third_party/crashpad",
+  ]
+
+  extra_source_filters = []
+  if (!is_linux) {
+    extra_source_filters += [
+      "*\bx/*",
+      "*_x11.h",
+      "*_x11.cc",
+      "*_gtk.h",
+      "*_gtk.cc",
+    ]
+  }
+  if (is_mac) {
+    extra_source_filters += [
+      "*_views.cc",
+      "*_views.h",
+      "*\bviews/*",
+      "*/autofill_popup.cc",
+      "*/autofill_popup.h",
+    ]
+  }
+
+  set_sources_assignment_filter(sources_assignment_filter + extra_source_filters)
+  sources = filenames_gypi.lib_sources
+  set_sources_assignment_filter(sources_assignment_filter)
+
+  if (enable_run_as_node) {
+    sources += [
+      "atom/app/node_main.cc",
+      "atom/app/node_main.h",
+    ]
+  }
+
+  if (enable_osr) {
+    sources += [
+      "atom/browser/api/atom_api_web_contents_osr.cc",
+      "atom/browser/osr/osr_output_device.cc",
+      "atom/browser/osr/osr_output_device.h",
+      "atom/browser/osr/osr_render_widget_host_view.cc",
+      "atom/browser/osr/osr_render_widget_host_view.h",
+      "atom/browser/osr/osr_render_widget_host_view_mac.mm",
+      "atom/browser/osr/osr_view_proxy.cc",
+      "atom/browser/osr/osr_view_proxy.h",
+      "atom/browser/osr/osr_web_contents_view.cc",
+      "atom/browser/osr/osr_web_contents_view.h",
+      "atom/browser/osr/osr_web_contents_view_mac.mm",
+    ]
+    deps += [
+      "//ui/compositor",
+      "//components/viz/service",
+    ]
+  }
+
+  if (is_mac) {
+    libs = [
+      "Squirrel.framework",
+      "ReactiveCocoa.framework",
+      "Mantle.framework",
+    ]
+    cflags_objcc = [
+      "-F", rebase_path("external_binaries", root_build_dir)
+    ]
+    if (true) { # !is_mas_build
+      # ReactiveCocoa which is used by Squirrel requires using __weak.
+      cflags_objcc += [ "-fobjc-weak" ]
+    }
+  }
+  if (is_linux) {
+    sources += filenames_gypi.lib_sources_linux
+  }
+}
+
+if (is_mac) {
+  electron_framework_name = electron_product_name + " Framework"
+  electron_helper_name = electron_product_name + " Helper"
+  electron_framework_version = "A"
+  electron_mac_bundle_id = "com.$electron_company_abbr.$electron_project_name"
+
+  mac_xib_bundle_data("electron_xibs") {
+    sources = [ "atom/common/resources/mac/MainMenu.xib" ]
+  }
+
+  bundle_data("electron_framework_resources") {
+    public_deps = [
+      "//content/shell:pak",
+      ":electron_locales",
+    ]
+    sources = [
+      "$root_out_dir/content_shell.pak",
+    ]
+    if (icu_use_data_file) {
+      sources += [ "$root_out_dir/icudtl.dat" ]
+      public_deps += [ "//third_party/icu:icudata" ]
+    }
+    if (v8_use_external_startup_data) {
+      sources += [
+        "$root_out_dir/natives_blob.bin",
+        "$root_out_dir/snapshot_blob.bin",
+      ]
+      public_deps += [ "//v8" ]
+    }
+    outputs = [
+      "{{bundle_resources_dir}}/{{source_file_part}}",
+    ]
+  }
+
+  bundle_data("electron_framework_libraries") {
+    public_deps = [ "build/node" ]
+    sources = [
+      "$root_out_dir/libnode.dylib"
+    ]
+    outputs = [
+      "{{bundle_contents_dir}}/Libraries/{{source_file_part}}"
+    ]
+  }
+
+  bundle_data("electron_framework_helpers") {
+    sources = [
+      "$root_out_dir/crashpad_handler",
+    ]
+
+    outputs = [
+      "{{bundle_resources_dir}}/{{source_file_part}}",
+    ]
+
+    public_deps = [
+      "//third_party/crashpad/crashpad/handler:crashpad_handler",
+    ]
+  }
+
+  mac_framework_bundle("electron_framework") {
+    output_name = electron_framework_name
+    framework_version = electron_framework_version
+    framework_contents = [ "Resources" ]
+    public_deps = [ ":electron_lib" ]
+    deps = [
+      "//base",
+      "//base:i18n",
+      ":electron_framework_helpers",
+      ":electron_framework_libraries",
+      ":electron_framework_resources",
+      ":electron_xibs",
+    ]
+    info_plist = "atom/common/resources/mac/Info.plist"
+    extra_substitutions = [
+      "ATOM_BUNDLE_ID=$electron_mac_bundle_id.framework",
+    ]
+
+    include_dirs = [
+      ".",
+    ]
+    sources = filenames_gypi.framework_sources
+
+    libs = [
+      "Carbon.framework",
+      "QuartzCore.framework",
+      "Quartz.framework",
+      "Security.framework",
+      "SecurityInterface.framework",
+      "ServiceManagement.framework",
+      "StoreKit.framework",
+    ]
+    ldflags = [
+      "-F", rebase_path("external_binaries", root_build_dir),
+      "-Wl,-install_name,@rpath/$output_name.framework/$output_name",
+      "-rpath",
+      "@loader_path/Libraries",
+    ]
+    if (is_component_build) {
+      ldflags += [
+        "-rpath",
+        "@executable_path/../../../../../.."
+      ]
+    }
+  }
+
+  mac_app_bundle("electron_helper_app") {
+    output_name = electron_helper_name
+    deps = [ ":electron_framework+link" ]
+    sources = filenames_gypi.app_sources
+    include_dirs = [ "." ]
+    info_plist = "atom/renderer/resources/mac/Info.plist"
+    extra_substitutions = [
+      "ATOM_BUNDLE_ID=$electron_mac_bundle_id.helper",
+    ]
+    ldflags = [
+      "-rpath",
+      "@executable_path/../../..",
+    ]
+  }
+
+  bundle_data("electron_app_framework_bundle_data") {
+    sources = [
+      "$root_out_dir/$electron_framework_name.framework",
+      "$root_out_dir/$electron_helper_name.app",
+      "external_binaries/Squirrel.framework",
+      "external_binaries/ReactiveCocoa.framework",
+      "external_binaries/Mantle.framework",
+    ]
+    outputs = [
+      "{{bundle_contents_dir}}/Frameworks/{{source_file_part}}",
+    ]
+    public_deps = [
+      ":electron_framework+link",
+      ":electron_helper_app",
+    ]
+  }
+
+  bundle_data("electron_app_resources") {
+    public_deps = [
+      ":js2asar",
+      ":app2asar",
+    ]
+    sources = [
+      "$root_out_dir/electron.asar",
+      "$root_out_dir/default_app.asar",
+    ]
+    outputs = [
+      "{{bundle_resources_dir}}/{{source_file_part}}"
+    ]
+  }
+
+  repack_locales("electron_locales") {
+    source_patterns = [
+      "${root_gen_dir}/content/app/strings/content_strings_",
+    ]
+    deps = [
+      "//content/app/strings",
+    ]
+
+    input_locales = locales
+
+    if (is_mac) {
+      output_locales = locales_as_mac_outputs
+    } else {
+      output_locales = locales
+    }
+
+    if (is_mac) {
+      output_dir = "$root_gen_dir/repack"
+      copy_data_to_bundle = true
+    } else {
+      output_dir = root_out_dir
+    }
+  }
+
+  mac_app_bundle("electron_app") {
+    output_name = electron_product_name
+    sources = filenames_gypi.app_sources
+    include_dirs = [ "." ]
+    deps = [
+      ":electron_app_framework_bundle_data",
+      ":electron_app_resources",
+    ]
+    info_plist = "atom/browser/resources/mac/Info.plist"
+    extra_substitutions = [
+      "ATOM_BUNDLE_ID=$electron_mac_bundle_id",
+    ]
+    ldflags = [
+      "-rpath",
+      "@executable_path/../Frameworks",
+    ]
+  }
+}

--- a/DEPS
+++ b/DEPS
@@ -1,0 +1,73 @@
+vars = {
+  'chromium_version':
+    '63.0.3239.150',
+  'libchromiumcontent_revision':
+    '0e8b7216fe616405ea14ff5bece3ca087ead613c',
+  'node_version':
+    'v9.7.0-33-g538a5023af',
+  'native_mate_revision':
+    '4cd7d113915de0cc08e9a218be35bff9c7361906',
+
+  'chromium_git':
+    'https://chromium.googlesource.com',
+
+  'electron_git':
+    'https://github.com/electron',
+}
+
+deps = {
+  'src':
+    (Var("chromium_git")) + '/chromium/src.git@' + (Var("chromium_version")),
+  'src/libchromiumcontent':
+    (Var("electron_git")) + '/libchromiumcontent.git@' + (Var("libchromiumcontent_revision")),
+  'src/third_party/electron_node':
+    (Var("electron_git")) + '/node.git@' + (Var("node_version")),
+  'src/third_party/native_mate':
+    (Var("electron_git")) + '/native-mate.git@' + (Var("native_mate_revision")),
+}
+
+hooks = [
+  {
+    'action': [
+      'src/libchromiumcontent/script/apply-patches'
+    ],
+    'pattern':
+      'src/libchromiumcontent',
+    'name':
+      'patch_chromium'
+  },
+  {
+    'action': [
+      'src/electron/script/update-external-binaries.py'
+    ],
+    'pattern':
+      'src/electron/script/update-external-binaries.py',
+    'name':
+      'electron_external_binaries'
+  },
+  {
+    'action': [
+      'bash',
+      '-c',
+      # NOTE(nornagon): this ridiculous {{}} stuff is because these strings get
+      # variable-substituted twice by gclient.
+      'echo -e "#\\n{{{{\'variables\':{{{{}}}}}}}}" > src/third_party/electron_node/config.gypi',
+    ],
+    'pattern': 'src/third_party/electron_node',
+    'name': 'touch_node_config_gypi'
+  },
+  {
+    'action': [
+      'bash',
+      '-c',
+      'cd src/electron; npm install',
+    ],
+    'pattern': 'src/electron/package.json',
+    'name': 'electron_npm_deps'
+  },
+]
+
+recursedeps = [
+  'src',
+  'src/libchromiumcontent',
+]

--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -1,0 +1,42 @@
+import("//build/config/ui.gni")
+
+filenames_gypi = exec_script(
+  "//build/gypi_to_gn.py",
+  [ rebase_path("filenames.gypi") ],
+  "scope",
+  [ "filenames.gypi" ]
+)
+
+static_library("brightray") {
+  deps = [
+    "//base",
+    "//components/network_session_configurator/common",
+    "//components/prefs",
+    "//content/public/browser",
+    "//content/shell:resources",
+    "//net:net_with_v8",
+    "//skia",
+    "//ui/views",
+  ]
+
+  include_dirs = [
+    "..",
+  ]
+
+  defines = [
+    "DISABLE_NACL=1",
+  ]
+
+  extra_source_filters = []
+  if (is_mac) {
+    extra_source_filters += [
+      "*_views.cc",
+      "*_views.h",
+      "*\bviews/*",
+    ]
+  }
+
+  set_sources_assignment_filter(sources_assignment_filter + extra_source_filters)
+  sources = filenames_gypi.brightray_sources
+  set_sources_assignment_filter(sources_assignment_filter)
+}

--- a/build/asar.gni
+++ b/build/asar.gni
@@ -1,0 +1,29 @@
+import("npm.gni")
+
+template("asar") {
+  assert(defined(invoker.sources),
+         "Need sources in $target_name listing the JS files.")
+  assert(defined(invoker.outputs),
+         "Need asar name (as 1-element array, e.g. \$root_out_dir/foo.asar)")
+  assert(defined(invoker.root),
+         "Need asar root directory")
+  asar_root = invoker.root
+  copy_target_name = target_name + "_inputs"
+  copy(copy_target_name) {
+    sources = invoker.sources
+    outputs = [
+      "$target_gen_dir/$target_name/{{source_target_relative}}"
+    ]
+  }
+  npm_action(target_name) {
+    forward_variables_from(invoker, ["deps", "public_deps"])
+    deps = [":$copy_target_name"]
+    sources = invoker.sources
+    script = "asar"
+    outputs = invoker.outputs
+    args = [
+      "pack",
+      rebase_path("$target_gen_dir/$target_name/$asar_root")
+    ] + rebase_path(outputs)
+  }
+}

--- a/build/node/BUILD.gn
+++ b/build/node/BUILD.gn
@@ -1,0 +1,72 @@
+action("gyp_node") {
+  script = "//tools/gyp/gyp_main.py"
+  inputs = [
+    "//third_party/electron_node/common.gypi",
+    "//third_party/electron_node/node.gyp",
+    "//third_party/electron_node/node.gypi",
+    "node.gypi",
+  ]
+  outputs = [
+    "$target_out_dir/Release_Base/build.ninja",
+  ]
+  args = [
+    "-I", rebase_path("node.gypi", root_build_dir),
+    "-D", "component=shared_library",
+    "-D", "buildtype=Custom",
+    "-D", "target_arch=x64",
+    "-D", "host_arch=x64",
+    "-Goutput_dir=./$target_out_dir", # bizarrely, gyp generates from the build root instead of from cwd
+    "-fninja",
+    rebase_path("//third_party/electron_node/node.gyp", root_build_dir),
+  ]
+}
+
+action("build_node") {
+  deps = [
+    "//third_party/icu",
+    "//v8",
+    "//v8:v8_libbase",
+    "//v8:v8_libplatform",
+    ":gyp_node",
+  ]
+  script = "//electron/build/run-ninja.py"
+  args = [
+    "-C", rebase_path(target_out_dir, root_build_dir) + "/Release_Base",
+    "node_lib"
+  ]
+  outputs = [
+    "$target_out_dir/Release_Base/libnode.dylib"
+  ]
+}
+
+copy("copy_node") {
+  deps = [ ":build_node" ]
+  sources = [ "$target_out_dir/Release_Base/libnode.dylib" ]
+  outputs = [ "$root_out_dir/{{source_file_part}}" ]
+}
+
+config("node_config") {
+  include_dirs = [
+    "//third_party/electron_node/src",
+    "//third_party/electron_node/deps/uv/include",
+    "//third_party/electron_node/deps/cares/include",
+  ]
+  libs = [
+    "$target_out_dir/Release_Base/libnode.dylib"
+  ]
+  cflags_cc = [
+    "-Wno-deprecated-declarations",
+  ]
+  defines = [
+    # We need to access internal implementations of Node.
+    "NODE_WANT_INTERNALS=1",
+    "NODE_SHARED_MODE",
+    "HAVE_OPENSSL=1",
+    "HAVE_INSPECTOR=1",
+  ]
+}
+
+group("node") {
+  public_configs = [ ":node_config" ]
+  public_deps = [ ":copy_node" ]
+}

--- a/build/node/node.gypi
+++ b/build/node/node.gypi
@@ -1,0 +1,305 @@
+{
+  #'includes': [ 'v8.gypi' ],
+  'variables': {
+    'openssl_fips': '',
+    'openssl_no_asm': 1,
+    'use_openssl_def': 0,
+    'openssl_product': 'libopenssl.a',
+    'clang': 1,
+    # XXX(alexeykuzmin): Must match the clang version we use. See `clang -v`.
+    'llvm_version': '6.0',
+    'node_release_urlbase': 'https://atom.io/download/electron',
+    'node_byteorder': '<!(node <(DEPTH)/electron/tools/get-endianness.js)',
+    'node_target_type': 'shared_library',
+    'library': 'static_library',
+    'node_install_npm': 'false',
+    'node_prefix': '',
+    'node_shared': 'true',
+    'node_shared_cares': 'false',
+    'node_shared_http_parser': 'false',
+    'node_shared_libuv': 'false',
+    'node_shared_openssl': 'false',
+    'node_shared_zlib': 'false',
+    'node_tag': '',
+    'node_use_dtrace': 'false',
+    'node_use_etw': 'false',
+    'node_use_mdb': 'false',
+    'node_use_openssl': 'true',
+    'node_use_perfctr': 'false',
+    'node_use_v8_platform': 'false',
+    'node_use_bundled_v8': 'false',
+    'node_enable_d8': 'false',
+    'uv_library': 'static_library',
+    'uv_parent_path': 'vendor/node/deps/uv',
+    'uv_use_dtrace': 'false',
+    'v8_base': '',
+    'v8_postmortem_support': 'false',
+    'v8_enable_i18n_support': 'false',
+    'v8_enable_inspector': '1',
+    'debug_http2': 0,
+    'debug_nghttp2': 0,
+
+    'node_module_version': '0',
+    'shlib_suffix': 'dylib',
+  },
+  # Settings to compile node under Windows.
+  'target_defaults': {
+    'target_conditions': [
+      ['_target_name in ["libuv", "http_parser", "openssl", "openssl-cli", "cares", "node_lib", "zlib", "nghttp2"]', {
+        'msvs_disabled_warnings': [
+          4003,  # not enough actual parameters for macro 'V'
+          4013,  # 'free' undefined; assuming extern returning int
+          4018,  # signed/unsigned mismatch
+          4054,  #
+          4055,  # 'type cast' : from data pointer 'void *' to function pointer
+          4057,  # 'function' : 'volatile LONG *' differs in indirection to slightly different base types from 'unsigned long *'
+          4065,  # switch statement contains 'default' but no 'case' labels
+          4129,  # unrecognized character escape sequence
+          4189,  #
+          4131,  # uses old-style declarator
+          4133,  # incompatible types
+          4146,  # unary minus operator applied to unsigned type, result still unsigned
+          4164,  # intrinsic function not declared
+          4152,  # function/data pointer conversion in expression
+          4206,  # translation unit is empty
+          4204,  # non-constant aggregate initializer
+          4210,  # nonstandard extension used : function given file scope
+          4214,  # bit field types other than int
+          4232,  # address of dllimport 'free' is not static, identity not guaranteed
+          4291,  # no matching operator delete found
+          4295,  # array is too small to include a terminating null character
+          4309,  # 'static_cast': truncation of constant value
+          4311,  # 'type cast': pointer truncation from 'void *const ' to 'unsigned long'
+          4389,  # '==' : signed/unsigned mismatch
+          4456,  # declaration of 'm' hides previous local declaration
+          4457,  # declaration of 'message' hides function parameter
+          4459,  # declaration of 'wq' hides global declaration
+          4477,  # format string '%.*s' requires an argument of type 'int'
+          4505,  # unreferenced local function has been removed
+          4701,  # potentially uninitialized local variable 'sizew' used
+          4703,  # potentially uninitialized local pointer variable 'req' used
+          4706,  # assignment within conditional expression
+          4804,  # unsafe use of type 'bool' in operation
+          4996,  # this function or variable may be unsafe.
+        ],
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'WarnAsError': 'false',
+          },
+        },
+        'xcode_settings': {
+          'GCC_TREAT_WARNINGS_AS_ERRORS': 'NO',
+          'WARNING_CFLAGS': [
+            '-Wno-unknown-warning-option',
+            '-Wno-parentheses-equality',
+            '-Wno-unused-function',
+            '-Wno-sometimes-uninitialized',
+            '-Wno-pointer-sign',
+            '-Wno-sign-compare',
+            '-Wno-string-plus-int',
+            '-Wno-unused-variable',
+            '-Wno-deprecated-declarations',
+            '-Wno-return-type',
+            '-Wno-gnu-folding-constant',
+            '-Wno-shift-negative-value',
+            '-Wno-varargs', # https://git.io/v6Olj
+            '-Wno-unused-private-field',
+          ],
+        },
+        'conditions': [
+          ['OS=="linux"', {
+            'cflags': [
+              '-Wno-unused-function',
+              '-Wno-unused-variable',
+              '-Wno-unused-value',
+              '-Wno-deprecated-declarations',
+              '-Wno-return-type',
+              '-Wno-format',
+              '-Wno-varargs', # https://git.io/v6Olj
+              # Required when building as shared library.
+              '-fPIC',
+            ],
+          }],
+          ['OS=="linux" and clang==1', {
+            'cflags': [
+              '-Wno-pointer-sign',
+              '-Wno-parentheses-equality',
+              '-Wno-sometimes-uninitialized',
+              '-Wno-string-plus-int',
+              '-Wno-shift-negative-value',
+              '-Wno-reserved-user-defined-literal',
+              '-Wno-implicit-function-declaration',
+              '-Wno-long-long',
+            ],
+          }],
+        ],
+      }],
+      ['_target_name=="node_lib"', {
+        'include_dirs': [
+          '../../../v8',
+          '../../../v8/include',
+          '../../../third_party/icu/source/common',
+          '../../../third_party/icu/source/i18n',
+        ],
+        'defines': [
+          # Export V8 symbols from node.dll / libnode.so
+          'BUILDING_V8_SHARED',
+          'BUILDING_V8_PLATFORM_SHARED',
+          'BUILDING_V8_BASE_SHARED',
+        ],
+        'cflags_cc': [
+          '-std=gnu++14',
+          '-fno-rtti',
+        ],
+        'xcode_settings': {
+          # apparently on mac, even if you're not generating xcode junk,
+          # cflags_cc is just flat out ignored, and this weirdo xcode_settings
+          # thing is used instead.
+          'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+          'OTHER_CFLAGS': ['-fno-rtti'],
+        },
+        'libraries': [
+          '../../../../../../libv8.dylib',
+          '../../../../../../libv8_libbase.dylib',
+          '../../../../../../libv8_libplatform.dylib',
+          '../../../../../../libicuuc.dylib',
+        ],
+        'conditions': [
+          #['OS=="mac" and libchromiumcontent_component==0', {
+            ## -all_load is the "whole-archive" on macOS.
+            #'xcode_settings': {
+              #'OTHER_LDFLAGS': [ '-Wl,-all_load' ],
+            #},
+          #}],
+          #[{
+            #'libraries': [
+              #'<@(libchromiumcontent_v8_libraries)',
+            #],
+          #}],
+        ],
+      }],
+      ['_target_name=="openssl"', {
+        'xcode_settings': {
+          'DEAD_CODE_STRIPPING': 'YES',  # -Wl,-dead_strip
+          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
+          'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',
+        },
+        'cflags': [
+          '-fvisibility=hidden',
+        ],
+      }],
+      ['_target_name=="openssl-cli"', {
+        'ldflags!': [
+          '-nostdlib++',
+        ]
+      }],
+      ['_target_name=="libuv"', {
+        'conditions': [
+          ['OS=="win"', {
+            # Expose libuv's symbols.
+            'defines': [
+              'BUILDING_UV_SHARED=1',
+            ],
+          }],  # OS=="win"
+        ],
+      }],
+      ['_target_name.startswith("crashpad")', {
+        'conditions': [
+          ['OS=="mac"', {
+            'xcode_settings': {
+              'WARNING_CFLAGS': [
+                '-Wno-unused-private-field',
+                '-Wno-address-of-packed-member',
+              ],
+            },
+          }],  # OS=="mac"
+        ],
+      }],
+      ['_target_name.startswith("breakpad") or _target_name in ["crash_report_sender", "dump_syms"]', {
+        'conditions': [
+          ['OS=="mac"', {
+            'xcode_settings': {
+              'WARNING_CFLAGS': [
+                '-Wno-deprecated-declarations',
+                '-Wno-deprecated-register',
+                '-Wno-unused-private-field',
+                '-Wno-unused-function',
+              ],
+            },
+          }],  # OS=="mac"
+          ['OS=="linux"', {
+            'cflags': [
+              '-Wno-empty-body',
+            ],
+          }],  # OS=="linux"
+          ['OS=="win"', {
+            'msvs_disabled_warnings': [
+              # unreferenced local function has been removed.
+              4505,
+            ],
+          }],  # OS=="win"
+        ],
+      }],
+      ['OS=="linux" and _toolset=="target" and _target_name in ["dump_syms", "node_lib"]', {
+        'conditions': [
+          #['libchromiumcontent_component==0', {
+            #'libraries': [
+              #'<(libchromiumcontent_dir)/libc++.a',
+            #],
+            #'ldflags': [
+              #'-lpthread',
+            ##],
+          #}, {
+            #'libraries': [
+              #'<(libchromiumcontent_dir)/libc++.so',
+            #],
+            #'ldflags': [
+              #'-Wl,-rpath=\$$ORIGIN',
+            #],
+          #}],
+        ],
+      }]
+    ],
+    'msvs_cygwin_shell': 0, # Strangely setting it to 1 would make building under cygwin fail.
+    'msvs_disabled_warnings': [
+      4005,  # (node.h) macro redefinition
+      4091,  # (node_extern.h) '__declspec(dllimport)' : ignored on left of 'node::Environment' when no variable is declared
+      4099,  # (pdf_render_settings.h) type name first seen using 'class' now seen using 'struct'
+      4189,  # local variable is initialized but not referenced
+      4201,  # (uv.h) nameless struct/union
+      4267,  # conversion from 'size_t' to 'int', possible loss of data
+      4302,  # (atldlgs.h) 'type cast': truncation from 'LPCTSTR' to 'WORD'
+      4458,  # (atldlgs.h) declaration of 'dwCommonButtons' hides class member
+      4503,  # decorated name length exceeded, name was truncated
+      4530,  # C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
+      4577,  # 'noexcept' used with no exception handling mode specified
+      4714,  # (atomicstring.h) function marked as __forceinline not inlined
+      4800,  # (v8.h) forcing value to bool 'true' or 'false'
+      4819,  # The file contains a character that cannot be represented in the current code page
+      4838,  # (atlgdi.h) conversion from 'int' to 'UINT' requires a narrowing conversion
+      4996,  # (atlapp.h) 'GetVersionExW': was declared deprecated
+    ],
+  },
+  'conditions': [
+    # The breakdpad on Windows assumes Debug_x64 and Release_x64 configurations.
+    ['OS=="win"', {
+      'target_defaults': {
+        'configurations': {
+          'Debug_x64': {
+          },
+          'Release_x64': {
+          },
+        },
+      },
+    }],  # OS=="win"
+    # The breakdpad on Mac assumes Release_Base configuration.
+    ['OS=="mac"', {
+      'target_defaults': {
+        'configurations': {
+          'Release_Base': {
+          },
+        },
+      },
+    }],  # OS=="mac"
+  ],
+}

--- a/build/npm-run.py
+++ b/build/npm-run.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
+args = ["npm", "run",
+    "--prefix",
+    SOURCE_ROOT
+    ] + sys.argv[1:]
+os.execvp("npm", args)

--- a/build/npm.gni
+++ b/build/npm.gni
@@ -1,0 +1,16 @@
+template("npm_action") {
+  assert(defined(invoker.script),
+         "Need script name to run (must be defined in package.json)")
+  assert(defined(invoker.args),
+         "Need script argumets")
+
+  action(target_name) {
+    forward_variables_from(invoker, ["deps", "public_deps", "sources", "inputs", "outputs"])
+    script = "//electron/build/npm-run.py"
+    args = [
+      "--silent",
+      invoker.script,
+      "--"
+    ] + invoker.args
+  }
+}

--- a/build/run-ninja.py
+++ b/build/run-ninja.py
@@ -1,0 +1,11 @@
+import sys
+import os
+import subprocess
+
+def main(argv):
+  src = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+  ninja_path = os.path.join(src, 'third_party', 'depot_tools', 'ninja')
+  os.execv(ninja_path, argv)
+
+if __name__ == '__main__':
+  main(sys.argv)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "private": true,
   "scripts": {
+    "asar": "asar",
     "bootstrap": "python ./script/bootstrap.py",
     "browserify": "browserify",
     "bump-version": "./script/bump-version.py",


### PR DESCRIPTION
This PR adds GN build infrastructure for building on macOS. This build system is still in the experimental phase while we continue to explore and look for the best way of integrating with Chromium's GN build system. This doesn't affect the GYP build, which should continue to function unimpacted by these changes. As of this PR, the build will only work as a component build on macOS.

Depends on [electron/libchromiumcontent#537](https://github.com/electron/libchromiumcontent/pull/537) and #12738.

The first commit in this PR updates `#include` paths to not refer to `vendor/`, since the GN build checks out those repositories in different locations.

Instructions for trying out the GN build on Mac (once this is merged):
```
$ mkdir electron-gn && cd electron-gn
$ cat > .gclient <<-GCLIENT
solutions = [
  {
    "url": "https://github.com/electron/electron",
    "managed": False,
    "name": "src/electron",
  },
]
GCLIENT
$ gclient sync --with_branch_heads --with_tags --nohooks && gclient runhooks
$ cd src
$ export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
$ gn gen out/Default --args='cc_wrapper="sccache" is_component_build=true use_jumbo_build=true root_extra_deps=["//electron"]'
$ ninja -C out/Default electron:electron_app
$ ./out/Default/Electron.app/Contents/MacOS/Electron
```

---

## Background information

This is a substantial structural change to how electron is checked out. Instead of git submodules, in the GN build electron and its dependencies (including chromium) are checked out with `gclient`. The structure of an electron checkout in the GN build world is:

```
.
├── .gclient
└── src
    ├── base
    ├── build
    ├── components
    ├── content
    ⋮
    ├── electron
    │   ├── atom
    │   ├── brightray
    │   ⋮
    ├── libchromiumcontent
    ⋮
    ├── third_party
    │   ├── WebKit
    │   ├── electron_node
    │   ├── native_mate
    │   ⋮
    ⋮
```

This is coordinated through DEPS files instead of git submodules.