### PR TITLE
refactor: use std::string instead of base::string16 for IPC channel names (ipcRenderer.sendTo)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -2081,7 +2081,7 @@ void WebContents::OnRendererMessageSync(content::RenderFrameHost* frame_host,
 void WebContents::OnRendererMessageTo(content::RenderFrameHost* frame_host,
                                       bool send_to_all,
                                       int32_t web_contents_id,
-                                      const base::string16& channel,
+                                      const std::string& channel,
                                       const base::ListValue& args) {
   auto* web_contents = mate::TrackableObject<WebContents>::FromWeakMapID(
       isolate(), web_contents_id);

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -423,7 +423,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void OnRendererMessageTo(content::RenderFrameHost* frame_host,
                            bool send_to_all,
                            int32_t web_contents_id,
-                           const base::string16& channel,
+                           const std::string& channel,
                            const base::ListValue& args);
 
   // Called when received a synchronous message from renderer to

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -36,7 +36,7 @@ IPC_SYNC_MESSAGE_ROUTED2_1(AtomFrameHostMsg_Message_Sync,
 IPC_MESSAGE_ROUTED4(AtomFrameHostMsg_Message_To,
                     bool /* send_to_all */,
                     int32_t /* web_contents_id */,
-                    base::string16 /* channel */,
+                    std::string /* channel */,
                     base::ListValue /* arguments */)
 
 IPC_MESSAGE_ROUTED3(AtomFrameMsg_Message,

--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -63,7 +63,7 @@ base::ListValue SendSync(mate::Arguments* args,
 void SendTo(mate::Arguments* args,
             bool send_to_all,
             int32_t web_contents_id,
-            const base::string16& channel,
+            const std::string& channel,
             const base::ListValue& arguments) {
   RenderFrame* render_frame = GetCurrentRenderFrame();
   if (render_frame == nullptr)

--- a/atom/renderer/api/atom_api_renderer_ipc.h
+++ b/atom/renderer/api/atom_api_renderer_ipc.h
@@ -25,7 +25,7 @@ base::ListValue SendSync(mate::Arguments* args,
 void SendTo(mate::Arguments* args,
             bool send_to_all,
             int32_t web_contents_id,
-            const base::string16& channel,
+            const std::string& channel,
             const base::ListValue& arguments);
 
 void Initialize(v8::Local<v8::Object> exports,


### PR DESCRIPTION
##### Description of Change
Follow up to https://github.com/electron/electron/pull/14285 and https://github.com/electron/electron/pull/14286

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes