### PR TITLE
fix: verify-ffmpeg crash

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ test_script:
       Write-Output "Skipping tests for release build"
     } else {
       Write-Output "Running tests for debug build"
-      python script\test.py --ci
+      python script\test.py --ci --rebuild_native_modules
       if ($LASTEXITCODE -ne '0') {
         throw "Tests failed with exit code $LASTEXITCODE"
       } else {


### PR DESCRIPTION
Fixes verify-ffmpeg crash that is happening on Appveyor CI, eg: https://windows-ci.electronjs.org/project/AppVeyor/electron/build/1.0.6368/job/3oofsog5chdxon47
We were not running test.py  with the `--rebuild_native_modules` argument, this PR adds that.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)