### PR TITLE
docs: clarify allowable background colors for BrowserWindow transparency

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -202,7 +202,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     than screen. Default is `false`.
   * `backgroundColor` String (optional) - Window's background color as a hexadecimal value,
     like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha is supported). Default is
-    `#FFF` (white). If `transparent` is set to `true`, only transparent (`#00000000`) or opaque (`#FFFFFFFF`) are respected.
+    `#FFF` (white). If `transparent` is set to `true`, only values with transparent (`#00-------`) or opaque (`#FF-----`) alpha values are respected.
   * `hasShadow` Boolean (optional) - Whether window should have a shadow. This is only
     implemented on macOS. Default is `true`.
   * `opacity` Number (optional) - Set the initial opacity of the window, between 0.0 (fully

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -202,7 +202,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     than screen. Default is `false`.
   * `backgroundColor` String (optional) - Window's background color as a hexadecimal value,
     like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha is supported). Default is
-    `#FFF` (white).
+    `#FFF` (white). If `transparent` is set to `true`, only transparent (`#00000000`) or opaque (`#FFFFFFFF`) are respected.
   * `hasShadow` Boolean (optional) - Whether window should have a shadow. This is only
     implemented on macOS. Default is `true`.
   * `opacity` Number (optional) - Set the initial opacity of the window, between 0.0 (fully


### PR DESCRIPTION
##### Description of Change

When declaring a new `BrowserWindow`, if `transparent` is set to true, `setBackgroundColor` will only respect `#00------` (transparent) or `#FF------` (opaque) alpha values. This PR updates the docs to reflect this. 

/cc @ckerr 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
-  [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: clarify allowable colors for setBackgroundColor when windows are transparent