### PR TITLE
Remove judgmental docs terms

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -26,7 +26,7 @@ this event represents the `applicationWillFinishLaunching` notification of
 `NSApplication`. You would usually set up listeners for the `open-file` and
 `open-url` events here, and start the crash reporter and auto updater.
 
-In most cases, you should just do everything in the `ready` event handler.
+In most cases, you should do everything in the `ready` event handler.
 
 ### Event: 'ready'
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -500,7 +500,7 @@ Emitted when the window is being resized.
 
 Emitted when the window is being moved to a new position.
 
-__Note__: On macOS this event is just an alias of `moved`.
+__Note__: On macOS this event is an alias of `moved`.
 
 #### Event: 'moved' _macOS_
 
@@ -825,7 +825,7 @@ on the right edge and 50 pixels of controls below the player. In order to
 maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
 the player itself we would call this function with arguments of 16/9 and
 [ 40, 50 ]. The second argument doesn't care where the extra width and height
-are within the content view--only that they exist. Just sum any extra width and
+are within the content view--only that they exist. Sum any extra width and
 height areas you have within the overall content view.
 
 #### `win.previewFile(path[, displayName])` _macOS_

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -152,7 +152,7 @@ button {
 }
 ```
 
-If you're setting just a custom titlebar as draggable, you also need to make all
+If you're only setting a custom titlebar as draggable, you also need to make all
 buttons in titlebar non-draggable.
 
 ## Text selection

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -49,7 +49,7 @@ for more information on macOS' native actions.
 
 Returns `Menu`
 
-Generally, the `template` is just an array of `options` for constructing a
+Generally, the `template` is an array of `options` for constructing a
 [MenuItem](menu-item.md). The usage can be referenced above.
 
 You can also attach other fields to the element of the `template` and they

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -858,7 +858,7 @@ Returns:
 
 Fired when the guest page has sent an asynchronous message to embedder page.
 
-With `sendToHost` method and `ipc-message` event you can easily communicate
+With `sendToHost` method and `ipc-message` event you can communicate
 between guest page and embedder page:
 
 ```javascript

--- a/docs/development/debug-instructions-windows.md
+++ b/docs/development/debug-instructions-windows.md
@@ -4,7 +4,7 @@ If you experience crashes or issues in Electron that you believe are not caused
 by your JavaScript application, but instead by Electron itself, debugging can
 be a little bit tricky, especially for developers not used to native/C++
 debugging. However, using Visual Studio, GitHub's hosted Electron Symbol Server,
-and the Electron source code, it is fairly easy to enable step-through debugging
+and the Electron source code, you can enable step-through debugging
 with breakpoints inside Electron's source code.
 
 ## Requirements
@@ -12,7 +12,7 @@ with breakpoints inside Electron's source code.
 * **A debug build of Electron**: The easiest way is usually building it
   yourself, using the tools and prerequisites listed in the
   [build instructions for Windows](build-instructions-windows.md). While you can
-  easily attach to and debug Electron as you can download it directly, you will
+  attach to and debug Electron as you can download it directly, you will
   find that it is heavily optimized, making debugging substantially more
   difficult: The debugger will not be able to show you the content of all
   variables and the execution path can seem strange because of inlining,
@@ -47,8 +47,7 @@ source code matches the code running in the attached process and break
 accordingly.
 
 Relevant code files can be found in `./atom/` as well as in Brightray, found in
-`./brightray/browser` and `./brightray/common`. If you're hardcore,
-you can also debug Chromium directly, which is obviously found in `chromium_src`.
+`./brightray/browser` and `./brightray/common`.
 
 ### Attaching
 

--- a/docs/development/debugging-instructions-macos.md
+++ b/docs/development/debugging-instructions-macos.md
@@ -3,8 +3,8 @@
 If you experience crashes or issues in Electron that you believe are not caused
 by your JavaScript application, but instead by Electron itself, debugging can
 be a little bit tricky, especially for developers not used to native/C++
-debugging. However, using lldb, and the Electron source code, it is fairly easy
-to enable step-through debugging with breakpoints inside Electron's source code.
+debugging. However, using lldb, and the Electron source code, you can enable
+step-through debugging with breakpoints inside Electron's source code.
 You can also use [XCode for debugging](debugging-instructions-macos-xcode.md) if
 you prefer a graphical interface.
 
@@ -13,7 +13,7 @@ you prefer a graphical interface.
 * **A debug build of Electron**: The easiest way is usually building it
   yourself, using the tools and prerequisites listed in the
   [build instructions for macOS](build-instructions-osx.md). While you can
-  easily attach to and debug Electron as you can download it directly, you will
+  attach to and debug Electron as you can download it directly, you will
   find that it is heavily optimized, making debugging substantially more
   difficult: The debugger will not be able to show you the content of all
   variables and the execution path can seem strange because of inlining,
@@ -42,8 +42,7 @@ that isn't behaving correctly - so you'd like to break on that command's C++
 counterpart inside the Electron source.
 
 Relevant code files can be found in `./atom/` as well as in Brightray, found in
-`./brightray/browser` and `./brightray/common`. If you're hardcore,
-you can also debug Chromium directly, which is obviously found in `chromium_src`.
+`./brightray/browser` and `./brightray/common`.
 
 Let's assume that you want to debug `app.setName()`, which is defined in `browser.cc`
 as `Browser::SetName()`. Set the breakpoint using the `breakpoint` command, specifying

--- a/docs/tutorial/application-architecture.md
+++ b/docs/tutorial/application-architecture.md
@@ -56,8 +56,8 @@ const electron = require('electron')
 
 All Electron APIs are assigned a process type. Many of them can only be
 used from the main process, some of them only from a renderer process,
-some from both. The documentation for the individual API will clearly
-state which process they can be used from.
+some from both. The documentation for each individual API will
+state which process it can be used from.
 
 A window in Electron is for instance created using the `BrowserWindow`
 class. It is only available in the main process.
@@ -133,8 +133,7 @@ compiled to be used with Electron.
 
 The vast majority of Node.js modules are _not_ native. Only 400 out of the
 ~650.000 modules are native. However, if you do need native modules, please
-consult [this guide on how to recompile them for Electron][native-node] (it's
-easy).
+consult [this guide on how to recompile them for Electron][native-node].
 
 [node-docs]: https://nodejs.org/en/docs/
 [security]: ./security.md

--- a/docs/tutorial/boilerplates-and-clis.md
+++ b/docs/tutorial/boilerplates-and-clis.md
@@ -28,7 +28,7 @@ beginners, using a command line tool is likely to be helpful*.
 
 A "complete tool for building modern Electron applications". Electron Forge
 unifies the existing (and well maintained) build tools for Electron development
-into a simple, easy to use package so that anyone can jump right in to Electron
+into a cohesive package so that anyone can jump right in to Electron
 development.
 
 Forge comes with [ready-to-use templates](https://electronforge.io/templates) for popular

--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -31,7 +31,7 @@ There are several major changes from our 1.x strategy outlined below. Each chang
 1. Strict use of semver
 2. Introduction of semver-compliant `-beta` tags
 3. Introduction of [conventional commit messages](https://conventionalcommits.org/)
-4. Clearly defined stabilization branches
+4. Well-defined stabilization branches
 5. The `master` branch is versionless; only stabilization branches contain version information
 
 We will cover in detail how git branching works, how npm tagging works, what developers should expect to see, and how one can backport changes.

--- a/docs/tutorial/keyboard-shortcuts.md
+++ b/docs/tutorial/keyboard-shortcuts.md
@@ -19,7 +19,7 @@ menu.append(new MenuItem({
 }))
 ```
 
-It's easy to configure different key combinations based on the user's operating system.
+You can configure different key combinations based on the user's operating system.
 
 ```js
 {

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -1,6 +1,6 @@
 # Recent Documents (Windows & macOS)
 
-Windows and macOS provide easy access to a list of recent documents opened by
+Windows and macOS provide access to a list of recent documents opened by
 the application via JumpList or dock menu, respectively.
 
 __JumpList:__

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -78,7 +78,7 @@ following things:
 
 ## Modules that rely on `prebuild`
 
-[`prebuild`](https://github.com/mafintosh/prebuild) provides a way to easily
+[`prebuild`](https://github.com/mafintosh/prebuild) provides a way to
 publish native Node modules with prebuilt binaries for multiple versions of Node
 and Electron.
 


### PR DESCRIPTION
Prompted by [this tweet](https://twitter.com/jesstelford/status/992756386160234497).

This PR removes some judgmental words from docs including 'easy', 'just', 'simply', and similar words which might be unfriendly to developers just entering the source and looking at docs.