### PR TITLE
docs: chrome-command-line-switches.md: update proxy-server support

### DIFF
--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -60,7 +60,8 @@ See the [Node documentation][node-cli] or run `node --help` in your terminal for
 Use a specified proxy server, which overrides the system setting. This switch
 only affects requests with HTTP protocol, including HTTPS and WebSocket
 requests. It is also noteworthy that not all proxy servers support HTTPS and
-WebSocket requests.
+WebSocket requests. The proxy URL does not support username and password
+authentication [per Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=615947).
 
 ## --proxy-bypass-list=`hosts`
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -82,7 +82,7 @@ improve the security of your application.
 11. [`<webview>`: Do not use `allowpopups`](#11-do-not-use-allowpopups)
 12. [`<webview>`: Verify options and params](#12-verify-webview-options-before-creation)
 13. [Disable or limit navigation](#13-disable-or-limit-navigation)
-14. [Disable or limit creation of new windows](#13-disable-or-limit-creation-of-new-windows)
+14. [Disable or limit creation of new windows](#14-disable-or-limit-creation-of-new-windows)
 
 ## 1) Only Load Secure Content
 


### PR DESCRIPTION
##### Description of Change
Refs #12443

This PR attempts to update the `chrome-command-line-switches.md` to denote the unsupported username & password support, since [Chromium issue #615947](https://bugs.chromium.org/p/chromium/issues/detail?id=615947) shares the status as "_WontFix_".

When running `npm run lint:docs` locally, linter picked up the following warning. So the PR updates accordingly.
> File Location: /Users/bchen/github/electron/docs/tutorial/security.md
	Broken links: #13-disable-or-limit-creation-of-new-windows
Parsed through 168 files within docs directory and its 5 subdirectories.
Found 1 broken relative links.

🙏 for your review in advance.

##### Checklist
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Minor documentation updates.