### PR TITLE
fix: some APIs modified for ASAR support cannot be util.promisify'ed (backport: 2-0-x)

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -3,6 +3,7 @@
   const {Buffer} = require('buffer')
   const childProcess = require('child_process')
   const path = require('path')
+  const util = require('util')
 
   const hasProp = {}.hasOwnProperty
 
@@ -217,6 +218,28 @@
       arguments[arg] = newPath
       return old.apply(this, arguments)
     }
+    if (old[util.promisify.custom]) {
+      module[name][util.promisify.custom] = function () {
+        const p = arguments[arg]
+        const [isAsar, asarPath, filePath] = splitPath(p)
+        if (!isAsar) {
+          return old[util.promisify.custom].apply(this, arguments)
+        }
+
+        const archive = getOrCreateArchive(asarPath)
+        if (!archive) {
+          return new Promise(() => invalidArchiveError(asarPath))
+        }
+
+        const newPath = archive.copyFileOut(filePath)
+        if (!newPath) {
+          return new Promise(() => notFoundError(asarPath, filePath))
+        }
+
+        arguments[arg] = newPath
+        return old[util.promisify.custom].apply(this, arguments)
+      }
+    }
   }
 
   // Override fs APIs.
@@ -371,6 +394,18 @@
         // eslint-disable-next-line standard/no-callback-literal
         callback(archive.stat(filePath) !== false)
       })
+    }
+
+    fs.exists[util.promisify.custom] = function (p) {
+      const [isAsar, asarPath, filePath] = splitPath(p)
+      if (!isAsar) {
+        return exists[util.promisify.custom](p)
+      }
+      const archive = getOrCreateArchive(asarPath)
+      if (!archive) {
+        return new Promise(() => invalidArchiveError(asarPath))
+      }
+      return Promise.resolve(archive.stat(filePath) !== false)
     }
 
     const {existsSync} = fs
@@ -680,18 +715,22 @@
     // called by `childProcess.{exec,execSync}`, causing
     // Electron to consider the full command as a single path
     // to an archive.
-    ['exec', 'execSync'].forEach(function (functionName) {
-      const old = childProcess[functionName]
-      childProcess[functionName] = function () {
+    const {exec, execSync} = childProcess
+    childProcess.exec = invokeWithNoAsar(exec)
+    childProcess.exec[util.promisify.custom] = invokeWithNoAsar(exec[util.promisify.custom])
+    childProcess.execSync = invokeWithNoAsar(execSync)
+
+    function invokeWithNoAsar (func) {
+      return function () {
         const processNoAsarOriginalValue = process.noAsar
         process.noAsar = true
         try {
-          return old.apply(this, arguments)
+          return func.apply(this, arguments)
         } finally {
           process.noAsar = processNoAsarOriginalValue
         }
       }
-    })
+    }
 
     overrideAPI(fs, 'open')
     overrideAPI(childProcess, 'execFile')


### PR DESCRIPTION
Backport https://github.com/electron/electron/pull/13845

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)