### PR TITLE
chore: [gn] fix DEPS to work on windows

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -36,6 +36,7 @@ deps = {
 hooks = [
   {
     'action': [
+      'python',
       'src/libchromiumcontent/script/apply-patches'
     ],
     'pattern':
@@ -45,6 +46,7 @@ hooks = [
   },
   {
     'action': [
+      'python',
       'src/electron/script/update-external-binaries.py'
     ],
     'pattern':
@@ -54,9 +56,9 @@ hooks = [
   },
   {
     'action': [
-      'bash',
+      'python',
       '-c',
-      'cd src/electron; npm install',
+      'import os; os.chdir("src"); os.chdir("electron"); os.system("npm install")',
     ],
     'pattern': 'src/electron/package.json',
     'name': 'electron_npm_deps'


### PR DESCRIPTION
Windows doesn't parse shebangs like macOS/Linux, so we need to explicitly call 'python' on the patch and update-external-binaries scripts. Also, bash isn't installed by default on windows, so use python instead as a pseudo-shell, since we know that'll be around :)

With these changes, `gclient sync` should work on Windows.