### PR TITLE
fix: create-api-json (and create-typescript-definitions) now work on any operating system

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "standard": "^10.0.0",
     "standard-markdown": "^4.0.0",
     "sumchecker": "^2.0.2",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+	"cross-var": "^1.1.0"
   },
   "standard": {
     "ignore": [
@@ -59,7 +60,7 @@
     "lint-docs": "remark docs -qf && npm run lint-js-in-markdown && npm run create-typescript-definitions && npm run lint-docs-relative-links",
     "lint-docs-relative-links": "python ./script/check-relative-doc-links.py",
     "lint-js-in-markdown": "standard-markdown docs",
-    "create-api-json": "electron-docs-linter docs --outfile=out/electron-api.json --version=$npm_package_version",
+    "create-api-json": "cross-var electron-docs-linter docs --outfile=out/electron-api.json --version=$npm_package_version",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=out/electron-api.json --out=out/electron.d.ts",
     "mock-release": "node ./script/ci-release-build.js",
     "preinstall": "node -e 'process.exit(0)'",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "standard-markdown": "^4.0.0",
     "sumchecker": "^2.0.2",
     "temp": "^0.8.3",
-	"cross-var": "^1.1.0"
+    "cross-var": "^1.1.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Used cross-var (https://github.com/elijahmanor/cross-var) to allow use of environment variables on any operating system.