### PR TITLE
feat: allow window above full screen windows on mac

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -691,16 +691,12 @@ void TopLevelWindow::SetOverlayIcon(const gfx::Image& overlay,
   window_->SetOverlayIcon(overlay, description);
 }
 
-#if defined(OS_MACOSX)
 void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible,
-                                               bool visibleOnFullScreen) {
-  return window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
+                                               mate::Arguments* args) {
+  bool visibleOnFullScreen = false;
+  args->GetNext(&visibleOnFullScreen);
+  window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
 }
-#else
-void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible) {
-  return window_->SetVisibleOnAllWorkspaces(visible);
-}
-#endif
 
 bool TopLevelWindow::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -693,9 +693,11 @@ void TopLevelWindow::SetOverlayIcon(const gfx::Image& overlay,
 
 void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible,
                                                mate::Arguments* args) {
+  mate::Dictionary options;
   bool visibleOnFullScreen = false;
-  args->GetNext(&visibleOnFullScreen);
-  window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
+  args->GetNext(&options) &&
+      options.Get("visibleOnFullScreen", &visibleOnFullScreen);
+  return window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
 }
 
 bool TopLevelWindow::IsVisibleOnAllWorkspaces() {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -691,9 +691,16 @@ void TopLevelWindow::SetOverlayIcon(const gfx::Image& overlay,
   window_->SetOverlayIcon(overlay, description);
 }
 
+#if defined(OS_MACOSX)
+void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible,
+                                               bool visibleOnFullScreen) {
+  return window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
+}
+#else
 void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible) {
   return window_->SetVisibleOnAllWorkspaces(visible);
 }
+#endif
 
 bool TopLevelWindow::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -163,7 +163,12 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void SetProgressBar(double progress, mate::Arguments* args);
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);
-  void SetVisibleOnAllWorkspaces(bool visible);
+#if defined(OS_MACOSX)
+  virtual void SetVisibleOnAllWorkspaces(bool visible,
+                                         bool visibleOnFullScreen);
+#else
+  virtual void SetVisibleOnAllWorkspaces(bool visible);
+#endif
   bool IsVisibleOnAllWorkspaces();
   void SetAutoHideCursor(bool auto_hide);
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -163,12 +163,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void SetProgressBar(double progress, mate::Arguments* args);
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);
-#if defined(OS_MACOSX)
-  virtual void SetVisibleOnAllWorkspaces(bool visible,
-                                         bool visibleOnFullScreen);
-#else
-  virtual void SetVisibleOnAllWorkspaces(bool visible);
-#endif
+  void SetVisibleOnAllWorkspaces(bool visible, mate::Arguments* args);
   bool IsVisibleOnAllWorkspaces();
   void SetAutoHideCursor(bool auto_hide);
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -165,7 +165,13 @@ class NativeWindow : public base::SupportsUserData,
                               const std::string& description) = 0;
 
   // Workspace APIs.
+#if defined(OS_MACOSX)
+  virtual void SetVisibleOnAllWorkspaces(bool visible,
+                                         bool visibleOnFullScreen) = 0;
+#else
   virtual void SetVisibleOnAllWorkspaces(bool visible) = 0;
+#endif
+
   virtual bool IsVisibleOnAllWorkspaces() = 0;
 
   virtual void SetAutoHideCursor(bool auto_hide);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -165,12 +165,8 @@ class NativeWindow : public base::SupportsUserData,
                               const std::string& description) = 0;
 
   // Workspace APIs.
-#if defined(OS_MACOSX)
   virtual void SetVisibleOnAllWorkspaces(bool visible,
-                                         bool visibleOnFullScreen) = 0;
-#else
-  virtual void SetVisibleOnAllWorkspaces(bool visible) = 0;
-#endif
+                                         bool visibleOnFullScreen = false) = 0;
 
   virtual bool IsVisibleOnAllWorkspaces() = 0;
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -107,7 +107,8 @@ class NativeWindowMac : public NativeWindow {
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
 
-  void SetVisibleOnAllWorkspaces(bool visible) override;
+  void SetVisibleOnAllWorkspaces(bool visible,
+                                 bool visibleOnFullScreen) override;
   bool IsVisibleOnAllWorkspaces() override;
 
   void SetAutoHideCursor(bool auto_hide) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1100,8 +1100,13 @@ void NativeWindowMac::SetProgressBar(double progress,
 void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
                                      const std::string& description) {}
 
-void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible) {
-  SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
+void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible,
+                                                bool visibleOnFullScreen) {
+  if (visible) {
+    SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
+  } else if (visible && visibleOnFullScreen) {
+    SetCollectionBehavior(visible, (NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorFullScreenAuxiliary));
+  }
 }
 
 bool NativeWindowMac::IsVisibleOnAllWorkspaces() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1102,11 +1102,9 @@ void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
 
 void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible,
                                                 bool visibleOnFullScreen) {
-  if (visible) {
-    SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
-  } else if (visible && visibleOnFullScreen) {
-    SetCollectionBehavior(visible, (NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorFullScreenAuxiliary));
-  }
+  SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
+  SetCollectionBehavior(visibleOnFullScreen,
+                        NSWindowCollectionBehaviorFullScreenAuxiliary);
 }
 
 bool NativeWindowMac::IsVisibleOnAllWorkspaces() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1002,16 +1002,10 @@ bool NativeWindowViews::IsMenuBarVisible() {
   return root_view_->IsMenuBarVisible();
 }
 
-#if defined(OS_MACOSX)
 void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible,
                                                   bool visibleOnFullScreen) {
   widget()->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
 }
-#else
-void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible) {
-  widget()->SetVisibleOnAllWorkspaces(visible);
-}
-#endif
 
 bool NativeWindowViews::IsVisibleOnAllWorkspaces() {
 #if defined(USE_X11)

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1002,9 +1002,16 @@ bool NativeWindowViews::IsMenuBarVisible() {
   return root_view_->IsMenuBarVisible();
 }
 
+#if defined(OS_MACOSX)
+void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible,
+                                                  bool visibleOnFullScreen) {
+  widget()->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
+}
+#else
 void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible) {
   widget()->SetVisibleOnAllWorkspaces(visible);
 }
+#endif
 
 bool NativeWindowViews::IsVisibleOnAllWorkspaces() {
 #if defined(USE_X11)

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1004,7 +1004,7 @@ bool NativeWindowViews::IsMenuBarVisible() {
 
 void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible,
                                                   bool visibleOnFullScreen) {
-  widget()->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
+  widget()->SetVisibleOnAllWorkspaces(visible);
 }
 
 bool NativeWindowViews::IsVisibleOnAllWorkspaces() {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -119,7 +119,14 @@ class NativeWindowViews : public NativeWindow,
   bool IsMenuBarAutoHide() override;
   void SetMenuBarVisibility(bool visible) override;
   bool IsMenuBarVisible() override;
+
+#if defined(OS_MACOSX)
+  void SetVisibleOnAllWorkspaces(bool visible,
+                                 bool visibleOnFullScreen) override;
+#else
   void SetVisibleOnAllWorkspaces(bool visible) override;
+#endif
+
   bool IsVisibleOnAllWorkspaces() override;
 
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -120,12 +120,8 @@ class NativeWindowViews : public NativeWindow,
   void SetMenuBarVisibility(bool visible) override;
   bool IsMenuBarVisible() override;
 
-#if defined(OS_MACOSX)
   void SetVisibleOnAllWorkspaces(bool visible,
                                  bool visibleOnFullScreen) override;
-#else
-  void SetVisibleOnAllWorkspaces(bool visible) override;
-#endif
 
   bool IsVisibleOnAllWorkspaces() override;
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1397,11 +1397,16 @@ can still bring up the menu bar by pressing the single `Alt` key.
 
 Returns `Boolean` - Whether the menu bar is visible.
 
-#### `win.setVisibleOnAllWorkspaces(visible)`
+#### `win.setVisibleOnAllWorkspaces(visible[, visibleOnFullScreen])`
 
 * `visible` Boolean
 
 Sets whether the window should be visible on all workspaces.
+
+* `visibleOnFullScreen` Boolean (optional)
+
+Sets whether the window should be visible above fullscreen windows, `visible`
+must be set to `true`.
 
 **Note:** This API does nothing on Windows.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1397,15 +1397,14 @@ can still bring up the menu bar by pressing the single `Alt` key.
 
 Returns `Boolean` - Whether the menu bar is visible.
 
-#### `win.setVisibleOnAllWorkspaces(visible[, visibleOnFullScreen])`
+#### `win.setVisibleOnAllWorkspaces(visible[, options])`
 
 * `visible` Boolean
-* `visibleOnFullScreen` Boolean (optional) _macOS_
+* `options` Object (optional)
+  * `visibleOnFullScreen` Boolean (optional) _macOS_ - Sets whether
+    the window should be visible above fullscreen windows
 
 Sets whether the window should be visible on all workspaces.
-
-`visibleOnFullScreen` sets whether the window should be visible above
-fullscreen windows
 
 **Note:** This API does nothing on Windows.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1400,13 +1400,12 @@ Returns `Boolean` - Whether the menu bar is visible.
 #### `win.setVisibleOnAllWorkspaces(visible[, visibleOnFullScreen])`
 
 * `visible` Boolean
+* `visibleOnFullScreen` Boolean (optional) _macOS_
 
 Sets whether the window should be visible on all workspaces.
 
-* `visibleOnFullScreen` Boolean (optional)
-
-Sets whether the window should be visible above fullscreen windows, `visible`
-must be set to `true`.
+`visibleOnFullScreen` sets whether the window should be visible above
+fullscreen windows
 
 **Note:** This API does nothing on Windows.
 


### PR DESCRIPTION
continuation of https://github.com/electron/electron/pull/11599

tested on macOS 10.13.6

I have followed https://github.com/electron/electron/blob/master/CONTRIBUTING.md and tested locally. Please let me know if I have missed anything or how I can improve this code

notes: Add visibleOnFullScreen option for SetVisibleOnAllWorkspaces for macOS