### PR TITLE
fix: listeners out of limit warning

### DIFF
--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -23,6 +23,12 @@ const runContentScript = function (extensionId, url, code) {
   return compiledWrapper.call(this, context.chrome)
 }
 
+const runAllContentScript = function (scripts, extensionId) {
+  for (const {url, code} of scripts) {
+    runContentScript.call(window, extensionId, url, code)
+  }
+}
+
 const runStylesheet = function (url, code) {
   const wrapper = `((code) => {
     function init() {
@@ -40,34 +46,36 @@ const runStylesheet = function (url, code) {
   return compiledWrapper.call(this, code)
 }
 
+const runAllStylesheet = function (css) {
+  for (const {url, code} of css) {
+    runStylesheet.call(window, url, code)
+  }
+}
+
 // Run injected scripts.
 // https://developer.chrome.com/extensions/content_scripts
 const injectContentScript = function (extensionId, script) {
   if (!script.matches.some(matchesPattern)) return
 
   if (script.js) {
-    for (const {url, code} of script.js) {
-      const fire = runContentScript.bind(window, extensionId, url, code)
-      if (script.runAt === 'document_start') {
-        process.once('document-start', fire)
-      } else if (script.runAt === 'document_end') {
-        process.once('document-end', fire)
-      } else {
-        document.addEventListener('DOMContentLoaded', fire)
-      }
+    const fire = runAllContentScript.bind(window, script.js, extensionId)
+    if (script.runAt === 'document_start') {
+      process.once('document-start', fire)
+    } else if (script.runAt === 'document_end') {
+      process.once('document-end', fire)
+    } else {
+      document.addEventListener('DOMContentLoaded', fire)
     }
   }
 
   if (script.css) {
-    for (const {url, code} of script.css) {
-      const fire = runStylesheet.bind(window, url, code)
-      if (script.runAt === 'document_start') {
-        process.once('document-start', fire)
-      } else if (script.runAt === 'document_end') {
-        process.once('document-end', fire)
-      } else {
-        document.addEventListener('DOMContentLoaded', fire)
-      }
+    const fire = runAllStylesheet.bind(window, script.css)
+    if (script.runAt === 'document_start') {
+      process.once('document-start', fire)
+    } else if (script.runAt === 'document_end') {
+      process.once('document-end', fire)
+    } else {
+      document.addEventListener('DOMContentLoaded', fire)
     }
   }
 }


### PR DESCRIPTION
When the Chrome Extension has too many content scripts (above default 10 counts), there will be a warning:
`warning: possible EventEmitter memory leak detected. 11 listeners added.`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->