### PR TITLE
chore: Updates for nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,13 @@ build-steps: &build-steps
               mkdir junit
               script/test.py --ci --rebuild_native_modules
             else
-              echo 'Testing Electron release build'
-              mkdir junit
-              script/test.py --ci --rebuild_native_modules -c R
+              if [ "$UPLOAD_TO_S3" == "1" ]; then
+                echo 'Testing Electron release build'
+                mkdir junit
+                script/test.py --ci --rebuild_native_modules -c R
+              else
+                echo 'Skipping tests on GitHub release'
+              fi
             fi
           else
            echo 'Skipping tests due to configuration'
@@ -141,10 +145,7 @@ build-steps: &build-steps
     - store_artifacts:
         path: junit
     - store_artifacts:
-        path: out/electron.d.ts
-    - store_artifacts:
-        path: out/electron-api.json
-
+        path: out
 
 build-defaults: &build-defaults
   docker:

--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_version':
     '66.0.3359.181',
   'libchromiumcontent_revision':
-    'ff1c994b0e4f5ddf664478aea0c836ba84479ea8',
+    '83a05b94ef363d574030ec2f018ec758e8314c19',
   'node_version':
     'v10.2.0-35-g4879332def',
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,28 +1,26 @@
 version: 1.0.{build}
+branches:
+  except:
+  - /^release$|^release-\d-\d-x$/
 build_cloud: electron-16
 image: electron-16-vs2017
 environment:
   DISABLE_CRASH_REPORTER_TESTS: true
-  matrix:
-  - TARGET_ARCH: ia32
-  - TARGET_ARCH: x64
 build_script:
 - ps: >-
     if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
       Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
-
     } else {
       Add-Path "$env:ProgramFiles (x86)\Windows Kits\10\Debuggers\x64"
-
       $env:path = "$env:ProgramFiles (x86)\Windows Kits\10\Debuggers\x64;$env:path"
-
+      if($env:APPVEYOR_SCHEDULED_BUILD -eq 'True')  {
+        $env:RUN_RELEASE_BUILD = "1"
+      }
       $Message = (git log --format=%B -n 1 HEAD) | Out-String
-
       if ((Test-Path Env:\RUN_RELEASE_BUILD)) {
         $env:ELECTRON_RELEASE = '1'
         Write-Output "release build triggered from api"
       }
-
       if ((Test-Path Env:\ELECTRON_RELEASE)) {
         Write-Output "Running release build"
         python script\bootstrap.py --target_arch=$env:TARGET_ARCH
@@ -38,8 +36,8 @@ build_script:
       } else {
         "Build succeeded."
       }
+      Push-AppveyorArtifact out
     }
-
 test_script:
 - ps: >-
     if (Test-Path Env:\ELECTRON_RELEASE) {
@@ -53,7 +51,6 @@ test_script:
         Write-Output "Tests succeeded."
       }
       python script\verify-ffmpeg.py
-
       if ($LASTEXITCODE -ne '0') {
         throw "Verify ffmpeg failed with exit code $LASTEXITCODE"
       } else {
@@ -61,5 +58,16 @@ test_script:
       }
     }
 artifacts:
-- path: out
-  name: out
+- path: test-results.xml
+  name: test-results.xml
+deploy_script:
+- ps: >-
+    if (Test-Path Env:\ELECTRON_RELEASE) {
+      if (Test-Path Env:\RUN_RELEASE_BUILD) {
+        Write-Output "Uploading Electron release distribution to s3"
+        & python script\upload.py --upload_to_s3
+      } else {
+        Write-Output "Uploading Electron release distribution to github releases"
+        & python script\upload.py
+      }
+    }

--- a/vsts.yml
+++ b/vsts.yml
@@ -54,6 +54,7 @@ steps:
       script/test.py --ci --rebuild_native_modules
     fi
   name: Test
+  condition: or(ne(variables['ELECTRON_RELEASE'], '1'), eq(variables['UPLOAD_TO_S3'], '1'))
 
 - bash: |
     echo 'Verifying ffmpeg on build'
@@ -63,6 +64,7 @@ steps:
       script/verify-ffmpeg.py
     fi
   name: Verify_FFmpeg
+  condition: or(ne(variables['ELECTRON_RELEASE'], '1'), eq(variables['UPLOAD_TO_S3'], '1'))
 
 - task: PublishTestResults@2
   displayName: Publish Test Results
@@ -70,26 +72,26 @@ steps:
     testResultsFiles: '**/test-*.xml'
   condition: and(always(), eq(variables['MOCHA_FILE'], 'test-results.xml'))
 
-- task: kasunkodagoda.slack-notification.slack-notification-task.SlackNotification@3
-  displayName: Post Slack Notification on Failure
-  inputs:
-    SlackApiToken: '$(slack_token)'
-    Channel: '#bot-nightly-releases'
-    Message: 'Build failed for *<$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)|$(Build.DefinitionName)>* nightly build.'
-    Title: '$(Build.DefinitionName) nightly build results'
-    TitleLink: '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)'
-    Color: '#FC5C3C'
-  condition: and(failed(), eq(variables['Build.Reason'], 'Schedule'))
+- bash: |
+    export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"
+    export MESSAGE="Build failed for *<$BUILD_URL|$BUILD_DEFINITIONNAME>* nightly build."
+    curl -g -H "Content-Type: application/json" -X POST \
+    -d "{\"text\": \"$MESSAGE\", \"attachments\": [{\"color\": \"#FC5C3C\",\"title\": \"$BUILD_DEFINITIONNAME nightly build results\",\"title_link\": \"$BUILD_URL\"}]}" $(slack_webhook)
+  name: Post_Slack_Notification_on_Failure
+  condition: failed()
 
-- task: kasunkodagoda.slack-notification.slack-notification-task.SlackNotification@3
-  displayName: Post Slack Notification on Success
+- bash: |
+    export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"
+    export MESSAGE="Build succeeded for *<$BUILD_URL|$BUILD_DEFINITIONNAME>* nightly build."
+    curl -g -H "Content-Type: application/json" -X POST \
+    -d "{\"text\": \"$MESSAGE\", \"attachments\": [{\"color\": \"#FC5C3C\",\"title\": \"$BUILD_DEFINITIONNAME nightly build results\",\"title_link\": \"$BUILD_URL\"}]}" $(slack_webhook)
+  name: Post_Slack_Notification_on_Success
+  condition: succeeded()
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Build Artifacts
   inputs:
-    SlackApiToken: '$(slack_token)'
-    Channel: '#bot-nightly-releases'
-    Message: 'Build succeeded for *<$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)|$(Build.DefinitionName)>* nightly build.'
-    Title: '$(Build.DefinitionName) nightly build results'
-    TitleLink: '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)'
-    Color: 'good'
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))
+    PathtoPublish: '$(Build.SourcesDirectory)/out'
+    ArtifactName: out
 
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3


### PR DESCRIPTION
This PR includes the following changes for nightly builds:
1. Make sure artifacts for nightly release builds are properly saved  on each CI platform.  This change allows the release artifacts to be downloaded directly from the CI build pages.
2. Fix for VSTS slack integration -- build results were not being posted to Slack.
3. Changes make sure tests don't run when building for GitHub releases.  Tests should run for nightly builds, but not when we are releasing an official release.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)