### PR TITLE
Fix typescript generation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.4",
-    "electron-typescript-definitions": "^1.3.2",
+    "electron-typescript-definitions": "1.3.2",
     "github": "^9.2.0",
     "husky": "^0.14.3",
     "minimist": "^1.2.0",


### PR DESCRIPTION
We need to lock down electron-typescript-definitions because it was pulling in a newer version incompatible with 2-0-x
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->