### PR TITLE
refactor: implement crashReporter.start() without the remote module

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -1,8 +1,11 @@
 'use strict'
 
+const { spawn } = require('child_process')
 const electron = require('electron')
 const { EventEmitter } = require('events')
 const fs = require('fs')
+const os = require('os')
+const path = require('path')
 const v8Util = process.atomBinding('v8_util')
 
 const { ipcMain, isPromise } = electron
@@ -394,6 +397,42 @@ ipcMain.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
     window.close()
   }
   event.returnValue = null
+})
+
+const getTempDirectory = function () {
+  try {
+    return electron.app.getPath('temp')
+  } catch (error) {
+    return os.tmpdir()
+  }
+}
+
+ipcMain.on('ELECTRON_CRASH_REPORTER_INIT', function (event, options) {
+  const productName = options.productName || electron.app.getName()
+  const crashesDirectory = path.join(getTempDirectory(), `${productName} Crashes`)
+
+  if (process.platform === 'win32') {
+    const env = {
+      ELECTRON_INTERNAL_CRASH_SERVICE: 1
+    }
+    const args = [
+      '--reporter-url=' + options.submitURL,
+      '--application-name=' + productName,
+      '--crashes-directory=' + crashesDirectory,
+      '--v=1'
+    ]
+
+    spawn(process.helperExecPath, args, {
+      env,
+      detached: true
+    })
+  }
+
+  event.returnValue = {
+    productName,
+    crashesDirectory,
+    appVersion: electron.app.getVersion()
+  }
 })
 
 ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -1,18 +1,29 @@
 'use strict'
 
-const { spawn } = require('child_process')
-const os = require('os')
-const path = require('path')
 const electron = require('electron')
-const { app } = process.type === 'browser' ? electron : electron.remote
 const binding = process.atomBinding('crash_reporter')
 
+const sendSync = function (channel, ...args) {
+  if (process.type === 'browser') {
+    let event = {}
+    electron.ipcMain.emit(channel, event, ...args)
+    return event.returnValue
+  } else {
+    return electron.ipcRenderer.sendSync(channel, ...args)
+  }
+}
+
 class CrashReporter {
+  contructor () {
+    this.productName = null
+    this.crashesDirectory = null
+  }
+
   start (options) {
     if (options == null) options = {}
-    this.productName = options.productName != null ? options.productName : app.getName()
 
     let {
+      productName,
       companyName,
       extra,
       ignoreSystemCrashHandler,
@@ -24,12 +35,9 @@ class CrashReporter {
       uploadToServer = true
     }
 
-    if (ignoreSystemCrashHandler == null) ignoreSystemCrashHandler = false
-    if (extra == null) extra = {}
-
-    if (extra._productName == null) extra._productName = this.getProductName()
-    if (extra._companyName == null) extra._companyName = companyName
-    if (extra._version == null) extra._version = app.getVersion()
+    if (ignoreSystemCrashHandler == null) {
+      ignoreSystemCrashHandler = false
+    }
 
     if (companyName == null) {
       throw new Error('companyName is a required option to crashReporter.start')
@@ -38,24 +46,20 @@ class CrashReporter {
       throw new Error('submitURL is a required option to crashReporter.start')
     }
 
-    if (process.platform === 'win32') {
-      const env = {
-        ELECTRON_INTERNAL_CRASH_SERVICE: 1
-      }
-      const args = [
-        '--reporter-url=' + submitURL,
-        '--application-name=' + this.getProductName(),
-        '--crashes-directory=' + this.getCrashesDirectory(),
-        '--v=1'
-      ]
+    const ret = sendSync('ELECTRON_CRASH_REPORTER_INIT', {
+      submitURL,
+      productName
+    })
 
-      this._crashServiceProcess = spawn(process.execPath, args, {
-        env: env,
-        detached: true
-      })
-    }
+    this.productName = ret.productName
+    this.crashesDirectory = ret.crashesDirectory
 
-    binding.start(this.getProductName(), companyName, submitURL, this.getCrashesDirectory(), uploadToServer, ignoreSystemCrashHandler, extra)
+    if (extra == null) extra = {}
+    if (extra._productName == null) extra._productName = ret.productName
+    if (extra._companyName == null) extra._companyName = companyName
+    if (extra._version == null) extra._version = ret.appVersion
+
+    binding.start(ret.productName, companyName, submitURL, ret.crashesDirectory, uploadToServer, ignoreSystemCrashHandler, extra)
   }
 
   getLastCrashReport () {
@@ -74,26 +78,11 @@ class CrashReporter {
   }
 
   getCrashesDirectory () {
-    const crashesDir = `${this.getProductName()} Crashes`
-    return path.join(this.getTempDirectory(), crashesDir)
+    return this.crashesDirectory
   }
 
   getProductName () {
-    if (this.productName == null) {
-      this.productName = app.getName()
-    }
     return this.productName
-  }
-
-  getTempDirectory () {
-    if (this.tempDirectory == null) {
-      try {
-        this.tempDirectory = app.getPath('temp')
-      } catch (error) {
-        this.tempDirectory = os.tmpdir()
-      }
-    }
-    return this.tempDirectory
   }
 
   getUploadToServer () {

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -204,13 +204,6 @@ describe('crashReporter module', () => {
     })
   })
 
-  describe('getTempDirectory', () => {
-    it('returns temp directory for app if one is specified', () => {
-      const tempDir = crashReporter.getTempDirectory()
-      assert.strictEqual(tempDir, app.getPath('temp'))
-    })
-  })
-
   describe('start(options)', () => {
     it('requires that the companyName and submitURL options be specified', () => {
       assert.throws(() => {


### PR DESCRIPTION
##### Description of Change
The `crashReporter.start()` method depends on the `remote` module when used in the renderer process. There is a PR, which adds the ability to disable the remote module to increase security, especially in the sandbox https://github.com/electron/electron/pull/13028. To enable this work, we need to implement this method by sending specialized IPC messages instead of using the remote module, which allows more fine gained validation of the IPCs to make sure they cannot be exploited.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes