### PR TITLE
fix: update clang/lld version to fix #13972

### DIFF
--- a/script/update-clang.sh
+++ b/script/update-clang.sh
@@ -8,10 +8,10 @@
 # Do NOT CHANGE this if you don't know what you're doing -- see
 # https://code.google.com/p/chromium/wiki/UpdatingClang
 # Reverting problematic clang rolls is safe, though.
-CLANG_REVISION=307486
+CLANG_REVISION=308728
 
 # This is incremented when pushing a new build of Clang at the same revision.
-CLANG_SUB_REVISION=1
+CLANG_SUB_REVISION=3
 
 PACKAGE_VERSION="${CLANG_REVISION}-${CLANG_SUB_REVISION}"
 


### PR DESCRIPTION
This seems like some sort of a weird linker bug, so just update the toolchain a bit. The exact clang revision is from the 3.0 branch (Chromium 62), I've picked this specific one because it's the closest that's known to be generally "good", having been used on the 3.0 branch for a while.

Some tests (`Browser.show` etc.) don't actually pass on my machine thanks to what I assume is a race condition between Electron itself and Kwin, but they don't pass on the old version either, so it's probably just me - let's see what CI says.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)