### PR TITLE
build: [gn] fix linking against base_static

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -178,6 +178,8 @@ static_library("electron_lib") {
     "brightray",
     "build/node",
     "native_mate",
+    "//base",
+    "//base:i18n",
     "//chrome/common:constants",
     "//components/cdm/renderer",
     "//components/network_session_configurator/common",
@@ -440,8 +442,6 @@ if (is_mac) {
     framework_contents = [ "Resources" ]
     public_deps = [ ":electron_lib" ]
     deps = [
-      "//base",
-      "//base:i18n",
       ":electron_framework_resources",
       ":electron_xibs",
     ]

--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -10,6 +10,7 @@ filenames_gypi = exec_script(
 static_library("brightray") {
   deps = [
     "//base",
+    "//base:base_static",
     "//components/network_session_configurator/common",
     "//components/prefs",
     "//content/public/browser",

--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -1,11 +1,9 @@
 import("//build/config/ui.gni")
 
-filenames_gypi = exec_script(
-  "//build/gypi_to_gn.py",
-  [ rebase_path("filenames.gypi") ],
-  "scope",
-  [ "filenames.gypi" ]
-)
+filenames_gypi = exec_script("//build/gypi_to_gn.py",
+                             [ rebase_path("filenames.gypi") ],
+                             "scope",
+                             [ "filenames.gypi" ])
 
 static_library("brightray") {
   deps = [
@@ -20,9 +18,7 @@ static_library("brightray") {
     "//ui/views",
   ]
 
-  include_dirs = [
-    "..",
-  ]
+  include_dirs = [ ".." ]
 
   defines = [
     "DISABLE_NACL=1",
@@ -30,9 +26,7 @@ static_library("brightray") {
   ]
 
   if (is_linux) {
-    deps += [
-      "//build/config/linux/gtk",
-    ]
+    deps += [ "//build/config/linux/gtk" ]
   }
 
   extra_source_filters = []
@@ -44,7 +38,8 @@ static_library("brightray") {
     ]
   }
 
-  set_sources_assignment_filter(sources_assignment_filter + extra_source_filters)
+  set_sources_assignment_filter(
+      sources_assignment_filter + extra_source_filters)
   sources = filenames_gypi.brightray_sources
   set_sources_assignment_filter(sources_assignment_filter)
 }


### PR DESCRIPTION
Fixes a link error for recently introduced usage of `kEnableFeatures` in `//base:base_static`:

```
Undefined symbols for architecture x86_64:
  "switches::kEnableFeatures", referenced from:
      brightray::BrowserMainParts::InitializeFeatureList() in libbrightray.a(browser_main_parts.o)
  "switches::kDisableFeatures", referenced from:
      brightray::BrowserMainParts::InitializeFeatureList() in libbrightray.a(browser_main_parts.o)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)