### PR TITLE
fix: quit properly in simpleFullScreen mode

### DIFF
--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -224,12 +224,22 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 // Custom window button methods
 
+- (BOOL)windowShouldClose:(id)sender { return YES; }
+
 - (void)performClose:(id)sender {
   if (shell_->title_bar_style() ==
-      atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER)
+      atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER) {
     [[self delegate] windowShouldClose:self];
-  else
+  } else if (shell_->IsSimpleFullScreen()) {
+    if([[self delegate] respondsToSelector:@selector(windowShouldClose:)]) {
+        if(![[self delegate] windowShouldClose:self]) return;
+    } else if([self respondsToSelector:@selector(windowShouldClose:)]) {
+        if(![self windowShouldClose:self]) return;
+    }
+    [self close];
+  } else {
     [super performClose:sender];
+  }
 }
 
 - (void)toggleFullScreenMode:(id)sender {


### PR DESCRIPTION
##### Description of Change

Fixes https://github.com/electron/electron/issues/13135.

Since borderless windows or windows without titlebars doen't have a close button, `performClose:` won't work. Therefore, we instead want to use the `close` method. However, this method doesn't call `windowShouldClose:` on the window's delegate so we manually must call it.

/cc @sethlu

##### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: fixes issue with app.quit() in simpleFullScreen mode