### PR TITLE
chore: remove private webContents.getId() API

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1103,17 +1103,6 @@ void WebContents::NavigationEntryCommitted(
        details.is_same_document, details.did_replace_entry);
 }
 
-int64_t WebContents::GetIDForContents(content::WebContents* web_contents) {
-  int64_t process_id = web_contents->GetMainFrame()->GetProcess()->GetID();
-  int64_t routing_id = web_contents->GetMainFrame()->GetRoutingID();
-  int64_t rv = (process_id << 32) + routing_id;
-  return rv;
-}
-
-int64_t WebContents::GetID() const {
-  return WebContents::GetIDForContents(web_contents());
-}
-
 int WebContents::GetProcessID() const {
   return web_contents()->GetMainFrame()->GetProcess()->GetID();
 }
@@ -1129,7 +1118,7 @@ WebContents::Type WebContents::GetType() const {
 }
 
 bool WebContents::Equal(const WebContents* web_contents) const {
-  return GetID() == web_contents->GetID();
+  return ID() == web_contents->ID();
 }
 
 void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
@@ -1992,7 +1981,6 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
   prototype->SetClassName(mate::StringToV8(isolate, "WebContents"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .MakeDestroyable()
-      .SetMethod("getId", &WebContents::GetID)
       .SetMethod("getProcessId", &WebContents::GetProcessID)
       .SetMethod("getOSProcessId", &WebContents::GetOSProcessID)
       .SetMethod("equal", &WebContents::Equal)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -98,12 +98,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
-  static int64_t GetIDForContents(content::WebContents* web_contents);
-
   // Notifies to destroy any guest web contents before destroying self.
   void DestroyWebContents(bool async);
 
-  int64_t GetID() const;
   int GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
   Type GetType() const;

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -344,10 +344,6 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
       web_preferences->AppendCommandLineSwitches(command_line);
     SessionPreferences::AppendExtraCommandLineSwitches(
         web_contents->GetBrowserContext(), command_line);
-
-    auto context_id = atom::api::WebContents::GetIDForContents(web_contents);
-    command_line->AppendSwitchASCII(switches::kContextId,
-                                    base::IntToString(context_id));
   }
 }
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -188,9 +188,6 @@ const char kAppUserModelId[] = "app-user-model-id";
 // The application path
 const char kAppPath[] = "app-path";
 
-// The context ID for this process
-const char kContextId[] = "context-id";
-
 // The command line switch versions of the options.
 const char kBackgroundColor[] = "background-color";
 const char kPreloadScript[] = "preload";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -92,7 +92,6 @@ extern const char kRegisterServiceWorkerSchemes[];
 extern const char kSecureSchemes[];
 extern const char kAppUserModelId[];
 extern const char kAppPath[];
-extern const char kContextId[];
 
 extern const char kBackgroundColor[];
 extern const char kPreloadScript[];

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -179,7 +179,7 @@ const createGuest = function (embedder, params) {
 const attachGuest = function (event, elementInstanceId, guestInstanceId, params) {
   const embedder = event.sender
   // Destroy the old guest when attaching.
-  const key = `${embedder.getId()}-${elementInstanceId}`
+  const key = `${embedder.id}-${elementInstanceId}`
   const oldGuestInstanceId = embedderElementsMap[key]
   if (oldGuestInstanceId != null) {
     // Reattachment to the same guest is just a no-op.
@@ -199,7 +199,7 @@ const attachGuest = function (event, elementInstanceId, guestInstanceId, params)
 
   // If this guest is already attached to an element then remove it
   if (guestInstance.elementInstanceId) {
-    const oldKey = `${guestInstance.embedder.getId()}-${guestInstance.elementInstanceId}`
+    const oldKey = `${guestInstance.embedder.id}-${guestInstance.elementInstanceId}`
     delete embedderElementsMap[oldKey]
 
     // Remove guest from embedder if moving across web views
@@ -290,7 +290,7 @@ const destroyGuest = function (embedder, guestInstanceId) {
   guestInstance.guest.destroy()
   delete guestInstances[guestInstanceId]
 
-  const key = `${embedder.getId()}-${guestInstance.elementInstanceId}`
+  const key = `${embedder.id}-${guestInstance.elementInstanceId}`
   delete embedderElementsMap[key]
 }
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -210,9 +210,9 @@ const unwrapArgs = function (sender, contextId, args) {
           return rendererFunctions.get(objectId)
         }
 
-        const webContentsId = sender.getId()
+        const processId = sender.getProcessId()
         let callIntoRenderer = function (...args) {
-          if (!sender.isDestroyed() && webContentsId === sender.getId()) {
+          if (!sender.isDestroyed() && processId === sender.getProcessId()) {
             sender.send('ELECTRON_RENDERER_CALLBACK', contextId, meta.id, valueToMeta(sender, contextId, args))
           } else {
             removeRemoteListenersAndLogWarning(this, meta, callIntoRenderer)
@@ -453,7 +453,6 @@ ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event, preloadPath) {
   event.returnValue = {
     preloadSrc: preloadSrc,
     preloadError: preloadError,
-    webContentsId: event.sender.getId(),
     platform: process.platform,
     execPath: process.execPath,
     env: process.env

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -361,7 +361,6 @@ const registerWebViewElement = function () {
     'replaceMisspelling',
     'findInPage',
     'stopFindInPage',
-    'getId',
     'downloadURL',
     'inspectServiceWorker',
     'print',

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -36,14 +36,8 @@ const loadedModules = new Map([
 ])
 
 const {
-  preloadSrc, preloadError, webContentsId, platform, execPath, env
+  preloadSrc, preloadError, platform, execPath, env
 } = electron.ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD', preloadPath)
-
-Object.defineProperty(process, 'webContentsId', {
-  configurable: false,
-  writable: false,
-  value: webContentsId
-})
 
 require('../renderer/web-frame-init')()
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -207,7 +207,7 @@ describe('BrowserWindow module', () => {
       const contents = w.webContents
       w.destroy()
       assert.throws(() => {
-        contents.getId()
+        contents.getProcessId()
       }, /Object has been destroyed/)
     })
   })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -40,7 +40,7 @@ describe('webContents module', () => {
     it('returns an array of web contents', (done) => {
       w.webContents.on('devtools-opened', () => {
         const all = webContents.getAllWebContents().sort((a, b) => {
-          return a.getId() - b.getId()
+          return a.id - b.id
         })
 
         assert.ok(all.length >= 4)
@@ -61,15 +61,15 @@ describe('webContents module', () => {
       if (isCi) return done()
 
       const specWebContents = remote.getCurrentWebContents()
-      assert.equal(specWebContents.getId(), webContents.getFocusedWebContents().getId())
+      assert.equal(specWebContents.id, webContents.getFocusedWebContents().id)
 
       specWebContents.once('devtools-opened', () => {
-        assert.equal(specWebContents.devToolsWebContents.getId(), webContents.getFocusedWebContents().getId())
+        assert.equal(specWebContents.devToolsWebContents.id, webContents.getFocusedWebContents().id)
         specWebContents.closeDevTools()
       })
 
       specWebContents.once('devtools-closed', () => {
-        assert.equal(specWebContents.getId(), webContents.getFocusedWebContents().getId())
+        assert.equal(specWebContents.id, webContents.getFocusedWebContents().id)
         done()
       })
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1034,7 +1034,7 @@ describe('<webview> tag', function () {
       assert.ok(webview.partition)
 
       const listener = function (webContents, permission, callback) {
-        if (webContents.getId() === webview.getId()) {
+        if (webContents.id === webview.getWebContents().id) {
           // requestMIDIAccess with sysex requests both midi and midiSysex so
           // grant the first midi one and then reject the midiSysex one
           if (requestedPermission === 'midiSysex' && permission === 'midi') {
@@ -1120,7 +1120,7 @@ describe('<webview> tag', function () {
       webview.partition = 'permissionTest'
       webview.setAttribute('nodeintegration', 'on')
       session.fromPartition(webview.partition).setPermissionRequestHandler((webContents, permission, callback) => {
-        if (webContents.getId() === webview.getId()) {
+        if (webContents.id === webview.getWebContents().id) {
           assert.equal(permission, 'notifications')
           setTimeout(() => { callback(true) }, 10)
         }


### PR DESCRIPTION
With #13603, there is no need to have the private `webContents.getId()` API, which is very easy to be confused with the public `webContents.id` property.

The `webContents.getId()` API has never been documented, after doing a search in GitHub I did not found any app code that used the API, the only users were Electron itself and its forks. So this change will not break apps.