### PR TITLE
fix: don't invoke callback after FrameSubscriber is destroyed

### DIFF
--- a/atom/browser/api/frame_subscriber.cc
+++ b/atom/browser/api/frame_subscriber.cc
@@ -26,7 +26,8 @@ FrameSubscriber::FrameSubscriber(v8::Isolate* isolate,
     : content::WebContentsObserver(web_contents),
       isolate_(isolate),
       callback_(callback),
-      only_dirty_(only_dirty) {}
+      only_dirty_(only_dirty),
+      weak_ptr_factory_(this) {}
 
 FrameSubscriber::~FrameSubscriber() = default;
 
@@ -64,7 +65,7 @@ void FrameSubscriber::DidReceiveCompositorFrame() {
 
   view->CopyFromSurface(
       gfx::Rect(), view->GetViewBounds().size(),
-      base::BindOnce(&FrameSubscriber::Done, base::Unretained(this),
+      base::BindOnce(&FrameSubscriber::Done, weak_ptr_factory_.GetWeakPtr(),
                      GetDamageRect()));
 }
 

--- a/atom/browser/api/frame_subscriber.h
+++ b/atom/browser/api/frame_subscriber.h
@@ -8,6 +8,7 @@
 #include "content/public/browser/web_contents.h"
 
 #include "base/callback.h"
+#include "base/memory/weak_ptr.h"
 #include "components/viz/common/frame_sinks/copy_output_result.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "ui/gfx/image/image.h"
@@ -38,6 +39,8 @@ class FrameSubscriber : public content::WebContentsObserver {
   v8::Isolate* isolate_;
   FrameCaptureCallback callback_;
   bool only_dirty_;
+
+  base::WeakPtrFactory<FrameSubscriber> weak_ptr_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(FrameSubscriber);
 };


### PR DESCRIPTION
This fixes a crash when running tests for `beginFrameSubscription`. Close #13655.