### PR TITLE
docs: Document missing quit events during shutdown

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -64,6 +64,9 @@ terminating the application.
 then `before-quit` is emitted *after* emitting `close` event on all windows and
 closing them.
 
+**Note:** This event will not be emitted if the application is killed, or closed
+due to a shutdown, restart, or user logout of Windows.
+
 ### Event: 'will-quit'
 
 Returns:
@@ -77,6 +80,9 @@ terminating the application.
 See the description of the `window-all-closed` event for the differences between
 the `will-quit` and `window-all-closed` events.
 
+**Note:** This event will not be emitted if the application is killed, or closed
+due to a shutdown, restart, or user logout of Windows.
+
 ### Event: 'quit'
 
 Returns:
@@ -85,6 +91,9 @@ Returns:
 * `exitCode` Integer
 
 Emitted when the application is quitting.
+
+**Note:** This event will not be emitted if the application is killed, or closed
+due to a shutdown, restart, or user logout of Windows.
 
 ### Event: 'open-file' _macOS_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -64,8 +64,8 @@ terminating the application.
 then `before-quit` is emitted *after* emitting `close` event on all windows and
 closing them.
 
-**Note:** This event will not be emitted if the application is killed, or closed
-due to a shutdown, restart, or user logout of Windows.
+**Note:** On Windows, this event will not be emitted if the app is closed due
+to a shutdown/restart of the system or a user logout.
 
 ### Event: 'will-quit'
 
@@ -80,8 +80,8 @@ terminating the application.
 See the description of the `window-all-closed` event for the differences between
 the `will-quit` and `window-all-closed` events.
 
-**Note:** This event will not be emitted if the application is killed, or closed
-due to a shutdown, restart, or user logout of Windows.
+**Note:** On Windows, this event will not be emitted if the app is closed due
+to a shutdown/restart of the system or a user logout.
 
 ### Event: 'quit'
 
@@ -92,8 +92,8 @@ Returns:
 
 Emitted when the application is quitting.
 
-**Note:** This event will not be emitted if the application is killed, or closed
-due to a shutdown, restart, or user logout of Windows.
+**Note:** On Windows, this event will not be emitted if the app is closed due
+to a shutdown/restart of the system or a user logout.
 
 ### Event: 'open-file' _macOS_
 


### PR DESCRIPTION
A simple documentation addition: I've been bitten by this before, forgot all about it, and was bitten by it again today.

We'll eventually fix the root cause properly (and deal with ``WM_QUERYENDSESSION`), but for now, we should at least warn people that you can't rely on these events to do anything that _needs_ to happen.