### PR TITLE
build: [gn] roll node DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,7 +4,7 @@ vars = {
   'libchromiumcontent_revision':
     '108379153e00ebaa8bdc4270008ac15feb901cc0',
   'node_version':
-    'v10.2.0-35-g4879332def',
+    'v10.2.0-36-ga782199c99',
 
   'chromium_git':
     'https://chromium.googlesource.com',


### PR DESCRIPTION
Pulls in the fs.statSyncNoException fixes to the GN build.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)