### PR TITLE
fix: tray icon bounds didn't allow negative macOS

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -479,10 +479,6 @@ void TrayIconCocoa::SetContextMenu(AtomMenuModel* menu_model) {
 
 gfx::Rect TrayIconCocoa::GetBounds() {
   auto bounds = gfx::ScreenRectFromNSRect([status_item_view_ window].frame);
-  // Calling [window frame] immediately after the view gets created will have
-  // negative |y| sometimes.
-  if (bounds.y() < 0)
-    bounds.set_y(0);
   return bounds;
 }
 


### PR DESCRIPTION
Tray bounds on MacOS returns 0. This is causing issues when using multiple monitors that are 'above' your main screen. The bounds returned are relative, so their y-value will be negative.

This solves this issue: https://github.com/electron/electron/issues/11709

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->