### PR TITLE
build: [gn] build release with is_cfi = false

### DIFF
--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -2,3 +2,7 @@ import("all.gn")
 is_component_build = false
 is_official_build = true
 is_component_ffmpeg = true
+
+# TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.
+# Once we can build nodejs with CFI flags matching Electron's, remove this.
+is_cfi = false


### PR DESCRIPTION
When is_cfi = true (the default on Linux Release), Electron crashes at
boot with SIGILL in V8::InitializePlatform.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)