### PR TITLE
Disable executable stack in `electron` binary

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -217,6 +217,11 @@
               ],
             },
           ],
+          'link_settings': {
+            'ldflags': [
+              '-Wl,-z,noexecstack',
+            ],
+          },
         }],  # OS=="linux"
       ],
     },  # target <(project_name)


### PR DESCRIPTION
Backports @alespergl's patch ad1929c4b6483661031364ea0097ffaa4c2ad9ce to 1-7-x.

1.7.x after this patch:

```sh
$ execstack ./out/R/electron
- out/R/electron
$ ./out/R/electron &
$ for i in `pidof electron`; do  cat /proc/$i/maps | grep rwxp; done
$
```

1.7.x before this patch:

```sh
$ execstack ./out/R/electron
X out/R/electron
$ ./out/R/electron &
$ for i in `pidof electron`; do  cat /proc/$i/maps | grep rwxp; done
054ff000-05514000 rwxp 04eff000 08:07 51276892                           /home/charles/src/electron/electron/1-7-x/out/R/electron
05514000-05569000 rwxp 00000000 00:00 0 
3def301000-3def31f000 rwxp 00000000 00:00 0 
8208d00000-8208d80000 rwxp 00000000 00:00 0 
10e51b80000-10e51c00000 rwxp 00000000 00:00 0 
24ae5e01000-24ae5e02000 rwxp 00000000 00:00 0 
24ae5e04000-24ae5ffc000 rwxp 00000000 00:00 0 
24ae6001000-24ae6002000 rwxp 00000000 00:00 0 
24ae6004000-24ae61fc000 rwxp 00000000 00:00 0 
50abeb80000-50abec00000 rwxp 00000000 00:00 0 
8d9b6900000-8d9b6980000 rwxp 00000000 00:00 0 
94ef4041000-94ef405f000 rwxp 00000000 00:00 0 
d2be05a1000-d2be05bf000 rwxp 00000000 00:00 0 
10bc220c1000-10bc220df000 rwxp 00000000 00:00 0 
1383fb901000-1383fb91f000 rwxp 00000000 00:00 0 
13aa60580000-13aa60600000 rwxp 00000000 00:00 0 
19b5c1241000-19b5c125f000 rwxp 00000000 00:00 0 
1b5de7500000-1b5de7503000 rwxp 00000000 00:00 0 
1b5de7504000-1b5de7505000 rwxp 00000000 00:00 0 
1b5de7580000-1b5de7583000 rwxp 00000000 00:00 0 
1b5de7584000-1b5de7585000 rwxp 00000000 00:00 0 
1b5de7600000-1b5de7603000 rwxp 00000000 00:00 0 
1b5de7604000-1b5de7605000 rwxp 00000000 00:00 0 
1b5de7680000-1b5de7683000 rwxp 00000000 00:00 0 
1b5de7684000-1b5de76ff000 rwxp 00000000 00:00 0 
1b5de7700000-1b5de7703000 rwxp 00000000 00:00 0 
1b5de7704000-1b5de777f000 rwxp 00000000 00:00 0 
1b5de7780000-1b5de7783000 rwxp 00000000 00:00 0 
1b5de7784000-1b5de779b000 rwxp 00000000 00:00 0 
1b5de7800000-1b5de7803000 rwxp 00000000 00:00 0 
1b5de7804000-1b5de787f000 rwxp 00000000 00:00 0 
1b7461100000-1b7461180000 rwxp 00000000 00:00 0 
1b9e12ea1000-1b9e12ebf000 rwxp 00000000 00:00 0 
1be680580000-1be680600000 rwxp 00000000 00:00 0 
1c37d5000000-1c37d5080000 rwxp 00000000 00:00 0 
1d8e26d00000-1d8e26d64000 rwxp 00000000 00:00 0 
1dbbaa401000-1dbbaa41f000 rwxp 00000000 00:00 0 
1fbec1c81000-1fbec1c9f000 rwxp 00000000 00:00 0 
228ba87f3000-228ba8812000 rwxp 00000000 00:00 0 
228ba8813000-228ba8832000 rwxp 00000000 00:00 0 
228ba8833000-228ba8869000 rwxp 00000000 00:00 0 
228ba886a000-228ba8999000 rwxp 00000000 00:00 0 
228ba8999000-228ba8c99000 rwxp 00000000 00:00 0 
2640b5e61000-2640b5e7f000 rwxp 00000000 00:00 0 
278fba180000-278fba200000 rwxp 00000000 00:00 0 
2a0eb4180000-2a0eb4200000 rwxp 00000000 00:00 0 
2e70ccd80000-2e70cce00000 rwxp 00000000 00:00 0 
2fdc9b980000-2fdc9ba00000 rwxp 00000000 00:00 0 
306307e01000-306307e02000 rwxp 00000000 00:00 0 
306307e04000-306307ffc000 rwxp 00000000 00:00 0 
321902401000-321902402000 rwxp 00000000 00:00 0 
321902404000-3219025fc000 rwxp 00000000 00:00 0 
321926c00000-321926c80000 rwxp 00000000 00:00 0 
325bc8200000-325bc8280000 rwxp 00000000 00:00 0 
35cac5300000-35cac5305000 rwxp 00000000 00:00 0 
368883601000-368883602000 rwxp 00000000 00:00 0 
368883604000-3688837fc000 rwxp 00000000 00:00 0 
382bc0c61000-382bc0c7f000 rwxp 00000000 00:00 0 
382bc0d81000-382bc0d9f000 rwxp 00000000 00:00 0 
38fd86000000-38fd86080000 rwxp 00000000 00:00 0 
3a1f842ac000-3a1f842ec000 rwxp 00000000 00:00 0 
3bfb8ba00000-3bfb8ba80000 rwxp 00000000 00:00 0 
3cc435c21000-3cc435c3f000 rwxp 00000000 00:00 0 
3dbab5b00000-3dbab5b08000 rwxp 00000000 00:00 0 
3e4aa02a1000-3e4aa02bf000 rwxp 00000000 00:00 0 
7f3a75889000-7f3a76089000 rwxp 00000000 00:00 0 
7f3a7608a000-7f3a7688a000 rwxp 00000000 00:00 0 
7f3a7689b000-7f3a7709b000 rwxp 00000000 00:00 0 
7f3a7709c000-7f3a7789c000 rwxp 00000000 00:00 0 
7f3a77b1d000-7f3a7831d000 rwxp 00000000 00:00 0 
7f3a7831e000-7f3a78b1e000 rwxp 00000000 00:00 0 
7f3a78b1f000-7f3a7931f000 rwxp 00000000 00:00 0 
7f3a79320000-7f3a79b20000 rwxp 00000000 00:00 0 
7f3a79b21000-7f3a7a321000 rwxp 00000000 00:00 0 
7f3a7a322000-7f3a7ab22000 rwxp 00000000 00:00 0 
7f3a7ab23000-7f3a7b323000 rwxp 00000000 00:00 0 
7f3a7b324000-7f3a7bb24000 rwxp 00000000 00:00 0 
7f3a7d572000-7f3a7d573000 rwxp 00003000 08:06 6295079                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7f3a7d787000-7f3a7d788000 rwxp 00014000 08:06 6296263                    /lib/x86_64-linux-gnu/libgpg-error.so.0.22.0
7f3a7d98e000-7f3a7d98f000 rwxp 00006000 08:06 6296392                    /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f3a7dbbb000-7f3a7dbbc000 rwxp 0002c000 08:06 4596056                    /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.0.1
7f3a7de3c000-7f3a7de3d000 rwxp 00080000 08:06 4596015                    /usr/lib/x86_64-linux-gnu/libgmp.so.10.3.2
7f3a7e070000-7f3a7e071000 rwxp 00033000 08:06 4596147                    /usr/lib/x86_64-linux-gnu/libhogweed.so.4.4
7f3a7e2a6000-7f3a7e2a7000 rwxp 00035000 08:06 4596360                    /usr/lib/x86_64-linux-gnu/libnettle.so.6.4
7f3a7e4b9000-7f3a7e4ba000 rwxp 00012000 08:06 4596611                    /usr/lib/x86_64-linux-gnu/libtasn1.so.6.5.5
7f3a7e837000-7f3a7e838000 rwxp 0017d000 08:06 4596651                    /usr/lib/x86_64-linux-gnu/libunistring.so.2.1.0
7f3a7ea54000-7f3a7ea55000 rwxp 0001c000 08:06 4596193                    /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.3
7f3a7ed79000-7f3a7ed83000 rwxp 00124000 08:06 4596398                    /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
7f3a7ed83000-7f3a7ed84000 rwxp 00000000 00:00 0 
7f3a7ef8e000-7f3a7ef8f000 rwxp 0000a000 08:06 4596254                    /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7f3a7f192000-7f3a7f193000 rwxp 00003000 08:06 6296122                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7f3a7f3c3000-7f3a7f3c4000 rwxp 00030000 08:06 4596244                    /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7f3a7f3c4000-7f3a7f3c5000 rwxp 00000000 00:00 0 
7f3a7f699000-7f3a7f69b000 rwxp 000d4000 08:06 4596252                    /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7f3a7f8ae000-7f3a7f8af000 rwxp 00013000 08:06 6296216                    /lib/x86_64-linux-gnu/libbsd.so.0.8.7
7f3a7f8af000-7f3a7f8b0000 rwxp 00000000 00:00 0 
7f3a7fbc5000-7f3a7fbca000 rwxp 00115000 08:06 6296259                    /lib/x86_64-linux-gnu/libgcrypt.so.20.2.1
7f3a7fbca000-7f3a7fbcb000 rwxp 00000000 00:00 0 
7f3a7fde6000-7f3a7fde7000 rwxp 0001b000 08:06 4589796                    /usr/lib/x86_64-linux-gnu/liblz4.so.1.7.1
7f3a8000c000-7f3a8000d000 rwxp 00025000 08:06 6296282                    /lib/x86_64-linux-gnu/liblzma.so.5.2.2
7f3a80213000-7f3a80214000 rwxp 00006000 08:06 4595805                    /usr/lib/x86_64-linux-gnu/libdatrie.so.1.3.3
7f3a8045f000-7f3a80460000 rwxp 0004b000 08:06 6296212                    /lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f3a80460000-7f3a80461000 rwxp 00000000 00:00 0 
7f3a806fe000-7f3a806ff000 rwxp 0009d000 08:06 4593522                    /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.10702.0
7f3a8090f000-7f3a80910000 rwxp 00010000 08:06 4595668                    /usr/lib/x86_64-linux-gnu/libavahi-client.so.3.2.9
7f3a80b1b000-7f3a80b1c000 rwxp 0000b000 08:06 4595670                    /usr/lib/x86_64-linux-gnu/libavahi-common.so.3.5.3
7f3a80e7f000-7f3a80e80000 rwxp 00163000 08:06 4596031                    /usr/lib/x86_64-linux-gnu/libgnutls.so.30.14.10
7f3a80e80000-7f3a80e81000 rwxp 00000000 00:00 0 
7f3a810ca000-7f3a810cc000 rwxp 00049000 08:06 4596070                    /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7f3a812cf000-7f3a812d0000 rwxp 00003000 08:06 4596442                    /usr/lib/x86_64-linux-gnu/libplds4.so
7f3a814d4000-7f3a814d5000 rwxp 00004000 08:06 4596441                    /usr/lib/x86_64-linux-gnu/libplc4.so
7f3a81746000-7f3a81747000 rwxp 00071000 08:06 6296344                    /lib/x86_64-linux-gnu/libpcre.so.3.13.3
7f3a8196d000-7f3a8196e000 rwxp 00026000 08:06 4595809                    /usr/lib/x86_64-linux-gnu/libdbus-glib-1.so.2.3.4
7f3a81b73000-7f3a81b74000 rwxp 00005000 08:06 4595585                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f3a81d77000-7f3a81d78000 rwxp 00003000 08:06 4595574                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f3a81ffa000-7f3a81ffb000 rwxp 00082000 08:06 6295923                    /lib/x86_64-linux-gnu/libsystemd.so.0.21.0
7f3a81ffb000-7f3a81ffc000 rwxp 00000000 00:00 0 
7f3a82203000-7f3a82204000 rwxp 00007000 08:06 4595917                    /usr/lib/x86_64-linux-gnu/libffi.so.6.0.4
7f3a8240c000-7f3a8240d000 rwxp 00008000 08:06 4596621                    /usr/lib/x86_64-linux-gnu/libthai.so.0.3.0
7f3a8265f000-7f3a82660000 rwxp 00052000 08:06 6296291                    /lib/x86_64-linux-gnu/libmount.so.1.1.0
7f3a82660000-7f3a82661000 rwxp 00000000 00:00 0 
7f3a82879000-7f3a8287a000 rwxp 00018000 08:06 6291525                    /lib/x86_64-linux-gnu/libresolv-2.27.so
7f3a8287a000-7f3a8287c000 rwxp 00000000 00:00 0 
7f3a82aa1000-7f3a82aa2000 rwxp 00025000 08:06 6296369                    /lib/x86_64-linux-gnu/libselinux.so.1
7f3a82aa2000-7f3a82aa4000 rwxp 00000000 00:00 0 
7f3a82cc0000-7f3a82cc1000 rwxp 0001c000 08:06 6296396                    /lib/x86_64-linux-gnu/libz.so.1.2.11
7f3a82ecd000-7f3a82ece000 rwxp 0000c000 08:06 4597831                    /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f3a830d0000-7f3a830d1000 rwxp 00002000 08:06 4597844                    /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f3a83302000-7f3a83303000 rwxp 00031000 08:06 4596446                    /usr/lib/x86_64-linux-gnu/libpng16.so.16.34.0
7f3a835a7000-7f3a835a8000 rwxp 000a4000 08:06 4596440                    /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0
7f3a837aa000-7f3a837ab000 rwxp 00002000 08:06 4595597                    /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f3a839c0000-7f3a839c1000 rwxp 00015000 08:06 4596412                    /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.4000.14
7f3a83dac000-7f3a83dae000 rwxp 001eb000 08:06 6291509                    /lib/x86_64-linux-gnu/libc-2.27.so
7f3a83dae000-7f3a83db2000 rwxp 00000000 00:00 0 
7f3a83fc9000-7f3a83fca000 rwxp 00017000 08:06 6295053                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7f3a84367000-7f3a84368000 rwxp 0019d000 08:06 6291513                    /lib/x86_64-linux-gnu/libm-2.27.so
7f3a846f0000-7f3a846f2000 rwxp 00188000 08:06 4589732                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
7f3a846f2000-7f3a846f6000 rwxp 00000000 00:00 0 
7f3a84927000-7f3a84928000 rwxp 00031000 08:06 6296250                    /lib/x86_64-linux-gnu/libexpat.so.1.6.7
7f3a84b2b000-7f3a84b2c000 rwxp 00003000 08:06 6291512                    /lib/x86_64-linux-gnu/libdl-2.27.so
7f3a84db7000-7f3a84db8000 rwxp 0008b000 08:06 4588161                    /usr/lib/x86_64-linux-gnu/libcups.so.2
7f3a850bf000-7f3a850c0000 rwxp 00107000 08:06 4595652                    /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f3a85595000-7f3a85598000 rwxp 002d5000 08:07 12470936                   /home/charles/src/electron/electron/1-7-x/out/R/libffmpeg.so
7f3a85598000-7f3a8575f000 rwxp 00000000 00:00 0 
7f3a85998000-7f3a85999000 rwxp 00039000 08:06 4596373                    /usr/lib/x86_64-linux-gnu/libnspr4.so
7f3a85999000-7f3a8599c000 rwxp 00000000 00:00 0 
7f3a85bc7000-7f3a85bc8000 rwxp 0002b000 08:06 4596568                    /usr/lib/x86_64-linux-gnu/libsmime3.so
7f3a85df6000-7f3a85df7000 rwxp 0002e000 08:06 4596375                    /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f3a86138000-7f3a8613a000 rwxp 00141000 08:06 4596374                    /usr/lib/x86_64-linux-gnu/libnss3.so
7f3a8613a000-7f3a8613b000 rwxp 00000000 00:00 0 
7f3a8644f000-7f3a86450000 rwxp 00114000 08:06 4589686                    /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5600.1
7f3a86450000-7f3a86451000 rwxp 00000000 00:00 0 
7f3a86658000-7f3a86659000 rwxp 00007000 08:06 6291526                    /lib/x86_64-linux-gnu/librt-2.27.so
7f3a8685c000-7f3a8685d000 rwxp 00003000 08:06 4589692                    /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.5600.1
7f3a86a8b000-7f3a86a8c000 rwxp 0002e000 08:06 4598171                    /usr/lib/x86_64-linux-gnu/libgconf-2.so.4.1.5
7f3a86c8f000-7f3a86c90000 rwxp 00003000 08:06 4595609                    /usr/lib/x86_64-linux-gnu/libXss.so.1.0.0
7f3a86e95000-7f3a86e96000 rwxp 00005000 08:06 4595613                    /usr/lib/x86_64-linux-gnu/libXtst.so.6.1.0
7f3a871cb000-7f3a871cf000 rwxp 00135000 08:06 4595570                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f3a873d8000-7f3a873d9000 rwxp 00009000 08:06 4595607                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f3a875de000-7f3a875df000 rwxp 00005000 08:06 4595589                    /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f3a877f0000-7f3a877f1000 rwxp 00011000 08:06 4595587                    /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f3a879f3000-7f3a879f4000 rwxp 00002000 08:06 4595579                    /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f3a87bfe000-7f3a87bff000 rwxp 0000a000 08:06 4595605                    /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f3a87e01000-7f3a87e02000 rwxp 00002000 08:06 4595583                    /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f3a8800b000-7f3a8800c000 rwxp 00009000 08:06 4595581                    /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f3a8821b000-7f3a8821c000 rwxp 0000f000 08:06 4595595                    /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f3a88443000-7f3a88444000 rwxp 00027000 08:06 4590276                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f3a88645000-7f3a88646000 rwxp 00001000 08:06 4595568                    /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f3a88892000-7f3a88893000 rwxp 0004c000 08:06 6296235                    /lib/x86_64-linux-gnu/libdbus-1.so.3.19.4
7f3a88ad3000-7f3a88ad8000 rwxp 00040000 08:06 4589832                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.10.1
7f3a88d8b000-7f3a88d8c000 rwxp 000b3000 08:06 4593516                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.15.0
7f3a88fdf000-7f3a88fe0000 rwxp 00053000 08:06 4589708                    /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5600.1
7f3a8922c000-7f3a8922d000 rwxp 0004c000 08:06 4596408                    /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.4000.14
7f3a895c8000-7f3a895c9000 rwxp 0019b000 08:06 4589682                    /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.5600.1
7f3a895c9000-7f3a895cb000 rwxp 00000000 00:00 0 
7f3a897ee000-7f3a897ef000 rwxp 00023000 08:06 4596630                    /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.3611.0
7f3a89b09000-7f3a89b0b000 rwxp 0011a000 08:06 4595723                    /usr/lib/x86_64-linux-gnu/libcairo.so.2.11510.0
7f3a89b0b000-7f3a89b0c000 rwxp 00000000 00:00 0 
7f3a89d31000-7f3a89d32000 rwxp 00025000 08:06 4595660                    /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.22810.1
7f3a89f3e000-7f3a89f3f000 rwxp 0000c000 08:06 4596410                    /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.4000.14
7f3a8a1f2000-7f3a8a1f4000 rwxp 000b3000 08:06 4595958                    /usr/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0.2400.32
7f3a8a82f000-7f3a8a833000 rwxp 0043b000 08:06 4595959                    /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0.2400.32
7f3a8a833000-7f3a8a836000 rwxp 00000000 00:00 0 
7f3a8aa50000-7f3a8aa51000 rwxp 0001a000 08:06 6291524                    /lib/x86_64-linux-gnu/libpthread-2.27.so
7f3a8aa51000-7f3a8aa55000 rwxp 00000000 00:00 0 
7f3a8c056000-7f3a8c07b000 rwxp 01401000 08:07 925194                     /home/charles/src/electron/electron/1-7-x/out/R/libnode.so
7f3a8c07b000-7f3a8c08f000 rwxp 00000000 00:00 0 
7f3a8c26b000-7f3a8c293000 rwxp 00000000 00:00 0 
7f3a8c2b4000-7f3a8c2b6000 rwxp 00000000 00:00 0 
7f3a8c2b7000-7f3a8c2b8000 rwxp 00028000 08:06 6291505                    /lib/x86_64-linux-gnu/ld-2.27.so
7f3a8c2b8000-7f3a8c2b9000 rwxp 00000000 00:00 0 
7fff30074000-7fff30095000 rwxp 00000000 00:00 0                          [stack]
054ff000-05514000 rwxp 04eff000 08:07 51276892                           /home/charles/src/electron/electron/1-7-x/out/R/electron
05514000-05569000 rwxp 00000000 00:00 0 
327ef556a000-327ef5589000 rwxp 00000000 00:00 0 
327ef558a000-327ef55a9000 rwxp 00000000 00:00 0 
327ef55aa000-327ef55e0000 rwxp 00000000 00:00 0 
327ef55e1000-327ef6118000 rwxp 00000000 00:00 0 
7f2f588e6000-7f2f590e6000 rwxp 00000000 00:00 0 
7f2f592e7000-7f2f59ae7000 rwxp 00000000 00:00 0 
7f2f59be8000-7f2f5a3e8000 rwxp 00000000 00:00 0 
7f2f5a3e9000-7f2f5abe9000 rwxp 00000000 00:00 0 
7f2f5adf1000-7f2f5adf2000 rwxp 00008000 08:06 4595984                    /usr/lib/x86_64-linux-gnu/libpciaccess.so.0.11.1
7f2f5affd000-7f2f5affe000 rwxp 0000b000 08:06 4590639                    /usr/lib/x86_64-linux-gnu/libdrm_radeon.so.1.0.1
7f2f5b205000-7f2f5b206000 rwxp 00007000 08:06 4590637                    /usr/lib/x86_64-linux-gnu/libdrm_nouveau.so.2.0.0
7f2f5b428000-7f2f5b429000 rwxp 00022000 08:06 4590634                    /usr/lib/x86_64-linux-gnu/libdrm_intel.so.1.0.0
7f2f5bef6000-7f2f5bf01000 rwxp 008cd000 08:06 4851348                    /usr/lib/x86_64-linux-gnu/dri/i965_dri.so
7f2f5bf01000-7f2f5bfa6000 rwxp 00000000 00:00 0 
7f2f5c1b6000-7f2f5c1b7000 rwxp 00010000 08:06 4597984                    /usr/lib/x86_64-linux-gnu/libdrm.so.2.4.0
7f2f5c3bc000-7f2f5c3bd000 rwxp 00005000 08:06 4595623                    /usr/lib/x86_64-linux-gnu/libXxf86vm.so.1.0.0
7f2f5c5c1000-7f2f5c5c2000 rwxp 00004000 08:06 4595560                    /usr/lib/x86_64-linux-gnu/libxcb-dri2.so.0.0.0
7f2f5c7dc000-7f2f5c7dd000 rwxp 0001a000 08:06 4597235                    /usr/lib/x86_64-linux-gnu/libxcb-glx.so.0.0.0
7f2f5ca0c000-7f2f5ca0d000 rwxp 0002f000 08:06 4590236                    /usr/lib/x86_64-linux-gnu/libglapi.so.0.0.0
7f2f5ca0d000-7f2f5ca0e000 rwxp 00000000 00:00 0 
7f2f5cc0f000-7f2f5cc10000 rwxp 00001000 08:06 4595468                    /usr/lib/x86_64-linux-gnu/libxshmfence.so.1.0.0
7f2f5ce16000-7f2f5ce17000 rwxp 00006000 08:06 4597840                    /usr/lib/x86_64-linux-gnu/libxcb-sync.so.1.0.0
7f2f5d019000-7f2f5d01a000 rwxp 00002000 08:06 4597238                    /usr/lib/x86_64-linux-gnu/libxcb-present.so.0.0.0
7f2f5d21d000-7f2f5d21e000 rwxp 00003000 08:06 4596988                    /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
7f2f5d490000-7f2f5d491000 rwxp 00072000 08:06 4590231                    /usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0.0.0
7f2f5d491000-7f2f5d492000 rwxp 00000000 00:00 0 
7f2f5d727000-7f2f5d728000 rwxp 00095000 08:06 4595536                    /usr/lib/x86_64-linux-gnu/libGLdispatch.so.0.0.0
7f2f5d728000-7f2f5d748000 rwxp 00000000 00:00 0 
7f2f5d958000-7f2f5d959000 rwxp 00010000 08:06 4595531                    /usr/lib/x86_64-linux-gnu/libGLX.so.0.0.0
7f2f5d959000-7f2f5d979000 rwxp 00000000 00:00 0 
7f2f5dc03000-7f2f5dc04000 rwxp 0008a000 08:06 4595525                    /usr/lib/x86_64-linux-gnu/libGL.so.1.0.0
7f2f5dc04000-7f2f5dc05000 rwxp 00000000 00:00 0 
7f2f5dc06000-7f2f5e406000 rwxp 00000000 00:00 0 
7f2f5f291000-7f2f5f292000 rwxp 00003000 08:06 6295079                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7f2f5f4a6000-7f2f5f4a7000 rwxp 00014000 08:06 6296263                    /lib/x86_64-linux-gnu/libgpg-error.so.0.22.0
7f2f5f6ad000-7f2f5f6ae000 rwxp 00006000 08:06 6296392                    /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f2f5f8da000-7f2f5f8db000 rwxp 0002c000 08:06 4596056                    /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.0.1
7f2f5fb5b000-7f2f5fb5c000 rwxp 00080000 08:06 4596015                    /usr/lib/x86_64-linux-gnu/libgmp.so.10.3.2
7f2f5fd8f000-7f2f5fd90000 rwxp 00033000 08:06 4596147                    /usr/lib/x86_64-linux-gnu/libhogweed.so.4.4
7f2f5ffc5000-7f2f5ffc6000 rwxp 00035000 08:06 4596360                    /usr/lib/x86_64-linux-gnu/libnettle.so.6.4
7f2f601d8000-7f2f601d9000 rwxp 00012000 08:06 4596611                    /usr/lib/x86_64-linux-gnu/libtasn1.so.6.5.5
7f2f60556000-7f2f60557000 rwxp 0017d000 08:06 4596651                    /usr/lib/x86_64-linux-gnu/libunistring.so.2.1.0
7f2f60773000-7f2f60774000 rwxp 0001c000 08:06 4596193                    /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.3
7f2f60a98000-7f2f60aa2000 rwxp 00124000 08:06 4596398                    /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
7f2f60aa2000-7f2f60aa3000 rwxp 00000000 00:00 0 
7f2f60cad000-7f2f60cae000 rwxp 0000a000 08:06 4596254                    /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7f2f60eb1000-7f2f60eb2000 rwxp 00003000 08:06 6296122                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7f2f610e2000-7f2f610e3000 rwxp 00030000 08:06 4596244                    /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7f2f610e3000-7f2f610e4000 rwxp 00000000 00:00 0 
7f2f613b8000-7f2f613ba000 rwxp 000d4000 08:06 4596252                    /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7f2f615cd000-7f2f615ce000 rwxp 00013000 08:06 6296216                    /lib/x86_64-linux-gnu/libbsd.so.0.8.7
7f2f615ce000-7f2f615cf000 rwxp 00000000 00:00 0 
7f2f618e4000-7f2f618e9000 rwxp 00115000 08:06 6296259                    /lib/x86_64-linux-gnu/libgcrypt.so.20.2.1
7f2f618e9000-7f2f618ea000 rwxp 00000000 00:00 0 
7f2f61b05000-7f2f61b06000 rwxp 0001b000 08:06 4589796                    /usr/lib/x86_64-linux-gnu/liblz4.so.1.7.1
7f2f61d2b000-7f2f61d2c000 rwxp 00025000 08:06 6296282                    /lib/x86_64-linux-gnu/liblzma.so.5.2.2
7f2f61f32000-7f2f61f33000 rwxp 00006000 08:06 4595805                    /usr/lib/x86_64-linux-gnu/libdatrie.so.1.3.3
7f2f6217e000-7f2f6217f000 rwxp 0004b000 08:06 6296212                    /lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f2f6217f000-7f2f62180000 rwxp 00000000 00:00 0 
7f2f6241d000-7f2f6241e000 rwxp 0009d000 08:06 4593522                    /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.10702.0
7f2f6262e000-7f2f6262f000 rwxp 00010000 08:06 4595668                    /usr/lib/x86_64-linux-gnu/libavahi-client.so.3.2.9
7f2f6283a000-7f2f6283b000 rwxp 0000b000 08:06 4595670                    /usr/lib/x86_64-linux-gnu/libavahi-common.so.3.5.3
7f2f62b9e000-7f2f62b9f000 rwxp 00163000 08:06 4596031                    /usr/lib/x86_64-linux-gnu/libgnutls.so.30.14.10
7f2f62b9f000-7f2f62ba0000 rwxp 00000000 00:00 0 
7f2f62de9000-7f2f62deb000 rwxp 00049000 08:06 4596070                    /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7f2f62fee000-7f2f62fef000 rwxp 00003000 08:06 4596442                    /usr/lib/x86_64-linux-gnu/libplds4.so
7f2f631f3000-7f2f631f4000 rwxp 00004000 08:06 4596441                    /usr/lib/x86_64-linux-gnu/libplc4.so
7f2f63465000-7f2f63466000 rwxp 00071000 08:06 6296344                    /lib/x86_64-linux-gnu/libpcre.so.3.13.3
7f2f6368c000-7f2f6368d000 rwxp 00026000 08:06 4595809                    /usr/lib/x86_64-linux-gnu/libdbus-glib-1.so.2.3.4
7f2f63892000-7f2f63893000 rwxp 00005000 08:06 4595585                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f2f63a96000-7f2f63a97000 rwxp 00003000 08:06 4595574                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f2f63d19000-7f2f63d1a000 rwxp 00082000 08:06 6295923                    /lib/x86_64-linux-gnu/libsystemd.so.0.21.0
7f2f63d1a000-7f2f63d1b000 rwxp 00000000 00:00 0 
7f2f63f22000-7f2f63f23000 rwxp 00007000 08:06 4595917                    /usr/lib/x86_64-linux-gnu/libffi.so.6.0.4
7f2f6412b000-7f2f6412c000 rwxp 00008000 08:06 4596621                    /usr/lib/x86_64-linux-gnu/libthai.so.0.3.0
7f2f6437e000-7f2f6437f000 rwxp 00052000 08:06 6296291                    /lib/x86_64-linux-gnu/libmount.so.1.1.0
7f2f6437f000-7f2f64380000 rwxp 00000000 00:00 0 
7f2f64598000-7f2f64599000 rwxp 00018000 08:06 6291525                    /lib/x86_64-linux-gnu/libresolv-2.27.so
7f2f64599000-7f2f6459b000 rwxp 00000000 00:00 0 
7f2f647c0000-7f2f647c1000 rwxp 00025000 08:06 6296369                    /lib/x86_64-linux-gnu/libselinux.so.1
7f2f647c1000-7f2f647c3000 rwxp 00000000 00:00 0 
7f2f649df000-7f2f649e0000 rwxp 0001c000 08:06 6296396                    /lib/x86_64-linux-gnu/libz.so.1.2.11
7f2f64bec000-7f2f64bed000 rwxp 0000c000 08:06 4597831                    /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f2f64def000-7f2f64df0000 rwxp 00002000 08:06 4597844                    /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f2f65021000-7f2f65022000 rwxp 00031000 08:06 4596446                    /usr/lib/x86_64-linux-gnu/libpng16.so.16.34.0
7f2f652c6000-7f2f652c7000 rwxp 000a4000 08:06 4596440                    /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0
7f2f654c9000-7f2f654ca000 rwxp 00002000 08:06 4595597                    /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f2f656df000-7f2f656e0000 rwxp 00015000 08:06 4596412                    /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.4000.14
7f2f65acb000-7f2f65acd000 rwxp 001eb000 08:06 6291509                    /lib/x86_64-linux-gnu/libc-2.27.so
7f2f65acd000-7f2f65ad1000 rwxp 00000000 00:00 0 
7f2f65ce8000-7f2f65ce9000 rwxp 00017000 08:06 6295053                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7f2f66086000-7f2f66087000 rwxp 0019d000 08:06 6291513                    /lib/x86_64-linux-gnu/libm-2.27.so
7f2f6640f000-7f2f66411000 rwxp 00188000 08:06 4589732                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
7f2f66411000-7f2f66415000 rwxp 00000000 00:00 0 
7f2f66646000-7f2f66647000 rwxp 00031000 08:06 6296250                    /lib/x86_64-linux-gnu/libexpat.so.1.6.7
7f2f6684a000-7f2f6684b000 rwxp 00003000 08:06 6291512                    /lib/x86_64-linux-gnu/libdl-2.27.so
7f2f66ad6000-7f2f66ad7000 rwxp 0008b000 08:06 4588161                    /usr/lib/x86_64-linux-gnu/libcups.so.2
7f2f66dde000-7f2f66ddf000 rwxp 00107000 08:06 4595652                    /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f2f672b4000-7f2f672b7000 rwxp 002d5000 08:07 12470936                   /home/charles/src/electron/electron/1-7-x/out/R/libffmpeg.so
7f2f672b7000-7f2f6747e000 rwxp 00000000 00:00 0 
7f2f676b7000-7f2f676b8000 rwxp 00039000 08:06 4596373                    /usr/lib/x86_64-linux-gnu/libnspr4.so
7f2f676b8000-7f2f676bb000 rwxp 00000000 00:00 0 
7f2f678e6000-7f2f678e7000 rwxp 0002b000 08:06 4596568                    /usr/lib/x86_64-linux-gnu/libsmime3.so
7f2f67b15000-7f2f67b16000 rwxp 0002e000 08:06 4596375                    /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f2f67e57000-7f2f67e59000 rwxp 00141000 08:06 4596374                    /usr/lib/x86_64-linux-gnu/libnss3.so
7f2f67e59000-7f2f67e5a000 rwxp 00000000 00:00 0 
7f2f6816e000-7f2f6816f000 rwxp 00114000 08:06 4589686                    /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5600.1
7f2f6816f000-7f2f68170000 rwxp 00000000 00:00 0 
7f2f68377000-7f2f68378000 rwxp 00007000 08:06 6291526                    /lib/x86_64-linux-gnu/librt-2.27.so
7f2f6857b000-7f2f6857c000 rwxp 00003000 08:06 4589692                    /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.5600.1
7f2f687aa000-7f2f687ab000 rwxp 0002e000 08:06 4598171                    /usr/lib/x86_64-linux-gnu/libgconf-2.so.4.1.5
7f2f689ae000-7f2f689af000 rwxp 00003000 08:06 4595609                    /usr/lib/x86_64-linux-gnu/libXss.so.1.0.0
7f2f68bb4000-7f2f68bb5000 rwxp 00005000 08:06 4595613                    /usr/lib/x86_64-linux-gnu/libXtst.so.6.1.0
7f2f68eea000-7f2f68eee000 rwxp 00135000 08:06 4595570                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f2f690f7000-7f2f690f8000 rwxp 00009000 08:06 4595607                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f2f692fd000-7f2f692fe000 rwxp 00005000 08:06 4595589                    /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f2f6950f000-7f2f69510000 rwxp 00011000 08:06 4595587                    /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f2f69712000-7f2f69713000 rwxp 00002000 08:06 4595579                    /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f2f6991d000-7f2f6991e000 rwxp 0000a000 08:06 4595605                    /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f2f69b20000-7f2f69b21000 rwxp 00002000 08:06 4595583                    /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f2f69d2a000-7f2f69d2b000 rwxp 00009000 08:06 4595581                    /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f2f69f3a000-7f2f69f3b000 rwxp 0000f000 08:06 4595595                    /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f2f6a162000-7f2f6a163000 rwxp 00027000 08:06 4590276                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f2f6a364000-7f2f6a365000 rwxp 00001000 08:06 4595568                    /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f2f6a5b1000-7f2f6a5b2000 rwxp 0004c000 08:06 6296235                    /lib/x86_64-linux-gnu/libdbus-1.so.3.19.4
7f2f6a7f2000-7f2f6a7f7000 rwxp 00040000 08:06 4589832                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.10.1
7f2f6aaaa000-7f2f6aaab000 rwxp 000b3000 08:06 4593516                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.15.0
7f2f6acfe000-7f2f6acff000 rwxp 00053000 08:06 4589708                    /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5600.1
7f2f6af4b000-7f2f6af4c000 rwxp 0004c000 08:06 4596408                    /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.4000.14
7f2f6b2e7000-7f2f6b2e8000 rwxp 0019b000 08:06 4589682                    /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.5600.1
7f2f6b2e8000-7f2f6b2ea000 rwxp 00000000 00:00 0 
7f2f6b50d000-7f2f6b50e000 rwxp 00023000 08:06 4596630                    /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.3611.0
7f2f6b828000-7f2f6b82a000 rwxp 0011a000 08:06 4595723                    /usr/lib/x86_64-linux-gnu/libcairo.so.2.11510.0
7f2f6b82a000-7f2f6b82b000 rwxp 00000000 00:00 0 
7f2f6ba50000-7f2f6ba51000 rwxp 00025000 08:06 4595660                    /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.22810.1
7f2f6bc5d000-7f2f6bc5e000 rwxp 0000c000 08:06 4596410                    /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.4000.14
7f2f6bf11000-7f2f6bf13000 rwxp 000b3000 08:06 4595958                    /usr/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0.2400.32
7f2f6c54e000-7f2f6c552000 rwxp 0043b000 08:06 4595959                    /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0.2400.32
7f2f6c552000-7f2f6c555000 rwxp 00000000 00:00 0 
7f2f6c76f000-7f2f6c770000 rwxp 0001a000 08:06 6291524                    /lib/x86_64-linux-gnu/libpthread-2.27.so
7f2f6c770000-7f2f6c774000 rwxp 00000000 00:00 0 
7f2f6dd75000-7f2f6dd9a000 rwxp 01401000 08:07 925194                     /home/charles/src/electron/electron/1-7-x/out/R/libnode.so
7f2f6dd9a000-7f2f6ddae000 rwxp 00000000 00:00 0 
7f2f6df8a000-7f2f6dfb2000 rwxp 00000000 00:00 0 
7f2f6dfc5000-7f2f6dfc6000 rwxp 00000000 00:00 0 
7f2f6dfd3000-7f2f6dfd5000 rwxp 00000000 00:00 0 
7f2f6dfd6000-7f2f6dfd7000 rwxp 00028000 08:06 6291505                    /lib/x86_64-linux-gnu/ld-2.27.so
7f2f6dfd7000-7f2f6dfd8000 rwxp 00000000 00:00 0 
7ffcdb52d000-7ffcdb54f000 rwxp 00000000 00:00 0                          [stack]
054ff000-05514000 rwxp 04eff000 08:07 51276892                           /home/charles/src/electron/electron/1-7-x/out/R/electron
05514000-05569000 rwxp 00000000 00:00 0 
228ba87f3000-228ba8812000 rwxp 00000000 00:00 0 
228ba8813000-228ba8832000 rwxp 00000000 00:00 0 
228ba8833000-228ba8869000 rwxp 00000000 00:00 0 
228ba886a000-228ba8999000 rwxp 00000000 00:00 0 
7f3a7d572000-7f3a7d573000 rwxp 00003000 08:06 6295079                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7f3a7d787000-7f3a7d788000 rwxp 00014000 08:06 6296263                    /lib/x86_64-linux-gnu/libgpg-error.so.0.22.0
7f3a7d98e000-7f3a7d98f000 rwxp 00006000 08:06 6296392                    /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f3a7dbbb000-7f3a7dbbc000 rwxp 0002c000 08:06 4596056                    /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.0.1
7f3a7de3c000-7f3a7de3d000 rwxp 00080000 08:06 4596015                    /usr/lib/x86_64-linux-gnu/libgmp.so.10.3.2
7f3a7e070000-7f3a7e071000 rwxp 00033000 08:06 4596147                    /usr/lib/x86_64-linux-gnu/libhogweed.so.4.4
7f3a7e2a6000-7f3a7e2a7000 rwxp 00035000 08:06 4596360                    /usr/lib/x86_64-linux-gnu/libnettle.so.6.4
7f3a7e4b9000-7f3a7e4ba000 rwxp 00012000 08:06 4596611                    /usr/lib/x86_64-linux-gnu/libtasn1.so.6.5.5
7f3a7e837000-7f3a7e838000 rwxp 0017d000 08:06 4596651                    /usr/lib/x86_64-linux-gnu/libunistring.so.2.1.0
7f3a7ea54000-7f3a7ea55000 rwxp 0001c000 08:06 4596193                    /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.3
7f3a7ed79000-7f3a7ed83000 rwxp 00124000 08:06 4596398                    /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
7f3a7ed83000-7f3a7ed84000 rwxp 00000000 00:00 0 
7f3a7ef8e000-7f3a7ef8f000 rwxp 0000a000 08:06 4596254                    /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7f3a7f192000-7f3a7f193000 rwxp 00003000 08:06 6296122                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7f3a7f3c3000-7f3a7f3c4000 rwxp 00030000 08:06 4596244                    /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7f3a7f3c4000-7f3a7f3c5000 rwxp 00000000 00:00 0 
7f3a7f699000-7f3a7f69b000 rwxp 000d4000 08:06 4596252                    /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7f3a7f8ae000-7f3a7f8af000 rwxp 00013000 08:06 6296216                    /lib/x86_64-linux-gnu/libbsd.so.0.8.7
7f3a7f8af000-7f3a7f8b0000 rwxp 00000000 00:00 0 
7f3a7fbc5000-7f3a7fbca000 rwxp 00115000 08:06 6296259                    /lib/x86_64-linux-gnu/libgcrypt.so.20.2.1
7f3a7fbca000-7f3a7fbcb000 rwxp 00000000 00:00 0 
7f3a7fde6000-7f3a7fde7000 rwxp 0001b000 08:06 4589796                    /usr/lib/x86_64-linux-gnu/liblz4.so.1.7.1
7f3a8000c000-7f3a8000d000 rwxp 00025000 08:06 6296282                    /lib/x86_64-linux-gnu/liblzma.so.5.2.2
7f3a80213000-7f3a80214000 rwxp 00006000 08:06 4595805                    /usr/lib/x86_64-linux-gnu/libdatrie.so.1.3.3
7f3a8045f000-7f3a80460000 rwxp 0004b000 08:06 6296212                    /lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f3a80460000-7f3a80461000 rwxp 00000000 00:00 0 
7f3a806fe000-7f3a806ff000 rwxp 0009d000 08:06 4593522                    /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.10702.0
7f3a8090f000-7f3a80910000 rwxp 00010000 08:06 4595668                    /usr/lib/x86_64-linux-gnu/libavahi-client.so.3.2.9
7f3a80b1b000-7f3a80b1c000 rwxp 0000b000 08:06 4595670                    /usr/lib/x86_64-linux-gnu/libavahi-common.so.3.5.3
7f3a80e7f000-7f3a80e80000 rwxp 00163000 08:06 4596031                    /usr/lib/x86_64-linux-gnu/libgnutls.so.30.14.10
7f3a80e80000-7f3a80e81000 rwxp 00000000 00:00 0 
7f3a810ca000-7f3a810cc000 rwxp 00049000 08:06 4596070                    /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7f3a812cf000-7f3a812d0000 rwxp 00003000 08:06 4596442                    /usr/lib/x86_64-linux-gnu/libplds4.so
7f3a814d4000-7f3a814d5000 rwxp 00004000 08:06 4596441                    /usr/lib/x86_64-linux-gnu/libplc4.so
7f3a81746000-7f3a81747000 rwxp 00071000 08:06 6296344                    /lib/x86_64-linux-gnu/libpcre.so.3.13.3
7f3a8196d000-7f3a8196e000 rwxp 00026000 08:06 4595809                    /usr/lib/x86_64-linux-gnu/libdbus-glib-1.so.2.3.4
7f3a81b73000-7f3a81b74000 rwxp 00005000 08:06 4595585                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f3a81d77000-7f3a81d78000 rwxp 00003000 08:06 4595574                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f3a81ffa000-7f3a81ffb000 rwxp 00082000 08:06 6295923                    /lib/x86_64-linux-gnu/libsystemd.so.0.21.0
7f3a81ffb000-7f3a81ffc000 rwxp 00000000 00:00 0 
7f3a82203000-7f3a82204000 rwxp 00007000 08:06 4595917                    /usr/lib/x86_64-linux-gnu/libffi.so.6.0.4
7f3a8240c000-7f3a8240d000 rwxp 00008000 08:06 4596621                    /usr/lib/x86_64-linux-gnu/libthai.so.0.3.0
7f3a8265f000-7f3a82660000 rwxp 00052000 08:06 6296291                    /lib/x86_64-linux-gnu/libmount.so.1.1.0
7f3a82660000-7f3a82661000 rwxp 00000000 00:00 0 
7f3a82879000-7f3a8287a000 rwxp 00018000 08:06 6291525                    /lib/x86_64-linux-gnu/libresolv-2.27.so
7f3a8287a000-7f3a8287c000 rwxp 00000000 00:00 0 
7f3a82aa1000-7f3a82aa2000 rwxp 00025000 08:06 6296369                    /lib/x86_64-linux-gnu/libselinux.so.1
7f3a82aa2000-7f3a82aa4000 rwxp 00000000 00:00 0 
7f3a82cc0000-7f3a82cc1000 rwxp 0001c000 08:06 6296396                    /lib/x86_64-linux-gnu/libz.so.1.2.11
7f3a82ecd000-7f3a82ece000 rwxp 0000c000 08:06 4597831                    /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f3a830d0000-7f3a830d1000 rwxp 00002000 08:06 4597844                    /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f3a83302000-7f3a83303000 rwxp 00031000 08:06 4596446                    /usr/lib/x86_64-linux-gnu/libpng16.so.16.34.0
7f3a835a7000-7f3a835a8000 rwxp 000a4000 08:06 4596440                    /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0
7f3a837aa000-7f3a837ab000 rwxp 00002000 08:06 4595597                    /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f3a839c0000-7f3a839c1000 rwxp 00015000 08:06 4596412                    /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.4000.14
7f3a83dac000-7f3a83dae000 rwxp 001eb000 08:06 6291509                    /lib/x86_64-linux-gnu/libc-2.27.so
7f3a83dae000-7f3a83db2000 rwxp 00000000 00:00 0 
7f3a83fc9000-7f3a83fca000 rwxp 00017000 08:06 6295053                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7f3a84367000-7f3a84368000 rwxp 0019d000 08:06 6291513                    /lib/x86_64-linux-gnu/libm-2.27.so
7f3a846f0000-7f3a846f2000 rwxp 00188000 08:06 4589732                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
7f3a846f2000-7f3a846f6000 rwxp 00000000 00:00 0 
7f3a84927000-7f3a84928000 rwxp 00031000 08:06 6296250                    /lib/x86_64-linux-gnu/libexpat.so.1.6.7
7f3a84b2b000-7f3a84b2c000 rwxp 00003000 08:06 6291512                    /lib/x86_64-linux-gnu/libdl-2.27.so
7f3a84db7000-7f3a84db8000 rwxp 0008b000 08:06 4588161                    /usr/lib/x86_64-linux-gnu/libcups.so.2
7f3a850bf000-7f3a850c0000 rwxp 00107000 08:06 4595652                    /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f3a85595000-7f3a85598000 rwxp 002d5000 08:07 12470936                   /home/charles/src/electron/electron/1-7-x/out/R/libffmpeg.so
7f3a85598000-7f3a8575f000 rwxp 00000000 00:00 0 
7f3a85998000-7f3a85999000 rwxp 00039000 08:06 4596373                    /usr/lib/x86_64-linux-gnu/libnspr4.so
7f3a85999000-7f3a8599c000 rwxp 00000000 00:00 0 
7f3a85bc7000-7f3a85bc8000 rwxp 0002b000 08:06 4596568                    /usr/lib/x86_64-linux-gnu/libsmime3.so
7f3a85df6000-7f3a85df7000 rwxp 0002e000 08:06 4596375                    /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f3a86138000-7f3a8613a000 rwxp 00141000 08:06 4596374                    /usr/lib/x86_64-linux-gnu/libnss3.so
7f3a8613a000-7f3a8613b000 rwxp 00000000 00:00 0 
7f3a8644f000-7f3a86450000 rwxp 00114000 08:06 4589686                    /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5600.1
7f3a86450000-7f3a86451000 rwxp 00000000 00:00 0 
7f3a86658000-7f3a86659000 rwxp 00007000 08:06 6291526                    /lib/x86_64-linux-gnu/librt-2.27.so
7f3a8685c000-7f3a8685d000 rwxp 00003000 08:06 4589692                    /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.5600.1
7f3a86a8b000-7f3a86a8c000 rwxp 0002e000 08:06 4598171                    /usr/lib/x86_64-linux-gnu/libgconf-2.so.4.1.5
7f3a86c8f000-7f3a86c90000 rwxp 00003000 08:06 4595609                    /usr/lib/x86_64-linux-gnu/libXss.so.1.0.0
7f3a86e95000-7f3a86e96000 rwxp 00005000 08:06 4595613                    /usr/lib/x86_64-linux-gnu/libXtst.so.6.1.0
7f3a871cb000-7f3a871cf000 rwxp 00135000 08:06 4595570                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f3a873d8000-7f3a873d9000 rwxp 00009000 08:06 4595607                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f3a875de000-7f3a875df000 rwxp 00005000 08:06 4595589                    /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f3a877f0000-7f3a877f1000 rwxp 00011000 08:06 4595587                    /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f3a879f3000-7f3a879f4000 rwxp 00002000 08:06 4595579                    /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f3a87bfe000-7f3a87bff000 rwxp 0000a000 08:06 4595605                    /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f3a87e01000-7f3a87e02000 rwxp 00002000 08:06 4595583                    /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f3a8800b000-7f3a8800c000 rwxp 00009000 08:06 4595581                    /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f3a8821b000-7f3a8821c000 rwxp 0000f000 08:06 4595595                    /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f3a88443000-7f3a88444000 rwxp 00027000 08:06 4590276                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f3a88645000-7f3a88646000 rwxp 00001000 08:06 4595568                    /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f3a88892000-7f3a88893000 rwxp 0004c000 08:06 6296235                    /lib/x86_64-linux-gnu/libdbus-1.so.3.19.4
7f3a88ad3000-7f3a88ad8000 rwxp 00040000 08:06 4589832                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.10.1
7f3a88d8b000-7f3a88d8c000 rwxp 000b3000 08:06 4593516                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.15.0
7f3a88fdf000-7f3a88fe0000 rwxp 00053000 08:06 4589708                    /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5600.1
7f3a8922c000-7f3a8922d000 rwxp 0004c000 08:06 4596408                    /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.4000.14
7f3a895c8000-7f3a895c9000 rwxp 0019b000 08:06 4589682                    /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.5600.1
7f3a895c9000-7f3a895cb000 rwxp 00000000 00:00 0 
7f3a897ee000-7f3a897ef000 rwxp 00023000 08:06 4596630                    /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.3611.0
7f3a89b09000-7f3a89b0b000 rwxp 0011a000 08:06 4595723                    /usr/lib/x86_64-linux-gnu/libcairo.so.2.11510.0
7f3a89b0b000-7f3a89b0c000 rwxp 00000000 00:00 0 
7f3a89d31000-7f3a89d32000 rwxp 00025000 08:06 4595660                    /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.22810.1
7f3a89f3e000-7f3a89f3f000 rwxp 0000c000 08:06 4596410                    /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.4000.14
7f3a8a1f2000-7f3a8a1f4000 rwxp 000b3000 08:06 4595958                    /usr/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0.2400.32
7f3a8a82f000-7f3a8a833000 rwxp 0043b000 08:06 4595959                    /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0.2400.32
7f3a8a833000-7f3a8a836000 rwxp 00000000 00:00 0 
7f3a8aa50000-7f3a8aa51000 rwxp 0001a000 08:06 6291524                    /lib/x86_64-linux-gnu/libpthread-2.27.so
7f3a8aa51000-7f3a8aa55000 rwxp 00000000 00:00 0 
7f3a8c056000-7f3a8c07b000 rwxp 01401000 08:07 925194                     /home/charles/src/electron/electron/1-7-x/out/R/libnode.so
7f3a8c07b000-7f3a8c08f000 rwxp 00000000 00:00 0 
7f3a8c26b000-7f3a8c293000 rwxp 00000000 00:00 0 
7f3a8c2b4000-7f3a8c2b6000 rwxp 00000000 00:00 0 
7f3a8c2b7000-7f3a8c2b8000 rwxp 00028000 08:06 6291505                    /lib/x86_64-linux-gnu/ld-2.27.so
7f3a8c2b8000-7f3a8c2b9000 rwxp 00000000 00:00 0 
7fff30074000-7fff30095000 rwxp 00000000 00:00 0                          [stack]
054ff000-05514000 rwxp 04eff000 08:07 51276892                           /home/charles/src/electron/electron/1-7-x/out/R/electron
05514000-05569000 rwxp 00000000 00:00 0 
44609580000-44609600000 rwxp 00000000 00:00 0 
ae191600000-ae191680000 rwxp 00000000 00:00 0 
de083e00000-de083e08000 rwxp 00000000 00:00 0 
187ad0d00000-187ad0d80000 rwxp 00000000 00:00 0 
1912b3b00000-1912b3b80000 rwxp 00000000 00:00 0 
1c3326380000-1c3326400000 rwxp 00000000 00:00 0 
1cfe2bee3000-1cfe2bf02000 rwxp 00000000 00:00 0 
1cfe2bf03000-1cfe2bf22000 rwxp 00000000 00:00 0 
1cfe2bf23000-1cfe2bf59000 rwxp 00000000 00:00 0 
1cfe2bf5a000-1cfe308b1000 rwxp 00000000 00:00 0 
1d7dfc980000-1d7dfc983000 rwxp 00000000 00:00 0 
1d7dfc984000-1d7dfc985000 rwxp 00000000 00:00 0 
1d7dfca00000-1d7dfca03000 rwxp 00000000 00:00 0 
1d7dfca04000-1d7dfca05000 rwxp 00000000 00:00 0 
1d7dfca80000-1d7dfca83000 rwxp 00000000 00:00 0 
1d7dfca84000-1d7dfca85000 rwxp 00000000 00:00 0 
1d7dfcb00000-1d7dfcb03000 rwxp 00000000 00:00 0 
1d7dfcb04000-1d7dfcb7f000 rwxp 00000000 00:00 0 
1d7dfcb80000-1d7dfcb83000 rwxp 00000000 00:00 0 
1d7dfcb84000-1d7dfcbff000 rwxp 00000000 00:00 0 
1d7dfcc00000-1d7dfcc03000 rwxp 00000000 00:00 0 
1d7dfcc04000-1d7dfcc1b000 rwxp 00000000 00:00 0 
1d7dfcc80000-1d7dfcc83000 rwxp 00000000 00:00 0 
1d7dfcc84000-1d7dfccff000 rwxp 00000000 00:00 0 
1d7dfcd00000-1d7dfcd03000 rwxp 00000000 00:00 0 
1d7dfcd04000-1d7dfcd7f000 rwxp 00000000 00:00 0 
1e22c0900000-1e22c0980000 rwxp 00000000 00:00 0 
2026fa200000-2026fa205000 rwxp 00000000 00:00 0 
206126d80000-206126e00000 rwxp 00000000 00:00 0 
20c684b80000-20c684c00000 rwxp 00000000 00:00 0 
25894cd00000-25894cd80000 rwxp 00000000 00:00 0 
2639c8b80000-2639c8c00000 rwxp 00000000 00:00 0 
271791c80000-271791d00000 rwxp 00000000 00:00 0 
2f3c71b00000-2f3c71b80000 rwxp 00000000 00:00 0 
2f3f60700000-2f3f60780000 rwxp 00000000 00:00 0 
335ed1b80000-335ed1c00000 rwxp 00000000 00:00 0 
3cab1d680000-3cab1d700000 rwxp 00000000 00:00 0 
3fff33780000-3fff337e4000 rwxp 00000000 00:00 0 
7f59e5755000-7f59e5756000 rwxp 0003e000 08:06 6295922                    /lib/x86_64-linux-gnu/libnss_systemd.so.2
7f59e5961000-7f59e5962000 rwxp 0000b000 08:06 6291519                    /lib/x86_64-linux-gnu/libnss_files-2.27.so
7f59e5962000-7f59e5968000 rwxp 00000000 00:00 0 
7f59e5b73000-7f59e5b74000 rwxp 0000b000 08:06 6291521                    /lib/x86_64-linux-gnu/libnss_nis-2.27.so
7f59e5d7d000-7f59e5d7e000 rwxp 00009000 08:06 6291517                    /lib/x86_64-linux-gnu/libnss_compat-2.27.so
7f59e645b000-7f59e6465000 rwxp 0007b000 08:06 4852665                    /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
7f59e66ec000-7f59e66ed000 rwxp 00087000 08:06 4852664                    /usr/lib/x86_64-linux-gnu/nss/libfreeblpriv3.so
7f59e66ed000-7f59e66f1000 rwxp 00000000 00:00 0 
7f59e69f7000-7f59e69f9000 rwxp 00106000 08:06 4596590                    /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
7f59e69f9000-7f59e69fa000 rwxp 00000000 00:00 0 
7f59e6c5c000-7f59e6c5d000 rwxp 00041000 08:06 4852669                    /usr/lib/x86_64-linux-gnu/nss/libsoftokn3.so
7f59e6c5e000-7f59e745e000 rwxp 00000000 00:00 0 
7f59e766a000-7f59e766b000 rwxp 0000c000 08:06 4851627                    /usr/lib/x86_64-linux-gnu/gio/modules/libdconfsettings.so
7f59e76a0000-7f59e7ea0000 rwxp 00000000 00:00 0 
7f59e7ea1000-7f59e86a1000 rwxp 00000000 00:00 0 
7f59e88be000-7f59e88bf000 rwxp 0001d000 08:06 6295977                    /lib/x86_64-linux-gnu/libudev.so.1.6.9
7f59e88c0000-7f59e90c0000 rwxp 00000000 00:00 0 
7f59f90c1000-7f59f98c1000 rwxp 00000000 00:00 0 
7f59f9b69000-7f59f9b6a000 rwxp 000a8000 08:06 4596091                    /usr/lib/x86_64-linux-gnu/libvorbisenc.so.2.0.11
7f59f9d94000-7f59f9d95000 rwxp 0002a000 08:06 4596099                    /usr/lib/x86_64-linux-gnu/libvorbis.so.0.4.8
7f59f9f9d000-7f59f9f9e000 rwxp 00008000 08:06 4596383                    /usr/lib/x86_64-linux-gnu/libogg.so.0.8.2
7f59fa214000-7f59fa215000 rwxp 00076000 08:06 4595523                    /usr/lib/x86_64-linux-gnu/libFLAC.so.8.3.0
7f59fa42c000-7f59fa42d000 rwxp 00017000 08:06 6291516                    /lib/x86_64-linux-gnu/libnsl-2.27.so
7f59fa42d000-7f59fa42f000 rwxp 00000000 00:00 0 
7f59fa634000-7f59fa635000 rwxp 00005000 08:06 4595658                    /usr/lib/x86_64-linux-gnu/libasyncns.so.0.3.1
7f59fa8ab000-7f59fa8ac000 rwxp 00076000 08:06 4596572                    /usr/lib/x86_64-linux-gnu/libsndfile.so.1.0.28
7f59fa8ac000-7f59fa8ae000 rwxp 00000000 00:00 0 
7f59faab7000-7f59faab8000 rwxp 00009000 08:06 6296394                    /lib/x86_64-linux-gnu/libwrap.so.0.7.6
7f59fad35000-7f59fad36000 rwxp 0007d000 08:06 4854118                    /usr/lib/x86_64-linux-gnu/pulseaudio/libpulsecommon-11.1.so
7f59faf85000-7f59faf86000 rwxp 0004f000 08:06 4596472                    /usr/lib/x86_64-linux-gnu/libpulse.so.0.20.2
7f59fafa8000-7f59fb7a8000 rwxp 00000000 00:00 0 
7f59fb7a9000-7f59fbfa9000 rwxp 00000000 00:00 0 
7f59fbfaa000-7f59fc7aa000 rwxp 00000000 00:00 0 
7f59fc7ab000-7f59fcfab000 rwxp 00000000 00:00 0 
7f59fcfac000-7f59fd7ac000 rwxp 00000000 00:00 0 
7f59fd7ad000-7f59fdfad000 rwxp 00000000 00:00 0 
7f59fdfae000-7f59fe7ae000 rwxp 00000000 00:00 0 
7f59fe7af000-7f59fefaf000 rwxp 00000000 00:00 0 
7f59fefb0000-7f59ff7b0000 rwxp 00000000 00:00 0 
7f59ff7b1000-7f59fffb1000 rwxp 00000000 00:00 0 
7f59fffb2000-7f5a007b2000 rwxp 00000000 00:00 0 
7f5a007b3000-7f5a00fb3000 rwxp 00000000 00:00 0 
7f5a00fb4000-7f5a017b4000 rwxp 00000000 00:00 0 
7f5a017b5000-7f5a01fb5000 rwxp 00000000 00:00 0 
7f5a01fb6000-7f5a027b6000 rwxp 00000000 00:00 0 
7f5a027b7000-7f5a02fb7000 rwxp 00000000 00:00 0 
7f5a03b7b000-7f5a0437b000 rwxp 00000000 00:00 0 
7f5a0437c000-7f5a04b7c000 rwxp 00000000 00:00 0 
7f5a04b7d000-7f5a0537d000 rwxp 00000000 00:00 0 
7f5a0537e000-7f5a05b7e000 rwxp 00000000 00:00 0 
7f5a05dba000-7f5a05dbb000 rwxp 0003c000 08:06 4850088                    /usr/lib/x86_64-linux-gnu/gvfs/libgvfscommon.so
7f5a05fee000-7f5a05fef000 rwxp 00033000 08:06 4850120                    /usr/lib/x86_64-linux-gnu/gio/modules/libgvfsdbus.so
7f5a06255000-7f5a06256000 rwxp 00066000 08:06 4587922                    /usr/lib/x86_64-linux-gnu/libibus-1.0.so.5.0.517
7f5a06257000-7f5a0625f000 rwxp 00000000 00:00 0 
7f5a0647e000-7f5a0647f000 rwxp 00007000 08:06 4851914                    /usr/lib/x86_64-linux-gnu/gtk-2.0/2.10.0/immodules/im-ibus.so
7f5a0656c000-7f5a06d6c000 rwxp 00000000 00:00 0 
7f5a06d6d000-7f5a0756d000 rwxp 00000000 00:00 0 
7f5a077a8000-7f5a077a9000 rwxp 0003b000 08:06 4851992                    /usr/lib/x86_64-linux-gnu/gtk-2.0/2.10.0/engines/libmurrine.so
7f5a079d8000-7f5a079d9000 rwxp 0002f000 08:06 4595664                    /usr/lib/x86_64-linux-gnu/libatspi.so.0.0.1
7f5a07c08000-7f5a07c09000 rwxp 0002f000 08:06 4595662                    /usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0.0.0
7f5a07c09000-7f5a07c0a000 rwxp 00000000 00:00 0 
7f5a07e0b000-7f5a07e0c000 rwxp 00001000 08:06 4852009                    /usr/lib/x86_64-linux-gnu/gtk-2.0/modules/libatk-bridge.so
7f5a08013000-7f5a08014000 rwxp 00007000 08:06 4595872                    /usr/lib/x86_64-linux-gnu/libgailutil.so.18.0.1
7f5a08262000-7f5a08264000 rwxp 0004e000 08:06 4855457                    /usr/lib/x86_64-linux-gnu/gtk-2.0/modules/libgail.so
7f5a08265000-7f5a08a65000 rwxp 00000000 00:00 0 
7f5a098f0000-7f5a098f1000 rwxp 00003000 08:06 6295079                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7f5a09b05000-7f5a09b06000 rwxp 00014000 08:06 6296263                    /lib/x86_64-linux-gnu/libgpg-error.so.0.22.0
7f5a09d0c000-7f5a09d0d000 rwxp 00006000 08:06 6296392                    /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f5a09f39000-7f5a09f3a000 rwxp 0002c000 08:06 4596056                    /usr/lib/x86_64-linux-gnu/libgraphite2.so.3.0.1
7f5a0a1ba000-7f5a0a1bb000 rwxp 00080000 08:06 4596015                    /usr/lib/x86_64-linux-gnu/libgmp.so.10.3.2
7f5a0a3ee000-7f5a0a3ef000 rwxp 00033000 08:06 4596147                    /usr/lib/x86_64-linux-gnu/libhogweed.so.4.4
7f5a0a624000-7f5a0a625000 rwxp 00035000 08:06 4596360                    /usr/lib/x86_64-linux-gnu/libnettle.so.6.4
7f5a0a837000-7f5a0a838000 rwxp 00012000 08:06 4596611                    /usr/lib/x86_64-linux-gnu/libtasn1.so.6.5.5
7f5a0abb5000-7f5a0abb6000 rwxp 0017d000 08:06 4596651                    /usr/lib/x86_64-linux-gnu/libunistring.so.2.1.0
7f5a0add2000-7f5a0add3000 rwxp 0001c000 08:06 4596193                    /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.3
7f5a0b0f7000-7f5a0b101000 rwxp 00124000 08:06 4596398                    /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
7f5a0b101000-7f5a0b102000 rwxp 00000000 00:00 0 
7f5a0b30c000-7f5a0b30d000 rwxp 0000a000 08:06 4596254                    /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7f5a0b510000-7f5a0b511000 rwxp 00003000 08:06 6296122                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7f5a0b741000-7f5a0b742000 rwxp 00030000 08:06 4596244                    /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7f5a0b742000-7f5a0b743000 rwxp 00000000 00:00 0 
7f5a0ba17000-7f5a0ba19000 rwxp 000d4000 08:06 4596252                    /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7f5a0bc2c000-7f5a0bc2d000 rwxp 00013000 08:06 6296216                    /lib/x86_64-linux-gnu/libbsd.so.0.8.7
7f5a0bc2d000-7f5a0bc2e000 rwxp 00000000 00:00 0 
7f5a0bf43000-7f5a0bf48000 rwxp 00115000 08:06 6296259                    /lib/x86_64-linux-gnu/libgcrypt.so.20.2.1
7f5a0bf48000-7f5a0bf49000 rwxp 00000000 00:00 0 
7f5a0c164000-7f5a0c165000 rwxp 0001b000 08:06 4589796                    /usr/lib/x86_64-linux-gnu/liblz4.so.1.7.1
7f5a0c38a000-7f5a0c38b000 rwxp 00025000 08:06 6296282                    /lib/x86_64-linux-gnu/liblzma.so.5.2.2
7f5a0c591000-7f5a0c592000 rwxp 00006000 08:06 4595805                    /usr/lib/x86_64-linux-gnu/libdatrie.so.1.3.3
7f5a0c7dd000-7f5a0c7de000 rwxp 0004b000 08:06 6296212                    /lib/x86_64-linux-gnu/libblkid.so.1.1.0
7f5a0c7de000-7f5a0c7df000 rwxp 00000000 00:00 0 
7f5a0ca7c000-7f5a0ca7d000 rwxp 0009d000 08:06 4593522                    /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.10702.0
7f5a0cc8d000-7f5a0cc8e000 rwxp 00010000 08:06 4595668                    /usr/lib/x86_64-linux-gnu/libavahi-client.so.3.2.9
7f5a0ce99000-7f5a0ce9a000 rwxp 0000b000 08:06 4595670                    /usr/lib/x86_64-linux-gnu/libavahi-common.so.3.5.3
7f5a0d1fd000-7f5a0d1fe000 rwxp 00163000 08:06 4596031                    /usr/lib/x86_64-linux-gnu/libgnutls.so.30.14.10
7f5a0d1fe000-7f5a0d1ff000 rwxp 00000000 00:00 0 
7f5a0d448000-7f5a0d44a000 rwxp 00049000 08:06 4596070                    /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7f5a0d64d000-7f5a0d64e000 rwxp 00003000 08:06 4596442                    /usr/lib/x86_64-linux-gnu/libplds4.so
7f5a0d852000-7f5a0d853000 rwxp 00004000 08:06 4596441                    /usr/lib/x86_64-linux-gnu/libplc4.so
7f5a0dac4000-7f5a0dac5000 rwxp 00071000 08:06 6296344                    /lib/x86_64-linux-gnu/libpcre.so.3.13.3
7f5a0dceb000-7f5a0dcec000 rwxp 00026000 08:06 4595809                    /usr/lib/x86_64-linux-gnu/libdbus-glib-1.so.2.3.4
7f5a0def1000-7f5a0def2000 rwxp 00005000 08:06 4595585                    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
7f5a0e0f5000-7f5a0e0f6000 rwxp 00003000 08:06 4595574                    /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
7f5a0e378000-7f5a0e379000 rwxp 00082000 08:06 6295923                    /lib/x86_64-linux-gnu/libsystemd.so.0.21.0
7f5a0e379000-7f5a0e37a000 rwxp 00000000 00:00 0 
7f5a0e581000-7f5a0e582000 rwxp 00007000 08:06 4595917                    /usr/lib/x86_64-linux-gnu/libffi.so.6.0.4
7f5a0e78a000-7f5a0e78b000 rwxp 00008000 08:06 4596621                    /usr/lib/x86_64-linux-gnu/libthai.so.0.3.0
7f5a0e9dd000-7f5a0e9de000 rwxp 00052000 08:06 6296291                    /lib/x86_64-linux-gnu/libmount.so.1.1.0
7f5a0e9de000-7f5a0e9df000 rwxp 00000000 00:00 0 
7f5a0ebf7000-7f5a0ebf8000 rwxp 00018000 08:06 6291525                    /lib/x86_64-linux-gnu/libresolv-2.27.so
7f5a0ebf8000-7f5a0ebfa000 rwxp 00000000 00:00 0 
7f5a0ee1f000-7f5a0ee20000 rwxp 00025000 08:06 6296369                    /lib/x86_64-linux-gnu/libselinux.so.1
7f5a0ee20000-7f5a0ee22000 rwxp 00000000 00:00 0 
7f5a0f03e000-7f5a0f03f000 rwxp 0001c000 08:06 6296396                    /lib/x86_64-linux-gnu/libz.so.1.2.11
7f5a0f24b000-7f5a0f24c000 rwxp 0000c000 08:06 4597831                    /usr/lib/x86_64-linux-gnu/libxcb-render.so.0.0.0
7f5a0f44e000-7f5a0f44f000 rwxp 00002000 08:06 4597844                    /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
7f5a0f680000-7f5a0f681000 rwxp 00031000 08:06 4596446                    /usr/lib/x86_64-linux-gnu/libpng16.so.16.34.0
7f5a0f925000-7f5a0f926000 rwxp 000a4000 08:06 4596440                    /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0
7f5a0fb28000-7f5a0fb29000 rwxp 00002000 08:06 4595597                    /usr/lib/x86_64-linux-gnu/libXinerama.so.1.0.0
7f5a0fd3e000-7f5a0fd3f000 rwxp 00015000 08:06 4596412                    /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.4000.14
7f5a1012a000-7f5a1012c000 rwxp 001eb000 08:06 6291509                    /lib/x86_64-linux-gnu/libc-2.27.so
7f5a1012c000-7f5a10130000 rwxp 00000000 00:00 0 
7f5a10347000-7f5a10348000 rwxp 00017000 08:06 6295053                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7f5a106e5000-7f5a106e6000 rwxp 0019d000 08:06 6291513                    /lib/x86_64-linux-gnu/libm-2.27.so
7f5a10a6e000-7f5a10a70000 rwxp 00188000 08:06 4589732                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
7f5a10a70000-7f5a10a74000 rwxp 00000000 00:00 0 
7f5a10ca5000-7f5a10ca6000 rwxp 00031000 08:06 6296250                    /lib/x86_64-linux-gnu/libexpat.so.1.6.7
7f5a10ea9000-7f5a10eaa000 rwxp 00003000 08:06 6291512                    /lib/x86_64-linux-gnu/libdl-2.27.so
7f5a11135000-7f5a11136000 rwxp 0008b000 08:06 4588161                    /usr/lib/x86_64-linux-gnu/libcups.so.2
7f5a1143d000-7f5a1143e000 rwxp 00107000 08:06 4595652                    /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
7f5a11913000-7f5a11916000 rwxp 002d5000 08:07 12470936                   /home/charles/src/electron/electron/1-7-x/out/R/libffmpeg.so
7f5a11916000-7f5a11add000 rwxp 00000000 00:00 0 
7f5a11d16000-7f5a11d17000 rwxp 00039000 08:06 4596373                    /usr/lib/x86_64-linux-gnu/libnspr4.so
7f5a11d17000-7f5a11d1a000 rwxp 00000000 00:00 0 
7f5a11f45000-7f5a11f46000 rwxp 0002b000 08:06 4596568                    /usr/lib/x86_64-linux-gnu/libsmime3.so
7f5a12174000-7f5a12175000 rwxp 0002e000 08:06 4596375                    /usr/lib/x86_64-linux-gnu/libnssutil3.so
7f5a124b6000-7f5a124b8000 rwxp 00141000 08:06 4596374                    /usr/lib/x86_64-linux-gnu/libnss3.so
7f5a124b8000-7f5a124b9000 rwxp 00000000 00:00 0 
7f5a127cd000-7f5a127ce000 rwxp 00114000 08:06 4589686                    /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5600.1
7f5a127ce000-7f5a127cf000 rwxp 00000000 00:00 0 
7f5a129d6000-7f5a129d7000 rwxp 00007000 08:06 6291526                    /lib/x86_64-linux-gnu/librt-2.27.so
7f5a12bda000-7f5a12bdb000 rwxp 00003000 08:06 4589692                    /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.5600.1
7f5a12e09000-7f5a12e0a000 rwxp 0002e000 08:06 4598171                    /usr/lib/x86_64-linux-gnu/libgconf-2.so.4.1.5
7f5a1300d000-7f5a1300e000 rwxp 00003000 08:06 4595609                    /usr/lib/x86_64-linux-gnu/libXss.so.1.0.0
7f5a13213000-7f5a13214000 rwxp 00005000 08:06 4595613                    /usr/lib/x86_64-linux-gnu/libXtst.so.6.1.0
7f5a13549000-7f5a1354d000 rwxp 00135000 08:06 4595570                    /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0
7f5a13756000-7f5a13757000 rwxp 00009000 08:06 4595607                    /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
7f5a1395c000-7f5a1395d000 rwxp 00005000 08:06 4595589                    /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
7f5a13b6e000-7f5a13b6f000 rwxp 00011000 08:06 4595587                    /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
7f5a13d71000-7f5a13d72000 rwxp 00002000 08:06 4595579                    /usr/lib/x86_64-linux-gnu/libXcomposite.so.1.0.0
7f5a13f7c000-7f5a13f7d000 rwxp 0000a000 08:06 4595605                    /usr/lib/x86_64-linux-gnu/libXrandr.so.2.2.0
7f5a1417f000-7f5a14180000 rwxp 00002000 08:06 4595583                    /usr/lib/x86_64-linux-gnu/libXdamage.so.1.1.0
7f5a14389000-7f5a1438a000 rwxp 00009000 08:06 4595581                    /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
7f5a14599000-7f5a1459a000 rwxp 0000f000 08:06 4595595                    /usr/lib/x86_64-linux-gnu/libXi.so.6.1.0
7f5a147c1000-7f5a147c2000 rwxp 00027000 08:06 4590276                    /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
7f5a149c3000-7f5a149c4000 rwxp 00001000 08:06 4595568                    /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
7f5a14c10000-7f5a14c11000 rwxp 0004c000 08:06 6296235                    /lib/x86_64-linux-gnu/libdbus-1.so.3.19.4
7f5a14e51000-7f5a14e56000 rwxp 00040000 08:06 4589832                    /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.10.1
7f5a15109000-7f5a1510a000 rwxp 000b3000 08:06 4593516                    /usr/lib/x86_64-linux-gnu/libfreetype.so.6.15.0
7f5a1535d000-7f5a1535e000 rwxp 00053000 08:06 4589708                    /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5600.1
7f5a155aa000-7f5a155ab000 rwxp 0004c000 08:06 4596408                    /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.4000.14
7f5a15946000-7f5a15947000 rwxp 0019b000 08:06 4589682                    /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.5600.1
7f5a15947000-7f5a15949000 rwxp 00000000 00:00 0 
7f5a15b6c000-7f5a15b6d000 rwxp 00023000 08:06 4596630                    /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0.3611.0
7f5a15e87000-7f5a15e89000 rwxp 0011a000 08:06 4595723                    /usr/lib/x86_64-linux-gnu/libcairo.so.2.11510.0
7f5a15e89000-7f5a15e8a000 rwxp 00000000 00:00 0 
7f5a160af000-7f5a160b0000 rwxp 00025000 08:06 4595660                    /usr/lib/x86_64-linux-gnu/libatk-1.0.so.0.22810.1
7f5a162bc000-7f5a162bd000 rwxp 0000c000 08:06 4596410                    /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.4000.14
7f5a16570000-7f5a16572000 rwxp 000b3000 08:06 4595958                    /usr/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0.2400.32
7f5a16bad000-7f5a16bb1000 rwxp 0043b000 08:06 4595959                    /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0.2400.32
7f5a16bb1000-7f5a16bb4000 rwxp 00000000 00:00 0 
7f5a16dce000-7f5a16dcf000 rwxp 0001a000 08:06 6291524                    /lib/x86_64-linux-gnu/libpthread-2.27.so
7f5a16dcf000-7f5a16dd3000 rwxp 00000000 00:00 0 
7f5a183d4000-7f5a183f9000 rwxp 01401000 08:07 925194                     /home/charles/src/electron/electron/1-7-x/out/R/libnode.so
7f5a183f9000-7f5a1840d000 rwxp 00000000 00:00 0 
7f5a185e9000-7f5a18611000 rwxp 00000000 00:00 0 
7f5a18632000-7f5a18634000 rwxp 00000000 00:00 0 
7f5a18635000-7f5a18636000 rwxp 00028000 08:06 6291505                    /lib/x86_64-linux-gnu/ld-2.27.so
7f5a18636000-7f5a18637000 rwxp 00000000 00:00 0 
7ffd219c3000-7ffd219e4000 rwxp 00000000 00:00 0                          [stack]
```