### PR TITLE
chore: fix linting error on master

### DIFF
--- a/brightray/common/main_delegate.cc
+++ b/brightray/common/main_delegate.cc
@@ -61,9 +61,9 @@ void LoadResourceBundle(const std::string& locale) {
   bundle.AddDataPackFromPath(pak_dir.Append(FILE_PATH_LITERAL("resources.pak")),
                              ui::SCALE_FACTOR_NONE);
 #if defined(ENABLE_PDF_VIEWER)
-  NOTIMPLEMENTED() << "Hi, whoever's fixing PDF support! Thanks! The pdf viewer "
-    "resources haven't been ported over to the GN build yet, so you'll "
-    "probably need to change this bit of code.";
+  NOTIMPLEMENTED() << "Hi, whoever's fixing PDF support! Thanks! The pdf "
+    "viewer resources haven't been ported over to the GN build yet, so "
+    "you'll probably need to change this bit of code.";
   bundle.AddDataPackFromPath(
       pak_dir.Append(FILE_PATH_LITERAL("pdf_viewer_resources.pak")),
       ui::GetSupportedScaleFactors()[0]);


### PR DESCRIPTION
This fixes the currently failing linter on master

Notes: no-notes