### PR TITLE
chore: breakpad #include compatibility between GN and GYP

### DIFF
--- a/atom/common/crash_reporter/linux/crash_dump_handler.cc
+++ b/atom/common/crash_reporter/linux/crash_dump_handler.cc
@@ -15,7 +15,7 @@
 #include "base/posix/eintr_wrapper.h"
 #include "breakpad/src/client/linux/minidump_writer/directory_reader.h"
 #include "breakpad/src/common/linux/linux_libc_support.h"
-#include "breakpad/src/common/memory.h"
+#include "breakpad/src/common/memory_allocator.h"
 
 #include "third_party/lss/linux_syscall_support.h"
 


### PR DESCRIPTION
The breakpad that the gyp build uses is ~9 months old, and in the mean time, one of the headers we include changed name. This makes it so the #include works in both the GYP build and the GN build.

Depends on electron/chromium-breakpad#7.