### PR TITLE
fix: set NSScrollViewRubberbanding in main process

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -73,9 +73,6 @@ WebContentsPreferences::WebContentsPreferences(
   } else {
     SetDefaultBoolIfUndefined(options::kAllowRunningInsecureContent, false);
   }
-#if defined(OS_MACOSX)
-  SetDefaultBoolIfUndefined(options::kScrollBounce, false);
-#endif
   SetDefaultBoolIfUndefined(options::kOffscreen, false);
 
   last_dict_ = std::move(*dict_.CreateDeepCopy());
@@ -211,12 +208,6 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   if (dict_.GetInteger(options::kOpenerID, &opener_id))
     command_line->AppendSwitchASCII(switches::kOpenerID,
                                     base::IntToString(opener_id));
-
-#if defined(OS_MACOSX)
-  // Enable scroll bounce.
-  if (dict_.GetBoolean(options::kScrollBounce, &b) && b)
-    command_line->AppendSwitch(switches::kScrollBounce);
-#endif
 
   // Custom command line switches.
   const base::ListValue* args;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -197,7 +197,6 @@ const char kNodeIntegration[] = "node-integration";
 const char kContextIsolation[] = "context-isolation";
 const char kGuestInstanceID[] = "guest-instance-id";
 const char kOpenerID[] = "opener-id";
-const char kScrollBounce[] = "scroll-bounce";
 const char kHiddenPage[] = "hidden-page";
 const char kNativeWindowOpen[] = "native-window-open";
 const char kWebviewTag[] = "webview-tag";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -101,7 +101,6 @@ extern const char kNodeIntegration[];
 extern const char kContextIsolation[];
 extern const char kGuestInstanceID[];
 extern const char kOpenerID[];
-extern const char kScrollBounce[];
 extern const char kHiddenPage[];
 extern const char kNativeWindowOpen[];
 extern const char kNodeIntegrationInWorker[];

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -35,7 +35,6 @@
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 
 #if defined(OS_MACOSX)
-#include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
 #endif
 
@@ -157,15 +156,6 @@ void RendererClientBase::RenderThreadStarted() {
   if (!app_id.empty()) {
     SetCurrentProcessExplicitAppUserModelID(app_id.c_str());
   }
-#endif
-
-#if defined(OS_MACOSX)
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  bool scroll_bounce = command_line->HasSwitch(switches::kScrollBounce);
-  CFPreferencesSetAppValue(CFSTR("NSScrollViewRubberbanding"),
-                           scroll_bounce ? kCFBooleanTrue : kCFBooleanFalse,
-                           kCFPreferencesCurrentApplication);
-  CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 #endif
 }
 


### PR DESCRIPTION
Recent versions of Chromium started to read `NSScrollViewRubberbanding` in the main process instead of renderer process.

Close https://github.com/electron/electron/issues/13493.