### PR TITLE
fix: use render client id to track deleted render process hosts

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -56,7 +56,6 @@
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/options_switches.h"
 #include "base/message_loop/message_loop.h"
-#include "base/process/process_handle.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "base/values.h"
@@ -777,8 +776,7 @@ void WebContents::RenderViewCreated(content::RenderViewHost* render_view_host) {
 }
 
 void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
-  Emit("render-view-deleted", render_view_host->GetProcess()->GetID(),
-       base::GetProcId(render_view_host->GetProcess()->GetHandle()));
+  Emit("render-view-deleted", render_view_host->GetProcess()->GetID());
 }
 
 void WebContents::RenderProcessGone(base::TerminationStatus status) {

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -96,8 +96,8 @@ void RendererClientBase::DidCreateScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {
   // global.setHidden("contextId", `${processHostId}-${++next_context_id_}`)
-  auto context_id = base::StringPrintf("%s-%d", renderer_client_id_.c_str(),
-                                       ++next_context_id_);
+  auto context_id = base::StringPrintf(
+      "%s-%" PRId64, renderer_client_id_.c_str(), ++next_context_id_);
   v8::Isolate* isolate = context->GetIsolate();
   v8::Local<v8::String> key = mate::StringToSymbol(isolate, "contextId");
   v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -56,7 +56,7 @@ class RendererClientBase : public content::ContentRendererClient {
   std::unique_ptr<PreferencesManager> preferences_manager_;
   ChromeKeySystemsProvider key_systems_provider_;
   bool isolated_world_;
-
+  std::string renderer_client_id_;
   // An increasing ID used for indentifying an V8 context in this process.
   int next_context_id_ = 0;
 };

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -58,7 +58,7 @@ class RendererClientBase : public content::ContentRendererClient {
   bool isolated_world_;
   std::string renderer_client_id_;
   // An increasing ID used for indentifying an V8 context in this process.
-  int next_context_id_ = 0;
+  int64_t next_context_id_ = 0;
 };
 
 }  // namespace atom

--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -87,9 +87,6 @@ class ObjectsRegistry {
 
   // Private: Dereference the object from store.
   dereference (id) {
-    // FIXME(MarshallOfSound): We should remove this once remote deref works well
-    if (process.env.ELECTRON_DISABLE_REMOTE_DEREFERENCING) return
-
     let pointer = this.storage[id]
     if (pointer == null) {
       return
@@ -103,10 +100,11 @@ class ObjectsRegistry {
 
   // Private: Clear the storage when renderer process is destroyed.
   registerDeleteListener (webContents, contextId) {
-    // contextId => ${OSProcessId}-${contextCount}
-    const OSProcessId = contextId.split('-')[0]
-    const listener = (event, deletedProcessId, deletedOSProcessId) => {
-      if (deletedOSProcessId && deletedOSProcessId.toString() === OSProcessId) {
+    // contextId => ${processHostId}-${contextCount}
+    const processHostId = contextId.split('-')[0]
+    const listener = (event, deletedProcessHostId) => {
+      if (deletedProcessHostId &&
+          deletedProcessHostId.toString() === processHostId) {
         webContents.removeListener('render-view-deleted', listener)
         this.clear(webContents, contextId)
       }

--- a/spec/fixtures/api/render-view-deleted.html
+++ b/spec/fixtures/api/render-view-deleted.html
@@ -17,7 +17,7 @@
       }
 
       // This should trigger a dereference and a remote getURL call should fail
-      contents.emit('render-view-deleted', {}, '', contents.getOSProcessId())
+      contents.emit('render-view-deleted', {}, contents.getProcessId())
       try {
         contents.getURL()
         ipcRenderer.send('error-message', 'No error thrown')


### PR DESCRIPTION
##### Description of Change

This fix supersedes https://github.com/electron/electron/pull/14324

Instead of relying on OS process id, which may not be unique when a process is reused, we rely on the renderer client id (which is the render process host id) passed by the content layer when starting the renderer process which is guaranteed to be unique for the lifetime of the app.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: fix missing remote objects https://github.com/electron/electron/issues/14054