### PR TITLE
chore: fix chromium-style errors in frame_subscriber

### DIFF
--- a/atom/browser/api/frame_subscriber.cc
+++ b/atom/browser/api/frame_subscriber.cc
@@ -82,7 +82,7 @@ void FrameSubscriber::Done(const gfx::Rect& damage, const SkBitmap& frame) {
                                        : frame;
 
   size_t rgb_row_size = bitmap.width() * bitmap.bytesPerPixel();
-  auto source = static_cast<const char*>(bitmap.getPixels());
+  auto* source = static_cast<const char*>(bitmap.getPixels());
 
   v8::MaybeLocal<v8::Object> buffer =
       node::Buffer::Copy(isolate_, source, rgb_row_size * bitmap.height());

--- a/atom/browser/api/frame_subscriber.h
+++ b/atom/browser/api/frame_subscriber.h
@@ -28,7 +28,7 @@ class FrameSubscriber : public content::WebContentsObserver {
                   content::WebContents* web_contents,
                   const FrameCaptureCallback& callback,
                   bool only_dirty);
-  ~FrameSubscriber();
+  ~FrameSubscriber() override;
 
  private:
   gfx::Rect GetDamageRect();


### PR DESCRIPTION
The chromium-style linter we run in the GN build was throwing errors
about these issues.