### PR TITLE
feat: Add method to get/set offscreen window's scale factor

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -87,6 +87,10 @@ TopLevelWindow::TopLevelWindow(v8::Isolate* isolate,
       web_preferences.Get("offscreen", &offscreen) && offscreen) {
     const_cast<mate::Dictionary&>(options).Set(options::kFrame, false);
   }
+
+  v8::Local<v8::Value> scaleFactor;
+  if (options.Get("scaleFactor", &scaleFactor))
+    web_preferences.Set("scaleFactor", scaleFactor);
 #endif
 
   // Creates NativeWindow.

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -310,9 +310,9 @@ void OnCapturePageDone(const base::Callback<void(const gfx::Image&)>& callback,
   callback.Run(gfx::Image::CreateFrom1xBitmap(bitmap));
 }
 
-void ScaleWebMouseEvent(blink::WebMouseEvent& event, float scale) {
-  blink::WebFloatPoint pos = event.PositionInWidget();
-  event.SetPositionInWidget(round(pos.x / scale), round(pos.y / scale));
+void ScaleWebMouseEvent(blink::WebMouseEvent* event, float scale) {
+  blink::WebFloatPoint pos = event->PositionInWidget();
+  event->SetPositionInWidget(round(pos.x / scale), round(pos.y / scale));
 }
 
 }  // namespace
@@ -1635,7 +1635,7 @@ void WebContents::SendInputEvent(v8::Isolate* isolate,
   if (blink::WebInputEvent::IsMouseEventType(type)) {
     blink::WebMouseEvent mouse_event;
     if (mate::ConvertFromV8(isolate, input_event, &mouse_event)) {
-      ScaleWebMouseEvent(mouse_event, scale);
+      ScaleWebMouseEvent(&mouse_event, scale);
       view->ProcessMouseEvent(mouse_event, ui::LatencyInfo());
       return;
     }
@@ -1650,7 +1650,7 @@ void WebContents::SendInputEvent(v8::Isolate* isolate,
   } else if (type == blink::WebInputEvent::kMouseWheel) {
     blink::WebMouseWheelEvent mouse_wheel_event;
     if (mate::ConvertFromV8(isolate, input_event, &mouse_wheel_event)) {
-      ScaleWebMouseEvent(mouse_wheel_event, scale);
+      ScaleWebMouseEvent(&mouse_wheel_event, scale);
       view->ProcessMouseWheelEvent(mouse_wheel_event, ui::LatencyInfo());
       return;
     }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -209,6 +209,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetFrameRate(int frame_rate);
   int GetFrameRate() const;
   void Invalidate();
+  void SetScaleFactor(float factor);
+  float GetScaleFactor();
   gfx::Size GetSizeForNewRenderView(content::WebContents*) const override;
 
   // Methods for zoom handling.

--- a/atom/browser/osr/osr_output_device.cc
+++ b/atom/browser/osr/osr_output_device.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/osr/osr_output_device.h"
 
+#include "atom/browser/osr/osr_render_widget_host_view.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/src/core/SkDevice.h"
@@ -11,11 +12,10 @@
 
 namespace atom {
 
-OffScreenOutputDevice::OffScreenOutputDevice(bool transparent,
-                                             const OnPaintCallback& callback)
-    : transparent_(transparent), callback_(callback) {
-  DCHECK(!callback_.is_null());
-}
+OffScreenOutputDevice::OffScreenOutputDevice(
+    OffScreenRenderWidgetHostView* view,
+    bool transparent)
+    : view_(view), transparent_(transparent) {}
 
 OffScreenOutputDevice::~OffScreenOutputDevice() {}
 
@@ -95,7 +95,7 @@ void OffScreenOutputDevice::OnPaint(const gfx::Rect& damage_rect) {
   if (rect.IsEmpty())
     return;
 
-  callback_.Run(rect, *bitmap_);
+  view_->OnPaint(rect, *bitmap_);
 }
 
 }  // namespace atom

--- a/atom/browser/osr/osr_output_device.h
+++ b/atom/browser/osr/osr_output_device.h
@@ -12,11 +12,11 @@
 
 namespace atom {
 
-typedef base::Callback<void(const gfx::Rect&, const SkBitmap&)> OnPaintCallback;
+class OffScreenRenderWidgetHostView;
 
 class OffScreenOutputDevice : public viz::SoftwareOutputDevice {
  public:
-  OffScreenOutputDevice(bool transparent, const OnPaintCallback& callback);
+  OffScreenOutputDevice(OffScreenRenderWidgetHostView* view, bool transparent);
   ~OffScreenOutputDevice() override;
 
   // viz::SoftwareOutputDevice:
@@ -28,8 +28,8 @@ class OffScreenOutputDevice : public viz::SoftwareOutputDevice {
   void OnPaint(const gfx::Rect& damage_rect);
 
  private:
+  OffScreenRenderWidgetHostView* view_;
   const bool transparent_;
-  OnPaintCallback callback_;
 
   bool active_ = false;
 

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -116,7 +116,7 @@ ui::MouseWheelEvent UiMouseWheelEventFromWebMouseEvent(
 
 class AtomCopyFrameGenerator {
  public:
-  AtomCopyFrameGenerator(OffScreenRenderWidgetHostView* view)
+  explicit AtomCopyFrameGenerator(OffScreenRenderWidgetHostView* view)
       : view_(view), weak_ptr_factory_(this) {}
 
   void GenerateCopyFrame(const gfx::Rect& damage_rect) {

--- a/atom/browser/osr/osr_view_proxy.cc
+++ b/atom/browser/osr/osr_view_proxy.cc
@@ -32,10 +32,10 @@ const SkBitmap* OffscreenViewProxy::GetBitmap() const {
 }
 
 void OffscreenViewProxy::SetBitmap(const SkBitmap& bitmap) {
-  if (view_bounds_.width() == bitmap.width() &&
-      view_bounds_.height() == bitmap.height() && observer_) {
+  if (GetBoundsScaled().width() == bitmap.width() &&
+      GetBoundsScaled().height() == bitmap.height() && observer_) {
     view_bitmap_.reset(new SkBitmap(bitmap));
-    observer_->OnProxyViewPaint(view_bounds_);
+    observer_->OnProxyViewPaint(GetBoundsScaled());
   }
 }
 
@@ -43,8 +43,23 @@ const gfx::Rect& OffscreenViewProxy::GetBounds() {
   return view_bounds_;
 }
 
+gfx::Rect OffscreenViewProxy::GetBoundsScaled() {
+  return gfx::Rect(std::floor(view_bounds_.x() * scale_factor_),
+                   std::floor(view_bounds_.y() * scale_factor_),
+                   std::floor(view_bounds_.width() * scale_factor_),
+                   std::floor(view_bounds_.height() * scale_factor_));
+}
+
 void OffscreenViewProxy::SetBounds(const gfx::Rect& bounds) {
   view_bounds_ = bounds;
+}
+
+float OffscreenViewProxy::GetScaleFactor() {
+  return scale_factor_;
+}
+
+void OffscreenViewProxy::SetScaleFactor(float scale) {
+  scale_factor_ = scale;
 }
 
 void OffscreenViewProxy::OnEvent(ui::Event* event) {

--- a/atom/browser/osr/osr_view_proxy.h
+++ b/atom/browser/osr/osr_view_proxy.h
@@ -34,7 +34,11 @@ class OffscreenViewProxy {
   void SetBitmap(const SkBitmap& bitmap);
 
   const gfx::Rect& GetBounds();
+  gfx::Rect GetBoundsScaled();
   void SetBounds(const gfx::Rect& bounds);
+
+  float GetScaleFactor();
+  void SetScaleFactor(float scale);
 
   void OnEvent(ui::Event* event);
 
@@ -44,6 +48,7 @@ class OffscreenViewProxy {
   views::View* view_;
 
   gfx::Rect view_bounds_;
+  float scale_factor_ = 1.0;
   std::unique_ptr<SkBitmap> view_bitmap_;
 
   OffscreenViewProxyObserver* observer_ = nullptr;

--- a/atom/browser/osr/osr_web_contents_view.h
+++ b/atom/browser/osr/osr_web_contents_view.h
@@ -23,7 +23,9 @@ namespace atom {
 class OffScreenWebContentsView : public content::WebContentsView,
                                  public content::RenderViewHostDelegateView {
  public:
-  OffScreenWebContentsView(bool transparent, const OnPaintCallback& callback);
+  OffScreenWebContentsView(bool transparent,
+                           float scale_factor,
+                           const OnPaintCallback& callback);
   ~OffScreenWebContentsView() override;
 
   void SetWebContents(content::WebContents*);
@@ -52,6 +54,9 @@ class OffScreenWebContentsView : public content::WebContentsView,
   void RenderViewSwappedIn(content::RenderViewHost* host) override;
   void SetOverscrollControllerEnabled(bool enabled) override;
   void GetScreenInfo(content::ScreenInfo* screen_info) const override;
+
+  void SetScaleFactor(float factor);
+  float GetScaleFactor();
 
 #if defined(OS_MACOSX)
   void SetAllowOtherViews(bool allow) override;
@@ -85,6 +90,7 @@ class OffScreenWebContentsView : public content::WebContentsView,
   const bool transparent_;
   bool painting_ = true;
   int frame_rate_ = 60;
+  float scale_factor_;
   OnPaintCallback callback_;
 
   // Weak refs.

--- a/atom/browser/ui/autofill_popup.cc
+++ b/atom/browser/ui/autofill_popup.cc
@@ -198,9 +198,13 @@ void AutofillPopup::UpdatePopupBounds() {
   popup_bounds_ =
       gfx::Rect(popup_x_and_width.first, popup_y_and_height.first,
                 popup_x_and_width.second, popup_y_and_height.second);
-  popup_bounds_in_view_ =
-      gfx::Rect(popup_bounds_in_view_.origin(),
-                gfx::Size(popup_x_and_width.second, popup_y_and_height.second));
+}
+
+gfx::Rect AutofillPopup::popup_bounds_in_view() {
+  gfx::Point origin(popup_bounds_.origin());
+  views::View::ConvertPointFromScreen(parent_, &origin);
+
+  return gfx::Rect(origin, popup_bounds_.size());
 }
 
 void AutofillPopup::OnViewBoundsChanged(views::View* view) {
@@ -241,11 +245,25 @@ gfx::Rect AutofillPopup::GetRowBounds(int index) {
                    kRowHeight);
 }
 
-const gfx::FontList& AutofillPopup::GetValueFontListForRow(int index) const {
+const gfx::FontList AutofillPopup::GetValueFontListForRow(int index) const {
+#if defined(ENABLE_OSR)
+  if (view_) {
+    int delta = -std::ceil(bold_font_list_.GetFontSize() *
+                           (1.0f - view_->ScaleFactor()));
+    return bold_font_list_.DeriveWithSizeDelta(delta);
+  }
+#endif
   return bold_font_list_;
 }
 
-const gfx::FontList& AutofillPopup::GetLabelFontListForRow(int index) const {
+const gfx::FontList AutofillPopup::GetLabelFontListForRow(int index) const {
+#if defined(ENABLE_OSR)
+  if (view_) {
+    int delta = -std::ceil(smaller_font_list_.GetFontSize() *
+                           (1.0f - view_->ScaleFactor()));
+    return smaller_font_list_.DeriveWithSizeDelta(delta);
+  }
+#endif
   return smaller_font_list_;
 }
 

--- a/atom/browser/ui/autofill_popup.h
+++ b/atom/browser/ui/autofill_popup.h
@@ -33,6 +33,8 @@ class AutofillPopup : public views::ViewObserver {
                 const std::vector<base::string16>& labels);
   void UpdatePopupBounds();
 
+  gfx::Rect popup_bounds_in_view();
+
  private:
   friend class AutofillPopupView;
 
@@ -45,8 +47,8 @@ class AutofillPopup : public views::ViewObserver {
   int GetDesiredPopupHeight();
   int GetDesiredPopupWidth();
   gfx::Rect GetRowBounds(int i);
-  const gfx::FontList& GetValueFontListForRow(int index) const;
-  const gfx::FontList& GetLabelFontListForRow(int index) const;
+  const gfx::FontList GetValueFontListForRow(int index) const;
+  const gfx::FontList GetLabelFontListForRow(int index) const;
   ui::NativeTheme::ColorId GetBackgroundColorIDForRow(int index) const;
 
   int GetLineCount();

--- a/atom/browser/ui/views/autofill_popup_view.h
+++ b/atom/browser/ui/views/autofill_popup_view.h
@@ -73,6 +73,10 @@ class AutofillPopupView : public views::WidgetDelegateView,
                            const gfx::Point&,
                            const gfx::Point&) override;
 
+#if defined(ENABLE_OSR)
+  float ScaleFactor();
+#endif
+
  private:
   friend class AutofillPopup;
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -335,6 +335,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       window. Defaults to `false`. See the
       [offscreen rendering tutorial](../tutorial/offscreen-rendering.md) for
       more details.
+    * `scaleFactor` Number (optional) - The scale factor to use in offscreen rendering mode. The default value is `1.0`.
     * `contextIsolation` Boolean (optional) - Whether to run Electron APIs and
       the specified `preload` script in a separate JavaScript context. Defaults
       to `false`. The context that the `preload` script runs in will still

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1452,11 +1452,21 @@ Returns `Boolean` - If *offscreen rendering* is enabled returns whether it is cu
 * `fps` Integer
 
 If *offscreen rendering* is enabled sets the frame rate to the specified number.
-Only values between 1 and 60 are accepted.
+Only values between 1 and 240 are accepted.
 
 #### `contents.getFrameRate()`
 
 Returns `Integer` - If *offscreen rendering* is enabled returns the current frame rate.
+
+#### `contents.setScaleFactor(scaleFactor)`
+
+* `scaleFactor` Number
+
+If *offscreen rendering* is enabled sets the scale factor to the specified number.
+
+#### `contents.getScaleFactor()`
+
+Returns `Number` - If *offscreen rendering* is enabled returns the current scale factor.
 
 #### `contents.invalidate()`
 
@@ -1499,7 +1509,7 @@ process.
 
 Returns `Integer` - The chromium internal `pid` of the associated renderer. Can
 be compared to the `frameProcessId` passed by frame specific navigation events
-(e.g. `did-frame-navigate`) 
+(e.g. `did-frame-navigate`)
 
 ### Instance Properties
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -3222,6 +3222,29 @@ describe('BrowserWindow module', () => {
         w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
       })
     })
+
+    describe('window.webContents.getScaleFactor()', () => {
+      it('has default scale factor', (done) => {
+        w.webContents.once('paint', function (event, rect, data) {
+          assert.equal(w.webContents.getScaleFactor(), 1.0)
+          done()
+        })
+        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+      })
+    })
+
+    describe('window.webContents.setScaleFactor(scaleFactor)', () => {
+      it('sets custom scale factor', (done) => {
+        w.webContents.on('dom-ready', () => {
+          w.webContents.setScaleFactor(2.0)
+          w.webContents.once('paint', function (event, rect, data) {
+            assert.equal(w.webContents.getScaleFactor(), 2.0)
+            done()
+          })
+        })
+        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+      })
+    })
   })
 })
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This PR adds a `scaleFactor` field to `webPreferences`, and a `get/setScaleFactor` method to `browserWindow/webContents`. These allow you to control the scale factor, which was previously locked to `1.0`. 