### PR TITLE
chore(ci): do not load dotenv on CI

### DIFF
--- a/script/find-release.js
+++ b/script/find-release.js
@@ -1,4 +1,4 @@
-require('dotenv-safe').load()
+if (!process.env.CI) require('dotenv-safe').load()
 
 const GitHub = require('github')
 const github = new GitHub()

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('dotenv-safe').load()
+if (!process.env.CI) require('dotenv-safe').load()
 require('colors')
 const args = require('minimist')(process.argv.slice(2), {
   boolean: ['automaticRelease', 'notesOnly', 'stable']

--- a/script/release.js
+++ b/script/release.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('dotenv-safe').load()
+if (!process.env.CI) require('dotenv-safe').load()
 require('colors')
 const args = require('minimist')(process.argv.slice(2))
 const fs = require('fs')

--- a/script/upload-to-github.js
+++ b/script/upload-to-github.js
@@ -1,4 +1,4 @@
-require('dotenv-safe').load()
+if (!process.env.CI) require('dotenv-safe').load()
 
 const GitHub = require('github')
 const github = new GitHub()


### PR DESCRIPTION
This adds conditionals to all the `require('dotenv-safe')` statements to avoid running it in CI environments.

🍐 @jkleinsc 