### PR TITLE
fix: deprecate lstatSyncNoException and statSyncNoException

### DIFF
--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -94,6 +94,10 @@ deprecate.removeProperty = (object, deprecatedName) => {
   }
 }
 
+deprecate.removeFunction = (deprecatedName) => {
+  return deprecate.log(`'${deprecatedName}' function has been deprecated and marked for removal.`)
+}
+
 // Replace the old name of a property
 deprecate.renameProperty = (object, deprecatedName, newName) => {
   let warned = false

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -3,6 +3,7 @@
   const {Buffer} = require('buffer')
   const childProcess = require('child_process')
   const path = require('path')
+  const {deprecate} = require('electron')
   const util = require('util')
 
   const hasProp = {}.hasOwnProperty
@@ -252,6 +253,15 @@
       fs.writeSync(logFDs[asarPath], offset + ': ' + filePath + '\n')
     }
 
+    // deprecate lstatSyncNoException
+    const {lstatSyncNoException} = fs
+    fs.lstatSyncNoException = p => {
+      if (!process.noDeprecations) {
+        deprecate.removeFunction('fs.lstatSyncNoException')
+      }
+      return lstatSyncNoException(p)
+    }
+
     const {lstatSync} = fs
     fs.lstatSync = function (p) {
       const [isAsar, asarPath, filePath] = splitPath(p)
@@ -314,6 +324,10 @@
 
     const {statSyncNoException} = fs
     fs.statSyncNoException = function (p) {
+      if (!process.noDeprecations) {
+        deprecate.removeFunction('fs.statSyncNoException')
+      }
+
       const [isAsar, asarPath, filePath] = splitPath(p)
       if (!isAsar) {
         return statSyncNoException(p)


### PR DESCRIPTION
##### Description of Change

Fixes https://github.com/electron/electron/issues/14451. What it says on the tin.

/cc @ckerr @alexeykuzmin 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: deprecate lstatSyncNoException and statSyncNoException