### PR TITLE
fix: Dialog does not close on ESCAPE if defaultId is set (Mac)

### DIFF
--- a/atom/browser/ui/message_box_mac.mm
+++ b/atom/browser/ui/message_box_mac.mm
@@ -97,17 +97,17 @@ NSAlert* CreateNSAlert(NativeWindow* parent_window,
   NSArray* ns_buttons = [alert buttons];
   int button_count = static_cast<int>([ns_buttons count]);
 
-  // Bind cancel id button to escape key if there is more than one button
-  if (button_count > 1 && cancel_id >= 0 && cancel_id < button_count) {
-    [[ns_buttons objectAtIndex:cancel_id] setKeyEquivalent:@"\e"];
-  }
-
   if (default_id >= 0 && default_id < button_count) {
     // Focus the button at default_id if the user opted to do so.
     // The first button added gets set as the default selected.
     // So remove that default, and make the requested button the default.
     [[ns_buttons objectAtIndex:0] setKeyEquivalent:@""];
     [[ns_buttons objectAtIndex:default_id] setKeyEquivalent:@"\r"];
+  }
+
+  // Bind cancel id button to escape key if there is more than one button
+  if (button_count > 1 && cancel_id >= 0 && cancel_id < button_count) {
+    [[ns_buttons objectAtIndex:cancel_id] setKeyEquivalent:@"\e"];
   }
 
   if (!checkbox_label.empty()) {


### PR DESCRIPTION
##### Description of Change
fix: #14160 Dialog does not close on ESCAPE if defaultId is set (Mac)

If `defaultId` is set, it was removing the key reference for the button at `0` which was previously set for the `cancel_id`

##### Checklist
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

Notes: Fix issue where pressing ESC key does not close the dialog box if defaultId is set