### PR TITLE
docs: Warn about the use of webviews

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -1,5 +1,15 @@
 # `<webview>` Tag
 
+## Warning
+
+Electron's `webview` tag is based on [Chromium's `webview`][chrome-webview], which
+is undergoing dramatic architectural changes. This impacts the stability of `webviews`,
+including rendering, navigation, and event routing. We currently recommend to not
+use the `webview` tag and to consider alternatives, like `iframe`, Electron's `BrowserView`,
+or an architecture that avoids embedded content altogether.
+
+## Overview
+
 > Display external web content in an isolated frame and process.
 
 Process: [Renderer](../glossary.md#renderer-process)
@@ -914,3 +924,4 @@ Emitted when DevTools is closed.
 Emitted when DevTools is focused / opened.
 
 [runtime-enabled-features]: https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/runtime_enabled_features.json5?l=70
+[chrome-webview]: https://developer.chrome.com/apps/tags/webview


### PR DESCRIPTION
In person today, we've discussed expressing our general feelings about the `webview` tag (which I'd describe as 😬) in documentation – Electron "insiders" and maintainers have known for quite some time that the tag isn't as stable as it should be (and that it involves plenty of subtle bugs).

One of the outcomes was that we should share those feelings and difficulties in our docs. This PR takes a first stab at that.

*This PR does not deprecate them (just yet), it just warns about them*

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

cc @codebytere 