### PR TITLE
fix: do not expose Node's external strings

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -70,6 +70,15 @@ describe('chromium feature', () => {
     })
   })
 
+  describe('accessing key names also used as Node.js module names', () => {
+    it('does not crash', (done) => {
+      w = new BrowserWindow({show: false})
+      w.webContents.once('did-finish-load', () => { done() })
+      w.webContents.once('crashed', () => done(new Error('WebContents crashed.')))
+      w.loadURL(`file://${fixtures}/pages/external-string.html`)
+    })
+  })
+
   describe('navigator.webkitGetUserMedia', () => {
     it('calls its callbacks', (done) => {
       navigator.webkitGetUserMedia({

--- a/spec/fixtures/pages/external-string.html
+++ b/spec/fixtures/pages/external-string.html
@@ -1,0 +1,1 @@
+<script>window.stream</script>


### PR DESCRIPTION
This fixes the first crash described in https://github.com/electron/electron/issues/12835#issuecomment-398941227, the fix relies on https://github.com/electron/node/pull/42, and more details can be found there.