### PR TITLE
fix: get background color from GtkMenuBar#menubar

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -5,12 +5,17 @@
 #include "atom/browser/ui/views/menu_bar.h"
 
 #include <memory>
+#include <string>
 
 #include "atom/browser/ui/views/menu_delegate.h"
 #include "atom/browser/ui/views/submenu_button.h"
 #include "ui/base/models/menu_model.h"
 #include "ui/views/background.h"
 #include "ui/views/layout/box_layout.h"
+
+#if defined(USE_X11)
+#include "chrome/browser/ui/libgtkui/gtk_util.h"
+#endif
 
 #if defined(OS_WIN)
 #include "ui/gfx/color_utils.h"
@@ -123,13 +128,17 @@ void MenuBar::RefreshColorCache(const ui::NativeTheme* theme) {
   if (!theme)
     theme = ui::NativeTheme::GetInstanceForNativeUi();
   if (theme) {
-    background_color_ =
-        theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);
 #if defined(USE_X11)
+    const std::string menubar_selector = "GtkMenuBar#menubar";
+    background_color_ = libgtkui::GetBgColor(menubar_selector);
+
     enabled_color_ = theme->GetSystemColor(
         ui::NativeTheme::kColorId_EnabledMenuItemForegroundColor);
     disabled_color_ = theme->GetSystemColor(
         ui::NativeTheme::kColorId_DisabledMenuItemForegroundColor);
+#else
+    background_color_ =
+        theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);
 #endif
   }
 #if defined(OS_WIN)

--- a/patches/common/chromium/libgtkui_export.patch
+++ b/patches/common/chromium/libgtkui_export.patch
@@ -74,6 +74,15 @@ index 665ec57..4ccb088 100644
  
  // Gets the transient parent aura window for |dialog|.
  aura::Window* GetAuraTransientParent(GtkWidget* dialog);
+@@ -190,7 +190,7 @@ void RenderBackground(const gfx::Size& size,
+ // Renders a background from the style context created by
+ // GetStyleContextFromCss(|css_selector|) into a 24x24 bitmap and
+ // returns the average color.
+-SkColor GetBgColor(const std::string& css_selector);
++LIBGTKUI_EXPORT SkColor GetBgColor(const std::string& css_selector);
+ 
+ // Renders the border from the style context created by
+ // GetStyleContextFromCss(|css_selector|) into a 24x24 bitmap and
 diff --git a/chrome/browser/ui/libgtkui/skia_utils_gtk.h b/chrome/browser/ui/libgtkui/skia_utils_gtk.h
 index e05fbe9..3afca9a 100644
 --- a/chrome/browser/ui/libgtkui/skia_utils_gtk.h


### PR DESCRIPTION
##### Description of Change

Resolves https://github.com/electron/electron/issues/13381.

Changes the background color of the menubar to match the GTK theme if there is one.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: fixes incorrect background color on GTK menubar