### PR TITLE
fix: opt into location services once device service has been started

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -32,6 +32,12 @@ declare_args() {
   enable_desktop_capturer = true
   enable_run_as_node = true
   enable_osr = false
+
+  # Provide a fake location provider for mocking
+  # the geolocation responses. Disable it if you
+  # need to test with chromium's location provider.
+  # Should not be enabled for release build.
+  enable_fake_location_provider = !is_official_build
 }
 
 if (is_mas_build) {
@@ -282,6 +288,13 @@ static_library("electron_lib") {
     ]
   }
 
+  if (enable_fake_location_provider) {
+    defines += [
+      "OVERRIDE_LOCATION_PROVIDER"
+    ]
+    sources += filenames_gypi.lib_sources_location_provider
+  }
+
   if (is_mac) {
     deps += [
       "//third_party/crashpad/crashpad/client",
@@ -377,7 +390,6 @@ static_library("electron_lib") {
   }
 
   if (enable_desktop_capturer) {
-    deps += [ "//third_party/webrtc/modules/desktop_capture" ]
     sources += [
       "atom/browser/api/atom_api_desktop_capturer.cc",
       "atom/browser/api/atom_api_desktop_capturer.h",

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -44,6 +44,7 @@
 #include "content/public/common/content_switches.h"
 #include "content/public/common/url_constants.h"
 #include "content/public/common/web_preferences.h"
+#include "device/geolocation/public/cpp/location_provider.h"
 #include "net/ssl/ssl_cert_request_info.h"
 #include "ppapi/host/ppapi_host.h"
 #include "services/network/public/cpp/resource_request_body.h"
@@ -63,6 +64,10 @@
 #if defined(ENABLE_PEPPER_FLASH)
 #include "chrome/browser/renderer_host/pepper/chrome_browser_pepper_host_factory.h"
 #endif  // defined(ENABLE_PEPPER_FLASH)
+
+#if defined(OVERRIDE_LOCATION_PROVIDER)
+#include "atom/browser/fake_location_provider.h"
+#endif  // defined(OVERRIDE_LOCATION_PROVIDER)
 
 using content::BrowserThread;
 
@@ -492,6 +497,15 @@ std::unique_ptr<net::ClientCertStore> AtomBrowserClient::CreateClientCertStore(
   return std::make_unique<net::ClientCertStoreMac>();
 #elif defined(USE_OPENSSL)
   return std::unique_ptr<net::ClientCertStore>();
+#endif
+}
+
+std::unique_ptr<device::LocationProvider>
+AtomBrowserClient::OverrideSystemLocationProvider() {
+#if defined(OVERRIDE_LOCATION_PROVIDER)
+  return std::make_unique<FakeLocationProvider>();
+#else
+  return nullptr;
 #endif
 }
 

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -106,6 +106,8 @@ class AtomBrowserClient : public brightray::BrowserClient,
   void SiteInstanceDeleting(content::SiteInstance* site_instance) override;
   std::unique_ptr<net::ClientCertStore> CreateClientCertStore(
       content::ResourceContext* resource_context) override;
+  std::unique_ptr<device::LocationProvider> OverrideSystemLocationProvider()
+      override;
 
   // brightray::BrowserClient:
   brightray::BrowserMainParts* OverrideCreateBrowserMainParts(

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -237,9 +237,6 @@ void AtomBrowserMainParts::PostMainMessageLoopStart() {
 #if defined(OS_POSIX)
   HandleShutdownSignals();
 #endif
-  // TODO(deepak1556): Enable this optionally based on response
-  // from AtomPermissionManager.
-  GetGeolocationControl()->UserDidOptIntoLocationServices();
 }
 
 void AtomBrowserMainParts::PostMainMessageLoopRun() {

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -54,6 +54,10 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   // Returns a closure that can be used to remove |callback| from the list.
   void RegisterDestructionCallback(base::OnceClosure callback);
 
+  // Returns the connection to GeolocationControl which can be
+  // used to enable the location services once per client.
+  device::mojom::GeolocationControl* GetGeolocationControl();
+
   Browser* browser() { return browser_.get(); }
 
  protected:
@@ -86,8 +90,6 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
 #else
   std::unique_ptr<brightray::ViewsDelegate> views_delegate_;
 #endif
-
-  device::mojom::GeolocationControl* GetGeolocationControl();
 
   // A fake BrowserProcess object that used to feed the source code from chrome.
   std::unique_ptr<BrowserProcess> fake_browser_process_;

--- a/atom/browser/fake_location_provider.cc
+++ b/atom/browser/fake_location_provider.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/fake_location_provider.h"
+
+#include "base/callback.h"
+#include "base/time/time.h"
+
+namespace atom {
+
+FakeLocationProvider::FakeLocationProvider() {
+  position_.latitude = 10;
+  position_.longitude = -10;
+  position_.accuracy = 1;
+  position_.error_code =
+      device::mojom::Geoposition::ErrorCode::POSITION_UNAVAILABLE;
+}
+
+FakeLocationProvider::~FakeLocationProvider() = default;
+
+void FakeLocationProvider::SetUpdateCallback(
+    const LocationProviderUpdateCallback& callback) {
+  callback_ = callback;
+}
+
+void FakeLocationProvider::StartProvider(bool high_accuracy) {}
+
+void FakeLocationProvider::StopProvider() {}
+
+const device::mojom::Geoposition& FakeLocationProvider::GetPosition() {
+  return position_;
+}
+
+void FakeLocationProvider::OnPermissionGranted() {
+  if (!callback_.is_null()) {
+    // Check device::ValidateGeoPosition for range of values.
+    position_.error_code = device::mojom::Geoposition::ErrorCode::NONE;
+    position_.timestamp = base::Time::Now();
+    callback_.Run(this, position_);
+  }
+}
+
+}  // namespace atom

--- a/atom/browser/fake_location_provider.h
+++ b/atom/browser/fake_location_provider.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_FAKE_LOCATION_PROVIDER_H_
+#define ATOM_BROWSER_FAKE_LOCATION_PROVIDER_H_
+
+#include "base/macros.h"
+#include "device/geolocation/public/cpp/location_provider.h"
+#include "services/device/public/mojom/geoposition.mojom.h"
+
+namespace atom {
+
+class FakeLocationProvider : public device::LocationProvider {
+ public:
+  FakeLocationProvider();
+  ~FakeLocationProvider() override;
+
+  // LocationProvider Implementation:
+  void SetUpdateCallback(
+      const LocationProviderUpdateCallback& callback) override;
+  void StartProvider(bool high_accuracy) override;
+  void StopProvider() override;
+  const device::mojom::Geoposition& GetPosition() override;
+  void OnPermissionGranted() override;
+
+ private:
+  device::mojom::Geoposition position_;
+  LocationProviderUpdateCallback callback_;
+
+  DISALLOW_COPY_AND_ASSIGN(FakeLocationProvider);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_FAKE_LOCATION_PROVIDER_H_

--- a/atom/common/api/features.cc
+++ b/atom/common/api/features.cc
@@ -31,6 +31,14 @@ bool IsPDFViewerEnabled() {
 #endif
 }
 
+bool IsFakeLocationProviderEnabled() {
+#if defined(OVERRIDE_LOCATION_PROVIDER)
+  return true;
+#else
+  return false;
+#endif
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
@@ -39,6 +47,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isDesktopCapturerEnabled", &IsDesktopCapturerEnabled);
   dict.SetMethod("isOffscreenRenderingEnabled", &IsOffscreenRenderingEnabled);
   dict.SetMethod("isPDFViewerEnabled", &IsPDFViewerEnabled);
+  dict.SetMethod("isFakeLocationProviderEnabled",
+                 &IsFakeLocationProviderEnabled);
 }
 
 }  // namespace

--- a/electron.gyp
+++ b/electron.gyp
@@ -356,6 +356,16 @@
           'link_settings': {
             'libraries': [ '<@(libchromiumcontent_v8_libraries)' ],
           },
+          'sources': [
+            '<@(lib_sources_location_provider)',
+          ],
+          'defines': [
+            # Enable fake location provider to mock geolocation
+            # responses in component build. Should not be enabled
+            # for release build. If you need to test with chromium's
+            # location provider, remove this definition.
+            'OVERRIDE_LOCATION_PROVIDER',
+          ],
         }],
         ['OS=="win"', {
           'sources': [

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -680,6 +680,10 @@
       'chromium_src/chrome/utility/printing_handler_win.cc',
       'chromium_src/chrome/utility/printing_handler_win.h',
     ],
+    'lib_sources_location_provider': [
+      'atom/browser/fake_location_provider.cc',
+      'atom/browser/fake_location_provider.h',
+    ],
     'framework_sources': [
       'atom/app/atom_library_main.h',
       'atom/app/atom_library_main.mm',

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -226,6 +226,47 @@ describe('chromium feature', () => {
     })
   })
 
+  describe('navigator.geolocation', () => {
+    before(function () {
+      if (!features.isFakeLocationProviderEnabled()) {
+        return this.skip()
+      }
+    })
+
+    it('returns position when permission is granted', (done) => {
+      navigator.geolocation.getCurrentPosition((position) => {
+        assert(position.timestamp)
+        done()
+      }, (error) => {
+        done(error)
+      })
+    })
+
+    it('returns error when permission is denied', (done) => {
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          partition: 'geolocation-spec'
+        }
+      })
+      w.webContents.on('ipc-message', (event, args) => {
+        if (args[0] === 'success') {
+          done()
+        } else {
+          done('unexpected response from geolocation api')
+        }
+      })
+      w.webContents.session.setPermissionRequestHandler((wc, permission, callback) => {
+        if (permission === 'geolocation') {
+          callback(false)
+        } else {
+          callback(true)
+        }
+      })
+      w.loadURL(`file://${fixtures}/pages/geolocation/index.html`)
+    })
+  })
+
   describe('window.open', () => {
     it('returns a BrowserWindowProxy object', () => {
       const b = window.open('about:blank', '', 'show=no')

--- a/spec/fixtures/pages/geolocation/index.html
+++ b/spec/fixtures/pages/geolocation/index.html
@@ -1,0 +1,12 @@
+<script>
+  const ipcRenderer = require('electron').ipcRenderer;
+  navigator.geolocation.getCurrentPosition((position) => {
+    ipcRenderer.send(position);
+  }, (error) => {
+    if (error) {
+      ipcRenderer.send('success')
+    } else {
+      ipcRenderer.send('unexpected error')
+    }
+  })
+</script>


### PR DESCRIPTION
##### Description of Change

The global permission for opting into geolocation services was trying to get initialized before the device service was started, this patch fixes it by initializing it as a part of the permission request as every geolocation api call is guaranteed to hit the permission manager before further processing.

Fixes https://github.com/electron/electron/issues/14111
Depends on https://github.com/electron/libchromiumcontent/pull/659

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: opt into location services once device service has been started