### PR TITLE
Lint runner support cc fix

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -98,7 +98,7 @@ function parseCommandLine () {
 }
 
 async function findChangedFiles (top) {
-  const result = await GitProcess.exec(['diff', 'HEAD', '--name-only'], top)
+  const result = await GitProcess.exec(['diff', '--name-only', '--cached'], top)
   if (result.exitCode !== 0) {
     console.log('Failed to find changed files', GitProcess.parseError(result.stderr))
     process.exit(1)

--- a/script/lint.js
+++ b/script/lint.js
@@ -59,7 +59,10 @@ const LINTERS = [ {
         }
       }
     }
-    if (result.status) process.exit(result.status)
+    if (result.status) {
+      if (opts.fix) spawnAndCheckExitCode('python', ['script/run-clang-format.py', ...filenames])
+      process.exit(result.status)
+    }
   }
 }, {
   key: 'python',


### PR DESCRIPTION
##### Description of Change

When `script/lint.js --cc --fix` finds cc warnings, run `script/run-clang-format.py` to generate a fix diff.

Fixes #14679.

See also https://github.com/electron/electron/pull/14689

cc @codebytere @nornagon 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes