### PR TITLE
fix: use OS process handle to clear object registry

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -766,7 +766,8 @@ void WebContents::RenderViewCreated(content::RenderViewHost* render_view_host) {
 }
 
 void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
-  Emit("render-view-deleted", render_view_host->GetProcess()->GetID());
+  Emit("render-view-deleted", render_view_host->GetProcess()->GetID(),
+       base::GetProcId(render_view_host->GetProcess()->GetHandle()));
 }
 
 void WebContents::RenderProcessGone(base::TerminationStatus status) {

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -16,7 +16,7 @@
 #include "atom/renderer/content_settings_observer.h"
 #include "atom/renderer/preferences_manager.h"
 #include "base/command_line.h"
-#include "base/process/process_handle.h"
+#include "base/process/process.h"
 #include "base/strings/string_split.h"
 #include "base/strings/stringprintf.h"
 #include "chrome/renderer/media/chrome_key_systems.h"
@@ -97,7 +97,8 @@ void RendererClientBase::DidCreateScriptContext(
     content::RenderFrame* render_frame) {
   // global.setHidden("contextId", `${processId}-${++next_context_id_}`)
   std::string context_id = base::StringPrintf(
-      "%" CrPRIdPid "-%d", base::GetCurrentProcId(), ++next_context_id_);
+      "%" CrPRIdPid "-%d", base::GetProcId(base::Process::Current().Handle()),
+      ++next_context_id_);
   v8::Isolate* isolate = context->GetIsolate();
   v8::Local<v8::String> key = mate::StringToSymbol(isolate, "contextId");
   v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);

--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -103,9 +103,10 @@ class ObjectsRegistry {
 
   // Private: Clear the storage when renderer process is destroyed.
   registerDeleteListener (webContents, contextId) {
-    const processId = webContents.getProcessId()
-    const listener = (event, deletedProcessId) => {
-      if (deletedProcessId === processId) {
+    // contextId => ${OSProcessId}-${contextCount}
+    const OSProcessId = contextId.split('-')[0]
+    const listener = (event, deletedProcessId, deletedOSProcessId) => {
+      if (deletedOSProcessId && deletedOSProcessId.toString() === OSProcessId) {
         webContents.removeListener('render-view-deleted', listener)
         this.clear(webContents, contextId)
       }

--- a/spec/fixtures/api/render-view-deleted.html
+++ b/spec/fixtures/api/render-view-deleted.html
@@ -17,7 +17,7 @@
       }
 
       // This should trigger a dereference and a remote getURL call should fail
-      contents.emit('render-view-deleted', {}, contents.getProcessId())
+      contents.emit('render-view-deleted', {}, '', contents.getOSProcessId())
       try {
         contents.getURL()
         ipcRenderer.send('error-message', 'No error thrown')


### PR DESCRIPTION
##### Description of Change

There might be some intermediate process before the renderer process is finalized because of how our default process arch works alongside plznavigate, this patch updates the registry to handle such scenarios.

Fixes https://github.com/electron/electron/issues/14054

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: fixes occasional issue with Remote object going missing unexpectedly.