### PR TITLE
feat: deprecate default value of nodeIntegration

### DIFF
--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -29,6 +29,11 @@ namespace atom {
 class WebContentsPreferences
     : public content::WebContentsUserData<WebContentsPreferences> {
  public:
+  enum DeprecationStatus {
+    Deprecated,
+    Stable,
+  };
+
   // Get self from WebContents.
   static WebContentsPreferences* From(content::WebContents* web_contents);
 
@@ -62,6 +67,9 @@ class WebContentsPreferences
 
   // Set preference value to given bool if user did not provide value
   bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);
+  bool SetDefaultBoolIfUndefined(const base::StringPiece& key,
+                                 bool val,
+                                 DeprecationStatus status);
 
   // Get preferences value as integer possibly coercing it from a string
   bool GetInteger(const base::StringPiece& attribute_name, int* val);

--- a/default_app/default_app.js
+++ b/default_app/default_app.js
@@ -16,6 +16,7 @@ exports.load = (appUrl) => {
       autoHideMenuBar: true,
       backgroundColor: '#FFFFFF',
       webPreferences: {
+        nodeIntegration: true,
         nodeIntegrationInWorker: true
       },
       useContentSize: true

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -287,6 +287,10 @@ WebContents.prototype._init = function () {
     ipcMain.emit(channel, event, ...args)
   })
 
+  this.on('-deprecated-default', function (event, key, oldDefault, newDefault) {
+    deprecate.default(key, oldDefault, newDefault)
+  })
+
   // Handle context menu action request from pepper plugin.
   this.on('pepper-context-menu', function (event, params, callback) {
     // Access Menu via electron.Menu to prevent circular require.

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -31,6 +31,13 @@ deprecate.warn = (oldName, newName) => {
   return deprecate.log(`'${oldName}' is deprecated. Use '${newName}' instead.`)
 }
 
+deprecate.default = (propName, oldDefault, newDefault) => {
+  return deprecate.log(`You have left '${propName}' undefined, currently it \
+has a default value of '${oldDefault}'. The default value is changing \
+in a future release to '${newDefault}', please explicitly declare the \
+value you want to keep the current behavior`)
+}
+
 let deprecationHandler = null
 
 // Print deprecation message.


### PR DESCRIPTION
⭐️  Security First ⭐️ 

This adds the underlying code to deprecate defaults in the future, only doing one in this PR so we can discuss that underlying logic.