### PR TITLE
spec: update browser-window-affinity spec to expect

### DIFF
--- a/spec/api-browser-window-affinity-spec.js
+++ b/spec/api-browser-window-affinity-spec.js
@@ -22,7 +22,7 @@ describe('BrowserWindow with affinity module', () => {
         webPreferences: webPrefs || {}
       })
       w.webContents.on('did-finish-load', () => { resolve(w) })
-      w.loadURL('file://' + path.join(fixtures, 'api', 'blank.html'))
+      w.loadURL(`file://${path.join(fixtures, 'api', 'blank.html')}`)
     })
   }
 


### PR DESCRIPTION
Ongoing work to migrate our specs from `assert` to chai's `expect` for better error messages.

This PR updates the `browser-window-affinity` spec.

/cc @alexeykuzmin