### PR TITLE
Allow frameless transparent windows to be sized smaller than 64x64 on Windows

### DIFF
--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -41,7 +41,7 @@ namespace gfx {
 class Point;
 class Rect;
 class Size;
-}
+}  // namespace gfx
 
 namespace mate {
 class Dictionary;
@@ -109,6 +109,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Size GetMinimumSize() const;
   virtual void SetMaximumSize(const gfx::Size& size);
   virtual gfx::Size GetMaximumSize() const;
+  virtual gfx::Size GetContentMinimumSize() const;
+  virtual gfx::Size GetContentMaximumSize() const;
   virtual void SetSheetOffset(const double offsetX, const double offsetY);
   virtual double GetSheetOffsetX();
   virtual double GetSheetOffsetY();
@@ -160,15 +162,14 @@ class NativeWindow : public base::SupportsUserData,
 
   // Taskbar/Dock APIs.
   enum ProgressState {
-    PROGRESS_NONE,               // no progress, no marking
-    PROGRESS_INDETERMINATE,      // progress, indeterminate
-    PROGRESS_ERROR,              // progress, errored (red)
-    PROGRESS_PAUSED,             // progress, paused (yellow)
-    PROGRESS_NORMAL,             // progress, not marked (green)
+    PROGRESS_NONE,           // no progress, no marking
+    PROGRESS_INDETERMINATE,  // progress, indeterminate
+    PROGRESS_ERROR,          // progress, errored (red)
+    PROGRESS_PAUSED,         // progress, paused (yellow)
+    PROGRESS_NORMAL,         // progress, not marked (green)
   };
 
-  virtual void SetProgressBar(double progress,
-                              const ProgressState state) = 0;
+  virtual void SetProgressBar(double progress, const ProgressState state) = 0;
   virtual void SetOverlayIcon(const gfx::Image& overlay,
                               const std::string& description) = 0;
 
@@ -230,12 +231,11 @@ class NativeWindow : public base::SupportsUserData,
   virtual void HandleKeyboardEvent(
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) {}
-  virtual void ShowAutofillPopup(
-    content::RenderFrameHost* frame_host,
-    content::WebContents* web_contents,
-    const gfx::RectF& bounds,
-    const std::vector<base::string16>& values,
-    const std::vector<base::string16>& labels) {}
+  virtual void ShowAutofillPopup(content::RenderFrameHost* frame_host,
+                                 content::WebContents* web_contents,
+                                 const gfx::RectF& bounds,
+                                 const std::vector<base::string16>& values,
+                                 const std::vector<base::string16>& labels) {}
   virtual void HideAutofillPopup(content::RenderFrameHost* frame_host) {}
 
   virtual void UpdateDraggableRegionViews() {}
@@ -270,13 +270,11 @@ class NativeWindow : public base::SupportsUserData,
                                      const base::DictionaryValue& details);
   void NotifyNewWindowForTab();
 
-  #if defined(OS_WIN)
+#if defined(OS_WIN)
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);
-  #endif
+#endif
 
-  void AddObserver(NativeWindowObserver* obs) {
-    observers_.AddObserver(obs);
-  }
+  void AddObserver(NativeWindowObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(NativeWindowObserver* obs) {
     observers_.RemoveObserver(obs);
   }
@@ -390,11 +388,11 @@ class NativeWindow : public base::SupportsUserData,
 };
 
 // This class provides a hook to get a NativeWindow from a WebContents.
-class NativeWindowRelay :
-    public content::WebContentsUserData<NativeWindowRelay> {
+class NativeWindowRelay
+    : public content::WebContentsUserData<NativeWindowRelay> {
  public:
   explicit NativeWindowRelay(base::WeakPtr<NativeWindow> window)
-    : key(UserDataKey()), window(window) {}
+      : key(UserDataKey()), window(window) {}
 
   static void* UserDataKey() {
     return content::WebContentsUserData<NativeWindowRelay>::UserDataKey();

--- a/atom/browser/ui/views/frameless_view.cc
+++ b/atom/browser/ui/views/frameless_view.cc
@@ -104,11 +104,11 @@ gfx::Size FramelessView::CalculatePreferredSize() const {
 }
 
 gfx::Size FramelessView::GetMinimumSize() const {
-  return window_->GetContentSizeConstraints().GetMinimumSize();
+  return window_->GetContentMinimumSize();
 }
 
 gfx::Size FramelessView::GetMaximumSize() const {
-  return window_->GetContentSizeConstraints().GetMaximumSize();
+  return window_->GetContentMaximumSize();
 }
 
 const char* FramelessView::GetClassName() const {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.4",
-    "electron-typescript-definitions": "^1.3.2",
+    "electron-typescript-definitions": "1.3.2",
     "github": "^9.2.0",
     "husky": "^0.14.3",
     "minimist": "^1.2.0",

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2213,6 +2213,24 @@ describe('BrowserWindow module', () => {
           assert.equal(w.isResizable(), false)
         }
       })
+
+      if (process.platform === 'win32') {
+        it('works for a window smaller than 64x64', () => {
+          w.destroy()
+          w = new BrowserWindow({
+            show: false,
+            frame: false,
+            resizable: false,
+            transparent: true
+          })
+          w.setContentSize(60, 60)
+          assertBoundsEqual(w.getContentSize(), [60, 60])
+          w.setContentSize(30, 30)
+          assertBoundsEqual(w.getContentSize(), [30, 30])
+          w.setContentSize(10, 10)
+          assertBoundsEqual(w.getContentSize(), [10, 10])
+        })
+      }
     })
 
     describe('loading main frame state', () => {


### PR DESCRIPTION
Backport of #12904

Trop should be able to backport thisto `1-8-x` now.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->