### PR TITLE
ci: more lenient check for is_ci in lib.util.download

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -87,7 +87,7 @@ def download(text, url, path):
     downloaded_size = 0
     block_size = 128
 
-    ci = os.environ.get('CI') == '1'
+    ci = os.environ.get('CI') is not None
 
     while True:
       buf = web_file.read(block_size)


### PR DESCRIPTION
AppVeyor sets CI=True or CI=true, not CI=1


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)