### PR TITLE
spec: suppress mixed-sandbox test in Windows CI

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -864,6 +864,13 @@ describe('app module', () => {
     })
 
     describe('when app.enableMixedSandbox() is called', () => {
+      // TODO(zcbenz): Find out why it fails in CI.
+      before(function () {
+        if (isCI && process.platform === 'win32') {
+          this.skip()
+        }
+      })
+
       it('adds --enable-sandbox to render processes created with sandbox: true', done => {
         const appPath = path.join(__dirname, 'fixtures', 'api', 'mixed-sandbox-app')
         appProcess = ChildProcess.spawn(remote.process.execPath, [appPath])
@@ -886,6 +893,13 @@ describe('app module', () => {
     })
 
     describe('when the app is launched with --enable-mixed-sandbox', () => {
+      // TODO(zcbenz): Find out why it fails in CI.
+      before(function () {
+        if (isCI && process.platform === 'win32') {
+          this.skip()
+        }
+      })
+
       it('adds --enable-sandbox to render processes created with sandbox: true', done => {
         const appPath = path.join(__dirname, 'fixtures', 'api', 'mixed-sandbox-app')
         appProcess = ChildProcess.spawn(remote.process.execPath, [appPath, '--enable-mixed-sandbox'])


### PR DESCRIPTION
The mixed sandbox related tests are currently failing on Windows for all branches.

```
[00:08:25] not ok 48 app module mixed sandbox option when app.enableMixedSandbox() is called adds --enable-sandbox to render processes created with sandbox: true
[00:08:25]   Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (C:\projects\electron-39ng6\spec\api-app-spec.js)
[00:08:25]       at Test.Runnable._timeoutError (C:\projects\electron-39ng6\spec\node_modules\mocha\lib\runnable.js:440:10)
[00:08:25]       at C:\projects\electron-39ng6\spec\node_modules\mocha\lib\runnable.js:251:24
[00:08:55] not ok 49 app module mixed sandbox option when the app is launched with --enable-mixed-sandbox adds --enable-sandbox to render processes created with sandbox: true
[00:08:55]   Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (C:\projects\electron-39ng6\spec\api-app-spec.js)
[00:08:55]       at Test.Runnable._timeoutError (C:\projects\electron-39ng6\spec\node_modules\mocha\lib\runnable.js:440:10)
[00:08:55]       at C:\projects\electron-39ng6\spec\node_modules\mocha\lib\runnable.js:251:24
```

My first thought was some commits had caused the regression, but after reverting all related commits the tests were still failing:

https://github.com/electron/electron/commits/test-context-id
https://github.com/electron/electron/commits/test-context-id-2-0-x
https://github.com/electron/electron/commits/test-context-id-3-0-x

I believe it is caused by something in Windows CI environment, but I don't know why. And the tests pass on local Windows machines. I think we should suppress the tests for now.