### PR TITLE
ci: Make sure that tests on VSTS get marked as failed if they fail

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -57,7 +57,6 @@ jobs:
     condition: and(succeeded(), ne(variables['ELECTRON_RELEASE'], '1'))
 
   - bash: |
-      set +e
       cd src
       # Make sure there aren't any Electron processes left running from previous tests
       killall Electron


### PR DESCRIPTION
##### Description of Change
Builds such as https://github.visualstudio.com/electron/_build/results?buildId=8597&view=logs were being marked as passing when they were actually failing.  This change will make sure those jobs get marked as failing.  I think this also may resolve the issue we have been having in VSTS where Electron crashes and the tests keep running until timeout is hit.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes