### PR TITLE
chore: add release-artifact-cleanup script

### DIFF
--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -22,71 +22,75 @@ github.authenticate({
 })
 
 async function getCurrentBranch (gitDir) {
-  console.log(`Determining current git branch`)
-  let gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
-  let branchDetails = await GitProcess.exec(gitArgs, gitDir)
+  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
+  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
   if (branchDetails.exitCode === 0) {
-    let currentBranch = branchDetails.stdout.trim()
-    console.log(`${pass} Successfully determined current git branch is ` +
-      `${currentBranch}`)
-    return currentBranch
+    return branchDetails.stdout.trim()
   } else {
-    let error = GitProcess.parseError(branchDetails.stderr)
-    console.log(`${fail} Could not get details for the current branch,
-    error was ${branchDetails.stderr}`, error)
+    const error = GitProcess.parseError(branchDetails.stderr)
+    console.log(`${fail} Couldn't get current branch: ${branchDetails.stderr}`, error)
     process.exit(1)
   }
 }
 
 async function revertBumpCommit (tag) {
-  let branch = getCurrentBranch()
-  let hashToRevert = await exec(`git log | grep 'Bump v[0-9.]*' | grep -o '\\w\\ {8,\\}' | head -n 1`)
+  const branch = getCurrentBranch()
+  const hashToRevert = await exec(`git log | grep 'Bump v[0-9.]*' | grep -o '\\w\\ {8,\\}' | head -n 1`)
   await GitProcess.exec(['revert', hashToRevert], gitDir)
-  let pushDetails = await GitProcess.exec(['push', 'origin', `HEAD:${branch}`, '--follow-tags'], gitDir)
+  const pushDetails = await GitProcess.exec(['push', 'origin', `HEAD:${branch}`, '--follow-tags'], gitDir)
   if (pushDetails.exitCode === 0) {
     console.log(`${pass} Successfully reverted release commit.`)
   } else {
-    console.log(`${fail} Failed to push release commit: ` +
-      `${pushDetails.stderr}`)
+    console.log(`${fail} Failed to push release commit: ${pushDetails.stderr}`)
     process.exit(1)
   }
 }
 
-// async function deleteDraft (tag) {
-
-// }
+async function deleteDraft (tag, repo) {
+  try {
+    const result = await github.repos.getReleaseByTag({
+      owner: 'electron',
+      repo,
+      tag
+    })
+    await github.repos.deleteRelease({
+      owner: 'electron',
+      repo,
+      release_id: result.id
+    })
+    console.log(`Successfully deleted draft with tag ${tag}`)
+  } catch (err) {
+    console.log(`Couldn't delete draft: ${err}`)
+    process.exit(1)
+  }
+}
 
 async function deleteTag (tag, targetRepo) {
-  const result = await (github.gitdata.deleteReference({
-    owner: 'electron',
-    repo: targetRepo,
-    ref: tag
-  }))
-
-  if (result.exitCode === 0) {
+  try {
+    await github.gitdata.deleteReference({
+      owner: 'electron',
+      repo: targetRepo,
+      ref: tag
+    })
     console.log(`Successfully deleted tag ${tag} from 'electron/electron'`)
-  } else {
+  } catch (err) {
     console.log(`Couldn't delete tag ${tag} from 'electron/electron'`)
+    process.exit(1)
   }
 }
 
 async function cleanReleaseArtifacts () {
   const tag = args.tag
-
-  // delete tag from nightlies repo
   const lastBumpCommit = execSync(`git log | grep 'Bump v[0-9.]*' | head -n 1`).toString()
 
   if (lastBumpCommit.indexOf('nightly' > 0)) {
+    await deleteDraft(tag, 'nightlies')
     await deleteTag(tag, 'nightlies')
+  } else {
+    await deleteDraft(tag, 'electron')
   }
 
-  // delete tag from `electron/electron`
   await deleteTag(tag, 'electron')
-
-  // delete release
-  // await deleteDraft(tag)
-
-  // revert commit in `electron/electron`
   await revertBumpCommit()
 
   console.log('Failed release artifact cleanup complete')

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+if (!process.env.CI) require('dotenv-safe').load()
+require('colors')
+const args = require('minimist')(process.argv.slice(2), {
+  boolean: ['tag']
+})
+const { exec } = require('child_process')
+const fail = '\u2717'.red
+const { GitProcess } = require('dugite')
+
+const GitHub = require('github')
+const pass = '\u2713'.green
+const path = require('path')
+
+const github = new GitHub()
+const gitDir = path.resolve(__dirname, '..')
+
+github.authenticate({
+  type: 'token',
+  token: process.env.ELECTRON_GITHUB_TOKEN
+})
+
+async function getCurrentBranch (gitDir) {
+  console.log(`Determining current git branch`)
+  let gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
+  let branchDetails = await GitProcess.exec(gitArgs, gitDir)
+  if (branchDetails.exitCode === 0) {
+    let currentBranch = branchDetails.stdout.trim()
+    console.log(`${pass} Successfully determined current git branch is ` +
+      `${currentBranch}`)
+    return currentBranch
+  } else {
+    let error = GitProcess.parseError(branchDetails.stderr)
+    console.log(`${fail} Could not get details for the current branch,
+    error was ${branchDetails.stderr}`, error)
+    process.exit(1)
+  }
+}
+
+async function revertBumpCommit (tag) {
+  let branch = getCurrentBranch()
+  let hashToRevert = await exec(`git log | grep 'Bump v[0-9.]*' | grep -o '\\w\\ {8,\\}' | head -n 1`)
+  await GitProcess.exec(['revert', hashToRevert], gitDir)
+  let pushDetails = await GitProcess.exec(['push', 'origin', `HEAD:${branch}`, '--follow-tags'], gitDir)
+  if (pushDetails.exitCode === 0) {
+    console.log(`${pass} Successfully reverted release commit.`)
+  } else {
+    console.log(`${fail} Failed to push release commit: ` +
+      `${pushDetails.stderr}`)
+    process.exit(1)
+  }
+}
+
+async function deleteTag (tag, targetRepo) {
+  const result = await (github.gitdata.deleteReference({
+    owner: 'electron',
+    repo: targetRepo,
+    ref: tag
+  }))
+
+  if (result.exitCode === 0) {
+    console.log(`Successfully deleted tag ${tag} from 'electron/electron'`)
+  } else {
+    console.log(`Couldn't delete tag ${tag} from 'electron/electron'`)
+  }
+}
+
+async function cleanReleaseArtifacts () {
+  const tag = args.tag
+
+  // delete tag from nightlies repo
+  let lastBumpCommit = await exec(`git log | grep 'Bump v[0-9.]*'`)
+  if (lastBumpCommit.indexOf('nightly' > 0)) {
+    await deleteTag(tag, 'nightlies')
+  }
+
+  // delete tag from  `electron/electron`
+  await deleteTag(tag, 'electron')
+
+  // revert commit in `electron/electron`
+  await revertBumpCommit()
+
+  console.log('Failed release artifact cleanup complete')
+}
+
+cleanReleaseArtifacts()

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -5,7 +5,7 @@ require('colors')
 const args = require('minimist')(process.argv.slice(2), {
   boolean: ['tag']
 })
-const { exec } = require('child_process')
+const { exec, execSync } = require('child_process')
 const fail = '\u2717'.red
 const { GitProcess } = require('dugite')
 
@@ -52,6 +52,10 @@ async function revertBumpCommit (tag) {
   }
 }
 
+// async function deleteDraft (tag) {
+
+// }
+
 async function deleteTag (tag, targetRepo) {
   const result = await (github.gitdata.deleteReference({
     owner: 'electron',
@@ -70,13 +74,17 @@ async function cleanReleaseArtifacts () {
   const tag = args.tag
 
   // delete tag from nightlies repo
-  let lastBumpCommit = await exec(`git log | grep 'Bump v[0-9.]*'`)
+  const lastBumpCommit = execSync(`git log | grep 'Bump v[0-9.]*' | head -n 1`).toString()
+
   if (lastBumpCommit.indexOf('nightly' > 0)) {
     await deleteTag(tag, 'nightlies')
   }
 
-  // delete tag from  `electron/electron`
+  // delete tag from `electron/electron`
   await deleteTag(tag, 'electron')
+
+  // delete release
+  // await deleteDraft(tag)
 
   // revert commit in `electron/electron`
   await revertBumpCommit()

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -53,11 +53,16 @@ async function deleteDraft (tag, repo) {
       repo,
       tag
     })
-    await github.repos.deleteRelease({
-      owner: 'electron',
-      repo,
-      release_id: result.id
-    })
+    if (result.draft) {
+      console.log(`Published drafts cannot be deleted.`)
+      process.exit(1)
+    } else {
+      await github.repos.deleteRelease({
+        owner: 'electron',
+        repo,
+        release_id: result.id
+      })
+    }
     console.log(`Successfully deleted draft with tag ${tag}`)
   } catch (err) {
     console.log(`Couldn't delete draft: ${err}`)

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -20,7 +20,7 @@ github.authenticate({
 })
 
 function getLastBumpCommit () {
-  const data = execSync(`git log - n1--grep "Bump v[0-9.]*"--format = "format:{hash: %H, message: '%s'}"`)
+  const data = execSync(`git log -n1 --grep "Bump v[0-9.]*" --format="format:{hash: %H, message: '%s'}"`)
   return JSON.parse(data)
 }
 
@@ -69,7 +69,7 @@ async function deleteDraft (tag, targetRepo) {
     }
     console.log(`Successfully deleted draft with tag ${tag} from ${targetRepo}`)
   } catch (err) {
-    console.error(`Couldn't delete draft with tag ${tag} from ${targetRepo}: ${err}`)
+    console.error(`Couldn't delete draft with tag ${tag} from ${targetRepo}: `, err)
     process.exit(1)
   }
 }
@@ -83,7 +83,7 @@ async function deleteTag (tag, targetRepo) {
     })
     console.log(`Successfully deleted tag ${tag} from ${targetRepo}`)
   } catch (err) {
-    console.log(`Couldn't delete tag ${tag} from ${targetRepo}`)
+    console.log(`Couldn't delete tag ${tag} from ${targetRepo}: `, err)
     process.exit(1)
   }
 }

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -53,8 +53,8 @@ async function deleteDraft (tag, repo) {
       repo,
       tag
     })
-    if (result.draft) {
-      console.log(`Published drafts cannot be deleted.`)
+    if (!result.draft) {
+      console.log(`Published releases cannot be deleted.`)
       process.exit(1)
     } else {
       await github.repos.deleteRelease({


### PR DESCRIPTION
##### Description of Change

Closes https://github.com/electron/sudowoodo/issues/53.

Adds a script to `script/` that does the following:
1) delete tag from nightlies repo
2) delete tag from  `electron/electron`
3) revert bump commit in `electron/electron`
4) Delete draft

/cc @MarshallOfSound 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes