### PR TITLE
fix: Stricter Testing For Menu Items

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -47,7 +47,7 @@ The built-in `role` behavior will give the best native experience.
 The `label` and `accelerator` values are optional when using a `role` and will
 default to appropriate values for each platform.
 
-Any menu item must have either a `role`, `label`, or in the case of a separator
+Every menu item must have either a `role`, `label`, or in the case of a separator
 a `type`.
 
 The `role` property can have following values:

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -47,6 +47,9 @@ The built-in `role` behavior will give the best native experience.
 The `label` and `accelerator` values are optional when using a `role` and will
 default to appropriate values for each platform.
 
+Any menu item must have either a `role`, `label`, or in the case of a separator
+a `type`.
+
 The `role` property can have following values:
 
 * `undo`

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -159,7 +159,10 @@ Menu.buildFromTemplate = function (template) {
     throw new TypeError('Invalid template for Menu')
   }
   const menu = new Menu()
-  typeCheckTemplate(template)
+  const isValid = isValidTemplate(template)
+  if (!isValid) {
+    throw new TypeError('Invalid template for MenuItem: must have at least one of label, role or type')
+  }
   const filtered = removeExtraSeparators(template)
   const sorted = sortTemplate(filtered)
 
@@ -173,13 +176,15 @@ Menu.buildFromTemplate = function (template) {
 /* Helper Functions */
 
 // validate the template against having the wrong attribute
-function typeCheckTemplate (template) {
+function isValidTemplate (template) {
+  let isValid = true
   template.forEach((item) => {
-    if ((item === null) || (typeof item !== 'object') ||
+    if ((item == null) || (typeof item !== 'object') ||
         (!item.label && !item.role && !item.type)) {
-      throw new TypeError('Invalid template for MenuItem')
+      isValid = false
     }
   })
+  return isValid
 }
 
 function sortTemplate (template) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -164,11 +164,8 @@ Menu.buildFromTemplate = function (template) {
   const sorted = sortTemplate(filtered)
 
   sorted.forEach((item) => {
-    if (typeof item !== 'object' || item == null) {
-      throw new TypeError('Invalid template for MenuItem')
-    }
-    // test item.type for separators
-    if (!item.label && !item.role && !item.type) {
+    if ((item === null) || (typeof item !== 'object') ||
+        (!item.label && !item.role && !item.type)) {
       throw new TypeError('Invalid template for MenuItem')
     }
     menu.append(new MenuItem(item))

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -164,15 +164,14 @@ Menu.buildFromTemplate = function (template) {
   const sorted = sortTemplate(filtered)
 
   sorted.forEach((item) => {
-    if (typeof item !== 'object' && item != null) {
+    if (typeof item !== 'object' && item == null) {
       throw new TypeError('Invalid template for MenuItem')
     }
-    if (item != null && Object.keys(item).length > 0) {
-      if (!item.label && !item.role && !item.type) {
-        throw new TypeError('Invalid template for MenuItem')
-      }
-      menu.append(new MenuItem(item))
+    // test item.type for separators
+    if (!item.label && !item.role && !item.type) {
+      throw new TypeError('Invalid template for MenuItem')
     }
+    menu.append(new MenuItem(item))
   })
 
   return menu

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -168,7 +168,7 @@ Menu.buildFromTemplate = function (template) {
       throw new TypeError('Invalid template for MenuItem')
     }
     if (item != null && Object.keys(item).length > 0) {
-      if (item.label == null && item.role == null && item.type == null) {
+      if (!item.label && !item.role && !item.type) {
         throw new TypeError('Invalid template for MenuItem')
       }
       menu.append(new MenuItem(item))

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -164,11 +164,11 @@ Menu.buildFromTemplate = function (template) {
   const sorted = sortTemplate(filtered)
 
   sorted.forEach((item) => {
-    if (typeof item !== ('object' || null)) {
+    if (typeof item !== 'object' && item != null) {
       throw new TypeError('Invalid template for MenuItem')
     }
-    if (Object.keys(item).length > 0 && item !== null) {
-      if (item.label === (undefined || null) && item.role === (undefined || null)){
+    if (Object.keys(item).length > 0 && item != null) {
+      if (item.label == null && item.role == null && item.type == null) {
         throw new TypeError('Invalid template for MenuItem')
       }
       menu.append(new MenuItem(item))
@@ -211,7 +211,8 @@ function generateGroupId (items, pos) {
 function removeExtraSeparators (items) {
   // fold adjacent separators together
   let ret = items.filter((e, idx, arr) => {
-    if (e === null) return false
+    // check if element is null then return false so we don't fold null
+    if (e == null) return false
     if (e.visible === false) return true
     return e.type !== 'separator' || idx === 0 || arr[idx - 1].type !== 'separator'
   })

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -167,7 +167,7 @@ Menu.buildFromTemplate = function (template) {
     if (typeof item !== 'object') {
       throw new TypeError('Invalid template for MenuItem')
     }
-    if( Object.keys(item).length > 0) {
+    if (Object.keys(item).length > 0) {
       menu.append(new MenuItem(item))
     }
   })

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -159,16 +159,13 @@ Menu.buildFromTemplate = function (template) {
     throw new TypeError('Invalid template for Menu')
   }
   const menu = new Menu()
-  const isValid = isValidTemplate(template)
-  if (!isValid) {
+  if (!isValidTemplate(template)) {
     throw new TypeError('Invalid template for MenuItem: must have at least one of label, role or type')
   }
   const filtered = removeExtraSeparators(template)
   const sorted = sortTemplate(filtered)
 
-  sorted.forEach((item) => {
-    menu.append(new MenuItem(item))
-  })
+  sorted.forEach((item) => menu.append(new MenuItem(item)))
 
   return menu
 }
@@ -177,14 +174,8 @@ Menu.buildFromTemplate = function (template) {
 
 // validate the template against having the wrong attribute
 function isValidTemplate (template) {
-  let isValid = true
-  template.forEach((item) => {
-    if ((item == null) || (typeof item !== 'object') ||
-        (!item.label && !item.role && !item.type)) {
-      isValid = false
-    }
-  })
-  return isValid
+  return template.every(item =>
+  item != null && typeof item === 'object' && (item.label || item.role || item.type === 'separator'))
 }
 
 function sortTemplate (template) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -164,7 +164,7 @@ Menu.buildFromTemplate = function (template) {
   const sorted = sortTemplate(filtered)
 
   sorted.forEach((item) => {
-    if (typeof item !== 'object' && item == null) {
+    if (typeof item !== 'object' || item == null) {
       throw new TypeError('Invalid template for MenuItem')
     }
     // test item.type for separators

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -158,16 +158,12 @@ Menu.buildFromTemplate = function (template) {
   if (!Array.isArray(template)) {
     throw new TypeError('Invalid template for Menu')
   }
-
   const menu = new Menu()
+  typeCheckTemplate(template)
   const filtered = removeExtraSeparators(template)
   const sorted = sortTemplate(filtered)
 
   sorted.forEach((item) => {
-    if ((item === null) || (typeof item !== 'object') ||
-        (!item.label && !item.role && !item.type)) {
-      throw new TypeError('Invalid template for MenuItem')
-    }
     menu.append(new MenuItem(item))
   })
 
@@ -175,6 +171,16 @@ Menu.buildFromTemplate = function (template) {
 }
 
 /* Helper Functions */
+
+// validate the template against having the wrong attribute
+function typeCheckTemplate (template) {
+  template.forEach((item) => {
+    if ((item === null) || (typeof item !== 'object') ||
+        (!item.label && !item.role && !item.type)) {
+      throw new TypeError('Invalid template for MenuItem')
+    }
+  })
+}
 
 function sortTemplate (template) {
   const sorted = sortMenuItems(template)
@@ -207,8 +213,6 @@ function generateGroupId (items, pos) {
 function removeExtraSeparators (items) {
   // fold adjacent separators together
   let ret = items.filter((e, idx, arr) => {
-    // check if element is null then return false so we don't fold null
-    if (e == null) return false
     if (e.visible === false) return true
     return e.type !== 'separator' || idx === 0 || arr[idx - 1].type !== 'separator'
   })

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -164,10 +164,13 @@ Menu.buildFromTemplate = function (template) {
   const sorted = sortTemplate(filtered)
 
   sorted.forEach((item) => {
-    if (typeof item !== 'object') {
+    if (typeof item !== ('object' || null)) {
       throw new TypeError('Invalid template for MenuItem')
     }
-    if (Object.keys(item).length > 0) {
+    if (Object.keys(item).length > 0 && item !== null) {
+      if (item.label === (undefined || null) && item.role === (undefined || null)){
+        throw new TypeError('Invalid template for MenuItem')
+      }
       menu.append(new MenuItem(item))
     }
   })
@@ -208,6 +211,7 @@ function generateGroupId (items, pos) {
 function removeExtraSeparators (items) {
   // fold adjacent separators together
   let ret = items.filter((e, idx, arr) => {
+    if (e === null) return false
     if (e.visible === false) return true
     return e.type !== 'separator' || idx === 0 || arr[idx - 1].type !== 'separator'
   })

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -167,7 +167,7 @@ Menu.buildFromTemplate = function (template) {
     if (typeof item !== 'object' && item != null) {
       throw new TypeError('Invalid template for MenuItem')
     }
-    if (Object.keys(item).length > 0 && item != null) {
+    if (item != null && Object.keys(item).length > 0) {
       if (item.label == null && item.role == null && item.type == null) {
         throw new TypeError('Invalid template for MenuItem')
       }

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -167,7 +167,9 @@ Menu.buildFromTemplate = function (template) {
     if (typeof item !== 'object') {
       throw new TypeError('Invalid template for MenuItem')
     }
-    menu.append(new MenuItem(item))
+    if( Object.keys(item).length > 0) {
+      menu.append(new MenuItem(item))
+    }
   })
 
   return menu

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -156,10 +156,10 @@ Menu.setApplicationMenu = function (menu) {
 
 Menu.buildFromTemplate = function (template) {
   if (!Array.isArray(template)) {
-    throw new TypeError('Invalid template for Menu')
+    throw new TypeError('Invalid template for Menu: Menu template must be an array')
   }
   const menu = new Menu()
-  if (!isValidTemplate(template)) {
+  if (!areValidTemplateItems(template)) {
     throw new TypeError('Invalid template for MenuItem: must have at least one of label, role or type')
   }
   const filtered = removeExtraSeparators(template)
@@ -173,9 +173,9 @@ Menu.buildFromTemplate = function (template) {
 /* Helper Functions */
 
 // validate the template against having the wrong attribute
-function isValidTemplate (template) {
+function areValidTemplateItems (template) {
   return template.every(item =>
-  item != null && typeof item === 'object' && (item.label || item.role || item.type === 'separator'))
+  item != null && typeof item === 'object' && (item.hasOwnProperty('label') || item.hasOwnProperty('role') || item.type === 'separator'))
 }
 
 function sortTemplate (template) {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -9,6 +9,8 @@ const {closeWindow} = require('./window-helpers')
 const {expect} = chai
 chai.use(dirtyChai)
 
+describe.only('some feature', function () {
+  // ... only tests in this block will be run
 describe('Menu module', () => {
   describe('Menu.buildFromTemplate', () => {
     it('should be able to attach extra fields', () => {
@@ -40,6 +42,18 @@ describe('Menu module', () => {
           }
         ])
       }).to.not.throw()
+    })
+
+    it('does not throw exceptions for empty objects and null values ', () => {
+      expect(() => {
+        Menu.buildFromTemplate([{}, {}, null, null]).to.not.throw()
+      })
+    })
+
+    it('does throw exception for object without role or label attribute', () => {
+      expect(() => {
+        Menu.buildFromTemplate([{"randomKey":"ldks"}]).to.throw('Invalid template for MenuItem')
+      })
     })
 
     it('returns 0 item count for empty objects ', () => {
@@ -705,4 +719,5 @@ describe('Menu module', () => {
       expect(Menu.getApplicationMenu()).to.be.null()
     })
   })
+})
 })

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -42,6 +42,12 @@ describe('Menu module', () => {
       }).to.not.throw()
     })
 
+    it('returns 0 item count for empty objects ', () => {
+      const menu = Menu.buildFromTemplate([{}, {}])
+      const items = menu.getItemCount()
+      expect(items).to.equal(0)
+    })
+
     describe('Menu sorting and building', () => {
       describe('sorts groups', () => {
         it('does a simple sort', () => {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -9,9 +9,7 @@ const {closeWindow} = require('./window-helpers')
 const {expect} = chai
 chai.use(dirtyChai)
 
-describe.only('some feature', function () {
-  // ... only tests in this block will be run
-describe('Menu module', () => {
+describe.only('Menu module', () => {
   describe('Menu.buildFromTemplate', () => {
     it('should be able to attach extra fields', () => {
       const menu = Menu.buildFromTemplate([
@@ -46,14 +44,14 @@ describe('Menu module', () => {
 
     it('does not throw exceptions for empty objects and null values ', () => {
       expect(() => {
-        Menu.buildFromTemplate([{}, {}, null, null]).to.not.throw()
-      })
+        Menu.buildFromTemplate([{}, {}, null, null])
+      }).to.not.throw()
     })
 
     it('does throw exception for object without role or label attribute', () => {
       expect(() => {
-        Menu.buildFromTemplate([{"randomKey":"ldks"}]).to.throw('Invalid template for MenuItem')
-      })
+        Menu.buildFromTemplate([{ 'randomKey':'ldks'}])
+      }).to.throw('Invalid template for MenuItem')
     })
 
     it('returns 0 item count for empty objects ', () => {
@@ -719,5 +717,4 @@ describe('Menu module', () => {
       expect(Menu.getApplicationMenu()).to.be.null()
     })
   })
-})
 })

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -9,7 +9,7 @@ const {closeWindow} = require('./window-helpers')
 const {expect} = chai
 chai.use(dirtyChai)
 
-describe.only('Menu module', () => {
+describe('Menu module', () => {
   describe('Menu.buildFromTemplate', () => {
     it('should be able to attach extra fields', () => {
       const menu = Menu.buildFromTemplate([

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -42,16 +42,21 @@ describe('Menu module', () => {
       }).to.not.throw()
     })
 
-    it('does throw exceptions for empty objects and null values ', () => {
+    it('does throw exceptions for empty objects and null values', () => {
       expect(() => {
-        Menu.buildFromTemplate([{}, {}, null, null])
-      }).to.throw(/Invalid template for MenuItem/)
+        Menu.buildFromTemplate([{}, null])
+      }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/)
     })
 
-    it('does throw exception for object without role or label attribute', () => {
+    it('does throw exception for object without role, label, or type attribute', () => {
       expect(() => {
-        Menu.buildFromTemplate([{ 'randomKey': 'ldks' }])
-      }).to.throw(/Invalid template for MenuItem/)
+        Menu.buildFromTemplate([{ 'visible': true }])
+      }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/)
+    })
+    it('does throw exception for undefined', () => {
+      expect(() => {
+        Menu.buildFromTemplate([undefined])
+      }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/)
     })
 
     describe('Menu sorting and building', () => {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -42,22 +42,16 @@ describe('Menu module', () => {
       }).to.not.throw()
     })
 
-    it('does not throw exceptions for empty objects and null values ', () => {
+    it('does throw exceptions for empty objects and null values ', () => {
       expect(() => {
         Menu.buildFromTemplate([{}, {}, null, null])
-      }).to.not.throw()
+      }).to.throw(/Invalid template for MenuItem/)
     })
 
     it('does throw exception for object without role or label attribute', () => {
       expect(() => {
         Menu.buildFromTemplate([{ 'randomKey': 'ldks' }])
       }).to.throw('Invalid template for MenuItem')
-    })
-
-    it('returns 0 item count for empty objects ', () => {
-      const menu = Menu.buildFromTemplate([{}, {}])
-      const items = menu.getItemCount()
-      expect(items).to.equal(0)
     })
 
     describe('Menu sorting and building', () => {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -50,7 +50,7 @@ describe.only('Menu module', () => {
 
     it('does throw exception for object without role or label attribute', () => {
       expect(() => {
-        Menu.buildFromTemplate([{ 'randomKey':'ldks'}])
+        Menu.buildFromTemplate([{ 'randomKey': 'ldks' }])
       }).to.throw('Invalid template for MenuItem')
     })
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -51,7 +51,7 @@ describe('Menu module', () => {
     it('does throw exception for object without role or label attribute', () => {
       expect(() => {
         Menu.buildFromTemplate([{ 'randomKey': 'ldks' }])
-      }).to.throw('Invalid template for MenuItem')
+      }).to.throw(/Invalid template for MenuItem/)
     })
 
     describe('Menu sorting and building', () => {


### PR DESCRIPTION
Fixes #13754
Currently, when a developer uses `Menu.buildFromTemplate()` and passes an array of empty objects it displays no menu items as expected for Mac but on Linux and Windows displays an empty menu. This PR includes stricter testing for empty objects so that false context menus are not created along with the tests to ensure future compatibility.
##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are added(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines]

Notes: strip falsey values from Menu templates