### PR TITLE
fix: pass scrollBounce by command line flag

### DIFF
--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -35,7 +35,6 @@
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 
 #if defined(OS_MACOSX)
-#include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
 #endif
 
@@ -157,15 +156,6 @@ void RendererClientBase::RenderThreadStarted() {
   if (!app_id.empty()) {
     SetCurrentProcessExplicitAppUserModelID(app_id.c_str());
   }
-#endif
-
-#if defined(OS_MACOSX)
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  bool scroll_bounce = command_line->HasSwitch(switches::kScrollBounce);
-  CFPreferencesSetAppValue(CFSTR("NSScrollViewRubberbanding"),
-                           scroll_bounce ? kCFBooleanTrue : kCFBooleanFalse,
-                           kCFPreferencesCurrentApplication);
-  CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 #endif
 }
 


### PR DESCRIPTION
This includes https://github.com/electron/libchromiumcontent/pull/613 from libcc.  

Close #13493 by recognizing `scroll-bounce` command line flag in Chromium directly.