### PR TITLE
chore: force patches to be checked out with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# `git apply` and friends don't understand CRLF, even on windows. Force those
+# files to be checked out with LF endings even if core.autocrlf is true.
+*.patch text eol=lf


### PR DESCRIPTION
If a user has core.autoclrf set to true in their git config, on Windows, git
will check out .patch files with CRLF line endings, which `git apply` doesn't
understand (& thus `gclient sync` will fail with a message about being unable
to apply patches). This forces git to always check out *.patch files with LF
line endings, regardless of the core.autoclrf setting.

Ref #14662, and thanks to @vulture for the suggestion.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


Notes: no-notes