### PR TITLE
ci: Split VSTS builds into build and test

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -53,6 +53,7 @@ jobs:
     displayName: Ninja build app
 
   - bash: |
+      cd src
       ninja -C out/Default third_party/electron_node:headers
     displayName: Build Node.js headers
     condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
@@ -78,24 +79,21 @@ jobs:
     inputs:
       PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/args.gn'
       ArtifactName: Default
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
   - task: PublishBuildArtifacts@1
     displayName: Publish build.ninja
     inputs:
       PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/build.ninja'
       ArtifactName: Default
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Node.js headers
     inputs:
       PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/gen/node_headers'
       ArtifactName: node_headers
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish non proprietary ffmpeg
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg/libffmpeg.dylib'
-      ArtifactName: ffmpeg
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
 - job: Test_Electron_Build
   displayName: Test
@@ -122,12 +120,6 @@ jobs:
       artifactName: node_headers
       downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
 
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download non proprietary ffmpeg'
-    inputs:
-      artifactName: ffmpeg
-      downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
-      
   - bash: |
       set +e
       cd src

--- a/vsts.yml
+++ b/vsts.yml
@@ -1,7 +1,22 @@
+step-checkout-electron: &step-checkout-electron
+  bash: |
+    set -ex
+    mkdir src
+    git clone https://github.com/electron/electron src/electron
+    # TODO: there's a subtle race condition here in that if you push two
+    # commits to $BUILD_SOURCEBRANCH in quick succession, it's possible that
+    # fetching the BUILD_SOURCEBRANCH ref will not actually fetch the
+    # BUILD_SOURCEVERSION commit, and so the checkout will fail. Find a
+    # better solution for checking out the commit to be built.
+    (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
+  displayName: Checkout Electron
+
 jobs:
 - job: Build_Electron_via_GN
-  timeoutInMinutes: 180
+  displayName: Build Electron via GN
+  timeoutInMinutes: 120
   steps:
+  - <<: *step-checkout-electron
   - bash: |
       export PATH="$PATH:/Users/electron/depot_tools"
       echo "##vso[task.setvariable variable=PATH]$PATH"
@@ -11,14 +26,6 @@ jobs:
         --name "src/electron" \
         --unmanaged \
         "https://github.com/electron/electron"
-      mkdir src
-      git clone https://github.com/electron/electron src/electron
-      # TODO: there's a subtle race condition here in that if you push two
-      # commits to $BUILD_SOURCEBRANCH in quick succession, it's possible that
-      # fetching the BUILD_SOURCEBRANCH ref will not actually fetch the
-      # BUILD_SOURCEVERSION commit, and so the checkout will fail. Find a
-      # better solution for checking out the commit to be built.
-      (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
       gclient sync --with_branch_heads --with_tags
       cd src
       export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
@@ -52,38 +59,87 @@ jobs:
     displayName: Ninja build app
 
   - bash: |
+      ninja -C out/Default third_party/electron_node:headers
+    displayName: Build Node.js headers
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+
+  - bash: |
       "$SCCACHE_BINARY" --stop-server
     displayName: Check sccache stats after build
     condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
-
-  - bash: |
-      set +e
-      cd src
-      # Make sure there aren't any Electron processes left running from previous tests
-      killall Electron
-      ninja -C out/Default third_party/electron_node:headers
-      export ELECTRON_OUT_DIR=Default
-      (cd electron && npm run test -- --ci --enable-logging)
-    displayName: Test
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
   - bash: |
       cd src
       ninja -C out/Default electron:electron_dist_zip
     displayName: Build dist zip
 
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Electron.app
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/Electron.app'
+      ArtifactName: Default
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish gn args
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/args.gn'
+      ArtifactName: Default
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish build.ninja
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/build.ninja'
+      ArtifactName: Default
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Node.js headers
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/gen/node_headers'
+      ArtifactName: node_headers
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish non proprietary ffmpeg
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg/libffmpeg.dylib'
+      ArtifactName: ffmpeg
+
+- job: Test_Electron_Build
+  displayName: Test
+  dependsOn: Build_Electron_via_GN
+  condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+  timeoutInMinutes: 30
+  steps:
+  - <<: *step-checkout-electron
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: Default
+      downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Node.js headers'
+    inputs:
+      artifactName: node_headers
+      downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download non proprietary ffmpeg'
+    inputs:
+      artifactName: ffmpeg
+      downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
+  - bash: |
+      set +e
+      cd src
+      # Make sure there aren't any Electron processes left running from previous tests
+      killall Electron
+      export ELECTRON_OUT_DIR=Default
+      (cd electron && npm run test -- --ci --enable-logging)
+    displayName: Test
+
   - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
       testResultsFiles: '*.xml'
       searchFolder: '$(System.DefaultWorkingDirectory)/src/junit/'
-    condition: and(always(), eq(variables['MOCHA_FILE'], 'junit/test-results.xml'), eq(variables['RUN_TESTS'], '1'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Build Artifacts
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/dist.zip'
-      ArtifactName: dist.zip
+    condition: and(always(), eq(variables['MOCHA_FILE'], 'junit/test-results.xml'))
 
   - bash: |
       export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"

--- a/vsts.yml
+++ b/vsts.yml
@@ -1,22 +1,8 @@
-step-checkout-electron: &step-checkout-electron
-  bash: |
-    set -ex
-    mkdir src
-    git clone https://github.com/electron/electron src/electron
-    # TODO: there's a subtle race condition here in that if you push two
-    # commits to $BUILD_SOURCEBRANCH in quick succession, it's possible that
-    # fetching the BUILD_SOURCEBRANCH ref will not actually fetch the
-    # BUILD_SOURCEVERSION commit, and so the checkout will fail. Find a
-    # better solution for checking out the commit to be built.
-    (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
-  displayName: Checkout Electron
-
 jobs:
 - job: Build_Electron_via_GN
   displayName: Build Electron via GN
   timeoutInMinutes: 120
   steps:
-  - <<: *step-checkout-electron
   - bash: |
       export PATH="$PATH:/Users/electron/depot_tools"
       echo "##vso[task.setvariable variable=PATH]$PATH"
@@ -26,6 +12,14 @@ jobs:
         --name "src/electron" \
         --unmanaged \
         "https://github.com/electron/electron"
+      mkdir src
+      git clone https://github.com/electron/electron src/electron
+      # TODO: there's a subtle race condition here in that if you push two
+      # commits to $BUILD_SOURCEBRANCH in quick succession, it's possible that
+      # fetching the BUILD_SOURCEBRANCH ref will not actually fetch the
+      # BUILD_SOURCEVERSION commit, and so the checkout will fail. Find a
+      # better solution for checking out the commit to be built.
+      (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
       gclient sync --with_branch_heads --with_tags
       cd src
       export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
@@ -109,22 +103,31 @@ jobs:
   condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
   timeoutInMinutes: 30
   steps:
-  - <<: *step-checkout-electron
+  - bash: |
+      set -ex
+      mkdir src
+      git clone https://github.com/electron/electron src/electron
+      (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
+    displayName: Checkout Electron
+
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
     inputs:
       artifactName: Default
       downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
+
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Node.js headers'
     inputs:
       artifactName: node_headers
       downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
+
   - task: DownloadBuildArtifacts@0
     displayName: 'Download non proprietary ffmpeg'
     inputs:
       artifactName: ffmpeg
       downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
+      
   - bash: |
       set +e
       cd src


### PR DESCRIPTION
##### Description of Change
This is a similar change to #14640.
This PR breaks out building and testing of Electron into separate jobs on VSTS.  This will help us to make sure that VSTS tests don't run more than 30 minutes and should give us better control over our jobs on VSTS

cc @alexeykuzmin 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes