### PR TITLE
build:Fix VSTS config for release builds

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -44,34 +44,25 @@ steps:
   condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
 - bash: |
-    echo 'Testing Electron debug build'
+    echo 'Testing Electron build'
     mkdir junit
     export MOCHA_FILE="junit/test-results.xml"
     export MOCHA_REPORTER="mocha-junit-reporter"
-    script/test.py --ci --rebuild_native_modules
+    if [ "$ELECTRON_RELEASE" == "1" ]; then
+      script/test.py --ci --rebuild_native_modules -c R
+    else
+      script/test.py --ci --rebuild_native_modules
+    fi
   name: Test
-  condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
 
 - bash: |
-    echo 'Testing Electron release build'
-    mkdir junit
-    export MOCHA_FILE="junit/test-results.xml"
-    export MOCHA_REPORTER="mocha-junit-reporter"
-    script/test.py --ci --rebuild_native_modules -c R
-  name: Test
-  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
-
-- bash: |
-    echo 'Verifying ffmpeg on debug build'
-    script/verify-ffmpeg.py
+    echo 'Verifying ffmpeg on build'
+    if [ "$ELECTRON_RELEASE" == "1" ]; then
+      script/verify-ffmpeg.py -R
+    else
+      script/verify-ffmpeg.py
+    fi
   name: Verify_FFmpeg
-  condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
-
-- bash: |
-    echo 'Verifying ffmpeg on release build'
-    script/verify-ffmpeg.py -R
-  name: Verify_FFmpeg
-  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
 - task: PublishTestResults@2
   displayName: Publish Test Results


### PR DESCRIPTION
The VSTS config had the following errors in it caused by the changes I made in #13241
```
Phase : The step name Test appears more than once. Step names must be unique within a phase.
Phase : The step name Verify_FFmpeg appears more than once. Step names must be unique within a phase.
```

This PR fixes those errors so that we can run our Mac release builds on VSTS.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)