### PR TITLE
fix: tray title not inverting when highlighted

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -403,6 +403,11 @@ const CGFloat kVerticalTitleMargin = 2;
   return YES;
 }
 
+- (void)setNeedsDisplay:(BOOL)display {
+  [self updateAttributedTitle];
+  [super setNeedsDisplay:display];
+}
+
 - (BOOL)shouldHighlight {
   switch (highlight_mode_) {
     case atom::TrayIcon::HighlightMode::ALWAYS:


### PR DESCRIPTION
Fixes #12960 

/cc @codebytere 

I didn't notice that you were assigned to this issue until after I started digging into it. Feel free to close this PR if you already have a fix in mind or if my fix seems unreasonable.   

I noticed that just adding `[self updateAttributedTitle];` in a few strategic places did the trick. However, I feel like it makes more sense to just update the attributed title whenever we redraw the icon. Probably less efficient this way though.
