### PR TITLE
 Require !OS_MACOSX as well as TOOLKIT_VIEWS for views code

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -854,9 +854,7 @@ void WebContents::DidFinishLoad(content::RenderFrameHost* render_frame_host,
   bool is_main_frame = !render_frame_host->GetParent();
   int frame_process_id = render_frame_host->GetProcess()->GetID();
   int frame_routing_id = render_frame_host->GetRoutingID();
-  Emit("did-frame-finish-load",
-       is_main_frame,
-       frame_process_id,
+  Emit("did-frame-finish-load", is_main_frame, frame_process_id,
        frame_routing_id);
 
   if (is_main_frame)
@@ -870,13 +868,8 @@ void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
   bool is_main_frame = !render_frame_host->GetParent();
   int frame_process_id = render_frame_host->GetProcess()->GetID();
   int frame_routing_id = render_frame_host->GetRoutingID();
-  Emit("did-fail-load",
-       error_code,
-       error_description,
-       url,
-       is_main_frame,
-       frame_process_id,
-       frame_routing_id);
+  Emit("did-fail-load", error_code, error_description, url, is_main_frame,
+       frame_process_id, frame_routing_id);
 }
 
 void WebContents::DidStartLoading() {
@@ -916,9 +909,9 @@ void WebContents::DidStartNavigation(
   bool is_main_frame = navigation_handle->IsInMainFrame();
   int frame_tree_node_id = navigation_handle->GetFrameTreeNodeId();
   content::FrameTreeNode* frame_tree_node =
-    content::FrameTreeNode::GloballyFindByID(frame_tree_node_id);
+      content::FrameTreeNode::GloballyFindByID(frame_tree_node_id);
   content::RenderFrameHostManager* render_manager =
-    frame_tree_node->render_manager();
+      frame_tree_node->render_manager();
   content::RenderFrameHost* frame_host = nullptr;
   if (render_manager) {
     frame_host = render_manager->speculative_frame_host();
@@ -932,12 +925,8 @@ void WebContents::DidStartNavigation(
   }
   bool is_same_document = navigation_handle->IsSameDocument();
   auto url = navigation_handle->GetURL();
-  Emit("did-start-navigation",
-       url,
-       is_same_document,
-       is_main_frame,
-       frame_process_id,
-       frame_routing_id);
+  Emit("did-start-navigation", url, is_same_document, is_main_frame,
+       frame_process_id, frame_routing_id);
 }
 
 void WebContents::DidFinishNavigation(
@@ -946,7 +935,7 @@ void WebContents::DidFinishNavigation(
     return;
   bool is_main_frame = navigation_handle->IsInMainFrame();
   content::RenderFrameHost* frame_host =
-    navigation_handle->GetRenderFrameHost();
+      navigation_handle->GetRenderFrameHost();
   int frame_process_id = -1, frame_routing_id = -1;
   if (frame_host) {
     frame_process_id = frame_host->GetProcess()->GetID();
@@ -956,27 +945,19 @@ void WebContents::DidFinishNavigation(
     auto url = navigation_handle->GetURL();
     bool is_same_document = navigation_handle->IsSameDocument();
     if (is_same_document) {
-      Emit("did-navigate-in-page",
-        url,
-        is_main_frame,
-        frame_process_id,
-        frame_routing_id);
+      Emit("did-navigate-in-page", url, is_main_frame, frame_process_id,
+           frame_routing_id);
     } else {
-      const net::HttpResponseHeaders* http_response
-        = navigation_handle->GetResponseHeaders();
+      const net::HttpResponseHeaders* http_response =
+          navigation_handle->GetResponseHeaders();
       std::string http_status_text;
       int http_response_code = -1;
       if (http_response) {
         http_status_text = http_response->GetStatusText();
         http_response_code = http_response->response_code();
       }
-      Emit("did-frame-navigate",
-           url,
-           http_response_code,
-           http_status_text,
-           is_main_frame,
-           frame_process_id,
-           frame_routing_id);
+      Emit("did-frame-navigate", url, http_response_code, http_status_text,
+           is_main_frame, frame_process_id, frame_routing_id);
       if (is_main_frame) {
         Emit("did-navigate", url, http_response_code, http_status_text);
       }
@@ -985,23 +966,13 @@ void WebContents::DidFinishNavigation(
     auto url = navigation_handle->GetURL();
     int code = navigation_handle->GetNetErrorCode();
     auto description = net::ErrorToShortString(code);
-    Emit("did-fail-provisional-load",
-         code,
-         description,
-         url,
-         is_main_frame,
-         frame_process_id,
-         frame_routing_id);
+    Emit("did-fail-provisional-load", code, description, url, is_main_frame,
+         frame_process_id, frame_routing_id);
 
     // Do not emit "did-fail-load" for canceled requests.
     if (code != net::ERR_ABORTED)
-      Emit("did-fail-load",
-           code,
-           description,
-           url,
-           is_main_frame,
-           frame_process_id,
-           frame_routing_id);
+      Emit("did-fail-load", code, description, url, is_main_frame,
+           frame_process_id, frame_routing_id);
   }
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -637,7 +637,7 @@ void WebContents::MoveContents(content::WebContents* source,
 
 void WebContents::CloseContents(content::WebContents* source) {
   Emit("close");
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
   HideAutofillPopup();
 #endif
   if (managed_web_contents())
@@ -1071,7 +1071,7 @@ void WebContents::DevToolsClosed() {
   Emit("devtools-closed");
 }
 
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
 void WebContents::ShowAutofillPopup(content::RenderFrameHost* frame_host,
                                     const gfx::RectF& bounds,
                                     const std::vector<base::string16>& values,
@@ -1106,7 +1106,7 @@ bool WebContents::OnMessageReceived(const IPC::Message& message,
         FrameDispatchHelper::OnSetTemporaryZoomLevel)
     IPC_MESSAGE_FORWARD_DELAY_REPLY(AtomFrameHostMsg_GetZoomLevel, &helper,
                                     FrameDispatchHelper::OnGetZoomLevel)
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
     IPC_MESSAGE_HANDLER(AtomAutofillFrameHostMsg_ShowPopup, ShowAutofillPopup)
     IPC_MESSAGE_HANDLER(AtomAutofillFrameHostMsg_HidePopup, HideAutofillPopup)
 #endif

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -178,7 +178,7 @@ void CommonWebContentsDelegate::SetOwnerWindow(
   auto relay = std::make_unique<NativeWindowRelay>(owner_window_);
   auto* relay_key = relay->key;
   if (owner_window) {
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
     autofill_popup_.reset(new AutofillPopup());
 #endif
     web_contents->SetUserData(relay_key, std::move(relay));

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -15,7 +15,7 @@
 #include "brightray/browser/inspectable_web_contents_view_delegate.h"
 #include "content/public/browser/web_contents_delegate.h"
 
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
 #include "atom/browser/ui/autofill_popup.h"
 #endif
 
@@ -91,7 +91,7 @@ class CommonWebContentsDelegate
       const content::NativeWebKeyboardEvent& event) override;
 
   // Autofill related events.
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
   void ShowAutofillPopup(bool offscreen,
                          content::RenderFrameHost* frame_host,
                          const gfx::RectF& bounds,
@@ -118,7 +118,7 @@ class CommonWebContentsDelegate
                             const std::string& query) override;
 
   // brightray::InspectableWebContentsViewDelegate:
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
   gfx::ImageSkia GetDevToolsWindowIcon() override;
 #endif
 #if defined(USE_X11)
@@ -165,7 +165,7 @@ class CommonWebContentsDelegate
   bool native_fullscreen_;
 
   // UI related helper classes.
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
   std::unique_ptr<AutofillPopup> autofill_popup_;
 #endif
   std::unique_ptr<WebDialogHelper> web_dialog_helper_;

--- a/brightray/browser/inspectable_web_contents_view.h
+++ b/brightray/browser/inspectable_web_contents_view.h
@@ -27,7 +27,7 @@ class InspectableWebContentsView {
   }
   InspectableWebContentsViewDelegate* GetDelegate() const { return delegate_; }
 
-#if defined(TOOLKIT_VIEWS)
+#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
   // Returns the container control, which has devtools view attached.
   virtual views::View* GetView() = 0;
 


### PR DESCRIPTION
The GN build defines TOOLKIT_VIEWS even on macOS, but some code in Electron guarded by TOOLKIT_VIEWS expects to be only built on Linux and Windows. This PR adds extra guards to that code.