### PR TITLE
Print error when removed webview attribute is used

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1715,10 +1715,6 @@ void WebContents::OnCursorChange(const content::WebCursor& cursor) {
   }
 }
 
-void WebContents::SetSize(v8::Local<v8::Value>) {
-  // TODO(zcbenz): Remove this method in 4.0.
-}
-
 bool WebContents::IsGuest() const {
   return type_ == WEB_VIEW;
 }
@@ -2016,7 +2012,6 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("beginFrameSubscription", &WebContents::BeginFrameSubscription)
       .SetMethod("endFrameSubscription", &WebContents::EndFrameSubscription)
       .SetMethod("startDrag", &WebContents::StartDrag)
-      .SetMethod("setSize", &WebContents::SetSize)
       .SetMethod("isGuest", &WebContents::IsGuest)
       .SetMethod("attachToIframe", &WebContents::AttachToIframe)
       .SetMethod("isOffscreen", &WebContents::IsOffScreen)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -196,7 +196,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void CapturePage(mate::Arguments* args);
 
   // Methods for creating <webview>.
-  void SetSize(v8::Local<v8::Value>);
   bool IsGuest() const;
   void AttachToIframe(content::WebContents* embedder_web_contents,
                       int embedder_frame_id);

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -182,6 +182,10 @@ tray.setHighlightMode('off')
 webContents.openDevTools({detach: true})
 // Replace with
 webContents.openDevTools({mode: 'detach'})
+
+// Removed
+webContents.setSize(options)
+// There is no replacement for this API
 ```
 
 ## `webFrame`
@@ -196,6 +200,18 @@ protocol.registerStandardSchemes(['app'], {secure: true})
 webFrame.registerURLSchemeAsPrivileged('app', {secure: true})
 // Replace with
 protocol.registerStandardSchemes(['app'], {secure: true})
+```
+
+## `<webview>`
+
+```js
+// Removed
+webview.setAttribute('disableguestresize', '')
+// There is no replacement for this API
+
+// Removed
+webview.setAttribute('guestinstance', instanceId)
+// There is no replacement for this API
 ```
 
 ## Node Headers URL

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1385,23 +1385,6 @@ win.webContents.on('did-finish-load', () => {
 
 Shows pop-up dictionary that searches the selected word on the page.
 
-#### `contents.setSize(options)`
-
-Set the size of the page. This is only supported for `<webview>` guest contents.
-
-* `options` Object
-  * `enableAutoSize` Boolean (optional) - true to make the webview container automatically
-    resize within the bounds specified by the attributes normal, min and max.
-  * `normal` [Size](structures/size.md) (optional) - Normal size of the page. This can be used in
-    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
-    attribute to manually resize the webview guest contents.
-  * `min` [Size](structures/size.md) (optional) - Minimum size of the page. This can be used in
-    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
-    attribute to manually resize the webview guest contents.
-  * `max` [Size](structures/size.md) (optional) - Maximium size of the page. This can be used in
-    combination with the [`disableguestresize`](webview-tag.md#disableguestresize)
-    attribute to manually resize the webview guest contents.
-
 #### `contents.isOffscreen()`
 
 Returns `Boolean` - Indicates whether *offscreen rendering* is enabled.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -244,59 +244,6 @@ A list of strings which specifies the blink features to be disabled separated by
 The full list of supported feature strings can be found in the
 [RuntimeEnabledFeatures.json5][runtime-enabled-features] file.
 
-### `guestinstance`
-
-```html
-<webview src="https://www.github.com/" guestinstance="3"></webview>
-```
-
-A value that links the webview to a specific webContents. When a webview
-first loads a new webContents is created and this attribute is set to its
-instance identifier. Setting this attribute on a new or existing webview
-connects it to the existing webContents that currently renders in a different
-webview.
-
-The existing webview will see the `destroy` event and will then create a new
-webContents when a new url is loaded.
-
-### `disableguestresize`
-
-```html
-<webview src="https://www.github.com/" disableguestresize></webview>
-```
-
-When this attribute is present the `webview` contents will be prevented from
-resizing when the `webview` element itself is resized.
-
-This can be used in combination with
-[`webContents.setSize`](web-contents.md#contentssetsizeoptions) to manually
-resize the webview contents in reaction to a window size change. This can
-make resizing faster compared to relying on the webview element bounds to
-automatically resize the contents.
-
-```javascript
-const {webContents} = require('electron')
-
-// We assume that `win` points to a `BrowserWindow` instance containing a
-// `<webview>` with `disableguestresize`.
-
-win.on('resize', () => {
-  const [width, height] = win.getContentSize()
-  for (let wc of webContents.getAllWebContents()) {
-    // Check if `wc` belongs to a webview in the `win` window.
-    if (wc.hostWebContents &&
-        wc.hostWebContents.id === win.webContents.id) {
-      wc.setSize({
-        normal: {
-          width: width,
-          height: height
-        }
-      })
-    }
-  }
-})
-```
-
 ## Methods
 
 The `webview` tag has the following methods:

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -264,6 +264,12 @@ WebContents.prototype.getZoomFactor = function (callback) {
   })
 }
 
+// TODO(zcbenz): Remove the stub in 4.0.
+WebContents.prototype.setSize = function () {
+  console.error('The WebContents.setSize method has been removed, see',
+                'https://github.com/electron/electron/issues/14120 for more.')
+}
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -16,6 +16,13 @@ const getNextId = function () {
   return ++nextId
 }
 
+// A list of removed attributes from 3.0.
+const removedAttributes = [
+  'autoresize',
+  'disableguestresize',
+  'guestinstance'
+]
+
 // Represents the internal state of the WebView node.
 class WebViewImpl {
   constructor (webviewNode) {
@@ -24,8 +31,16 @@ class WebViewImpl {
     this.elementAttached = false
     this.beforeFirstNavigation = true
 
+    // Check for removed attributes.
+    for (const attributeName of removedAttributes) {
+      if (this.webviewNode.hasAttribute(attributeName)) {
+        this.reportRemovedAttribute(attributeName)
+      }
+    }
+
     // on* Event handlers.
     this.on = {}
+
     this.internalElement = this.createInternalElement()
     const shadowRoot = this.webviewNode.attachShadow({mode: 'open'})
     shadowRoot.innerHTML = '<!DOCTYPE html><style type="text/css">:host { display: flex; }</style>'
@@ -102,6 +117,11 @@ class WebViewImpl {
   // attribute, if necessary. See BrowserPlugin::UpdateDOMAttribute for more
   // details.
   handleWebviewAttributeMutation (attributeName, oldValue, newValue) {
+    if (removedAttributes.includes(attributeName)) {
+      this.reportRemovedAttribute(attributeName)
+      return
+    }
+
     if (!this.attributes[attributeName] || this.attributes[attributeName].ignoreMutation) {
       return
     }
@@ -196,6 +216,12 @@ class WebViewImpl {
     // TODO(zcbenz): Should we deprecate the "resize" event? Wait, it is not
     // even documented.
     this.resizeObserver = new ResizeObserver(this.onElementResize.bind(this)).observe(this.internalElement)
+  }
+
+  // TODO(zcbenz): Remove the warning in 4.0.
+  reportRemovedAttribute (attributeName) {
+    console.error(`The "${attributeName}" attribute has been removed from the <webview> tag,`,
+                  'see https://github.com/electron/electron/issues/14120 for more.')
   }
 }
 


### PR DESCRIPTION
We don't have a chance to deprecate those attributes, but we can at least warn the users.

Close https://github.com/electron/electron/issues/14120

notes: Print error when removed webview attribute is used.