### PR TITLE
fix: don't expose view APIs when not enabled

### DIFF
--- a/atom/common/api/features.cc
+++ b/atom/common/api/features.cc
@@ -39,6 +39,14 @@ bool IsFakeLocationProviderEnabled() {
 #endif
 }
 
+bool IsViewApiEnabled() {
+#if defined(ENABLE_VIEW_API)
+  return true;
+#else
+  return false;
+#endif
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
@@ -49,6 +57,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isPDFViewerEnabled", &IsPDFViewerEnabled);
   dict.SetMethod("isFakeLocationProviderEnabled",
                  &IsFakeLocationProviderEnabled);
+  dict.SetMethod("isViewApiEnabled", &IsViewApiEnabled);
 }
 
 }  // namespace

--- a/lib/browser/api/module-list.js
+++ b/lib/browser/api/module-list.js
@@ -1,9 +1,9 @@
+const features = process.atomBinding('features')
+
 // Browser side modules, please sort alphabetically.
 module.exports = [
   {name: 'app', file: 'app'},
   {name: 'autoUpdater', file: 'auto-updater'},
-  {name: 'BoxLayout', file: 'box-layout'},
-  {name: 'Button', file: 'button'},
   {name: 'BrowserView', file: 'browser-view'},
   {name: 'BrowserWindow', file: 'browser-window'},
   {name: 'contentTracing', file: 'content-tracing'},
@@ -11,8 +11,6 @@ module.exports = [
   {name: 'globalShortcut', file: 'global-shortcut'},
   {name: 'ipcMain', file: 'ipc-main'},
   {name: 'inAppPurchase', file: 'in-app-purchase'},
-  {name: 'LabelButton', file: 'label-button'},
-  {name: 'LayoutManager', file: 'layout-manager'},
   {name: 'Menu', file: 'menu'},
   {name: 'MenuItem', file: 'menu-item'},
   {name: 'net', file: 'net'},
@@ -24,7 +22,6 @@ module.exports = [
   {name: 'screen', file: 'screen'},
   {name: 'session', file: 'session'},
   {name: 'systemPreferences', file: 'system-preferences'},
-  {name: 'TextField', file: 'text-field'},
   {name: 'TopLevelWindow', file: 'top-level-window'},
   {name: 'TouchBar', file: 'touch-bar'},
   {name: 'Tray', file: 'tray'},
@@ -34,3 +31,13 @@ module.exports = [
   // The internal modules, invisible unless you know their names.
   {name: 'NavigationController', file: 'navigation-controller', private: true}
 ]
+
+if (features.isViewApiEnabled()) {
+  module.exports.push(
+    {name: 'BoxLayout', file: 'box-layout'},
+    {name: 'Button', file: 'button'},
+    {name: 'LabelButton', file: 'label-button'},
+    {name: 'LayoutManager', file: 'layout-manager'},
+    {name: 'TextField', file: 'text-field'}
+  )
+}


### PR DESCRIPTION
##### Description of Change
Fixes https://github.com/electron/electron/issues/13930

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Removes access to experimental view APIs unless enabled in features.