### PR TITLE
ci: [gn] build 32-bit node modules on 32-bit linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,7 @@ jobs:
       DISPLAY: ':99.0'
       GN_CONFIG: //electron/build/args/debug.gn
       GN_EXTRA_ARGS: 'target_cpu = "x86"'
+      NPM_CONFIG_ARCH: ia32
     docker:
       - image: electronbuilds/electron:0.0.8
     resource_class: 2xlarge
@@ -413,6 +414,7 @@ jobs:
       DISPLAY: ':99.0'
       GN_CONFIG: //electron/build/args/release.gn
       GN_EXTRA_ARGS: 'target_cpu = "x86"'
+      NPM_CONFIG_ARCH: ia32
     docker:
       - image: electronbuilds/electron:0.0.8
     resource_class: 2xlarge


### PR DESCRIPTION
Should fix CI for 32-bit linux

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)