### PR TITLE
chore: [gn] remove gclient hook for node config.gypi

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -49,17 +49,6 @@ hooks = [
     'action': [
       'bash',
       '-c',
-      # NOTE(nornagon): this ridiculous {{}} stuff is because these strings get
-      # variable-substituted twice by gclient.
-      'echo -e "#\\n{{{{\'variables\':{{{{}}}}}}}}" > src/third_party/electron_node/config.gypi',
-    ],
-    'pattern': 'src/third_party/electron_node',
-    'name': 'touch_node_config_gypi'
-  },
-  {
-    'action': [
-      'bash',
-      '-c',
       'cd src/electron; npm install',
     ],
     'pattern': 'src/electron/package.json',


### PR DESCRIPTION
This is no longer necessary since we changed the way we configure node in 4321db401