### PR TITLE
Updated CI configs for nightly release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,80 +1,134 @@
+build-steps: &build-steps
+  steps:
+    - checkout
+    - run:
+        name: Check for release
+        command: |
+          if [ -n "${RUN_RELEASE_BUILD}" ]; then
+            echo 'release build triggered from api'
+            echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
+          fi
+    - run:
+       name: Bootstrap
+       command: |
+        if [ "$ELECTRON_RELEASE" == "1" ]; then
+          echo "Bootstrapping Electron for release build for $TARGET_ARCH"
+          script/bootstrap.py --target_arch=$TARGET_ARCH
+        else
+          echo "Bootstrapping Electron for debug build for $TARGET_ARCH"
+          script/bootstrap.py --target_arch=$TARGET_ARCH --dev
+        fi
+    - run:
+        name: Lint
+        command: npm run lint
+    - run:
+       name: Build
+       command: |
+         if [ "$ELECTRON_RELEASE" == "1" ]; then
+           echo 'Building Electron for release'
+           script/build.py -c R
+         else
+           echo 'Building Electron for debug'
+           script/build.py -c D
+         fi
+    - run:
+        name: Create distribution
+        command: |
+          if [ "$ELECTRON_RELEASE" == "1" ]; then
+            echo 'Creating Electron release distribution'
+            script/create-dist.py
+          else
+            echo 'Skipping create distribution because build is not for release'
+          fi
+    - run:
+        name: Upload distribution
+        command: |
+          if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
+            echo 'Uploading Electron release distribution to github releases'
+            script/upload.py
+          elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
+            echo 'Uploading Electron release distribution to s3'
+            script/upload.py --upload_to_s3
+          else
+            echo 'Skipping upload distribution because build is not for release'
+          fi
+    - run:
+        name: Setup for headless testing
+        command: |
+          if [ "$ELECTRON_RELEASE" != "1" ] && [ "$RUN_HEADLESS_TESTS" == "true" ]; then
+            echo 'Setup for headless testing'
+            sh -e /etc/init.d/xvfb start
+          else
+            echo 'Headless testing not needed'
+          fi
+    - run:
+        name: Test
+        environment:
+          MOCHA_FILE: junit/test-results.xml
+          MOCHA_REPORTER: mocha-junit-reporter
+        command: |
+          if [ "$ELECTRON_RELEASE" != "1" ] && [ "$RUN_TESTS" == "true" ]; then
+            echo 'Testing Electron debug build'
+            mkdir junit
+            script/test.py --ci
+          else
+            if [ "$ELECTRON_RELEASE" == "1" ]; then
+              echo 'Skipping testing on release build'
+            else
+              echo 'Skipping tests due to configuration'
+            fi
+          fi
+    - run:
+        name: Verify FFmpeg
+        command: |
+          if [ "$ELECTRON_RELEASE" != "1" ] && [ "$RUN_TESTS" == "true" ]; then
+            echo 'Verifying ffmpeg on debug build'
+            script/verify-ffmpeg.py
+          else
+            if [ "$ELECTRON_RELEASE" == "1" ]; then
+              echo 'Skipping verify ffmpeg on release build'
+            else
+              echo 'Skipping tests due to configuration'
+            fi
+          fi
+    - run:
+        name: Generate Typescript Definitions
+        command: |
+          if [ "$CREATE_TYPESCRIPT_DEFS" == "true" ]; then
+            npm run create-typescript-definitions
+          fi
+    - persist_to_workspace:
+        root: out
+        paths:
+          - "*"
+    - store_test_results:
+        path: junit
+    - store_artifacts:
+        path: junit
+    - store_artifacts:
+        path: out/electron.d.ts
+    - store_artifacts:
+        path: out/electron-api.json
+
+
+build-defaults: &build-defaults
+  docker:
+    - image: electronbuilds/electron:0.0.7
+  <<: *build-steps
 
 version: 2
 jobs:
   electron-linux-arm:
-    docker:
-      - image: electronbuilds/electron:0.0.7
-        environment:
-          TARGET_ARCH: arm
+    environment:
+      TARGET_ARCH: arm
+    <<: *build-defaults
     resource_class: 2xlarge
-    steps:
-      - checkout
-      - run:
-          name: Check for release
-          command: |
-            if [ -n "${RUN_RELEASE_BUILD}" ]; then
-              echo 'release build triggered from api'
-              echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
-            fi
-      - run:
-         name: Bootstrap
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Bootstrapping Electron for release build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH
-           else
-              echo 'Bootstrapping Electron for debug build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-           fi
-      - run: npm run lint
-      - run:
-         name: Build
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Building Electron for release'
-              script/build.py -c R
-           else
-              echo 'Building Electron for debug'
-              script/build.py -c D
-           fi
-      - run:
-          name: Create distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ]; then
-                echo 'Creating Electron release distribution'
-                script/create-dist.py
-             else
-                echo 'Skipping create distribution because build is not for release'
-             fi
-      - run:
-          name: Upload distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
-                echo 'Uploading Electron release distribution to github releases'
-                script/upload.py
-             elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
-                echo 'Uploading Electron release distribution to s3'
-                script/upload.py --upload_to_s3
-             else
-                echo 'Skipping upload distribution because build is not for release'
-             fi
-      - run:
-          name: Zip out directory
-          command: |
-            if [ "$ELECTRON_RELEASE" != "1" ]; then
-              zip -r electron.zip out/D
-            fi
-      - persist_to_workspace:
-          root: /home/builduser
-          paths:
-            - project/out
-      - store_artifacts:
-          path: electron.zip
+
   electron-linux-arm-test:
     machine: true
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: /tmp/workspace/project/out
       - checkout
       - run:
           name: Test in ARM docker container
@@ -94,80 +148,25 @@ jobs:
             else
               echo "Skipping test for release build"
             fi
-  electron-linux-arm64:
-    docker:
-      - image: electronbuilds/electron:0.0.7
-        environment:
-          TARGET_ARCH: arm64
+
+  electron-linux-arm-release-nightly:
+    environment:
+      TARGET_ARCH: arm
+      RUN_RELEASE_BUILD: true
+    <<: *build-defaults
     resource_class: 2xlarge
-    steps:
-      - checkout
-      - run:
-          name: Check for release
-          command: |
-            if [ -n "${RUN_RELEASE_BUILD}" ]; then
-              echo 'release build triggered from api'
-              echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
-            fi
-      - run:
-         name: Bootstrap
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Bootstrapping Electron for release build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH
-           else
-              echo 'Bootstrapping Electron for debug build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-           fi
-      - run: npm run lint
-      - run:
-         name: Build
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Building Electron for release'
-              script/build.py -c R
-           else
-              echo 'Building Electron for debug'
-              script/build.py -c D
-           fi
-      - run:
-          name: Create distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ]; then
-                echo 'Creating Electron release distribution'
-                script/create-dist.py
-             else
-                echo 'Skipping create distribution because build is not for release'
-             fi
-      - run:
-          name: Upload distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
-                echo 'Uploading Electron release distribution to github releases'
-                script/upload.py
-             elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
-                echo 'Uploading Electron release distribution to s3'
-                script/upload.py --upload_to_s3
-             else
-                echo 'Skipping upload distribution because build is not for release'
-             fi
-      - run:
-          name: Zip out directory
-          command: |
-            if [ "$ELECTRON_RELEASE" != "1" ]; then
-              zip -r electron.zip out/D
-            fi
-      - persist_to_workspace:
-          root: /home/builduser
-          paths:
-            - project/out
-      - store_artifacts:
-          path: electron.zip
+
+  electron-linux-arm64:
+    environment:
+      TARGET_ARCH: arm64
+    <<: *build-defaults
+    resource_class: 2xlarge
+
   electron-linux-arm64-test:
     machine: true
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: /tmp/workspace/project/out
       - checkout
       - run:
           name: Test in ARM64 docker container
@@ -187,444 +186,87 @@ jobs:
             else
               echo "Skipping test for release build"
             fi
+
+  electron-linux-arm64-release-nightly:
+    environment:
+      TARGET_ARCH: arm64
+      RUN_RELEASE_BUILD: true
+    <<: *build-defaults
+    resource_class: 2xlarge
+
   electron-linux-ia32:
-    docker:
-      - image: electronbuilds/electron:0.0.7
-        environment:
-          TARGET_ARCH: ia32
-          DISPLAY: ':99.0'
-          ELECTRON_ENABLE_LOGGING: 'true'
+    environment:
+      TARGET_ARCH: ia32
+      DISPLAY: ':99.0'
+      RUN_TESTS: true
+      RUN_HEADLESS_TESTS: true
+    <<: *build-defaults
     resource_class: xlarge
-    steps:
-      - checkout
-      - run:
-          name: Setup for headless testing
-          command: sh -e /etc/init.d/xvfb start
-      - run:
-          name: Check for release
-          command: |
-            if [ -n "${RUN_RELEASE_BUILD}" ]; then
-              echo 'release build triggered from api'
-              echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
-            fi
-      - run:
-         name: Bootstrap
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Bootstrapping Electron for release build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH
-           else
-              echo 'Bootstrapping Electron for debug build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-           fi
-      - run: npm run lint
-      - run:
-         name: Build
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Building Electron for release'
-              script/build.py -c R
-           else
-              echo 'Building Electron for debug'
-              script/build.py -c D
-           fi
-      - run:
-          name: Create distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ]; then
-                echo 'Creating Electron release distribution'
-                script/create-dist.py
-             else
-                echo 'Skipping create distribution because build is not for release'
-             fi
-      - run:
-          name: Upload distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
-                echo 'Uploading Electron release distribution to github releases'
-                script/upload.py
-             elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
-                echo 'Uploading Electron release distribution to s3'
-                script/upload.py --upload_to_s3
-             else
-                echo 'Skipping upload distribution because build is not for release'
-             fi
-      - run:
-          name: Test
-          environment:
-            MOCHA_FILE: junit/test-results.xml
-            MOCHA_REPORTER: mocha-junit-reporter
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Testing Electron debug build'
-                out/D/electron --version
-                mkdir junit
-                script/test.py --ci --rebuild_native_modules
-             else
-                echo 'Skipping testing on release build'
-             fi
-      - run:
-          name: Verify FFmpeg
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Verifying ffmpeg on debug build'
-                script/verify-ffmpeg.py
-             else
-                echo 'Skipping verify ffmpeg on release build'
-             fi
-      - store_test_results:
-          path: junit
-      - store_artifacts:
-          path: junit
+
+  electron-linux-ia32-release-nightly:
+    environment:
+      TARGET_ARCH: ia32
+      RUN_RELEASE_BUILD: true
+    <<: *build-defaults
+    resource_class: xlarge
+
   electron-linux-mips64el:
-    docker:
-      - image: electronbuilds/electron:0.0.7
-        environment:
-          TARGET_ARCH: mips64el
+    environment:
+      TARGET_ARCH: mips64el
+    <<: *build-defaults
     resource_class: xlarge
-    steps:
-      - checkout
-      - run:
-          name: Check for release
-          command: |
-            if [ -n "${RUN_RELEASE_BUILD}" ]; then
-              echo 'release build triggered from api'
-              echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
-            fi
-      - run:
-         name: Bootstrap
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Bootstrapping Electron for release build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH
-           else
-              echo 'Bootstrapping Electron for debug build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-           fi
-      - run: npm run lint
-      - run:
-         name: Build
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Building Electron for release'
-              script/build.py -c R
-           else
-              echo 'Building Electron for debug'
-              script/build.py -c D
-           fi
-      - run:
-          name: Create distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ]; then
-                echo 'Creating Electron release distribution'
-                script/create-dist.py
-             else
-                echo 'Skipping create distribution because build is not for release'
-             fi
-      - run:
-          name: Upload distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
-                echo 'Uploading Electron release distribution to github releases'
-                script/upload.py
-             elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
-                echo 'Uploading Electron release distribution to s3'
-                script/upload.py --upload_to_s3
-             else
-                echo 'Skipping upload distribution because build is not for release'
-             fi
 
   electron-linux-x64:
-    docker:
-      - image: electronbuilds/electron:0.0.7
-        environment:
-          TARGET_ARCH: x64
-          DISPLAY: ':99.0'
+    environment:
+      TARGET_ARCH: x64
+      DISPLAY: ':99.0'
+      RUN_TESTS: true
+      RUN_HEADLESS_TESTS: true
+      CREATE_TYPESCRIPT_DEFS: true
+    <<: *build-defaults
     resource_class: xlarge
-    steps:
-      - checkout
-      - run:
-          name: Setup for headless testing
-          command: sh -e /etc/init.d/xvfb start
-      - run:
-          name: Check for release
-          command: |
-            if [ -n "${RUN_RELEASE_BUILD}" ]; then
-              echo 'release build triggered from api'
-              echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
-            fi
-      - run:
-         name: Bootstrap
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Bootstrapping Electron for release build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH
-           else
-              echo 'Bootstrapping Electron for debug build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-           fi
-      - run: npm run lint
-      - run:
-         name: Build
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Building Electron for release'
-              script/build.py -c R
-           else
-              echo 'Building Electron for debug'
-              script/build.py -c D
-           fi
-      - run:
-          name: Create distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ]; then
-                echo 'Creating Electron release distribution'
-                script/create-dist.py
-             else
-                echo 'Skipping create distribution because build is not for release'
-             fi
-      - run:
-          name: Upload distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
-                echo 'Uploading Electron release distribution to github releases'
-                script/upload.py
-             elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
-                echo 'Uploading Electron release distribution to s3'
-                script/upload.py --upload_to_s3
-             else
-                echo 'Skipping upload distribution because build is not for release'
-             fi
-      - run:
-          name: Test
-          environment:
-            MOCHA_FILE: junit/test-results.xml
-            MOCHA_REPORTER: mocha-junit-reporter
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Testing Electron debug build'
-                mkdir junit
-                script/test.py --ci --rebuild_native_modules
-             else
-                echo 'Skipping testing on release build'
-             fi
-      - run:
-          name: Verify FFmpeg
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Verifying ffmpeg on debug build'
-                script/verify-ffmpeg.py
-             else
-                echo 'Skipping verify ffmpeg on release build'
-             fi
-      - run:
-          name: Generate Typescript Definitions
-          command: npm run create-typescript-definitions
-      - store_test_results:
-          path: junit
-      - store_artifacts:
-          path: junit
-      - store_artifacts:
-          path: out/electron.d.ts
-      - store_artifacts:
-          path: out/electron-api.json
+
+  electron-linux-x64-release-nightly:
+    environment:
+      TARGET_ARCH: x64
+      RUN_RELEASE_BUILD: true
+    <<: *build-defaults
+    resource_class: xlarge
 
   electron-osx-x64:
     environment:
       TARGET_ARCH: x64
+      RUN_TESTS: true
     macos:
-        xcode: "9.0"
-    resource_class: xlarge
-    steps:
-      - checkout
-      - run:
-          name: Reclaim disk space
-          command: |
-            df -h
-            sudo rm -rf /Library/Developer/CoreSimulator
-            df -h
-            sysctl -n hw.ncpu
-      - run:
-          name: Check for release
-          command: |
-            if [ -n "${RUN_RELEASE_BUILD}" ]; then
-              echo 'release build triggered from api'
-              echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
-            fi
-      - run:
-         name: Bootstrap
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Bootstrapping Electron for release build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH
-           else
-              echo 'Bootstrapping Electron for debug build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-           fi
-      - run: npm run lint
-      - run:
-         name: Build
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Building Electron for release'
-              script/build.py -c R
-           else
-              echo 'Building Electron for debug'
-              script/build.py -c D
-           fi
-      - run:
-          name: Create distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ]; then
-                echo 'Creating Electron release distribution'
-                script/create-dist.py
-             else
-                echo 'Skipping create distribution because build is not for release'
-             fi
-      - run:
-          name: Upload distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
-                echo 'Uploading Electron release distribution to github releases'
-                script/upload.py
-             elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
-                echo 'Uploading Electron release distribution to s3'
-                script/upload.py --upload_to_s3
-             else
-                echo 'Skipping upload distribution because build is not for release'
-             fi
-      - run:
-          name: Test
-          environment:
-            MOCHA_FILE: junit/test-results.xml
-            MOCHA_REPORTER: mocha-junit-reporter
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Testing Electron debug build'
-                mkdir junit
-                script/test.py --ci --rebuild_native_modules
-             else
-                echo 'Skipping testing on release build'
-             fi
-      - run:
-          name: Verify FFmpeg
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Verifying ffmpeg on debug build'
-                script/verify-ffmpeg.py
-             else
-                echo 'Skipping verify ffmpeg on release build'
-             fi
-      - run:
-          name: Generate Typescript Definitions
-          command: npm run create-typescript-definitions
-      - store_test_results:
-          path: junit
-      - store_artifacts:
-          path: junit
-      - store_artifacts:
-          path: out/electron.d.ts
-      - store_artifacts:
-          path: out/electron-api.json
+      xcode: "9.0"
+    <<: *build-steps
+
+  electron-osx-x64-release-nightly:
+    environment:
+      TARGET_ARCH: x64
+      RUN_RELEASE_BUILD: true
+    macos:
+      xcode: "9.0"
+    <<: *build-steps
 
   electron-mas-x64:
     environment:
       TARGET_ARCH: x64
       MAS_BUILD: 1
+      RUN_TESTS: true
     macos:
-        xcode: "9.0"
-    resource_class: xlarge
-    steps:
-      - checkout
-      - run:
-          name: Reclaim disk space
-          command: |
-            df -h
-            sudo rm -rf /Library/Developer/CoreSimulator
-            df -h
-            sysctl -n hw.ncpu
-      - run:
-          name: Check for release
-          command: |
-            if [ -n "${RUN_RELEASE_BUILD}" ]; then
-              echo 'release build triggered from api'
-              echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
-            fi
-      - run:
-         name: Bootstrap
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Bootstrapping Electron for release build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH
-           else
-              echo 'Bootstrapping Electron for debug build'
-              script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-           fi
-      - run: npm run lint
-      - run:
-         name: Build
-         command: |
-           if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Building Electron for release'
-              script/build.py -c R
-           else
-              echo 'Building Electron for debug'
-              script/build.py -c D
-           fi
-      - run:
-          name: Create distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ]; then
-                echo 'Creating Electron release distribution'
-                script/create-dist.py
-             else
-                echo 'Skipping create distribution because build is not for release'
-             fi
-      - run:
-          name: Upload distribution
-          command: |
-             if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
-                echo 'Uploading Electron release distribution to github releases'
-                script/upload.py
-             elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
-                echo 'Uploading Electron release distribution to s3'
-                script/upload.py --upload_to_s3
-             else
-                echo 'Skipping upload distribution because build is not for release'
-             fi
-      - run:
-          name: Test
-          environment:
-            MOCHA_FILE: junit/test-results.xml
-            MOCHA_REPORTER: mocha-junit-reporter
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Testing Electron debug build'
-                mkdir junit
-                script/test.py --ci --rebuild_native_modules
-             else
-                echo 'Skipping testing on release build'
-             fi
-      - run:
-          name: Verify FFmpeg
-          command: |
-             if [ "$ELECTRON_RELEASE" != "1" ]; then
-                echo 'Verifying ffmpeg on debug build'
-                script/verify-ffmpeg.py
-             else
-                echo 'Skipping verify ffmpeg on release build'
-             fi
-      - run:
-          name: Generate Typescript Definitions
-          command: npm run create-typescript-definitions
-      - store_test_results:
-          path: junit
-      - store_artifacts:
-          path: junit
-      - store_artifacts:
-          path: out/electron.d.ts
-      - store_artifacts:
-          path: out/electron-api.json
+      xcode: "9.0"
+    <<: *build-steps
+
+  electron-mas-x64-release-nightly:
+    environment:
+      TARGET_ARCH: x64
+      MAS_BUILD: 1
+      RUN_RELEASE_BUILD: true
+    macos:
+      xcode: "9.0"
+    <<: *build-steps
+
 
 workflows:
   version: 2
@@ -652,3 +294,20 @@ workflows:
   build-mas-x64:
     jobs:
       - electron-mas-x64
+
+  nightly-release-test:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - 2-0-x
+                - 1-8-x
+                - 1-7-x
+    jobs:
+      - electron-linux-arm-release-nightly
+      - electron-linux-arm64-release-nightly
+      - electron-linux-ia32-release-nightly
+      - electron-linux-x64-release-nightly

--- a/vsts.yml
+++ b/vsts.yml
@@ -1,0 +1,68 @@
+resources:
+- repo: self
+steps:
+- bash: |
+    if [ "$ELECTRON_RELEASE" == "1" ]; then
+      echo 'Bootstrapping Electron for release build'
+      script/bootstrap.py --target_arch=$TARGET_ARCH
+    else
+      echo 'Bootstrapping Electron for debug build'
+      script/bootstrap.py --target_arch=$TARGET_ARCH --dev
+    fi
+  name: Bootstrap
+
+- bash: |
+    npm run lint
+  name: Lint
+  condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
+
+- bash: |
+    if [ "$ELECTRON_RELEASE" == "1" ]; then
+      echo 'Building Electron for release'
+      script/build.py -c R
+    else
+      echo 'Building Electron for debug'
+      script/build.py -c D
+    fi
+  name: Build
+
+- bash: |
+    echo 'Creating Electron release distribution'
+    script/create-dist.py
+  name: Create_distribution
+  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
+
+- bash: |
+    if [ "$TRIGGERED_BY_API" != "1" ]; then
+      echo 'Uploading Electron release distribution to github releases'
+      ELECTRON_S3_BUCKET="$(s3_bucket)" ELECTRON_S3_ACCESS_KEY="$(s3_access_key)" ELECTRON_S3_SECRET_KEY="$(s3_secret_key)" ELECTRON_GITHUB_TOKEN="$(github_token)" script/upload.py
+    else
+      echo 'Uploading Electron release distribution to s3'
+      ELECTRON_S3_BUCKET="$(s3_bucket)" ELECTRON_S3_ACCESS_KEY="$(s3_access_key)" ELECTRON_S3_SECRET_KEY="$(s3_secret_key)" ELECTRON_GITHUB_TOKEN="$(github_token)" script/upload.py --upload_to_s3
+    fi
+  name: Upload_distribution
+  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
+
+- bash: |
+    echo 'Testing Electron debug build'
+    mkdir junit
+    export MOCHA_FILE="junit/test-results.xml"
+    export MOCHA_REPORTER="mocha-junit-reporter"
+    script/test.py --ci
+  name: Test
+  condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
+
+- bash: |
+    echo 'Verifying ffmpeg on debug build'
+    script/verify-ffmpeg.py
+  name: Verify_FFmpeg
+  condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
+
+- task: PublishTestResults@2
+  displayName: Publish Test Results
+  inputs:
+    testResultsFiles: 'test-results.xml'
+    searchFolder: junit
+  condition: and(always(), ne(variables['ELECTRON_RELEASE'], '1'))
+
+- task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3


### PR DESCRIPTION
This PR updates our CI platforms to better support nightly release builds.  Additionally, it adds a timestamp to s3 release uploads so that we have an archive of nightly releases.

The current plan is run the nightly release builds as follows:

- Linux - CircleCI
- MacOS - VSTS
- Windows -Appveyor

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->