### PR TITLE
refactor: [gn] compile node with boringssl

### DIFF
--- a/build/node/BUILD.gn
+++ b/build/node/BUILD.gn
@@ -2,9 +2,12 @@ action("configure_node") {
   script = "//third_party/electron_node/configure"
   args = [
     "--enable-static",
-    "--openssl-no-asm",
     "--release-urlbase=https://atom.io/download/electron",
     "--shared",
+    "--shared-openssl",
+    "--shared-openssl-includes=" + rebase_path("//third_party/boringssl/src/include"),
+    "--shared-openssl-libname=boringssl",
+    "--shared-openssl-libpath=" + rebase_path(root_out_dir),
     "--without-npm",
     "--without-bundled-v8",
     "--without-dtrace",
@@ -57,6 +60,7 @@ action("gyp_node") {
 
 action("build_node") {
   deps = [
+    "//third_party/boringssl",
     "//third_party/icu",
     "//v8",
     "//v8:v8_libbase",

--- a/build/node/node_override.gypi
+++ b/build/node/node_override.gypi
@@ -26,6 +26,15 @@
           '../../../../../../libv8_libplatform.dylib',
           '../../../../../../libicuuc.dylib',
         ],
+        'defines': [
+          # These will no longer be necessary once
+          # https://github.com/google/boringssl/commit/a02ed04d527e1b57b4efaa0b4f9bdbc1ed5975b2
+          # is in the past for Electron
+          'EVP_CIPH_CCM_MODE=0',
+          'EVP_CIPH_WRAP_MODE=0',
+          'EVP_CIPHER_CTX_FLAG_WRAP_ALLOW=0',
+          'EVP_CIPHER_CTX_set_flags(...)',
+        ],
       }],
     ],
   },


### PR DESCRIPTION
**NB**: this currently only affects the experimental GN build of Electron.

Instead of compiling node with openssl, use the boringssl library that's already built with chrome. There are a couple of reasons for this:

1. It's not possible to build a single statically-linked binary that has both BoringSSL and OpenSSL compiled in, because their symbols conflict. So this makes it possible to ship a single static executable that has node.js, chromium and electron all in one.
  - this is an important prerequisite for the release build of Electron when building with GN. Having node.js (and thus v8) being linked into a separate shared library is a significant difficulty for the GN build system.
2. It reduces the amount of code we ship (one SSL library instead of two).

It could potentially lead to incompatibilities with third-party modules, since BoringSSL and OpenSSL don't support identical feature sets, but I don't know of any issues specifically. See https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md for a (non-exhaustive) list of differences.

Depends on https://github.com/electron/node/pull/39