### PR TITLE
build: [gn] pack ui_strings in locales

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -140,9 +140,13 @@ template("electron_paks") {
       repack_whitelist = invoker.repack_whitelist
     }
 
-    source_patterns = [ "${root_gen_dir}/content/app/strings/content_strings_" ]
+    source_patterns = [
+      "${root_gen_dir}/content/app/strings/content_strings_",
+      "${root_gen_dir}/ui/strings/ui_strings_",
+    ]
     deps = [
       "//content/app/strings",
+      "//ui/strings:ui_strings",
     ]
 
     input_locales = locales


### PR DESCRIPTION
Fixes a crash when running the tests on linux:

```
[15860:0726/132247.086106:WARNING:resource_bundle.cc(586)] unable to find resource: 27282
[15860:0726/132247.086189:FATAL:resource_bundle.cc(587)] Check failed: false.
0 0x7f1cad88ed7d base::debug::StackTrace::StackTrace()
1 0x7f1cad88eccc base::debug::StackTrace::StackTrace()
2 0x7f1cad9327ba logging::LogMessage::~LogMessage()
3 0x7f1ca4dea3ae ui::ResourceBundle::GetLocalizedString()
4 0x7f1ca4db5113 l10n_util::GetStringUTF16()
5 0x7f1ca3753bdd views::(anonymous namespace)::EmptyMenuMenuItem::EmptyMenuMenuItem()
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)