### PR TITLE
child focuses in sandbox

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -620,6 +620,7 @@ void WebContents::CloseContents(content::WebContents* source) {
 }
 
 void WebContents::ActivateContents(content::WebContents* source) {
+  source->Focus();
   Emit("activate");
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1207,11 +1207,10 @@ describe('BrowserWindow module', () => {
       it('should focus on window correctly', () => {
         w.destroy()
         w = new BrowserWindow({
-            webPreferences: {
+          webPreferences: {
             sandbox: true
           }
         })
-
         w.focus()
         assert(w.isFocused())
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1204,6 +1204,18 @@ describe('BrowserWindow module', () => {
         })
       })
 
+      it('should focus on window correctly', () => {
+        w.destroy()
+        w = new BrowserWindow({
+            webPreferences: {
+            sandbox: true
+          }
+        })
+
+        w.focus()
+        assert(w.isFocused())
+      })
+
       it('exposes ipcRenderer to preload script', (done) => {
         ipcMain.once('answer', function (event, test) {
           assert.equal(test, 'preload')


### PR DESCRIPTION
Fixes #8969.

This PR allows for `window.focus()` to work in Sandbox mode.