### PR TITLE
build: make nightly filenames more guessable with YMD format

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -37,7 +37,7 @@ def main():
   args = parse_args()
   if  args.upload_to_s3:
     utcnow = datetime.datetime.utcnow()
-    args.upload_timestamp = utcnow.strftime('%Y-%m-%d_%H:%M:%S')
+    args.upload_timestamp = utcnow.strftime('%Y%m%d')
 
   if not dist_newer_than_head():
     run_python_script('create-dist.py')


### PR DESCRIPTION
This changes the nightly URLs from `https://gh-contractor-zcbenz.s3.amazonaws.com/electron-artifacts/v0.0.0-dev_2018-07-16_00:12:33/electron-v0.0.0-dev-linux-x64.zip` to https://gh-contractor-zcbenz.s3.amazonaws.com/electron-artifacts/v0.0.0-dev_20180716/electron-v0.0.0-dev-linux-x64.zip` so they can be "guessed" by day.