### PR TITLE
build: Updates for GN release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,8 +399,7 @@ steps-build-mac: &steps-build-mac
     # It would be better to verify ffmpeg as a part of a test job,
     # but it requires `gn` to run, and it's complicated
     # to store all gn's dependencies and configs.
-    # FIXME(alexeykuzmin): Enable the next step back.
-    # - *step-verify-ffmpeg
+    - <<: *step-verify-ffmpeg
 
     # Node.js headers for tests
     - *step-nodejs-headers-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,18 @@ step-electron-dist-store: &step-electron-dist-store
     path: src/out/Default/dist.zip
     destination: dist.zip
 
+step-electron-chromedriver-build: &step-electron-chromedriver-build
+  run:
+    name: Build chromedriver.zip
+    command: |
+      cd src
+      ninja -C out/Default electron:electron_chromedriver_zip
+
+step-electron-chromedriver-store: &step-electron-chromedriver-store
+  store_artifacts:
+    path: src/out/Default/chromedriver.zip
+    destination: chromedriver.zip
+
 step-nodejs-headers-build: &step-nodejs-headers-build
   run:
     name: Build Node.js headers
@@ -272,6 +284,10 @@ steps-electron-build-for-tests: &steps-electron-build-for-tests
     - *step-electron-dist-build
     - *step-electron-dist-store
 
+    # chromedriver
+    - *step-electron-chromedriver-build
+    - *step-electron-chromedriver-store
+
     # Node.js headers
     - *step-nodejs-headers-build
 
@@ -388,6 +404,10 @@ steps-build-mac: &steps-build-mac
     - *step-electron-build
     - *step-electron-dist-build
     - *step-electron-dist-store
+
+    # chromedriver
+    - *step-electron-chromedriver-build
+    - *step-electron-chromedriver-store
 
     # ffmpeg
     - *step-ffmpeg-gn-gen

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ steps-build-mac: &steps-build-mac
     # It would be better to verify ffmpeg as a part of a test job,
     # but it requires `gn` to run, and it's complicated
     # to store all gn's dependencies and configs.
-    - <<: *step-verify-ffmpeg
+    - *step-verify-ffmpeg
 
     # Node.js headers for tests
     - *step-nodejs-headers-build

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -222,6 +222,7 @@ static_library("electron_lib") {
     "//base",
     "//base:i18n",
     "//chrome/common:constants",
+    "//chrome/test/chromedriver",
     "//components/network_session_configurator/common",
     "//components/prefs",
     "//components/printing/common",
@@ -497,14 +498,10 @@ if (is_mac) {
     ]
   }
 
-  if (!is_component_build) {
+  if (is_component_ffmpeg) {
     bundle_data("electron_framework_libraries") {
-      sources = []
-      public_deps = []
-      if (is_component_ffmpeg) {
-        sources += [ "$root_out_dir/libffmpeg.dylib" ]
-        public_deps += [ "//third_party/ffmpeg:ffmpeg" ]
-      }
+      sources =  [ "$root_out_dir/libffmpeg.dylib" ]
+      public_deps = [ "//third_party/ffmpeg:ffmpeg" ]
       outputs = [
         "{{bundle_contents_dir}}/Libraries/{{source_file_part}}",
       ]
@@ -531,7 +528,7 @@ if (is_mac) {
   mac_framework_bundle("electron_framework") {
     output_name = electron_framework_name
     framework_version = electron_framework_version
-    framework_contents = [ "Resources" ]
+    framework_contents = [ "Resources", "Libraries" ]
     public_deps = [
       ":electron_lib",
     ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -906,7 +906,6 @@ dist_zip("electron_dist_zip") {
   ]
 }
 
-
 dist_zip("electron_ffmpeg_zip") {
   data_deps = [
     "//third_party/ffmpeg",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -222,7 +222,6 @@ static_library("electron_lib") {
     "//base",
     "//base:i18n",
     "//chrome/common:constants",
-    "//chrome/test/chromedriver",
     "//components/network_session_configurator/common",
     "//components/prefs",
     "//components/printing/common",
@@ -498,10 +497,14 @@ if (is_mac) {
     ]
   }
 
-  if (is_component_ffmpeg) {
+  if (!is_component_build) {
     bundle_data("electron_framework_libraries") {
-      sources =  [ "$root_out_dir/libffmpeg.dylib" ]
-      public_deps = [ "//third_party/ffmpeg:ffmpeg" ]
+      sources = []
+      public_deps = []
+      if (is_component_ffmpeg) {
+        sources += [ "$root_out_dir/libffmpeg.dylib" ]
+        public_deps += [ "//third_party/ffmpeg:ffmpeg" ]
+      }
       outputs = [
         "{{bundle_contents_dir}}/Libraries/{{source_file_part}}",
       ]
@@ -903,12 +906,23 @@ dist_zip("electron_dist_zip") {
   ]
 }
 
+
 dist_zip("electron_ffmpeg_zip") {
   data_deps = [
     "//third_party/ffmpeg",
   ]
   outputs = [
     "$root_build_dir/ffmpeg.zip",
+  ]
+}
+
+dist_zip("electron_chromedriver_zip") {
+  data_deps = [
+    "//chrome/test/chromedriver",
+    ":licenses",
+  ]
+  outputs = [
+    "$root_build_dir/chromedriver.zip",
   ]
 }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -705,7 +705,8 @@ if (is_mac) {
     }
 
     if (!is_mac) {
-      data += [ "$root_out_dir/resources" ]
+      data += [ "$root_out_dir/resources/default_app.asar" ]
+      data += [ "$root_out_dir/resources/electron.asar" ]
     }
 
     public_deps = [

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,9 @@ build_script:
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/ffmpeg third_party/ffmpeg
   - ninja -C out/Default electron:electron_dist_zip
+  - ninja -C out/Default electron:electron_chromedriver_zip
   - appveyor PushArtifact out/Default/dist.zip
+  - appveyor PushArtifact out/Default/chromedriver.zip
 test_script:
   - if "%GN_CONFIG%"=="testing" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
   - ps: >-

--- a/brightray/BUILD.gn
+++ b/brightray/BUILD.gn
@@ -7,7 +7,7 @@ static_library("brightray") {
     "//components/network_session_configurator/common",
     "//components/prefs",
     "//content/public/browser",
-    "//content/shell:resources",
+    "//content/shell:copy_shell_resources",
     "//net:extras",
     "//net:net_with_v8",
     "//skia",

--- a/build/zip.py
+++ b/build/zip.py
@@ -21,15 +21,12 @@ PATHS_TO_SKIP = [
 ]
 
 def skip_path(dep):
-  should_skip = False
-  for path in PATHS_TO_SKIP:
-    if dep.startswith(path):
-      print 'Skipping: '+dep
-      should_skip = True
-  for extension in EXTENSIONS_TO_SKIP:
-    if dep.endswith(extension):
-      print 'Skipping: '+dep
-      should_skip = True
+    should_skip = (
+        any(dep.startswith(path) for path in PATHS_TO_SKIP) or
+        any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP))
+    if should_skip:
+      print("Skipping {}".format(dep))
+    return should_skip
 
 def strip_binaries(target_cpu, dep):
   for binary in LINUX_BINARIES_TO_STRIP:

--- a/build/zip.py
+++ b/build/zip.py
@@ -10,6 +10,27 @@ LINUX_BINARIES_TO_STRIP = [
   'libnode.so'
 ]
 
+EXTENSIONS_TO_SKIP = [
+  '.pdb'
+]
+
+PATHS_TO_SKIP = [
+  'angledata',
+  'swiftshader',
+  'resources/inspector'
+]
+
+def skip_path(dep):
+  should_skip = False
+  for path in PATHS_TO_SKIP:
+    if dep.startswith(path):
+      print 'Skipping: '+dep
+      should_skip = True
+  for extension in EXTENSIONS_TO_SKIP:
+    if dep.endswith(extension):
+      print 'Skipping: '+dep
+      should_skip = True
+
 def strip_binaries(target_cpu, dep):
   for binary in LINUX_BINARIES_TO_STRIP:
     if dep.endswith(binary):
@@ -48,6 +69,8 @@ def main(argv):
       for dep in dist_files:
         if target_os == 'linux':
             strip_binaries(target_cpu, dep)
+        if skip_path(dep):
+          continue
         if os.path.isdir(dep):
           for root, dirs, files in os.walk(dep):
             for file in files:

--- a/build/zip.py
+++ b/build/zip.py
@@ -21,12 +21,10 @@ PATHS_TO_SKIP = [
 ]
 
 def skip_path(dep):
-    should_skip = (
-        any(dep.startswith(path) for path in PATHS_TO_SKIP) or
-        any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP))
-    if should_skip:
-      print("Skipping {}".format(dep))
-    return should_skip
+  should_skip = (
+    any(dep.startswith(path) for path in PATHS_TO_SKIP) or
+    any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP))
+  return should_skip
 
 def strip_binaries(target_cpu, dep):
   for binary in LINUX_BINARIES_TO_STRIP:

--- a/build/zip.py
+++ b/build/zip.py
@@ -15,15 +15,17 @@ EXTENSIONS_TO_SKIP = [
 ]
 
 PATHS_TO_SKIP = [
-  'angledata',
-  'swiftshader',
-  'resources/inspector'
+  'angledata', #Skipping because it is an output of //ui/gl that we don't need
+  'swiftshader', #Skipping because it is an output of //ui/gl that we don't need
+  'resources/inspector' 
 ]
 
 def skip_path(dep):
   should_skip = (
     any(dep.startswith(path) for path in PATHS_TO_SKIP) or
     any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP))
+  if should_skip:
+    print("Skipping {}".format(dep))
   return should_skip
 
 def strip_binaries(target_cpu, dep):
@@ -69,7 +71,10 @@ def main(argv):
         if os.path.isdir(dep):
           for root, dirs, files in os.walk(dep):
             for file in files:
-              z.write(os.path.join(root, file))
+              file_path = os.path.join(root, file)
+              if skip_path(file_path):
+                continue
+              z.write(file_path)
         else:
           z.write(dep)
 

--- a/build/zip.py
+++ b/build/zip.py
@@ -17,7 +17,6 @@ EXTENSIONS_TO_SKIP = [
 PATHS_TO_SKIP = [
   'angledata', #Skipping because it is an output of //ui/gl that we don't need
   'swiftshader', #Skipping because it is an output of //ui/gl that we don't need
-  'resources/inspector' 
 ]
 
 def skip_path(dep):
@@ -71,10 +70,7 @@ def main(argv):
         if os.path.isdir(dep):
           for root, dirs, files in os.walk(dep):
             for file in files:
-              file_path = os.path.join(root, file)
-              if skip_path(file_path):
-                continue
-              z.write(file_path)
+              z.write(os.path.join(root, file))
         else:
           z.write(dep)
 

--- a/vsts.yml
+++ b/vsts.yml
@@ -52,6 +52,13 @@ jobs:
     displayName: Ninja build app
 
   - bash: |
+      cd src
+      gn gen out/ffmpeg --args='import("//electron/build/args/ffmpeg.gn") cc_wrapper="'"$SCCACHE_PATH"'"'" $GN_EXTRA_ARGS"
+      ninja -C out/ffmpeg third_party/ffmpeg
+    displayName: Non proprietary ffmpeg build
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+
+  - bash: |
       "$SCCACHE_BINARY" --stop-server
     displayName: Check sccache stats after build
     condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))

--- a/vsts.yml
+++ b/vsts.yml
@@ -1,6 +1,7 @@
 jobs:
 - job: Build_Electron_via_GN
-  timeoutInMinutes: 180
+  displayName: Build Electron via GN
+  timeoutInMinutes: 120
   steps:
   - bash: |
       export PATH="$PATH:/Users/electron/depot_tools"
@@ -53,6 +54,12 @@ jobs:
 
   - bash: |
       cd src
+      ninja -C out/Default third_party/electron_node:headers
+    displayName: Build Node.js headers for testing
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+
+  - bash: |
+      cd src
       gn gen out/ffmpeg --args='import("//electron/build/args/ffmpeg.gn") cc_wrapper="'"$SCCACHE_PATH"'"'" $GN_EXTRA_ARGS"
       ninja -C out/ffmpeg third_party/ffmpeg
     displayName: Non proprietary ffmpeg build
@@ -65,16 +72,6 @@ jobs:
 
   - bash: |
       cd src
-      # Make sure there aren't any Electron processes left running from previous tests
-      killall Electron
-      ninja -C out/Default third_party/electron_node:headers
-      export ELECTRON_OUT_DIR=Default
-      (cd electron && npm run test -- --ci --enable-logging)
-    displayName: Test
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
-
-  - bash: |
-      cd src
       ninja -C out/Default electron:electron_dist_zip
     displayName: Build dist zip
 
@@ -83,24 +80,109 @@ jobs:
       ninja -C out/Default electron:electron_chromedriver_zip
     displayName: Build chromedriver and zip
 
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts (application zip)
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/dist.zip'
+      ArtifactName: Default
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts (chromedriver.zip)
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/chromedriver.zip'
+      ArtifactName: Default
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish gn args for ffmpeg testing
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/args.gn'
+      ArtifactName: Default
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish build.ninja for ffmpeg testing
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/build.ninja'
+      ArtifactName: Default
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish libffmpeg.dylib for testing
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg/libffmpeg.dylib'
+      ArtifactName: ffmpeg
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Node.js headers for testing
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/gen/node_headers'
+      ArtifactName: node_headers
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+
+- job: Test_Electron_Build
+  displayName: Test
+  dependsOn: Build_Electron_via_GN
+  condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+  timeoutInMinutes: 30
+  steps:
+  - bash: |
+      set -ex
+      mkdir -p src/out/Default/gen
+      mkdir -p src/out/ffmpeg
+      git clone https://github.com/electron/electron src/electron
+      (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
+    displayName: Checkout Electron
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download files needed for testing'
+    inputs:
+      artifactName: Default
+      downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download ffmpeg.dylib for testing'
+    inputs:
+      artifactName: ffmpeg
+      downloadPath: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg'
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Node.js headers'
+    inputs:
+      artifactName: node_headers
+      downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
+
+  - bash: |
+      cd src/out/Default
+      unzip dist.zip
+    displayName: Unzip Electron app
+
+  - bash: |
+      set +e
+      killall Electron
+    displayName: Make sure Electron isn't running from previous tests
+
+  - bash: |
+      cd src
+      python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
+    displayName: Verify non proprietary ffmpeg
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+    timeoutInMinutes: 5
+
+  - bash: |
+      cd src
+      ninja -C out/Default third_party/electron_node:headers
+      export ELECTRON_OUT_DIR=Default
+      (cd electron && npm run test -- --ci --enable-logging)
+    displayName: Run Electron test suite
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+    timeoutInMinutes: 10
+
   - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
       testResultsFiles: '*.xml'
       searchFolder: '$(System.DefaultWorkingDirectory)/src/junit/'
-    condition: and(always(), eq(variables['MOCHA_FILE'], 'junit/test-results.xml'), eq(variables['RUN_TESTS'], '1'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Build Artifacts
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/dist.zip'
-      ArtifactName: dist
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Build Artifacts
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/chromedriver.zip'
-      ArtifactName: dist
+    condition: and(always(), eq(variables['MOCHA_FILE'], 'junit/test-results.xml'))
 
   - bash: |
       export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"

--- a/vsts.yml
+++ b/vsts.yml
@@ -78,6 +78,11 @@ jobs:
       ninja -C out/Default electron:electron_dist_zip
     displayName: Build dist zip
 
+  - bash: |
+      cd src
+      ninja -C out/Default electron:electron_chromedriver_zip
+    displayName: Build chromedriver and zip
+
   - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
@@ -89,7 +94,13 @@ jobs:
     displayName: Publish Build Artifacts
     inputs:
       PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/dist.zip'
-      ArtifactName: dist.zip
+      ArtifactName: dist
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/chromedriver.zip'
+      ArtifactName: dist
 
   - bash: |
       export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"

--- a/vsts.yml
+++ b/vsts.yml
@@ -131,6 +131,9 @@ jobs:
       mkdir -p src/out/ffmpeg
       git clone https://github.com/electron/electron src/electron
       (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
+      cd src
+      export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
+      echo "##vso[task.setvariable variable=CHROMIUM_BUILDTOOLS_PATH]`pwd`/buildtools"
     displayName: Checkout Electron
 
   - task: DownloadBuildArtifacts@0
@@ -143,7 +146,7 @@ jobs:
     displayName: 'Download ffmpeg.dylib for testing'
     inputs:
       artifactName: ffmpeg
-      downloadPath: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg'
+      downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
 
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Node.js headers'
@@ -157,8 +160,9 @@ jobs:
     displayName: Unzip Electron app
 
   - bash: |
-      set +e
-      killall Electron
+      if pgrep Electron; then
+        killall Electron
+      fi
     displayName: Make sure Electron isn't running from previous tests
 
   - bash: |

--- a/vsts.yml
+++ b/vsts.yml
@@ -112,6 +112,11 @@ jobs:
       ArtifactName: ffmpeg
     condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
+  - bash: |
+      cd src
+      find -L buildtools -type l -exec rm -- {} +
+    displayName: Remove broken symlinks from buildtools
+
   - task: PublishBuildArtifacts@1
     displayName: Publish buildtools for ffmpeg testing
     inputs:

--- a/vsts.yml
+++ b/vsts.yml
@@ -106,10 +106,17 @@ jobs:
     condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish libffmpeg.dylib for testing
+    displayName: Publish libffmpeg.dylib for ffmpeg testing
     inputs:
       PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg/libffmpeg.dylib'
       ArtifactName: ffmpeg
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish buildtools for ffmpeg testing
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/buildtools'
+      ArtifactName: buildtools
     condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
   - task: PublishBuildArtifacts@1
@@ -143,10 +150,16 @@ jobs:
       downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
 
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download ffmpeg.dylib for testing'
+    displayName: 'Download ffmpeg.dylib for testing ffmpeg'
     inputs:
       artifactName: ffmpeg
       downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download buildtools for testing ffmpeg'
+    inputs:
+      artifactName: buildtools
+      downloadPath: '$(System.DefaultWorkingDirectory)/src'
 
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Node.js headers'

--- a/vsts.yml
+++ b/vsts.yml
@@ -71,113 +71,6 @@ jobs:
     condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
 
   - bash: |
-      cd src
-      ninja -C out/Default electron:electron_dist_zip
-    displayName: Build dist zip
-
-  - bash: |
-      cd src
-      ninja -C out/Default electron:electron_chromedriver_zip
-    displayName: Build chromedriver and zip
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Build Artifacts (application zip)
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/dist.zip'
-      ArtifactName: Default
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Build Artifacts (chromedriver.zip)
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/chromedriver.zip'
-      ArtifactName: Default
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish gn args for ffmpeg testing
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/args.gn'
-      ArtifactName: Default
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish build.ninja for ffmpeg testing
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/build.ninja'
-      ArtifactName: Default
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish libffmpeg.dylib for ffmpeg testing
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg/libffmpeg.dylib'
-      ArtifactName: ffmpeg
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
-
-  - bash: |
-      cd src
-      find -L buildtools -type l -exec rm -- {} +
-    displayName: Remove broken symlinks from buildtools
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish buildtools for ffmpeg testing
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/buildtools'
-      ArtifactName: buildtools
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Node.js headers for testing
-    inputs:
-      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/gen/node_headers'
-      ArtifactName: node_headers
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
-
-- job: Test_Electron_Build
-  displayName: Test
-  dependsOn: Build_Electron_via_GN
-  condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
-  timeoutInMinutes: 30
-  steps:
-  - bash: |
-      set -ex
-      mkdir -p src/out/Default/gen
-      mkdir -p src/out/ffmpeg
-      git clone https://github.com/electron/electron src/electron
-      (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
-      cd src
-      export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
-      echo "##vso[task.setvariable variable=CHROMIUM_BUILDTOOLS_PATH]`pwd`/buildtools"
-    displayName: Checkout Electron
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download files needed for testing'
-    inputs:
-      artifactName: Default
-      downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download ffmpeg.dylib for testing ffmpeg'
-    inputs:
-      artifactName: ffmpeg
-      downloadPath: '$(System.DefaultWorkingDirectory)/src/out'
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download buildtools for testing ffmpeg'
-    inputs:
-      artifactName: buildtools
-      downloadPath: '$(System.DefaultWorkingDirectory)/src'
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Node.js headers'
-    inputs:
-      artifactName: node_headers
-      downloadPath: '$(System.DefaultWorkingDirectory)/src/out/Default/gen'
-
-  - bash: |
-      cd src/out/Default
-      unzip dist.zip
-    displayName: Unzip Electron app
-
-  - bash: |
       if pgrep Electron; then
         killall Electron
       fi
@@ -199,12 +92,34 @@ jobs:
     condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
     timeoutInMinutes: 10
 
+  - bash: |
+      cd src
+      ninja -C out/Default electron:electron_dist_zip
+    displayName: Build dist zip
+
+  - bash: |
+      cd src
+      ninja -C out/Default electron:electron_chromedriver_zip
+    displayName: Build chromedriver and zip
+
   - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
       testResultsFiles: '*.xml'
       searchFolder: '$(System.DefaultWorkingDirectory)/src/junit/'
     condition: and(always(), eq(variables['MOCHA_FILE'], 'junit/test-results.xml'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts (application zip)
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/dist.zip'
+      ArtifactName: Default
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts (chromedriver.zip)
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/chromedriver.zip'
+      ArtifactName: Default
 
   - bash: |
       export BUILD_URL="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}"


### PR DESCRIPTION
##### Description of Change
This PR has several updates that are needed to release GN builds:
1. Added chromedriver to the build 
2. Make sure certain paths/files don't make it into the dist zip
3. Make sure libffmpeg.dylib gets put in the right place for testing and release builds
4. Run verify-ffmpeg on Mac builds. We weren't running this previously on Mac and therefore didn't notice that non proprietary ffmpeg builds were broken on Mac.
5. Splits out VSTS into build and testing jobs.  Originally this was in #14707, but this PR and that one were intertangled so I decided to move that change into this PR.   
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes