### PR TITLE
chore: update package-lock.json when bumping package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron",
-  "version": "4.0.0-nightly.20180823",
+  "version": "4.0.0-nightly.20180905",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1535,7 +1535,7 @@
         "dot-prop": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -7234,6 +7234,15 @@
         "resolve": "^1.1.6"
       }
     },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -9422,7 +9431,7 @@
         },
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -10142,7 +10151,7 @@
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -196,18 +196,19 @@ def update_info_plist(version):
 
 
 def update_package_json(version, suffix):
-  package_json = 'package.json'
-  with open(package_json, 'r') as f:
-    lines = f.readlines()
+  metadata_json_files = ['package.json', 'package-lock.json']
+  for json_file in metadata_json_files:
+    with open(json_file, 'r') as f:
+      lines = f.readlines()
 
-  for i in range(0, len(lines)):
-    line = lines[i];
-    if 'version' in line:
-      lines[i] = '  "version": "{0}",\n'.format(version + suffix)
-      break
+    for i in range(0, len(lines)):
+      line = lines[i];
+      if 'version' in line:
+        lines[i] = '  "version": "{0}",\n'.format(version + suffix)
+        break
 
-  with open(package_json, 'w') as f:
-    f.write(''.join(lines))
+    with open(json_file, 'w') as f:
+      f.write(''.join(lines))
 
 
 def tag_version(version, suffix):


### PR DESCRIPTION
This updates the package-lock.json as it was out of date (somehow) and updates our release scripts to also bump the version in the `package-lock.json` when bumping `package.json`

Notes: no-notes