### PR TITLE
feat: Add electron version to framework

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -494,7 +494,7 @@ if (is_mac) {
       deps += [ ":electron_crashpad_helper" ]
     }
     info_plist = "atom/common/resources/mac/Info.plist"
-    extra_substitutions = [ "ATOM_BUNDLE_ID=$electron_mac_bundle_id.framework" ]
+    extra_substitutions = [ "ATOM_BUNDLE_ID=$electron_mac_bundle_id.framework", "ELECTRON_VERSION=$electron_version" ]
 
     include_dirs = [ "." ]
     sources = filenames_gypi.framework_sources

--- a/atom/common/resources/mac/Info.plist
+++ b/atom/common/resources/mac/Info.plist
@@ -12,5 +12,7 @@
 	<string>FMWK</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>Version</key>
+	<string>${ELECTRON_VERSION}</string>
 </dict>
 </plist>

--- a/atom/common/resources/mac/Info.plist
+++ b/atom/common/resources/mac/Info.plist
@@ -12,7 +12,7 @@
 	<string>FMWK</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
-	<key>Version</key>
+	<key>CFBundleVersion</key>
 	<string>${ELECTRON_VERSION}</string>
 </dict>
 </plist>


### PR DESCRIPTION
##### Description of Change

Beginning with MacOS, we don't have an easy way to extract the Electron version from an application build. This can be handy for bulk scanning apps to determine if they're using a version of Electron with any exploits, and either remove, disable, update those apps.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Add `Version` key to `Electron Framework` bundle's `Info.plist`