### PR TITLE
spec: convert IAP and GC specs to expect

### DIFF
--- a/spec/api-global-shortcut-spec.js
+++ b/spec/api-global-shortcut-spec.js
@@ -23,7 +23,7 @@ describe('globalShortcut module', () => {
 
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
     globalShortcut.register(accelerator, () => {})
-    expect(globalShortcut.isRegistered(accelerator), true)
+    expect(globalShortcut.isRegistered(accelerator)).to.be.true()
     globalShortcut.unregister(accelerator)
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
 

--- a/spec/api-global-shortcut-spec.js
+++ b/spec/api-global-shortcut-spec.js
@@ -1,7 +1,11 @@
 const {globalShortcut} = require('electron').remote
 
-const assert = require('assert')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
 const isCI = require('electron').remote.getGlobal('isCi')
+
+const {expect} = chai
+chai.use(dirtyChai)
 
 describe('globalShortcut module', () => {
   before(function () {
@@ -17,16 +21,16 @@ describe('globalShortcut module', () => {
   it('can register and unregister accelerators', () => {
     const accelerator = 'CommandOrControl+A+B+C'
 
-    assert.equal(globalShortcut.isRegistered(accelerator), false)
+    expect(globalShortcut.isRegistered(accelerator)).to.be.false()
     globalShortcut.register(accelerator, () => {})
-    assert.equal(globalShortcut.isRegistered(accelerator), true)
+    expect(globalShortcut.isRegistered(accelerator), true)
     globalShortcut.unregister(accelerator)
-    assert.equal(globalShortcut.isRegistered(accelerator), false)
+    expect(globalShortcut.isRegistered(accelerator)).to.be.false()
 
-    assert.equal(globalShortcut.isRegistered(accelerator), false)
+    expect(globalShortcut.isRegistered(accelerator)).to.be.false()
     globalShortcut.register(accelerator, () => {})
-    assert.equal(globalShortcut.isRegistered(accelerator), true)
+    expect(globalShortcut.isRegistered(accelerator)).to.be.true()
     globalShortcut.unregisterAll()
-    assert.equal(globalShortcut.isRegistered(accelerator), false)
+    expect(globalShortcut.isRegistered(accelerator)).to.be.false()
   })
 })

--- a/spec/api-in-app-purchase-spec.js
+++ b/spec/api-in-app-purchase-spec.js
@@ -54,7 +54,7 @@ describe('inAppPurchase module', function () {
 
   it('getProducts() returns an empty list when getting invalid product', done => {
     inAppPurchase.getProducts(['non-exist'], products => {
-      expect(products.length).to.equal(0)
+      expect(products).to.be.an('array').of.length(0)
       done()
     })
   })

--- a/spec/api-in-app-purchase-spec.js
+++ b/spec/api-in-app-purchase-spec.js
@@ -1,6 +1,10 @@
 'use strict'
 
-const assert = require('assert')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+
+const {expect} = chai
+chai.use(dirtyChai)
 
 const {remote} = require('electron')
 
@@ -12,38 +16,45 @@ describe('inAppPurchase module', function () {
   const {inAppPurchase} = remote
 
   it('canMakePayments() does not throw', () => {
-    inAppPurchase.canMakePayments()
+    expect(() => {
+      inAppPurchase.canMakePayments()
+    }).to.not.throw()
   })
 
   it('finishAllTransactions() does not throw', () => {
-    inAppPurchase.finishAllTransactions()
+    expect(() => {
+      inAppPurchase.finishAllTransactions()
+    }).to.not.throw()
   })
 
   it('finishTransactionByDate() does not throw', () => {
-    inAppPurchase.finishTransactionByDate(new Date().toISOString())
+    expect(() => {
+      inAppPurchase.finishTransactionByDate(new Date().toISOString())
+    }).to.not.throw()
   })
 
   it('getReceiptURL() returns receipt URL', () => {
-    assert.ok(inAppPurchase.getReceiptURL().endsWith('_MASReceipt/receipt'))
+    const correctUrlEnd = inAppPurchase.getReceiptURL().endsWith('_MASReceipt/receipt')
+    expect(correctUrlEnd).to.be.true()
   })
 
-  it('purchaseProduct() fails when buying invalid product', (done) => {
-    inAppPurchase.purchaseProduct('non-exist', 1, (success) => {
-      assert.ok(!success)
+  it('purchaseProduct() fails when buying invalid product', done => {
+    inAppPurchase.purchaseProduct('non-exist', 1, success => {
+      expect(success).to.be.false()
       done()
     })
   })
 
-  it('purchaseProduct() accepts optional arguments', (done) => {
+  it('purchaseProduct() accepts optional arguments', done => {
     inAppPurchase.purchaseProduct('non-exist', () => {
       inAppPurchase.purchaseProduct('non-exist', 1)
       done()
     })
   })
 
-  it('getProducts() returns an empty list when getting invalid product', (done) => {
-    inAppPurchase.getProducts(['non-exist'], (products) => {
-      assert.ok(products.length === 0)
+  it('getProducts() returns an empty list when getting invalid product', done => {
+    inAppPurchase.getProducts(['non-exist'], products => {
+      expect(products.length).to.equal(0)
       done()
     })
   })


### PR DESCRIPTION
Ongoing work to migrate our specs from `assert` to chai's `expect` for better error messages.

This PR groups two small specs: `global-shortcut` and `in-app-purchase`