### PR TITLE
[wip] Weakly bound deferred emissions

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -69,6 +69,17 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
     return buffer.ToLocalChecked();
 }
 
+void EmitNextTickTask(TopLevelWindow* emitter, const std::string& name) {
+  emitter->Emit(name);
+}
+
+void EmitNextTick(TopLevelWindow* emitter, const std::string& name) {
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE,
+      base::Bind(&EmitNextTickTask,
+                 emitter, name));
+}
+
 }  // namespace
 
 TopLevelWindow::TopLevelWindow(v8::Isolate* isolate,
@@ -163,11 +174,11 @@ void TopLevelWindow::OnWindowEndSession() {
 }
 
 void TopLevelWindow::OnWindowBlur() {
-  Emit("blur");
+  EmitNextTick(this, "blur");
 }
 
 void TopLevelWindow::OnWindowFocus() {
-  Emit("focus");
+  EmitNextTick(this, "focus");
 }
 
 void TopLevelWindow::OnWindowShow() {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -69,6 +69,7 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
     return buffer.ToLocalChecked();
 }
 
+#if 0
 void EmitNextTickTask(TopLevelWindow* emitter, const std::string& name) {
   emitter->Emit(name);
 }
@@ -79,6 +80,7 @@ void EmitNextTick(TopLevelWindow* emitter, const std::string& name) {
       base::Bind(&EmitNextTickTask,
                  emitter, name));
 }
+#endif
 
 }  // namespace
 
@@ -173,12 +175,31 @@ void TopLevelWindow::OnWindowEndSession() {
   Emit("session-end");
 }
 
+void TopLevelWindow::EmitBlur() {
+  Emit("blur");
+}
+void TopLevelWindow::EmitFocus() {
+  Emit("focus");
+}
+
 void TopLevelWindow::OnWindowBlur() {
+#if 1
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE,
+      base::BindOnce(&TopLevelWindow::EmitBlur, weak_factory_.GetWeakPtr()));
+#else
   EmitNextTick(this, "blur");
+#endif
 }
 
 void TopLevelWindow::OnWindowFocus() {
+#if 1
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE,
+      base::BindOnce(&TopLevelWindow::EmitFocus, weak_factory_.GetWeakPtr()));
+#else
   EmitNextTick(this, "focus");
+#endif
 }
 
 void TopLevelWindow::OnWindowShow() {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -175,31 +175,12 @@ void TopLevelWindow::OnWindowEndSession() {
   Emit("session-end");
 }
 
-void TopLevelWindow::EmitBlur() {
-  Emit("blur");
-}
-void TopLevelWindow::EmitFocus() {
-  Emit("focus");
-}
-
 void TopLevelWindow::OnWindowBlur() {
-#if 1
-  content::BrowserThread::PostTask(
-      content::BrowserThread::UI, FROM_HERE,
-      base::BindOnce(&TopLevelWindow::EmitBlur, weak_factory_.GetWeakPtr()));
-#else
-  EmitNextTick(this, "blur");
-#endif
+  EmitEventSoon("blur");
 }
 
 void TopLevelWindow::OnWindowFocus() {
-#if 1
-  content::BrowserThread::PostTask(
-      content::BrowserThread::UI, FROM_HERE,
-      base::BindOnce(&TopLevelWindow::EmitFocus, weak_factory_.GetWeakPtr()));
-#else
-  EmitNextTick(this, "focus");
-#endif
+  EmitEventSoon("focus");
 }
 
 void TopLevelWindow::OnWindowShow() {
@@ -982,6 +963,16 @@ void TopLevelWindow::RemoveFromParentChildWindows() {
   }
 
   parent->child_windows_.Remove(weak_map_id());
+}
+
+void TopLevelWindow::EmitEvent(base::StringPiece eventName) {
+  Emit(eventName);
+}
+
+void TopLevelWindow::EmitEventSoon(base::StringPiece eventName) {
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE,
+      base::BindOnce(&TopLevelWindow::EmitEvent, weak_factory_.GetWeakPtr(), eventName));
 }
 
 // static

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -222,8 +222,8 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   // Remove this window from parent window's |child_windows_|.
   void RemoveFromParentChildWindows();
 
-  void EmitBlur();
-  void EmitFocus();
+  void EmitEvent(base::StringPiece name);
+  void EmitEventSoon(base::StringPiece name);
 
 #if defined(OS_WIN)
   typedef std::map<UINT, MessageCallback> MessageCallbackMap;

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -222,6 +222,9 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   // Remove this window from parent window's |child_windows_|.
   void RemoveFromParentChildWindows();
 
+  void EmitBlur();
+  void EmitFocus();
+
 #if defined(OS_WIN)
   typedef std::map<UINT, MessageCallback> MessageCallbackMap;
   MessageCallbackMap messages_callback_map_;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1109,12 +1109,10 @@ void NativeWindowViews::OnWidgetActivationChanged(views::Widget* changed_widget,
   if (changed_widget != widget())
     return;
 
-  // Post the notification to next tick.
-  content::BrowserThread::PostTask(
-      content::BrowserThread::UI, FROM_HERE,
-      base::Bind(active ? &NativeWindow::NotifyWindowFocus
-                        : &NativeWindow::NotifyWindowBlur,
-                 GetWeakPtr()));
+  if (active)
+    NativeWindow::NotifyWindowFocus();
+  else
+    NativeWindow::NotifyWindowBlur();
 
   // Hide menu bar when window is blured.
   if (!active && IsMenuBarAutoHide() && IsMenuBarVisible())


### PR DESCRIPTION
Related to https://github.com/electron/electron/pull/14453

This is an experimental patch that binds to a WeakPtr of `this` s.t. the deferred `Emit()` calls will be discarded if the `TopLevelWindow` is destroyed.

PR'ing separately from #14453 because I want to see what CI thinks of this before pushing directly to that branch.

Also I'd like to BindOnce to `Emit()` directly so that `EmitBlur()` and `EmitFocus()` aren't needed. :thinking: 

cc @jkleinsc @nitsakh 

further reading: https://chromium.googlesource.com/chromium/src/+/lkcr/docs/callback.md#binding-a-class-method-with-weak-pointers

Notes: Fixed windows multiple windows focus bug.

