### PR TITLE
build: don't ship pdf_viewer_resources.pak when feature flag is disabled

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -193,6 +193,12 @@ def electron_gyp():
     obj = eval(f.read());
     return obj['variables']
 
+def electron_features():
+  SOURCE_ROOT = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+  gyp = os.path.join(SOURCE_ROOT, 'features.gypi')
+  with open(gyp) as f:
+    obj = eval(f.read());
+    return obj['variables']['variables']
 
 def get_electron_version():
   return 'v' + electron_gyp()['version%']


### PR DESCRIPTION
Fixes packaging release builds on windows and linux