### PR TITLE
ci:Split out appveyor gn builds into separate jobs

### DIFF
--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -43,10 +43,7 @@ test_script:
       } else {
         echo "Skipping tests for $env:GN_CONFIG build"
       }
-  - >-
-      if "%GN_CONFIG%"=="testing" (
-        .\out\Default\electron.exe electron\spec --ci
-      )
+  - if "%GN_CONFIG%"=="testing" ( echo "Running test suite" & .\out\Default\electron.exe electron\spec --ci )
 artifacts:
 - path: src/out/Default/dist.zip
   name: dist.zip

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -31,6 +31,7 @@ build_script:
 test_script:
   - ps: >-
       if ($env:GN_CONFIG -eq 'testing') {
+        python electron\script\verify-ffmpeg.py -c Default --source-root "$PWD" --ffmpeg-path "$PWD\out\ffmpeg"
         ninja -C out/Default third_party/electron_node:headers
         $env:npm_config_nodedir="$pwd/out/Default/gen/node_headers"
         $env:npm_config_msvs_version="2017"
@@ -39,11 +40,13 @@ test_script:
         Push-Location; cd electron/spec
         npm install
         Pop-Location
-        .\out\Default\electron.exe electron\spec --ci
-        python electron\script\verify-ffmpeg.py -c Default --source-root "$PWD" --ffmpeg-path "$PWD\out\ffmpeg"
       } else {
         echo "Skipping tests for $env:GN_CONFIG build"
       }
+  - >-
+      if "%GN_CONFIG%"=="testing" (
+        .\out\Default\electron.exe electron\spec --ci
+      )
 artifacts:
 - path: src/out/Default/dist.zip
   name: dist.zip

--- a/appveyor-gn.yml
+++ b/appveyor-gn.yml
@@ -1,21 +1,15 @@
 version: 1.0.{build}
-branches:
-  except:
-  - /^release$|^release-\d-\d-x$/
 build_cloud: libcc-20
 image: libcc-20-vs2017-15.4.5
 environment:
   GIT_CACHE_PATH: C:\Users\electron\libcc_cache
   DISABLE_CRASH_REPORTER_TESTS: true
-  ELECTRON_ENABLE_LOGGING: true
-  matrix:
-    - gn_args: debug
-      ELECTRON_SKIP_NATIVE_MODULE_TESTS: 1
-    - gn_args: testing
-platform:
-  - x86
-  - x64
 build_script:
+  - ps: >-
+      if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+        Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
+      }
+  - echo "Building $env:GN_CONFIG build"
   - git config --global core.longpaths true
   - cd ..
   - md src
@@ -29,27 +23,27 @@ build_script:
       "https://github.com/electron/electron"
   - gclient sync --with_branch_heads --with_tags
   - cd src
-  - gn gen out/Default "--args=import(\"//electron/build/args/%gn_args%.gn\")"
+  - gn gen out/Default "--args=import(\"//electron/build/args/%GN_CONFIG%.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/Default electron:electron_app
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\")"
   - ninja -C out/ffmpeg third_party/ffmpeg
   - ninja -C out/Default electron:electron_dist_zip
 test_script:
-  - ninja -C out/Default third_party/electron_node:headers
-  - ps: $env:npm_config_nodedir="$pwd/out/Default/gen/node_headers"
-  - ps: $env:npm_config_msvs_version="2017"
   - ps: >-
-      if ($env:gn_args -eq 'testing') {
+      if ($env:GN_CONFIG -eq 'testing') {
+        ninja -C out/Default third_party/electron_node:headers
+        $env:npm_config_nodedir="$pwd/out/Default/gen/node_headers"
+        $env:npm_config_msvs_version="2017"
         New-Item .\out\Default\gen\node_headers\Release -Type directory
         Copy-Item -path .\out\Default\electron.lib -destination .\out\Default\gen\node_headers\Release\node.lib
+        Push-Location; cd electron/spec
+        npm install
+        Pop-Location
+        .\out\Default\electron.exe electron\spec --ci
+        python electron\script\verify-ffmpeg.py -c Default --source-root "$PWD" --ffmpeg-path "$PWD\out\ffmpeg"
+      } else {
+        echo "Skipping tests for $env:GN_CONFIG build"
       }
-  - ps: Push-Location; cd electron/spec
-  - npm install
-  - ps: Pop-Location
-  - .\out\Default\electron.exe electron\spec --ci
-  - python electron\verify-ffmpeg.py -c Default --source-root "%pwd%" --ffmpeg-path "%pwd%\out\ffmpeg"
 artifacts:
-- path: test-results.xml
-  name: test-results.xml
 - path: src/out/Default/dist.zip
   name: dist.zip

--- a/script/verify-ffmpeg.py
+++ b/script/verify-ffmpeg.py
@@ -50,6 +50,8 @@ def main():
   except KeyboardInterrupt:
     returncode = 0
 
+  if returncode == 0:
+    print 'ok Non proprietary ffmpeg does not contain proprietary codes.'
   return returncode
 
 


### PR DESCRIPTION
##### Description of Change
This PR changes our appveyor config for GN builds so that we can split them out into separate builds instead of one large matrixed build.  This allows for individual statuses to be displayed on our PRs.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes