### PR TITLE
feat: add getUploadProgress API to the net API

### DIFF
--- a/atom/browser/api/atom_api_url_request.cc
+++ b/atom/browser/api/atom_api_url_request.cc
@@ -125,6 +125,18 @@ bool URLRequest::ResponseState::Failed() const {
   return IsFlagSet(ResponseStateFlags::kFailed);
 }
 
+mate::Dictionary URLRequest::GetUploadProgress(v8::Isolate* isolate) {
+  mate::Dictionary progress = mate::Dictionary::CreateEmpty(isolate);
+
+  if (atom_request_) {
+    progress.Set("active", true);
+    atom_request_->GetUploadProgress(&progress);
+  } else {
+    progress.Set("active", false);
+  }
+  return progress;
+}
+
 URLRequest::URLRequest(v8::Isolate* isolate, v8::Local<v8::Object> wrapper) {
   InitWith(isolate, wrapper);
 }
@@ -183,6 +195,7 @@ void URLRequest::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setChunkedUpload", &URLRequest::SetChunkedUpload)
       .SetMethod("followRedirect", &URLRequest::FollowRedirect)
       .SetMethod("_setLoadFlags", &URLRequest::SetLoadFlags)
+      .SetMethod("getUploadProgress", &URLRequest::GetUploadProgress)
       .SetProperty("notStarted", &URLRequest::NotStarted)
       .SetProperty("finished", &URLRequest::Finished)
       // Response APi

--- a/atom/browser/api/atom_api_url_request.h
+++ b/atom/browser/api/atom_api_url_request.h
@@ -112,6 +112,7 @@ class URLRequest : public mate::EventEmitter<URLRequest> {
   void OnResponseData(scoped_refptr<const net::IOBufferWithSize> data);
   void OnResponseCompleted();
   void OnError(const std::string& error, bool isRequestError);
+  mate::Dictionary GetUploadProgress(v8::Isolate* isolate);
 
  protected:
   explicit URLRequest(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);

--- a/atom/browser/net/atom_url_request.cc
+++ b/atom/browser/net/atom_url_request.cc
@@ -504,4 +504,16 @@ void AtomURLRequest::InformDelegateErrorOccured(const std::string& error,
     delegate_->OnError(error, isRequestError);
 }
 
+void AtomURLRequest::GetUploadProgress(mate::Dictionary* progress) const {
+  net::UploadProgress upload_progress;
+  if (request_) {
+    progress->Set("started", true);
+    upload_progress = request_->GetUploadProgress();
+  } else {
+    progress->Set("started", false);
+  }
+  progress->Set("current", upload_progress.position());
+  progress->Set("total", upload_progress.size());
+}
+
 }  // namespace atom

--- a/atom/browser/net/atom_url_request.h
+++ b/atom/browser/net/atom_url_request.h
@@ -43,6 +43,7 @@ class AtomURLRequest : public base::RefCountedThreadSafe<AtomURLRequest>,
   void PassLoginInformation(const base::string16& username,
                             const base::string16& password) const;
   void SetLoadFlags(int flags) const;
+  void GetUploadProgress(mate::Dictionary* progress) const;
 
  protected:
   // Overrides of net::URLRequest::Delegate

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -215,3 +215,17 @@ response object,it will emit the `aborted` event.
 #### `request.followRedirect()`
 
 Continues any deferred redirection request when the redirection mode is `manual`.
+
+#### `request.getUploadProgress()`
+
+Returns `Object`:
+
+* `active` Boolean - Whether the request is currently active. If this is false
+no other properties will be set
+* `started` Boolean - Whether the upload has started. If this is false both
+`current` and `total` will be set to 0.
+* `current` Integer - The number of bytes that have been uploaded so far
+* `total` Integer - The number of bytes that will be uploaded this request
+
+You can use this method in conjunction with `POST` requests to get the progress
+of a file upload or other data transfer.

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -352,6 +352,10 @@ class ClientRequest extends EventEmitter {
   abort () {
     this.urlRequest.cancel()
   }
+
+  getUploadProgress () {
+    return this.urlRequest.getUploadProgress()
+  }
 }
 
 function writeAfterEndNT (self, error, callback) {


### PR DESCRIPTION
As the title says, added a new method to the `net` API to get the upload progress of requests.  This is required because we can't use streaming to get upload progress (unlike nodes http module) because Chromium handles the backpressure / buffering.