### PR TITLE
chore: fix cpplint.js when LINTER_PATH doesn't exist

### DIFF
--- a/script/cpplint.js
+++ b/script/cpplint.js
@@ -88,7 +88,7 @@ const blacklist = new Set([
 
 async function main () {
   if (!fs.existsSync(LINTER_PATH)) {
-    print('[INFO] Skipping cpplint, dependencies have not been bootstrapped')
+    console.log('[INFO] Skipping cpplint, dependencies have not been bootstrapped')
     return
   }
 


### PR DESCRIPTION
`print` doesn't exist. Caused an error when I had misconfigured a lint job in CI.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes