### PR TITLE
refactor: remove experimentalCanvasFeatures property

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -53,7 +53,6 @@ WebContentsPreferences::WebContentsPreferences(
   // Set WebPreferences defaults onto the JS object
   SetDefaultBoolIfUndefined(options::kPlugins, false);
   SetDefaultBoolIfUndefined(options::kExperimentalFeatures, false);
-  SetDefaultBoolIfUndefined(options::kExperimentalCanvasFeatures, false);
   bool node = SetDefaultBoolIfUndefined(options::kNodeIntegration, true);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, node);
@@ -139,8 +138,6 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   if (dict_.GetBoolean(options::kExperimentalFeatures, &b) && b)
     command_line->AppendSwitch(
         ::switches::kEnableExperimentalWebPlatformFeatures);
-  if (dict_.GetBoolean(options::kExperimentalCanvasFeatures, &b) && b)
-    command_line->AppendSwitch(::switches::kEnableExperimentalCanvasFeatures);
 
   // Check if we have node integration specified.
   bool node_integration = true;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -118,7 +118,6 @@ const char kGuestInstanceID[] = "guestInstanceId";
 
 // Web runtime features.
 const char kExperimentalFeatures[] = "experimentalFeatures";
-const char kExperimentalCanvasFeatures[] = "experimentalCanvasFeatures";
 
 // Opener window's ID.
 const char kOpenerID[] = "openerId";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -61,7 +61,6 @@ extern const char kNodeIntegration[];
 extern const char kContextIsolation[];
 extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
-extern const char kExperimentalCanvasFeatures[];
 extern const char kOpenerID[];
 extern const char kScrollBounce[];
 extern const char kEnableBlinkFeatures[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -305,8 +305,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `plugins` Boolean (optional) - Whether plugins should be enabled. Default is `false`.
     * `experimentalFeatures` Boolean (optional) - Enables Chromium's experimental features.
       Default is `false`.
-    * `experimentalCanvasFeatures` Boolean (optional) - Enables Chromium's experimental
-      canvas features. Default is `false`.
     * `scrollBounce` Boolean (optional) - Enables scroll bounce (rubber banding) effect on
       macOS. Default is `false`.
     * `enableBlinkFeatures` String (optional) - A list of feature strings separated by `,`, like

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -355,7 +355,7 @@ Content-Security-Policy: script-src 'self' https://apis.mydomain.com
 ### CSP HTTP Header
 
 Electron respects the [`Content-Security-Policy` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
-which can be set using Electron's 
+which can be set using Electron's
 [`webRequest.onHeadersReceived`](../api/web-request.md#webrequestonheadersreceivedfilter-listener)
 handler:
 
@@ -369,7 +369,7 @@ session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
 
 ### CSP Meta Tag
 
-CSP's preferred delivery mechanism is an HTTP header. It can be useful, however, 
+CSP's preferred delivery mechanism is an HTTP header. It can be useful, however,
 to set a policy on a page directly in the markup using a `<meta>` tag:
 
 ```html
@@ -445,7 +445,7 @@ const mainWindow = new BrowserWindow({})
 _Recommendation is Electron's default_
 
 Advanced users of Electron can enable experimental Chromium features using the
-`experimentalFeatures` and `experimentalCanvasFeatures` properties.
+`experimentalFeatures` property.
 
 ### Why?
 

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -210,8 +210,7 @@ module.exports = {
    */
   warnAboutExperimentalFeatures: () => {
     const webPreferences = getWebPreferences()
-    if (!webPreferences || (!webPreferences.experimentalFeatures &&
-        !webPreferences.experimentalCanvasFeatures)) {
+    if (!webPreferences || (!webPreferences.experimentalFeatures)) {
       return
     }
 


### PR DESCRIPTION
This PR removes the `experimentalCanvasFeatures` property from WebPreferences as it's now been merged to web platform features with [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/957646). 

The features formerly contained therein can now be accessed with `experimentalFeatures`.

/cc @deepak1556 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)