### PR TITLE
docs: Add Electron Fiddle to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ versioning. As of version 2.0.0, Electron follows semver, so you don't need `--s
 For more installation options and troubleshooting tips, see
 [installation](docs/tutorial/installation.md).
 
-## Quick start
+## Quick start & Electron Fiddle
 
-Clone and run the
+Getting started with Electron is painless and easy. Use [`Electron Fiddle`](https://github.com/electron/fiddle)
+to build, run, and package small Electron experiments, see code examples for all of Electron's APIs, and
+to try out different versions of Electron.
+
+Alternatively, clone and run the
 [electron/electron-quick-start](https://github.com/electron/electron-quick-start)
 repository to see a minimal Electron app in action:
 
@@ -55,6 +59,7 @@ npm start
 ## Resources for learning Electron
 
 - [electronjs.org/docs](https://electronjs.org/docs) - all of Electron's documentation
+- [electron/fiddle](https://github.com/electron/fiddle) - A tool to build, run, and package small Electron experiments
 - [electron/electron-quick-start](https://github.com/electron/electron-quick-start) - a very basic starter Electron app
 - [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) - sample starter apps created by the community
 - [electron/simple-samples](https://github.com/electron/simple-samples) - small applications with ideas for taking them further

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ For more installation options and troubleshooting tips, see
 
 ## Quick start & Electron Fiddle
 
-Getting started with Electron is painless and easy. Use [`Electron Fiddle`](https://github.com/electron/fiddle)
+Use [`Electron Fiddle`](https://github.com/electron/fiddle)
 to build, run, and package small Electron experiments, see code examples for all of Electron's APIs, and
-to try out different versions of Electron.
+to try out different versions of Electron. It's specifically built to make the start of your journey with
+Electron a bit easier.
 
 Alternatively, clone and run the
 [electron/electron-quick-start](https://github.com/electron/electron-quick-start)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For more installation options and troubleshooting tips, see
 ## Quick start & Electron Fiddle
 
 Use [`Electron Fiddle`](https://github.com/electron/fiddle)
-to build, run, and package small Electron experiments, see code examples for all of Electron's APIs, and
+to build, run, and package small Electron experiments, to see code examples for all of Electron's APIs, and
 to try out different versions of Electron. It's specifically built to make the start of your journey with
 Electron a bit easier.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ For more installation options and troubleshooting tips, see
 
 Use [`Electron Fiddle`](https://github.com/electron/fiddle)
 to build, run, and package small Electron experiments, to see code examples for all of Electron's APIs, and
-to try out different versions of Electron. It's specifically built to make the start of your journey with
-Electron a bit easier.
+to try out different versions of Electron. It's designed to make the start of your journey with
+Electron easier.
 
 Alternatively, clone and run the
 [electron/electron-quick-start](https://github.com/electron/electron-quick-start)


### PR DESCRIPTION
##### Description of Change
This change was discussed with @zeke, @ckerr, and a few other maintainers during the recent Hack Week in Vancouver – and now that Fiddle 0.2 is out, I feel comfortable enough to recommend it to newcomers. I am convinced that Fiddle makes getting started with Electron a whole lot easier, which is why I think we should recommend it as an alternative to `electron-quick-start`.

For reference, Fiddle _includes_ `electron-quick-start`, it just also includes a tutorial, type information, code samples, and an easy way to build, package, and share small app.s

##### Checklist
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
Notes: Added Fiddle to README.md