### PR TITLE
fix: issue 10962, crash when open devtool

### DIFF
--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -699,7 +699,7 @@ void InspectableWebContentsImpl::WebContentsDestroyed() {
     delete pair.first;
 
   pending_requests_.clear();
-  
+
   if (view_ && view_->GetDelegate())
     view_->GetDelegate()->DevToolsClosed();
 }

--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -698,6 +698,8 @@ void InspectableWebContentsImpl::WebContentsDestroyed() {
   for (const auto& pair : pending_requests_)
     delete pair.first;
 
+  pending_requests_.clear();
+  
   if (view_ && view_->GetDelegate())
     view_->GetDelegate()->DevToolsClosed();
 }


### PR DESCRIPTION
Fixes #10962

In InspectableWebContentsImpl::WebContentsDestroyed,  pending_requests_ is not cleared, so "delete pair.first" may be called multiple times for for same instance of URLFetcher.

Notes: Fix sporadic crash the occurred while opening devtools