### PR TITLE
refactor: use std::make_unique<T>

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -83,7 +83,7 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 #endif  // !defined(OS_WIN)
 
   // Only enable logging when --enable-logging is specified.
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   if (!command_line->HasSwitch(::switches::kEnableLogging) &&
       !env->HasVar("ELECTRON_ENABLE_LOGGING")) {
     settings.logging_dest = logging::LOG_NONE;
@@ -203,7 +203,7 @@ bool AtomMainDelegate::DelaySandboxInitialization(
 
 std::unique_ptr<brightray::ContentClient>
 AtomMainDelegate::CreateContentClient() {
-  return std::unique_ptr<brightray::ContentClient>(new AtomContentClient);
+  return std::make_unique<AtomContentClient>();
 }
 
 }  // namespace atom

--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -38,7 +38,7 @@ int NodeMain(int argc, char* argv[]) {
     base::ThreadTaskRunnerHandle handle(uv_task_runner);
 
     // Initialize feature list.
-    std::unique_ptr<base::FeatureList> feature_list(new base::FeatureList);
+    auto feature_list = std::make_unique<base::FeatureList>();
     feature_list->InitializeFromCommandLine("", "");
     base::FeatureList::SetInstance(std::move(feature_list));
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -547,9 +547,9 @@ App::App(v8::Isolate* isolate) {
   Browser::Get()->AddObserver(this);
   content::GpuDataManager::GetInstance()->AddObserver(this);
   base::ProcessId pid = base::GetCurrentProcId();
-  std::unique_ptr<atom::ProcessMetric> process_metric(new atom::ProcessMetric(
+  auto process_metric = std::make_unique<atom::ProcessMetric>(
       content::PROCESS_TYPE_BROWSER, pid,
-      base::ProcessMetrics::CreateCurrentProcessMetrics()));
+      base::ProcessMetrics::CreateCurrentProcessMetrics());
   app_metrics_[pid] = std::move(process_metric);
   Init(isolate);
 }
@@ -811,9 +811,8 @@ void App::ChildProcessLaunched(int process_type, base::ProcessHandle handle) {
   std::unique_ptr<base::ProcessMetrics> metrics(
       base::ProcessMetrics::CreateProcessMetrics(handle));
 #endif
-  std::unique_ptr<atom::ProcessMetric> process_metric(
-      new atom::ProcessMetric(process_type, pid, std::move(metrics)));
-  app_metrics_[pid] = std::move(process_metric);
+  app_metrics_[pid] = std::make_unique<atom::ProcessMetric>(process_type, pid,
+                                                            std::move(metrics));
 }
 
 void App::ChildProcessDisconnected(base::ProcessId pid) {

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -336,7 +336,7 @@ v8::Local<v8::Value> BrowserWindow::GetWebContents(v8::Isolate* isolate) {
 // Convert draggable regions in raw format to SkRegion format.
 std::unique_ptr<SkRegion> BrowserWindow::DraggableRegionsToSkRegion(
     const std::vector<DraggableRegion>& regions) {
-  std::unique_ptr<SkRegion> sk_region(new SkRegion);
+  auto sk_region = std::make_unique<SkRegion>();
   for (const DraggableRegion& region : regions) {
     sk_region->op(
         region.bounds.x(), region.bounds.y(), region.bounds.right(),

--- a/atom/browser/api/atom_api_browser_window_mac.mm
+++ b/atom/browser/api/atom_api_browser_window_mac.mm
@@ -42,10 +42,10 @@ std::vector<gfx::Rect> CalculateNonDraggableRegions(
     int width,
     int height) {
   std::vector<gfx::Rect> result;
-  std::unique_ptr<SkRegion> non_draggable(new SkRegion);
-  non_draggable->op(0, 0, width, height, SkRegion::kUnion_Op);
-  non_draggable->op(*draggable, SkRegion::kDifference_Op);
-  for (SkRegion::Iterator it(*non_draggable); !it.done(); it.next()) {
+  SkRegion non_draggable;
+  non_draggable.op(0, 0, width, height, SkRegion::kUnion_Op);
+  non_draggable.op(*draggable, SkRegion::kDifference_Op);
+  for (SkRegion::Iterator it(non_draggable); !it.done(); it.next()) {
     result.push_back(gfx::SkIRectToRect(it.rect()));
   }
   return result;

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -46,8 +46,8 @@ void MenuViews::PopupAt(TopLevelWindow* window,
   int32_t window_id = window->weak_map_id();
   auto close_callback = base::Bind(
       &MenuViews::OnClosed, weak_factory_.GetWeakPtr(), window_id, callback);
-  menu_runners_[window_id] = std::unique_ptr<MenuRunner>(
-      new MenuRunner(model(), flags, close_callback));
+  menu_runners_[window_id] =
+      std::make_unique<MenuRunner>(model(), flags, close_callback);
   menu_runners_[window_id]->RunMenuAt(
       native_window->widget(), NULL, gfx::Rect(location, gfx::Size()),
       views::MENU_ANCHOR_TOPLEFT, ui::MENU_SOURCE_MOUSE);

--- a/atom/browser/api/atom_api_power_save_blocker.cc
+++ b/atom/browser/api/atom_api_power_save_blocker.cc
@@ -72,12 +72,11 @@ void PowerSaveBlocker::UpdatePowerSaveBlocker() {
   }
 
   if (!power_save_blocker_ || new_blocker_type != current_blocker_type_) {
-    std::unique_ptr<device::PowerSaveBlocker> new_blocker(
-        new device::PowerSaveBlocker(
-            new_blocker_type, device::PowerSaveBlocker::kReasonOther,
-            ATOM_PRODUCT_NAME,
-            BrowserThread::GetTaskRunnerForThread(BrowserThread::UI),
-            BrowserThread::GetTaskRunnerForThread(BrowserThread::FILE)));
+    auto new_blocker = std::make_unique<device::PowerSaveBlocker>(
+        new_blocker_type, device::PowerSaveBlocker::kReasonOther,
+        ATOM_PRODUCT_NAME,
+        BrowserThread::GetTaskRunnerForThread(BrowserThread::UI),
+        BrowserThread::GetTaskRunnerForThread(BrowserThread::FILE));
     power_save_blocker_.swap(new_blocker);
     current_blocker_type_ = new_blocker_type;
   }

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -117,9 +117,8 @@ class Protocol : public mate::TrackableObject<Protocol> {
         request_context_getter->job_factory());
     if (job_factory->IsHandledProtocol(scheme))
       return PROTOCOL_REGISTERED;
-    std::unique_ptr<CustomProtocolHandler<RequestJob>> protocol_handler(
-        new CustomProtocolHandler<RequestJob>(
-            isolate, request_context_getter.get(), handler));
+    auto protocol_handler = std::make_unique<CustomProtocolHandler<RequestJob>>(
+        isolate, request_context_getter.get(), handler);
     if (job_factory->SetProtocolHandler(scheme, std::move(protocol_handler)))
       return PROTOCOL_OK;
     else
@@ -166,9 +165,8 @@ class Protocol : public mate::TrackableObject<Protocol> {
     // It is possible a protocol is handled but can not be intercepted.
     if (!job_factory->HasProtocolHandler(scheme))
       return PROTOCOL_FAIL;
-    std::unique_ptr<CustomProtocolHandler<RequestJob>> protocol_handler(
-        new CustomProtocolHandler<RequestJob>(
-            isolate, request_context_getter.get(), handler));
+    auto protocol_handler = std::make_unique<CustomProtocolHandler<RequestJob>>(
+        isolate, request_context_getter.get(), handler);
     if (!job_factory->InterceptProtocol(scheme, std::move(protocol_handler)))
       return PROTOCOL_INTERCEPTED;
     return PROTOCOL_OK;

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -772,9 +772,7 @@ void WebContents::RequestToLockMouse(content::WebContents* web_contents,
 std::unique_ptr<content::BluetoothChooser> WebContents::RunBluetoothChooser(
     content::RenderFrameHost* frame,
     const content::BluetoothChooser::EventHandler& event_handler) {
-  std::unique_ptr<BluetoothChooser> bluetooth_chooser(
-      new BluetoothChooser(this, event_handler));
-  return std::move(bluetooth_chooser);
+  return std::make_unique<BluetoothChooser>(this, event_handler);
 }
 
 content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -223,8 +223,7 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
 #if !defined(OS_MACOSX)
   // The corresponding call in macOS is in AtomApplicationDelegate.
   Browser::Get()->WillFinishLaunching();
-  std::unique_ptr<base::DictionaryValue> empty_info(new base::DictionaryValue);
-  Browser::Get()->DidFinishLaunching(*empty_info);
+  Browser::Get()->DidFinishLaunching(base::DictionaryValue());
 #endif
 
   // Notify observers that main thread message loop was initialized.

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -134,12 +134,12 @@ std::unique_ptr<net::ClientCertStore>
 AtomResourceDispatcherHostDelegate::CreateClientCertStore(
     content::ResourceContext* resource_context) {
 #if defined(USE_NSS_CERTS)
-  return std::unique_ptr<net::ClientCertStore>(new net::ClientCertStoreNSS(
-      net::ClientCertStoreNSS::PasswordDelegateFactory()));
+  return std::make_unique<net::ClientCertStoreNSS>(
+      net::ClientCertStoreNSS::PasswordDelegateFactory());
 #elif defined(OS_WIN)
-  return std::unique_ptr<net::ClientCertStore>(new net::ClientCertStoreWin());
+  return std::make_unique<net::ClientCertStoreWin>();
 #elif defined(OS_MACOSX)
-  return std::unique_ptr<net::ClientCertStore>(new net::ClientCertStoreMac());
+  return std::make_unique<net::ClientCertStoreMac>();
 #elif defined(USE_OPENSSL)
   return std::unique_ptr<net::ClientCertStore>();
 #endif

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -62,9 +62,7 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
         atom::NSDictionaryToDictionaryValue(user_notification.userInfo);
     atom::Browser::Get()->DidFinishLaunching(*launch_info);
   } else {
-    std::unique_ptr<base::DictionaryValue> empty_info(
-        new base::DictionaryValue);
-    atom::Browser::Get()->DidFinishLaunching(*empty_info);
+    atom::Browser::Get()->DidFinishLaunching(base::DictionaryValue());
   }
 
 #if BUILDFLAG(USE_ALLOCATOR_SHIM)

--- a/atom/browser/mac/dict_util.mm
+++ b/atom/browser/mac/dict_util.mm
@@ -26,7 +26,7 @@ std::unique_ptr<base::ListValue> NSArrayToListValue(NSArray* arr) {
   if (!arr)
     return nullptr;
 
-  std::unique_ptr<base::ListValue> result(new base::ListValue);
+  auto result = std::make_unique<base::ListValue>();
   for (id value in arr) {
     if ([value isKindOfClass:[NSString class]]) {
       result->AppendString(base::SysNSStringToUTF8(value));
@@ -79,7 +79,7 @@ std::unique_ptr<base::DictionaryValue> NSDictionaryToDictionaryValue(
   if (!dict)
     return nullptr;
 
-  std::unique_ptr<base::DictionaryValue> result(new base::DictionaryValue);
+  auto result = std::make_unique<base::DictionaryValue>();
   for (id key in dict) {
     std::string str_key = base::SysNSStringToUTF8(
         [key isKindOfClass:[NSString class]] ? key : [key description]);

--- a/atom/browser/net/atom_cert_verifier.cc
+++ b/atom/browser/net/atom_cert_verifier.cc
@@ -88,7 +88,7 @@ class CertVerifierRequest : public AtomCertVerifier::Request {
 
   void OnDefaultVerificationDone(int error) {
     error_ = error;
-    std::unique_ptr<VerifyRequestParams> request(new VerifyRequestParams());
+    auto request = std::make_unique<VerifyRequestParams>();
     request->hostname = params_.hostname();
     request->default_result = net::ErrorToString(error);
     request->error_code = error;
@@ -174,8 +174,7 @@ int AtomCertVerifier::Verify(const RequestParams& params,
     CertVerifierRequest* request = FindRequest(params);
     if (!request) {
       out_req->reset();
-      std::unique_ptr<CertVerifierRequest> new_request =
-          std::make_unique<CertVerifierRequest>(params, this);
+      auto new_request = std::make_unique<CertVerifierRequest>(params, this);
       new_request->Start(crl_set, net_log);
       request = new_request.get();
       *out_req = std::move(new_request);

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -105,7 +105,7 @@ void ToDictionary(base::DictionaryValue* details, net::URLRequest* request) {
 
 void ToDictionary(base::DictionaryValue* details,
                   const net::HttpRequestHeaders& headers) {
-  std::unique_ptr<base::DictionaryValue> dict(new base::DictionaryValue);
+  auto dict = std::make_unique<base::DictionaryValue>();
   net::HttpRequestHeaders::Iterator it(headers);
   while (it.GetNext())
     dict->SetKey(it.name(), base::Value(it.value()));
@@ -117,7 +117,7 @@ void ToDictionary(base::DictionaryValue* details,
   if (!headers)
     return;
 
-  std::unique_ptr<base::DictionaryValue> dict(new base::DictionaryValue);
+  auto dict = std::make_unique<base::DictionaryValue>();
   size_t iter = 0;
   std::string key;
   std::string value;
@@ -127,7 +127,7 @@ void ToDictionary(base::DictionaryValue* details,
       if (dict->GetList(key, &values))
         values->AppendString(value);
     } else {
-      std::unique_ptr<base::ListValue> values(new base::ListValue);
+      auto values = std::make_unique<base::ListValue>();
       values->AppendString(value);
       dict->Set(key, std::move(values));
     }
@@ -388,7 +388,7 @@ int AtomNetworkDelegate::HandleResponseEvent(
   if (!MatchesFilterCondition(request, info.url_patterns))
     return net::OK;
 
-  std::unique_ptr<base::DictionaryValue> details(new base::DictionaryValue);
+  auto details = std::make_unique<base::DictionaryValue>();
   FillDetailsObject(details.get(), request, args...);
 
   int render_process_id, render_frame_id;
@@ -416,7 +416,7 @@ void AtomNetworkDelegate::HandleSimpleEvent(SimpleEvent type,
   if (!MatchesFilterCondition(request, info.url_patterns))
     return;
 
-  std::unique_ptr<base::DictionaryValue> details(new base::DictionaryValue);
+  auto details = std::make_unique<base::DictionaryValue>();
   FillDetailsObject(details.get(), request, args...);
 
   int render_process_id, render_frame_id;

--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -68,8 +68,7 @@ class JsAsker : public RequestJob {
  private:
   // RequestJob:
   void Start() override {
-    std::unique_ptr<base::DictionaryValue> request_details(
-        new base::DictionaryValue);
+    auto request_details = std::make_unique<base::DictionaryValue>();
     request_start_time_ = base::TimeTicks::Now();
     FillRequestDetails(request_details.get(), RequestJob::request());
     content::BrowserThread::PostTask(

--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -187,8 +187,8 @@ void FileChooserDialog::AddFilters(const Filters& filters) {
     GtkFileFilter* gtk_filter = gtk_file_filter_new();
 
     for (size_t j = 0; j < filter.second.size(); ++j) {
-      std::unique_ptr<std::string> file_extension(
-          new std::string("." + filter.second[j]));
+      auto file_extension =
+          std::make_unique<std::string>("." + filter.second[j]);
       gtk_file_filter_add_custom(
           gtk_filter, GTK_FILE_FILTER_FILENAME,
           reinterpret_cast<GtkFileFilterFunc>(FileFilterCaseInsensitive),

--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -85,13 +85,9 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   // Create array to keep file types and their name.
   for (const Filter& filter : filters) {
     NSMutableSet* file_type_set = [NSMutableSet set];
-    base::ScopedCFTypeRef<CFStringRef> name_cf(
-        base::SysUTF8ToCFStringRef(filter.first));
-    [filter_names addObject:base::mac::CFToNSCast(name_cf.get())];
+    [filter_names addObject:@(filter.first.c_str())];
     for (const std::string& ext : filter.second) {
-      base::ScopedCFTypeRef<CFStringRef> ext_cf(
-          base::SysUTF8ToCFStringRef(ext));
-      [file_type_set addObject:base::mac::CFToNSCast(ext_cf.get())];
+      [file_type_set addObject:@(ext.c_str())];
     }
     [file_types_list addObject:[file_type_set allObjects]];
   }

--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -151,8 +151,8 @@ struct RunState {
 };
 
 bool CreateDialogThread(RunState* run_state) {
-  std::unique_ptr<base::Thread> thread(
-      new base::Thread(ATOM_PRODUCT_NAME "FileDialogThread"));
+  auto thread =
+      std::make_unique<base::Thread>(ATOM_PRODUCT_NAME "FileDialogThread");
   thread->init_com_with_mta(false);
   if (!thread->Start())
     return false;

--- a/atom/browser/ui/message_box_win.cc
+++ b/atom/browser/ui/message_box_win.cc
@@ -257,8 +257,8 @@ void ShowMessageBox(NativeWindow* parent,
                     bool checkbox_checked,
                     const gfx::ImageSkia& icon,
                     const MessageBoxCallback& callback) {
-  std::unique_ptr<base::Thread> thread(
-      new base::Thread(ATOM_PRODUCT_NAME "MessageBoxThread"));
+  auto thread =
+      std::make_unique<base::Thread>(ATOM_PRODUCT_NAME "MessageBoxThread");
   thread->init_com_with_mta(false);
   if (!thread->Start()) {
     callback.Run(cancel_id, checkbox_checked);

--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -23,7 +23,7 @@ class Archive : public mate::Wrappable<Archive> {
  public:
   static v8::Local<v8::Value> Create(v8::Isolate* isolate,
                                      const base::FilePath& path) {
-    std::unique_ptr<asar::Archive> archive(new asar::Archive(path));
+    auto archive = std::make_unique<asar::Archive>(path);
     if (!archive->Init())
       return v8::False(isolate);
     return (new Archive(isolate, std::move(archive)))->GetWrapper();

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -85,7 +85,7 @@ bool AddImageSkiaRep(gfx::ImageSkia* image,
                      int width,
                      int height,
                      double scale_factor) {
-  std::unique_ptr<SkBitmap> decoded(new SkBitmap());
+  auto decoded = std::make_unique<SkBitmap>();
 
   // Try PNG first.
   if (!gfx::PNGCodec::Decode(data, size, decoded.get())) {

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -157,8 +157,7 @@ v8::Local<v8::Value> AtomBindings::GetHeapStatistics(v8::Isolate* isolate) {
 
 // static
 v8::Local<v8::Value> AtomBindings::GetProcessMemoryInfo(v8::Isolate* isolate) {
-  std::unique_ptr<base::ProcessMetrics> metrics(
-      base::ProcessMetrics::CreateCurrentProcessMetrics());
+  auto metrics = base::ProcessMetrics::CreateCurrentProcessMetrics();
 
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
   dict.Set("workingSetSize",
@@ -224,8 +223,7 @@ v8::Local<v8::Value> AtomBindings::GetCPUUsage(v8::Isolate* isolate) {
 
 // static
 v8::Local<v8::Value> AtomBindings::GetIOCounters(v8::Isolate* isolate) {
-  std::unique_ptr<base::ProcessMetrics> metrics(
-      base::ProcessMetrics::CreateCurrentProcessMetrics());
+  auto metrics = base::ProcessMetrics::CreateCurrentProcessMetrics();
   base::IoCounters io_counters;
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
 

--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -291,7 +291,7 @@ bool Archive::CopyFileOut(const base::FilePath& path, base::FilePath* out) {
     return true;
   }
 
-  std::unique_ptr<ScopedTemporaryFile> temp_file(new ScopedTemporaryFile);
+  auto temp_file = std::make_unique<ScopedTemporaryFile>();
   base::FilePath::StringType ext = path.Extension();
   if (!temp_file->InitFromFile(&file_, ext, info.offset, info.size))
     return false;

--- a/atom/common/native_mate_converters/content_converter.cc
+++ b/atom/common/native_mate_converters/content_converter.cc
@@ -209,10 +209,9 @@ v8::Local<v8::Value> Converter<scoped_refptr<ResourceRequestBody>>::ToV8(
     const scoped_refptr<ResourceRequestBody>& val) {
   if (!val)
     return v8::Null(isolate);
-  std::unique_ptr<base::ListValue> list(new base::ListValue);
+  auto list = std::make_unique<base::ListValue>();
   for (const auto& element : *(val->elements())) {
-    std::unique_ptr<base::DictionaryValue> post_data_dict(
-        new base::DictionaryValue);
+    auto post_data_dict = std::make_unique<base::DictionaryValue>();
     auto type = element.type();
     if (type == ResourceRequestBody::Element::TYPE_BYTES) {
       std::unique_ptr<base::Value> bytes(base::Value::CreateWithCopiedBuffer(
@@ -249,7 +248,7 @@ bool Converter<scoped_refptr<ResourceRequestBody>>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
     scoped_refptr<ResourceRequestBody>* out) {
-  std::unique_ptr<base::ListValue> list(new base::ListValue);
+  auto list = std::make_unique<base::ListValue>();
   if (!ConvertFromV8(isolate, val, list.get()))
     return false;
   *out = new content::ResourceRequestBody();

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -158,7 +158,7 @@ v8::Local<v8::Value> Converter<net::HttpResponseHeaders*>::ToV8(
         if (response_headers.GetList(key, &values))
           values->AppendString(value);
       } else {
-        std::unique_ptr<base::ListValue> values(new base::ListValue());
+        auto values = std::make_unique<base::ListValue>();
         values->AppendString(value);
         response_headers.Set(key, std::move(values));
       }
@@ -208,12 +208,11 @@ void FillRequestDetails(base::DictionaryValue* details,
     url = request->url().spec();
   details->SetKey("url", base::Value(url));
   details->SetString("referrer", request->referrer());
-  std::unique_ptr<base::ListValue> list(new base::ListValue);
+  auto list = std::make_unique<base::ListValue>();
   GetUploadData(list.get(), request);
   if (!list->empty())
     details->Set("uploadData", std::move(list));
-  std::unique_ptr<base::DictionaryValue> headers_value(
-      new base::DictionaryValue);
+  auto headers_value = std::make_unique<base::DictionaryValue>();
   for (net::HttpRequestHeaders::Iterator it(request->extra_request_headers());
        it.GetNext();) {
     headers_value->SetString(it.name(), it.value());
@@ -229,8 +228,7 @@ void GetUploadData(base::ListValue* upload_data_list,
   const std::vector<std::unique_ptr<net::UploadElementReader>>* readers =
       upload_data->GetElementReaders();
   for (const auto& reader : *readers) {
-    std::unique_ptr<base::DictionaryValue> upload_data_dict(
-        new base::DictionaryValue);
+    auto upload_data_dict = std::make_unique<base::DictionaryValue>();
     if (reader->AsBytesReader()) {
       const net::UploadBytesElementReader* bytes_reader =
           reader->AsBytesReader();

--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -429,7 +429,7 @@ base::Value* V8ValueConverter::FromV8Object(v8::Local<v8::Object> val,
       val->CreationContext() != isolate->GetCurrentContext())
     scope.reset(new v8::Context::Scope(val->CreationContext()));
 
-  std::unique_ptr<base::DictionaryValue> result(new base::DictionaryValue());
+  auto result = std::make_unique<base::DictionaryValue>();
   v8::Local<v8::Array> property_names(val->GetOwnPropertyNames());
 
   for (uint32_t i = 0; i < property_names->Length(); ++i) {

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -195,8 +195,8 @@ void WebFrame::SetSpellCheckProvider(mate::Arguments* args,
     return;
   }
 
-  std::unique_ptr<SpellCheckClient> client(new SpellCheckClient(
-      language, auto_spell_correct_turned_on, args->isolate(), provider));
+  auto client = std::make_unique<SpellCheckClient>(
+      language, auto_spell_correct_turned_on, args->isolate(), provider);
   // Set spellchecker for all live frames in the same process or
   // in the sandbox mode for all live sub frames to this WebFrame.
   FrameSpellChecker spell_checker(

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -136,9 +136,7 @@ void RendererClientBase::RenderThreadStarted() {
 #if defined(OS_MACOSX)
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   bool scroll_bounce = command_line->HasSwitch(switches::kScrollBounce);
-  base::ScopedCFTypeRef<CFStringRef> rubber_banding_key(
-      base::SysUTF8ToCFStringRef("NSScrollViewRubberbanding"));
-  CFPreferencesSetAppValue(rubber_banding_key,
+  CFPreferencesSetAppValue(CFSTR("NSScrollViewRubberbanding"),
                            scroll_bounce ? kCFBooleanTrue : kCFBooleanFalse,
                            kCFPreferencesCurrentApplication);
   CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);


### PR DESCRIPTION
- replace `std::unique_ptr<T> xyz(new T(...))` with `auto xyz = std::make_unique<T>(...)` for shorter and safer code
- don't allocate on the heap when stack allocation is more suitable