### PR TITLE
Don't pass preloadPath via ELECTRON_BROWSER_SANDBOX_LOAD for security reasons

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -156,16 +156,12 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   if (!render_frame->IsMainFrame() && !IsDevTools(render_frame))
     return;
 
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  base::FilePath preload_script_path =
-      command_line->GetSwitchValuePath(switches::kPreloadScript);
-
   auto* isolate = context->GetIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);
   // Wrap the bundle into a function that receives the binding object and the
   // preload script path as arguments.
-  std::string left = "(function(binding, preloadPath, require) {\n";
+  std::string left = "(function(binding, require) {\n";
   std::string right = "\n})";
   // Compile the wrapper and run it to get the function object
   auto script = v8::Script::Compile(v8::String::Concat(
@@ -178,10 +174,10 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   auto binding = v8::Object::New(isolate);
   InitializeBindings(binding, context);
   AddRenderBindings(isolate, binding);
-  v8::Local<v8::Value> args[] = {
-      binding, mate::ConvertToV8(isolate, preload_script_path.value())};
+  v8::Local<v8::Value> args[] = {binding};
   // Execute the function with proper arguments
-  ignore_result(func->Call(context, v8::Null(isolate), 2, args));
+  ignore_result(
+      func->Call(context, v8::Null(isolate), node::arraysize(args), args));
 }
 
 void AtomSandboxedRendererClient::WillReleaseScriptContext(

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -450,7 +450,9 @@ ipcMain.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
   event.returnValue = null
 })
 
-ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event, preloadPath) {
+ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
+  const webPreferences = event.sender.getLastWebPreferences()
+  const preloadPath = webPreferences ? webPreferences.preload : ''
   let preloadSrc = null
   let preloadError = null
   if (preloadPath) {

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -1,5 +1,5 @@
 /* eslint no-eval: "off" */
-/* global binding, preloadPath, Buffer */
+/* global binding, Buffer */
 const events = require('events')
 const electron = require('electron')
 
@@ -37,7 +37,7 @@ const loadedModules = new Map([
 
 const {
   preloadSrc, preloadError, webContentsId, platform, execPath, env
-} = electron.ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD', preloadPath)
+} = electron.ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 Object.defineProperty(process, 'webContentsId', {
   configurable: false,


### PR DESCRIPTION
Follow up to https://github.com/electron/electron/pull/12877. @tarruda please review, thanks.