### PR TITLE
docs: `Notification::close` dismisses notification in macOS Notification Center

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -111,6 +111,8 @@ shown notification and create a new one with identical properties.
 
 Dismisses the notification.
 
+_macOS_: Removes notification from Notification Center. Caveat: Only the last notification can be removed via this API.
+
 ### Playing Sounds
 
 On macOS, you can specify the name of the sound you'd like to play when the


### PR DESCRIPTION
`Notification::close` removes a notification from the macOS Notification Center.

Caveat: Only the last notification can be removed using this API, see: https://github.com/electron/electron/issues/12880.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->