### PR TITLE
chore: [gn] link against debug node when in debug mode

### DIFF
--- a/build/node/BUILD.gn
+++ b/build/node/BUILD.gn
@@ -66,18 +66,23 @@ action("build_node") {
     ":gyp_node",
   ]
   script = "//electron/build/run-ninja.py"
+  if (is_debug) {
+    configuration = "Debug"
+  } else {
+    configuration = "Release"
+  }
   args = [
-    "-C", rebase_path(target_out_dir, root_build_dir) + "/Release",
+    "-C", rebase_path(target_out_dir, root_build_dir) + "/$configuration",
     "node_lib"
   ]
   if (is_mac) {
-    outputs = [ "$target_out_dir/Release/libnode.dylib" ]
+    outputs = [ "$target_out_dir/$configuration/libnode.dylib" ]
   }
   if (is_linux) {
-    outputs = [ "$target_out_dir/Release/lib/libnode.so" ]
+    outputs = [ "$target_out_dir/$configuration/lib/libnode.so" ]
   }
   if (is_win) {
-    outputs = [ "$target_out_dir/Release/node.dll.lib", "$target_out_dir/Release/node.dll" ]
+    outputs = [ "$target_out_dir/$configuration/node.dll.lib", "$target_out_dir/$configuration/node.dll" ]
   }
 }
 


### PR DESCRIPTION
This is required on Windows, because in Debug mode, C++ stdlib containers have a different size to when in Release mode, so the code in `node.dll` thought that `node::Environment` was a different size to the code in `electron.exe`, which uh, caused problems.

It should also make debugging through node a bit easier on all platforms.