### PR TITLE
feat: BrowserWindow.getNormalBounds()

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -358,6 +358,10 @@ gfx::Rect TopLevelWindow::GetBounds() {
   return window_->GetBounds();
 }
 
+bool TopLevelWindow::IsNormal() {
+  return window_->IsNormal();
+}
+
 gfx::Rect TopLevelWindow::GetNormalBounds() {
   return window_->GetNormalBounds();
 }
@@ -953,6 +957,7 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isFullScreen", &TopLevelWindow::IsFullscreen)
       .SetMethod("setBounds", &TopLevelWindow::SetBounds)
       .SetMethod("getBounds", &TopLevelWindow::GetBounds)
+      .SetMethod("IsNormal", &TopLevelWindow::IsNormal)
       .SetMethod("getNormalBounds", &TopLevelWindow::GetNormalBounds)
       .SetMethod("setSize", &TopLevelWindow::SetSize)
       .SetMethod("getSize", &TopLevelWindow::GetSize)

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -957,7 +957,7 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isFullScreen", &TopLevelWindow::IsFullscreen)
       .SetMethod("setBounds", &TopLevelWindow::SetBounds)
       .SetMethod("getBounds", &TopLevelWindow::GetBounds)
-      .SetMethod("IsNormal", &TopLevelWindow::IsNormal)
+      .SetMethod("isNormal", &TopLevelWindow::IsNormal)
       .SetMethod("getNormalBounds", &TopLevelWindow::GetNormalBounds)
       .SetMethod("setSize", &TopLevelWindow::SetSize)
       .SetMethod("getSize", &TopLevelWindow::GetSize)

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -358,6 +358,10 @@ gfx::Rect TopLevelWindow::GetBounds() {
   return window_->GetBounds();
 }
 
+gfx::Rect TopLevelWindow::GetNormalBounds() {
+  return window_->GetNormalBounds();
+}
+
 void TopLevelWindow::SetContentBounds(const gfx::Rect& bounds,
                                       mate::Arguments* args) {
   bool animate = false;
@@ -949,6 +953,7 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isFullScreen", &TopLevelWindow::IsFullscreen)
       .SetMethod("setBounds", &TopLevelWindow::SetBounds)
       .SetMethod("getBounds", &TopLevelWindow::GetBounds)
+      .SetMethod("getNormalBounds", &TopLevelWindow::GetNormalBounds)
       .SetMethod("setSize", &TopLevelWindow::SetSize)
       .SetMethod("getSize", &TopLevelWindow::GetSize)
       .SetMethod("setContentBounds", &TopLevelWindow::SetContentBounds)

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -108,6 +108,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   std::vector<int> GetContentSize();
   void SetContentBounds(const gfx::Rect& bounds, mate::Arguments* args);
   gfx::Rect GetContentBounds();
+  bool IsNormal();
   gfx::Rect GetNormalBounds();
   void SetMinimumSize(int width, int height);
   std::vector<int> GetMinimumSize();

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -108,6 +108,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   std::vector<int> GetContentSize();
   void SetContentBounds(const gfx::Rect& bounds, mate::Arguments* args);
   gfx::Rect GetContentBounds();
+  gfx::Rect GetNormalBounds();
   void SetMinimumSize(int width, int height);
   std::vector<int> GetMinimumSize();
   void SetMaximumSize(int width, int height);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -208,6 +208,10 @@ gfx::Rect NativeWindow::GetContentBounds() {
   return WindowBoundsToContentBounds(GetBounds());
 }
 
+bool NativeWindow::IsNormal() {
+  return !IsMinimized() && !IsMaximized() && !IsFullscreen();
+}
+
 void NativeWindow::SetSizeConstraints(
     const extensions::SizeConstraints& window_constraints) {
   extensions::SizeConstraints content_constraints(GetContentSizeConstraints());

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -87,6 +87,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Size GetContentSize();
   virtual void SetContentBounds(const gfx::Rect& bounds, bool animate = false);
   virtual gfx::Rect GetContentBounds();
+  virtual gfx::Rect GetNormalBounds() = 0;
   virtual void SetSizeConstraints(
       const extensions::SizeConstraints& size_constraints);
   virtual extensions::SizeConstraints GetSizeConstraints() const;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -87,6 +87,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Size GetContentSize();
   virtual void SetContentBounds(const gfx::Rect& bounds, bool animate = false);
   virtual gfx::Rect GetContentBounds();
+  virtual bool IsNormal();
   virtual gfx::Rect GetNormalBounds() = 0;
   virtual void SetSizeConstraints(
       const extensions::SizeConstraints& size_constraints);

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -52,6 +52,7 @@ class NativeWindowMac : public NativeWindow {
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
   gfx::Rect GetBounds() override;
+  gfx::Rect GetNormalBounds() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -52,6 +52,7 @@ class NativeWindowMac : public NativeWindow {
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
   gfx::Rect GetBounds() override;
+  bool IsNormal() override;
   gfx::Rect GetNormalBounds() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -595,7 +595,8 @@ void NativeWindowMac::Maximize() {
     return;
 
   // Take note of the current window size
-  original_frame_ = [window_ frame];
+  if (IsNormal())
+    original_frame_ = [window_ frame];
   [window_ zoom:nil];
 }
 
@@ -624,7 +625,8 @@ void NativeWindowMac::Minimize() {
      return;
 
   // Take note of the current window size
-  original_frame_ = [window_ frame];
+  if (IsNormal())
+    original_frame_ = [window_ frame];
   [window_ miniaturize:nil];
 }
 
@@ -641,7 +643,8 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
     return;
 
   // Take note of the current window size
-  original_frame_ = [window_ frame];
+  if (IsNormal())
+    original_frame_ = [window_ frame];
   [window_ toggleFullScreenMode:nil];
 }
 
@@ -887,7 +890,8 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     is_simple_fullscreen_ = true;
 
     // Take note of the current window size
-    original_frame_ = [window frame];
+    if (IsNormal())
+      original_frame_ = [window_ frame];
 
     simple_fullscreen_options_ = [NSApp currentSystemPresentationOptions];
     simple_fullscreen_mask_ = [window styleMask];

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -351,6 +351,8 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   widget()->Init(params);
   window_ = static_cast<AtomNSWindow*>(widget()->GetNativeWindow());
 
+  original_frame_ = bounds;
+
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
 
   window_delegate_.reset([[AtomNSWindowDelegate alloc] initWithShell:this]);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -623,8 +623,8 @@ bool NativeWindowMac::IsMaximized() {
 }
 
 void NativeWindowMac::Minimize() {
-   if (IsMinimized())
-     return;
+  if (IsMinimized())
+    return;
 
   // Take note of the current window size
   if (IsNormal())
@@ -672,7 +672,6 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
   cocoa_bounds.origin.y = NSHeight([screen frame]) - size.height() - bounds.y();
 
   [window_ setFrame:cocoa_bounds display:YES animate:animate];
-    
 }
 
 gfx::Rect NativeWindowMac::GetBounds() {
@@ -682,9 +681,9 @@ gfx::Rect NativeWindowMac::GetBounds() {
   bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
   return bounds;
 }
-    
+
 bool NativeWindowMac::IsNormal() {
-    return NativeWindow::IsNormal() && !IsSimpleFullScreen();
+  return NativeWindow::IsNormal() && !IsSimpleFullScreen();
 }
 
 gfx::Rect NativeWindowMac::GetNormalBounds() {
@@ -697,7 +696,7 @@ gfx::Rect NativeWindowMac::GetNormalBounds() {
   bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
   return bounds;
   // Works on OS_WIN !
-  //return widget()->GetRestoredBounds();
+  // return widget()->GetRestoredBounds();
 }
 
 void NativeWindowMac::SetContentSizeConstraints(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -668,6 +668,10 @@ gfx::Rect NativeWindowMac::GetBounds() {
   return bounds;
 }
 
+gfx::Rect NativeWindowMac::GetNormalBounds() {
+  return widget()->getRestoredBounds();
+}
+
 void NativeWindowMac::SetContentSizeConstraints(
     const extensions::SizeConstraints& size_constraints) {
   auto convertSize = [this](const gfx::Size& size) {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -669,7 +669,7 @@ gfx::Rect NativeWindowMac::GetBounds() {
 }
 
 gfx::Rect NativeWindowMac::GetNormalBounds() {
-  return widget()->getRestoredBounds();
+  return widget()->GetRestoredBounds();
 }
 
 void NativeWindowMac::SetContentSizeConstraints(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -640,6 +640,8 @@ void NativeWindowMac::SetFullScreen(bool fullscreen) {
   if (fullscreen == IsFullscreen())
     return;
 
+  // Take note of the current window size
+  original_frame_ = [window_ frame];
   [window_ toggleFullScreenMode:nil];
 }
 
@@ -675,9 +677,13 @@ gfx::Rect NativeWindowMac::GetBounds() {
   bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
   return bounds;
 }
+    
+bool NativeWindowMac::IsNormal() {
+    return NativeWindow::IsNormal() && !IsSimpleFullScreen();
+}
 
 gfx::Rect NativeWindowMac::GetNormalBounds() {
-  if (!IsMinimized() && !IsMaximized() && !IsFullscreen()) {
+  if (IsNormal()) {
     return GetBounds();
   }
   NSRect frame = original_frame_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -469,9 +469,6 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   // Default content view.
   SetContentView(new views::View());
   AddContentViewLayers();
-
-  // Take note of the current window size
-  original_frame_ = [window_ frame];
 }
 
 NativeWindowMac::~NativeWindowMac() {
@@ -680,12 +677,16 @@ gfx::Rect NativeWindowMac::GetBounds() {
 }
 
 gfx::Rect NativeWindowMac::GetNormalBounds() {
-    NSRect frame = original_frame_;
-    gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
-    NSScreen* screen = [[NSScreen screens] firstObject];
-    bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
-    return bounds;
-    //return widget()->GetRestoredBounds();
+  if (!IsMinimized() && !IsMaximized() && !IsFullscreen()) {
+    return GetBounds();
+  }
+  NSRect frame = original_frame_;
+  gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
+  NSScreen* screen = [[NSScreen screens] firstObject];
+  bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
+  return bounds;
+  // Works on OS_WIN !
+  //return widget()->GetRestoredBounds();
 }
 
 void NativeWindowMac::SetContentSizeConstraints(

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -351,8 +351,6 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   widget()->Init(params);
   window_ = static_cast<AtomNSWindow*>(widget()->GetNativeWindow());
 
-  original_frame_ = bounds;
-
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
 
   window_delegate_.reset([[AtomNSWindowDelegate alloc] initWithShell:this]);
@@ -471,6 +469,8 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   // Default content view.
   SetContentView(new views::View());
   AddContentViewLayers();
+
+  original_frame_ = [window_ frame];
 }
 
 NativeWindowMac::~NativeWindowMac() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -562,6 +562,10 @@ gfx::Size NativeWindowViews::GetContentSize() {
   return content_view() ? content_view()->size() : gfx::Size();
 }
 
+gfx::Rect NativeWindowViews::GetNormalBounds() {
+  return widget()->GetRestoredBounds();
+}
+
 void NativeWindowViews::SetContentSizeConstraints(
     const extensions::SizeConstraints& size_constraints) {
   NativeWindow::SetContentSizeConstraints(size_constraints);

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -67,6 +67,7 @@ class NativeWindowViews : public NativeWindow,
   gfx::Rect GetBounds() override;
   gfx::Rect GetContentBounds() override;
   gfx::Size GetContentSize() override;
+  gfx::Rect GetNormalBounds() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -807,6 +807,10 @@ Simple fullscreen mode emulates the native fullscreen behavior found in versions
 
 Returns `Boolean` - Whether the window is in simple (pre-Lion) fullscreen mode.
 
+#### `win.isNormal()`
+
+Returns `Boolean` - Whether the window is in normal state (not maximized, not minimized, not in fullscreen mode).
+
 #### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_
 
 * `aspectRatio` Float - The aspect ratio to maintain for some portion of the

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -869,6 +869,12 @@ the supplied bounds.
 
 Returns [`Rectangle`](structures/rectangle.md)
 
+#### `win.getBormalBounds()`
+
+Returns [`Rectangle`](structures/rectangle.md) - Contains the window bounds of the normal state
+
+**Note:** whatever the current state of the window : maximized, minimized or in fullscreen, this function always returns the position and size of the window in normal state. In normal state, getBounds and getNormalBounds returns the same [`Rectangle`](structures/rectangle.md).
+
 #### `win.setEnabled(enable)`
 
 * `enable` Boolean

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -869,7 +869,7 @@ the supplied bounds.
 
 Returns [`Rectangle`](structures/rectangle.md)
 
-#### `win.getBormalBounds()`
+#### `win.getNormalBounds()`
 
 Returns [`Rectangle`](structures/rectangle.md) - Contains the window bounds of the normal state
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -568,6 +568,10 @@ describe('BrowserWindow module', () => {
       w.setPosition(pos[0], pos[1])
     })
     it('checks normal bounds when maximized', (done) => {
+      if (isCI) {
+        return done()
+      }
+
       const bounds = w.getBounds()
       w.once('maximize', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
@@ -580,6 +584,10 @@ describe('BrowserWindow module', () => {
       w.maximize()
     })
     it('checks normal bounds when minimized', (done) => {
+      if (isCI) {
+        return done()
+      }
+
       const bounds = w.getBounds()
       w.once('minimize', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
@@ -592,6 +600,10 @@ describe('BrowserWindow module', () => {
       w.minimize()
     })
     it('checks normal bounds when full-screen', (done) => {
+      if (isCI) {
+        return done()
+      }
+
       const bounds = w.getBounds()
       w.once('enter-full-screen', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -550,70 +550,108 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.getNormalBounds()', () => {
-    it('checks normal bounds after resize', (done) => {
-      const size = [300, 400]
-      w.once('resize', () => {
-        assertBoundsEqual(w.getNormalBounds(), w.getBounds())
-        done()
+  describe(`BrowserWindow.getNormalBounds()`, () => {
+    describe(`Normal state`, () => {
+      it(`checks normal bounds after resize`, (done) => {
+        const size = [300, 400]
+        w.once('resize', () => {
+          assertBoundsEqual(w.getNormalBounds(), w.getBounds())
+          done()
+        })
+        w.setSize(size[0], size[1])
       })
-      w.setSize(size[0], size[1])
+      it(`checks normal bounds after move`, (done) => {
+        const pos = [10, 10]
+        w.once('move', () => {
+          assertBoundsEqual(w.getNormalBounds(), w.getBounds())
+          done()
+        })
+        w.setPosition(pos[0], pos[1])
+      })
     })
-    it('checks normal bounds after move', (done) => {
-      const pos = [10, 10]
-      w.once('move', () => {
-        assertBoundsEqual(w.getNormalBounds(), w.getBounds())
-        done()
+    describe(`Maximized state`, () => {
+      before(function () {
+        if (isCI) {
+          this.skip()
+        }
       })
-      w.setPosition(pos[0], pos[1])
+      it(`checks normal bounds when maximized`, (done) => {
+        const bounds = w.getBounds()
+        w.once('maximize', () => {
+          assertBoundsEqual(w.getNormalBounds(), bounds)
+          done()
+        })
+        w.show()
+        w.maximize()
+      })
+      it(`checks normal bounds when unmaximized`, (done) => {
+        const bounds = w.getBounds()
+        w.once('maximize', () => {
+          w.unmaximize()
+        })
+        w.once('unmaximize', () => {
+          assertBoundsEqual(w.getNormalBounds(), bounds)
+          done()
+        })
+        w.show()
+        w.maximize()
+      })
     })
-    it('checks normal bounds when maximized', (done) => {
-      if (isCI) {
-        return done()
-      }
-
-      const bounds = w.getBounds()
-      w.once('maximize', () => {
-        assertBoundsEqual(w.getNormalBounds(), bounds)
-        w.unmaximize()
+    describe(`Minimized state`, () => {
+      before(function () {
+        if (isCI) {
+          this.skip()
+        }
       })
-      w.once('unmaximize', () => {
-        assertBoundsEqual(w.getNormalBounds(), bounds)
-        done()
+      it(`checks normal bounds when minimized`, (done) => {
+        const bounds = w.getBounds()
+        w.once('minimize', () => {
+          assertBoundsEqual(w.getNormalBounds(), bounds)
+          done()
+        })
+        w.show()
+        w.minimize()
       })
-      w.maximize()
+      it(`checks normal bounds when restored`, (done) => {
+        const bounds = w.getBounds()
+        w.once('minimize', () => {
+          w.restore()
+        })
+        w.once('restore', () => {
+          assertBoundsEqual(w.getNormalBounds(), bounds)
+          done()
+        })
+        w.show()
+        w.minimize()
+      })
     })
-    it('checks normal bounds when minimized', (done) => {
-      if (isCI) {
-        return done()
-      }
-
-      const bounds = w.getBounds()
-      w.once('minimize', () => {
-        assertBoundsEqual(w.getNormalBounds(), bounds)
-        w.restore()
+    describe(`Fullscreen state`, () => {
+      before(function () {
+        if (isCI) {
+          this.skip()
+        }
       })
-      w.once('restore', () => {
-        assertBoundsEqual(w.getNormalBounds(), bounds)
-        done()
+      it(`checks normal bounds when fullscreen'ed`, (done) => {
+        const bounds = w.getBounds()
+        w.once('enter-full-screen', () => {
+          assertBoundsEqual(w.getNormalBounds(), bounds)
+          done()
+        })
+        w.show()
+        w.setFullScreen(true)
       })
-      w.minimize()
-    })
-    it('checks normal bounds when full-screen', (done) => {
-      if (isCI) {
-        return done()
-      }
-
-      const bounds = w.getBounds()
-      w.once('enter-full-screen', () => {
-        assertBoundsEqual(w.getNormalBounds(), bounds)
-        w.setFullScreen(false)
+      it(`checks normal bounds when unfullscreen'ed`, (done) => {
+        const bounds = w.getBounds()
+        w.once('enter-full-screen', () => {
+          w.setFullScreen(false)
+        })
+        w.once('leave-full-screen', () => {
+          assertBoundsEqual(w.getNormalBounds(), bounds)
+          done()
+        })
+        w.show()
+        w.setFullScreen(true)
       })
-      w.once('leave-full-screen', () => {
-        assertBoundsEqual(w.getNormalBounds(), bounds)
-        done()
-      })
-      w.setFullScreen(true)
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -571,9 +571,9 @@ describe('BrowserWindow module', () => {
     })
     describe(`Maximized state`, () => {
       before(function () {
-        if (isCI) {
-          this.skip()
-        }
+//        if (isCI) {
+//          this.skip()
+//        }
       })
       it(`checks normal bounds when maximized`, (done) => {
         const bounds = w.getBounds()
@@ -599,9 +599,9 @@ describe('BrowserWindow module', () => {
     })
     describe(`Minimized state`, () => {
       before(function () {
-        if (isCI) {
-          this.skip()
-        }
+//        if (isCI) {
+//          this.skip()
+//        }
       })
       it(`checks normal bounds when minimized`, (done) => {
         const bounds = w.getBounds()
@@ -627,9 +627,9 @@ describe('BrowserWindow module', () => {
     })
     describe(`Fullscreen state`, () => {
       before(function () {
-        if (isCI) {
-          this.skip()
-        }
+//        if (isCI) {
+//          this.skip()
+//        }
       })
       it(`checks normal bounds when fullscreen'ed`, (done) => {
         const bounds = w.getBounds()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -550,6 +550,54 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('BrowserWindow.getNormalBounds()', () => {
+    it('checks normal bounds after resize', (done) => {
+      const size = [300, 400]
+      w.once('resize', () => {
+        assertBoundsEqual(w.getNormalBounds(), w.getBounds())
+        done()
+      })
+      w.setSize(size[0], size[1])
+    })
+    it('checks normal bounds after move', (done) => {
+      const pos = [10, 10]
+      w.once('move', () => {
+        assertBoundsEqual(w.getNormalBounds(), w.getBounds())
+        done()
+      })
+      w.setPosition(pos[0], pos[1])
+    })
+    it('checks normal bounds when maximized', (done) => {
+      const bounds = w.getBounds()
+      w.once('maximize', () => {
+        assertBoundsEqual(w.getNormalBounds(), bounds)
+        w.unmaximize()
+        done()
+      })
+      w.maximize()
+    })
+    it('checks normal bounds when minimized', (done) => {
+      const bounds = w.getBounds()
+      w.once('minimize', () => {
+        assertBoundsEqual(w.getNormalBounds(), bounds)
+        w.restore()
+        done()
+      })
+      w.minimize()
+    })
+    it('checks normal bounds when full-screen', (done) => {
+      const bounds = w.getBounds()
+      w.once('enter-full-screen', () => {
+        assertBoundsEqual(w.getNormalBounds(), bounds)
+        w.once('leave-full-screen', () => {
+          done()
+        })
+        w.setFullScreen(false)
+      })
+      w.setFullScreen(true)
+    })
+  })
+
   describe('BrowserWindow.setProgressBar(progress)', () => {
     it('sets the progress', () => {
       assert.doesNotThrow(() => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -571,6 +571,10 @@ describe('BrowserWindow module', () => {
       const bounds = w.getBounds()
       w.once('maximize', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
+        w.unmaximize()
+      })
+      w.once('unmaximize', () => {
+        assertBoundsEqual(w.getNormalBounds(), bounds)
         done()
       })
       w.maximize()
@@ -579,6 +583,10 @@ describe('BrowserWindow module', () => {
       const bounds = w.getBounds()
       w.once('minimize', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
+        w.restore()
+      })
+      w.once('restore', () => {
+        assertBoundsEqual(w.getNormalBounds(), bounds)
         done()
       })
       w.minimize()
@@ -586,6 +594,10 @@ describe('BrowserWindow module', () => {
     it('checks normal bounds when full-screen', (done) => {
       const bounds = w.getBounds()
       w.once('enter-full-screen', () => {
+        assertBoundsEqual(w.getNormalBounds(), bounds)
+        w.setFullScreen(false)
+      })
+      w.once('leave-full-screen', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
         done()
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -571,7 +571,6 @@ describe('BrowserWindow module', () => {
       const bounds = w.getBounds()
       w.once('maximize', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
-        w.unmaximize()
         done()
       })
       w.maximize()
@@ -580,7 +579,6 @@ describe('BrowserWindow module', () => {
       const bounds = w.getBounds()
       w.once('minimize', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
-        w.restore()
         done()
       })
       w.minimize()
@@ -589,10 +587,7 @@ describe('BrowserWindow module', () => {
       const bounds = w.getBounds()
       w.once('enter-full-screen', () => {
         assertBoundsEqual(w.getNormalBounds(), bounds)
-        w.once('leave-full-screen', () => {
-          done()
-        })
-        w.setFullScreen(false)
+        done()
       })
       w.setFullScreen(true)
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -571,9 +571,9 @@ describe('BrowserWindow module', () => {
     })
     describe(`Maximized state`, () => {
       before(function () {
-//        if (isCI) {
-//          this.skip()
-//        }
+        if (isCI) {
+          this.skip()
+        }
       })
       it(`checks normal bounds when maximized`, (done) => {
         const bounds = w.getBounds()
@@ -599,9 +599,9 @@ describe('BrowserWindow module', () => {
     })
     describe(`Minimized state`, () => {
       before(function () {
-//        if (isCI) {
-//          this.skip()
-//        }
+        if (isCI) {
+          this.skip()
+        }
       })
       it(`checks normal bounds when minimized`, (done) => {
         const bounds = w.getBounds()
@@ -627,9 +627,9 @@ describe('BrowserWindow module', () => {
     })
     describe(`Fullscreen state`, () => {
       before(function () {
-//        if (isCI) {
-//          this.skip()
-//        }
+        if (isCI) {
+          this.skip()
+        }
       })
       it(`checks normal bounds when fullscreen'ed`, (done) => {
         const bounds = w.getBounds()

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -630,6 +630,9 @@ describe('BrowserWindow module', () => {
         if (isCI) {
           this.skip()
         }
+        if (process.platform === 'darwin') {
+          this.skip()
+        }
       })
       it(`checks normal bounds when fullscreen'ed`, (done) => {
         const bounds = w.getBounds()


### PR DESCRIPTION
•	Electron version: master branch
•	Operating system: All

When you have to serialize a layout of windows : position, size, state and visibility. If the window is in ‘maximized’ or ‘full-screen’ state, you have no way to get its bounds when restored.
Purpose is to add a function which, whatever the state of window, returns the bounds of the window in normal state.

**Proposal**

     BrowserWindow.getBormalBounds(): Rectangle
Returns Rectangle - Contains the window bounds of the normal state

**Expected Behavior**

     const w = new BrowserWindow({
        width: 400,
        height: 400
      })
     assertBoundsEqual(w.getBounds(),w.getNormalBounds())
     const normalBounds = w.getBounds();

      w.once('maximize', () => {
        assertBoundsEqual(w.getNormalBounds(),normalBounds)
      })
      w.maximize()

Note : I have been hesitating for a long time between getNormalBounds and getRestoredBounds (name of the internal Chromium function). But we are used to talk of minimized, maximized, full-screen and **normal** state (not restored or unmaximized) so I choose **normal**. Feel free to challenge this.

Notes: Added a `getNormalBounds()` API to the `BrowserWindow` class to fetch window bounds while minimized.

