### PR TITLE
fix: make menu.popup options optional

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -61,7 +61,7 @@ The `menu` object has the following instance methods:
 
 #### `menu.popup(options)`
 
-* `options` Object
+* `options` Object (optional)
   * `window` [BrowserWindow](browser-window.md) (optional) - Default is the focused window.
   * `x` Number (optional) - Default is the current mouse cursor position.
     Must be declared if `y` is declared.

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -47,8 +47,8 @@ Menu.prototype._init = function () {
   this.delegate = delegate
 }
 
-Menu.prototype.popup = function (options) {
-  if (options == null || typeof options !== 'object') {
+Menu.prototype.popup = function (options = {}) {
+  if (typeof options !== 'object') {
     throw new TypeError('Options must be an object')
   }
   let {window, x, y, positioningItem, callback} = options

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -48,7 +48,7 @@ Menu.prototype._init = function () {
 }
 
 Menu.prototype.popup = function (options = {}) {
-  if (typeof options !== 'object') {
+  if (options == null || typeof options !== 'object') {
     throw new TypeError('Options must be an object')
   }
   let {window, x, y, positioningItem, callback} = options

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -633,8 +633,14 @@ describe('Menu module', () => {
 
     it('throws an error if options is not an object', () => {
       expect(() => {
-        menu.popup()
+        menu.popup('this is a string, not an object')
       }).to.throw(/Options must be an object/)
+    })
+
+    it('allows for options to be optional', () => {
+      expect(() => {
+        menu.popup({})
+      }).to.not.throw()
     })
 
     it('should emit menu-will-show event', (done) => {


### PR DESCRIPTION
## Background

fixes #12915 

The menu.popup `options` object has all optional fields. One would think with that being the case, the `options` object as a whole could be optional.

## Implementation

This PR adds a default param to `Menu.prototype.popup` that will allow the function to work, even when an object is passed in.

```js
Menu.prototype.popup = function (options = {}) {
	// ...
}
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)