### PR TITLE
Fix crash when opening devtools for frameless window

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -87,7 +87,7 @@ BrowserWindow::BrowserWindow(v8::Isolate* isolate,
 
 #if defined(OS_MACOSX)
   if (!window()->has_frame())
-    OverrideNSWindowContentView();
+    OverrideNSWindowContentView(web_contents->managed_web_contents());
 #endif
 
   // Init window after everything has been setup.

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -81,7 +81,7 @@ class BrowserWindow : public TopLevelWindow,
 
  private:
 #if defined(OS_MACOSX)
-  void OverrideNSWindowContentView();
+  void OverrideNSWindowContentView(brightray::InspectableWebContents* iwc);
 #endif
 
   // Helpers.

--- a/atom/browser/api/atom_api_browser_window_mac.mm
+++ b/atom/browser/api/atom_api_browser_window_mac.mm
@@ -10,6 +10,7 @@
 #include "atom/browser/native_window_mac.h"
 #include "atom/common/draggable_region.h"
 #include "base/mac/scoped_nsobject.h"
+#include "brightray/browser/inspectable_web_contents_view.h"
 
 @interface NSView (WebContentsView)
 - (void)setMouseDownCanMoveWindow:(BOOL)can_move;
@@ -54,11 +55,12 @@ std::vector<gfx::Rect> CalculateNonDraggableRegions(
 
 }  // namespace
 
-void BrowserWindow::OverrideNSWindowContentView() {
+void BrowserWindow::OverrideNSWindowContentView(
+    brightray::InspectableWebContents* iwc) {
   // Make NativeWindow use a NSView as content view.
   static_cast<NativeWindowMac*>(window())->OverrideNSWindowContentView();
   // Add webview to contentView.
-  NSView* webView = web_contents()->GetNativeView();
+  NSView* webView = iwc->GetView()->GetNativeView();
   NSView* contentView = [window()->GetNativeWindow() contentView];
   [webView setFrame:[contentView bounds]];
   [contentView addSubview:webView];

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -839,6 +839,14 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('BrowserWindow.openDevTools()', () => {
+    it('does not crash for frameless window', () => {
+      w.destroy()
+      w = new BrowserWindow({ show: false })
+      w.openDevTools()
+    })
+  })
+
   describe('BrowserWindow.fromBrowserView(browserView)', () => {
     let bv = null
 


### PR DESCRIPTION
Close  #13628.
This PR fixes the crash caused by #13599 when opening devtools for frameless window.