### PR TITLE
fix: dont parse arguments after a -- in the inspector

### DIFF
--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -4,6 +4,8 @@
 
 #include "atom/browser/node_debugger.h"
 
+#include <string>
+
 #include "base/command_line.h"
 #include "base/strings/utf_string_conversions.h"
 #include "libplatform/libplatform.h"
@@ -25,10 +27,15 @@ void NodeDebugger::Start(node::MultiIsolatePlatform* platform) {
   node::DebugOptions options;
   for (auto& arg : base::CommandLine::ForCurrentProcess()->argv()) {
 #if defined(OS_WIN)
-    options.ParseOption("Electron", base::UTF16ToUTF8(arg));
+    const std::string nice_arg = base::UTF16ToUTF8(arg);
 #else
-    options.ParseOption("Electron", arg);
+    const std::string& nice_arg = arg;
 #endif
+    // Stop handling arguments after a "--" to be consistent with Chromium
+    if (nice_arg == "--")
+      break;
+
+    options.ParseOption("Electron", nice_arg);
   }
 
   // Set process._debugWaitConnect if --inspect-brk was specified to stop

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -214,6 +214,7 @@ void NodeBindings::Initialize() {
 
   // Init node.
   // (we assume node::Init would not modify the parameters under embedded mode).
+  // NOTE: If you change this line, please ping @codebytere or @MarshallOfSound
   node::Init(nullptr, nullptr, nullptr, nullptr);
 
 #if defined(OS_WIN)


### PR DESCRIPTION
Notes: Stop handling node arguments after a "--" on the CLI