### PR TITLE
chore: turn off clang-format for ATOM_PRE_RELEASE_VERSION

### DIFF
--- a/atom/common/atom_version.h
+++ b/atom/common/atom_version.h
@@ -8,7 +8,9 @@
 #define ATOM_MAJOR_VERSION 4
 #define ATOM_MINOR_VERSION 0
 #define ATOM_PATCH_VERSION 0
+// clang-format off
 #define ATOM_PRE_RELEASE_VERSION -nightly.20180905
+// clang-format on
 
 #ifndef ATOM_STRINGIFY
 #define ATOM_STRINGIFY(n) ATOM_STRINGIFY_HELPER(n)


### PR DESCRIPTION
##### Description of Change
clang-format was insisting that there should be a space after the `-`.

I think it would be even better to not have this weird token (e.g. make it a string?) but this will at least prevent clang-format from breaking this code.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes