### PR TITLE
build: [gn] explicitly override rtc_use_h264

### DIFF
--- a/build/args/debug.gn
+++ b/build/args/debug.gn
@@ -1,3 +1,10 @@
 import("all.gn")
 is_debug = true
 is_component_build = true
+
+# This may be guarded behind is_chrome_branded alongside
+# proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
+# explicitly override here to build OpenH264 encoder/FFmpeg decoder.
+# The initialization of the decoder depends on whether ffmpeg has
+# been built with H.264 support.
+rtc_use_h264 = proprietary_codecs

--- a/build/args/ffmpeg.gn
+++ b/build/args/ffmpeg.gn
@@ -1,3 +1,6 @@
-import("release.gn")
+import("all.gn")
+is_component_build = false
+is_component_ffmpeg = true
+is_official_build = true
 proprietary_codecs = false
 ffmpeg_branding = "Chromium"

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -7,3 +7,10 @@ strip_debug_info = true
 # TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.
 # Once we can build nodejs with CFI flags matching Electron's, remove this.
 is_cfi = false
+
+# This may be guarded behind is_chrome_branded alongside
+# proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
+# explicitly override here to build OpenH264 encoder/FFmpeg decoder.
+# The initialization of the decoder depends on whether ffmpeg has
+# been built with H.264 support.
+rtc_use_h264 = proprietary_codecs

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -4,10 +4,6 @@ is_component_ffmpeg = true
 is_official_build = true
 strip_debug_info = true
 
-# TODO(nornagon): linking non-CFI code (nodejs) with CFI code fails at runtime.
-# Once we can build nodejs with CFI flags matching Electron's, remove this.
-is_cfi = false
-
 # This may be guarded behind is_chrome_branded alongside
 # proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
 # explicitly override here to build OpenH264 encoder/FFmpeg decoder.

--- a/build/args/testing.gn
+++ b/build/args/testing.gn
@@ -5,4 +5,10 @@ is_component_ffmpeg = true
 is_official_build = false
 dcheck_always_on = true
 symbol_level = 1
-is_component_ffmpeg = true
+
+# This may be guarded behind is_chrome_branded alongside
+# proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
+# explicitly override here to build OpenH264 encoder/FFmpeg decoder.
+# The initialization of the decoder depends on whether ffmpeg has
+# been built with H.264 support.
+rtc_use_h264 = proprietary_codecs


### PR DESCRIPTION
##### Description of Change

Align with https://github.com/electron/libchromiumcontent/pull/667 for the GN build config.
Ref https://github.com/electron/electron/issues/14256

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: no-notes