### PR TITLE
refactor: use loadFile when appropriate in tests

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -42,7 +42,7 @@ describe('electron module', () => {
 
     it('always returns the internal electron module', (done) => {
       ipcMain.once('answer', () => done())
-      window.loadURL(`file://${path.join(__dirname, 'fixtures', 'api', 'electron-module-app', 'index.html')}`)
+      window.loadFile(path.join(__dirname, 'fixtures', 'api', 'electron-module-app', 'index.html'))
     })
   })
 })

--- a/spec/api-browser-window-affinity-spec.js
+++ b/spec/api-browser-window-affinity-spec.js
@@ -22,7 +22,7 @@ describe('BrowserWindow with affinity module', () => {
         webPreferences: webPrefs || {}
       })
       w.webContents.on('did-finish-load', () => { resolve(w) })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'blank.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'blank.html'))
     })
   }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -158,12 +158,12 @@ describe('BrowserWindow module', () => {
         assert.equal(String(content), 'unload')
         done()
       })
-      w.loadURL('file://' + path.join(fixtures, 'api', 'unload.html'))
+      w.loadFile(path.join(fixtures, 'api', 'unload.html'))
     })
     it('should emit beforeunload handler', (done) => {
       w.once('onbeforeunload', () => { done() })
       w.webContents.on('did-finish-load', () => { w.close() })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'beforeunload-false.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'beforeunload-false.html'))
     })
     it('should not crash when invoked synchronously inside navigation observer', (done) => {
       const events = [
@@ -205,11 +205,11 @@ describe('BrowserWindow module', () => {
         assert.equal(String(content), 'close')
         done()
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'close.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'close.html'))
     })
     it('should emit beforeunload handler', (done) => {
       w.once('onbeforeunload', () => { done() })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'close-beforeunload-false.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-false.html'))
     })
   })
 
@@ -255,7 +255,7 @@ describe('BrowserWindow module', () => {
         assert.equal(isMainFrame, false)
         done()
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'did-fail-load-iframe.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'did-fail-load-iframe.html'))
     })
     it('does not crash in did-fail-provisional-load handler', (done) => {
       w.webContents.once('did-fail-provisional-load', () => {
@@ -334,7 +334,7 @@ describe('BrowserWindow module', () => {
     it('allows the window to be closed from the event listener', (done) => {
       ipcRenderer.send('close-on-will-navigate', w.id)
       ipcRenderer.once('closed-on-will-navigate', () => { done() })
-      w.loadURL(`file://${fixtures}/pages/will-navigate.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'will-navigate.html'))
     })
   })
 
@@ -1202,7 +1202,7 @@ describe('BrowserWindow module', () => {
             preload: preload
           }
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'preload.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
       it('can successfully delete the Buffer global', (done) => {
         const preload = path.join(fixtures, 'module', 'delete-buffer.js')
@@ -1217,7 +1217,7 @@ describe('BrowserWindow module', () => {
             preload: preload
           }
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'preload.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
     })
 
@@ -1254,7 +1254,7 @@ describe('BrowserWindow module', () => {
             preload: path.join(fixtures, 'module', 'set-global-preload-3.js')
           }
         })
-        w.loadURL('file://' + path.join(fixtures, 'api', 'preloads.html'))
+        w.loadFile(path.join(fixtures, 'api', 'preloads.html'))
       })
     })
 
@@ -1273,7 +1273,7 @@ describe('BrowserWindow module', () => {
             additionalArguments: ['--my-magic-arg']
           }
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'blank.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'blank.html'))
       })
 
       it('adds extra value args to process.argv in the renderer process', (done) => {
@@ -1290,7 +1290,7 @@ describe('BrowserWindow module', () => {
             additionalArguments: ['--my-magic-arg=foo']
           }
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'blank.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'blank.html'))
       })
     })
 
@@ -1310,7 +1310,7 @@ describe('BrowserWindow module', () => {
             nodeIntegration: false
           }
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'blank.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'blank.html'))
       })
     })
 
@@ -1362,7 +1362,7 @@ describe('BrowserWindow module', () => {
             preload: preload
           }
         })
-        w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
+        w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
 
       it('exposes ipcRenderer to preload script (path has special chars)', function (done) {
@@ -1379,7 +1379,7 @@ describe('BrowserWindow module', () => {
             preload: preloadSpecialChars
           }
         })
-        w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
+        w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
 
       it('exposes "exit" event to preload script', function (done) {
@@ -1487,7 +1487,7 @@ describe('BrowserWindow module', () => {
           assert.equal(args.includes('--enable-sandbox'), true)
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'new-window.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
       })
 
       it('should open windows with the options configured via new-window event listeners', (done) => {
@@ -1506,7 +1506,7 @@ describe('BrowserWindow module', () => {
           assert.equal(webPreferences.foo, 'bar')
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'new-window.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
       })
 
       it('should set ipc event sender correctly', (done) => {
@@ -1630,7 +1630,7 @@ describe('BrowserWindow module', () => {
             done()
           }, 100)
         })
-        w.loadURL('file://' + path.join(fixtures, 'pages', 'window-open.html'))
+        w.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
       })
 
       it('releases memory after popup is closed', (done) => {
@@ -1747,7 +1747,7 @@ describe('BrowserWindow module', () => {
             preload: preload
           }
         })
-        w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
+        w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
 
       it('webview in sandbox renderer', async () => {
@@ -1760,7 +1760,7 @@ describe('BrowserWindow module', () => {
             webviewTag: true
           }
         })
-        w.loadURL(`file://${fixtures}/pages/webview-did-attach-event.html`)
+        w.loadFile(path.join(fixtures, 'pages', 'webview-did-attach-event.html'))
 
         const [, webContents] = await emittedOnce(w.webContents, 'did-attach-webview')
         const [, id] = await emittedOnce(ipcMain, 'webview-dom-ready')
@@ -1784,28 +1784,28 @@ describe('BrowserWindow module', () => {
           assert.equal(content, 'Hello')
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'native-window-open-blank.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'native-window-open-blank.html'))
       })
       it('opens window of same domain with cross-scripting enabled', (done) => {
         ipcMain.once('answer', (event, content) => {
           assert.equal(content, 'Hello')
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'native-window-open-file.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'native-window-open-file.html'))
       })
       it('blocks accessing cross-origin frames', (done) => {
         ipcMain.once('answer', (event, content) => {
           assert.equal(content, 'Blocked a frame with origin "file://" from accessing a cross-origin frame.')
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'native-window-open-cross-origin.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'native-window-open-cross-origin.html'))
       })
       it('opens window from <iframe> tags', (done) => {
         ipcMain.once('answer', (event, content) => {
           assert.equal(content, 'Hello')
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'native-window-open-iframe.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'native-window-open-iframe.html'))
       });
       (nativeModulesEnabled ? it : it.skip)('loads native addons correctly after reload', (done) => {
         ipcMain.once('answer', (event, content) => {
@@ -1816,7 +1816,7 @@ describe('BrowserWindow module', () => {
           })
           w.reload()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'native-window-open-native-addon.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'native-window-open-native-addon.html'))
       })
       it('should inherit the nativeWindowOpen setting in opened windows', (done) => {
         w.destroy()
@@ -1833,7 +1833,7 @@ describe('BrowserWindow module', () => {
           assert.equal(args.includes('--native-window-open'), true)
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'new-window.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
       })
       it('should open windows with the options configured via new-window event listeners', (done) => {
         w.destroy()
@@ -1851,7 +1851,7 @@ describe('BrowserWindow module', () => {
           assert.equal(webPreferences.foo, 'bar')
           done()
         })
-        w.loadURL(`file://${path.join(fixtures, 'api', 'new-window.html')}`)
+        w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
       })
       it('retains the original web preferences when window.location is changed to a new origin', async () => {
         await serveFileFromProtocol('foo', path.join(fixtures, 'api', 'window-open-location-change.html'))
@@ -1874,7 +1874,7 @@ describe('BrowserWindow module', () => {
             assert.equal(typeofProcess, 'undefined')
             resolve()
           })
-          w.loadURL(`file://${path.join(fixtures, 'api', 'window-open-location-open.html')}`)
+          w.loadFile(path.join(fixtures, 'api', 'window-open-location-open.html'))
         })
       })
     })
@@ -1898,22 +1898,22 @@ describe('BrowserWindow module', () => {
         assert.equal(content, 'Hello')
         done()
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'native-window-open-isolated.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'native-window-open-isolated.html'))
     })
   })
 
   describe('beforeunload handler', () => {
     it('returning undefined would not prevent close', (done) => {
       w.once('closed', () => { done() })
-      w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-undefined.html'))
+      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-undefined.html'))
     })
     it('returning false would prevent close', (done) => {
       w.once('onbeforeunload', () => { done() })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'close-beforeunload-false.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-false.html'))
     })
     it('returning empty string would prevent close', (done) => {
       w.once('onbeforeunload', () => { done() })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'close-beforeunload-empty-string.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-empty-string.html'))
     })
     it('emits for each close attempt', (done) => {
       let beforeUnloadCount = 0
@@ -1926,7 +1926,7 @@ describe('BrowserWindow module', () => {
         }
       })
       w.webContents.once('did-finish-load', () => { w.close() })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'beforeunload-false-prevent3.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'beforeunload-false-prevent3.html'))
     })
     it('emits for each reload attempt', (done) => {
       let beforeUnloadCount = 0
@@ -1944,7 +1944,7 @@ describe('BrowserWindow module', () => {
         })
         w.reload()
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'beforeunload-false-prevent3.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'beforeunload-false-prevent3.html'))
     })
     it('emits for each navigation attempt', (done) => {
       let beforeUnloadCount = 0
@@ -1962,7 +1962,7 @@ describe('BrowserWindow module', () => {
         })
         w.loadURL('about:blank')
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'beforeunload-false-prevent3.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'beforeunload-false-prevent3.html'))
     })
   })
 
@@ -2004,7 +2004,7 @@ describe('BrowserWindow module', () => {
         done()
       })
 
-      w.loadURL(`file://${path.join(fixtures, 'pages', 'visibilitychange.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState changes when window is hidden', (done) => {
       w = new BrowserWindow({width: 100, height: 100})
@@ -2022,7 +2022,7 @@ describe('BrowserWindow module', () => {
         w.hide()
       })
 
-      w.loadURL(`file://${path.join(fixtures, 'pages', 'visibilitychange.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState changes when window is shown', (done) => {
       w = new BrowserWindow({width: 100, height: 100})
@@ -2039,7 +2039,7 @@ describe('BrowserWindow module', () => {
         w.show()
       })
 
-      w.loadURL(`file://${path.join(fixtures, 'pages', 'visibilitychange.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState changes when window is shown inactive', function (done) {
       if (isCI && process.platform === 'win32') {
@@ -2065,7 +2065,7 @@ describe('BrowserWindow module', () => {
         w.showInactive()
       })
 
-      w.loadURL(`file://${path.join(fixtures, 'pages', 'visibilitychange.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState changes when window is minimized', function (done) {
       if (isCI && process.platform === 'linux') {
@@ -2092,7 +2092,7 @@ describe('BrowserWindow module', () => {
         w.minimize()
       })
 
-      w.loadURL(`file://${path.join(fixtures, 'pages', 'visibilitychange.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState remains visible if backgroundThrottling is disabled', (done) => {
       w = new BrowserWindow({
@@ -2124,7 +2124,7 @@ describe('BrowserWindow module', () => {
       })
       w.show()
 
-      w.loadURL(`file://${path.join(fixtures, 'pages', 'visibilitychange.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
   })
 
@@ -2143,7 +2143,7 @@ describe('BrowserWindow module', () => {
         assert.equal(additionalFeatures[0], 'this-is-not-a-standard-feature')
         done()
       })
-      w.loadURL(`file://${fixtures}/pages/window-open.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
     })
     it('emits when window.open is called with no webPreferences', (done) => {
       w.destroy()
@@ -2155,8 +2155,9 @@ describe('BrowserWindow module', () => {
         assert.equal(additionalFeatures[0], 'this-is-not-a-standard-feature')
         done()
       })
-      w.loadURL(`file://${fixtures}/pages/window-open.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
     })
+
     it('emits when link with target is called', (done) => {
       w.webContents.once('new-window', (e, url, frameName) => {
         e.preventDefault()
@@ -2164,7 +2165,7 @@ describe('BrowserWindow module', () => {
         assert.equal(frameName, 'target')
         done()
       })
-      w.loadURL(`file://${fixtures}/pages/target-name.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'target-name.html'))
     })
   })
 
@@ -2264,7 +2265,7 @@ describe('BrowserWindow module', () => {
 
     it('subscribes to frame updates', (done) => {
       let called = false
-      w.loadURL(`file://${fixtures}/api/frame-subscriber.html`)
+      w.loadFile(path.join(fixtures, 'api', 'frame-subscriber.html'))
       w.webContents.on('dom-ready', () => {
         w.webContents.beginFrameSubscription(function (data) {
           // This callback might be called twice.
@@ -2279,7 +2280,7 @@ describe('BrowserWindow module', () => {
     })
     it('subscribes to frame updates (only dirty rectangle)', (done) => {
       let called = false
-      w.loadURL(`file://${fixtures}/api/frame-subscriber.html`)
+      w.loadFile(path.join(fixtures, 'api', 'frame-subscriber.html'))
       w.webContents.on('dom-ready', () => {
         w.webContents.beginFrameSubscription(true, (data) => {
           // This callback might be called twice.
@@ -2293,7 +2294,7 @@ describe('BrowserWindow module', () => {
       })
     })
     it('throws error when subscriber is not well defined', (done) => {
-      w.loadURL(`file://${fixtures}'/api/frame-subscriber.html`)
+      w.loadFile(path.join(fixtures, 'api', 'frame-subscriber.html'))
       try {
         w.webContents.beginFrameSubscription(true, true)
       } catch (e) {
@@ -2330,7 +2331,7 @@ describe('BrowserWindow module', () => {
           done()
         })
       })
-      w.loadURL('file://' + fixtures + '/pages/save_page/index.html')
+      w.loadFile(path.join(fixtures, 'pages', 'save_page', 'index.html'))
     })
   })
 
@@ -3276,29 +3277,29 @@ describe('BrowserWindow module', () => {
     })
 
     it('separates the page context from the Electron/preload context', async () => {
-      iw.loadURL(`file://${fixtures}/api/isolated.html`)
+      iw.loadFile(path.join(fixtures, 'api', 'isolated.html'))
       const [, data] = await emittedOnce(ipcMain, 'isolated-world')
       assert.deepEqual(data, expectedContextData)
     })
     it('recreates the contexts on reload', async () => {
-      iw.loadURL(`file://${fixtures}/api/isolated.html`)
+      iw.loadFile(path.join(fixtures, 'api', 'isolated.html'))
       await emittedOnce(iw.webContents, 'did-finish-load')
       iw.webContents.reload()
       const [, data] = await emittedOnce(ipcMain, 'isolated-world')
       assert.deepEqual(data, expectedContextData)
     })
     it('enables context isolation on child windows', async () => {
-      iw.loadURL(`file://${fixtures}/pages/window-open.html`)
+      iw.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
       const [, window] = await emittedOnce(app, 'browser-window-created')
       assert.ok(window.webContents.getLastWebPreferences().contextIsolation)
     })
     it('separates the page context from the Electron/preload context with sandbox on', async () => {
-      ws.loadURL(`file://${fixtures}/api/isolated.html`)
+      ws.loadFile(path.join(fixtures, 'api', 'isolated.html'))
       const [, data] = await emittedOnce(ipcMain, 'isolated-world')
       assert.deepEqual(data, expectedContextData)
     })
     it('recreates the contexts on reload with sandbox on', async () => {
-      ws.loadURL(`file://${fixtures}/api/isolated.html`)
+      ws.loadFile(path.join(fixtures, 'api', 'isolated.html'))
       await emittedOnce(ws.webContents, 'did-finish-load')
       ws.webContents.reload()
       const [, data] = await emittedOnce(ipcMain, 'isolated-world')
@@ -3358,12 +3359,12 @@ describe('BrowserWindow module', () => {
         assertWithinDelta(size.height, 100, 2, 'height')
         done()
       })
-      w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+      w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))
     })
 
     describe('window.webContents.isOffscreen()', () => {
       it('is true for offscreen type', () => {
-        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))
         assert.equal(w.webContents.isOffscreen(), true)
       })
 
@@ -3380,7 +3381,7 @@ describe('BrowserWindow module', () => {
           assert.equal(w.webContents.isPainting(), true)
           done()
         })
-        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))
       })
     })
 
@@ -3391,7 +3392,7 @@ describe('BrowserWindow module', () => {
           assert.equal(w.webContents.isPainting(), false)
           done()
         })
-        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))
       })
     })
 
@@ -3405,7 +3406,7 @@ describe('BrowserWindow module', () => {
             done()
           })
         })
-        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))
       })
     })
 
@@ -3415,7 +3416,7 @@ describe('BrowserWindow module', () => {
           assert.equal(w.webContents.getFrameRate(), 60)
           done()
         })
-        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))
       })
     })
 
@@ -3428,7 +3429,7 @@ describe('BrowserWindow module', () => {
             done()
           })
         })
-        w.loadURL('file://' + fixtures + '/api/offscreen-rendering.html')
+        w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))
       })
     })
   })

--- a/spec/api-debugger-spec.js
+++ b/spec/api-debugger-spec.js
@@ -33,7 +33,7 @@ describe('debugger module', () => {
           done()
         }
       })
-      w.webContents.loadURL(`file://${path.join(fixtures, 'pages', 'a.html')}`)
+      w.webContents.loadFile(path.join(fixtures, 'pages', 'a.html'))
     })
 
     it('fails when protocol version is not supported', done => {
@@ -108,7 +108,7 @@ describe('debugger module', () => {
       const url = process.platform !== 'win32'
         ? `file://${path.join(fixtures, 'pages', 'a.html')}`
         : `file:///${path.join(fixtures, 'pages', 'a.html').replace(/\\/g, '/')}`
-      w.webContents.loadURL(url)
+      w.webContents.loadFile(path.join(fixtures, 'pages', 'a.html'))
 
       try {
         w.webContents.debugger.attach()

--- a/spec/api-ipc-main-spec.js
+++ b/spec/api-ipc-main-spec.js
@@ -27,7 +27,7 @@ describe('ipc main module', () => {
         event.returnValue = null
         done()
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'send-sync-message.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'send-sync-message.html'))
     })
 
     it('does not crash when reply is sent by multiple listeners', (done) => {
@@ -39,7 +39,7 @@ describe('ipc main module', () => {
         event.returnValue = null
         done()
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'send-sync-message.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'send-sync-message.html'))
     })
   })
 
@@ -77,7 +77,7 @@ describe('ipc main module', () => {
         done()
       })
 
-      w.loadURL(`file://${path.join(fixtures, 'api', 'render-view-deleted.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'render-view-deleted.html'))
     })
   })
 })

--- a/spec/api-ipc-renderer-spec.js
+++ b/spec/api-ipc-renderer-spec.js
@@ -154,7 +154,7 @@ describe('ipc renderer module', () => {
         ipcRenderer.sendTo(contents.id, 'ping', payload)
       })
 
-      contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)
+      contents.loadFile(path.join(fixtures, 'pages', 'ping-pong.html'))
     })
 
     it('sends message to WebContents (sanboxed renderer)', done => {
@@ -174,7 +174,7 @@ describe('ipc renderer module', () => {
         ipcRenderer.sendTo(contents.id, 'ping', payload)
       })
 
-      contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)
+      contents.loadFile(path.join(fixtures, 'pages', 'ping-pong.html'))
     })
 
     it('sends message to WebContents (channel has special chars)', done => {
@@ -193,7 +193,7 @@ describe('ipc renderer module', () => {
         ipcRenderer.sendTo(contents.id, 'ping-æøåü', payload)
       })
 
-      contents.loadURL(`file://${path.join(fixtures, 'pages', 'ping-pong.html')}`)
+      contents.loadFile(path.join(fixtures, 'pages', 'ping-pong.html'))
     })
   })
 
@@ -221,7 +221,7 @@ describe('ipc renderer module', () => {
 
         w.webContents.reload()
       })
-      w.loadURL(`file://${path.join(fixtures, 'api', 'remote-event-handler.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'remote-event-handler.html'))
     })
   })
 

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -221,7 +221,7 @@ describe('session module', () => {
         assert.equal(count, 0)
         done()
       })
-      w.loadURL('file://' + path.join(fixtures, 'api', 'localstorage.html'))
+      w.loadFile(path.join(fixtures, 'api', 'localstorage.html'))
       w.webContents.on('did-finish-load', () => {
         const options = {
           origin: 'file://',

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -51,7 +51,7 @@ describe('webContents module', () => {
         done()
       })
 
-      w.loadURL(`file://${path.join(fixtures, 'pages', 'webview-zoom-factor.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-factor.html'))
       w.webContents.openDevTools()
     })
   })
@@ -125,7 +125,7 @@ describe('webContents module', () => {
   // Disabled because flaky. See #13969
   xdescribe('isCurrentlyAudible() API', () => {
     it('returns whether audio is playing', async () => {
-      w.loadURL(`file://${path.join(__dirname, 'fixtures', 'api', 'is-currently-audible.html')}`)
+      w.loadFile(path.join(fixtures, 'api', 'is-currently-audible.html'))
       w.show()
       await emittedOnce(w.webContents, 'did-finish-load')
 
@@ -150,7 +150,7 @@ describe('webContents module', () => {
 
   describe('before-input-event event', () => {
     it('can prevent document keyboard events', (done) => {
-      w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'key-events.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'key-events.html'))
       w.webContents.once('did-finish-load', () => {
         ipcMain.once('keydown', (event, key) => {
           assert.equal(key, 'b')
@@ -164,7 +164,7 @@ describe('webContents module', () => {
     })
 
     it('has the correct properties', (done) => {
-      w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'base-page.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'base-page.html'))
       w.webContents.once('did-finish-load', () => {
         const testBeforeInput = (opts) => {
           return new Promise((resolve, reject) => {
@@ -250,7 +250,7 @@ describe('webContents module', () => {
 
   describe('sendInputEvent(event)', () => {
     beforeEach((done) => {
-      w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'key-events.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'key-events.html'))
       w.webContents.once('did-finish-load', () => done())
     })
 
@@ -342,7 +342,7 @@ describe('webContents module', () => {
   describe('startDrag({file, icon})', () => {
     it('throws errors for a missing file or a missing/empty icon', () => {
       assert.throws(() => {
-        w.webContents.startDrag({icon: path.join(__dirname, 'fixtures', 'assets', 'logo.png')})
+        w.webContents.startDrag({icon: path.join(fixtures, 'assets', 'logo.png')})
       }, /Must specify either 'file' or 'files' option/)
 
       assert.throws(() => {
@@ -367,7 +367,7 @@ describe('webContents module', () => {
           done()
         })
         w.show()
-        w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'focus-web-contents.html')}`)
+        w.loadFile(path.join(fixtures, 'pages', 'focus-web-contents.html'))
       })
     })
   })
@@ -556,10 +556,10 @@ describe('webContents module', () => {
         })
       })
       ipcMain.once('temporary-zoom-set', (e, zoomLevel) => {
-        w2.loadURL(`file://${fixtures}/pages/c.html`)
+        w2.loadFile(path.join(fixtures, 'pages', 'c.html'))
         finalZoomLevel = zoomLevel
       })
-      w.loadURL(`file://${fixtures}/pages/webframe-zoom.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'webframe-zoom.html'))
     })
 
     it('cannot persist zoom level after navigation with webFrame', (done) => {
@@ -581,10 +581,10 @@ describe('webContents module', () => {
       })
       ipcMain.once('zoom-level-set', (e, zoomLevel) => {
         assert.equal(zoomLevel, 0.6)
-        w.loadURL(`file://${fixtures}/pages/d.html`)
+        w.loadFile(path.join(fixtures, 'pages', 'd.html'))
         initialNavigation = false
       })
-      w.loadURL(`file://${fixtures}/pages/c.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'c.html'))
     })
   })
 
@@ -611,20 +611,20 @@ describe('webContents module', () => {
       w.webContents.on('will-prevent-unload', (e) => {
         assert.fail('should not have fired')
       })
-      w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-undefined.html'))
+      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-undefined.html'))
     })
 
     it('emits if beforeunload returns false', (done) => {
       w.webContents.on('will-prevent-unload', () => {
         done()
       })
-      w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-false.html'))
+      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-false.html'))
     })
 
     it('supports calling preventDefault on will-prevent-unload events', (done) => {
       ipcRenderer.send('prevent-next-will-prevent-unload', w.webContents.id)
       w.once('closed', () => done())
-      w.loadURL('file://' + path.join(fixtures, 'api', 'close-beforeunload-false.html'))
+      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-false.html'))
     })
   })
 
@@ -708,13 +708,13 @@ describe('webContents module', () => {
         if (count === 0) {
           count += 1
           assert.equal(color, '#FFEEDD')
-          w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'base-page.html')}`)
+          w.loadFile(path.join(fixtures, 'pages', 'base-page.html'))
         } else if (count === 1) {
           assert.equal(color, null)
           done()
         }
       })
-      w.loadURL(`file://${path.join(__dirname, 'fixtures', 'pages', 'theme-color.html')}`)
+      w.loadFile(path.join(fixtures, 'pages', 'theme-color.html'))
     })
   })
 
@@ -726,7 +726,7 @@ describe('webContents module', () => {
           done()
         }
       })
-      w.loadURL(`file://${fixtures}/pages/a.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'a.html'))
     })
   })
 

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -147,7 +147,7 @@ describe('webFrame module', function () {
 
   it('calls a spellcheck provider', async () => {
     w = new BrowserWindow({show: false})
-    w.loadURL(`file://${fixtures}/pages/webframe-spell-check.html`)
+    w.loadFile(path.join(fixtures, 'pages', 'webframe-spell-check.html'))
     await emittedOnce(w.webContents, 'did-finish-load')
 
     const spellCheckerFeedback = emittedOnce(ipcMain, 'spec-spell-check')

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -1003,7 +1003,6 @@ describe('asar package', function () {
   })
 
   describe('asar protocol', function () {
-    var url = require('url')
     var w = null
 
     afterEach(function () {
@@ -1064,16 +1063,11 @@ describe('asar package', function () {
         height: 400
       })
       var p = path.resolve(fixtures, 'asar', 'web.asar', 'index.html')
-      var u = url.format({
-        protocol: 'file',
-        slashed: true,
-        pathname: p
-      })
       ipcMain.once('dirname', function (event, dirname) {
         assert.equal(dirname, path.dirname(p))
         done()
       })
-      w.loadURL(u)
+      w.loadFile(p)
     })
 
     it('loads script tag in html', function (done) {
@@ -1087,12 +1081,7 @@ describe('asar package', function () {
         height: 400
       })
       var p = path.resolve(fixtures, 'asar', 'script.asar', 'index.html')
-      var u = url.format({
-        protocol: 'file',
-        slashed: true,
-        pathname: p
-      })
-      w.loadURL(u)
+      w.loadFile(p)
       ipcMain.once('ping', function (event, message) {
         assert.equal(message, 'pong')
         done()
@@ -1112,12 +1101,7 @@ describe('asar package', function () {
         height: 400
       })
       var p = path.resolve(fixtures, 'asar', 'video.asar', 'index.html')
-      var u = url.format({
-        protocol: 'file',
-        slashed: true,
-        pathname: p
-      })
-      w.loadURL(u)
+      w.loadFile(p)
       ipcMain.on('asar-video', function (event, message, error) {
         if (message === 'ended') {
           assert(!error)

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -75,7 +75,7 @@ describe('chromium feature', () => {
       w = new BrowserWindow({show: false})
       w.webContents.once('did-finish-load', () => { done() })
       w.webContents.once('crashed', () => done(new Error('WebContents crashed.')))
-      w.loadURL(`file://${fixtures}/pages/external-string.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'external-string.html'))
     })
   })
 
@@ -89,7 +89,7 @@ describe('chromium feature', () => {
       })
       w.webContents.once('did-finish-load', () => { done() })
       w.webContents.once('crashed', () => done(new Error('WebContents crashed.')))
-      w.loadURL(`file://${fixtures}/pages/jquery.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'jquery.html'))
     })
   })
 
@@ -162,7 +162,7 @@ describe('chromium feature', () => {
           })
         }
       })
-      w.loadURL(`file://${fixtures}/pages/media-id-reset.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'media-id-reset.html'))
     })
   })
 
@@ -201,7 +201,7 @@ describe('chromium feature', () => {
         }
       })
       w.webContents.on('crashed', () => done(new Error('WebContents crashed.')))
-      w.loadURL(`file://${fixtures}/pages/service-worker/index.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'service-worker', 'index.html'))
     })
 
     it('should register for intercepted file scheme', (done) => {
@@ -239,7 +239,7 @@ describe('chromium feature', () => {
         }
       })
       w.webContents.on('crashed', () => done(new Error('WebContents crashed.')))
-      w.loadURL(`file://${fixtures}/pages/service-worker/index.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'service-worker', 'index.html'))
     })
   })
 
@@ -280,7 +280,7 @@ describe('chromium feature', () => {
           callback(true)
         }
       })
-      w.loadURL(`file://${fixtures}/pages/geolocation/index.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'geolocation', 'index.html'))
     })
   })
 
@@ -333,7 +333,7 @@ describe('chromium feature', () => {
           w.close()
           done()
         })
-        w.loadURL(`file://${fixtures}/pages/window-open.html`)
+        w.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
       })
     }
 
@@ -454,7 +454,7 @@ describe('chromium feature', () => {
 
     it('handles cycles when merging the parent options into the child options', (done) => {
       w = BrowserWindow.fromId(ipcRenderer.sendSync('create-window-with-options-cycle'))
-      w.loadURL(`file://${fixtures}/pages/window-open.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
       w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
         assert.equal(options.show, false)
         assert.deepEqual(options.foo, {
@@ -572,14 +572,13 @@ describe('chromium feature', () => {
 
   describe('window.opener', () => {
     let url = `file://${fixtures}/pages/window-opener.html`
-
     it('is null for main window', (done) => {
       w = new BrowserWindow({ show: false })
       w.webContents.once('ipc-message', (event, args) => {
         assert.deepEqual(args, ['opener', null])
         done()
       })
-      w.loadURL(url)
+      w.loadFile(path.join(fixtures, 'pages', 'window-opener.html'))
     })
 
     it('is not null for window opened by window.open', (done) => {
@@ -1159,7 +1158,7 @@ describe('chromium feature', () => {
           assert.equal(parsedURL.query.src, pagePath)
           assert.equal(w.webContents.getTitle(), 'cat.pdf')
         })
-        w.webContents.loadURL(pagePath)
+        w.loadFile(path.join(fixtures, 'pages', page))
       }
     })
 

--- a/spec/fixtures/no-proprietary-codecs.js
+++ b/spec/fixtures/no-proprietary-codecs.js
@@ -6,7 +6,6 @@
 
 const {app, BrowserWindow, ipcMain} = require('electron')
 const path = require('path')
-const url = require('url')
 
 const MEDIA_ERR_SRC_NOT_SUPPORTED = 4
 const FIVE_MINUTES = 5 * 60 * 1000
@@ -18,11 +17,7 @@ app.once('ready', () => {
     show: false
   })
 
-  window.loadURL(url.format({
-    protocol: 'file',
-    slashed: true,
-    pathname: path.resolve(__dirname, 'asar', 'video.asar', 'index.html')
-  }))
+  window.loadFile(path.resolve(__dirname, 'asar', 'video.asar', 'index.html'))
 
   ipcMain.on('asar-video', (event, message, error) => {
     if (message === 'ended') {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -66,7 +66,7 @@ describe('<webview> tag', function () {
 
   it('works without script tag in page', async () => {
     const w = await openTheWindow({show: false})
-    w.loadURL('file://' + fixtures + '/pages/webview-no-script.html')
+    w.loadFile(path.join(fixtures, 'pages', 'webview-no-script.html'))
     await emittedOnce(ipcMain, 'pong')
   })
 
@@ -79,7 +79,7 @@ describe('<webview> tag', function () {
       }
     })
 
-    w.loadURL(`file://${fixtures}/pages/webview-no-script.html`)
+    w.loadFile(path.join(fixtures, 'pages', 'webview-no-script.html'))
     const [, type] = await emittedOnce(ipcMain, 'webview')
 
     expect(type).to.equal('undefined', 'WebView still exists')
@@ -95,7 +95,7 @@ describe('<webview> tag', function () {
       }
     })
 
-    w.loadURL(`file://${fixtures}/pages/webview-no-script.html`)
+    w.loadFile(path.join(fixtures, 'pages', 'webview-no-script.html'))
     const [, type] = await emittedOnce(ipcMain, 'webview')
 
     expect(type).to.not.equal('undefined', 'WebView is not created')
@@ -1144,7 +1144,7 @@ describe('<webview> tag', function () {
       const w = await openTheWindow({ show: false })
       const readyToShowSignal = emittedOnce(w, 'ready-to-show')
       const pongSignal1 = emittedOnce(ipcMain, 'pong')
-      w.loadURL(`file://${fixtures}/pages/webview-visibilitychange.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'webview-visibilitychange.html'))
       await pongSignal1
       const pongSignal2 = emittedOnce(ipcMain, 'pong')
       await readyToShowSignal
@@ -1157,8 +1157,7 @@ describe('<webview> tag', function () {
 
     it('inherits the parent window visibility state and receives visibilitychange events', async () => {
       const w = await openTheWindow({ show: false })
-      w.loadURL(`file://${fixtures}/pages/webview-visibilitychange.html`)
-
+      w.loadFile(path.join(fixtures, 'pages', 'webview-visibilitychange.html'))
       let [, visibilityState, hidden] = await emittedOnce(ipcMain, 'pong')
       assert.equal(visibilityState, 'hidden')
       assert.equal(hidden, true)
@@ -1229,7 +1228,7 @@ describe('<webview> tag', function () {
   describe('did-attach-webview event', () => {
     it('is emitted when a webview has been attached', async () => {
       const w = await openTheWindow({ show: false })
-      w.loadURL(`file://${fixtures}/pages/webview-did-attach-event.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'webview-did-attach-event.html'))
 
       const [, webContents] = await emittedOnce(w.webContents, 'did-attach-webview')
       const [, id] = await emittedOnce(ipcMain, 'webview-dom-ready')
@@ -1244,7 +1243,7 @@ describe('<webview> tag', function () {
     const extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
     BrowserWindow.addDevToolsExtension(extensionPath)
 
-    w.loadURL(`file://${fixtures}/pages/webview-devtools.html`)
+    w.loadFile(path.join(fixtures, 'pages', 'webview-devtools.html'))
 
     const [, {runtimeId, tabId}] = await emittedOnce(ipcMain, 'answer')
     expect(runtimeId).to.equal('foo')
@@ -1332,7 +1331,7 @@ describe('<webview> tag', function () {
           zoomFactor: 1.2
         }
       })
-      w.loadURL(`file://${fixtures}/pages/webview-zoom-factor.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-factor.html'))
 
       const [, zoomFactor, zoomLevel] = await emittedOnce(ipcMain, 'webview-parent-zoom-level')
       expect(zoomFactor).to.equal(1.2)
@@ -1362,7 +1361,7 @@ describe('<webview> tag', function () {
           })
         })
 
-        w.loadURL(`file://${fixtures}/pages/webview-custom-zoom-level.html`)
+        w.loadFile(path.join(fixtures, 'pages', 'webview-custom-zoom-level.html'))
 
         return promise
       })
@@ -1386,7 +1385,7 @@ describe('<webview> tag', function () {
           })
         })
 
-        w.loadURL(`file://${fixtures}/pages/webview-in-page-navigate.html`)
+        w.loadFile(path.join(fixtures, 'pages', 'webview-in-page-navigate.html'))
 
         return promise
       })
@@ -1399,7 +1398,7 @@ describe('<webview> tag', function () {
           zoomFactor: 1.2
         }
       })
-      w.loadURL(`file://${fixtures}/pages/webview-origin-zoom-level.html`)
+      w.loadFile(path.join(fixtures, 'pages', 'webview-origin-zoom-level.html'))
 
       const [, zoomLevel] = await emittedOnce(ipcMain, 'webview-origin-zoom-level')
       expect(zoomLevel).to.equal(2.0)


### PR DESCRIPTION
##### Description of Change
Replace loadURL with loadFile when loading files in tests. Makes the code a bit more readable.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes