### PR TITLE
Backport (1-8-x) - Fix contents.setSize(options) documentation in web-contents.md

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1291,11 +1291,17 @@ Shows pop-up dictionary that searches the selected word on the page.
 Set the size of the page. This is only supported for `<webview>` guest contents.
 
 * `options` Object
-  * `normal` Object (optional) - Normal size of the page. This can be used in
-    combination with the [`disableguestresize`](web-view-tag.md#disableguestresize)
+  * `enableAutoSize` Boolean (optional) - true to make the webview container automatically
+    resize within the bounds specified by the attributes normal, min and max.
+  * `normal` [Size](structures/size.md) (optional) - Normal size of the page. This can be used in
+    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
     attribute to manually resize the webview guest contents.
-    * `width` Integer
-    * `height` Integer
+  * `min` [Size](structures/size.md) (optional) - Minimum size of the page. This can be used in
+    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
+    attribute to manually resize the webview guest contents.
+  * `max` [Size](structures/size.md) (optional) - Maximium size of the page. This can be used in
+    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
+    attribute to manually resize the webview guest contents.
 
 #### `contents.isOffscreen()`
 


### PR DESCRIPTION
Backport of #12922

See that PR for details.