### PR TITLE
chore: Don't show download stats of libchromiumcontent for CI.

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -169,6 +169,8 @@ def setup_libchromiumcontent(is_dev, target_arch, url,
     mkdir_p(target_dir)
   else:
     mkdir_p(DOWNLOAD_DIR)
+  if is_verbose_mode():
+    args += ['-v']
   if is_dev:
     subprocess.check_call([sys.executable, script] + args)
   else:


### PR DESCRIPTION
This PR makes sure that when libchromiumcontent is downloaded via `script/bootstrap.py` the percentage downloaded only shows when the `verbose (-v)` flag is passed to  `script/bootstrap.py`.  This will allow our CI builds to run faster and will make the log sizes on CI more reasonable.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)