### PR TITLE
 fix: emit focus/blur events for webview

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -26,6 +26,7 @@ const supportedWebViewEvents = [
   'did-navigate',
   'did-frame-navigate',
   'did-navigate-in-page',
+  'focus-change',
   'close',
   'crashed',
   'gpu-crashed',
@@ -320,6 +321,10 @@ ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST_SYNC', function (event, par
 
 ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, embedderFrameId, elementInstanceId, guestInstanceId, params) {
   attachGuest(event, embedderFrameId, elementInstanceId, guestInstanceId, params)
+})
+
+ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', function (event, focus, guestInstanceId) {
+  event.sender.emit('focus-change', {}, focus, guestInstanceId)
 })
 
 // Returns WebContents from its guest id.

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -25,6 +25,7 @@ var v8Util = process.atomBinding('v8_util')
 v8Util.setHiddenValue(global, 'ipc', new events.EventEmitter())
 
 // Use electron module after everything is ready.
+const {ipcRenderer} = require('electron')
 
 const {
   warnAboutNodeWithRemoteContent,
@@ -184,3 +185,15 @@ window.addEventListener('load', function loadHandler () {
 
   window.removeEventListener('load', loadHandler)
 })
+
+// Report focus/blur events of webview to browser.
+// Note that while Chromium content APIs have observer for focus/blur, they
+// unfortunately do not work for webview.
+if (process.guestInstanceId) {
+  window.addEventListener('focus', () => {
+    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', true, process.guestInstanceId)
+  })
+  window.addEventListener('blur', () => {
+    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', false, process.guestInstanceId)
+  })
+}

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -24,6 +24,7 @@ const WEB_VIEW_EVENTS = {
   'did-navigate': ['url', 'httpResponseCode', 'httpStatusText'],
   'did-frame-navigate': ['url', 'httpResponseCode', 'httpStatusText', 'isMainFrame', 'frameProcessId', 'frameRoutingId'],
   'did-navigate-in-page': ['url', 'isMainFrame', 'frameProcessId', 'frameRoutingId'],
+  'focus-change': ['focus', 'guestInstanceId'],
   'close': [],
   'crashed': [],
   'gpu-crashed': [],
@@ -55,6 +56,8 @@ const dispatchEvent = function (webView, eventName, eventKey, ...args) {
   webView.dispatchEvent(domEvent)
   if (eventName === 'load-commit') {
     webView.onLoadCommit(domEvent)
+  } else if (eventName === 'focus-change') {
+    webView.onFocusChange(domEvent)
   }
 }
 

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -30,6 +30,7 @@ class WebViewImpl {
     v8Util.setHiddenValue(this.webviewNode, 'internal', this)
     this.elementAttached = false
     this.beforeFirstNavigation = true
+    this.hasFocus = false
 
     // Check for removed attributes.
     for (const attributeName of removedAttributes) {
@@ -45,7 +46,6 @@ class WebViewImpl {
     const shadowRoot = this.webviewNode.attachShadow({mode: 'open'})
     shadowRoot.innerHTML = '<!DOCTYPE html><style type="text/css">:host { display: flex; }</style>'
     this.setupWebViewAttributes()
-    this.setupFocusPropagation()
     this.viewInstanceId = getNextId()
     shadowRoot.appendChild(this.internalElement)
   }
@@ -88,26 +88,6 @@ class WebViewImpl {
     Object.defineProperty(this.webviewNode, 'request', {
       value: request,
       enumerable: true
-    })
-  }
-
-  setupFocusPropagation () {
-    if (!this.webviewNode.hasAttribute('tabIndex')) {
-      // <webview> needs a tabIndex in order to be focusable.
-      // TODO(fsamuel): It would be nice to avoid exposing a tabIndex attribute
-      // to allow <webview> to be focusable.
-      // See http://crbug.com/231664.
-      this.webviewNode.setAttribute('tabIndex', -1)
-    }
-
-    // Focus the BrowserPlugin when the <webview> takes focus.
-    this.webviewNode.addEventListener('focus', () => {
-      this.internalElement.focus()
-    })
-
-    // Blur the BrowserPlugin when the <webview> loses focus.
-    this.webviewNode.addEventListener('blur', () => {
-      this.internalElement.blur()
     })
   }
 
@@ -182,6 +162,15 @@ class WebViewImpl {
       // triggering a page reload on every guest-initiated navigation,
       // we do not handle this mutation.
       this.attributes[webViewConstants.ATTRIBUTE_SRC].setValueIgnoreMutation(newValue)
+    }
+  }
+
+  // Emits focus/blur events.
+  onFocusChange () {
+    const hasFocus = document.activeElement === this.webviewNode
+    if (hasFocus !== this.hasFocus) {
+      this.hasFocus = hasFocus
+      this.dispatchEvent(new Event(hasFocus ? 'focus' : 'blur'))
     }
   }
 

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -42,12 +42,21 @@ class WebViewImpl {
     // on* Event handlers.
     this.on = {}
 
+    // Create internal iframe element.
     this.internalElement = this.createInternalElement()
     const shadowRoot = this.webviewNode.attachShadow({mode: 'open'})
     shadowRoot.innerHTML = '<!DOCTYPE html><style type="text/css">:host { display: flex; }</style>'
     this.setupWebViewAttributes()
     this.viewInstanceId = getNextId()
     shadowRoot.appendChild(this.internalElement)
+
+    // Provide access to contentWindow.
+    Object.defineProperty(this.webviewNode, 'contentWindow', {
+      get: () => {
+        return this.internalElement.contentWindow
+      },
+      enumerable: true
+    })
   }
 
   createInternalElement () {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1294,6 +1294,19 @@ describe('<webview> tag', function () {
       expect(secondResizeEvent.newWidth).to.equal(newWidth)
       expect(secondResizeEvent.newHeight).to.equal(newHeight)
     })
+
+    it('emits focus event', async () => {
+      const domReadySignal = waitForEvent(webview, 'dom-ready')
+      webview.src = `file://${fixtures}/pages/a.html`
+      document.body.appendChild(webview)
+
+      await domReadySignal
+
+      const focusSignal = waitForEvent(webview, 'focus')
+      webview.contentWindow.focus()
+
+      await focusSignal
+    })
   })
 
   describe('zoom behavior', () => {


### PR DESCRIPTION
##### Description of Change

Capture focus/blur events in OOPIF and transfer them to the DOM webview element.

Close https://github.com/electron/electron/issues/14255.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: fix webview not emitting focus/blur events.