### PR TITLE
chore: have 'use strict' consistently across our lib files

### DIFF
--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "parserOptions": {
+    "sourceType": "script"
+  },
+  "rules": {
+    "strict": ["error", "global"]
+  }
+}

--- a/lib/browser/api/auto-updater.js
+++ b/lib/browser/api/auto-updater.js
@@ -1,3 +1,5 @@
+'use strict'
+
 if (process.platform === 'win32') {
   module.exports = require('@electron/internal/browser/api/auto-updater/auto-updater-win')
 } else {

--- a/lib/browser/api/auto-updater/auto-updater-native.js
+++ b/lib/browser/api/auto-updater/auto-updater-native.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const EventEmitter = require('events').EventEmitter
 const { autoUpdater, AutoUpdater } = process.atomBinding('auto_updater')
 

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('fs')
 const path = require('path')
 const spawn = require('child_process').spawn

--- a/lib/browser/api/content-tracing.js
+++ b/lib/browser/api/content-tracing.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = process.atomBinding('content_tracing')

--- a/lib/browser/api/exports/electron.js
+++ b/lib/browser/api/exports/electron.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const common = require('@electron/internal/common/api/exports/electron')
 // since browser module list is also used in renderer, keep it separate.
 const moduleList = require('@electron/internal/browser/api/module-list')

--- a/lib/browser/api/global-shortcut.js
+++ b/lib/browser/api/global-shortcut.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = process.atomBinding('global_shortcut').globalShortcut

--- a/lib/browser/api/ipc-main.js
+++ b/lib/browser/api/ipc-main.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const EventEmitter = require('events').EventEmitter
 
 const emitter = new EventEmitter()

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { app } = require('electron')
 
 const roles = {

--- a/lib/browser/api/menu-utils.js
+++ b/lib/browser/api/menu-utils.js
@@ -1,3 +1,5 @@
+'use strict'
+
 function splitArray (arr, predicate) {
   const result = arr.reduce((multi, item) => {
     const current = multi[multi.length - 1]

--- a/lib/browser/api/module-list.js
+++ b/lib/browser/api/module-list.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const features = process.atomBinding('features')
 
 // Browser side modules, please sort alphabetically.

--- a/lib/browser/api/notification.js
+++ b/lib/browser/api/notification.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { EventEmitter } = require('events')
 const { Notification, isSupported } = process.atomBinding('notification')
 

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { EventEmitter } = require('events')
 const { powerMonitor, PowerMonitor } = process.atomBinding('power_monitor')
 

--- a/lib/browser/api/power-save-blocker.js
+++ b/lib/browser/api/power-save-blocker.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = process.atomBinding('power_save_blocker').powerSaveBlocker

--- a/lib/browser/api/protocol.js
+++ b/lib/browser/api/protocol.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { app, session } = require('electron')
 
 // Global protocol APIs.

--- a/lib/browser/api/screen.js
+++ b/lib/browser/api/screen.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { EventEmitter } = require('events')
 const { screen, Screen } = process.atomBinding('screen')
 

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { EventEmitter } = require('events')
 const { app } = require('electron')
 const { fromPartition, Session, Cookies } = process.atomBinding('session')

--- a/lib/browser/api/system-preferences.js
+++ b/lib/browser/api/system-preferences.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { EventEmitter } = require('events')
 const { systemPreferences, SystemPreferences } = process.atomBinding('system_preferences')
 

--- a/lib/browser/api/touch-bar.js
+++ b/lib/browser/api/touch-bar.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { EventEmitter } = require('events')
 
 let nextItemID = 1

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { EventEmitter } = require('events')
 const { Tray } = process.atomBinding('tray')
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { app, ipcMain, webContents, BrowserWindow } = require('electron')
 const { getAllWebContents } = process.atomBinding('web_contents')
 const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllWebContents()

--- a/lib/common/api/clipboard.js
+++ b/lib/common/api/clipboard.js
@@ -1,3 +1,5 @@
+'use strict'
+
 if (process.platform === 'linux' && process.type === 'renderer') {
   // On Linux we could not access clipboard in renderer process.
   module.exports = require('electron').remote.clipboard

--- a/lib/common/api/exports/electron.js
+++ b/lib/common/api/exports/electron.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const moduleList = require('@electron/internal/common/api/module-list')
 
 exports.memoizedGetter = (getter) => {

--- a/lib/common/api/module-list.js
+++ b/lib/common/api/module-list.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // Common modules, please sort alphabetically
 module.exports = [
   { name: 'clipboard', file: 'clipboard' },

--- a/lib/common/api/native-image.js
+++ b/lib/common/api/native-image.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = process.atomBinding('native_image')

--- a/lib/common/api/shell.js
+++ b/lib/common/api/shell.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = process.atomBinding('shell')

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -1,3 +1,5 @@
+'use strict';
+
 (function () {
   const asar = process.binding('atom_common_asar')
   const assert = require('assert')

--- a/lib/common/asar_init.js
+++ b/lib/common/asar_init.js
@@ -1,3 +1,5 @@
+'use strict'
+
 ;(function () { // eslint-disable-line
   return function (process, require, asarSource) {
     const source = process.binding('natives')

--- a/lib/common/atom-binding-setup.js
+++ b/lib/common/atom-binding-setup.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = function atomBindingSetup (binding, processType) {
   return function atomBinding (name) {
     try {

--- a/lib/common/buffer-utils.js
+++ b/lib/common/buffer-utils.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // Note: Don't use destructuring assignment for `Buffer`, or we'll hit a
 // browserify bug that makes the statement invalid, throwing an error in
 // sandboxed renderer.

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const timers = require('timers')
 const util = require('util')
 

--- a/lib/common/parse-features-string.js
+++ b/lib/common/parse-features-string.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // parses a feature string that has the format used in window.open()
 // - `features` input string
 // - `emit` function(key, value) - called for each parsed KV

--- a/lib/common/reset-search-paths.js
+++ b/lib/common/reset-search-paths.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const path = require('path')
 const Module = require('module')
 

--- a/lib/isolated_renderer/init.js
+++ b/lib/isolated_renderer/init.js
@@ -1,6 +1,6 @@
-/* global binding */
-
 'use strict'
+
+/* global binding */
 
 const { send, sendSync } = binding
 

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { ipcRenderer, nativeImage } = require('electron')
 
 const includes = [].includes

--- a/lib/renderer/api/exports/electron.js
+++ b/lib/renderer/api/exports/electron.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const common = require('@electron/internal/common/api/exports/electron')
 const moduleList = require('@electron/internal/renderer/api/module-list')
 

--- a/lib/renderer/api/module-list.js
+++ b/lib/renderer/api/module-list.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const features = process.atomBinding('features')
 
 // Renderer side modules, please sort alphabetically.

--- a/lib/renderer/api/screen.js
+++ b/lib/renderer/api/screen.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('electron').remote.screen

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { ipcRenderer } = require('electron')
 const Event = require('@electron/internal/renderer/extensions/event')
 const url = require('url')

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { ipcRenderer } = require('electron')
 const { runInThisContext } = require('vm')
 

--- a/lib/renderer/extensions/event.js
+++ b/lib/renderer/extensions/event.js
@@ -1,3 +1,5 @@
+'use strict'
+
 class Event {
   constructor () {
     this.listeners = []

--- a/lib/renderer/extensions/i18n.js
+++ b/lib/renderer/extensions/i18n.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // Implementation of chrome.i18n.getMessage
 // https://developer.chrome.com/extensions/i18n#method-getMessage
 //

--- a/lib/renderer/extensions/storage.js
+++ b/lib/renderer/extensions/storage.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('fs')
 const path = require('path')
 const { remote } = require('electron')

--- a/lib/renderer/extensions/web-navigation.js
+++ b/lib/renderer/extensions/web-navigation.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Event = require('@electron/internal/renderer/extensions/event')
 const { ipcRenderer } = require('electron')
 

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -1,3 +1,5 @@
+'use strict'
+
 window.onload = function () {
   // Use menu API to show context menu.
   window.InspectorFrontendHost.showContextMenuAtPoint = createMenu

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -1,3 +1,5 @@
+'use strict'
+
 let shouldLog = null
 
 /**

--- a/lib/renderer/web-frame-init.js
+++ b/lib/renderer/web-frame-init.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { ipcRenderer, webFrame } = require('electron')
 const errorUtils = require('@electron/internal/common/error-utils')
 

--- a/lib/renderer/web-view/web-view-constants.js
+++ b/lib/renderer/web-view/web-view-constants.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
   // Attributes.
   ATTRIBUTE_NAME: 'name',

--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // This file should have no requires since it is used by the isolated context
 // preload bundle. Instead arguments should be passed in for everything it
 // needs.
@@ -20,8 +22,6 @@
 // - window.prompt()
 // - document.hidden
 // - document.visibilityState
-
-'use strict'
 
 const { defineProperty } = Object
 

--- a/lib/sandboxed_renderer/api/exports/child_process.js
+++ b/lib/sandboxed_renderer/api/exports/child_process.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('electron').remote.require('child_process')

--- a/lib/sandboxed_renderer/api/exports/electron.js
+++ b/lib/sandboxed_renderer/api/exports/electron.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const moduleList = require('@electron/internal/sandboxed_renderer/api/module-list')
 
 for (const {

--- a/lib/sandboxed_renderer/api/exports/fs.js
+++ b/lib/sandboxed_renderer/api/exports/fs.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('electron').remote.require('fs')

--- a/lib/sandboxed_renderer/api/exports/os.js
+++ b/lib/sandboxed_renderer/api/exports/os.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('electron').remote.require('os')

--- a/lib/sandboxed_renderer/api/exports/path.js
+++ b/lib/sandboxed_renderer/api/exports/path.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('electron').remote.require('path')

--- a/lib/sandboxed_renderer/api/ipc-renderer.js
+++ b/lib/sandboxed_renderer/api/ipc-renderer.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const ipcRenderer = require('@electron/internal/renderer/api/ipc-renderer')
 
 const v8Util = process.atomBinding('v8_util')

--- a/lib/sandboxed_renderer/api/module-list.js
+++ b/lib/sandboxed_renderer/api/module-list.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const features = process.atomBinding('features')
 
 module.exports = [

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /* eslint no-eval: "off" */
 /* global binding, Buffer */
 const events = require('events')


### PR DESCRIPTION
Our lib files were inconsistent around usage of `use strict` this PR updates them to **all** use `use strict` and adds a linting rule to enforce it

Notes: no-notes