### PR TITLE
docs: cancelId works on windows

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -141,7 +141,7 @@ will be passed via `callback(filename)`.
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
     label. If no such labeled buttons exist and this option is not set, `0` will be used as the
-    return value or callback response. This option is ignored on Windows.
+    return value or callback response.
   * `noLink` Boolean (optional) - On Windows Electron will try to figure out which one of
     the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
     others as command links in the dialog. This can make the dialog appear in


### PR DESCRIPTION
The note about cancelId not working on windows is not valid. Tried on Windows 7 and Windows 10 and it works in both cases (with electron 1.8.7).



- [ ] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)