### PR TITLE
fix: Use --enable-features and --disable-features (2.0.x)

### DIFF
--- a/brightray/browser/browser_main_parts.h
+++ b/brightray/browser/browser_main_parts.h
@@ -52,6 +52,8 @@ class BrowserMainParts : public content::BrowserMainParts {
   void OverrideAppLogsPath();
 #endif
 
+  void InitializeFeatureList();
+
   std::unique_ptr<IOThread> io_thread_;
 
 #if defined(TOOLKIT_VIEWS)


### PR DESCRIPTION
Unlike Chrome, we were not using the --enable-features and
--disable-features command-line arguments to initialize
`base::FeatureList`.

This backports #13784 to `2-0-x`.