### PR TITLE
test: Better path compare than just strings

### DIFF
--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -291,7 +291,7 @@ describe('session module', () => {
     })
 
     const isPathEqual = (path1, path2) => {
-      return path.relative(path1, path2) === '';
+      return path.relative(path1, path2) === ''
     }
     const assertDownload = (event, state, url, mimeType,
                                    receivedBytes, totalBytes, disposition,

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -289,12 +289,16 @@ describe('session module', () => {
       res.end(mockPDF)
       downloadServer.close()
     })
+
+    const isPathEqual = (path1, path2) => {
+      return path.relative(path1, path2) === '';
+    }
     const assertDownload = (event, state, url, mimeType,
                                    receivedBytes, totalBytes, disposition,
                                    filename, port, savePath, isCustom) => {
       assert.equal(state, 'completed')
       assert.equal(filename, 'mock.pdf')
-      assert.equal(savePath, path.join(__dirname, 'fixtures', 'mock.pdf'))
+      assert.equal(isPathEqual(savePath, path.join(__dirname, 'fixtures', 'mock.pdf')), true)
       if (isCustom) {
         assert.equal(url, `${protocolName}://item`)
       } else {

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -298,6 +298,7 @@ describe('session module', () => {
                                    filename, port, savePath, isCustom) => {
       assert.equal(state, 'completed')
       assert.equal(filename, 'mock.pdf')
+      assert.ok(path.isAbsolute(savePath))
       assert.ok(isPathEqual(savePath, path.join(__dirname, 'fixtures', 'mock.pdf')))
       if (isCustom) {
         assert.equal(url, `${protocolName}://item`)

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -291,10 +291,7 @@ describe('session module', () => {
     })
 
     const isPathEqual = (path1, path2) => {
-      const absPath1 = path.resolve(path1)
-      const absPath2 = path.resolve(path2)
-
-      return path.relative(absPath1, absPath2) === ''
+      return path.relative(path1, path2) === ''
     }
     const assertDownload = (event, state, url, mimeType,
                                    receivedBytes, totalBytes, disposition,

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -301,7 +301,7 @@ describe('session module', () => {
                                    filename, port, savePath, isCustom) => {
       assert.equal(state, 'completed')
       assert.equal(filename, 'mock.pdf')
-      assert.equal(isPathEqual(savePath, path.join(__dirname, 'fixtures', 'mock.pdf')), true)
+      assert.ok(isPathEqual(savePath, path.join(__dirname, 'fixtures', 'mock.pdf')))
       if (isCustom) {
         assert.equal(url, `${protocolName}://item`)
       } else {

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -291,7 +291,10 @@ describe('session module', () => {
     })
 
     const isPathEqual = (path1, path2) => {
-      return path.relative(path1, path2) === ''
+      const absPath1 = path.resolve(path1)
+      const absPath2 = path.resolve(path2)
+
+      return path.relative(absPath1, absPath2) === ''
     }
     const assertDownload = (event, state, url, mimeType,
                                    receivedBytes, totalBytes, disposition,


### PR DESCRIPTION
__Unit test fix__
Comparing paths as string doesn't work well. On my machine the test failed because one path started with 'E:\\' and second with 'e:\\'. Otherwise they were the same.
Added small function which uses path.relative to compare paths. If relative path between two is empty string, it means both paths are the same.