### PR TITLE
test: re-enable app.getAppMetric API

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -796,8 +796,7 @@ describe('app module', () => {
     })
   })
 
-  // TODO(marshallofsound): [Ch66] Failed on Windows x64 + ia32 on CI, passes locally
-  xdescribe('getAppMetrics() API', () => {
+  describe('getAppMetrics() API', () => {
     it('returns memory and cpu stats of all running electron processes', () => {
       const appMetrics = app.getAppMetrics()
       expect(appMetrics).to.be.an('array').and.have.lengthOf.at.least(1, 'App memory info object is not > 0')
@@ -805,8 +804,13 @@ describe('app module', () => {
       const types = []
       for (const {memory, pid, type, cpu} of appMetrics) {
         expect(memory.workingSetSize).to.be.above(0, 'working set size is not > 0')
-        expect(memory.privateBytes).to.be.above(0, 'private bytes is not > 0')
-        expect(memory.sharedBytes).to.be.above(0, 'shared bytes is not > 0')
+
+        // windows causes failures here due to CI server configuration
+        if (process.platform !== 'win32') {
+          expect(memory.privateBytes).to.be.above(0, 'private bytes is not > 0')
+          expect(memory.sharedBytes).to.be.above(0, 'shared bytes is not > 0')
+        }
+
         expect(pid).to.be.above(0, 'pid is not > 0')
         expect(type).to.be.a('string').that.is.not.empty()
 


### PR DESCRIPTION
Refs: [this card](https://github.com/electron/electron/projects/9#card-11911845) and https://github.com/electron/electron/issues/13447

Re-enables `app.getAppMetrics()` API on all platforms; previously disabled as a part of the Ch66 upgrade. CI configuration on Windows causes `privateBytes` and `sharedBytes` to not show up as a result of Chromium issues that will be remedied anyways as soon as we upgrade to Ch67 and we no longer call `GetMemoryBytes` as it's been deprecated.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)