### PR TITLE
test: add more assertions to help smoke out the close all window failures

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -168,8 +168,9 @@ describe('app module', () => {
       const electronPath = remote.getGlobal('process').execPath
 
       appProcess = ChildProcess.spawn(electronPath, [appPath])
-      appProcess.on('close', code => {
-        expect(code).to.equal(123)
+      appProcess.on('close', (code, signal) => {
+        expect(signal).to.equal(null, 'exit signal should be null, if you see this please tag @MarshallOfSound')
+        expect(code).to.equal(123, 'exit code should be 123, if you see this please tag @MarshallOfSound')
         done()
       })
     })


### PR DESCRIPTION
This is to help track down #13865

I have tried and failed to reproduce this locally on a variety of machines with a variety of lag / other tests running.

The assertion failing is that the exit code is null, if the exit code is null that according to the nodejs docs the signal must be non-null.  If we assert on both we'll figure out what's going on (hopefully)