### PR TITLE
refactor: address TODO for WebContents type parsing

### DIFF
--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -60,7 +60,7 @@ void BrowserView::Init(v8::Isolate* isolate,
                        const mate::Dictionary& options) {
   mate::Dictionary web_preferences = mate::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
-  web_preferences.Set("isBrowserView", true);
+  web_preferences.Set("type", "browserView");
   mate::Handle<class WebContents> web_contents =
       WebContents::Create(isolate, web_preferences);
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -332,20 +332,12 @@ WebContents::WebContents(v8::Isolate* isolate,
   // Read options.
   options.Get("backgroundThrottling", &background_throttling_);
 
-  // FIXME(zcbenz): We should read "type" parameter for better design, but
-  // on Windows we have encountered a compiler bug that if we read "type"
-  // from |options| and then set |type_|, a memory corruption will happen
-  // and Electron will soon crash.
-  // Remvoe this after we upgraded to use VS 2015 Update 3.
+  // Get type
+  options.Get("type", &type_);
+
   bool b = false;
-  if (options.Get("isGuest", &b) && b)
-    type_ = WEB_VIEW;
-  else if (options.Get("isBackgroundPage", &b) && b)
-    type_ = BACKGROUND_PAGE;
-  else if (options.Get("isBrowserView", &b) && b)
-    type_ = BROWSER_VIEW;
 #if defined(ENABLE_OSR)
-  else if (options.Get(options::kOffscreen, &b) && b)
+  if (options.Get(options::kOffscreen, &b) && b)
     type_ = OFF_SCREEN;
 #endif
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -85,7 +85,7 @@ const startBackgroundPages = function (manifest) {
 
   const contents = webContents.create({
     partition: 'persist:__chrome_extension',
-    isBackgroundPage: true,
+    type: 'backgroundPage',
     commandLineSwitches: ['--background-page']
   })
   backgroundPages[manifest.extensionId] = { html: html, webContents: contents, name: name }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -59,7 +59,7 @@ const createGuest = function (embedder, params) {
 
   const guestInstanceId = getNextGuestInstanceId(embedder)
   const guest = webContents.create({
-    isGuest: true,
+    type: 'webView',
     partition: params.partition,
     embedder: embedder
   })

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -25,7 +25,7 @@ const mergeOptions = function (child, parent, visited) {
 
   visited.add(parent)
   for (const key in parent) {
-    if (key === 'isBrowserView') continue
+    if (key === 'type') continue
     if (!hasProp.call(parent, key)) continue
     if (key in child && key !== 'webPreferences') continue
 


### PR DESCRIPTION
##### Description of Change
```
// FIXME(zcbenz): We should read "type" parameter for better design, but
// on Windows we have encountered a compiler bug that if we read "type"
// from |options| and then set |type_|, a memory corruption will happen
// and Electron will soon crash.
// Remove this after we upgraded to use VS 2015 Update 3.
```

##### Checklist
- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes