### PR TITLE
fix: simpleFullscreen window should be on top

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -209,6 +209,7 @@ class NativeWindowMac : public NativeWindow {
   bool was_maximizable_ = false;
   bool was_movable_ = false;
   NSRect original_frame_;
+  NSInteger original_level_;
   NSUInteger simple_fullscreen_mask_;
 
   base::scoped_nsobject<NSColor> background_color_before_vibrancy_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -473,6 +473,7 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   AddContentViewLayers();
 
   original_frame_ = [window_ frame];
+  original_level_ = [window_ level];
 }
 
 NativeWindowMac::~NativeWindowMac() {
@@ -892,9 +893,11 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
   if (simple_fullscreen && !is_simple_fullscreen_) {
     is_simple_fullscreen_ = true;
 
-    // Take note of the current window size
-    if (IsNormal())
+    // Take note of the current window size and level
+    if (IsNormal()) {
       original_frame_ = [window_ frame];
+      original_level_ = [window_ level];
+    }
 
     simple_fullscreen_options_ = [NSApp currentSystemPresentationOptions];
     simple_fullscreen_mask_ = [window styleMask];
@@ -910,6 +913,13 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     was_movable_ = IsMovable();
 
     NSRect fullscreenFrame = [window.screen frame];
+
+    // If our app has dock hidden, set the window level higher so another app's
+    // menu bar doesn't appear on top of our fullscreen app.
+    if ([[NSRunningApplication currentApplication] activationPolicy] !=
+        NSApplicationActivationPolicyRegular) {
+      window.level = NSPopUpMenuWindowLevel;
+    }
 
     if (!fullscreen_window_title()) {
       // Hide the titlebar
@@ -951,6 +961,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
         setHidden:window_button_hidden];
 
     [window setFrame:original_frame_ display:YES animate:YES];
+    window.level = original_level_;
 
     [NSApp setPresentationOptions:simple_fullscreen_options_];
 


### PR DESCRIPTION
First let me say that Electron is great and has empowered me to build fun + useful desktop software that I wouldn't have otherwise been able to create.
So thanks for your hard work and stewardship of the project --- if any of y'all catch me in person at a conference, etc., drinks are on me!

##### Description of Change

If an app has no menu bar (because `app.dock.hide()` has been called),
OS X will still render the menu bar of the previously-focused app.

This commit ensures simpleFullscreen windows will be drawn on top of
that menu bar by setting their level to NSPopUpMenuWindowLevel while
simpleFullscreen mode is active.

Ref: https://github.com/electron/electron/issues/11468

This fix is motivated by [Finda](https://keminglabs.com/finda/), a keyboard-only app that needs to popup full screen on any OS X space without showing up in the Dock or with a menu bar.
The video on that page demonstrates this problem "in the wild" (note how Finda doesn't cover the QuickTime Player OS X menu bar when it pops up.)

Here's a reduced video showing before/after the fix:

![simplefullscreen-no-dock-fix](https://user-images.githubusercontent.com/147919/46245796-b965fd80-c3eb-11e8-9bfe-bab32f8af888.gif)

Before fix the `no_dock.js` still shows iTerm's menu bar; after the fix the `no_dock.js` is actually fullscreen.
Included `dock.js` to show that this fix doesn't break menu bar when dock isn't hidden.

no_dock.js:

```javascript
const electron = require('electron')
const app = electron.app
const BrowserWindow = electron.BrowserWindow

app.dock.hide()
app.on('ready', function(){
  new BrowserWindow({simpleFullscreen: true, fullscreen: true})
})
```

(`dock.js` is the same, but without the `app.dock.hide()` line.)


##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: Fixed simpleFullscreen windows in hidden-dock apps from being drawn below OS X menu bar of previously-focused app.