### PR TITLE
feat: route frame based permission checks through our permission check handler

### DIFF
--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -214,6 +214,7 @@ blink::mojom::PermissionStatus AtomPermissionManager::GetPermissionStatus(
     content::PermissionType permission,
     const GURL& requesting_origin,
     const GURL& embedding_origin) {
+  // TODO(MarshallOfSound): Investigate how we can emit this permission check on a session object
   return blink::mojom::PermissionStatus::GRANTED;
 }
 
@@ -245,9 +246,13 @@ bool AtomPermissionManager::CheckPermissionWithDetails(
 blink::mojom::PermissionStatus
 AtomPermissionManager::GetPermissionStatusForFrame(
     content::PermissionType permission,
-    content::RenderFrameHost* render_frame_host,
+    content::RenderFrameHost* rfh,
     const GURL& requesting_origin) {
-  return blink::mojom::PermissionStatus::GRANTED;
+  base::DictionaryValue details;
+  bool granted = CheckPermissionWithDetails(permission, rfh, requesting_origin,
+                                            &details);
+  return granted ? blink::mojom::PermissionStatus::GRANTED
+                 : blink::mojom::PermissionStatus::DENIED;
 }
 
 }  // namespace atom

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -315,16 +315,20 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
 
 * `handler` Function<Boolean> | null
   * `webContents` [WebContents](web-contents.md) - WebContents checking the permission.
-  * `permission` String - Enum of 'media'.
+  * `permission` String - Enum of 'media', 'midiSysex', 'notifications', 'geolocation', 'mediaKeySystem' or 'midi'.
   * `requestingOrigin` String - The origin URL of the permission check
   * `details` Object - Some properties are only available on certain permission types.
     * `securityOrigin` String - The security orign of the `media` check.
     * `mediaType` String - The type of media access being requested, can be `video`,
-      `audio` or `unknown`
+      `audio` or `unknown`.  This property is only set on `media` checks.
 
 Sets the handler which can be used to respond to permission checks for the `session`.
 Returning `true` will allow the permission and `false` will reject it.
 To clear the handler, call `setPermissionCheckHandler(null)`.
+
+Please note not all syncronous permission checks are passed through this handler,
+for instance `Notification.granted` is not routed but `new Notification` will cause
+the `permissionRequestHandler` to be fired. 
 
 ```javascript
 const {session} = require('electron')


### PR DESCRIPTION
Fixes #14544 

There is a TODO remaining because the legacy chromium permission status API does not pass a RFH or any way to get a web contents so it can't be emitted on a session object.  Current plan is to leave it there till chromium removes that API.  Chromium is already suggesting the frame based API over the old origin based one.

https://cs.chromium.org/chromium/src/chrome/browser/permissions/permission_manager.h?dr=CSs&g=0&l=71

Notes: Add more of chromiums permission checks to the permission check handler API