### PR TITLE
chore: [gn] remove some cruft from the :electron_lib target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -271,8 +271,6 @@ static_library("electron_lib") {
     ]
   }
   defines = [
-    # This is defined in skia/skia_common.gypi.
-    "SK_SUPPORT_LEGACY_GETTOPDEVICE",
     # Disable warnings for g_settings_list_schemas.
     "GLIB_DISABLE_DEPRECATION_WARNINGS",
 
@@ -280,9 +278,6 @@ static_library("electron_lib") {
     "USING_V8_SHARED",
     "USING_V8_PLATFORM_SHARED",
     "USING_V8_BASE_SHARED",
-
-    # Enables SkBitmap size 64 operations
-    #"SK_SUPPORT_LEGACY_SAFESIZE64", # doesn't seem to be needed to build?
   ]
   include_dirs = [
     "chromium_src",

--- a/electron.gyp
+++ b/electron.gyp
@@ -272,8 +272,6 @@
         'NODE_SHARED_MODE',
         'HAVE_OPENSSL=1',
         'HAVE_INSPECTOR=1',
-        # This is defined in skia/skia_common.gypi.
-        'SK_SUPPORT_LEGACY_GETTOPDEVICE',
         # Disable warnings for g_settings_list_schemas.
         'GLIB_DISABLE_DEPRECATION_WARNINGS',
         # Defined in Chromium but not exposed in its gyp file.
@@ -287,9 +285,6 @@
         # See Chromium src/third_party/protobuf/BUILD.gn
         'GOOGLE_PROTOBUF_NO_RTTI',
         'GOOGLE_PROTOBUF_NO_STATIC_INITIALIZER',
-
-        # Enables SkBitmap size 64 operations
-        'SK_SUPPORT_LEGACY_SAFESIZE64',
       ],
       'sources': [
         '<@(lib_sources)',


### PR DESCRIPTION
`SK_SUPPORT_LEGACY_GETTOPDEVICE` was removed in [Jan 2017](https://chromium.googlesource.com/skia/+/76467a11a0aa4ba15f0f2e3ee078ba9b6ecbaa91)

`SK_SUPPORT_LEGACY_SAFESIZE64` was removed in [Oct 2017](https://chromium.googlesource.com/skia/+/3bd0fece5fadd522c2e8c1b0ca9934d7455d9ccd)