### PR TITLE
fix: update docs for the ts parser

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -758,66 +758,6 @@ app.setJumpList([
 ])
 ```
 
-### `app.makeSingleInstance(callback)` *(Deprecated)*
-
-* `callback` Function
-  * `argv` String[] - An array of the second instance's command line arguments
-  * `workingDirectory` String - The second instance's working directory
-
-Returns `Boolean`.
-
-**Deprecated**: This method has been deprecated and is scheduled for removal.
-Please use `app.requestSingleInstanceLock()` instead.
-
-This method makes your application a Single Instance Application - instead of
-allowing multiple instances of your app to run, this will ensure that only a
-single instance of your app is running, and other instances signal this
-instance and exit.
-
-`callback` will be called by the first instance with `callback(argv, workingDirectory)`
-when a second instance has been executed. `argv` is an Array of the second instance's
-command line arguments, and `workingDirectory` is its current working directory. Usually
-applications respond to this by making their primary window focused and
-non-minimized.
-
-The `callback` is guaranteed to be executed after the `ready` event of `app`
-gets emitted.
-
-This method returns `false` if your process is the primary instance of the
-application and your app should continue loading. And returns `true` if your
-process has sent its parameters to another instance, and you should immediately
-quit.
-
-On macOS the system enforces single instance automatically when users try to open
-a second instance of your app in Finder, and the `open-file` and `open-url`
-events will be emitted for that. However when users start your app in command
-line the system's single instance mechanism will be bypassed and you have to
-use this method to ensure single instance.
-
-An example of activating the window of primary instance when a second instance
-starts:
-
-```javascript
-const {app} = require('electron')
-let myWindow = null
-
-const isSecondInstance = app.makeSingleInstance((commandLine, workingDirectory) => {
-  // Someone tried to run a second instance, we should focus our window.
-  if (myWindow) {
-    if (myWindow.isMinimized()) myWindow.restore()
-    myWindow.focus()
-  }
-})
-
-if (isSecondInstance) {
-  app.quit()
-}
-
-// Create myWindow, load the rest of the app, etc...
-app.on('ready', () => {
-})
-```
-
 ### `app.requestSingleInstanceLock()`
 
 Returns `Boolean`
@@ -877,15 +817,6 @@ This method returns whether or not this instance of your app is currently
 holding the single instance lock.  You can request the lock with
 `app.requestSingleInstanceLock()` and release with
 `app.releaseSingleInstanceLock()`
-
-### `app.releaseSingleInstance()` *(Deprecated)*
-
-Releases all locks that were created by `makeSingleInstance`. This will allow
-multiple instances of the application to once again run side by side.
-
-**Deprecated**: This method has been deprecated and is scheduled for removal.
-Please use the `app.requestSingleInstanceLock()` and `app.releaseSingleInstanceLock()`
-methods instead.
 
 ### `app.releaseSingleInstanceLock()`
 

--- a/docs/api/structures/referrer.md
+++ b/docs/api/structures/referrer.md
@@ -3,7 +3,7 @@
 * `url` String - HTTP Referrer URL.
 * `policy` String - Can be `default`, `unsafe-url`,
   `no-referrer-when-downgrade`, `no-referrer`, `origin`,
-  `strict-origin-when-cross-origin`, `same-origin`, `strict-origin`.
+  `strict-origin-when-cross-origin`, `same-origin` or `strict-origin`.
   See the [Referrer-Policy spec][1] for more details on the
   meaning of these values.
 

--- a/docs/api/structures/transaction.md
+++ b/docs/api/structures/transaction.md
@@ -3,7 +3,7 @@
 * `transactionIdentifier` String - A string that uniquely identifies a successful payment transaction.
 * `transactionDate` String - The date the transaction was added to the App Store’s payment queue.
 * `originalTransactionIdentifier` String - The identifier of the restored transaction by the App Store.
-* `transactionState` String - The transaction state (`"purchasing"`, `"purchased"`, `"failed"`, `"restored"`, or `"deferred"`)
+* `transactionState` String - The transaction state, can be `purchasing`, `purchased`, `failed`, `restored` or `deferred`.
 * `errorCode` Integer - The error code if an error occurred while processing the transaction.
 * `errorMessage` String - The error message if an error occurred while processing the transaction.
 * `payment` Object

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -20,7 +20,7 @@ You can run `npm run lint` to show any style issues detected by `cpplint` and
   * Use `os.tmpdir()` rather than `/tmp` when you need to reference the
     temporary directory.
 * Using a plain `return` when returning explicitly at the end of a function.
-  * Not `return null`, `return undefined`, `null`, or `undefined`
+  * Not `return null`, `return undefined`, `null` or `undefined`
 
 ## C++ and Python
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -184,7 +184,7 @@ of argument is notated by either the common types:
 
 If an argument or a method is unique to certain platforms, those platforms are
 denoted using a space-delimited italicized list following the datatype. Values
-can be `macOS`, `Windows`, or `Linux`.
+can be `macOS`, `Windows` or `Linux`.
 
 ```markdown
 * `animate` Boolean (optional) _macOS_ _Windows_ - Animate the thing.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.4",
-    "electron-typescript-definitions": "^1.3.2",
+    "electron-typescript-definitions": "^1.3.3",
     "github": "^9.2.0",
     "husky": "^0.14.3",
     "lint": "^1.1.2",


### PR DESCRIPTION
This is a follow up to #12900 

Basically:

* Don't document deprecated API's so they don't go into the definition file
* That PR updates the TS tests to use the new API so that they pass
* This PR also updates a few other ", or" situations that would cause issues