### PR TITLE
chore: wrap new NSAppearance in correct check

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -36,7 +36,7 @@ struct Converter<NSAppearance*> {
     if (name == "light") {
       *out = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
       return true;
-    } else if (name == "dark") {
+    } else if (@available(macOS 10.14, *) && name == "dark") {
       *out = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
       return true;
     }
@@ -48,10 +48,11 @@ struct Converter<NSAppearance*> {
     if (val == nil) {
       return v8::Null(isolate);
     }
+
     if (val.name == NSAppearanceNameAqua) {
       return mate::ConvertToV8(isolate, "light");
     }
-    if (val.name == NSAppearanceNameDarkAqua) {
+    if (@available(macOS 10.14, *) && val.name == NSAppearanceNameDarkAqua) {
       return mate::ConvertToV8(isolate, "dark");
     }
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -36,8 +36,12 @@ struct Converter<NSAppearance*> {
     if (name == "light") {
       *out = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
       return true;
-    } else if (@available(macOS 10.14, *) && name == "dark") {
-      *out = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+    } else if (name == "dark") {
+      if (@available(macOS 10.14, *)) {
+        *out = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+      } else {
+        *out = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+      }
       return true;
     }
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -56,8 +56,10 @@ struct Converter<NSAppearance*> {
     if (val.name == NSAppearanceNameAqua) {
       return mate::ConvertToV8(isolate, "light");
     }
-    if (@available(macOS 10.14, *) && val.name == NSAppearanceNameDarkAqua) {
-      return mate::ConvertToV8(isolate, "dark");
+    if (@available(macOS 10.14, *)) {
+      if (val.name == NSAppearanceNameDarkAqua) {
+        return mate::ConvertToV8(isolate, "dark");
+      }
     }
 
     return mate::ConvertToV8(isolate, "unknown");


### PR DESCRIPTION
##### Description of Change

Adds additional availability check in the converter for `NSAppearanceNameDarkAqua`.

/cc @MarshallOfSound 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes