### PR TITLE
fix: allow stream protocols to return headers with multiple values

### DIFF
--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -197,25 +197,20 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
           return false;
         }
 
-        v8::String::Utf8Value key_utf8(key);
-        v8::String::Utf8Value value_utf8(value);
-        std::string k(*key_utf8, key_utf8.length());
-        std::string v(*value_utf8, value_utf8.length());
-        std::ostringstream tmp;
-        tmp << k << ": " << v;
-        out->AddHeader(tmp.str());
+        std::string k, v;
+        mate::ConvertFromV8(isolate, key, &k);
+        mate::ConvertFromV8(isolate, value, &v);
+        out->AddHeader(k + ": " + v);
       }
     } else {
       if (!headers->Get(key)->ToString(context).ToLocal(&value)) {
         return false;
       }
-      v8::String::Utf8Value key_utf8(key);
-      v8::String::Utf8Value value_utf8(value);
-      std::string k(*key_utf8, key_utf8.length());
-      std::string v(*value_utf8, value_utf8.length());
-      std::ostringstream tmp;
-      tmp << k << ": " << v;
-      out->AddHeader(tmp.str());
+
+      std::string k, v;
+      mate::ConvertFromV8(isolate, key, &k);
+      mate::ConvertFromV8(isolate, value, &v);
+      out->AddHeader(k + ": " + v);
     }
   }
   return true;

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -529,7 +529,7 @@ describe('protocol module', () => {
           cache: false,
           success: (data, _, request) => {
             assert.strictEqual(request.status, 200)
-            assert.strictEqual(request.getResponseHeader('x-electron'), 'a,b')
+            assert.strictEqual(request.getResponseHeader('x-electron'), 'a, b')
             assert.strictEqual(data, text)
             done()
           },

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -589,6 +589,36 @@ describe('protocol module', () => {
         })
       })
     })
+
+    it('returns response multiple response headers with the same name', (done) => {
+      const handler = (request, callback) => {
+        callback({
+          headers: {
+            'header1': ['value1', 'value2'],
+            'header2': 'value3'
+          },
+          data: getStream()
+        })
+      }
+
+      protocol.registerStreamProtocol(protocolName, handler, (error) => {
+        if (error) return done(error)
+        $.ajax({
+          url: protocolName + '://fake-host',
+          cache: false,
+          success: (data, status, request) => {
+            // SUBTLE: when the response headers have multiple values it
+            // separates values by ", ". When the response headers are incorrectly
+            // converting an array to a string it separates values by ",".
+            assert.strictEqual(request.getAllResponseHeaders(), 'header1: value1, value2\r\nheader2: value3\r\n')
+            done()
+          },
+          error: (xhr, errorType, error) => {
+            done(error || new Error(`Request failed: ${xhr.status}`))
+          }
+        })
+      })
+    })
   })
 
   describe('protocol.isProtocolHandled', () => {


### PR DESCRIPTION
##### Description of Change

This allows stream protocols to return headers with multiple values as
an array of values.

Fixes https://github.com/electron/electron/issues/14778

cc @sofianguy 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Fixed returning headers with multiple values for stream protocols.