### PR TITLE
Add ipcRenderer.sendToSync(webContentsId, channel, ...args)

### DIFF
--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -74,13 +74,31 @@ and replies by setting `event.returnValue`.
 **Note:** Sending a synchronous message will block the whole renderer process,
 unless you know what you are doing you should never use it.
 
-### `ipcRenderer.sendTo(windowId, channel, [, arg1][, arg2][, ...])`
+### `ipcRenderer.sendTo(webContentsId, channel, [, arg1][, arg2][, ...])`
 
-* `windowId` Number
+* `webContentsId` Number
 * `channel` String
 * `...args` any[]
 
-Sends a message to a window with `windowid` via `channel`.
+Sends a message to a webContents with `webContentsId` asynchronously via `channel`.
+
+The renderer process handles it by listening for `channel` with [`ipcRenderer`](ipc-renderer.md) module.
+
+### `ipcRenderer.sendToSync(webContentsId, channel, [, arg1][, arg2][, ...])`
+
+* `webContentsId` Number
+* `channel` String
+* `...args` any[]
+
+Returns `any` - The value sent back by the [`ipcRenderer`](ipc-renderer.md) handler.
+
+Sends a message to a webContents with `webContentsId` synchronously via `channel`.
+
+The renderer process handles it by listening for `channel` with [`ipcRenderer`](ipc-renderer.md) module,
+and replies by setting `event.returnValue`.
+
+**Note:** Sending a synchronous message will block the whole renderer process,
+unless you know what you are doing you should never use it.
 
 ### `ipcRenderer.sendToHost(channel[, arg1][, arg2][, ...])`
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -104,6 +104,16 @@ WebContents.prototype.sendToAll = function (channel, ...args) {
   return this._send(true, channel, args)
 }
 
+WebContents.prototype.sendWithReply = function (channel, ...args) {
+  const requestId = getNextId()
+  return new Promise((resolve, reject) => {
+    this.send('ELECTRON_RENDERER_SEND_TO_SYNC', requestId, channel, ...args)
+    ipcMain.once(`ELECTRON_BROWSER_SEND_TO_SYNC_REPLY_${requestId}`, (e, value) => {
+      resolve(value)
+    })
+  })
+}
+
 // Following methods are mapped to webFrame.
 const webFrameMethods = [
   'insertCSS',

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -441,6 +441,18 @@ ipcMain.on('ELECTRON_BROWSER_SEND_TO', function (event, sendToAll, webContentsId
   }
 })
 
+ipcMain.on('ELECTRON_BROWSER_SEND_TO_SYNC', function (event, webContentsId, channel, ...args) {
+  let contents = webContents.fromId(webContentsId)
+  if (!contents) {
+    event.returnValue = [`Sending message to WebContents with unknown ID ${webContentsId}`]
+    return
+  }
+
+  contents.sendWithReply(channel, ...args).then((result) => {
+    event.returnValue = [null, result]
+  })
+})
+
 // Implements window.close()
 ipcMain.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
   const window = event.sender.getOwnerBrowserWindow()

--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -34,6 +34,18 @@ ipcRenderer.sendToAll = function (webContentsId, channel, ...args) {
   ipcRenderer.send('ELECTRON_BROWSER_SEND_TO', true, webContentsId, channel, ...args)
 }
 
+ipcRenderer.sendToSync = function (webContentsId, channel, ...args) {
+  if (typeof webContentsId !== 'number') {
+    throw new TypeError('First argument has to be webContentsId')
+  }
+
+  const [error, result] = ipcRenderer.sendSync('ELECTRON_BROWSER_SEND_TO_SYNC', webContentsId, channel, ...args)
+  if (error) {
+    throw new Error(error)
+  }
+  return result
+}
+
 const removeAllListeners = ipcRenderer.removeAllListeners.bind(ipcRenderer)
 ipcRenderer.removeAllListeners = function (...args) {
   if (args.length === 0) {
@@ -41,5 +53,15 @@ ipcRenderer.removeAllListeners = function (...args) {
   }
   removeAllListeners(...args)
 }
+
+ipcRenderer.on('ELECTRON_RENDERER_SEND_TO_SYNC', (event, requestId, channel, ...args) => {
+  Object.defineProperty(event, 'returnValue', {
+    set: (value) => {
+      event.sender.send(`ELECTRON_BROWSER_SEND_TO_SYNC_REPLY_${requestId}`, value)
+    },
+    get: () => undefined
+  })
+  ipcRenderer.emit(channel, event, ...args)
+})
 
 module.exports = ipcRenderer


### PR DESCRIPTION
Add a synchronous version of the `ipcRenderer.sendTo` API. Only the sending renderer process is blocked.