### PR TITLE
spec: update browser-view spec to expect

### DIFF
--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -1,12 +1,16 @@
 'use strict'
 
-const {expect} = require('chai')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
 const {closeWindow} = require('./window-helpers')
 
 const {remote} = require('electron')
 const {BrowserView, BrowserWindow} = remote
 
-describe('BrowserView module', () => {
+const {expect} = chai
+chai.use(dirtyChai)
+
+describe.only('BrowserView module', () => {
   let w = null
   let view = null
 
@@ -40,9 +44,9 @@ describe('BrowserView module', () => {
   describe('BrowserView.isDestroyed()', () => {
     it('returns correct value', () => {
       view = new BrowserView()
-      expect(!view.isDestroyed()).to.equal(true)
+      expect(!view.isDestroyed()).to.be.true()
       view.destroy()
-      expect(view.isDestroyed()).to.equal(true)
+      expect(view.isDestroyed()).to.be.true()
     })
   })
 
@@ -110,7 +114,7 @@ describe('BrowserView module', () => {
     it('returns the set view', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.equal(null)
+      expect(view.id).to.not.be.null()
 
       let view2 = w.getBrowserView()
       expect(view2.webContents.id).to.equal(view.webContents.id)
@@ -118,20 +122,20 @@ describe('BrowserView module', () => {
 
     it('returns null if none is set', () => {
       let view = w.getBrowserView()
-      expect(view).to.equal(null)
+      expect(view).to.be.null()
     })
   })
 
   describe('BrowserView.webContents.getOwnerBrowserWindow()', () => {
     it('points to owning window', () => {
       view = new BrowserView()
-      expect(!view.webContents.getOwnerBrowserWindow()).to.equal(true)
+      expect(!view.webContents.getOwnerBrowserWindow()).to.be.true()
 
       w.setBrowserView(view)
       expect(view.webContents.getOwnerBrowserWindow()).to.equal(w)
 
       w.setBrowserView(null)
-      expect(!view.webContents.getOwnerBrowserWindow()).to.equal(true)
+      expect(!view.webContents.getOwnerBrowserWindow()).to.be.true()
     })
   })
 
@@ -139,7 +143,7 @@ describe('BrowserView module', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.equal(null)
+      expect(view.id).to.not.be.null()
 
       let view2 = BrowserView.fromId(view.id)
       expect(view2.webContents.id).to.equal(view.webContents.id)
@@ -150,7 +154,7 @@ describe('BrowserView module', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.equal(null)
+      expect(view.id).to.not.be.null()
 
       let view2 = BrowserView.fromWebContents(view.webContents)
       expect(view2.webContents.id).to.equal(view.webContents.id)
@@ -161,7 +165,7 @@ describe('BrowserView module', () => {
     it('returns all views', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.equal(null)
+      expect(view.id).to.not.be.null()
 
       const views = BrowserView.getAllViews()
       expect(views.length).to.equal(1)

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const assert = require('assert')
+const {expect} = require('chai')
 const {closeWindow} = require('./window-helpers')
 
 const {remote} = require('electron')
 const {BrowserView, BrowserWindow} = remote
 
-describe('BrowserView module', () => {
+describe.only('BrowserView module', () => {
   let w = null
   let view = null
 
@@ -40,9 +40,9 @@ describe('BrowserView module', () => {
   describe('BrowserView.isDestroyed()', () => {
     it('returns correct value', () => {
       view = new BrowserView()
-      assert.ok(!view.isDestroyed())
+      expect(!view.isDestroyed()).to.equal(true)
       view.destroy()
-      assert.ok(view.isDestroyed())
+      expect(view.isDestroyed()).to.equal(true)
     })
   })
 
@@ -54,9 +54,9 @@ describe('BrowserView module', () => {
 
     it('throws for invalid args', () => {
       view = new BrowserView()
-      assert.throws(() => {
+      expect(() => {
         view.setBackgroundColor(null)
-      }, /conversion failure/)
+      }).to.throw(/conversion failure/)
     })
   })
 
@@ -69,9 +69,9 @@ describe('BrowserView module', () => {
 
     it('throws for invalid args', () => {
       view = new BrowserView()
-      assert.throws(() => {
+      expect(() => {
         view.setAutoResize(null)
-      }, /conversion failure/)
+      }).to.throw(/conversion failure/)
     })
   })
 
@@ -83,12 +83,12 @@ describe('BrowserView module', () => {
 
     it('throws for invalid args', () => {
       view = new BrowserView()
-      assert.throws(() => {
+      expect(() => {
         view.setBounds(null)
-      }, /conversion failure/)
-      assert.throws(() => {
+      }).to.throw(/conversion failure/)
+      expect(() => {
         view.setBounds({})
-      }, /conversion failure/)
+      }).to.throw(/conversion failure/)
     })
   })
 
@@ -110,25 +110,28 @@ describe('BrowserView module', () => {
     it('returns the set view', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      assert.notEqual(view.id, null)
+      expect(view.id).to.not.equal(null)
+
       let view2 = w.getBrowserView()
-      assert.equal(view2.webContents.id, view.webContents.id)
+      expect(view2.webContents.id).to.equal(view.webContents.id)
     })
 
     it('returns null if none is set', () => {
       let view = w.getBrowserView()
-      assert.equal(null, view)
+      expect(view).to.equal(null)
     })
   })
 
   describe('BrowserView.webContents.getOwnerBrowserWindow()', () => {
     it('points to owning window', () => {
       view = new BrowserView()
-      assert.ok(!view.webContents.getOwnerBrowserWindow())
+      expect(!view.webContents.getOwnerBrowserWindow()).to.equal(true)
+
       w.setBrowserView(view)
-      assert.equal(view.webContents.getOwnerBrowserWindow(), w)
+      expect(view.webContents.getOwnerBrowserWindow()).to.equal(w)
+
       w.setBrowserView(null)
-      assert.ok(!view.webContents.getOwnerBrowserWindow())
+      expect(!view.webContents.getOwnerBrowserWindow()).to.equal(true)
     })
   })
 
@@ -136,9 +139,10 @@ describe('BrowserView module', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      assert.notEqual(view.id, null)
+      expect(view.id).to.not.equal(null)
+
       let view2 = BrowserView.fromId(view.id)
-      assert.equal(view2.webContents.id, view.webContents.id)
+      expect(view2.webContents.id).to.equal(view.webContents.id)
     })
   })
 
@@ -146,9 +150,10 @@ describe('BrowserView module', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      assert.notEqual(view.id, null)
+      expect(view.id).to.not.equal(null)
+
       let view2 = BrowserView.fromWebContents(view.webContents)
-      assert.equal(view2.webContents.id, view.webContents.id)
+      expect(view2.webContents.id).to.equal(view.webContents.id)
     })
   })
 
@@ -156,11 +161,11 @@ describe('BrowserView module', () => {
     it('returns all views', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      assert.notEqual(view.id, null)
+      expect(view.id).to.not.equal(null)
 
       const views = BrowserView.getAllViews()
-      assert.equal(views.length, 1)
-      assert.equal(views[0].webContents.id, view.webContents.id)
+      expect(views.length).to.equal(1)
+      expect(views[0].webContents.id).to.equal(view.webContents.id)
     })
   })
 })

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -6,7 +6,7 @@ const {closeWindow} = require('./window-helpers')
 const {remote} = require('electron')
 const {BrowserView, BrowserWindow} = remote
 
-describe.only('BrowserView module', () => {
+describe('BrowserView module', () => {
   let w = null
   let view = null
 

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -10,7 +10,7 @@ const {BrowserView, BrowserWindow} = remote
 const {expect} = chai
 chai.use(dirtyChai)
 
-describe.only('BrowserView module', () => {
+describe('BrowserView module', () => {
   let w = null
   let view = null
 

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -44,7 +44,7 @@ describe('BrowserView module', () => {
   describe('BrowserView.isDestroyed()', () => {
     it('returns correct value', () => {
       view = new BrowserView()
-      expect(!view.isDestroyed()).to.be.true()
+      expect(view.isDestroyed()).to.be.false()
       view.destroy()
       expect(view.isDestroyed()).to.be.true()
     })
@@ -129,13 +129,13 @@ describe('BrowserView module', () => {
   describe('BrowserView.webContents.getOwnerBrowserWindow()', () => {
     it('points to owning window', () => {
       view = new BrowserView()
-      expect(!view.webContents.getOwnerBrowserWindow()).to.be.true()
+      expect(view.webContents.getOwnerBrowserWindow()).to.be.null()
 
       w.setBrowserView(view)
       expect(view.webContents.getOwnerBrowserWindow()).to.equal(w)
 
       w.setBrowserView(null)
-      expect(!view.webContents.getOwnerBrowserWindow()).to.be.true()
+      expect(view.webContents.getOwnerBrowserWindow()).to.be.null()
     })
   })
 
@@ -168,7 +168,7 @@ describe('BrowserView module', () => {
       expect(view.id).to.not.be.null()
 
       const views = BrowserView.getAllViews()
-      expect(views.length).to.equal(1)
+      expect(views).to.be.an('array').that.has.lengthOf(1)
       expect(views[0].webContents.id).to.equal(view.webContents.id)
     })
   })


### PR DESCRIPTION
Ongoing work to migrate our specs from `assert` to chai's `expect` for better error messages.

This PR updates the `browser-view` spec.

/cc @alexeykuzmin 