### PR TITLE
fix: override fs.realpathSync.native and fs.realpath.native

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -339,43 +339,68 @@
     const {realpathSync} = fs
     fs.realpathSync = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return realpathSync.apply(this, arguments)
-      }
+      if (!isAsar) return realpathSync.apply(this, arguments)
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        invalidArchiveError(asarPath)
-      }
+      if (!archive) return invalidArchiveError(asarPath)
+
       const real = archive.realpath(filePath)
-      if (real === false) {
-        notFoundError(asarPath, filePath)
-      }
+      if (real === false) notFoundError(asarPath, filePath)
+
       return path.join(realpathSync(asarPath), real)
+    }
+
+    fs.realpathSync.native = function (p) {
+      const [isAsar, asarPath, filePath] = splitPath(p)
+      if (!isAsar) return realpathSync.native.apply(this, arguments)
+
+      const archive = getOrCreateArchive(asarPath)
+      if (!archive) return invalidArchiveError(asarPath)
+
+      const real = archive.realpath.native(filePath)
+      if (real === false) notFoundError(asarPath, filePath)
+
+      return path.join(realpathSync.native(asarPath), real)
     }
 
     const {realpath} = fs
     fs.realpath = function (p, cache, callback) {
       const [isAsar, asarPath, filePath] = splitPath(p)
-      if (!isAsar) {
-        return realpath.apply(this, arguments)
-      }
+      if (!isAsar) return realpath.apply(this, arguments)
+
       if (typeof cache === 'function') {
         callback = cache
         cache = void 0
       }
+
       const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        return invalidArchiveError(asarPath, callback)
-      }
+      if (!archive) return invalidArchiveError(asarPath, callback)
+
       const real = archive.realpath(filePath)
-      if (real === false) {
-        return notFoundError(asarPath, filePath, callback)
+      if (real === false) return notFoundError(asarPath, filePath, callback)
+
+      return realpath(asarPath, (err, p) => {
+        return (err) ? callback(err) : callback(null, path.join(p, real))
+      })
+    }
+
+    fs.realpath.native = function (p, cache, callback) {
+      const [isAsar, asarPath, filePath] = splitPath(p)
+      if (!isAsar) return realpath.native.apply(this, arguments)
+
+      if (typeof cache === 'function') {
+        callback = cache
+        cache = void 0
       }
-      return realpath(asarPath, function (err, p) {
-        if (err) {
-          return callback(err)
-        }
-        return callback(null, path.join(p, real))
+
+      const archive = getOrCreateArchive(asarPath)
+      if (!archive) return invalidArchiveError(asarPath, callback)
+
+      const real = archive.realpath.native(filePath)
+      if (real === false) return notFoundError(asarPath, filePath, callback)
+
+      return realpath.native(asarPath, (err, p) => {
+        return (err) ? callback(err) : callback(null, path.join(p, real))
       })
     }
 

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -357,7 +357,7 @@
       const archive = getOrCreateArchive(asarPath)
       if (!archive) return invalidArchiveError(asarPath)
 
-      const real = archive.realpath.native(filePath)
+      const real = archive.realpath(filePath)
       if (real === false) notFoundError(asarPath, filePath)
 
       return path.join(realpathSync.native(asarPath), real)
@@ -396,7 +396,7 @@
       const archive = getOrCreateArchive(asarPath)
       if (!archive) return invalidArchiveError(asarPath, callback)
 
-      const real = archive.realpath.native(filePath)
+      const real = archive.realpath(filePath)
       if (real === false) return notFoundError(asarPath, filePath, callback)
 
       return realpath.native(asarPath, (err, p) => {

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -297,129 +297,250 @@ describe('asar package', function () {
       })
     })
 
-    describe('fs.realpathSync', function () {
-      it('returns real path root', function () {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = 'a.asar'
-        var r = fs.realpathSync(path.join(parent, p))
+    describe('fs.realpathSync', () => {
+      it('returns real path root', () => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = 'a.asar'
+        const r = fs.realpathSync(path.join(parent, p))
         assert.equal(r, path.join(parent, p))
       })
 
-      it('returns real path of a normal file', function () {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'file1')
-        var r = fs.realpathSync(path.join(parent, p))
+      it('returns real path of a normal file', () => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'file1')
+        const r = fs.realpathSync(path.join(parent, p))
         assert.equal(r, path.join(parent, p))
       })
 
-      it('returns real path of a normal directory', function () {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'dir1')
-        var r = fs.realpathSync(path.join(parent, p))
+      it('returns real path of a normal directory', () => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'dir1')
+        const r = fs.realpathSync(path.join(parent, p))
         assert.equal(r, path.join(parent, p))
       })
 
-      it('returns real path of a linked file', function () {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'link2', 'link1')
-        var r = fs.realpathSync(path.join(parent, p))
+      it('returns real path of a linked file', () => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link1')
+        const r = fs.realpathSync(path.join(parent, p))
         assert.equal(r, path.join(parent, 'a.asar', 'file1'))
       })
 
-      it('returns real path of a linked directory', function () {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'link2', 'link2')
-        var r = fs.realpathSync(path.join(parent, p))
+      it('returns real path of a linked directory', () => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link2')
+        const r = fs.realpathSync(path.join(parent, p))
         assert.equal(r, path.join(parent, 'a.asar', 'dir1'))
       })
 
-      it('returns real path of an unpacked file', function () {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('unpack.asar', 'a.txt')
-        var r = fs.realpathSync(path.join(parent, p))
+      it('returns real path of an unpacked file', () => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('unpack.asar', 'a.txt')
+        const r = fs.realpathSync(path.join(parent, p))
         assert.equal(r, path.join(parent, p))
       })
 
-      it('throws ENOENT error when can not find file', function () {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'not-exist')
-        var throws = function () {
-          fs.realpathSync(path.join(parent, p))
-        }
+      it('throws ENOENT error when can not find file', () => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'not-exist')
+        const throws = () => fs.realpathSync(path.join(parent, p))
         assert.throws(throws, /ENOENT/)
       })
     })
 
-    describe('fs.realpath', function () {
-      it('returns real path root', function (done) {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = 'a.asar'
-        fs.realpath(path.join(parent, p), function (err, r) {
+    describe('fs.realpathSync.native', () => {
+      it('returns real path root', () => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = 'a.asar'
+        const r = fs.realpathSync.native(path.join(parent, p))
+        assert.equal(r, path.join(parent, p))
+      })
+
+      it('returns real path of a normal file', () => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'file1')
+        const r = fs.realpathSync.native(path.join(parent, p))
+        assert.equal(r, path.join(parent, p))
+      })
+
+      it('returns real path of a normal directory', () => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'dir1')
+        const r = fs.realpathSync.native(path.join(parent, p))
+        assert.equal(r, path.join(parent, p))
+      })
+
+      it('returns real path of a linked file', () => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link1')
+        const r = fs.realpathSync.native(path.join(parent, p))
+        assert.equal(r, path.join(parent, 'a.asar', 'file1'))
+      })
+
+      it('returns real path of a linked directory', () => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link2')
+        const r = fs.realpathSync.native(path.join(parent, p))
+        assert.equal(r, path.join(parent, 'a.asar', 'dir1'))
+      })
+
+      it('returns real path of an unpacked file', () => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('unpack.asar', 'a.txt')
+        const r = fs.realpathSync.native(path.join(parent, p))
+        assert.equal(r, path.join(parent, p))
+      })
+
+      it('throws ENOENT error when can not find file', () => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'not-exist')
+        const throws = () => fs.realpathSync.native(path.join(parent, p))
+        assert.throws(throws, /ENOENT/)
+      })
+    })
+
+    describe('fs.realpath', () => {
+      it('returns real path root', done => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = 'a.asar'
+        fs.realpath(path.join(parent, p), (err, r) => {
           assert.equal(err, null)
           assert.equal(r, path.join(parent, p))
           done()
         })
       })
 
-      it('returns real path of a normal file', function (done) {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'file1')
-        fs.realpath(path.join(parent, p), function (err, r) {
+      it('returns real path of a normal file', done => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'file1')
+        fs.realpath(path.join(parent, p), (err, r) => {
           assert.equal(err, null)
           assert.equal(r, path.join(parent, p))
           done()
         })
       })
 
-      it('returns real path of a normal directory', function (done) {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'dir1')
-        fs.realpath(path.join(parent, p), function (err, r) {
+      it('returns real path of a normal directory', done => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'dir1')
+        fs.realpath(path.join(parent, p), (err, r) => {
           assert.equal(err, null)
           assert.equal(r, path.join(parent, p))
           done()
         })
       })
 
-      it('returns real path of a linked file', function (done) {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'link2', 'link1')
-        fs.realpath(path.join(parent, p), function (err, r) {
+      it('returns real path of a linked file', done => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link1')
+        fs.realpath(path.join(parent, p), (err, r) => {
           assert.equal(err, null)
           assert.equal(r, path.join(parent, 'a.asar', 'file1'))
           done()
         })
       })
 
-      it('returns real path of a linked directory', function (done) {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'link2', 'link2')
-        fs.realpath(path.join(parent, p), function (err, r) {
+      it('returns real path of a linked directory', done => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link2')
+        fs.realpath(path.join(parent, p), (err, r) => {
           assert.equal(err, null)
           assert.equal(r, path.join(parent, 'a.asar', 'dir1'))
           done()
         })
       })
 
-      it('returns real path of an unpacked file', function (done) {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('unpack.asar', 'a.txt')
-        fs.realpath(path.join(parent, p), function (err, r) {
+      it('returns real path of an unpacked file', done => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('unpack.asar', 'a.txt')
+        fs.realpath(path.join(parent, p), (err, r) => {
           assert.equal(err, null)
           assert.equal(r, path.join(parent, p))
           done()
         })
       })
 
-      it('throws ENOENT error when can not find file', function (done) {
-        var parent = fs.realpathSync(path.join(fixtures, 'asar'))
-        var p = path.join('a.asar', 'not-exist')
-        fs.realpath(path.join(parent, p), function (err) {
+      it('throws ENOENT error when can not find file', done => {
+        const parent = fs.realpathSync(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'not-exist')
+        fs.realpath(path.join(parent, p), err => {
           assert.equal(err.code, 'ENOENT')
           done()
         })
       })
     })
+
+    describe('fs.realpath.native', () => {
+      it('returns real path root', done => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = 'a.asar'
+        fs.realpath.native(path.join(parent, p), (err, r) => {
+          assert.equal(err, null)
+          assert.equal(r, path.join(parent, p))
+          done()
+        })
+      })
+
+      it('returns real path of a normal file', done => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'file1')
+        fs.realpath.native(path.join(parent, p), (err, r) => {
+          assert.equal(err, null)
+          assert.equal(r, path.join(parent, p))
+          done()
+        })
+      })
+
+      it('returns real path of a normal directory', done => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'dir1')
+        fs.realpath.native(path.join(parent, p), (err, r) => {
+          assert.equal(err, null)
+          assert.equal(r, path.join(parent, p))
+          done()
+        })
+      })
+
+      it('returns real path of a linked file', done => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link1')
+        fs.realpath.native(path.join(parent, p), (err, r) => {
+          assert.equal(err, null)
+          assert.equal(r, path.join(parent, 'a.asar', 'file1'))
+          done()
+        })
+      })
+
+      it('returns real path of a linked directory', done => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'link2', 'link2')
+        fs.realpath.native(path.join(parent, p), (err, r) => {
+          assert.equal(err, null)
+          assert.equal(r, path.join(parent, 'a.asar', 'dir1'))
+          done()
+        })
+      })
+
+      it('returns real path of an unpacked file', done => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('unpack.asar', 'a.txt')
+        fs.realpath.native(path.join(parent, p), (err, r) => {
+          assert.equal(err, null)
+          assert.equal(r, path.join(parent, p))
+          done()
+        })
+      })
+
+      it('throws ENOENT error when can not find file', done => {
+        const parent = fs.realpathSync.native(path.join(fixtures, 'asar'))
+        const p = path.join('a.asar', 'not-exist')
+        fs.realpath.native(path.join(parent, p), err => {
+          assert.equal(err.code, 'ENOENT')
+          done()
+        })
+      })
+    })
+
     describe('fs.readdirSync', function () {
       it('reads dirs from root', function () {
         var p = path.join(fixtures, 'asar', 'a.asar')


### PR DESCRIPTION
Fixes https://github.com/electron/node/issues/44.

Overrides `fs.realpath.native` and `fs.realpathSync.native` to account for asar paths.

/cc @ckerr @MarshallOfSound 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)