### PR TITLE
feat: add activate option to webContents.openDevTools

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1307,14 +1307,16 @@ void WebContents::OpenDevTools(mate::Arguments* args) {
   if (type_ == WEB_VIEW || !owner_window()) {
     state = "detach";
   }
+  bool activate = true;
   if (args && args->Length() == 1) {
     mate::Dictionary options;
     if (args->GetNext(&options)) {
       options.Get("mode", &state);
+      options.Get("activate", &activate);
     }
   }
   managed_web_contents()->SetDockState(state);
-  managed_web_contents()->ShowDevTools();
+  managed_web_contents()->ShowDevTools(activate);
 }
 
 void WebContents::CloseDevTools() {

--- a/atom/browser/ui/cocoa/atom_inspectable_web_contents_view.h
+++ b/atom/browser/ui/cocoa/atom_inspectable_web_contents_view.h
@@ -34,10 +34,10 @@ using atom::InspectableWebContentsViewMac;
     (InspectableWebContentsViewMac*)view;
 - (void)removeObservers;
 - (void)notifyDevToolsFocused;
-- (void)setDevToolsVisible:(BOOL)visible;
+- (void)setDevToolsVisible:(BOOL)visible activate:(BOOL)activate;
 - (BOOL)isDevToolsVisible;
 - (BOOL)isDevToolsFocused;
-- (void)setIsDocked:(BOOL)docked;
+- (void)setIsDocked:(BOOL)docked activate:(BOOL)activate;
 - (void)setContentsResizingStrategy:
     (const DevToolsContentsResizingStrategy&)strategy;
 - (void)setTitle:(NSString*)title;

--- a/atom/browser/ui/cocoa/atom_inspectable_web_contents_view.mm
+++ b/atom/browser/ui/cocoa/atom_inspectable_web_contents_view.mm
@@ -63,7 +63,7 @@
 }
 
 - (IBAction)showDevTools:(id)sender {
-  inspectableWebContentsView_->inspectable_web_contents()->ShowDevTools();
+  inspectableWebContentsView_->inspectable_web_contents()->ShowDevTools(true);
 }
 
 - (void)notifyDevToolsFocused {
@@ -71,7 +71,7 @@
     inspectableWebContentsView_->GetDelegate()->DevToolsFocused();
 }
 
-- (void)setDevToolsVisible:(BOOL)visible {
+- (void)setDevToolsVisible:(BOOL)visible activate:(BOOL)activate {
   if (visible == devtools_visible_)
     return;
 
@@ -106,7 +106,11 @@
     }
   } else {
     if (visible) {
-      [devtools_window_ makeKeyAndOrderFront:nil];
+      if (activate) {
+        [devtools_window_ makeKeyAndOrderFront:nil];
+      } else {
+        [devtools_window_ orderBack:nil];
+      }
     } else {
       [devtools_window_ setDelegate:nil];
       [devtools_window_ close];
@@ -127,9 +131,9 @@
   }
 }
 
-- (void)setIsDocked:(BOOL)docked {
+- (void)setIsDocked:(BOOL)docked activate:(BOOL)activate {
   // Revert to no-devtools state.
-  [self setDevToolsVisible:NO];
+  [self setDevToolsVisible:NO activate:NO];
 
   // Switch to new state.
   devtools_docked_ = docked;
@@ -163,7 +167,7 @@
 
     [contentView addSubview:devToolsView];
   }
-  [self setDevToolsVisible:YES];
+  [self setDevToolsVisible:YES activate:activate];
 }
 
 - (void)setContentsResizingStrategy:

--- a/atom/browser/ui/inspectable_web_contents.h
+++ b/atom/browser/ui/inspectable_web_contents.h
@@ -47,7 +47,7 @@ class InspectableWebContents {
   virtual void ReleaseWebContents() = 0;
   virtual void SetDevToolsWebContents(content::WebContents* devtools) = 0;
   virtual void SetDockState(const std::string& state) = 0;
-  virtual void ShowDevTools() = 0;
+  virtual void ShowDevTools(bool activate) = 0;
   virtual void CloseDevTools() = 0;
   virtual bool IsDevToolsViewShowing() = 0;
   virtual void AttachTo(scoped_refptr<content::DevToolsAgentHost>) = 0;

--- a/atom/browser/ui/inspectable_web_contents_impl.cc
+++ b/atom/browser/ui/inspectable_web_contents_impl.cc
@@ -306,12 +306,14 @@ void InspectableWebContentsImpl::SetDevToolsWebContents(
     external_devtools_web_contents_ = devtools;
 }
 
-void InspectableWebContentsImpl::ShowDevTools() {
+void InspectableWebContentsImpl::ShowDevTools(bool activate) {
   if (embedder_message_dispatcher_) {
     if (managed_devtools_web_contents_)
-      view_->ShowDevTools();
+      view_->ShowDevTools(activate);
     return;
   }
+
+  activate_ = activate;
 
   // Show devtools only after it has done loading, this is to make sure the
   // SetIsDocked is called *BEFORE* ShowDevTools.
@@ -430,7 +432,7 @@ void InspectableWebContentsImpl::CloseWindow() {
 void InspectableWebContentsImpl::LoadCompleted() {
   frontend_loaded_ = true;
   if (managed_devtools_web_contents_)
-    view_->ShowDevTools();
+    view_->ShowDevTools(activate_);
 
   // If the devtools can dock, "SetIsDocked" will be called by devtools itself.
   if (!can_dock_) {
@@ -501,7 +503,7 @@ void InspectableWebContentsImpl::LoadNetworkResource(
 void InspectableWebContentsImpl::SetIsDocked(const DispatchCallback& callback,
                                              bool docked) {
   if (managed_devtools_web_contents_)
-    view_->SetIsDocked(docked);
+    view_->SetIsDocked(docked, activate_);
   if (!callback.is_null())
     callback.Run(nullptr);
 }

--- a/atom/browser/ui/inspectable_web_contents_impl.h
+++ b/atom/browser/ui/inspectable_web_contents_impl.h
@@ -55,7 +55,7 @@ class InspectableWebContentsImpl
   void ReleaseWebContents() override;
   void SetDevToolsWebContents(content::WebContents* devtools) override;
   void SetDockState(const std::string& state) override;
-  void ShowDevTools() override;
+  void ShowDevTools(bool activate) override;
   void CloseDevTools() override;
   bool IsDevToolsViewShowing() override;
   void AttachTo(scoped_refptr<content::DevToolsAgentHost>) override;
@@ -211,6 +211,7 @@ class InspectableWebContentsImpl
   gfx::Rect devtools_bounds_;
   bool can_dock_;
   std::string dock_state_;
+  bool activate_ = true;
 
   using PendingRequestsMap = std::map<const net::URLFetcher*, DispatchCallback>;
   PendingRequestsMap pending_requests_;

--- a/atom/browser/ui/inspectable_web_contents_view.h
+++ b/atom/browser/ui/inspectable_web_contents_view.h
@@ -43,12 +43,12 @@ class InspectableWebContentsView {
   virtual gfx::NativeView GetNativeView() const = 0;
 #endif
 
-  virtual void ShowDevTools() = 0;
+  virtual void ShowDevTools(bool activate) = 0;
   // Hide the DevTools view.
   virtual void CloseDevTools() = 0;
   virtual bool IsDevToolsViewShowing() = 0;
   virtual bool IsDevToolsViewFocused() = 0;
-  virtual void SetIsDocked(bool docked) = 0;
+  virtual void SetIsDocked(bool docked, bool activate) = 0;
   virtual void SetContentsResizingStrategy(
       const DevToolsContentsResizingStrategy& strategy) = 0;
   virtual void SetTitle(const base::string16& title) = 0;

--- a/atom/browser/ui/inspectable_web_contents_view_mac.h
+++ b/atom/browser/ui/inspectable_web_contents_view_mac.h
@@ -23,11 +23,11 @@ class InspectableWebContentsViewMac : public InspectableWebContentsView {
   ~InspectableWebContentsViewMac() override;
 
   gfx::NativeView GetNativeView() const override;
-  void ShowDevTools() override;
+  void ShowDevTools(bool activate) override;
   void CloseDevTools() override;
   bool IsDevToolsViewShowing() override;
   bool IsDevToolsViewFocused() override;
-  void SetIsDocked(bool docked) override;
+  void SetIsDocked(bool docked, bool activate) override;
   void SetContentsResizingStrategy(
       const DevToolsContentsResizingStrategy& strategy) override;
   void SetTitle(const base::string16& title) override;

--- a/atom/browser/ui/inspectable_web_contents_view_mac.mm
+++ b/atom/browser/ui/inspectable_web_contents_view_mac.mm
@@ -34,12 +34,12 @@ gfx::NativeView InspectableWebContentsViewMac::GetNativeView() const {
   return view_.get();
 }
 
-void InspectableWebContentsViewMac::ShowDevTools() {
-  [view_ setDevToolsVisible:YES];
+void InspectableWebContentsViewMac::ShowDevTools(bool activate) {
+  [view_ setDevToolsVisible:YES activate:activate];
 }
 
 void InspectableWebContentsViewMac::CloseDevTools() {
-  [view_ setDevToolsVisible:NO];
+  [view_ setDevToolsVisible:NO activate:NO];
 }
 
 bool InspectableWebContentsViewMac::IsDevToolsViewShowing() {
@@ -50,8 +50,8 @@ bool InspectableWebContentsViewMac::IsDevToolsViewFocused() {
   return [view_ isDevToolsFocused];
 }
 
-void InspectableWebContentsViewMac::SetIsDocked(bool docked) {
-  [view_ setIsDocked:docked];
+void InspectableWebContentsViewMac::SetIsDocked(bool docked, bool activate) {
+  [view_ setIsDocked:docked activate:activate];
 }
 
 void InspectableWebContentsViewMac::SetContentsResizingStrategy(

--- a/atom/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/atom/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -115,7 +115,7 @@ views::View* InspectableWebContentsViewViews::GetWebView() {
   return contents_web_view_;
 }
 
-void InspectableWebContentsViewViews::ShowDevTools() {
+void InspectableWebContentsViewViews::ShowDevTools(bool activate) {
   if (devtools_visible_)
     return;
 
@@ -125,7 +125,11 @@ void InspectableWebContentsViewViews::ShowDevTools() {
         inspectable_web_contents_->GetDevToolsWebContents());
     devtools_window_->SetBounds(
         inspectable_web_contents()->GetDevToolsBounds());
-    devtools_window_->Show();
+    if (activate) {
+      devtools_window_->Show();
+    } else {
+      devtools_window_->ShowInactive();
+    }
   } else {
     devtools_web_view_->SetVisible(true);
     devtools_web_view_->SetWebContents(
@@ -166,7 +170,7 @@ bool InspectableWebContentsViewViews::IsDevToolsViewFocused() {
     return false;
 }
 
-void InspectableWebContentsViewViews::SetIsDocked(bool docked) {
+void InspectableWebContentsViewViews::SetIsDocked(bool docked, bool activate) {
   CloseDevTools();
 
   if (!docked) {
@@ -191,7 +195,7 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked) {
     devtools_window_->UpdateWindowIcon();
   }
 
-  ShowDevTools();
+  ShowDevTools(activate);
 }
 
 void InspectableWebContentsViewViews::SetContentsResizingStrategy(

--- a/atom/browser/ui/views/inspectable_web_contents_view_views.h
+++ b/atom/browser/ui/views/inspectable_web_contents_view_views.h
@@ -32,11 +32,11 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
   // InspectableWebContentsView:
   views::View* GetView() override;
   views::View* GetWebView() override;
-  void ShowDevTools() override;
+  void ShowDevTools(bool activate) override;
   void CloseDevTools() override;
   bool IsDevToolsViewShowing() override;
   bool IsDevToolsViewFocused() override;
-  void SetIsDocked(bool docked) override;
+  void SetIsDocked(bool docked, bool activate) override;
   void SetContentsResizingStrategy(
       const DevToolsContentsResizingStrategy& strategy) override;
   void SetTitle(const base::string16& title) override;

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1245,8 +1245,10 @@ app.once('ready', () => {
 
 * `options` Object (optional)
   * `mode` String - Opens the devtools with specified dock state, can be
-  `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
-  In `undocked` mode it's possible to dock back. In `detach` mode it's not.
+    `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
+    In `undocked` mode it's possible to dock back. In `detach` mode it's not.
+  * `activate` Boolean (optional) - Whether to bring the opened devtools window
+    to the foreground. The default is `true`.
 
 Opens the devtools.
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -159,6 +159,22 @@ describe('webContents module', () => {
     })
   })
 
+  describe('openDevTools() API', () => {
+    it('can show window with activation', async () => {
+      w.show()
+      assert.strictEqual(w.isFocused(), true)
+      w.webContents.openDevTools({ mode: 'detach', activate: true })
+      await emittedOnce(w.webContents, 'devtools-opened')
+      assert.strictEqual(w.isFocused(), false)
+    })
+
+    it('can show window without activation', async () => {
+      w.webContents.openDevTools({ mode: 'detach', activate: false })
+      await emittedOnce(w.webContents, 'devtools-opened')
+      assert.strictEqual(w.isDevToolsOpened(), true)
+    })
+  })
+
   describe('before-input-event event', () => {
     it('can prevent document keyboard events', (done) => {
       ipcMain.once('keydown', (event, key) => {


### PR DESCRIPTION
Make it possible to show the devtools window without focusing. Fixes https://github.com/electron/electron/issues/13095

##### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

Notes: Add `activate` option to `webContents.openDevTools`