### PR TITLE
Add "enable_desktop_capturer" build flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -24,6 +24,7 @@ declare_args() {
   electron_company_abbr = "github"
   electron_version = "0.0.0-dev"
 
+  enable_desktop_capturer = true
   enable_run_as_node = true
   enable_osr = true
 }
@@ -47,6 +48,9 @@ config("branding") {
 
 config("features") {
   defines = []
+  if (enable_desktop_capturer) {
+    defines += [ "ENABLE_DESKTOP_CAPTURER=1" ]
+  }
   if (enable_run_as_node) {
     defines += [ "ENABLE_RUN_AS_NODE=1" ]
   }

--- a/atom/common/api/features.cc
+++ b/atom/common/api/features.cc
@@ -7,6 +7,14 @@
 
 namespace {
 
+bool IsDesktopCapturerEnabled() {
+#if defined(ENABLE_DESKTOP_CAPTURER)
+  return true;
+#else
+  return false;
+#endif
+}
+
 bool IsOffscreenRenderingEnabled() {
 #if defined(ENABLE_OSR)
   return true;
@@ -28,6 +36,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
+  dict.SetMethod("isDesktopCapturerEnabled", &IsDesktopCapturerEnabled);
   dict.SetMethod("isOffscreenRenderingEnabled", &IsOffscreenRenderingEnabled);
   dict.SetMethod("isPDFViewerEnabled", &IsPDFViewerEnabled);
 }

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -33,7 +33,6 @@
   V(atom_browser_browser_view)               \
   V(atom_browser_content_tracing)            \
   V(atom_browser_debugger)                   \
-  V(atom_browser_desktop_capturer)           \
   V(atom_browser_dialog)                     \
   V(atom_browser_download_item)              \
   V(atom_browser_global_shortcut)            \
@@ -69,6 +68,8 @@
   V(atom_browser_box_layout)     \
   V(atom_browser_layout_manager)
 
+#define ELECTRON_DESKTOP_CAPTURER_MODULE(V) V(atom_browser_desktop_capturer)
+
 // This is used to load built-in modules. Instead of using
 // __attribute__((constructor)), we call the _register_<modname>
 // function for each built-in modules explicitly. This is only
@@ -78,6 +79,9 @@
 ELECTRON_BUILTIN_MODULES(V)
 #if defined(ENABLE_VIEW_API)
 ELECTRON_VIEW_MODULES(V)
+#endif
+#if defined(ENABLE_DESKTOP_CAPTURER)
+ELECTRON_DESKTOP_CAPTURER_MODULE(V)
 #endif
 #undef V
 
@@ -176,6 +180,9 @@ void NodeBindings::RegisterBuiltinModules() {
   ELECTRON_BUILTIN_MODULES(V)
 #if defined(ENABLE_VIEW_API)
   ELECTRON_VIEW_MODULES(V)
+#endif
+#if defined(ENABLE_DESKTOP_CAPTURER)
+  ELECTRON_DESKTOP_CAPTURER_MODULE(V)
 #endif
 #undef V
 }

--- a/electron.gyp
+++ b/electron.gyp
@@ -23,6 +23,11 @@
           '<(source_root)/external_binaries',
         ],
       }],
+      ['enable_desktop_capturer==1', {
+        'defines': [
+          'ENABLE_DESKTOP_CAPTURER',
+        ],
+      }],  # enable_desktop_capturer==1
       ['enable_osr==1', {
         'defines': [
           'ENABLE_OSR',

--- a/features.gypi
+++ b/features.gypi
@@ -2,11 +2,13 @@
   # If it looks stupid but it works it ain't stupid.
   'variables': {
     'variables': {
+      'enable_desktop_capturer%': 1,
       'enable_osr%': 1,  # FIXME(alexeykuzmin)
       'enable_pdf_viewer%': 0,  # FIXME(deepak1556)
       'enable_run_as_node%': 1,
       'enable_view_api%': 0,
     },
+    'enable_desktop_capturer%': '<(enable_desktop_capturer)',
     'enable_osr%': '<(enable_osr)',
     'enable_pdf_viewer%': '<(enable_pdf_viewer)',
     'enable_run_as_node%': '<(enable_run_as_node)',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -42,7 +42,6 @@
       'lib/browser/api/web-contents.js',
       'lib/browser/api/web-contents-view.js',
       'lib/browser/chrome-extension.js',
-      'lib/browser/desktop-capturer.js',
       'lib/browser/guest-view-manager.js',
       'lib/browser/guest-window-manager.js',
       'lib/browser/init.js',
@@ -75,7 +74,6 @@
       'lib/renderer/web-view/web-view.js',
       'lib/renderer/web-view/web-view-attributes.js',
       'lib/renderer/web-view/web-view-constants.js',
-      'lib/renderer/api/desktop-capturer.js',
       'lib/renderer/api/exports/electron.js',
       'lib/renderer/api/ipc-renderer.js',
       'lib/renderer/api/module-list.js',
@@ -121,8 +119,6 @@
       'atom/browser/api/atom_api_cookies.h',
       'atom/browser/api/atom_api_debugger.cc',
       'atom/browser/api/atom_api_debugger.h',
-      'atom/browser/api/atom_api_desktop_capturer.cc',
-      'atom/browser/api/atom_api_desktop_capturer.h',
       'atom/browser/api/atom_api_dialog.cc',
       'atom/browser/api/atom_api_download_item.cc',
       'atom/browser/api/atom_api_download_item.h',
@@ -742,6 +738,16 @@
           '<(libchromiumcontent_src_dir)/ui/resources/cursors/zoom_out.cur',
         ],
       }],  # OS=="win"
+      ['enable_desktop_capturer==1', {
+        'js_sources': [
+          'lib/browser/desktop-capturer.js',
+          'lib/renderer/api/desktop-capturer.js',
+        ],
+        'lib_sources': [
+          'atom/browser/api/atom_api_desktop_capturer.cc',
+          'atom/browser/api/atom_api_desktop_capturer.h',
+        ],
+      }],  # enable_desktop_capturer
       ['enable_osr==1', {
         'lib_sources': [
           'atom/browser/api/atom_api_web_contents_osr.cc',

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -153,8 +153,11 @@ app.setAppPath(packagePath)
 // Load the chrome extension support.
 require('./chrome-extension')
 
-// Load internal desktop-capturer module.
-require('./desktop-capturer')
+const features = process.atomBinding('features')
+if (features.isDesktopCapturerEnabled()) {
+  // Load internal desktop-capturer module.
+  require('./desktop-capturer')
+}
 
 // Load protocol module to ensure it is populated on app ready
 require('./api/protocol')

--- a/lib/renderer/api/exports/electron.js
+++ b/lib/renderer/api/exports/electron.js
@@ -4,9 +4,18 @@ const moduleList = require('../module-list')
 // Import common modules.
 common.defineProperties(exports)
 
-for (const module of moduleList) {
-  Object.defineProperty(exports, module.name, {
-    enumerable: !module.private,
-    get: () => require(`../${module.file}`)
+for (const {
+        name,
+        file,
+        enabled = true,
+        private: isPrivate = false
+    } of moduleList) {
+  if (!enabled) {
+    continue
+  }
+
+  Object.defineProperty(exports, name, {
+    enumerable: !isPrivate,
+    get: () => require(`../${file}`)
   })
 }

--- a/lib/renderer/api/module-list.js
+++ b/lib/renderer/api/module-list.js
@@ -1,8 +1,9 @@
 // Renderer side modules, please sort alphabetically.
+// A module is `enabled` if there is no explicit condition defined.
 module.exports = [
-  {name: 'desktopCapturer', file: 'desktop-capturer'},
-  {name: 'ipcRenderer', file: 'ipc-renderer'},
-  {name: 'remote', file: 'remote'},
-  {name: 'screen', file: 'screen'},
-  {name: 'webFrame', file: 'web-frame'}
+  {name: 'desktopCapturer', file: 'desktop-capturer', enabled: true},
+  {name: 'ipcRenderer', file: 'ipc-renderer', enabled: true},
+  {name: 'remote', file: 'remote', enabled: true},
+  {name: 'screen', file: 'screen', enabled: true},
+  {name: 'webFrame', file: 'web-frame', enabled: true}
 ]

--- a/lib/renderer/api/module-list.js
+++ b/lib/renderer/api/module-list.js
@@ -1,7 +1,13 @@
+const features = process.atomBinding('features')
+
 // Renderer side modules, please sort alphabetically.
 // A module is `enabled` if there is no explicit condition defined.
 module.exports = [
-  {name: 'desktopCapturer', file: 'desktop-capturer', enabled: true},
+  {
+    name: 'desktopCapturer',
+    file: 'desktop-capturer',
+    enabled: features.isDesktopCapturerEnabled()
+  },
   {name: 'ipcRenderer', file: 'ipc-renderer', enabled: true},
   {name: 'remote', file: 'remote', enabled: true},
   {name: 'screen', file: 'screen', enabled: true},

--- a/lib/sandboxed_renderer/api/exports/electron.js
+++ b/lib/sandboxed_renderer/api/exports/electron.js
@@ -33,6 +33,8 @@ Object.defineProperties(exports, {
       return require('../../../common/api/is-promise')
     }
   },
+  // XXX(alexeykuzmin): It won't be available if the Desktop Capturer
+  // was disabled during build time.
   desktopCapturer: {
     get: function () {
       return require('../../../renderer/api/desktop-capturer')

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -1,10 +1,17 @@
 const assert = require('assert')
 const {desktopCapturer, remote, screen} = require('electron')
+const features = process.atomBinding('features')
 
 const isCI = remote.getGlobal('isCi')
 
 describe('desktopCapturer', () => {
   before(function () {
+    if (!features.isDesktopCapturerEnabled()) {
+      // It's been disabled during build time.
+      this.skip()
+      return
+    }
+
     if (isCI && process.platform === 'win32') {
       this.skip()
     }


### PR DESCRIPTION
Two goals:
- not everyone needs Desktop Capturer, like Teams
- we have several issues with it in the Ch66 upgrade branch, I need a nice way to disable it

See #13141 for build results with this feature being disabled.