### PR TITLE
fix: remove race condition for executeJavaScript

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -184,7 +184,7 @@ WebContents.prototype.executeJavaScript = function (code, hasUserGesture, callba
     return asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture)
   } else {
     return new Promise((resolve, reject) => {
-      this.once('did-finish-load', () => {
+      this.once('did-stop-loading', () => {
         asyncWebFrameMethods.call(this, requestId, 'executeJavaScript', callback, code, hasUserGesture).then(resolve).catch(reject)
       })
     })


### PR DESCRIPTION
Replaces 'did-finish-load' with 'did-stop-loading' which semantically
maps to the events inside Chromium.  Before I think we were relying
on a natural 99% winnable race condition.

Fixes #13504

refs: https://cs.chromium.org/chromium/src/content/browser/web_contents/web_contents_impl.cc?type=cs&g=0&l=4985