### PR TITLE
build: [gn] build node with clang-cl

### DIFF
--- a/build/node/node_override.gypi
+++ b/build/node/node_override.gypi
@@ -32,7 +32,13 @@
           }]
         ]
       }
-    }]
+    }],
+    ['OS=="win"', {
+      'make_global_settings': [
+        ['CC', '<(llvm_dir)/bin/clang-cl'],
+        # Also defining CXX doesn't appear to be necessary.
+      ]
+    }],
   ],
   'target_defaults': {
     'target_conditions': [


### PR DESCRIPTION
Mostly because it gives way better error messages.