### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve Electron
+
+---
+
+* Electron Version:
+* Operating System (Platform and Version):
+* Last known working Electron version: 
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happened.
+
+**To Reproduce**
+Your best chance of getting this bug looked at quickly is to provide a REPOSITORY that can be cloned and run.
+
+You can fork [electron-quick-start](https://github.com/electron/electron-quick-start) and include a link to the branch with your changes.
+
+If you provide a URL, please list the commands required to clone/setup/run your repo e.g.
+```sh
+$ git clone $YOUR_URL -b $BRANCH
+$ npm install
+$ npm start || electron .
+```
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional Information**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for Electron
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Move to prescribed templates for bugs and features, Take 2.

There was previously a bug that caused the issues page to 500 when a `config.yml` file existed in `.github`, but it should be fixed now!

/cc @electron/electrocats 