### PR TITLE
chore: fix some more warnings in windows build

### DIFF
--- a/atom/browser/ui/win/jump_list.cc
+++ b/atom/browser/ui/win/jump_list.cc
@@ -275,9 +275,9 @@ JumpListResult JumpList::AppendCategory(const JumpListCategory& category) {
         result = JumpListResult::GENERIC_ERROR;
     }
   } else {
-    auto hr = destinations_->AppendCategory(category.name.c_str(), items);
+    HRESULT hr = destinations_->AppendCategory(category.name.c_str(), items);
     if (FAILED(hr)) {
-      if (hr == 0x80040F03) {
+      if (hr == static_cast<HRESULT>(0x80040F03)) {
         LOG(ERROR) << "Failed to append custom category "
                    << "'" << category.name << "' "
                    << "to Jump List due to missing file type registration.";

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -31,22 +31,6 @@
 
 namespace {
 
-// Old ShellExecute crashes the process when the command for a given scheme
-// is empty. This function tells if it is.
-bool ValidateShellCommandForScheme(const std::string& scheme) {
-  base::win::RegKey key;
-  base::string16 registry_path =
-      base::ASCIIToUTF16(scheme) + L"\\shell\\open\\command";
-  key.Open(HKEY_CLASSES_ROOT, registry_path.c_str(), KEY_READ);
-  if (!key.Valid())
-    return false;
-  DWORD size = 0;
-  key.ReadValue(NULL, NULL, &size, NULL);
-  if (size <= 2)
-    return false;
-  return true;
-}
-
 // Required COM implementation of IFileOperationProgressSink so we can
 // precheck files before deletion to make sure they can be move to the
 // Recycle Bin.


### PR DESCRIPTION
Remove an unused function and fix an int type comparison warning. Only showed up when building with GN.