### PR TITLE
feat: Implement process.getProcessMemoryInfo to get the process memory usage

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/browser/browser.h"
 #include "atom/common/api/locker.h"
 #include "atom/common/application_info.h"
 #include "atom/common/atom_version.h"
@@ -221,6 +222,12 @@ v8::Local<v8::Value> AtomBindings::GetSystemMemoryInfo(v8::Isolate* isolate,
 v8::Local<v8::Promise> AtomBindings::GetProcessMemoryInfo(
     v8::Isolate* isolate) {
   scoped_refptr<util::Promise> promise = new util::Promise(isolate);
+
+  if (!Browser::Get()->is_ready()) {
+    promise->RejectWithErrorMessage(
+        "Memory Info is available only after app ready");
+    return promise->GetHandle();
+  }
 
   memory_instrumentation::MemoryInstrumentation::GetInstance()
       ->RequestGlobalDumpForPid(

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -263,6 +263,7 @@ void AtomBindings::DidReceiveMemoryDump(
       dict.Set("sharedBytes", osdump.shared_footprint_kb);
       promise->Resolve(dict.GetHandle());
       resolved = true;
+      break;
     }
   }
   if (!resolved) {

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -221,10 +221,10 @@ v8::Local<v8::Promise> AtomBindings::GetMemoryFootprint(v8::Isolate* isolate) {
   scoped_refptr<util::Promise> promise = new util::Promise(isolate);
   node::Environment* env = node::Environment::GetCurrent(isolate);
   memory_instrumentation::MemoryInstrumentation::GetInstance()
-      ->RequestGlobalDump(std::vector<std::string>(),
-                          base::AdaptCallbackForRepeating(base::BindOnce(
-                              &AtomBindings::DidReceiveMemoryDump,
-                              base::Unretained(env), promise)));
+      ->RequestGlobalDumpForPid(base::GetCurrentProcId(),
+                                base::AdaptCallbackForRepeating(base::BindOnce(
+                                    &AtomBindings::DidReceiveMemoryDump,
+                                    base::Unretained(env), promise)));
   return promise->GetHandle();
 }
 

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -244,7 +244,7 @@ void AtomBindings::DidReceiveMemoryDump(
   v8::Context::Scope context_scope(env->context());
 
   if (!success) {
-    promise->RejectWithErrorMessage("Failed to receive memory dump");
+    promise->RejectWithErrorMessage("Failed to create memory dump");
     return;
   }
 

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -254,13 +254,11 @@ void AtomBindings::DidReceiveMemoryDump(
     if (base::GetCurrentProcId() == dump.pid()) {
       mate::Dictionary dict = mate::Dictionary::CreateEmpty(env->isolate());
       const auto& osdump = dump.os_dump();
-#if defined(OS_LINUX)
-      dict.Set("residentSetBytes", osdump.resident_set_kb);
-#elif defined(OS_WIN)
-      dict.Set("workingSetSize", osdump.resident_set_kb);
+#if defined(OS_LINUX) || defined(OS_WIN)
+      dict.Set("residentSet", osdump.resident_set_kb);
 #endif
-      dict.Set("privateBytes", osdump.private_footprint_kb);
-      dict.Set("sharedBytes", osdump.shared_footprint_kb);
+      dict.Set("private", osdump.private_footprint_kb);
+      dict.Set("shared", osdump.shared_footprint_kb);
       promise->Resolve(dict.GetHandle());
       resolved = true;
       break;

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -18,7 +18,7 @@
 
 namespace memory_instrumentation {
 class GlobalMemoryDump;
-}  // namespace memory_instrumentation
+}
 
 namespace node {
 class Environment;
@@ -62,9 +62,11 @@ class AtomBindings {
   static void OnCallNextTick(uv_async_t* handle);
 
   static void DidReceiveMemoryDump(
+      node::Environment* env,
       scoped_refptr<util::Promise> promise,
       bool success,
       std::unique_ptr<memory_instrumentation::GlobalMemoryDump> dump);
+
   uv_async_t call_next_tick_async_;
   std::list<node::Environment*> pending_next_ticks_;
   std::unique_ptr<base::ProcessMetrics> metrics_;

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -10,6 +10,7 @@
 
 #include "base/files/file_path.h"
 #include "base/macros.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/process/process_metrics.h"
 #include "base/strings/string16.h"
 #include "native_mate/arguments.h"

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -49,7 +49,7 @@ class AtomBindings {
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,
                                                   mate::Arguments* args);
-  static v8::Local<v8::Promise> GetMemoryFootprint(v8::Isolate* isolate);
+  static v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,
                                           v8::Isolate* isolate);
   static v8::Local<v8::Value> GetIOCounters(v8::Isolate* isolate);

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -16,11 +16,19 @@
 #include "uv.h"  // NOLINT(build/include)
 #include "v8/include/v8.h"
 
+namespace memory_instrumentation {
+class GlobalMemoryDump;
+}  // namespace memory_instrumentation
+
 namespace node {
 class Environment;
 }
 
 namespace atom {
+
+namespace util {
+class Promise;
+}
 
 class AtomBindings {
  public:
@@ -41,6 +49,7 @@ class AtomBindings {
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,
                                                   mate::Arguments* args);
+  static v8::Local<v8::Promise> GetMemoryFootprint(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,
                                           v8::Isolate* isolate);
   static v8::Local<v8::Value> GetIOCounters(v8::Isolate* isolate);
@@ -52,6 +61,10 @@ class AtomBindings {
 
   static void OnCallNextTick(uv_async_t* handle);
 
+  static void DidReceiveMemoryDump(
+      scoped_refptr<util::Promise> promise,
+      bool success,
+      std::unique_ptr<memory_instrumentation::GlobalMemoryDump> dump);
   uv_async_t call_next_tick_async_;
   std::list<node::Environment*> pending_next_ticks_;
   std::unique_ptr<base::ProcessMetrics> metrics_;

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -63,7 +63,6 @@ class AtomBindings {
   static void OnCallNextTick(uv_async_t* handle);
 
   static void DidReceiveMemoryDump(
-      node::Environment* env,
       scoped_refptr<util::Promise> promise,
       bool success,
       std::unique_ptr<memory_instrumentation::GlobalMemoryDump> dump);

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -63,6 +63,7 @@ class AtomBindings {
   static void OnCallNextTick(uv_async_t* handle);
 
   static void DidReceiveMemoryDump(
+      const v8::Global<v8::Context>& context,
       scoped_refptr<util::Promise> promise,
       bool success,
       std::unique_ptr<memory_instrumentation::GlobalMemoryDump> dump);

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -181,7 +181,8 @@ This api should be called after app ready.
 Chromium does not provide `residentSet` value for macos. This is because macos 
 performs in-memory compression of pages that haven't been recently used. As a
 result the resident set size value is not what one would expect. `private` memory
-is more representative of the actual pre-compression memory usage of the process.
+is more representative of the actual pre-compression memory usage of the process
+on macOS.
 
 ### `process.getSystemMemoryInfo()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -176,6 +176,7 @@ currently pinned to actual physical RAM.
 
 Returns an object giving memory usage statistics about the current process. Note
 that all statistics are reported in Kilobytes.
+This api should be called after app ready.
 
 ### `process.getSystemMemoryInfo()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -168,15 +168,20 @@ Returns an object with V8 heap statistics. Note that all statistics are reported
 Returns `Object`:
 
 * `residentSet` Integer _Linux_ and _Windows_ - The amount of memory 
-currently pinned to actual physical RAM.
+currently pinned to actual physical RAM in Kilobytes.
 * `private` Integer - The amount of memory not shared by other processes, such as
-  JS heap or HTML content.
+  JS heap or HTML content in Kilobytes.
 * `shared` Integer - The amount of memory shared between processes, typically
-  memory consumed by the Electron code itself.
+  memory consumed by the Electron code itself in Kilobytes.
 
 Returns an object giving memory usage statistics about the current process. Note
 that all statistics are reported in Kilobytes.
 This api should be called after app ready.
+
+Chromium does not provide `residentSet` value for macos. This is because macos 
+performs in-memory compression of pages that haven't been recently used. As a
+result the resident set size value is not what one would expect. `private` memory
+is more representative of the actual pre-compression memory usage of the process.
 
 ### `process.getSystemMemoryInfo()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -178,7 +178,7 @@ Returns an object giving memory usage statistics about the current process. Note
 that all statistics are reported in Kilobytes.
 This api should be called after app ready.
 
-Chromium does not provide `residentSet` value for macos. This is because macos 
+Chromium does not provide `residentSet` value for macOS. This is because macOS 
 performs in-memory compression of pages that haven't been recently used. As a
 result the resident set size value is not what one would expect. `private` memory
 is more representative of the actual pre-compression memory usage of the process

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -167,11 +167,11 @@ Returns an object with V8 heap statistics. Note that all statistics are reported
 
 Returns `Object`:
 
-* `residentSetBytes` Integer on _Linux_ or `workingSetSize` Integer on _Windows_ - The
-amount of memory currently pinned to actual physical RAM.
-* `privateBytes` Integer - The amount of memory not shared by other processes, such as
+* `residentSet` Integer _Linux_ and _Windows_ - The amount of memory 
+currently pinned to actual physical RAM.
+* `private` Integer - The amount of memory not shared by other processes, such as
   JS heap or HTML content.
-* `sharedBytes` Integer - The amount of memory shared between processes, typically
+* `shared` Integer - The amount of memory shared between processes, typically
   memory consumed by the Electron code itself.
 
 Returns an object giving memory usage statistics about the current process. Note

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -14,6 +14,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 - `crash()`
 - `hang()`
 - `getHeapStatistics()`
+- `getProcessMemoryInfo()`
 - `getSystemMemoryInfo()`
 - `getCPUUsage()`
 - `getIOCounters()`
@@ -161,6 +162,20 @@ Returns `Object`:
 * `doesZapGarbage` Boolean
 
 Returns an object with V8 heap statistics. Note that all statistics are reported in Kilobytes.
+
+### `process.getProcessMemoryInfo()`
+
+Returns `Object`:
+
+* `residentSetBytes` Integer on _Linux_ or `workingSetSize` Integer on _Windows_ - The
+amount of memory currently pinned to actual physical RAM.
+* `privateBytes` Integer - The amount of memory not shared by other processes, such as
+  JS heap or HTML content.
+* `sharedBytes` Integer - The amount of memory shared between processes, typically
+  memory consumed by the Electron code itself.
+
+Returns an object giving memory usage statistics about the current process. Note
+that all statistics are reported in Kilobytes.
 
 ### `process.getSystemMemoryInfo()`
 

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -39,11 +39,9 @@ describe('process module', () => {
   })
 
   describe('process.getMemoryFootprint()', () => {
-    it('resolves promise successfully with non zero value', (done) => {
-      process.getMemoryFootprint().then((memoryFootprint) => {
-        expect(memoryFootprint).to.be.a('number').greaterThan(0)
-        done()
-      })
+    it('resolves promise successfully with non zero value', async () => {
+      let memoryFootprint = await process.getMemoryFootprint()
+      expect(memoryFootprint).to.be.a('number').greaterThan(0)
     })
   })
 

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -38,10 +38,18 @@ describe('process module', () => {
     })
   })
 
-  describe('process.getMemoryFootprint()', () => {
+  describe('process.getProcessMemoryInfo()', async () => {
     it('resolves promise successfully with non zero value', async () => {
-      let memoryFootprint = await process.getMemoryFootprint()
-      expect(memoryFootprint).to.be.a('number').greaterThan(0)
+      const memoryInfo = await process.getProcessMemoryInfo()
+      expect(memoryInfo).to.be.an('object')
+      if (process.platform === 'linux') {
+        expect(memoryInfo.residentSetBytes).to.be.a('number').greaterThan(0)
+      }
+      if (process.platform === 'windows') {
+        expect(memoryInfo.workingSetSize).to.be.a('number').greaterThan(0)
+      }
+      expect(memoryInfo.privateBytes).to.be.a('number').greaterThan(0)
+      expect(memoryInfo.sharedBytes).to.be.a('number').greaterThan(0)
     })
   })
 

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -38,16 +38,14 @@ describe('process module', () => {
     })
   })
 
-  // FIXME: Chromium 67 - getProcessMemoryInfo has been removed
-  // describe('process.getProcessMemoryInfo()', () => {
-  //   it('returns process memory info object', () => {
-  //     const processMemoryInfo = process.getProcessMemoryInfo()
-  //     expect(processMemoryInfo.peakWorkingSetSize).to.be.a('number')
-  //     expect(processMemoryInfo.privateBytes).to.be.a('number')
-  //     expect(processMemoryInfo.sharedBytes).to.be.a('number')
-  //     expect(processMemoryInfo.workingSetSize).to.be.a('number')
-  //   })
-  // })
+  describe('process.getMemoryFootprint()', () => {
+    it('resolves promise successfully with non zero value', (done) => {
+      process.getMemoryFootprint().then((memoryFootprint) => {
+        expect(memoryFootprint).to.be.a('number').greaterThan(0)
+        done()
+      })
+    })
+  })
 
   describe('process.getSystemMemoryInfo()', () => {
     it('returns system memory info object', () => {

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -39,7 +39,7 @@ describe('process module', () => {
   })
 
   describe('process.getProcessMemoryInfo()', async () => {
-    it('resolves promise successfully with non zero value', async () => {
+    it('resolves promise successfully with valid data', async () => {
       const memoryInfo = await process.getProcessMemoryInfo()
       expect(memoryInfo).to.be.an('object')
       if (process.platform === 'linux') {
@@ -49,7 +49,8 @@ describe('process module', () => {
         expect(memoryInfo.workingSetSize).to.be.a('number').greaterThan(0)
       }
       expect(memoryInfo.privateBytes).to.be.a('number').greaterThan(0)
-      expect(memoryInfo.sharedBytes).to.be.a('number').greaterThan(0)
+      // Shared bytes can be zero
+      expect(memoryInfo.sharedBytes).to.be.a('number').greaterThan(-1)
     })
   })
 

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -42,15 +42,12 @@ describe('process module', () => {
     it('resolves promise successfully with valid data', async () => {
       const memoryInfo = await process.getProcessMemoryInfo()
       expect(memoryInfo).to.be.an('object')
-      if (process.platform === 'linux') {
-        expect(memoryInfo.residentSetBytes).to.be.a('number').greaterThan(0)
+      if (process.platform === 'linux' || process.platform === 'windows') {
+        expect(memoryInfo.residentSet).to.be.a('number').greaterThan(0)
       }
-      if (process.platform === 'windows') {
-        expect(memoryInfo.workingSetSize).to.be.a('number').greaterThan(0)
-      }
-      expect(memoryInfo.privateBytes).to.be.a('number').greaterThan(0)
+      expect(memoryInfo.private).to.be.a('number').greaterThan(0)
       // Shared bytes can be zero
-      expect(memoryInfo.sharedBytes).to.be.a('number').greaterThan(-1)
+      expect(memoryInfo.shared).to.be.a('number').greaterThan(-1)
     })
   })
 


### PR DESCRIPTION
##### Description of Change
This implements the memory footprint API.
Since version 67, chromium has moved to using memory footprint internally as the cross platform memory indicator. They got rid of other various cross platform APIs that mean different things on different platforms #13447.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Add getMemoryFootprint API