### PR TITLE
chore: remove --version from "create-api-json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lint:docs": "remark docs -qf && npm run lint:js-in-markdown && npm run create-typescript-definitions && npm run lint:docs-relative-links",
     "lint:docs-relative-links": "python ./script/check-relative-doc-links.py",
     "lint:js-in-markdown": "standard-markdown docs",
-    "create-api-json": "electron-docs-linter docs --outfile=electron-api.json --version=$npm_package_version",
+    "create-api-json": "electron-docs-linter docs --outfile=electron-api.json",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=electron-api.json --out=electron.d.ts",
     "preinstall": "node -e 'process.exit(0)'",
     "precommit": "python script/run-clang-format.py -r -c atom/ chromium_src/ brightray/ && node ./script/cpplint.js -c && npm run lint:js && remark docs -qf || (echo \"Code not formatted correctly.\" && exit 1)",


### PR DESCRIPTION
The variable already [defaults](https://github.com/electron/electron-docs-linter/blob/master/cli.js#L10) to this value and this `$` syntax does not work cross platform

Closes #13462

Notes: no-notes