### PR TITLE
refactor: remove deprecated CreateWithCopiedBuffer

### DIFF
--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -239,8 +239,11 @@ void GetUploadData(base::ListValue* upload_data_list,
     if (reader->AsBytesReader()) {
       const net::UploadBytesElementReader* bytes_reader =
           reader->AsBytesReader();
-      std::unique_ptr<base::Value> bytes(base::Value::CreateWithCopiedBuffer(
-          bytes_reader->bytes(), bytes_reader->length()));
+      std::vector<char> bytes_vector(
+          bytes_reader->bytes(),
+          bytes_reader->bytes() + bytes_reader->length());
+      std::unique_ptr<base::Value> bytes =
+          std::make_unique<base::Value>(&bytes_vector);
       upload_data_dict->Set("bytes", std::move(bytes));
     } else if (reader->AsFileReader()) {
       const net::UploadFileElementReader* file_reader = reader->AsFileReader();

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -239,11 +239,10 @@ void GetUploadData(base::ListValue* upload_data_list,
     if (reader->AsBytesReader()) {
       const net::UploadBytesElementReader* bytes_reader =
           reader->AsBytesReader();
-      std::vector<char> bytes_vector(
-          bytes_reader->bytes(),
-          bytes_reader->bytes() + bytes_reader->length());
-      std::unique_ptr<base::Value> bytes =
-          std::make_unique<base::Value>(&bytes_vector);
+      auto vec =
+          std::vector<char>(bytes_reader->bytes(),
+                            bytes_reader->bytes() + bytes_reader->length());
+      auto bytes = std::make_unique<base::Value>(vec);
       upload_data_dict->Set("bytes", std::move(bytes));
     } else if (reader->AsFileReader()) {
       const net::UploadFileElementReader* file_reader = reader->AsFileReader();

--- a/atom/common/native_mate_converters/network_converter.cc
+++ b/atom/common/native_mate_converters/network_converter.cc
@@ -25,8 +25,10 @@ Converter<scoped_refptr<network::ResourceRequestBody>>::ToV8(
     auto post_data_dict = std::make_unique<base::DictionaryValue>();
     auto type = element.type();
     if (type == network::DataElement::TYPE_BYTES) {
-      auto bytes = base::Value::CreateWithCopiedBuffer(
-          element.bytes(), static_cast<size_t>(element.length()));
+      std::vector<char> bytes_vector(
+          element.bytes(),
+          element.bytes() + static_cast<size_t>(element.length()));
+      auto bytes = std::make_unique<base::Value>(&bytes_vector);
       post_data_dict->SetString("type", "rawData");
       post_data_dict->Set("bytes", std::move(bytes));
     } else if (type == network::DataElement::TYPE_FILE) {

--- a/atom/common/native_mate_converters/network_converter.cc
+++ b/atom/common/native_mate_converters/network_converter.cc
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "native_mate/dictionary.h"

--- a/atom/common/native_mate_converters/network_converter.cc
+++ b/atom/common/native_mate_converters/network_converter.cc
@@ -26,10 +26,10 @@ Converter<scoped_refptr<network::ResourceRequestBody>>::ToV8(
     auto post_data_dict = std::make_unique<base::DictionaryValue>();
     auto type = element.type();
     if (type == network::DataElement::TYPE_BYTES) {
-      std::vector<char> bytes_vector(
+      auto vec = std::vector<char>(
           element.bytes(),
           element.bytes() + static_cast<size_t>(element.length()));
-      auto bytes = std::make_unique<base::Value>(&bytes_vector);
+      auto bytes = std::make_unique<base::Value>(vec);
       post_data_dict->SetString("type", "rawData");
       post_data_dict->Set("bytes", std::move(bytes));
     } else if (type == network::DataElement::TYPE_FILE) {

--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/logging.h"
 #include "base/values.h"

--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -345,8 +345,8 @@ base::Value* V8ValueConverter::FromV8ValueImpl(FromV8ValueState* state,
   if (val->IsRegExp()) {
     if (!reg_exp_allowed_)
       // JSON.stringify converts to an object.
-      return FromV8Object(val->ToObject(context).ToLocalChecked(),
-          state, isolate);
+      return FromV8Object(val->ToObject(context).ToLocalChecked(), state,
+                          isolate);
     return new base::Value(
         *v8::String::Utf8Value(val->ToString(context).ToLocalChecked()));
   }
@@ -359,8 +359,8 @@ base::Value* V8ValueConverter::FromV8ValueImpl(FromV8ValueState* state,
     if (!function_allowed_)
       // JSON.stringify refuses to convert function(){}.
       return nullptr;
-    return FromV8Object(val->ToObject(context).ToLocalChecked(),
-        state, isolate);
+    return FromV8Object(val->ToObject(context).ToLocalChecked(), state,
+                        isolate);
   }
 
   if (node::Buffer::HasInstance(val)) {
@@ -368,8 +368,8 @@ base::Value* V8ValueConverter::FromV8ValueImpl(FromV8ValueState* state,
   }
 
   if (val->IsObject()) {
-    return FromV8Object(val->ToObject(context).ToLocalChecked(),
-        state, isolate);
+    return FromV8Object(val->ToObject(context).ToLocalChecked(), state,
+                        isolate);
   }
 
   LOG(ERROR) << "Unexpected v8 value type encountered.";
@@ -418,9 +418,10 @@ base::Value* V8ValueConverter::FromV8Array(v8::Local<v8::Array> val,
 base::Value* V8ValueConverter::FromNodeBuffer(v8::Local<v8::Value> value,
                                               FromV8ValueState* state,
                                               v8::Isolate* isolate) const {
-  return base::Value::CreateWithCopiedBuffer(node::Buffer::Data(value),
-                                             node::Buffer::Length(value))
-      .release();
+  std::vector<char> bytes_vector(
+      node::Buffer::Data(value),
+      node::Buffer::Data(value) + node::Buffer::Length(value));
+  return std::make_unique<base::Value>(&bytes_vector).release();
 }
 
 base::Value* V8ValueConverter::FromV8Object(v8::Local<v8::Object> val,

--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -419,10 +419,10 @@ base::Value* V8ValueConverter::FromV8Array(v8::Local<v8::Array> val,
 base::Value* V8ValueConverter::FromNodeBuffer(v8::Local<v8::Value> value,
                                               FromV8ValueState* state,
                                               v8::Isolate* isolate) const {
-  std::vector<char> bytes_vector(
+  auto vec = std::vector<char>(
       node::Buffer::Data(value),
       node::Buffer::Data(value) + node::Buffer::Length(value));
-  return std::make_unique<base::Value>(&bytes_vector).release();
+  return std::make_unique<base::Value>(vec).release();
 }
 
 base::Value* V8ValueConverter::FromV8Object(v8::Local<v8::Object> val,


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/12770.

Documentation for deprecation of `CreateWithCopiedBuffer` says to replace it with `std::make_unique(const BlobStorage&)`. However, `BlobStorage`, which is just a `std::vector<char>` isn't exposed and therefore this PR just replaces the deprecated calls with the underlying implementation of that structure. 

/cc @alexeykuzmin 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)