### PR TITLE
chore: always target master for nightly releases

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -179,7 +179,7 @@ async function createRelease (branchToTarget, isBeta) {
     githubOpts.body = releaseNotes
   }
   githubOpts.tag_name = newVersion
-  githubOpts.target_commitish = branchToTarget
+  githubOpts.target_commitish = newVersion.indexOf('nightly') !== -1 ? 'master' : branchToTarget
   await github.repos.createRelease(githubOpts)
     .catch(err => {
       console.log(`${fail} Error creating new release: `, err)


### PR DESCRIPTION
This was landed ad-hoc onto 3-0-x yesterday to handle nightly releases from a non-master branch.  We need to target the release to "master" because the release is published to `electron/nightlies` which only has a master branch

Notes: no-notes