### PR TITLE
chore: fix chromium-style errors in windows code

### DIFF
--- a/brightray/browser/win/notification_presenter_win.h
+++ b/brightray/browser/win/notification_presenter_win.h
@@ -35,7 +35,7 @@ namespace brightray {
 class NotificationPresenterWin : public NotificationPresenter {
  public:
   NotificationPresenterWin();
-  ~NotificationPresenterWin();
+  ~NotificationPresenterWin() override;
 
   bool Init();
 

--- a/brightray/browser/win/notification_presenter_win7.cc
+++ b/brightray/browser/win/notification_presenter_win7.cc
@@ -13,8 +13,8 @@ brightray::Notification* NotificationPresenterWin7::CreateNotificationObject(
 
 Win32Notification* NotificationPresenterWin7::GetNotificationObjectByRef(
     const DesktopNotificationController::Notification& ref) {
-  for (auto n : this->notifications()) {
-    auto w32n = static_cast<Win32Notification*>(n);
+  for (auto* n : this->notifications()) {
+    auto* w32n = static_cast<Win32Notification*>(n);
     if (w32n->GetRef() == ref)
       return w32n;
   }
@@ -24,8 +24,8 @@ Win32Notification* NotificationPresenterWin7::GetNotificationObjectByRef(
 
 Win32Notification* NotificationPresenterWin7::GetNotificationObjectByTag(
     const std::string& tag) {
-  for (auto n : this->notifications()) {
-    auto w32n = static_cast<Win32Notification*>(n);
+  for (auto* n : this->notifications()) {
+    auto* w32n = static_cast<Win32Notification*>(n);
     if (w32n->GetTag() == tag)
       return w32n;
   }
@@ -35,14 +35,14 @@ Win32Notification* NotificationPresenterWin7::GetNotificationObjectByTag(
 
 void NotificationPresenterWin7::OnNotificationClicked(
     Notification& notification) {
-  auto n = GetNotificationObjectByRef(notification);
+  auto* n = GetNotificationObjectByRef(notification);
   if (n)
     n->NotificationClicked();
 }
 
 void NotificationPresenterWin7::OnNotificationDismissed(
     Notification& notification) {
-  auto n = GetNotificationObjectByRef(notification);
+  auto* n = GetNotificationObjectByRef(notification);
   if (n)
     n->NotificationDismissed();
 }

--- a/brightray/browser/win/win32_desktop_notifications/common.h
+++ b/brightray/browser/win/win32_desktop_notifications/common.h
@@ -36,7 +36,7 @@ struct ScreenMetrics {
         GetProcAddress(GetModuleHandle(TEXT("shcore")), "GetDpiForMonitor"));
 
     if (GetDpiForMonitor) {
-      auto monitor = MonitorFromPoint({}, MONITOR_DEFAULTTOPRIMARY);
+      auto* monitor = MonitorFromPoint({}, MONITOR_DEFAULTTOPRIMARY);
       if (GetDpiForMonitor(monitor, 0, &dpi_x, &dpi_y) == S_OK)
         return;
     }

--- a/brightray/browser/win/win32_desktop_notifications/desktop_notification_controller.h
+++ b/brightray/browser/win/win32_desktop_notifications/desktop_notification_controller.h
@@ -88,8 +88,10 @@ class DesktopNotificationController {
 
 class DesktopNotificationController::Notification {
  public:
-  Notification() = default;
+  Notification();
   explicit Notification(const std::shared_ptr<NotificationData>& data);
+  Notification(const Notification&);
+  ~Notification();
 
   bool operator==(const Notification& other) const;
 

--- a/brightray/browser/win/win32_desktop_notifications/toast.cc
+++ b/brightray/browser/win/win32_desktop_notifications/toast.cc
@@ -83,7 +83,7 @@ static HBITMAP StretchBitmap(HBITMAP bitmap, unsigned width, unsigned height) {
       if (GetDIBits(hdc_screen, bitmap, 0, 0, 0,
                     reinterpret_cast<BITMAPINFO*>(&bmi), DIB_RGB_COLORS) &&
           bmi.biSizeImage > 0 && (bmi.biSizeImage % 4) == 0) {
-        auto buf = reinterpret_cast<BYTE*>(
+        auto* buf = reinterpret_cast<BYTE*>(
             _aligned_malloc(bmi.biSizeImage, sizeof(DWORD)));
 
         if (buf) {
@@ -117,12 +117,12 @@ static HBITMAP StretchBitmap(HBITMAP bitmap, unsigned width, unsigned height) {
     bmi.biCompression = BI_RGB;
 
     void* color_bits;
-    auto color_bitmap =
+    auto* color_bitmap =
         CreateDIBSection(NULL, reinterpret_cast<BITMAPINFO*>(&bmi),
                          DIB_RGB_COLORS, &color_bits, NULL, 0);
 
     void* alpha_bits;
-    auto alpha_bitmap =
+    auto* alpha_bitmap =
         CreateDIBSection(NULL, reinterpret_cast<BITMAPINFO*>(&bmi),
                          DIB_RGB_COLORS, &alpha_bits, NULL, 0);
 
@@ -148,9 +148,9 @@ static HBITMAP StretchBitmap(HBITMAP bitmap, unsigned width, unsigned height) {
       GdiFlush();
 
       // apply the alpha channel
-      auto dest = reinterpret_cast<BYTE*>(color_bits);
-      auto src = reinterpret_cast<const BYTE*>(alpha_bits);
-      auto end = src + (width * height * 4);
+      auto* dest = reinterpret_cast<BYTE*>(color_bits);
+      auto* src = reinterpret_cast<const BYTE*>(alpha_bits);
+      auto* end = src + (width * height * 4);
       while (src != end) {
         dest[3] = src[0];
         dest += 4;
@@ -214,10 +214,10 @@ LRESULT DesktopNotificationController::Toast::WndProc(HWND hwnd,
                                                       LPARAM lparam) {
   switch (message) {
     case WM_CREATE: {
-      auto& cs = reinterpret_cast<const CREATESTRUCT*&>(lparam);
-      auto data =
+      auto*& cs = reinterpret_cast<const CREATESTRUCT*&>(lparam);
+      auto* data =
           static_cast<shared_ptr<NotificationData>*>(cs->lpCreateParams);
-      auto inst = new Toast(hwnd, data);
+      auto* inst = new Toast(hwnd, data);
       SetWindowLongPtr(hwnd, 0, (LONG_PTR)inst);
     } break;
 
@@ -236,7 +236,7 @@ LRESULT DesktopNotificationController::Toast::WndProc(HWND hwnd,
       return 0;
 
     case WM_LBUTTONDOWN: {
-      auto inst = Get(hwnd);
+      auto* inst = Get(hwnd);
 
       inst->Dismiss();
 
@@ -249,7 +249,7 @@ LRESULT DesktopNotificationController::Toast::WndProc(HWND hwnd,
       return 0;
 
     case WM_MOUSEMOVE: {
-      auto inst = Get(hwnd);
+      auto* inst = Get(hwnd);
       if (!inst->is_highlighted_) {
         inst->is_highlighted_ = true;
 
@@ -269,7 +269,7 @@ LRESULT DesktopNotificationController::Toast::WndProc(HWND hwnd,
       return 0;
 
     case WM_MOUSELEAVE: {
-      auto inst = Get(hwnd);
+      auto* inst = Get(hwnd);
       inst->is_highlighted_ = false;
       inst->is_close_hot_ = false;
       inst->UpdateContents();
@@ -283,7 +283,7 @@ LRESULT DesktopNotificationController::Toast::WndProc(HWND hwnd,
       return 0;
 
     case WM_WINDOWPOSCHANGED: {
-      auto& wp = reinterpret_cast<WINDOWPOS*&>(lparam);
+      auto*& wp = reinterpret_cast<WINDOWPOS*&>(lparam);
       if (wp->flags & SWP_HIDEWINDOW) {
         if (!IsWindowVisible(hwnd))
           Get(hwnd)->is_highlighted_ = false;
@@ -357,7 +357,7 @@ void DesktopNotificationController::Toast::Draw() {
 
   // Draw background
   {
-    auto brush = CreateSolidBrush(back_color);
+    auto* brush = CreateSolidBrush(back_color);
 
     RECT rc = {0, 0, toast_size_.cx, toast_size_.cy};
     FillRect(hdc_, &rc, brush);
@@ -368,8 +368,8 @@ void DesktopNotificationController::Toast::Draw() {
   SetBkMode(hdc_, TRANSPARENT);
 
   const auto close = L'\x2715';
-  auto caption_font = data_->controller->GetCaptionFont();
-  auto body_font = data_->controller->GetBodyFont();
+  auto* caption_font = data_->controller->GetCaptionFont();
+  auto* body_font = data_->controller->GetBodyFont();
 
   TEXTMETRIC tm_cap;
   SelectFont(hdc_, caption_font);
@@ -520,7 +520,7 @@ void DesktopNotificationController::Toast::UpdateBufferSize() {
     if (new_size.cx != this->toast_size_.cx ||
         new_size.cy != this->toast_size_.cy) {
       HDC hdc_screen = GetDC(NULL);
-      auto new_bitmap =
+      auto* new_bitmap =
           CreateCompatibleBitmap(hdc_screen, new_size.cx, new_size.cy);
       ReleaseDC(NULL, hdc_screen);
 
@@ -733,7 +733,7 @@ HDWP DesktopNotificationController::Toast::Animate(HDWP hdwp,
   // ULWI fails, which can happen when one of the dimensions is zero (e.g.
   // at the beginning of ease-in).
 
-  auto ulw_result = UpdateLayeredWindowIndirect(hwnd_, &ulw);
+  UpdateLayeredWindowIndirect(hwnd_, &ulw);
   hdwp = DeferWindowPos(hdwp, hwnd_, HWND_TOPMOST, pt.x, pt.y, size.cx, size.cy,
                         dwpFlags);
   return hdwp;

--- a/brightray/browser/win/win32_notification.cc
+++ b/brightray/browser/win/win32_notification.cc
@@ -11,7 +11,7 @@
 namespace brightray {
 
 void Win32Notification::Show(const NotificationOptions& options) {
-  auto presenter = static_cast<NotificationPresenterWin7*>(this->presenter());
+  auto* presenter = static_cast<NotificationPresenterWin7*>(this->presenter());
   if (!presenter)
     return;
 

--- a/brightray/browser/win/windows_toast_notification.cc
+++ b/brightray/browser/win/windows_toast_notification.cc
@@ -80,7 +80,7 @@ WindowsToastNotification::~WindowsToastNotification() {
 }
 
 void WindowsToastNotification::Show(const NotificationOptions& options) {
-  auto presenter_win = static_cast<NotificationPresenterWin*>(presenter());
+  auto* presenter_win = static_cast<NotificationPresenterWin*>(presenter());
   std::wstring icon_path =
       presenter_win->SaveIconToFilesystem(options.icon, options.icon_url);
 

--- a/brightray/browser/win/windows_toast_notification.h
+++ b/brightray/browser/win/windows_toast_notification.h
@@ -47,7 +47,7 @@ class WindowsToastNotification : public Notification {
 
   WindowsToastNotification(NotificationDelegate* delegate,
                            NotificationPresenter* presenter);
-  ~WindowsToastNotification();
+  ~WindowsToastNotification() override;
 
  protected:
   // Notification:
@@ -108,7 +108,7 @@ class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,
                                               DesktopToastFailedEventHandler> {
  public:
   explicit ToastEventHandler(Notification* notification);
-  ~ToastEventHandler();
+  ~ToastEventHandler() override;
 
   IFACEMETHODIMP Invoke(
       ABI::Windows::UI::Notifications::IToastNotification* sender,

--- a/brightray/common/application_info.h
+++ b/brightray/common/application_info.h
@@ -2,6 +2,7 @@
 #define BRIGHTRAY_COMMON_APPLICATION_INFO_H_
 
 #if defined(OS_WIN)
+#include "base/strings/string16.h"
 #include "brightray/browser/win/scoped_hstring.h"
 #endif
 

--- a/brightray/common/application_info_win.cc
+++ b/brightray/common/application_info_win.cc
@@ -22,14 +22,14 @@ base::string16 g_app_user_model_id;
 const wchar_t kAppUserModelIDFormat[] = L"electron.app.$1";
 
 std::string GetApplicationName() {
-  auto module = GetModuleHandle(nullptr);
+  auto* module = GetModuleHandle(nullptr);
   std::unique_ptr<FileVersionInfo> info(
       FileVersionInfo::CreateFileVersionInfoForModule(module));
   return base::UTF16ToUTF8(info->product_name());
 }
 
 std::string GetApplicationVersion() {
-  auto module = GetModuleHandle(nullptr);
+  auto* module = GetModuleHandle(nullptr);
   std::unique_ptr<FileVersionInfo> info(
       FileVersionInfo::CreateFileVersionInfoForModule(module));
   return base::UTF16ToUTF8(info->product_version());


### PR DESCRIPTION
This fixes errors that the `chromium-style` linter plugin was producing when attempting to build Electron with GN on Windows.