### PR TITLE
ci: start the dbus mock server in GN CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ gn-build-steps: &gn-build-steps
           ninja -C out/Default electron/build/node:headers
           export npm_config_nodedir="$PWD/out/Default/gen/node_headers"
           (cd electron/spec && npm install)
-          ./out/Default/electron electron/spec --ci --enable-logging
+          python electron/script/lib/dbus_mock.py ./out/Default/electron electron/spec --ci --enable-logging
     - store_test_results:
         path: src/junit
     - store_artifacts:

--- a/script/lib/dbus_mock.py
+++ b/script/lib/dbus_mock.py
@@ -6,17 +6,23 @@ import os
 import sys
 
 
-def cleanup():
+def stop():
     DBusTestCase.stop_dbus(DBusTestCase.system_bus_pid)
     DBusTestCase.stop_dbus(DBusTestCase.session_bus_pid)
 
+def start():
+    dbusmock_log = sys.stdout if is_verbose_mode() else open(os.devnull, 'w')
 
-atexit.register(cleanup)
+    DBusTestCase.start_system_bus()
+    DBusTestCase.spawn_server_template('logind', None, dbusmock_log)
 
-dbusmock_log = sys.stdout if is_verbose_mode() else open(os.devnull, 'w')
+    DBusTestCase.start_session_bus()
+    DBusTestCase.spawn_server_template('notification_daemon', None, dbusmock_log)
 
-DBusTestCase.start_system_bus()
-DBusTestCase.spawn_server_template('logind', None, dbusmock_log)
-
-DBusTestCase.start_session_bus()
-DBusTestCase.spawn_server_template('notification_daemon', None, dbusmock_log)
+if __name__ == '__main__':
+    import subprocess
+    start()
+    try:
+        subprocess.check_call(sys.argv[1:])
+    finally:
+        stop()

--- a/script/test.py
+++ b/script/test.py
@@ -18,6 +18,9 @@ if sys.platform == 'linux2':
     # will be picked up by electron.
     try:
         import lib.dbus_mock
+        import atexit
+        lib.dbus_mock.start()
+        atexit.register(lib.dbus_mock.stop)
     except ImportError:
         # If not available, the powerMonitor tests will be skipped since
         # DBUS_SYSTEM_BUS_ADDRESS will not be set


### PR DESCRIPTION
Should fix the dbus failures we're seeing in the linux GN CI

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)