### PR TITLE
refactor: rpc-server.js cleanup

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -171,7 +171,6 @@ const removeRemoteListenersAndLogWarning = (sender, meta, callIntoRenderer) => {
 // Convert array of meta data from renderer into array of real values.
 const unwrapArgs = function (sender, args) {
   const metaToValue = function (meta) {
-    let i, len, member, ref, returnValue
     switch (meta.type) {
       case 'value':
         return meta.value
@@ -191,15 +190,13 @@ const unwrapArgs = function (sender, args) {
         let ret = {}
         Object.defineProperty(ret.constructor, 'name', { value: meta.name })
 
-        ref = meta.members
-        for (i = 0, len = ref.length; i < len; i++) {
-          member = ref[i]
-          ret[member.name] = metaToValue(member.value)
+        for (const {name, value} of meta.members) {
+          ret[name] = metaToValue(value)
         }
         return ret
       }
       case 'function-with-return-value':
-        returnValue = metaToValue(meta.value)
+        const returnValue = metaToValue(meta.value)
         return function () {
           return returnValue
         }
@@ -237,9 +234,8 @@ const unwrapArgs = function (sender, args) {
 // Call a function and send reply asynchronously if it's a an asynchronous
 // style function and the caller didn't pass a callback.
 const callFunction = function (event, func, caller, args) {
-  let err, funcMarkedAsync, funcName, funcPassedCallback, ref, ret
-  funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous')
-  funcPassedCallback = typeof args[args.length - 1] === 'function'
+  const funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous')
+  const funcPassedCallback = typeof args[args.length - 1] === 'function'
   try {
     if (funcMarkedAsync && !funcPassedCallback) {
       args.push(function (ret) {
@@ -247,15 +243,15 @@ const callFunction = function (event, func, caller, args) {
       })
       func.apply(caller, args)
     } else {
-      ret = func.apply(caller, args)
+      const ret = func.apply(caller, args)
       event.returnValue = valueToMeta(event.sender, ret, true)
     }
   } catch (error) {
     // Catch functions thrown further down in function invocation and wrap
     // them with the function name so it's easier to trace things like
     // `Error processing argument -1.`
-    funcName = ((ref = func.name) != null) ? ref : 'anonymous'
-    err = new Error(`Could not call remote function '${funcName}'. Check that the function signature is correct. Underlying error: ${error.message}`)
+    const funcName = func.name || 'anonymous'
+    const err = new Error(`Could not call remote function '${funcName}'. Check that the function signature is correct. Underlying error: ${error.message}`)
     err.cause = error
     throw err
   }

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -302,10 +302,7 @@ ipcMain.on('ELECTRON_BROWSER_CONSTRUCTOR', function (event, id, args) {
       throwRPCError(`Cannot call constructor on missing remote object ${id}`)
     }
 
-    // Call new with array of arguments.
-    // http://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible
-    let obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)))()
-    event.returnValue = valueToMeta(event.sender, obj)
+    event.returnValue = valueToMeta(event.sender, new constructor(...args))
   } catch (error) {
     event.returnValue = exceptionToMeta(event.sender, error)
   }
@@ -335,10 +332,7 @@ ipcMain.on('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', function (event, id, method, a
       throwRPCError(`Cannot call constructor '${method}' on missing remote object ${id}`)
     }
 
-    // Call new with array of arguments.
-    let constructor = object[method]
-    let obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)))()
-    event.returnValue = valueToMeta(event.sender, obj)
+    event.returnValue = valueToMeta(event.sender, new object[method](...args))
   } catch (error) {
     event.returnValue = exceptionToMeta(event.sender, error)
   }


### PR DESCRIPTION
Variables should be declared before use, block scoped properly, using `const` or `let`