### PR TITLE
chore: [gn] add desktop capturer sources to GN build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -339,6 +339,13 @@ static_library("electron_lib") {
     ]
   }
 
+  if (enable_desktop_capturer) {
+    sources += [
+      "atom/browser/api/atom_api_desktop_capturer.cc",
+      "atom/browser/api/atom_api_desktop_capturer.h",
+    ]
+  }
+
   if (is_mac) {
     libs = [
       "Squirrel.framework",


### PR DESCRIPTION
These files were made conditional in the GYP build in dee9aef975794deeb070574436d12945d4076242, but the "gyp-to-gn" helper doesn't understand conditionals, so this just includes those files in the GN build in the same conditions as when they're included in the GYP build.