### PR TITLE
chore: enable jumbo builds in the GN release config

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -1,5 +1,6 @@
 is_electron_build = true
 is_electron_gn_build = true
+use_jumbo_build = true
 root_extra_deps = [ "//electron" ]
 
 v8_promise_internal_field_count = 1

--- a/build/args/debug.gn
+++ b/build/args/debug.gn
@@ -1,4 +1,3 @@
 import("all.gn")
 is_debug = true
 is_component_build = true
-use_jumbo_build = true

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -1,7 +1,7 @@
 import("all.gn")
 is_component_build = false
-is_official_build = true
 is_component_ffmpeg = true
+is_official_build = true
 use_jumbo_build = true
 
 # TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -2,7 +2,6 @@ import("all.gn")
 is_component_build = false
 is_component_ffmpeg = true
 is_official_build = true
-use_jumbo_build = true
 
 # TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.
 # Once we can build nodejs with CFI flags matching Electron's, remove this.

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -2,6 +2,7 @@ import("all.gn")
 is_component_build = false
 is_official_build = true
 is_component_ffmpeg = true
+use_jumbo_build = true
 
 # TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.
 # Once we can build nodejs with CFI flags matching Electron's, remove this.


### PR DESCRIPTION
Enables jumbo builds in the GN release config.

@jkleinsc 

Notes: no-notes