### PR TITLE
chore: add option to return next version from prepare-release

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -270,6 +270,9 @@ async function prepareRelease (isBeta, notesOnly) {
   if (notesOnly) {
     let releaseNotes = await getReleaseNotes(currentBranch)
     console.log(`Draft release notes are: \n${releaseNotes}`)
+  } else if (args.dryRun) {
+    let newVersion = await getNewVersion(true)
+    return newVersion
   } else {
     const changes = await changesToRelease(currentBranch)
     if (changes) {

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -31,7 +31,9 @@ const gitDir = path.resolve(__dirname, '..')
 github.authenticate({type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN})
 
 async function getNewVersion (dryRun) {
-  console.log(`Bumping for new "${versionType}" version.`)
+  if (!dryRun) {
+    console.log(`Bumping for new "${versionType}" version.`)
+  }
   let bumpScript = path.join(__dirname, 'bump-version.py')
   let scriptArgs = [bumpScript, '--bump', versionType]
   if (args.stable) {
@@ -261,28 +263,25 @@ async function prepareRelease (isBeta, notesOnly) {
     console.log(`${fail} Automatic release is only supported for beta and nightly releases`)
     process.exit(1)
   }
-  let currentBranch
-  if (args.branch) {
-    currentBranch = args.branch
-  } else {
-    currentBranch = await getCurrentBranch(gitDir)
-  }
-  if (notesOnly) {
-    let releaseNotes = await getReleaseNotes(currentBranch)
-    console.log(`Draft release notes are: \n${releaseNotes}`)
-  } else if (args.dryRun) {
+  if (args.dryRun) {
     let newVersion = await getNewVersion(true)
-    return newVersion
+    console.log(newVersion)
   } else {
-    const changes = await changesToRelease(currentBranch)
-    if (changes) {
-      await verifyNewVersion()
-      await createRelease(currentBranch, isBeta)
-      await pushRelease(currentBranch)
-      await runReleaseBuilds(currentBranch)
+    const currentBranch = (args.branch) ? args.branch : await getCurrentBranch(gitDir)
+    if (notesOnly) {
+      let releaseNotes = await getReleaseNotes(currentBranch)
+      console.log(`Draft release notes are: \n${releaseNotes}`)
     } else {
-      console.log(`There are no new changes to this branch since the last release, aborting release.`)
-      process.exit(1)
+      const changes = await changesToRelease(currentBranch)
+      if (changes) {
+        await verifyNewVersion()
+        await createRelease(currentBranch, isBeta)
+        await pushRelease(currentBranch)
+        await runReleaseBuilds(currentBranch)
+      } else {
+        console.log(`There are no new changes to this branch since the last release, aborting release.`)
+        process.exit(1)
+      }
     }
   }
 }


### PR DESCRIPTION
##### Description of Change

Adds option to just return the next version from `prepare-release` by passing `--dryRun` and without performing any other operations. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
-  [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes