### PR TITLE
docs: specify BrowserWindow features passable to window.open

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -24,7 +24,12 @@ Returns [`BrowserWindowProxy`](browser-window-proxy.md) - Creates a new window
 and returns an instance of `BrowserWindowProxy` class.
 
 The `features` string follows the format of standard browser, but each feature
-has to be a field of `BrowserWindow`'s options.
+has to be a field of `BrowserWindow`'s options. These are the features you can set via `features` string: `zoomFactor`, `nodeIntegration`, `preload`, `javascript`, `contextIsolation`, `webviewTag`.
+
+For example:
+```js
+window.open('https://github.com', '_blank', 'nodeIntegration=no')
+```
 
 **Notes:**
 


### PR DESCRIPTION
##### Description of Change

Improve the docs about features passable via `features` string (3rd parameter) into `window.open()` calls. Based on discussion in [Slack](https://electronhq.slack.com/archives/CB6CG54DB/p1536238852000100) with @MarshallOfSound.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Update BrowserWindow window.open documentation