### PR TITLE
fix: send null in debugger callback when no error

### DIFF
--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -67,14 +67,17 @@ void Debugger::DispatchProtocolMessage(DevToolsAgentHost* agent_host,
       return;
     base::DictionaryValue* error_body = nullptr;
     base::DictionaryValue error;
-    if (dict->GetDictionary("error", &error_body))
+    bool has_error;
+    if ((has_error = dict->GetDictionary("error", &error_body))) {
       error.Swap(error_body);
+    }
 
     base::DictionaryValue* result_body = nullptr;
     base::DictionaryValue result;
     if (dict->GetDictionary("result", &result_body))
       result.Swap(result_body);
-    send_command_callback.Run(error, result);
+    send_command_callback.Run(has_error ? error.Clone() : base::Value(),
+                              result);
   }
 }
 

--- a/spec/api-debugger-spec.js
+++ b/spec/api-debugger-spec.js
@@ -111,7 +111,7 @@ describe('debugger module', () => {
       }
 
       const callback = (err, res) => {
-        expect(err.message).to.be.undefined()
+        expect(err).to.be.null()
         expect(res.wasThrown).to.be.undefined()
         expect(res.result.value).to.equal(6)
 
@@ -131,7 +131,7 @@ describe('debugger module', () => {
         return done(`unexpected error : ${err}`)
       }
       const callback = (err, res) => {
-        expect(err.message).to.be.undefined()
+        expect(err).to.be.null()
         expect(res.wasThrown).to.be.undefined()
         expect(res.result.value).to.equal(6)
         w.webContents.debugger.detach()
@@ -178,6 +178,7 @@ describe('debugger module', () => {
       }
 
       w.webContents.debugger.sendCommand('Test', err => {
+        expect(err).to.not.be.null()
         expect(err.message).to.equal("'Test' wasn't found")
         w.webContents.debugger.detach()
         done()


### PR DESCRIPTION
Fixes #14811

All node style callbacks should have `null` in the error slot when no error is present, basically all callback based code has logic like

```js
if (err) return logError(err);
```

Notes: debugger command callbacks now run with `null` as the error when no error has occurred