### PR TITLE
fix: Disable chromium's redraw locking on Windows when DWM is disabled (#12501)

### DIFF
--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -25,4 +25,11 @@ bool AtomDesktopWindowTreeHostWin::PreHandleMSG(
   return delegate_->PreHandleMSG(message, w_param, l_param, result);
 }
 
+bool AtomDesktopWindowTreeHostWin::HasNativeFrame() const {
+  // Since we never use chromium's titlebar implementation, we can just say
+  // that we use a native titlebar. This will disable the repaint locking when
+  // DWM composition is disabled.
+  return true;
+}
+
 }  // namespace atom

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
@@ -27,6 +27,7 @@ class AtomDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin {
  protected:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
+  bool HasNativeFrame() const override;
 
  private:
   MessageHandlerDelegate* delegate_;  // weak ref


### PR DESCRIPTION
Disable chromium's redraw locking on Windows when DWM is disabled (#12501)








* disable redraw locking on windows

* update libcc ref

(cherry picked from commit a14ebc80d2f8c30d8443cdbfc0f9dd7aebad1040)

Backporting https://github.com/electron/electron/pull/12501 and backport libcc PR is https://github.com/electron/libchromiumcontent/pull/582.

Fixes #1821 for 2-0-x.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)