### PR TITLE
fix: create a window capturer correctly

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -69,7 +69,7 @@ void StartHandlingTask(bool capture_window,
       capture_screen ? content::desktop_capture::CreateScreenCapturer()
                      : nullptr);
   std::unique_ptr<webrtc::DesktopCapturer> window_capturer(
-      capture_window ? content::desktop_capture::CreateScreenCapturer()
+      capture_window ? content::desktop_capture::CreateWindowCapturer()
                      : nullptr);
   cap->media_list_.reset(new NativeDesktopMediaList(
       std::move(screen_capturer), std::move(window_capturer)));

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -8,7 +8,7 @@ chai.use(dirtyChai)
 
 const isCI = remote.getGlobal('isCi')
 
-describe('desktopCapturer', () => {
+describe.only('desktopCapturer', () => {
   before(function () {
     if (!features.isDesktopCapturerEnabled()) {
       // It's been disabled during build time.
@@ -69,7 +69,11 @@ describe('desktopCapturer', () => {
       return done()
     }
 
+    const { BrowserWindow } = remote
+    const w = new BrowserWindow({ width: 200, height: 200 })
+
     desktopCapturer.getSources({types: ['window']}, (error, sources) => {
+      w.destroy()
       expect(error).to.be.null()
       expect(sources).to.be.an('array').that.is.not.empty()
       for (const {display_id: displayId} of sources) {

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -8,7 +8,7 @@ chai.use(dirtyChai)
 
 const isCI = remote.getGlobal('isCi')
 
-describe.only('desktopCapturer', () => {
+describe('desktopCapturer', () => {
   before(function () {
     if (!features.isDesktopCapturerEnabled()) {
       // It's been disabled during build time.


### PR DESCRIPTION
We were incorrectly creating two screen capturers instead of a window
capturer

Fixes #13617