### PR TITLE
chore: remove only on deprecations api spec

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -44,7 +44,7 @@ const nativeFn = app.getAppMetrics
 app.getAppMetrics = () => {
   let metrics = nativeFn.call(app)
   for (const metric of metrics) {
-    deprecate.removeProperty(metric, 'memory')
+    deprecate.removeProperty(metric, 'memory', true)
   }
 
   return metrics

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -63,7 +63,7 @@ const deprecate = {
       this.emit(oldName, ...args)
     })
   },
-  removeProperty: (object, deprecated) => {
+  removeProperty: (object, deprecated, ignoreMissingProps = false) => {
     let warned = false
     let warn = () => {
       if (!(warned || process.noDeprecation)) {
@@ -73,6 +73,7 @@ const deprecate = {
     }
 
     if (!(deprecated in object)) {
+      if (ignoreMissingProps) return
       throw new Error('Cannot deprecate a property on an object which does not have that property')
     }
 

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -5,7 +5,7 @@ const {deprecations, deprecate, nativeImage} = require('electron')
 const {expect} = chai
 chai.use(dirtyChai)
 
-describe.only('deprecations', () => {
+describe('deprecations', () => {
   beforeEach(() => {
     deprecations.setHandler(null)
     process.throwDeprecation = true


### PR DESCRIPTION
Updates `deprecate.removeProperty` to take an option to ignore missing properties. Also remove stray `.only`

Notes: no-notes