### PR TITLE
feat: automatically round numbers that are converted to points

### DIFF
--- a/atom/common/native_mate_converters/gfx_converter.cc
+++ b/atom/common/native_mate_converters/gfx_converter.cc
@@ -28,10 +28,11 @@ bool Converter<gfx::Point>::FromV8(v8::Isolate* isolate,
   mate::Dictionary dict;
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
-  int x, y;
+  double x, y;
   if (!dict.Get("x", &x) || !dict.Get("y", &y))
     return false;
-  *out = gfx::Point(x, y);
+  *out = gfx::Point(static_cast<int>(std::round(x)),
+                    static_cast<int>(std::round(y)));
   return true;
 }
 

--- a/docs/api/structures/point.md
+++ b/docs/api/structures/point.md
@@ -2,3 +2,7 @@
 
 * `x` Number
 * `y` Number
+
+**Note:** Both `x` and `y` must be whole integers, when providing a point object
+as input to an Electron API we will automatically round your `x` and `y` values
+to the nearest whole integer.


### PR DESCRIPTION
Fixes #14490

##### Description of Change
Points that are taken in as input to Electron API's are now auto rounded if floats are provided as input.  E.g. `{ x: 5.5, y: 6 }` becomes `{ x: 6, y: 6 }`.  This is the current expected user workaround and will have no impact on currently working code however I consider this `semver/minor`.

##### Release Notes

Notes: Point based API's now automatically round incoming `x` and `y` values