### PR TITLE
build: [gn] fix rpath when building with component ffmpeg

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,6 +6,7 @@ import("build/npm.gni")
 import("//pdf/features.gni")
 import("//build/config/win/manifest.gni")
 import("electron_paks.gni")
+import("//third_party/ffmpeg/ffmpeg_options.gni")
 
 if (is_mac) {
   import("//build/config/mac/rules.gni")
@@ -594,6 +595,9 @@ if (is_mac) {
       "//ui/strings",
       "//content:sandbox_helper_win",
     ]
+    if (!is_component_build && is_component_ffmpeg) {
+      configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+    }
 
     public_deps = [
       "//tools/v8_context_snapshot:v8_context_snapshot",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -595,9 +595,6 @@ if (is_mac) {
       "//ui/strings",
       "//content:sandbox_helper_win",
     ]
-    if (!is_component_build && is_component_ffmpeg) {
-      configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
-    }
 
     public_deps = [
       "//tools/v8_context_snapshot:v8_context_snapshot",
@@ -635,6 +632,11 @@ if (is_mac) {
         "/DELAYLOAD:API-MS-WIN-CORE-WINRT-L1-1-0.DLL",
         "/DELAYLOAD:API-MS-WIN-CORE-WINRT-STRING-L1-1-0.DLL",
       ]
+    }
+    if (is_linux) {
+      if (!is_component_build && is_component_ffmpeg) {
+        configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+      }
     }
   }
 }


### PR DESCRIPTION
The new `release.gn` args file specifies `is_component_ffmpeg = true`, which means that the electron exe has to have its rpath set so that it's able to find the `libffmpeg.so` stored alongside it. Otherwise:

```
./out/Default/electron: error while loading shared libraries: libffmpeg.so: cannot open shared object file: No such file or directory
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)