### PR TITLE
chore: fix bootstrap script on 3-0-x

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -169,8 +169,6 @@ def setup_libchromiumcontent(is_dev, target_arch, url,
     mkdir_p(target_dir)
   else:
     mkdir_p(DOWNLOAD_DIR)
-  if is_verbose_mode():
-    args += ['-v']
   if is_dev:
     subprocess.check_call([sys.executable, script] + args)
   else:


### PR DESCRIPTION
This "-v" flag doesn't exist in the libcc version currently in 3-0-x

Notes: no-notes