### PR TITLE
fix broken doc errors

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -818,11 +818,6 @@ app.on('ready', () => {
 })
 ```
 
-### `app.releaseSingleInstance()`
-
-Releases all locks that were created by `makeSingleInstance`. This will allow
-multiple instances of the application to once again run side by side.
-
 ### `app.requestSingleInstanceLock()`
 
 Returns `Boolean`

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -758,6 +758,71 @@ app.setJumpList([
 ])
 ```
 
+### `app.makeSingleInstance(callback)` *(Deprecated)*
+
+* `callback` Function
+  * `argv` String[] - An array of the second instance's command line arguments
+  * `workingDirectory` String - The second instance's working directory
+
+Returns `Boolean`.
+
+**Deprecated**: This method has been deprecated and is scheduled for removal.
+Please use `app.requestSingleInstanceLock()` instead.
+
+This method makes your application a Single Instance Application - instead of
+allowing multiple instances of your app to run, this will ensure that only a
+single instance of your app is running, and other instances signal this
+instance and exit.
+
+`callback` will be called by the first instance with `callback(argv, workingDirectory)`
+when a second instance has been executed. `argv` is an Array of the second instance's
+command line arguments, and `workingDirectory` is its current working directory. Usually
+applications respond to this by making their primary window focused and
+non-minimized.
+
+The `callback` is guaranteed to be executed after the `ready` event of `app`
+gets emitted.
+
+This method returns `false` if your process is the primary instance of the
+application and your app should continue loading. And returns `true` if your
+process has sent its parameters to another instance, and you should immediately
+quit.
+
+On macOS the system enforces single instance automatically when users try to open
+a second instance of your app in Finder, and the `open-file` and `open-url`
+events will be emitted for that. However when users start your app in command
+line the system's single instance mechanism will be bypassed and you have to
+use this method to ensure single instance.
+
+An example of activating the window of primary instance when a second instance
+starts:
+
+```javascript
+const {app} = require('electron')
+let myWindow = null
+
+const isSecondInstance = app.makeSingleInstance((commandLine, workingDirectory) => {
+  // Someone tried to run a second instance, we should focus our window.
+  if (myWindow) {
+    if (myWindow.isMinimized()) myWindow.restore()
+    myWindow.focus()
+  }
+})
+
+if (isSecondInstance) {
+  app.quit()
+}
+
+// Create myWindow, load the rest of the app, etc...
+app.on('ready', () => {
+})
+```
+
+### `app.releaseSingleInstance()`
+
+Releases all locks that were created by `makeSingleInstance`. This will allow
+multiple instances of the application to once again run side by side.
+
 ### `app.requestSingleInstanceLock()`
 
 Returns `Boolean`
@@ -817,6 +882,15 @@ This method returns whether or not this instance of your app is currently
 holding the single instance lock.  You can request the lock with
 `app.requestSingleInstanceLock()` and release with
 `app.releaseSingleInstanceLock()`
+
+### `app.releaseSingleInstance()` *(Deprecated)*
+
+Releases all locks that were created by `makeSingleInstance`. This will allow
+multiple instances of the application to once again run side by side.
+
+**Deprecated**: This method has been deprecated and is scheduled for removal.
+Please use the `app.requestSingleInstanceLock()` and `app.releaseSingleInstanceLock()`
+methods instead.
 
 ### `app.releaseSingleInstanceLock()`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1150,7 +1150,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
 
 * `url` String
 * `options` Object (optional)
-  * `httpReferrer` String (optional) - An HTTP Referrer url.
+  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)

--- a/docs/api/structures/referrer.md
+++ b/docs/api/structures/referrer.md
@@ -3,8 +3,8 @@
 * `url` String - HTTP Referrer URL.
 * `policy` String - Can be `default`, `unsafe-url`,
   `no-referrer-when-downgrade`, `no-referrer`, `origin`,
-  `strict-origin-when-cross-origin`, `same-origin`, `strict-origin`, or
-  `no-referrer`. See the [Referrer-Policy spec][1] for more details on the
+  `strict-origin-when-cross-origin`, `same-origin`, `strict-origin`.
+  See the [Referrer-Policy spec][1] for more details on the
   meaning of these values.
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -237,10 +237,10 @@ renderer process.
 
 ### `webFrame.findFrameByRoutingId(routingId)`
 
-* `routingId` Integer - A unique frame id in the current renderer process.
-  Routing IDs can be retrieved from `WebFrame` instances (`webFrame.routingId`)
-  and are also passed by frame specific `WebContents` navigation events (e.g. 
-  `did-frame-navigate`)
+* `routingId` Integer - An `Integer` representing the unique frame id in the
+   current renderer process. Routing IDs can be retrieved from `WebFrame`
+   instances (`webFrame.routingId`) and are also passed by frame
+   specific `WebContents` navigation events (e.g. `did-frame-navigate`)
   
 Returns `WebFrame` - that has the supplied `routingId`, `null` if not found. 
 
@@ -276,5 +276,6 @@ current renderer process.
 
 ### `webFrame.routingId`
 
-A unique frame id in the current renderer process. Distinct WebFrame instances
-that refer to the same underlying frame will have the same `routingId`.
+An `Integer` representing the unique frame id in the current renderer process.
+Distinct WebFrame instances that refer to the same underlying frame will have
+the same `routingId`.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -306,7 +306,7 @@ webview.addEventListener('dom-ready', () => {
 
 * `url` URL
 * `options` Object (optional)
-  * `httpReferrer` String (optional) - An HTTP Referrer url.
+  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadFileSystem[]](structures/upload-file-system.md) | [UploadBlob[]](structures/upload-blob.md)) (optional) -

--- a/spec/package.json
+++ b/spec/package.json
@@ -10,7 +10,6 @@
     "chai-as-promised": "^7.1.1",
     "coffee-script": "1.12.7",
     "dbus-native": "^0.2.3",
-    "fs-extra": "^6.0.0",
     "graceful-fs": "^4.1.9",
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.0",

--- a/spec/package.json
+++ b/spec/package.json
@@ -10,6 +10,7 @@
     "chai-as-promised": "^7.1.1",
     "coffee-script": "1.12.7",
     "dbus-native": "^0.2.3",
+    "fs-extra": "^6.0.0",
     "graceful-fs": "^4.1.9",
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.0",


### PR DESCRIPTION
Fix a handful of errors that prevented `create-typescript-definitions` from running in `master`.

 - [x] Fix missing documentation for methods mentioned in 'breaking-changes.md' that caused the run to error out with "error TS2339"
 - [x] Fix routingId type. Previous phrasing confused the parser. Previously, the string "A unique id" got parsed as `routingId` being of type `unique` :smiley:
 - [x] Tweak Referrer.policy type so that all the possible values were read. Previously, the parser got confused by the word 'or' in 'Can be foo, bar, or mum'.
 - [x] Make LoadURLOptions.Referrer type consistent in the different files. Some definitions had it as a string; others had it as a string | Referrer, which caused the run to fail with `Error: Interface "LoadURLOptions" has already been declared` (cc @jkleinsc)