### PR TITLE
fix: Set mac default protocol to none when it is going to set it back to the app trying to deregister

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -78,6 +78,11 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
     }
   }
 
+  // No other app was found set it to none instead of setting it back to itself.
+  if ([identifier isEqualToString:(__bridge NSString*)other]) {
+    other = base::mac::NSToCFCast(@"None");
+  }
+
   OSStatus return_code = LSSetDefaultHandlerForURLScheme(protocol_cf, other);
   return return_code == noErr;
 }


### PR DESCRIPTION
On Mac currently, RemoveAsDefaultProtocolClient will not remove the protocol as a default if only one app is registered for that protocol.
```
app.setAsDefaultProtocolClient('foo');
let val1 = app.removeAsDefaultProtocolClient('foo');
```
This will still have the default protocol 'foo' point to the app com.github.electron

The change made in this PR will ensure that protocol handler 'foo' points to None if we are going to set it back to the app that is trying to deregister from the protocol