### PR TITLE
fix: macOS window title and accessibility focus

### DIFF
--- a/atom/browser/ui/cocoa/atom_ns_window.h
+++ b/atom/browser/ui/cocoa/atom_ns_window.h
@@ -7,6 +7,7 @@
 
 #include "brightray/browser/mac/event_dispatching_window.h"
 #include "ui/views/cocoa/native_widget_mac_nswindow.h"
+#include "ui/views/widget/native_widget_mac.h"
 
 namespace atom {
 
@@ -40,6 +41,7 @@ class ScopedDisableResize {
 - (id)initWithShell:(atom::NativeWindowMac*)shell
           styleMask:(NSUInteger)styleMask;
 - (atom::NativeWindowMac*)shell;
+- (id)accessibilityFocusedUIElement;
 - (NSRect)originalContentRectForFrameRect:(NSRect)frameRect;
 - (void)enableWindowButtonsOffset;
 - (void)toggleFullScreenMode:(id)sender;

--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -7,6 +7,8 @@
 #include "atom/browser/native_window_mac.h"
 #include "atom/browser/ui/cocoa/atom_preview_item.h"
 #include "atom/browser/ui/cocoa/atom_touch_bar.h"
+#include "atom/browser/ui/cocoa/root_view_mac.h"
+#include "base/strings/sys_string_conversions.h"
 #include "ui/base/cocoa/window_size_constants.h"
 
 namespace atom {
@@ -39,6 +41,13 @@ bool ScopedDisableResize::disable_resize_ = false;
   return shell_;
 }
 
+- (id)accessibilityFocusedUIElement {
+  views::Widget* widget = shell_->widget();
+  id superFocus = [super accessibilityFocusedUIElement];
+  if (!widget || shell_->IsFocused())
+    return superFocus;
+  return nil;
+}
 - (NSRect)originalContentRectForFrameRect:(NSRect)frameRect {
   return [super contentRectForFrameRect:frameRect];
 }
@@ -91,6 +100,10 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (id)accessibilityAttributeValue:(NSString*)attribute {
+  if ([attribute isEqual:NSAccessibilityTitleAttribute])
+    return base::SysUTF8ToNSString(shell_->GetTitle());
+  if ([attribute isEqual:NSAccessibilityEnabledAttribute])
+    return [NSNumber numberWithBool:YES];
   if (![attribute isEqualToString:@"AXChildren"])
     return [super accessibilityAttributeValue:attribute];
 


### PR DESCRIPTION
##### Description of Change
This fixes bug #13722. ~This is not the final change, but I'm just putting it up for feedback.~ _Ready for PR now._
Between ch61 and ch66 chromium added https://cs.chromium.org/chromium/src/ui/views/cocoa/native_widget_mac_nswindow.mm?rcl=5cf4f38c44183d5dc8f57dc40d033b8bf1c38112&l=301 and that broke the existing working.
This change just overrides those in AtomNSWindow.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Fixed macos window title and focus for accessibility apps