### PR TITLE
spec: run tests on release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,3 +315,12 @@ workflows:
       - electron-linux-arm64-release-nightly
       - electron-linux-ia32-release-nightly
       - electron-linux-x64-release-nightly
+
+experimental:
+  notify:
+    branches:
+      only:
+        - master
+        - 2-0-x
+        - 1-8-x
+        - 1-7-x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ build-steps: &build-steps
         command: |
           if [ -n "${RUN_RELEASE_BUILD}" ]; then
             echo 'release build triggered from api'
-            echo 'export ELECTRON_RELEASE=1 TRIGGERED_BY_API=1' >> $BASH_ENV
+            echo 'export ELECTRON_RELEASE=1 UPLOAD_TO_S3=1' >> $BASH_ENV
           fi
     - run:
        name: Bootstrap
@@ -43,10 +43,10 @@ build-steps: &build-steps
     - run:
         name: Upload distribution
         command: |
-          if [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" != "1" ]; then
+          if [ "$ELECTRON_RELEASE" == "1" ] && [ "$UPLOAD_TO_S3" != "1" ]; then
             echo 'Uploading Electron release distribution to github releases'
             script/upload.py
-          elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$TRIGGERED_BY_API" == "1" ]; then
+          elif [ "$ELECTRON_RELEASE" == "1" ] && [ "$UPLOAD_TO_S3" == "1" ]; then
             echo 'Uploading Electron release distribution to s3'
             script/upload.py --upload_to_s3
           else
@@ -55,7 +55,7 @@ build-steps: &build-steps
     - run:
         name: Setup for headless testing
         command: |
-          if [ "$ELECTRON_RELEASE" != "1" ] && [ "$RUN_HEADLESS_TESTS" == "true" ]; then
+          if [ "$RUN_HEADLESS_TESTS" == "true" ]; then
             echo 'Setup for headless testing'
             sh -e /etc/init.d/xvfb start
           else
@@ -67,30 +67,34 @@ build-steps: &build-steps
           MOCHA_FILE: junit/test-results.xml
           MOCHA_REPORTER: mocha-junit-reporter
         command: |
-          if [ "$ELECTRON_RELEASE" != "1" ] && [ "$RUN_TESTS" == "true" ]; then
-            echo 'Testing Electron debug build'
-            mkdir junit
-            script/test.py --ci
-          else
-            if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Skipping testing on release build'
+          if [ "$RUN_TESTS" == "true" ]; then
+            if [ "$ELECTRON_RELEASE" != "1" ]; then
+              echo 'Testing Electron debug build'
+              mkdir junit
+              script/test.py --ci --rebuild_native_modules
             else
-              echo 'Skipping tests due to configuration'
+              echo 'Testing Electron release build'
+              mkdir junit
+              script/test.py --ci --rebuild_native_modules -c R
             fi
+          else
+           echo 'Skipping tests due to configuration'
           fi
     - run:
         name: Verify FFmpeg
         command: |
-          if [ "$ELECTRON_RELEASE" != "1" ] && [ "$RUN_TESTS" == "true" ]; then
-            echo 'Verifying ffmpeg on debug build'
-            script/verify-ffmpeg.py
-          else
-            if [ "$ELECTRON_RELEASE" == "1" ]; then
-              echo 'Skipping verify ffmpeg on release build'
+          if [ "$RUN_TESTS" == "true" ]; then
+            if [ "$ELECTRON_RELEASE" != "1" ]; then
+              echo 'Verifying ffmpeg on debug build'
+              script/verify-ffmpeg.py
             else
-              echo 'Skipping tests due to configuration'
+              echo 'Verifying ffmpeg on release build'
+              script/verify-ffmpeg.py -R
             fi
+          else
+            echo 'Skipping tests due to configuration'
           fi
+
     - run:
         name: Generate Typescript Definitions
         command: |

--- a/script/upload.py
+++ b/script/upload.py
@@ -212,6 +212,7 @@ def create_release_draft(github, tag):
 
 
 def upload_electron(github, release, file_path, args):
+  filename = os.path.basename(file_path)
 
   # if upload_to_s3 is set, skip github upload.
   if args.upload_to_s3:
@@ -221,10 +222,11 @@ def upload_electron(github, release, file_path, args):
     s3put(bucket, access_key, secret_key, os.path.dirname(file_path),
           key_prefix, [file_path])
     upload_sha256_checksum(release['tag_name'], file_path, key_prefix)
+    s3url = 'https://gh-contractor-zcbenz.s3.amazonaws.com'
+    print '{0} uploaded to {1}/{2}/{0}'.format(filename, s3url, key_prefix)
     return
 
   # Delete the original file before uploading in CI.
-  filename = os.path.basename(file_path)
   if os.environ.has_key('CI'):
     try:
       for asset in release['assets']:

--- a/vsts.yml
+++ b/vsts.yml
@@ -80,4 +80,12 @@ steps:
     searchFolder: junit
   condition: and(always(), ne(variables['ELECTRON_RELEASE'], '1'))
 
+- task: kasunkodagoda.slack-notification.slack-notification-task.SlackNotification@3
+  displayName: Post Slack Notification
+  inputs:
+    SlackApiToken: '$(slack_token)'
+    Channel: '#bot-nightly-releases'
+    Message: '$(Build.DefinitionName)-$(Build.BuildNumber) finished with a $(Agent.JobStatus) status.'
+  condition: and(always(), eq(variables['Build.Reason'], 'Schedule'))
+
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3

--- a/vsts.yml
+++ b/vsts.yml
@@ -33,7 +33,7 @@ steps:
   condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
 - bash: |
-    if [ "$TRIGGERED_BY_API" != "1" ]; then
+    if [ "$UPLOAD_TO_S3" != "1" ]; then
       echo 'Uploading Electron release distribution to github releases'
       ELECTRON_S3_BUCKET="$(s3_bucket)" ELECTRON_S3_ACCESS_KEY="$(s3_access_key)" ELECTRON_S3_SECRET_KEY="$(s3_secret_key)" ELECTRON_GITHUB_TOKEN="$(github_token)" script/upload.py
     else
@@ -48,15 +48,30 @@ steps:
     mkdir junit
     export MOCHA_FILE="junit/test-results.xml"
     export MOCHA_REPORTER="mocha-junit-reporter"
-    script/test.py --ci
+    script/test.py --ci --rebuild_native_modules
   name: Test
   condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
+
+- bash: |
+    echo 'Testing Electron release build'
+    mkdir junit
+    export MOCHA_FILE="junit/test-results.xml"
+    export MOCHA_REPORTER="mocha-junit-reporter"
+    script/test.py --ci --rebuild_native_modules -c R
+  name: Test
+  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
 - bash: |
     echo 'Verifying ffmpeg on debug build'
     script/verify-ffmpeg.py
   name: Verify_FFmpeg
   condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
+
+- bash: |
+    echo 'Verifying ffmpeg on release build'
+    script/verify-ffmpeg.py -R
+  name: Verify_FFmpeg
+  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
 - task: PublishTestResults@2
   displayName: Publish Test Results


### PR DESCRIPTION
This PR changes our CI to run tests on release builds.  We currently run nightly release builds and it makes sense to run tests on those builds.  This PR also adds the ability to call VSTS release builds via API.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->