### PR TITLE
fix: do not bubble up resize event from webview (2-0-x)

### DIFF
--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -145,9 +145,7 @@ class WebViewImpl {
 
   onElementResize (newSize) {
     // Dispatch the 'resize' event.
-    const resizeEvent = new Event('resize', {
-      bubbles: true
-    })
+    const resizeEvent = new Event('resize')
 
     // Using client size values, because when a webview is transformed `newSize`
     // is incorrect


### PR DESCRIPTION
Backport #14271 to 2-0-x.

notes: fix the problem that resizing webview triggers resize event on window.