### PR TITLE
Update mac symbol dump

### DIFF
--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -22,18 +22,24 @@ def main(destination):
     generate_breakpad_symbols = os.path.join(SOURCE_ROOT, 'tools', 'posix',
                                              'generate_breakpad_symbols.py')
     if PLATFORM == 'darwin':
-      start = os.path.join(OUT_DIR, '{0}.app'.format(product_name), 'Contents',
+      #macOS has an additional helper app, so provide the path to that binary as well.
+      main_app = os.path.join(OUT_DIR, '{0}.app'.format(product_name), 'Contents',
                            'MacOS', product_name)
+      helper_app = os.path.join(OUT_DIR, '{0}.app'.format(product_name + " Helper"), 'Contents',
+                           'MacOS', product_name + " Helper")
+      binaries = [main_app, helper_app]
     else:
-      start = os.path.join(OUT_DIR, project_name)
+      binaries = [os.path.join(OUT_DIR, project_name)]
     args = [
       '--build-dir={0}'.format(OUT_DIR),
-      '--binary={0}'.format(start),
       '--symbols-dir={0}'.format(destination),
       '--libchromiumcontent-dir={0}'.format(CHROMIUM_DIR),
       '--clear',
       '--jobs=16',
     ]
+    for binary in binaries:
+      args += '--binary={0}'.format(binary),
+
   else:
     generate_breakpad_symbols = os.path.join(SOURCE_ROOT, 'tools', 'win',
                                              'generate_breakpad_symbols.py')

--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -22,11 +22,12 @@ def main(destination):
     generate_breakpad_symbols = os.path.join(SOURCE_ROOT, 'tools', 'posix',
                                              'generate_breakpad_symbols.py')
     if PLATFORM == 'darwin':
-      #macOS has an additional helper app, so provide the path to that binary as well.
-      main_app = os.path.join(OUT_DIR, '{0}.app'.format(product_name), 'Contents',
-                           'MacOS', product_name)
-      helper_app = os.path.join(OUT_DIR, '{0}.app'.format(product_name + " Helper"), 'Contents',
-                           'MacOS', product_name + " Helper")
+      #macOS has an additional helper app; provide the path to that binary also
+      main_app = os.path.join(OUT_DIR, '{0}.app'.format(product_name),
+                            'Contents', 'MacOS', product_name)
+      helper_name = product_name + " Helper"
+      helper_app = os.path.join(OUT_DIR, '{0}.app'.format(helper_name),
+                            'Contents', 'MacOS', product_name + " Helper")
       binaries = [main_app, helper_app]
     else:
       binaries = [os.path.join(OUT_DIR, project_name)]


### PR DESCRIPTION
Update posix generate_breakpad_symbols.py file to use argparse instead of deprecated optparse.
Also, make changes to the posix generate_breakpad_symbols.py file to accept multiple binaries.
And update dump-symbols.py to get symbols for the mac helper app as well.
