### PR TITLE
feat: Add BrowserWindow.setWindowButtonVisibility()

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -738,6 +738,13 @@ void TopLevelWindow::AddTabbedWindow(NativeWindow* window,
     args->ThrowError("AddTabbedWindow cannot be called by a window on itself.");
 }
 
+void TopLevelWindow::SetWindowButtonVisibility(bool visible,
+                                               mate::Arguments* args) {
+  if (!window_->SetWindowButtonVisibility(visible)) {
+    args->ThrowError("Not supported for this window");
+  }
+}
+
 void TopLevelWindow::SetAutoHideMenuBar(bool auto_hide) {
   window_->SetAutoHideMenuBar(auto_hide);
 }
@@ -1030,6 +1037,8 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("moveTabToNewWindow", &TopLevelWindow::MoveTabToNewWindow)
       .SetMethod("toggleTabBar", &TopLevelWindow::ToggleTabBar)
       .SetMethod("addTabbedWindow", &TopLevelWindow::AddTabbedWindow)
+      .SetMethod("setWindowButtonVisibility",
+                 &TopLevelWindow::SetWindowButtonVisibility)
 #endif
       .SetMethod("setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
       .SetMethod("isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -173,6 +173,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void MoveTabToNewWindow();
   void ToggleTabBar();
   void AddTabbedWindow(NativeWindow* window, mate::Arguments* args);
+  void SetWindowButtonVisibility(bool visible, mate::Arguments* args);
   void SetAutoHideMenuBar(bool auto_hide);
   bool IsMenuBarAutoHide();
   void SetMenuBarVisibility(bool visible);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -355,6 +355,10 @@ bool NativeWindow::IsMenuBarVisible() {
   return true;
 }
 
+bool NativeWindow::SetWindowButtonVisibility(bool visible) {
+  return false;
+}
+
 double NativeWindow::GetAspectRatio() {
   return aspect_ratio_;
 }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -187,6 +187,9 @@ class NativeWindow : public base::SupportsUserData,
   virtual void ToggleTabBar();
   virtual bool AddTabbedWindow(NativeWindow* window);
 
+  // Returns false if unsupported.
+  virtual bool SetWindowButtonVisibility(bool visible);
+
   // Toggle the menu bar.
   virtual void SetAutoHideMenuBar(bool auto_hide);
   virtual bool IsMenuBarAutoHide();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -119,6 +119,8 @@ class NativeWindowMac : public NativeWindow {
   void ToggleTabBar() override;
   bool AddTabbedWindow(NativeWindow* window) override;
 
+  bool SetWindowButtonVisibility(bool visible) override;
+
   void SetVibrancy(const std::string& type) override;
   void SetTouchBar(
       const std::vector<mate::PersistentDictionary>& items) override;
@@ -192,6 +194,10 @@ class NativeWindowMac : public NativeWindow {
 
   // The "titleBarStyle" option.
   TitleBarStyle title_bar_style_ = NORMAL;
+
+  // The visibility mode of window button controls when explicitly set through
+  // setWindowButtonVisibility().
+  base::Optional<bool> window_button_visibility_;
 
   // Simple (pre-Lion) Fullscreen Settings
   bool always_simple_fullscreen_ = false;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1346,8 +1346,9 @@ Changes window icon.
 
 * `visible` Boolean
 
-Sets whether the window traffic light buttons should be visible. This has no
-effect when `titleBarStyle` is set to `customButtonsOnHover`.
+Sets whether the window traffic light buttons should be visible.
+
+This cannot be called when `titleBarStyle` is set to `customButtonsOnHover`.
 
 #### `win.setAutoHideMenuBar(hide)`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1342,6 +1342,13 @@ Same as `webContents.showDefinitionForSelection()`.
 
 Changes window icon.
 
+#### `win.setWindowButtonVisibility(visible)` _macOS_
+
+* `visible` Boolean
+
+Sets whether the window traffic light buttons should be visible. This has no
+effect when `titleBarStyle` is set to `customButtonsOnHover`.
+
 #### `win.setAutoHideMenuBar(hide)`
 
 * `hide` Boolean

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -757,6 +757,33 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('BrowserWindow.setWindowButtonVisibility()', () => {
+    before(function () {
+      if (process.platform !== 'darwin') {
+        this.skip()
+      }
+    })
+
+    it('does not throw', () => {
+      assert.doesNotThrow(() => {
+        w.setWindowButtonVisibility(true)
+        w.setWindowButtonVisibility(false)
+      })
+    })
+
+    it('throws with custom title bar buttons', () => {
+      assert.throws(() => {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          titleBarStyle: 'customButtonsOnHover',
+          frame: false
+        })
+        w.setWindowButtonVisibility(true)
+      }, /Not supported for this window/)
+    })
+  })
+
   describe('BrowserWindow.setVibrancy(type)', () => {
     it('allows setting, changing, and removing the vibrancy', () => {
       assert.doesNotThrow(() => {


### PR DESCRIPTION
Fixes #12701 and supersedes #13131.

Ideally we would have added `setTitleBarStyle()`, but that is a
significantly more involved change. For example, consider the case where
we switch from `hidden` to `normal`. We would not only have to show the
traffic light buttons, we would also have to switch the window from a
frameless to a framed window and deal with various other window state.
Lets instead implement a simple solution for #12701.