### PR TITLE
spec: convert deprecations to expect

### DIFF
--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -1,5 +1,9 @@
-const assert = require('assert')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
 const {deprecations, deprecate, nativeImage} = require('electron')
+
+const {expect} = chai
+chai.use(dirtyChai)
 
 describe('deprecations', () => {
   beforeEach(() => {
@@ -10,43 +14,43 @@ describe('deprecations', () => {
   it('allows a deprecation handler function to be specified', () => {
     const messages = []
 
-    deprecations.setHandler((message) => {
+    deprecations.setHandler(message => {
       messages.push(message)
     })
 
     deprecate.log('this is deprecated')
-    assert.deepEqual(messages, ['this is deprecated'])
+    expect(messages).to.deep.equal(['this is deprecated'])
   })
 
   it('returns a deprecation handler after one is set', () => {
     const messages = []
 
-    deprecations.setHandler((message) => {
+    deprecations.setHandler(message => {
       messages.push(message)
     })
 
     deprecate.log('this is deprecated')
-    assert(typeof deprecations.getHandler() === 'function')
+    expect(deprecations.getHandler()).to.be.a('function')
   })
 
   it('returns a deprecation warning', () => {
     const messages = []
 
-    deprecations.setHandler((message) => {
+    deprecations.setHandler(message => {
       messages.push(message)
     })
 
     deprecate.warn('old', 'new')
-    assert.deepEqual(messages, [`'old' is deprecated. Use 'new' instead.`])
+    expect(messages).to.deep.equal([`'old' is deprecated. Use 'new' instead.`])
   })
 
   it('renames a method', () => {
-    assert.equal(typeof nativeImage.createFromDataUrl, 'undefined')
-    assert.equal(typeof nativeImage.createFromDataURL, 'function')
+    expect(nativeImage.createFromDataUrl).to.be.undefined()
+    expect(nativeImage.createFromDataURL).to.be.a('function')
 
     deprecate.alias(nativeImage, 'createFromDataUrl', 'createFromDataURL')
 
-    assert.equal(typeof nativeImage.createFromDataUrl, 'function')
+    expect(nativeImage.createFromDataUrl).to.be.a('function')
   })
 
   it('renames a property', () => {
@@ -58,19 +62,19 @@ describe('deprecations', () => {
 
     let value = 0
     let o = { [newPropertyName]: value }
-    assert.strictEqual(typeof o[oldPropertyName], 'undefined')
-    assert.strictEqual(typeof o[newPropertyName], 'number')
+    expect(o[oldPropertyName]).to.be.undefined()
+    expect(o[newPropertyName]).to.be.a('number')
 
     deprecate.property(o, oldPropertyName, newPropertyName)
-    assert.notEqual(typeof msg, 'string')
+    expect(msg).to.not.be.a('string')
     o[oldPropertyName] = ++value
 
-    assert.strictEqual(typeof msg, 'string')
-    assert.ok(msg.includes(oldPropertyName))
-    assert.ok(msg.includes(newPropertyName))
+    expect(msg).to.be.a('string')
+    expect(msg).to.include(oldPropertyName)
+    expect(msg).to.include(newPropertyName)
 
-    assert.strictEqual(o[newPropertyName], value)
-    assert.strictEqual(o[oldPropertyName], value)
+    expect(o[newPropertyName]).to.equal(value)
+    expect(o[oldPropertyName]).to.equal(value)
   })
 
   it('warns if deprecated property is already set', () => {
@@ -84,14 +88,14 @@ describe('deprecations', () => {
     let o = { [oldPropertyName]: value }
     deprecate.property(o, oldPropertyName, newPropertyName)
 
-    assert.strictEqual(typeof msg, 'string')
-    assert.ok(msg.includes(oldPropertyName))
-    assert.ok(msg.includes(newPropertyName))
+    expect(msg).to.be.a('string')
+    expect(msg).to.include(oldPropertyName)
+    expect(msg).to.include(newPropertyName)
   })
 
   it('throws an exception if no deprecation handler is specified', () => {
-    assert.throws(() => {
+    expect(() => {
       deprecate.log('this is deprecated')
-    }, /this is deprecated/)
+    }).to.throw(/this is deprecated/)
   })
 })

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -62,19 +62,18 @@ describe('deprecations', () => {
 
     let value = 0
     let o = { [newPropertyName]: value }
-    expect(o[oldPropertyName]).to.be.undefined()
-    expect(o[newPropertyName]).to.be.a('number')
+    expect(o).to.not.have.a.property(oldPropertyName)
+    expect(o).to.have.a.property(newPropertyName).that.is.a('number')
 
     deprecate.property(o, oldPropertyName, newPropertyName)
-    expect(msg).to.not.be.a('string')
     o[oldPropertyName] = ++value
 
     expect(msg).to.be.a('string')
     expect(msg).to.include(oldPropertyName)
     expect(msg).to.include(newPropertyName)
 
-    expect(o[newPropertyName]).to.equal(value)
-    expect(o[oldPropertyName]).to.equal(value)
+    expect(o).to.have.a.property(newPropertyName).that.is.equal(value)
+    expect(o).to.have.a.property(oldPropertyName).that.is.equal(value)
   })
 
   it('warns if deprecated property is already set', () => {


### PR DESCRIPTION
Ongoing work to migrate our specs from `assert` to chai's `expect` for better error messages.

This PR updates the `deprecations` spec.