### PR TITLE
docs: keyboard listeners no longer work on webview

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -212,6 +212,10 @@ webview.setAttribute('disableguestresize', '')
 // Removed
 webview.setAttribute('guestinstance', instanceId)
 // There is no replacement for this API
+
+// Keyboard listeners no longer work on webview tag
+webview.onkeydown = () => { /* handler */ }
+webview.onkeyup = () => { /* handler */ }
 ```
 
 ## Node Headers URL


### PR DESCRIPTION
##### Description of Change

Due to webview moved to OOPIF architecture, there is no way to install keyboard listeners on webview.

Close https://github.com/electron/electron/issues/14258.

##### Checklist

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: (docs) Add note that keyboard listeners no longer work on webview