### PR TITLE
build: [gn win] fix clashing paths in pak target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -362,11 +362,9 @@ static_library("electron_lib") {
 }
 
 electron_paks("packed_resources") {
+  output_dir = "$root_gen_dir/electron_repack"
   if (is_mac) {
-    output_dir = "$root_gen_dir/electron_repack"
     copy_data_to_bundle = true
-  } else {
-    output_dir = root_out_dir
   }
 }
 


### PR DESCRIPTION
Fixes:

```
ERROR at //tools/grit/repack.gni:35:3: Duplicate output file.
  action(_repack_target_name) {
  ^-----------------------------
Two or more targets generate the same output:
  chrome_100_percent.pak

This is can often be fixed by changing one of the target names, or by
setting an output_name on one of them.

Collisions:
  //chrome:packed_resources_100_percent
  //electron:packed_resources_100_percent

See //tools/grit/repack.gni:35:3: Collision.
  action(_repack_target_name) {
  ^-----------------------------
ninja: error: rebuilding 'build.ninja': subcommand failed
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)