### PR TITLE
feat: support chrome:// URLs in default_app

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -320,7 +320,7 @@ if (option.file && !option.webdriver) {
   const file = option.file
   const protocol = url.parse(file).protocol
   const extension = path.extname(file)
-  if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:') {
+  if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:' || protocol === 'chrome:') {
     loadApplicationByUrl(file)
   } else if (extension === '.html' || extension === '.htm') {
     loadApplicationByUrl('file://' + path.resolve(file))


### PR DESCRIPTION
This allows running `electron.exe chrome://gpu` for example.

##### Checklist
- [x] PR description included and stakeholders cc'd
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)