### PR TITLE
fix wrapping of welcome comment

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -12,11 +12,7 @@ newIssueWelcomeComment: |
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
 
-  We use 
-  [semantic commit messages](https://github.com/electron/electron/blob/semantic-first-pr/docs/development/pull-requests.md#commit-message-guidelines) 
-  to streamline the release process. Before your pull request can be merged, you 
-  should **update your pull request title** to start with a semantic prefix, 
-  OR prefix at least one of your commit messages.
+  We use [semantic commit messages](https://github.com/electron/electron/blob/semantic-first-pr/docs/development/pull-requests.md#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix, OR prefix at least one of your commit messages.
 
   Examples of commit messages with semantic prefixes:
 


### PR DESCRIPTION
This PR fixes line wrapping of the welcome bot first-time PR comment.

https://github.com/electron/electron/pull/13063#issuecomment-391750656 is an example of what this will fix:

![image](https://user-images.githubusercontent.com/2289/40509026-b3be4692-5f4d-11e8-93e1-6e65208713fb.png)
