### PR TITLE
docs: use .env (and .env.example) for tokens used in release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# See docs/development/releasing.md
+
+APPVEYOR_TOKEN=
+CIRCLE_TOKEN=
+ELECTRON_GITHUB_TOKEN=
+VSTS_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# These env vars are only necessary for creating Electron releases.
 # See docs/development/releasing.md
 
 APPVEYOR_TOKEN=

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -2,6 +2,26 @@
 
 This document describes the process for releasing a new version of Electron.
 
+## Set your tokens and environment variables
+You'll need Electron S3 credentials in order to create and
+upload an Electron release. Contact a team member for more
+information.
+
+There are a handful of `*_TOKEN` environment variables needed by the release
+scripts:
+
+* `ELECTRON_GITHUB_TOKEN`:
+Create this by visiting https://github.com/settings/tokens/new?scopes=repo
+* `APPVEYOR_TOKEN`:
+Create a token from https://windows-ci.electronjs.org/api-token
+If you don't have an account, ask a team member to add you.
+* `CIRCLE_TOKEN`:
+Create a token from "Personal API Tokens" at https://circleci.com/account/api
+
+Once you've generated these tokens, put them in a `.env` file in the root directory
+of the project. This file is gitignored, and will be loaded into the 
+environment by the release scripts.
+
 ## Determine which branch to release from
 
 - **If releasing beta,** run the scripts below from `master`.
@@ -18,23 +38,6 @@ patch, or beta version change. Read the
 `git checkout 1-8-x` rather than `git checkout -b remotes/origin/1-8-x`.
 The scripts need `git rev-parse --abbrev-ref HEAD` to return a short name,
 e.g. no `remotes/origin/`
-
-## Set your tokens and environment variables
-You'll need Electron S3 credentials in order to create and
-upload an Electron release. Contact a team member for more
-information.
-
-There are a handful of `*_TOKEN` environment variables needed by the release
-scripts. Once you've generated these per-user tokens, you may want to keep
-them in a local file that you can `source` when starting a release.
-* `ELECTRON_GITHUB_TOKEN`:
-Create as described at https://github.com/settings/tokens/new,
-giving the token repo access scope.
-* `APPVEYOR_TOKEN`:
-Create a token from https://windows-ci.electronjs.org/api-token
-If you don't have an account, ask a team member to add you.
-* `CIRCLE_TOKEN`:
-Create a token from "Personal API Tokens" at https://circleci.com/account/api
 
 ## Run the prepare-release script
 The prepare release script will do the following:

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -46,7 +46,6 @@ async function makeRequest (requestOptions, parseResponse) {
 }
 
 async function circleCIcall (buildUrl, targetBranch, job, options) {
-  assert(process.env.CIRCLE_TOKEN, 'CIRCLE_TOKEN not found in environment')
   console.log(`Triggering CircleCI to run build job: ${job} on branch: ${targetBranch} with release flag.`)
   let buildRequest = {
     'build_parameters': {
@@ -79,7 +78,6 @@ async function circleCIcall (buildUrl, targetBranch, job, options) {
 }
 
 function buildAppVeyor (targetBranch, options) {
-  assert(process.env.APPVEYOR_TOKEN, 'APPVEYOR_TOKEN not found in environment')
   const validJobs = Object.keys(appVeyorJobs)
   if (options.job) {
     assert(validJobs.includes(options.job), `Unknown AppVeyor CI job name: ${options.job}.  Valid values are: ${validJobs}.`)
@@ -141,7 +139,6 @@ async function buildVSTS (targetBranch, options) {
     assert(vstsJobs.includes(options.job), `Unknown VSTS CI job name: ${options.job}. Valid values are: ${vstsJobs}.`)
   }
   console.log(`Triggering VSTS to run build on branch: ${targetBranch} with release flag.`)
-  assert(process.env.VSTS_TOKEN, 'VSTS_TOKEN not found in environment')
   let environmentVariables = {}
 
   if (!options.ghRelease) {

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -1,3 +1,5 @@
+require('dotenv-safe').load()
+
 const assert = require('assert')
 const request = require('request')
 const buildAppVeyorURL = 'https://windows-ci.electronjs.org/api/builds'

--- a/script/find-release.js
+++ b/script/find-release.js
@@ -1,3 +1,5 @@
+require('dotenv-safe').load()
+
 const GitHub = require('github')
 const github = new GitHub()
 

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+require('dotenv-safe').load()
 require('colors')
 const args = require('minimist')(process.argv.slice(2), {
   boolean: ['automaticRelease', 'notesOnly', 'stable']

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -5,7 +5,6 @@ require('colors')
 const args = require('minimist')(process.argv.slice(2), {
   boolean: ['automaticRelease', 'notesOnly', 'stable']
 })
-const assert = require('assert')
 const ciReleaseBuild = require('./ci-release-build')
 const { execSync } = require('child_process')
 const fail = '\u2717'.red
@@ -20,7 +19,6 @@ const versionType = args._[0]
 // TODO (future) automatically determine version based on conventional commits
 // via conventional-recommended-bump
 
-assert(process.env.ELECTRON_GITHUB_TOKEN, 'ELECTRON_GITHUB_TOKEN not found in environment')
 if (!versionType && !args.notesOnly) {
   console.log(`Usage: prepare-release versionType [major | minor | patch | beta]` +
      ` (--stable) (--notesOnly) (--automaticRelease) (--branch)`)

--- a/script/release.js
+++ b/script/release.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+require('dotenv-safe').load()
 require('colors')
 const args = require('minimist')(process.argv.slice(2))
 const assert = require('assert')

--- a/script/release.js
+++ b/script/release.js
@@ -3,7 +3,6 @@
 require('dotenv-safe').load()
 require('colors')
 const args = require('minimist')(process.argv.slice(2))
-const assert = require('assert')
 const fs = require('fs')
 const { execSync } = require('child_process')
 const GitHub = require('github')
@@ -18,8 +17,6 @@ const sumchecker = require('sumchecker')
 const temp = require('temp').track()
 const { URL } = require('url')
 let failureCount = 0
-
-assert(process.env.ELECTRON_GITHUB_TOKEN, 'ELECTRON_GITHUB_TOKEN not found in environment')
 
 const github = new GitHub({
   followRedirects: false

--- a/script/upload-to-github.js
+++ b/script/upload-to-github.js
@@ -1,3 +1,5 @@
+require('dotenv-safe').load()
+
 const GitHub = require('github')
 const github = new GitHub()
 github.authenticate({type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN})


### PR DESCRIPTION
This PR adds a `.env.example` file to the repo which serves as a document of all the env vars required by the release scripts. The release scripts now run `require('dotenv-safe').load()` which loads the contents of `.env` into `process.env` and ensures that any human running commands like `npm run prepare-release` or `npm run release` will see helpful output if any of the required env is missing.

Eventually we should have the S3_* env vars in this file too, but for now I think those are still only used in python files. Is that correct, @jkleinsc 