### PR TITLE
feat: add options to webContents.loadFile

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1221,9 +1221,13 @@ win.loadURL('http://localhost:8000/post', {
 })
 ```
 
-#### `win.loadFile(filePath)`
+#### `win.loadFile(filePath[, options])`
 
 * `filePath` String
+* `options` Object (optional)
+  * `query` Object (optional) - Passed to `url.format()`.
+  * `search` String (optional) - Passed to `url.format()`.
+  * `hash` String (optional) - Passed to `url.format()`.
 
 Same as `webContents.loadFile`, `filePath` should be a path to an HTML
 file relative to the root of your application.  See the `webContents` docs

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -647,9 +647,13 @@ const options = {extraHeaders: 'pragma: no-cache\n'}
 webContents.loadURL('https://github.com', options)
 ```
 
-#### `contents.loadFile(filePath)`
+#### `contents.loadFile(filePath[, options])`
 
 * `filePath` String
+* `options` Object (optional)
+  * `query` Object (optional) - Passed to `url.format()`.
+  * `search` String (optional) - Passed to `url.format()`.
+  * `hash` String (optional) - Passed to `url.format()`.
 
 Loads the given file in the window, `filePath` should be a path to
 an HTML file relative to the root of your application.  For instance

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -182,8 +182,8 @@ Object.assign(BrowserWindow.prototype, {
   getURL (...args) {
     return this.webContents.getURL()
   },
-  loadFile (filePath) {
-    return this.webContents.loadFile(filePath)
+  loadFile (...args) {
+    return this.webContents.loadFile(...args)
   },
   reload (...args) {
     return this.webContents.reload(...args)

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -243,14 +243,19 @@ WebContents.prototype.getZoomLevel = function (callback) {
   })
 }
 
-WebContents.prototype.loadFile = function (filePath) {
+WebContents.prototype.loadFile = function (filePath, options = {}) {
   if (typeof filePath !== 'string') {
     throw new Error('Must pass filePath as a string')
   }
+  const {query, search, hash} = options
+
   return this.loadURL(url.format({
     protocol: 'file',
     slashes: true,
-    pathname: path.resolve(app.getAppPath(), filePath)
+    pathname: path.resolve(app.getAppPath(), filePath),
+    query,
+    search,
+    hash
   }))
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1441,10 +1441,8 @@ describe('BrowserWindow module', () => {
           }
         })
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
-        let htmlPath = path.join(fixtures, 'api', 'sandbox.html?window-open-external')
-        const pageUrl = 'file://' + htmlPath
         let popupWindow
-        w.loadURL(pageUrl)
+        w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'window-open-external'})
         w.webContents.once('new-window', (e, url, frameName, disposition, options) => {
           assert.equal(url, 'http://www.google.com/#q=electron')
           assert.equal(options.width, 505)
@@ -1518,8 +1516,6 @@ describe('BrowserWindow module', () => {
         })
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
 
-        let htmlPath = path.join(fixtures, 'api', 'sandbox.html?verify-ipc-sender')
-        const pageUrl = 'file://' + htmlPath
         let childWc
         w.webContents.once('new-window', (e, url, frameName, disposition, options) => {
           childWc = options.webContents
@@ -1538,7 +1534,7 @@ describe('BrowserWindow module', () => {
           'parent-answer',
           'child-answer'
         ], done)
-        w.loadURL(pageUrl)
+        w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'verify-ipc-sender'})
       })
 
       describe('event handling', () => {
@@ -1546,7 +1542,7 @@ describe('BrowserWindow module', () => {
           waitForEvents(w, [
             'page-title-updated'
           ], done)
-          w.loadURL('file://' + path.join(fixtures, 'api', 'sandbox.html?window-events'))
+          w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'window-events'})
         })
 
         it('works for stop events', (done) => {
@@ -1555,7 +1551,7 @@ describe('BrowserWindow module', () => {
             'did-fail-load',
             'did-stop-loading'
           ], done)
-          w.loadURL('file://' + path.join(fixtures, 'api', 'sandbox.html?webcontents-stop'))
+          w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'webcontents-stop'})
         })
 
         it('works for web contents events', (done) => {
@@ -1569,7 +1565,7 @@ describe('BrowserWindow module', () => {
             'did-frame-finish-load',
             'dom-ready'
           ], done)
-          w.loadURL('file://' + path.join(fixtures, 'api', 'sandbox.html?webcontents-events'))
+          w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'webcontents-events'})
         })
       })
 
@@ -1640,7 +1636,7 @@ describe('BrowserWindow module', () => {
             sandbox: true
           }
         })
-        w.loadURL('file://' + path.join(fixtures, 'api', 'sandbox.html?allocate-memory'))
+        w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'allocate-memory'})
         ipcMain.once('answer', function (event, {bytesBeforeOpen, bytesAfterOpen, bytesAfterClose}) {
           const memoryIncreaseByOpen = bytesAfterOpen - bytesBeforeOpen
           const memoryDecreaseByClose = bytesAfterOpen - bytesAfterClose
@@ -1663,7 +1659,7 @@ describe('BrowserWindow module', () => {
             sandbox: true
           }
         })
-        w.loadURL('file://' + path.join(fixtures, 'api', 'sandbox.html?reload-remote'))
+        w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'reload-remote'})
 
         ipcMain.on('get-remote-module-path', (event) => {
           event.returnValue = path.join(fixtures, 'module', 'hello.js')
@@ -1698,7 +1694,7 @@ describe('BrowserWindow module', () => {
         })
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
 
-        w.loadURL('file://' + path.join(fixtures, 'api', 'sandbox.html?reload-remote-child'))
+        w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), {search: 'reload-remote-child'})
 
         ipcMain.on('get-remote-module-path', (event) => {
           event.returnValue = path.join(fixtures, 'module', 'hello-child.js')

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -64,12 +64,7 @@ describe('crashReporter module', () => {
 
         stopServer = startServer({
           callback (port) {
-            const crashUrl = url.format({
-              protocol: 'file',
-              pathname: path.join(fixtures, 'api', 'crash.html'),
-              search: '?port=' + port
-            })
-            w.loadURL(crashUrl)
+            w.loadFile(path.join(fixtures, 'api', 'crash.html'), {query: {port}})
           },
           processType: 'renderer',
           done: done

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -1445,6 +1445,7 @@ describe('net module', () => {
       ipcRenderer.send('eval', `
         const {net} = require('electron')
         const http = require('http')
+        const url = require('url')
         const netRequest = net.request('${server.url}${netRequestUrl}')
         netRequest.on('response', function (netResponse) {
           const serverUrl = url.parse('${server.url}')

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -8,7 +8,6 @@ const {Coverage} = require('electabul')
 
 const fs = require('fs')
 const path = require('path')
-const url = require('url')
 const util = require('util')
 const v8 = require('v8')
 
@@ -139,14 +138,12 @@ app.on('ready', function () {
       backgroundThrottling: false
     }
   })
-  window.loadURL(url.format({
-    pathname: path.join(__dirname, '/index.html'),
-    protocol: 'file',
+  window.loadFile('static/index.html', {
     query: {
       grep: argv.grep,
       invert: argv.invert ? 'true' : ''
     }
-  }))
+  })
   window.on('unresponsive', function () {
     var chosen = dialog.showMessageBox(window, {
       type: 'warning',


### PR DESCRIPTION
##### Description of Change
Allows passing the following options to `url.format` called by `webContents.loadFile`:
- query
- search
- hash

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Added options to `webContents.loadFile` allowing to pass `query`, `search`, `hash` to `url.format`. 