### PR TITLE
fix: refactor some asar functionality

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -11,19 +11,15 @@
   const cachedArchives = {}
 
   const envNoAsar = process.env.ELECTRON_NO_ASAR && process.type !== 'browser' && process.type !== 'renderer'
-  const isAsarDisabled = function () {
-    return process.noAsar || envNoAsar
-  }
+  const isAsarDisabled = () => process.noAsar || envNoAsar
 
-  const getOrCreateArchive = function (p) {
+  const getOrCreateArchive = (p) => {
     let archive = cachedArchives[p]
-    if (archive != null) {
-      return archive
-    }
+    if (archive != null) return archive
+
     archive = asar.createArchive(p)
-    if (!archive) {
-      return false
-    }
+    if (!archive) return false
+
     cachedArchives[p] = archive
     return archive
   }
@@ -39,27 +35,16 @@
   // Separate asar package's path from full path.
   const splitPath = function (p) {
     // shortcut to disable asar.
-    if (isAsarDisabled()) {
-      return [false]
-    }
-
-    if (Buffer.isBuffer(p)) {
-      p = p.toString()
-    }
-
-    if (typeof p !== 'string') {
-      return [false]
-    }
-
-    if (p.substr(-5) === '.asar') {
-      return [true, p, '']
-    }
+    if (isAsarDisabled()) return [false]
+    if (Buffer.isBuffer(p)) p = p.toString()
+    if (typeof p !== 'string') return [false]
+    if (p.substr(-5) === '.asar') return [true, p, '']
 
     p = path.normalize(p)
+
     const index = p.lastIndexOf('.asar' + path.sep)
-    if (index === -1) {
-      return [false]
-    }
+    if (index === -1) return [false]
+
     return [true, p.substr(0, index + 5), p.substr(index + 6)]
   }
 
@@ -67,47 +52,53 @@
   let nextInode = 0
 
   const uid = process.getuid != null ? process.getuid() : 0
-
   const gid = process.getgid != null ? process.getgid() : 0
 
   const fakeTime = new Date()
+  const msec = (date) => (date || fakeTime).getTime()
 
   const asarStatsToFsStats = function (stats) {
-    return {
-      dev: 1,
-      ino: ++nextInode,
-      mode: 33188,
-      nlink: 1,
-      uid: uid,
-      gid: gid,
-      rdev: 0,
-      atime: stats.atime || fakeTime,
-      birthtime: stats.birthtime || fakeTime,
-      mtime: stats.mtime || fakeTime,
-      ctime: stats.ctime || fakeTime,
-      size: stats.size,
-      isFile: function () {
-        return stats.isFile
-      },
-      isDirectory: function () {
-        return stats.isDirectory
-      },
-      isSymbolicLink: function () {
-        return stats.isLink
-      },
-      isBlockDevice: function () {
-        return false
-      },
-      isCharacterDevice: function () {
-        return false
-      },
-      isFIFO: function () {
-        return false
-      },
-      isSocket: function () {
-        return false
-      }
+    const { Stats, constants } = require('fs')
+
+    let mode = constants.S_IROTH ^ constants.S_IRGRP ^ constants.S_IRUSR ^ constants.S_IWUSR
+
+    if (stats.isFile) {
+      mode ^= constants.S_IFREG
+    } else if (stats.isDirectory) {
+      mode ^= constants.S_IFDIR
+    } else if (stats.isLink) {
+      mode ^= constants.S_IFLNK
     }
+
+    const nodeStats = new Stats(
+      1, // dev
+      33188, // mode
+      1, // nlink
+      uid,
+      gid,
+      0, // rdev
+      undefined, // blksize
+      ++nextInode, // ino
+      stats.size,
+      undefined, // blocks,
+      msec(stats.atime), // atim_msec
+      msec(stats.mtime), // mtim_msec
+      msec(stats.ctime), // ctim_msec
+      msec(stats.birthtime) // birthtim_msec
+    )
+
+    nodeStats.isFile = () => stats.isFile
+    nodeStats.isDirectory = () => stats.isDirectory
+    nodeStats.isSymbolicLink = () => stats.isLink
+
+    const forceFalse = (method) => { stats[method] = () => false }
+
+    forceFalse('isBlockDevice')
+    forceFalse('isCharacterDevice')
+    forceFalse('isFIFO')
+    forceFalse('isSocket')
+
+    return nodeStats
   }
 
   // Create a ENOENT error.
@@ -118,9 +109,7 @@
     if (typeof callback !== 'function') {
       throw error
     }
-    process.nextTick(function () {
-      callback(error)
-    })
+    process.nextTick(() => { callback(error) })
   }
 
   // Create a ENOTDIR error.
@@ -131,9 +120,7 @@
     if (typeof callback !== 'function') {
       throw error
     }
-    process.nextTick(function () {
-      callback(error)
-    })
+    process.nextTick(() => { callback(error) })
   }
 
   // Create a EACCES error.
@@ -144,9 +131,7 @@
     if (typeof callback !== 'function') {
       throw error
     }
-    process.nextTick(function () {
-      callback(error)
-    })
+    process.nextTick(() => { callback(error) })
   }
 
   // Create invalid archive error.
@@ -155,9 +140,7 @@
     if (typeof callback !== 'function') {
       throw error
     }
-    process.nextTick(function () {
-      callback(error)
-    })
+    process.nextTick(() => { callback(error) })
   }
 
   // Override APIs that rely on passing file path instead of content to C++.
@@ -337,7 +320,7 @@
     }
 
     const {realpathSync} = fs
-    fs.realpathSync = (p) => {
+    fs.realpathSync = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
       if (!isAsar) return realpathSync.apply(this, arguments)
 
@@ -350,7 +333,7 @@
       return path.join(realpathSync(asarPath), real)
     }
 
-    fs.realpathSync.native = (p) => {
+    fs.realpathSync.native = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
       if (!isAsar) return realpathSync.native.apply(this, arguments)
 
@@ -364,7 +347,7 @@
     }
 
     const {realpath} = fs
-    fs.realpath = (p, cache, callback) => {
+    fs.realpath = function (p, cache, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
       if (!isAsar) return realpath.apply(this, arguments)
 
@@ -384,7 +367,7 @@
       })
     }
 
-    fs.realpath.native = (p, cache, callback) => {
+    fs.realpath.native = function (p, cache, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
       if (!isAsar) return realpath.native.apply(this, arguments)
 

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -70,9 +70,9 @@
       mode ^= constants.S_IFLNK
     }
 
-    const nodeStats = new Stats(
+    return new Stats(
       1, // dev
-      33188, // mode
+      mode, // mode
       1, // nlink
       uid,
       gid,
@@ -86,19 +86,6 @@
       msec(stats.ctime), // ctim_msec
       msec(stats.birthtime) // birthtim_msec
     )
-
-    nodeStats.isFile = () => stats.isFile
-    nodeStats.isDirectory = () => stats.isDirectory
-    nodeStats.isSymbolicLink = () => stats.isLink
-
-    const forceFalse = (method) => { stats[method] = () => false }
-
-    forceFalse('isBlockDevice')
-    forceFalse('isCharacterDevice')
-    forceFalse('isFIFO')
-    forceFalse('isSocket')
-
-    return nodeStats
   }
 
   const errors = ['NOT_FOUND', 'NOT_DIR', 'NO_ACCESS', 'INVALID_ARCHIVE']

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -101,34 +101,31 @@
     return nodeStats
   }
 
-  const types = ['notFound', 'notDir', 'access', 'invalidArchive']
+  const errors = ['NOT_FOUND', 'NOT_DIR', 'NO_ACCESS', 'INVALID_ARCHIVE']
   const createError = (type, {asarPath, filePath, callback}) => {
     let error
-    if (!types.includes(type)) throw new Error('invalid error type')
-    if (type === 'notFound') {
+    if (!errors.includes(type)) throw new Error('invalid error type')
+    if (type === 'NOT_FOUND') {
       error = new Error(`ENOENT, ${filePath} not found in ${asarPath}`)
       error.code = 'ENOENT'
       error.errno = -2
-    } else if (type === 'notDir') {
+    } else if (type === 'NOT_DIR') {
       error = new Error('ENOTDIR, not a directory')
       error.code = 'ENOTDIR'
       error.errno = -20
-    } else if (type === 'access') {
+    } else if (type === 'NO_ACCESS') {
       error = new Error(`EACCES: permission denied, access '${filePath}'`)
       error.code = 'EACCES'
       error.errno = -13
-    } else if (type === 'invalidArchive') {
+    } else if (type === 'INVALID_ARCHIVE') {
       error = new Error(`Invalid package ${asarPath}`)
     }
     if (typeof callback !== 'function') throw error
-    process.nextTick(() => { callback(error) })
+    process.nextTick(() => callback(error))
   }
 
   // Override APIs that rely on passing file path instead of content to C++.
-  const overrideAPISync = function (module, name, arg) {
-    if (arg == null) {
-      arg = 0
-    }
+  const overrideAPISync = function (module, name, arg = 0) {
     const old = module[name]
     module[name] = function () {
       const p = arguments[arg]
@@ -136,10 +133,10 @@
       if (!isAsar) return old.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) createError('invalidArchive', {asarPath})
+      if (!archive) createError('INVALID_ARCHIVE', {asarPath})
 
       const newPath = archive.copyFileOut(filePath)
-      if (!newPath) createError('notFound', {asarPath, filePath})
+      if (!newPath) createError('NOT_FOUND', {asarPath, filePath})
 
       arguments[arg] = newPath
       return old.apply(this, arguments)
@@ -157,10 +154,10 @@
       if (typeof callback !== 'function') return overrideAPISync(module, name, arg)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       const newPath = archive.copyFileOut(filePath)
-      if (!newPath) return createError('notFound', {asarPath, filePath, callback})
+      if (!newPath) return createError('NOT_FOUND', {asarPath, filePath, callback})
 
       arguments[arg] = newPath
       return old.apply(this, arguments)
@@ -173,10 +170,10 @@
         if (!isAsar) return old[util.promisify.custom].apply(this, arguments)
 
         const archive = getOrCreateArchive(asarPath)
-        if (!archive) return new Promise(() => createError('invalidArchive', {asarPath}))
+        if (!archive) return new Promise(() => createError('INVALID_ARCHIVE', {asarPath}))
 
         const newPath = archive.copyFileOut(filePath)
-        if (!newPath) return new Promise(() => createError('notFound', {asarPath, filePath}))
+        if (!newPath) return new Promise(() => createError('NOT_FOUND', {asarPath, filePath}))
 
         arguments[arg] = newPath
         return old[util.promisify.custom].apply(this, arguments)
@@ -205,10 +202,10 @@
       if (!isAsar) return lstatSync(p)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) createError('invalidArchive', {asarPath})
+      if (!archive) createError('INVALID_ARCHIVE', {asarPath})
 
       const stats = archive.stat(filePath)
-      if (!stats) createError('notFound', {asarPath, filePath})
+      if (!stats) createError('NOT_FOUND', {asarPath, filePath})
 
       return asarStatsToFsStats(stats)
     }
@@ -219,12 +216,12 @@
       if (!isAsar) return lstat(p, callback)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       const stats = getOrCreateArchive(asarPath).stat(filePath)
-      if (!stats) return createError('notFound', {asarPath, filePath, callback})
+      if (!stats) return createError('NOT_FOUND', {asarPath, filePath, callback})
 
-      process.nextTick(() => { callback(null, asarStatsToFsStats(stats)) })
+      process.nextTick(() => callback(null, asarStatsToFsStats(stats)))
     }
 
     const {statSync} = fs
@@ -265,10 +262,10 @@
       if (!isAsar) return realpathSync.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) createError('invalidArchive', {asarPath})
+      if (!archive) createError('INVALID_ARCHIVE', {asarPath})
 
       const real = archive.realpath(filePath)
-      if (real === false) createError('notFound', {asarPath, filePath})
+      if (real === false) createError('NOT_FOUND', {asarPath, filePath})
 
       return path.join(realpathSync(asarPath), real)
     }
@@ -278,10 +275,10 @@
       if (!isAsar) return realpathSync.native.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) createError('invalidArchive', {asarPath})
+      if (!archive) createError('INVALID_ARCHIVE', {asarPath})
 
       const real = archive.realpath.native(filePath)
-      if (real === false) createError('invalidArchive', {asarPath, filePath})
+      if (real === false) createError('INVALID_ARCHIVE', {asarPath, filePath})
 
       return path.join(realpathSync.native(asarPath), real)
     }
@@ -293,14 +290,14 @@
 
       if (typeof cache === 'function') {
         callback = cache
-        cache = void 0
+        cache = undefined
       }
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       const real = archive.realpath(filePath)
-      if (real === false) return createError('notFound', {asarPath, filePath, callback})
+      if (real === false) return createError('NOT_FOUND', {asarPath, filePath, callback})
 
       return realpath(asarPath, (err, p) => {
         return (err) ? callback(err) : callback(null, path.join(p, real))
@@ -317,10 +314,10 @@
       }
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       const real = archive.realpath.native(filePath)
-      if (real === false) return createError('notFound', {asarPath, filePath, callback})
+      if (real === false) return createError('NOT_FOUND', {asarPath, filePath, callback})
 
       return realpath.native(asarPath, (err, p) => {
         return (err) ? callback(err) : callback(null, path.join(p, real))
@@ -333,7 +330,7 @@
       if (!isAsar) return exists(p, callback)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       process.nextTick(() => {
         // Disabled due to false positive in StandardJS
@@ -347,7 +344,7 @@
       if (!isAsar) return exists[util.promisify.custom](p)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return new Promise(() => createError('invalidArchive', {asarPath}))
+      if (!archive) return new Promise(() => createError('INVALID_ARCHIVE', {asarPath}))
 
       return Promise.resolve(archive.stat(filePath) !== false)
     }
@@ -374,23 +371,23 @@
       }
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       const info = archive.getFileInfo(filePath)
-      if (!info) return createError('notFound', {asarPath, filePath, callback})
+      if (!info) return createError('NOT_FOUND', {asarPath, filePath, callback})
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
         return fs.access(realPath, mode, callback)
       }
 
       const stats = getOrCreateArchive(asarPath).stat(filePath)
-      if (!stats) return createError('notFound', {asarPath, filePath, callback})
+      if (!stats) return createError('NOT_FOUND', {asarPath, filePath, callback})
 
       if (mode & fs.constants.W_OK) {
-        createError('access', {asarPath, filePath, callback})
+        createError('NO_ACCESS', {asarPath, filePath, callback})
       }
 
-      process.nextTick(() => { callback() })
+      process.nextTick(() => callback())
     }
 
     const {accessSync} = fs
@@ -399,20 +396,20 @@
       if (!isAsar) return accessSync.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) createError('invalidArchive', {asarPath})
+      if (!archive) createError('INVALID_ARCHIVE', {asarPath})
 
       const info = archive.getFileInfo(filePath)
-      if (!info) createError('notFound', {asarPath, filePath})
+      if (!info) createError('NOT_FOUND', {asarPath, filePath})
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
         return fs.accessSync(realPath, mode)
       }
 
       const stats = getOrCreateArchive(asarPath).stat(filePath)
-      if (!stats) createError('notFound', {asarPath, filePath})
+      if (!stats) createError('NOT_FOUND', {asarPath, filePath})
 
       if (mode & fs.constants.W_OK) {
-        createError('access', {asarPath, filePath})
+        createError('NO_ACCESS', {asarPath, filePath})
       }
     }
 
@@ -434,10 +431,10 @@
       const {encoding} = options
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       const info = archive.getFileInfo(filePath)
-      if (!info) return createError('notFound', {asarPath, filePath, callback})
+      if (!info) return createError('NOT_FOUND', {asarPath, filePath, callback})
 
       if (info.size === 0) {
         return process.nextTick(() => {
@@ -453,7 +450,7 @@
       const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
       if (!(fd >= 0)) {
-        return createError('notFound', {asarPath, filePath, callback})
+        return createError('NOT_FOUND', {asarPath, filePath, callback})
       }
 
       logASARAccess(asarPath, filePath, info.offset)
@@ -468,10 +465,10 @@
       if (!isAsar) return readFileSync.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) createError('invalidArchive', {asarPath})
+      if (!archive) createError('INVALID_ARCHIVE', {asarPath})
 
       const info = archive.getFileInfo(filePath)
-      if (!info) createError('notFound', {asarPath, filePath})
+      if (!info) createError('NOT_FOUND', {asarPath, filePath})
       if (info.size === 0) return (options) ? '' : Buffer.alloc(0)
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
@@ -489,7 +486,7 @@
       const {encoding} = options
       const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
-      if (!(fd >= 0)) createError('notFound', {asarPath, filePath})
+      if (!(fd >= 0)) createError('NOT_FOUND', {asarPath, filePath})
 
       logASARAccess(asarPath, filePath, info.offset)
       fs.readSync(fd, buffer, 0, info.size, info.offset)
@@ -502,12 +499,12 @@
       if (!isAsar) return readdir.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return createError('invalidArchive', {asarPath, callback})
+      if (!archive) return createError('INVALID_ARCHIVE', {asarPath, callback})
 
       const files = archive.readdir(filePath)
-      if (!files) return createError('notFound', {asarPath, filePath, callback})
+      if (!files) return createError('NOT_FOUND', {asarPath, filePath, callback})
 
-      process.nextTick(() => { callback(null, files) })
+      process.nextTick(() => callback(null, files))
     }
 
     const {readdirSync} = fs
@@ -516,10 +513,10 @@
       if (!isAsar) return readdirSync.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) createError('invalidArchive', {asarPath})
+      if (!archive) createError('INVALID_ARCHIVE', {asarPath})
 
       const files = archive.readdir(filePath)
-      if (!files) createError('notFound', {asarPath, filePath})
+      if (!files) createError('NOT_FOUND', {asarPath, filePath})
       return files
     }
 
@@ -575,14 +572,14 @@
           callback = mode
         }
         const [isAsar, , filePath] = splitPath(p)
-        if (isAsar && filePath.length) return createError('notDir', {callback})
+        if (isAsar && filePath.length) return createError('NOT_DIR', {callback})
         mkdir(p, mode, callback)
       }
 
       const {mkdirSync} = fs
       fs.mkdirSync = function (p, mode) {
         const [isAsar, , filePath] = splitPath(p)
-        if (isAsar && filePath.length) createError('notDir', {})
+        if (isAsar && filePath.length) createError('NOT_DIR', {})
         return mkdirSync(p, mode)
       }
     }

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -337,45 +337,70 @@
     }
 
     const {realpathSync} = fs
-    fs.realpathSync = function (p) {
+    fs.realpathSync = (p) => {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return realpathSync.apply(this, arguments)
-      }
+      if (!isAsar) return realpathSync.apply(this, arguments)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        invalidArchiveError(asarPath)
-      }
+      if (!archive) invalidArchiveError(asarPath)
+
       const real = archive.realpath(filePath)
-      if (real === false) {
-        notFoundError(asarPath, filePath)
-      }
+      if (real === false) notFoundError(asarPath, filePath)
+
       return path.join(realpathSync(asarPath), real)
     }
 
-    const {realpath} = fs
-    fs.realpath = function (p, cache, callback) {
+    fs.realpathSync.native = (p) => {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return realpath.apply(this, arguments)
-      }
+      if (!isAsar) return realpathSync.native.apply(this, arguments)
+
+      const archive = getOrCreateArchive(asarPath)
+      if (!archive) invalidArchiveError(asarPath)
+
+      const real = archive.realpath.native(filePath)
+      if (real === false) notFoundError(asarPath, filePath)
+
+      return path.join(realpathSync.native(asarPath), real)
+    }
+
+    const {realpath} = fs
+    fs.realpath = (p, cache, callback) => {
+      const [isAsar, asarPath, filePath] = splitPath(p)
+      if (!isAsar) return realpath.apply(this, arguments)
+
       if (typeof cache === 'function') {
         callback = cache
         cache = void 0
       }
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return invalidArchiveError(asarPath, callback)
-      }
+      if (!archive) return invalidArchiveError(asarPath, callback)
+
       const real = archive.realpath(filePath)
-      if (real === false) {
-        return notFoundError(asarPath, filePath, callback)
+      if (real === false) return notFoundError(asarPath, filePath, callback)
+
+      return realpath(asarPath, (err, p) => {
+        return (err) ? callback(err) : callback(null, path.join(p, real))
+      })
+    }
+
+    fs.realpath.native = (p, cache, callback) => {
+      const [isAsar, asarPath, filePath] = splitPath(p)
+      if (!isAsar) return realpath.native.apply(this, arguments)
+
+      if (typeof cache === 'function') {
+        callback = cache
+        cache = void 0
       }
-      return realpath(asarPath, function (err, p) {
-        if (err) {
-          return callback(err)
-        }
-        return callback(null, path.join(p, real))
+
+      const archive = getOrCreateArchive(asarPath)
+      if (!archive) return invalidArchiveError(asarPath, callback)
+
+      const real = archive.realpath.native(filePath)
+      if (real === false) return notFoundError(asarPath, filePath, callback)
+
+      return realpath.native(asarPath, (err, p) => {
+        return (err) ? callback(err) : callback(null, path.join(p, real))
       })
     }
 

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -133,72 +133,50 @@
     module[name] = function () {
       const p = arguments[arg]
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return old.apply(this, arguments)
-      }
+      if (!isAsar) return old.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        createError('invalidArchive', {asarPath})
-      }
+      if (!archive) createError('invalidArchive', {asarPath})
 
       const newPath = archive.copyFileOut(filePath)
-      if (!newPath) {
-        createError('notFound', {asarPath, filePath})
-      }
+      if (!newPath) createError('notFound', {asarPath, filePath})
 
       arguments[arg] = newPath
       return old.apply(this, arguments)
     }
   }
 
-  const overrideAPI = function (module, name, arg) {
-    if (arg == null) {
-      arg = 0
-    }
+  const overrideAPI = function (module, name, arg = 0) {
     const old = module[name]
     module[name] = function () {
       const p = arguments[arg]
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return old.apply(this, arguments)
-      }
+      if (!isAsar) return old.apply(this, arguments)
 
       const callback = arguments[arguments.length - 1]
-      if (typeof callback !== 'function') {
-        return overrideAPISync(module, name, arg)
-      }
+      if (typeof callback !== 'function') return overrideAPISync(module, name, arg)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return createError('invalidArchive', {asarPath, callback})
-      }
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
 
       const newPath = archive.copyFileOut(filePath)
-      if (!newPath) {
-        return createError('notFound', {asarPath, filePath, callback})
-      }
+      if (!newPath) return createError('notFound', {asarPath, filePath, callback})
 
       arguments[arg] = newPath
       return old.apply(this, arguments)
     }
+
     if (old[util.promisify.custom]) {
       module[name][util.promisify.custom] = function () {
         const p = arguments[arg]
         const [isAsar, asarPath, filePath] = splitPath(p)
-        if (!isAsar) {
-          return old[util.promisify.custom].apply(this, arguments)
-        }
+        if (!isAsar) return old[util.promisify.custom].apply(this, arguments)
 
         const archive = getOrCreateArchive(asarPath)
-        if (!archive) {
-          return new Promise(() => createError('invalidArchive', {asarPath}))
-        }
+        if (!archive) return new Promise(() => createError('invalidArchive', {asarPath}))
 
         const newPath = archive.copyFileOut(filePath)
-        if (!newPath) {
-          return new Promise(() => createError('notFound', {asarPath, filePath}))
-        }
+        if (!newPath) return new Promise(() => createError('notFound', {asarPath, filePath}))
 
         arguments[arg] = newPath
         return old[util.promisify.custom].apply(this, arguments)
@@ -210,93 +188,74 @@
   exports.wrapFsWithAsar = function (fs) {
     const logFDs = {}
     const logASARAccess = function (asarPath, filePath, offset) {
-      if (!process.env.ELECTRON_LOG_ASAR_READS) {
-        return
-      }
+      if (!process.env.ELECTRON_LOG_ASAR_READS) return
       if (!logFDs[asarPath]) {
         const path = require('path')
         const logFilename = path.basename(asarPath, '.asar') + '-access-log.txt'
         const logPath = path.join(require('os').tmpdir(), logFilename)
         logFDs[asarPath] = fs.openSync(logPath, 'a')
-        console.log('Logging ' + asarPath + ' access to ' + logPath)
+        console.log(`Logging ${asarPath} access to ${logPath}`)
       }
-      fs.writeSync(logFDs[asarPath], offset + ': ' + filePath + '\n')
+      fs.writeSync(logFDs[asarPath], `offset:${filePath}\n`)
     }
 
     const {lstatSync} = fs
     fs.lstatSync = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return lstatSync(p)
-      }
+      if (!isAsar) return lstatSync(p)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        createError('invalidArchive', {asarPath})
-      }
+      if (!archive) createError('invalidArchive', {asarPath})
+
       const stats = archive.stat(filePath)
-      if (!stats) {
-        createError('notFound', {asarPath, filePath})
-      }
+      if (!stats) createError('notFound', {asarPath, filePath})
+
       return asarStatsToFsStats(stats)
     }
 
     const {lstat} = fs
     fs.lstat = function (p, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return lstat(p, callback)
-      }
+      if (!isAsar) return lstat(p, callback)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return createError('invalidArchive', {asarPath, callback})
-      }
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
+
       const stats = getOrCreateArchive(asarPath).stat(filePath)
-      if (!stats) {
-        return createError('notFound', {asarPath, filePath, callback})
-      }
-      process.nextTick(function () {
-        callback(null, asarStatsToFsStats(stats))
-      })
+      if (!stats) return createError('notFound', {asarPath, filePath, callback})
+
+      process.nextTick(() => { callback(null, asarStatsToFsStats(stats)) })
     }
 
     const {statSync} = fs
-    fs.statSync = function (p) {
+    fs.statSync = (p) => {
       const [isAsar] = splitPath(p)
-      if (!isAsar) {
-        return statSync(p)
-      }
+      if (!isAsar) return statSync(p)
 
       // Do not distinguish links for now.
       return fs.lstatSync(p)
     }
 
     const {stat} = fs
-    fs.stat = function (p, callback) {
+    fs.stat = (p, callback) => {
       const [isAsar] = splitPath(p)
-      if (!isAsar) {
-        return stat(p, callback)
-      }
+      if (!isAsar) return stat(p, callback)
 
       // Do not distinguish links for now.
-      process.nextTick(function () {
-        fs.lstat(p, callback)
-      })
+      process.nextTick(() => { fs.lstat(p, callback) })
     }
 
     const {statSyncNoException} = fs
     fs.statSyncNoException = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return statSyncNoException(p)
-      }
+      if (!isAsar) return statSyncNoException(p)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return false
-      }
+      if (!archive) return false
+
       const stats = archive.stat(filePath)
-      if (!stats) {
-        return false
-      }
+      if (!stats) return false
+
       return asarStatsToFsStats(stats)
     }
 
@@ -371,14 +330,12 @@
     const {exists} = fs
     fs.exists = function (p, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return exists(p, callback)
-      }
+      if (!isAsar) return exists(p, callback)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return createError('invalidArchive', {asarPath, callback})
-      }
-      process.nextTick(function () {
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
+
+      process.nextTick(() => {
         // Disabled due to false positive in StandardJS
         // eslint-disable-next-line standard/no-callback-literal
         callback(archive.stat(filePath) !== false)
@@ -387,88 +344,73 @@
 
     fs.exists[util.promisify.custom] = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return exists[util.promisify.custom](p)
-      }
+      if (!isAsar) return exists[util.promisify.custom](p)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return new Promise(() => createError('invalidArchive', {asarPath}))
-      }
+      if (!archive) return new Promise(() => createError('invalidArchive', {asarPath}))
+
       return Promise.resolve(archive.stat(filePath) !== false)
     }
 
     const {existsSync} = fs
     fs.existsSync = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return existsSync(p)
-      }
+      if (!isAsar) return existsSync(p)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return false
-      }
+      if (!archive) return false
+
       return archive.stat(filePath) !== false
     }
 
     const {access} = fs
     fs.access = function (p, mode, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return access.apply(this, arguments)
-      }
+      if (!isAsar) return access.apply(this, arguments)
+
       if (typeof mode === 'function') {
         callback = mode
         mode = fs.constants.F_OK
       }
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return createError('invalidArchive', {asarPath, callback})
-      }
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
+
       const info = archive.getFileInfo(filePath)
-      if (!info) {
-        return createError('notFound', {asarPath, filePath, callback})
-      }
+      if (!info) return createError('notFound', {asarPath, filePath, callback})
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
         return fs.access(realPath, mode, callback)
       }
+
       const stats = getOrCreateArchive(asarPath).stat(filePath)
-      if (!stats) {
-        return createError('notFound', {asarPath, filePath, callback})
-      }
+      if (!stats) return createError('notFound', {asarPath, filePath, callback})
+
       if (mode & fs.constants.W_OK) {
         createError('access', {asarPath, filePath, callback})
       }
-      process.nextTick(function () {
-        callback()
-      })
+
+      process.nextTick(() => { callback() })
     }
 
     const {accessSync} = fs
-    fs.accessSync = function (p, mode) {
+    fs.accessSync = function (p, mode = fs.constants.F_OK) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return accessSync.apply(this, arguments)
-      }
-      if (mode == null) {
-        mode = fs.constants.F_OK
-      }
+      if (!isAsar) return accessSync.apply(this, arguments)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        createError('invalidArchive', {asarPath})
-      }
+      if (!archive) createError('invalidArchive', {asarPath})
+
       const info = archive.getFileInfo(filePath)
-      if (!info) {
-        createError('notFound', {asarPath, filePath})
-      }
+      if (!info) createError('notFound', {asarPath, filePath})
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
         return fs.accessSync(realPath, mode)
       }
+
       const stats = getOrCreateArchive(asarPath).stat(filePath)
-      if (!stats) {
-        createError('notFound', {asarPath, filePath})
-      }
+      if (!stats) createError('notFound', {asarPath, filePath})
+
       if (mode & fs.constants.W_OK) {
         createError('access', {asarPath, filePath})
       }
@@ -477,40 +419,32 @@
     const {readFile} = fs
     fs.readFile = function (p, options, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return readFile.apply(this, arguments)
-      }
+      if (!isAsar) return readFile.apply(this, arguments)
+
       if (typeof options === 'function') {
         callback = options
-        options = {
-          encoding: null
-        }
+        options = { encoding: null }
       } else if (typeof options === 'string') {
-        options = {
-          encoding: options
-        }
+        options = { encoding: options }
       } else if (options === null || options === undefined) {
-        options = {
-          encoding: null
-        }
+        options = { encoding: null }
       } else if (typeof options !== 'object') {
         throw new TypeError('Bad arguments')
       }
       const {encoding} = options
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return createError('invalidArchive', {asarPath, callback})
-      }
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
+
       const info = archive.getFileInfo(filePath)
-      if (!info) {
-        return createError('notFound', {asarPath, filePath, callback})
-      }
+      if (!info) return createError('notFound', {asarPath, filePath, callback})
+
       if (info.size === 0) {
-        return process.nextTick(function () {
+        return process.nextTick(() => {
           callback(null, encoding ? '' : Buffer.alloc(0))
         })
       }
+
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
         return fs.readFile(realPath, options, callback)
@@ -521,8 +455,9 @@
       if (!(fd >= 0)) {
         return createError('notFound', {asarPath, filePath, callback})
       }
+
       logASARAccess(asarPath, filePath, info.offset)
-      fs.read(fd, buffer, 0, info.size, info.offset, function (error) {
+      fs.read(fd, buffer, 0, info.size, info.offset, (error) => {
         callback(error, encoding ? buffer.toString(encoding) : buffer)
       })
     }
@@ -530,118 +465,84 @@
     const {readFileSync} = fs
     fs.readFileSync = function (p, options) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return readFileSync.apply(this, arguments)
-      }
+      if (!isAsar) return readFileSync.apply(this, arguments)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        createError('invalidArchive', {asarPath})
-      }
+      if (!archive) createError('invalidArchive', {asarPath})
+
       const info = archive.getFileInfo(filePath)
-      if (!info) {
-        createError('notFound', {asarPath, filePath})
-      }
-      if (info.size === 0) {
-        if (options) {
-          return ''
-        } else {
-          return Buffer.alloc(0)
-        }
-      }
+      if (!info) createError('notFound', {asarPath, filePath})
+      if (info.size === 0) return (options) ? '' : Buffer.alloc(0)
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
         return fs.readFileSync(realPath, options)
       }
+
       if (!options) {
-        options = {
-          encoding: null
-        }
+        options = { encoding: null }
       } else if (typeof options === 'string') {
-        options = {
-          encoding: options
-        }
+        options = { encoding: options }
       } else if (typeof options !== 'object') {
         throw new TypeError('Bad arguments')
       }
+
       const {encoding} = options
       const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
-      if (!(fd >= 0)) {
-        createError('notFound', {asarPath, filePath})
-      }
+      if (!(fd >= 0)) createError('notFound', {asarPath, filePath})
+
       logASARAccess(asarPath, filePath, info.offset)
       fs.readSync(fd, buffer, 0, info.size, info.offset)
-      if (encoding) {
-        return buffer.toString(encoding)
-      } else {
-        return buffer
-      }
+      return (encoding) ? buffer.toString(encoding) : buffer
     }
 
     const {readdir} = fs
     fs.readdir = function (p, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return readdir.apply(this, arguments)
-      }
+      if (!isAsar) return readdir.apply(this, arguments)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return createError('invalidArchive', {asarPath, callback})
-      }
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
+
       const files = archive.readdir(filePath)
-      if (!files) {
-        return createError('notFound', {asarPath, filePath, callback})
-      }
-      process.nextTick(function () {
-        callback(null, files)
-      })
+      if (!files) return createError('notFound', {asarPath, filePath, callback})
+
+      process.nextTick(() => { callback(null, files) })
     }
 
     const {readdirSync} = fs
     fs.readdirSync = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return readdirSync.apply(this, arguments)
-      }
+      if (!isAsar) return readdirSync.apply(this, arguments)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        createError('invalidArchive', {asarPath})
-      }
+      if (!archive) createError('invalidArchive', {asarPath})
+
       const files = archive.readdir(filePath)
-      if (!files) {
-        createError('notFound', {asarPath, filePath})
-      }
+      if (!files) createError('notFound', {asarPath, filePath})
       return files
     }
 
     const {internalModuleReadJSON} = process.binding('fs')
     process.binding('fs').internalModuleReadJSON = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return internalModuleReadJSON(p)
-      }
+      if (!isAsar) return internalModuleReadJSON(p)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return
-      }
+      if (!archive) return
+
       const info = archive.getFileInfo(filePath)
-      if (!info) {
-        return
-      }
-      if (info.size === 0) {
-        return ''
-      }
+      if (!info) return
+      if (info.size === 0) return ''
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
-        return fs.readFileSync(realPath, {
-          encoding: 'utf8'
-        })
+        return fs.readFileSync(realPath, { encoding: 'utf8' })
       }
+
       const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
-      if (!(fd >= 0)) {
-        return
-      }
+      if (!(fd >= 0)) return
+
       logASARAccess(asarPath, filePath, info.offset)
       fs.readSync(fd, buffer, 0, info.size, info.offset)
       return buffer.toString('utf8')
@@ -650,26 +551,17 @@
     const {internalModuleStat} = process.binding('fs')
     process.binding('fs').internalModuleStat = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return internalModuleStat(p)
-      }
+      if (!isAsar) return internalModuleStat(p)
+
       const archive = getOrCreateArchive(asarPath)
 
       // -ENOENT
-      if (!archive) {
-        return -34
-      }
+      if (!archive) return -34
       const stats = archive.stat(filePath)
 
       // -ENOENT
-      if (!stats) {
-        return -34
-      }
-      if (stats.isDirectory) {
-        return 1
-      } else {
-        return 0
-      }
+      if (!stats) return -34
+      return (stats.isDirectory) ? 1 : 0
     }
 
     // Calling mkdir for directory inside asar archive should throw ENOTDIR
@@ -683,18 +575,14 @@
           callback = mode
         }
         const [isAsar, , filePath] = splitPath(p)
-        if (isAsar && filePath.length) {
-          return createError('notDir', {callback})
-        }
+        if (isAsar && filePath.length) return createError('notDir', {callback})
         mkdir(p, mode, callback)
       }
 
       const {mkdirSync} = fs
       fs.mkdirSync = function (p, mode) {
         const [isAsar, , filePath] = splitPath(p)
-        if (isAsar && filePath.length) {
-          createError('notDir', {})
-        }
+        if (isAsar && filePath.length) createError('notDir', {})
         return mkdirSync(p, mode)
       }
     }

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -101,45 +101,26 @@
     return nodeStats
   }
 
-  // Create a ENOENT error.
-  const notFoundError = function (asarPath, filePath, callback) {
-    const error = new Error(`ENOENT, ${filePath} not found in ${asarPath}`)
-    error.code = 'ENOENT'
-    error.errno = -2
-    if (typeof callback !== 'function') {
-      throw error
+  const types = ['notFound', 'notDir', 'access', 'invalidArchive']
+  const createError = (type, {asarPath, filePath, callback}) => {
+    let error
+    if (!types.includes(type)) throw new Error('invalid error type')
+    if (type === 'notFound') {
+      error = new Error(`ENOENT, ${filePath} not found in ${asarPath}`)
+      error.code = 'ENOENT'
+      error.errno = -2
+    } else if (type === 'notDir') {
+      error = new Error('ENOTDIR, not a directory')
+      error.code = 'ENOTDIR'
+      error.errno = -20
+    } else if (type === 'access') {
+      error = new Error(`EACCES: permission denied, access '${filePath}'`)
+      error.code = 'EACCES'
+      error.errno = -13
+    } else if (type === 'invalidArchive') {
+      error = new Error(`Invalid package ${asarPath}`)
     }
-    process.nextTick(() => { callback(error) })
-  }
-
-  // Create a ENOTDIR error.
-  const notDirError = function (callback) {
-    const error = new Error('ENOTDIR, not a directory')
-    error.code = 'ENOTDIR'
-    error.errno = -20
-    if (typeof callback !== 'function') {
-      throw error
-    }
-    process.nextTick(() => { callback(error) })
-  }
-
-  // Create a EACCES error.
-  const accessError = function (asarPath, filePath, callback) {
-    const error = new Error(`EACCES: permission denied, access '${filePath}'`)
-    error.code = 'EACCES'
-    error.errno = -13
-    if (typeof callback !== 'function') {
-      throw error
-    }
-    process.nextTick(() => { callback(error) })
-  }
-
-  // Create invalid archive error.
-  const invalidArchiveError = function (asarPath, callback) {
-    const error = new Error(`Invalid package ${asarPath}`)
-    if (typeof callback !== 'function') {
-      throw error
-    }
+    if (typeof callback !== 'function') throw error
     process.nextTick(() => { callback(error) })
   }
 
@@ -158,12 +139,12 @@
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        invalidArchiveError(asarPath)
+        createError('invalidArchive', {asarPath})
       }
 
       const newPath = archive.copyFileOut(filePath)
       if (!newPath) {
-        notFoundError(asarPath, filePath)
+        createError('notFound', {asarPath, filePath})
       }
 
       arguments[arg] = newPath
@@ -190,12 +171,12 @@
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        return invalidArchiveError(asarPath, callback)
+        return createError('invalidArchive', {asarPath, callback})
       }
 
       const newPath = archive.copyFileOut(filePath)
       if (!newPath) {
-        return notFoundError(asarPath, filePath, callback)
+        return createError('notFound', {asarPath, filePath, callback})
       }
 
       arguments[arg] = newPath
@@ -211,12 +192,12 @@
 
         const archive = getOrCreateArchive(asarPath)
         if (!archive) {
-          return new Promise(() => invalidArchiveError(asarPath))
+          return new Promise(() => createError('invalidArchive', {asarPath}))
         }
 
         const newPath = archive.copyFileOut(filePath)
         if (!newPath) {
-          return new Promise(() => notFoundError(asarPath, filePath))
+          return new Promise(() => createError('notFound', {asarPath, filePath}))
         }
 
         arguments[arg] = newPath
@@ -250,11 +231,11 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        invalidArchiveError(asarPath)
+        createError('invalidArchive', {asarPath})
       }
       const stats = archive.stat(filePath)
       if (!stats) {
-        notFoundError(asarPath, filePath)
+        createError('notFound', {asarPath, filePath})
       }
       return asarStatsToFsStats(stats)
     }
@@ -267,11 +248,11 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        return invalidArchiveError(asarPath, callback)
+        return createError('invalidArchive', {asarPath, callback})
       }
       const stats = getOrCreateArchive(asarPath).stat(filePath)
       if (!stats) {
-        return notFoundError(asarPath, filePath, callback)
+        return createError('notFound', {asarPath, filePath, callback})
       }
       process.nextTick(function () {
         callback(null, asarStatsToFsStats(stats))
@@ -325,10 +306,10 @@
       if (!isAsar) return realpathSync.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) invalidArchiveError(asarPath)
+      if (!archive) createError('invalidArchive', {asarPath})
 
       const real = archive.realpath(filePath)
-      if (real === false) notFoundError(asarPath, filePath)
+      if (real === false) createError('notFound', {asarPath, filePath})
 
       return path.join(realpathSync(asarPath), real)
     }
@@ -338,10 +319,10 @@
       if (!isAsar) return realpathSync.native.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) invalidArchiveError(asarPath)
+      if (!archive) createError('invalidArchive', {asarPath})
 
       const real = archive.realpath.native(filePath)
-      if (real === false) notFoundError(asarPath, filePath)
+      if (real === false) createError('invalidArchive', {asarPath, filePath})
 
       return path.join(realpathSync.native(asarPath), real)
     }
@@ -357,10 +338,10 @@
       }
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return invalidArchiveError(asarPath, callback)
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
 
       const real = archive.realpath(filePath)
-      if (real === false) return notFoundError(asarPath, filePath, callback)
+      if (real === false) return createError('notFound', {asarPath, filePath, callback})
 
       return realpath(asarPath, (err, p) => {
         return (err) ? callback(err) : callback(null, path.join(p, real))
@@ -377,10 +358,10 @@
       }
 
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) return invalidArchiveError(asarPath, callback)
+      if (!archive) return createError('invalidArchive', {asarPath, callback})
 
       const real = archive.realpath.native(filePath)
-      if (real === false) return notFoundError(asarPath, filePath, callback)
+      if (real === false) return createError('notFound', {asarPath, filePath, callback})
 
       return realpath.native(asarPath, (err, p) => {
         return (err) ? callback(err) : callback(null, path.join(p, real))
@@ -395,7 +376,7 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        return invalidArchiveError(asarPath, callback)
+        return createError('invalidArchive', {asarPath, callback})
       }
       process.nextTick(function () {
         // Disabled due to false positive in StandardJS
@@ -411,7 +392,7 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        return new Promise(() => invalidArchiveError(asarPath))
+        return new Promise(() => createError('invalidArchive', {asarPath}))
       }
       return Promise.resolve(archive.stat(filePath) !== false)
     }
@@ -441,11 +422,11 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        return invalidArchiveError(asarPath, callback)
+        return createError('invalidArchive', {asarPath, callback})
       }
       const info = archive.getFileInfo(filePath)
       if (!info) {
-        return notFoundError(asarPath, filePath, callback)
+        return createError('notFound', {asarPath, filePath, callback})
       }
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
@@ -453,10 +434,10 @@
       }
       const stats = getOrCreateArchive(asarPath).stat(filePath)
       if (!stats) {
-        return notFoundError(asarPath, filePath, callback)
+        return createError('notFound', {asarPath, filePath, callback})
       }
       if (mode & fs.constants.W_OK) {
-        return accessError(asarPath, filePath, callback)
+        createError('access', {asarPath, filePath, callback})
       }
       process.nextTick(function () {
         callback()
@@ -474,11 +455,11 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        invalidArchiveError(asarPath)
+        createError('invalidArchive', {asarPath})
       }
       const info = archive.getFileInfo(filePath)
       if (!info) {
-        notFoundError(asarPath, filePath)
+        createError('notFound', {asarPath, filePath})
       }
       if (info.unpacked) {
         const realPath = archive.copyFileOut(filePath)
@@ -486,10 +467,10 @@
       }
       const stats = getOrCreateArchive(asarPath).stat(filePath)
       if (!stats) {
-        notFoundError(asarPath, filePath)
+        createError('notFound', {asarPath, filePath})
       }
       if (mode & fs.constants.W_OK) {
-        accessError(asarPath, filePath)
+        createError('access', {asarPath, filePath})
       }
     }
 
@@ -519,11 +500,11 @@
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        return invalidArchiveError(asarPath, callback)
+        return createError('invalidArchive', {asarPath, callback})
       }
       const info = archive.getFileInfo(filePath)
       if (!info) {
-        return notFoundError(asarPath, filePath, callback)
+        return createError('notFound', {asarPath, filePath, callback})
       }
       if (info.size === 0) {
         return process.nextTick(function () {
@@ -538,7 +519,7 @@
       const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
       if (!(fd >= 0)) {
-        return notFoundError(asarPath, filePath, callback)
+        return createError('notFound', {asarPath, filePath, callback})
       }
       logASARAccess(asarPath, filePath, info.offset)
       fs.read(fd, buffer, 0, info.size, info.offset, function (error) {
@@ -554,11 +535,11 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        invalidArchiveError(asarPath)
+        createError('invalidArchive', {asarPath})
       }
       const info = archive.getFileInfo(filePath)
       if (!info) {
-        notFoundError(asarPath, filePath)
+        createError('notFound', {asarPath, filePath})
       }
       if (info.size === 0) {
         if (options) {
@@ -586,7 +567,7 @@
       const buffer = Buffer.alloc(info.size)
       const fd = archive.getFd()
       if (!(fd >= 0)) {
-        notFoundError(asarPath, filePath)
+        createError('notFound', {asarPath, filePath})
       }
       logASARAccess(asarPath, filePath, info.offset)
       fs.readSync(fd, buffer, 0, info.size, info.offset)
@@ -605,11 +586,11 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        return invalidArchiveError(asarPath, callback)
+        return createError('invalidArchive', {asarPath, callback})
       }
       const files = archive.readdir(filePath)
       if (!files) {
-        return notFoundError(asarPath, filePath, callback)
+        return createError('notFound', {asarPath, filePath, callback})
       }
       process.nextTick(function () {
         callback(null, files)
@@ -624,11 +605,11 @@
       }
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
-        invalidArchiveError(asarPath)
+        createError('invalidArchive', {asarPath})
       }
       const files = archive.readdir(filePath)
       if (!files) {
-        notFoundError(asarPath, filePath)
+        createError('notFound', {asarPath, filePath})
       }
       return files
     }
@@ -703,7 +684,7 @@
         }
         const [isAsar, , filePath] = splitPath(p)
         if (isAsar && filePath.length) {
-          return notDirError(callback)
+          return createError('notDir', {callback})
         }
         mkdir(p, mode, callback)
       }
@@ -712,7 +693,7 @@
       fs.mkdirSync = function (p, mode) {
         const [isAsar, , filePath] = splitPath(p)
         if (isAsar && filePath.length) {
-          notDirError()
+          createError('notDir', {})
         }
         return mkdirSync(p, mode)
       }


### PR DESCRIPTION
Fixes https://github.com/electron/node/issues/44 
Fixes https://github.com/electron/electron/issues/13826.

Overrides `fs.realpath.native` and `fs.realpathSync.native` to account for `asar` paths.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)