### PR TITLE
build: add missing enable_view_api flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -38,6 +38,8 @@ declare_args() {
   # need to test with chromium's location provider.
   # Should not be enabled for release build.
   enable_fake_location_provider = !is_official_build
+
+  enable_view_api = false
 }
 
 if (is_mas_build) {
@@ -71,6 +73,9 @@ config("features") {
   }
   if (enable_osr) {
     defines += [ "ENABLE_OSR=1" ]
+  }
+  if (enable_view_api) {
+    defines += [ "ENABLE_VIEW_API" ]
   }
 }
 
@@ -175,6 +180,15 @@ asar("js2asar") {
       "lib/renderer/api/desktop-capturer.js",
     ]
   }
+  if (enable_view_api) {
+     sources += [
+      "lib/browser/api/box-layout.js",
+      "lib/browser/api/button.js",
+      "lib/browser/api/label-button.js",
+      "lib/browser/api/layout-manager.js",
+      "lib/browser/api/text-field.js",
+     ]
+   }
   outputs = [
     "$root_out_dir/resources/electron.asar",
   ]
@@ -395,6 +409,21 @@ static_library("electron_lib") {
     sources += [
       "atom/browser/api/atom_api_desktop_capturer.cc",
       "atom/browser/api/atom_api_desktop_capturer.h",
+    ]
+  }
+
+  if (enable_view_api) {
+    sources += [
+      "atom/browser/api/atom_api_box_layout.cc",
+      "atom/browser/api/atom_api_box_layout.h",
+      "atom/browser/api/atom_api_button.cc",
+      "atom/browser/api/atom_api_button.h",
+      "atom/browser/api/atom_api_label_button.cc",
+      "atom/browser/api/atom_api_label_button.h",
+      "atom/browser/api/atom_api_layout_manager.cc",
+      "atom/browser/api/atom_api_layout_manager.h",
+      "atom/browser/api/atom_api_text_field.cc",
+      "atom/browser/api/atom_api_text_field.h",
     ]
   }
 }

--- a/atom/browser/api/atom_api_view.cc
+++ b/atom/browser/api/atom_api_view.cc
@@ -26,9 +26,7 @@ View::~View() {
 #if defined(ENABLE_VIEW_API)
 void View::SetLayoutManager(mate::Handle<LayoutManager> layout_manager) {
   layout_manager_.Reset(isolate(), layout_manager->GetWrapper());
-  // TODO(zcbenz): New versions of Chrome takes std::unique_ptr instead of raw
-  // pointer, remove the "release()" call when we upgraded to it.
-  view()->SetLayoutManager(layout_manager->TakeOver().release());
+  view()->SetLayoutManager(layout_manager->TakeOver());
 }
 
 void View::AddChildView(mate::Handle<View> child) {


### PR DESCRIPTION
##### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Fixes #14340.
I tried to run builds on all platforms with the flag being enabled and they all succeeded.

/cc @zcbenz 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no notes