### PR TITLE
chore: ask for specific info in bug templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,11 +7,11 @@ Thanks for opening an issue! A few things to keep in mind:
 - If you need general advice, join our Slack: http://atom-slack.herokuapp.com
 -->
 
-* Electron version:
+* Output of `electron --version`:
 * Operating system:
 
 <!-- If this used to work -->
-* Last known working Electron version: 
+* Output of `electron --version` on last known working Electron version: 
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,11 +7,11 @@ Thanks for opening an issue! A few things to keep in mind:
 - If you need general advice, join our Slack: http://atom-slack.herokuapp.com
 -->
 
-* Output of `electron --version`:
-* Operating system:
+* Output of `node_modules/.bin/electron --version`:
+* Operating System (Platform and Version):
 
 <!-- If this used to work -->
-* Output of `electron --version` on last known working Electron version: 
+* Output of `node_modules/.bin/electron --version` on last known working Electron version (if applicable):
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,9 +4,9 @@ about: Create a report to help us improve Electron
 
 ---
 
-* Electron Version:
+* Output of `electron --version`:
 * Operating System (Platform and Version):
-* Last known working Electron version: 
+* Output of `electron --version` on last known working Electron version: 
 
 **Expected Behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,9 +4,9 @@ about: Create a report to help us improve Electron
 
 ---
 
-* Output of `electron --version`:
+* Output of `node_modules/.bin/electron --version`:
 * Operating System (Platform and Version):
-* Output of `electron --version` on last known working Electron version: 
+* Output of `node_modules/.bin/electron --version` on last known working Electron version (if applicable):
 
 **Expected Behavior**
 A clear and concise description of what you expected to happen.


### PR DESCRIPTION
##### Description of Change

When taking bug reports, ask for the output of `electron --version` instead of asking for the version number. If users run this and paste it into the issue report, we'll get fewer misreported versions.

We often get reports against Electron versions that don't exist or bug reports that are named _almost_ like a brand new release but have a digit off and instead name an older beta from months ago, which is suspicious. Now that we have nightly builds and master represented as a number newer than the beta line, the confusion is likely to get worse.

thoughts, @sofianguy @codebytere  ? Is this overkill?

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes