### PR TITLE
chore: Annotate fallthrough switch paths with FALLTHROUGH

### DIFF
--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -173,12 +173,12 @@ bool ScopedDisableResize::disable_resize_ = false;
       buttonFrame.origin.x += NSWidth(
           [[self standardWindowButton:NSWindowMiniaturizeButton] frame]);
       buttonFrame.origin.x += windowButtonsInterButtonSpacing_;
-      // fallthrough
+      FALLTHROUGH;
     case NSWindowMiniaturizeButton:
       buttonFrame.origin.x +=
           NSWidth([[self standardWindowButton:NSWindowCloseButton] frame]);
       buttonFrame.origin.x += windowButtonsInterButtonSpacing_;
-      // fallthrough
+      FALLTHROUGH;
     default:
       break;
   }

--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -220,6 +220,7 @@ void WebDialogHelper::RunFileChooser(
     switch (params.mode) {
       case content::FileChooserParams::OpenMultiple:
         flags |= file_dialog::FILE_DIALOG_MULTI_SELECTIONS;
+        FALLTHROUGH;
       case content::FileChooserParams::Open:
         flags |= file_dialog::FILE_DIALOG_OPEN_FILE;
         flags |= file_dialog::FILE_DIALOG_TREAT_PACKAGE_APP_AS_DIRECTORY;

--- a/atom/common/keyboard_util.cc
+++ b/atom/common/keyboard_util.cc
@@ -88,87 +88,108 @@ ui::KeyboardCode KeyboardCodeFromCharCode(base::char16 c, bool* shifted) {
 
     case ')':
       *shifted = true;
+      FALLTHROUGH;
     case '0':
       return ui::VKEY_0;
     case '!':
       *shifted = true;
+      FALLTHROUGH;
     case '1':
       return ui::VKEY_1;
     case '@':
       *shifted = true;
+      FALLTHROUGH;
     case '2':
       return ui::VKEY_2;
     case '#':
       *shifted = true;
+      FALLTHROUGH;
     case '3':
       return ui::VKEY_3;
     case '$':
       *shifted = true;
+      FALLTHROUGH;
     case '4':
       return ui::VKEY_4;
     case '%':
       *shifted = true;
+      FALLTHROUGH;
     case '5':
       return ui::VKEY_5;
     case '^':
       *shifted = true;
+      FALLTHROUGH;
     case '6':
       return ui::VKEY_6;
     case '&':
       *shifted = true;
+      FALLTHROUGH;
     case '7':
       return ui::VKEY_7;
     case '*':
       *shifted = true;
+      FALLTHROUGH;
     case '8':
       return ui::VKEY_8;
     case '(':
       *shifted = true;
+      FALLTHROUGH;
     case '9':
       return ui::VKEY_9;
 
     case ':':
       *shifted = true;
+      FALLTHROUGH;
     case ';':
       return ui::VKEY_OEM_1;
     case '+':
       *shifted = true;
+      FALLTHROUGH;
     case '=':
       return ui::VKEY_OEM_PLUS;
     case '<':
       *shifted = true;
+      FALLTHROUGH;
     case ',':
       return ui::VKEY_OEM_COMMA;
     case '_':
       *shifted = true;
+      FALLTHROUGH;
     case '-':
       return ui::VKEY_OEM_MINUS;
     case '>':
       *shifted = true;
+      FALLTHROUGH;
     case '.':
       return ui::VKEY_OEM_PERIOD;
     case '?':
       *shifted = true;
+      FALLTHROUGH;
     case '/':
       return ui::VKEY_OEM_2;
     case '~':
       *shifted = true;
+      FALLTHROUGH;
     case '`':
       return ui::VKEY_OEM_3;
     case '{':
       *shifted = true;
+      FALLTHROUGH;
     case '[':
       return ui::VKEY_OEM_4;
     case '|':
       *shifted = true;
+      FALLTHROUGH;
     case '\\':
       return ui::VKEY_OEM_5;
     case '}':
       *shifted = true;
+      FALLTHROUGH;
     case ']':
       return ui::VKEY_OEM_6;
     case '"':
       *shifted = true;
+      FALLTHROUGH;
     case '\'':
       return ui::VKEY_OEM_7;
 

--- a/atom/common/native_mate_converters/content_converter.cc
+++ b/atom/common/native_mate_converters/content_converter.cc
@@ -43,10 +43,12 @@ v8::Local<v8::Value> MenuItemToV8(
     case content::MenuItem::CHECKABLE_OPTION:
     case content::MenuItem::GROUP:
       v8_item.Set("checked", item.checked);
+      FALLTHROUGH;
     case content::MenuItem::OPTION:
     case content::MenuItem::SUBMENU:
       v8_item.Set("label", item.label);
       v8_item.Set("enabled", item.enabled);
+      FALLTHROUGH;
     default:
       v8_item.Set("type", item.type);
   }


### PR DESCRIPTION
The compiler was throwing errors about unannotated fallthroughs when
building with GN.