### PR TITLE
Add a tag to libchromiumcontent when a release is created.

### DIFF
--- a/script/release.js
+++ b/script/release.js
@@ -6,6 +6,7 @@ const assert = require('assert')
 const fs = require('fs')
 const { execSync } = require('child_process')
 const GitHub = require('github')
+const { GitProcess } = require('dugite')
 const nugget = require('nugget')
 const pkg = require('../package.json')
 const pkgVersion = `v${pkg.version}`
@@ -283,6 +284,7 @@ async function makeRelease (releaseToValidate) {
     // Fetch latest version of release before verifying
     draftRelease = await getDraftRelease(pkgVersion, true)
     await validateReleaseAssets(draftRelease)
+    await tagLibCC()
     await publishRelease(draftRelease)
     console.log(`${pass} SUCCESS!!! Release has been published. Please run ` +
       `"npm run publish-to-npm" to publish release to npm.`)
@@ -449,6 +451,25 @@ async function validateChecksums (validationArgs) {
     })
   console.log(`${pass} All files from ${validationArgs.fileSource} match ` +
     `shasums defined in ${validationArgs.shaSumFile}.`)
+}
+
+async function tagLibCC () {
+  const tag = `electron-${pkg.version}`
+  const libccDir = path.join(path.resolve(__dirname, '..'), 'vendor', 'libchromiumcontent')
+  console.log(`Tagging release ${tag}.`)
+  let tagDetails = await GitProcess.exec([ 'tag', '-a', '-m', tag, tag ], libccDir)
+  if (tagDetails.exitCode === 0) {
+    let pushDetails = await GitProcess.exec(['push', '--tags'], libccDir)
+    if (pushDetails.exitCode === 0) {
+      console.log(`${pass} Successfully tagged libchromiumcontent with ${tag}.`)
+    } else {
+      console.log(`${fail} Error pushing libchromiumcontent tag ${tag}: ` +
+        `${pushDetails.stderr}`)
+    }
+  } else {
+    console.log(`${fail} Error tagging libchromiumcontent with ${tag}: ` +
+      `${tagDetails.stderr}`)
+  }
 }
 
 makeRelease(args.validateRelease)


### PR DESCRIPTION
This PR adds logic to tag the libchromiumcontent commit used for a release with a tag corresponding to that release.  The tags will be formatted as `electron-versionnumber`, eg `electron-2.0.1`
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->