### PR TITLE
refactor: add promise helper and change whenReady to be native impl

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1219,6 +1219,7 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getName", base::Bind(&Browser::GetName, browser))
       .SetMethod("setName", base::Bind(&Browser::SetName, browser))
       .SetMethod("isReady", base::Bind(&Browser::is_ready, browser))
+      .SetProperty("whenReady", base::Bind(&Browser::WhenReady, browser))
       .SetMethod("addRecentDocument",
                  base::Bind(&Browser::AddRecentDocument, browser))
       .SetMethod("clearRecentDocuments",

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1219,7 +1219,7 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getName", base::Bind(&Browser::GetName, browser))
       .SetMethod("setName", base::Bind(&Browser::SetName, browser))
       .SetMethod("isReady", base::Bind(&Browser::is_ready, browser))
-      .SetProperty("whenReady", base::Bind(&Browser::WhenReady, browser))
+      .SetMethod("whenReady", base::Bind(&Browser::WhenReady, browser))
       .SetMethod("addRecentDocument",
                  base::Bind(&Browser::AddRecentDocument, browser))
       .SetMethod("clearRecentDocuments",

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -15,6 +15,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/browser_observer.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/promise_util.h"
 #include "base/process/process_iterator.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "chrome/browser/icon_manager.h"

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -154,8 +154,21 @@ void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
     base::CreateDirectoryAndGetError(user_data, nullptr);
 
   is_ready_ = true;
+  if (ready_promise_) {
+    ready_promise_->Resolve();
+  }
   for (BrowserObserver& observer : observers_)
     observer.OnFinishLaunching(launch_info);
+}
+
+util::Promise* Browser::WhenReady(v8::Isolate* isolate) {
+  if (!ready_promise_) {
+    ready_promise_ = new util::Promise(isolate);
+    if (is_ready()) {
+      ready_promise_->Resolve();
+    }
+  }
+  return ready_promise_;
 }
 
 void Browser::OnAccessibilitySupportChanged() {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -278,7 +278,7 @@ class Browser : public WindowListObserver {
 
   int badge_count_ = 0;
 
-  util::Promise* ready_promise_;
+  util::Promise* ready_promise_ = nullptr;
 
 #if defined(OS_MACOSX)
   base::DictionaryValue about_panel_options_;

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -10,6 +10,7 @@
 
 #include "atom/browser/browser_observer.h"
 #include "atom/browser/window_list_observer.h"
+#include "atom/common/promise_util.h"
 #include "base/compiler_specific.h"
 #include "base/macros.h"
 #include "base/observer_list.h"
@@ -241,6 +242,7 @@ class Browser : public WindowListObserver {
   bool is_shutting_down() const { return is_shutdown_; }
   bool is_quiting() const { return is_quiting_; }
   bool is_ready() const { return is_ready_; }
+  util::Promise* WhenReady(v8::Isolate* isolate);
 
  protected:
   // Returns the version of application bundle or executable file.
@@ -275,6 +277,8 @@ class Browser : public WindowListObserver {
   bool is_shutdown_ = false;
 
   int badge_count_ = 0;
+
+  util::Promise* ready_promise_;
 
 #if defined(OS_MACOSX)
   base::DictionaryValue about_panel_options_;

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -10,12 +10,12 @@ namespace atom {
 
 namespace util {
 
-Promise* Promise::RejectWithErrorMessage(const std::string& string) {
+v8::Maybe<bool> Promise::RejectWithErrorMessage(const std::string& string) {
   v8::Local<v8::String> error_message =
       v8::String::NewFromUtf8(isolate(), string.c_str());
   v8::Local<v8::Value> error = v8::Exception::Error(error_message);
-  GetInner()->Reject(mate::ConvertToV8(isolate(), error));
-  return this;
+  return GetInner()->Reject(isolate()->GetCurrentContext(),
+                            mate::ConvertToV8(isolate(), error));
 }
 
 v8::Local<v8::Object> Promise::GetHandle() const {

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -8,19 +8,6 @@ namespace atom {
 
 namespace util {
 
-// Promise::Promise()
-//     : isolate_(NULL) {
-// }
-
-// Promise::Promise(v8::Isolate* isolate)
-//     : isolate_(isolate) {
-//   resolver_.Reset(isolate, v8::Promise::Resolver::New(isolate));
-// }
-
-// Promise::~Promise() {
-//   resolver_.Reset();
-// }
-
 Promise* Promise::RejectWithErrorMessage(const std::string& string) {
   v8::Local<v8::String> error_message =
       v8::String::NewFromUtf8(isolate(), string.c_str());

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -12,12 +12,12 @@ Promise* Promise::RejectWithErrorMessage(const std::string& string) {
   v8::Local<v8::String> error_message =
       v8::String::NewFromUtf8(isolate(), string.c_str());
   v8::Local<v8::Value> error = v8::Exception::Error(error_message);
-  resolver_.Get(isolate())->Reject(mate::ConvertToV8(isolate(), error));
+  GetInner()->Reject(mate::ConvertToV8(isolate(), error));
   return this;
 }
 
 v8::Local<v8::Object> Promise::GetHandle() const {
-  return resolver_.Get(isolate())->GetPromise();
+  return GetInner()->GetPromise();
 }
 
 }  // namespace util

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -29,7 +29,7 @@ v8::Local<v8::Object> Promise::GetHandle() const {
 namespace mate {
 
 v8::Local<v8::Value> mate::Converter<atom::util::Promise*>::ToV8(
-    v8::Isolate* unused,
+    v8::Isolate*,
     atom::util::Promise* val) {
   return val->GetHandle();
 }

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -4,6 +4,8 @@
 
 #include "atom/common/promise_util.h"
 
+#include <string>
+
 namespace atom {
 
 namespace util {

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -29,7 +29,7 @@ v8::Local<v8::Object> Promise::GetHandle() const {
 namespace mate {
 
 v8::Local<v8::Value> mate::Converter<atom::util::Promise*>::ToV8(
-    v8::Isolate* isolate,
+    v8::Isolate* unused,
     atom::util::Promise* val) {
   return val->GetHandle();
 }

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/promise_util.h"
+
+namespace atom {
+
+namespace util {
+
+// Promise::Promise()
+//     : isolate_(NULL) {
+// }
+
+// Promise::Promise(v8::Isolate* isolate)
+//     : isolate_(isolate) {
+//   resolver_.Reset(isolate, v8::Promise::Resolver::New(isolate));
+// }
+
+// Promise::~Promise() {
+//   resolver_.Reset();
+// }
+
+Promise* Promise::RejectWithErrorMessage(const std::string& string) {
+  v8::Local<v8::String> error_message =
+      v8::String::NewFromUtf8(isolate(), string.c_str());
+  v8::Local<v8::Value> error = v8::Exception::Error(error_message);
+  resolver_.Get(isolate())->Reject(mate::ConvertToV8(isolate(), error));
+  return this;
+}
+
+v8::Local<v8::Object> Promise::GetHandle() const {
+  return resolver_.Get(isolate())->GetPromise();
+}
+
+}  // namespace util
+
+}  // namespace atom
+
+namespace mate {
+
+v8::Local<v8::Value> mate::Converter<atom::util::Promise*>::ToV8(
+    v8::Isolate* isolate,
+    atom::util::Promise* val) {
+  return val->GetHandle();
+}
+
+}  // namespace mate

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_PROMISE_UTIL_H_
+#define ATOM_COMMON_PROMISE_UTIL_H_
+
+#include "native_mate/converter.h"
+
+namespace atom {
+
+namespace util {
+
+class Promise {
+ public:
+  Promise(v8::Isolate* isolate) {
+    isolate_ = isolate;
+    resolver_.Reset(isolate, v8::Promise::Resolver::New(isolate));
+  }
+  ~Promise() { resolver_.Reset(); }
+
+  v8::Isolate* isolate() const { return isolate_; }
+
+  virtual v8::Local<v8::Object> GetHandle() const;
+
+  Promise* Resolve() {
+    resolver_.Get(isolate())->Resolve(v8::Undefined(isolate()));
+    return this;
+  }
+
+  template <typename T>
+  Promise* Resolve(T* value) {
+    resolver_.Get(isolate())->Resolve(mate::ConvertToV8(isolate(), value));
+    return this;
+  }
+
+  template <typename T>
+  Promise* Reject(T* value) {
+    resolver_.Get(isolate())->Reject(mate::ConvertToV8(isolate(), value));
+    return this;
+  }
+
+  Promise* RejectWithErrorMessage(const std::string& error);
+
+ protected:
+  v8::Isolate* isolate_;
+
+ private:
+  v8::Global<v8::Promise::Resolver> resolver_;
+
+  // DISALLOW_COPY_AND_ASSIGN(Promise);
+};
+
+}  // namespace util
+
+}  // namespace atom
+
+namespace mate {
+
+template <>
+struct Converter<atom::util::Promise*> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   atom::util::Promise* val);
+  // TODO(MarshallOfSound): Implement FromV8 to allow promise chaining
+  //                        in native land
+  // static bool FromV8(v8::Isolate* isolate,
+  //                    v8::Local<v8::Value> val,
+  //                    Promise* out);
+};
+
+}  // namespace mate
+
+#endif  // ATOM_COMMON_PROMISE_UTIL_H_

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -19,7 +19,7 @@ class Promise {
     isolate_ = isolate;
     resolver_.Reset(isolate, v8::Promise::Resolver::New(isolate));
   }
-  ~Promise() { resolver_.Reset(); }
+  ~Promise() {}
 
   v8::Isolate* isolate() const { return isolate_; }
 
@@ -59,7 +59,7 @@ class Promise {
 
   v8::Global<v8::Promise::Resolver> resolver_;
 
-  // DISALLOW_COPY_AND_ASSIGN(Promise);
+  DISALLOW_COPY_AND_ASSIGN(Promise);
 };
 
 }  // namespace util

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_COMMON_PROMISE_UTIL_H_
 #define ATOM_COMMON_PROMISE_UTIL_H_
 
+#include <string>
+
 #include "native_mate/converter.h"
 
 namespace atom {
@@ -13,7 +15,7 @@ namespace util {
 
 class Promise {
  public:
-  Promise(v8::Isolate* isolate) {
+  explicit Promise(v8::Isolate* isolate) {
     isolate_ = isolate;
     resolver_.Reset(isolate, v8::Promise::Resolver::New(isolate));
   }

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -24,19 +24,19 @@ class Promise {
   virtual v8::Local<v8::Object> GetHandle() const;
 
   Promise* Resolve() {
-    resolver_.Get(isolate())->Resolve(v8::Undefined(isolate()));
+    GetInner()->Resolve(v8::Undefined(isolate()));
     return this;
   }
 
   template <typename T>
   Promise* Resolve(T* value) {
-    resolver_.Get(isolate())->Resolve(mate::ConvertToV8(isolate(), value));
+    GetInner()->Resolve(mate::ConvertToV8(isolate(), value));
     return this;
   }
 
   template <typename T>
   Promise* Reject(T* value) {
-    resolver_.Get(isolate())->Reject(mate::ConvertToV8(isolate(), value));
+    GetInner()->Reject(mate::ConvertToV8(isolate(), value));
     return this;
   }
 
@@ -46,6 +46,10 @@ class Promise {
   v8::Isolate* isolate_;
 
  private:
+  v8::Local<v8::Promise::Resolver> GetInner() const {
+    return resolver_.Get(isolate());
+  }
+
   v8::Global<v8::Promise::Resolver> resolver_;
 
   // DISALLOW_COPY_AND_ASSIGN(Promise);

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -28,6 +28,11 @@ class Promise {
     return this;
   }
 
+  Promise* Reject() {
+    GetInner()->Reject(v8::Undefined(isolate()));
+    return this;
+  }
+
   template <typename T>
   Promise* Resolve(T* value) {
     GetInner()->Resolve(mate::ConvertToV8(isolate(), value));

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -25,29 +25,29 @@ class Promise {
 
   virtual v8::Local<v8::Object> GetHandle() const;
 
-  Promise* Resolve() {
-    GetInner()->Resolve(v8::Undefined(isolate()));
-    return this;
+  v8::Maybe<bool> Resolve() {
+    return GetInner()->Resolve(isolate()->GetCurrentContext(),
+                               v8::Undefined(isolate()));
   }
 
-  Promise* Reject() {
-    GetInner()->Reject(v8::Undefined(isolate()));
-    return this;
-  }
-
-  template <typename T>
-  Promise* Resolve(T* value) {
-    GetInner()->Resolve(mate::ConvertToV8(isolate(), value));
-    return this;
+  v8::Maybe<bool> Reject() {
+    return GetInner()->Reject(isolate()->GetCurrentContext(),
+                              v8::Undefined(isolate()));
   }
 
   template <typename T>
-  Promise* Reject(T* value) {
-    GetInner()->Reject(mate::ConvertToV8(isolate(), value));
-    return this;
+  v8::Maybe<bool> Resolve(T* value) {
+    return GetInner()->Resolve(isolate()->GetCurrentContext(),
+                               mate::ConvertToV8(isolate(), value));
   }
 
-  Promise* RejectWithErrorMessage(const std::string& error);
+  template <typename T>
+  v8::Maybe<bool> Reject(T* value) {
+    return GetInner()->Reject(isolate()->GetCurrentContext(),
+                              mate::ConvertToV8(isolate(), value));
+  }
+
+  v8::Maybe<bool> RejectWithErrorMessage(const std::string& error);
 
  protected:
   v8::Isolate* isolate_;

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "content/public/browser/browser_thread.h"
 #include "native_mate/converter.h"
 
 namespace atom {
@@ -16,6 +17,7 @@ namespace util {
 class Promise {
  public:
   explicit Promise(v8::Isolate* isolate) {
+    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
     isolate_ = isolate;
     resolver_.Reset(isolate, v8::Promise::Resolver::New(isolate));
   }
@@ -54,6 +56,7 @@ class Promise {
 
  private:
   v8::Local<v8::Promise::Resolver> GetInner() const {
+    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
     return resolver_.Get(isolate());
   }
 

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -522,6 +522,8 @@
       'atom/common/platform_util_linux.cc',
       'atom/common/platform_util_mac.mm',
       'atom/common/platform_util_win.cc',
+      'atom/common/promise_util.h',
+      'atom/common/promise_util.cc',
       'atom/renderer/api/atom_api_renderer_ipc.h',
       'atom/renderer/api/atom_api_renderer_ipc.cc',
       'atom/renderer/api/atom_api_spell_check_client.cc',

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -12,30 +12,12 @@ const {deprecate, Menu} = electron
 const {EventEmitter} = require('events')
 
 let dockMenu = null
-let readyPromise = null
 
 // App is an EventEmitter.
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 EventEmitter.call(app)
 
 Object.assign(app, {
-  whenReady () {
-    if (readyPromise !== null) {
-      return readyPromise
-    }
-
-    if (app.isReady()) {
-      readyPromise = Promise.resolve()
-    } else {
-      readyPromise = new Promise(resolve => {
-        // XXX(alexeykuzmin): Explicitly ignore any data
-        // passed to the event handler to avoid memory leaks.
-        app.once('ready', () => resolve())
-      })
-    }
-
-    return readyPromise
-  },
   setApplicationMenu (menu) {
     return Menu.setApplicationMenu(menu)
   },


### PR DESCRIPTION
This is laying the ground work for #9882

* Adds a promise helper
  * The native_mate helper should be removed in favor of this one, with the upcoming removal of native_mate it makes sense for this to live outside of that code base
* Refactors `whenReady` to use native promises