### PR TITLE
fix: gn cpplint warnings

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -5,6 +5,7 @@
 #include "atom/app/atom_main_delegate.h"
 
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "atom/app/atom_content_client.h"

--- a/atom/app/atom_main_delegate.h
+++ b/atom/app/atom_main_delegate.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_APP_ATOM_MAIN_DELEGATE_H_
 #define ATOM_APP_ATOM_MAIN_DELEGATE_H_
 
+#include <memory>
 #include <string>
 
 #include "brightray/common/content_client.h"

--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -4,6 +4,9 @@
 
 #ifdef ENABLE_RUN_AS_NODE
 
+#include <memory>
+#include <utility>
+
 #include "atom/app/node_main.h"
 
 #include "atom/app/uv_task_runner.h"

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "atom/browser/api/atom_api_browser_window.h"
 
 #include "atom/browser/browser.h"

--- a/atom/browser/api/atom_api_browser_window.h
+++ b/atom/browser/api/atom_api_browser_window.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_BROWSER_WINDOW_H_
 #define ATOM_BROWSER_API_ATOM_API_BROWSER_WINDOW_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+#include <utility>
+
 #include "atom/browser/api/atom_api_cookies.h"
 
 #include "atom/browser/atom_browser_context.h"

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_COOKIES_H_
 #define ATOM_BROWSER_API_ATOM_API_COOKIES_H_
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/api/trackable_object.h"

--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -4,7 +4,9 @@
 
 #include "atom/browser/api/atom_api_debugger.h"
 
+#include <memory>
 #include <string>
+#include <utility>
 
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/value_converter.h"

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -4,6 +4,8 @@
 
 #include "atom/browser/api/atom_api_desktop_capturer.h"
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 using base::PlatformThreadRef;

--- a/atom/browser/api/atom_api_desktop_capturer.h
+++ b/atom/browser/api/atom_api_desktop_capturer.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_DESKTOP_CAPTURER_H_
 #define ATOM_BROWSER_API_ATOM_API_DESKTOP_CAPTURER_H_
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/api/event_emitter.h"

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "atom/browser/api/atom_api_menu_views.h"
 
 #include "atom/browser/native_window_views.h"

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_API_ATOM_API_MENU_VIEWS_H_
 
 #include <map>
+#include <memory>
 
 #include "atom/browser/api/atom_api_menu.h"
 #include "base/memory/weak_ptr.h"

--- a/atom/browser/api/atom_api_net_log.cc
+++ b/atom/browser/api/atom_api_net_log.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "atom/browser/api/atom_api_net_log.h"
 #include "atom/browser/atom_browser_client.h"
 #include "atom/common/native_mate_converters/callback.h"

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -6,7 +6,9 @@
 #define ATOM_BROWSER_API_ATOM_API_PROTOCOL_H_
 
 #include <map>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/browser/api/trackable_object.h"

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -5,7 +5,9 @@
 #include "atom/browser/api/atom_api_session.h"
 
 #include <map>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/browser/api/atom_api_cookies.h"

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_SYSTEM_PREFERENCES_H_
 #define ATOM_BROWSER_API_ATOM_API_SYSTEM_PREFERENCES_H_
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/api/event_emitter.h"

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -4,8 +4,10 @@
 
 #include "atom/browser/api/atom_api_web_contents.h"
 
+#include <memory>
 #include <set>
 #include <string>
+#include <utility>
 
 // We have problems with redefinition of ssize_t between node.h and
 // port_chromium.h, and the latter was introduced by leveldb.mojom.h.

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_WEB_CONTENTS_H_
 #define ATOM_BROWSER_API_ATOM_API_WEB_CONTENTS_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/browser/api/atom_api_web_request.cc
+++ b/atom/browser/api/atom_api_web_request.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/api/atom_api_web_request.h"
 
 #include <string>
+#include <utility>
 
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/net/atom_network_delegate.h"

--- a/atom/browser/api/event_subscriber.cc
+++ b/atom/browser/api/event_subscriber.cc
@@ -1,7 +1,9 @@
 // Copyright (c) 2017 GitHub, Inc.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
+
 #include <string>
+#include <utility>
 
 #include "atom/browser/api/event_subscriber.h"
 #include "atom/common/native_mate_converters/callback.h"

--- a/atom/browser/api/event_subscriber.h
+++ b/atom/browser/api/event_subscriber.h
@@ -6,7 +6,9 @@
 #define ATOM_BROWSER_API_EVENT_SUBSCRIBER_H_
 
 #include <map>
+#include <memory>
 #include <string>
+#include <utility>
 
 #include "atom/common/api/event_emitter_caller.h"
 #include "base/synchronization/lock.h"

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "atom/browser/api/trackable_object.h"
 
 #include "atom/browser/atom_browser_main_parts.h"

--- a/atom/browser/atom_blob_reader.cc
+++ b/atom/browser/atom_blob_reader.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "atom/browser/atom_blob_reader.h"
 
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"

--- a/atom/browser/atom_blob_reader.h
+++ b/atom/browser/atom_blob_reader.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_ATOM_BLOB_READER_H_
 #define ATOM_BROWSER_ATOM_BLOB_READER_H_
 
+#include <memory>
 #include <string>
 
 #include "base/callback.h"

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -86,7 +86,7 @@ namespace {
 bool g_suppress_renderer_process_restart = false;
 
 // Custom schemes to be registered to handle service worker.
-base::NoDestructor<std::string> g_custom_service_worker_schemes = "";
+base::NoDestructor<std::string> g_custom_service_worker_schemes;
 
 bool IsSameWebSite(content::BrowserContext* browser_context,
                    const GURL& src_url,

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -8,6 +8,9 @@
 #include <shlobj.h>
 #endif
 
+#include <memory>
+#include <utility>
+
 #include "atom/browser/api/atom_api_app.h"
 #include "atom/browser/api/atom_api_protocol.h"
 #include "atom/browser/api/atom_api_web_contents.h"

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -31,6 +31,7 @@
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/files/file_util.h"
+#include "base/no_destructor.h"
 #include "base/stl_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
@@ -85,7 +86,7 @@ namespace {
 bool g_suppress_renderer_process_restart = false;
 
 // Custom schemes to be registered to handle service worker.
-std::string g_custom_service_worker_schemes = "";
+base::NoDestructor<std::string> g_custom_service_worker_schemes = "";
 
 bool IsSameWebSite(content::BrowserContext* browser_context,
                    const GURL& src_url,
@@ -108,7 +109,7 @@ void AtomBrowserClient::SuppressRendererProcessRestartForOnce() {
 
 void AtomBrowserClient::SetCustomServiceWorkerSchemes(
     const std::vector<std::string>& schemes) {
-  g_custom_service_worker_schemes = base::JoinString(schemes, ",");
+  *g_custom_service_worker_schemes = base::JoinString(schemes, ",");
 }
 
 AtomBrowserClient::AtomBrowserClient() {}
@@ -329,9 +330,9 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
                                  arraysize(kCommonSwitchNames));
 
   // The registered service worker schemes.
-  if (!g_custom_service_worker_schemes.empty())
+  if (!g_custom_service_worker_schemes->empty())
     command_line->AppendSwitchASCII(switches::kRegisterServiceWorkerSchemes,
-                                    g_custom_service_worker_schemes);
+                                    *g_custom_service_worker_schemes);
 
 #if defined(OS_WIN)
   // Append --app-user-model-id.

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_ATOM_BROWSER_CLIENT_H_
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_ATOM_BROWSER_CONTEXT_H_
 #define ATOM_BROWSER_ATOM_BROWSER_CONTEXT_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "atom/browser/atom_browser_main_parts.h"
 
 #include "atom/browser/api/atom_api_app.h"

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_ATOM_BROWSER_MAIN_PARTS_H_
 
 #include <list>
+#include <memory>
 #include <string>
 
 #include "base/callback.h"

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/atom_javascript_dialog_manager.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/browser/api/atom_api_web_contents.h"

--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/atom_permission_manager.h"
 
+#include <memory>
 #include <vector>
 
 #include "atom/browser/atom_browser_client.h"

--- a/atom/browser/atom_permission_manager.h
+++ b/atom/browser/atom_permission_manager.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_ATOM_PERMISSION_MANAGER_H_
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "base/callback.h"

--- a/atom/browser/atom_speech_recognition_manager_delegate.cc
+++ b/atom/browser/atom_speech_recognition_manager_delegate.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/atom_speech_recognition_manager_delegate.h"
 
 #include <string>
+#include <utility>
 
 #include "base/callback.h"
 

--- a/atom/browser/bridge_task_runner.cc
+++ b/atom/browser/bridge_task_runner.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "atom/browser/bridge_task_runner.h"
 
 #include "base/message_loop/message_loop.h"

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/browser.h"
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/atom_browser_main_parts.h"

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_BROWSER_H_
 #define ATOM_BROWSER_BROWSER_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -4,8 +4,10 @@
 
 #include "atom/browser/common_web_contents_delegate.h"
 
+#include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/browser/atom_browser_context.h"

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_COMMON_WEB_CONTENTS_DELEGATE_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/browser/lib/power_observer_linux.cc
+++ b/atom/browser/lib/power_observer_linux.cc
@@ -5,7 +5,9 @@
 
 #include <unistd.h>
 #include <uv.h>
+
 #include <iostream>
+#include <utility>
 
 #include "base/bind.h"
 #include "device/bluetooth/dbus/dbus_thread_manager_linux.h"

--- a/atom/browser/loader/layered_resource_handler.cc
+++ b/atom/browser/loader/layered_resource_handler.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+#include <utility>
+
 #include "atom/browser/loader/layered_resource_handler.h"
 
 namespace atom {

--- a/atom/browser/loader/layered_resource_handler.h
+++ b/atom/browser/loader/layered_resource_handler.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_LOADER_LAYERED_RESOURCE_HANDLER_H_
 #define ATOM_BROWSER_LOADER_LAYERED_RESOURCE_HANDLER_H_
 
+#include <memory>
+
 #include "content/browser/loader/layered_resource_handler.h"
 #include "services/network/public/cpp/resource_response.h"
 

--- a/atom/browser/login_handler.cc
+++ b/atom/browser/login_handler.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+#include <utility>
+
 #include "atom/browser/login_handler.h"
 
 #include "atom/browser/browser.h"

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -7,6 +7,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -9,6 +9,8 @@
 #include <wrl/client.h>
 #endif
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "atom/browser/api/atom_api_web_contents.h"

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -7,6 +7,7 @@
 
 #include "atom/browser/native_window.h"
 
+#include <memory>
 #include <set>
 #include <string>
 

--- a/atom/browser/net/asar/url_request_asar_job.cc
+++ b/atom/browser/net/asar/url_request_asar_job.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/net/asar/url_request_asar_job.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/common/asar/archive.h"

--- a/atom/browser/net/atom_cert_verifier.cc
+++ b/atom/browser/net/atom_cert_verifier.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <utility>
+
 #include "atom/browser/net/atom_cert_verifier.h"
 
 #include "atom/browser/browser.h"

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "atom/browser/net/atom_network_delegate.h"
-
+#include <memory>
 #include <utility>
+
+#include "atom/browser/net/atom_network_delegate.h"
 
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/login_handler.h"

--- a/atom/browser/net/atom_network_delegate.h
+++ b/atom/browser/net/atom_network_delegate.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_NET_ATOM_NETWORK_DELEGATE_H_
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>

--- a/atom/browser/net/atom_url_request.cc
+++ b/atom/browser/net/atom_url_request.cc
@@ -3,8 +3,11 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "atom/browser/net/atom_url_request.h"
 #include <string>
+#include <memory>
+#include <utility>
+
+#include "atom/browser/net/atom_url_request.h"
 #include "atom/browser/api/atom_api_url_request.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/net/atom_url_request_job_factory.h"

--- a/atom/browser/net/atom_url_request.h
+++ b/atom/browser/net/atom_url_request.h
@@ -7,7 +7,9 @@
 #define ATOM_BROWSER_NET_ATOM_URL_REQUEST_H_
 
 #include <string>
+#include <memory>
 #include <vector>
+
 #include "atom/browser/api/atom_api_url_request.h"
 #include "atom/browser/atom_browser_context.h"
 #include "base/memory/ref_counted.h"

--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -4,6 +4,8 @@
 
 #include "atom/browser/net/js_asker.h"
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "atom/common/native_mate_converters/callback.h"

--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -5,6 +5,9 @@
 #ifndef ATOM_BROWSER_NET_JS_ASKER_H_
 #define ATOM_BROWSER_NET_JS_ASKER_H_
 
+#include <memory>
+#include <utility>
+
 #include "atom/common/native_mate_converters/net_converter.h"
 #include "base/callback.h"
 #include "base/memory/ref_counted.h"

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/net/url_request_async_asar_job.h"
 
+#include <memory>
 #include <string>
 
 #include "atom/common/atom_constants.h"

--- a/atom/browser/net/url_request_async_asar_job.h
+++ b/atom/browser/net/url_request_async_asar_job.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_NET_URL_REQUEST_ASYNC_ASAR_JOB_H_
 #define ATOM_BROWSER_NET_URL_REQUEST_ASYNC_ASAR_JOB_H_
 
+#include <memory>
+
 #include "atom/browser/net/asar/url_request_asar_job.h"
 #include "atom/browser/net/js_asker.h"
 

--- a/atom/browser/net/url_request_buffer_job.cc
+++ b/atom/browser/net/url_request_buffer_job.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/net/url_request_buffer_job.h"
 
+#include <memory>
 #include <string>
 
 #include "atom/common/atom_constants.h"

--- a/atom/browser/net/url_request_buffer_job.h
+++ b/atom/browser/net/url_request_buffer_job.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_NET_URL_REQUEST_BUFFER_JOB_H_
 #define ATOM_BROWSER_NET_URL_REQUEST_BUFFER_JOB_H_
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/net/js_asker.h"

--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/net/url_request_fetch_job.h"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 
 #include "atom/browser/api/atom_api_session.h"

--- a/atom/browser/net/url_request_fetch_job.h
+++ b/atom/browser/net/url_request_fetch_job.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_NET_URL_REQUEST_FETCH_JOB_H_
 #define ATOM_BROWSER_NET_URL_REQUEST_FETCH_JOB_H_
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/net/js_asker.h"

--- a/atom/browser/net/url_request_stream_job.cc
+++ b/atom/browser/net/url_request_stream_job.cc
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 #include <algorithm>
+#include <memory>
 #include <ostream>
 #include <string>
+#include <utility>
 
 #include "atom/browser/net/url_request_stream_job.h"
 #include "atom/common/api/event_emitter_caller.h"

--- a/atom/browser/net/url_request_stream_job.h
+++ b/atom/browser/net/url_request_stream_job.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_NET_URL_REQUEST_STREAM_JOB_H_
 
 #include <deque>
+#include <memory>
 #include <string>
 
 #include "atom/browser/api/event_subscriber.h"

--- a/atom/browser/net/url_request_string_job.cc
+++ b/atom/browser/net/url_request_string_job.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/net/url_request_string_job.h"
 
+#include <memory>
 #include <string>
 
 #include "atom/common/atom_constants.h"

--- a/atom/browser/net/url_request_string_job.h
+++ b/atom/browser/net/url_request_string_job.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_NET_URL_REQUEST_STRING_JOB_H_
 #define ATOM_BROWSER_NET_URL_REQUEST_STRING_JOB_H_
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/net/js_asker.h"

--- a/atom/browser/osr/osr_output_device.h
+++ b/atom/browser/osr/osr_output_device.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_OSR_OSR_OUTPUT_DEVICE_H_
 #define ATOM_BROWSER_OSR_OSR_OUTPUT_DEVICE_H_
 
+#include <memory>
+
 #include "base/callback.h"
 #include "components/viz/service/display/software_output_device.h"
 #include "third_party/skia/include/core/SkBitmap.h"

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_OSR_OSR_RENDER_WIDGET_HOST_VIEW_H_
 #define ATOM_BROWSER_OSR_OSR_RENDER_WIDGET_HOST_VIEW_H_
 
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>

--- a/atom/browser/osr/osr_view_proxy.h
+++ b/atom/browser/osr/osr_view_proxy.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_OSR_OSR_VIEW_PROXY_H_
 #define ATOM_BROWSER_OSR_OSR_VIEW_PROXY_H_
 
+#include <memory>
 #include <set>
 
 #include "third_party/skia/include/core/SkBitmap.h"

--- a/atom/browser/relauncher.cc
+++ b/atom/browser/relauncher.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/relauncher.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/common/atom_command_line.h"

--- a/atom/browser/request_context_delegate.cc
+++ b/atom/browser/request_context_delegate.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+#include <utility>
+
 #include "atom/browser/request_context_delegate.h"
 
 #include "atom/browser/api/atom_api_protocol.h"

--- a/atom/browser/request_context_delegate.h
+++ b/atom/browser/request_context_delegate.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_REQUEST_CONTEXT_DELEGATE_H_
 #define ATOM_BROWSER_REQUEST_CONTEXT_DELEGATE_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/browser/ui/tray_icon_gtk.h
+++ b/atom/browser/ui/tray_icon_gtk.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_UI_TRAY_ICON_GTK_H_
 #define ATOM_BROWSER_UI_TRAY_ICON_GTK_H_
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/ui/tray_icon.h"

--- a/atom/browser/ui/views/autofill_popup_view.cc
+++ b/atom/browser/ui/views/autofill_popup_view.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "atom/browser/ui/views/autofill_popup_view.h"
 #include "base/bind.h"
 #include "base/i18n/rtl.h"

--- a/atom/browser/ui/views/autofill_popup_view.h
+++ b/atom/browser/ui/views/autofill_popup_view.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_UI_VIEWS_AUTOFILL_POPUP_VIEW_H_
 #define ATOM_BROWSER_UI_VIEWS_AUTOFILL_POPUP_VIEW_H_
 
+#include <memory>
+
 #include "atom/browser/ui/autofill_popup.h"
 
 #if defined(ENABLE_OSR)

--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "atom/browser/ui/views/menu_bar.h"
 
 #include "atom/browser/ui/views/menu_delegate.h"

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+#include <utility>
+
 #include "atom/browser/ui/views/submenu_button.h"
 
 #include "base/strings/string_util.h"

--- a/atom/browser/ui/views/submenu_button.h
+++ b/atom/browser/ui/views/submenu_button.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_UI_VIEWS_SUBMENU_BUTTON_H_
 #define ATOM_BROWSER_UI_VIEWS_SUBMENU_BUTTON_H_
 
+#include <memory>
+
 #include "ui/views/animation/ink_drop_highlight.h"
 #include "ui/views/controls/button/menu_button.h"
 

--- a/atom/browser/ui/webui/pdf_viewer_handler.cc
+++ b/atom/browser/ui/webui/pdf_viewer_handler.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+#include <utility>
+
 #include "atom/browser/ui/webui/pdf_viewer_handler.h"
 
 #include "atom/common/atom_constants.h"

--- a/atom/browser/ui/webui/pdf_viewer_handler.h
+++ b/atom/browser/ui/webui/pdf_viewer_handler.h
@@ -9,6 +9,7 @@
 #error("This header can only be used when enable_pdf_viewer gyp flag is enabled")  // NOLINT
 #endif  // defined(ENABLE_PDF_VIEWER)
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/web_contents_zoom_controller.h"

--- a/atom/browser/ui/webui/pdf_viewer_ui.cc
+++ b/atom/browser/ui/webui/pdf_viewer_ui.cc
@@ -5,6 +5,8 @@
 #include "atom/browser/ui/webui/pdf_viewer_ui.h"
 
 #include <map>
+#include <memory>
+#include <utility>
 
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/loader/layered_resource_handler.h"

--- a/atom/browser/ui/webui/pdf_viewer_ui.h
+++ b/atom/browser/ui/webui/pdf_viewer_ui.h
@@ -9,6 +9,7 @@
 #error("This header can only be used when enable_pdf_viewer gyp flag is enabled")  // NOLINT
 #endif  // defined(ENABLE_PDF_VIEWER)
 
+#include <memory>
 #include <string>
 
 #include "base/macros.h"

--- a/atom/browser/ui/win/notify_icon.h
+++ b/atom/browser/ui/win/notify_icon.h
@@ -9,6 +9,7 @@
 
 #include <shellapi.h>
 
+#include <memory>
 #include <string>
 
 #include "atom/browser/ui/tray_icon.h"

--- a/atom/browser/ui/x/event_disabler.cc
+++ b/atom/browser/ui/x/event_disabler.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "atom/browser/ui/x/event_disabler.h"
 
 namespace atom {

--- a/atom/browser/ui/x/event_disabler.h
+++ b/atom/browser/ui/x/event_disabler.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_UI_X_EVENT_DISABLER_H_
 #define ATOM_BROWSER_UI_X_EVENT_DISABLER_H_
 
+#include <memory>
+
 #include "base/macros.h"
 #include "ui/events/event_rewriter.h"
 

--- a/atom/browser/ui/x/x_window_utils.cc
+++ b/atom/browser/ui/x/x_window_utils.cc
@@ -6,6 +6,8 @@
 
 #include <X11/Xatom.h>
 
+#include <memory>
+
 #include "base/environment.h"
 #include "base/strings/string_util.h"
 #include "base/threading/thread_restrictions.h"

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/browser/native_window.h"

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -4,7 +4,9 @@
 
 #include "atom/common/api/atom_api_native_image.h"
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/common/asar/asar_util.h"

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -6,6 +6,7 @@
 #define ATOM_COMMON_API_ATOM_BINDINGS_H_
 
 #include <list>
+#include <memory>
 
 #include "base/macros.h"
 #include "base/process/process_metrics.h"

--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -5,6 +5,7 @@
 #include "atom/common/asar/archive.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/common/asar/scoped_temporary_file.h"

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -6,6 +6,7 @@
 #define ATOM_COMMON_CRASH_REPORTER_CRASH_REPORTER_MAC_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -5,6 +5,8 @@
 #include "atom/common/native_mate_converters/net_converter.h"
 
 #include <string>
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "atom/common/native_mate_converters/gurl_converter.h"

--- a/atom/common/native_mate_converters/network_converter.cc
+++ b/atom/common/native_mate_converters/network_converter.cc
@@ -4,6 +4,7 @@
 
 #include "atom/common/native_mate_converters/network_converter.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "atom/common/native_mate_converters/value_converter.h"
 
 #include "atom/common/native_mate_converters/v8_value_converter.h"

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -5,6 +5,7 @@
 #include "atom/common/node_bindings.h"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/renderer/api/atom_api_spell_check_client.h
+++ b/atom/renderer/api/atom_api_spell_check_client.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_RENDERER_API_ATOM_API_SPELL_CHECK_CLIENT_H_
 #define ATOM_RENDERER_API_ATOM_API_SPELL_CHECK_CLIENT_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_RENDERER_ATOM_RENDERER_CLIENT_H_
 #define ATOM_RENDERER_ATOM_RENDERER_CLIENT_H_
 
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -30,8 +30,8 @@ namespace atom {
 
 namespace {
 
-const std::string kIpcKey = "ipcNative";
-const std::string kModuleCacheKey = "native-module-cache";
+const char kIpcKey[] = "ipcNative";
+const char kModuleCacheKey[] = "native-module-cache";
 
 bool IsDevTools(content::RenderFrame* render_frame) {
   return render_frame->GetWebFrame()->GetDocument().Url().ProtocolIs(

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -4,6 +4,7 @@
 #ifndef ATOM_RENDERER_ATOM_SANDBOXED_RENDERER_CLIENT_H_
 #define ATOM_RENDERER_ATOM_SANDBOXED_RENDERER_CLIENT_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/renderer/guest_view_container.cc
+++ b/atom/renderer/guest_view_container.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "atom/renderer/guest_view_container.h"
-
 #include <map>
+#include <utility>
+
+#include "atom/renderer/guest_view_container.h"
 
 #include "base/bind.h"
 #include "base/lazy_instance.h"

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -4,6 +4,7 @@
 
 #include "atom/renderer/renderer_client_base.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_RENDERER_RENDERER_CLIENT_BASE_H_
 #define ATOM_RENDERER_RENDERER_CLIENT_BASE_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/atom/renderer/web_worker_observer.h
+++ b/atom/renderer/web_worker_observer.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_RENDERER_WEB_WORKER_OBSERVER_H_
 #define ATOM_RENDERER_WEB_WORKER_OBSERVER_H_
 
+#include <memory>
+
 #include "base/macros.h"
 #include "v8/include/v8.h"
 

--- a/brightray/browser/browser_client.cc
+++ b/brightray/browser/browser_client.cc
@@ -5,6 +5,7 @@
 #include "brightray/browser/browser_client.h"
 
 #include "base/lazy_instance.h"
+#include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "brightray/browser/browser_context.h"
 #include "brightray/browser/browser_main_parts.h"
@@ -26,7 +27,8 @@ BrowserClient* g_browser_client;
 base::LazyInstance<std::string>::DestructorAtExit
     g_io_thread_application_locale = LAZY_INSTANCE_INITIALIZER;
 
-std::string g_application_locale;
+base::NoDestructor<std::string> g_application_locale;
+
 
 void SetApplicationLocaleOnIOThread(const std::string& locale) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
@@ -45,7 +47,7 @@ void BrowserClient::SetApplicationLocale(const std::string& locale) {
           base::BindOnce(&SetApplicationLocaleOnIOThread, locale))) {
     g_io_thread_application_locale.Get() = locale;
   }
-  g_application_locale = locale;
+  *g_application_locale = locale;
 }
 
 BrowserClient* BrowserClient::Get() {
@@ -127,7 +129,7 @@ content::DevToolsManagerDelegate* BrowserClient::GetDevToolsManagerDelegate() {
 std::string BrowserClient::GetApplicationLocale() {
   if (BrowserThread::CurrentlyOn(BrowserThread::IO))
     return g_io_thread_application_locale.Get();
-  return g_application_locale;
+  return *g_application_locale;
 }
 
 }  // namespace brightray

--- a/brightray/browser/browser_client.h
+++ b/brightray/browser/browser_client.h
@@ -5,6 +5,7 @@
 #ifndef BRIGHTRAY_BROWSER_BROWSER_CLIENT_H_
 #define BRIGHTRAY_BROWSER_BROWSER_CLIENT_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/brightray/browser/browser_context.cc
+++ b/brightray/browser/browser_context.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
+#include <memory>
+#include <utility>
+
 #include "brightray/browser/browser_context.h"
 
 #include "base/files/file_path.h"

--- a/brightray/browser/browser_context.h
+++ b/brightray/browser/browser_context.h
@@ -6,6 +6,7 @@
 #define BRIGHTRAY_BROWSER_BROWSER_CONTEXT_H_
 
 #include <map>
+#include <memory>
 #include <string>
 
 #include "base/memory/ref_counted.h"

--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -10,6 +10,7 @@
 
 #include <sys/stat.h>
 #include <string>
+#include <utility>
 
 #if defined(OS_LINUX)
 #include <glib.h>  // for g_setenv()

--- a/brightray/browser/devtools_manager_delegate.cc
+++ b/brightray/browser/devtools_manager_delegate.cc
@@ -4,6 +4,7 @@
 
 #include "brightray/browser/devtools_manager_delegate.h"
 
+#include <memory>
 #include <vector>
 
 #include "base/bind.h"

--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
+#include <memory>
 #include <utility>
 
 #include "brightray/browser/inspectable_web_contents_impl.h"

--- a/brightray/browser/inspectable_web_contents_impl.h
+++ b/brightray/browser/inspectable_web_contents_impl.h
@@ -7,6 +7,7 @@
 #define BRIGHTRAY_BROWSER_INSPECTABLE_WEB_CONTENTS_IMPL_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/brightray/browser/media/media_stream_devices_controller.cc
+++ b/brightray/browser/media/media_stream_devices_controller.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
+#include <memory>
+
 #include "brightray/browser/media/media_stream_devices_controller.h"
 
 #include "brightray/browser/media/media_capture_devices_dispatcher.h"

--- a/brightray/browser/net_log.h
+++ b/brightray/browser/net_log.h
@@ -5,6 +5,8 @@
 #ifndef BRIGHTRAY_BROWSER_NET_LOG_H_
 #define BRIGHTRAY_BROWSER_NET_LOG_H_
 
+#include <memory>
+
 #include "base/callback.h"
 #include "base/files/file_path.h"
 #include "net/log/net_log.h"

--- a/brightray/browser/url_request_context_getter.cc
+++ b/brightray/browser/url_request_context_getter.cc
@@ -5,6 +5,8 @@
 #include "brightray/browser/url_request_context_getter.h"
 
 #include <algorithm>
+#include <memory>
+#include <utility>
 
 #include "base/command_line.h"
 #include "base/memory/ptr_util.h"

--- a/brightray/browser/url_request_context_getter.h
+++ b/brightray/browser/url_request_context_getter.h
@@ -5,6 +5,7 @@
 #ifndef BRIGHTRAY_BROWSER_URL_REQUEST_CONTEXT_GETTER_H_
 #define BRIGHTRAY_BROWSER_URL_REQUEST_CONTEXT_GETTER_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/brightray/browser/views/inspectable_web_contents_view_views.h
+++ b/brightray/browser/views/inspectable_web_contents_view_views.h
@@ -1,6 +1,8 @@
 #ifndef BRIGHTRAY_BROWSER_VIEWS_INSPECTABLE_WEB_CONTENTS_VIEW_VIEWS_H_
 #define BRIGHTRAY_BROWSER_VIEWS_INSPECTABLE_WEB_CONTENTS_VIEW_VIEWS_H_
 
+#include <memory>
+
 #include "base/compiler_specific.h"
 #include "brightray/browser/inspectable_web_contents_view.h"
 #include "chrome/browser/devtools/devtools_contents_resizing_strategy.h"

--- a/brightray/browser/views/views_delegate.cc
+++ b/brightray/browser/views/views_delegate.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
+#include <memory>
+
 #include "brightray/browser/views/views_delegate.h"
 
 #include "ui/views/widget/desktop_aura/desktop_native_widget_aura.h"

--- a/brightray/browser/win/notification_presenter_win.cc
+++ b/brightray/browser/win/notification_presenter_win.cc
@@ -6,6 +6,7 @@
 
 #include "brightray/browser/win/notification_presenter_win.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/brightray/browser/win/win32_desktop_notifications/toast.cc
+++ b/brightray/browser/win/win32_desktop_notifications/toast.cc
@@ -9,6 +9,7 @@
 #include <uxtheme.h>
 #include <windowsx.h>
 #include <algorithm>
+#include <memory>
 
 #include "base/logging.h"
 #include "brightray/browser/win/win32_desktop_notifications/common.h"

--- a/brightray/browser/win/win32_notification.cc
+++ b/brightray/browser/win/win32_notification.cc
@@ -6,6 +6,7 @@
 
 #include <windows.h>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "third_party/skia/include/core/SkBitmap.h"

--- a/brightray/browser/zoom_level_delegate.h
+++ b/brightray/browser/zoom_level_delegate.h
@@ -5,6 +5,7 @@
 #ifndef BRIGHTRAY_BROWSER_ZOOM_LEVEL_DELEGATE_H_
 #define BRIGHTRAY_BROWSER_ZOOM_LEVEL_DELEGATE_H_
 
+#include <memory>
 #include <string>
 
 #include "base/files/file_path.h"

--- a/brightray/common/application_info.cc
+++ b/brightray/common/application_info.cc
@@ -1,28 +1,29 @@
+#include "base/no_destructor.h"
 #include "brightray/common/application_info.h"
 
 namespace brightray {
 
 namespace {
 
-std::string g_overridden_application_name;
-std::string g_overridden_application_version;
+base::NoDestructor<std::string> g_overridden_application_name;
+base::NoDestructor<std::string> g_overridden_application_version;
 
 }  // namespace
 
 // name
 void OverrideApplicationName(const std::string& name) {
-  g_overridden_application_name = name;
+  *g_overridden_application_name = name;
 }
 std::string GetOverriddenApplicationName() {
-  return g_overridden_application_name;
+  return *g_overridden_application_name;
 }
 
 // version
 void OverrideApplicationVersion(const std::string& version) {
-  g_overridden_application_version = version;
+  *g_overridden_application_version = version;
 }
 std::string GetOverriddenApplicationVersion() {
-  return g_overridden_application_version;
+  return *g_overridden_application_version;
 }
 
 }  // namespace brightray

--- a/script/precommit.js
+++ b/script/precommit.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+const childProcess = require('child_process')
+const path = require('path')
+
+const SOURCE_ROOT = path.normalize(path.dirname(__dirname))
+
+function callExecutable (executable, args) {
+  console.log(executable + ' ' + args.join(' '))
+  try {
+    console.log(String(childProcess.execFileSync(executable, args, {cwd: SOURCE_ROOT})))
+  } catch (e) {
+    console.log(e)
+    process.exit(1)
+  }
+}
+
+const script = path.join(SOURCE_ROOT, 'script', 'run-clang-format.py')
+const dirs = ['atom', 'brightray', 'chromium_src'].map(x => path.join(SOURCE_ROOT, x))
+const args = [script, '-r', '-c', ...dirs]
+callExecutable('python', args)
+
+callExecutable(path.join(SOURCE_ROOT, 'script', 'cpplint.js'), ['--only-changed'])
+
+callExecutable('npm', ['run', 'lint:js'])
+
+callExecutable('remark', ['docs', '-qf'])


### PR DESCRIPTION
##### Description of Change

After getting [cpplint working in GN builds](https://github.com/electron/electron/pull/14581) there were about 150 linter warnings, mostly trivial:

 * following the include-what-you-use policy, e.g. include `<memory>` before using `std::unique_ptr`, include `<utility>` before using `std::move()`, etc.
 * static const strings should use C-style char arrays rather than std::strings because strings have [non-trivial destructors](https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables)
 * when using a global std::string to hold state, e.g. in a namespace, wrap it in a [`base::NoDestructor`]( https://cs.chromium.org/chromium/src/base/no_destructor.h?q=base::NoDestructor&sq=package:chromium&g=0&l=17) container

cc @nornagon 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes