### PR TITLE
ci: [gn] add ci build for gn on windows

### DIFF
--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -7,6 +7,9 @@ image: libcc-20-vs2017
 environment:
   DISABLE_CRASH_REPORTER_TESTS: true
   ELECTRON_ENABLE_LOGGING: true
+  matrix:
+    - gn_args: debug
+    - gn_args: release
 build_script:
   - git config --global core.longpaths true
   - cd ..
@@ -21,7 +24,7 @@ build_script:
       "https://github.com/electron/electron"
   - gclient sync --with_branch_heads --with_tags
   - cd src
-  - gn gen out/Default "--args=import(\"//electron/build/args/debug.gn\")"
+  - gn gen out/Default "--args=import(\"//electron/build/args/%gn_args%.gn\")"
   - ninja -C out/Default electron:electron_app
 test_script:
   - ninja -C out/Default electron/build/node:headers

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -9,6 +9,7 @@ environment:
   ELECTRON_ENABLE_LOGGING: true
   matrix:
     - gn_args: debug
+      ELECTRON_SKIP_NATIVE_MODULE_TESTS: 1
     - gn_args: release
 build_script:
   - git config --global core.longpaths true

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -30,6 +30,7 @@ build_script:
 test_script:
   - ninja -C out/Default electron/build/node:headers
   - ps: $env:npm_config_nodedir="$pwd/out/Default/gen/node_headers"
+  - ps: $env:npm_config_msvs_version="2017"
   - ps: Push-Location; cd electron/spec
   - npm install
   - ps: Pop-Location

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -1,0 +1,36 @@
+version: 1.0.{build}
+branches:
+  except:
+  - /^release$|^release-\d-\d-x$/
+build_cloud: libcc-20
+image: libcc-20-vs2017
+environment:
+  DISABLE_CRASH_REPORTER_TESTS: true
+  ELECTRON_ENABLE_LOGGING: true
+build_script:
+  - git config --global core.longpaths true
+  - cd ..
+  - md src
+  - ps: Move-Item $env:APPVEYOR_BUILD_FOLDER -Destination src\electron
+  - ps: $env:CHROMIUM_BUILDTOOLS_PATH="$pwd\src\buildtools"
+  - >-
+      gclient config
+      --name "src\electron"
+      --unmanaged
+      --cache-dir "C:\Users\electron\libcc_cache"
+      "https://github.com/electron/electron"
+  - gclient sync --with_branch_heads --with_tags
+  - cd src
+  - gn gen out/Default "--args=import(\"//electron/build/args/debug.gn\")"
+  - ninja -C out/Default electron:electron_app
+test_script:
+  - ninja -C out/Default electron/build/node:headers
+  - ps: $env:npm_config_nodedir="$pwd/out/Default/gen/node_headers"
+  - ps: Push-Location; cd electron/spec
+  - npm install
+  - ps: Pop-Location
+  - python -c "import subprocess; subprocess.check_call([\"./out/Default/electron.exe\", \"electron/spec\", \"--ci\"])"
+  # TODO(nornagon): verify-ffmpeg step
+artifacts:
+- path: test-results.xml
+  name: test-results.xml


### PR DESCRIPTION
This adds `appveyor-gn.yml`, which configures the `electron-win-gn` project on Appveyor. The tests aren't succeeding, but at least they're running!

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)