### PR TITLE
refactor: use error-utils for remote exception serialization / deserialization

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -9,6 +9,7 @@ const { ipcMain, isPromise } = electron
 
 const objectsRegistry = require('@electron/internal/browser/objects-registry')
 const bufferUtils = require('@electron/internal/common/buffer-utils')
+const errorUtils = require('@electron/internal/common/error-utils')
 
 const hasProp = {}.hasOwnProperty
 
@@ -135,9 +136,7 @@ const plainObjectToMeta = function (obj) {
 const exceptionToMeta = function (sender, contextId, error) {
   return {
     type: 'exception',
-    message: error.message,
-    stack: error.stack || error,
-    cause: valueToMeta(sender, contextId, error.cause)
+    value: errorUtils.serialize(error)
   }
 }
 

--- a/lib/common/error-utils.js
+++ b/lib/common/error-utils.js
@@ -11,10 +11,12 @@ const constructors = new Map([
 ])
 
 exports.deserialize = function (error) {
-  if (error.__ELECTRON_SERIALIZED_ERROR__ && constructors.has(error.name)) {
+  if (error && error.__ELECTRON_SERIALIZED_ERROR__ && constructors.has(error.name)) {
     const constructor = constructors.get(error.name)
     const deserializedError = new constructor(error.message)
     deserializedError.stack = error.stack
+    deserializedError.from = error.from
+    deserializedError.cause = exports.deserialize(error.cause)
     return deserializedError
   }
   return error
@@ -28,6 +30,8 @@ exports.serialize = function (error) {
       message: error.message,
       stack: error.stack,
       name: error.name,
+      from: process.type,
+      cause: exports.serialize(error.cause),
       __ELECTRON_SERIALIZED_ERROR__: true
     }
   }

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -6,6 +6,7 @@ const resolvePromise = Promise.resolve.bind(Promise)
 
 const CallbacksRegistry = require('@electron/internal/renderer/callbacks-registry')
 const bufferUtils = require('@electron/internal/common/buffer-utils')
+const errorUtils = require('@electron/internal/common/error-utils')
 
 const callbacksRegistry = new CallbacksRegistry()
 const remoteObjectCache = v8Util.createIDWeakMap()
@@ -217,7 +218,7 @@ function metaToValue (meta) {
     promise: () => resolvePromise({ then: metaToValue(meta.then) }),
     error: () => metaToPlainObject(meta),
     date: () => new Date(meta.value),
-    exception: () => { throw metaToException(meta) }
+    exception: () => { throw errorUtils.deserialize(meta.value) }
   }
 
   if (meta.type in types) {
@@ -265,15 +266,6 @@ function metaToPlainObject (meta) {
     obj[name] = value
   }
   return obj
-}
-
-// Construct an exception error from the meta.
-function metaToException (meta) {
-  const error = new Error(`${meta.message}\n${meta.stack}`)
-  const remoteProcess = exports.process
-  error.from = remoteProcess ? remoteProcess.type : null
-  error.cause = metaToValue(meta.cause)
-  return error
 }
 
 function handleMessage (channel, handler) {

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -54,12 +54,16 @@ preloadProcess.getHeapStatistics = () => binding.getHeapStatistics()
 preloadProcess.getSystemMemoryInfo = () => binding.getSystemMemoryInfo()
 preloadProcess.getCPUUsage = () => binding.getCPUUsage()
 preloadProcess.getIOCounters = () => binding.getIOCounters()
-preloadProcess.argv = process.argv = binding.getArgv()
-preloadProcess.execPath = process.execPath = binding.getExecPath()
-preloadProcess.pid = process.pid = binding.getPid()
-preloadProcess.resourcesPath = binding.getResourcesPath()
-preloadProcess.sandboxed = true
-preloadProcess.type = 'renderer'
+
+Object.assign(processProps, {
+  argv: binding.getArgv(),
+  execPath: binding.getExecPath(),
+  pid: binding.getPid(),
+  resourcesPath: binding.getResourcesPath(),
+  sandboxed: true,
+  type: 'renderer'
+})
+
 Object.assign(preloadProcess, processProps)
 Object.assign(process, processProps)
 


### PR DESCRIPTION
##### Description of Change
Use error-utils for remote exception serialization / deserialization to avoid code duplication.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes