### PR TITLE
ci: don't run gn debug build on older branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,13 @@ build_cloud: electron-16
 image: electron-16-vs2017-15.4.5
 build_script:
 - ps: >-
-    if($env:SKIP_GYP_BUILD -eq "true") {
-      Write-warning "Skipping debug build for older branch"; Exit-AppveyorBuild
-    }
-
     echo "Build worker image $env:APPVEYOR_BUILD_WORKER_IMAGE"
 
     &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
-
-    if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+    
+    if($env:SKIP_GYP_BUILD -eq "true") {
+      Write-warning "Skipping debug build for older branch"; Exit-AppveyorBuild
+    } elseif(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
       Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
     } else {
       Add-Path "$env:ProgramFiles (x86)\Windows Kits\10\Debuggers\x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ build_cloud: electron-16
 image: electron-16-vs2017-15.4.5
 build_script:
 - ps: >-
+    if($env:SKIP_GYP_BUILD -eq "true") {
+      Write-warning "Skipping debug build for older branch"; Exit-AppveyorBuild
+    }
+
     echo "Build worker image $env:APPVEYOR_BUILD_WORKER_IMAGE"
 
     &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"


### PR DESCRIPTION
Older branches that build using gyp do not run both a debug and testing build, so this PR will disable the `appveyor: win-ia32-debug` and `appveyor: win-x64-debug` jobs for 3-0-x and older branches.  For 3-0-x and older branches the `appveyor: win-ia32-testing-pr`, `appveyor: win-ia32-testing`, `appveyor: win-x64-testing-pr` and `appveyor: win-x64-testing` builds will be used to for testing purposes.
##### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes