### PR TITLE
fix: doc recipe for debug build

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -88,7 +88,7 @@ out/Default --list`.
 Electron:**
 
 ```sh
-$ gn gen out/Default --args='import("//electron/build/args/debug.gn") $GN_EXTRA_ARGS'
+$ gn gen out/Default --args="import(\"//electron/build/args/debug.gn\") $GN_EXTRA_ARGS"
 ```
 
 **For generating Release (aka "non-component" or "static") build config of


### PR DESCRIPTION
A small bug, but one that might trip up people copy-pasting from the instructions guide.

Basically we need to pass args in "double quotes" rather than 'single quotes' so that environment variables get interpolated.

Notes: no-notes