### PR TITLE
refactor: remove unused, duplicated code in deprecate module

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -44,7 +44,7 @@ const nativeFn = app.getAppMetrics
 app.getAppMetrics = () => {
   let metrics = nativeFn.call(app)
   for (const metric of metrics) {
-    deprecate.removeProperty(metric, 'memory', true)
+    deprecate.removeProperty(metric, 'memory')
   }
 
   return metrics

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -44,7 +44,9 @@ const nativeFn = app.getAppMetrics
 app.getAppMetrics = () => {
   let metrics = nativeFn.call(app)
   for (const metric of metrics) {
-    deprecate.removeProperty(metric, 'memory')
+    if ('memory' in metric) {
+      deprecate.removeProperty(metric, 'memory')
+    }
   }
 
   return metrics

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -32,10 +32,6 @@ const deprecate = {
       return console.warn(`(electron) ${message}`)
     }
   },
-  renameFunction: function (fn, oldName, newName) {
-    const warn = warnOnce(oldName, newName)
-    return () => { warn(); return fn.apply(this, arguments) }
-  },
   alias: function (object, oldName, newName) {
     const warn = warnOnce(oldName, newName)
     const newFn = () => {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -32,14 +32,8 @@ const deprecate = {
     }
   },
   renameFunction: function (fn, oldName, newName) {
-    let warned = false
-    return function () {
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.warn(oldName, newName)
-      }
-      return fn.apply(this, arguments)
-    }
+    const warn = warnOnce(oldName, newName)
+    return () => { warn(); return fn.apply(this, arguments) }
   },
   removeFunction: (oldName) => {
     if (!process.noDeprecation) {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -48,17 +48,12 @@ const deprecate = {
     }
   },
   event: (emitter, oldName, newName) => {
-    let warned = false
+    const warn = newName.startsWith('-') /* private event */
+      ? warnOnce(`${oldName} event`)
+      : warnOnce(`${oldName} event`, `${newName} event`)
     return emitter.on(newName, function (...args) {
       if (this.listenerCount(oldName) === 0) return
-      if (warned || process.noDeprecation) return
-
-      warned = true
-      if (newName.startsWith('-')) {
-        deprecate.log(`'${oldName}' event has been deprecated.`)
-      } else {
-        deprecate.warn(`'${oldName}' event`, `'${newName}' event`)
-      }
+      warn()
       this.emit(oldName, ...args)
     })
   },

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -46,12 +46,13 @@ const deprecate = {
   },
 
   removeProperty: (o, removedName) => {
-    const warn = warnOnce(removedName)
-
     // if the property's already been removed, warn about it
-    if (!(removedName in o)) warn()
+    if (!(removedName in o)) {
+      deprecate.log(`Unable to remove property '${removedName}' from an object that lacks it.`)
+    }
 
     // wrap the deprecated property in an accessor to warn
+    const warn = warnOnce(removedName)
     let val = o[removedName]
     return Object.defineProperty(o, removedName, {
       configurable: true,

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -58,29 +58,15 @@ const deprecate = {
     })
   },
   removeProperty: (object, deprecated) => {
-    let warned = false
-    let warn = () => {
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.log(`The '${deprecated}' property has been deprecated and marked for removal.`)
-      }
-    }
-
     if (!(deprecated in object)) {
-      throw new Error('Cannot deprecate a property on an object which does not have that property')
+      throw new Error('Cannot deprecate a property on an object which lacks that property')
     }
-
-    let temp = object[deprecated]
+    const warn = warnOnce(deprecated)
+    let value = object[deprecated]
     return Object.defineProperty(object, deprecated, {
       configurable: true,
-      get: () => {
-        warn()
-        return temp
-      },
-      set: (newValue) => {
-        warn()
-        temp = newValue
-      }
+      get: () => { warn(); return value },
+      set: (newValue) => { warn(); value = newValue }
     })
   },
   renameProperty: (object, oldName, newName) => {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -59,7 +59,7 @@ const deprecate = {
   },
   removeProperty: (object, deprecated) => {
     if (!(deprecated in object)) {
-      throw new Error('Cannot deprecate a property on an object which lacks that property')
+      throw new Error(`Object lacks property '${deprecated}' to deprecate`)
     }
     const warn = warnOnce(deprecated)
     let value = object[deprecated]

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -1,25 +1,17 @@
 
 let deprecationHandler = null
 
-function warnSentinel (msg) {
+function warnOnce (oldName, newName) {
   let warned = false
+  const msg = newName
+    ? `'${oldName}' is deprecated and will be removed. Please use '${newName}' instead.`
+    : `'${oldName}' is deprecated and will be removed.`
   return () => {
-    if (warned || process.noDeprecation) {
-      return
+    if (!warned && !process.noDeprecation) {
+      warned = true
+      deprecate.log(msg)
     }
-    deprecate.log(msg)
-    warned = true
   }
-}
-
-function warnReplaced (oldName, newName) {
-  const msg = `'${oldName}' is deprecated. Use '${newName}' instead.`
-  return warnSentinel(msg)
-}
-
-function warnRemoved (name) {
-  const msg = `'${name}' is deprecated and will be removed.`
-  return warnSentinel(msg)
 }
 
 const deprecate = {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -66,32 +66,18 @@ const deprecate = {
     return Object.defineProperty(object, deprecated, {
       configurable: true,
       get: () => { warn(); return value },
-      set: (newValue) => { warn(); value = newValue }
+      set: newValue => { warn(); value = newValue }
     })
   },
   renameProperty: (object, oldName, newName) => {
-    let warned = false
-    let warn = () => {
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.warn(oldName, newName)
-      }
-    }
-
+    const warn = warnOnce(oldName, newName)
     if (!(newName in object) && (oldName in object)) {
       warn()
       object[newName] = object[oldName]
     }
-
     return Object.defineProperty(object, oldName, {
-      get: function () {
-        warn()
-        return this[newName]
-      },
-      set: function (value) {
-        warn()
-        this[newName] = value
-      }
+      get: () => { warn(); return this[newName] },
+      set: value => { warn(); this[newName] = value }
     })
   }
 }

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -1,6 +1,27 @@
 
 let deprecationHandler = null
 
+function warnSentinel (msg) {
+  let warned = false
+  return () => {
+    if (warned || process.noDeprecation)
+      return
+    deprecate.log(msg)
+    warned = true
+  }
+}
+
+function warnReplaced (oldName, newName) {
+  const msg = `'${oldName}' is deprecated. Use '${newName}' instead.`
+  return warnSentinel (msg)
+}
+
+function warnRemoved (name) {
+  const msg = `'${name}' is deprecated and will be removed.. Use '${newName}' instead.`
+  return warnSentinel (msg)
+}
+
+
 const deprecate = {
   setHandler: (handler) => { deprecationHandler = handler },
   getHandler: () => deprecationHandler,

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -59,10 +59,8 @@ const deprecate = {
     })
   },
   removeProperty: (object, deprecated) => {
-    if (!(deprecated in object)) {
-      throw new Error(`Object lacks property '${deprecated}' to deprecate`)
-    }
     const warn = warnOnce(deprecated)
+    if (!(deprecated in object)) warn()
     let value = object[deprecated]
     return Object.defineProperty(object, deprecated, {
       configurable: true,

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -16,8 +16,10 @@ function warnOnce (oldName, newName) {
 }
 
 const deprecate = {
+
   setHandler: (handler) => { deprecationHandler = handler },
   getHandler: () => deprecationHandler,
+
   warn: (oldName, newName) => {
     return deprecate.log(`'${oldName}' is deprecated. Use '${newName}' instead.`)
   },
@@ -32,35 +34,49 @@ const deprecate = {
       return console.warn(`(electron) ${message}`)
     }
   },
+
   event: (emitter, oldName, newName) => {
     const warn = newName.startsWith('-') /* internal event */
       ? warnOnce(`${oldName} event`)
       : warnOnce(`${oldName} event`, `${newName} event`)
     return emitter.on(newName, function (...args) {
-      if (this.listenerCount(oldName) === 0) return
-      warn()
-      this.emit(oldName, ...args)
+      if (this.listenerCount(oldName) !== 0) {
+        warn()
+        this.emit(oldName, ...args)
+      }
     })
   },
-  removeProperty: (object, deprecated) => {
-    const warn = warnOnce(deprecated)
-    if (!(deprecated in object)) warn()
-    let value = object[deprecated]
-    return Object.defineProperty(object, deprecated, {
+
+  removeProperty: (o, removedName) => {
+    const warn = warnOnce(removedName)
+
+    // if the property's already been removed, warn about it
+    if (!(removedName in o)) warn()
+
+    // wrap the deprecated property in an accessor to warn
+    let val = o[removedName]
+    return Object.defineProperty(o, removedName, {
       configurable: true,
-      get: () => { warn(); return value },
-      set: newValue => { warn(); value = newValue }
+      get: () => { warn(); return val },
+      set: newVal => { warn(); val = newVal }
     })
   },
-  renameProperty: (object, oldName, newName) => {
+
+  renameProperty: (o, oldName, newName) => {
     const warn = warnOnce(oldName, newName)
-    if (!(newName in object) && (oldName in object)) {
+
+    // if the new property isn't there yet,
+    // inject it and warn about it
+    if ((oldName in o) && !(newName in o)) {
       warn()
-      object[newName] = object[oldName]
+      o[newName] = o[oldName]
     }
-    return Object.defineProperty(object, oldName, {
-      get: () => { warn(); return object[newName] },
-      set: value => { warn(); object[newName] = value }
+
+    // wrap the deprecated property in an accessor to warn
+    // and redirect to the new property
+    return Object.defineProperty(o, oldName, {
+      get: () => { warn(); return o[newName] },
+      set: value => { warn(); o[newName] = value }
     })
   }
 }

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -16,10 +16,8 @@ function warnOnce (oldName, newName) {
 }
 
 const deprecate = {
-
   setHandler: (handler) => { deprecationHandler = handler },
   getHandler: () => deprecationHandler,
-
   warn: (oldName, newName) => {
     return deprecate.log(`'${oldName}' is deprecated. Use '${newName}' instead.`)
   },
@@ -57,8 +55,14 @@ const deprecate = {
     let val = o[removedName]
     return Object.defineProperty(o, removedName, {
       configurable: true,
-      get: () => { warn(); return val },
-      set: newVal => { warn(); val = newVal }
+      get: () => {
+        warn()
+        return val
+      },
+      set: newVal => {
+        warn()
+        val = newVal
+      }
     })
   },
 
@@ -75,8 +79,14 @@ const deprecate = {
     // wrap the deprecated property in an accessor to warn
     // and redirect to the new property
     return Object.defineProperty(o, oldName, {
-      get: () => { warn(); return o[newName] },
-      set: value => { warn(); o[newName] = value }
+      get: () => {
+        warn()
+        return o[newName]
+      },
+      set: value => {
+        warn()
+        o[newName] = value
+      }
     })
   }
 }

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -36,12 +36,9 @@ const deprecate = {
     return () => { warn(); return fn.apply(this, arguments) }
   },
   alias: function (object, oldName, newName) {
-    let warned = false
-    const newFn = function () {
-      if (!(warned || process.noDeprecation)) {
-        warned = true
-        deprecate.warn(oldName, newName)
-      }
+    const warn = warnOnce(oldName, newName)
+    const newFn = () => {
+      warn()
       return this[newName].apply(this, arguments)
     }
     if (typeof object === 'function') {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -35,11 +35,6 @@ const deprecate = {
     const warn = warnOnce(oldName, newName)
     return () => { warn(); return fn.apply(this, arguments) }
   },
-  removeFunction: (oldName) => {
-    if (!process.noDeprecation) {
-      deprecate.log(`The '${oldName}' function has been deprecated and marked for removal.`)
-    }
-  },
   alias: function (object, oldName, newName) {
     let warned = false
     const newFn = function () {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -4,8 +4,9 @@ let deprecationHandler = null
 function warnSentinel (msg) {
   let warned = false
   return () => {
-    if (warned || process.noDeprecation)
+    if (warned || process.noDeprecation) {
       return
+    }
     deprecate.log(msg)
     warned = true
   }
@@ -13,14 +14,13 @@ function warnSentinel (msg) {
 
 function warnReplaced (oldName, newName) {
   const msg = `'${oldName}' is deprecated. Use '${newName}' instead.`
-  return warnSentinel (msg)
+  return warnSentinel(msg)
 }
 
 function warnRemoved (name) {
-  const msg = `'${name}' is deprecated and will be removed.. Use '${newName}' instead.`
-  return warnSentinel (msg)
+  const msg = `'${name}' is deprecated and will be removed.`
+  return warnSentinel(msg)
 }
-
 
 const deprecate = {
   setHandler: (handler) => { deprecationHandler = handler },

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -1,3 +1,4 @@
+'use strict'
 
 let deprecationHandler = null
 

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -48,7 +48,7 @@ const deprecate = {
     }
   },
   event: (emitter, oldName, newName) => {
-    const warn = newName.startsWith('-') /* private event */
+    const warn = newName.startsWith('-') /* internal event */
       ? warnOnce(`${oldName} event`)
       : warnOnce(`${oldName} event`, `${newName} event`)
     return emitter.on(newName, function (...args) {
@@ -76,8 +76,8 @@ const deprecate = {
       object[newName] = object[oldName]
     }
     return Object.defineProperty(object, oldName, {
-      get: () => { warn(); return this[newName] },
-      set: value => { warn(); this[newName] = value }
+      get: () => { warn(); return object[newName] },
+      set: value => { warn(); object[newName] = value }
     })
   }
 }

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -32,18 +32,6 @@ const deprecate = {
       return console.warn(`(electron) ${message}`)
     }
   },
-  alias: function (object, oldName, newName) {
-    const warn = warnOnce(oldName, newName)
-    const newFn = () => {
-      warn()
-      return this[newName].apply(this, arguments)
-    }
-    if (typeof object === 'function') {
-      object.prototype[newName] = newFn
-    } else {
-      object[oldName] = newFn
-    }
-  },
   event: (emitter, oldName, newName) => {
     const warn = newName.startsWith('-') /* internal event */
       ? warnOnce(`${oldName} event`)

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const {deprecations, deprecate, nativeImage} = require('electron')

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -89,6 +89,21 @@ describe('deprecations', () => {
     expect(msg).to.include(prop)
   })
 
+  it('warns only once per item', () => {
+    const messages = []
+    deprecations.setHandler(message => { messages.push(message) })
+
+    const key = 'foo'
+    const val = 'bar'
+    let o = {[key]: val}
+    deprecate.removeProperty(o, key)
+
+    for (let i = 0; i < 3; ++i) {
+      expect(o[key]).to.equal(val)
+      expect(messages).to.have.length(1)
+    }
+  })
+
   it('warns if deprecated property is already set', () => {
     let msg
     deprecations.setHandler(m => { msg = m })

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -33,17 +33,6 @@ describe.only('deprecations', () => {
     expect(deprecations.getHandler()).to.be.a('function')
   })
 
-  it('returns a deprecation warning', () => {
-    const messages = []
-
-    deprecations.setHandler(message => {
-      messages.push(message)
-    })
-
-    deprecate.warn('old', 'new')
-    expect(messages).to.deep.equal([`'old' is deprecated. Use 'new' instead.`])
-  })
-
   it('renames a method', () => {
     expect(nativeImage.createFromDataUrl).to.be.undefined()
     expect(nativeImage.createFromDataURL).to.be.a('function')

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
-const {deprecations, deprecate, nativeImage} = require('electron')
+const {deprecations, deprecate} = require('electron')
 
 const {expect} = chai
 chai.use(dirtyChai)
@@ -33,15 +33,6 @@ describe('deprecations', () => {
 
     deprecate.log('this is deprecated')
     expect(deprecations.getHandler()).to.be.a('function')
-  })
-
-  it('renames a method', () => {
-    expect(nativeImage.createFromDataUrl).to.be.undefined()
-    expect(nativeImage.createFromDataURL).to.be.a('function')
-
-    deprecate.alias(nativeImage, 'createFromDataUrl', 'createFromDataURL')
-
-    expect(nativeImage.createFromDataUrl).to.be.a('function')
   })
 
   it('renames a property', () => {

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -5,7 +5,7 @@ const {deprecations, deprecate, nativeImage} = require('electron')
 const {expect} = chai
 chai.use(dirtyChai)
 
-describe.only('deprecations', () => {
+describe('deprecations', () => {
   beforeEach(() => {
     deprecations.setHandler(null)
     process.throwDeprecation = true
@@ -70,7 +70,7 @@ describe.only('deprecations', () => {
 
     expect(() => {
       deprecate.removeProperty(o, 'iDontExist')
-    }).to.throw(/Cannot deprecate a property on an object which does not have that property/)
+    }).to.throw(/Cannot deprecate a property on an object which lacks that property/)
   })
 
   it('deprecates a property of an object', () => {

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -69,8 +69,8 @@ describe('deprecations', () => {
     const o = {}
 
     expect(() => {
-      deprecate.removeProperty(o, 'iDontExist')
-    }).to.throw(/Cannot deprecate a property on an object which lacks that property/)
+      deprecate.removeProperty(o, 'iDoNotExist')
+    }).to.throw(/iDoNotExist/)
   })
 
   it('deprecates a property of an object', () => {


### PR DESCRIPTION
##### Description of Change

This started as a refactor to extract-method the warn-once idiom, and kept growing. Builds on yesterday's cool patch from @codebytere 

 * Extract-method the deprecate module's warn-once idiom
 * Remove unused deprecate API
 * Make deprecation warnings more consistent
 * Add test to check that warnings are only made once

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are changed, added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes