### PR TITLE
spec: convert desktop capturer to expect

### DIFF
--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -1,6 +1,10 @@
-const assert = require('assert')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
 const {desktopCapturer, remote, screen} = require('electron')
 const features = process.atomBinding('features')
+
+const {expect} = chai
+chai.use(dirtyChai)
 
 const isCI = remote.getGlobal('isCi')
 
@@ -17,19 +21,19 @@ describe('desktopCapturer', () => {
     }
   })
 
-  it('should return a non-empty array of sources', (done) => {
+  it('should return a non-empty array of sources', done => {
     desktopCapturer.getSources({
       types: ['window', 'screen']
     }, (error, sources) => {
-      assert.equal(error, null)
-      assert.notEqual(sources.length, 0)
+      expect(error).to.be.null()
+      expect(sources.length).to.not.equal(0)
       done()
     })
   })
 
-  it('throws an error for invalid options', (done) => {
-    desktopCapturer.getSources(['window', 'screen'], (error) => {
-      assert.equal(error.message, 'Invalid options')
+  it('throws an error for invalid options', done => {
+    desktopCapturer.getSources(['window', 'screen'], error => {
+      expect(error.message).to.equal('Invalid options')
       done()
     })
   })
@@ -38,8 +42,8 @@ describe('desktopCapturer', () => {
     let callCount = 0
     const callback = (error, sources) => {
       callCount++
-      assert.equal(error, null)
-      assert.notEqual(sources.length, 0)
+      expect(error).to.be.null()
+      expect(sources.length).to.not.equal(0)
       if (callCount === 2) done()
     }
 
@@ -47,11 +51,11 @@ describe('desktopCapturer', () => {
     desktopCapturer.getSources({types: ['window', 'screen']}, callback)
   })
 
-  it('responds to subsequent calls of different options', (done) => {
+  it('responds to subsequent calls of different options', done => {
     let callCount = 0
     const callback = (error, sources) => {
       callCount++
-      assert.equal(error, null)
+      expect(error).to.be.null()
       if (callCount === 2) done()
     }
 
@@ -59,30 +63,35 @@ describe('desktopCapturer', () => {
     desktopCapturer.getSources({types: ['screen']}, callback)
   })
 
-  it('returns an empty display_id for window sources on Windows and Mac', (done) => {
+  it('returns an empty display_id for window sources on Windows and Mac', done => {
     // Linux doesn't return any window sources.
     if (process.platform !== 'win32' && process.platform !== 'darwin') {
       return done()
     }
+
     desktopCapturer.getSources({types: ['window']}, (error, sources) => {
-      assert.equal(error, null)
-      assert.notEqual(sources.length, 0)
-      sources.forEach((source) => { assert.equal(source.display_id.length, 0) })
+      expect(error).to.be.null()
+      expect(sources.length).to.not.equal(0)
+      sources.forEach((source) => {
+        expect(source.display_id.length).to.equal(0)
+      })
       done()
     })
   })
 
-  it('returns display_ids matching the Screen API on Windows and Mac', (done) => {
+  it('returns display_ids matching the Screen API on Windows and Mac', done => {
     if (process.platform !== 'win32' && process.platform !== 'darwin') {
       return done()
     }
+
     const displays = screen.getAllDisplays()
     desktopCapturer.getSources({types: ['screen']}, (error, sources) => {
-      assert.equal(error, null)
-      assert.notEqual(sources.length, 0)
-      assert.equal(sources.length, displays.length)
+      expect(error).to.be.null()
+      expect(sources.length).to.not.equal(0)
+      expect(sources.length).to.equal(displays.length)
+
       for (let i = 0; i < sources.length; i++) {
-        assert.equal(sources[i].display_id, displays[i].id)
+        expect(sources[i].display_id).to.equal(displays[i].id.toString())
       }
       done()
     })

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -26,7 +26,7 @@ describe('desktopCapturer', () => {
       types: ['window', 'screen']
     }, (error, sources) => {
       expect(error).to.be.null()
-      expect(sources.length).to.not.equal(0)
+      expect(sources).to.be.an('array').that.is.not.empty()
       done()
     })
   })
@@ -43,7 +43,7 @@ describe('desktopCapturer', () => {
     const callback = (error, sources) => {
       callCount++
       expect(error).to.be.null()
-      expect(sources.length).to.not.equal(0)
+      expect(sources).to.be.an('array').that.is.not.empty()
       if (callCount === 2) done()
     }
 
@@ -71,10 +71,10 @@ describe('desktopCapturer', () => {
 
     desktopCapturer.getSources({types: ['window']}, (error, sources) => {
       expect(error).to.be.null()
-      expect(sources.length).to.not.equal(0)
-      sources.forEach((source) => {
-        expect(source.display_id.length).to.equal(0)
-      })
+      expect(sources).to.be.an('array').that.is.not.empty()
+      for (const {display_id: displayId} of sources) {
+        expect(displayId).to.be.a('string').and.be.empty()
+      }
       done()
     })
   })
@@ -87,8 +87,7 @@ describe('desktopCapturer', () => {
     const displays = screen.getAllDisplays()
     desktopCapturer.getSources({types: ['screen']}, (error, sources) => {
       expect(error).to.be.null()
-      expect(sources.length).to.not.equal(0)
-      expect(sources.length).to.equal(displays.length)
+      expect(sources).to.be.an('array').of.length(displays.length)
 
       for (let i = 0; i < sources.length; i++) {
         expect(sources[i].display_id).to.equal(displays[i].id.toString())


### PR DESCRIPTION
Ongoing work to migrate our specs from `assert` to chai's `expect` for better error messages.

This PR updates the `desktop-capturer` spec.