### PR TITLE
change c++ std from gnu++14 to c++14

### DIFF
--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -180,7 +180,7 @@
           }],
           ['OS=="linux" and _toolset=="target"', {
             'cflags_cc': [
-              '-std=gnu++14',
+              '-std=c++14',
               '-nostdinc++',
               '-isystem<(libchromiumcontent_src_dir)/buildtools/third_party/libc++/trunk/include',
               '-isystem<(libchromiumcontent_src_dir)/buildtools/third_party/libc++abi/trunk/include',
@@ -191,7 +191,7 @@
           }],
           ['OS=="linux" and _toolset=="host"', {
             'cflags_cc': [
-              '-std=gnu++14',
+              '-std=c++14',
             ],
           }],
         ],
@@ -207,7 +207,7 @@
       ],
       'target_defaults': {
         'cflags_cc': [
-          '-std=gnu++14',
+          '-std=c++14',
         ],
       },
     }],


### PR DESCRIPTION
Does what it says on the tin.

We have been building with c++14 plus gnu extensions. Since we don't seem to be using the gnu extensions, this patch changes the standard to stock c++14.

NB: This only modifies toolchain.gypi. I haven't looked to see if this is an issue in the new build. @nornagon?