### PR TITLE
Add deprecation warning for FrameSubscriber's callback [ci skip]

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -272,6 +272,15 @@ WebContents.prototype.getZoomFactor = function (callback) {
   })
 }
 
+// TODO(brenca): remove in 4.0
+const nativeBeginFrameSubscription = WebContents.prototype.beginFrameSubscription
+WebContents.prototype.beginFrameSubscription = function (onlyDirty, callback) {
+  if (!process.noDeprecations) {
+    deprecate.warn('webContents.beginFrameSubscription((frameBuffer, dirtyRect) => {})', `webContents.beginFrameSubscription((nativeImage, dirtyRect) => {})`)
+  }
+  return nativeBeginFrameSubscription.call(this, onlyDirty, callback)
+}
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.


### PR DESCRIPTION
We are using `NativeImage` instances in most places, so I replaced the buffer on the `chromium66` branch with a `NativeImage` to make life easier for everyone.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->