### PR TITLE
build: [gn] define WIN32_LEAN_AND_MEAN in the node build

### DIFF
--- a/build/node/node_override.gypi
+++ b/build/node/node_override.gypi
@@ -47,6 +47,7 @@
           'EVP_CTRL_AEAD_SET_IVLEN=EVP_CTRL_GCM_SET_IVLEN',
           'EVP_CTRL_CCM_SET_TAG=EVP_CTRL_GCM_SET_TAG',
           'EVP_CTRL_AEAD_GET_TAG=EVP_CTRL_GCM_GET_TAG',
+          'WIN32_LEAN_AND_MEAN',
         ],
         'conditions': [
           ['OS=="win"', {


### PR DESCRIPTION
This prevents `uv-win.h` from indirectly including `wincrypt.h`, which causes symbol conflicts in boringssl. Specifically, `wincrypt.h` defines `X509_NAME`, and so does boringssl, so you end up with errors like:

```
In file included from ..\..\..\..\..\..\..\third_party\electron_node\src\node_constants.cc:38:
In file included from C:\Users\nornagon\work\electron\src\third_party\boringssl\src\include\openssl/ec.h:71:
C:\Users\nornagon\work\electron\src\third_party\boringssl\src\include\openssl/base.h(271,29):  error: expected ')'
typedef struct X509_name_st X509_NAME;
                            ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.17134.0\um\wincrypt.h(2897,55):  note: expanded from macro 'X509_NAME'
#define X509_NAME                           ((LPCSTR) 7)
                                                      ^
C:\Users\nornagon\work\electron\src\third_party\boringssl\src\include\openssl/base.h(271,29):  note: to match this '('
C:\Program Files (x86)\Windows Kits\10\include\10.0.17134.0\um\wincrypt.h(2897,45):  note: expanded from macro 'X509_NAME'
#define X509_NAME                           ((LPCSTR) 7)
                                            ^
```

Other parts of node and libuv expect `WIN32_LEAN_AND_MEAN` to be defined, so I don't think this will cause any issues there.