### PR TITLE
chore:  shortcut to error early for component build pkg in GN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,14 +155,24 @@ gn-build-steps: &gn-build-steps
           git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
           echo 'export PATH="$PATH:'"$PWD"'/depot_tools"' >> $BASH_ENV
           echo 'export GIT_CACHE_PATH="$HOME/.gclient-cache"' >> $BASH_ENV
+    - run:
+        name: Install Node.js 10 on MacOS
+        command: |
+          if [ "$INSTALL_MACOS_NODE" == "true" ]; then
+            echo 'Installing Node.js 10 for MacOS'
+            brew update
+            brew install node@10
+            brew install gnu-tar
+            echo 'export PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"' >> $BASH_ENV
+          fi
     - checkout:
         path: src/electron
     - restore_cache:
         paths:
           - ~/.gclient-cache
         keys:
-          - v1-gclient-cache-{{ arch }}-{{ checksum "src/electron/DEPS" }}
-          - v1-gclient-cache-{{ arch }}-
+          - v3-gclient-cache-{{ arch }}-{{ checksum "src/electron/DEPS" }}
+          - v3-gclient-cache-{{ arch }}-
     - run:
         name: Gclient sync
         command: |
@@ -177,12 +187,16 @@ gn-build-steps: &gn-build-steps
     - save_cache:
         paths:
           - ~/.gclient-cache
-        key: v1-gclient-cache-{{ arch }}-{{ checksum "src/electron/DEPS" }}
+        key: v3-gclient-cache-{{ arch }}-{{ checksum "src/electron/DEPS" }}
     - run:
         name: GN gen
         command: |
           cd src
-          SCCACHE_PATH="$PWD/libchromiumcontent/tools/sccache/aad2120/linux/sccache"
+          if [ "$(uname)" = "Linux" ]; then
+            SCCACHE_PATH="$PWD/libchromiumcontent/tools/sccache/aad2120/linux/sccache"
+          else
+            SCCACHE_PATH="$PWD/libchromiumcontent/tools/sccache/aad2120/mac/sccache"
+          fi
           echo 'export SCCACHE_WRAPPER="'"$SCCACHE_PATH"'"' >> $BASH_ENV
           echo 'export CHROMIUM_BUILDTOOLS_PATH="'"$PWD"'/buildtools"' >> $BASH_ENV
           source $BASH_ENV
@@ -193,12 +207,19 @@ gn-build-steps: &gn-build-steps
           cd src
           ninja -C out/Default electron:electron_app
     - run:
+        name: Build dist.zip
+        command: |
+          cd src
+          ninja -C out/Default electron:electron_dist_zip
+    - run:
         name: Check sccache stats after build
         command: $SCCACHE_WRAPPER -s
     - run:
         name: Setup for headless testing
         command: |
-          sh -e /etc/init.d/xvfb start
+          if [ "$(uname)" = "Linux" ]; then
+            sh -e /etc/init.d/xvfb start
+          fi
     - run:
         name: Test
         environment:
@@ -211,12 +232,18 @@ gn-build-steps: &gn-build-steps
             ninja -C out/Default third_party/electron_node:headers
             export npm_config_nodedir="$PWD/out/Default/gen/node_headers"
             (cd electron/spec && npm install)
-            python electron/script/lib/dbus_mock.py ./out/Default/electron electron/spec --ci --enable-logging
+            if [ "$(uname)" = "Darwin" ]; then
+              ./out/Default/Electron.app/Contents/MacOS/Electron electron/spec --ci --enable-logging
+            else
+              python electron/script/lib/dbus_mock.py ./out/Default/electron electron/spec --ci --enable-logging
+            fi
           fi
     - store_test_results:
         path: src/junit
     - store_artifacts:
         path: src/junit
+    - store_artifacts:
+        path: src/out/Default/dist.zip
 
 build-defaults: &build-defaults
   docker:
@@ -351,6 +378,7 @@ jobs:
       INSTALL_MACOS_NODE: true
     macos:
       xcode: "8.3.3"
+    resource_class: xlarge
     <<: *build-steps
 
   electron-osx-x64-release-nightly:
@@ -371,6 +399,7 @@ jobs:
       INSTALL_MACOS_NODE: true
     macos:
       xcode: "8.3.3"
+    resource_class: 2xlarge
     <<: *build-steps
 
   electron-mas-x64-release-nightly:
@@ -512,6 +541,48 @@ jobs:
     resource_class: 2xlarge
     <<: *gn-build-steps
 
+  electron-gn-osx-debug-fyi:
+    environment:
+      GN_CONFIG: //electron/build/args/debug.gn
+      INSTALL_MACOS_NODE: true
+      RUN_TESTS: false
+    macos:
+      xcode: "8.3.3"
+    resource_class: large
+    <<: *gn-build-steps
+
+  electron-gn-osx-testing-fyi:
+    environment:
+      GN_CONFIG: //electron/build/args/testing.gn
+      INSTALL_MACOS_NODE: true
+      RUN_TESTS: true
+    macos:
+      xcode: "8.3.3"
+    resource_class: large
+    <<: *gn-build-steps
+
+  electron-gn-mas-debug-fyi:
+    environment:
+      GN_CONFIG: //electron/build/args/debug.gn
+      INSTALL_MACOS_NODE: true
+      RUN_TESTS: false
+      GN_EXTRA_ARGS: 'is_mas_build = true'
+    macos:
+      xcode: "8.3.3"
+    resource_class: large
+    <<: *gn-build-steps
+
+  electron-gn-mas-testing-fyi:
+    environment:
+      GN_CONFIG: //electron/build/args/testing.gn
+      INSTALL_MACOS_NODE: true
+      RUN_TESTS: true
+      GN_EXTRA_ARGS: 'is_mas_build = true'
+    macos:
+      xcode: "8.3.3"
+    resource_class: large
+    <<: *gn-build-steps
+
 workflows:
   version: 2
   build-arm:
@@ -548,6 +619,13 @@ workflows:
       - electron-gn-linux-arm-testing-fyi
       - electron-gn-linux-arm64-debug-fyi
       - electron-gn-linux-arm64-testing-fyi
+      - electron-gn-linux-x64-release-fyi
+  build-gn-mac:
+    jobs:
+      - electron-gn-osx-debug-fyi
+      - electron-gn-osx-testing-fyi
+      - electron-gn-mas-debug-fyi
+      - electron-gn-mas-testing-fyi
 
   nightly-release-test:
     triggers:

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -183,12 +183,6 @@ asar("app2asar") {
   root = "default_app"
 }
 
-group("electron") {
-  deps = [
-    ":electron_lib",
-  ]
-}
-
 static_library("electron_lib") {
   configs += [ "//v8:external_startup_data" ]
   configs += [ "//third_party/electron_node:node_internals" ]
@@ -609,6 +603,17 @@ if (is_mac) {
       "//ui/strings",
     ]
 
+    data = []
+
+    data += [ "$root_out_dir/resources.pak" ]
+    data += [ "$root_out_dir/chrome_100_percent.pak" ]
+    if (enable_hidpi) {
+      data += [ "$root_out_dir/chrome_200_percent.pak" ]
+    }
+    foreach(locale, locales) {
+      data += [ "$root_out_dir/locales/$locale.pak" ]
+    }
+
     public_deps = [
       "//tools/v8_context_snapshot:v8_context_snapshot",
     ]
@@ -652,4 +657,57 @@ if (is_mac) {
       }
     }
   }
+}
+
+
+template("dist_zip") {
+  _runtime_deps_target = "${target_name}__deps"
+  _runtime_deps_file =
+      "$root_out_dir/gen.runtime/" +
+      get_label_info(target_name, "dir") + "/" +
+      get_label_info(target_name, "name") + ".runtime_deps"
+
+  group(_runtime_deps_target) {
+    forward_variables_from(invoker, [ "deps", "data_deps", "data" ])
+    write_runtime_deps = _runtime_deps_file
+  }
+
+  action(target_name) {
+    script = "//electron/build/zip.py"
+    deps = [ ":$_runtime_deps_target" ]
+    forward_variables_from(invoker, [ "outputs" ])
+    args = rebase_path(outputs + [ _runtime_deps_file ], root_build_dir)
+  }
+}
+
+
+copy("electron_license") {
+  sources = [ "LICENSE" ]
+  outputs = [ "$root_build_dir/{{source_file_part}}" ]
+}
+copy("chromium_licenses") {
+  deps = [ "//components/resources:about_credits" ]
+  sources = [ "$root_gen_dir/components/resources/about_credits.html" ]
+  outputs = [ "$root_build_dir/LICENSES.chromium.html" ]
+}
+
+group("licenses") {
+  data_deps = [ ":electron_license", ":chromium_licenses" ]
+}
+
+action("electron_version") {
+  script = "build/write_version.py"
+  outputs = [ "$root_build_dir/version" ]
+  args = rebase_path(outputs, root_build_dir) + [ electron_version ]
+}
+
+
+dist_zip("electron_dist_zip") {
+  data_deps = [ ":electron_app", ":licenses", ":electron_version" ]
+  outputs = [ "$root_build_dir/dist.zip" ]
+}
+
+
+group("electron") {
+  deps = [ ":electron_app" ]
 }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -701,12 +701,13 @@ action("electron_version") {
   args = rebase_path(outputs, root_build_dir) + [ electron_version ]
 }
 
-
 dist_zip("electron_dist_zip") {
+  # Shortcut to error early if we try to package a component build
+  assert(is_component_build == false, "Cannot package a component build")
+
   data_deps = [ ":electron_app", ":licenses", ":electron_version" ]
   outputs = [ "$root_build_dir/dist.zip" ]
 }
-
 
 group("electron") {
   deps = [ ":electron_app" ]

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -31,6 +31,7 @@ build_script:
   - cd src
   - gn gen out/Default "--args=import(\"//electron/build/args/%gn_args%.gn\")"
   - ninja -C out/Default electron:electron_app
+  - ninja -C out/Default electron:electron_dist_zip
 test_script:
   - ninja -C out/Default electron/build/node:headers
   - ps: $env:npm_config_nodedir="$pwd/out/Default/gen/node_headers"
@@ -43,3 +44,5 @@ test_script:
 artifacts:
 - path: test-results.xml
   name: test-results.xml
+- path: src/out/Default/dist.zip
+  name: dist.zip

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -2,6 +2,7 @@ import("all.gn")
 is_component_build = false
 is_component_ffmpeg = true
 is_official_build = true
+strip_debug_info = true
 
 # TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.
 # Once we can build nodejs with CFI flags matching Electron's, remove this.

--- a/build/write_version.py
+++ b/build/write_version.py
@@ -1,0 +1,11 @@
+import sys
+
+
+def main(argv):
+  out_file, version = argv
+  with open(out_file, 'w') as f:
+    f.write(version)
+
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))

--- a/build/zip.py
+++ b/build/zip.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import os
+import sys
+import zipfile
+
+def main(argv):
+  dist_zip, runtime_deps = argv
+  with zipfile.ZipFile(dist_zip, 'w', allowZip64=True) as z:
+    with open(runtime_deps) as f:
+      for dep in f.readlines():
+        dep = dep.strip()
+        if os.path.isdir(dep):
+          for root, dirs, files in os.walk(dep):
+            for file in files:
+              z.write(os.path.join(root, file))
+        else:
+          z.write(dep)
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))

--- a/vsts-gn.yml
+++ b/vsts-gn.yml
@@ -33,11 +33,11 @@ phases:
       cd src
       export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
       export SCCACHE_WRAPPER="`pwd`/libchromiumcontent/tools/sccache/aad2120/mac/sccache"
-      "$SCCACHE_WRAPPER" --start-server --azure_container "$(SCCACHE_AZURE_BLOB_CONTAINER)" --azure_connection "$(SCCACHE_AZURE_CONNECTION_STRING)"
-      "$SCCACHE_WRAPPER" -s
+      export SCCACHE_HELPER="`pwd`/libchromiumcontent/script/sccache"
+      "$SCCACHE_HELPER" --start-server --azure_container "$(SCCACHE_AZURE_BLOB_CONTAINER)" --azure_connection "$(SCCACHE_AZURE_CONNECTION_STRING)"
       echo "##vso[task.setvariable variable=SCCACHE_WRAPPER]$SCCACHE_WRAPPER"
       echo "##vso[task.setvariable variable=CHROMIUM_BUILDTOOLS_PATH]`pwd`/buildtools"
-      gn gen out/Default --args='import("//electron/build/args/testing.gn") cc_wrapper="'"$SCCACHE_WRAPPER"'"'
+      gn gen out/Default --args='import("'$GN_CONFIG'") cc_wrapper="'"$SCCACHE_PATH"'"'
     name: GN_gen
 
   - bash: |
@@ -58,12 +58,26 @@ phases:
       (cd electron/spec && npm install)
       ./out/Default/Electron.app/Contents/MacOS/Electron electron/spec --ci --enable-logging
     name: Test
+    condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
+
+  - bash: |
+      cd src
+      ninja -C out/Default electron:electron_dist_zip
+    name: Build_dist_zip
+    condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
   - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
       testResultsFiles: '**/test-*.xml'
-    condition: and(always(), eq(variables['MOCHA_FILE'], 'junit/test-results.xml'))
+    condition: and(always(), eq(variables['MOCHA_FILE'], 'junit/test-results.xml'), ne(variables['ELECTRON_RELEASE'], '1'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)/out/Default/dist.zip'
+      ArtifactName: dist.zip
+    condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
   - bash: |
       export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"


### PR DESCRIPTION
##### Description of Change

Shortcut to error early if we try to package a component build

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

Notes: no-notes