### PR TITLE
chore(spec): convert smaller specs to expect

### DIFF
--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -1,10 +1,12 @@
 'use strict'
 
-/* eslint-disable no-unused-expressions */
-
-const {expect} = require('chai')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
 const {nativeImage} = require('electron')
 const path = require('path')
+
+const {expect} = chai
+chai.use(dirtyChai)
 
 describe('nativeImage module', () => {
   const ImageFormat = {
@@ -111,16 +113,16 @@ describe('nativeImage module', () => {
       expect(empty.toDataURL()).to.equal('data:image/png;base64,')
       expect(empty.toDataURL({scaleFactor: 2.0})).to.equal('data:image/png;base64,')
       expect(empty.getSize()).to.deep.equal({width: 0, height: 0})
-      expect(empty.getBitmap()).to.be.empty
-      expect(empty.getBitmap({scaleFactor: 2.0})).to.be.empty
-      expect(empty.toBitmap()).to.be.empty
-      expect(empty.toBitmap({scaleFactor: 2.0})).to.be.empty
-      expect(empty.toJPEG(100)).to.be.empty
-      expect(empty.toPNG()).to.be.empty
-      expect(empty.toPNG({scaleFactor: 2.0})).to.be.empty
+      expect(empty.getBitmap()).to.be.empty()
+      expect(empty.getBitmap({scaleFactor: 2.0})).to.be.empty()
+      expect(empty.toBitmap()).to.be.empty()
+      expect(empty.toBitmap({scaleFactor: 2.0})).to.be.empty()
+      expect(empty.toJPEG(100)).to.be.empty()
+      expect(empty.toPNG()).to.be.empty()
+      expect(empty.toPNG({scaleFactor: 2.0})).to.be.empty()
 
       if (process.platform === 'darwin') {
-        expect(empty.getNativeHandle()).to.be.empty
+        expect(empty.getNativeHandle()).to.be.empty()
       }
     })
   })
@@ -135,7 +137,7 @@ describe('nativeImage module', () => {
 
       const imageB = nativeImage.createFromBuffer(imageA.toPNG())
       expect(imageB.getSize()).to.deep.equal({width: 538, height: 190})
-      expect(imageA.toBitmap().equals(imageB.toBitmap())).to.be.true
+      expect(imageA.toBitmap().equals(imageB.toBitmap())).to.be.true()
 
       const imageC = nativeImage.createFromBuffer(imageA.toJPEG(100))
       expect(imageC.getSize()).to.deep.equal({width: 538, height: 190})
@@ -214,7 +216,7 @@ describe('nativeImage module', () => {
       expect(imageTwo.getSize()).to.deep.equal(
           {width: imageData.width, height: imageData.height})
 
-      expect(imageOne.toBitmap().equals(imageTwo.toBitmap())).to.be.true
+      expect(imageOne.toBitmap().equals(imageTwo.toBitmap())).to.be.true()
     })
 
     it('supports a scale factor', () => {
@@ -249,7 +251,7 @@ describe('nativeImage module', () => {
       expect(imageC.getSize()).to.deep.equal(
           {width: imageData.width, height: imageData.height})
 
-      expect(imageB.toBitmap().equals(imageC.toBitmap())).to.be.true
+      expect(imageB.toBitmap().equals(imageC.toBitmap())).to.be.true()
     })
 
     it('supports a scale factor', () => {
@@ -280,21 +282,21 @@ describe('nativeImage module', () => {
     it('loads images from paths relative to the current working directory', () => {
       const imagePath = `.${path.sep}${path.join('spec', 'fixtures', 'assets', 'logo.png')}`
       const image = nativeImage.createFromPath(imagePath)
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
       expect(image.getSize()).to.deep.equal({width: 538, height: 190})
     })
 
     it('loads images from paths with `.` segments', () => {
       const imagePath = `${path.join(__dirname, 'fixtures')}${path.sep}.${path.sep}${path.join('assets', 'logo.png')}`
       const image = nativeImage.createFromPath(imagePath)
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
       expect(image.getSize()).to.deep.equal({width: 538, height: 190})
     })
 
     it('loads images from paths with `..` segments', () => {
       const imagePath = `${path.join(__dirname, 'fixtures', 'api')}${path.sep}..${path.sep}${path.join('assets', 'logo.png')}`
       const image = nativeImage.createFromPath(imagePath)
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
       expect(image.getSize()).to.deep.equal({width: 538, height: 190})
     })
 
@@ -325,7 +327,7 @@ describe('nativeImage module', () => {
 
       const imagePath = path.join(__dirname, 'fixtures', 'assets', 'icon.ico')
       const image = nativeImage.createFromPath(imagePath)
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
       expect(image.getSize()).to.deep.equal({width: 256, height: 256})
     })
   })
@@ -355,7 +357,7 @@ describe('nativeImage module', () => {
       }
 
       const image = nativeImage.createFromNamedImage('NSActionTemplate')
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
     })
 
     it('returns allows an HSL shift for a valid image on darwin', function () {
@@ -366,7 +368,7 @@ describe('nativeImage module', () => {
       }
 
       const image = nativeImage.createFromNamedImage('NSActionTemplate', [0.5, 0.2, 0.8])
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
     })
   })
 
@@ -425,7 +427,7 @@ describe('nativeImage module', () => {
       const cropB = image.crop({width: 25, height: 64, x: 30, y: 40})
       expect(cropA.getSize()).to.deep.equal({width: 25, height: 64})
       expect(cropB.getSize()).to.deep.equal({width: 25, height: 64})
-      expect(cropA.toPNG().equals(cropB.toPNG())).to.be.false
+      expect(cropA.toPNG().equals(cropB.toPNG())).to.be.false()
     })
   })
 
@@ -471,7 +473,7 @@ describe('nativeImage module', () => {
         buffer: 'invalid'
       })
 
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
       expect(image.getSize()).to.deep.equal({width: 1, height: 1})
 
       expect(image.toDataURL({scaleFactor: 1.0})).to.equal(imageDataOne.dataUrl)
@@ -506,7 +508,7 @@ describe('nativeImage module', () => {
         dataURL: 'invalid'
       })
 
-      expect(image.isEmpty()).to.be.false
+      expect(image.isEmpty()).to.be.false()
       expect(image.getSize()).to.deep.equal({width: 1, height: 1})
 
       expect(image.toDataURL({scaleFactor: 1.0})).to.equal(imageDataOne.dataUrl)

--- a/spec/api-net-log-spec.js
+++ b/spec/api-net-log-spec.js
@@ -1,4 +1,5 @@
-const assert = require('assert')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
 const http = require('http')
 const fs = require('fs')
 const os = require('os')
@@ -10,13 +11,15 @@ const appPath = path.join(__dirname, 'fixtures', 'api', 'net-log')
 const dumpFile = path.join(os.tmpdir(), 'net_log.json')
 const dumpFileDynamic = path.join(os.tmpdir(), 'net_log_dynamic.json')
 
+const {expect} = chai
+chai.use(dirtyChai)
 const isCI = remote.getGlobal('isCi')
 
 describe('netLog module', () => {
   let server
   const connections = new Set()
 
-  before((done) => {
+  before(done => {
     server = http.createServer()
     server.listen(0, '127.0.0.1', () => {
       server.url = `http://127.0.0.1:${server.address().port}`
@@ -33,7 +36,7 @@ describe('netLog module', () => {
     })
   })
 
-  after((done) => {
+  after(done => {
     for (const connection of connections) {
       connection.destroy()
     }
@@ -52,36 +55,35 @@ describe('netLog module', () => {
     }
   })
 
-  it('should begin and end logging to file when .startLogging() and .stopLogging() is called', (done) => {
-    assert(!netLog.currentlyLogging)
-    assert.equal(netLog.currentlyLoggingPath, '')
+  it('should begin and end logging to file when .startLogging() and .stopLogging() is called', done => {
+    expect(netLog.currentlyLogging).to.be.false()
+    expect(netLog.currentlyLoggingPath).to.equal('')
 
     netLog.startLogging(dumpFileDynamic)
 
-    assert(netLog.currentlyLogging)
-    assert.equal(netLog.currentlyLoggingPath, dumpFileDynamic)
+    expect(netLog.currentlyLogging).to.be.true()
+    expect(netLog.currentlyLoggingPath).to.equal(dumpFileDynamic)
 
     netLog.stopLogging((path) => {
-      assert(!netLog.currentlyLogging)
-      assert.equal(netLog.currentlyLoggingPath, '')
+      expect(netLog.currentlyLogging).to.be.false()
+      expect(netLog.currentlyLoggingPath).to.equal('')
 
-      assert.equal(path, dumpFileDynamic)
-
-      assert(fs.existsSync(dumpFileDynamic))
+      expect(path).to.equal(dumpFileDynamic)
+      expect(fs.existsSync(dumpFileDynamic)).to.be.true()
 
       done()
     })
   })
 
-  it('should silence when .stopLogging() is called without calling .startLogging()', (done) => {
-    assert(!netLog.currentlyLogging)
-    assert.equal(netLog.currentlyLoggingPath, '')
+  it('should silence when .stopLogging() is called without calling .startLogging()', done => {
+    expect(netLog.currentlyLogging).to.be.false()
+    expect(netLog.currentlyLoggingPath).to.equal('')
 
-    netLog.stopLogging((path) => {
-      assert(!netLog.currentlyLogging)
-      assert.equal(netLog.currentlyLoggingPath, '')
+    netLog.stopLogging(path => {
+      expect(netLog.currentlyLogging).to.be.false()
+      expect(netLog.currentlyLoggingPath).to.equal('')
 
-      assert.equal(path, '')
+      expect(path).to.equal('')
 
       done()
     })
@@ -89,7 +91,7 @@ describe('netLog module', () => {
 
   // The following tests are skipped on Linux CI
 
-  it('should begin and end logging automatically when --log-net-log is passed', (done) => {
+  it('should begin and end logging automatically when --log-net-log is passed', done => {
     if (isCI && process.platform === 'linux') {
       done()
       return
@@ -103,12 +105,12 @@ describe('netLog module', () => {
       })
 
     appProcess.once('exit', () => {
-      assert(fs.existsSync(dumpFile))
+      expect(fs.existsSync(dumpFile)).to.be.true()
       done()
     })
   })
 
-  it('should begin and end logging automtically when --log-net-log is passed, and behave correctly when .startLogging() and .stopLogging() is called', (done) => {
+  it('should begin and end logging automtically when --log-net-log is passed, and behave correctly when .startLogging() and .stopLogging() is called', done => {
     if (isCI && process.platform === 'linux') {
       done()
       return
@@ -123,18 +125,18 @@ describe('netLog module', () => {
         }
       })
 
-    appProcess.stdout.on('data', (data) => {
+    appProcess.stdout.on('data', data => {
       console.log(data.toString())
     })
 
     appProcess.once('exit', () => {
-      assert(fs.existsSync(dumpFile))
-      assert(fs.existsSync(dumpFileDynamic))
+      expect(fs.existsSync(dumpFile)).to.be.true()
+      expect(fs.existsSync(dumpFileDynamic)).to.be.true()
       done()
     })
   })
 
-  it('should end logging automatically when only .startLogging() is called', (done) => {
+  it('should end logging automatically when only .startLogging() is called', done => {
     if (isCI && process.platform === 'linux') {
       done()
       return
@@ -149,7 +151,7 @@ describe('netLog module', () => {
       })
 
     appProcess.once('exit', () => {
-      assert(fs.existsSync(dumpFileDynamic))
+      expect(fs.existsSync(dumpFileDynamic)).to.be.true()
       done()
     })
   })

--- a/spec/api-notification-dbus-spec.js
+++ b/spec/api-notification-dbus-spec.js
@@ -100,10 +100,12 @@ const skip = process.platform !== 'linux' ||
 
     it(`should call ${serviceName} to show notifications`, async () => {
       const calls = await getCalls()
-      expect(calls.length).to.be.at.least(1)
+      expect(calls).to.be.an('array').of.lengthOf.at.least(1)
+
       let lastCall = calls[calls.length - 1]
       let methodName = lastCall[1]
       expect(methodName).to.equal('Notify')
+
       let args = unmarshalDBusNotifyArgs(lastCall[2])
       expect(args).to.deep.equal({
         app_name: appName,

--- a/spec/api-notification-dbus-spec.js
+++ b/spec/api-notification-dbus-spec.js
@@ -6,7 +6,7 @@
 //
 // See https://pypi.python.org/pypi/python-dbusmock to read about dbusmock.
 
-const assert = require('assert')
+const {expect} = require('chai')
 const dbus = require('dbus-native')
 const Promise = require('bluebird')
 
@@ -27,12 +27,12 @@ const skip = process.platform !== 'linux' ||
   before(async () => {
     // init app
     app.setName(appName)
-    app.setDesktopName(appName + '.desktop')
+    app.setDesktopName(`${appName}.desktop`)
     // init dbus
     const path = '/org/freedesktop/Notifications'
     const iface = 'org.freedesktop.DBus.Mock'
     const bus = dbus.sessionBus()
-    console.log('session bus: ' + process.env.DBUS_SESSION_BUS_ADDRESS)
+    console.log(`session bus: ${process.env.DBUS_SESSION_BUS_ADDRESS}`)
     const service = bus.getService(serviceName)
     const getInterface = Promise.promisify(service.getInterface, {context: service})
     mock = await getInterface(path, iface)
@@ -48,10 +48,10 @@ const skip = process.platform !== 'linux' ||
     app.setVersion(realAppVersion)
   })
 
-  describe('Notification module using ' + serviceName, () => {
+  describe(`Notification module using ${serviceName}`, () => {
     function onMethodCalled (done) {
       function cb (name) {
-        console.log('onMethodCalled: ' + name)
+        console.log(`onMethodCalled: ${name}`)
         if (name === 'Notify') {
           mock.removeListener('MethodCalled', cb)
           console.log('done')
@@ -83,7 +83,7 @@ const skip = process.platform !== 'linux' ||
       }
     }
 
-    before((done) => {
+    before(done => {
       mock.on('MethodCalled', onMethodCalled(done))
       // lazy load Notification after we listen to MethodCalled mock signal
       Notification = require('electron').remote.Notification
@@ -98,14 +98,14 @@ const skip = process.platform !== 'linux' ||
       n.show()
     })
 
-    it('should call ' + serviceName + ' to show notifications', async () => {
+    it(`should call ${serviceName} to show notifications`, async () => {
       const calls = await getCalls()
-      assert(calls.length >= 1)
+      expect(calls.length).to.be.at.least(1)
       let lastCall = calls[calls.length - 1]
       let methodName = lastCall[1]
-      assert.equal(methodName, 'Notify')
+      expect(methodName).to.equal('Notify')
       let args = unmarshalDBusNotifyArgs(lastCall[2])
-      assert.deepEqual(args, {
+      expect(args).to.deep.equal({
         app_name: appName,
         replaces_id: 0,
         app_icon: '',


### PR DESCRIPTION
This PR updates the `net-log`, `native-image`, `notification-dbus` specs as part of ongoing work to migrate our specs from `assert` to chai's `expect` with `dirty-chai`for better error messages.

/cc @alexeykuzmin 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)