### PR TITLE
fix: read ignoreMenuShortcuts per WebContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1393,7 +1393,10 @@ void WebContents::UnregisterServiceWorker(
 }
 
 void WebContents::SetIgnoreMenuShortcuts(bool ignore) {
-  set_ignore_menu_shortcuts(ignore);
+  auto* web_preferences = WebContentsPreferences::From(web_contents());
+  DCHECK(web_preferences);
+  web_preferences->preference()->SetKey("ignoreMenuShortcuts",
+                                        base::Value(ignore));
 }
 
 void WebContents::SetAudioMuted(bool muted) {

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -62,10 +62,6 @@ class CommonWebContentsDelegate
 
   NativeWindow* owner_window() const { return owner_window_.get(); }
 
-  void set_ignore_menu_shortcuts(bool ignore) {
-    ignore_menu_shortcuts_ = ignore;
-  }
-
   bool is_html_fullscreen() const { return html_fullscreen_; }
 
  protected:
@@ -157,7 +153,6 @@ class CommonWebContentsDelegate
   base::WeakPtr<NativeWindow> owner_window_;
 
   bool offscreen_ = false;
-  bool ignore_menu_shortcuts_ = false;
 
   // Whether window is fullscreened by HTML5 api.
   bool html_fullscreen_ = false;

--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -6,6 +6,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include "atom/browser/web_contents_preferences.h"
 #include "brightray/browser/mac/event_dispatching_window.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "ui/events/keycodes/keyboard_codes.h"
@@ -27,15 +28,17 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
   if (event.windows_key_code == ui::VKEY_ESCAPE && is_html_fullscreen())
     ExitFullscreenModeForTab(source);
 
-  if (!ignore_menu_shortcuts_) {
-    // Send the event to the menu before sending it to the window
-    if (event.os_event.type == NSKeyDown &&
-        [[NSApp mainMenu] performKeyEquivalent:event.os_event])
-      return;
+  if (auto* web_preferences = WebContentsPreferences::From(source)) {
+    if (!web_preferences->IsEnabled("ignoreMenuShortcuts", false)) {
+      // Send the event to the menu before sending it to the window
+      if (event.os_event.type == NSKeyDown &&
+          [[NSApp mainMenu] performKeyEquivalent:event.os_event])
+        return;
 
-    if (event.os_event.window &&
-        [event.os_event.window isKindOfClass:[EventDispatchingWindow class]])
-      [event.os_event.window redispatchKeyEvent:event.os_event];
+      if (event.os_event.window &&
+          [event.os_event.window isKindOfClass:[EventDispatchingWindow class]])
+        [event.os_event.window redispatchKeyEvent:event.os_event];
+    }
   }
 }
 

--- a/atom/browser/common_web_contents_delegate_views.cc
+++ b/atom/browser/common_web_contents_delegate_views.cc
@@ -6,6 +6,7 @@
 
 #include "atom/browser/api/atom_api_web_contents_view.h"
 #include "atom/browser/native_window_views.h"
+#include "atom/browser/web_contents_preferences.h"
 #include "base/strings/string_util.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "ui/events/keycodes/keyboard_codes.h"
@@ -24,8 +25,12 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
     ExitFullscreenModeForTab(source);
 
   // Let the NativeWindow handle other parts.
-  if (!ignore_menu_shortcuts_ && owner_window())
-    owner_window()->HandleKeyboardEvent(source, event);
+  if (auto* web_preferences = WebContentsPreferences::From(source)) {
+    if (owner_window() &&
+        !web_preferences->IsEnabled("ignoreMenuShortcuts", false)) {
+      owner_window()->HandleKeyboardEvent(source, event);
+    }
+  }
 }
 
 void CommonWebContentsDelegate::ShowAutofillPopup(


### PR DESCRIPTION
##### Description of Change

Close https://github.com/electron/electron/issues/14514.

Fix the problem that calling `setIgnoreMenuShortcuts` does not have effect on webview. 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: Fix the problem that calling `setIgnoreMenuShortcuts` does not have effect on webview. 