### PR TITLE
fix: speechSynthesis now returns voices on Windows

### DIFF
--- a/chromium_src/chrome/browser/speech/tts_win.cc
+++ b/chromium_src/chrome/browser/speech/tts_win.cc
@@ -6,13 +6,22 @@
 #include <objbase.h>
 #include <sapi.h>
 #include <wrl/client.h>
+#include <sphelper.h>
 
 #include "base/memory/singleton.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
+#include "base/win/scoped_co_mem.h"
 #include "chrome/browser/speech/tts_controller.h"
 #include "chrome/browser/speech/tts_platform.h"
+
+namespace {
+// ISpObjectToken key and value names.
+const wchar_t kAttributesKey[] = L"Attributes";
+const wchar_t kGenderValue[] = L"Gender";
+const wchar_t kLanguageValue[] = L"Language";
+}  // anonymous namespace.
 
 class TtsPlatformImplWin : public TtsPlatformImpl {
  public:
@@ -44,7 +53,7 @@ class TtsPlatformImplWin : public TtsPlatformImpl {
   ~TtsPlatformImplWin() override {}
 
   void OnSpeechEvent();
-
+  void SetVoiceFromName(const std::string& name);
   Microsoft::WRL::ComPtr<ISpVoice> speech_synthesizer_;
 
   // These apply to the current utterance only.
@@ -54,7 +63,7 @@ class TtsPlatformImplWin : public TtsPlatformImpl {
   ULONG stream_number_;
   int char_position_;
   bool paused_;
-
+  std::string last_voice_name_;
   friend struct base::DefaultSingletonTraits<TtsPlatformImplWin>;
 
   DISALLOW_COPY_AND_ASSIGN(TtsPlatformImplWin);
@@ -75,9 +84,7 @@ bool TtsPlatformImplWin::Speak(int utterance_id,
 
   if (!speech_synthesizer_.Get())
     return false;
-
-  // TODO(dmazzoni): support languages other than the default: crbug.com/88059
-
+  SetVoiceFromName(voice.name);
   if (params.rate >= 0.0) {
     // Map our multiplicative range of 0.1x to 10.0x onto Microsoft's
     // linear range of -10 to 10:
@@ -166,19 +173,51 @@ bool TtsPlatformImplWin::IsSpeaking() {
 }
 
 void TtsPlatformImplWin::GetVoices(std::vector<VoiceData>* out_voices) {
-  // TODO: get all voices, not just default voice.
-  // http://crbug.com/88059
-  out_voices->push_back(VoiceData());
-  VoiceData& voice = out_voices->back();
-  voice.native = true;
-  voice.name = "native";
-  voice.events.insert(TTS_EVENT_START);
-  voice.events.insert(TTS_EVENT_END);
-  voice.events.insert(TTS_EVENT_MARKER);
-  voice.events.insert(TTS_EVENT_WORD);
-  voice.events.insert(TTS_EVENT_SENTENCE);
-  voice.events.insert(TTS_EVENT_PAUSE);
-  voice.events.insert(TTS_EVENT_RESUME);
+  Microsoft::WRL::ComPtr<IEnumSpObjectTokens> voice_tokens;
+  unsigned long voice_count;
+  if (S_OK !=
+      SpEnumTokens(SPCAT_VOICES, NULL, NULL, voice_tokens.GetAddressOf()))
+    return;
+  if (S_OK != voice_tokens->GetCount(&voice_count))
+    return;
+  for (unsigned i = 0; i < voice_count; i++) {
+    VoiceData voice;
+    Microsoft::WRL::ComPtr<ISpObjectToken> voice_token;
+    if (S_OK != voice_tokens->Next(1, voice_token.GetAddressOf(), NULL))
+      return;
+    base::win::ScopedCoMem<WCHAR> description;
+    if (S_OK != SpGetDescription(voice_token.Get(), &description))
+      continue;
+    voice.name = base::WideToUTF8(description.get());
+    Microsoft::WRL::ComPtr<ISpDataKey> attributes;
+    if (S_OK != voice_token->OpenKey(kAttributesKey, attributes.GetAddressOf()))
+      continue;
+    base::win::ScopedCoMem<WCHAR> gender;
+    if (S_OK == attributes->GetStringValue(kGenderValue, &gender)) {
+      if (0 == _wcsicmp(gender.get(), L"male"))
+        voice.gender = TTS_GENDER_MALE;
+      else if (0 == _wcsicmp(gender.get(), L"female"))
+        voice.gender = TTS_GENDER_FEMALE;
+    }
+    base::win::ScopedCoMem<WCHAR> language;
+    if (S_OK == attributes->GetStringValue(kLanguageValue, &language)) {
+      int lcid_value;
+      base::HexStringToInt(base::WideToUTF8(language.get()), &lcid_value);
+      LCID lcid = MAKELCID(lcid_value, SORT_DEFAULT);
+      WCHAR locale_name[LOCALE_NAME_MAX_LENGTH] = {0};
+      LCIDToLocaleName(lcid, locale_name, LOCALE_NAME_MAX_LENGTH, 0);
+      voice.lang = base::WideToUTF8(locale_name);
+    }
+    voice.native = true;
+    voice.events.insert(TTS_EVENT_START);
+    voice.events.insert(TTS_EVENT_END);
+    voice.events.insert(TTS_EVENT_MARKER);
+    voice.events.insert(TTS_EVENT_WORD);
+    voice.events.insert(TTS_EVENT_SENTENCE);
+    voice.events.insert(TTS_EVENT_PAUSE);
+    voice.events.insert(TTS_EVENT_RESUME);
+    out_voices->push_back(voice);
+  }
 }
 
 void TtsPlatformImplWin::OnSpeechEvent() {
@@ -217,7 +256,30 @@ void TtsPlatformImplWin::OnSpeechEvent() {
     }
   }
 }
-
+void TtsPlatformImplWin::SetVoiceFromName(const std::string& name) {
+  if (name.empty() || name == last_voice_name_)
+    return;
+  last_voice_name_ = name;
+  Microsoft::WRL::ComPtr<IEnumSpObjectTokens> voice_tokens;
+  unsigned long voice_count;
+  if (S_OK !=
+      SpEnumTokens(SPCAT_VOICES, NULL, NULL, voice_tokens.GetAddressOf()))
+    return;
+  if (S_OK != voice_tokens->GetCount(&voice_count))
+    return;
+  for (unsigned i = 0; i < voice_count; i++) {
+    Microsoft::WRL::ComPtr<ISpObjectToken> voice_token;
+    if (S_OK != voice_tokens->Next(1, voice_token.GetAddressOf(), NULL))
+      return;
+    base::win::ScopedCoMem<WCHAR> description;
+    if (S_OK != SpGetDescription(voice_token.Get(), &description))
+      continue;
+    if (name == base::WideToUTF8(description.get())) {
+      speech_synthesizer_->SetVoice(voice_token.Get());
+      break;
+    }
+  }
+}
 TtsPlatformImplWin::TtsPlatformImplWin()
     : utterance_id_(0),
       prefix_len_(0),


### PR DESCRIPTION
The implementation of tts_win.cc was brought up-to-speed with Chromium 70.0.3522.1 (https://chromium.googlesource.com/chromium/src.git/+/70.0.3522.1/chrome/browser/speech/tts_win.cc).

This to solve the issue with no voices being returned on Windows (#11585).

Ping @AlbrechtStriffler

##### Checklist

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Steps to test this

###### Setup text-to-speech in Windows
1. Install Microsoft Speech Platform - Runtime (https://www.microsoft.com/en-us/download/details.aspx?id=27225)
2. Install some text-to-speech voices (https://www.microsoft.com/en-us/download/details.aspx?id=27224)

###### Run the demo application

```
<!DOCTYPE html>
<html>
  <head>
    <meta charset="UTF-8">
    <title>Hello World!</title>
  </head>
  <body>

    <form id="speechSynthesisForm">
      <h2>speechSynthesis demo</h2>
      <label for="voiceSelect">Voice</label>
      <select id="voiceSelect">
        <option>No voices available</option>
      </select>
      <div>
        <label for="textInput">Text to speak</label>
        <input type="text" id="textInput" />
      </div>
      <input type="submit" value="Speak" />
    </form>

    <script>
      (function() {
        var synth = speechSynthesis;

        var voiceSelect = document.getElementById("voiceSelect");
        var textInput = document.getElementById("textInput");
        var speechSynthesisForm = document.getElementById("speechSynthesisForm");

        function populateVoiceList() {
          var voices = synth.getVoices();

          if (voices.length == 0) {
            return;
          }

          voiceSelect.innerHTML = "";
          for (var i = 0; i < voices.length; i++) {
            var voiceOption = document.createElement("option");
            voiceOption.innerText = voices[i].name;
            voiceOption.value = voices[i].voiceURI;
            voiceSelect.appendChild(voiceOption);
          }
        }

        function speak() {
          var voices = synth.getVoices();

          if (voices.length == 0) {
            return;
          }

          var selectedVoice = null;
          for (var i = 0; i < voices.length; i++) {
            if (voices[i].voiceURI === voiceSelect.value) {
              selectedVoice = voices[i];
              break;
            }
          }

          var utterance = new SpeechSynthesisUtterance(textInput.value);
          utterance.voice = selectedVoice;
          synth.speak(utterance);
        }

        populateVoiceList();
        synth.onvoiceschanged = populateVoiceList;

        speechSynthesisForm.onsubmit = function(e) {
          e.preventDefault();
          speak();
        }
      })();
    </script>
  </body>
</html>

```

![demo_app](https://user-images.githubusercontent.com/302151/44077050-a556726a-9fa2-11e8-9f61-1f0df6c251d2.PNG)

Notes: speech synthesis APIs now return OS voices on Windows