### PR TITLE
fix: add a hidden option to disable remote dereferencing

### DIFF
--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -87,6 +87,8 @@ class ObjectsRegistry {
 
   // Private: Dereference the object from store.
   dereference (id) {
+    if (process.env.ELECTRON_DISABLE_REMOTE_DEREFERENCING) return
+
     let pointer = this.storage[id]
     if (pointer == null) {
       return


### PR DESCRIPTION
This gives people the option to opt out of remote dereferencing.  This can cause memory leaks so we don't want people using it unless they know what they are doing

This is intentionally left undocumented.

cc @felixrieseberg 

notes: no-notes