### PR TITLE
Allow frameless transparent windows to be sized smaller than 64x64 on Windows

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -25,20 +25,19 @@ namespace atom {
 namespace {
 
 #if defined(OS_WIN)
-  gfx::Size GetExpandedWindowSize(const NativeWindow* window, gfx::Size size) {
-    if (!window->transparent() || !ui::win::IsAeroGlassEnabled())
-      return size;
+gfx::Size GetExpandedWindowSize(const NativeWindow* window, gfx::Size size) {
+  if (!window->transparent() || !ui::win::IsAeroGlassEnabled())
+    return size;
 
-    gfx::Size min_size = display::win::ScreenWin::ScreenToDIPSize(
+  gfx::Size min_size = display::win::ScreenWin::ScreenToDIPSize(
       window->GetAcceleratedWidget(), gfx::Size(64, 64));
 
-    // Some AMD drivers can't display windows that are less than 64x64 pixels,
-    // so expand them to be at least that size. http://crbug.com/286609
-    gfx::Size expanded(
-      std::max(size.width(), min_size.width()),
-      std::max(size.height(), min_size.height()));
-    return expanded;
-  }
+  // Some AMD drivers can't display windows that are less than 64x64 pixels,
+  // so expand them to be at least that size. http://crbug.com/286609
+  gfx::Size expanded(std::max(size.width(), min_size.width()),
+                     std::max(size.height(), min_size.height()));
+  return expanded;
+}
 #endif
 
 }  // namespace

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -14,9 +14,12 @@
 #include "atom/common/color_util.h"
 #include "atom/common/options_switches.h"
 #include "native_mate/dictionary.h"
+#include "ui/views/widget/widget.h"
+
+#if defined(OS_WIN)
 #include "ui/base/win/shell.h"
 #include "ui/display/win/screen_win.h"
-#include "ui/views/widget/widget.h"
+#endif
 
 DEFINE_WEB_CONTENTS_USER_DATA_KEY(atom::NativeWindowRelay);
 
@@ -556,7 +559,7 @@ const views::Widget* NativeWindow::GetWidget() const {
 }
 
 NativeWindowRelay::NativeWindowRelay(base::WeakPtr<NativeWindow> window)
-  : key(UserDataKey()), window(window) {}
+    : key(UserDataKey()), window(window) {}
 
 NativeWindowRelay::~NativeWindowRelay() = default;
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -288,7 +288,7 @@ gfx::Size NativeWindow::GetContentMaximumSize() const {
   gfx::Size maximum_size = GetContentSizeConstraints().GetMaximumSize();
 #if defined(OS_WIN)
   return GetExpandedWindowSize(this, maximum_size);
-#elif
+#else
   return maximum_size;
 #endif
 }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -102,6 +102,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Size GetMinimumSize() const;
   virtual void SetMaximumSize(const gfx::Size& size);
   virtual gfx::Size GetMaximumSize() const;
+  virtual gfx::Size GetContentMinimumSize() const;
+  virtual gfx::Size GetContentMaximumSize() const;
   virtual void SetSheetOffset(const double offsetX, const double offsetY);
   virtual double GetSheetOffsetX();
   virtual double GetSheetOffsetY();

--- a/atom/browser/ui/views/frameless_view.cc
+++ b/atom/browser/ui/views/frameless_view.cc
@@ -100,11 +100,11 @@ gfx::Size FramelessView::CalculatePreferredSize() const {
 }
 
 gfx::Size FramelessView::GetMinimumSize() const {
-  return window_->GetContentSizeConstraints().GetMinimumSize();
+  return window_->GetContentMinimumSize();
 }
 
 gfx::Size FramelessView::GetMaximumSize() const {
-  return window_->GetContentSizeConstraints().GetMaximumSize();
+  return window_->GetContentMaximumSize();
 }
 
 const char* FramelessView::GetClassName() const {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2235,6 +2235,24 @@ describe('BrowserWindow module', () => {
           assert.equal(w.isResizable(), false)
         }
       })
+
+      if (process.platform === 'win32') {
+        it('works for a window smaller than 64x64', () => {
+          w.destroy()
+          w = new BrowserWindow({
+            show: false,
+            frame: false,
+            resizable: false,
+            transparent: true
+          })
+          w.setContentSize(60, 60)
+          assertBoundsEqual(w.getContentSize(), [60, 60])
+          w.setContentSize(30, 30)
+          assertBoundsEqual(w.getContentSize(), [30, 30])
+          w.setContentSize(10, 10)
+          assertBoundsEqual(w.getContentSize(), [10, 10])
+        })
+      }
     })
 
     describe('loading main frame state', () => {


### PR DESCRIPTION
Fixes #12875 

There is a [workaround](https://cs.chromium.org/chromium/src/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc?sq=package:chromium&l=50) in chromium for an AMD graphics driver issue that causes windows to be always expanded to be at least 64x64 pixels in size. This works flawlessly in chromium, but we are using `SizeConstraints` when the window is set to `resizable: false`, which messes with this behavior.

I've added code to allow the `MaximumSize` to be expanded as well when the workaround internally applies.