### PR TITLE
feat: add location url to "Node.js Integration with Remote Content" warning

### DIFF
--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -137,8 +137,8 @@ module.exports = {
   warnAboutNodeWithRemoteContent: () => {
     if (getIsRemoteProtocol()) {
       const warning = `This renderer process has Node.js integration enabled
-      and attempted to load remote content. This exposes users of this app to
-      severe security risks.\n ${moreInformation}`
+      and attempted to load remote content from '${window.location}'. This
+      exposes users of this app to severe security risks.\n ${moreInformation}`
 
       console.warn('%cElectron Security Warning (Node.js Integration with Remote Content)',
         'font-weight: bold;', warning)

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -45,7 +45,7 @@ const shouldLogSecurityWarnings = function () {
 }
 
 /**
- * Check's if the current window is remote.
+ * Checks if the current window is remote.
  *
  * @returns {boolean} - Is this a remote protocol?
  */


### PR DESCRIPTION
A small change: when logging the "Node.js Integration with Remote Content" warning, include the `window.location` to make it easier for developers to see what content triggered the warning.

Inspired by https://github.com/electron/electron/issues/12049.

cc @felixrieseberg 

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines]

