### PR TITLE
fix: Update broken dock link in app doc

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1147,7 +1147,7 @@ Sets the `image` associated with this dock icon.
 
 A `Boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.
 
-[dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103
+[dock-menu]:https://developer.apple.com/macos/human-interface-guidelines/menus/dock-menus/
 [tasks]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [CFBundleURLTypes]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102207-TPXREF115


### PR DESCRIPTION
The link we have about Dock menu (macOS) in [app.md](https://github.com/electron/electron/blob/master/docs/api/app.md#appdocksetmenumenu-macos) is broken and the page on Apple docs seems removed rather than being moved to somewhere else on their docs. So I have replaced the broken link with Dock Menus page on Apple's Human Interface Guidelines to indicate what we mean by "dock menu".