### PR TITLE
chore: [gn] only define WIN32_LEAN_AND_MEAN if not already defined

### DIFF
--- a/brightray/browser/win/win32_desktop_notifications/desktop_notification_controller.cc
+++ b/brightray/browser/win/win32_desktop_notifications/desktop_notification_controller.cc
@@ -1,5 +1,9 @@
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include "brightray/browser/win/win32_desktop_notifications/desktop_notification_controller.h"
 #include <windowsx.h>
 #include <algorithm>

--- a/brightray/browser/win/win32_desktop_notifications/toast.cc
+++ b/brightray/browser/win/win32_desktop_notifications/toast.cc
@@ -1,4 +1,6 @@
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include "brightray/browser/win/win32_desktop_notifications/toast.h"
 #include <uxtheme.h>
 #include <windowsx.h>

--- a/brightray/browser/win/win32_notification.cc
+++ b/brightray/browser/win/win32_notification.cc
@@ -1,4 +1,6 @@
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 
 #include "brightray/browser/win/win32_notification.h"
 


### PR DESCRIPTION
Chromium's GN build already defines `WIN32_LEAN_AND_MEAN` and `NOMINMAX` (see [build/config/win/BUILD.gn](https://chromium.googlesource.com/chromium/src/+/dbe762aaff7e5ec435082d7bf0ac7f06a066774c/build/config/win/BUILD.gn#515) in chrome), so we don't need to define them ourselves. Left as #ifndefs so as not to break the gyp build.