### PR TITLE
chore: upload node.lib for v4

### DIFF
--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -52,12 +52,15 @@ def parse_args():
 def get_files_list(version):
   return [
     { "filename": 'node-{0}.tar.gz'.format(version), "required": True },
+    { "filename": 'node-{0}-headers.tar.gz'.format(version), "required": True },
     { "filename": 'iojs-{0}.tar.gz'.format(version), "required": True },
     { "filename": 'iojs-{0}-headers.tar.gz'.format(version), "required": True },
     { "filename": 'node.lib', "required": False },
     { "filename": 'x64/node.lib', "required": False },
     { "filename": 'win-x86/iojs.lib', "required": False },
-    { "filename": 'win-x64/iojs.lib', "required": False }
+    { "filename": 'win-x64/iojs.lib', "required": False },
+    { "filename": 'win-x86/node.lib', "required": False },
+    { "filename": 'win-x64/node.lib', "required": False }
   ]
 
 

--- a/script/upload-node-headers.py
+++ b/script/upload-node-headers.py
@@ -40,16 +40,19 @@ def upload_node(bucket, access_key, secret_key, version):
     if get_target_arch() == 'ia32':
       node_lib = os.path.join(DIST_DIR, 'node.lib')
       iojs_lib = os.path.join(DIST_DIR, 'win-x86', 'iojs.lib')
+      v4_node_lib = os.path.join(DIST_DIR, 'win-x86', 'node.lib')
     else:
       node_lib = os.path.join(DIST_DIR, 'x64', 'node.lib')
       iojs_lib = os.path.join(DIST_DIR, 'win-x64', 'iojs.lib')
+      v4_node_lib = os.path.join(DIST_DIR, 'win-x64', 'node.lib')
     safe_mkdir(os.path.dirname(node_lib))
     safe_mkdir(os.path.dirname(iojs_lib))
 
-    # Copy atom.lib to node.lib and iojs.lib.
+    # Copy atom.lib to node.lib, iojs.lib and v4 node.lib
     atom_lib = os.path.join(OUT_DIR, 'node.dll.lib')
     shutil.copy2(atom_lib, node_lib)
     shutil.copy2(atom_lib, iojs_lib)
+    shutil.copy2(atom_lib, v4_node_lib)
 
     # Upload the node.lib.
     s3put(bucket, access_key, secret_key, DIST_DIR,
@@ -58,6 +61,10 @@ def upload_node(bucket, access_key, secret_key, version):
     # Upload the iojs.lib.
     s3put(bucket, access_key, secret_key, DIST_DIR,
           'atom-shell/dist/{0}'.format(version), [iojs_lib])
+
+    # Upload the v4 node.lib.
+    s3put(bucket, access_key, secret_key, DIST_DIR,
+          'atom-shell/dist/{0}'.format(version), [v4_node_lib])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #14828

This doesn't need to be backported, it's for >= v4

Notes: no-notes