### PR TITLE
docs: fix broken link to commit message guidelines

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,7 +4,7 @@
 newIssueWelcomeComment: |
   👋 Thanks for opening your first issue here! If you're reporting a 🐞 bug, please make sure you include steps to reproduce it. We get a lot of issues on this repo, so please be patient and we will get back to you as soon as we can.
 
-  To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md#submitting-issues).
+  To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md).
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 
@@ -12,13 +12,13 @@ newIssueWelcomeComment: |
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
 
-  We use [semantic commit messages](https://github.com/electron/electron/blob/semantic-first-pr/docs/development/pull-requests.md#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix, OR prefix at least one of your commit messages.
+  We use [semantic commit messages](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix, OR prefix at least one of your commit messages.
 
   Examples of commit messages with semantic prefixes:
 
   - `fix: don't overwrite prevent_default if default wasn't prevented`
   - `feat: add app.isPackaged() method`
-  - `docs: app.isDefaultProtocolClient is now available on Linux` 
+  - `docs: app.isDefaultProtocolClient is now available on Linux`
 
   Things that will help get your PR across the finish line:
 
@@ -27,7 +27,7 @@ newPRWelcomeComment: |
   - Document any user-facing changes you've made following the [documentation styleguide](https://github.com/electron/electron/blob/master/docs/styleguide.md).
   - Include tests when adding/changing behavior.
   - Include screenshots and animated GIFs whenever possible.
-  
+
   We get a lot of pull requests on this repo, so please be patient and we will get back to you as soon as we can.
 
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,14 +36,13 @@ an issue:
 * [Application Architecture](tutorial/application-architecture.md)
   * [Main and Renderer Processes](tutorial/application-architecture.md#main-and-renderer-processes)
   * [Using Electron's APIs](tutorial/application-architecture.md#using-electron-apis)
-  * [Using Node.js APIs](tutorial/application-architecture.md#using-node.js-apis)
+  * [Using Node.js APIs](tutorial/application-architecture.md#using-nodejs-apis)
   * [Using Native Node.js Modules](tutorial/using-native-node-modules.md)
-  * [Inter-Process Communication](tutorial/application-architecture.md#)
 * Adding Features to Your App
   * [Notifications](tutorial/notifications.md)
-  * [Recent Documents](tutorial/desktop-environment-integration.md#recent-documents-windows-mac-os)
+  * [Recent Documents](tutorial/desktop-environment-integration.md#recent-documents)
   * [Application Progress](tutorial/progress-bar.md)
-  * [Custom Dock Menu](tutorial/desktop-environment-integration.md#custom-dock-menu-mac-os)
+  * [Custom Dock Menu](tutorial/macos-dock.md)
   * [Custom Windows Taskbar](tutorial/windows-taskbar.md)
   * [Custom Linux Desktop Actions](tutorial/linux-desktop-actions.md)
   * [Keyboard Shortcuts](tutorial/keyboard-shortcuts.md)
@@ -82,7 +81,6 @@ an issue:
 These individual tutorials expand on topics discussed in the guide above.
 
 * [In Detail: Installing Electron](tutorial/installation.md)
-  * [Global versus Local Installation](tutorial/installation.md#global-versus-local-installation)
   * [Proxies](tutorial/installation.md#proxies)
   * [Custom Mirrors and Caches](tutorial/installation.md#custom-mirrors-and-caches)
   * [Troubleshooting](tutorial/installation.md#troubleshooting)

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -2,7 +2,7 @@
 
 > Display external web content in an isolated frame and process.
 
-Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Renderer](../glossary.md#renderer-process)
 
 Use the `webview` tag to embed 'guest' content (such as web pages) in your
 Electron app. The guest content is contained within the `webview` container.

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -1,6 +1,5 @@
 # Pull Requests
 
-* [Dependencies](#dependencies)
 * [Setting up your local environment](#setting-up-your-local-environment)
   * [Step 1: Fork](#step-1-fork)
   * [Step 2: Build](#step-2-build)
@@ -84,19 +83,19 @@ Note that multiple commits often get squashed when they are landed.
 #### Commit message guidelines
 
 A good commit message should describe what changed and why. The Electron project
-uses [semantic commit messages](https://conventionalcommits.org/) to streamline 
+uses [semantic commit messages](https://conventionalcommits.org/) to streamline
 the release process.
 
-Before a pull request can be merged, it should include at least one semantic 
-commit message, though it's not necessary for all commits in the pull request 
-to be semantic. Alternatively, you can **update your pull request title**  to 
+Before a pull request can be merged, it should include at least one semantic
+commit message, though it's not necessary for all commits in the pull request
+to be semantic. Alternatively, you can **update your pull request title**  to
 start with a semantic prefix.
 
 Examples of commit messages with semantic prefixes:
 
 - `fix: don't overwrite prevent_default if default wasn't prevented`
 - `feat: add app.isPackaged() method`
-- `docs: app.isDefaultProtocolClient is now available on Linux` 
+- `docs: app.isDefaultProtocolClient is now available on Linux`
 
 Common prefixes:
 
@@ -122,10 +121,10 @@ Other things to keep in mind when writing a commit message:
 
 #### Breaking Changes
 
-A commit that has the text `BREAKING CHANGE:` at the beginning of its optional 
-body or footer section introduces a breaking API change (correlating with Major 
-in semantic versioning). A breaking change can be part of commits of any type. 
-e.g., a `fix:`, `feat:` & `chore:` types would all be valid, in addition to any 
+A commit that has the text `BREAKING CHANGE:` at the beginning of its optional
+body or footer section introduces a breaking API change (correlating with Major
+in semantic versioning). A breaking change can be part of commits of any type.
+e.g., a `fix:`, `feat:` & `chore:` types would all be valid, in addition to any
 other type.
 
 See [conventionalcommits.org](https://conventionalcommits.org) for more details.

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -1,6 +1,6 @@
 # Code Signing
 
-Code signing is a security technology that you use to certify that an app was 
+Code signing is a security technology that you use to certify that an app was
 created by you.
 
 On macOS the system can detect any change to the  app, whether the change is
@@ -11,23 +11,23 @@ if you don't have, or if your trust level is low will cause security dialogs to
 appear when users start using your application.  Trust level builds over time
 so it's better to start code signing as early as possible.
 
-While it is possible to distribute unsigned apps, it is not recommended. 
+While it is possible to distribute unsigned apps, it is not recommended.
 For example, here's what macOS users see when attempting to start an unsigned app:
 
 ![unsigned app warning on macOS](https://user-images.githubusercontent.com/2289/39488937-bdc854ba-4d38-11e8-88f8-7b3c125baefc.png)
 
 > App can't be opened because it is from an unidentified developer
 
-If you are building an Electron app that you intend to package and distribute, 
-it should be code signed. The Mac and Windows app stores do not allow unsigned 
+If you are building an Electron app that you intend to package and distribute,
+it should be code signed. The Mac and Windows app stores do not allow unsigned
 apps.
 
 # Signing macOS builds
 
 Before signing macOS builds, you must do the following:
 
-1. Enroll in the [Apple Developer Program](Apple Developer Program) (requires an annual fee)
-2. Download and install Xcode
+1. Enroll in the [Apple Developer Program] (requires an annual fee)
+2. Download and install [Xcode]
 3. Generate, download, and install [signing certificates]
 
 There are a number of tools for signing your packaged app:

--- a/docs/tutorial/macos-dock.md
+++ b/docs/tutorial/macos-dock.md
@@ -1,7 +1,7 @@
 # MacOS Dock
 
 Electron has APIs to configure the app's icon in the macOS Dock. A macOS-only
-API exists to create a [a custom dock menu](#custom-dock-menu-mac-os), but
+API exists to create a custom dock menu, but
 Electron also uses the app's dock icon to implement cross-platform features
 like [recent documents][recent-documents] and
 [application progress][progress-bar].

--- a/docs/tutorial/windows-taskbar.md
+++ b/docs/tutorial/windows-taskbar.md
@@ -3,7 +3,7 @@
 Electron has APIs to configure the app's icon in the Windows taskbar. Supported
 are the [creation of a `JumpList`](#jumplist),
 [custom thumbnails and toolbars](#thumbnail-toolbars),
-[icon overlays](#icon-overlays-in-taskbar-windows), and the so-called
+[icon overlays](#icon-overlays-in-taskbar), and the so-called
 ["Flash Frame" effect](#flash-frame), but
 Electron also uses the app's dock icon to implement cross-platform features
 like [recent documents][recent-documents] and


### PR DESCRIPTION
This pull request, fixes broken link to commit message guideline documentation, also fixes link to not found paragraph in Contributing file.

Fixes #13230