### PR TITLE
test: add test for synchronous access to blink APIs

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1286,6 +1286,21 @@ describe('BrowserWindow module', () => {
         })
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
+      it('has synchronous access to all eventual window APIs', async () => {
+        const preload = path.join(fixtures, 'module', 'access-blink-apis.js')
+        const w = await openTheWindow({
+          show: false,
+          webPreferences: {
+            preload: preload
+          }
+        })
+        w.loadFile(path.join(fixtures, 'api', 'preload.html'))
+        const [, test] = await emittedOnce(ipcMain, 'answer')
+        expect(test).to.be.an('object')
+        expect(test.atPreload).to.be.an('array')
+        expect(test.atLoad).to.be.an('array')
+        expect(test.atPreload).to.deep.equal(test.atLoad, 'should have access to the same window APIs')
+      })
     })
 
     describe('session preload scripts', function () {

--- a/spec/fixtures/api/preload.html
+++ b/spec/fixtures/api/preload.html
@@ -1,9 +1,16 @@
 <html>
 <body>
 <script type="text/javascript" charset="utf-8">
-if (!window.test)
-  window.test = 'window'
-require('electron').ipcRenderer.send('answer', window.test);
+const send = () => {
+  if (!window.test)
+    window.test = 'window'
+  require('electron').ipcRenderer.send('answer', window.test);
+}
+if (window.delayed) {
+  window.addEventListener('load', send)
+} else {
+  send()
+}
 </script>
 </body>
 </html>

--- a/spec/fixtures/module/access-blink-apis.js
+++ b/spec/fixtures/module/access-blink-apis.js
@@ -1,0 +1,17 @@
+window.delayed = true
+
+global.getGlobalNames = () => {
+  return Object.getOwnPropertyNames(global)
+    .filter(key => typeof global[key] === 'function')
+    .filter(key => key !== 'WebView')
+    .sort()
+}
+
+const atPreload = global.getGlobalNames()
+
+window.addEventListener('load', () => {
+  window.test = {
+    atPreload,
+    atLoad: global.getGlobalNames()
+  }
+})


### PR DESCRIPTION
This test should ensure we catch a regression of #13787

Notes: no-notes