### PR TITLE
fix: do not bubble up resize event from webview

### DIFF
--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -111,7 +111,7 @@ class WebViewImpl {
   }
 
   onElementResize () {
-    const resizeEvent = new Event('resize', { bubbles: true })
+    const resizeEvent = new Event('resize')
     resizeEvent.newWidth = this.webviewNode.clientWidth
     resizeEvent.newHeight = this.webviewNode.clientHeight
     this.dispatchEvent(resizeEvent)


### PR DESCRIPTION
There is no meaning bubbling the event. I don't remember why this behavior was introduced in the first place, probably because of careless copy-paste.

notes: fix the problem that resizing webview triggers `resize` event on window.

Close  #13278.