### PR TITLE
Fix docs formatting for ts defs

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -250,7 +250,7 @@ to detect every individual click of the tray icon.
 
 This value is set to false by default.
 
-### `tray.getIgnoreDoubleClickEvents()` _macOS_
+#### `tray.getIgnoreDoubleClickEvents()` _macOS_
 
 Returns `Boolean` - Whether double click events will be ignored.
 


### PR DESCRIPTION
The header in [this](https://github.com/electron/electron/pull/12496) PR had `###` instead of `####` which caused typescript header definition failures in CI. 

This PR fixes that.