### PR TITLE
build: enable v8 checks in debug mode

### DIFF
--- a/brightray/brightray.gypi
+++ b/brightray/brightray.gypi
@@ -205,6 +205,7 @@
           'SKIA_DLL',
           'USING_V8_SHARED',
           'WEBKIT_DLL',
+          'V8_ENABLE_CHECKS',
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {


### PR DESCRIPTION
We should probably be running our tests with these checks enabled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)