### PR TITLE
fix: window.setVibrancy parameter passing

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -311,10 +311,7 @@ void BrowserWindow::SetBrowserView(v8::Local<v8::Value> value) {
 #endif
 }
 
-void BrowserWindow::SetVibrancy(mate::Arguments* args) {
-  std::string type;
-  args->GetNext(&type);
-
+void BrowserWindow::SetVibrancy(const std::string& type) {
   auto* render_view_host = web_contents()->GetRenderViewHost();
   if (render_view_host) {
     auto* impl = content::RenderWidgetHostImpl::FromID(
@@ -324,7 +321,7 @@ void BrowserWindow::SetVibrancy(mate::Arguments* args) {
       impl->SetBackgroundOpaque(type.empty() ? !window_->transparent() : false);
   }
 
-  TopLevelWindow::SetVibrancy(args);
+  TopLevelWindow::SetVibrancy(type);
 }
 
 void BrowserWindow::FocusOnWebView() {

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -71,7 +71,7 @@ class BrowserWindow : public TopLevelWindow,
   void Blur() override;
   void SetBackgroundColor(const std::string& color_name) override;
   void SetBrowserView(v8::Local<v8::Value> value) override;
-  void SetVibrancy(mate::Arguments* args) override;
+  void SetVibrancy(const std::string& type) override;
 
   // BrowserWindow APIs.
   void FocusOnWebView();

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -692,9 +692,7 @@ void TopLevelWindow::SetAutoHideCursor(bool auto_hide) {
   window_->SetAutoHideCursor(auto_hide);
 }
 
-void TopLevelWindow::SetVibrancy(mate::Arguments* args) {
-  std::string type;
-  args->GetNext(&type);
+void TopLevelWindow::SetVibrancy(const std::string& type) {
   window_->SetVibrancy(type);
 }
 

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -163,7 +163,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void SetVisibleOnAllWorkspaces(bool visible);
   bool IsVisibleOnAllWorkspaces();
   void SetAutoHideCursor(bool auto_hide);
-  virtual void SetVibrancy(mate::Arguments* args);
+  virtual void SetVibrancy(const std::string& type);
   void SetTouchBar(const std::vector<mate::PersistentDictionary>& items);
   void RefreshTouchBarItem(const std::string& item_id);
   void SetEscapeTouchBarItem(const mate::PersistentDictionary& item);


### PR DESCRIPTION
This PR fixes the parameter passing of the `browserWindow.setVibrancy` method, because previously calling `setVibrancy` multiple times didn't respond to changes. 

Mentioned in #12726.
