### PR TITLE
fix: don't use deprecated fstatNoException API

### DIFF
--- a/lib/renderer/extensions/i18n.js
+++ b/lib/renderer/extensions/i18n.js
@@ -19,13 +19,15 @@ const getExtensionMetadata = (extensionId) => {
 
 const getMessagesPath = (extensionId, language) => {
   const metadata = getExtensionMetadata(extensionId)
-  const defaultLocale = metadata.default_locale || 'en'
   const localesDirectory = path.join(metadata.srcDirectory, '_locales')
-  let messagesPath = path.join(localesDirectory, language, 'messages.json')
-  if (!fs.statSyncNoException(messagesPath)) {
-    messagesPath = path.join(localesDirectory, defaultLocale, 'messages.json')
+  try {
+    const filename = path.join(localesDirectory, language, 'messages.json')
+    fs.accessSync(filename, fs.constants.R_OK)
+    return filename
+  } catch (err) {
+    const defaultLocale = metadata.default_locale || 'en'
+    return path.join(localesDirectory, defaultLocale, 'messages.json')
   }
-  return messagesPath
 }
 
 const getMessages = (extensionId, language) => {


### PR DESCRIPTION
Remove use of [deprecated](https://github.com/electron/electron/pull/14454) API.

cc @codebytere 

Notes: no-notes
