### PR TITLE
docs: dipToScreenRect / screenToDipRect - window can be null

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -136,7 +136,7 @@ The DPI scale is performed relative to the display containing the DIP point.
 
 ### `screen.screenToDipRect(window, rect)` _Windows_
 
-* `window` [BrowserWindow](browser-window.md)
+* `window` [BrowserWindow](browser-window.md) | null
 * `rect` [Rectangle](structures/rectangle.md)
 
 Returns [`Rectangle`](structures/rectangle.md)
@@ -147,7 +147,7 @@ If `window` is null, scaling will be performed to the display nearest to `rect`.
 
 ### `screen.dipToScreenRect(window, rect)` _Windows_
 
-* `window` [BrowserWindow](browser-window.md)
+* `window` [BrowserWindow](browser-window.md) | null
 * `rect` [Rectangle](structures/rectangle.md)
 
 Returns [`Rectangle`](structures/rectangle.md)


### PR DESCRIPTION
##### Checklist
- [x] PR description included and stakeholders cc'd
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)