### PR TITLE
build: [gn] add target for building node headers

### DIFF
--- a/build/node/BUILD.gn
+++ b/build/node/BUILD.gn
@@ -185,3 +185,90 @@ group("node") {
   public_configs = [ ":node_config" ]
   public_deps = [ ":copy_node" ]
 }
+
+node_headers_dir = "$root_gen_dir/node_headers/include/node"
+
+copy("node_headers") {
+  deps = [ ":configure_node" ]
+  sources = [
+    "$target_gen_dir/config.gypi",
+    "//third_party/electron_node/common.gypi",
+    "//third_party/electron_node/src/callback_scope.h",
+    "//third_party/electron_node/src/core.h",
+    "//third_party/electron_node/src/exceptions.h",
+    "//third_party/electron_node/src/node.h",
+    "//third_party/electron_node/src/node_api.h",
+    "//third_party/electron_node/src/node_api_types.h",
+    "//third_party/electron_node/src/node_buffer.h",
+    "//third_party/electron_node/src/node_object_wrap.h",
+    "//third_party/electron_node/src/node_version.h",
+  ]
+  outputs = [ "$node_headers_dir/{{source_file_part}}" ]
+}
+
+copy("v8_headers") {
+  sources = [
+    "//v8/include/v8-inspector-protocol.h",
+    "//v8/include/v8-inspector.h",
+    "//v8/include/v8-platform.h",
+    "//v8/include/v8-profiler.h",
+    "//v8/include/v8-testing.h",
+    "//v8/include/v8-util.h",
+    "//v8/include/v8-value-serializer-version.h",
+    "//v8/include/v8-version-string.h",
+    "//v8/include/v8-version.h",
+    "//v8/include/v8.h",
+    "//v8/include/v8config.h",
+  ]
+  outputs = [ "$node_headers_dir/{{source_file_part}}" ]
+}
+
+copy("v8_platform_headers") {
+  sources = [
+    "//v8/include/libplatform/libplatform-export.h",
+    "//v8/include/libplatform/libplatform.h",
+    "//v8/include/libplatform/v8-tracing.h",
+  ]
+  outputs = [ "$node_headers_dir/libplatform/{{source_file_part}}" ]
+}
+
+copy("uv_headers") {
+  sources = [
+    "//third_party/electron_node/deps/uv/include/android-ifaddrs.h",
+    "//third_party/electron_node/deps/uv/include/pthread-barrier.h",
+    "//third_party/electron_node/deps/uv/include/stdint-msvc2008.h",
+    "//third_party/electron_node/deps/uv/include/tree.h",
+    "//third_party/electron_node/deps/uv/include/uv-aix.h",
+    "//third_party/electron_node/deps/uv/include/uv-bsd.h",
+    "//third_party/electron_node/deps/uv/include/uv-darwin.h",
+    "//third_party/electron_node/deps/uv/include/uv-errno.h",
+    "//third_party/electron_node/deps/uv/include/uv-linux.h",
+    "//third_party/electron_node/deps/uv/include/uv-os390.h",
+    "//third_party/electron_node/deps/uv/include/uv-posix.h",
+    "//third_party/electron_node/deps/uv/include/uv-sunos.h",
+    "//third_party/electron_node/deps/uv/include/uv-threadpool.h",
+    "//third_party/electron_node/deps/uv/include/uv-unix.h",
+    "//third_party/electron_node/deps/uv/include/uv-version.h",
+    "//third_party/electron_node/deps/uv/include/uv-win.h",
+    "//third_party/electron_node/deps/uv/include/uv.h",
+  ]
+  outputs = [ "$node_headers_dir/{{source_file_part}}" ]
+}
+
+copy("zlib_headers") {
+  sources = [
+    "//third_party/electron_node/deps/zlib/zconf.h",
+    "//third_party/electron_node/deps/zlib/zlib.h",
+  ]
+  outputs = [ "$node_headers_dir/{{source_file_part}}" ]
+}
+
+group("headers") {
+  public_deps = [
+    ":node_headers",
+    ":uv_headers",
+    ":v8_headers",
+    ":v8_platform_headers",
+    ":zlib_headers",
+  ]
+}


### PR DESCRIPTION
This adds a target that builds a node_headers directory suitable for building test modules against (i.e. to be passed as `npm_config_nodedir` to `npm rebuild`). We can't just use `//third_party/electron_node`, because that will result modules being built using the headers from `deps/v8`, instead of those in `//v8`. This target builds a hybrid header dir combining nodejs's headers and those of its non-v8 dependencies, combined with the v8 headers from chromium's v8.

To build the headers:

```sh
$ ninja -C out/Default electron/build/node:headers
```

This will produce a directory in `out/Default/gen/node_headers` containing the hybrid headers. You can pass this directory as `nodedir` to `npm rebuild`..

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)