### PR TITLE
fix: update rebuild-test-modules.py for node 10

### DIFF
--- a/script/rebuild-test-modules.py
+++ b/script/rebuild-test-modules.py
@@ -39,6 +39,8 @@ def main():
     iojs_lib = os.path.join(lib_dir, 'iojs.lib')
     atom_lib = os.path.join(out_dir, 'node.dll.lib')
     shutil.copy2(atom_lib, iojs_lib)
+    node_lib = os.path.join(lib_dir, 'node.lib')
+    shutil.copy2(atom_lib, node_lib)
 
   # Native modules can only be compiled against release builds on Windows
   if config[0] == 'R' or PLATFORM != 'win32':


### PR DESCRIPTION
For our nightly releases, we run our test suite and it was throwing the following error when rebuilding the native node modules used by our tests:
```
LINK : fatal error LNK1181: cannot open input file 
'C:\Users\electron\electron\out\R\node-v0.0.0-dev\Release\node.lib' 
[C:\Users\electron\electron\spec\node_modules\runas\build\runas.vcxproj]
```

This PR updates `rebuild-test-modules.py` so that it will work properly with node 10 and resolve the error above.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)