### PR TITLE
fix: tray setContextMenu crash

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -123,7 +123,9 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
     [menu_ cancelTracking];
     isMenuOpen_ = NO;
     model_->MenuWillClose();
-    closeCallback.Run();
+    if (!closeCallback.is_null()) {
+      BrowserThread::PostTask(BrowserThread::UI, FROM_HERE, closeCallback);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #12803 and related to #11818.

This PR addresses an issue whereby on  close the Tray context menu attempted to run a `Callback` which had not been set and was therefore `null`. Instead, we now wrap the call in a `null` check and post a task asynchronously to mirror parallel behavior on regular context menu close. 

cc @codebytere @sethlu @gnahzak

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)