### PR TITLE
ci: [win] simplify call to electron.exe in appveyor

### DIFF
--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -37,7 +37,7 @@ test_script:
   - ps: Push-Location; cd electron/spec
   - npm install
   - ps: Pop-Location
-  - python -c "import subprocess; subprocess.check_call([\"./out/Default/electron.exe\", \"electron/spec\", \"--ci\"])"
+  - ./out/Default/electron.exe electron/spec --ci
   # TODO(nornagon): verify-ffmpeg step
 artifacts:
 - path: test-results.xml


### PR DESCRIPTION
the python junk was there previously because PowerShell is bad at exit
codes

notes: no-notes