### PR TITLE
docs: update an estimate of how much we are behind Chromium

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -31,7 +31,7 @@ While Electron strives to support new versions of Chromium as soon as possible,
 developers should be aware that upgrading is a serious undertaking - involving
 hand-editing dozens or even hundreds of files. Given the resources and
 contributions available today, Electron will often not be on the very latest
-version of Chromium, lagging behind by either days or weeks.
+version of Chromium, lagging behind by several weeks or a few months.
 
 We feel that our current system of updating the Chromium component strikes an
 appropriate balance between the resources we have available and the needs of


### PR DESCRIPTION
Seems like a stable Electron is never behind a stable Chromium "by either days or weeks" .

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added(https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)