### PR TITLE
build: add config to build Electron for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,16 @@ jobs:
     environment:
       DISPLAY: ':99.0'
       GN_CONFIG: //electron/build/args/debug.gn
+      RUN_TESTS: false
+    docker:
+      - image: electronbuilds/electron:0.0.8
+    resource_class: 2xlarge
+    <<: *gn-build-steps
+
+  electron-gn-linux-x64-testing-fyi:
+    environment:
+      DISPLAY: ':99.0'
+      GN_CONFIG: //electron/build/args/testing.gn
     docker:
       - image: electronbuilds/electron:0.0.8
     resource_class: 2xlarge
@@ -405,6 +415,18 @@ jobs:
     environment:
       DISPLAY: ':99.0'
       GN_CONFIG: //electron/build/args/debug.gn
+      GN_EXTRA_ARGS: 'target_cpu = "x86"'
+      NPM_CONFIG_ARCH: ia32
+      RUN_TESTS: false
+    docker:
+      - image: electronbuilds/electron:0.0.8
+    resource_class: 2xlarge
+    <<: *gn-build-steps
+
+  electron-gn-linux-ia32-testing-fyi:
+    environment:
+      DISPLAY: ':99.0'
+      GN_CONFIG: //electron/build/args/testing.gn
       GN_EXTRA_ARGS: 'target_cpu = "x86"'
       NPM_CONFIG_ARCH: ia32
     docker:
@@ -434,6 +456,17 @@ jobs:
     resource_class: 2xlarge
     <<: *gn-build-steps
 
+  electron-gn-linux-arm-testing-fyi:
+    environment:
+      GN_CONFIG: //electron/build/args/testing.gn
+      GN_EXTRA_ARGS: 'target_cpu = "arm"'
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True'
+      RUN_TESTS: false
+    docker:
+      - image: electronbuilds/electron:0.0.8
+    resource_class: 2xlarge
+    <<: *gn-build-steps
+
   electron-gn-linux-arm-release-fyi:
     environment:
       GN_CONFIG: //electron/build/args/release.gn
@@ -448,6 +481,17 @@ jobs:
   electron-gn-linux-arm64-debug-fyi:
     environment:
       GN_CONFIG: //electron/build/args/debug.gn
+      GN_EXTRA_ARGS: 'target_cpu = "arm64" fatal_linker_warnings = false enable_linux_installer = false'
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm64=True'
+      RUN_TESTS: false
+    docker:
+      - image: electronbuilds/electron:0.0.8
+    resource_class: 2xlarge
+    <<: *gn-build-steps
+
+  electron-gn-linux-arm64-testing-fyi:
+    environment:
+      GN_CONFIG: //electron/build/args/testing.gn
       GN_EXTRA_ARGS: 'target_cpu = "arm64" fatal_linker_warnings = false enable_linux_installer = false'
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm64=True'
       RUN_TESTS: false
@@ -496,13 +540,13 @@ workflows:
   build-gn-linux:
     jobs:
       - electron-gn-linux-x64-debug-fyi
-      - electron-gn-linux-x64-release-fyi
+      - electron-gn-linux-x64-testing-fyi
       - electron-gn-linux-ia32-debug-fyi
-      - electron-gn-linux-ia32-release-fyi
+      - electron-gn-linux-ia32-testing-fyi
       - electron-gn-linux-arm-debug-fyi
-      - electron-gn-linux-arm-release-fyi
+      - electron-gn-linux-arm-testing-fyi
       - electron-gn-linux-arm64-debug-fyi
-      - electron-gn-linux-arm64-release-fyi
+      - electron-gn-linux-arm64-testing-fyi
 
   nightly-release-test:
     triggers:
@@ -521,3 +565,17 @@ workflows:
       - electron-linux-arm64-release-nightly
       - electron-linux-ia32-release-nightly
       - electron-linux-x64-release-nightly
+
+  nightly-gn-release-test:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - electron-gn-linux-x64-release-fyi
+      - electron-gn-linux-ia32-release-fyi
+      - electron-gn-linux-arm-release-fyi
+      - electron-gn-linux-arm64-release-fyi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,6 +512,7 @@ workflows:
             branches:
               only:
                 - master
+                - 3-0-x
                 - 2-0-x
                 - 1-8-x
                 - 1-7-x

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -10,7 +10,7 @@ environment:
   matrix:
     - gn_args: debug
       ELECTRON_SKIP_NATIVE_MODULE_TESTS: 1
-    - gn_args: release
+    - gn_args: testing
 platform:
   - x86
   - x64

--- a/build/args/testing.gn
+++ b/build/args/testing.gn
@@ -1,0 +1,7 @@
+import("all.gn")
+is_debug = false
+is_component_build = false
+is_official_build = false
+dcheck_always_on = true
+symbol_level = 1
+use_jumbo_build = true

--- a/vsts-gn.yml
+++ b/vsts-gn.yml
@@ -36,7 +36,7 @@ phases:
       "$SCCACHE_WRAPPER" -s
       echo "##vso[task.setvariable variable=SCCACHE_WRAPPER]$SCCACHE_WRAPPER"
       echo "##vso[task.setvariable variable=CHROMIUM_BUILDTOOLS_PATH]`pwd`/buildtools"
-      gn gen out/Default --args='import("//electron/build/args/debug.gn") cc_wrapper="'"$SCCACHE_WRAPPER"'"'
+      gn gen out/Default --args='import("//electron/build/args/testing.gn") cc_wrapper="'"$SCCACHE_WRAPPER"'"'
     name: GN_gen
 
   - bash: |


### PR DESCRIPTION
- build: add config to build Electron for tests
- build: run nightly linux builds for the 3-0-x branch
-  build: gn: update CI config for **linux** builds
   - run GN debug and testing builds for PRs (as FYI)
   - do not run tests for GN debug builds
   - run GN release builds nightly
-  build: gn: run testing builds on CI instead of release on **Windows**

   - Should save some time since release builds set 'official_build=true'
  which make the builds take much more time.
-  build: gn: use testing config to run CI jobs on **Mac**

   - Tests should run faster for testing builds.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

notes: no-notes