### PR TITLE
refactor: use env var to skip native module tests on win32/debug

### DIFF
--- a/script/test.py
+++ b/script/test.py
@@ -55,6 +55,8 @@ def main():
     electron = os.path.join(SOURCE_ROOT, 'out', config,
                               '{0}.exe'.format(PROJECT_NAME))
     resources_path = os.path.join(SOURCE_ROOT, 'out', config)
+    if config != 'R':
+      os.environ['ELECTRON_SKIP_NATIVE_MODULE_TESTS'] = '1'
   else:
     electron = os.path.join(SOURCE_ROOT, 'out', config, PROJECT_NAME)
     resources_path = os.path.join(SOURCE_ROOT, 'out', config)

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -99,7 +99,7 @@ if (global.isCi) {
   })
 }
 
-global.nativeModulesEnabled = process.platform !== 'win32' || process.execPath.toLowerCase().indexOf('\\out\\d\\') === -1
+global.nativeModulesEnabled = !process.env.ELECTRON_SKIP_NATIVE_MODULE_TESTS
 
 // Register app as standard scheme.
 global.standardScheme = 'app'


### PR DESCRIPTION
This is because the GN build doesn't build in `out/D`.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)