### PR TITLE
fix: make asarStatsToFsStats nherit from fs.stats

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -67,47 +67,40 @@
   let nextInode = 0
 
   const uid = process.getuid != null ? process.getuid() : 0
-
   const gid = process.getgid != null ? process.getgid() : 0
 
   const fakeTime = new Date()
+  const msec = (date) => (date || fakeTime).getTime()
 
   const asarStatsToFsStats = function (stats) {
-    return {
-      dev: 1,
-      ino: ++nextInode,
-      mode: 33188,
-      nlink: 1,
-      uid: uid,
-      gid: gid,
-      rdev: 0,
-      atime: stats.atime || fakeTime,
-      birthtime: stats.birthtime || fakeTime,
-      mtime: stats.mtime || fakeTime,
-      ctime: stats.ctime || fakeTime,
-      size: stats.size,
-      isFile: function () {
-        return stats.isFile
-      },
-      isDirectory: function () {
-        return stats.isDirectory
-      },
-      isSymbolicLink: function () {
-        return stats.isLink
-      },
-      isBlockDevice: function () {
-        return false
-      },
-      isCharacterDevice: function () {
-        return false
-      },
-      isFIFO: function () {
-        return false
-      },
-      isSocket: function () {
-        return false
-      }
+    const {Stats, constants} = require('fs')
+
+    let mode = constants.S_IROTH ^ constants.S_IRGRP ^ constants.S_IRUSR ^ constants.S_IWUSR
+
+    if (stats.isFile) {
+      mode ^= constants.S_IFREG
+    } else if (stats.isDirectory) {
+      mode ^= constants.S_IFDIR
+    } else if (stats.isLink) {
+      mode ^= constants.S_IFLNK
     }
+
+    return new Stats(
+      1, // dev
+      mode, // mode
+      1, // nlink
+      uid,
+      gid,
+      0, // rdev
+      undefined, // blksize
+      ++nextInode, // ino
+      stats.size,
+      undefined, // blocks,
+      msec(stats.atime), // atim_msec
+      msec(stats.mtime), // mtim_msec
+      msec(stats.ctime), // ctim_msec
+      msec(stats.birthtime) // birthtim_msec
+    )
   }
 
   // Create a ENOENT error.


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/13826.

Alters `asarStatsToFsStats` such that it now inherits from `fs.stats` instead of returning a plain object.

/cc @ckerr @MarshallOfSound 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)