### PR TITLE
chore: dont install spec deps on sync needlessly

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -61,15 +61,6 @@ hooks = [
     'pattern': 'src/electron/package.json',
     'name': 'electron_npm_deps'
   },
-  {
-    'action': [
-      'python',
-      '-c',
-      'import os; os.chdir("src"); os.chdir("electron/spec"); os.system("npm install")',
-    ],
-    'pattern': 'src/electron/spec/package.json',
-    'name': 'electron_spec_npm_deps'
-  },
 ]
 
 recursedeps = [


### PR DESCRIPTION
We run install for testing only when required anyway

Notes: no-notes