### PR TITLE
Detect EventEmitter in removeRemoteListenersAndLogWarning (rpc-server)

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -2,8 +2,8 @@
 
 const {Buffer} = require('buffer')
 const electron = require('electron')
+const {EventEmitter} = require('events')
 const v8Util = process.atomBinding('v8_util')
-const {WebContents} = process.atomBinding('web_contents')
 
 const {ipcMain, isPromise, webContents} = electron
 
@@ -147,12 +147,17 @@ const throwRPCError = function (message) {
   throw error
 }
 
-const removeRemoteListenersAndLogWarning = (meta, args, callIntoRenderer) => {
+const isEventEmitter = (object) => {
+  if (!object) return false
+  const prototype = Object.getPrototypeOf(object)
+  return prototype === EventEmitter.prototype || isEventEmitter(prototype)
+}
+
+const removeRemoteListenersAndLogWarning = (sender, meta, callIntoRenderer) => {
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
     `\nFunction provided here: ${meta.location}`
 
-  if (args.length > 0 && (args[0].sender instanceof WebContents)) {
-    const {sender} = args[0]
+  if (isEventEmitter(sender)) {
     const remoteEvents = sender.eventNames().filter((eventName) => {
       return sender.listeners(eventName).includes(callIntoRenderer)
     })
@@ -218,7 +223,7 @@ const unwrapArgs = function (sender, args) {
           if (!sender.isDestroyed() && webContentsId === sender.getId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', meta.id, valueToMeta(sender, args))
           } else {
-            removeRemoteListenersAndLogWarning(meta, args, callIntoRenderer)
+            removeRemoteListenersAndLogWarning(this, meta, callIntoRenderer)
           }
         }
         Object.defineProperty(callIntoRenderer, 'length', { value: meta.length })


### PR DESCRIPTION
Instead of checking for WebContents, check if the object inherits the EventEmitter, which is more robust. @zcbenz can you please review?