### PR TITLE
chore: [gn] fix WTL include paths and namespace include

### DIFF
--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -6,7 +6,10 @@
 
 #include <windows.h>  // windows.h must be included first
 
-#include <atlbase.h>
+#include <atlbase.h>  // atlbase.h must be included before atlapp.h
+
+#include <atlapp.h>
+#include <atldlgs.h>
 #include <commdlg.h>
 #include <shlobj.h>
 
@@ -20,8 +23,9 @@
 #include "base/threading/thread.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "base/win/registry.h"
-#include "third_party/wtl/include/atlapp.h"
-#include "third_party/wtl/include/atldlgs.h"
+
+using WTL::CShellFileOpenDialog;
+using WTL::CShellFileSaveDialog;
 
 namespace file_dialog {
 


### PR DESCRIPTION
As of electron/libchromiumcontent#576, the WTL namespace isn't included by default in the GN build.