### PR TITLE
fix: support multiple inherited ubuntu session for indicators

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -162,11 +162,24 @@ require('./api/protocol')
 // Set main startup script of the app.
 const mainStartupScript = packageJson.main || 'index.js'
 
+const KNOWN_XDG_DESKTOP_VALUES = ['Pantheon', 'Unity:Unity7', 'pop:GNOME']
+
+function currentPlatformSupportsAppIndicator() {
+  if (process.platform !== 'linux') return false
+  const currentDesktop = process.env.XDG_CURRENT_DESKTOP
+
+  if (!currentDesktop) return false
+  if (KNOWN_XDG_DESKTOP_VALUES.includes(currentDesktop)) return true
+  // ubuntu based or derived session (default ubuntu one, communitheme…) supports
+  // indicator too.
+  if (/ubuntu/ig.test(currentDesktop)) return true
+
+  return false
+}
+
 // Workaround for electron/electron#5050 and electron/electron#9046
-if (process.platform === 'linux') {
-  if (['Pantheon', 'Unity:Unity7', 'pop:GNOME'].includes(process.env.XDG_CURRENT_DESKTOP) || process.env.XDG_CURRENT_DESKTOP.includes('ubuntu')) {
-    process.env.XDG_CURRENT_DESKTOP = 'Unity'
-  }
+if (currentPlatformSupportsAppIndicator()) {
+  process.env.XDG_CURRENT_DESKTOP = 'Unity'
 }
 
 // Finally load app's main.js and transfer control to C++.

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -164,7 +164,7 @@ const mainStartupScript = packageJson.main || 'index.js'
 
 const KNOWN_XDG_DESKTOP_VALUES = ['Pantheon', 'Unity:Unity7', 'pop:GNOME']
 
-function currentPlatformSupportsAppIndicator() {
+function currentPlatformSupportsAppIndicator () {
   if (process.platform !== 'linux') return false
   const currentDesktop = process.env.XDG_CURRENT_DESKTOP
 

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -163,8 +163,10 @@ require('./api/protocol')
 const mainStartupScript = packageJson.main || 'index.js'
 
 // Workaround for electron/electron#5050 and electron/electron#9046
-if (process.platform === 'linux' && ['Pantheon', 'Unity:Unity7', 'ubuntu:GNOME', 'pop:GNOME'].includes(process.env.XDG_CURRENT_DESKTOP)) {
-  process.env.XDG_CURRENT_DESKTOP = 'Unity'
+if (process.platform === 'linux') {
+  if (['Pantheon', 'Unity:Unity7', 'pop:GNOME'].includes(process.env.XDG_CURRENT_DESKTOP) || process.env.XDG_CURRENT_DESKTOP.includes('ubuntu')) {
+    process.env.XDG_CURRENT_DESKTOP = 'Unity'
+  }
 }
 
 // Finally load app's main.js and transfer control to C++.


### PR DESCRIPTION
Multiple sessions inherits the "ubuntu" base settings properties in ubuntu.
One of the most popular one is communitheme: the next ubuntu default theme
has its dedicated session, with thus duplicated indicators for dropbox.
Rather than a string comparison for ubuntu, only match a substring then.
XDG_CURRENT_DESKTOP can be of form: "communitheme:ubuntu:GNOME",
"ubuntu:GNOME", …
Fixes: #12843.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->