### PR TITLE
chore: remove unneeded ssize_t hack

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -7,16 +7,6 @@
 #include <set>
 #include <string>
 
-// We have problems with redefinition of ssize_t between node.h and
-// port_chromium.h, and the latter was introduced by leveldb.mojom.h.
-// The best solution is to not include content/browser/frame_host/ headers
-// and node.h in the same file, but for now I'm just working around the
-// problem.
-#if defined(OS_WIN)
-#define COMPONENTS_SERVICES_LEVELDB_PUBLIC_INTERFACES_LEVELDB_MOJOM_H_
-#define COMPONENTS_LEVELDB_PUBLIC_INTERFACES_LEVELDB_MOJOM_H_
-#endif
-
 #include "atom/browser/api/atom_api_browser_window.h"
 #include "atom/browser/api/atom_api_debugger.h"
 #include "atom/browser/api/atom_api_session.h"


### PR DESCRIPTION
##### Description of Change
This hack was introduced to deal with a conflict between node and leveldb's idea of what the `ssize_t` type was. That conflict is now dealt with by a patch to leveldb (see electron/libchromiumcontent#682), so this hack is no longer necessary.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes