### PR TITLE
build: [gn win] fix dllimport usage in node's usage of icu

### DIFF
--- a/build/node/node_override.gypi
+++ b/build/node/node_override.gypi
@@ -81,6 +81,10 @@
                     ],
                   },
                 },
+              }, {
+                'defines': [
+                  'U_STATIC_IMPLEMENTATION'
+                ]
               }]
             ],
           }, {


### PR DESCRIPTION
We're abusing the nodejs build a little bit by building it without ICU support, but forcing the inspector to be built, which depends on ICU. This synchronizes one of the build flags that's required to get ICU to link on Windows.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)