### PR TITLE
fix: Windows build after ch66 rebase

### DIFF
--- a/atom/common/native_mate_converters/gfx_converter.cc
+++ b/atom/common/native_mate_converters/gfx_converter.cc
@@ -35,6 +35,28 @@ bool Converter<gfx::Point>::FromV8(v8::Isolate* isolate,
   return true;
 }
 
+v8::Local<v8::Value> Converter<gfx::PointF>::ToV8(v8::Isolate* isolate,
+                                                 const gfx::PointF& val) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
+  dict.Set("x", val.x());
+  dict.Set("y", val.y());
+  return dict.GetHandle();
+}
+
+bool Converter<gfx::PointF>::FromV8(v8::Isolate* isolate,
+                                   v8::Local<v8::Value> val,
+                                   gfx::PointF* out) {
+  mate::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+  float x, y;
+  if (!dict.Get("x", &x) || !dict.Get("y", &y))
+    return false;
+  *out = gfx::PointF(x, y);
+  return true;
+}
+
 v8::Local<v8::Value> Converter<gfx::Size>::ToV8(v8::Isolate* isolate,
                                                 const gfx::Size& val) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);

--- a/atom/common/native_mate_converters/gfx_converter.h
+++ b/atom/common/native_mate_converters/gfx_converter.h
@@ -6,6 +6,7 @@
 #define ATOM_COMMON_NATIVE_MATE_CONVERTERS_GFX_CONVERTER_H_
 
 #include "native_mate/converter.h"
+#include "ui/gfx/geometry/point_f.h"
 
 namespace display {
 class Display;
@@ -25,6 +26,14 @@ struct Converter<gfx::Point> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      gfx::Point* out);
+};
+
+template <>
+struct Converter<gfx::PointF> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const gfx::PointF& val);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     gfx::PointF* out);
 };
 
 template <>


### PR DESCRIPTION
Adding gfx::PointF support to mate::Converter which is needed by atom_api_screen, BuildPrototype function on Windows.

This is needed because BuildPrototype now contains several Windows specific functions and one of them returns gfx::PointF which was not handled by the converter.