### PR TITLE
chore: remove vendored depot_tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/depot_tools"]
-	path = vendor/depot_tools
-	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git
 [submodule "vendor/requests"]
 	path = vendor/requests
 	url = https://github.com/kennethreitz/requests


### PR DESCRIPTION
The GN build now requires that users install depot_tools to their path, rendering our vendored version obsolete.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes