### PR TITLE
Update locale setting documentation

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -561,8 +561,9 @@ Overrides the current application's name.
 
 ### `app.getLocale()`
 
-Returns `String` - The current application locale. Possible return values are documented
-[here](locales.md).
+Returns `String` - The current application locale. Possible return values are documented [here](locales.md).
+
+To set the locale, you'll want to use a command line switch at app startup, which may be found [here](https://github.com/electron/electron/blob/master/docs/api/chrome-command-line-switches.md).
 
 **Note:** When distributing your packaged app, you have to also ship the
 `locales` folder.


### PR DESCRIPTION
Some users have been attempting to call `app.setLocale()`, which doesn't exist as we repurposed the functionality to command line switches. 

This PR links to that under the `app.getLocale()` doc to make the current method clearer ✨  

/cc @ckerr 
