### PR TITLE
docs: correct key code reqs for accelerator doc

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -2,7 +2,7 @@
 
 > Define keyboard shortcuts.
 
-Accelerators are Strings that can contain multiple modifiers and key codes,
+Accelerators are Strings that can contain multiple modifiers and a single key code,
 combined by the `+` character, and are used to define keyboard shortcuts
 throughout your application.
 


### PR DESCRIPTION
##### Description of Change

Resolves https://github.com/electron/electron/issues/14818.

Clarifies that global accelerator registration can accept multiple modifiers but only **one** key code.

/cc @ckerr 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: correct key code allowance for accelerator doc