### PR TITLE
fix: support macos 10.14 SDK

### DIFF
--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -98,8 +98,8 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 - (BOOL)application:(NSApplication*)sender
     continueUserActivity:(NSUserActivity*)userActivity
       restorationHandler:
-          (void (^)(NSArray* restorableObjects))restorationHandler
-    API_AVAILABLE(macosx(10.10)) {
+          (void (^)(NSArray<id<NSUserActivityRestoring>>* restorableObjects))
+              restorationHandler API_AVAILABLE(macosx(10.10)) {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
   std::unique_ptr<base::DictionaryValue> user_info =
       atom::NSDictionaryToDictionaryValue(userActivity.userInfo);

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -37,10 +37,6 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 @end
 #endif  // BUILDFLAG(USE_ALLOCATOR_SHIM)
 
-// NOTE(jeremy): this forward declaration once we're building against macOS
-// 10.14.
-@protocol NSUserActivityRestoring;
-
 @implementation AtomApplicationDelegate
 
 - (void)setApplicationDockMenu:(atom::AtomMenuModel*)model {
@@ -102,7 +98,11 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 - (BOOL)application:(NSApplication*)sender
     continueUserActivity:(NSUserActivity*)userActivity
       restorationHandler:
+#ifdef MAC_OS_X_VERSION_10_14
           (void (^)(NSArray<id<NSUserActivityRestoring>>* restorableObjects))
+#else
+          (void (^)(NSArray* restorableObjects))
+#endif
               restorationHandler API_AVAILABLE(macosx(10.10)) {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
   std::unique_ptr<base::DictionaryValue> user_info =

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -37,6 +37,10 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 @end
 #endif  // BUILDFLAG(USE_ALLOCATOR_SHIM)
 
+// NOTE(jeremy): this forward declaration once we're building against macOS
+// 10.14.
+@protocol NSUserActivityRestoring;
+
 @implementation AtomApplicationDelegate
 
 - (void)setApplicationDockMenu:(atom::AtomMenuModel*)model {

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -455,3 +455,7 @@ patches:
   description: |
     Accept all HTTP codes in [200, 300) as successful, instead of just 200.
     For example HockeyApp responds with 202.
+-
+  author: Jeremy Apthorp <jeremya@chromium.org>
+  file: backport_cd7154e0bb5.patch
+  description: Support macosx 10.14 SDK

--- a/patches/common/chromium/backport_cd7154e0bb5.patch
+++ b/patches/common/chromium/backport_cd7154e0bb5.patch
@@ -1,0 +1,100 @@
+From 0dc7f85f52b9a5668481dfa206e6e55d40357cc2 Mon Sep 17 00:00:00 2001
+From: Elly Fong-Jones <ellyjones@chromium.org>
+Date: Wed, 6 Jun 2018 21:31:34 +0000
+Subject: mac: support build with 10.14 SDK
+
+Two changes are required:
+
+1) Explicitly upcast the result of dispatch_get_global_queue() to a
+dispatch_queue_t*, since it changed to return dispatch_queue_global_t*;
+2) Add empty implementations of the new methods on ICCameraDeviceDelegate for
+ImageCaptureDevice
+
+TBR=maxmorin@chromium.org
+
+Bug: 849689
+Cq-Include-Trybots: luci.chromium.try:android_optional_gpu_tests_rel;luci.chromium.try:linux_optional_gpu_tests_rel;luci.chromium.try:mac_optional_gpu_tests_rel;luci.chromium.try:win_optional_gpu_tests_rel
+Change-Id: I9448d1b07f8d4116ecdb0c75a7796472e51c6dd8
+Reviewed-on: https://chromium-review.googlesource.com/1087169
+Reviewed-by: Elly Fong-Jones <ellyjones@chromium.org>
+Reviewed-by: Robert Sesek <rsesek@chromium.org>
+Reviewed-by: Tommy Li <tommycli@chromium.org>
+Commit-Queue: Elly Fong-Jones <ellyjones@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#565040}
+
+diff --git a/components/storage_monitor/image_capture_device.mm b/components/storage_monitor/image_capture_device.mm
+index af289bd66eb6..831cb65ac970 100644
+--- a/components/storage_monitor/image_capture_device.mm
++++ b/components/storage_monitor/image_capture_device.mm
+@@ -231,4 +231,38 @@ base::FilePath PathForCameraItem(ICCameraItem* item) {
+                  name));
+ }
+ 
++// MacOS 10.14 SDK methods, not yet implemented (https://crbug.com/849689)
++- (void)cameraDevice:(ICCameraDevice*)camera
++      didRenameItems:(NSArray<ICCameraItem*>*)items {
++  NOTIMPLEMENTED();
++}
++
++- (void)cameraDevice:(ICCameraDevice*)camera didRemoveItem:(ICCameraItem*)item {
++  NOTIMPLEMENTED();
++}
++
++- (void)cameraDevice:(ICCameraDevice*)camera
++    didCompleteDeleteFilesWithError:(NSError*)error {
++  NOTIMPLEMENTED();
++}
++
++- (void)cameraDeviceDidChangeCapability:(ICCameraDevice*)camera {
++  NOTIMPLEMENTED();
++}
++
++- (void)cameraDevice:(ICCameraDevice*)camera
++    didReceiveThumbnailForItem:(ICCameraItem*)item {
++  NOTIMPLEMENTED();
++}
++
++- (void)cameraDevice:(ICCameraDevice*)camera
++    didReceiveMetadataForItem:(ICCameraItem*)item {
++  NOTIMPLEMENTED();
++}
++
++- (void)cameraDevice:(ICCameraDevice*)camera
++    didReceivePTPEvent:(NSData*)eventData {
++  NOTIMPLEMENTED();
++}
++
+ @end  // ImageCaptureDevice
+diff --git a/media/audio/mac/coreaudio_dispatch_override.cc b/media/audio/mac/coreaudio_dispatch_override.cc
+index 2ac812b0f3fc..34d1ad2a0fbe 100644
+--- a/media/audio/mac/coreaudio_dispatch_override.cc
++++ b/media/audio/mac/coreaudio_dispatch_override.cc
+@@ -22,6 +22,9 @@ struct dyld_interpose_tuple {
+   const void* replacement;
+   const void* replacee;
+ };
++
++using DispatchGetGlobalQueueFunc = dispatch_queue_t (*)(long id,
++                                                        unsigned long flags);
+ }  // namespace
+ 
+ // This method, and the tuple above, is defined in dyld_priv.h; see:
+@@ -175,8 +178,13 @@ bool InitializeCoreAudioDispatchOverride() {
+   const auto* header = reinterpret_cast<const mach_header*>(info.dli_fbase);
+   g_pause_resume_queue =
+       dispatch_queue_create("org.chromium.CoreAudioPauseResumeQueue", nullptr);
+-  dyld_interpose_tuple interposition(&GetGlobalQueueOverride,
+-                                     &dispatch_get_global_queue);
++  // The reinterpret_cast<> is needed because in the macOS 10.14 SDK, the return
++  // type of dispatch_get_global_queue changed to return a subtype of
++  // dispatch_queue_t* instead of dispatch_queue_t* itself, and T(*)(...) isn't
++  // automatically converted to U(*)(...) even if U is a superclass of T.
++  dyld_interpose_tuple interposition(
++      &GetGlobalQueueOverride,
++      reinterpret_cast<DispatchGetGlobalQueueFunc>(&dispatch_get_global_queue));
+   dyld_dynamic_interpose(header, &interposition, 1);
+   g_dispatch_override_installed = true;
+   LogInitResult(RESULT_INITIALIZED);
+-- 
+2.17.0
+


### PR DESCRIPTION
##### Description of Change
Backports https://chromium.googlesource.com/chromium/src.git/+/cd7154e0bb5f3ca9c72586da79f87d13afb5361a and fixes one API in Electron to work with the 10.14 SDK.

Building with 10.14 still requires setting `FORCE_MAC_SDK_MIN=10.14` in your environment, see https://bugs.chromium.org/p/chromium/issues/detail?id=887214#c12

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes