### PR TITLE
chore: fix windows dump syms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,21 @@ step-nodejs-headers-build: &step-nodejs-headers-build
       cd src
       ninja -C out/Default third_party/electron_node:headers
 
+step-electron-publish: &step-electron-publish
+  run:
+    name: Publish Electron Dist
+    command: |
+      cd src/electron
+      if [ "$ELECTRON_RELEASE" == "1" ]; then
+        if [ "$UPLOAD_TO_S3" != "1" ]; then
+          echo 'Uploading Electron release distribution to github releases'
+          script/upload.py
+        else
+          echo 'Uploading Electron release distribution to s3'
+          script/upload.py --upload_to_s3
+        fi
+      fi
+
 step-persist-data-for-tests: &step-persist-data-for-tests
   persist_to_workspace:
     root: .
@@ -410,6 +425,9 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
 
     # Node.js headers
     - *step-nodejs-headers-build
+
+    # Publish
+    - *step-electron-publish
 
 
 steps-native-mksnapshot-build: &steps-native-mksnapshot-build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,10 @@ build_script:
   - ps: >-
       if ($env:GN_CONFIG -eq 'release') {
         ninja -C out/Default third_party/breakpad:dump_syms
-        python electron\script\dump-symbols.py -d %cd%/out/Default/electron.breakpad.syms
+      }
+  - if "%GN_CONFIG%"=="release" ( python electron\script\dump-symbols.py -d %cd%\out\Default\electron.breakpad.syms -v)
+  - ps: >-
+      if ($env:GN_CONFIG -eq 'release') {
         python electron\script\zip-symbols.py
         appveyor PushArtifact out/Default/electron.breakpad.syms
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ build_script:
   - ninja -C out/Default electron:electron_dist_zip
   - ninja -C out/Default electron:electron_mksnapshot_zip
   - ninja -C out/Default electron:electron_chromedriver_zip
+  - ninja -C out/Default third_party/electron_node:headers
   - appveyor PushArtifact out/Default/dist.zip
   - appveyor PushArtifact out/Default/chromedriver.zip
 
@@ -49,7 +50,6 @@ test_script:
   - if "%GN_CONFIG%"=="testing" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
   - ps: >-
       if ($env:GN_CONFIG -eq 'testing') {
-        ninja -C out/Default third_party/electron_node:headers
         New-Item .\out\Default\gen\node_headers\Release -Type directory
         Copy-Item -path .\out\Default\electron.lib -destination .\out\Default\gen\node_headers\Release\node.lib
       } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ build_script:
   - ps: >-
       if ($env:GN_CONFIG -eq 'release') {
         python electron\script\zip-symbols.py
-        appveyor PushArtifact out/Default/electron.breakpad.syms
+        appveyor PushArtifact out/Default/symbols.zip
       }
 test_script:
   - if "%GN_CONFIG%"=="testing" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )

--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -5,7 +5,8 @@ import os
 import sys
 
 from lib.config import PLATFORM, enable_verbose_mode, is_verbose_mode
-from lib.util import get_electron_branding, execute, rm_rf, get_out_dir
+from lib.util import get_electron_branding, execute, rm_rf, get_out_dir, \
+                     GN_SRC_DIR
 
 ELECTRON_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 SOURCE_ROOT = os.path.abspath(os.path.dirname(ELECTRON_ROOT))
@@ -30,12 +31,12 @@ def main():
       helper_app = os.path.join(build_path, '{0}.app'.format(helper_name),
                             'Contents', 'MacOS', product_name + " Helper")
       binaries = [main_app, helper_app]
-      for binary in binaries:        
-        generate_posix_symbols(binary, source_root, build_path, 
+      for binary in binaries:
+        generate_posix_symbols(binary, source_root, build_path,
                                         args.destination)
     else:
       binary = os.path.join(build_path, project_name)
-      generate_posix_symbols(binary, source_root, build_path, 
+      generate_posix_symbols(binary, source_root, build_path,
                                       args.destination)
 
   else:
@@ -45,8 +46,14 @@ def main():
       '--symbols-dir={0}'.format(args.destination),
       '--jobs=16',
       os.path.relpath(build_path),
-    ]  
-    execute([sys.executable, generate_breakpad_symbols] + args)
+    ]
+    #Make sure msdia140.dll is in the path (needed for dump_syms.exe)
+    env = os.environ.copy()
+    msdia140_dll_path =  os.path.join(GN_SRC_DIR, 'third_party', 'llvm-build',
+                                      'Release+Asserts', 'bin')
+    env['PATH'] = os.path.pathsep.join(
+        [env.get('PATH', '')] + [msdia140_dll_path])
+    execute([sys.executable, generate_breakpad_symbols] + args, env)
 
 def get_names_from_branding():
   variables = get_electron_branding()
@@ -62,9 +69,9 @@ def generate_posix_symbols(binary, source_root, build_dir, destination):
     '--jobs=16',
     '--binary={0}'.format(binary),
   ]
-  if is_verbose_mode(): 
+  if is_verbose_mode():
     args += ['-v']
-  execute([sys.executable, generate_breakpad_symbols] + args)    
+  execute([sys.executable, generate_breakpad_symbols] + args)
 
 def parse_args():
   parser = argparse.ArgumentParser(description='Create breakpad symbols')
@@ -83,7 +90,7 @@ def parse_args():
                       required=False)
   parser.add_argument('-v', '--verbose',
                       action='store_true',
-                      help='Prints the output of the subprocesses')                      
+                      help='Prints the output of the subprocesses')
   return parser.parse_args()
 
 if __name__ == '__main__':

--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -47,6 +47,8 @@ def main():
       '--jobs=16',
       os.path.relpath(build_path),
     ]
+    if is_verbose_mode():
+      args += ['-v']
     #Make sure msdia140.dll is in the path (needed for dump_syms.exe)
     env = os.environ.copy()
     msdia140_dll_path =  os.path.join(GN_SRC_DIR, 'third_party', 'llvm-build',

--- a/script/upload-symbols.py
+++ b/script/upload-symbols.py
@@ -10,16 +10,13 @@ from lib.util import get_electron_branding, execute, rm_rf, safe_mkdir, s3put, \
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 RELEASE_DIR = get_out_dir()
-GEN_DIR = os.path.join(RELEASE_DIR, 'gen')
 
 
 PROJECT_NAME = get_electron_branding()['project_name']
 PRODUCT_NAME = get_electron_branding()['product_name']
-
-if PLATFORM == 'win32':
-  SYMBOLS_DIR = os.path.join(GEN_DIR, 'symbols')
-else:
-  SYMBOLS_DIR = os.path.join(GEN_DIR, '{0}.breakpad.syms'.format(PROJECT_NAME))
+SYMBOLS_DIR = os.path.join(
+  RELEASE_DIR, '{0}.breakpad.syms'.format(PROJECT_NAME)
+)
 
 PDB_LIST = [
   os.path.join(RELEASE_DIR, '{0}.exe.pdb'.format(PROJECT_NAME))

--- a/script/upload.py
+++ b/script/upload.py
@@ -65,7 +65,7 @@ def main():
   upload_electron(release, electron_zip, args)
   if get_target_arch() != 'mips64el':
     symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
-    shutil.copy2(os.path.join(OUT_DIR, 'symobls.zip'), symbols_zip)
+    shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
     upload_electron(release, symbols_zip, args)
   if PLATFORM == 'darwin':
     api_path = os.path.join(OUT_DIR, 'electron-api.json')
@@ -77,7 +77,9 @@ def main():
     shutil.copy2(os.path.join(OUT_DIR, 'dsym.zip'), dsym_zip)
     upload_electron(release, dsym_zip, args)
   elif PLATFORM == 'win32':
-    upload_electron(release, os.path.join(OUT_DIR, PDB_NAME), args)
+    pdb_zip = os.path.join(OUT_DIR, PDB_NAME)
+    shutil.copy2(os.path.join(OUT_DIR, 'pdb.zip'), pdb_zip)
+    upload_electron(release, pdb_zip, args)
 
   # Upload free version of ffmpeg.
   ffmpeg = get_zip_name('ffmpeg', ELECTRON_VERSION)

--- a/script/upload.py
+++ b/script/upload.py
@@ -84,7 +84,8 @@ def main():
   # Upload free version of ffmpeg.
   ffmpeg = get_zip_name('ffmpeg', ELECTRON_VERSION)
   ffmpeg_zip = os.path.join(OUT_DIR, ffmpeg)
-  shutil.copy2(os.path.join(OUT_DIR, 'ffmpeg.zip'), ffmpeg_zip)
+  ffmpeg_build_path = os.path.join(GN_SRC_DIR, 'out', 'ffmpeg', 'ffmpeg.zip')
+  shutil.copy2(ffmpeg_build_path, ffmpeg_zip)
   upload_electron(release, ffmpeg_zip, args)
 
   chromedriver = get_zip_name('chromedriver', ELECTRON_VERSION)

--- a/vsts.yml
+++ b/vsts.yml
@@ -56,7 +56,6 @@ jobs:
       cd src
       ninja -C out/Default third_party/electron_node:headers
     displayName: Build Node.js headers for testing
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
 
   - bash: |
       cd src


### PR DESCRIPTION
##### Description of Change
This PR is to fix the issues with generating the breakpad symbols on Windows release builds.
There were several issues this PR addresses:
1. The appveyor.yml config was incorrectly invoking `python electron\script\dump-symbols.py`
2. `dump_syms.exe` requires `msdia140.dll` be available in the system path.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes