### PR TITLE
docs: update pr template with checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,14 @@
 Thank you for your Pull Request. Please provide a description above and review
 the requirements below.
 
-Bug fixes and new features should include tests and possibly benchmarks.
-
 Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
 -->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm test` passes
+- [ ] `npm run lint` passes
+- [ ] tests are included
+- [ ] documentation is changed or added
+- [ ] commit message follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,6 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 - [ ] PR description included and stakeholders cc'd
 - [ ] `npm test` passes
-- [ ] `npm run lint` passes
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
 - [ ] relevant documentation is changed or added
-- [ ] commit message follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
+- [ ] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 ##### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
+- [ ] PR description included and stakeholders cc'd
 - [ ] `npm test` passes
 - [ ] `npm run lint` passes
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 - [ ] `npm test` passes
 - [ ] `npm run lint` passes
-- [ ] tests are included
-- [ ] documentation is changed or added
+- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
+- [ ] relevant documentation is changed or added
 - [ ] commit message follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


### PR DESCRIPTION
This PR updates the Pull Request template so that contributors see a clearer checklist of items they need to complete in order to have a given PR reviewed and landed. 