### PR TITLE
chore: fix compilation with XCode 10

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -463,7 +463,7 @@ patches:
   author: Shelley Vohr <shelley.vohr@gmail.com>
   file: fix_xcode_ten.patch
   description: |
-    Backports 4287a0d3, a commit which does the following -
+    Backports 27f9cbd8, a commit which does the following -
       * Removes IDEBundleInjection.framework from egtests.
       * Corrects the DTXcode generation function to handle leading '10'.
       * Fixes a main_application_delegate SDK change

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -459,3 +459,13 @@ patches:
   author: Jeremy Apthorp <jeremya@chromium.org>
   file: backport_cd7154e0bb5.patch
   description: Support macosx 10.14 SDK
+-
+  author: Shelley Vohr <shelley.vohr@gmail.com>
+  file: fix_xcode_ten.patch
+  description: |
+    Backports 4287a0d3, a commit which does the following -
+      * Removes IDEBundleInjection.framework from egtests.
+      * Corrects the DTXcode generation function to handle leading '10'.
+      * Fixes a main_application_delegate SDK change
+      * Fixes a non-null SDK change in a net unittest.
+    This is needed for Electron to compile with XCode 10.0.

--- a/patches/common/chromium/fix_xcode_ten.patch
+++ b/patches/common/chromium/fix_xcode_ten.patch
@@ -1,0 +1,86 @@
+diff --git a/build/config/ios/rules.gni b/build/config/ios/rules.gni
+index df6033b..7fdc931 100644
+--- a/build/config/ios/rules.gni
++++ b/build/config/ios/rules.gni
+@@ -1805,10 +1805,15 @@
+     # Xcode needs those two framework installed in the application (and signed)
+     # for the XCTest to run, so install them using extra_system_frameworks.
+     _ios_platform_library = "$ios_sdk_platform_path/Developer/Library"
+-    extra_system_frameworks = [
+-      "$_ios_platform_library/Frameworks/XCTest.framework",
+-      "$_ios_platform_library/PrivateFrameworks/IDEBundleInjection.framework",
+-    ]
++    extra_system_frameworks =
++        [ "$_ios_platform_library/Frameworks/XCTest.framework" ]
++
++    # TODO: Remove this once support for Xcode 9.x is dropped.
++    if (xcode_version_int < 1000) {
++      extra_system_frameworks += [
++        "$_ios_platform_library/PrivateFrameworks/IDEBundleInjection.framework",
++      ]
++    }
+ 
+     _xctest_bundle = _xctest_target + "_bundle"
+     if (current_toolchain == default_toolchain) {
+diff --git a/build/config/mac/sdk_info.py b/build/config/mac/sdk_info.py
+index 8a9edc1..46dcec8 100644
+--- a/build/config/mac/sdk_info.py
++++ b/build/config/mac/sdk_info.py
+@@ -3,6 +3,8 @@
+ # found in the LICENSE file.
+ 
+ import argparse
++import doctest
++import itertools
+ import os
+ import subprocess
+ import sys
+@@ -10,16 +12,32 @@
+ # This script prints information about the build system, the operating
+ # system and the iOS or Mac SDK (depending on the platform "iphonesimulator",
+ # "iphoneos" or "macosx" generally).
+-#
+-# In the GYP build, this is done inside GYP itself based on the SDKROOT
+-# variable.
++
++def SplitVersion(version):
++  """Splits the Xcode version to 3 values.
++
++  >>> list(SplitVersion('8.2.1.1'))
++  ['8', '2', '1']
++  >>> list(SplitVersion('9.3'))
++  ['9', '3', '0']
++  >>> list(SplitVersion('10.0'))
++  ['10', '0', '0']
++  """
++  version = version.split('.')
++  return itertools.islice(itertools.chain(version, itertools.repeat('0')), 0, 3)
+ 
+ def FormatVersion(version):
+-  """Converts Xcode version to a format required for Info.plist."""
+-  version = version.replace('.', '')
+-  version = version + '0' * (3 - len(version))
+-  return version.zfill(4)
++  """Converts Xcode version to a format required for DTXcode in Info.plist
+ 
++  >>> FormatVersion('8.2.1')
++  '0821'
++  >>> FormatVersion('9.3')
++  '0930'
++  >>> FormatVersion('10.0')
++  '1000'
++  """
++  major, minor, patch = SplitVersion(version)
++  return ('%2s%s%s' % (major, minor, patch)).replace(' ', '0')
+ 
+ def FillXcodeVersion(settings):
+   """Fills the Xcode version and build number into |settings|."""
+@@ -53,6 +71,8 @@
+ 
+ 
+ if __name__ == '__main__':
++  doctest.testmod()
++
+   parser = argparse.ArgumentParser()
+   parser.add_argument("--developer_dir", required=False)
+   args, unknownargs = parser.parse_known_args()


### PR DESCRIPTION
##### Description of Change 

This PR backports [this commit](https://chromium.googlesource.com/chromium/src/build.git/+/4287a0d364541583a50cc91465330251460d489a%5E%21), which does the following:
  * Removes IDEBundleInjection.framework from egtests.
  * Corrects the DTXcode generation function to handle leading '10'.
  * Fixes a main_application_delegate SDK change
  * Fixes a non-null SDK change in a net unittest.

And allows Chromium, and thus Electron, to build once more.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes