### PR TITLE
Replace isEventEmitter with instanceof EventEmitter (rpc-server)

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -147,17 +147,11 @@ const throwRPCError = function (message) {
   throw error
 }
 
-const isEventEmitter = (object) => {
-  if (!object) return false
-  const prototype = Object.getPrototypeOf(object)
-  return prototype === EventEmitter.prototype || isEventEmitter(prototype)
-}
-
 const removeRemoteListenersAndLogWarning = (sender, meta, callIntoRenderer) => {
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
     `\nFunction provided here: ${meta.location}`
 
-  if (isEventEmitter(sender)) {
+  if (sender instanceof EventEmitter) {
     const remoteEvents = sender.eventNames().filter((eventName) => {
       return sender.listeners(eventName).includes(callIntoRenderer)
     })


### PR DESCRIPTION
I've just realized that I should have used `instanceof EventEmitter` instead of writing custom `isEventEmitter` function in my previous PR https://github.com/electron/electron/pull/12975