### PR TITLE
refactor: remove instances of createDeepCopy

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -990,7 +990,8 @@ void App::ImportCertificate(const base::DictionaryValue& options,
                             const net::CompletionCallback& callback) {
   auto browser_context = AtomBrowserContext::From("", false);
   if (!certificate_manager_model_) {
-    std::unique_ptr<base::DictionaryValue> copy = options.CreateDeepCopy();
+    auto copy = base::DictionaryValue::From(
+        base::Value::ToUniquePtrValue(options.Clone()));
     CertificateManagerModel::Create(
         browser_context.get(),
         base::Bind(&App::OnCertificateManagerModelCreated,

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -55,7 +55,9 @@ BrowserWindow::BrowserWindow(v8::Isolate* isolate,
     base::DictionaryValue web_preferences_dict;
     if (mate::ConvertFromV8(isolate, web_preferences.GetHandle(),
                             &web_preferences_dict)) {
-      existing_preferences->dict()->Clear();
+      base::DictionaryValue* to_clear;
+      if (existing_preferences->dict()->GetAsDictionary(&to_clear))
+        to_clear->Clear();
       existing_preferences->Merge(web_preferences_dict);
     }
   } else {

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -55,9 +55,7 @@ BrowserWindow::BrowserWindow(v8::Isolate* isolate,
     base::DictionaryValue web_preferences_dict;
     if (mate::ConvertFromV8(isolate, web_preferences.GetHandle(),
                             &web_preferences_dict)) {
-      base::DictionaryValue* to_clear;
-      if (existing_preferences->dict()->GetAsDictionary(&to_clear))
-        to_clear->Clear();
+      existing_preferences->Clear();
       existing_preferences->Merge(web_preferences_dict);
     }
   } else {

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -262,12 +262,13 @@ Cookies::~Cookies() {}
 
 void Cookies::Get(const base::DictionaryValue& filter,
                   const GetCallback& callback) {
-  std::unique_ptr<base::DictionaryValue> copied(filter.CreateDeepCopy());
+  auto copy = base::DictionaryValue::From(
+      base::Value::ToUniquePtrValue(filter.Clone()));
   auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter),
-                     std::move(copied), callback));
+      base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter), std::move(copy),
+                     callback));
 }
 
 void Cookies::Remove(const GURL& url,
@@ -282,12 +283,13 @@ void Cookies::Remove(const GURL& url,
 
 void Cookies::Set(const base::DictionaryValue& details,
                   const SetCallback& callback) {
-  std::unique_ptr<base::DictionaryValue> copied(details.CreateDeepCopy());
+  auto copy = base::DictionaryValue::From(
+      base::Value::ToUniquePtrValue(details.Clone()));
   auto* getter = browser_context_->GetRequestContext();
   content::BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
-      base::BindOnce(SetCookieOnIO, base::RetainedRef(getter),
-                     std::move(copied), callback));
+      base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), std::move(copy),
+                     callback));
 }
 
 void Cookies::FlushStore(const base::Closure& callback) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1174,7 +1174,8 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   if (view) {
     auto* web_preferences = WebContentsPreferences::From(web_contents());
     std::string color_name;
-    if (web_preferences->GetString(options::kBackgroundColor, &color_name)) {
+    if (web_preferences->GetPreference(options::kBackgroundColor,
+                                       &color_name)) {
       view->SetBackgroundColor(ParseHexColor(color_name));
     } else {
       view->SetBackgroundColor(SK_ColorTRANSPARENT);
@@ -1887,7 +1888,7 @@ v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (!web_preferences)
     return v8::Null(isolate);
-  return mate::ConvertToV8(isolate, *web_preferences->dict());
+  return mate::ConvertToV8(isolate, *web_preferences->preference());
 }
 
 v8::Local<v8::Value> WebContents::GetLastWebPreferences(v8::Isolate* isolate) {
@@ -1895,7 +1896,7 @@ v8::Local<v8::Value> WebContents::GetLastWebPreferences(v8::Isolate* isolate) {
       WebContentsPreferences::FromWebContents(web_contents());
   if (!web_preferences)
     return v8::Null(isolate);
-  return mate::ConvertToV8(isolate, *web_preferences->last_dict());
+  return mate::ConvertToV8(isolate, *web_preferences->last_preference());
 }
 
 v8::Local<v8::Value> WebContents::GetOwnerBrowserWindow() {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1174,8 +1174,7 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   if (view) {
     auto* web_preferences = WebContentsPreferences::From(web_contents());
     std::string color_name;
-    if (web_preferences->dict()->GetString(options::kBackgroundColor,
-                                           &color_name)) {
+    if (web_preferences->GetString(options::kBackgroundColor, &color_name)) {
       view->SetBackgroundColor(ParseHexColor(color_name));
     } else {
       view->SetBackgroundColor(SK_ColorTRANSPARENT);

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -27,7 +27,6 @@ void AddGuest(int guest_instance_id,
   if (manager)
     manager->AddGuest(guest_instance_id, element_instance_id, embedder,
                       guest_web_contents);
-  printf("HELLO %d\n", guest_instance_id);
   double zoom_factor;
   if (options.GetDouble(atom::options::kZoomFactor, &zoom_factor)) {
     atom::WebContentsZoomController::FromWebContents(guest_web_contents)

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -27,7 +27,7 @@ void AddGuest(int guest_instance_id,
   if (manager)
     manager->AddGuest(guest_instance_id, element_instance_id, embedder,
                       guest_web_contents);
-
+  printf("HELLO %d\n", guest_instance_id);
   double zoom_factor;
   if (options.GetDouble(atom::options::kZoomFactor, &zoom_factor)) {
     atom::WebContentsZoomController::FromWebContents(guest_web_contents)

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -27,6 +27,7 @@ void AddGuest(int guest_instance_id,
   if (manager)
     manager->AddGuest(guest_instance_id, element_instance_id, embedder,
                       guest_web_contents);
+
   double zoom_factor;
   if (options.GetDouble(atom::options::kZoomFactor, &zoom_factor)) {
     atom::WebContentsZoomController::FromWebContents(guest_web_contents)

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -252,11 +252,10 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
     return;
 
   // Do we have an affinity site to manage ?
-  std::string affinity;
   auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
   auto* web_preferences = WebContentsPreferences::From(web_contents);
-  if (web_preferences &&
-      web_preferences->dict()->GetString("affinity", &affinity) &&
+  std::string affinity;
+  if (web_preferences && web_preferences->GetString("affinity", &affinity) &&
       !affinity.empty()) {
     affinity = base::ToLowerASCII(affinity);
     auto iter = site_per_affinities.find(affinity);

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -255,7 +255,8 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
   auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
   auto* web_preferences = WebContentsPreferences::From(web_contents);
   std::string affinity;
-  if (web_preferences && web_preferences->GetString("affinity", &affinity) &&
+  if (web_preferences &&
+      web_preferences->GetPreference("affinity", &affinity) &&
       !affinity.empty()) {
     affinity = base::ToLowerASCII(affinity);
     auto iter = site_per_affinities.find(affinity);

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -62,7 +62,7 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
   std::string checkbox;
   if (origin_counts_[origin] > 1 && web_preferences &&
       web_preferences->IsEnabled("safeDialogs") &&
-      !web_preferences->dict()->GetString("safeDialogsMessage", &checkbox)) {
+      !web_preferences->GetString("safeDialogsMessage", &checkbox)) {
     checkbox = "Prevent this app from creating additional dialogs";
   }
 

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -62,7 +62,7 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
   std::string checkbox;
   if (origin_counts_[origin] > 1 && web_preferences &&
       web_preferences->IsEnabled("safeDialogs") &&
-      !web_preferences->GetString("safeDialogsMessage", &checkbox)) {
+      !web_preferences->GetPreference("safeDialogsMessage", &checkbox)) {
     checkbox = "Prevent this app from creating additional dialogs";
   }
 

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -452,7 +452,8 @@ void AtomNetworkDelegate::OnListenerResultInUI(
     uint64_t id,
     T out,
     const base::DictionaryValue& response) {
-  std::unique_ptr<base::DictionaryValue> copy = response.CreateDeepCopy();
+  auto copy = base::DictionaryValue::From(
+      base::Value::ToUniquePtrValue(response.Clone()));
   BrowserThread::PostTask(
       BrowserThread::IO, FROM_HERE,
       base::BindOnce(&AtomNetworkDelegate::OnListenerResultInIO<T>,

--- a/atom/browser/render_process_preferences.cc
+++ b/atom/browser/render_process_preferences.cc
@@ -21,7 +21,8 @@ RenderProcessPreferences::~RenderProcessPreferences() {}
 
 int RenderProcessPreferences::AddEntry(const base::DictionaryValue& entry) {
   int id = ++next_id_;
-  entries_[id] = entry.CreateDeepCopy();
+  entries_[id] =
+      base::DictionaryValue::From(base::Value::ToUniquePtrValue(entry.Clone()));
   cache_needs_update_ = true;
   return id;
 }

--- a/atom/browser/ui/webui/pdf_viewer_handler.cc
+++ b/atom/browser/ui/webui/pdf_viewer_handler.cc
@@ -112,7 +112,6 @@ void PdfViewerHandler::Initialize(const base::ListValue* args) {
     PopulateStreamInfo(stream_info.get(), stream_, original_url_);
     ResolveJavascriptCallback(*callback_id, *stream_info);
   } else {
-    // initialize_callback_id_ = callback_id->CreateDeepCopy();
     initialize_callback_id_ = std::make_unique(callback_id.Clone());
   }
 

--- a/atom/browser/ui/webui/pdf_viewer_handler.cc
+++ b/atom/browser/ui/webui/pdf_viewer_handler.cc
@@ -112,7 +112,8 @@ void PdfViewerHandler::Initialize(const base::ListValue* args) {
     PopulateStreamInfo(stream_info.get(), stream_, original_url_);
     ResolveJavascriptCallback(*callback_id, *stream_info);
   } else {
-    initialize_callback_id_ = callback_id->CreateDeepCopy();
+    // initialize_callback_id_ = callback_id->CreateDeepCopy();
+    initialize_callback_id_ = std::make_unique(callback_id.Clone());
   }
 
   auto zoom_controller =

--- a/atom/browser/ui/webui/pdf_viewer_handler.cc
+++ b/atom/browser/ui/webui/pdf_viewer_handler.cc
@@ -112,7 +112,8 @@ void PdfViewerHandler::Initialize(const base::ListValue* args) {
     PopulateStreamInfo(stream_info.get(), stream_, original_url_);
     ResolveJavascriptCallback(*callback_id, *stream_info);
   } else {
-    initialize_callback_id_ = std::make_unique(callback_id.Clone());
+    initialize_callback_id_ =
+        base::Value::ToUniquePtrValue(callback_id.Clone());
   }
 
   auto zoom_controller =

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -78,7 +78,9 @@ WebContentsPreferences::WebContentsPreferences(
 #endif
   SetDefaultBoolIfUndefined(options::kOffscreen, false);
 
-  last_dict_ = std::move(*dict_.CreateDeepCopy());
+  auto copy =
+      base::DictionaryValue::From(base::Value::ToUniquePtrValue(dict_.Clone()));
+  last_dict_.Swap(copy.get());
 }
 
 WebContentsPreferences::~WebContentsPreferences() {
@@ -260,7 +262,9 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents
   // we can fetch the options used to initally configure the WebContents
-  last_dict_ = std::move(*dict_.CreateDeepCopy());
+  auto copy =
+      base::DictionaryValue::From(base::Value::ToUniquePtrValue(dict_.Clone()));
+  last_dict_.Swap(copy.get());
 }
 
 void WebContentsPreferences::OverrideWebkitPrefs(

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -119,7 +119,9 @@ bool WebContentsPreferences::IsEnabled(const base::StringPiece& name,
 }
 
 void WebContentsPreferences::Merge(const base::DictionaryValue& extend) {
-  dict_.MergeDictionary(&extend);
+  base::DictionaryValue* to_merge;
+  if (dict_.GetAsDictionary(&to_merge))
+    to_merge->MergeDictionary(&extend);
 }
 
 // static

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_WEB_CONTENTS_PREFERENCES_H_
 #define ATOM_BROWSER_WEB_CONTENTS_PREFERENCES_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -48,10 +49,18 @@ class WebContentsPreferences
   // Modify the WebPreferences according to preferences.
   void OverrideWebkitPrefs(content::WebPreferences* prefs);
 
+  bool GetString(const base::StringPiece& key, std::string* val) const;
+
+  // Get preferences value as integer possibly coercing it from a string
+  bool GetInteger(const base::StringPiece& key, int* val) const;
+
+  // Get preferences value as boolean
+  bool GetBoolean(const base::StringPiece& key, bool* val) const;
+
   // Returns the web preferences.
-  base::DictionaryValue* dict() { return &dict_; }
-  const base::DictionaryValue* dict() const { return &dict_; }
-  base::DictionaryValue* last_dict() { return &last_dict_; }
+  base::Value* dict() { return &dict_; }
+  const base::Value* dict() const { return &dict_; }
+  base::Value* last_dict() { return &last_dict_; }
 
  private:
   friend class content::WebContentsUserData<WebContentsPreferences>;
@@ -63,15 +72,12 @@ class WebContentsPreferences
   // Set preference value to given bool if user did not provide value
   bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);
 
-  // Get preferences value as integer possibly coercing it from a string
-  bool GetInteger(const base::StringPiece& attribute_name, int* val);
-
   static std::vector<WebContentsPreferences*> instances_;
 
   content::WebContents* web_contents_;
 
-  base::DictionaryValue dict_;
-  base::DictionaryValue last_dict_;
+  base::Value dict_;
+  base::Value last_dict_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContentsPreferences);
 };

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -5,7 +5,6 @@
 #ifndef ATOM_BROWSER_WEB_CONTENTS_PREFERENCES_H_
 #define ATOM_BROWSER_WEB_CONTENTS_PREFERENCES_H_
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -49,18 +48,15 @@ class WebContentsPreferences
   // Modify the WebPreferences according to preferences.
   void OverrideWebkitPrefs(content::WebPreferences* prefs);
 
-  bool GetString(const base::StringPiece& key, std::string* val) const;
+  // Clear the current WebPreferences.
+  void Clear();
 
-  // Get preferences value as integer possibly coercing it from a string
-  bool GetInteger(const base::StringPiece& key, int* val) const;
-
-  // Get preferences value as boolean
-  bool GetBoolean(const base::StringPiece& key, bool* val) const;
+  // Return true if the particular preference value exists.
+  bool GetPreference(const base::StringPiece& name, std::string* value);
 
   // Returns the web preferences.
-  base::Value* dict() { return &dict_; }
-  const base::Value* dict() const { return &dict_; }
-  base::Value* last_dict() { return &last_dict_; }
+  base::Value* preference() { return &preference_; }
+  base::Value* last_preference() { return &last_preference_; }
 
  private:
   friend class content::WebContentsUserData<WebContentsPreferences>;
@@ -76,8 +72,8 @@ class WebContentsPreferences
 
   content::WebContents* web_contents_;
 
-  base::Value dict_;
-  base::Value last_dict_;
+  base::Value preference_ = base::Value(base::Value::Type::DICTIONARY);
+  base::Value last_preference_ = base::Value(base::Value::Type::DICTIONARY);
 
   DISALLOW_COPY_AND_ASSIGN(WebContentsPreferences);
 };

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -37,7 +37,8 @@ class WebContentsPreferences
   ~WebContentsPreferences() override;
 
   // A simple way to know whether a Boolean property is enabled.
-  bool IsEnabled(const base::StringPiece& name, bool default_value = false);
+  bool IsEnabled(const base::StringPiece& name,
+                 bool default_value = false) const;
 
   // $.extend(|web_preferences|, |new_web_preferences|).
   void Merge(const base::DictionaryValue& new_web_preferences);
@@ -52,7 +53,7 @@ class WebContentsPreferences
   void Clear();
 
   // Return true if the particular preference value exists.
-  bool GetPreference(const base::StringPiece& name, std::string* value);
+  bool GetPreference(const base::StringPiece& name, std::string* value) const;
 
   // Returns the web preferences.
   base::Value* preference() { return &preference_; }

--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -51,6 +51,20 @@ v8::Local<v8::Value> Converter<base::Value>::ToV8(v8::Isolate* isolate,
   return converter.ToV8Value(&val, isolate->GetCurrentContext());
 }
 
+bool Converter<base::ListValue>::FromV8(v8::Isolate* isolate,
+                                        v8::Local<v8::Value> val,
+                                        base::ListValue* out) {
+  atom::V8ValueConverter converter;
+  std::unique_ptr<base::Value> value(
+      converter.FromV8Value(val, isolate->GetCurrentContext()));
+  if (value->is_list()) {
+    out->Swap(static_cast<base::ListValue*>(value.get()));
+    return true;
+  } else {
+    return false;
+  }
+}
+
 v8::Local<v8::Value> Converter<base::ListValue>::ToV8(
     v8::Isolate* isolate,
     const base::ListValue& val) {

--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -30,6 +30,27 @@ v8::Local<v8::Value> Converter<base::DictionaryValue>::ToV8(
   return converter.ToV8Value(&val, isolate->GetCurrentContext());
 }
 
+bool Converter<base::Value>::FromV8(v8::Isolate* isolate,
+                                              v8::Local<v8::Value> val,
+                                              base::Value* out) {
+  atom::V8ValueConverter converter;
+  std::unique_ptr<base::Value> value(
+      converter.FromV8Value(val, isolate->GetCurrentContext()));
+  if (value) {
+    out->static_cast<base::Value*>(value.get());
+    return true;
+  } else {
+    return false;
+  }
+}
+
+v8::Local<v8::Value> Converter<base::Value>::ToV8(
+    v8::Isolate* isolate,
+    const base::Value& val) {
+  atom::V8ValueConverter converter;
+  return converter.ToV8Value(&val, isolate->GetCurrentContext());
+}
+
 bool Converter<base::ListValue>::FromV8(v8::Isolate* isolate,
                                         v8::Local<v8::Value> val,
                                         base::ListValue* out) {

--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -31,38 +31,24 @@ v8::Local<v8::Value> Converter<base::DictionaryValue>::ToV8(
 }
 
 bool Converter<base::Value>::FromV8(v8::Isolate* isolate,
-                                              v8::Local<v8::Value> val,
-                                              base::Value* out) {
+                                    v8::Local<v8::Value> val,
+                                    base::Value* out) {
   atom::V8ValueConverter converter;
   std::unique_ptr<base::Value> value(
       converter.FromV8Value(val, isolate->GetCurrentContext()));
   if (value) {
-    out->static_cast<base::Value*>(value.get());
+    base::Value* t = value.get();
+    std::swap(out, t);
     return true;
   } else {
     return false;
   }
 }
 
-v8::Local<v8::Value> Converter<base::Value>::ToV8(
-    v8::Isolate* isolate,
-    const base::Value& val) {
+v8::Local<v8::Value> Converter<base::Value>::ToV8(v8::Isolate* isolate,
+                                                  const base::Value& val) {
   atom::V8ValueConverter converter;
   return converter.ToV8Value(&val, isolate->GetCurrentContext());
-}
-
-bool Converter<base::ListValue>::FromV8(v8::Isolate* isolate,
-                                        v8::Local<v8::Value> val,
-                                        base::ListValue* out) {
-  atom::V8ValueConverter converter;
-  std::unique_ptr<base::Value> value(
-      converter.FromV8Value(val, isolate->GetCurrentContext()));
-  if (value->is_list()) {
-    out->Swap(static_cast<base::ListValue*>(value.get()));
-    return true;
-  } else {
-    return false;
-  }
 }
 
 v8::Local<v8::Value> Converter<base::ListValue>::ToV8(

--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -37,8 +37,7 @@ bool Converter<base::Value>::FromV8(v8::Isolate* isolate,
   std::unique_ptr<base::Value> value(
       converter.FromV8Value(val, isolate->GetCurrentContext()));
   if (value) {
-    base::Value* t = value.get();
-    std::swap(out, t);
+    *out = value->Clone();
     return true;
   } else {
     return false;

--- a/atom/common/native_mate_converters/value_converter.h
+++ b/atom/common/native_mate_converters/value_converter.h
@@ -10,6 +10,7 @@
 namespace base {
 class DictionaryValue;
 class ListValue;
+class Value;
 }  // namespace base
 
 namespace mate {
@@ -21,6 +22,15 @@ struct Converter<base::DictionaryValue> {
                      base::DictionaryValue* out);
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const base::DictionaryValue& val);
+};
+
+template <>
+struct Converter<base::Value> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     base::Value* out);
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::Value& val);
 };
 
 template <>

--- a/atom/renderer/preferences_manager.cc
+++ b/atom/renderer/preferences_manager.cc
@@ -26,7 +26,9 @@ bool PreferencesManager::OnControlMessageReceived(const IPC::Message& message) {
 
 void PreferencesManager::OnUpdatePreferences(
     const base::ListValue& preferences) {
-  preferences_ = preferences.CreateDeepCopy();
+  auto copy =
+      base::ListValue::From(base::Value::ToUniquePtrValue(preferences.Clone()));
+  preferences_.swap(copy);
 }
 
 }  // namespace atom


### PR DESCRIPTION
This PR removes deprecated instances of `createDeepCopy` specified [here](https://chromium.googlesource.com/chromium/src/+/master/base/values.h)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] commit messages or PR title follow semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)