### PR TITLE
docs: Make appUserModelId requirement clearer

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -24,12 +24,20 @@ are subtle differences.
 
 ## Windows
 
-* On Windows 10, notifications "just work".
-* On Windows 8.1 and Windows 8, a shortcut to your app, with an [Application User
-Model ID][app-user-model-id], must be installed to the Start screen. Note,
+* On Windows 10, a shortcut to your app with an [Application User
+Model ID][app-user-model-id] must be installed to the Start Menu.
+* On Windows 8.1 and Windows 8, a shortcut to your app with an [Application User
+Model ID][app-user-model-id] must be installed to the Start screen. Note,
 however, that it does not need to be pinned to the Start screen.
 * On Windows 7, notifications work via a custom implementation which visually
- resembles the native one on newer systems.
+resembles the native one on newer systems.
+
+Electron attempts to automate the work around the Application User Model ID. When
+Electron is used together with the installation and update framework Squirrel,
+[shortcuts will automatically be set correctly][squirrel-events]. Furthermore,
+Electron will detect that Squirrel was used and will automatically call
+`app.setAppUserModelId()` with the correct value. During development, you may have
+to call [`app.setAppUserModelId()`][[set-app-user-model-id]] yourself.
 
 Furthermore, in Windows 8, the maximum length for the notification body is 250
 characters, with the Windows team recommending that notifications should be kept
@@ -88,3 +96,5 @@ GNOME, KDE.
 
 [notification-spec]: https://developer.gnome.org/notification-spec/
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
+[set-app-user-model-id]: ../api/app.md#appsetappusermodelidid-windows
+[squirrel-events]: https://github.com/electron/windows-installer/blob/master/README.md#handling-squirrel-events


### PR DESCRIPTION
I'm not 100% sure if I made a mistake at the beginning of time or if the requirements in Windows 10 have actually changed. The whole notification system has undergone changes, so I think the latter is likely.

Either way, this PR makes the requirements around shortcuts with an `appUserModelId` and notifications on Windows more clear.

Once #13258 is merged, we can update this further to say that things "just work" in the desktop bridge.