### PR TITLE
test: guarantee the order of webview and devtools creation

### DIFF
--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -46,14 +46,16 @@ describe('webContents module', () => {
 
         assert.ok(all.length >= 4)
         assert.strictEqual(all[0].getType(), 'window')
-        assert.strictEqual(all[all.length - 2].getType(), 'remote')
-        assert.strictEqual(all[all.length - 1].getType(), 'webview')
+        assert.strictEqual(all[all.length - 2].getType(), 'webview')
+        assert.strictEqual(all[all.length - 1].getType(), 'remote')
 
         done()
       })
 
       w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-factor.html'))
-      w.webContents.openDevTools()
+      w.webContents.on('did-attach-webview', () => {
+        w.webContents.openDevTools()
+      })
     })
   })
 


### PR DESCRIPTION
Fixes #14848

This ensure the webview is created (and attached) first and then we open the devtools.  I think the newly created race condition comes from the OOPIF work.

Notes: no-notes