### PR TITLE
fix: dont parse arguments after a -- in the inspector (#14297) (2-0-x)

### DIFF
--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -4,6 +4,8 @@
 
 #include "atom/browser/node_debugger.h"
 
+#include <string>
+
 #include "base/command_line.h"
 #include "base/strings/utf_string_conversions.h"
 #include "libplatform/libplatform.h"
@@ -28,10 +30,15 @@ void NodeDebugger::Start(node::NodePlatform* platform) {
   node::DebugOptions options;
   for (auto& arg : base::CommandLine::ForCurrentProcess()->argv()) {
 #if defined(OS_WIN)
-    options.ParseOption("Electron", base::UTF16ToUTF8(arg));
+    const std::string nice_arg = base::UTF16ToUTF8(arg);
 #else
-    options.ParseOption("Electron", arg);
+    const std::string& nice_arg = arg;
 #endif
+    // Stop handling arguments after a "--" to be consistent with Chromium
+    if (nice_arg == "--")
+      break;
+
+    options.ParseOption("Electron", nice_arg);
   }
 
   if (options.inspector_enabled()) {

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -168,6 +168,7 @@ void NodeBindings::Initialize() {
 
   // Init node.
   // (we assume node::Init would not modify the parameters under embedded mode).
+  // NOTE: If you change this line, please ping @codebytere or @MarshallOfSound
   node::Init(nullptr, nullptr, nullptr, nullptr);
 
 #if defined(OS_WIN)


### PR DESCRIPTION
Backport of #14297 into 2-0-x

CC @codebytere 

Notes: Stop handling node arguments after a "--" on the CLI