### PR TITLE
fix: enable osr

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -812,18 +812,6 @@ void App::ChildProcessLaunched(int process_type, base::ProcessHandle handle) {
       base::ProcessMetrics::CreateProcessMetrics(
           handle, content::BrowserChildProcessHost::GetPortProvider()));
 #else
-  // We do the same check here as what CreateProcessMetrics DCHECKs for,
-  // because that DCHECK triggers a crash when we run in OSR with GPU
-  // rendering disabled - @brenca
-#if defined(OS_WIN)
-  HANDLE duplicate_handle;
-  BOOL result =
-      ::DuplicateHandle(::GetCurrentProcess(), handle, ::GetCurrentProcess(),
-                        &duplicate_handle, PROCESS_QUERY_INFORMATION, FALSE, 0);
-  if (!result)
-    return;
-#endif
-
   std::unique_ptr<base::ProcessMetrics> metrics(
       base::ProcessMetrics::CreateProcessMetrics(handle));
 #endif

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -776,8 +776,6 @@ void App::OnGpuProcessCrashed(base::TerminationStatus status) {
 
 void App::BrowserChildProcessLaunchedAndConnected(
     const content::ChildProcessData& data) {
-  if (data.handle == base::kNullProcessHandle)
-    return;
   ChildProcessLaunched(data.process_type, data.handle);
 }
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -815,12 +815,14 @@ void App::ChildProcessLaunched(int process_type, base::ProcessHandle handle) {
   // We do the same check here as what CreateProcessMetrics DCHECKs for,
   // because that DCHECK triggers a crash when we run in OSR with GPU
   // rendering disabled - @brenca
+#if defined(OS_WIN)
   HANDLE duplicate_handle;
   BOOL result =
       ::DuplicateHandle(::GetCurrentProcess(), handle, ::GetCurrentProcess(),
                         &duplicate_handle, PROCESS_QUERY_INFORMATION, FALSE, 0);
   if (!result)
     return;
+#endif
 
   std::unique_ptr<base::ProcessMetrics> metrics(
       base::ProcessMetrics::CreateProcessMetrics(handle));

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -1111,7 +1111,7 @@ void OffScreenRenderWidgetHostView::SendMouseWheelEvent(
 
   blink::WebMouseWheelEvent mouse_wheel_event(event);
 
-  mouse_wheel_phase_handler_.SendWheelEndForTouchpadScrollingIfNeeded();
+  mouse_wheel_phase_handler_.SendWheelEndIfNeeded();
   mouse_wheel_phase_handler_.AddPhaseIfNeededAndScheduleEndEvent(
       mouse_wheel_event, false);
 

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -264,7 +264,7 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
       size_(native_window->GetSize()),
       painting_(painting),
       is_showing_(!render_widget_host_->is_hidden()),
-      mouse_wheel_phase_handler_(this),
+      mouse_wheel_phase_handler_(parent_host_view, this),
       weak_ptr_factory_(this) {
   DCHECK(render_widget_host_);
   bool is_guest_view_hack = parent_host_view_ != nullptr;

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -264,7 +264,7 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
       size_(native_window->GetSize()),
       painting_(painting),
       is_showing_(!render_widget_host_->is_hidden()),
-      mouse_wheel_phase_handler_(parent_host_view, this),
+      mouse_wheel_phase_handler_(render_widget_host_, this),
       weak_ptr_factory_(this) {
   DCHECK(render_widget_host_);
   bool is_guest_view_hack = parent_host_view_ != nullptr;

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -281,6 +281,7 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
   local_surface_id_ = local_surface_id_allocator_.GenerateId();
 
 #if defined(OS_MACOSX)
+  last_frame_root_background_color_ = SK_ColorTRANSPARENT;
   CreatePlatformWidget(is_guest_view_hack);
 #else
   // On macOS the ui::Compositor is created/owned by the platform view.
@@ -511,6 +512,10 @@ void OffScreenRenderWidgetHostView::SubmitCompositorFrame(
     viz::mojom::HitTestRegionListPtr hit_test_region_list) {
   TRACE_EVENT0("electron",
                "OffScreenRenderWidgetHostView::SubmitCompositorFrame");
+
+#if defined(OS_MACOSX)
+  last_frame_root_background_color_ = frame.metadata.root_background_color;
+#endif
 
   if (frame.metadata.root_scroll_offset != last_scroll_offset_) {
     last_scroll_offset_ = frame.metadata.root_scroll_offset;

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -108,12 +108,12 @@ class OffScreenRenderWidgetHostView
   void SetNeedsBeginFrames(bool needs_begin_frames) override;
   void SetWantsAnimateOnlyBeginFrames() override;
 #if defined(OS_MACOSX)
-  ui::AcceleratedWidgetMac* GetAcceleratedWidgetMac() const override;
   void SetActive(bool active) override;
   void ShowDefinitionForSelection() override;
   bool SupportsSpeech() const override;
   void SpeakSelection() override;
   bool IsSpeaking() const override;
+  bool ShouldContinueToPauseForFrame() override;
   void StopSpeaking() override;
 #endif  // defined(OS_MACOSX)
 

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -27,6 +27,7 @@
 #include "content/browser/frame_host/render_widget_host_view_guest.h"
 #include "content/browser/renderer_host/compositor_resize_lock.h"
 #include "content/browser/renderer_host/delegated_frame_host.h"
+#include "content/browser/renderer_host/input/mouse_wheel_phase_handler.h"
 #include "content/browser/renderer_host/render_widget_host_impl.h"
 #include "content/browser/renderer_host/render_widget_host_view_base.h"
 #include "content/browser/web_contents/web_contents_view.h"
@@ -332,6 +333,8 @@ class OffScreenRenderWidgetHostView
   // Selected text on the renderer.
   std::string selected_text_;
 #endif
+
+  content::MouseWheelPhaseHandler mouse_wheel_phase_handler_;
 
   viz::mojom::CompositorFrameSinkClient* renderer_compositor_frame_sink_ =
       nullptr;

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -170,7 +170,6 @@ class OffScreenRenderWidgetHostView
   bool DelegatedFrameCanCreateResizeLock() const override;
   std::unique_ptr<content::CompositorResizeLock>
   DelegatedFrameHostCreateResizeLock() override;
-  viz::LocalSurfaceId GetLocalSurfaceId() const override;
   void OnFirstSurfaceActivation(const viz::SurfaceInfo& surface_info) override;
   void OnBeginFrame(base::TimeTicks frame_time) override;
   void OnFrameTokenChanged(uint32_t frame_token) override;
@@ -181,6 +180,11 @@ class OffScreenRenderWidgetHostView
   void CompositorResizeLockEnded() override;
   bool IsAutoResizeEnabled() const override;
 #endif  // !defined(OS_MACOSX)
+
+  viz::LocalSurfaceId GetLocalSurfaceId() const override;
+  viz::FrameSinkId GetFrameSinkId() override;
+
+  void DidNavigate() override;
 
   bool TransformPointToLocalCoordSpace(const gfx::PointF& point,
                                        const viz::SurfaceId& original_surface,
@@ -261,11 +265,9 @@ class OffScreenRenderWidgetHostView
     child_host_view_ = child_view;
   }
 
-  viz::LocalSurfaceId local_surface_id() const { return local_surface_id_; }
-
  private:
   void SetupFrameRate(bool force);
-  void ResizeRootLayer();
+  void ResizeRootLayer(bool force);
 
   viz::FrameSinkId AllocateFrameSinkId(bool is_guest_view_hack);
 

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -210,6 +210,9 @@ class OffScreenRenderWidgetHostView
 #if defined(OS_MACOSX)
   void CreatePlatformWidget(bool is_guest_view_hack);
   void DestroyPlatformWidget();
+  SkColor last_frame_root_background_color() const {
+    return last_frame_root_background_color_;
+  }
 #endif
 
   void CancelWidget();

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -328,6 +328,8 @@ class OffScreenRenderWidgetHostView
 #if defined(OS_MACOSX)
   std::unique_ptr<content::BrowserCompositorMac> browser_compositor_;
 
+  SkColor last_frame_root_background_color_;
+
   // Can not be managed by smart pointer because its header can not be included
   // in the file that has the destructor.
   MacHelper* mac_helper_;

--- a/atom/browser/osr/osr_render_widget_host_view_mac.mm
+++ b/atom/browser/osr/osr_render_widget_host_view_mac.mm
@@ -98,6 +98,10 @@ void OffScreenRenderWidgetHostView::DestroyPlatformWidget() {
   delete mac_helper_;
 }
 
+viz::LocalSurfaceId OffScreenRenderWidgetHostView::GetLocalSurfaceId() const {
+  return browser_compositor_->GetRendererLocalSurfaceId();
+}
+
 ui::Compositor* OffScreenRenderWidgetHostView::GetCompositor() const {
   return browser_compositor_->GetCompositor();
 }

--- a/atom/browser/osr/osr_render_widget_host_view_mac.mm
+++ b/atom/browser/osr/osr_render_widget_host_view_mac.mm
@@ -22,7 +22,7 @@ class MacHelper : public content::BrowserCompositorMacClient,
   virtual ~MacHelper() {}
 
   // content::BrowserCompositorMacClient:
-  SkColor BrowserCompositorMacGetGutterColor(SkColor color) const override {
+  SkColor BrowserCompositorMacGetGutterColor() const override {
     // When making an element on the page fullscreen the element's background
     // may not match the page's, so use black as the gutter color to avoid
     // flashes of brighter colors during the transition.
@@ -30,7 +30,7 @@ class MacHelper : public content::BrowserCompositorMacClient,
         view_->render_widget_host()->delegate()->IsFullscreenForCurrentTab()) {
       return SK_ColorBLACK;
     }
-    return color;
+    return SK_ColorTRANSPARENT;
   }
 
   void BrowserCompositorMacOnBeginFrame() override {}
@@ -81,7 +81,7 @@ bool OffScreenRenderWidgetHostView::IsSpeaking() const {
 
 void OffScreenRenderWidgetHostView::StopSpeaking() {}
 
-bool CefRenderWidgetHostViewOSR::ShouldContinueToPauseForFrame() {
+bool OffScreenRenderWidgetHostView::ShouldContinueToPauseForFrame() {
   return browser_compositor_->ShouldContinueToPauseForFrame();
 }
 

--- a/atom/browser/osr/osr_render_widget_host_view_mac.mm
+++ b/atom/browser/osr/osr_render_widget_host_view_mac.mm
@@ -30,7 +30,7 @@ class MacHelper : public content::BrowserCompositorMacClient,
         view_->render_widget_host()->delegate()->IsFullscreenForCurrentTab()) {
       return SK_ColorBLACK;
     }
-    return SK_ColorTRANSPARENT;
+    return last_frame_root_background_color_;
   }
 
   void BrowserCompositorMacOnBeginFrame() override {}

--- a/atom/browser/osr/osr_render_widget_host_view_mac.mm
+++ b/atom/browser/osr/osr_render_widget_host_view_mac.mm
@@ -30,7 +30,7 @@ class MacHelper : public content::BrowserCompositorMacClient,
         view_->render_widget_host()->delegate()->IsFullscreenForCurrentTab()) {
       return SK_ColorBLACK;
     }
-    return last_frame_root_background_color_;
+    return view_->last_frame_root_background_color();
   }
 
   void BrowserCompositorMacOnBeginFrame() override {}

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -186,8 +186,7 @@ void BrowserMainParts::InitializeFeatureList() {
   auto disable_features =
       cmd_line->GetSwitchValueASCII(switches::kDisableFeatures);
 
-  // Disable surface synchronization and async wheel events to make OSR work.
-  disable_features += ",SurfaceSynchronization,AsyncWheelEvents";
+  disable_features += ",GuestViewCrossProcessFrames";
 
   auto feature_list = std::make_unique<base::FeatureList>();
   feature_list->InitializeFromCommandLine(enable_features, disable_features);

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -185,9 +185,6 @@ void BrowserMainParts::InitializeFeatureList() {
       cmd_line->GetSwitchValueASCII(switches::kEnableFeatures);
   auto disable_features =
       cmd_line->GetSwitchValueASCII(switches::kDisableFeatures);
-
-  disable_features += ",GuestViewCrossProcessFrames";
-
   auto feature_list = std::make_unique<base::FeatureList>();
   feature_list->InitializeFromCommandLine(enable_features, disable_features);
   base::FeatureList::SetInstance(std::move(feature_list));

--- a/features.gypi
+++ b/features.gypi
@@ -3,7 +3,7 @@
   'variables': {
     'variables': {
       'enable_desktop_capturer%': 1,
-      'enable_osr%': 0,  # FIXME(alexeykuzmin)
+      'enable_osr%': 1,
       'enable_pdf_viewer%': 0,  # FIXME(deepak1556)
       'enable_run_as_node%': 1,
       'enable_view_api%': 0,


### PR DESCRIPTION
Enable OSR compilation and add back `MouseWheelPhaseHandler` and Surface synchronization.

Related: https://github.com/electron/libchromiumcontent/pull/649

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines]

Notes: Enable OSR
