### PR TITLE
fix: electron path for postinstall

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -17,7 +17,9 @@ try {
 
 var platformPath = getPlatformPath()
 
-if (installedVersion === version && fs.existsSync(path.join(__dirname, 'dist', platformPath))) {
+var electronPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist', platformPath)
+
+if (installedVersion === version && fs.existsSync(electronPath)) {
   process.exit(0)
 }
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -17,7 +17,7 @@ try {
 
 var platformPath = getPlatformPath()
 
-if (installedVersion === version && fs.existsSync(path.join(__dirname, platformPath))) {
+if (installedVersion === version && fs.existsSync(path.join(__dirname, 'dist', platformPath))) {
   process.exit(0)
 }
 


### PR DESCRIPTION
##### Description of Change
Fixes #14127

##### Checklist
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

Notes: Fix issue where npm installing electron would throw errors on reinstalls