### PR TITLE
docs: prefer out/Debug to out/Default in build docs

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -79,36 +79,36 @@ $ cd src
 $ export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
 # this next line is needed only if building with sccache
 $ export GN_EXTRA_ARGS="${GN_EXTRA_ARGS} cc_wrapper=\"${PWD}/electron/external_binaries/sccache\""
-$ gn gen out/Default --args="import(\"//electron/build/args/debug.gn\") $GN_EXTRA_ARGS"
+$ gn gen out/Debug --args="import(\"//electron/build/args/debug.gn\") $GN_EXTRA_ARGS"
 ```
 
-This will generate a build directory `out/Default` under `src/` with
-debug build configuration. You can replace `Default` with another name,
+This will generate a build directory `out/Debug` under `src/` with
+debug build configuration. You can replace `Debug` with another name,
 but it should be a subdirectory of `out`.
 Also you shouldn't have to run `gn gen` again—if you want to change the
-build arguments, you can run `gn args out/Default` to bring up an editor.
+build arguments, you can run `gn args out/Debug` to bring up an editor.
 
 To see the list of available build configuration options, run `gn args
-out/Default --list`.
+out/Debug --list`.
 
 **For generating Debug (aka "component" or "shared") build config of
 Electron:**
 
 ```sh
-$ gn gen out/Default --args="import(\"//electron/build/args/debug.gn\") $GN_EXTRA_ARGS"
+$ gn gen out/Debug --args="import(\"//electron/build/args/debug.gn\") $GN_EXTRA_ARGS"
 ```
 
 **For generating Release (aka "non-component" or "static") build config of
 Electron:**
 
 ```sh
-$ gn gen out/Default --args="import(\"//electron/build/args/release.gn\") $GN_EXTRA_ARGS"
+$ gn gen out/Debug --args="import(\"//electron/build/args/release.gn\") $GN_EXTRA_ARGS"
 ```
 
-**To build, run `ninja` with the `electron:electron_app` target:**
+**To build, run `ninja` with the `electron` target:**
 
 ```sh
-$ ninja -C out/Default electron:electron_app
+$ ninja -C out/Debug electron
 # This will also take a while and probably heat up your lap.
 ```
 
@@ -117,19 +117,19 @@ This will build all of what was previously 'libchromiumcontent' (i.e. the
 so it will take a while.
 
 To speed up subsequent builds, you can use [sccache][sccache]. Add the GN arg
-`cc_wrapper = "sccache"` by running `gn args out/Default` to bring up an
+`cc_wrapper = "sccache"` by running `gn args out/Debug` to bring up an
 editor and adding a line to the end of the file.
 
 [sccache]: https://github.com/mozilla/sccache
 
-The built executable will be under `./out/Default`:
+The built executable will be under `./out/Debug`:
 
 ```sh
-$ ./out/Default/Electron.app/Contents/MacOS/Electron
+$ ./out/Debug/Electron.app/Contents/MacOS/Electron
 # or, on Windows
-$ ./out/Default/electron.exe
+$ ./out/Debug/electron.exe
 # or, on Linux
-$ ./out/Default/electron
+$ ./out/Debug/electron
 ```
 
 ### Cross-compiling
@@ -139,7 +139,7 @@ set the `target_cpu` and `target_os` GN arguments. For example, to compile an
 x86 target from an x64 host, specify `target_cpu = "x86"` in `gn args`.
 
 ```sh
-$ gn gen out/Default-x86 --args='... target_cpu = "x86"'
+$ gn gen out/Debug-x86 --args='... target_cpu = "x86"'
 ```
 
 Not all combinations of source and target CPU/OS are supported by Chromium.
@@ -161,27 +161,27 @@ generate build headers for the modules to compile against, run the following
 under `src/` directory.
 
 ```sh
-$ ninja -C out/Default third_party/electron_node:headers
+$ ninja -C out/Debug third_party/electron_node:headers
 # Install the test modules with the generated headers
-$ (cd electron/spec && npm i --nodedir=../../out/Default/gen/node_headers)
+$ (cd electron/spec && npm i --nodedir=../../out/Debug/gen/node_headers)
 ```
 
 Then, run Electron with `electron/spec` as the argument:
 
 ```sh
 # on Mac:
-$ ./out/Default/Electron.app/Contents/MacOS/Electron electron/spec
+$ ./out/Debug/Electron.app/Contents/MacOS/Electron electron/spec
 # on Windows:
-$ ./out/Default/electron.exe electron/spec
+$ ./out/Debug/electron.exe electron/spec
 # on Linux:
-$ ./out/Default/electron electron/spec
+$ ./out/Debug/electron electron/spec
 ```
 
 If you're debugging something, it can be helpful to pass some extra flags to
 the Electron binary:
 
 ```sh
-$ ./out/Default/Electron.app/Contents/MacOS/Electron electron/spec \
+$ ./out/Debug/Electron.app/Contents/MacOS/Electron electron/spec \
   --ci --enable-logging -g 'BrowserWindow module'
 ```
 

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -1,4 +1,4 @@
-const OUT_DIR = process.env.ELECTRON_OUT_DIR || 'Default'
+const OUT_DIR = process.env.ELECTRON_OUT_DIR || 'Debug'
 
 const path = require('path')
 


### PR DESCRIPTION
##### Description of Change
It was unclear what "Default" meant, and I think "Debug" reinforces that there can be multiple different directories under `out/` with different configurations.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes