### PR TITLE
feat: add process.takeHeapSnapshot() / webContents.takeHeapSnapshot()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -250,6 +250,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // the specified URL.
   void GrantOriginAccess(const GURL& url);
 
+  bool TakeHeapSnapshot(const base::FilePath& file_path,
+                        const std::string& channel);
+
   // Properties.
   int32_t ID() const;
   v8::Local<v8::Value> Session(v8::Isolate* isolate);

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -10,6 +10,7 @@
 #include "content/public/common/common_param_traits.h"
 #include "content/public/common/referrer.h"
 #include "ipc/ipc_message_macros.h"
+#include "ipc/ipc_platform_file.h"
 #include "ui/gfx/geometry/rect_f.h"
 #include "ui/gfx/ipc/gfx_param_traits.h"
 #include "url/gurl.h"
@@ -76,3 +77,7 @@ IPC_SYNC_MESSAGE_ROUTED0_1(AtomFrameHostMsg_GetZoomLevel, double /* result */)
 IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_PDFSaveURLAs,
                     GURL /* url */,
                     content::Referrer /* referrer */)
+
+IPC_MESSAGE_ROUTED2(AtomFrameMsg_TakeHeapSnapshot,
+                    IPC::PlatformFileForTransit /* file_handle */,
+                    std::string /* channel */)

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -11,12 +11,15 @@
 #include "atom/common/api/locker.h"
 #include "atom/common/atom_version.h"
 #include "atom/common/chrome_version.h"
+#include "atom/common/heap_snapshot.h"
+#include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/node_includes.h"
 #include "base/logging.h"
 #include "base/process/process_info.h"
 #include "base/process/process_metrics_iocounters.h"
 #include "base/sys_info.h"
+#include "base/threading/thread_restrictions.h"
 #include "native_mate/dictionary.h"
 
 namespace atom {
@@ -60,6 +63,7 @@ void AtomBindings::BindTo(v8::Isolate* isolate, v8::Local<v8::Object> process) {
   dict.SetMethod("getCPUUsage", base::Bind(&AtomBindings::GetCPUUsage,
                                            base::Unretained(metrics_.get())));
   dict.SetMethod("getIOCounters", &GetIOCounters);
+  dict.SetMethod("takeHeapSnapshot", &TakeHeapSnapshot);
 #if defined(OS_POSIX)
   dict.SetMethod("setFdLimit", &base::SetFdLimit);
 #endif
@@ -236,6 +240,17 @@ v8::Local<v8::Value> AtomBindings::GetIOCounters(v8::Isolate* isolate) {
   }
 
   return dict.GetHandle();
+}
+
+// static
+bool AtomBindings::TakeHeapSnapshot(v8::Isolate* isolate,
+                                    const base::FilePath& file_path) {
+  base::ThreadRestrictions::ScopedAllowIO allow_io;
+
+  base::File file(file_path,
+                  base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE);
+
+  return atom::TakeHeapSnapshot(isolate, &file);
 }
 
 }  // namespace atom

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -8,6 +8,7 @@
 #include <list>
 #include <memory>
 
+#include "base/files/file_path.h"
 #include "base/macros.h"
 #include "base/process/process_metrics.h"
 #include "base/strings/string16.h"
@@ -43,6 +44,8 @@ class AtomBindings {
   static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,
                                           v8::Isolate* isolate);
   static v8::Local<v8::Value> GetIOCounters(v8::Isolate* isolate);
+  static bool TakeHeapSnapshot(v8::Isolate* isolate,
+                               const base::FilePath& file_path);
 
  private:
   void ActivateUVLoop(v8::Isolate* isolate);

--- a/atom/common/heap_snapshot.cc
+++ b/atom/common/heap_snapshot.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/heap_snapshot.h"
+
+#include "v8/include/v8-profiler.h"
+
+namespace {
+
+class HeapSnapshotOutputStream : public v8::OutputStream {
+ public:
+  explicit HeapSnapshotOutputStream(base::File* file) : file_(file) {
+    DCHECK(file_);
+  }
+
+  bool IsComplete() const { return is_complete_; }
+
+  // v8::OutputStream
+  int GetChunkSize() override { return 65536; }
+  void EndOfStream() override { is_complete_ = true; }
+
+  v8::OutputStream::WriteResult WriteAsciiChunk(char* data, int size) override {
+    auto bytes_written = file_->WriteAtCurrentPos(data, size);
+    return bytes_written == size ? kContinue : kAbort;
+  }
+
+ private:
+  base::File* file_ = nullptr;
+  bool is_complete_ = false;
+};
+
+}  // namespace
+
+namespace atom {
+
+bool TakeHeapSnapshot(v8::Isolate* isolate, base::File* file) {
+  DCHECK(isolate);
+  DCHECK(file);
+
+  if (!file->IsValid())
+    return false;
+
+  auto* snapshot = isolate->GetHeapProfiler()->TakeHeapSnapshot();
+  if (!snapshot)
+    return false;
+
+  HeapSnapshotOutputStream stream(file);
+  snapshot->Serialize(&stream, v8::HeapSnapshot::kJSON);
+
+  const_cast<v8::HeapSnapshot*>(snapshot)->Delete();
+
+  return stream.IsComplete();
+}
+
+}  // namespace atom

--- a/atom/common/heap_snapshot.h
+++ b/atom/common/heap_snapshot.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_HEAP_SNAPSHOT_H_
+#define ATOM_COMMON_HEAP_SNAPSHOT_H_
+
+#include "base/files/file.h"
+#include "v8/include/v8.h"
+
+namespace atom {
+
+bool TakeHeapSnapshot(v8::Isolate* isolate, base::File* file);
+
+}  // namespace atom
+
+#endif  // ATOM_COMMON_HEAP_SNAPSHOT_H_

--- a/atom/renderer/atom_render_frame_observer.h
+++ b/atom/renderer/atom_render_frame_observer.h
@@ -10,6 +10,7 @@
 #include "atom/renderer/renderer_client_base.h"
 #include "base/strings/string16.h"
 #include "content/public/renderer/render_frame_observer.h"
+#include "ipc/ipc_platform_file.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 namespace base {
@@ -57,6 +58,8 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
                         const std::string& channel,
                         const base::ListValue& args,
                         int32_t sender_id);
+  void OnTakeHeapSnapshot(IPC::PlatformFileForTransit file_handle,
+                          const std::string& channel);
 
   content::RenderFrame* render_frame_;
   RendererClientBase* renderer_client_;

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -171,6 +171,14 @@ Returns `Object`:
 Returns an object giving memory usage statistics about the entire system. Note
 that all statistics are reported in Kilobytes.
 
+### `process.takeHeapSnapshot(filePath)`
+
+* `filePath` String - Path to the output file.
+
+Returns `Boolean` - Indicates whether the snapshot has been created successfully.
+
+Takes a V8 heap snapshot and saves it to `filePath`.
+
 ### `process.hang()`
 
 Causes the main thread of the current process hang.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1497,6 +1497,14 @@ Returns `Integer` - The Chromium internal `pid` of the associated renderer. Can
 be compared to the `frameProcessId` passed by frame specific navigation events
 (e.g. `did-frame-navigate`)
 
+#### `contents.takeHeapSnapshot(filePath)`
+
+* `filePath` String - Path to the output file.
+
+Returns `Promise` - Indicates whether the snapshot has been created successfully.
+
+Takes a V8 heap snapshot and saves it to `filePath`.
+
 ### Instance Properties
 
 #### `contents.id`

--- a/filenames.gni
+++ b/filenames.gni
@@ -486,6 +486,8 @@ filenames = {
     "atom/common/draggable_region.cc",
     "atom/common/draggable_region.h",
     "atom/common/google_api_key.h",
+    "atom/common/heap_snapshot.cc",
+    "atom/common/heap_snapshot.h",
     "atom/common/key_weak_map.h",
     "atom/common/keyboard_util.cc",
     "atom/common/keyboard_util.h",

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -160,6 +160,22 @@ WebContents.prototype.executeJavaScript = function (code, hasUserGesture, callba
   }
 }
 
+WebContents.prototype.takeHeapSnapshot = function (filePath) {
+  return new Promise((resolve, reject) => {
+    const channel = `ELECTRON_TAKE_HEAP_SNAPSHOT_RESULT_${getNextId()}`
+    ipcMain.once(channel, (event, success) => {
+      if (success) {
+        resolve()
+      } else {
+        reject(new Error('takeHeapSnapshot failed'))
+      }
+    })
+    if (!this._takeHeapSnapshot(filePath, channel)) {
+      ipcMain.emit(channel, false)
+    }
+  })
+}
+
 // Translate the options of printToPDF.
 WebContents.prototype.printToPDF = function (options, callback) {
   const printingSetting = Object.assign({}, defaultPrintingSetting)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2841,9 +2841,9 @@
       }
     },
     "electron-typescript-definitions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-typescript-definitions/-/electron-typescript-definitions-2.0.0.tgz",
-      "integrity": "sha512-uhbLoHoIWNafFqGEtdUMtkKimvxusU2GmdbgcXoT3CjD85B2vRyffbMxXYPpxx+o88z1xMP/lw2rQq2um/G6fw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/electron-typescript-definitions/-/electron-typescript-definitions-2.0.1.tgz",
+      "integrity": "sha512-H1DD4g+Usrddyb5VK94Ofxn2gQUSUfj8gHRYcZKbkIe5CTWQ+Gl/kc/qRQ+QL+oH/8B8MHM6UJoxNfbcCrzIgQ==",
       "dev": true,
       "requires": {
         "@types/node": "^7.0.18",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dugite": "^1.45.0",
     "electabul": "~0.0.4",
     "electron-docs-linter": "^2.3.4",
-    "electron-typescript-definitions": "^2.0.0",
+    "electron-typescript-definitions": "^2.0.1",
     "eslint": "^5.6.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-mocha": "^5.2.0",

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -1,3 +1,7 @@
+const { remote } = require('electron')
+const fs = require('fs')
+const path = require('path')
+
 const { expect } = require('chai')
 
 describe('process module', () => {
@@ -65,6 +69,34 @@ describe('process module', () => {
       expect(heapStats.mallocedMemory).to.be.a('number')
       expect(heapStats.peakMallocedMemory).to.be.a('number')
       expect(heapStats.doesZapGarbage).to.be.a('boolean')
+    })
+  })
+
+  describe('process.takeHeapSnapshot()', () => {
+    it('returns true on success', () => {
+      const filePath = path.join(remote.app.getPath('temp'), 'test.heapsnapshot')
+
+      const cleanup = () => {
+        try {
+          fs.unlinkSync(filePath)
+        } catch (e) {
+          // ignore error
+        }
+      }
+
+      try {
+        const success = process.takeHeapSnapshot(filePath)
+        expect(success).to.be.true()
+        const stats = fs.statSync(filePath)
+        expect(stats.size).not.to.be.equal(0)
+      } finally {
+        cleanup()
+      }
+    })
+
+    it('returns false on failure', () => {
+      const success = process.takeHeapSnapshot('')
+      expect(success).to.be.false()
     })
   })
 })


### PR DESCRIPTION
##### Description of Change
There is a node module for getting V8 heap snapshots https://github.com/bnoordhuis/node-heapdump, but it cannot be used in sandboxed renderers due to node not being available. Currently the only way to do this programmatically is to expose this API in Electron.

This PR is adding these new methods:
- `process.takeHeapSnapshot()` - allows the main process and non-sandboxed renderers to take its own V8 heap snapshot
- `webContents.takeHeapSnapshot()` - allows the main process to ask any renderer (including sandboxed ones) to create its V8 heap snapshot 

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Added `process.getHeapSnapshot()` / `webContents.takeHeapSnapshot()` for taking V8 heap snapshots.