### PR TITLE
fix: cpplint didn't work in GN

### DIFF
--- a/script/cpplint.js
+++ b/script/cpplint.js
@@ -24,7 +24,14 @@ function findCppLint () {
 function callCpplint (linter, filenames, args) {
   if (args.verbose) console.log([linter, ...filenames].join(' '))
   try {
-    console.log(String(childProcess.execFileSync(linter, filenames, {cwd: SOURCE_ROOT})))
+    childProcess.execFile(linter, filenames, {cwd: SOURCE_ROOT}, (error, stdout, stderr) => {
+      if (error) {
+        console.warn(error)
+      }
+      for (let line of stderr.split(/[\r\n]+/)) {
+        if (!line.startsWith('Done processing ')) console.warn(line)
+      }
+    })
   } catch (e) {
     process.exit(1)
   }

--- a/script/cpplint.js
+++ b/script/cpplint.js
@@ -16,7 +16,7 @@ function callCpplint (filenames, args) {
       if (error) {
         console.warn(error)
       }
-      for (let line of stderr.split(/[\r\n]+/)) {
+      for (const line of stderr.split(/[\r\n]+/)) {
         if (!line.startsWith('Done processing ')) console.warn(line)
       }
     })


### PR DESCRIPTION
##### Description of Change

cpplint didn't work in the GN world because it was looking for depot_tools to exist as a result of `./script/bootstrap.py` rather than already being in the user's environment.

@codebytere @jkleinsc 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: no-notes