### PR TITLE
feat: Add ability to avoid creating the default Menu when using a custom Menu

### DIFF
--- a/default_app/default_app.js
+++ b/default_app/default_app.js
@@ -8,7 +8,7 @@ app.on('window-all-closed', () => {
   app.quit()
 })
 
-exports.load = (appUrl) => {
+exports.load = (appUrl, callback) => {
   app.on('ready', () => {
     const options = {
       width: 900,
@@ -27,5 +27,6 @@ exports.load = (appUrl) => {
     mainWindow = new BrowserWindow(options)
     mainWindow.loadURL(appUrl)
     mainWindow.focus()
+    if (callback) callback()
   })
 }

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -52,10 +52,9 @@ app.on('window-all-closed', () => {
   }
 })
 
-// Create default menu.
-app.once('ready', () => {
+// Create menu
+function createMenu () {
   if (Menu.getApplicationMenu()) return
-
   const template = [
     {
       label: 'Edit',
@@ -164,7 +163,6 @@ app.once('ready', () => {
       ]
     }
   ]
-
   if (process.platform === 'darwin') {
     template.unshift({
       label: 'Electron',
@@ -237,11 +235,9 @@ app.once('ready', () => {
       }]
     })
   }
-
   const menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
-})
-
+}
 if (option.modules.length > 0) {
   Module._preloadModules(option.modules)
 }
@@ -271,6 +267,12 @@ function loadApplicationPackage (packagePath) {
       } else if (packageJson.name) {
         app.setName(packageJson.name)
       }
+      // Only create the menu if the customMenu variable wasn't defined as was faulty
+      if (!packageJson.customMenu || packageJson.customMenu !== true) {
+        app.once('ready', () => {
+          createMenu()
+        })
+      }
       app.setPath('userData', path.join(app.getPath('appData'), app.getName()))
       app.setPath('userCache', path.join(app.getPath('cache'), app.getName()))
       app.setAppPath(packagePath)
@@ -299,7 +301,7 @@ function showErrorMessage (message) {
 }
 
 function loadApplicationByUrl (appUrl) {
-  require('./default_app').load(appUrl)
+  require('./default_app').load(appUrl, createMenu)
 }
 
 function startRepl () {

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -264,6 +264,13 @@ window.addEventListener('contextmenu', (e) => {
 </script>
 ```
 
+## Avoid creating the default Menu
+
+When using a custom `Menu` avoiding the creation of the default `Menu` will increase the performance of the app.
+
+To avoid rendering the default `Menu`, add the following property in your `package.json`:
+
+- `customMenu: true`
 
 ## Notes on macOS Application Menu
 


### PR DESCRIPTION
## Feature description
This PR adds the ability to avoid rendering the default `Menu`.

The reason is that in applications with many windows that use custom `Menus` or no menus at all, rendering the default `Menu` for no reason affects the performance.

The changes were in the JavaScript layer and no unit tests should be affected by those changes.

## How this works

- Add a `customMenu` key with `true` value at your app's package.json file to instruct the electron app that app will build the menu itself.
- Create custom the custom `Menu` by following the instructions here https://github.com/electron/electron/blob/master/docs/api/menu.md#examples

If you specified `"customMenu":"true"`, but you don't create a custom `Menu`, there will not be menu in your app.  

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)