### PR TITLE
fix: deprecate properties in app.getAppMetrics()

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -35,7 +35,7 @@ app.releaseSingleInstanceLock()
 ```
 
 
-# Planned Breaking API Changes (3.0)
+# Breaking API Changes (3.0)
 
 The following list includes the breaking API changes planned for Electron 3.0.
 
@@ -46,6 +46,11 @@ The following list includes the breaking API changes planned for Electron 3.0.
 app.getAppMemoryInfo()
 // Replace with
 app.getAppMetrics()
+
+// Deprecated
+const metrics = app.getAppMetrics()
+const privateBytes = metrics['privateBytes'] // deprecated property
+const sharedBytes = metrics['sharedBytes'] // deprecated property
 ```
 
 ## `BrowserWindow`

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -49,8 +49,9 @@ app.getAppMetrics()
 
 // Deprecated
 const metrics = app.getAppMetrics()
-const privateBytes = metrics.privateBytes // deprecated property
-const sharedBytes = metrics.sharedBytes // deprecated property
+const {memory} = metrics[0]
+memory.privateBytes  // Deprecated property
+memory.sharedBytes  // Deprecated property
 ```
 
 ## `BrowserWindow`

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -37,7 +37,7 @@ app.releaseSingleInstanceLock()
 
 # Breaking API Changes (3.0)
 
-The following list includes the breaking API changes planned for Electron 3.0.
+The following list includes the breaking API changes in Electron 3.0.
 
 ## `app`
 
@@ -49,8 +49,8 @@ app.getAppMetrics()
 
 // Deprecated
 const metrics = app.getAppMetrics()
-const privateBytes = metrics['privateBytes'] // deprecated property
-const sharedBytes = metrics['sharedBytes'] // deprecated property
+const privateBytes = metrics.privateBytes // deprecated property
+const sharedBytes = metrics.sharedBytes // deprecated property
 ```
 
 ## `BrowserWindow`
@@ -127,6 +127,15 @@ nativeImage.createFromBuffer(buffer, 1.0)
 nativeImage.createFromBuffer(buffer, {
   scaleFactor: 1.0
 })
+```
+
+## `process`
+
+```js
+// Deprecated
+const info = process.getProcessMemoryInfo()
+const privateBytes = info.privateBytes // deprecated property
+const sharedBytes = info.sharedBytes // deprecated property
 ```
 
 ## `screen`

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -58,11 +58,11 @@ Object.assign(app, {
   }
 })
 
-const nativeFn = app.getAppMetrics()
+const nativeFn = app.getAppMetrics
 app.getAppMetrics = () => {
   deprecate.removeProperty(nativeFn, 'privateBytes')
   deprecate.removeProperty(nativeFn, 'sharedBytes')
-  return nativeFn
+  return nativeFn.call(app)
 }
 
 app.isPackaged = (() => {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -58,6 +58,13 @@ Object.assign(app, {
   }
 })
 
+const nativeFn = app.getAppMetrics()
+app.getAppMetrics = () => {
+  deprecate.removeProperty(nativeFn, 'privateBytes')
+  deprecate.removeProperty(nativeFn, 'sharedBytes')
+  return nativeFn
+}
+
 app.isPackaged = (() => {
   const execFile = path.basename(process.execPath).toLowerCase()
   if (process.platform === 'win32') {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -88,8 +88,14 @@ deprecate.getHandler = () => deprecationHandler
 //   }
 // }
 
-// Deprecate the old name of a property
-deprecate.property = (object, deprecatedName, newName) => {
+deprecate.removeProperty = (object, deprecatedName) => {
+  if (!process.noDeprecation) {
+    deprecate.log(`The '${deprecatedName}' property has been deprecated.`)
+  }
+}
+
+// Replace the old name of a property
+deprecate.renameProperty = (object, deprecatedName, newName) => {
   let warned = false
   let warn = () => {
     if (!(warned || process.noDeprecation)) {

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -78,13 +78,10 @@ describe('deprecations', () => {
 
   it('deprecates a property of an object', () => {
     let msg
-    deprecations.setHandler((m) => { msg = m })
+    deprecations.setHandler(m => { msg = m })
 
     const propertyName = 'itMustGo'
-    let value = 0
-
-    let o = { [propertyName]: value }
-    expect(o).to.have.a.property(propertyName).that.is.a('number')
+    const o = { [propertyName]: 0 }
 
     deprecate.removeProperty(o, propertyName)
 

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -65,7 +65,7 @@ describe('deprecations', () => {
     expect(o).to.not.have.a.property(oldPropertyName)
     expect(o).to.have.a.property(newPropertyName).that.is.a('number')
 
-    deprecate.property(o, oldPropertyName, newPropertyName)
+    deprecate.renameProperty(o, oldPropertyName, newPropertyName)
     o[oldPropertyName] = ++value
 
     expect(msg).to.be.a('string')
@@ -74,6 +74,22 @@ describe('deprecations', () => {
 
     expect(o).to.have.a.property(newPropertyName).that.is.equal(value)
     expect(o).to.have.a.property(oldPropertyName).that.is.equal(value)
+  })
+
+  it('deprecates a property of an object', () => {
+    let msg
+    deprecations.setHandler((m) => { msg = m })
+
+    const propertyName = 'itMustGo'
+    let value = 0
+
+    let o = { [propertyName]: value }
+    expect(o).to.have.a.property(propertyName).that.is.a('number')
+
+    deprecate.removeProperty(o, propertyName)
+
+    expect(msg).to.be.a('string')
+    expect(msg).to.include(propertyName)
   })
 
   it('warns if deprecated property is already set', () => {
@@ -85,7 +101,7 @@ describe('deprecations', () => {
     const value = 0
 
     let o = { [oldPropertyName]: value }
-    deprecate.property(o, oldPropertyName, newPropertyName)
+    deprecate.renameProperty(o, oldPropertyName, newPropertyName)
 
     expect(msg).to.be.a('string')
     expect(msg).to.include(oldPropertyName)


### PR DESCRIPTION
Related to https://github.com/electron/electron/issues/13383.

This PR deprecates two of the properties returned by `app.getAppMetrics()`, `sharedBytes` and `privateBytes` which are returned from chromium methods removed in [this PR](https://chromium-review.googlesource.com/c/chromium/src/+/969089). 

It also adds a new method to the deprecate module for removing properties of objects (`deprecate.removeFunction`), as well as a test for that method 🔧 

/cc @alexeykuzmin 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)