### PR TITLE
fix: don't expose desktopCapturer in sandboxed renderers when the feature is disabled (backport: 3-0-x)

### DIFF
--- a/lib/sandboxed_renderer/api/exports/electron.js
+++ b/lib/sandboxed_renderer/api/exports/electron.js
@@ -1,48 +1,17 @@
-Object.defineProperties(exports, {
-  ipcRenderer: {
-    enumerable: true,
-    get: function () {
-      return require('../ipc-renderer')
-    }
-  },
-  remote: {
-    enumerable: true,
-    get: function () {
-      return require('../../../renderer/api/remote')
-    }
-  },
-  webFrame: {
-    enumerable: true,
-    get: function () {
-      return require('../../../renderer/api/web-frame')
-    }
-  },
-  crashReporter: {
-    enumerable: true,
-    get: function () {
-      return require('../../../common/api/crash-reporter')
-    }
-  },
-  CallbacksRegistry: {
-    get: function () {
-      return require('../../../common/api/callbacks-registry')
-    }
-  },
-  isPromise: {
-    get: function () {
-      return require('../../../common/api/is-promise')
-    }
-  },
-  // XXX(alexeykuzmin): It won't be available if the Desktop Capturer
-  // was disabled during build time.
-  desktopCapturer: {
-    get: function () {
-      return require('../../../renderer/api/desktop-capturer')
-    }
-  },
-  nativeImage: {
-    get: function () {
-      return require('../../../common/api/native-image')
-    }
+const moduleList = require('../module-list')
+
+for (const {
+        name,
+        load,
+        enabled = true,
+        private: isPrivate = false
+    } of moduleList) {
+  if (!enabled) {
+    continue
   }
-})
+
+  Object.defineProperty(exports, name, {
+    enumerable: !isPrivate,
+    get: load
+  })
+}

--- a/lib/sandboxed_renderer/api/module-list.js
+++ b/lib/sandboxed_renderer/api/module-list.js
@@ -1,0 +1,39 @@
+const features = process.atomBinding('features')
+
+module.exports = [
+  {
+    name: 'CallbacksRegistry',
+    load: () => require('../../common/api/callbacks-registry'),
+    private: true
+  },
+  {
+    name: 'crashReporter',
+    load: () => require('../../common/api/crash-reporter')
+  },
+  {
+    name: 'desktopCapturer',
+    load: () => require('../../renderer/api/desktop-capturer'),
+    enabled: features.isDesktopCapturerEnabled()
+  },
+  {
+    name: 'ipcRenderer',
+    load: () => require('./ipc-renderer')
+  },
+  {
+    name: 'isPromise',
+    load: () => require('../../common/api/is-promise'),
+    private: true
+  },
+  {
+    name: 'nativeImage',
+    load: () => require('../../common/api/native-image')
+  },
+  {
+    name: 'remote',
+    load: () => require('../../renderer/api/remote')
+  },
+  {
+    name: 'webFrame',
+    load: () => require('../../renderer/api/web-frame')
+  }
+]

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -1,9 +1,11 @@
 /* eslint no-eval: "off" */
 /* global binding, Buffer */
 const events = require('events')
-const electron = require('electron')
 
 process.atomBinding = require('../common/atom-binding-setup')(binding.get, 'renderer')
+
+// The electron module depends on process.atomBinding
+const electron = require('electron')
 
 const v8Util = process.atomBinding('v8_util')
 // Expose browserify Buffer as a hidden value. This is used by C++ code to


### PR DESCRIPTION
##### Description of Change
Backport https://github.com/electron/electron/pull/14310

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Don't expose desktopCapturer in sandboxed renderers when the feature is disabled.