### PR TITLE
Do not capture cookies and credentials in net log

### DIFF
--- a/brightray/browser/net_log.cc
+++ b/brightray/browser/net_log.cc
@@ -50,8 +50,7 @@ void NetLog::StartLogging() {
   base::FilePath log_path =
       command_line->GetSwitchValuePath(switches::kLogNetLog);
   std::unique_ptr<base::Value> constants(GetConstants());
-  net::NetLogCaptureMode capture_mode =
-      net::NetLogCaptureMode::IncludeCookiesAndCredentials();
+  net::NetLogCaptureMode capture_mode = net::NetLogCaptureMode::Default();
 
   file_net_log_observer_ =
       net::FileNetLogObserver::CreateUnbounded(log_path, std::move(constants));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Should fix a regression issue since v2.0.0 that began logging cookies and credentials in the net log dump.

Example before:

```
{"params":{"headers":["Host: electronjs.org","Connection: keep-alive","Upgrade-Insecure-Requests: 1","User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.150 Electron/0.0.0-dev Safari/537.36","Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8","Accept-Encoding: gzip, deflate","Accept-Language: en-US","Cookie: _ga=GA1.2.841154891.1527180598; _gid=GA1.2.1425473778.1527180598","If-None-Match: W/\"fa71-1YHlWm/t2URUlWiRjYQEfcqoWdk\""],"line":"GET /blog HTTP/1.1\r\n"},"phase":0,"source":{"id":7,"type":1},"time":"66290013","type":152},
```

Example after (with `[64 bytes were stripped]`):

```
{"params":{"headers":["Host: electronjs.org","Connection: keep-alive","Upgrade-Insecure-Requests: 1","User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.150 Electron/0.0.0-dev Safari/537.36","Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8","Accept-Encoding: gzip, deflate","Accept-Language: en-US","Cookie: [64 bytes were stripped]","If-None-Match: W/\"fa71-1YHlWm/t2URUlWiRjYQEfcqoWdk\""],"line":"GET /blog HTTP/1.1\r\n"},"phase":0,"source":{"id":7,"type":1},"time":"66386714","type":152},
```