### PR TITLE
test: reenable app module > app.exit(exitCode) > closes all windows

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -162,15 +162,7 @@ describe('app module', () => {
       expect(code).to.equal(123)
     })
 
-    // FIXME(alexeykuzmin): Constantly fails with Ch66 on linux,
-    // but looks good with Ch67.
-    // Enable the test after Ch67 is merged into master.
     it('closes all windows', async function () {
-      if (process.platform === 'linux') {
-        this.skip()
-        return
-      }
-
       const appPath = path.join(__dirname, 'fixtures', 'api', 'exit-closes-all-windows-app')
       const electronPath = remote.getGlobal('process').execPath
 


### PR DESCRIPTION
##### Description of Change
#14314 disabled this flaky test.  According to @alexeykuzmin it should be reenabled once Chromium 67 is merged to master, which it has now been merged, so this PR renables that test for Linux.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes