### PR TITLE
test: runas is not an optional dependency

### DIFF
--- a/spec/package.json
+++ b/spec/package.json
@@ -18,14 +18,12 @@
     "mocha-multi-reporters": "^1.1.7",
     "multiparty": "^4.1.4",
     "q": "^1.5.1",
+    "runas": "3.x",
     "send": "^0.16.2",
     "temp": "^0.8.3",
     "walkdir": "0.0.12",
     "winreg": "^1.2.4",
     "ws": "^5.2.0",
     "yargs": "^11.0.0"
-  },
-  "optionalDependencies": {
-    "runas": "3.x"
   }
 }


### PR DESCRIPTION
##### Description of Change
This was resulting in `npm install` not correctly exiting with failure when `runas` failed to build. `runas` is required to run the Electron tests, and so should not be an optional dependency.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes