### PR TITLE
fix: pass down the bool value of enableAutoSize to setSize

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -130,7 +130,7 @@ struct Converter<atom::SetSizeParams> {
       return false;
     bool autosize;
     if (params.Get("enableAutoSize", &autosize))
-      out->enable_auto_size.reset(new bool(true));
+      out->enable_auto_size.reset(autosize);
     gfx::Size size;
     if (params.Get("min", &size))
       out->min_size.reset(new gfx::Size(size));

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -130,7 +130,7 @@ struct Converter<atom::SetSizeParams> {
       return false;
     bool autosize;
     if (params.Get("enableAutoSize", &autosize))
-      out->enable_auto_size.reset(autosize);
+      out->enable_auto_size.reset(new bool(autosize));
     gfx::Size size;
     if (params.Get("min", &size))
       out->min_size.reset(new gfx::Size(size));


### PR DESCRIPTION
The webContents setSize API takes in an optional enableAutoSize boolean.
Looking in the code, if that property is set, regardless if you pass in
true or false, it will always set it to true. This change passes the
appropriate boolean value down properly.