### PR TITLE
build: [gn] use libnotify from custom sysroot

### DIFF
--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -7,28 +7,6 @@ filenames_gypi = exec_script(
   [ "filenames.gypi" ]
 )
 
-
-if (is_linux) {
-  # TODO: Experiment with using //tools/generate_library_loader for generating
-  # the libnotify loader.
-  copy("libnotify_headers") {
-    sources = [
-      "/usr/include/libnotify/notify.h",
-      "/usr/include/libnotify/notification.h",
-      "/usr/include/libnotify/notify-enum-types.h",
-      "/usr/include/libnotify/notify-features.h",
-    ]
-    outputs = [ "$target_gen_dir/libnotify-copy/libnotify/{{source_file_part}}" ]
-  }
-  config("libnotify_config") {
-    include_dirs = [ "$target_gen_dir/libnotify-copy" ]
-  }
-  group("libnotify") {
-    deps = [ ":libnotify_headers" ]
-    public_configs = [ ":libnotify_config" ]
-  }
-}
-
 static_library("brightray") {
   deps = [
     "//base",
@@ -52,7 +30,6 @@ static_library("brightray") {
   if (is_linux) {
     deps += [
       "//build/config/linux/gtk",
-      ":libnotify",
     ]
   }
 


### PR DESCRIPTION
Instead of hackily copying from the local machine.

Depends on electron/libchromiumcontent#601

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)