### PR TITLE
fix: webview.focus() should move page focus to webview

### DIFF
--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -366,6 +366,11 @@ const registerWebViewElement = function () {
     return internal.webContents
   }
 
+  // Focusing the webview should move page focus to the underlying iframe.
+  proto.focus = function () {
+    this.contentWindow.focus()
+  }
+
   window.WebView = webFrame.registerEmbedderCustomElement('webview', {
     prototype: proto
   })

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1302,8 +1302,9 @@ describe('<webview> tag', function () {
 
       await domReadySignal
 
+      // If this test fails, check if webview.focus() still works.
       const focusSignal = waitForEvent(webview, 'focus')
-      webview.contentWindow.focus()
+      webview.focus()
 
       await focusSignal
     })


### PR DESCRIPTION
##### Description of Change

Fix the problem that calling `webview.focus()` does not move focus to webview https://github.com/electron/electron/issues/14259#issuecomment-417921145.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Fix the problem that calling `webview.focus()` does not move focus to webview.