### PR TITLE
Fix the crash when loading site with jquery

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -79,6 +79,20 @@ describe('chromium feature', () => {
     })
   })
 
+  describe('loading jquery', () => {
+    it('does not crash', (done) => {
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: false
+        }
+      })
+      w.webContents.once('did-finish-load', () => { done() })
+      w.webContents.once('crashed', () => done(new Error('WebContents crashed.')))
+      w.loadURL(`file://${fixtures}/pages/jquery.html`)
+    })
+  })
+
   describe('navigator.webkitGetUserMedia', () => {
     it('calls its callbacks', (done) => {
       navigator.webkitGetUserMedia({

--- a/spec/fixtures/pages/jquery.html
+++ b/spec/fixtures/pages/jquery.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+  <script src="../../static/jquery-2.0.3.min.js"></script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Close https://github.com/electron/electron/issues/12835.

This PR updates libcc to include https://github.com/electron/libchromiumcontent/pull/577, more details of the crash can be found there.