### PR TITLE
Fix crash on startup on macOS 10.9 due to linking with CoreBluetooth

### DIFF
--- a/brightray/brightray.gyp
+++ b/brightray/brightray.gyp
@@ -268,6 +268,20 @@
                 ],
               },
             }],
+            # In the OSX 10.10 SDK, CoreBluetooth became a top level framework.
+            # Previously, it was nested in IOBluetooth. In order for Chrome to run on
+            # OSes older than OSX 10.10, the top level CoreBluetooth framework must be
+            # weakly linked.
+            ['mac_sdk=="10.10" and libchromiumcontent_component==0', {
+              'direct_dependent_settings': {
+                'xcode_settings': {
+                  'OTHER_LDFLAGS': [
+                    '-weak_framework',
+                    'CoreBluetooth',
+                  ],
+                },
+              },
+            }],
           ]
         }],  # OS=="mac"
         ['OS=="win"', {


### PR DESCRIPTION
From https://cs.chromium.org/chromium/src/device/BUILD.gn?type=cs&q=CoreBluetooth&sq=package:chromium&g=0&l=267-276:

```
    # In the OSX 10.10 SDK, CoreBluetooth became a top level framework.
    # Previously, it was nested in IOBluetooth. In order for Chrome to run on
    # OSes older than OSX 10.10, the top level CoreBluetooth framework must be
    # weakly linked.
```

This may not entirely be able to fix the #13459, since according to https://github.com/electron/electron/issues/13404 we also have a problem with our build machine configuration.