### PR TITLE
fix: handle SIGINT and SIGTERM from the Electron CLI helper

### DIFF
--- a/npm/cli.js
+++ b/npm/cli.js
@@ -8,3 +8,14 @@ var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit'})
 child.on('close', function (code) {
   process.exit(code)
 })
+
+const handleTerminationSignal = function (signal) {
+  process.on(signal, function signalHandler () {
+    if (!child.killed) {
+      child.kill(signal)
+    }
+  })
+}
+
+handleTerminationSignal('SIGINT')
+handleTerminationSignal('SIGTERM')


### PR DESCRIPTION
Fixes #12840

This updates our CLI wrapper to correctly respond to SIGINT and SIGTERM signals and forward them to the child process.

Note this is deliberately not ES6 (arrow functions and such) to support Node 4.x