### PR TITLE
fix: add native function to create preload script

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -81,11 +81,19 @@ base::CommandLine::StringVector GetArgv() {
   return base::CommandLine::ForCurrentProcess()->argv();
 }
 
+v8::Local<v8::Value> CreatePreloadScript(v8::Isolate* isolate,
+                                         v8::Local<v8::String> preloadSrc) {
+  auto script = v8::Script::Compile(preloadSrc);
+  auto func = script->Run();
+  return func;
+}
+
 void InitializeBindings(v8::Local<v8::Object> binding,
                         v8::Local<v8::Context> context) {
   auto* isolate = context->GetIsolate();
   mate::Dictionary b(isolate, binding);
   b.SetMethod("get", GetBinding);
+  b.SetMethod("createPreloadScript", CreatePreloadScript);
   b.SetMethod("crash", AtomBindings::Crash);
   b.SetMethod("hang", AtomBindings::Hang);
   b.SetMethod("getArgv", GetArgv);

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -102,10 +102,8 @@ if (preloadSrc) {
   ${preloadSrc}
   })`
 
-  // eval in window scope:
-  // http://www.ecma-international.org/ecma-262/5.1/#sec-10.4.2
-  const geval = eval
-  const preloadFn = geval(preloadWrapperSrc)
+  // eval in window scope
+  const preloadFn = binding.createPreloadScript(preloadWrapperSrc)
   const {setImmediate, clearImmediate} = require('timers')
   preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate, clearImmediate)
 } else if (preloadError) {

--- a/spec/fixtures/module/preload-context.js
+++ b/spec/fixtures/module/preload-context.js
@@ -1,4 +1,4 @@
-var test = 'test'
+var test = 'test' // eslint-disable-line
 
 const types = {
   require: typeof require,

--- a/spec/fixtures/module/preload-context.js
+++ b/spec/fixtures/module/preload-context.js
@@ -1,0 +1,10 @@
+var test = 'test'
+
+const types = {
+  require: typeof require,
+  electron: typeof electron,
+  window: typeof window,
+  localVar: typeof window.test
+}
+
+console.log(JSON.stringify(types))

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -256,10 +256,10 @@ describe('<webview> tag', function () {
 
       const types = JSON.parse(message)
       expect(types).to.include({
-        require: "function", //arguments passed to it should be availale
-        electron: "undefined", //objects from the scope it is called from should not be available
-        window: "object", //the window object should be available
-        localVar: "undefined", //but local variables should not be exposed to the window
+        require: 'function', // arguments passed to it should be availale
+        electron: 'undefined', // objects from the scope it is called from should not be available
+        window: 'object', // the window object should be available
+        localVar: 'undefined' // but local variables should not be exposed to the window
       })
     })
 
@@ -267,15 +267,15 @@ describe('<webview> tag', function () {
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         preload: `${fixtures}/module/preload-context.js`,
         src: `file://${fixtures}/api/blank.html`,
-        webpreferences: "sandbox=yes",
+        webpreferences: 'sandbox=yes'
       })
 
       const types = JSON.parse(message)
       expect(types).to.include({
-        require: "function", //arguments passed to it should be availale
-        electron: "undefined", //objects from the scope it is called from should not be available
-        window: "object", //the window object should be available
-        localVar: "undefined", //but local variables should not be exposed to the window
+        require: 'function', // arguments passed to it should be availale
+        electron: 'undefined', // objects from the scope it is called from should not be available
+        window: 'object', // the window object should be available
+        localVar: 'undefined' // but local variables should not be exposed to the window
       })
     })
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -248,22 +248,7 @@ describe('<webview> tag', function () {
       })
     })
 
-    it('runs in the correct context', async () => {
-      const message = await startLoadingWebViewAndWaitForMessage(webview, {
-        preload: `${fixtures}/module/preload-context.js`,
-        src: `file://${fixtures}/api/blank.html`
-      })
-
-      const types = JSON.parse(message)
-      expect(types).to.include({
-        require: 'function', // arguments passed to it should be availale
-        electron: 'undefined', // objects from the scope it is called from should not be available
-        window: 'object', // the window object should be available
-        localVar: 'undefined' // but local variables should not be exposed to the window
-      })
-    })
-
-    it('runs in the correct context when sandboxed', async () => {
+    it('runs in the correct scope when sandboxed', async () => {
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         preload: `${fixtures}/module/preload-context.js`,
         src: `file://${fixtures}/api/blank.html`,

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -248,6 +248,37 @@ describe('<webview> tag', function () {
       })
     })
 
+    it('runs in the correct context', async () => {
+      const message = await startLoadingWebViewAndWaitForMessage(webview, {
+        preload: `${fixtures}/module/preload-context.js`,
+        src: `file://${fixtures}/api/blank.html`
+      })
+
+      const types = JSON.parse(message)
+      expect(types).to.include({
+        require: "function", //arguments passed to it should be availale
+        electron: "undefined", //objects from the scope it is called from should not be available
+        window: "object", //the window object should be available
+        localVar: "undefined", //but local variables should not be exposed to the window
+      })
+    })
+
+    it('runs in the correct context when sandboxed', async () => {
+      const message = await startLoadingWebViewAndWaitForMessage(webview, {
+        preload: `${fixtures}/module/preload-context.js`,
+        src: `file://${fixtures}/api/blank.html`,
+        webpreferences: "sandbox=yes",
+      })
+
+      const types = JSON.parse(message)
+      expect(types).to.include({
+        require: "function", //arguments passed to it should be availale
+        electron: "undefined", //objects from the scope it is called from should not be available
+        window: "object", //the window object should be available
+        localVar: "undefined", //but local variables should not be exposed to the window
+      })
+    })
+
     it('preload script can require modules that still use "process" and "Buffer" when nodeintegration is off', async () => {
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         preload: `${fixtures}/module/preload-node-off-wrapper.js`,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes #9276.

It looks like ```file:///``` and ```data:``` URL's are always able to use eval() regardless of what the CSP is, so I'm not really sure how to add a test for this. I guess a custom protocol might work?