### PR TITLE
fix: Windows Background color issue

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -792,6 +792,7 @@ void NativeWindowViews::SetBackgroundColor(SkColor background_color) {
                       reinterpret_cast<LONG_PTR>(brush));
   if (previous_brush)
     DeleteObject((HBRUSH)previous_brush);
+  InvalidateRect(GetAcceleratedWidget(), NULL, 1);
 #endif
 }
 


### PR DESCRIPTION
Call InvalidateRect for windows after setting the bg color

##### Description of Change
This change addresses issue #14360.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Fixed windows flicker when maximizing