### PR TITLE
docs: Specify VS 2017 15.4.5 for 3-0-x

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -5,8 +5,8 @@ Follow the guidelines below for building Electron on Windows.
 ## Prerequisites
 
 * Windows 7 / Server 2008 R2 or higher
-* Visual Studio 2017 15.7.2 or higher - [download VS 2017 Community Edition for
-  free](https://www.visualstudio.com/vs/)
+* [Visual Studio 2017 15.4.5](https://web.archive.org/web/20180220131834/https://docs.microsoft.com/en-us/visualstudio/productinfo/installing-an-earlier-release-of-vs2017) - Electron 3-0-x specifically requires Visual Studion 15.4.5 to build and newer versions will not work.  You can [download VS 2017 15.4.5 Community Edition for
+  free](https://aka.ms/eam4b7).
 * [Python 2.7](http://www.python.org/download/releases/2.7/)
 * [Node.js](https://nodejs.org/download/)
 * [Git](http://git-scm.com)


### PR DESCRIPTION
##### Description of Change
Due to electron/libchromiumcontent#642, we moved our 3-0-x libchromiumcontent builds to use Visual Studio 15.4.5.  This means that if you are building Electron on 3-0-x, you will get an error if you try to use a newer version of Visual Studio.  This documentation update includes links to download the specific version of Visual Studio 2017 required.

Resolves #12898
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Updated Visual Studio 2017 requirement for 3-0-x