### PR TITLE
build: [gn win] link comctl32.lib to fix component build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -676,8 +676,9 @@ if (is_mac) {
       ]
 
       libs = [
-        "wtsapi32.lib",
+        "comctl32.lib",
         "uiautomationcore.lib",
+        "wtsapi32.lib",
       ]
 
       configs += [ "//build/config/win:windowed" ]


### PR DESCRIPTION
Fixes build error:

```
electron_lib.lib(native_window_views_win.obj) : error LNK2019: unresolved external symbol SetWindowSubclass referenced in function "private: void __cdecl atom::NativeWindowViews::SetForwardMouseMessages(bool)" (?SetForwardMouseMessages@NativeWindowViews@atom@@AEAAX_N@Z)
```