### PR TITLE
fix: loading of devtools extensions on startup

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -357,20 +357,6 @@ app.on('will-quit', function () {
 
 // We can not use protocol or BrowserWindow until app is ready.
 app.once('ready', function () {
-  // Load persisted extensions.
-  loadedDevToolsExtensionsPath = path.join(app.getPath('userData'), 'DevTools Extensions')
-  try {
-    const loadedDevToolsExtensions = JSON.parse(fs.readFileSync(loadedDevToolsExtensionsPath))
-    if (Array.isArray(loadedDevToolsExtensions)) {
-      for (const srcDirectory of loadedDevToolsExtensions) {
-        // Start background pages and set content scripts.
-        BrowserWindow.addDevToolsExtension(srcDirectory)
-      }
-    }
-  } catch (error) {
-    // Ignore error
-  }
-
   // The public API to add/remove extensions.
   BrowserWindow.addExtension = function (srcDirectory) {
     const manifest = getManifestFromPath(srcDirectory)
@@ -425,5 +411,19 @@ app.once('ready', function () {
       devExtensions[name] = extensions[name]
     })
     return devExtensions
+  }
+  
+  // Load persisted extensions.
+  loadedDevToolsExtensionsPath = path.join(app.getPath('userData'), 'DevTools Extensions')
+  try {
+    const loadedDevToolsExtensions = JSON.parse(fs.readFileSync(loadedDevToolsExtensionsPath))
+    if (Array.isArray(loadedDevToolsExtensions)) {
+      for (const srcDirectory of loadedDevToolsExtensions) {
+        // Start background pages and set content scripts.
+        BrowserWindow.addDevToolsExtension(srcDirectory)
+      }
+    }
+  } catch (error) {
+    // Ignore error
   }
 })


### PR DESCRIPTION
The persisted DevTools Extensions were not being loaded correctly at startup. The `addDevToolsExtension` function was not defined before it was being called. An error was being thrown and ignored, so the whole thing would fail silently. I moved the code to load the extensions to the end of the event handler, so now it works.
