### PR TITLE
fix: don't crash on tray.setContextMenu(null)

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -210,7 +210,7 @@ void Tray::PopUpContextMenu(mate::Arguments* args) {
 
 void Tray::SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu) {
   menu_.Reset(isolate, menu.ToV8());
-  tray_icon_->SetContextMenu(menu->model());
+  tray_icon_->SetContextMenu(menu.IsEmpty() ? nullptr : menu->model());
 }
 
 gfx::Rect Tray::GetBounds() {

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -474,11 +474,18 @@ void TrayIconCocoa::SetContextMenu(AtomMenuModel* menu_model) {
   // Substribe to MenuClosed event.
   if (menu_model_)
     menu_model_->RemoveObserver(this);
-  menu_model->AddObserver(this);
 
-  // Create native menu.
-  menu_.reset([[AtomMenuController alloc] initWithModel:menu_model
-                                  useDefaultAccelerator:NO]);
+  menu_model_ = menu_model;
+
+  if (menu_model) {
+    menu_model->AddObserver(this);
+    // Create native menu.
+    menu_.reset([[AtomMenuController alloc] initWithModel:menu_model
+                                    useDefaultAccelerator:NO]);
+  } else {
+    menu_.reset();
+  }
+
   [status_item_view_ setMenuController:menu_.get()];
 }
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -275,7 +275,7 @@ The `position` is only available on Windows, and it is (0, 0) by default.
 
 #### `tray.setContextMenu(menu)`
 
-* `menu` Menu
+* `menu` Menu | null
 
 Sets the context menu for this icon.
 

--- a/spec/api-tray-spec.js
+++ b/spec/api-tray-spec.js
@@ -1,0 +1,25 @@
+const {remote} = require('electron')
+const {Menu, Tray, nativeImage} = remote
+
+describe('tray module', () => {
+  describe('tray.setContextMenu', () => {
+    let tray
+
+    beforeEach(() => {
+      tray = new Tray(nativeImage.createEmpty())
+    })
+
+    afterEach(() => {
+      tray.destroy()
+      tray = null
+    })
+
+    it('accepts menu instance', () => {
+      tray.setContextMenu(new Menu())
+    })
+
+    it('accepts null', () => {
+      tray.setContextMenu(null)
+    })
+  })
+})


### PR DESCRIPTION
##### Description of Change
Fixes https://github.com/electron/electron/issues/14188

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Fixed crash on `tray.setContextMenu(null)`.