### PR TITLE
test: make nativeImage relative path test robust to different cwd

### DIFF
--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -280,7 +280,7 @@ describe('nativeImage module', () => {
     })
 
     it('loads images from paths relative to the current working directory', () => {
-      const imagePath = `.${path.sep}${path.join('spec', 'fixtures', 'assets', 'logo.png')}`
+      const imagePath = path.relative('.', path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
       const image = nativeImage.createFromPath(imagePath)
       expect(image.isEmpty()).to.be.false()
       expect(image.getSize()).to.deep.equal({width: 538, height: 190})


### PR DESCRIPTION
GN runs the tests from a different cwd. this makes the test agnostic to cwd, while still testing relative path support.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)