### PR TITLE
build: [gn win] fix webrtc link error in component build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -200,6 +200,7 @@ static_library("electron_lib") {
     "//third_party/boringssl",
     "//third_party/leveldatabase",
     "//third_party/libyuv",
+    "//third_party/webrtc_overrides:init_webrtc",
     "//ui/events:dom_keycode_converter",
     "//ui/gl",
     "//ui/views",


### PR DESCRIPTION
Fixes a "missing symbols" link error when building on Windows with the component build.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)