### PR TITLE
fix: Invalidate weak ptrs before window Javascript object is destroyed

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -142,6 +142,11 @@ void TopLevelWindow::WillCloseWindow(bool* prevent_default) {
 }
 
 void TopLevelWindow::OnWindowClosed() {
+  // Invalidate weak ptrs before the Javascript object is destroyed,
+  // there might be some delayed emit events which shouldn't be
+  // triggered after this.
+  weak_factory_.InvalidateWeakPtrs();
+
   RemoveFromWeakMap();
   window_->RemoveObserver(this);
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -221,6 +221,17 @@ describe('BrowserWindow module', () => {
         contents.getProcessId()
       }, /Object has been destroyed/)
     })
+    it('should not crash when destroying windows with pending events', (done) => {
+      let focusListener = (event, win) => win.id
+      app.on('browser-window-focus', focusListener)
+      const windowCount = 3
+      const windows = Array.from(Array(windowCount)).map(x => new BrowserWindow(defaultOptions))
+      windows.forEach(win => win.show())
+      windows.forEach(win => win.focus())
+      windows.forEach(win => win.destroy())
+      app.removeListener('browser-window-focus', focusListener)
+      done()
+    })
   })
 
   describe('BrowserWindow.loadURL(url)', () => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -222,15 +222,9 @@ describe('BrowserWindow module', () => {
       }, /Object has been destroyed/)
     })
     it('should not crash when destroying windows with pending events', (done) => {
-      let focusListener = (event, win) => win.id
-      app.on('browser-window-focus', focusListener)
-      const windowCount = 3
-      const windows = Array.from(Array(windowCount)).map(x => new BrowserWindow(defaultOptions))
-      windows.forEach(win => win.show())
-      windows.forEach(win => win.focus())
-      windows.forEach(win => win.destroy())
-      app.removeListener('browser-window-focus', focusListener)
-      done()
+      const responseEvent = 'destroy-test-completed'
+      ipcRenderer.on(responseEvent, () => done())
+      ipcRenderer.send('test-browserwindow-destroy', { responseEvent })
     })
   })
 

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -384,6 +384,26 @@ ipcMain.on('test-webcontents-navigation-observer', (event, options) => {
   contents.loadURL(options.url)
 })
 
+ipcMain.on('test-browserwindow-destroy', (event, testOptions) => {
+  let focusListener = (event, win) => win.id
+  app.on('browser-window-focus', focusListener)
+  const windowCount = 3
+  const windowOptions = {
+    show: false,
+    width: 400,
+    height: 400,
+    webPreferences: {
+      backgroundThrottling: false
+    }
+  }
+  const windows = Array.from(Array(windowCount)).map(x => new BrowserWindow(windowOptions))
+  windows.forEach(win => win.show())
+  windows.forEach(win => win.focus())
+  windows.forEach(win => win.destroy())
+  app.removeListener('browser-window-focus', focusListener)
+  event.sender.send(testOptions.responseEvent)
+})
+
 // Suspend listeners until the next event and then restore them
 const suspendListeners = (emitter, eventName, callback) => {
   const listeners = emitter.listeners(eventName)


### PR DESCRIPTION
##### Description of Change

Fixes https://github.com/electron/electron/issues/14513

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: fix: Object has been destroyed upon quit with multiple windows open