### PR TITLE
Backport (1-8-x) - fix: prevent bundles from being selected in <input file="type"> open file dialog (macOS)

### DIFF
--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -215,6 +215,7 @@ void WebDialogHelper::RunFileChooser(
         flags |= file_dialog::FILE_DIALOG_MULTI_SELECTIONS;
       case content::FileChooserParams::Open:
         flags |= file_dialog::FILE_DIALOG_OPEN_FILE;
+        flags |= file_dialog::FILE_DIALOG_TREAT_PACKAGE_APP_AS_DIRECTORY;
         break;
       case content::FileChooserParams::UploadFolder:
         flags |= file_dialog::FILE_DIALOG_OPEN_DIRECTORY;


### PR DESCRIPTION
Backport: https://github.com/electron/electron/pull/13220