### PR TITLE
chore: fix lint warnings

### DIFF
--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -80,7 +80,7 @@ def main():
   else:
     raise Exception("Invalid current version: " + curr_version)
 
-  if args.new_version == None and args.bump == None and args.stable == False:
+  if args.new_version is None and args.bump is None and not args.stable:
     parser.print_help()
     return 1
 

--- a/script/check-relative-doc-links.py
+++ b/script/check-relative-doc-links.py
@@ -57,29 +57,28 @@ def getBrokenLinks(filepath):
 
   for link in links:
     sections = link.split('#')
-    if len(sections) > 1:
-      if str(link).startswith('#'):
-        if not checkSections(sections, lines):
-          brokenLinks.append(link)
-      else:
-        tempFile = os.path.join(currentDir, sections[0])
-        if os.path.isfile(tempFile):
-          try:
-            newFile = open(tempFile, 'r')
-            newLines = newFile.readlines()
-          except KeyboardInterrupt:
-            print('Keyboard interruption whle parsing. Please try again.')
-          finally:
-            newFile.close()
-
-          if not checkSections(sections, newLines):
-            brokenLinks.append(link)
-        else:
-          brokenLinks.append(link)
-
-    else:
+    if len(sections) < 2:
       if not os.path.isfile(os.path.join(currentDir, link)):
         brokenLinks.append(link)
+    elif str(link).startswith('#'):
+      if not checkSections(sections, lines):
+        brokenLinks.append(link)
+    else:
+      tempFile = os.path.join(currentDir, sections[0])
+      if os.path.isfile(tempFile):
+        try:
+          newFile = open(tempFile, 'r')
+          newLines = newFile.readlines()
+        except KeyboardInterrupt:
+          print('Keyboard interruption whle parsing. Please try again.')
+        finally:
+          newFile.close()
+
+        if not checkSections(sections, newLines):
+          brokenLinks.append(link)
+      else:
+        brokenLinks.append(link)
+
 
   print_errors(filepath, brokenLinks)
   return len(brokenLinks)

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -6,10 +6,13 @@ import platform
 import sys
 
 # URL to the mips64el sysroot image.
-MIPS64EL_SYSROOT_URL = 'https://github.com/electron/debian-sysroot-image-creator/releases/download/v0.5.0/debian_jessie_mips64-sysroot.tar.bz2'
+MIPS64EL_SYSROOT_URL = 'https://github.com/electron' \
+                     + '/debian-sysroot-image-creator/releases/download' \
+                     + '/v0.5.0/debian_jessie_mips64-sysroot.tar.bz2'
 # URL to the mips64el toolchain.
 MIPS64EL_GCC = 'gcc-4.8.3-d197-n64-loongson'
-MIPS64EL_GCC_URL = 'http://ftp.loongnix.org/toolchain/gcc/release/' + MIPS64EL_GCC + '.tar.gz'
+MIPS64EL_GCC_URL = 'http://ftp.loongnix.org/toolchain/gcc/release/' \
+                 + MIPS64EL_GCC + '.tar.gz'
 
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
@@ -89,7 +92,8 @@ def get_zip_name(name, version, suffix=''):
 def build_env():
   env = os.environ.copy()
   if get_target_arch() == "mips64el":
-    SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    SOURCE_ROOT = os.path.abspath(os.path.dirname(
+                    os.path.dirname(os.path.dirname(__file__))))
     VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
     gcc_dir = os.path.join(VENDOR_DIR, MIPS64EL_GCC)
     ldlib_dirs = [

--- a/script/lib/dbus_mock.py
+++ b/script/lib/dbus_mock.py
@@ -1,26 +1,26 @@
-from config import is_verbose_mode
-from dbusmock import DBusTestCase
-
 import atexit
 import os
+import subprocess
 import sys
 
+from dbusmock import DBusTestCase
+
+from lib.config import is_verbose_mode
 
 def stop():
     DBusTestCase.stop_dbus(DBusTestCase.system_bus_pid)
     DBusTestCase.stop_dbus(DBusTestCase.session_bus_pid)
 
 def start():
-    dbusmock_log = sys.stdout if is_verbose_mode() else open(os.devnull, 'w')
+    log = sys.stdout if is_verbose_mode() else open(os.devnull, 'w')
 
     DBusTestCase.start_system_bus()
-    DBusTestCase.spawn_server_template('logind', None, dbusmock_log)
+    DBusTestCase.spawn_server_template('logind', None, log)
 
     DBusTestCase.start_session_bus()
-    DBusTestCase.spawn_server_template('notification_daemon', None, dbusmock_log)
+    DBusTestCase.spawn_server_template('notification_daemon', None, log)
 
 if __name__ == '__main__':
-    import subprocess
     start()
     try:
         subprocess.check_call(sys.argv[1:])

--- a/script/lib/env_util.py
+++ b/script/lib/env_util.py
@@ -16,9 +16,10 @@ def validate_pair(ob):
     return True
 
 
-def consume(iter):
+def consume(iterator):
   try:
-    while True: next(iter)
+    while True:
+      next(iterator)
   except StopIteration:
     pass
 
@@ -36,11 +37,11 @@ def get_environment_from_batch_command(env_cmd, initial=None):
   if not isinstance(env_cmd, (list, tuple)):
     env_cmd = [env_cmd]
   # Construct the command that will alter the environment.
-  env_cmd = subprocess.list2cmdline(env_cmd)
+  cmd = subprocess.list2cmdline(env_cmd)
   # Create a tag so we can tell in the output when the proc is done.
   tag = 'END OF BATCH COMMAND'
   # Construct a cmd.exe command to do accomplish this.
-  cmd = 'cmd.exe /s /c "{env_cmd} && echo "{tag}" && set"'.format(**vars())
+  cmd = 'cmd.exe /s /c "{cmd} && echo "{tag}" && set"'.format(**locals())
   # Launch the process.
   proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=initial)
   # Parse the output sent to stdout.
@@ -63,10 +64,11 @@ def get_vs_location(vs_version):
     """
     Returns the location of the VS building environment.
 
-    The vs_version can be strings like "[15.0,16.0)", meaning 2017, but not the next version.
+    The vs_version can be strings like "[15.0,16.0)", meaning 2017,
+    but not the next version.
     """
 
-    # vswhere can't handle spaces, like "[15.0, 16.0)" should become "[15.0,16.0)"
+    # vswhere can't handle spaces. "[15.0, 16.0)" should become "[15.0,16.0)"
     vs_version = vs_version.replace(" ", "")
 
     program_files = os.environ.get('ProgramFiles(x86)')
@@ -86,10 +88,10 @@ def get_vs_env(vs_version, arch):
   """
   Returns the env object for VS building environment.
 
-  vs_version is the version of Visual Studio to use.  See get_vs_location for
-  more details.
-  The arch has to be one of "x86", "amd64", "arm", "x86_amd64", "x86_arm", "amd64_x86",
-  "amd64_arm", i.e. the args passed to vcvarsall.bat.
+  vs_version is the version of Visual Studio to use.
+  See get_vs_location for more details.
+  The arch must be one of "x86", "amd64", "arm", "x86_amd64", "x86_arm",
+  "amd64_x86", "amd64_arm", i.e. the args passed to vcvarsall.bat.
   """
 
   location = get_vs_location(vs_version)

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -1,13 +1,13 @@
 """Git helper functions.
 
-Everything in here should be project agnostic, shouldn't rely on project's structure,
-and make any assumptions about the passed arguments or calls outcomes.
+Everything here should be project agnostic: it shouldn't rely on project's
+structure, or make assumptions about the passed arguments or calls' outcomes.
 """
 
 import os
 import subprocess
 
-from util import scoped_cwd
+from lib.util import scoped_cwd
 
 
 def is_repo_root(path):
@@ -40,7 +40,7 @@ def get_repo_root(path):
   return get_repo_root(parent_path)
 
 
-def apply(repo, patch_path, directory=None, index=False, reverse=False):
+def apply_patch(repo, patch_path, directory=None, index=False, reverse=False):
   args = ['git', 'apply',
           '--ignore-space-change',
           '--ignore-whitespace',
@@ -64,7 +64,7 @@ def get_patch(repo, commit_hash):
   args = ['git', 'diff-tree',
           '-p',
           commit_hash,
-          '--'  # Explicitly tell Git that `commit_hash` is a revision, not a path.
+          '--'  # Explicitly tell Git `commit_hash` is a revision, not a path.
           ]
 
   with scoped_cwd(repo):

--- a/script/lib/gn.py
+++ b/script/lib/gn.py
@@ -3,7 +3,7 @@
 import subprocess
 import sys
 
-from util import scoped_cwd
+from lib.util import scoped_cwd
 
 
 class GNProject:
@@ -18,7 +18,8 @@ class GNProject:
 
   def run(self, command_name, command_args):
     with scoped_cwd(self.out_dir):
-      complete_args = [self._get_executable_name(), command_name, '.'] + command_args
+      complete_args = [self._get_executable_name(), command_name, '.'] + \
+                      command_args
       return subprocess.check_output(complete_args)
 
   def args(self):

--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -1,17 +1,20 @@
 import os
 import sys
 
-import git
+import yaml
 
-SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+from lib import git
+
+SOURCE_ROOT = os.path.abspath(os.path.dirname(
+                os.path.dirname(os.path.dirname(__file__))))
 VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
 PYYAML_LIB_DIR = os.path.join(VENDOR_DIR, 'pyyaml', 'lib')
 sys.path.append(PYYAML_LIB_DIR)
-import yaml
 
 
 class Patch:
-  def __init__(self, file_path, repo_path, paths_prefix=None, author='Anonymous <anonymous@electronjs.org>', description=None):
+  def __init__(self, file_path, repo_path, paths_prefix=None,
+               author='Anonymous <anonymous@electronjs.org>', description=None):
     self.author = author
     self.description = description
     self.file_path = file_path
@@ -21,14 +24,17 @@ class Patch:
   def apply(self, reverse=False, commit=False, index=False):
     # Add the change to index only if we're going to commit it later.
     add_to_index = index or commit
-    patch_applied = git.apply(self.repo_path, self.file_path, directory=self.paths_prefix, index=add_to_index, reverse=reverse)
+    patch_applied = git.apply_patches(self.repo_path, self.file_path,
+                                      directory=self.paths_prefix,
+                                      index=add_to_index, reverse=reverse)
 
     if not patch_applied:
       return False
 
     if commit:
       message = self.__get_commit_message(reverse)
-      patch_committed = git.commit(self.repo_path, author=self.author, message=message)
+      patch_committed = git.commit(self.repo_path, author=self.author,
+                                   message=message)
       return patch_committed
 
     return True
@@ -72,7 +78,8 @@ class PatchesList:
       # Applying all commits takes about 10 minutes (!) on a fast dev machine.
       # Instead of it we are going only to add all changes to the index
       # and commit them all at once later.
-      applied_successfully = patch.apply(reverse=reverse, index=commit, commit=False)
+      applied_successfully = patch.apply(reverse=reverse, index=commit,
+                                         commit=False)
 
       if not applied_successfully:
         all_patches_applied = False
@@ -133,7 +140,8 @@ class PatchesConfig:
     if raw_data['description'] is not None:
       description += '\n\n' + raw_data['description']
 
-    return Patch(absolute_file_path, repo_path, paths_prefix=paths_prefix, author=author, description=description)
+    return Patch(absolute_file_path, repo_path, paths_prefix=paths_prefix,
+                 author=author, description=description)
 
   def __create_patches_list(self):
     config_contents = self.__parse()
@@ -154,7 +162,8 @@ class PatchesConfig:
     patches_data = config_contents['patches']
     base_directory = os.path.abspath(os.path.dirname(self.path))
 
-    patches = [self.__create_patch(data, base_directory, absolute_repo_path, paths_prefix) for data in patches_data]
+    patches = [self.__create_patch(data, base_directory, absolute_repo_path,
+                                   paths_prefix) for data in patches_data]
     patches_list = PatchesList(repo_path=absolute_repo_path, patches=patches)
     return patches_list
 

--- a/script/pump.py
+++ b/script/pump.py
@@ -62,11 +62,11 @@ GRAMMAR:
        EXPRESSION has Python syntax.
 """
 
-__author__ = 'wan@google.com (Zhanyong Wan)'
-
 import os
 import re
 import sys
+
+__author__ = 'wan@google.com (Zhanyong Wan)'
 
 
 TOKEN_TABLE = [

--- a/script/test.py
+++ b/script/test.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
 import argparse
+import atexit
 import os
 import shutil
 import subprocess
 import sys
 
 from lib.config import enable_verbose_mode
+import lib.dbus_mock
 from lib.util import electron_gyp, execute_stdout, rm_rf
 
 
@@ -17,8 +19,6 @@ if sys.platform == 'linux2':
     # while also setting DBUS_SYSTEM_BUS_ADDRESS environment variable, which
     # will be picked up by electron.
     try:
-        import lib.dbus_mock
-        import atexit
         lib.dbus_mock.start()
         atexit.register(lib.dbus_mock.stop)
     except ImportError:

--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import os
 import shutil
+import sys
 import tempfile
 
 from lib.config import s3_config
@@ -95,5 +96,4 @@ def copy_files(source_files, output_dir):
     shutil.copy2(source_file, output_path)
 
 if __name__ == '__main__':
-  import sys
   sys.exit(main())

--- a/script/upload.py
+++ b/script/upload.py
@@ -210,5 +210,4 @@ def get_release(version):
   return release
 
 if __name__ == '__main__':
-  import sys
   sys.exit(main())


### PR DESCRIPTION
##### Description of Change

The python linter is broken in `master`. I have a PR that fixes that, but before it can land the warnings need to be fixed. This PR does that.

Reasons that so many new warnings appeared:
 * newer version of pylint in depot_tools
 * the files in `script/lib/` have never been linted before

Also, it appears that 72526927d95eaf9b6ee629e9b98bd0b499d69054 removed `lib/utils.py's parse_version()` which broke lots of other things that depended on it. This PR restores that function.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes