### PR TITLE
fix: Use --enable-features and --disable-features

### DIFF
--- a/brightray/brightray.gyp
+++ b/brightray/brightray.gyp
@@ -111,6 +111,7 @@
               'link_settings': {
                 'libraries': [
                   # Following libraries are always linked statically.
+                  '<(libchromiumcontent_dir)/libbase_static.a',
                   '<(libchromiumcontent_dir)/libgtkui.a',
                   '<(libchromiumcontent_dir)/libhttp_server.a',
                   '<(libchromiumcontent_dir)/libdevice_service.a',
@@ -204,6 +205,7 @@
               'link_settings': {
                 'libraries': [
                   # Following libraries are always linked statically.
+                  '<(libchromiumcontent_dir)/libbase_static.a',
                   '<(libchromiumcontent_dir)/libhttp_server.a',
                   '<(libchromiumcontent_dir)/libdevice_service.a',
                   '<(libchromiumcontent_dir)/libdom_keycode_converter.a',

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -15,6 +15,7 @@
 #include <glib.h>  // for g_setenv()
 #endif
 
+#include "base/base_switches.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/message_loop/message_loop.h"
@@ -178,14 +179,29 @@ void OverrideAppLogsPath() {
 }
 #endif
 
-int BrowserMainParts::PreEarlyInitialization() {
-  std::unique_ptr<base::FeatureList> feature_list(new base::FeatureList);
+void BrowserMainParts::InitializeFeatureList() {
+  auto* cmd_line = base::CommandLine::ForCurrentProcess();
+  const auto enable_features =
+      cmd_line->GetSwitchValueASCII(switches::kEnableFeatures);
+  auto disable_features =
+      cmd_line->GetSwitchValueASCII(switches::kDisableFeatures);
+
   // TODO(deepak1556): Disable guest webcontents based on OOPIF feature.
   // Disable surface synchronization and async wheel events to make OSR work.
-  feature_list->InitializeFromCommandLine(
-      "",
-      "GuestViewCrossProcessFrames,SurfaceSynchronization,AsyncWheelEvents");
+  disable_features +=
+      ",GuestViewCrossProcessFrames,SurfaceSynchronization,AsyncWheelEvents";
+
+  auto feature_list = std::make_unique<base::FeatureList>();
+  feature_list->InitializeFromCommandLine(enable_features, disable_features);
   base::FeatureList::SetInstance(std::move(feature_list));
+}
+
+bool BrowserMainParts::ShouldContentCreateFeatureList() {
+  return false;
+}
+
+int BrowserMainParts::PreEarlyInitialization() {
+  InitializeFeatureList();
   OverrideAppLogsPath();
 #if defined(USE_X11)
   views::LinuxUI::SetInstance(BuildGtkUi());
@@ -252,6 +268,16 @@ void BrowserMainParts::PreMainMessageLoopStart() {
 }
 
 void BrowserMainParts::PreMainMessageLoopRun() {
+  // We already initialized the feature list in PreEarlyInitialization(), but
+  // the user JS script would not have had a chance to alter the command-line
+  // switches at that point. Lets force re-initialization here to pick up the
+  // command-line changes. Note that some Chromium code (e.g.
+  // gpu_process_host.cc) queries the feature list between
+  // PreEarlyInitialization() and here so the user script may not have
+  // control over all features. Better than nothing though!
+  base::FeatureList::ClearInstanceForTesting();
+  InitializeFeatureList();
+
   content::WebUIControllerFactory::RegisterFactory(
       WebUIControllerFactory::GetInstance());
 

--- a/brightray/browser/browser_main_parts.h
+++ b/brightray/browser/browser_main_parts.h
@@ -33,6 +33,7 @@ class BrowserMainParts : public content::BrowserMainParts {
 
  protected:
   // content::BrowserMainParts:
+  bool ShouldContentCreateFeatureList() override;
   int PreEarlyInitialization() override;
   void ToolkitInitialized() override;
   void PreMainMessageLoopStart() override;
@@ -47,6 +48,8 @@ class BrowserMainParts : public content::BrowserMainParts {
   void InitializeMainNib();
   void OverrideAppLogsPath();
 #endif
+
+  void InitializeFeatureList();
 
   std::unique_ptr<IOThread> io_thread_;
 


### PR DESCRIPTION
Unlike Chrome, we were not using the --enable-features and
--disable-features command-line arguments to initialize
`base::FeatureList`.