### PR TITLE
chore: [gn] use full path for ui_unscaled_resources.h

### DIFF
--- a/atom/browser/resources/win/atom.rc
+++ b/atom/browser/resources/win/atom.rc
@@ -1,6 +1,6 @@
 // Microsoft Visual C++ generated resource script.
 //
-#include "grit\\ui_unscaled_resources.h"
+#include "ui\\resources\\grit\\ui_unscaled_resources.h"
 #include "resource.h"
 #include <winresrc.h>
 #ifdef IDC_STATIC

--- a/electron.gyp
+++ b/electron.gyp
@@ -163,9 +163,6 @@
           ],
         }],  # OS!="mac"
         ['OS=="win"', {
-          'include_dirs': [
-            '<(libchromiumcontent_dir)/gen/ui/resources',
-          ],
           'msvs_settings': {
             'VCManifestTool': {
               'EmbedManifest': 'true',


### PR DESCRIPTION
This is the path that resolves in Chromium, and I think it'll also work fine in the gyp build.