### PR TITLE
build: [gn] include node_modules in default_app asar

### DIFF
--- a/build/asar.gni
+++ b/build/asar.gni
@@ -1,29 +1,44 @@
 import("npm.gni")
 
+# Run an action with a given working directory. Behaves identically to the
+# action() target type, with the exception that it changes directory before
+# running the script.
+#
+# Parameters:
+#   cwd [required]: Directory to change to before running the script.
+template("chdir_action") {
+  action(target_name) {
+    forward_variables_from(invoker,
+                           "*",
+                           [
+                             "script",
+                             "args",
+                           ])
+    assert(defined(cwd), "Need cwd in $target_name")
+    script = "//electron/build/run-in-dir.py"
+    args = [
+      cwd,
+      rebase_path(invoker.script),
+    ]
+    args += invoker.args
+  }
+}
+
 template("asar") {
   assert(defined(invoker.sources),
          "Need sources in $target_name listing the JS files.")
   assert(defined(invoker.outputs),
          "Need asar name (as 1-element array, e.g. \$root_out_dir/foo.asar)")
-  assert(defined(invoker.root),
-         "Need asar root directory")
+  assert(defined(invoker.root), "Need asar root directory")
   asar_root = invoker.root
-  copy_target_name = target_name + "_inputs"
-  copy(copy_target_name) {
+
+  # js2asar.py expects relative paths to its inputs, so we must run it in a
+  # working directory in which those relative paths make sense.
+  chdir_action(target_name) {
     sources = invoker.sources
-    outputs = [
-      "$target_gen_dir/$target_name/{{source_target_relative}}"
-    ]
-  }
-  npm_action(target_name) {
-    forward_variables_from(invoker, ["deps", "public_deps"])
-    deps = [":$copy_target_name"]
-    sources = invoker.sources
-    script = "asar"
     outputs = invoker.outputs
-    args = [
-      "pack",
-      rebase_path("$target_gen_dir/$target_name/$asar_root")
-    ] + rebase_path(outputs)
+    script = "//electron/tools/js2asar.py"
+    cwd = rebase_path(get_path_info(".", "abspath"))
+    args = rebase_path(outputs, cwd) + [ asar_root ] + rebase_path(sources, ".")
   }
 }

--- a/build/run-in-dir.py
+++ b/build/run-in-dir.py
@@ -1,0 +1,11 @@
+import sys
+import os
+import subprocess
+
+def main(argv):
+  cwd = argv[1]
+  os.chdir(cwd)
+  os.execv(sys.executable, [sys.executable] + argv[2:])
+
+if __name__ == '__main__':
+  main(sys.argv)


### PR DESCRIPTION
The default_app asar was recently changed to reference files inside
`node_modules/` in addition to files inside `default_app/`. The
`js2asar.py` script was updated to interpret what this meant, but the GN
build wasn't. This change somewhat hackily makes the GN build reuse the
`js2asar.py` script so that this and also hopefully any future changes
will work in the GN build as well as the GYP build.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)