### PR TITLE
build: [gn win] fix webrtc link error

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -630,7 +630,6 @@ if (is_mac) {
         # TODO: move non-windows specific deps into the non-windows-specific list
         "//third_party/breakpad:breakpad_handler",
         "//third_party/breakpad:breakpad_sender",
-        "//third_party/webrtc/system_wrappers:metrics_default",
         "//ui/native_theme:native_theme_browser",
         "//ui/shell_dialogs",
         "//ui/views/controls/webview",


### PR DESCRIPTION
Fixes link errors of the form

```
init_webrtc.lib(init_webrtc.obj) : error LNK2005: "class webrtc::metrics::Histogram * __cdecl webrtc::metrics::HistogramFactoryGetCounts(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,int,int,int)" (?HistogramFactoryGetCounts@metrics@webrtc@@YAPAVHistogram@12@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@HHH@Z) already defined in metrics_default.obj
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)