### PR TITLE
chore: fix relative links in docs and enforce we dont break them again

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,7 +13,7 @@ For guides on Electron app development, see
 * [Coding Style](coding-style.md)
 * [Using clang-format on C++ Code](clang-format.md)
 * [Build System Overview](build-system-overview.md)
-* [Build Instructions (macOS)](build-instructions-osx.md)
+* [Build Instructions (macOS)](build-instructions-macos.md)
 * [Build Instructions (Windows)](build-instructions-windows.md)
 * [Build Instructions (Linux)](build-instructions-linux.md)
 * [Chromium Development](chromium-development.md)

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -6,7 +6,7 @@ Follow the guidelines below for building Electron.
 
 Check the build prerequisites for your platform before proceeding
 
-  * [macOS](build-instructions-osx.md#prerequisites)
+  * [macOS](build-instructions-macos.md#prerequisites)
   * [Linux](build-instructions-linux.md#prerequisites)
   * [Windows](build-instructions-windows.md#prerequisites)
 

--- a/docs/development/debugging-instructions-macos.md
+++ b/docs/development/debugging-instructions-macos.md
@@ -12,7 +12,7 @@ you prefer a graphical interface.
 
 * **A debug build of Electron**: The easiest way is usually building it
   yourself, using the tools and prerequisites listed in the
-  [build instructions for macOS](build-instructions-osx.md). While you can
+  [build instructions for macOS](build-instructions-macos.md). While you can
   attach to and debug Electron as you can download it directly, you will
   find that it is heavily optimized, making debugging substantially more
   difficult: The debugger will not be able to show you the content of all

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -35,7 +35,7 @@ $ git fetch upstream
 
 Build steps and dependencies differ slightly depending on your operating system.
 See these detailed guides on building Electron locally:
-* [Building on MacOS](https://electronjs.org/docs/development/build-instructions-osx)
+* [Building on MacOS](https://electronjs.org/docs/development/build-instructions-macos)
 * [Building on Linux](https://electronjs.org/docs/development/build-instructions-linux)
 * [Building on Windows](https://electronjs.org/docs/development/build-instructions-windows)
 

--- a/script/check-relative-doc-links.py
+++ b/script/check-relative-doc-links.py
@@ -32,6 +32,7 @@ def main():
         ' files within docs directory and its ' +
         str(totalDirs) + ' subdirectories.')
   print('Found ' + str(totalBrokenLinks) + ' broken relative links.')
+  return totalBrokenLinks
 
 
 def getBrokenLinks(filepath):

--- a/script/tls.py
+++ b/script/tls.py
@@ -30,7 +30,7 @@ def check_tls(verbose):
   if sys.platform == "linux" or sys.platform == "linux2":
     tutorial = "./docs/development/build-instructions-linux.md"
   elif sys.platform == "darwin":
-    tutorial = "./docs/development/build-instructions-osx.md"
+    tutorial = "./docs/development/build-instructions-macos.md"
   elif sys.platform == "win32":
     tutorial = "./docs/development/build-instructions-windows.md"
   else:


### PR DESCRIPTION
I was running lint and noticed we had a few broken relative links but linting still passed 🤔 This fixes the broken links and updates the relative link script to ensure that linting fails if we break any again.

Notes: no-notes