### PR TITLE
Expose Windows specific DIP <-> screen coordinate conversion methods

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -119,3 +119,43 @@ Returns [`Display`](structures/display.md) - The display nearest the specified p
 
 Returns [`Display`](structures/display.md) - The display that most closely
 intersects the provided bounds.
+
+### `screen.screenToDipPoint(point)` _Windows_
+
+* `point` [Point](structures/point.md)
+
+Returns [`Point`](structures/point.md)
+
+Converts a screen physical point to a screen DIP point.
+The DPI scale is performed relative to the display containing the physical point.
+
+### `screen.dipToScreenPoint(point)` _Windows_
+
+* `point` [Point](structures/point.md)
+
+Returns [`Point`](structures/point.md)
+
+Converts a screen DIP point to a screen physical point.
+The DPI scale is performed relative to the display containing the DIP point.
+
+### `screen.screenToDipRect(window, rect)` _Windows_
+
+* `window` [BrowserWindow](browser-window.md)
+* `rect` [Rectangle](structures/rectangle.md)
+
+Returns [`Rectangle`](structures/rectangle.md)
+
+Converts a screen physical rect to a screen DIP rect.
+The DPI scale is performed relative to the display nearest to `window`.
+If `window` is null, scaling will be performed to the display nearest to `rect`.
+
+### `screen.dipToScreenRect(window, rect)` _Windows_
+
+* `window` [BrowserWindow](browser-window.md)
+* `rect` [Rectangle](structures/rectangle.md)
+
+Returns [`Rectangle`](structures/rectangle.md)
+
+Converts a screen DIP rect to a screen physical rect.
+The DPI scale is performed relative to the display nearest to `window`.
+If `window` is null, scaling will be performed to the display nearest to `rect`.


### PR DESCRIPTION
These methods are mapped to the following APIs in `display::win::ScreenWin` (`libchromiumcontent/src/ui/display/win/screen_win.h`):
- `ScreenToDIPPoint`
- `DIPToScreenPoint`
- `ScreenToDIPRect`
- `DIPToScreenRect`

This new API is useful when calling Windows APIs in native code (node modules), which operate on physical coordinates.