### PR TITLE
refactor: replace var with const / let

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": "standard",
   "env": {
     "browser": true
+  },
+  "rules": {
+    "no-var": "error"
   }
 }

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -86,13 +86,13 @@ exports.processStart = function () {
 // Download the releases specified by the URL and write new results to stdout.
 exports.checkForUpdate = function (updateURL, callback) {
   return spawnUpdate(['--checkForUpdate', updateURL], false, function (error, stdout) {
-    var json, ref, ref1, update
+    let ref, ref1, update
     if (error != null) {
       return callback(error)
     }
     try {
       // Last line of output is the JSON details about the releases
-      json = stdout.trim().split('\n').pop()
+      const json = stdout.trim().split('\n').pop()
       update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === 'function' ? ref1.pop() : void 0 : void 0 : void 0
     } catch (jsonError) {
       // Disabled for backwards compatibility:

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -16,7 +16,7 @@ ipcMain.on('ELECTRON_SYNC_NAVIGATION_CONTROLLER', function (event, method, ...ar
 // control on user land, and only rely on WebContents.loadURL for navigation.
 // This helps us avoid Chromium's various optimizations so we can ensure renderer
 // process is restarted everytime.
-var NavigationController = (function () {
+const NavigationController = (function () {
   function NavigationController (webContents) {
     this.webContents = webContents
     this.clearHistory()
@@ -141,7 +141,7 @@ var NavigationController = (function () {
   }
 
   NavigationController.prototype.goToOffset = function (offset) {
-    var pendingIndex
+    let pendingIndex
     if (!this.canGoToOffset(offset)) {
       return
     }

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -7,7 +7,7 @@ const util = require('util')
 const Module = require('module')
 const v8 = require('v8')
 
-// We modified the original process.argv to let node.js load the atom.js,
+// We modified the original process.argv to let node.js load the init.js,
 // we need to restore it here.
 process.argv.splice(1, 1)
 
@@ -17,7 +17,7 @@ require('../common/reset-search-paths')
 // Import common settings.
 require('@electron/internal/common/init')
 
-var globalPaths = Module.globalPaths
+const globalPaths = Module.globalPaths
 
 // Expose public APIs.
 globalPaths.push(path.join(__dirname, 'api', 'exports'))
@@ -25,10 +25,10 @@ globalPaths.push(path.join(__dirname, 'api', 'exports'))
 if (process.platform === 'win32') {
   // Redirect node's console to use our own implementations, since node can not
   // handle console output when running as GUI program.
-  var consoleLog = function (...args) {
+  const consoleLog = function (...args) {
     return process.log(util.format(...args) + '\n')
   }
-  var streamWrite = function (chunk, encoding, callback) {
+  const streamWrite = function (chunk, encoding, callback) {
     if (Buffer.isBuffer(chunk)) {
       chunk = chunk.toString(encoding)
     }
@@ -45,15 +45,14 @@ if (process.platform === 'win32') {
 // Don't quit on fatal error.
 process.on('uncaughtException', function (error) {
   // Do nothing if the user has a custom uncaught exception handler.
-  var dialog, message, ref, stack
   if (process.listeners('uncaughtException').length > 1) {
     return
   }
 
   // Show error in GUI.
-  dialog = require('electron').dialog
-  stack = (ref = error.stack) != null ? ref : error.name + ': ' + error.message
-  message = 'Uncaught Exception:\n' + stack
+  const dialog = require('electron').dialog
+  const stack = error.stack ? error.stack : `${error.name}: ${error.message}`
+  const message = 'Uncaught Exception:\n' + stack
   dialog.showErrorBox('A JavaScript error occurred in the main process', message)
 })
 

--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -31,7 +31,6 @@ function wrap (func, wrapper) {
 process.nextTick = wrapWithActivateUvLoop(process.nextTick)
 
 global.setImmediate = wrapWithActivateUvLoop(timers.setImmediate)
-
 global.clearImmediate = timers.clearImmediate
 
 if (process.type === 'browser') {

--- a/lib/renderer/extensions/storage.js
+++ b/lib/renderer/extensions/storage.js
@@ -93,7 +93,7 @@ const getStorageManager = (storageType, extensionId) => {
 
         let items = {}
         keys.forEach(function (key) {
-          var value = storage[key]
+          let value = storage[key]
           if (value == null) value = defaults[key]
           items[key] = value
         })

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -14,13 +14,13 @@ require('../common/reset-search-paths')
 // Import common settings.
 require('@electron/internal/common/init')
 
-var globalPaths = Module.globalPaths
+const globalPaths = Module.globalPaths
 
 // Expose public APIs.
 globalPaths.push(path.join(__dirname, 'api', 'exports'))
 
 // The global variable will be used by ipc for event dispatching
-var v8Util = process.atomBinding('v8_util')
+const v8Util = process.atomBinding('v8_util')
 
 v8Util.setHiddenValue(global, 'ipc', new events.EventEmitter())
 

--- a/script/lib/tls/index.js
+++ b/script/lib/tls/index.js
@@ -1,8 +1,8 @@
-var fs = require('fs')
-var https = require('https')
-var path = require('path')
+const fs = require('fs')
+const https = require('https')
+const path = require('path')
 
-var server = https.createServer({
+const server = https.createServer({
   key: fs.readFileSync(path.resolve(__dirname, 'tls.key.pem')),
   cert: fs.readFileSync(path.resolve(__dirname, 'tls.cert.pem'))
 }, (req, res) => {

--- a/script/start.js
+++ b/script/start.js
@@ -4,7 +4,7 @@ const utils = require('./lib/utils')
 
 const electronPath = utils.getAbsoluteElectronExec()
 
-var child = cp.spawn(electronPath, process.argv.slice(2), { stdio: 'inherit' })
+const child = cp.spawn(electronPath, process.argv.slice(2), { stdio: 'inherit' })
 child.on('close', (code) => process.exit(code))
 
 const handleTerminationSignal = (signal) =>

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -581,7 +581,7 @@ describe('BrowserWindow module', () => {
     it('sets the content size', () => {
       const size = [400, 400]
       w.setContentSize(size[0], size[1])
-      var after = w.getContentSize()
+      const after = w.getContentSize()
       assert.strictEqual(after[0], size[0])
       assert.strictEqual(after[1], size[1])
     })
@@ -3132,7 +3132,7 @@ describe('BrowserWindow module', () => {
         }
       })
 
-      var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
+      const extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
       BrowserWindow.removeDevToolsExtension('foo')
       BrowserWindow.addDevToolsExtension(extensionPath)
 
@@ -3148,9 +3148,9 @@ describe('BrowserWindow module', () => {
     })
 
     it('serializes the registered extensions on quit', () => {
-      var extensionName = 'foo'
-      var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', extensionName)
-      var serializedPath = path.join(app.getPath('userData'), 'DevTools Extensions')
+      const extensionName = 'foo'
+      const extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', extensionName)
+      const serializedPath = path.join(app.getPath('userData'), 'DevTools Extensions')
 
       BrowserWindow.addDevToolsExtension(extensionPath)
       app.emit('will-quit')
@@ -3166,7 +3166,7 @@ describe('BrowserWindow module', () => {
         BrowserWindow.removeExtension('foo')
         assert.strictEqual(BrowserWindow.getExtensions().hasOwnProperty('foo'), false)
 
-        var extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
+        const extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
         BrowserWindow.addExtension(extensionPath)
         assert.strictEqual(BrowserWindow.getExtensions().hasOwnProperty('foo'), true)
 

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -663,7 +663,7 @@ describe('protocol module', () => {
     })
 
     it('does not crash when handler is called twice', (done) => {
-      var doubleHandler = (request, callback) => {
+      const doubleHandler = (request, callback) => {
         try {
           callback(text)
           callback()

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -14,8 +14,8 @@ chai.use(dirtyChai)
 /* eslint-disable standard/no-callback-literal */
 
 describe('webFrame module', function () {
-  var fixtures = path.resolve(__dirname, 'fixtures')
-  var w = null
+  const fixtures = path.resolve(__dirname, 'fixtures')
+  let w = null
 
   afterEach(function () {
     return closeWindow(w).then(function () { w = null })
@@ -23,7 +23,7 @@ describe('webFrame module', function () {
 
   describe('webFrame.registerURLSchemeAsPrivileged', function () {
     it('supports fetch api by default', function (done) {
-      var url = 'file://' + fixtures + '/assets/logo.png'
+      const url = 'file://' + fixtures + '/assets/logo.png'
       window.fetch(url).then(function (response) {
         assert(response.ok)
         done()
@@ -102,7 +102,7 @@ describe('webFrame module', function () {
       </html>`, done)
     })
 
-    var runNumber = 1
+    let runNumber = 1
     function allowsCORSRequests (expected, content, done) {
       const standardScheme = remote.getGlobal('standardScheme') + runNumber
       const corsScheme = 'cors' + runNumber

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -13,17 +13,17 @@ const ipcMain = remote.require('electron').ipcMain
 const BrowserWindow = remote.require('electron').BrowserWindow
 
 describe('asar package', function () {
-  var fixtures = path.join(__dirname, 'fixtures')
+  const fixtures = path.join(__dirname, 'fixtures')
 
   describe('node api', function () {
     it('supports paths specified as a Buffer', function () {
-      var file = Buffer.from(path.join(fixtures, 'asar', 'a.asar', 'file1'))
+      const file = Buffer.from(path.join(fixtures, 'asar', 'a.asar', 'file1'))
       assert.strictEqual(fs.existsSync(file), true)
     })
 
     describe('fs.readFileSync', function () {
       it('does not leak fd', function () {
-        var readCalls = 1
+        let readCalls = 1
         while (readCalls <= 10000) {
           fs.readFileSync(path.join(process.resourcesPath, 'electron.asar', 'renderer', 'api', 'ipc-renderer.js'))
           readCalls++
@@ -31,44 +31,44 @@ describe('asar package', function () {
       })
 
       it('reads a normal file', function () {
-        var file1 = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const file1 = path.join(fixtures, 'asar', 'a.asar', 'file1')
         assert.strictEqual(fs.readFileSync(file1).toString().trim(), 'file1')
-        var file2 = path.join(fixtures, 'asar', 'a.asar', 'file2')
+        const file2 = path.join(fixtures, 'asar', 'a.asar', 'file2')
         assert.strictEqual(fs.readFileSync(file2).toString().trim(), 'file2')
-        var file3 = path.join(fixtures, 'asar', 'a.asar', 'file3')
+        const file3 = path.join(fixtures, 'asar', 'a.asar', 'file3')
         assert.strictEqual(fs.readFileSync(file3).toString().trim(), 'file3')
       })
 
       it('reads from a empty file', function () {
-        var file = path.join(fixtures, 'asar', 'empty.asar', 'file1')
-        var buffer = fs.readFileSync(file)
+        const file = path.join(fixtures, 'asar', 'empty.asar', 'file1')
+        const buffer = fs.readFileSync(file)
         assert.strictEqual(buffer.length, 0)
         assert.strictEqual(buffer.toString(), '')
       })
 
       it('reads a linked file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link1')
         assert.strictEqual(fs.readFileSync(p).toString().trim(), 'file1')
       })
 
       it('reads a file from linked directory', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1')
-        assert.strictEqual(fs.readFileSync(p).toString().trim(), 'file1')
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
-        assert.strictEqual(fs.readFileSync(p).toString().trim(), 'file1')
+        const p1 = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1')
+        assert.strictEqual(fs.readFileSync(p1).toString().trim(), 'file1')
+        const p2 = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
+        assert.strictEqual(fs.readFileSync(p2).toString().trim(), 'file1')
       })
 
       it('throws ENOENT error when can not find file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
-        var throws = function () {
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const throws = function () {
           fs.readFileSync(p)
         }
         assert.throws(throws, /ENOENT/)
       })
 
       it('passes ENOENT error to callback when can not find file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
-        var async = false
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        let async = false
         fs.readFile(p, function (e) {
           assert(async)
           assert(/ENOENT/.test(e))
@@ -77,14 +77,14 @@ describe('asar package', function () {
       })
 
       it('reads a normal file with unpacked files', function () {
-        var p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
+        const p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
         assert.strictEqual(fs.readFileSync(p).toString().trim(), 'a')
       })
     })
 
     describe('fs.readFile', function () {
       it('reads a normal file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         fs.readFile(p, function (err, content) {
           assert.strictEqual(err, null)
           assert.strictEqual(String(content).trim(), 'file1')
@@ -93,7 +93,7 @@ describe('asar package', function () {
       })
 
       it('reads from a empty file', function (done) {
-        var p = path.join(fixtures, 'asar', 'empty.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'empty.asar', 'file1')
         fs.readFile(p, function (err, content) {
           assert.strictEqual(err, null)
           assert.strictEqual(String(content), '')
@@ -102,7 +102,7 @@ describe('asar package', function () {
       })
 
       it('reads from a empty file with encoding', function (done) {
-        var p = path.join(fixtures, 'asar', 'empty.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'empty.asar', 'file1')
         fs.readFile(p, 'utf8', function (err, content) {
           assert.strictEqual(err, null)
           assert.strictEqual(content, '')
@@ -111,7 +111,7 @@ describe('asar package', function () {
       })
 
       it('reads a linked file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link1')
         fs.readFile(p, function (err, content) {
           assert.strictEqual(err, null)
           assert.strictEqual(String(content).trim(), 'file1')
@@ -120,7 +120,7 @@ describe('asar package', function () {
       })
 
       it('reads a file from linked directory', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
         fs.readFile(p, function (err, content) {
           assert.strictEqual(err, null)
           assert.strictEqual(String(content).trim(), 'file1')
@@ -129,7 +129,7 @@ describe('asar package', function () {
       })
 
       it('throws ENOENT error when can not find file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         fs.readFile(p, function (err) {
           assert.strictEqual(err.code, 'ENOENT')
           done()
@@ -139,14 +139,14 @@ describe('asar package', function () {
 
     describe('fs.lstatSync', function () {
       it('handles path with trailing slash correctly', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
         fs.lstatSync(p)
         fs.lstatSync(p + '/')
       })
 
       it('returns information of root', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar')
-        var stats = fs.lstatSync(p)
+        const p = path.join(fixtures, 'asar', 'a.asar')
+        const stats = fs.lstatSync(p)
         assert.strictEqual(stats.isFile(), false)
         assert.strictEqual(stats.isDirectory(), true)
         assert.strictEqual(stats.isSymbolicLink(), false)
@@ -154,12 +154,11 @@ describe('asar package', function () {
       })
 
       it('returns information of a normal file', function () {
-        var file, j, len, p, ref2, stats
-        ref2 = ['file1', 'file2', 'file3', path.join('dir1', 'file1'), path.join('link2', 'file1')]
-        for (j = 0, len = ref2.length; j < len; j++) {
-          file = ref2[j]
-          p = path.join(fixtures, 'asar', 'a.asar', file)
-          stats = fs.lstatSync(p)
+        const ref2 = ['file1', 'file2', 'file3', path.join('dir1', 'file1'), path.join('link2', 'file1')]
+        for (let j = 0, len = ref2.length; j < len; j++) {
+          const file = ref2[j]
+          const p = path.join(fixtures, 'asar', 'a.asar', file)
+          const stats = fs.lstatSync(p)
           assert.strictEqual(stats.isFile(), true)
           assert.strictEqual(stats.isDirectory(), false)
           assert.strictEqual(stats.isSymbolicLink(), false)
@@ -168,12 +167,11 @@ describe('asar package', function () {
       })
 
       it('returns information of a normal directory', function () {
-        var file, j, len, p, ref2, stats
-        ref2 = ['dir1', 'dir2', 'dir3']
-        for (j = 0, len = ref2.length; j < len; j++) {
-          file = ref2[j]
-          p = path.join(fixtures, 'asar', 'a.asar', file)
-          stats = fs.lstatSync(p)
+        const ref2 = ['dir1', 'dir2', 'dir3']
+        for (let j = 0, len = ref2.length; j < len; j++) {
+          const file = ref2[j]
+          const p = path.join(fixtures, 'asar', 'a.asar', file)
+          const stats = fs.lstatSync(p)
           assert.strictEqual(stats.isFile(), false)
           assert.strictEqual(stats.isDirectory(), true)
           assert.strictEqual(stats.isSymbolicLink(), false)
@@ -182,12 +180,11 @@ describe('asar package', function () {
       })
 
       it('returns information of a linked file', function () {
-        var file, j, len, p, ref2, stats
-        ref2 = ['link1', path.join('dir1', 'link1'), path.join('link2', 'link2')]
-        for (j = 0, len = ref2.length; j < len; j++) {
-          file = ref2[j]
-          p = path.join(fixtures, 'asar', 'a.asar', file)
-          stats = fs.lstatSync(p)
+        const ref2 = ['link1', path.join('dir1', 'link1'), path.join('link2', 'link2')]
+        for (let j = 0, len = ref2.length; j < len; j++) {
+          const file = ref2[j]
+          const p = path.join(fixtures, 'asar', 'a.asar', file)
+          const stats = fs.lstatSync(p)
           assert.strictEqual(stats.isFile(), false)
           assert.strictEqual(stats.isDirectory(), false)
           assert.strictEqual(stats.isSymbolicLink(), true)
@@ -196,12 +193,11 @@ describe('asar package', function () {
       })
 
       it('returns information of a linked directory', function () {
-        var file, j, len, p, ref2, stats
-        ref2 = ['link2', path.join('dir1', 'link2'), path.join('link2', 'link2')]
-        for (j = 0, len = ref2.length; j < len; j++) {
-          file = ref2[j]
-          p = path.join(fixtures, 'asar', 'a.asar', file)
-          stats = fs.lstatSync(p)
+        const ref2 = ['link2', path.join('dir1', 'link2'), path.join('link2', 'link2')]
+        for (let j = 0, len = ref2.length; j < len; j++) {
+          const file = ref2[j]
+          const p = path.join(fixtures, 'asar', 'a.asar', file)
+          const stats = fs.lstatSync(p)
           assert.strictEqual(stats.isFile(), false)
           assert.strictEqual(stats.isDirectory(), false)
           assert.strictEqual(stats.isSymbolicLink(), true)
@@ -210,12 +206,11 @@ describe('asar package', function () {
       })
 
       it('throws ENOENT error when can not find file', function () {
-        var file, j, len, p, ref2, throws
-        ref2 = ['file4', 'file5', path.join('dir1', 'file4')]
-        for (j = 0, len = ref2.length; j < len; j++) {
-          file = ref2[j]
-          p = path.join(fixtures, 'asar', 'a.asar', file)
-          throws = function () {
+        const ref2 = ['file4', 'file5', path.join('dir1', 'file4')]
+        for (let j = 0, len = ref2.length; j < len; j++) {
+          const file = ref2[j]
+          const p = path.join(fixtures, 'asar', 'a.asar', file)
+          const throws = function () {
             fs.lstatSync(p)
           }
           assert.throws(throws, /ENOENT/)
@@ -225,12 +220,12 @@ describe('asar package', function () {
 
     describe('fs.lstat', function () {
       it('handles path with trailing slash correctly', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1')
         fs.lstat(p + '/', done)
       })
 
       it('returns information of root', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar')
+        const p = path.join(fixtures, 'asar', 'a.asar')
         fs.lstat(p, function (err, stats) {
           assert.strictEqual(err, null)
           assert.strictEqual(stats.isFile(), false)
@@ -242,7 +237,7 @@ describe('asar package', function () {
       })
 
       it('returns information of a normal file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1')
         fs.lstat(p, function (err, stats) {
           assert.strictEqual(err, null)
           assert.strictEqual(stats.isFile(), true)
@@ -254,7 +249,7 @@ describe('asar package', function () {
       })
 
       it('returns information of a normal directory', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'dir1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'dir1')
         fs.lstat(p, function (err, stats) {
           assert.strictEqual(err, null)
           assert.strictEqual(stats.isFile(), false)
@@ -266,7 +261,7 @@ describe('asar package', function () {
       })
 
       it('returns information of a linked file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link1')
         fs.lstat(p, function (err, stats) {
           assert.strictEqual(err, null)
           assert.strictEqual(stats.isFile(), false)
@@ -278,7 +273,7 @@ describe('asar package', function () {
       })
 
       it('returns information of a linked directory', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2')
         fs.lstat(p, function (err, stats) {
           assert.strictEqual(err, null)
           assert.strictEqual(stats.isFile(), false)
@@ -290,7 +285,7 @@ describe('asar package', function () {
       })
 
       it('throws ENOENT error when can not find file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file4')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file4')
         fs.lstat(p, function (err) {
           assert.strictEqual(err.code, 'ENOENT')
           done()
@@ -544,26 +539,26 @@ describe('asar package', function () {
 
     describe('fs.readdirSync', function () {
       it('reads dirs from root', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar')
-        var dirs = fs.readdirSync(p)
+        const p = path.join(fixtures, 'asar', 'a.asar')
+        const dirs = fs.readdirSync(p)
         assert.deepStrictEqual(dirs, ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js'])
       })
 
       it('reads dirs from a normal dir', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'dir1')
-        var dirs = fs.readdirSync(p)
+        const p = path.join(fixtures, 'asar', 'a.asar', 'dir1')
+        const dirs = fs.readdirSync(p)
         assert.deepStrictEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2'])
       })
 
       it('reads dirs from a linked dir', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2')
-        var dirs = fs.readdirSync(p)
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2')
+        const dirs = fs.readdirSync(p)
         assert.deepStrictEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2'])
       })
 
       it('throws ENOENT error when can not find file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
-        var throws = function () {
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const throws = function () {
           fs.readdirSync(p)
         }
         assert.throws(throws, /ENOENT/)
@@ -572,7 +567,7 @@ describe('asar package', function () {
 
     describe('fs.readdir', function () {
       it('reads dirs from root', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar')
+        const p = path.join(fixtures, 'asar', 'a.asar')
         fs.readdir(p, function (err, dirs) {
           assert.strictEqual(err, null)
           assert.deepStrictEqual(dirs, ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js'])
@@ -581,7 +576,7 @@ describe('asar package', function () {
       })
 
       it('reads dirs from a normal dir', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'dir1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'dir1')
         fs.readdir(p, function (err, dirs) {
           assert.strictEqual(err, null)
           assert.deepStrictEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2'])
@@ -589,7 +584,7 @@ describe('asar package', function () {
         })
       })
       it('reads dirs from a linked dir', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2')
         fs.readdir(p, function (err, dirs) {
           assert.strictEqual(err, null)
           assert.deepStrictEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2'])
@@ -598,7 +593,7 @@ describe('asar package', function () {
       })
 
       it('throws ENOENT error when can not find file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         fs.readdir(p, function (err) {
           assert.strictEqual(err.code, 'ENOENT')
           done()
@@ -608,13 +603,12 @@ describe('asar package', function () {
 
     describe('fs.openSync', function () {
       it('opens a normal/linked/under-linked-directory file', function () {
-        var buffer, fd, file, j, len, p, ref2
-        ref2 = ['file1', 'link1', path.join('link2', 'file1')]
-        for (j = 0, len = ref2.length; j < len; j++) {
-          file = ref2[j]
-          p = path.join(fixtures, 'asar', 'a.asar', file)
-          fd = fs.openSync(p, 'r')
-          buffer = Buffer.alloc(6)
+        const ref2 = ['file1', 'link1', path.join('link2', 'file1')]
+        for (let j = 0, len = ref2.length; j < len; j++) {
+          const file = ref2[j]
+          const p = path.join(fixtures, 'asar', 'a.asar', file)
+          const fd = fs.openSync(p, 'r')
+          const buffer = Buffer.alloc(6)
           fs.readSync(fd, buffer, 0, 6, 0)
           assert.strictEqual(String(buffer).trim(), 'file1')
           fs.closeSync(fd)
@@ -622,8 +616,8 @@ describe('asar package', function () {
       })
 
       it('throws ENOENT error when can not find file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
-        var throws = function () {
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const throws = function () {
           fs.openSync(p)
         }
         assert.throws(throws, /ENOENT/)
@@ -632,10 +626,10 @@ describe('asar package', function () {
 
     describe('fs.open', function () {
       it('opens a normal file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         fs.open(p, 'r', function (err, fd) {
           assert.strictEqual(err, null)
-          var buffer = Buffer.alloc(6)
+          const buffer = Buffer.alloc(6)
           fs.read(fd, buffer, 0, 6, 0, function (err) {
             assert.strictEqual(err, null)
             assert.strictEqual(String(buffer).trim(), 'file1')
@@ -645,7 +639,7 @@ describe('asar package', function () {
       })
 
       it('throws ENOENT error when can not find file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         fs.open(p, 'r', function (err) {
           assert.strictEqual(err.code, 'ENOENT')
           done()
@@ -655,7 +649,7 @@ describe('asar package', function () {
 
     describe('fs.mkdir', function () {
       it('throws error when calling inside asar archive', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         fs.mkdir(p, function (err) {
           assert.strictEqual(err.code, 'ENOTDIR')
           done()
@@ -665,7 +659,7 @@ describe('asar package', function () {
 
     describe('fs.mkdirSync', function () {
       it('throws error when calling inside asar archive', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         assert.throws(function () {
           fs.mkdirSync(p)
         }, new RegExp('ENOTDIR'))
@@ -674,7 +668,7 @@ describe('asar package', function () {
 
     describe('fs.exists', function () {
       it('handles an existing file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         // eslint-disable-next-line
         fs.exists(p, function (exists) {
           assert.strictEqual(exists, true)
@@ -683,7 +677,7 @@ describe('asar package', function () {
       })
 
       it('handles a non-existent file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         // eslint-disable-next-line
         fs.exists(p, function (exists) {
           assert.strictEqual(exists, false)
@@ -692,7 +686,7 @@ describe('asar package', function () {
       })
 
       it('promisified version handles an existing file', (done) => {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         // eslint-disable-next-line
         util.promisify(fs.exists)(p).then(exists => {
           assert.strictEqual(exists, true)
@@ -701,7 +695,7 @@ describe('asar package', function () {
       })
 
       it('promisified version handles a non-existent file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         // eslint-disable-next-line
         util.promisify(fs.exists)(p).then(exists => {
           assert.strictEqual(exists, false)
@@ -712,14 +706,14 @@ describe('asar package', function () {
 
     describe('fs.existsSync', function () {
       it('handles an existing file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         assert.doesNotThrow(function () {
           assert.strictEqual(fs.existsSync(p), true)
         })
       })
 
       it('handles a non-existent file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         assert.doesNotThrow(function () {
           assert.strictEqual(fs.existsSync(p), false)
         })
@@ -728,7 +722,7 @@ describe('asar package', function () {
 
     describe('fs.access', function () {
       it('accesses a normal file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         fs.access(p, function (err) {
           assert(err == null)
           done()
@@ -736,7 +730,7 @@ describe('asar package', function () {
       })
 
       it('throws an error when called with write mode', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         fs.access(p, fs.constants.R_OK | fs.constants.W_OK, function (err) {
           assert.strictEqual(err.code, 'EACCES')
           done()
@@ -744,7 +738,7 @@ describe('asar package', function () {
       })
 
       it('throws an error when called on non-existent file', function (done) {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         fs.access(p, function (err) {
           assert.strictEqual(err.code, 'ENOENT')
           done()
@@ -752,7 +746,7 @@ describe('asar package', function () {
       })
 
       it('allows write mode for unpacked files', function (done) {
-        var p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
+        const p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
         fs.access(p, fs.constants.R_OK | fs.constants.W_OK, function (err) {
           assert(err == null)
           done()
@@ -762,28 +756,28 @@ describe('asar package', function () {
 
     describe('fs.accessSync', function () {
       it('accesses a normal file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         assert.doesNotThrow(function () {
           fs.accessSync(p)
         })
       })
 
       it('throws an error when called with write mode', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
         assert.throws(function () {
           fs.accessSync(p, fs.constants.R_OK | fs.constants.W_OK)
         }, /EACCES/)
       })
 
       it('throws an error when called on non-existent file', function () {
-        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+        const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
         assert.throws(function () {
           fs.accessSync(p)
         }, /ENOENT/)
       })
 
       it('allows write mode for unpacked files', function () {
-        var p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
+        const p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
         assert.doesNotThrow(function () {
           fs.accessSync(p, fs.constants.R_OK | fs.constants.W_OK)
         })
@@ -792,7 +786,7 @@ describe('asar package', function () {
 
     describe('child_process.fork', function () {
       it('opens a normal js file', function (done) {
-        var child = ChildProcess.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'))
+        const child = ChildProcess.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'))
         child.on('message', function (msg) {
           assert.strictEqual(msg, 'message')
           done()
@@ -801,8 +795,8 @@ describe('asar package', function () {
       })
 
       it('supports asar in the forked js', function (done) {
-        var file = path.join(fixtures, 'asar', 'a.asar', 'file1')
-        var child = ChildProcess.fork(path.join(fixtures, 'module', 'asar.js'))
+        const file = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const child = ChildProcess.fork(path.join(fixtures, 'module', 'asar.js'))
         child.on('message', function (content) {
           assert.strictEqual(content, fs.readFileSync(file).toString())
           done()
@@ -812,7 +806,7 @@ describe('asar package', function () {
     })
 
     describe('child_process.exec', function () {
-      var echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
+      const echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
       it('should not try to extract the command if there is a reference to a file inside an .asar', function (done) {
         ChildProcess.exec('echo ' + echo + ' foo bar', function (error, stdout) {
@@ -830,20 +824,19 @@ describe('asar package', function () {
     })
 
     describe('child_process.execSync', function () {
-      var echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
+      const echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
       it('should not try to extract the command if there is a reference to a file inside an .asar', function (done) {
-        var stdout = ChildProcess.execSync('echo ' + echo + ' foo bar')
+        const stdout = ChildProcess.execSync('echo ' + echo + ' foo bar')
         assert.strictEqual(stdout.toString().replace(/\r/g, ''), echo + ' foo bar\n')
         done()
       })
     })
 
     describe('child_process.execFile', function () {
-      var echo, execFile, execFileSync
-      execFile = ChildProcess.execFile
-      execFileSync = ChildProcess.execFileSync
-      echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
+      const execFile = ChildProcess.execFile
+      const execFileSync = ChildProcess.execFileSync
+      const echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
       before(function () {
         if (process.platform !== 'darwin') {
@@ -860,7 +853,7 @@ describe('asar package', function () {
       })
 
       xit('execFileSync executes binaries', function () {
-        var output = execFileSync(echo, ['test'])
+        const output = execFileSync(echo, ['test'])
         assert.strictEqual(String(output), 'test\n')
       })
 
@@ -872,19 +865,19 @@ describe('asar package', function () {
     })
 
     describe('internalModuleReadJSON', function () {
-      var internalModuleReadJSON = process.binding('fs').internalModuleReadJSON
+      const internalModuleReadJSON = process.binding('fs').internalModuleReadJSON
 
       it('read a normal file', function () {
-        var file1 = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const file1 = path.join(fixtures, 'asar', 'a.asar', 'file1')
         assert.strictEqual(internalModuleReadJSON(file1).toString().trim(), 'file1')
-        var file2 = path.join(fixtures, 'asar', 'a.asar', 'file2')
+        const file2 = path.join(fixtures, 'asar', 'a.asar', 'file2')
         assert.strictEqual(internalModuleReadJSON(file2).toString().trim(), 'file2')
-        var file3 = path.join(fixtures, 'asar', 'a.asar', 'file3')
+        const file3 = path.join(fixtures, 'asar', 'a.asar', 'file3')
         assert.strictEqual(internalModuleReadJSON(file3).toString().trim(), 'file3')
       })
 
       it('reads a normal file with unpacked files', function () {
-        var p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
+        const p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
         assert.strictEqual(internalModuleReadJSON(p).toString().trim(), 'a')
       })
     })
@@ -910,7 +903,7 @@ describe('asar package', function () {
     })
 
     describe('process.noAsar', function () {
-      var errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR'
+      const errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR'
 
       beforeEach(function () {
         process.noAsar = true
@@ -921,8 +914,8 @@ describe('asar package', function () {
       })
 
       it('disables asar support in sync API', function () {
-        var file = path.join(fixtures, 'asar', 'a.asar', 'file1')
-        var dir = path.join(fixtures, 'asar', 'a.asar', 'dir1')
+        const file = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const dir = path.join(fixtures, 'asar', 'a.asar', 'dir1')
         assert.throws(function () {
           fs.readFileSync(file)
         }, new RegExp(errorName))
@@ -938,8 +931,8 @@ describe('asar package', function () {
       })
 
       it('disables asar support in async API', function (done) {
-        var file = path.join(fixtures, 'asar', 'a.asar', 'file1')
-        var dir = path.join(fixtures, 'asar', 'a.asar', 'dir1')
+        const file = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const dir = path.join(fixtures, 'asar', 'a.asar', 'dir1')
         fs.readFile(file, function (error) {
           assert.strictEqual(error.code, errorName)
           fs.lstat(file, function (error) {
@@ -956,10 +949,10 @@ describe('asar package', function () {
       })
 
       it('treats *.asar as normal file', function () {
-        var originalFs = require('original-fs')
-        var asar = path.join(fixtures, 'asar', 'a.asar')
-        var content1 = fs.readFileSync(asar)
-        var content2 = originalFs.readFileSync(asar)
+        const originalFs = require('original-fs')
+        const asar = path.join(fixtures, 'asar', 'a.asar')
+        const content1 = fs.readFileSync(asar)
+        const content2 = originalFs.readFileSync(asar)
         assert.strictEqual(content1.compare(content2), 0)
         assert.throws(function () {
           fs.readdirSync(asar)
@@ -1012,14 +1005,14 @@ describe('asar package', function () {
   })
 
   describe('asar protocol', function () {
-    var w = null
+    let w = null
 
     afterEach(function () {
       return closeWindow(w).then(function () { w = null })
     })
 
     it('can request a file in package', function (done) {
-      var p = path.resolve(fixtures, 'asar', 'a.asar', 'file1')
+      const p = path.resolve(fixtures, 'asar', 'a.asar', 'file1')
       $.get('file://' + p, function (data) {
         assert.strictEqual(data.trim(), 'file1')
         done()
@@ -1027,7 +1020,7 @@ describe('asar package', function () {
     })
 
     it('can request a file in package with unpacked files', function (done) {
-      var p = path.resolve(fixtures, 'asar', 'unpack.asar', 'a.txt')
+      const p = path.resolve(fixtures, 'asar', 'unpack.asar', 'a.txt')
       $.get('file://' + p, function (data) {
         assert.strictEqual(data.trim(), 'a')
         done()
@@ -1035,7 +1028,7 @@ describe('asar package', function () {
     })
 
     it('can request a linked file in package', function (done) {
-      var p = path.resolve(fixtures, 'asar', 'a.asar', 'link2', 'link1')
+      const p = path.resolve(fixtures, 'asar', 'a.asar', 'link2', 'link1')
       $.get('file://' + p, function (data) {
         assert.strictEqual(data.trim(), 'file1')
         done()
@@ -1043,7 +1036,7 @@ describe('asar package', function () {
     })
 
     it('can request a file in filesystem', function (done) {
-      var p = path.resolve(fixtures, 'asar', 'file')
+      const p = path.resolve(fixtures, 'asar', 'file')
       $.get('file://' + p, function (data) {
         assert.strictEqual(data.trim(), 'file')
         done()
@@ -1051,7 +1044,7 @@ describe('asar package', function () {
     })
 
     it('gets 404 when file is not found', function (done) {
-      var p = path.resolve(fixtures, 'asar', 'a.asar', 'no-exist')
+      const p = path.resolve(fixtures, 'asar', 'a.asar', 'no-exist')
       $.ajax({
         url: 'file://' + p,
         error: function (err) {
@@ -1071,7 +1064,7 @@ describe('asar package', function () {
         width: 400,
         height: 400
       })
-      var p = path.resolve(fixtures, 'asar', 'web.asar', 'index.html')
+      const p = path.resolve(fixtures, 'asar', 'web.asar', 'index.html')
       ipcMain.once('dirname', function (event, dirname) {
         assert.strictEqual(dirname, path.dirname(p))
         done()
@@ -1089,7 +1082,7 @@ describe('asar package', function () {
         width: 400,
         height: 400
       })
-      var p = path.resolve(fixtures, 'asar', 'script.asar', 'index.html')
+      const p = path.resolve(fixtures, 'asar', 'script.asar', 'index.html')
       w.loadFile(p)
       ipcMain.once('ping', function (event, message) {
         assert.strictEqual(message, 'pong')
@@ -1109,7 +1102,7 @@ describe('asar package', function () {
         width: 400,
         height: 400
       })
-      var p = path.resolve(fixtures, 'asar', 'video.asar', 'index.html')
+      const p = path.resolve(fixtures, 'asar', 'video.asar', 'index.html')
       w.loadFile(p)
       ipcMain.on('asar-video', function (event, message, error) {
         if (message === 'ended') {
@@ -1123,16 +1116,16 @@ describe('asar package', function () {
   })
 
   describe('original-fs module', function () {
-    var originalFs = require('original-fs')
+    const originalFs = require('original-fs')
 
     it('treats .asar as file', function () {
-      var file = path.join(fixtures, 'asar', 'a.asar')
-      var stats = originalFs.statSync(file)
+      const file = path.join(fixtures, 'asar', 'a.asar')
+      const stats = originalFs.statSync(file)
       assert(stats.isFile())
     })
 
     it('is available in forked scripts', function (done) {
-      var child = ChildProcess.fork(path.join(fixtures, 'module', 'original-fs.js'))
+      const child = ChildProcess.fork(path.join(fixtures, 'module', 'original-fs.js'))
       child.on('message', function (msg) {
         assert.strictEqual(msg, 'object')
         done()
@@ -1142,10 +1135,10 @@ describe('asar package', function () {
   })
 
   describe('graceful-fs module', function () {
-    var gfs = require('graceful-fs')
+    const gfs = require('graceful-fs')
 
     it('recognize asar archvies', function () {
-      var p = path.join(fixtures, 'asar', 'a.asar', 'link1')
+      const p = path.join(fixtures, 'asar', 'a.asar', 'link1')
       assert.strictEqual(gfs.readFileSync(p).toString().trim(), 'file1')
     })
     it('does not touch global fs object', function () {
@@ -1154,10 +1147,10 @@ describe('asar package', function () {
   })
 
   describe('mkdirp module', function () {
-    var mkdirp = require('mkdirp')
+    const mkdirp = require('mkdirp')
 
     it('throws error when calling inside asar archive', function () {
-      var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
+      const p = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
       assert.throws(function () {
         mkdirp.sync(p)
       }, new RegExp('ENOTDIR'))
@@ -1166,8 +1159,8 @@ describe('asar package', function () {
 
   describe('native-image', function () {
     it('reads image from asar archive', function () {
-      var p = path.join(fixtures, 'asar', 'logo.asar', 'logo.png')
-      var logo = nativeImage.createFromPath(p)
+      const p = path.join(fixtures, 'asar', 'logo.asar', 'logo.png')
+      const logo = nativeImage.createFromPath(p)
       assert.deepStrictEqual(logo.getSize(), {
         width: 55,
         height: 55
@@ -1175,8 +1168,8 @@ describe('asar package', function () {
     })
 
     it('reads image from asar archive with unpacked files', function () {
-      var p = path.join(fixtures, 'asar', 'unpack.asar', 'atom.png')
-      var logo = nativeImage.createFromPath(p)
+      const p = path.join(fixtures, 'asar', 'unpack.asar', 'atom.png')
+      const logo = nativeImage.createFromPath(p)
       assert.deepStrictEqual(logo.getSize(), {
         width: 1024,
         height: 1024

--- a/spec/fixtures/api/quit-app/main.js
+++ b/spec/fixtures/api/quit-app/main.js
@@ -1,4 +1,4 @@
-var app = require('electron').app
+const { app } = require('electron')
 
 app.on('ready', function () {
   // This setImmediate call gets the spec passing on Linux

--- a/spec/fixtures/module/answer.js
+++ b/spec/fixtures/module/answer.js
@@ -1,4 +1,4 @@
-var ipcRenderer = require('electron').ipcRenderer
+const { ipcRenderer } = require('electron')
 window.answer = function (answer) {
   ipcRenderer.send('answer', answer)
 }

--- a/spec/fixtures/module/asar.js
+++ b/spec/fixtures/module/asar.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+const fs = require('fs')
 process.on('message', function (file) {
   process.send(fs.readFileSync(file).toString())
 })

--- a/spec/fixtures/module/check-arguments.js
+++ b/spec/fixtures/module/check-arguments.js
@@ -1,4 +1,4 @@
-var ipcRenderer = require('electron').ipcRenderer
+const { ipcRenderer } = require('electron')
 window.onload = function () {
   ipcRenderer.send('answer', process.argv)
 }

--- a/spec/fixtures/module/create_socket.js
+++ b/spec/fixtures/module/create_socket.js
@@ -1,4 +1,4 @@
-var net = require('net')
-var server = net.createServer(function () {})
+const net = require('net')
+const server = net.createServer(function () {})
 server.listen(process.argv[2])
 process.exit(0)

--- a/spec/fixtures/module/fork_ping.js
+++ b/spec/fixtures/module/fork_ping.js
@@ -4,7 +4,7 @@ process.on('uncaughtException', function (error) {
   process.send(error.stack)
 })
 
-var child = require('child_process').fork(path.join(__dirname, '/ping.js'))
+const child = require('child_process').fork(path.join(__dirname, '/ping.js'))
 process.on('message', function (msg) {
   child.send(msg)
 })

--- a/spec/fixtures/module/preload-ipc.js
+++ b/spec/fixtures/module/preload-ipc.js
@@ -1,4 +1,4 @@
-var ipcRenderer = require('electron').ipcRenderer
+const { ipcRenderer } = require('electron')
 ipcRenderer.on('ping', function (event, message) {
   ipcRenderer.sendToHost('pong', message)
 })

--- a/spec/fixtures/module/preload-pdf-loaded-in-nested-subframe.js
+++ b/spec/fixtures/module/preload-pdf-loaded-in-nested-subframe.js
@@ -1,10 +1,10 @@
 const { ipcRenderer } = require('electron')
 
 document.addEventListener('DOMContentLoaded', (event) => {
-  var outerFrame = document.querySelector('#outer-frame')
+  const outerFrame = document.querySelector('#outer-frame')
   if (outerFrame) {
     outerFrame.onload = function () {
-      var pdframe = outerFrame.contentWindow.document.getElementById('pdf-frame')
+      const pdframe = outerFrame.contentWindow.document.getElementById('pdf-frame')
       if (pdframe) {
         pdframe.contentWindow.addEventListener('pdf-loaded', (event) => {
           ipcRenderer.send('pdf-loaded', event.detail)

--- a/spec/fixtures/module/preload-pdf-loaded-in-subframe.js
+++ b/spec/fixtures/module/preload-pdf-loaded-in-subframe.js
@@ -1,7 +1,7 @@
 const { ipcRenderer } = require('electron')
 
 document.addEventListener('DOMContentLoaded', (event) => {
-  var subframe = document.querySelector('#pdf-frame')
+  const subframe = document.querySelector('#pdf-frame')
   if (subframe) {
     subframe.contentWindow.addEventListener('pdf-loaded', (event) => {
       ipcRenderer.send('pdf-loaded', event.detail)

--- a/spec/fixtures/module/send-later.js
+++ b/spec/fixtures/module/send-later.js
@@ -1,4 +1,4 @@
-var ipcRenderer = require('electron').ipcRenderer
+const { ipcRenderer } = require('electron')
 window.onload = function () {
   ipcRenderer.send('answer', typeof window.process, typeof window.Buffer)
 }

--- a/spec/fixtures/pages/service-worker/service-worker.js
+++ b/spec/fixtures/pages/service-worker/service-worker.js
@@ -1,9 +1,9 @@
 self.addEventListener('fetch', function (event) {
-  var requestUrl = new URL(event.request.url)
+  const requestUrl = new URL(event.request.url)
 
   if (requestUrl.pathname === '/echo' &&
     event.request.headers.has('X-Mock-Response')) {
-    var mockResponse = new Response('Hello from serviceWorker!')
+    const mockResponse = new Response('Hello from serviceWorker!')
     event.respondWith(mockResponse)
   }
 })

--- a/spec/fixtures/workers/shared_worker.js
+++ b/spec/fixtures/workers/shared_worker.js
@@ -1,5 +1,5 @@
 this.onconnect = function (event) {
-  var port = event.ports[0]
+  const port = event.ports[0]
   port.start()
   port.onmessage = function (event) {
     port.postMessage(event.data)

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -11,13 +11,13 @@ const path = require('path')
 const util = require('util')
 const v8 = require('v8')
 
-var argv = require('yargs')
+const argv = require('yargs')
   .boolean('ci')
   .string('g').alias('g', 'grep')
   .boolean('i').alias('i', 'invert')
   .argv
 
-var window = null
+let window = null
 
 // will be used by crash-reporter spec.
 process.port = 0
@@ -145,7 +145,7 @@ app.on('ready', function () {
     }
   })
   window.on('unresponsive', function () {
-    var chosen = dialog.showMessageBox(window, {
+    const chosen = dialog.showMessageBox(window, {
       type: 'warning',
       buttons: ['Close', 'Keep Waiting'],
       message: 'Window is not responsing',
@@ -160,7 +160,7 @@ app.on('ready', function () {
 
   // For session's download test, listen 'will-download' event in browser, and
   // reply the result to renderer for verifying
-  var downloadFilePath = path.join(__dirname, '..', 'fixtures', 'mock.pdf')
+  const downloadFilePath = path.join(__dirname, '..', 'fixtures', 'mock.pdf')
   ipcMain.on('set-download-option', function (event, needCancel, preventDefault, filePath = downloadFilePath) {
     window.webContents.session.once('will-download', function (e, item) {
       window.webContents.send('download-created',


### PR DESCRIPTION
##### Description of Change
Disallow the use of `var` in JavaScript code (https://eslint.org/docs/rules/no-var), replace all occurrences with `const` or `let` as appropriate. 

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes