### PR TITLE
fix: change subprocess.Popen calls to work on Linux too

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -255,8 +255,7 @@ def main():
         popen = subprocess.Popen(
             ["git", "diff", "--name-only", "--cached"],
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            shell = True
+            stderr=subprocess.STDOUT
         )
         for line in popen.stdout:
             file_name = line.rstrip()

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -107,10 +107,11 @@ def run_clang_format_diff(args, file_name):
     invocation = [args.clang_format_executable, file_name]
     try:
         proc = subprocess.Popen(
-            invocation,
+            ' '.join(invocation),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True)
+            universal_newlines=True,
+            shell=True)
     except OSError as exc:
         raise DiffError(str(exc))
     proc_stdout = proc.stdout
@@ -252,9 +253,10 @@ def main():
     parse_files = []
     if args.changed:
         popen = subprocess.Popen(
-            ["git", "diff", "--name-only", "--cached"],
+            'git diff --name-only --cached',
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT
+            stderr=subprocess.STDOUT,
+            shell=True
         )
         for line in popen.stdout:
             file_name = line.rstrip()

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -110,8 +110,7 @@ def run_clang_format_diff(args, file_name):
             invocation,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True,
-            shell = True)
+            universal_newlines=True)
     except OSError as exc:
         raise DiffError(str(exc))
     proc_stdout = proc.stdout


### PR DESCRIPTION
##### Description of Change

Calling subprocess.Popen() with a list of args and shell=True causes the args to be ignored, so ['git', 'diff', '--name-only', '--staged'] was turning into just 'git'. Instead of getting a list of changed files, we got the --help message.
    
Two possible fixes: change it from a list to a single string, or remove 'shell=True'. The shell doesn't seem to be needed, so I chose that.

https://stackoverflow.com/a/26417712

cc @codebytere 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes