### PR TITLE
docs: using chrome://flash to get the flash path

### DIFF
--- a/docs/tutorial/using-pepper-flash-plugin.md
+++ b/docs/tutorial/using-pepper-flash-plugin.md
@@ -7,7 +7,7 @@ and then enable it in your application.
 ## Prepare a Copy of Flash Plugin
 
 On macOS and Linux, the details of the Pepper Flash plugin can be found by
-navigating to `chrome://plugins` in the Chrome browser. Its location and version
+navigating to `chrome://flash` in the Chrome browser. Its location and version
 are useful for Electron's Pepper Flash support. You can also copy it to another
 location.
 


### PR DESCRIPTION
chrome://about no longer works , so we should use chrome://flash instead.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)