### PR TITLE
docs : Fix tls.py script path

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -12,7 +12,7 @@ Follow the guidelines below for building Electron on Linux.
   For a quick test, run the following script:
 
   ```sh
-  $ python ./script/check-tls.py
+  $ python ./script/tls.py
   ```
 
   If the script returns that your configuration is using an outdated security

--- a/docs/development/build-instructions-osx.md
+++ b/docs/development/build-instructions-osx.md
@@ -15,7 +15,7 @@ Please also ensure that your system and Python version support at least TLS 1.2.
 This depends on both your version of macOS and Python. For a quick test, run:
 
 ```sh
-$ python ./script/check-tls.py
+$ python ./script/tls.py
 ```
 
 If the script returns that your configuration is using an outdated security


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

[Build instructions for Linux/OSX](https://electronjs.org/docs/development/build-instructions-osx) contains link to ```python ./script/check-tls.py``` but file was renamed from ```check-tls.py``` to ```tls.py``` in PR-12276. [Link to commit](https://github.com/electron/electron/pull/12276/commits/a9c5408a4f827618f3df585a7ca821341b829170#diff-8964578daf983cac667c7471090c134f)