### PR TITLE
fix: always create `privateBytes` and `sharedBytes`fields in the memory info structures

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1123,12 +1123,14 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
         static_cast<double>(
             process_metric.second->metrics->GetPeakWorkingSetSize() >> 10));
 
-    size_t private_bytes, shared_bytes;
-    if (process_metric.second->metrics->GetMemoryBytes(&private_bytes,
-                                                       &shared_bytes)) {
-      memory_dict.Set("privateBytes", static_cast<double>(private_bytes >> 10));
-      memory_dict.Set("sharedBytes", static_cast<double>(shared_bytes >> 10));
-    }
+    size_t private_bytes = 0;
+    size_t shared_bytes = 0;
+
+    // If GetMemoryBytes fails it will not change values of parameters
+    process_metric.second->metrics->GetMemoryBytes(&private_bytes,
+                                                   &shared_bytes);
+    memory_dict.Set("privateBytes", static_cast<double>(private_bytes >> 10));
+    memory_dict.Set("sharedBytes", static_cast<double>(shared_bytes >> 10));
 
     pid_dict.Set("memory", memory_dict);
     cpu_dict.Set(

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -166,11 +166,13 @@ v8::Local<v8::Value> AtomBindings::GetProcessMemoryInfo(v8::Isolate* isolate) {
   dict.Set("peakWorkingSetSize",
            static_cast<double>(metrics->GetPeakWorkingSetSize() >> 10));
 
-  size_t private_bytes, shared_bytes;
-  if (metrics->GetMemoryBytes(&private_bytes, &shared_bytes)) {
-    dict.Set("privateBytes", static_cast<double>(private_bytes >> 10));
-    dict.Set("sharedBytes", static_cast<double>(shared_bytes >> 10));
-  }
+  size_t private_bytes = 0;
+  size_t shared_bytes = 0;
+
+  // If GetMemoryBytes fails it will not change values of parameters
+  metrics->GetMemoryBytes(&private_bytes, &shared_bytes);
+  dict.Set("privateBytes", static_cast<double>(private_bytes >> 10));
+  dict.Set("sharedBytes", static_cast<double>(shared_bytes >> 10));
 
   return dict.GetHandle();
 }

--- a/docs/api/structures/memory-info.md
+++ b/docs/api/structures/memory-info.md
@@ -5,9 +5,9 @@
 * `peakWorkingSetSize` Integer - The maximum amount of memory that has ever been pinned
   to actual physical RAM. On macOS its value will always be 0.
 * `privateBytes` Integer - The amount of memory not shared by other processes, such as
-  JS heap or HTML content. Value 0 means the value cannot be obtained in the moment.
+  JS heap or HTML content. Value 0 means the value cannot be obtained at the moment.
 * `sharedBytes` Integer - The amount of memory shared between processes, typically
   memory consumed by the Electron code itself. Value 0 means the value cannot 
-  be obtained in the moment.
+  be obtained at the moment.
 
 Note that all statistics are reported in Kilobytes.

--- a/docs/api/structures/memory-info.md
+++ b/docs/api/structures/memory-info.md
@@ -5,8 +5,9 @@
 * `peakWorkingSetSize` Integer - The maximum amount of memory that has ever been pinned
   to actual physical RAM. On macOS its value will always be 0.
 * `privateBytes` Integer - The amount of memory not shared by other processes, such as
-  JS heap or HTML content.
+  JS heap or HTML content. Value 0 means the value cannot be obtained in the moment.
 * `sharedBytes` Integer - The amount of memory shared between processes, typically
-  memory consumed by the Electron code itself
+  memory consumed by the Electron code itself. Value 0 means the value cannot 
+  be obtained in the moment.
 
 Note that all statistics are reported in Kilobytes.

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -803,8 +803,8 @@ describe('app module', () => {
       const types = []
       for (const {memory, pid, type, cpu} of appMetrics) {
         expect(memory.workingSetSize).to.be.above(0, 'working set size is not > 0')
-        expect(memory.privateBytes).to.be.above(0, 'private bytes is not > 0')
-        expect(memory.sharedBytes).to.be.above(0, 'shared bytes is not > 0')
+        expect(memory.privateBytes).to.be.gte(0, 'private bytes is not >= 0')
+        expect(memory.sharedBytes).to.be.gte(0, 'shared bytes is not >= 0')
         expect(pid).to.be.above(0, 'pid is not > 0')
         expect(type).to.be.a('string').that.is.not.empty()
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -802,7 +802,6 @@ describe('app module', () => {
 
       const types = []
       for (const {memory, pid, type, cpu} of appMetrics) {
-        
         expect(memory).to.have.own.property('workingSetSize').that.is.a('number').to.be.above(0, 'working set size is not > 0')
         expect(memory).to.have.own.property('privateBytes').that.is.a('number').to.be.gte(0, 'private bytes is not >= 0')
         expect(memory).to.have.own.property('sharedBytes').that.is.a('number').to.be.gte(0, 'shared bytes is not >= 0')

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -803,8 +803,12 @@ describe('app module', () => {
       const types = []
       for (const {memory, pid, type, cpu} of appMetrics) {
         expect(memory.workingSetSize).to.be.above(0, 'working set size is not > 0')
+        
+        //TODO: check first if it exists and than if it has gte value
         expect(memory.privateBytes).to.be.gte(0, 'private bytes is not >= 0')
         expect(memory.sharedBytes).to.be.gte(0, 'shared bytes is not >= 0')
+        //
+
         expect(pid).to.be.above(0, 'pid is not > 0')
         expect(type).to.be.a('string').that.is.not.empty()
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -795,8 +795,7 @@ describe('app module', () => {
     })
   })
 
-  // TODO(marshallofsound): [Ch66] Failed on Windows x64 + ia32 on CI, passes locally
-  xdescribe('getAppMetrics() API', () => {
+  describe('getAppMetrics() API', () => {
     it('returns memory and cpu stats of all running electron processes', () => {
       const appMetrics = app.getAppMetrics()
       expect(appMetrics).to.be.an('array').and.have.lengthOf.at.least(1, 'App memory info object is not > 0')

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -802,12 +802,10 @@ describe('app module', () => {
 
       const types = []
       for (const {memory, pid, type, cpu} of appMetrics) {
-        expect(memory.workingSetSize).to.be.above(0, 'working set size is not > 0')
         
-        //TODO: check first if it exists and than if it has gte value
-        expect(memory.privateBytes).to.be.gte(0, 'private bytes is not >= 0')
-        expect(memory.sharedBytes).to.be.gte(0, 'shared bytes is not >= 0')
-        //
+        expect(memory).to.have.own.property('workingSetSize').that.is.a('number').to.be.above(0, 'working set size is not > 0')
+        expect(memory).to.have.own.property('privateBytes').that.is.a('number').to.be.gte(0, 'private bytes is not >= 0')
+        expect(memory).to.have.own.property('sharedBytes').that.is.a('number').to.be.gte(0, 'shared bytes is not >= 0')
 
         expect(pid).to.be.above(0, 'pid is not > 0')
         expect(type).to.be.a('string').that.is.not.empty()


### PR DESCRIPTION
Test seems to pass now even with enabled DCHECK in process_metrics_win.cc in Chromium.

Fixes #13385.