### PR TITLE
Update copy_vcruntime_binaries for VS2017

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -15,6 +15,7 @@ from lib.config import BASE_URL, PLATFORM, enable_verbose_mode, \
                        get_target_arch, get_zip_name, build_env
 from lib.util import scoped_cwd, rm_rf, get_electron_version, make_zip, \
                      execute, electron_gyp, electron_features
+from lib.env_util import get_vs_location
 
 
 ELECTRON_VERSION = get_electron_version()
@@ -146,22 +147,20 @@ def copy_chrome_binary(binary):
   os.chmod(dest, os.stat(dest).st_mode | stat.S_IEXEC)
 
 def copy_vcruntime_binaries():
-  with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
-                       r"SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VC", 0,
-                       _winreg.KEY_READ | _winreg.KEY_WOW64_32KEY) as key:
-    crt_dir = _winreg.QueryValueEx(key, "ProductDir")[0]
+  vs_location = get_vs_location('[15.0,16.0)')
 
   arch = get_target_arch()
   if arch == "ia32":
     arch = "x86"
 
-  crt_dir += r"redist\{0}\Microsoft.VC140.CRT\\".format(arch)
+  crt_dir = os.path.join(vs_location, 'VC', 'Redist', 'MSVC', '14.13.26020',
+                          arch, 'Microsoft.VC141.CRT')
 
   dlls = ["msvcp140.dll", "vcruntime140.dll"]
 
   # Note: copyfile is used to remove the read-only flag
   for dll in dlls:
-    shutil.copyfile(crt_dir + dll, os.path.join(DIST_DIR, dll))
+    shutil.copyfile(os.path.join(crt_dir, dll), os.path.join(DIST_DIR, dll))
     TARGET_BINARIES_EXT.append(dll)
 
 

--- a/script/lib/env_util.py
+++ b/script/lib/env_util.py
@@ -58,6 +58,29 @@ def get_environment_from_batch_command(env_cmd, initial=None):
   proc.communicate()
   return result
 
+def get_vs_location(vs_version):
+    """
+    Returns the location of the VS building environment.
+
+    The vs_version can be strings like "[15.0,16.0)", meaning 2017, but not the next version.
+    The arch has to be one of "x86", "amd64", "arm", "x86_amd64", "x86_arm", "amd64_x86",
+    "amd64_arm", e.g. the args passed to vcvarsall.bat.
+    """
+
+    # vswhere can't handle spaces, like "[15.0, 16.0)" should become "[15.0,16.0)"
+    vs_version = vs_version.replace(" ", "")
+
+    # Find visual studio
+    proc = subprocess.Popen(
+      "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe "
+      "-property installationPath "
+      "-requires Microsoft.VisualStudio.Component.VC.CoreIde "
+      "-format value "
+      "-version {0}".format(vs_version),
+      stdout=subprocess.PIPE)
+
+    location = proc.stdout.readline().rstrip()
+    return location
 
 def get_vs_env(vs_version, arch):
   """
@@ -68,19 +91,7 @@ def get_vs_env(vs_version, arch):
   "amd64_arm", e.g. the args passed to vcvarsall.bat.
   """
 
-  # vswhere can't handle spaces, like "[15.0, 16.0)" should become "[15.0,16.0)"
-  vs_version = vs_version.replace(" ", "")
-
-  # Find visual studio
-  proc = subprocess.Popen(
-    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe "
-    "-property installationPath "
-    "-requires Microsoft.VisualStudio.Component.VC.CoreIde "
-    "-format value "
-    "-version {0}".format(vs_version),
-    stdout=subprocess.PIPE)
-  
-  location = proc.stdout.readline().rstrip()
+  location = get_vs_location(vs_version)
 
   # Launch the process.
   vsvarsall = "{0}\\VC\\Auxiliary\\Build\\vcvarsall.bat".format(location)


### PR DESCRIPTION
Release builds were failing on VS 2017 only installations during the `create-dist.py` script while running 
copy_vcruntime_binaries.  This PR updates the `create-dist.py` script to copy the runtime files from the proper location for VS2017.  cc @alespergl who originally added this functionality.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->