### PR TITLE
chore: update PR template for new notes bot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+##### Description of Change
 <!--
 Thank you for your Pull Request. Please provide a description above and review
 the requirements below.
@@ -13,3 +14,8 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
 - [ ] relevant documentation is changed or added
 - [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
+
+
+##### Release Notes
+
+Notes: <!-- One-line Change Summary Here-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,6 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 
 ##### Release Notes
+<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->
 
 Notes: <!-- One-line Change Summary Here-->


### PR DESCRIPTION
##### Description of Change

This PR updates the PR template to include a section for release notes, in accordance with the new release notes bot.

/cc @MarshallOfSound 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes