### PR TITLE
chore: [gn] remove vendor/ from windows include paths

### DIFF
--- a/atom/common/crash_reporter/crash_reporter_win.h
+++ b/atom/common/crash_reporter/crash_reporter_win.h
@@ -11,7 +11,7 @@
 
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "base/compiler_specific.h"
-#include "vendor/breakpad/src/client/windows/handler/exception_handler.h"
+#include "breakpad/src/client/windows/handler/exception_handler.h"
 
 namespace base {
 template <typename T>

--- a/atom/common/crash_reporter/win/crash_service.cc
+++ b/atom/common/crash_reporter/win/crash_service.cc
@@ -17,9 +17,9 @@
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
 #include "base/win/windows_version.h"
-#include "vendor/breakpad/src/client/windows/crash_generation/client_info.h"
-#include "vendor/breakpad/src/client/windows/crash_generation/crash_generation_server.h"
-#include "vendor/breakpad/src/client/windows/sender/crash_report_sender.h"
+#include "breakpad/src/client/windows/crash_generation/client_info.h"
+#include "breakpad/src/client/windows/crash_generation/crash_generation_server.h"
+#include "breakpad/src/client/windows/sender/crash_report_sender.h"
 
 namespace breakpad {
 

--- a/atom/common/node_bindings_win.cc
+++ b/atom/common/node_bindings_win.cc
@@ -8,10 +8,6 @@
 
 #include "base/logging.h"
 
-extern "C" {
-#include "vendor/node/deps/uv/src/win/internal.h"
-}
-
 namespace atom {
 
 NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env)


### PR DESCRIPTION
The GN build doesn't organize code in the same way as the GYP build, and these changes make it possible to build both ways (independent of whether the code is in `third_party/breakpad` or `electron/vendor/breakpad`.)