### PR TITLE
fix: re-enable mixed-sandbox tests

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -869,13 +869,6 @@ describe('app module', () => {
     })
 
     describe('when app.enableMixedSandbox() is called', () => {
-      // TODO(zcbenz): Find out why it fails in CI.
-      before(function () {
-        if (isCI && process.platform === 'win32') {
-          this.skip()
-        }
-      })
-
       it('adds --enable-sandbox to render processes created with sandbox: true', done => {
         const appPath = path.join(__dirname, 'fixtures', 'api', 'mixed-sandbox-app')
         appProcess = ChildProcess.spawn(remote.process.execPath, [appPath])
@@ -898,13 +891,6 @@ describe('app module', () => {
     })
 
     describe('when the app is launched with --enable-mixed-sandbox', () => {
-      // TODO(zcbenz): Find out why it fails in CI.
-      before(function () {
-        if (isCI && process.platform === 'win32') {
-          this.skip()
-        }
-      })
-
       it('adds --enable-sandbox to render processes created with sandbox: true', done => {
         const appPath = path.join(__dirname, 'fixtures', 'api', 'mixed-sandbox-app')
         appProcess = ChildProcess.spawn(remote.process.execPath, [appPath, '--enable-mixed-sandbox'])


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/13770.

This PR re-enables mixed-sandbox tests. Investigation by @jkleinsc determined that adding `ELECTRON_ENABLE_LOGGING=true` to the environment vars on AppVeyor in fact triggers a DCHECK that caused the tests to fail. Once this environment variable is removed, the tests will pass once more on windows CI, but these tests can be re-enabled now as they don't require any `e/e`- side code to be written to fix them.

/cc @jkleinsc @zcbenz 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)