### PR TITLE
fix: some APIs modified for ASAR support cannot be util.promisify'ed

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -3,6 +3,7 @@
   const {Buffer} = require('buffer')
   const childProcess = require('child_process')
   const path = require('path')
+  const util = require('util')
 
   const hasProp = {}.hasOwnProperty
 
@@ -217,6 +218,28 @@
       arguments[arg] = newPath
       return old.apply(this, arguments)
     }
+    if (old[util.promisify.custom]) {
+      module[name][util.promisify.custom] = function () {
+        const p = arguments[arg]
+        const [isAsar, asarPath, filePath] = splitPath(p)
+        if (!isAsar) {
+          return old[util.promisify.custom].apply(this, arguments)
+        }
+
+        const archive = getOrCreateArchive(asarPath)
+        if (!archive) {
+          return new Promise(() => invalidArchiveError(asarPath))
+        }
+
+        const newPath = archive.copyFileOut(filePath)
+        if (!newPath) {
+          return new Promise(() => notFoundError(asarPath, filePath))
+        }
+
+        arguments[arg] = newPath
+        return old[util.promisify.custom].apply(this, arguments)
+      }
+    }
   }
 
   // Override fs APIs.
@@ -371,6 +394,18 @@
         // eslint-disable-next-line standard/no-callback-literal
         callback(archive.stat(filePath) !== false)
       })
+    }
+
+    fs.exists[util.promisify.custom] = function (p) {
+      const [isAsar, asarPath, filePath] = splitPath(p)
+      if (!isAsar) {
+        return exists[util.promisify.custom](p)
+      }
+      const archive = getOrCreateArchive(asarPath)
+      if (!archive) {
+        return new Promise(() => invalidArchiveError(asarPath))
+      }
+      return Promise.resolve(archive.stat(filePath) !== false)
     }
 
     const {existsSync} = fs
@@ -680,18 +715,22 @@
     // called by `childProcess.{exec,execSync}`, causing
     // Electron to consider the full command as a single path
     // to an archive.
-    ['exec', 'execSync'].forEach(function (functionName) {
-      const old = childProcess[functionName]
-      childProcess[functionName] = function () {
+    const {exec, execSync} = childProcess
+    childProcess.exec = invokeWithNoAsar(exec)
+    childProcess.exec[util.promisify.custom] = invokeWithNoAsar(exec[util.promisify.custom])
+    childProcess.execSync = invokeWithNoAsar(execSync)
+
+    function invokeWithNoAsar (func) {
+      return function () {
         const processNoAsarOriginalValue = process.noAsar
         process.noAsar = true
         try {
-          return old.apply(this, arguments)
+          return func.apply(this, arguments)
         } finally {
           process.noAsar = processNoAsarOriginalValue
         }
       }
-    })
+    }
 
     overrideAPI(fs, 'open')
     overrideAPI(childProcess, 'execFile')

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const ChildProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const util = require('util')
 const {closeWindow} = require('./window-helpers')
 
 const nativeImage = require('electron').nativeImage
@@ -549,6 +550,60 @@ describe('asar package', function () {
       })
     })
 
+    describe('fs.exists', function () {
+      it('handles an existing file', function (done) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        // eslint-disable-next-line
+        fs.exists(p, function (exists) {
+          assert.equal(exists, true)
+          done()
+        })
+      })
+
+      it('handles a non-existent file', function (done) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        // eslint-disable-next-line
+        fs.exists(p, function (exists) {
+          assert.equal(exists, false)
+          done()
+        })
+      })
+
+      it('promisified version handles an existing file', (done) => {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        // eslint-disable-next-line
+        util.promisify(fs.exists)(p).then(exists => {
+          assert.equal(exists, true)
+          done()
+        })
+      })
+
+      it('promisified version handles a non-existent file', function (done) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        // eslint-disable-next-line
+        util.promisify(fs.exists)(p).then(exists => {
+          assert.equal(exists, false)
+          done()
+        })
+      })
+    })
+
+    describe('fs.existsSync', function () {
+      it('handles an existing file', function () {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        assert.doesNotThrow(function () {
+          assert.equal(fs.existsSync(p), true)
+        })
+      })
+
+      it('handles a non-existent file', function () {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        assert.doesNotThrow(function () {
+          assert.equal(fs.existsSync(p), false)
+        })
+      })
+    })
+
     describe('fs.access', function () {
       it('accesses a normal file', function (done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
@@ -644,6 +699,12 @@ describe('asar package', function () {
           done()
         })
       })
+
+      it('can be promisified', () => {
+        return util.promisify(ChildProcess.exec)('echo ' + echo + ' foo bar').then(({ stdout }) => {
+          assert.equal(stdout.toString().replace(/\r/g, ''), echo + ' foo bar\n')
+        })
+      })
     })
 
     describe('child_process.execSync', function () {
@@ -680,6 +741,12 @@ describe('asar package', function () {
         var output = execFileSync(echo, ['test'])
         assert.equal(String(output), 'test\n')
       })
+
+      it('can be promisified', () => {
+        return util.promisify(ChildProcess.execFile)(echo, ['test']).then(({ stdout }) => {
+          assert.equal(stdout, 'test\n')
+        })
+      })
     })
 
     describe('internalModuleReadJSON', function () {
@@ -697,6 +764,18 @@ describe('asar package', function () {
       it('reads a normal file with unpacked files', function () {
         var p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
         assert.equal(internalModuleReadJSON(p).toString().trim(), 'a')
+      })
+    })
+
+    describe('util.promisify', function () {
+      it('can promisify all fs functions', function () {
+        const originalFs = require('original-fs')
+
+        for (const key in originalFs) {
+          if (originalFs[key][util.promisify.custom] && !fs[key][util.promisify.custom]) {
+            assert(false, `fs.${key}[util.promisify.custom] missing`)
+          }
+        }
       })
     })
 


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/13458

Promisification of the following functions is being fixed:
- `fs.exists()`
- `child_process.exec()`
- `child_process.execFile()`

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)