### PR TITLE
[WIP] feat: ability to apply patch to clang-format errors

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -19,6 +19,7 @@ import signal
 import subprocess
 import sys
 import traceback
+import tempfile
 
 from functools import partial
 
@@ -68,8 +69,8 @@ def make_diff(diff_file, original, reformatted):
         difflib.unified_diff(
             original,
             reformatted,
-            fromfile='{}\t(original)'.format(diff_file),
-            tofile='{}\t(reformatted)'.format(diff_file),
+            fromfile='a/{}'.format(diff_file),
+            tofile='b/{}'.format(diff_file),
             n=3))
 
 
@@ -312,6 +313,11 @@ def main():
                 continue
             if not args.quiet:
                 print_diff(outs, use_color=colored_stdout)
+                with tempfile.NamedTemporaryFile(delete=False) as patch_file:
+                    for line in outs:
+                        patch_file.write(line)
+                    patch_file.write('\n')
+                    print("To apply this patch, run:\n\n  $ git apply {}".format(patch_file.name))
             if retcode == ExitStatus.SUCCESS:
                 retcode = ExitStatus.DIFF
     return retcode


### PR DESCRIPTION
The PR adds the ability to automatically apply the patch that is shown in console when a developer fails the `clang-format` pre-commit hook. A random temporary file is generated with python's `tempfile` lib, which can then be deleted after application. The formatting of this is not final, and so far looks like:

<img width="578" alt="screen shot 2018-07-06 at 11 48 27 am" src="https://user-images.githubusercontent.com/2036040/42395401-a927eab2-8112-11e8-8dba-b479d535d30f.png">

Please feel free to comment with suggestions or improvements 🚧 

/cc @nornagon 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)