### PR TITLE
docs: security.md: Fix navigation lockdown example code

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -612,13 +612,13 @@ sometimes be fooled - a `startsWith('https://google.com')` test would let
 `https://google.com.attacker.com` through.
 
 ```js
-const URL = require('url')
+const URL = require('url').URL
 
 app.on('web-contents-created', (event, contents) => {
   contents.on('will-navigate', (event, navigationUrl) => {
     const parsedUrl = new URL(navigationUrl)
 
-    if (parsedUrl.hostname !== 'my-own-server.com') {
+    if (parsedUrl.origin !== 'https://my-own-server.com') {
       event.preventDefault()
     }
   })


### PR DESCRIPTION
The `url` module is not a constructor; change `require('url')` to `require('url').URL`. Also, check the entire origin rather than just the hostname, since otherwise `http://my-own-server.com` is allowed in addition to `https://my-own-server.com`, in violation of point 1 (only load secure content).

notes: Documentation improvements.