### PR TITLE
fix: get background color from GtkMenuBar#menubar (2-0-x)

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -4,11 +4,18 @@
 
 #include "atom/browser/ui/views/menu_bar.h"
 
+#include <memory>
+#include <string>
+
 #include "atom/browser/ui/views/menu_delegate.h"
 #include "atom/browser/ui/views/submenu_button.h"
 #include "ui/base/models/menu_model.h"
 #include "ui/views/background.h"
 #include "ui/views/layout/box_layout.h"
+
+#if defined(USE_X11)
+#include "chrome/browser/ui/libgtkui/gtk_util.h"
+#endif
 
 #if defined(OS_WIN)
 #include "ui/gfx/color_utils.h"
@@ -130,13 +137,17 @@ void MenuBar::RefreshColorCache(const ui::NativeTheme* theme) {
   if (!theme)
     theme = ui::NativeTheme::GetInstanceForNativeUi();
   if (theme) {
-    background_color_ =
-        theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);
 #if defined(USE_X11)
+    const std::string menubar_selector = "GtkMenuBar#menubar";
+    background_color_ = libgtkui::GetBgColor(menubar_selector);
+
     enabled_color_ = theme->GetSystemColor(
         ui::NativeTheme::kColorId_EnabledMenuItemForegroundColor);
     disabled_color_ = theme->GetSystemColor(
         ui::NativeTheme::kColorId_DisabledMenuItemForegroundColor);
+#else
+    background_color_ =
+        theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);
 #endif
   }
 #if defined(OS_WIN)


### PR DESCRIPTION
##### Description of Change

Backport of https://github.com/electron/electron/pull/14785 to `2-0-x`.

Depends on https://github.com/electron/libchromiumcontent/pull/691.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: fixes incorrect background color on GTK menubar