### PR TITLE
chore: pass tag correctly for bump commit reversion

### DIFF
--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -19,8 +19,8 @@ github.authenticate({
   token: process.env.ELECTRON_GITHUB_TOKEN
 })
 
-function getLastBumpCommit () {
-  const data = execSync(`git log -n1 --grep "Bump v[0-9.]*" --format="format:{hash: %H, message: '%s'}"`)
+function getLastBumpCommit (tag) {
+  const data = execSync(`git log -n1 --grep "Bump ${tag}" --format="format:{hash: %H, message: '%s'}"`)
   return JSON.parse(data)
 }
 
@@ -38,7 +38,7 @@ async function getCurrentBranch (gitDir) {
 
 async function revertBumpCommit (tag) {
   const branch = getCurrentBranch()
-  const commitToRevert = getLastBumpCommit().hash
+  const commitToRevert = getLastBumpCommit(tag).hash
   await GitProcess.exec(['revert', commitToRevert], gitDir)
   const pushDetails = await GitProcess.exec(['push', 'origin', `HEAD:${branch}`, '--follow-tags'], gitDir)
   if (pushDetails.exitCode === 0) {
@@ -100,7 +100,7 @@ async function cleanReleaseArtifacts () {
   }
 
   await deleteTag(tag, 'electron')
-  await revertBumpCommit()
+  await revertBumpCommit(tag)
 
   console.log('Failed release artifact cleanup complete')
 }


### PR DESCRIPTION
##### Description of Change

Fix tag passing in `getLastBumpCommit` and grep for bump commit by exact date instead of regex to prevent previous tags from accidentally being reverted.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes