### PR TITLE
feat: On macOS, Closing Notifications Triggers the 'close' Event

### DIFF
--- a/brightray/browser/mac/cocoa_notification.h
+++ b/brightray/browser/mac/cocoa_notification.h
@@ -31,6 +31,7 @@ class CocoaNotification : public Notification {
   void NotificationActivated();
   void NotificationActivated(NSUserNotificationAction* action)
     API_AVAILABLE(macosx(10.10));
+  void NotificationDismissed();
 
   NSUserNotification* notification() const { return notification_; }
 

--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -156,6 +156,13 @@ void CocoaNotification::NotificationActivated(
   this->LogAction("button clicked");
 }
 
+void CocoaNotification::NotificationDismissed() {
+  if (delegate())
+    delegate()->NotificationClosed();
+
+  this->LogAction("dismissed");
+}
+
 void CocoaNotification::LogAction(const char* action) {
   if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
     NSString* identifier = [notification_ valueForKey:@"identifier"];

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -74,4 +74,15 @@
     notification->NotificationDismissed();
 }
 
+// This undocumented method notifies us if a user closes "Banner" notifications
+// https://github.com/mozilla/gecko-dev/blob/master/widget/cocoa/OSXNotificationCenter.mm
+- (void)userNotificationCenter:(NSUserNotificationCenter*)center
+    didRemoveDeliveredNotifications:(NSArray*)notifications {
+  for (NSUserNotification* notif in notifications) {
+    auto* notification = presenter_->GetNotification(notif);
+    if (notification)
+      notification->NotificationDismissed();
+  }
+}
+
 @end

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -65,6 +65,7 @@
   return YES;
 }
 
+#if !defined(MAS_BUILD)
 // This undocumented method notifies us if a user closes "Alert" notifications
 // https://chromium.googlesource.com/chromium/src/+/lkgr/chrome/browser/notifications/notification_platform_bridge_mac.mm
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
@@ -73,7 +74,9 @@
   if (notification)
     notification->NotificationDismissed();
 }
+#endif
 
+#if !defined(MAS_BUILD)
 // This undocumented method notifies us if a user closes "Banner" notifications
 // https://github.com/mozilla/gecko-dev/blob/master/widget/cocoa/OSXNotificationCenter.mm
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
@@ -84,5 +87,6 @@
       notification->NotificationDismissed();
   }
 }
+#endif
 
 @end

--- a/brightray/browser/mac/notification_center_delegate.mm
+++ b/brightray/browser/mac/notification_center_delegate.mm
@@ -65,4 +65,13 @@
   return YES;
 }
 
+// This undocumented method notifies us if a user closes "Alert" notifications
+// https://chromium.googlesource.com/chromium/src/+/lkgr/chrome/browser/notifications/notification_platform_bridge_mac.mm
+- (void)userNotificationCenter:(NSUserNotificationCenter*)center
+               didDismissAlert:(NSUserNotification*)notif {
+  auto* notification = presenter_->GetNotification(notif);
+  if (notification)
+    notification->NotificationDismissed();
+}
+
 @end


### PR DESCRIPTION
## 🤷🏽‍♂️ Previous Behaviour
On macOS, notifications created via ´Electron.Notification´ module do not emit the `close` event when closing them via the "Close"-button.

## 🤷🏽‍♂️ Screenshot
<img width="252" alt="screen shot 2018-06-19 at 22 33 08" src="https://user-images.githubusercontent.com/1630917/41622820-1468d3b8-7411-11e8-8f72-6d4b4b122b7c.PNG">

## 🎯 New Behaviour
When clicking the "Close" button, Notifications created via ´Electron.Notification´ now emit the expected `close` event. This is supported by both `Alert`- and ´Banner´-style notifications, and also works when dismissing multiple notifications at the same time.