### PR TITLE
docs: add note about how to remove a previously set aspect ratio

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -828,6 +828,9 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Sum any extra width and
 height areas you have within the overall content view.
 
+Calling this function with a value of `0` will remove any previously set aspect
+ratios.
+
 #### `win.previewFile(path[, displayName])` _macOS_
 
 * `path` String - The absolute path to the file to preview with QuickLook. This


### PR DESCRIPTION
##### Checklist

- [x] relevant documentation is changed or added
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

**Note**

Hello! First time PR on this repository 👋 
I tried to follow the [guide that is laid out here](https://electronjs.org/docs/development/pull-requests#step-8-opening-the-pull-request) but it's a bit intimidating. Any/all guidance in how to improve this PR and/or future PRs would be appreciated 👍 


**About this PR**

I was hanging out in Atom's Slack's #Electron channel and someone asked how to "unset" an aspect ratio that was set with `win.setAspectRatio()`. The docs didn't have a clear answer, but I found this test in the spec: https://github.com/electron/electron/blob/bcbcb4c6436e84e7f1f2387c2d7581bbdadb5732/spec/api-browser-window-spec.js#L477-L488

I've added a brief note to the existing documentation for the `win.setAspectRatio()` function that notes functionality can be reset by passing `0` to the function.