### PR TITLE
ci: Use vs2017-15.4.5 for 3-0-x on AppVeyor

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_version':
     '63.0.3239.150',
   'libchromiumcontent_revision':
-    '1c542968990da951df27c8a0371a4ab5494a5a6c',
+    'a81166ad79e68fbfe7cf5ba243192d6412e26b37',
   'node_version':
     'v9.7.0-33-g538a5023af',
   'native_mate_revision':

--- a/appveyor-override.yml
+++ b/appveyor-override.yml
@@ -1,13 +1,11 @@
-version: 1.0.{build}
-branches:
-  except:
-  - /^release$|^release-\d-\d-x$/
 build_cloud: electron-16
-image: electron-16-vs2017
-environment:
-  DISABLE_CRASH_REPORTER_TESTS: true
+image: electron-16-vs2017-15.4.5
 build_script:
 - ps: >-
+    echo "Build worker image $env:APPVEYOR_BUILD_WORKER_IMAGE"
+
+    &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+
     if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
       Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
     } else {


### PR DESCRIPTION
This PR updates Appveyor to use Visual Studio 2017 version 15.4.5 for 3-0-x.  This includes a libcc update that is built with VS2017 15.4.5 see electron/libchromiumcontent#642

Fixes #13618 which is the issue of fetch failing on POST requests.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)