### PR TITLE
refactor: statically link functions available on Windows 7+

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -50,11 +50,6 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 #if defined(OS_WIN)
   bool IsAeroGlassEnabled();
 
-  typedef HRESULT(STDAPICALLTYPE* DwmGetColorizationColor)(DWORD*, BOOL*);
-  DwmGetColorizationColor dwmGetColorizationColor =
-      (DwmGetColorizationColor)GetProcAddress(LoadLibraryW(L"dwmapi.dll"),
-                                              "DwmGetColorizationColor");
-
   std::string GetAccentColor();
   std::string GetColor(const std::string& color, mate::Arguments* args);
 

--- a/atom/browser/api/atom_api_system_preferences_win.cc
+++ b/atom/browser/api/atom_api_system_preferences_win.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <dwmapi.h>
 #include <iomanip>
 
 #include "atom/browser/api/atom_api_system_preferences.h"
@@ -38,7 +39,7 @@ std::string SystemPreferences::GetAccentColor() {
   DWORD color = 0;
   BOOL opaque = FALSE;
 
-  if (FAILED(dwmGetColorizationColor(&color, &opaque))) {
+  if (FAILED(DwmGetColorizationColor(&color, &opaque))) {
     return "";
   }
 

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -240,33 +240,6 @@ bool ShowItemInFolder(const base::FilePath& full_path) {
   if (dir.empty())
     return false;
 
-  typedef HRESULT(WINAPI * SHOpenFolderAndSelectItemsFuncPtr)(
-      PCIDLIST_ABSOLUTE pidl_Folder, UINT cidl, PCUITEMID_CHILD_ARRAY pidls,
-      DWORD flags);
-
-  static SHOpenFolderAndSelectItemsFuncPtr open_folder_and_select_itemsPtr =
-      NULL;
-  static bool initialize_open_folder_proc = true;
-  if (initialize_open_folder_proc) {
-    initialize_open_folder_proc = false;
-    // The SHOpenFolderAndSelectItems API is exposed by shell32 version 6
-    // and does not exist in Win2K. We attempt to retrieve this function export
-    // from shell32 and if it does not exist, we just invoke ShellExecute to
-    // open the folder thus losing the functionality to select the item in
-    // the process.
-    HMODULE shell32_base = GetModuleHandle(L"shell32.dll");
-    if (!shell32_base) {
-      NOTREACHED() << " " << __FUNCTION__ << "(): Can't open shell32.dll";
-      return false;
-    }
-    open_folder_and_select_itemsPtr =
-        reinterpret_cast<SHOpenFolderAndSelectItemsFuncPtr>(
-            GetProcAddress(shell32_base, "SHOpenFolderAndSelectItems"));
-  }
-  if (!open_folder_and_select_itemsPtr) {
-    return ui::win::OpenFolderViaShell(dir);
-  }
-
   Microsoft::WRL::ComPtr<IShellFolder> desktop;
   HRESULT hr = SHGetDesktopFolder(desktop.GetAddressOf());
   if (FAILED(hr))
@@ -290,8 +263,8 @@ bool ShowItemInFolder(const base::FilePath& full_path) {
 
   const ITEMIDLIST* highlight[] = {file_item};
 
-  hr = (*open_folder_and_select_itemsPtr)(dir_item, arraysize(highlight),
-                                          highlight, NULL);
+  hr = SHOpenFolderAndSelectItems(dir_item, arraysize(highlight), highlight,
+                                  NULL);
   if (!FAILED(hr))
     return true;
 

--- a/electron.gyp
+++ b/electron.gyp
@@ -363,6 +363,7 @@
           ],
           'link_settings': {
             'libraries': [
+              '-ldwmapi.lib',
               '-limm32.lib',
               '-lgdi32.lib',
               '-loleacc.lib',


### PR DESCRIPTION
[DwmGetColorizationColor](https://docs.microsoft.com/en-us/windows/desktop/api/dwmapi/nf-dwmapi-dwmgetcolorizationcolor) and [SHOpenFolderAndSelectItems](https://docs.microsoft.com/en-us/windows/desktop/api/shlobj_core/nf-shlobj_core-shopenfolderandselectitems) can be statically linked as they are available on all supported versions of Windows.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)