### PR TITLE
chore: add debugger specs for multiple sessions

### DIFF
--- a/spec/api-debugger-spec.js
+++ b/spec/api-debugger-spec.js
@@ -72,6 +72,24 @@ describe('debugger module', () => {
       }
       w.webContents.debugger.detach()
     })
+
+    it('doesn\'t disconnect an active devtools session', done => {
+      w.webContents.loadURL('about:blank')
+      try {
+        w.webContents.debugger.attach()
+      } catch (err) {
+        return done(`unexpected error : ${err}`)
+      }
+      w.webContents.openDevTools()
+      w.webContents.once('devtools-opened', () => {
+        w.webContents.debugger.detach()
+      })
+      w.webContents.debugger.on('detach', (e, reason) => {
+        expect(w.webContents.debugger.isAttached()).to.be.false()
+        expect(w.devToolsWebContents.isDestroyed()).to.be.false()
+        done()
+      })
+    })
   })
 
   describe('debugger.sendCommand', () => {
@@ -103,6 +121,27 @@ describe('debugger module', () => {
 
       const params = {'expression': '4+2'}
       w.webContents.debugger.sendCommand('Runtime.evaluate', params, callback)
+    })
+
+    it('returns response when devtools is opened', done => {
+      w.webContents.loadURL('about:blank')
+      try {
+        w.webContents.debugger.attach()
+      } catch (err) {
+        return done(`unexpected error : ${err}`)
+      }
+      const callback = (err, res) => {
+        expect(err.message).to.be.undefined()
+        expect(res.wasThrown).to.be.undefined()
+        expect(res.result.value).to.equal(6)
+        w.webContents.debugger.detach()
+        done()
+      }
+      w.webContents.openDevTools()
+      w.webContents.once('devtools-opened', () => {
+        const params = {'expression': '4+2'}
+        w.webContents.debugger.sendCommand('Runtime.evaluate', params, callback)
+      })
     })
 
     it('fires message event', done => {


### PR DESCRIPTION
##### Description of Change

This was added in https://github.com/electron/electron/pull/14566

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: no-notes