### PR TITLE
Fix contents.setSize(options) documentation in web-contents.md

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1419,11 +1419,17 @@ Shows pop-up dictionary that searches the selected word on the page.
 Set the size of the page. This is only supported for `<webview>` guest contents.
 
 * `options` Object
-  * `normal` Object (optional) - Normal size of the page. This can be used in
+  * `enableAutoSize` Boolean (optional) - true to make the webview container automatically
+    resize within the bounds specified by the attributes normal, min and max.
+  * `normal` [Size](structures/size.md) (optional) - Normal size of the page. This can be used in
     combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
     attribute to manually resize the webview guest contents.
-    * `width` Integer
-    * `height` Integer
+  * `min` [Size](structures/size.md) (optional) - Minimum size of the page. This can be used in
+    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
+    attribute to manually resize the webview guest contents.
+  * `max` [Size](structures/size.md) (optional) - Maximium size of the page. This can be used in
+    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
+    attribute to manually resize the webview guest contents.
 
 #### `contents.isOffscreen()`
 


### PR DESCRIPTION
Diff for electron.d.ts after the fix:
```diff
   interface SizeOptions {
     /**
+     * true to make the webview container automatically resize within the bounds
+     * specified by the attributes normal, min and max.
+     */
+    enableAutoSize?: boolean;
+    /**
      * Normal size of the page. This can be used in combination with the attribute to
      * manually resize the webview guest contents.
      */
-    normal?: Normal;
+    normal?: Size;
+    /**
+     * Minimum size of the page. This can be used in combination with the attribute to
+     * manually resize the webview guest contents.
+     */
+    min?: Size;
+    /**
+     * Maximium size of the page. This can be used in combination with the attribute to
+     * manually resize the webview guest contents.
+     */
+    max?: Size;
   }

...

-  interface Normal {
-    width: number;
-    height: number;
-  }
```

This is how the options are [parsed](https://github.com/electron/electron/blob/cc386f2345ad896470249b5c04b0eb4bfd62285e/atom/browser/api/atom_api_web_contents.cc#L123-L143):
```cpp
template<>
struct Converter<atom::SetSizeParams> {
  static bool FromV8(v8::Isolate* isolate,
                     v8::Local<v8::Value> val,
                     atom::SetSizeParams* out) {
    mate::Dictionary params;
    if (!ConvertFromV8(isolate, val, &params))
      return false;
    bool autosize;
    if (params.Get("enableAutoSize", &autosize))
      out->enable_auto_size.reset(new bool(true));
    gfx::Size size;
    if (params.Get("min", &size))
      out->min_size.reset(new gfx::Size(size));
    if (params.Get("max", &size))
      out->max_size.reset(new gfx::Size(size));
    if (params.Get("normal", &size))
      out->normal_size.reset(new gfx::Size(size));
    return true;
  }
};
```