### PR TITLE
 build: gn: commit patches after they have been applied

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -33,7 +33,9 @@ hooks = [
   {
     'action': [
       'python',
-      'src/libchromiumcontent/script/apply-patches'
+      'src/libchromiumcontent/script/apply-patches',
+      '--project-root=.',
+      '--commit'
     ],
     'pattern':
       'src/libchromiumcontent',

--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_version':
     '66.0.3359.181',
   'libchromiumcontent_revision':
-    'd6411e421b0b2f0105d274ac4e5c90dc979463ca',
+    '5ff3486fc02a6a7b4b9e31d81034c4583c21114a',
   'node_version':
     'ece0a06ac8147efb5b5af431c21f312f1884616e',
 


### PR DESCRIPTION
It prevents a hooks run failure when `gclient sync` is called
for a second time. Error message:

```
error: ui/latency/ui_latency_export.h: already exists in working directory
latency_info.patch failed to apply
```

##### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes