### PR TITLE
fix: Improve --enable-features/--disable-features handling

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -154,6 +154,14 @@ void AtomBrowserMainParts::PostEarlyInitialization() {
 
   // Wrap the uv loop with global env.
   node_bindings_->set_uv_env(env);
+
+  // We already initialized the feature list in
+  // brightray::BrowserMainParts::PreEarlyInitialization(), but
+  // the user JS script would not have had a chance to alter the command-line
+  // switches at that point. Lets reinitialize it here to pick up the
+  // command-line changes.
+  base::FeatureList::ClearInstanceForTesting();
+  brightray::BrowserMainParts::InitializeFeatureList();
 }
 
 int AtomBrowserMainParts::PreCreateThreads() {

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -268,16 +268,6 @@ void BrowserMainParts::PreMainMessageLoopStart() {
 }
 
 void BrowserMainParts::PreMainMessageLoopRun() {
-  // We already initialized the feature list in PreEarlyInitialization(), but
-  // the user JS script would not have had a chance to alter the command-line
-  // switches at that point. Lets force re-initialization here to pick up the
-  // command-line changes. Note that some Chromium code (e.g.
-  // gpu_process_host.cc) queries the feature list between
-  // PreEarlyInitialization() and here so the user script may not have
-  // control over all features. Better than nothing though!
-  base::FeatureList::ClearInstanceForTesting();
-  InitializeFeatureList();
-
   content::WebUIControllerFactory::RegisterFactory(
       WebUIControllerFactory::GetInstance());
 

--- a/brightray/browser/browser_main_parts.h
+++ b/brightray/browser/browser_main_parts.h
@@ -43,13 +43,13 @@ class BrowserMainParts : public content::BrowserMainParts {
   int PreCreateThreads() override;
   void PostDestroyThreads() override;
 
+  void InitializeFeatureList();
+
  private:
 #if defined(OS_MACOSX)
   void InitializeMainNib();
   void OverrideAppLogsPath();
 #endif
-
-  void InitializeFeatureList();
 
   std::unique_ptr<IOThread> io_thread_;
 


### PR DESCRIPTION
As it turns out, we can reinitialize the feature list directly after the
user JS script has been executed instead of much later. This allows
modifications to `--enable-features`/`--disable-features` to work with a
greater set of features.