### PR TITLE
docs: update instructions for building win32 target

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -31,11 +31,13 @@ See [Build Instructions: GN](build-instructions-gn.md)
 
 ## 32bit Build
 
-To build for the 32bit target, you need to pass `--target_arch=ia32` when
-running the bootstrap script:
+To build for the 32bit target, you need to pass `target_cpu = "x86"` as a GN
+arg. You can build the 32bit target alongside the 64bit target by using a
+different output directory for GN, e.g. `out/Release-x86`, with different
+arguments.
 
 ```powershell
-$ python script\bootstrap.py -v --target_arch=ia32
+$ gn gen out/Release-x86 --args="import(\"//electron/build/args/release.gn\") target_cpu=\"x86\""
 ```
 
 The other building steps are exactly the same.


### PR DESCRIPTION
The docs were referring to bootstrap.py, which no longer exists.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes