### PR TITLE
add end-of-support warning

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -52,6 +52,14 @@ if (process.platform === 'darwin') {
   }
 }
 
+// end-of-life support warning. goodbye, `electron/1-6-x` ...
+console.warn(
+  'Electron 1.6.x has reached the end of its support cycle.\n',
+  'Developers are encouraged to upgrade their applications to a newer series.\n',
+  'Read about newer series at https://electronjs.org/releases .\n',
+  'Read about Electron support at https://electronjs.org/docs/tutorial/support#supported-versions .'
+)
+
 if (process.platform === 'linux') {
   app.launcher = {
     setBadgeCount: bindings.unityLauncherSetBadgeCount,


### PR DESCRIPTION
Adds the much-discussed end-of-support `console.warn()` warning:

```text
Electron 1.6.x has reached the end of its support cycle.
Developers are encouraged to upgrade their applications to a newer series.
Read about newer series at https://electronjs.org/releases .
Read about Electron support at https://electronjs.org/docs/tutorial/support#supported-versions .
```