### PR TITLE
fix: enable key accelerator flags for Windows and Linux

### DIFF
--- a/atom/browser/ui/accelerator_util.cc
+++ b/atom/browser/ui/accelerator_util.cc
@@ -91,7 +91,7 @@ bool TriggerAcceleratorTableCommand(AcceleratorTable* table,
   if (base::ContainsKey(*table, accelerator)) {
     const accelerator_util::MenuItem& item = (*table)[accelerator];
     if (item.model->IsEnabledAt(item.position)) {
-      const auto event_flags = 
+      const auto event_flags =
         accelerator.MaskOutKeyEventFlags(accelerator.modifiers());
       item.model->ActivatedAt(item.position, event_flags);
       return true;

--- a/atom/browser/ui/accelerator_util.cc
+++ b/atom/browser/ui/accelerator_util.cc
@@ -91,7 +91,8 @@ bool TriggerAcceleratorTableCommand(AcceleratorTable* table,
   if (base::ContainsKey(*table, accelerator)) {
     const accelerator_util::MenuItem& item = (*table)[accelerator];
     if (item.model->IsEnabledAt(item.position)) {
-      const auto event_flags = accelerator.MaskOutKeyEventFlags(accelerator.modifiers());
+      const auto event_flags = 
+        accelerator.MaskOutKeyEventFlags(accelerator.modifiers());
       item.model->ActivatedAt(item.position, event_flags);
       return true;
     }

--- a/atom/browser/ui/accelerator_util.cc
+++ b/atom/browser/ui/accelerator_util.cc
@@ -91,7 +91,8 @@ bool TriggerAcceleratorTableCommand(AcceleratorTable* table,
   if (base::ContainsKey(*table, accelerator)) {
     const accelerator_util::MenuItem& item = (*table)[accelerator];
     if (item.model->IsEnabledAt(item.position)) {
-      item.model->ActivatedAt(item.position);
+      const auto event_flags = accelerator.MaskOutKeyEventFlags(accelerator.modifiers());
+      item.model->ActivatedAt(item.position, event_flags);
       return true;
     }
   }


### PR DESCRIPTION
##### Description of Change
Fixes #13289
Currently, the default accelerators are disabled on Linux and Windows. This PR is meant to allow them to be true by default when firing events.


##### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are added
- [x] relevant documentation is changed or added
- [x] PR title follows semantic

##### Release Notes
Notes: Fixed Accelerator event flags to be on by default for Windows and Linux