### PR TITLE
feat: expose missing process APIs in sandboxed renderers

### DIFF
--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -40,7 +40,8 @@ class AtomBindings {
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,
                                                   mate::Arguments* args);
-  v8::Local<v8::Value> GetCPUUsage(v8::Isolate* isolate);
+  static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,
+                                          v8::Isolate* isolate);
   static v8::Local<v8::Value> GetIOCounters(v8::Isolate* isolate);
 
  private:

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -15,7 +15,6 @@
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/environment.h"
-#include "base/files/file_path.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
@@ -193,6 +192,10 @@ void NodeBindings::RegisterBuiltinModules() {
 
 bool NodeBindings::IsInitialized() {
   return g_is_initialized;
+}
+
+base::FilePath::StringType NodeBindings::GetHelperResourcesPath() {
+  return GetResourcesPath(false).value();
 }
 
 void NodeBindings::Initialize() {

--- a/atom/common/node_bindings.h
+++ b/atom/common/node_bindings.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_COMMON_NODE_BINDINGS_H_
 #define ATOM_COMMON_NODE_BINDINGS_H_
 
+#include "base/files/file_path.h"
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "base/single_thread_task_runner.h"
@@ -33,6 +34,7 @@ class NodeBindings {
   static NodeBindings* Create(BrowserEnvironment browser_env);
   static void RegisterBuiltinModules();
   static bool IsInitialized();
+  static base::FilePath::StringType GetHelperResourcesPath();
 
   virtual ~NodeBindings();
 

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "atom/renderer/renderer_client_base.h"
+#include "base/process/process_metrics.h"
 
 namespace atom {
 
@@ -16,6 +17,8 @@ class AtomSandboxedRendererClient : public RendererClientBase {
   AtomSandboxedRendererClient();
   ~AtomSandboxedRendererClient() override;
 
+  void InitializeBindings(v8::Local<v8::Object> binding,
+                          v8::Local<v8::Context> context);
   void InvokeIpcCallback(v8::Handle<v8::Context> context,
                          const std::string& callback_name,
                          std::vector<v8::Handle<v8::Value>> args);
@@ -30,6 +33,8 @@ class AtomSandboxedRendererClient : public RendererClientBase {
   void RenderViewCreated(content::RenderView*) override;
 
  private:
+  std::unique_ptr<base::ProcessMetrics> metrics_;
+
   DISALLOW_COPY_AND_ASSIGN(AtomSandboxedRendererClient);
 };
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -16,10 +16,19 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 - `getHeapStatistics()`
 - `getProcessMemoryInfo()`
 - `getSystemMemoryInfo()`
+- `getCPUUsage()`
+- `getIOCounters()`
 - `argv`
 - `execPath`
 - `env`
+- `pid`
+- `arch`
 - `platform`
+- `resourcesPath`
+- `sandboxed`
+- `type`
+- `version`
+- `versions`
 
 ## Events
 
@@ -67,6 +76,11 @@ instead of the `--no-deprecation` command line flag.
 ### `process.resourcesPath`
 
 A `String` representing the path to the resources directory.
+
+### `process.sandboxed`
+
+A `Boolean`. When the renderer process is sandboxed, this property is `true`,
+otherwise it is `undefined`.
 
 ### `process.throwDeprecation`
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -452,9 +452,14 @@ ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
     }
   }
   event.returnValue = {
-    preloadSrc,
-    preloadError,
-    platform: process.platform,
-    env: process.env
+    preloadSrc: preloadSrc,
+    preloadError: preloadError,
+    process: {
+      arch: process.arch,
+      platform: process.platform,
+      env: process.env,
+      version: process.version,
+      versions: process.versions
+    }
   }
 })

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -36,7 +36,7 @@ const loadedModules = new Map([
 ])
 
 const {
-  preloadSrc, preloadError, platform, env
+  preloadSrc, preloadError, process: processProps
 } = electron.ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 require('../renderer/web-frame-init')()
@@ -49,10 +49,16 @@ preloadProcess.hang = () => binding.hang()
 preloadProcess.getHeapStatistics = () => binding.getHeapStatistics()
 preloadProcess.getProcessMemoryInfo = () => binding.getProcessMemoryInfo()
 preloadProcess.getSystemMemoryInfo = () => binding.getSystemMemoryInfo()
+preloadProcess.getCPUUsage = () => binding.getCPUUsage()
+preloadProcess.getIOCounters = () => binding.getIOCounters()
 preloadProcess.argv = process.argv = binding.getArgv()
 preloadProcess.execPath = process.execPath = binding.getExecPath()
-preloadProcess.platform = process.platform = platform
-preloadProcess.env = process.env = env
+preloadProcess.pid = process.pid = binding.getPid()
+preloadProcess.resourcesPath = binding.getResourcesPath()
+preloadProcess.sandboxed = true
+preloadProcess.type = 'renderer'
+Object.assign(preloadProcess, processProps)
+Object.assign(process, processProps)
 
 process.on('exit', () => preloadProcess.emit('exit'))
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1617,9 +1617,16 @@ describe('BrowserWindow module', () => {
 
       it('validates process APIs access in sandboxed renderer', (done) => {
         ipcMain.once('answer', function (event, test) {
+          assert.equal(test.pid, w.webContents.getOSProcessId())
+          assert.equal(test.arch, remote.process.arch)
           assert.equal(test.platform, remote.process.platform)
           assert.deepEqual(test.env, remote.process.env)
           assert.equal(test.execPath, remote.process.helperExecPath)
+          assert.equal(test.resourcesPath, remote.process.resourcesPath)
+          assert.equal(test.sandboxed, true)
+          assert.equal(test.type, 'renderer')
+          assert.equal(test.version, remote.process.version)
+          assert.deepEqual(test.versions, remote.process.versions)
           done()
         })
         remote.process.env.sandboxmain = 'foo'

--- a/spec/fixtures/module/preload-sandbox.js
+++ b/spec/fixtures/module/preload-sandbox.js
@@ -11,7 +11,14 @@
       window.test = {
         env: process.env,
         execPath: process.execPath,
-        platform: process.platform
+        pid: process.pid,
+        arch: process.arch,
+        platform: process.platform,
+        resourcesPath: process.resourcesPath,
+        sandboxed: process.sandboxed,
+        type: process.type,
+        version: process.version,
+        versions: process.versions
       }
     }
   } else if (location.href !== 'about:blank') {


### PR DESCRIPTION
Add the following APIs:

`process.getCPUUsage()`
`process.getIOCounters()`
`process.arch`
`process.pid`
`process.resourcesPath`
`process.sandboxed`
`process.type`
`process.version`
`process.versions`

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

Notes: Several missing `process` object APIs exposed to sandboxed renderers