### PR TITLE
chore: [gn] copy node.dll in addition to node.dll.lib

### DIFF
--- a/build/node/BUILD.gn
+++ b/build/node/BUILD.gn
@@ -77,7 +77,7 @@ action("build_node") {
     outputs = [ "$target_out_dir/Release/lib/libnode.so" ]
   }
   if (is_win) {
-    outputs = [ "$target_out_dir/Release/node.dll" ]
+    outputs = [ "$target_out_dir/Release/node.dll.lib", "$target_out_dir/Release/node.dll" ]
   }
 }
 
@@ -95,7 +95,7 @@ config("node_config") {
     "//third_party/electron_node/deps/uv/include",
     "//third_party/electron_node/deps/cares/include",
   ]
-  libs = node_libs
+  libs = [ node_libs[0] ]
   cflags_cc = [
     "-Wno-deprecated-declarations",
   ]


### PR DESCRIPTION
On Windows, you need to link against the `.lib` but the `.dll` needs to be next to the `.exe` at runtime, so we need to copy both.