### PR TITLE
fix: ipcRemote.sendSync() in lib/isolated_renderer/init.js

### DIFF
--- a/lib/isolated_renderer/init.js
+++ b/lib/isolated_renderer/init.js
@@ -3,7 +3,6 @@
 'use strict'
 
 const {send, sendSync} = binding
-const {parse} = JSON
 
 const ipcRenderer = {
   send (...args) {
@@ -11,7 +10,7 @@ const ipcRenderer = {
   },
 
   sendSync (...args) {
-    return parse(sendSync('ipc-message-sync', args))
+    return sendSync('ipc-message-sync', args)[0]
   },
 
   // No-ops since events aren't received

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -3120,6 +3120,7 @@ describe('BrowserWindow module', () => {
         typeofFunctionApply: 'function'
       },
       pageContext: {
+        openedLocation: '',
         preloadProperty: 'undefined',
         pageProperty: 'string',
         typeofRequire: 'undefined',

--- a/spec/fixtures/api/isolated.html
+++ b/spec/fixtures/api/isolated.html
@@ -9,9 +9,11 @@
       Function.prototype.apply = true
 
       const opened = window.open()
+      const openedLocation = opened.location
       opened.close()
 
       window.postMessage({
+        openedLocation,
         preloadProperty: typeof window.foo,
         pageProperty: typeof window.hello,
         typeofRequire: typeof require,

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -544,6 +544,7 @@ describe('<webview> tag', function () {
           typeofFunctionApply: 'function'
         },
         pageContext: {
+          openedLocation: '',
           preloadProperty: 'undefined',
           pageProperty: 'string',
           typeofRequire: 'undefined',


### PR DESCRIPTION
This is regression introduced by https://github.com/electron/electron/pull/8953, where we forgot to modify the `ipcRemote.sendSync()` implementation in `lib/isolated_renderer/init.js`

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)