### PR TITLE
[WIP] feat: Enable apps on macOS to register for APNs

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -662,6 +662,21 @@ void App::OnUpdateUserActivityState(bool* prevent_default,
   }
 }
 
+void App::OnDidRegisterForRemoteNotificationsWithDeviceToken(
+    const std::string& token) {
+  Emit("registered-for-remote-notifications", token);
+}
+
+void App::OnDidFailToRegisterForRemoteNotificationsWithError(
+    const std::string& error) {
+  Emit("failed-to-register-for-remote-notifications", error);
+}
+
+void App::OnDidReceiveRemoteNotification(
+    const base::DictionaryValue& user_info) {
+  Emit("received-remote-notification", user_info);
+}
+
 void App::OnNewWindowForTab() {
   Emit("new-window-for-tab");
 }
@@ -1250,6 +1265,11 @@ void App::BuildPrototype(v8::Isolate* isolate,
                  base::Bind(&Browser::UpdateCurrentActivity, browser))
       .SetMethod("setAboutPanelOptions",
                  base::Bind(&Browser::SetAboutPanelOptions, browser))
+      .SetMethod("registerForRemoteNotifications",
+                 base::Bind(&Browser::RegisterForRemoteNotifications, browser))
+      .SetMethod(
+          "unregisterForRemoteNotifications",
+          base::Bind(&Browser::UnregisterForRemoteNotifications, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -118,6 +118,12 @@ class App : public AtomBrowserClient::Delegate,
       bool* prevent_default,
       const std::string& type,
       const base::DictionaryValue& user_info) override;
+  void OnDidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token) override;
+  void OnDidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error) override;
+  void OnDidReceiveRemoteNotification(
+      const base::DictionaryValue& user_info) override;
   void OnNewWindowForTab() override;
 #endif
 

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -154,6 +154,24 @@ class Browser : public WindowListObserver {
   bool UpdateUserActivityState(const std::string& type,
                                const base::DictionaryValue& user_info);
 
+  // Register with APNs
+  void RegisterForRemoteNotifications();
+
+  void UnregisterForRemoteNotifications();
+
+  // Indicates that APNs registration succeeded, the token can be used to send
+  // notifications.
+  void DidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token);
+
+  // Indicates a failure to register for APNs
+  void DidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error);
+
+  // Indicates that a new remote notification has been received while the app is
+  // running.
+  void DidReceiveRemoteNotification(const base::DictionaryValue& user_info);
+
   // Bounce the dock icon.
   enum BounceType {
     BOUNCE_CRITICAL = 0,

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -134,6 +134,17 @@ bool Browser::SetBadgeCount(int count) {
   return true;
 }
 
+void Browser::RegisterForRemoteNotifications() {
+  [[AtomApplication sharedApplication]
+      registerForRemoteNotificationTypes:NSRemoteNotificationTypeBadge |
+                                         NSRemoteNotificationTypeAlert |
+                                         NSRemoteNotificationTypeSound];
+}
+
+void Browser::UnregisterForRemoteNotifications() {
+  [[AtomApplication sharedApplication] unregisterForRemoteNotifications];
+}
+
 void Browser::SetUserActivity(const std::string& type,
                               const base::DictionaryValue& user_info,
                               mate::Arguments* args) {
@@ -200,6 +211,24 @@ bool Browser::UpdateUserActivityState(const std::string& type,
   for (BrowserObserver& observer : observers_)
     observer.OnUpdateUserActivityState(&prevent_default, type, user_info);
   return prevent_default;
+}
+
+void Browser::DidRegisterForRemoteNotificationsWithDeviceToken(
+    const std::string& token) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidRegisterForRemoteNotificationsWithDeviceToken(token);
+}
+
+void Browser::DidFailToRegisterForRemoteNotificationsWithError(
+    const std::string& error) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidFailToRegisterForRemoteNotificationsWithError(error);
+}
+
+void Browser::DidReceiveRemoteNotification(
+    const base::DictionaryValue& user_info) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidReceiveRemoteNotification(user_info);
 }
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings(

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -78,6 +78,13 @@ class BrowserObserver {
       bool* prevent_default,
       const std::string& type,
       const base::DictionaryValue& user_info) {}
+  // The browser failed to register for APNS. (macOS only)
+  virtual void OnDidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token) {}
+  virtual void OnDidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error) {}
+  virtual void OnDidReceiveRemoteNotification(
+      const base::DictionaryValue& user_info) {}
   // User clicked the native macOS new tab button. (macOS only)
   virtual void OnNewWindowForTab() {}
 #endif

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -129,6 +129,30 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
   browser->DidFailToContinueUserActivity(activity_type, error_message);
 }
 
+- (void)application:(NSApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
+  // TODO: Convert data to hex? or pipe it to Electron as binary blob?
+  std::string token(base::SysNSStringToUTF8([deviceToken description]));
+  atom::Browser* browser = atom::Browser::Get();
+  browser->DidRegisterForRemoteNotificationsWithDeviceToken(token);
+}
+
+- (void)application:(NSApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
+  std::string error_message(
+      base::SysNSStringToUTF8([error localizedDescription]));
+  atom::Browser* browser = atom::Browser::Get();
+  browser->DidFailToRegisterForRemoteNotificationsWithError(error_message);
+}
+
+- (void)application:(NSApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo {
+  std::unique_ptr<base::DictionaryValue> user_info =
+      atom::NSDictionaryToDictionaryValue(userInfo);
+  atom::Browser* browser = atom::Browser::Get();
+  browser->DidReceiveRemoteNotification(*user_info);
+}
+
 - (IBAction)newWindowForTab:(id)sender {
   atom::Browser::Get()->NewWindowForTab();
 }


### PR DESCRIPTION
RFC. This PR is not ready to be merged in, but I'm hoping to get feedback on the general approach and whenever this functionality belongs here.

This functionality will let macOS apps use [Apple's Push Notifications](https://developer.apple.com/notifications/) for desktop to send notifications even when the app is not running. Here's [a modified example](https://github.com/frantic/electron-quick-start-apns) that uses new stuff and the screenshot of it in action:

![electron-apns](https://user-images.githubusercontent.com/192222/43109472-d8c0c820-8e9b-11e8-88ab-8a2a848ac33b.png)
 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)