### PR TITLE
build: use GIT_CACHE_PATH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ gn-build-steps: &gn-build-steps
         command: |
           git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
           echo 'export PATH="$PATH:'"$PWD"'/depot_tools"' >> $BASH_ENV
+          echo 'export GIT_CACHE_PATH="$HOME/.gclient-cache"' >> $BASH_ENV
     - checkout:
         path: src/electron
     - restore_cache:
@@ -168,7 +169,7 @@ gn-build-steps: &gn-build-steps
           gclient config \
             --name "src/electron" \
             --unmanaged \
-            --cache-dir "$HOME/.gclient-cache" \
+            --cache-dir "${GIT_CACHE_PATH}" \
             $GCLIENT_EXTRA_ARGS \
             "$CIRCLE_REPOSITORY_URL"
 

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -5,6 +5,7 @@ branches:
 build_cloud: libcc-20
 image: libcc-20-vs2017-15.4.5
 environment:
+  GIT_CACHE_PATH: "C:\Users\electron\libcc_cache"
   DISABLE_CRASH_REPORTER_TESTS: true
   ELECTRON_ENABLE_LOGGING: true
   matrix:
@@ -24,7 +25,7 @@ build_script:
       gclient config
       --name "src\electron"
       --unmanaged
-      --cache-dir "C:\Users\electron\libcc_cache"
+      --cache-dir "${GIT_CACHE_PATH}"
       "https://github.com/electron/electron"
   - gclient sync --with_branch_heads --with_tags
   - cd src

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -29,6 +29,19 @@ try to download a Google-internal version that only Googlers have access to).
 
 ## Getting the Code
 
+### Using a Git cache (optional step)
+
+`gclient` fetches about 16G worth of repository data. If you plan on building
+more than once, consider using its cache feature to make future calls faster:
+
+```sh
+$ export GIT_CACHE_PATH="$HOME/.git_cache"
+$ mkdir -p "$GIT_CACHE_PATH"
+# This will take about 16G.
+```
+
+### Getting the code with gclient
+
 ```sh
 $ mkdir electron-gn && cd electron-gn
 $ gclient config \

--- a/vsts-gn.yml
+++ b/vsts-gn.yml
@@ -11,11 +11,12 @@ phases:
     name: Setup_depot_tools
 
   - bash: |
+      export GIT_CACHE_PATH="/Users/electron/libcc_cache"
       set -ex
       gclient config \
         --name "src/electron" \
         --unmanaged \
-        --cache-dir "/Users/electron/libcc_cache" \
+        --cache-dir "${GIT_CACHE_PATH}" \
         "https://github.com/electron/electron"
       mkdir src
       git clone https://github.com/electron/electron src/electron


### PR DESCRIPTION
Add `GIT_CACHE_PATH` to the CI configs and document its use in the GN build docs. This is the preferred way of `gclient` caching.

See commit at https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/1105473

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

Notes: no-notes