### PR TITLE
build: stop defining is_mas_build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -30,8 +30,6 @@ declare_args() {
   enable_desktop_capturer = true
   enable_run_as_node = true
   enable_osr = false
-
-  is_mas_build = false
 }
 
 if (is_mas_build) {

--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_version':
     '66.0.3359.181',
   'libchromiumcontent_revision':
-    'a4c59c8494f22904cbd7f79051ecc42587aa11f6',
+    'f11f66be68240ef6f723e42161e23a8684d369c8',
   'node_version':
     'v10.2.0-35-g4879332def',
 

--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_version':
     '66.0.3359.181',
   'libchromiumcontent_revision':
-    'f11f66be68240ef6f723e42161e23a8684d369c8',
+    '108379153e00ebaa8bdc4270008ac15feb901cc0',
   'node_version':
     'v10.2.0-35-g4879332def',
 


### PR DESCRIPTION
Depends on electron/libchromiumcontent#605

`is_mas_build` is now defined in libcc.