### PR TITLE
spec: convert dialog spec to expect

### DIFF
--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -1,112 +1,112 @@
-const assert = require('assert')
+const {expect} = require('chai')
 const {dialog} = require('electron').remote
 
 describe('dialog module', () => {
   describe('showOpenDialog', () => {
     it('throws errors when the options are invalid', () => {
-      assert.throws(() => {
+      expect(() => {
         dialog.showOpenDialog({properties: false})
-      }, /Properties must be an array/)
+      }).to.throw(/Properties must be an array/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showOpenDialog({title: 300})
-      }, /Title must be a string/)
+      }).to.throw(/Title must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showOpenDialog({buttonLabel: []})
-      }, /Button label must be a string/)
+      }).to.throw(/Button label must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showOpenDialog({defaultPath: {}})
-      }, /Default path must be a string/)
+      }).to.throw(/Default path must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showOpenDialog({message: {}})
-      }, /Message must be a string/)
+      }).to.throw(/Message must be a string/)
     })
   })
 
   describe('showSaveDialog', () => {
     it('throws errors when the options are invalid', () => {
-      assert.throws(() => {
+      expect(() => {
         dialog.showSaveDialog({title: 300})
-      }, /Title must be a string/)
+      }).to.throw(/Title must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showSaveDialog({buttonLabel: []})
-      }, /Button label must be a string/)
+      }).to.throw(/Button label must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showSaveDialog({defaultPath: {}})
-      }, /Default path must be a string/)
+      }).to.throw(/Default path must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showSaveDialog({message: {}})
-      }, /Message must be a string/)
+      }).to.throw(/Message must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showSaveDialog({nameFieldLabel: {}})
-      }, /Name field label must be a string/)
+      }).to.throw(/Name field label must be a string/)
     })
   })
 
   describe('showMessageBox', () => {
     it('throws errors when the options are invalid', () => {
-      assert.throws(() => {
+      expect(() => {
         dialog.showMessageBox(undefined, {type: 'not-a-valid-type'})
-      }, /Invalid message box type/)
+      }).to.throw(/Invalid message box type/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showMessageBox(null, {buttons: false})
-      }, /Buttons must be an array/)
+      }).to.throw(/Buttons must be an array/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showMessageBox({title: 300})
-      }, /Title must be a string/)
+      }).to.throw(/Title must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showMessageBox({message: []})
-      }, /Message must be a string/)
+      }).to.throw(/Message must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showMessageBox({detail: 3.14})
-      }, /Detail must be a string/)
+      }).to.throw(/Detail must be a string/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showMessageBox({checkboxLabel: false})
-      }, /checkboxLabel must be a string/)
+      }).to.throw(/checkboxLabel must be a string/)
     })
   })
 
   describe('showErrorBox', () => {
     it('throws errors when the options are invalid', () => {
-      assert.throws(() => {
+      expect(() => {
         dialog.showErrorBox()
-      }, /Insufficient number of arguments/)
+      }).to.throw(/Insufficient number of arguments/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showErrorBox(3, 'four')
-      }, /Error processing argument at index 0/)
+      }).to.throw(/Error processing argument at index 0/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showErrorBox('three', 4)
-      }, /Error processing argument at index 1/)
+      }).to.throw(/Error processing argument at index 1/)
     })
   })
 
   describe('showCertificateTrustDialog', () => {
     it('throws errors when the options are invalid', () => {
-      assert.throws(() => {
+      expect(() => {
         dialog.showCertificateTrustDialog()
-      }, /options must be an object/)
+      }).to.throw(/options must be an object/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showCertificateTrustDialog({})
-      }, /certificate must be an object/)
+      }).to.throw(/certificate must be an object/)
 
-      assert.throws(() => {
+      expect(() => {
         dialog.showCertificateTrustDialog({certificate: {}, message: false})
-      }, /message must be a string/)
+      }).to.throw(/message must be a string/)
     })
   })
 })


### PR DESCRIPTION
Ongoing work to migrate our specs from `assert` to chai's `expect` for better error messages.

This PR updates the `dialog` spec.