### PR TITLE
feat: add event.senderId property to IPCs sent via ipcRenderer.sendTo

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1556,10 +1556,17 @@ void WebContents::TabTraverse(bool reverse) {
 bool WebContents::SendIPCMessage(bool all_frames,
                                  const std::string& channel,
                                  const base::ListValue& args) {
+  return SendIPCMessageWithSender(all_frames, channel, args);
+}
+
+bool WebContents::SendIPCMessageWithSender(bool all_frames,
+                                           const std::string& channel,
+                                           const base::ListValue& args,
+                                           int32_t sender_id) {
   auto* frame_host = web_contents()->GetMainFrame();
   if (frame_host) {
     return frame_host->Send(new AtomFrameMsg_Message(
-        frame_host->GetRoutingID(), all_frames, channel, args));
+        frame_host->GetRoutingID(), all_frames, channel, args, sender_id));
   }
   return false;
 }
@@ -2090,7 +2097,7 @@ void WebContents::OnRendererMessageTo(content::RenderFrameHost* frame_host,
       isolate(), web_contents_id);
 
   if (web_contents) {
-    web_contents->SendIPCMessage(send_to_all, channel, args);
+    web_contents->SendIPCMessageWithSender(send_to_all, channel, args, ID());
   }
 }
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -181,6 +181,11 @@ class WebContents : public mate::TrackableObject<WebContents>,
                       const std::string& channel,
                       const base::ListValue& args);
 
+  bool SendIPCMessageWithSender(bool all_frames,
+                                const std::string& channel,
+                                const base::ListValue& args,
+                                int32_t sender_id = 0);
+
   // Send WebInputEvent to the page.
   void SendInputEvent(v8::Isolate* isolate, v8::Local<v8::Value> input_event);
 

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -39,10 +39,11 @@ IPC_MESSAGE_ROUTED4(AtomFrameHostMsg_Message_To,
                     std::string /* channel */,
                     base::ListValue /* arguments */)
 
-IPC_MESSAGE_ROUTED3(AtomFrameMsg_Message,
+IPC_MESSAGE_ROUTED4(AtomFrameMsg_Message,
                     bool /* send_to_all */,
                     std::string /* channel */,
-                    base::ListValue /* arguments */)
+                    base::ListValue /* arguments */,
+                    int32_t /* sender_id */)
 
 IPC_MESSAGE_ROUTED0(AtomViewMsg_Offscreen)
 

--- a/atom/common/api/remote_callback_freer.cc
+++ b/atom/common/api/remote_callback_freer.cc
@@ -36,12 +36,13 @@ RemoteCallbackFreer::~RemoteCallbackFreer() {}
 void RemoteCallbackFreer::RunDestructor() {
   auto* channel = "ELECTRON_RENDERER_RELEASE_CALLBACK";
   base::ListValue args;
+  int32_t sender_id = 0;
   args.AppendString(context_id_);
   args.AppendInteger(object_id_);
   auto* frame_host = web_contents()->GetMainFrame();
   if (frame_host) {
     frame_host->Send(new AtomFrameMsg_Message(frame_host->GetRoutingID(), false,
-                                              channel, args));
+                                              channel, args, sender_id));
   }
 
   Observe(nullptr);

--- a/atom/renderer/atom_render_frame_observer.h
+++ b/atom/renderer/atom_render_frame_observer.h
@@ -45,7 +45,8 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
  protected:
   virtual void EmitIPCEvent(blink::WebLocalFrame* frame,
                             const std::string& channel,
-                            const base::ListValue& args);
+                            const base::ListValue& args,
+                            int32_t sender_id);
 
  private:
   bool ShouldNotifyClient(int world_id);
@@ -54,7 +55,8 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
   bool IsIsolatedWorld(int world_id);
   void OnBrowserMessage(bool send_to_all,
                         const std::string& channel,
-                        const base::ListValue& args);
+                        const base::ListValue& args,
+                        int32_t sender_id);
 
   content::RenderFrame* render_frame_;
   RendererClientBase* renderer_client_;

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -107,7 +107,8 @@ class AtomSandboxedRenderFrameObserver : public AtomRenderFrameObserver {
  protected:
   void EmitIPCEvent(blink::WebLocalFrame* frame,
                     const std::string& channel,
-                    const base::ListValue& args) override {
+                    const base::ListValue& args,
+                    int32_t sender_id) override {
     if (!frame)
       return;
 
@@ -116,7 +117,8 @@ class AtomSandboxedRenderFrameObserver : public AtomRenderFrameObserver {
     auto context = frame->MainWorldScriptContext();
     v8::Context::Scope context_scope(context);
     v8::Local<v8::Value> argv[] = {mate::ConvertToV8(isolate, channel),
-                                   mate::ConvertToV8(isolate, args)};
+                                   mate::ConvertToV8(isolate, args),
+                                   mate::ConvertToV8(isolate, sender_id)};
     renderer_client_->InvokeIpcCallback(
         context, "onMessage",
         std::vector<v8::Local<v8::Value>>(argv, argv + node::arraysize(argv)));

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -89,3 +89,17 @@ Sends a message to a window with `windowid` via `channel`.
 
 Like `ipcRenderer.send` but the event will be sent to the `<webview>` element in
 the host page instead of the main process.
+
+## Event object
+
+The `event` object passed to the `callback` has the following methods:
+
+### `event.senderId`
+
+Returns the `webContents.id` that sent the message, you can call
+`event.sender.sendTo(event.senderId, ...)` to reply to the message, see
+[ipcRenderer.sendTo][ipc-renderer-sendto] for more information.
+This only applies to messages sent from a different renderer.
+Messages sent directly from the main process set `event.senderId` to `0`.
+
+[ipc-renderer-sendto]: #ipcrenderersendtowindowid-channel--arg1-arg2-

--- a/lib/sandboxed_renderer/api/ipc-renderer.js
+++ b/lib/sandboxed_renderer/api/ipc-renderer.js
@@ -9,8 +9,8 @@ const ipcNative = process.atomBinding('ipc')
 // private/public APIs.
 v8Util.setHiddenValue(global, 'ipcNative', ipcNative)
 
-ipcNative.onMessage = function (channel, args) {
-  ipcRenderer.emit(channel, {sender: ipcRenderer}, ...args)
+ipcNative.onMessage = function (channel, args, senderId) {
+  ipcRenderer.emit(channel, {sender: ipcRenderer, senderId}, ...args)
 }
 
 ipcNative.onExit = function () {

--- a/spec/api-ipc-renderer-spec.js
+++ b/spec/api-ipc-renderer-spec.js
@@ -132,8 +132,6 @@ describe('ipc renderer module', () => {
   describe('ipcRenderer.sendTo', () => {
     let contents = null
 
-    beforeEach(() => { contents = webContents.create({}) })
-
     afterEach(() => {
       ipcRenderer.removeAllListeners('pong')
       contents.destroy()
@@ -141,30 +139,58 @@ describe('ipc renderer module', () => {
     })
 
     it('sends message to WebContents', done => {
-      const webContentsId = remote.getCurrentWebContents().id
+      contents = webContents.create({
+        preload: path.join(fixtures, 'module', 'preload-inject-ipc.js')
+      })
 
-      ipcRenderer.once('pong', (event, id) => {
-        expect(webContentsId).to.equal(id)
+      const payload = 'Hello World!'
+
+      ipcRenderer.once('pong', (event, data) => {
+        expect(payload).to.equal(data)
         done()
       })
 
       contents.once('did-finish-load', () => {
-        ipcRenderer.sendTo(contents.id, 'ping', webContentsId)
+        ipcRenderer.sendTo(contents.id, 'ping', payload)
+      })
+
+      contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)
+    })
+
+    it('sends message to WebContents (sanboxed renderer)', done => {
+      contents = webContents.create({
+        preload: path.join(fixtures, 'module', 'preload-inject-ipc.js'),
+        sandbox: true
+      })
+
+      const payload = 'Hello World!'
+
+      ipcRenderer.once('pong', (event, data) => {
+        expect(payload).to.equal(data)
+        done()
+      })
+
+      contents.once('did-finish-load', () => {
+        ipcRenderer.sendTo(contents.id, 'ping', payload)
       })
 
       contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)
     })
 
     it('sends message to WebContents (channel has special chars)', done => {
-      const webContentsId = remote.getCurrentWebContents().id
+      contents = webContents.create({
+        preload: path.join(fixtures, 'module', 'preload-inject-ipc.js')
+      })
 
-      ipcRenderer.once('pong-æøåü', (event, id) => {
-        expect(webContentsId).to.equal(id)
+      const payload = 'Hello World!'
+
+      ipcRenderer.once('pong-æøåü', (event, data) => {
+        expect(payload).to.equal(data)
         done()
       })
 
       contents.once('did-finish-load', () => {
-        ipcRenderer.sendTo(contents.id, 'ping-æøåü', webContentsId)
+        ipcRenderer.sendTo(contents.id, 'ping-æøåü', payload)
       })
 
       contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)

--- a/spec/fixtures/pages/ping-pong.html
+++ b/spec/fixtures/pages/ping-pong.html
@@ -1,14 +1,12 @@
 <html>
 <body>
 <script type="text/javascript" charset="utf-8">
-  const {ipcRenderer} = require('electron')
-  ipcRenderer.on('ping', function (event, id) {
-    ipcRenderer.sendTo(id, 'pong', id)
+  ipcRenderer.on('ping', function (event, payload) {
+    ipcRenderer.sendTo(event.senderId, 'pong', payload)
   })
-  ipcRenderer.on('ping-æøåü', function (event, id) {
-    ipcRenderer.sendTo(id, 'pong-æøåü', id)
+  ipcRenderer.on('ping-æøåü', function (event, payload) {
+    ipcRenderer.sendTo(event.senderId, 'pong-æøåü', payload)
   })
 </script>
 </body>
 </html>
-


### PR DESCRIPTION
##### Description of Change
Currently, it's not possible to tell whether an IPC was sent directly from the main process or from another renderer via `renderer.sendTo`. This PR adds `event.senderId` property, which identifies the originating webContents. If the IPC was sent directly from the main process, the value is 0.

The modified `spec/api-ipc-renderer-spec.js` demonstrates this.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Added `event.senderId` property to IPCs sent via `ipcRenderer.sendTo`.