### PR TITLE
fix: remember the render_process_id when permission requests occur on the IO thread

### DIFF
--- a/brightray/browser/platform_notification_service.cc
+++ b/brightray/browser/platform_notification_service.cc
@@ -90,6 +90,7 @@ PlatformNotificationService::CheckPermissionOnIOThread(
     content::ResourceContext* resource_context,
     const GURL& origin,
     int render_process_id) {
+  render_process_id_ = render_process_id;
   return blink::mojom::PermissionStatus::GRANTED;
 }
 


### PR DESCRIPTION
Fixes #13620 

Requests in C61 -> C66 changed threads I guess 😄 We should have been doing this in the first place anyway 👍 