### PR TITLE
chore: [gn] fix CSP warning in debugger API test

### DIFF
--- a/spec/fixtures/pages/a.html
+++ b/spec/fixtures/pages/a.html
@@ -1,6 +1,7 @@
 <html>
 <link rel="icon" type="image/png" href="/favicon.png"/>
 <link rel="icon" type="image/png" href="http://test.com/favicon.png"/>
+<meta http-equiv="content-security-policy" content="script-src 'self' 'unsafe-inline'" />
 <body>
 <script type="text/javascript" charset="utf-8">
   console.log('a');


### PR DESCRIPTION
There's an attempt to suppress the warning in `spec/static/main.js`, which
sets `process.env.ELECTRON_DISABLE_SECURITY_WARNINGS`. However, it sets the
variable too late in the boot process: by the time that line in main.js has
run, a child zygote has already been booted. `test.py` works around this by
setting that environment variable outside of the test process, to ensure that
it gets propagated to all children.

I've been running the GN tests directly with `./out/Default/electron
electron/spec`, rather than through the wrapper script, and the
`api-debugger-spec.js` tests were failing, because they depend on a particular
log message being the first one emitted, and the CSP warning was causing that
test to fail, since it wasn't being correctly suppressed.

Instead of writing another wrapper script, this just fixes the underlying thing
that the warning is complaining about, which I think is reasonable because the
test's pass/fail depends on this specific behaviour.