### PR TITLE
feat: Add isCurrentlyAudible() to WebContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1434,6 +1434,10 @@ bool WebContents::IsAudioMuted() {
   return web_contents()->IsAudioMuted();
 }
 
+bool WebContents::IsCurrentlyAudible() {
+  return web_contents()->IsCurrentlyAudible();
+}
+
 void WebContents::Print(mate::Arguments* args) {
   PrintSettings settings = {false, false, base::string16()};
   if (args->Length() >= 1 && !args->GetNext(&settings)) {
@@ -2018,6 +2022,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setIgnoreMenuShortcuts", &WebContents::SetIgnoreMenuShortcuts)
       .SetMethod("setAudioMuted", &WebContents::SetAudioMuted)
       .SetMethod("isAudioMuted", &WebContents::IsAudioMuted)
+      .SetMethod("isCurrentlyAudible", &WebContents::IsCurrentlyAudible)
       .SetMethod("undo", &WebContents::Undo)
       .SetMethod("redo", &WebContents::Redo)
       .SetMethod("cut", &WebContents::Cut)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -143,6 +143,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetIgnoreMenuShortcuts(bool ignore);
   void SetAudioMuted(bool muted);
   bool IsAudioMuted();
+  bool IsCurrentlyAudible();
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   void SetEmbedder(const WebContents* embedder);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -832,6 +832,10 @@ Mute the audio on the current web page.
 
 Returns `Boolean` - Whether this page has been muted.
 
+#### `contents.isCurrentlyAudible()`
+
+Returns `Boolean` - Whether audio is currently playing.
+
 #### `contents.setZoomFactor(factor)`
 
 * `factor` Number - Zoom factor.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -450,6 +450,10 @@ Set guest page muted.
 
 Returns `Boolean` - Whether guest page has been muted.
 
+#### `<webview>.isCurrentlyAudible()`
+
+Returns `Boolean` - Whether audio is currently playing.
+
 ### `<webview>.undo()`
 
 Executes editing command `undo` in page.

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -344,6 +344,7 @@ const registerWebViewElement = function () {
     'inspectElement',
     'setAudioMuted',
     'isAudioMuted',
+    'isCurrentlyAudible',
     'undo',
     'redo',
     'cut',

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -5,11 +5,16 @@ const http = require('http')
 const path = require('path')
 const {closeWindow} = require('./window-helpers')
 const {emittedOnce} = require('./events-helpers')
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
 
 const {ipcRenderer, remote} = require('electron')
 const {BrowserWindow, webContents, ipcMain, session} = remote
+const {expect} = chai
 
 const isCi = remote.getGlobal('isCi')
+
+chai.use(dirtyChai)
 
 /* The whole webContents API doesn't use standard callbacks */
 /* eslint-disable standard/no-callback-literal */

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -116,6 +116,23 @@ describe('webContents module', () => {
     })
   })
 
+  describe('isCurrentlyAudible() API', () => {
+    it('returns whether audio is playing', (done) => {
+      w.loadURL(`file://${path.join(__dirname, 'fixtures', 'api', 'is-currently-audible.html')}`)
+      w.show()
+      w.webContents.once('did-finish-load', () => {
+        assert.equal(w.webContents.isCurrentlyAudible(), false)
+
+        ipcMain.once('playing', () => {
+          assert.equal(w.webContents.isCurrentlyAudible(), true)
+          done()
+        })
+
+        w.webContents.send('play')
+      })
+    })
+  })
+
   describe('getWebPreferences() API', () => {
     it('should not crash when called for devTools webContents', (done) => {
       w.webContents.openDevTools()

--- a/spec/fixtures/api/is-currently-audible.html
+++ b/spec/fixtures/api/is-currently-audible.html
@@ -1,0 +1,21 @@
+<html>
+<body>
+<div id="video"></div>
+<script type="text/javascript" charset="utf-8">
+  const {ipcRenderer} = window.top != null ? window.top.require('electron') : require('electron')
+  ipcRenderer.on('play', (event) => {
+    const context = new window.AudioContext();
+    const oscillator = context.createOscillator();
+
+    // A beep
+    oscillator.type = 'sine';
+    oscillator.frequency.value = 440
+    oscillator.connect(context.destination)
+    oscillator.start()
+
+    // It'll take a few ms before the beep shows up
+    setTimeout(() => event.sender.send('playing'), 100)
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
##### Checklist
This PR adds `IsCurrentlyAudible` to WebContents, allowing developers to determine whether or not audio is currently playing. 

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

![audible](https://user-images.githubusercontent.com/1426799/42523218-0504f82a-8465-11e8-9819-5481a3dc1f4b.gif)
