### PR TITLE
feat: add deprecate.property()

### DIFF
--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -87,20 +87,27 @@ deprecate.getHandler = () => deprecationHandler
 //     return this[member][method].apply(this[member], arguments)
 //   }
 // }
-//
-// // Deprecate a property.
-// deprecate.property = (object, property, method) => {
-//   return Object.defineProperty(object, property, {
-//     get: function () {
-//       let warned = false
-//       if (!(warned || process.noDeprecation)) {
-//         warned = true
-//         deprecate.warn(`${property} property`, `${method} method`)
-//       }
-//       return this[method]()
-//     }
-//   })
-// }
-//
+
+// Deprecate the old name of a property
+deprecate.property = (object, deprecatedName, newName) => {
+  return Object.defineProperty(object, deprecatedName, {
+    get: function () {
+      let warned = false
+      if (!(warned || process.noDeprecation)) {
+        warned = true
+        deprecate.warn(deprecatedName, newName)
+      }
+      return this[newName]
+    },
+    set: function (value) {
+      let warned = false
+      if (!(warned || process.noDeprecation)) {
+        warned = true
+        deprecate.warn(deprecatedName, newName)
+      }
+      this[newName] = value
+    }
+  })
+}
 
 module.exports = deprecate

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -90,21 +90,27 @@ deprecate.getHandler = () => deprecationHandler
 
 // Deprecate the old name of a property
 deprecate.property = (object, deprecatedName, newName) => {
+  let warned = false
+  let warn = () => {
+    if (!(warned || process.noDeprecation)) {
+      warned = true
+      deprecate.warn(deprecatedName, newName)
+    }
+  }
+
+  if ((typeof object[newName] === 'undefined') &&
+      (typeof object[deprecatedName] !== 'undefined')) {
+    warn()
+    object[newName] = object[deprecatedName]
+  }
+
   return Object.defineProperty(object, deprecatedName, {
     get: function () {
-      let warned = false
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.warn(deprecatedName, newName)
-      }
+      warn()
       return this[newName]
     },
     set: function (value) {
-      let warned = false
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.warn(deprecatedName, newName)
-      }
+      warn()
       this[newName] = value
     }
   })

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -49,6 +49,30 @@ describe('deprecations', () => {
     assert.equal(typeof nativeImage.createFromDataUrl, 'function')
   })
 
+  it('renames a property', () => {
+    let msg
+    deprecations.setHandler((m) => { msg = m })
+
+    const oldPropertyName = 'dingyOldName'
+    const newPropertyName = 'shinyNewName'
+
+    let value = 0
+    let o = { [newPropertyName]: value }
+    assert.strictEqual(typeof o[oldPropertyName], 'undefined')
+    assert.strictEqual(typeof o[newPropertyName], 'number')
+
+    deprecate.property(o, oldPropertyName, newPropertyName)
+    assert.notEqual(typeof msg, 'string')
+    o[oldPropertyName] = ++value
+
+    assert.strictEqual(typeof msg, 'string')
+    assert.ok(msg.includes(oldPropertyName))
+    assert.ok(msg.includes(newPropertyName))
+
+    assert.strictEqual(o[newPropertyName], value)
+    assert.strictEqual(o[oldPropertyName], value)
+  })
+
   it('throws an exception if no deprecation handler is specified', () => {
     assert.throws(() => {
       deprecate.log('this is deprecated')

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -73,6 +73,22 @@ describe('deprecations', () => {
     assert.strictEqual(o[oldPropertyName], value)
   })
 
+  it('warns if deprecated property is already set', () => {
+    let msg
+    deprecations.setHandler((m) => { msg = m })
+
+    const oldPropertyName = 'dingyOldName'
+    const newPropertyName = 'shinyNewName'
+    const value = 0
+
+    let o = { [oldPropertyName]: value }
+    deprecate.property(o, oldPropertyName, newPropertyName)
+
+    assert.strictEqual(typeof msg, 'string')
+    assert.ok(msg.includes(oldPropertyName))
+    assert.ok(msg.includes(newPropertyName))
+  })
+
   it('throws an exception if no deprecation handler is specified', () => {
     assert.throws(() => {
       deprecate.log('this is deprecated')


### PR DESCRIPTION
Does what it says on the tin.

 - [x] re-add deprecate.property()
 - [x] add a property setter
 - [x] add getter & setter tests
 - [x] test to see if deprecated property is set when deprecate.property() is called

This is in preparation for planned object property deprecations in 3.0, e.g. `blinkFeatures` -> `enaleBlinkFeatures`

This eliminates copy-and-paste repetition for each deprecated property ([example](https://github.com/electron/electron/blob/master/lib/common/api/crash-reporter.js#L23)) but is a little more heavyweight, so I'd like a second opinion on this replacement.