### PR TITLE
sec: deprecate some webPreference defaults to be secure-by-default

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -101,7 +101,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kPlugins, false);
   SetDefaultBoolIfUndefined(options::kExperimentalFeatures, false);
   bool node = SetDefaultBoolIfUndefined(options::kNodeIntegration, true,
-                                        DeprecationStatus::Deprecated);
+                                        Status::Deprecated);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, node);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
@@ -137,7 +137,7 @@ WebContentsPreferences::~WebContentsPreferences() {
 bool WebContentsPreferences::SetDefaultBoolIfUndefined(
     const base::StringPiece& key,
     bool val,
-    DeprecationStatus status) {
+    Status status) {
   auto* current_value =
       preference_.FindKeyOfType(key, base::Value::Type::BOOLEAN);
   if (current_value) {
@@ -145,7 +145,7 @@ bool WebContentsPreferences::SetDefaultBoolIfUndefined(
   } else {
     preference_.SetKey(key, base::Value(val));
 
-    if (status == DeprecationStatus::Deprecated && web_contents_) {
+    if (status == Status::Deprecated && web_contents_) {
       auto internal_contents = atom::api::WebContents::CreateFrom(
           v8::Isolate::GetCurrent(), web_contents_);
       internal_contents->Emit("-deprecated-default",

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/web_view_manager.h"
 #include "atom/common/native_mate_converters/value_converter.h"
@@ -99,7 +100,8 @@ WebContentsPreferences::WebContentsPreferences(
   // Set WebPreferences defaults onto the JS object
   SetDefaultBoolIfUndefined(options::kPlugins, false);
   SetDefaultBoolIfUndefined(options::kExperimentalFeatures, false);
-  bool node = SetDefaultBoolIfUndefined(options::kNodeIntegration, true);
+  bool node = SetDefaultBoolIfUndefined(options::kNodeIntegration, true,
+                                        DeprecationStatus::Deprecated);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, node);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
@@ -135,14 +137,29 @@ WebContentsPreferences::~WebContentsPreferences() {
 bool WebContentsPreferences::SetDefaultBoolIfUndefined(
     const base::StringPiece& key,
     bool val) {
+  return SetDefaultBoolIfUndefined(key, val, DeprecationStatus::Stable);
+}
+
+bool WebContentsPreferences::SetDefaultBoolIfUndefined(
+    const base::StringPiece& key,
+    bool val,
+    DeprecationStatus status) {
   auto* current_value =
       preference_.FindKeyOfType(key, base::Value::Type::BOOLEAN);
   if (current_value) {
     return current_value->GetBool();
   } else {
     preference_.SetKey(key, base::Value(val));
-    return val;
+
+    if (status == DeprecationStatus::Deprecated && web_contents_) {
+      auto internal_contents = atom::api::WebContents::CreateFrom(
+          v8::Isolate::GetCurrent(), web_contents_);
+      internal_contents->Emit("-deprecated-default",
+                              std::string("webPreferences.") + key.data(), val,
+                              !val);
+    }
   }
+  return val;
 }
 
 bool WebContentsPreferences::IsEnabled(const base::StringPiece& name,

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -150,8 +150,8 @@ bool WebContentsPreferences::SetDefaultBoolIfUndefined(
       auto internal_contents = atom::api::WebContents::CreateFrom(
           v8::Isolate::GetCurrent(), web_contents_);
       internal_contents->Emit("-deprecated-default",
-                              std::string("webPreferences.") + key.data(), val,
-                              !val);
+                              std::string("webPreferences.") + key.data(),
+                              /* oldDefault */ val, /* newDefault */ !val);
     }
   }
   return val;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -136,12 +136,6 @@ WebContentsPreferences::~WebContentsPreferences() {
 
 bool WebContentsPreferences::SetDefaultBoolIfUndefined(
     const base::StringPiece& key,
-    bool val) {
-  return SetDefaultBoolIfUndefined(key, val, DeprecationStatus::Stable);
-}
-
-bool WebContentsPreferences::SetDefaultBoolIfUndefined(
-    const base::StringPiece& key,
     bool val,
     DeprecationStatus status) {
   auto* current_value =

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -103,10 +103,11 @@ WebContentsPreferences::WebContentsPreferences(
   bool node = SetDefaultBoolIfUndefined(options::kNodeIntegration, true,
                                         Status::Deprecated);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
-  SetDefaultBoolIfUndefined(options::kWebviewTag, node);
+  SetDefaultBoolIfUndefined(options::kWebviewTag, node, Status::Deprecated);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
   SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
-  SetDefaultBoolIfUndefined(options::kContextIsolation, false);
+  SetDefaultBoolIfUndefined(options::kContextIsolation, false,
+                            Status::Deprecated);
   SetDefaultBoolIfUndefined("javascript", true);
   SetDefaultBoolIfUndefined("images", true);
   SetDefaultBoolIfUndefined("textAreasAreResizable", true);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -75,10 +75,10 @@ class WebContentsPreferences
   static content::WebContents* GetWebContentsFromProcessID(int process_id);
 
   // Set preference value to given bool if user did not provide value
-  bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);
-  bool SetDefaultBoolIfUndefined(const base::StringPiece& key,
-                                 bool val,
-                                 DeprecationStatus status);
+  bool SetDefaultBoolIfUndefined(
+      const base::StringPiece& key,
+      bool val,
+      DeprecationStatus status = DeprecationStatus::Stable);
 
   static std::vector<WebContentsPreferences*> instances_;
 

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -29,8 +29,6 @@ namespace atom {
 class WebContentsPreferences
     : public content::WebContentsUserData<WebContentsPreferences> {
  public:
-  enum class Status { Deprecated, Stable };
-
   // Get self from WebContents.
   static WebContentsPreferences* From(content::WebContents* web_contents);
 
@@ -67,6 +65,8 @@ class WebContentsPreferences
  private:
   friend class content::WebContentsUserData<WebContentsPreferences>;
   friend class AtomBrowserClient;
+
+  enum class Status { Deprecated, Stable };
 
   // Get WebContents according to process ID.
   static content::WebContents* GetWebContentsFromProcessID(int process_id);

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -29,6 +29,11 @@ namespace atom {
 class WebContentsPreferences
     : public content::WebContentsUserData<WebContentsPreferences> {
  public:
+  enum DeprecationStatus {
+    Deprecated,
+    Stable,
+  };
+
   // Get self from WebContents.
   static WebContentsPreferences* From(content::WebContents* web_contents);
 
@@ -71,6 +76,9 @@ class WebContentsPreferences
 
   // Set preference value to given bool if user did not provide value
   bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);
+  bool SetDefaultBoolIfUndefined(const base::StringPiece& key,
+                                 bool val,
+                                 DeprecationStatus status);
 
   static std::vector<WebContentsPreferences*> instances_;
 

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -29,10 +29,7 @@ namespace atom {
 class WebContentsPreferences
     : public content::WebContentsUserData<WebContentsPreferences> {
  public:
-  enum DeprecationStatus {
-    Deprecated,
-    Stable,
-  };
+  enum class Status { Deprecated, Stable };
 
   // Get self from WebContents.
   static WebContentsPreferences* From(content::WebContents* web_contents);
@@ -75,10 +72,9 @@ class WebContentsPreferences
   static content::WebContents* GetWebContentsFromProcessID(int process_id);
 
   // Set preference value to given bool if user did not provide value
-  bool SetDefaultBoolIfUndefined(
-      const base::StringPiece& key,
-      bool val,
-      DeprecationStatus status = DeprecationStatus::Stable);
+  bool SetDefaultBoolIfUndefined(const base::StringPiece& key,
+                                 bool val,
+                                 Status status = Status::Stable);
 
   static std::vector<WebContentsPreferences*> instances_;
 

--- a/default_app/default_app.js
+++ b/default_app/default_app.js
@@ -16,8 +16,10 @@ exports.load = (appUrl) => {
       autoHideMenuBar: true,
       backgroundColor: '#FFFFFF',
       webPreferences: {
-        nodeIntegration: true,
-        nodeIntegrationInWorker: true
+        nodeIntegration: false,
+        webviewTag: false,
+        contextIsolation: true,
+        preload: path.resolve(__dirname, 'renderer.js')
       },
       useContentSize: true,
       show: false

--- a/default_app/default_app.js
+++ b/default_app/default_app.js
@@ -16,6 +16,7 @@ exports.load = (appUrl) => {
       autoHideMenuBar: true,
       backgroundColor: '#FFFFFF',
       webPreferences: {
+        nodeIntegration: true,
         nodeIntegrationInWorker: true
       },
       useContentSize: true,

--- a/default_app/index.html
+++ b/default_app/index.html
@@ -83,8 +83,6 @@
       </div>
     </div>
   </nav>
-
-  <script src="./renderer.js"></script>
 </body>
 
 </html>

--- a/default_app/renderer.js
+++ b/default_app/renderer.js
@@ -4,49 +4,60 @@ const path = require('path')
 const URL = require('url')
 const electronPath = path.relative(process.cwd(), remote.process.execPath)
 
-Array.from(document.querySelectorAll('a[href]')).forEach(link => {
-  // safely add `?utm_source=default_app
-  let url = URL.parse(link.getAttribute('href'), true)
-  url.query = Object.assign(url.query, {utm_source: 'default_app'})
-  url = URL.format(url)
+function initialize () {
+  Array.from(document.querySelectorAll('a[href]')).forEach(link => {
+    // safely add `?utm_source=default_app
+    let url = URL.parse(link.getAttribute('href'), true)
+    url.query = Object.assign(url.query, {utm_source: 'default_app'})
+    url = URL.format(url)
 
-  link.addEventListener('click', (e) => {
-    e.preventDefault()
-    shell.openExternal(url)
+    link.addEventListener('click', (e) => {
+      e.preventDefault()
+      shell.openExternal(url)
+    })
   })
-})
 
-document.querySelector('.electron-version').innerText = `Electron v${process.versions.electron}`
-document.querySelector('.chrome-version').innerText = `Chromium v${process.versions.chrome}`
-document.querySelector('.node-version').innerText = `Node v${process.versions.node}`
-document.querySelector('.v8-version').innerText = `v8 v${process.versions.v8}`
-document.querySelector('.command-example').innerText = `${electronPath} path-to-app`
+  document.querySelector('.electron-version').innerText = `Electron v${process.versions.electron}`
+  document.querySelector('.chrome-version').innerText = `Chromium v${process.versions.chrome}`
+  document.querySelector('.node-version').innerText = `Node v${process.versions.node}`
+  document.querySelector('.v8-version').innerText = `v8 v${process.versions.v8}`
+  document.querySelector('.command-example').innerText = `${electronPath} path-to-app`
 
-function getOcticonSvg (name) {
-  const octiconPath = path.resolve(__dirname, 'node_modules', 'octicons', 'build', 'svg', `${name}.svg`)
-  if (fs.existsSync(octiconPath)) {
-    const content = fs.readFileSync(octiconPath, 'utf8')
-    const div = document.createElement('div')
-    div.innerHTML = content
-    return div
+  function getOcticonSvg (name) {
+    const octiconPath = path.resolve(__dirname, 'node_modules', 'octicons', 'build', 'svg', `${name}.svg`)
+    if (fs.existsSync(octiconPath)) {
+      const content = fs.readFileSync(octiconPath, 'utf8')
+      const div = document.createElement('div')
+      div.innerHTML = content
+      return div
+    }
+    return null
   }
-  return null
-}
 
-function loadSVG (element) {
-  for (const cssClass of element.classList) {
-    if (cssClass.startsWith('octicon-')) {
-      const icon = getOcticonSvg(cssClass.substr(8))
-      if (icon) {
-        icon.classList = element.classList
-        element.parentNode.insertBefore(icon, element)
-        element.remove()
-        break
+  function loadSVG (element) {
+    for (const cssClass of element.classList) {
+      if (cssClass.startsWith('octicon-')) {
+        const icon = getOcticonSvg(cssClass.substr(8))
+        if (icon) {
+          icon.classList = element.classList
+          element.parentNode.insertBefore(icon, element)
+          element.remove()
+          break
+        }
       }
     }
   }
+
+  for (const element of document.querySelectorAll('.octicon')) {
+    loadSVG(element)
+  }
 }
 
-for (const element of document.querySelectorAll('.octicon')) {
-  loadSVG(element)
+function onReadyStateChange () {
+  if (document.readyState === 'complete') {
+    document.removeEventListener('readystatechange', onReadyStateChange)
+    initialize()
+  }
 }
+
+document.addEventListener('readystatechange', onReadyStateChange)

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -34,6 +34,18 @@ app.releaseSingleInstance()
 app.releaseSingleInstanceLock()
 ```
 
+## `new BrowserWindow({ webPreferences: { ... }})`
+
+```js
+// Deprecated defaults
+const webPreferences = {}
+new BrowserWindow({ webPreferences })
+
+// webPreferences.contextIsolation - Default was false, will be true
+// webPreferences.nodeIntegration - Default was true, will be false
+// webPreferences.webviewTag - Default was true, will be false
+```
+
 
 # Breaking API Changes (3.0)
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -287,6 +287,10 @@ WebContents.prototype._init = function () {
     ipcMain.emit(channel, event, ...args)
   })
 
+  this.on('-deprecated-default', function (event, key, oldDefault, newDefault) {
+    deprecate.default(key, oldDefault, newDefault)
+  })
+
   // Handle context menu action request from pepper plugin.
   this.on('pepper-context-menu', function (event, params, callback) {
     // Access Menu via electron.Menu to prevent circular require.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -288,7 +288,7 @@ WebContents.prototype._init = function () {
   })
 
   this.on('-deprecated-default', function (event, key, oldDefault, newDefault) {
-    deprecate.default(key, oldDefault, newDefault)
+    deprecate.warnDefault(key, oldDefault, newDefault)
   })
 
   // Handle context menu action request from pepper plugin.

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -31,6 +31,13 @@ deprecate.warn = (oldName, newName) => {
   return deprecate.log(`'${oldName}' is deprecated. Use '${newName}' instead.`)
 }
 
+deprecate.default = (propName, oldDefault, newDefault) => {
+  return deprecate.log(`You have left '${propName}' undefined, currently it \
+has a default value of '${oldDefault}'. The default value is changing \
+in a future release to '${newDefault}', please explicitly declare the \
+value you want to keep the current behavior`)
+}
+
 let deprecationHandler = null
 
 // Print deprecation message.

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -31,11 +31,10 @@ deprecate.warn = (oldName, newName) => {
   return deprecate.log(`'${oldName}' is deprecated. Use '${newName}' instead.`)
 }
 
-deprecate.default = (propName, oldDefault, newDefault) => {
-  return deprecate.log(`You have left '${propName}' undefined, currently it \
-has a default value of '${oldDefault}'. The default value is changing \
-in a future release to '${newDefault}', please explicitly declare the \
-value you want to keep the current behavior`)
+deprecate.warnDefault = (propName, oldDefault, newDefault) => {
+  return deprecate.log(`The default value of '${propName}' is changing from \
+'${oldDefault}' to '${newDefault}' in a future release. If you want to keep \
+the current value, please explicitly declare the property.`)
 }
 
 let deprecationHandler = null

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -61,6 +61,13 @@ const getIsRemoteProtocol = function () {
  * @returns {boolean} Is a CSP with `unsafe-eval` set?
  */
 const isUnsafeEvalEnabled = function () {
+  // FIXME(MarshallOfSound): Although not exactly true, this warning is incorrect
+  // when contextIsolation is enabled
+  // FIXME(MarshallOfSound): Once remote issues have gone away we can remove
+  // the falsey check
+  const prefs = getWebPreferences()
+  if (prefs && prefs.contextIsolation) return false
+
   try {
     //eslint-disable-next-line
     new Function('');


### PR DESCRIPTION
Notes: Deprecated the default values of `contextIsolation`, `nodeIntegration` and `webviewTag`