### PR TITLE
fix: Revert "remove MarkHghMemoryUsage api"

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -331,6 +331,10 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
       request_id_(0),
       background_throttling_(true),
       enable_devtools_(true) {
+  // WebContents may need to emit events when it is garbage collected, so it
+  // has to be deleted in the first gc callback.
+  MarkHighMemoryUsage();
+
   // Read options.
   options.Get("backgroundThrottling", &background_throttling_);
 

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -223,6 +223,7 @@ NativeImage::NativeImage(v8::Isolate* isolate, const gfx::Image& image)
     isolate->AdjustAmountOfExternalAllocatedMemory(
       image_.ToImageSkia()->bitmap()->computeSize64());
   }
+  MarkHighMemoryUsage();
 }
 
 #if defined(OS_WIN)
@@ -237,6 +238,7 @@ NativeImage::NativeImage(v8::Isolate* isolate, const base::FilePath& hicon_path)
     isolate->AdjustAmountOfExternalAllocatedMemory(
       image_.ToImageSkia()->bitmap()->computeSize64());
   }
+  MarkHighMemoryUsage();
 }
 #endif
 


### PR DESCRIPTION
This reverts commit 0de85fd49f6b66ec66d23714eee1c7428b5237f5 that went in accidentally with https://github.com/electron/electron/pull/12448. Part of the reason because we didn't have release branches in native_mate.

Fixes https://github.com/electron/electron/issues/12676
Ref https://github.com/electron/electron/issues/13102, https://github.com/electron/electron/issues/12864

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)