### PR TITLE
refactor: remove deprecated GetAs methods

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -336,10 +336,9 @@ void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
   for (base::DictionaryValue::Iterator iter(options); !iter.IsAtEnd();
        iter.Advance()) {
     std::string key = iter.key();
-    std::string value;
-    if (!key.empty() && iter.value().GetAsString(&value)) {
+    if (!key.empty() && iter.value().is_string()) {
       key[0] = base::ToUpperASCII(key[0]);
-      about_panel_options_.SetString(key, value);
+      about_panel_options_.SetString(key, iter.value().GetString());
     }
   }
 }

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -183,9 +183,10 @@ void ReadFromResponseObject(const base::DictionaryValue& response,
     headers->Clear();
     for (base::DictionaryValue::Iterator it(*dict); !it.IsAtEnd();
          it.Advance()) {
-      std::string value;
-      if (it.value().GetAsString(&value))
+      if (it.value().is_string()) {
+        std::string value = it.value().GetString();
         headers->SetHeader(it.key(), value);
+      }
     }
   }
 }

--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -62,8 +62,8 @@ bool IsErrorOptions(base::Value* value, int* error) {
     if (dict->GetInteger("error", error))
       return true;
   } else if (value->is_int()) {
-    if (value->GetAsInteger(error))
-      return true;
+    *error = value->GetInt();
+    return true;
   }
   return false;
 }

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -22,7 +22,7 @@ void URLRequestAsyncAsarJob::StartAsync(std::unique_ptr<base::Value> options) {
     static_cast<base::DictionaryValue*>(options.get())
         ->GetString("path", &file_path);
   } else if (options->is_string()) {
-    options->GetAsString(&file_path);
+    file_path = options->GetString();
   }
 
   if (file_path.empty()) {

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "atom/common/atom_constants.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/task_scheduler/post_task.h"
 
 namespace atom {

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -17,10 +17,11 @@ URLRequestAsyncAsarJob::URLRequestAsyncAsarJob(
     : JsAsker<asar::URLRequestAsarJob>(request, network_delegate) {}
 
 void URLRequestAsyncAsarJob::StartAsync(std::unique_ptr<base::Value> options) {
-  base::FilePath::StringType file_path;
+  std::string file_path;
   if (options->is_dict()) {
-    static_cast<base::DictionaryValue*>(options.get())
-        ->GetString("path", &file_path);
+    auto path_value = options->FindKeyOfType("path", base::Value::Type::STRING);
+    if (path_value)
+      file_path = path_value->GetString();
   } else if (options->is_string()) {
     file_path = options->GetString();
   }
@@ -33,7 +34,11 @@ void URLRequestAsyncAsarJob::StartAsync(std::unique_ptr<base::Value> options) {
         base::CreateSequencedTaskRunnerWithTraits(
             {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
              base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN}),
+#if defined(OS_WIN)
+        base::FilePath(base::UTF8ToWide(file_path)));
+#else
         base::FilePath(file_path));
+#endif
     asar::URLRequestAsarJob::Start();
   }
 }

--- a/atom/browser/net/url_request_string_job.cc
+++ b/atom/browser/net/url_request_string_job.cc
@@ -25,7 +25,7 @@ void URLRequestStringJob::StartAsync(std::unique_ptr<base::Value> options) {
     dict->GetString("charset", &charset_);
     dict->GetString("data", &data_);
   } else if (options->is_string()) {
-    options->GetAsString(&data_);
+    data_ = options->GetString();
   }
   net::URLRequestSimpleJob::Start();
 }

--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -162,26 +162,22 @@ v8::Local<v8::Value> V8ValueConverter::ToV8ValueImpl(
       return v8::Null(isolate);
 
     case base::Value::Type::BOOLEAN: {
-      bool val = false;
-      value->GetAsBoolean(&val);
+      bool val = value->GetBool();
       return v8::Boolean::New(isolate, val);
     }
 
     case base::Value::Type::INTEGER: {
-      int val = 0;
-      value->GetAsInteger(&val);
+      int val = value->GetInt();
       return v8::Integer::New(isolate, val);
     }
 
     case base::Value::Type::DOUBLE: {
-      double val = 0.0;
-      value->GetAsDouble(&val);
+      double val = value->GetDouble();
       return v8::Number::New(isolate, val);
     }
 
     case base::Value::Type::STRING: {
-      std::string val;
-      value->GetAsString(&val);
+      std::string val = value->GetString();
       return v8::String::NewFromUtf8(isolate, val.c_str(),
                                      v8::String::kNormalString, val.length());
     }
@@ -345,8 +341,8 @@ base::Value* V8ValueConverter::FromV8ValueImpl(FromV8ValueState* state,
   if (val->IsRegExp()) {
     if (!reg_exp_allowed_)
       // JSON.stringify converts to an object.
-      return FromV8Object(val->ToObject(context).ToLocalChecked(),
-          state, isolate);
+      return FromV8Object(val->ToObject(context).ToLocalChecked(), state,
+                          isolate);
     return new base::Value(
         *v8::String::Utf8Value(val->ToString(context).ToLocalChecked()));
   }
@@ -359,8 +355,8 @@ base::Value* V8ValueConverter::FromV8ValueImpl(FromV8ValueState* state,
     if (!function_allowed_)
       // JSON.stringify refuses to convert function(){}.
       return nullptr;
-    return FromV8Object(val->ToObject(context).ToLocalChecked(),
-        state, isolate);
+    return FromV8Object(val->ToObject(context).ToLocalChecked(), state,
+                        isolate);
   }
 
   if (node::Buffer::HasInstance(val)) {
@@ -368,8 +364,8 @@ base::Value* V8ValueConverter::FromV8ValueImpl(FromV8ValueState* state,
   }
 
   if (val->IsObject()) {
-    return FromV8Object(val->ToObject(context).ToLocalChecked(),
-        state, isolate);
+    return FromV8Object(val->ToObject(context).ToLocalChecked(), state,
+                        isolate);
   }
 
   LOG(ERROR) << "Unexpected v8 value type encountered.";


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/12774.

Removes instances of `Value::GetAs<TYPE>` from `atom/` and `brightray/`.

/cc @alexeykuzmin 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)