### PR TITLE
src: base::Value::HasKey(key) => base::Value::FindKey(key)

### DIFF
--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -122,7 +122,7 @@ void ToDictionary(base::DictionaryValue* details,
   std::string key;
   std::string value;
   while (headers->EnumerateHeaderLines(&iter, &key, &value)) {
-    if (dict->HasKey(key)) {
+    if (dict->FindKey(key)) {
       base::ListValue* values = nullptr;
       if (dict->GetList(key, &values))
         values->AppendString(value);

--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -221,13 +221,13 @@ bool Archive::Stat(const base::FilePath& path, Stats* stats) {
   if (!GetNodeFromPath(path.AsUTF8Unsafe(), header_.get(), &node))
     return false;
 
-  if (node->HasKey("link")) {
+  if (node->FindKey("link")) {
     stats->is_file = false;
     stats->is_link = true;
     return true;
   }
 
-  if (node->HasKey("files")) {
+  if (node->FindKey("files")) {
     stats->is_file = false;
     stats->is_directory = true;
     return true;

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -160,7 +160,7 @@ v8::Local<v8::Value> Converter<net::HttpResponseHeaders*>::ToV8(
     std::string value;
     while (headers->EnumerateHeaderLines(&iter, &key, &value)) {
       key = base::ToLowerASCII(key);
-      if (response_headers.HasKey(key)) {
+      if (response_headers.FindKey(key)) {
         base::ListValue* values = nullptr;
         if (response_headers.GetList(key, &values))
           values->AppendString(value);


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/12772.

Replaces deprecated `base::Value::HasKey(key)` with `base::Value::FindKey(key)`. 

/cc @alexeykuzmin 