### PR TITLE
ci: Use VS2017 15.4.5 for Chromium 66

### DIFF
--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -3,7 +3,7 @@ branches:
   except:
   - /^release$|^release-\d-\d-x$/
 build_cloud: libcc-20
-image: libcc-20-vs2017
+image: libcc-20-vs2017-15.4.5
 environment:
   DISABLE_CRASH_REPORTER_TESTS: true
   ELECTRON_ENABLE_LOGGING: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ branches:
   except:
   - /^release$|^release-\d-\d-x$/
 build_cloud: electron-16
-image: electron-16-vs2017
+image: electron-16-vs2017-15.4.5
 environment:
   DISABLE_CRASH_REPORTER_TESTS: true
 build_script:


### PR DESCRIPTION
This PR updates our AppVeyor configs to use Visual Studion 2017 15.4.5 for master (Chromium 66).

This resolves #13618 for master.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)