### PR TITLE
feat: add mediaTypes to media permission requests

### DIFF
--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -4,7 +4,9 @@
 
 #include "atom/browser/web_contents_permission_helper.h"
 
+#include <memory>
 #include <string>
+#include <utility>
 
 #include "atom/browser/atom_permission_manager.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
@@ -100,9 +102,23 @@ void WebContentsPermissionHelper::RequestMediaAccessPermission(
     const content::MediaStreamRequest& request,
     const content::MediaResponseCallback& response_callback) {
   auto callback = base::Bind(&MediaAccessAllowed, request, response_callback);
+
+  base::DictionaryValue details;
+  std::unique_ptr<base::ListValue> media_types(new base::ListValue);
+  if (request.audio_type
+      == content::MediaStreamType::MEDIA_DEVICE_AUDIO_CAPTURE) {
+    media_types->AppendString("audio");
+  }
+  if (request.video_type
+      == content::MediaStreamType::MEDIA_DEVICE_VIDEO_CAPTURE) {
+    media_types->AppendString("video");
+  }
+  details.SetList("mediaTypes", std::move(media_types));
+
   // The permission type doesn't matter here, AUDIO_CAPTURE/VIDEO_CAPTURE
   // are presented as same type in content_converter.h.
-  RequestPermission(content::PermissionType::AUDIO_CAPTURE, callback);
+  RequestPermission(content::PermissionType::AUDIO_CAPTURE, callback,
+                    false, &details);
 }
 
 void WebContentsPermissionHelper::RequestWebNotificationPermission(

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -295,6 +295,8 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
     * `permissionGranted` Boolean - Allow or deny the permission.
   * `details` Object - Some properties are only available on certain permission types.
     * `externalURL` String - The url of the `openExternal` request.
+    * `mediaTypes` String[] - The types of media access being requested, elements can be `video`
+      or `audio`
 
 Sets the handler which can be used to respond to permission requests for the `session`.
 Calling `callback(true)` will allow the permission and `callback(false)` will reject it.


### PR DESCRIPTION
Media permission requests now have a details object with a "mediaTypes" key 😄 

This is done to be consistent with setPermissionCheckHandler and to be
backwards compatible.

Fixes #14168 

Notes: Added a `mediaType` property to media permission requests to distinguish between video and audio requests