### PR TITLE
fix: Ensure DirectX capturer is supported

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -19,6 +19,7 @@ using base::PlatformThreadRef;
 #include "third_party/webrtc/modules/desktop_capture/desktop_capturer.h"
 #if defined(OS_WIN)
 #include "third_party/webrtc/modules/desktop_capture/win/dxgi_duplicator_controller.h"
+#include "third_party/webrtc/modules/desktop_capture/win/screen_capturer_win_directx.h"
 #include "ui/display/win/display_info.h"
 #endif  // defined(OS_WIN)
 
@@ -62,7 +63,14 @@ void DesktopCapturer::StartHandling(bool capture_window,
   webrtc::DesktopCaptureOptions options =
     content::CreateDesktopCaptureOptions();
 #if defined(OS_WIN)
-  using_directx_capturer_ = options.allow_directx_capturer();
+  if (content::desktop_capture::CreateDesktopCaptureOptions()
+      .allow_directx_capturer()) {
+    // DxgiDuplicatorController should be alive in this scope according to
+    // screen_capturer_win.cc.
+    auto duplicator = webrtc::DxgiDuplicatorController::Instance();
+    cap->using_directx_capturer_ =
+        webrtc::ScreenCapturerWinDirectx::IsSupported();
+  }
 #endif  // defined(OS_WIN)
 
   std::unique_ptr<webrtc::DesktopCapturer> screen_capturer(

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -63,12 +63,11 @@ void DesktopCapturer::StartHandling(bool capture_window,
   webrtc::DesktopCaptureOptions options =
     content::CreateDesktopCaptureOptions();
 #if defined(OS_WIN)
-  if (content::desktop_capture::CreateDesktopCaptureOptions()
-      .allow_directx_capturer()) {
+  if (options.allow_directx_capturer()) {
     // DxgiDuplicatorController should be alive in this scope according to
     // screen_capturer_win.cc.
     auto duplicator = webrtc::DxgiDuplicatorController::Instance();
-    cap->using_directx_capturer_ =
+    using_directx_capturer_ =
         webrtc::ScreenCapturerWinDirectx::IsSupported();
   }
 #endif  // defined(OS_WIN)

--- a/atom/browser/api/atom_api_desktop_capturer.h
+++ b/atom/browser/api/atom_api_desktop_capturer.h
@@ -52,7 +52,6 @@ class DesktopCapturer: public mate::EventEmitter<DesktopCapturer>,
   bool using_directx_capturer_ = false;
 #endif  // defined(OS_WIN)
 
-
   DISALLOW_COPY_AND_ASSIGN(DesktopCapturer);
 };
 

--- a/atom/browser/api/atom_api_desktop_capturer.h
+++ b/atom/browser/api/atom_api_desktop_capturer.h
@@ -49,8 +49,9 @@ class DesktopCapturer: public mate::EventEmitter<DesktopCapturer>,
  private:
   std::unique_ptr<DesktopMediaList> media_list_;
 #if defined(OS_WIN)
-  bool using_directx_capturer_;
+  bool using_directx_capturer_ = false;
 #endif  // defined(OS_WIN)
+
 
   DISALLOW_COPY_AND_ASSIGN(DesktopCapturer);
 };


### PR DESCRIPTION
Manual backport of https://github.com/electron/electron/pull/13543

I don't even know yet if this builds on Windows and usually wouldn't do a premature PR like this; however since time is a factor for `2.1.0` and I'm about to EOD, this is here if someone wants to take the baton and run with it.

@ajmacd @MarshallOfSound 