### PR TITLE
docs: Add import of remote module for renderer process.(tutorial/application-debugging)

### DIFF
--- a/docs/tutorial/application-debugging.md
+++ b/docs/tutorial/application-debugging.md
@@ -13,7 +13,8 @@ can open them programmatically by calling the `openDevTools()` API on the
 `webContents` of the instance:
 
 ```javascript
-const { BrowserWindow } = require('electron')
+const { remote } = require('electron')
+const { BrowserWindow } = remote
 
 let win = new BrowserWindow()
 win.webContents.openDevTools()


### PR DESCRIPTION
##### Description of Change
Since the BrowserWindow is used in the renderer process, the remote module must first be imported and the BrowserWindow must be take from the remote module.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: <!-- One-line Change Summary Here--> Make changes to docs/tutorial/application-debugging.