### PR TITLE
fix: initialize tracing controller before starting platform

### DIFF
--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -49,11 +49,12 @@ bool JavascriptEnvironment::Initialize() {
 
   // The V8Platform of gin relies on Chromium's task schedule, which has not
   // been started at this point, so we have to rely on Node's V8Platform.
+  auto* tracing_controller = new v8::TracingController();
+  node::tracing::TraceEventHelper::SetTracingController(tracing_controller);
   platform_ = node::CreatePlatform(
-      base::RecommendedMaxNumberOfThreadsInPool(3, 8, 0.1, 0), nullptr);
+      base::RecommendedMaxNumberOfThreadsInPool(3, 8, 0.1, 0),
+      tracing_controller);
   v8::V8::InitializePlatform(platform_);
-  node::tracing::TraceEventHelper::SetTracingController(
-      new v8::TracingController());
   gin::IsolateHolder::Initialize(
       gin::IsolateHolder::kNonStrictMode, gin::IsolateHolder::kStableV8Extras,
       gin::ArrayBufferAllocator::SharedInstance(),


### PR DESCRIPTION
Fixes a segfault on startup when electron/node#59 is merged.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes