### PR TITLE
build: don't upload aliased arm builds anymore

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -4,7 +4,6 @@ import argparse
 import errno
 import hashlib
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -236,14 +235,6 @@ def upload_electron(github, release, file_path, upload_to_s3):
 
   # Upload the checksum file.
   upload_sha256_checksum(release['tag_name'], file_path)
-
-  # Upload ARM assets without the v7l suffix for backwards compatibility
-  # TODO Remove for 2.0
-  if 'armv7l' in filename:
-    arm_filename = filename.replace('armv7l', 'arm')
-    arm_file_path = os.path.join(os.path.dirname(file_path), arm_filename)
-    shutil.copy2(file_path, arm_file_path)
-    upload_electron(github, release, arm_file_path, upload_to_s3)
 
 
 def upload_io_to_github(release, filename, filepath):


### PR DESCRIPTION
They are literally a copy/paste of the `armv7l` builds, and have been deprecated ever since they were renamed 2 years ago. (Note how the comment says `TODO Remove for 2.0` :smile:)

FWIW, Electron Packager has never officially supported the `arm` variant.

This is technically a breaking change and should be mentioned in the release notes.