### PR TITLE
fix: failure to generate TypeScript definition due to inconsistent docs

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1150,7 +1150,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
 
 * `url` String
 * `options` Object (optional)
-  * `httpReferrer` String (optional) - An HTTP Referrer url.
+  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -276,5 +276,6 @@ current renderer process.
 
 ### `webFrame.routingId`
 
-A unique frame id in the current renderer process. Distinct WebFrame instances
-that refer to the same underlying frame will have the same `routingId`.
+An `Integer` representing a unique frame id in the current renderer process.
+Distinct WebFrame instances that refer to the same underlying frame will have
+the same `routingId`.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -306,7 +306,7 @@ webview.addEventListener('dom-ready', () => {
 
 * `url` URL
 * `options` Object (optional)
-  * `httpReferrer` String (optional) - An HTTP Referrer url.
+  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) (optional) -


### PR DESCRIPTION
See https://github.com/electron/electron-typescript-definitions/pull/99 for the backstory.

There are two issues with the current docs that currently prevent [electron-typescript-definitions](https://github.com/electron/electron-typescript-definitions) from generating TypeScript definitions against `master`.

The first is due to a mismatch in the LoadURLOptions interface caused by a docs change in https://github.com/electron/electron/pull/12397 where the `webContents.loadURL` gained the ability to accept a referrer structure in addition to a string.  I'm gonna need some help to verify that this extra type is actually allowed for all the incantations of loadURL (i.e. `<webview>.loadURL` and `win.loadURL`). I feel fairly confident about the `browserView` one because the doc mentions its loadURL being the exact same as the `webContents` one

> Same as `webContents.loadURL(url[, options])`.

The second issue is an omission of a code-fenced type for the `webFrame.routingId` property which caused the TypeScript type to be `unique` (picked up from the description) rather than 'number'.