### PR TITLE
feat: add support to toggle the MacOS traffic lights controls

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -780,6 +780,14 @@ v8::Local<v8::Value> TopLevelWindow::GetContentView() const {
     return v8::Local<v8::Value>::New(isolate(), content_view_);
 }
 
+void TopLevelWindow::SetWindowControlsVisibility(bool visible) {
+  window_->SetWindowControlsVisibility(visible);
+}
+
+bool TopLevelWindow::IsWindowControlsVisible() {
+  return window_->IsWindowControlsVisible();
+}
+
 v8::Local<v8::Value> TopLevelWindow::GetParentWindow() const {
   if (parent_window_.IsEmpty())
     return v8::Null(isolate());
@@ -1030,6 +1038,11 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("moveTabToNewWindow", &TopLevelWindow::MoveTabToNewWindow)
       .SetMethod("toggleTabBar", &TopLevelWindow::ToggleTabBar)
       .SetMethod("addTabbedWindow", &TopLevelWindow::AddTabbedWindow)
+
+      .SetMethod("setWindowControlsVisibility",
+                 &TopLevelWindow::SetWindowControlsVisibility)
+      .SetMethod("isWindowControlsVisible",
+                 &TopLevelWindow::IsWindowControlsVisible)
 #endif
       .SetMethod("setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
       .SetMethod("isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -784,8 +784,8 @@ void TopLevelWindow::SetWindowControlsVisibility(bool visible) {
   window_->SetWindowControlsVisibility(visible);
 }
 
-bool TopLevelWindow::IsWindowControlsVisible() {
-  return window_->IsWindowControlsVisible();
+bool TopLevelWindow::AreWindowControlsVisible() {
+  return window_->AreWindowControlsVisible();
 }
 
 v8::Local<v8::Value> TopLevelWindow::GetParentWindow() const {
@@ -1041,8 +1041,8 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
 
       .SetMethod("setWindowControlsVisibility",
                  &TopLevelWindow::SetWindowControlsVisibility)
-      .SetMethod("isWindowControlsVisible",
-                 &TopLevelWindow::IsWindowControlsVisible)
+      .SetMethod("AreWindowControlsVisible",
+                 &TopLevelWindow::AreWindowControlsVisible)
 #endif
       .SetMethod("setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
       .SetMethod("isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -181,6 +181,9 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void PreviewFile(const std::string& path, mate::Arguments* args);
   void CloseFilePreview();
 
+  void SetWindowControlsVisibility(bool visible);
+  bool IsWindowControlsVisible();
+
   // Public getters of NativeWindow.
   v8::Local<v8::Value> GetContentView() const;
   v8::Local<v8::Value> GetParentWindow() const;

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -182,7 +182,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void CloseFilePreview();
 
   void SetWindowControlsVisibility(bool visible);
-  bool IsWindowControlsVisible();
+  bool AreWindowControlsVisible();
 
   // Public getters of NativeWindow.
   v8::Local<v8::Value> GetContentView() const;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -355,6 +355,12 @@ bool NativeWindow::IsMenuBarVisible() {
   return true;
 }
 
+void NativeWindow::SetWindowControlsVisibility(bool visible) {}
+
+bool NativeWindow::IsWindowControlsVisible() {
+  return true;
+}
+
 double NativeWindow::GetAspectRatio() {
   return aspect_ratio_;
 }

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -357,7 +357,7 @@ bool NativeWindow::IsMenuBarVisible() {
 
 void NativeWindow::SetWindowControlsVisibility(bool visible) {}
 
-bool NativeWindow::IsWindowControlsVisible() {
+bool NativeWindow::AreWindowControlsVisible() {
   return true;
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -193,6 +193,10 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetMenuBarVisibility(bool visible);
   virtual bool IsMenuBarVisible();
 
+  // Toggle the window controls visibility
+  virtual void SetWindowControlsVisibility(bool visible);
+  virtual bool IsWindowControlsVisible();
+
   // Set the aspect ratio when resizing window.
   double GetAspectRatio();
   gfx::Size GetAspectRatioExtraSize();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -195,7 +195,7 @@ class NativeWindow : public base::SupportsUserData,
 
   // Toggle the window controls visibility
   virtual void SetWindowControlsVisibility(bool visible);
-  virtual bool IsWindowControlsVisible();
+  virtual bool AreWindowControlsVisible();
 
   // Set the aspect ratio when resizing window.
   double GetAspectRatio();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -119,6 +119,9 @@ class NativeWindowMac : public NativeWindow {
   void ToggleTabBar() override;
   bool AddTabbedWindow(NativeWindow* window) override;
 
+  void SetWindowControlsVisibility(bool visible) override;
+  bool IsWindowControlsVisible() override;
+
   void SetVibrancy(const std::string& type) override;
   void SetTouchBar(
       const std::vector<mate::PersistentDictionary>& items) override;
@@ -186,6 +189,12 @@ class NativeWindowMac : public NativeWindow {
 
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_ = NORMAL;
+
+  // The visibility mode of window controls set by user.
+  bool window_controls_visibility_ = true;
+  // Flag is used to override default traffic light icons visibility behavior
+  // for simple fullscreen mode in case when user specified state explicitly.
+  bool was_window_controls_visibility_specified_ = false;
 
   // Simple (pre-Lion) Fullscreen Settings
   bool always_simple_fullscreen_ = false;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -120,7 +120,7 @@ class NativeWindowMac : public NativeWindow {
   bool AddTabbedWindow(NativeWindow* window) override;
 
   void SetWindowControlsVisibility(bool visible) override;
-  bool IsWindowControlsVisible() override;
+  bool AreWindowControlsVisible() override;
 
   void SetVibrancy(const std::string& type) override;
   void SetTouchBar(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1190,7 +1190,7 @@ void NativeWindowMac::SetWindowControlsVisibility(bool visible) {
   [[window_ standardWindowButton:NSWindowZoomButton] setHidden:!visible];
 }
 
-bool NativeWindowMac::IsWindowControlsVisible() {
+bool NativeWindowMac::AreWindowControlsVisible() {
   return !(
       [[window_ standardWindowButton:NSWindowCloseButton] isHidden] &&
       [[window_ standardWindowButton:NSWindowMiniaturizeButton] isHidden] &&

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1471,6 +1471,16 @@ Adds a window as a tab on this window, after the tab for the window instance.
 Adds a vibrancy effect to the browser window. Passing `null` or an empty string
 will remove the vibrancy effect on the window.
 
+#### `win.setWindowControlsVisibility(visible)` _macOS_
+
+* `visible` Boolean
+
+Sets whether the window controls buttons should be visible.
+
+#### `win.isWindowControlsVisible()` _macOS_
+
+Returns `Boolean` - Whether window controls are visible.
+
 #### `win.setTouchBar(touchBar)` _macOS_ _Experimental_
 
 * `touchBar` TouchBar

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1477,7 +1477,7 @@ will remove the vibrancy effect on the window.
 
 Sets whether the window controls buttons should be visible.
 
-#### `win.isWindowControlsVisible()` _macOS_
+#### `win.AreWindowControlsVisible()` _macOS_
 
 Returns `Boolean` - Whether window controls are visible.
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -754,11 +754,15 @@ describe('BrowserWindow module', () => {
   })
 
   describe('BrowserWindow.setWindowControlsVisibility()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
+    /**
+     * FIXME: Skip the tests instead of using the `return` here.
+     * - `.skip()` called in the 'before' hook doesn't affect
+     *     nested `describe`s.
+     * - Bad support of async test cases
+     */
+    if (process.platform !== 'darwin') {
+      return
+    }
 
     it('does not throw', () => {
       assert.doesNotThrow(() => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -753,6 +753,68 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('BrowserWindow.setWindowControlsVisibility()', () => {
+    before(function () {
+      if (process.platform !== 'darwin') {
+        this.skip()
+      }
+    })
+
+    it('does not throw', () => {
+      assert.doesNotThrow(() => {
+        w.setWindowControlsVisibility(true)
+      })
+    })
+
+    // Checks that window controls visibility behaviour remains the same in simple fullscreen mode
+    // if user did not specified it explicitly.
+    describe('when fullscreen titlebar on', () => {
+      beforeEach(() => {
+        w.destroy()
+        w = new BrowserWindow({ fullscreenWindowTitle: true })
+      })
+
+      it('hides controls when enters simple fullscreen mode', () => {
+        // BUG in SimpleFullScreen implementation? It does not trigger enter/leave-full-screen events
+        w.setSimpleFullScreen(true)
+        assert.equal(w.isWindowControlsVisible(), false)
+      })
+
+      it('shows controls after leaving simple fullscreen mode', () => {
+        w.setSimpleFullScreen(true)
+        w.setSimpleFullScreen(false)
+
+        assert.equal(w.isWindowControlsVisible(), true)
+      })
+    })
+
+    describe('hidden window control buttons', () => {
+      beforeEach(() => {
+        w.setWindowControlsVisibility(false)
+      })
+
+      it('remain hidden when window enters and leaves fullscreen mode', (done) => {
+        w.once('enter-full-screen', () => {
+          assert.equal(w.isWindowControlsVisible(), false)
+          w.setFullScreen(false)
+        })
+
+        w.once('leave-full-screen', () => {
+          assert.equal(w.isWindowControlsVisible(), false)
+          done()
+        })
+
+        w.setFullScreen(true)
+      })
+
+      it('remain hidden after window enters and leaves simple-fullscreen mode', () => {
+        w.setSimpleFullScreen(true)
+        w.setSimpleFullScreen(false)
+        assert.equal(w.isWindowControlsVisible(), false)
+      })
+    })
+  })
+
   describe('BrowserWindow.addTabbedWindow()', () => {
     before(function () {
       if (process.platform !== 'darwin') {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -781,14 +781,14 @@ describe('BrowserWindow module', () => {
       it('hides controls when enters simple fullscreen mode', () => {
         // BUG in SimpleFullScreen implementation? It does not trigger enter/leave-full-screen events
         w.setSimpleFullScreen(true)
-        assert.equal(w.isWindowControlsVisible(), false)
+        assert.equal(w.AreWindowControlsVisible(), false)
       })
 
       it('shows controls after leaving simple fullscreen mode', () => {
         w.setSimpleFullScreen(true)
         w.setSimpleFullScreen(false)
 
-        assert.equal(w.isWindowControlsVisible(), true)
+        assert.equal(w.AreWindowControlsVisible(), true)
       })
     })
 
@@ -799,12 +799,12 @@ describe('BrowserWindow module', () => {
 
       it('remain hidden when window enters and leaves fullscreen mode', (done) => {
         w.once('enter-full-screen', () => {
-          assert.equal(w.isWindowControlsVisible(), false)
+          assert.equal(w.AreWindowControlsVisible(), false)
           w.setFullScreen(false)
         })
 
         w.once('leave-full-screen', () => {
-          assert.equal(w.isWindowControlsVisible(), false)
+          assert.equal(w.AreWindowControlsVisible(), false)
           done()
         })
 
@@ -814,7 +814,7 @@ describe('BrowserWindow module', () => {
       it('remain hidden after window enters and leaves simple-fullscreen mode', () => {
         w.setSimpleFullScreen(true)
         w.setSimpleFullScreen(false)
-        assert.equal(w.isWindowControlsVisible(), false)
+        assert.equal(w.AreWindowControlsVisible(), false)
       })
     })
   })


### PR DESCRIPTION
This PR adds the ability to toggle the native MacOS "traffic light" controls after the BrowserWindow was created.

It also includes:
- Updated documentation
- Unit tests