### PR TITLE
feat: upgrade electron-download to 4.x

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -12,7 +12,7 @@
   "types": "electron.d.ts",
   "dependencies": {
     "@types/node": "^8.0.24",
-    "electron-download": "^3.0.1",
+    "electron-download": "^4.1.0",
     "extract-zip": "^1.0.3"
   },
   "devDependencies": {
@@ -22,5 +22,8 @@
   },
   "directories": {
     "test": "test"
+  },
+  "engines": {
+    "node": ">= 4.0"
   }
 }


### PR DESCRIPTION
This is a breaking change, as it causes the `electron` module to require Node 4.x (which has been EOL'd anyway).

Upgrading adds features such as a customizable cache location (via the `ELECTRON_CACHE` environment variable).

Originally merged in #10922 but was reverted because it was going into a version of Electron that did not allow breaking changes.

The main difference between this and #10922 is that I explicitly added the `engines` directive (which in NPM generates a warning, but in Yarn throws an error).

This should go in the release notes.