### PR TITLE
fix: allow Tray with title only (without icon) on Mac

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -47,8 +47,7 @@ const CGFloat kVerticalTitleMargin = 2;
   [super dealloc];
 }
 
-- (id)initWithImage:(NSImage*)image icon:(atom::TrayIconCocoa*)icon {
-  image_.reset([image copy]);
+- (id)initWithIcon:(atom::TrayIconCocoa*)icon {
   trayIcon_ = icon;
   menuController_ = nil;
   highlight_mode_ = atom::TrayIcon::HighlightMode::SELECTION;
@@ -164,6 +163,8 @@ const CGFloat kVerticalTitleMargin = 2;
 
 // The width of the icon.
 - (CGFloat)iconWidth {
+  if (!image_ && title_)
+    return kHorizontalMargin;
   CGFloat thickness = [[NSStatusBar systemStatusBar] thickness];
   CGFloat imageHeight = [image_ size].height;
   CGFloat imageWidth = [image_ size].width;
@@ -432,7 +433,9 @@ const CGFloat kVerticalTitleMargin = 2;
 
 namespace atom {
 
-TrayIconCocoa::TrayIconCocoa() {}
+TrayIconCocoa::TrayIconCocoa() {
+  status_item_view_.reset([[StatusItemView alloc] initWithIcon:this]);
+}
 
 TrayIconCocoa::~TrayIconCocoa() {
   [status_item_view_ removeItem];
@@ -441,12 +444,7 @@ TrayIconCocoa::~TrayIconCocoa() {
 }
 
 void TrayIconCocoa::SetImage(const gfx::Image& image) {
-  if (status_item_view_) {
-    [status_item_view_ setImage:image.AsNSImage()];
-  } else {
-    status_item_view_.reset(
-        [[StatusItemView alloc] initWithImage:image.AsNSImage() icon:this]);
-  }
+  [status_item_view_ setImage:image.IsEmpty() ? nil : image.AsNSImage()];
 }
 
 void TrayIconCocoa::SetPressedImage(const gfx::Image& image) {

--- a/spec/api-tray-spec.js
+++ b/spec/api-tray-spec.js
@@ -2,24 +2,46 @@ const {remote} = require('electron')
 const {Menu, Tray, nativeImage} = remote
 
 describe('tray module', () => {
+  let tray
+
+  beforeEach(() => {
+    tray = new Tray(nativeImage.createEmpty())
+  })
+
+  afterEach(() => {
+    tray.destroy()
+    tray = null
+  })
+
   describe('tray.setContextMenu', () => {
-    let tray
-
-    beforeEach(() => {
-      tray = new Tray(nativeImage.createEmpty())
-    })
-
-    afterEach(() => {
-      tray.destroy()
-      tray = null
-    })
-
     it('accepts menu instance', () => {
       tray.setContextMenu(new Menu())
     })
 
     it('accepts null', () => {
       tray.setContextMenu(null)
+    })
+  })
+
+  describe('tray.setImage', () => {
+    it('accepts empty image', () => {
+      tray.setImage(nativeImage.createEmpty())
+    })
+  })
+
+  describe('tray.setPressedImage', () => {
+    it('accepts empty image', () => {
+      tray.setPressedImage(nativeImage.createEmpty())
+    })
+  })
+
+  describe('tray.setTitle', () => {
+    it('accepts non-empty string', () => {
+      tray.setTitle('Hello World!')
+    })
+
+    it('accepts empty string', () => {
+      tray.setTitle('')
     })
   })
 })


### PR DESCRIPTION
##### Description of Change
Fixes https://github.com/electron/electron/issues/13202

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Allow Tray with title only (without icon) on Mac.