### PR TITLE
build: Don't run tests on GitHub release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,13 @@ build-steps: &build-steps
               mkdir junit
               script/test.py --ci --rebuild_native_modules
             else
-              echo 'Testing Electron release build'
-              mkdir junit
-              script/test.py --ci --rebuild_native_modules -c R
+              if [ "$UPLOAD_TO_S3" == "1" ]; then
+                echo 'Testing Electron release build'
+                mkdir junit
+                script/test.py --ci --rebuild_native_modules -c R
+              else
+                echo 'Skipping tests on GitHub release'
+              fi
             fi
           else
            echo 'Skipping tests due to configuration'
@@ -118,10 +122,7 @@ build-steps: &build-steps
     - store_artifacts:
         path: junit
     - store_artifacts:
-        path: out/electron.d.ts
-    - store_artifacts:
-        path: out/electron-api.json
-
+        path: out
 
 build-defaults: &build-defaults
   docker:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,22 @@
 version: 1.0.{build}
+branches:
+  except:
+  - /^release$|^release-\d-\d-x$/
 build_cloud: electron-16
 image: electron-16-vs2017
 environment:
   DISABLE_CRASH_REPORTER_TESTS: true
-  matrix:
-  - TARGET_ARCH: ia32
-  - TARGET_ARCH: x64
 build_script:
 - ps: >-
     if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
       Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
-
     } else {
       Add-Path "$env:ProgramFiles (x86)\Windows Kits\10\Debuggers\x64"
-
       $env:path = "$env:ProgramFiles (x86)\Windows Kits\10\Debuggers\x64;$env:path"
       if($env:APPVEYOR_SCHEDULED_BUILD -eq 'True')  {
         $env:RUN_RELEASE_BUILD = "1"
       }
       $Message = (git log --format=%B -n 1 HEAD) | Out-String
-
       if ((Test-Path Env:\RUN_RELEASE_BUILD)) {
         $env:ELECTRON_RELEASE = '1'
         Write-Output "release build triggered from api"
@@ -39,8 +36,8 @@ build_script:
       } else {
         "Build succeeded."
       }
+      Push-AppveyorArtifact out
     }
-
 test_script:
 - ps: >-
     if (Test-Path Env:\ELECTRON_RELEASE) {
@@ -54,7 +51,6 @@ test_script:
         Write-Output "Tests succeeded."
       }
       python script\verify-ffmpeg.py
-
       if ($LASTEXITCODE -ne '0') {
         throw "Verify ffmpeg failed with exit code $LASTEXITCODE"
       } else {
@@ -73,22 +69,5 @@ deploy_script:
       } else {
         Write-Output "Uploading Electron release distribution to github releases"
         & python script\upload.py
-        if (Test-Path Env:\AUTO_RELEASE) {
-          node script\release.js --validateRelease --automaticRelease
-          if ($? -eq 'True') {
-            echo 'Release is ready to go; now running release'
-            node script\release.js --automaticRelease
-            if ($? -eq 'True') {
-              echo 'Release successful, now publishing to npm'
-              $npmfile = "$HOME\.npmrc"
-              "//registry.npmjs.org/:_authToken=$env:ELECTRON_NPM_TOKEN" > $npmfile
-              npm run publish-to-npm
-            }
-          } else {
-            echo 'Release is not complete, skipping publish for now.'
-          }
-        }
       }
-    } else {
-      Write-Output "Skipping upload distribution because build is not for release"
     }

--- a/vsts.yml
+++ b/vsts.yml
@@ -54,6 +54,7 @@ steps:
       script/test.py --ci --rebuild_native_modules
     fi
   name: Test
+  condition: or(ne(variables['ELECTRON_RELEASE'], '1'), eq(variables['UPLOAD_TO_S3'], '1'))
 
 - bash: |
     echo 'Verifying ffmpeg on build'
@@ -63,6 +64,7 @@ steps:
       script/verify-ffmpeg.py
     fi
   name: Verify_FFmpeg
+  condition: or(ne(variables['ELECTRON_RELEASE'], '1'), eq(variables['UPLOAD_TO_S3'], '1'))
 
 - task: PublishTestResults@2
   displayName: Publish Test Results
@@ -71,12 +73,26 @@ steps:
     searchFolder: junit
   condition: and(always(), ne(variables['ELECTRON_RELEASE'], '1'))
 
-- task: kasunkodagoda.slack-notification.slack-notification-task.SlackNotification@3
-  displayName: Post Slack Notification
+- bash: |
+    export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"
+    export MESSAGE="Build failed for *<$BUILD_URL|$BUILD_DEFINITIONNAME>* nightly build."
+    curl -g -H "Content-Type: application/json" -X POST \
+    -d "{\"text\": \"$MESSAGE\", \"attachments\": [{\"color\": \"#FC5C3C\",\"title\": \"$BUILD_DEFINITIONNAME nightly build results\",\"title_link\": \"$BUILD_URL\"}]}" $(slack_webhook)
+  name: Post_Slack_Notification_on_Failure
+  condition: failed()
+
+- bash: |
+    export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"
+    export MESSAGE="Build succeeded for *<$BUILD_URL|$BUILD_DEFINITIONNAME>* nightly build."
+    curl -g -H "Content-Type: application/json" -X POST \
+    -d "{\"text\": \"$MESSAGE\", \"attachments\": [{\"color\": \"#FC5C3C\",\"title\": \"$BUILD_DEFINITIONNAME nightly build results\",\"title_link\": \"$BUILD_URL\"}]}" $(slack_webhook)
+  name: Post_Slack_Notification_on_Success
+  condition: succeeded()
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Build Artifacts
   inputs:
-    SlackApiToken: '$(slack_token)'
-    Channel: '#bot-nightly-releases'
-    Message: '$(Build.DefinitionName)-$(Build.BuildNumber) finished with a $(Agent.JobStatus) status.'
-  condition: and(always(), eq(variables['Build.Reason'], 'Schedule'))
+    PathtoPublish: '$(Build.SourcesDirectory)/out'
+    ArtifactName: out
 
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3


### PR DESCRIPTION
Backport of #13662 for 3-0-x
Most importantly this contains the following change for the release process:
Changes make sure tests don't run when building for GitHub releases. Tests should run for nightly builds, but not when we are releasing an official release. 

This PR also includes the following changes for nightly builds:

1. Make sure artifacts for nightly release builds are properly saved on each CI platform. This change allows the release artifacts to be downloaded directly from the CI build pages.
2. Fix for VSTS slack integration -- build results were not being posted to Slack.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)