### PR TITLE
fix: add missing "simple" property in several APIs to prevent proxying of return values

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1114,6 +1114,10 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
     mate::Dictionary memory_dict = mate::Dictionary::CreateEmpty(isolate);
     mate::Dictionary cpu_dict = mate::Dictionary::CreateEmpty(isolate);
 
+    pid_dict.SetHidden("simple", true);
+    memory_dict.SetHidden("simple", true);
+    cpu_dict.SetHidden("simple", true);
+
     memory_dict.Set(
         "workingSetSize",
         static_cast<double>(

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -133,6 +133,7 @@ v8::Local<v8::Value> AtomBindings::GetHeapStatistics(v8::Isolate* isolate) {
   isolate->GetHeapStatistics(&v8_heap_stats);
 
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
   dict.Set("totalHeapSize",
            static_cast<double>(v8_heap_stats.total_heap_size() >> 10));
   dict.Set(
@@ -161,6 +162,7 @@ v8::Local<v8::Value> AtomBindings::GetProcessMemoryInfo(v8::Isolate* isolate) {
   auto metrics = base::ProcessMetrics::CreateCurrentProcessMetrics();
 
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
   dict.Set("workingSetSize",
            static_cast<double>(metrics->GetWorkingSetSize() >> 10));
   dict.Set("peakWorkingSetSize",
@@ -185,6 +187,7 @@ v8::Local<v8::Value> AtomBindings::GetSystemMemoryInfo(v8::Isolate* isolate,
   }
 
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
   dict.Set("total", mem_info.total);
 
   // See Chromium's "base/process/process_metrics.h" for an explanation.
@@ -207,6 +210,7 @@ v8::Local<v8::Value> AtomBindings::GetSystemMemoryInfo(v8::Isolate* isolate,
 
 v8::Local<v8::Value> AtomBindings::GetCPUUsage(v8::Isolate* isolate) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
   int processor_count = base::SysInfo::NumberOfProcessors();
   dict.Set("percentCPUUsage",
            metrics_->GetPlatformIndependentCPUUsage() / processor_count);
@@ -227,6 +231,7 @@ v8::Local<v8::Value> AtomBindings::GetIOCounters(v8::Isolate* isolate) {
   auto metrics = base::ProcessMetrics::CreateCurrentProcessMetrics();
   base::IoCounters io_counters;
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
 
   if (metrics->GetIOCounters(&io_counters)) {
     dict.Set("readOperationCount", io_counters.ReadOperationCount);

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -1,11 +1,11 @@
-const assert = require('assert')
+const {expect} = require('chai')
 
 describe('process module', () => {
   describe('process.getCPUUsage()', () => {
     it('returns a cpu usage object', () => {
       const cpuUsage = process.getCPUUsage()
-      assert.equal(typeof cpuUsage.percentCPUUsage, 'number')
-      assert.equal(typeof cpuUsage.idleWakeupsPerSecond, 'number')
+      expect(cpuUsage.percentCPUUsage).to.be.a('number')
+      expect(cpuUsage.idleWakeupsPerSecond).to.be.a('number')
     })
   })
 
@@ -18,27 +18,45 @@ describe('process module', () => {
 
     it('returns an io counters object', () => {
       const ioCounters = process.getIOCounters()
-      assert.equal(typeof ioCounters.readOperationCount, 'number')
-      assert.equal(typeof ioCounters.writeOperationCount, 'number')
-      assert.equal(typeof ioCounters.otherOperationCount, 'number')
-      assert.equal(typeof ioCounters.readTransferCount, 'number')
-      assert.equal(typeof ioCounters.writeTransferCount, 'number')
-      assert.equal(typeof ioCounters.otherTransferCount, 'number')
+      expect(ioCounters.readOperationCount).to.be.a('number')
+      expect(ioCounters.writeOperationCount).to.be.a('number')
+      expect(ioCounters.otherOperationCount).to.be.a('number')
+      expect(ioCounters.readTransferCount).to.be.a('number')
+      expect(ioCounters.writeTransferCount).to.be.a('number')
+      expect(ioCounters.otherTransferCount).to.be.a('number')
+    })
+  })
+
+  describe('process.getProcessMemoryInfo()', () => {
+    it('returns process memory info object', () => {
+      const processMemoryInfo = process.getProcessMemoryInfo()
+      expect(processMemoryInfo.peakWorkingSetSize).to.be.a('number')
+      expect(processMemoryInfo.privateBytes).to.be.a('number')
+      expect(processMemoryInfo.sharedBytes).to.be.a('number')
+      expect(processMemoryInfo.workingSetSize).to.be.a('number')
+    })
+  })
+
+  describe('process.getSystemMemoryInfo()', () => {
+    it('returns system memory info object', () => {
+      const systemMemoryInfo = process.getSystemMemoryInfo()
+      expect(systemMemoryInfo.free).to.be.a('number')
+      expect(systemMemoryInfo.total).to.be.a('number')
     })
   })
 
   describe('process.getHeapStatistics()', () => {
     it('returns heap statistics object', () => {
       const heapStats = process.getHeapStatistics()
-      assert.equal(typeof heapStats.totalHeapSize, 'number')
-      assert.equal(typeof heapStats.totalHeapSizeExecutable, 'number')
-      assert.equal(typeof heapStats.totalPhysicalSize, 'number')
-      assert.equal(typeof heapStats.totalAvailableSize, 'number')
-      assert.equal(typeof heapStats.usedHeapSize, 'number')
-      assert.equal(typeof heapStats.heapSizeLimit, 'number')
-      assert.equal(typeof heapStats.mallocedMemory, 'number')
-      assert.equal(typeof heapStats.peakMallocedMemory, 'number')
-      assert.equal(typeof heapStats.doesZapGarbage, 'boolean')
+      expect(heapStats.totalHeapSize).to.be.a('number')
+      expect(heapStats.totalHeapSizeExecutable).to.be.a('number')
+      expect(heapStats.totalPhysicalSize).to.be.a('number')
+      expect(heapStats.totalAvailableSize).to.be.a('number')
+      expect(heapStats.usedHeapSize).to.be.a('number')
+      expect(heapStats.heapSizeLimit).to.be.a('number')
+      expect(heapStats.mallocedMemory).to.be.a('number')
+      expect(heapStats.peakMallocedMemory).to.be.a('number')
+      expect(heapStats.doesZapGarbage).to.be.a('boolean')
     })
   })
 })


### PR DESCRIPTION
Fixes the the following APIs
- `app.getAppMetrics()`
- `process.getHeapStatistics()`
- `process.getProcessMemoryInfo()`
- `process.getSystemMemoryInfo()`
- `process.getCPUUsage()`
- `process.getIOCounters()`

I have also converted `api-process-spec.js` to chai / expect

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added]
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)