### PR TITLE
chore: remove ELECTRON_GN_BUILD define

### DIFF
--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -16,10 +16,6 @@ static_library("brightray") {
 
   include_dirs = [ ".." ]
 
-  defines = [
-    "DISABLE_NACL=1",
-  ]
-
   if (is_linux) {
     deps += [ "//build/config/linux/gtk" ]
   }

--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -18,7 +18,6 @@ static_library("brightray") {
 
   defines = [
     "DISABLE_NACL=1",
-    "ELECTRON_GN_BUILD",
   ]
 
   if (is_linux) {

--- a/brightray/common/main_delegate.cc
+++ b/brightray/common/main_delegate.cc
@@ -57,40 +57,20 @@ void LoadResourceBundle(const std::string& locale) {
   PathService::Get(base::DIR_MODULE, &pak_dir);
 #endif
 
-#if defined(ELECTRON_GN_BUILD)
   ui::ResourceBundle::InitSharedInstanceWithLocale(
       locale, nullptr, ui::ResourceBundle::LOAD_COMMON_RESOURCES);
   ui::ResourceBundle& bundle = ui::ResourceBundle::GetSharedInstance();
   bundle.ReloadLocaleResources(locale);
   bundle.AddDataPackFromPath(pak_dir.Append(FILE_PATH_LITERAL("resources.pak")),
                              ui::SCALE_FACTOR_NONE);
-#else
-  ui::ResourceBundle::InitSharedInstanceWithLocale(
-      locale, nullptr, ui::ResourceBundle::DO_NOT_LOAD_COMMON_RESOURCES);
-  ui::ResourceBundle& bundle = ui::ResourceBundle::GetSharedInstance();
-  bundle.ReloadLocaleResources(locale);
-
-  bundle.AddDataPackFromPath(
-      pak_dir.Append(FILE_PATH_LITERAL("content_shell.pak")),
-      ui::GetSupportedScaleFactors()[0]);
 #if defined(ENABLE_PDF_VIEWER)
+  NOTIMPLEMENTED() << "Hi, whoever's fixing PDF support! Thanks! The pdf viewer "
+    "resources haven't been ported over to the GN build yet, so you'll "
+    "probably need to change this bit of code.";
   bundle.AddDataPackFromPath(
       pak_dir.Append(FILE_PATH_LITERAL("pdf_viewer_resources.pak")),
       ui::GetSupportedScaleFactors()[0]);
 #endif  // defined(ENABLE_PDF_VIEWER)
-  bundle.AddDataPackFromPath(pak_dir.Append(FILE_PATH_LITERAL(
-                                 "blink_image_resources_200_percent.pak")),
-                             ui::SCALE_FACTOR_200P);
-  bundle.AddDataPackFromPath(
-      pak_dir.Append(FILE_PATH_LITERAL("content_resources_200_percent.pak")),
-      ui::SCALE_FACTOR_200P);
-  bundle.AddDataPackFromPath(
-      pak_dir.Append(FILE_PATH_LITERAL("ui_resources_200_percent.pak")),
-      ui::SCALE_FACTOR_200P);
-  bundle.AddDataPackFromPath(
-      pak_dir.Append(FILE_PATH_LITERAL("views_resources_200_percent.pak")),
-      ui::SCALE_FACTOR_200P);
-#endif
 }
 
 MainDelegate::MainDelegate() {}

--- a/brightray/common/main_delegate.cc
+++ b/brightray/common/main_delegate.cc
@@ -30,9 +30,6 @@ bool SubprocessNeedsResourceBundle(const std::string& process_type) {
 #if defined(OS_MACOSX)
   // Mac needs them too for scrollbar related images and for sandbox
   // profiles.
-#if !defined(DISABLE_NACL)
-      process_type == switches::kNaClLoaderProcess ||
-#endif
       process_type == switches::kPpapiPluginProcess ||
       process_type == switches::kPpapiBrokerProcess ||
       process_type == switches::kGpuProcess ||


### PR DESCRIPTION
It's no longer needed now that the GN build is the only build.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes