### PR TITLE
refactor: cleanup web-frame-init.js

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -56,6 +56,7 @@ filenames = {
     "lib/common/api/shell.js",
     "lib/common/atom-binding-setup.js",
     "lib/common/buffer-utils.js",
+    "lib/common/error-utils.js",
     "lib/common/init.js",
     "lib/common/parse-features-string.js",
     "lib/common/reset-search-paths.js",

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -6,6 +6,8 @@ const path = require('path')
 const url = require('url')
 const {app, ipcMain, session, NavigationController, deprecate} = electron
 
+const errorUtils = require('../../common/error-utils')
+
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
 // eslint-disable-next-line
@@ -113,16 +115,6 @@ const webFrameMethods = [
 ]
 const webFrameMethodsWithResult = []
 
-const errorConstructors = {
-  Error,
-  EvalError,
-  RangeError,
-  ReferenceError,
-  SyntaxError,
-  TypeError,
-  URIError
-}
-
 const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
   return new Promise((resolve, reject) => {
     this.send('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', requestId, method, args)
@@ -131,14 +123,7 @@ const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
         if (typeof callback === 'function') callback(result)
         resolve(result)
       } else {
-        if (error.__ELECTRON_SERIALIZED_ERROR__ && errorConstructors[error.name]) {
-          const rehydratedError = new errorConstructors[error.name](error.message)
-          rehydratedError.stack = error.stack
-
-          reject(rehydratedError)
-        } else {
-          reject(error)
-        }
+        reject(errorUtils.deserialize(error))
       }
     })
   })

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -113,7 +113,6 @@ const webFrameMethods = [
   'setLayoutZoomLevelLimits',
   'setVisualZoomLevelLimits'
 ]
-const webFrameMethodsWithResult = []
 
 const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
   return new Promise((resolve, reject) => {
@@ -129,24 +128,9 @@ const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
   })
 }
 
-const syncWebFrameMethods = function (requestId, method, callback, ...args) {
-  this.send('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', requestId, method, args)
-  ipcMain.once(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, function (event, result) {
-    if (callback) callback(result)
-  })
-}
-
 for (const method of webFrameMethods) {
   WebContents.prototype[method] = function (...args) {
     this.send('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, args)
-  }
-}
-
-for (const method of webFrameMethodsWithResult) {
-  WebContents.prototype[method] = function (...args) {
-    const callback = args[args.length - 1]
-    const actualArgs = args.slice(0, args.length - 2)
-    syncWebFrameMethods.call(this, getNextId(), method, callback, ...actualArgs)
   }
 }
 

--- a/lib/common/error-utils.js
+++ b/lib/common/error-utils.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const constructors = new Map([
+  [Error.name, Error],
+  [EvalError.name, EvalError],
+  [RangeError.name, RangeError],
+  [ReferenceError.name, ReferenceError],
+  [SyntaxError.name, SyntaxError],
+  [TypeError.name, TypeError],
+  [URIError.name, URIError]
+])
+
+exports.deserialize = function (error) {
+  if (error.__ELECTRON_SERIALIZED_ERROR__ && constructors.has(error.name)) {
+    const constructor = constructors.get(error.name)
+    const rehydratedError = new constructor(error.message)
+    rehydratedError.stack = error.stack
+    return rehydratedError
+  }
+  return error
+}
+
+exports.serialize = function (error) {
+  if (error instanceof Error) {
+    // Errors get lost, because: JSON.stringify(new Error('Message')) === {}
+    // Take the serializable properties and construct a generic object
+    return {
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
+      __ELECTRON_SERIALIZED_ERROR__: true
+    }
+  }
+  return error
+}

--- a/lib/common/error-utils.js
+++ b/lib/common/error-utils.js
@@ -13,9 +13,9 @@ const constructors = new Map([
 exports.deserialize = function (error) {
   if (error.__ELECTRON_SERIALIZED_ERROR__ && constructors.has(error.name)) {
     const constructor = constructors.get(error.name)
-    const rehydratedError = new constructor(error.message)
-    rehydratedError.stack = error.stack
-    return rehydratedError
+    const deserializedError = new constructor(error.message)
+    deserializedError.stack = error.stack
+    return deserializedError
   }
   return error
 }

--- a/lib/renderer/web-frame-init.js
+++ b/lib/renderer/web-frame-init.js
@@ -1,38 +1,28 @@
-const electron = require('electron')
+const {ipcRenderer, webFrame} = require('electron')
+const errorUtils = require('../common/error-utils')
 
 module.exports = () => {
   // Call webFrame method
-  electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, method, args) => {
-    electron.webFrame[method](...args)
+  ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, method, args) => {
+    webFrame[method](...args)
   })
 
-  electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
-    const result = electron.webFrame[method](...args)
+  ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
+    const result = webFrame[method](...args)
     event.sender.send(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, result)
   })
 
-  electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
+  ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
     const responseCallback = function (result) {
       Promise.resolve(result)
         .then((resolvedResult) => {
           event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, null, resolvedResult)
         })
         .catch((resolvedError) => {
-          if (resolvedError instanceof Error) {
-            // Errors get lost, because: JSON.stringify(new Error('Message')) === {}
-            // Take the serializable properties and construct a generic object
-            resolvedError = {
-              message: resolvedError.message,
-              stack: resolvedError.stack,
-              name: resolvedError.name,
-              __ELECTRON_SERIALIZED_ERROR__: true
-            }
-          }
-
-          event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, resolvedError)
+          event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, errorUtils.serialize(resolvedError))
         })
     }
     args.push(responseCallback)
-    electron.webFrame[method](...args)
+    webFrame[method](...args)
   })
 }

--- a/lib/renderer/web-frame-init.js
+++ b/lib/renderer/web-frame-init.js
@@ -4,7 +4,11 @@ const errorUtils = require('../common/error-utils')
 module.exports = () => {
   // Call webFrame method
   ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, method, args) => {
-    webFrame[method](...args)
+    try {
+      webFrame[method](...args)
+    } catch (error) {
+      console.error(`${error}`)
+    }
   })
 
   ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {

--- a/lib/renderer/web-frame-init.js
+++ b/lib/renderer/web-frame-init.js
@@ -4,11 +4,7 @@ const errorUtils = require('../common/error-utils')
 module.exports = () => {
   // Call webFrame method
   ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, method, args) => {
-    try {
-      webFrame[method](...args)
-    } catch (error) {
-      console.error(`${error}`)
-    }
+    webFrame[method](...args)
   })
 
   ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {

--- a/lib/renderer/web-frame-init.js
+++ b/lib/renderer/web-frame-init.js
@@ -7,11 +7,6 @@ module.exports = () => {
     webFrame[method](...args)
   })
 
-  ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_SYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
-    const result = webFrame[method](...args)
-    event.sender.send(`ELECTRON_INTERNAL_BROWSER_SYNC_WEB_FRAME_RESPONSE_${requestId}`, result)
-  })
-
   ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
     new Promise(resolve =>
       webFrame[method](...args, resolve)

--- a/lib/renderer/web-frame-init.js
+++ b/lib/renderer/web-frame-init.js
@@ -13,16 +13,14 @@ module.exports = () => {
   })
 
   ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (event, requestId, method, args) => {
-    const responseCallback = function (result) {
-      Promise.resolve(result)
-        .then((resolvedResult) => {
-          event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, null, resolvedResult)
-        })
-        .catch((resolvedError) => {
-          event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, errorUtils.serialize(resolvedError))
-        })
-    }
-    args.push(responseCallback)
-    webFrame[method](...args)
+    new Promise(resolve =>
+      webFrame[method](...args, resolve)
+    ).then(result => {
+      return [null, result]
+    }, error => {
+      return [errorUtils.serialize(error)]
+    }).then(responseArgs => {
+      event.sender.send(`ELECTRON_INTERNAL_BROWSER_ASYNC_WEB_FRAME_RESPONSE_${requestId}`, ...responseArgs)
+    })
   })
 }


### PR DESCRIPTION
##### Description of Change
- move generic `Error` serialization/deserialization code to `error-utils.js`
- fix exception handling for `webFrameMethods` and `asyncWebFrameMethods`
- remove unused `syncWebFrameMethods` related code

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes