### PR TITLE
fix: notify request context shutdown on IO before cleanup

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/api/atom_api_cookies.h"
 
 #include "atom/browser/atom_browser_context.h"
+#include "atom/browser/request_context_delegate.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
@@ -253,9 +254,10 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
 Cookies::Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context)
     : browser_context_(browser_context) {
   Init(isolate);
-  auto subscription = browser_context->RegisterCookieChangeCallback(
-      base::Bind(&Cookies::OnCookieChanged, base::Unretained(this)));
-  browser_context->set_cookie_change_subscription(std::move(subscription));
+  cookie_change_subscription_ =
+      browser_context->GetRequestContextDelegate()
+          ->RegisterCookieChangeCallback(
+              base::Bind(&Cookies::OnCookieChanged, base::Unretained(this)));
 }
 
 Cookies::~Cookies() {}

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -9,7 +9,7 @@
 
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/net/cookie_details.h"
-#include "base/callback.h"
+#include "base/callback_list.h"
 #include "native_mate/handle.h"
 #include "net/cookies/canonical_cookie.h"
 
@@ -59,6 +59,8 @@ class Cookies : public mate::TrackableObject<Cookies> {
   void OnCookieChanged(const CookieDetails*);
 
  private:
+  std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
+      cookie_change_subscription_;
   scoped_refptr<AtomBrowserContext> browser_context_;
 
   DISALLOW_COPY_AND_ASSIGN(Cookies);

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -78,13 +78,13 @@ class Protocol : public mate::TrackableObject<Protocol> {
         net::URLRequest* request,
         net::NetworkDelegate* network_delegate) const override {
       RequestJob* request_job = new RequestJob(request, network_delegate);
-      request_job->SetHandlerInfo(isolate_, request_context_.get(), handler_);
+      request_job->SetHandlerInfo(isolate_, request_context_, handler_);
       return request_job;
     }
 
    private:
     v8::Isolate* isolate_;
-    scoped_refptr<net::URLRequestContextGetter> request_context_;
+    net::URLRequestContextGetter* request_context_;
     Protocol::Handler handler_;
 
     DISALLOW_COPY_AND_ASSIGN(CustomProtocolHandler);

--- a/atom/browser/api/atom_api_web_request.cc
+++ b/atom/browser/api/atom_api_web_request.cc
@@ -95,7 +95,7 @@ void WebRequest::SetListener(Method method, Event type, mate::Arguments* args) {
   }
 
   brightray::URLRequestContextGetter* url_request_context_getter =
-      browser_context_->url_request_context_getter();
+      browser_context_->GetRequestContext();
   if (!url_request_context_getter)
     return;
   BrowserThread::PostTask(

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -4,58 +4,29 @@
 
 #include "atom/browser/atom_browser_context.h"
 
-#include "atom/browser/api/atom_api_protocol.h"
 #include "atom/browser/atom_blob_reader.h"
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/atom_download_manager_delegate.h"
 #include "atom/browser/atom_permission_manager.h"
 #include "atom/browser/browser.h"
-#include "atom/browser/net/about_protocol_handler.h"
-#include "atom/browser/net/asar/asar_protocol_handler.h"
-#include "atom/browser/net/atom_cert_verifier.h"
-#include "atom/browser/net/atom_network_delegate.h"
-#include "atom/browser/net/atom_url_request_job_factory.h"
-#include "atom/browser/net/cookie_details.h"
-#include "atom/browser/net/http_protocol_handler.h"
+#include "atom/browser/request_context_delegate.h"
 #include "atom/browser/web_view_manager.h"
 #include "atom/common/atom_version.h"
 #include "atom/common/chrome_version.h"
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
-#include "base/memory/ptr_util.h"
 #include "base/path_service.h"
-#include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
-#include "base/task_scheduler/post_task.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"
-#include "content/public/browser/browser_thread.h"
-#include "content/public/browser/storage_partition.h"
-#include "content/public/common/url_constants.h"
 #include "content/public/common/user_agent.h"
-#include "net/ftp/ftp_network_layer.h"
-#include "net/url_request/data_protocol_handler.h"
-#include "net/url_request/ftp_protocol_handler.h"
-#include "net/url_request/url_request_context.h"
-#include "net/url_request/url_request_intercepting_job_factory.h"
-#include "url/url_constants.h"
-
-using content::BrowserThread;
 
 namespace atom {
 
 namespace {
-
-class NoCacheBackend : public net::HttpCache::BackendFactory {
-  int CreateBackend(net::NetLog* net_log,
-                    std::unique_ptr<disk_cache::Backend>* backend,
-                    const net::CompletionCallback& callback) override {
-    return net::ERR_FAILED;
-  }
-};
 
 std::string RemoveWhitespace(const std::string& str) {
   std::string trimmed;
@@ -70,7 +41,8 @@ std::string RemoveWhitespace(const std::string& str) {
 AtomBrowserContext::AtomBrowserContext(const std::string& partition,
                                        bool in_memory,
                                        const base::DictionaryValue& options)
-    : brightray::BrowserContext(partition, in_memory) {
+    : brightray::BrowserContext(partition, in_memory),
+      url_request_context_getter_(nullptr) {
   // Construct user agent string.
   Browser* browser = Browser::Get();
   std::string name = RemoveWhitespace(browser->GetName());
@@ -86,85 +58,22 @@ AtomBrowserContext::AtomBrowserContext(const std::string& partition,
   user_agent_ = content::BuildUserAgentFromProduct(user_agent);
 
   // Read options.
-  use_cache_ = true;
-  options.GetBoolean("cache", &use_cache_);
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  bool use_cache = !command_line->HasSwitch(switches::kDisableHttpCache);
+  options.GetBoolean("cache", &use_cache);
+
+  request_context_delegate_.reset(new RequestContextDelegate(use_cache));
 
   // Initialize Pref Registry in brightray.
   InitPrefs();
 }
 
-AtomBrowserContext::~AtomBrowserContext() {}
+AtomBrowserContext::~AtomBrowserContext() {
+  url_request_context_getter_->set_delegate(nullptr);
+}
 
 void AtomBrowserContext::SetUserAgent(const std::string& user_agent) {
   user_agent_ = user_agent;
-}
-
-std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
-AtomBrowserContext::RegisterCookieChangeCallback(
-    const base::Callback<void(const CookieDetails*)>& cb) {
-  return cookie_change_sub_list_.Add(cb);
-}
-
-std::unique_ptr<net::NetworkDelegate>
-AtomBrowserContext::CreateNetworkDelegate() {
-  return std::make_unique<AtomNetworkDelegate>();
-}
-
-std::string AtomBrowserContext::GetUserAgent() {
-  return user_agent_;
-}
-
-std::unique_ptr<net::URLRequestJobFactory>
-AtomBrowserContext::CreateURLRequestJobFactory(
-    content::ProtocolHandlerMap* protocol_handlers) {
-  std::unique_ptr<AtomURLRequestJobFactory> job_factory(
-      new AtomURLRequestJobFactory);
-
-  for (auto& it : *protocol_handlers) {
-    job_factory->SetProtocolHandler(it.first,
-                                    base::WrapUnique(it.second.release()));
-  }
-  protocol_handlers->clear();
-
-  job_factory->SetProtocolHandler(url::kAboutScheme,
-                                  base::WrapUnique(new AboutProtocolHandler));
-  job_factory->SetProtocolHandler(
-      url::kDataScheme, base::WrapUnique(new net::DataProtocolHandler));
-  job_factory->SetProtocolHandler(
-      url::kFileScheme,
-      base::WrapUnique(
-          new asar::AsarProtocolHandler(base::CreateTaskRunnerWithTraits(
-              {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
-               base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN}))));
-  job_factory->SetProtocolHandler(
-      url::kHttpScheme,
-      base::WrapUnique(new HttpProtocolHandler(url::kHttpScheme)));
-  job_factory->SetProtocolHandler(
-      url::kHttpsScheme,
-      base::WrapUnique(new HttpProtocolHandler(url::kHttpsScheme)));
-  job_factory->SetProtocolHandler(
-      url::kWsScheme,
-      base::WrapUnique(new HttpProtocolHandler(url::kWsScheme)));
-  job_factory->SetProtocolHandler(
-      url::kWssScheme,
-      base::WrapUnique(new HttpProtocolHandler(url::kWssScheme)));
-
-  auto* host_resolver =
-      url_request_context_getter()->GetURLRequestContext()->host_resolver();
-  job_factory->SetProtocolHandler(
-      url::kFtpScheme, net::FtpProtocolHandler::Create(host_resolver));
-
-  return std::move(job_factory);
-}
-
-net::HttpCache::BackendFactory*
-AtomBrowserContext::CreateHttpCacheBackendFactory(
-    const base::FilePath& base_path) {
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (!use_cache_ || command_line->HasSwitch(switches::kDisableHttpCache))
-    return new NoCacheBackend;
-  else
-    return brightray::BrowserContext::CreateHttpCacheBackendFactory(base_path);
 }
 
 content::DownloadManagerDelegate*
@@ -189,26 +98,6 @@ content::PermissionManager* AtomBrowserContext::GetPermissionManager() {
   return permission_manager_.get();
 }
 
-std::unique_ptr<net::CertVerifier> AtomBrowserContext::CreateCertVerifier(
-    brightray::RequireCTDelegate* ct_delegate) {
-  return base::WrapUnique(new AtomCertVerifier(ct_delegate));
-}
-
-std::vector<std::string> AtomBrowserContext::GetCookieableSchemes() {
-  auto default_schemes = brightray::BrowserContext::GetCookieableSchemes();
-  const auto& standard_schemes = atom::api::GetStandardSchemes();
-  default_schemes.insert(default_schemes.end(), standard_schemes.begin(),
-                         standard_schemes.end());
-  return default_schemes;
-}
-
-void AtomBrowserContext::NotifyCookieChange(const net::CanonicalCookie& cookie,
-                                            bool removed,
-                                            net::CookieChangeCause cause) {
-  CookieDetails cookie_details(&cookie, removed, cause);
-  cookie_change_sub_list_.Notify(&cookie_details);
-}
-
 void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
   pref_registry->RegisterFilePathPref(prefs::kSelectFileLastDirectory,
                                       base::FilePath());
@@ -217,6 +106,16 @@ void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
   pref_registry->RegisterFilePathPref(prefs::kDownloadDefaultDirectory,
                                       download_dir);
   pref_registry->RegisterDictionaryPref(prefs::kDevToolsFileSystemPaths);
+}
+
+std::string AtomBrowserContext::GetUserAgent() const {
+  return user_agent_;
+}
+
+void AtomBrowserContext::OnMainRequestContextCreated(
+    brightray::URLRequestContextGetter* getter) {
+  getter->set_delegate(request_context_delegate_.get());
+  url_request_context_getter_ = getter;
 }
 
 AtomBlobReader* AtomBrowserContext::GetBlobReader() {

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -8,17 +8,15 @@
 #include <string>
 #include <vector>
 
-#include "base/callback_list.h"
 #include "brightray/browser/browser_context.h"
 
 namespace atom {
 
 class AtomBlobReader;
 class AtomDownloadManagerDelegate;
-class AtomNetworkDelegate;
 class AtomPermissionManager;
+class RequestContextDelegate;
 class WebViewManager;
-struct CookieDetails;
 
 class AtomBrowserContext : public brightray::BrowserContext {
  public:
@@ -31,24 +29,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
       const base::DictionaryValue& options = base::DictionaryValue());
 
   void SetUserAgent(const std::string& user_agent);
-  // Register callbacks that needs to notified on any cookie store changes.
-  std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
-  RegisterCookieChangeCallback(
-      const base::Callback<void(const CookieDetails*)>& cb);
-
-  // brightray::URLRequestContextGetter::Delegate:
-  std::unique_ptr<net::NetworkDelegate> CreateNetworkDelegate() override;
-  std::string GetUserAgent() override;
-  std::unique_ptr<net::URLRequestJobFactory> CreateURLRequestJobFactory(
-      content::ProtocolHandlerMap* protocol_handlers) override;
-  net::HttpCache::BackendFactory* CreateHttpCacheBackendFactory(
-      const base::FilePath& base_path) override;
-  std::unique_ptr<net::CertVerifier> CreateCertVerifier(
-      brightray::RequireCTDelegate* ct_delegate) override;
-  std::vector<std::string> GetCookieableSchemes() override;
-  void NotifyCookieChange(const net::CanonicalCookie& cookie,
-                          bool removed,
-                          net::CookieChangeCause cause) override;
+  AtomBlobReader* GetBlobReader();
 
   // content::BrowserContext:
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;
@@ -57,14 +38,12 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // brightray::BrowserContext:
   void RegisterPrefs(PrefRegistrySimple* pref_registry) override;
+  std::string GetUserAgent() const override;
+  void OnMainRequestContextCreated(
+      brightray::URLRequestContextGetter* getter) override;
 
-  AtomBlobReader* GetBlobReader();
-
-  void set_cookie_change_subscription(
-      std::unique_ptr<
-          base::CallbackList<void(const CookieDetails*)>::Subscription>
-          subscription) {
-    cookie_change_subscription_.swap(subscription);
+  RequestContextDelegate* GetRequestContextDelegate() const {
+    return request_context_delegate_.get();
   }
 
  protected:
@@ -74,16 +53,14 @@ class AtomBrowserContext : public brightray::BrowserContext {
   ~AtomBrowserContext() override;
 
  private:
+  brightray::URLRequestContextGetter* url_request_context_getter_;
+
   std::unique_ptr<AtomDownloadManagerDelegate> download_manager_delegate_;
   std::unique_ptr<WebViewManager> guest_manager_;
   std::unique_ptr<AtomPermissionManager> permission_manager_;
   std::unique_ptr<AtomBlobReader> blob_reader_;
+  std::unique_ptr<RequestContextDelegate> request_context_delegate_;
   std::string user_agent_;
-  bool use_cache_;
-
-  base::CallbackList<void(const CookieDetails*)> cookie_change_sub_list_;
-  std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
-      cookie_change_subscription_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserContext);
 };

--- a/atom/browser/net/atom_url_request.cc
+++ b/atom/browser/net/atom_url_request.cc
@@ -70,11 +70,8 @@ scoped_refptr<AtomURLRequest> AtomURLRequest::Create(
     return nullptr;
   }
   scoped_refptr<brightray::URLRequestContextGetter> request_context_getter(
-      browser_context->url_request_context_getter());
+      browser_context->GetRequestContext());
   DCHECK(request_context_getter);
-  if (!request_context_getter) {
-    return nullptr;
-  }
   scoped_refptr<AtomURLRequest> atom_url_request(new AtomURLRequest(delegate));
   if (content::BrowserThread::PostTask(
           content::BrowserThread::IO, FROM_HERE,

--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -9,6 +9,7 @@
 
 #include "atom/browser/api/atom_api_session.h"
 #include "atom/browser/atom_browser_context.h"
+#include "base/guid.h"
 #include "base/memory/ptr_util.h"
 #include "base/strings/string_util.h"
 #include "native_mate/dictionary.h"
@@ -93,16 +94,15 @@ void URLRequestFetchJob::BeforeStartInUI(v8::Isolate* isolate,
   if (options.Get("session", &val)) {
     if (val->IsNull()) {
       // We have to create the URLRequestContextGetter on UI thread.
-      url_request_context_getter_ = new brightray::URLRequestContextGetter(
-          this, nullptr, base::FilePath(), true,
-          BrowserThread::GetTaskRunnerForThread(BrowserThread::IO), nullptr,
-          content::URLRequestInterceptorScopedVector());
+      custom_browser_context_ =
+          AtomBrowserContext::From(base::GenerateGUID(), true);
+      url_request_context_getter_ =
+          custom_browser_context_->GetRequestContext();
     } else {
       mate::Handle<api::Session> session;
       if (mate::ConvertFromV8(isolate, val, &session) && !session.IsEmpty()) {
         AtomBrowserContext* browser_context = session->browser_context();
-        url_request_context_getter_ =
-            browser_context->url_request_context_getter();
+        url_request_context_getter_ = browser_context->GetRequestContext();
       }
     }
   }

--- a/atom/browser/net/url_request_fetch_job.h
+++ b/atom/browser/net/url_request_fetch_job.h
@@ -8,16 +8,17 @@
 #include <string>
 
 #include "atom/browser/net/js_asker.h"
-#include "brightray/browser/url_request_context_getter.h"
 #include "content/browser/streams/stream.h"
 #include "content/browser/streams/stream_read_observer.h"
 #include "net/url_request/url_fetcher_delegate.h"
+#include "net/url_request/url_request_context_getter.h"
 
 namespace atom {
 
+class AtomBrowserContext;
+
 class URLRequestFetchJob : public JsAsker<net::URLRequestJob>,
-                           public net::URLFetcherDelegate,
-                           public brightray::URLRequestContextGetter::Delegate {
+                           public net::URLFetcherDelegate {
  public:
   URLRequestFetchJob(net::URLRequest*, net::NetworkDelegate*);
   ~URLRequestFetchJob() override;
@@ -51,6 +52,7 @@ class URLRequestFetchJob : public JsAsker<net::URLRequestJob>,
   void ClearPendingBuffer();
   void ClearWriteBuffer();
 
+  scoped_refptr<AtomBrowserContext> custom_browser_context_;
   scoped_refptr<net::URLRequestContextGetter> url_request_context_getter_;
   std::unique_ptr<net::URLFetcher> fetcher_;
   std::unique_ptr<net::HttpResponseInfo> response_info_;

--- a/atom/browser/request_context_delegate.cc
+++ b/atom/browser/request_context_delegate.cc
@@ -1,0 +1,163 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/request_context_delegate.h"
+
+#include "atom/browser/api/atom_api_protocol.h"
+#include "atom/browser/net/about_protocol_handler.h"
+#include "atom/browser/net/asar/asar_protocol_handler.h"
+#include "atom/browser/net/atom_cert_verifier.h"
+#include "atom/browser/net/atom_network_delegate.h"
+#include "atom/browser/net/atom_url_request_job_factory.h"
+#include "atom/browser/net/cookie_details.h"
+#include "atom/browser/net/http_protocol_handler.h"
+#include "atom/common/options_switches.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/task_scheduler/post_task.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/common/url_constants.h"
+#include "net/ftp/ftp_network_layer.h"
+#include "net/url_request/data_protocol_handler.h"
+#include "net/url_request/ftp_protocol_handler.h"
+#include "net/url_request/url_request_context.h"
+#include "net/url_request/url_request_intercepting_job_factory.h"
+#include "url/url_constants.h"
+
+using content::BrowserThread;
+
+namespace atom {
+
+namespace {
+
+class NoCacheBackend : public net::HttpCache::BackendFactory {
+  int CreateBackend(net::NetLog* net_log,
+                    std::unique_ptr<disk_cache::Backend>* backend,
+                    const net::CompletionCallback& callback) override {
+    return net::ERR_FAILED;
+  }
+};
+
+}  // namespace
+
+RequestContextDelegate::RequestContextDelegate(bool use_cache)
+    : use_cache_(use_cache), weak_factory_(this) {}
+
+RequestContextDelegate::~RequestContextDelegate() {}
+
+std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
+RequestContextDelegate::RegisterCookieChangeCallback(
+    const base::Callback<void(const CookieDetails*)>& cb) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+  return cookie_change_sub_list_.Add(cb);
+}
+
+void RequestContextDelegate::NotifyCookieChange(
+    const net::CanonicalCookie& cookie,
+    net::CookieChangeCause cause) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+  CookieDetails cookie_details(
+      &cookie, !(cause == net::CookieChangeCause::INSERTED), cause);
+  cookie_change_sub_list_.Notify(&cookie_details);
+}
+
+std::unique_ptr<net::NetworkDelegate>
+RequestContextDelegate::CreateNetworkDelegate() {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  return std::make_unique<AtomNetworkDelegate>();
+}
+
+std::unique_ptr<net::URLRequestJobFactory>
+RequestContextDelegate::CreateURLRequestJobFactory(
+    net::URLRequestContext* url_request_context,
+    content::ProtocolHandlerMap* protocol_handlers) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  std::unique_ptr<AtomURLRequestJobFactory> job_factory(
+      new AtomURLRequestJobFactory);
+
+  for (auto& it : *protocol_handlers) {
+    job_factory->SetProtocolHandler(it.first,
+                                    base::WrapUnique(it.second.release()));
+  }
+  protocol_handlers->clear();
+
+  job_factory->SetProtocolHandler(url::kAboutScheme,
+                                  base::WrapUnique(new AboutProtocolHandler));
+  job_factory->SetProtocolHandler(
+      url::kDataScheme, base::WrapUnique(new net::DataProtocolHandler));
+  job_factory->SetProtocolHandler(
+      url::kFileScheme,
+      base::WrapUnique(
+          new asar::AsarProtocolHandler(base::CreateTaskRunnerWithTraits(
+              {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+               base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN}))));
+  job_factory->SetProtocolHandler(
+      url::kHttpScheme,
+      base::WrapUnique(new HttpProtocolHandler(url::kHttpScheme)));
+  job_factory->SetProtocolHandler(
+      url::kHttpsScheme,
+      base::WrapUnique(new HttpProtocolHandler(url::kHttpsScheme)));
+  job_factory->SetProtocolHandler(
+      url::kWsScheme,
+      base::WrapUnique(new HttpProtocolHandler(url::kWsScheme)));
+  job_factory->SetProtocolHandler(
+      url::kWssScheme,
+      base::WrapUnique(new HttpProtocolHandler(url::kWssScheme)));
+
+  auto* host_resolver = url_request_context->host_resolver();
+  job_factory->SetProtocolHandler(
+      url::kFtpScheme, net::FtpProtocolHandler::Create(host_resolver));
+
+  return std::move(job_factory);
+}
+
+net::HttpCache::BackendFactory*
+RequestContextDelegate::CreateHttpCacheBackendFactory(
+    const base::FilePath& base_path) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (!use_cache_) {
+    return new NoCacheBackend;
+  } else {
+    int max_size = 0;
+    base::StringToInt(
+        command_line->GetSwitchValueASCII(switches::kDiskCacheSize), &max_size);
+
+    base::FilePath cache_path = base_path.Append(FILE_PATH_LITERAL("Cache"));
+    return new net::HttpCache::DefaultBackend(
+        net::DISK_CACHE, net::CACHE_BACKEND_DEFAULT, cache_path, max_size);
+  }
+}
+
+std::unique_ptr<net::CertVerifier> RequestContextDelegate::CreateCertVerifier(
+    brightray::RequireCTDelegate* ct_delegate) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  return std::make_unique<AtomCertVerifier>(ct_delegate);
+}
+
+void RequestContextDelegate::GetCookieableSchemes(
+    std::vector<std::string>* cookie_schemes) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  const auto& standard_schemes = atom::api::GetStandardSchemes();
+  cookie_schemes->insert(cookie_schemes->end(), standard_schemes.begin(),
+                         standard_schemes.end());
+}
+
+void RequestContextDelegate::OnCookieChanged(const net::CanonicalCookie& cookie,
+                                             net::CookieChangeCause cause) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::BindRepeating(&RequestContextDelegate::NotifyCookieChange,
+                          weak_factory_.GetWeakPtr(), cookie, cause));
+}
+
+}  // namespace atom

--- a/atom/browser/request_context_delegate.h
+++ b/atom/browser/request_context_delegate.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_REQUEST_CONTEXT_DELEGATE_H_
+#define ATOM_BROWSER_REQUEST_CONTEXT_DELEGATE_H_
+
+#include <string>
+#include <vector>
+
+#include "base/callback_list.h"
+#include "base/macros.h"
+#include "base/memory/weak_ptr.h"
+#include "brightray/browser/url_request_context_getter.h"
+
+namespace atom {
+
+struct CookieDetails;
+
+class RequestContextDelegate
+    : public brightray::URLRequestContextGetter::Delegate {
+ public:
+  explicit RequestContextDelegate(bool use_cache);
+  ~RequestContextDelegate() override;
+
+  // Register callbacks that needs to notified on any cookie store changes.
+  std::unique_ptr<base::CallbackList<void(const CookieDetails*)>::Subscription>
+  RegisterCookieChangeCallback(
+      const base::Callback<void(const CookieDetails*)>& cb);
+
+ protected:
+  std::unique_ptr<net::NetworkDelegate> CreateNetworkDelegate() override;
+  std::unique_ptr<net::URLRequestJobFactory> CreateURLRequestJobFactory(
+      net::URLRequestContext* url_request_context,
+      content::ProtocolHandlerMap* protocol_handlers) override;
+  net::HttpCache::BackendFactory* CreateHttpCacheBackendFactory(
+      const base::FilePath& base_path) override;
+  std::unique_ptr<net::CertVerifier> CreateCertVerifier(
+      brightray::RequireCTDelegate* ct_delegate) override;
+  void GetCookieableSchemes(std::vector<std::string>* cookie_schemes) override;
+  void OnCookieChanged(const net::CanonicalCookie& cookie,
+                       net::CookieChangeCause cause) override;
+
+ private:
+  void NotifyCookieChange(const net::CanonicalCookie& cookie,
+                          net::CookieChangeCause cause);
+
+  base::CallbackList<void(const CookieDetails*)> cookie_change_sub_list_;
+  bool use_cache_ = true;
+
+  base::WeakPtrFactory<RequestContextDelegate> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(RequestContextDelegate);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_REQUEST_CONTEXT_DELEGATE_H_

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -210,6 +210,9 @@ const char kWidevineCdmPath[] = "widevine-cdm-path";
 // Widevine CDM version.
 const char kWidevineCdmVersion[] = "widevine-cdm-version";
 
+// Forces the maximum disk space to be used by the disk cache, in bytes.
+const char kDiskCacheSize[] = "disk-cache-size";
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -109,6 +109,8 @@ extern const char kWebviewTag[];
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];
 
+extern const char kDiskCacheSize[];
+
 }  // namespace switches
 
 }  // namespace atom

--- a/brightray/browser/browser_context.cc
+++ b/brightray/browser/browser_context.cc
@@ -11,7 +11,6 @@
 #include "brightray/browser/brightray_paths.h"
 #include "brightray/browser/browser_client.h"
 #include "brightray/browser/inspectable_web_contents_impl.h"
-#include "brightray/browser/network_delegate.h"
 #include "brightray/browser/special_storage_policy.h"
 #include "brightray/browser/zoom_level_delegate.h"
 #include "brightray/common/application_info.h"
@@ -20,7 +19,6 @@
 #include "components/prefs/pref_service.h"
 #include "components/prefs/pref_service_factory.h"
 #include "content/public/browser/browser_thread.h"
-#include "content/public/browser/resource_context.h"
 #include "content/public/browser/storage_partition.h"
 #include "net/base/escape.h"
 
@@ -37,25 +35,10 @@ std::string MakePartitionName(const std::string& input) {
 
 }  // namespace
 
-class BrowserContext::ResourceContext : public content::ResourceContext {
- public:
-  ResourceContext() : getter_(nullptr) {}
-
-  void set_url_request_context_getter(URLRequestContextGetter* getter) {
-    getter_ = getter;
-  }
-
- private:
-  net::HostResolver* GetHostResolver() override {
-    return getter_->host_resolver();
-  }
-
-  net::URLRequestContext* GetRequestContext() override {
-    return getter_->GetURLRequestContext();
-  }
-
-  URLRequestContextGetter* getter_;
-};
+// static
+void BrowserContextDeleter::Destruct(const BrowserContext* browser_context) {
+  browser_context->OnDestruct();
+}
 
 // static
 BrowserContext::BrowserContextMap BrowserContext::browser_context_map_;
@@ -72,7 +55,6 @@ scoped_refptr<BrowserContext> BrowserContext::Get(const std::string& partition,
 
 BrowserContext::BrowserContext(const std::string& partition, bool in_memory)
     : in_memory_(in_memory),
-      resource_context_(new ResourceContext),
       storage_policy_(new SpecialStoragePolicy),
       weak_factory_(this) {
   if (!PathService::Get(DIR_USER_DATA, &path_)) {
@@ -88,6 +70,8 @@ BrowserContext::BrowserContext(const std::string& partition, bool in_memory)
 
   content::BrowserContext::Initialize(this, path_);
 
+  io_handle_ = new URLRequestContextGetter::Handle(GetWeakPtr());
+
   browser_context_map_[PartitionKey(partition, in_memory)] = GetWeakPtr();
 }
 
@@ -95,13 +79,14 @@ BrowserContext::~BrowserContext() {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   NotifyWillBeDestroyed(this);
   ShutdownStoragePartitions();
-  if (BrowserThread::IsMessageLoopValid(BrowserThread::IO)) {
-    BrowserThread::DeleteSoon(BrowserThread::IO, FROM_HERE,
-                              resource_context_.release());
-    BrowserThread::PostTask(
-        BrowserThread::IO, FROM_HERE,
-        base::BindOnce(&URLRequestContextGetter::NotifyContextShutdownOnIO,
-                       base::RetainedRef(url_request_getter_)));
+  io_handle_->ShutdownOnUIThread();
+}
+
+void BrowserContext::OnDestruct() const {
+  if (BrowserThread::CurrentlyOn(BrowserThread::UI)) {
+    delete this;
+  } else {
+    BrowserThread::DeleteSoon(BrowserThread::UI, FROM_HERE, this);
   }
 }
 
@@ -135,17 +120,10 @@ URLRequestContextGetter* BrowserContext::GetRequestContext() {
 net::URLRequestContextGetter* BrowserContext::CreateRequestContext(
     content::ProtocolHandlerMap* protocol_handlers,
     content::URLRequestInterceptorScopedVector protocol_interceptors) {
-  DCHECK(!url_request_getter_.get());
-  url_request_getter_ = new URLRequestContextGetter(
-      this, static_cast<NetLog*>(BrowserClient::Get()->GetNetLog()), GetPath(),
-      in_memory_, BrowserThread::GetTaskRunnerForThread(BrowserThread::IO),
-      protocol_handlers, std::move(protocol_interceptors));
-  resource_context_->set_url_request_context_getter(url_request_getter_.get());
-  return url_request_getter_.get();
-}
-
-std::unique_ptr<net::NetworkDelegate> BrowserContext::CreateNetworkDelegate() {
-  return std::make_unique<NetworkDelegate>();
+  return io_handle_
+      ->CreateMainRequestContextGetter(protocol_handlers,
+                                       std::move(protocol_interceptors))
+      .get();
 }
 
 std::string BrowserContext::GetMediaDeviceIDSalt() {
@@ -171,7 +149,7 @@ bool BrowserContext::IsOffTheRecord() const {
 }
 
 content::ResourceContext* BrowserContext::GetResourceContext() {
-  return resource_context_.get();
+  return io_handle_->GetResourceContext();
 }
 
 content::DownloadManagerDelegate* BrowserContext::GetDownloadManagerDelegate() {
@@ -214,17 +192,19 @@ BrowserContext::CreateRequestContextForStoragePartition(
     bool in_memory,
     content::ProtocolHandlerMap* protocol_handlers,
     content::URLRequestInterceptorScopedVector request_interceptors) {
+  NOTREACHED();
   return nullptr;
 }
 
 net::URLRequestContextGetter* BrowserContext::CreateMediaRequestContext() {
-  return url_request_getter_.get();
+  return io_handle_->GetMainRequestContextGetter().get();
 }
 
 net::URLRequestContextGetter*
 BrowserContext::CreateMediaRequestContextForStoragePartition(
     const base::FilePath& partition_path,
     bool in_memory) {
+  NOTREACHED();
   return nullptr;
 }
 

--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -472,7 +472,7 @@ void InspectableWebContentsImpl::LoadNetworkResource(
   net::URLFetcher* fetcher =
       (net::URLFetcher::Create(gurl, net::URLFetcher::GET, this)).release();
   pending_requests_[fetcher] = callback;
-  fetcher->SetRequestContext(browser_context->url_request_context_getter());
+  fetcher->SetRequestContext(browser_context->GetRequestContext());
   fetcher->SetExtraRequestHeaders(headers);
   fetcher->SaveResponseWithWriter(
       std::unique_ptr<net::URLFetcherResponseWriter>(

--- a/brightray/common/switches.cc
+++ b/brightray/common/switches.cc
@@ -50,9 +50,6 @@ const char kAuthServerWhitelist[] = "auth-server-whitelist";
 const char kAuthNegotiateDelegateWhitelist[] =
     "auth-negotiate-delegate-whitelist";
 
-// Forces the maximum disk space to be used by the disk cache, in bytes.
-const char kDiskCacheSize[] = "disk-cache-size";
-
 }  // namespace switches
 
 }  // namespace brightray

--- a/brightray/common/switches.h
+++ b/brightray/common/switches.h
@@ -17,7 +17,6 @@ extern const char kProxyPacUrl[];
 extern const char kDisableHttp2[];
 extern const char kAuthServerWhitelist[];
 extern const char kAuthNegotiateDelegateWhitelist[];
-extern const char kDiskCacheSize[];
 
 }  // namespace switches
 

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -313,6 +313,8 @@
       'atom/browser/relauncher.h',
       'atom/browser/render_process_preferences.cc',
       'atom/browser/render_process_preferences.h',
+      'atom/browser/request_context_delegate.cc',
+      'atom/browser/request_context_delegate.h',
       'atom/browser/session_preferences.cc',
       'atom/browser/session_preferences.h',
       'atom/browser/ui/accelerator_util.cc',


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/13686

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

notes: fixes crash in net::ClientSocketHandle destructor