### PR TITLE
fix: create persistent channel ID store when cookie store is persistent

### DIFF
--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -13,6 +13,7 @@ static_library("brightray") {
     "//components/prefs",
     "//content/public/browser",
     "//content/shell:resources",
+    "//net:extras",
     "//net:net_with_v8",
     "//skia",
     "//ui/views",

--- a/brightray/brightray.gyp
+++ b/brightray/brightray.gyp
@@ -112,6 +112,7 @@
                 'libraries': [
                   # Following libraries are always linked statically.
                   '<(libchromiumcontent_dir)/libbase_static.a',
+                  '<(libchromiumcontent_dir)/libextras.a',
                   '<(libchromiumcontent_dir)/libgtkui.a',
                   '<(libchromiumcontent_dir)/libhttp_server.a',
                   '<(libchromiumcontent_dir)/libdevice_service.a',
@@ -206,6 +207,7 @@
                 'libraries': [
                   # Following libraries are always linked statically.
                   '<(libchromiumcontent_dir)/libbase_static.a',
+                  '<(libchromiumcontent_dir)/libextras.a',
                   '<(libchromiumcontent_dir)/libhttp_server.a',
                   '<(libchromiumcontent_dir)/libdevice_service.a',
                   '<(libchromiumcontent_dir)/libdom_keycode_converter.a',
@@ -342,6 +344,7 @@
                   '-ldxgi.lib',
                   # Following libs are always linked statically.
                   '<(libchromiumcontent_dir)/base_static.lib',
+                  '<(libchromiumcontent_dir)/extras.lib',
                   '<(libchromiumcontent_dir)/sandbox.lib',
                   '<(libchromiumcontent_dir)/sandbox_helper_win.lib',
                   '<(libchromiumcontent_dir)/http_server.lib',


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/13906
Depends on https://github.com/electron/libchromiumcontent/pull/651

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

notes: create persistent channel ID store for persistent user data