### PR TITLE
ci: Skip VSTS builds on older branches

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -2,29 +2,21 @@ resources:
 - repo: self
 steps:
 - bash: |
-    if [ "$ELECTRON_RELEASE" == "1" ]; then
-      echo 'Bootstrapping Electron for release build'
-      script/bootstrap.py --target_arch=$TARGET_ARCH
-    else
-      echo 'Bootstrapping Electron for debug build'
-      script/bootstrap.py --target_arch=$TARGET_ARCH --dev
-    fi
+    echo 'Non release VSTS builds do not run on older branches'
+  displayName: Skip build on older branch
+  condition: ne(variables['ELECTRON_RELEASE'], '1')
+
+- bash: |
+    echo 'Bootstrapping Electron for release build'
+    script/bootstrap.py --target_arch=$TARGET_ARCH
   name: Bootstrap
+  condition: eq(variables['ELECTRON_RELEASE'], '1')
 
 - bash: |
-    npm run lint
-  name: Lint
-  condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
-
-- bash: |
-    if [ "$ELECTRON_RELEASE" == "1" ]; then
-      echo 'Building Electron for release'
-      script/build.py -c R
-    else
-      echo 'Building Electron for debug'
-      script/build.py -c D
-    fi
+    echo 'Building Electron for release'
+    script/build.py -c R
   name: Build
+  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
 - bash: |
     echo 'Creating Electron release distribution'
@@ -43,56 +35,11 @@ steps:
   name: Upload_distribution
   condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
-- bash: |
-    echo 'Testing Electron build'
-    mkdir junit
-    export MOCHA_FILE="junit/test-results.xml"
-    export MOCHA_REPORTER="mocha-junit-reporter"
-    if [ "$ELECTRON_RELEASE" == "1" ]; then
-      script/test.py --ci --rebuild_native_modules -c R
-    else
-      script/test.py --ci --rebuild_native_modules
-    fi
-  name: Test
-  condition: or(ne(variables['ELECTRON_RELEASE'], '1'), eq(variables['UPLOAD_TO_S3'], '1'))
-
-- bash: |
-    echo 'Verifying ffmpeg on build'
-    if [ "$ELECTRON_RELEASE" == "1" ]; then
-      script/verify-ffmpeg.py -R
-    else
-      script/verify-ffmpeg.py
-    fi
-  name: Verify_FFmpeg
-  condition: or(ne(variables['ELECTRON_RELEASE'], '1'), eq(variables['UPLOAD_TO_S3'], '1'))
-
-- task: PublishTestResults@2
-  displayName: Publish Test Results
-  inputs:
-    testResultsFiles: 'test-results.xml'
-    searchFolder: junit
-  condition: and(always(), ne(variables['ELECTRON_RELEASE'], '1'))
-
-- bash: |
-    export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"
-    export MESSAGE="Build failed for *<$BUILD_URL|$BUILD_DEFINITIONNAME>* nightly build."
-    curl -g -H "Content-Type: application/json" -X POST \
-    -d "{\"text\": \"$MESSAGE\", \"attachments\": [{\"color\": \"#FC5C3C\",\"title\": \"$BUILD_DEFINITIONNAME nightly build results\",\"title_link\": \"$BUILD_URL\"}]}" $(slack_webhook)
-  name: Post_Slack_Notification_on_Failure
-  condition: failed()
-
-- bash: |
-    export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"
-    export MESSAGE="Build succeeded for *<$BUILD_URL|$BUILD_DEFINITIONNAME>* nightly build."
-    curl -g -H "Content-Type: application/json" -X POST \
-    -d "{\"text\": \"$MESSAGE\", \"attachments\": [{\"color\": \"#FC5C3C\",\"title\": \"$BUILD_DEFINITIONNAME nightly build results\",\"title_link\": \"$BUILD_URL\"}]}" $(slack_webhook)
-  name: Post_Slack_Notification_on_Success
-  condition: succeeded()
-
 - task: PublishBuildArtifacts@1
   displayName: Publish Build Artifacts
   inputs:
     PathtoPublish: '$(Build.SourcesDirectory)/out'
     ArtifactName: out
+  condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))
 
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3


### PR DESCRIPTION
##### Description of Change
This PR accomplishes two things:
1. It skips VSTS testing/debug builds on older branches as they are done on CircleCI
2. It makes sure that actual releases don't send a slack notification to the nightly release test channel on Slack.  
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes