### PR TITLE
chore: add removeFunction to deprecate module

### DIFF
--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -73,17 +73,18 @@ deprecate.setHandler = (handler) => {
 
 deprecate.getHandler = () => deprecationHandler
 
-// Forward the method to member.
-deprecate.member = (object, method, member) => {
-  let warned = false
-  object.prototype[method] = function () {
-    if (!(warned || process.noDeprecation)) {
-      warned = true
-      deprecate.warn(method, `${member}.${method}`)
-    }
-    return this[member][method].apply(this[member], arguments)
-  }
-}
+// Commented out until such time as it is needed
+// // Forward the method to member.
+// deprecate.member = (object, method, member) => {
+//   let warned = false
+//   object.prototype[method] = function () {
+//     if (!(warned || process.noDeprecation)) {
+//       warned = true
+//       deprecate.warn(method, `${member}.${method}`)
+//     }
+//     return this[member][method].apply(this[member], arguments)
+//   }
+// }
 
 // Remove a property with no replacement
 deprecate.removeProperty = (object, deprecatedName) => {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -73,24 +73,29 @@ deprecate.setHandler = (handler) => {
 
 deprecate.getHandler = () => deprecationHandler
 
-// None of the below methods are used, and so will be commented
-// out until such time that they are needed to be used and tested.
+// Forward the method to member.
+deprecate.member = (object, method, member) => {
+  let warned = false
+  object.prototype[method] = function () {
+    if (!(warned || process.noDeprecation)) {
+      warned = true
+      deprecate.warn(method, `${member}.${method}`)
+    }
+    return this[member][method].apply(this[member], arguments)
+  }
+}
 
-// // Forward the method to member.
-// deprecate.member = (object, method, member) => {
-//   let warned = false
-//   object.prototype[method] = function () {
-//     if (!(warned || process.noDeprecation)) {
-//       warned = true
-//       deprecate.warn(method, `${member}.${method}`)
-//     }
-//     return this[member][method].apply(this[member], arguments)
-//   }
-// }
-
+// Remove a property with no replacement
 deprecate.removeProperty = (object, deprecatedName) => {
   if (!process.noDeprecation) {
-    deprecate.log(`The '${deprecatedName}' property has been deprecated.`)
+    deprecate.log(`The '${deprecatedName}' property of ${object} has been deprecated and marked for removal.`)
+  }
+}
+
+// Remove a function with no replacement
+deprecate.removeFunction = (deprecatedName) => {
+  if (!process.noDeprecation) {
+    deprecate.log(`The '${deprecatedName}' function has been deprecated and marked for removal.`)
   }
 }
 


### PR DESCRIPTION
##### Description of Change

Adds `removeProperty` api to the deprecate module to allow for removing functions with no replacement.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes