### PR TITLE
docs: mention git's core.longpaths options in the windows build instructions

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -153,3 +153,11 @@ $ mkdir ~\AppData\Roaming\npm
 
 You may get this error if you are using Git Bash for building, you should use
 PowerShell or VS2015 Command Prompt instead.
+
+### cannot create directory at '...': Filename too long
+
+node.js has some [extremely long pathnames](https://github.com/electron/node/tree/electron/deps/npm/node_modules/libnpx/node_modules/yargs/node_modules/read-pkg-up/node_modules/read-pkg/node_modules/load-json-file/node_modules/parse-json/node_modules/error-ex/node_modules/is-arrayish), and by default git on windows doesn't handle long pathnames correctly (even though windows supports them). This should fix it:
+
+```sh
+$ git config --system core.longpaths true
+```


### PR DESCRIPTION
I tried to build electron on windows and ran into this; seems like others probably will too.