### PR TITLE
refactor: refactor dialogs to take options objects

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -8,7 +8,7 @@ An example of showing a dialog to select multiple files and directories:
 
 ```javascript
 const {dialog} = require('electron')
-console.log(dialog.showOpenDialog({properties: ['openFile', 'openDirectory', 'multiSelections']}))
+console.log(dialog.showOpenDialog({options = {properties: ['openFile', 'openDirectory', 'multiSelections']}}))
 ```
 
 The Dialog is opened from Electron's main thread. If you want to use the dialog
@@ -23,37 +23,38 @@ console.log(dialog)
 
 The `dialog` module has the following methods:
 
-### `dialog.showOpenDialog([browserWindow, ]options[, callback])`
+### `dialog.showOpenDialog(opts)`
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
-* `options` Object
-  * `title` String (optional)
-  * `defaultPath` String (optional)
-  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
-    left empty the default label will be used.
-  * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `properties` String[] (optional) - Contains which features the dialog should
-    use. The following values are supported:
-    * `openFile` - Allow files to be selected.
-    * `openDirectory` - Allow directories to be selected.
-    * `multiSelections` - Allow multiple paths to be selected.
-    * `showHiddenFiles` - Show hidden files in dialog.
-    * `createDirectory` _macOS_ - Allow creating new directories from dialog.
-    * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
-      in the dialog does not exist. This does not actually create the file at
-      the path but allows non-existent paths to be returned that should be
-      created by the application.
-    * `noResolveAliases` _macOS_ - Disable the automatic alias (symlink) path
-      resolution. Selected aliases will now return the alias path instead of
-      their target path.
-    * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
-      as a directory instead of a file.
-  * `message` String (optional) _macOS_ - Message to display above input
-    boxes.
-  * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
-* `callback` Function (optional)
-  * `filePaths` String[] - An array of file paths chosen by the user
-  * `bookmarks` String[] _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated.
+* `opts` Object
+  * `browserWindow` [BrowserWindow](browser-window.md) (optional)
+  * `options` Object (optional)
+    * `title` String (optional)
+    * `defaultPath` String (optional)
+    * `buttonLabel` String (optional) - Custom label for the confirmation button, when
+      left empty the default label will be used.
+    * `filters` [FileFilter[]](structures/file-filter.md) (optional)
+    * `properties` String[] (optional) - Contains which features the dialog should
+      use. The following values are supported:
+      * `openFile` - Allow files to be selected.
+      * `openDirectory` - Allow directories to be selected.
+      * `multiSelections` - Allow multiple paths to be selected.
+      * `showHiddenFiles` - Show hidden files in dialog.
+      * `createDirectory` _macOS_ - Allow creating new directories from dialog.
+      * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
+        in the dialog does not exist. This does not actually create the file at
+        the path but allows non-existent paths to be returned that should be
+        created by the application.
+      * `noResolveAliases` _macOS_ - Disable the automatic alias (symlink) path
+        resolution. Selected aliases will now return the alias path instead of
+        their target path.
+      * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
+        as a directory instead of a file.
+    * `message` String (optional) _macOS_ - Message to display above input
+      boxes.
+    * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
+  * `callback` Function (optional)
+    * `filePaths` String[] - An array of file paths chosen by the user
+    * `bookmarks` String[] _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated.
 
 Returns `String[]`, an array of file paths chosen by the user,
 if the callback is provided it returns `undefined`.
@@ -86,25 +87,26 @@ and a directory selector, so if you set `properties` to
 `['openFile', 'openDirectory']` on these platforms, a directory selector will be
 shown.
 
-### `dialog.showSaveDialog([browserWindow, ]options[, callback])`
+### `dialog.showSaveDialog(opts)`
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
-* `options` Object
-  * `title` String (optional)
-  * `defaultPath` String (optional) - Absolute directory path, absolute file
-    path, or file name to use by default.
-  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
-    left empty the default label will be used.
-  * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `message` String (optional) _macOS_ - Message to display above text fields.
-  * `nameFieldLabel` String (optional) _macOS_ - Custom label for the text
-    displayed in front of the filename text field.
-  * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
-    defaults to `true`.
-  * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
-* `callback` Function (optional)
-  * `filename` String
-  * `bookmark` String _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present.
+* `opts` Object
+  * `browserWindow` [BrowserWindow](browser-window.md) (optional)
+  * `options` Object (optional)
+    * `title` String (optional)
+    * `defaultPath` String (optional) - Absolute directory path, absolute file
+      path, or file name to use by default.
+    * `buttonLabel` String (optional) - Custom label for the confirmation button, when
+      left empty the default label will be used.
+    * `filters` [FileFilter[]](structures/file-filter.md) (optional)
+    * `message` String (optional) _macOS_ - Message to display above text fields.
+    * `nameFieldLabel` String (optional) _macOS_ - Custom label for the text
+      displayed in front of the filename text field.
+    * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
+      defaults to `true`.
+    * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
+  * `callback` Function (optional)
+    * `filename` String
+    * `bookmark` String _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present.
 
 Returns `String`, the path of the file chosen by the user,
 if a callback is provided it returns `undefined`.
@@ -117,48 +119,49 @@ The `filters` specifies an array of file types that can be displayed, see
 If a `callback` is passed, the API call will be asynchronous and the result
 will be passed via `callback(filename)`.
 
-### `dialog.showMessageBox([browserWindow, ]options[, callback])`
+### `dialog.showMessageBox(opts)`
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
-* `options` Object
-  * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
-  `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
-  you set an icon using the `"icon"` option. On macOS, both `"warning"` and
-  `"error"` display the same warning icon.
-  * `buttons` String[] (optional) - Array of texts for buttons. On Windows, an empty array
-    will result in one button labeled "OK".
-  * `defaultId` Integer (optional) - Index of the button in the buttons array which will
-    be selected by default when the message box opens.
-  * `title` String (optional) - Title of the message box, some platforms will not show it.
-  * `message` String - Content of the message box.
-  * `detail` String (optional) - Extra information of the message.
-  * `checkboxLabel` String (optional) - If provided, the message box will
-    include a checkbox with the given label. The checkbox state can be
-    inspected only when using `callback`.
-  * `checkboxChecked` Boolean (optional) - Initial checked state of the
-    checkbox. `false` by default.
-  * `icon` [NativeImage](native-image.md) (optional)
-  * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
-    the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
-    label. If no such labeled buttons exist and this option is not set, `0` will be used as the
-    return value or callback response.
-  * `noLink` Boolean (optional) - On Windows Electron will try to figure out which one of
-    the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
-    others as command links in the dialog. This can make the dialog appear in
-    the style of modern Windows apps. If you don't like this behavior, you can
-    set `noLink` to `true`.
-  * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
-    across platforms. Default is `false`. Enabling this assumes `&` is used in
-    the button labels for the placement of the keyboard shortcut access key
-    and labels will be converted so they work correctly on each platform, `&`
-    characters are removed on macOS, converted to `_` on Linux, and left
-    untouched on Windows. For example, a button label of `Vie&w` will be
-    converted to `Vie_w` on Linux and `View` on macOS and can be selected
-    via `Alt-W` on Windows and Linux.
-* `callback` Function (optional)
-  * `response` Number - The index of the button that was clicked.
-  * `checkboxChecked` Boolean - The checked state of the checkbox if
-    `checkboxLabel` was set. Otherwise `false`.
+* `opts` Object
+  * `browserWindow` [BrowserWindow](browser-window.md) (optional)
+  * `options` Object (optional)
+    * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
+    `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
+    you set an icon using the `"icon"` option. On macOS, both `"warning"` and
+    `"error"` display the same warning icon.
+    * `buttons` String[] (optional) - Array of texts for buttons. On Windows, an empty array
+      will result in one button labeled "OK".
+    * `defaultId` Integer (optional) - Index of the button in the buttons array which will
+      be selected by default when the message box opens.
+    * `title` String (optional) - Title of the message box, some platforms will not show it.
+    * `message` String - Content of the message box.
+    * `detail` String (optional) - Extra information of the message.
+    * `checkboxLabel` String (optional) - If provided, the message box will
+      include a checkbox with the given label. The checkbox state can be
+      inspected only when using `callback`.
+    * `checkboxChecked` Boolean (optional) - Initial checked state of the
+      checkbox. `false` by default.
+    * `icon` [NativeImage](native-image.md) (optional)
+    * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
+      the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
+      label. If no such labeled buttons exist and this option is not set, `0` will be used as the
+      return value or callback response.
+    * `noLink` Boolean (optional) - On Windows Electron will try to figure out which one of
+      the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
+      others as command links in the dialog. This can make the dialog appear in
+      the style of modern Windows apps. If you don't like this behavior, you can
+      set `noLink` to `true`.
+    * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
+      across platforms. Default is `false`. Enabling this assumes `&` is used in
+      the button labels for the placement of the keyboard shortcut access key
+      and labels will be converted so they work correctly on each platform, `&`
+      characters are removed on macOS, converted to `_` on Linux, and left
+      untouched on Windows. For example, a button label of `Vie&w` will be
+      converted to `Vie_w` on Linux and `View` on macOS and can be selected
+      via `Alt-W` on Windows and Linux.
+  * `callback` Function (optional)
+    * `response` Number - The index of the button that was clicked.
+    * `checkboxChecked` Boolean - The checked state of the checkbox if
+      `checkboxLabel` was set. Otherwise `false`.
 
 Returns `Integer`, the index of the clicked button, if a callback is provided
 it returns undefined.
@@ -183,13 +186,14 @@ it is usually used to report errors in early stage of startup. If called
 before the app `ready`event on Linux, the message will be emitted to stderr,
 and no GUI dialog will appear.
 
-### `dialog.showCertificateTrustDialog([browserWindow, ]options, callback)` _macOS_ _Windows_
+### `dialog.showCertificateTrustDialog(opts)` _macOS_ _Windows_
 
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
-* `options` Object
-  * `certificate` [Certificate](structures/certificate.md) - The certificate to trust/import.
-  * `message` String - The message to display to the user.
-* `callback` Function
+* `opts` Object
+  * `browserWindow` [BrowserWindow](browser-window.md) (optional)
+  * `options` Object
+    * `certificate` [Certificate](structures/certificate.md) - The certificate to trust/import.
+    * `message` String - The message to display to the user.
+  * `callback` Function
 
 On macOS, this displays a modal dialog that shows a message and certificate
 information, and gives the user the option of trusting/importing the

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -8,7 +8,7 @@ An example of showing a dialog to select multiple files and directories:
 
 ```javascript
 const {dialog} = require('electron')
-console.log(dialog.showOpenDialog({options = {properties: ['openFile', 'openDirectory', 'multiSelections']}}))
+console.log(dialog.showOpenDialog({options: {properties: ['openFile', 'openDirectory', 'multiSelections']}}))
 ```
 
 The Dialog is opened from Electron's main thread. If you want to use the dialog

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -21,7 +21,7 @@ const messageBoxOptions = {
   noLink: 1 << 0
 }
 
-const normalizeAccessKey = (text) => {
+const normalizeAccessKey = text => {
   if (typeof text !== 'string') return text
 
   // macOS does not have access keys so remove single ampersands
@@ -44,14 +44,14 @@ const normalizeAccessKey = (text) => {
   return text
 }
 
-const checkAppInitialized = function () {
+const checkAppInitialized = () => {
   if (!app.isReady()) {
     throw new Error('dialog module can only be used after app is ready')
   }
 }
 
 module.exports = {
-  showOpenDialog: function (opts) {
+  showOpenDialog: opts => {
     checkAppInitialized()
 
     // destructure params with default options value
@@ -73,9 +73,9 @@ module.exports = {
       throw new TypeError('Properties must be an array')
     }
 
-    for (const p in {buttonLabel, defaultPath, title, message}) {
-      if (typeof p !== 'string') {
-        throw new TypeError(`${p} must be a string`)
+    for (const [name, value] of Object.entries({buttonLabel, defaultPath, title, message})) {
+      if (typeof value !== 'string') {
+        throw new TypeError(`${name} must be a string`)
       }
     }
 
@@ -100,7 +100,7 @@ module.exports = {
     return binding.showOpenDialog(settings, wrappedCallback)
   },
 
-  showSaveDialog: function (opts) {
+  showSaveDialog: opts => {
     checkAppInitialized()
 
     // destructure params with default options value
@@ -119,9 +119,9 @@ module.exports = {
     } = options
 
     // check correct options types
-    for (const p in {title, buttonLabel, defaultPath, message, nameFieldLabel}) {
-      if (typeof p !== 'string') {
-        throw new TypeError(`${p} must be a string`)
+    for (const [name, value] of Object.entries({title, buttonLabel, defaultPath, message, nameFieldLabel})) {
+      if (typeof value !== 'string') {
+        throw new TypeError(`${name} must be a string`)
       }
     }
 
@@ -137,7 +137,7 @@ module.exports = {
     return binding.showSaveDialog(settings, wrappedCallback)
   },
 
-  showMessageBox: function (opts) {
+  showMessageBox: opts => {
     checkAppInitialized()
 
     // destructure params with default options value
@@ -166,9 +166,9 @@ module.exports = {
       throw new TypeError('Buttons must be an array')
     }
 
-    for (const prop in {title, message, detail, checkboxLabel}) {
-      if (typeof prop !== 'string') {
-        throw new TypeError(`${prop} must be a string`)
+    for (const [name, value] of Object.entries({title, message, detail, checkboxLabel})) {
+      if (typeof value !== 'string') {
+        throw new TypeError(`${name} must be a string`)
       }
     }
 
@@ -200,7 +200,9 @@ module.exports = {
     return binding.showErrorBox(...args)
   },
 
-  showCertificateTrustDialog: function (opts) {
+  showCertificateTrustDialog: (opts) => {
+    if (opts == null) throw new Error('Insufficient number of arguments')
+
     // destructure params with default options value
     let {window, options = {}, callback} = opts
 

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -208,7 +208,7 @@ module.exports = {
       throw new TypeError('options must be an object')
     }
 
-    let {certificate, message = ''} = options
+    let {certificate = {}, message = ''} = options
 
     // check correct options types
     if (typeof certificate !== 'object') {

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {app, BrowserWindow} = require('electron')
+const {app} = require('electron')
 const binding = process.atomBinding('dialog')
 const v8Util = process.atomBinding('v8_util')
 
@@ -19,26 +19,6 @@ const messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']
 
 const messageBoxOptions = {
   noLink: 1 << 0
-}
-
-const parseArgs = function (window, options, callback, ...args) {
-  if (window != null && window.constructor !== BrowserWindow) {
-    // Shift.
-    [callback, options, window] = [options, window, null]
-  }
-
-  if ((callback == null) && typeof options === 'function') {
-    // Shift.
-    [callback, options] = [options, null]
-  }
-
-  // Fallback to using very last argument as the callback function
-  const lastArgument = args[args.length - 1]
-  if ((callback == null) && typeof lastArgument === 'function') {
-    callback = lastArgument
-  }
-
-  return [window, options, callback]
 }
 
 const normalizeAccessKey = (text) => {
@@ -71,26 +51,35 @@ const checkAppInitialized = function () {
 }
 
 module.exports = {
-  showOpenDialog: function (...args) {
+  showOpenDialog: function (opts) {
     checkAppInitialized()
 
-    let [window, options, callback] = parseArgs(...args)
+    // destructure params with default options value
+    let {window, options = {title: 'Open', properties: ['openFile']}, callback} = opts
 
-    if (options == null) {
-      options = {
-        title: 'Open',
-        properties: ['openFile']
-      }
-    }
+    // destructure individual options with defaults
+    let {
+      buttonLabel = '',
+      defaultPath = '',
+      filters = [],
+      properties = ['openFile'],
+      title = '',
+      message = '',
+      securityScopedBookmarks = false
+    } = options
 
-    let {buttonLabel, defaultPath, filters, properties, title, message, securityScopedBookmarks = false} = options
-
-    if (properties == null) {
-      properties = ['openFile']
-    } else if (!Array.isArray(properties)) {
+    // check correct options types
+    if (!Array.isArray(properties)) {
       throw new TypeError('Properties must be an array')
     }
 
+    for (const p in {buttonLabel, defaultPath, title, message}) {
+      if (typeof p !== 'string') {
+        throw new TypeError(`${p} must be a string`)
+      }
+    }
+
+    // populate fileDialogProperties
     let dialogProperties = 0
     for (const prop in fileDialogProperties) {
       if (properties.includes(prop)) {
@@ -98,168 +87,96 @@ module.exports = {
       }
     }
 
-    if (title == null) {
-      title = ''
-    } else if (typeof title !== 'string') {
-      throw new TypeError('Title must be a string')
+    // set up callback if one passed
+    let wrappedCallback = null
+    if (typeof callback === 'function') {
+      wrappedCallback = (success, result, bookmarkData) => {
+        return success ? callback(result, bookmarkData) : callback()
+      }
     }
 
-    if (buttonLabel == null) {
-      buttonLabel = ''
-    } else if (typeof buttonLabel !== 'string') {
-      throw new TypeError('Button label must be a string')
-    }
-
-    if (defaultPath == null) {
-      defaultPath = ''
-    } else if (typeof defaultPath !== 'string') {
-      throw new TypeError('Default path must be a string')
-    }
-
-    if (filters == null) {
-      filters = []
-    }
-
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
-      throw new TypeError('Message must be a string')
-    }
-
-    const wrappedCallback = typeof callback === 'function' ? function (success, result, bookmarkData) {
-      return success ? callback(result, bookmarkData) : callback()
-    } : null
     const settings = {title, buttonLabel, defaultPath, filters, message, securityScopedBookmarks, window}
     settings.properties = dialogProperties
     return binding.showOpenDialog(settings, wrappedCallback)
   },
 
-  showSaveDialog: function (...args) {
+  showSaveDialog: function (opts) {
     checkAppInitialized()
 
-    let [window, options, callback] = parseArgs(...args)
+    // destructure params with default options value
+    let {window, options = {title: 'Save'}, callback} = opts
 
-    if (options == null) {
-      options = {
-        title: 'Save'
+    // destructure individual options with defaults
+    let {
+      buttonLabel = '',
+      defaultPath = '',
+      filters = [],
+      title = '',
+      message = '',
+      securityScopedBookmarks = false,
+      nameFieldLabel = '',
+      showsTagField = true
+    } = options
+
+    // check correct options types
+    for (const p in {title, buttonLabel, defaultPath, message, nameFieldLabel}) {
+      if (typeof p !== 'string') {
+        throw new TypeError(`${p} must be a string`)
       }
     }
 
-    let {buttonLabel, defaultPath, filters, title, message, securityScopedBookmarks = false, nameFieldLabel, showsTagField} = options
-
-    if (title == null) {
-      title = ''
-    } else if (typeof title !== 'string') {
-      throw new TypeError('Title must be a string')
+    // set up callback if one passed
+    let wrappedCallback = null
+    if (typeof callback === 'function') {
+      wrappedCallback = (success, result, bookmarkData) => {
+        return success ? callback(result, bookmarkData) : callback()
+      }
     }
 
-    if (buttonLabel == null) {
-      buttonLabel = ''
-    } else if (typeof buttonLabel !== 'string') {
-      throw new TypeError('Button label must be a string')
-    }
-
-    if (defaultPath == null) {
-      defaultPath = ''
-    } else if (typeof defaultPath !== 'string') {
-      throw new TypeError('Default path must be a string')
-    }
-
-    if (filters == null) {
-      filters = []
-    }
-
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
-      throw new TypeError('Message must be a string')
-    }
-
-    if (nameFieldLabel == null) {
-      nameFieldLabel = ''
-    } else if (typeof nameFieldLabel !== 'string') {
-      throw new TypeError('Name field label must be a string')
-    }
-
-    if (showsTagField == null) {
-      showsTagField = true
-    }
-
-    const wrappedCallback = typeof callback === 'function' ? function (success, result, bookmarkData) {
-      return success ? callback(result, bookmarkData) : callback()
-    } : null
     const settings = {title, buttonLabel, defaultPath, filters, message, securityScopedBookmarks, nameFieldLabel, showsTagField, window}
     return binding.showSaveDialog(settings, wrappedCallback)
   },
 
-  showMessageBox: function (...args) {
+  showMessageBox: function (opts) {
     checkAppInitialized()
 
-    let [window, options, callback] = parseArgs(...args)
-
-    if (options == null) {
-      options = {
-        type: 'none'
-      }
-    }
+    // destructure params with default options value
+    let {window, options = {type: 'none'}, callback} = opts
 
     let {
-      buttons, cancelId, checkboxLabel, checkboxChecked, defaultId, detail,
-      icon, message, title, type
+      buttons = [],
+      cancelId,
+      checkboxLabel = '',
+      checkboxChecked,
+      defaultId = -1,
+      detail = '',
+      icon,
+      message = '',
+      title = '',
+      type = 'none'
     } = options
 
-    if (type == null) {
-      type = 'none'
-    }
-
+    // check correct options types
     const messageBoxType = messageBoxTypes.indexOf(type)
     if (messageBoxType === -1) {
       throw new TypeError('Invalid message box type')
     }
 
-    if (buttons == null) {
-      buttons = []
-    } else if (!Array.isArray(buttons)) {
+    if (!Array.isArray(buttons)) {
       throw new TypeError('Buttons must be an array')
+    }
+
+    for (const prop in {title, message, detail, checkboxLabel}) {
+      if (typeof prop !== 'string') {
+        throw new TypeError(`${prop} must be a string`)
+      }
     }
 
     if (options.normalizeAccessKeys) {
       buttons = buttons.map(normalizeAccessKey)
     }
 
-    if (title == null) {
-      title = ''
-    } else if (typeof title !== 'string') {
-      throw new TypeError('Title must be a string')
-    }
-
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
-      throw new TypeError('Message must be a string')
-    }
-
-    if (detail == null) {
-      detail = ''
-    } else if (typeof detail !== 'string') {
-      throw new TypeError('Detail must be a string')
-    }
-
     checkboxChecked = !!checkboxChecked
-
-    if (checkboxLabel == null) {
-      checkboxLabel = ''
-    } else if (typeof checkboxLabel !== 'string') {
-      throw new TypeError('checkboxLabel must be a string')
-    }
-
-    if (icon == null) {
-      icon = null
-    }
-
-    if (defaultId == null) {
-      defaultId = -1
-    }
 
     // Choose a default button to get selected when dialog is cancelled.
     if (cancelId == null) {
@@ -283,21 +200,22 @@ module.exports = {
     return binding.showErrorBox(...args)
   },
 
-  showCertificateTrustDialog: function (...args) {
-    let [window, options, callback] = parseArgs(...args)
+  showCertificateTrustDialog: function (opts) {
+    // destructure params with default options value
+    let {window, options = {}, callback} = opts
 
-    if (options == null || typeof options !== 'object') {
+    if (typeof options !== 'object') {
       throw new TypeError('options must be an object')
     }
 
-    let {certificate, message} = options
-    if (certificate == null || typeof certificate !== 'object') {
+    let {certificate, message = ''} = options
+
+    // check correct options types
+    if (typeof certificate !== 'object') {
       throw new TypeError('certificate must be an object')
     }
 
-    if (message == null) {
-      message = ''
-    } else if (typeof message !== 'string') {
+    if (typeof message !== 'string') {
       throw new TypeError('message must be a string')
     }
 

--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -1,80 +1,80 @@
 const {expect} = require('chai')
 const {dialog} = require('electron').remote
 
-describe('dialog module', () => {
+describe.only('dialog module', () => {
   describe('showOpenDialog', () => {
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showOpenDialog({properties: false})
+        dialog.showOpenDialog({options: {properties: false}})
       }).to.throw(/Properties must be an array/)
 
       expect(() => {
-        dialog.showOpenDialog({title: 300})
-      }).to.throw(/Title must be a string/)
+        dialog.showOpenDialog({options: {title: 300}})
+      }).to.throw(/title must be a string/)
 
       expect(() => {
-        dialog.showOpenDialog({buttonLabel: []})
-      }).to.throw(/Button label must be a string/)
+        dialog.showOpenDialog({options: {buttonLabel: []}})
+      }).to.throw(/buttonLabel must be a string/)
 
       expect(() => {
-        dialog.showOpenDialog({defaultPath: {}})
-      }).to.throw(/Default path must be a string/)
+        dialog.showOpenDialog({options: {defaultPath: {}}})
+      }).to.throw(/defaultPath must be a string/)
 
       expect(() => {
-        dialog.showOpenDialog({message: {}})
-      }).to.throw(/Message must be a string/)
+        dialog.showOpenDialog({options: {message: {}}})
+      }).to.throw(/message must be a string/)
     })
   })
 
   describe('showSaveDialog', () => {
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showSaveDialog({title: 300})
-      }).to.throw(/Title must be a string/)
+        dialog.showSaveDialog({options: {title: 300}})
+      }).to.throw(/title must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({buttonLabel: []})
-      }).to.throw(/Button label must be a string/)
+        dialog.showSaveDialog({options: {buttonLabel: []}})
+      }).to.throw(/buttonLabel must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({defaultPath: {}})
-      }).to.throw(/Default path must be a string/)
+        dialog.showSaveDialog({options: {defaultPath: {}}})
+      }).to.throw(/defaultPath must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({message: {}})
-      }).to.throw(/Message must be a string/)
+        dialog.showSaveDialog({options: {message: {}}})
+      }).to.throw(/message must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({nameFieldLabel: {}})
-      }).to.throw(/Name field label must be a string/)
+        dialog.showSaveDialog({options: {nameFieldLabel: {}}})
+      }).to.throw(/nameFieldLabel must be a string/)
     })
   })
 
   describe('showMessageBox', () => {
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showMessageBox(undefined, {type: 'not-a-valid-type'})
+        dialog.showMessageBox({window: undefined, options: {type: 'not-a-valid-type'}})
       }).to.throw(/Invalid message box type/)
 
       expect(() => {
-        dialog.showMessageBox(null, {buttons: false})
-      }).to.throw(/Buttons must be an array/)
+        dialog.showMessageBox({window: null, options: {buttons: false}})
+      }).to.throw(/buttons must be an array/)
 
       expect(() => {
-        dialog.showMessageBox({title: 300})
-      }).to.throw(/Title must be a string/)
+        dialog.showMessageBox({options: {title: 300}})
+      }).to.throw(/title must be a string/)
 
       expect(() => {
-        dialog.showMessageBox({message: []})
-      }).to.throw(/Message must be a string/)
+        dialog.showMessageBox({options: {message: []}})
+      }).to.throw(/message must be a string/)
 
       expect(() => {
-        dialog.showMessageBox({detail: 3.14})
-      }).to.throw(/Detail must be a string/)
+        dialog.showMessageBox({options: {detail: 3.14}})
+      }).to.throw(/detail must be a string/)
 
       expect(() => {
-        dialog.showMessageBox({checkboxLabel: false})
-      }).to.throw(/checkboxLabel must be a string/)
+        dialog.showMessageBox({options: {checkboxLabel: false}})
+      }).to.throw(/checkboxLabe must be a string/)
     })
   })
 
@@ -101,11 +101,11 @@ describe('dialog module', () => {
       }).to.throw(/options must be an object/)
 
       expect(() => {
-        dialog.showCertificateTrustDialog({})
+        dialog.showCertificateTrustDialog({options: {}})
       }).to.throw(/certificate must be an object/)
 
       expect(() => {
-        dialog.showCertificateTrustDialog({certificate: {}, message: false})
+        dialog.showCertificateTrustDialog({options: {certificate: {}, message: false}})
       }).to.throw(/message must be a string/)
     })
   })

--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -1,7 +1,7 @@
 const {expect} = require('chai')
 const {dialog} = require('electron').remote
 
-describe.only('dialog module', () => {
+describe('dialog module', () => {
   describe('showOpenDialog', () => {
     it('throws errors when the options are invalid', () => {
       expect(() => {
@@ -58,7 +58,7 @@ describe.only('dialog module', () => {
 
       expect(() => {
         dialog.showMessageBox({window: null, options: {buttons: false}})
-      }).to.throw(/buttons must be an array/)
+      }).to.throw(/Buttons must be an array/)
 
       expect(() => {
         dialog.showMessageBox({options: {title: 300}})
@@ -74,7 +74,7 @@ describe.only('dialog module', () => {
 
       expect(() => {
         dialog.showMessageBox({options: {checkboxLabel: false}})
-      }).to.throw(/checkboxLabe must be a string/)
+      }).to.throw(/checkboxLabel must be a string/)
     })
   })
 
@@ -98,10 +98,14 @@ describe.only('dialog module', () => {
     it('throws errors when the options are invalid', () => {
       expect(() => {
         dialog.showCertificateTrustDialog()
+      }).to.throw(/Insufficient number of arguments/)
+
+      expect(() => {
+        dialog.showCertificateTrustDialog({options: 300})
       }).to.throw(/options must be an object/)
 
       expect(() => {
-        dialog.showCertificateTrustDialog({options: {}})
+        dialog.showCertificateTrustDialog({options: {certificate: 300}})
       }).to.throw(/certificate must be an object/)
 
       expect(() => {


### PR DESCRIPTION
##### Description of Change

🎥 Dialog refactor, Take 2: More Precise Changes Edition

This changes our dialog functions to take options objects instead of several options parameters, simplifying options parsing and improving code readability.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Refactor dialogs to take options objects as parameters