### PR TITLE
chore: Updates for release process

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -2,23 +2,6 @@
 
 This document describes the process for releasing a new version of Electron.
 
-## Determine which branch to release from
-
-- **If releasing beta,** run the scripts below from `master`.
-- **If releasing a stable version,** run the scripts below from the branch
-  you're stabilizing.
-
-## Find out what version change is needed
-Run `npm run prepare-release -- --notesOnly` to view auto generated release
-notes. The notes generated should help you determine if this is a major, minor,
-patch, or beta version change. Read the
-[Version Change Rules](../tutorial/electron-versioning.md#semver) for more information.
-
-**NB:** If releasing from a branch, e.g. 1-8-x, check out the branch with
-`git checkout 1-8-x` rather than `git checkout -b remotes/origin/1-8-x`.
-The scripts need `git rev-parse --abbrev-ref HEAD` to return a short name,
-e.g. no `remotes/origin/`
-
 ## Set your tokens and environment variables
 You'll need Electron S3 credentials in order to create and
 upload an Electron release. Contact a team member for more
@@ -35,6 +18,26 @@ Create a token from https://windows-ci.electronjs.org/api-token
 If you don't have an account, ask a team member to add you.
 * `CIRCLE_TOKEN`:
 Create a token from "Personal API Tokens" at https://circleci.com/account/api
+* `VSTS_TOKEN`:
+Create a Personal Access Token at https://github.visualstudio.com/_usersSettings/tokens
+with the scope of `Build (read and execute)`.
+
+## Determine which branch to release from
+
+- **If releasing beta,** run the scripts below from `master`.
+- **If releasing a stable version,** run the scripts below from the branch
+  you're stabilizing.
+
+## Find out what version change is needed
+Run `npm run prepare-release -- --notesOnly` to view auto generated release
+notes. The notes generated should help you determine if this is a major, minor,
+patch, or beta version change. Read the
+[Version Change Rules](../tutorial/electron-versioning.md#semver) for more information.
+
+**NB:** If releasing from a branch, e.g. 1-8-x, check out the branch with
+`git checkout 1-8-x` rather than `git checkout -b remotes/origin/1-8-x`.
+The scripts need `git rev-parse --abbrev-ref HEAD` to return a short name,
+e.g. no `remotes/origin/`
 
 ## Run the prepare-release script
 The prepare release script will do the following:
@@ -84,8 +87,11 @@ $ ./script/bump-version.py --bump minor --dry-run
 The `prepare-release` script will trigger the builds via API calls.
 To monitor the build progress, see the following pages:
 
-- [circleci.com/gh/electron/electron](https://circleci.com/gh/electron) for OS X and Linux
-- [windows-ci.electronjs.org/project/AppVeyor/electron](https://windows-ci.electronjs.org/project/AppVeyor/electron) for Windows
+- [electron-release-mas-x64](https://github.visualstudio.com/electron/_build/index?context=allDefinitions&path=%5C&definitionId=19&_a=completed) for MAS builds.
+- [electron-release-osx-x64](https://github.visualstudio.com/electron/_build/index?context=allDefinitions&path=%5C&definitionId=18&_a=completed) for OSX builds.
+- [circleci.com/gh/electron/electron](https://circleci.com/gh/electron) for Linux builds.
+- [windows-ci.electronjs.org/project/AppVeyor/electron-39ng6](https://windows-ci.electronjs.org/project/AppVeyor/electron-39ng6) for Windows 32-bit builds.
+- [windows-ci.electronjs.org/project/AppVeyor/electron](https://windows-ci.electronjs.org/project/AppVeyor/electron) for Windows 64-bit builds.
 
 ## Compile release notes
 
@@ -192,33 +198,11 @@ under the `beta` tag and can be installed via `npm install electron@beta`.
 1. Visit [the releases page] and you'll see a new draft release with placeholder
 release notes.
 2. Edit the release and add release notes.
-3. Uncheck the `prerelease` checkbox if you're publishing a stable release;
-leave it checked for beta releases.
-4. Click 'Save draft'. **Do not click 'Publish release'!**
-5. Wait for all builds to pass before proceeding.
-6. In the `release` branch, verify that the release's files have been created:
+3. Click 'Save draft'. **Do not click 'Publish release'!**
+4. Wait for all builds to pass before proceeding.
+5. In the branch, verify that the release's files have been created:
 ```sh
-$ git rev-parse --abbrev-ref HEAD
-release
 $ npm run release -- --validateRelease
-```
-
-## Merge temporary branch (pre-2-0-x branches only)
-Once the release builds have finished, merge the `release` branch back into
-the source release branch using the `merge-release` script.
-If the branch cannot be successfully merged back this script will automatically
-rebase the `release` branch and push the changes which will trigger the release
-builds again, which means you will need to wait for the release builds to run
-again before proceeding.
-
-### Merging back into master
-```sh
-npm run merge-release -- master
-```
-
-### Merging back into old release branch
-```sh
-npm run merge-release -- 1-7-x
 ```
 
 ## Publish the release
@@ -234,7 +218,6 @@ on Windows by node-gyp to build native modules.
 5. Validate that all of the required files are present on GitHub and S3 and have
 the correct checksums as specified in the SHASUMS files.
 6. Publish the release on GitHub
-7. Delete the `release` branch.
 
 ## Publish to npm
 
@@ -264,15 +247,38 @@ electron
 $ npm run publish-to-npm
 ```
 
-Note: In general you should be using the latest Node during this
-process; however, older versions of the `publish-to-npm` script
-may have trouble with Node 7 or higher. If you have trouble with
-this in an older branch, try running with an older version of Node,
-e.g. a 6.x LTS.
-
 [the releases page]: https://github.com/electron/electron/releases
 [this bump commit]: https://github.com/electron/electron/commit/78ec1b8f89b3886b856377a1756a51617bc33f5a
 [versioning]: /docs/tutorial/electron-versioning.md
+
+# Troubleshooting
+
+## Rerun broken builds
+
+If a release build fails for some reason, you can use `script/ci-release-build.js` to rerun a release build:
+
+### Rerun all linux builds:
+```sh
+node script/ci-release-build.js --ci=CircleCI --ghRelease TARGET_BRANCH
+(TARGET_BRANCH) is the branch you are releasing from.
+```
+
+### Rerun all macOS builds:
+```sh
+node script/ci-release-build.js --ci=VSTS --ghRelease TARGET_BRANCH
+(TARGET_BRANCH) is the branch you are releasing from.
+```
+
+### Rerun all Windows builds:
+```sh
+node script/ci-release-build.js --ci=AppVeyor --ghRelease TARGET_BRANCH
+(TARGET_BRANCH) is the branch you are releasing from.
+```
+
+Additionally you can pass a job name to the script to run an individual job, eg:
+````sh
+node script/ci-release-build.js --ci=AppVeyor --ghRelease --job=electron-x64 TARGET_BRANCH
+```
 
 ## Fix missing binaries of a release manually
 

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -120,7 +120,7 @@ async function callAppVeyor (targetBranch, job, options) {
   let appVeyorResponse = await makeRequest(requestOpts, true).catch(err => {
     console.log('Error calling AppVeyor:', err)
   })
-  const buildUrl = `https://windows-ci.electronjs.org/project/AppVeyor/electron/build/${appVeyorResponse.version}`
+  const buildUrl = `https://windows-ci.electronjs.org/project/AppVeyor/${appVeyorJobs[job]}/build/${appVeyorResponse.version}`
   console.log(`AppVeyor release build request for ${job} successful.  Check build status at ${buildUrl}`)
 }
 


### PR DESCRIPTION
While running the 3.0.0-beta.2, there were a couple of issues discovered that this PR corrects:

1. When running `npm run prepare-release`, the URL for the 32-bit Windows release build was wrong.
2. The documentation was missing information about VSTS, had outdated references/information to pre 2-0-x releases and was missing some troubleshooting steps.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)