### PR TITLE
refactor: use std::string instead of base::string16 for IPC channel names

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -303,7 +303,7 @@ struct WebContents::FrameDispatchHelper {
     api_web_contents->OnGetZoomLevel(rfh, reply_msg);
   }
 
-  void OnRendererMessageSync(const base::string16& channel,
+  void OnRendererMessageSync(const std::string& channel,
                              const base::ListValue& args,
                              IPC::Message* message) {
     api_web_contents->OnRendererMessageSync(rfh, channel, args, message);
@@ -1550,7 +1550,7 @@ void WebContents::TabTraverse(bool reverse) {
 }
 
 bool WebContents::SendIPCMessage(bool all_frames,
-                                 const base::string16& channel,
+                                 const std::string& channel,
                                  const base::ListValue& args) {
   auto* frame_host = web_contents()->GetMainFrame();
   if (frame_host) {
@@ -2063,18 +2063,18 @@ AtomBrowserContext* WebContents::GetBrowserContext() const {
 }
 
 void WebContents::OnRendererMessage(content::RenderFrameHost* frame_host,
-                                    const base::string16& channel,
+                                    const std::string& channel,
                                     const base::ListValue& args) {
   // webContents.emit(channel, new Event(), args...);
-  Emit(base::UTF16ToUTF8(channel), args);
+  Emit(channel, args);
 }
 
 void WebContents::OnRendererMessageSync(content::RenderFrameHost* frame_host,
-                                        const base::string16& channel,
+                                        const std::string& channel,
                                         const base::ListValue& args,
                                         IPC::Message* message) {
   // webContents.emit(channel, new Event(sender, message), args...);
-  EmitWithSender(base::UTF16ToUTF8(channel), frame_host, message, args);
+  EmitWithSender(channel, frame_host, message, args);
 }
 
 // static

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -178,7 +178,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Send messages to browser.
   bool SendIPCMessage(bool all_frames,
-                      const base::string16& channel,
+                      const std::string& channel,
                       const base::ListValue& args);
 
   // Send WebInputEvent to the page.
@@ -410,12 +410,12 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Called when received a message from renderer.
   void OnRendererMessage(content::RenderFrameHost* frame_host,
-                         const base::string16& channel,
+                         const std::string& channel,
                          const base::ListValue& args);
 
   // Called when received a synchronous message from renderer.
   void OnRendererMessageSync(content::RenderFrameHost* frame_host,
-                             const base::string16& channel,
+                             const std::string& channel,
                              const base::ListValue& args,
                              IPC::Message* message);
 

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -25,17 +25,17 @@ IPC_STRUCT_TRAITS_BEGIN(atom::DraggableRegion)
 IPC_STRUCT_TRAITS_END()
 
 IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_Message,
-                    base::string16 /* channel */,
+                    std::string /* channel */,
                     base::ListValue /* arguments */)
 
 IPC_SYNC_MESSAGE_ROUTED2_1(AtomFrameHostMsg_Message_Sync,
-                           base::string16 /* channel */,
+                           std::string /* channel */,
                            base::ListValue /* arguments */,
                            base::ListValue /* result */)
 
 IPC_MESSAGE_ROUTED3(AtomFrameMsg_Message,
                     bool /* send_to_all */,
-                    base::string16 /* channel */,
+                    std::string /* channel */,
                     base::ListValue /* arguments */)
 
 IPC_MESSAGE_ROUTED0(AtomViewMsg_Offscreen)

--- a/atom/common/api/remote_callback_freer.cc
+++ b/atom/common/api/remote_callback_freer.cc
@@ -34,8 +34,7 @@ RemoteCallbackFreer::RemoteCallbackFreer(v8::Isolate* isolate,
 RemoteCallbackFreer::~RemoteCallbackFreer() {}
 
 void RemoteCallbackFreer::RunDestructor() {
-  base::string16 channel =
-      base::ASCIIToUTF16("ELECTRON_RENDERER_RELEASE_CALLBACK");
+  auto* channel = "ELECTRON_RENDERER_RELEASE_CALLBACK";
   base::ListValue args;
   args.AppendString(context_id_);
   args.AppendInteger(object_id_);

--- a/atom/common/api/remote_object_freer.cc
+++ b/atom/common/api/remote_object_freer.cc
@@ -56,7 +56,7 @@ void RemoteObjectFreer::RunDestructor() {
   if (!render_frame)
     return;
 
-  base::string16 channel = base::ASCIIToUTF16("ipc-message");
+  auto* channel = "ipc-message";
   base::ListValue args;
   args.AppendString("ELECTRON_BROWSER_DEREFERENCE");
   args.AppendString(context_id_);

--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -28,7 +28,7 @@ RenderFrame* GetCurrentRenderFrame() {
 }
 
 void Send(mate::Arguments* args,
-          const base::string16& channel,
+          const std::string& channel,
           const base::ListValue& arguments) {
   RenderFrame* render_frame = GetCurrentRenderFrame();
   if (render_frame == nullptr)
@@ -42,7 +42,7 @@ void Send(mate::Arguments* args,
 }
 
 base::ListValue SendSync(mate::Arguments* args,
-                         const base::string16& channel,
+                         const std::string& channel,
                          const base::ListValue& arguments) {
   base::ListValue result;
 

--- a/atom/renderer/api/atom_api_renderer_ipc.h
+++ b/atom/renderer/api/atom_api_renderer_ipc.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_RENDERER_API_ATOM_API_RENDERER_IPC_H_
 #define ATOM_RENDERER_API_ATOM_API_RENDERER_IPC_H_
 
+#include <string>
+
 #include "base/values.h"
 #include "native_mate/arguments.h"
 
@@ -13,11 +15,11 @@ namespace atom {
 namespace api {
 
 void Send(mate::Arguments* args,
-          const base::string16& channel,
+          const std::string& channel,
           const base::ListValue& arguments);
 
 base::ListValue SendSync(mate::Arguments* args,
-                         const base::string16& channel,
+                         const std::string& channel,
                          const base::ListValue& arguments);
 
 void Initialize(v8::Local<v8::Object> exports,

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -168,7 +168,7 @@ bool AtomRenderFrameObserver::OnMessageReceived(const IPC::Message& message) {
 }
 
 void AtomRenderFrameObserver::OnBrowserMessage(bool send_to_all,
-                                               const base::string16& channel,
+                                               const std::string& channel,
                                                const base::ListValue& args) {
   // Don't handle browser messages before document element is created.
   // When we receive a message from the browser, we try to transfer it
@@ -195,7 +195,7 @@ void AtomRenderFrameObserver::OnBrowserMessage(bool send_to_all,
 }
 
 void AtomRenderFrameObserver::EmitIPCEvent(blink::WebLocalFrame* frame,
-                                           const base::string16& channel,
+                                           const std::string& channel,
                                            const base::ListValue& args) {
   if (!frame)
     return;

--- a/atom/renderer/atom_render_frame_observer.h
+++ b/atom/renderer/atom_render_frame_observer.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_RENDERER_ATOM_RENDER_FRAME_OBSERVER_H_
 #define ATOM_RENDERER_ATOM_RENDER_FRAME_OBSERVER_H_
 
+#include <string>
+
 #include "atom/renderer/renderer_client_base.h"
 #include "base/strings/string16.h"
 #include "content/public/renderer/render_frame_observer.h"
@@ -42,7 +44,7 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
 
  protected:
   virtual void EmitIPCEvent(blink::WebLocalFrame* frame,
-                            const base::string16& channel,
+                            const std::string& channel,
                             const base::ListValue& args);
 
  private:
@@ -51,7 +53,7 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
   bool IsMainWorld(int world_id);
   bool IsIsolatedWorld(int world_id);
   void OnBrowserMessage(bool send_to_all,
-                        const base::string16& channel,
+                        const std::string& channel,
                         const base::ListValue& args);
 
   content::RenderFrame* render_frame_;

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -106,7 +106,7 @@ class AtomSandboxedRenderFrameObserver : public AtomRenderFrameObserver {
 
  protected:
   void EmitIPCEvent(blink::WebLocalFrame* frame,
-                    const base::string16& channel,
+                    const std::string& channel,
                     const base::ListValue& args) override {
     if (!frame)
       return;

--- a/spec/api-ipc-renderer-spec.js
+++ b/spec/api-ipc-renderer-spec.js
@@ -154,6 +154,21 @@ describe('ipc renderer module', () => {
 
       contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)
     })
+
+    it('sends message to WebContents (channel has special chars)', done => {
+      const webContentsId = remote.getCurrentWebContents().id
+
+      ipcRenderer.once('pong-æøåü', (event, id) => {
+        expect(webContentsId).to.equal(id)
+        done()
+      })
+
+      contents.once('did-finish-load', () => {
+        ipcRenderer.sendTo(contents.id, 'ping-æøåü', webContentsId)
+      })
+
+      contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)
+    })
   })
 
   describe('remote listeners', () => {

--- a/spec/fixtures/pages/ping-pong.html
+++ b/spec/fixtures/pages/ping-pong.html
@@ -5,6 +5,9 @@
   ipcRenderer.on('ping', function (event, id) {
     ipcRenderer.sendTo(id, 'pong', id)
   })
+  ipcRenderer.on('ping-æøåü', function (event, id) {
+    ipcRenderer.sendTo(id, 'pong-æøåü', id)
+  })
 </script>
 </body>
 </html>


### PR DESCRIPTION
##### Description of Change
There is no need to use UTF-16 for IPC channel names, as they are almost always ASCII strings (UTF-8 is therefore more efficient). This change makes IPC messages slightly smaller, which should improve performance slightly.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes