### PR TITLE
refactor: remove unnecessary std::moves in linux code

### DIFF
--- a/atom/browser/lib/power_observer_linux.cc
+++ b/atom/browser/lib/power_observer_linux.cc
@@ -23,7 +23,7 @@ std::string get_executable_basename() {
   if (!uv_exepath(buf, &buf_size)) {
     rv = strrchr(static_cast<const char*>(buf), '/') + 1;
   }
-  return std::move(rv);
+  return rv;
 }
 
 }  // namespace

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -31,7 +31,7 @@ SubmenuButton::SubmenuButton(const base::string16& title,
       background_color_(background_color) {
 #if defined(OS_LINUX)
   // Dont' use native style border.
-  SetBorder(std::move(CreateDefaultBorder()));
+  SetBorder(CreateDefaultBorder());
 #endif
 
   if (GetUnderlinePosition(title, &accelerator_, &underline_start_,


### PR DESCRIPTION
The compiler was complaining that the move was preventing copy elision.