### PR TITLE
fix: inconsistent titleBarStyle on transparent fullscreen

### DIFF
--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -212,6 +212,7 @@
 
       // Set window style to hide the toolbar, otherwise the toolbar will show
       // in fullscreen mode.
+      [window setTitlebarAppearsTransparent:NO];
       shell_->SetStyleMask(true, NSFullSizeContentViewWindowMask);
     }
   }
@@ -230,6 +231,7 @@
     // Turn off the style for toolbar.
     if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
       shell_->SetStyleMask(false, NSFullSizeContentViewWindowMask);
+      [window setTitlebarAppearsTransparent:YES];
     }
   }
 }


### PR DESCRIPTION
##### Description of Change

Resolves https://github.com/electron/electron/issues/13147.

Before:
![40882373-22fdf79e-6734-11e8-9f61-0711323ff52b](https://user-images.githubusercontent.com/2036040/45912944-bf9e1d80-bdde-11e8-9ac2-5d885c6ff78f.png)

After:
<img width="674" alt="screen shot 2018-09-21 at 8 45 48 pm" src="https://user-images.githubusercontent.com/2036040/45912982-5b2f8e00-bddf-11e8-85a3-50d94c15a5bf.png">


I can try to look into a more ideal fix but for now i think this should address the base problem of the window control buttons looking strange during fullscreen mode. 

/cc @zacharyrs @ckerr 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: fix inconsistent titleBarStyle on transparent fullscreen