### PR TITLE
deps: disable node options in node submodule

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -155,6 +155,7 @@
           'BUILDING_V8_SHARED',
           'BUILDING_V8_PLATFORM_SHARED',
           'BUILDING_V8_BASE_SHARED',
+          'NODE_WITHOUT_NODE_OPTIONS',
         ],
         'conditions': [
           ['OS=="mac" and libchromiumcontent_component==0', {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fix for issue #12695: starting Electron with Node options (`export NODE_OPTIONS=--max-old-space-size=4096`) resulted in a segfault. This was originally caused by calling `node::Init()` with a null pointer for `argv`, which occurs when `NODE_WITHOUT_NODE_OPTIONS` is undefined. We attempted defining `NODE_WITHOUT_NODE_OPTIONS` in `electron.gyp` but the definition did not propagate, ~so we defined it in `node.gyp` instead~ so we ended up changing `common.gypi` to introduce the definition for node compilation.

Fix coded with @sethlu, with the help of @codebytere @nitsakh @groundwater and @nornagon. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)