### PR TITLE
docs: fix electron.d.ts typings

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -167,6 +167,7 @@ Set the security origin of the isolated world.
 Returns `Object`:
 
 * `images` [MemoryUsageDetails](structures/memory-usage-details.md)
+* `scripts` [MemoryUsageDetails](structures/memory-usage-details.md)
 * `cssStyleSheets` [MemoryUsageDetails](structures/memory-usage-details.md)
 * `xslStyleSheets` [MemoryUsageDetails](structures/memory-usage-details.md)
 * `fonts` [MemoryUsageDetails](structures/memory-usage-details.md)


### PR DESCRIPTION
Add missing `scripts` property to `webFrame.getResourceUsage()` result
Refer to [`Converter<blink::WebCache::ResourceTypeStats>::ToV8`](https://github.com/electron/electron/blob/master/atom/common/native_mate_converters/blink_converter.cc#L482)

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Minor documentation updates and fixes.