### PR TITLE
[WIP] build: set strip_debug_info in release builds

### DIFF
--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -1,7 +1,8 @@
 import("all.gn")
 is_component_build = false
-is_official_build = true
 is_component_ffmpeg = true
+is_official_build = true
+strip_debug_info = true
 
 # TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.
 # Once we can build nodejs with CFI flags matching Electron's, remove this.


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin.

Previous release zipfile was 2.7 GB and 2.2 GB of that was the electron executable. Stripped, the executable was 89 MB :smiley: 

The docs for `strip_debug_info` discuss this stripping shared libraries but doesn't discuss executables. So this PR is a tracer WIP.

cc @jkleinsc 

#### Release Notes

Notes: no-notes