### PR TITLE
docs: add note about origin URLs to GN build docs

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -26,7 +26,7 @@ try to download a Google-internal version that only Googlers have access to).
 
 ## Cached builds (optional step)
 
-### GIT_CACHE_PATH
+### GIT\_CACHE\_PATH
 
 If you plan on building Electron more than once, adding a git cache will
 speed up subsequent calls to `gclient`. To do this, set a `GIT_CACHE_PATH`
@@ -37,6 +37,16 @@ $ export GIT_CACHE_PATH="${HOME}/.git_cache"
 $ mkdir -p "${GIT_CACHE_PATH}"
 # This will use about 16G.
 ```
+
+> **NOTE**: the git cache will set the `origin` of the `src/electron`
+> repository to point to the local cache, instead of the upstream git
+> repository. This is undesirable when running `git push`—you probably want to
+> push to github, not your local cache. To fix this, from the `src/electron`
+> directory, run:
+>
+> ```sh
+$ git remote set-url origin https://github.com/electron/electron
+> ```
 
 ### sccache
 

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -43,10 +43,10 @@ $ mkdir -p "${GIT_CACHE_PATH}"
 > repository. This is undesirable when running `git push`—you probably want to
 > push to github, not your local cache. To fix this, from the `src/electron`
 > directory, run:
->
-> ```sh
+
+```sh
 $ git remote set-url origin https://github.com/electron/electron
-> ```
+```
 
 ### sccache
 


### PR DESCRIPTION
This came up a few times while people were switching over to GN.


- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes