### PR TITLE
docs: add notes on OOPIF webview's behaviors

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -62,6 +62,20 @@ and displays a "loading..." message during the load time:
 </script>
 ```
 
+## Internal implementation
+
+Under the hood `webview` is implemented with [Out-of-Process iframes (OOPIFs)](https://www.chromium.org/developers/design-documents/oop-iframes).
+The `webview` tag is essentially a custom element using shadow DOM to wrap an
+`iframe` element inside it.
+
+So the behavior of `webview` is very similar to a cross-domain `iframe`, as
+examples:
+
+* When clicking into a `webview`, the page focus will move from the embedder
+  frame to `webview`.
+* You can not add keyboard event listeners to `webview`.
+* All reactions between the embedder frame and `webview` are asynchronous.
+
 ## CSS Styling Notes
 
 Please note that the `webview` tag's style uses `display:flex;` internally to


### PR DESCRIPTION
##### Description of Change

As mentioned in https://github.com/electron/electron/issues/14259#issuecomment-417301464, we can not really fix some behavior changes introduced by OOPIF webview, so we have to document the changes instead of fixing them.

Close #14259.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: add docs on OOPIF webview's behaviors.