### PR TITLE
docs: warning about the unicity of webRequest event listeners

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -9,8 +9,9 @@ property of a `Session`.
 
 The methods of `WebRequest` accept an optional `filter` and a `listener`. The
 `listener` will be called with `listener(details)` when the API's event has
-happened. The `details` object describes the request. Passing `null`
-as `listener` will unsubscribe from the event.
+happened. The `details` object describes the request.
+
+⚠️ Only the last attached `listener` will be used. Passing `null` as `listener` will unsubscribe from the event.
 
 The `filter` object has a `urls` property which is an Array of URL
 patterns that will be used to filter out the requests that do not match the URL


### PR DESCRIPTION
Relates to #10478
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)