### PR TITLE
chore: dont pass --stable through to bump-version.py

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -36,9 +36,6 @@ async function getNewVersion (dryRun) {
   }
   let bumpScript = path.join(__dirname, 'bump-version.py')
   let scriptArgs = [bumpScript, '--bump', versionType]
-  if (args.stable) {
-    scriptArgs.push('--stable')
-  }
   if (dryRun) {
     scriptArgs.push('--dry-run')
   }


### PR DESCRIPTION
I want to clean up this "stable" and "beta" code smell eventually but
for now this will unblock the 2.0.x releases.

Notes: no-notes