### PR TITLE
build: [gn win] fix path names in js2asar

### DIFF
--- a/build/asar.gni
+++ b/build/asar.gni
@@ -16,6 +16,7 @@ template("chdir_action") {
                            ])
     assert(defined(cwd), "Need cwd in $target_name")
     script = "//electron/build/run-in-dir.py"
+    sources += [ invoker.script ]
     args = [
       cwd,
       rebase_path(invoker.script),

--- a/tools/js2asar.py
+++ b/tools/js2asar.py
@@ -26,7 +26,7 @@ def copy_files(source_files, output_dir, folder_name):
     output_path = os.path.join(output_dir, source_file)
     # Files that aren't in the default_app folder need to be put inside
     # the temp one we are making so they end up in the ASAR
-    if not source_file.startswith(folder_name + os.sep):
+    if not os.path.normpath(source_file).startswith(folder_name + os.sep):
       output_path = os.path.join(output_dir, folder_name, source_file)
     safe_mkdir(os.path.dirname(output_path))
     shutil.copy2(source_file, output_path)


### PR DESCRIPTION
GN was passing those paths to js2asar.py with forward slashes, but `os.sep` was `\`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)