### PR TITLE
test: update power/notification specs to expect

### DIFF
--- a/spec/api-notification-spec.js
+++ b/spec/api-notification-spec.js
@@ -70,6 +70,7 @@ describe('Notification module', () => {
       ]
     })
 
+    expect(n.actions.length).to.equal(2)
     expect(n.actions[0].type).to.equal('button')
     expect(n.actions[0].text).to.equal('1')
     expect(n.actions[1].type).to.equal('button')
@@ -85,6 +86,7 @@ describe('Notification module', () => {
       }
     ]
 
+    expect(n.actions.length).to.equal(2)
     expect(n.actions[0].type).to.equal('button')
     expect(n.actions[0].text).to.equal('3')
     expect(n.actions[1].type).to.equal('button')

--- a/spec/api-notification-spec.js
+++ b/spec/api-notification-spec.js
@@ -1,4 +1,8 @@
-const assert = require('assert')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+
+const {expect} = chai
+chai.use(dirtyChai)
 
 const {Notification} = require('electron').remote
 
@@ -13,29 +17,29 @@ describe('Notification module', () => {
       closeButtonText: 'closeButtonText'
     })
 
-    assert.equal(n.title, 'title')
+    expect(n.title).to.equal('title')
     n.title = 'title1'
-    assert.equal(n.title, 'title1')
+    expect(n.title).to.equal('title1')
 
-    assert.equal(n.subtitle, 'subtitle')
+    expect(n.subtitle).equal('subtitle')
     n.subtitle = 'subtitle1'
-    assert.equal(n.subtitle, 'subtitle1')
+    expect(n.subtitle).equal('subtitle1')
 
-    assert.equal(n.body, 'body')
+    expect(n.body).to.equal('body')
     n.body = 'body1'
-    assert.equal(n.body, 'body1')
+    expect(n.body).to.equal('body1')
 
-    assert.equal(n.replyPlaceholder, 'replyPlaceholder')
+    expect(n.replyPlaceholder).to.equal('replyPlaceholder')
     n.replyPlaceholder = 'replyPlaceholder1'
-    assert.equal(n.replyPlaceholder, 'replyPlaceholder1')
+    expect(n.replyPlaceholder).to.equal('replyPlaceholder1')
 
-    assert.equal(n.sound, 'sound')
+    expect(n.sound).to.equal('sound')
     n.sound = 'sound1'
-    assert.equal(n.sound, 'sound1')
+    expect(n.sound).to.equal('sound1')
 
-    assert.equal(n.closeButtonText, 'closeButtonText')
+    expect(n.closeButtonText).to.equal('closeButtonText')
     n.closeButtonText = 'closeButtonText1'
-    assert.equal(n.closeButtonText, 'closeButtonText1')
+    expect(n.closeButtonText).to.equal('closeButtonText1')
   })
 
   it('inits, gets and sets basic boolean properties correctly', () => {
@@ -44,13 +48,13 @@ describe('Notification module', () => {
       hasReply: true
     })
 
-    assert.equal(n.silent, true)
+    expect(n.silent).to.be.true()
     n.silent = false
-    assert.equal(n.silent, false)
+    expect(n.silent).to.be.false()
 
-    assert.equal(n.hasReply, true)
+    expect(n.hasReply).to.be.true()
     n.hasReply = false
-    assert.equal(n.hasReply, false)
+    expect(n.hasReply).to.be.false()
   })
 
   it('inits, gets and sets actions correctly', () => {
@@ -66,10 +70,10 @@ describe('Notification module', () => {
       ]
     })
 
-    assert.equal(n.actions[0].type, 'button')
-    assert.equal(n.actions[0].text, '1')
-    assert.equal(n.actions[1].type, 'button')
-    assert.equal(n.actions[1].text, '2')
+    expect(n.actions[0].type).to.equal('button')
+    expect(n.actions[0].text).to.equal('1')
+    expect(n.actions[1].type).to.equal('button')
+    expect(n.actions[1].text).to.equal('2')
 
     n.actions = [
       {
@@ -81,10 +85,10 @@ describe('Notification module', () => {
       }
     ]
 
-    assert.equal(n.actions[0].type, 'button')
-    assert.equal(n.actions[0].text, '3')
-    assert.equal(n.actions[1].type, 'button')
-    assert.equal(n.actions[1].text, '4')
+    expect(n.actions[0].type).to.equal('button')
+    expect(n.actions[0].text).to.equal('3')
+    expect(n.actions[1].type).to.equal('button')
+    expect(n.actions[1].text).to.equal('4')
   })
 
   // TODO(sethlu): Find way to test init with notification icon?

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -31,7 +31,7 @@ xdescribe('powerMonitor', () => {
       reset = Promise.promisify(logindMock.Reset, {context: logindMock})
     })
 
-    after(async () => { await reset() })
+    after(reset)
   }
 
   (skip ? describe.skip : describe)('when powerMonitor module is loaded with dbus mock', () => {
@@ -51,7 +51,7 @@ xdescribe('powerMonitor', () => {
 
     it('should call Inhibit to delay suspend', async () => {
       const calls = await getCalls()
-      expect(calls.length).to.equal(1)
+      expect(calls).to.be.an('array').that.has.lengthOf(1)
       expect(calls[0].slice(1)).to.deep.equal([
         'Inhibit', [
           [[{type: 's', child: []}], ['sleep']],
@@ -78,7 +78,7 @@ xdescribe('powerMonitor', () => {
 
         it('should have called Inhibit again', async () => {
           const calls = await getCalls()
-          expect(calls.length).to.equal(2)
+          expect(calls).to.be.an('array').that.has.lengthOf(2)
           expect(calls[1].slice(1)).to.deep.equal([
             'Inhibit', [
               [[{type: 's', child: []}], ['sleep']],
@@ -94,13 +94,13 @@ xdescribe('powerMonitor', () => {
     describe('when a listener is added to shutdown event', () => {
       before(async () => {
         const calls = await getCalls()
-        expect(calls.length).to.equal(2)
+        expect(calls).to.be.an('array').that.has.lengthOf(2)
         dbusMockPowerMonitor.once('shutdown', () => { })
       })
 
       it('should call Inhibit to delay shutdown', async () => {
         const calls = await getCalls()
-        expect(calls.length).to.equal(3)
+        expect(calls).to.be.an('array').that.has.lengthOf(3)
         expect(calls[2].slice(1)).to.deep.equal([
           'Inhibit', [
             [[{type: 's', child: []}], ['shutdown']],

--- a/spec/api-power-save-blocker-spec.js
+++ b/spec/api-power-save-blocker-spec.js
@@ -1,13 +1,17 @@
 const {powerSaveBlocker} = require('electron').remote
-const assert = require('assert')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+
+const {expect} = chai
+chai.use(dirtyChai)
 
 describe('powerSaveBlocker module', () => {
   it('can be started and stopped', () => {
-    assert.equal(powerSaveBlocker.isStarted(-1), false)
+    expect(powerSaveBlocker.isStarted(-1)).to.be.false()
     const id = powerSaveBlocker.start('prevent-app-suspension')
-    assert.ok(id != null)
-    assert.equal(powerSaveBlocker.isStarted(id), true)
+    expect(id).to.not.be.null()
+    expect(powerSaveBlocker.isStarted(id)).to.be.true()
     powerSaveBlocker.stop(id)
-    assert.equal(powerSaveBlocker.isStarted(id), false)
+    expect(powerSaveBlocker.isStarted(id)).to.be.false()
   })
 })

--- a/spec/api-power-save-blocker-spec.js
+++ b/spec/api-power-save-blocker-spec.js
@@ -9,7 +9,7 @@ describe('powerSaveBlocker module', () => {
   it('can be started and stopped', () => {
     expect(powerSaveBlocker.isStarted(-1)).to.be.false()
     const id = powerSaveBlocker.start('prevent-app-suspension')
-    expect(id).to.not.be.null()
+    expect(id).to.to.be.a('number')
     expect(powerSaveBlocker.isStarted(id)).to.be.true()
     powerSaveBlocker.stop(id)
     expect(powerSaveBlocker.isStarted(id)).to.be.false()


### PR DESCRIPTION
##### Description of Change
This PR updates the `notification`, `power-monitor`, and `power-save-monitor` specs as part of ongoing work to migrate our specs from `assert` to chai's `expect` with `dirty-chai` for better error messages.

/cc @alexeykuzmin

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes