### PR TITLE
chore: only prepare release if last commit not a bump

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -248,6 +248,13 @@ async function promptForVersion (version) {
   })
 }
 
+// function to determine if there have been commits to master since the last release
+async function changesToRelease () {
+  let lastCommitWasRelease = new RegExp(`Bump v[0-9.]*(-beta[0-9.]*)?(-nightly[0-9.]*)?`, 'g')
+  let lastCommit = await GitProcess.exec(['log', '-n', '1', `--pretty=format:'%s'`], gitDir)
+  return !lastCommitWasRelease.test(lastCommit.stdout)
+}
+
 async function prepareRelease (isBeta, notesOnly) {
   if (args.automaticRelease && (pkg.version.indexOf('beta') === -1 ||
       versionType !== 'beta') && versionType !== 'nightly' && versionType !== 'stable') {
@@ -264,10 +271,16 @@ async function prepareRelease (isBeta, notesOnly) {
     let releaseNotes = await getReleaseNotes(currentBranch)
     console.log(`Draft release notes are: \n${releaseNotes}`)
   } else {
-    await verifyNewVersion()
-    await createRelease(currentBranch, isBeta)
-    await pushRelease(currentBranch)
-    await runReleaseBuilds(currentBranch)
+    const changes = await changesToRelease(currentBranch)
+    if (changes) {
+      await verifyNewVersion()
+      await createRelease(currentBranch, isBeta)
+      await pushRelease(currentBranch)
+      await runReleaseBuilds(currentBranch)
+    } else {
+      console.log(`There are no new changes to this branch since the last release, aborting release.`)
+      process.exit(1)
+    }
   }
 }
 


### PR DESCRIPTION
##### Description of Change

Closes https://github.com/electron/sudowoodo/issues/38.

This PR makes it such that `npm run prepare-release` exits with 1 if the last commit to the current branch was a bump, meaning that there haven't been any changes since the last release.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes