### PR TITLE
ci: don't run gn debug build on older branches (1-7-x)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,9 @@ build_cloud: electron-16
 image: electron-16-vs2015
 build_script:
 - ps: >-
-    if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+    if($env:SKIP_GYP_BUILD -eq "true") {
+      Write-warning "Skipping debug build for older branch"; Exit-AppveyorBuild
+    } elseif(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
       Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
     } else {
       Add-Path "$env:ProgramFiles (x86)\Windows Kits\10\Debuggers\x64"


### PR DESCRIPTION
##### Description of Change
Backports #14584 to 1-7-x.

* ci: don't run gn debug build on older branches

Older branches that build using gyp do not run both a debug and testing build.

(cherry picked from commit 5f3bedd1e0aed868d4634dd31bdb8b543f7802d8)
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes