### PR TITLE
fix: prevent bundles from being selected in <input file="type"> open file dialog (macOS)

### DIFF
--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -222,6 +222,7 @@ void WebDialogHelper::RunFileChooser(
         flags |= file_dialog::FILE_DIALOG_MULTI_SELECTIONS;
       case content::FileChooserParams::Open:
         flags |= file_dialog::FILE_DIALOG_OPEN_FILE;
+        flags |= file_dialog::FILE_DIALOG_TREAT_PACKAGE_APP_AS_DIRECTORY;
         break;
       case content::FileChooserParams::UploadFolder:
         flags |= file_dialog::FILE_DIALOG_OPEN_DIRECTORY;


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/13219

Another option is to use `NSOpenSavePanelDelegate` and don't allow bundles to be selected:
```
- (BOOL)panel:(id)sender shouldEnableURL:(NSURL *)url {
    NSString* itemUTI = nil;
    [url getResourceValue:&itemUTI forKey:NSURLTypeIdentifierKey error:nil];

    return UTTypeConformsTo((__bridge CFStringRef)itemUTI, kUTTypeData)
        || UTTypeConformsTo((__bridge CFStringRef)itemUTI, kUTTypeFolder);
}
```