### PR TITLE
feat: remove needless additional mojave dark mode APIs

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -292,8 +292,12 @@ maps to [NSApplication.effectiveAppearance](https://developer.apple.com/document
 
 Please note that until Electron is built targeting the 10.14 SDK, your application's
 `effectiveAppearance` will default to 'light' and won't inherit the OS preference. In
-the interim we have provided a helper method `startAppLevelAppearanceTrackingOS()`
-which emulates this behavior.
+the interim in order for your application to inherit the OS preference you must set the
+`NSRequiresAquaSystemAppearance` key in your apps `Info.plist` to `false`.  If you are
+using `electron-packager` or `electron-forge` just set the `enableDarwinDarkMode`
+packager option to `true`.  See the [Electron Packager API](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
+for more details.
+
 
 ### `systemPreferences.getAppLevelAppearance()` _macOS_
 
@@ -309,24 +313,3 @@ You can use the `setAppLevelAppearance` API to set this value.
 
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
-
-### `systemPreferences.startAppLevelAppearanceTrackingOS()` _macOS_
-
-This is a helper method to make your application's "appearance" setting track the
-user's OS level appearance setting.  I.e. your app will have dark mode enabled if
-the user's system has dark mode enabled.
-
-You can track this automatic change with the `appearance-changed` event.
-
-**Note:** This method is exempt from our standard deprecation cycle and will be removed
-without deprecation in an upcoming major release of Electron as soon as we target the 10.14
-SDK
-
-### `systemPreferences.stopAppLevelAppearanceTrackingOS()` _macOS_
-
-This is a helper method to stop your application tracking the OS level appearance
-setting.  It is a no-op if you have not called `startAppLevelAppearanceTrackingOS()`
-
-**Note:** This method is exempt from our standard deprecation cycle and will be removed
-without deprecation in an upcoming major release of Electron as soon as we target the 10.14
-SDK

--- a/lib/browser/api/system-preferences.js
+++ b/lib/browser/api/system-preferences.js
@@ -1,47 +1,10 @@
 'use strict'
 
-const { app } = require('electron')
 const { EventEmitter } = require('events')
 const { systemPreferences, SystemPreferences } = process.atomBinding('system_preferences')
 
 // SystemPreferences is an EventEmitter.
 Object.setPrototypeOf(SystemPreferences.prototype, EventEmitter.prototype)
 EventEmitter.call(systemPreferences)
-
-if (process.platform === 'darwin') {
-  let appearanceTrackingSubscriptionID = null
-
-  systemPreferences.startAppLevelAppearanceTrackingOS = () => {
-    if (appearanceTrackingSubscriptionID !== null) return
-
-    const updateAppearanceBasedOnOS = () => {
-      const newAppearance = systemPreferences.isDarkMode()
-        ? 'dark'
-        : 'light'
-
-      if (systemPreferences.getAppLevelAppearance() !== newAppearance) {
-        systemPreferences.setAppLevelAppearance(newAppearance)
-        // TODO(MarshallOfSound): Once we remove this logic and build against 10.14
-        // SDK we should re-implement this event as a monitor of `effectiveAppearance`
-        systemPreferences.emit('appearance-changed', newAppearance)
-      }
-    }
-
-    appearanceTrackingSubscriptionID = systemPreferences.subscribeNotification(
-      'AppleInterfaceThemeChangedNotification',
-      updateAppearanceBasedOnOS
-    )
-
-    updateAppearanceBasedOnOS()
-  }
-
-  systemPreferences.stopAppLevelAppearanceTrackingOS = () => {
-    if (appearanceTrackingSubscriptionID === null) return
-
-    systemPreferences.unsubscribeNotification(appearanceTrackingSubscriptionID)
-  }
-
-  app.on('quit', systemPreferences.stopAppLevelAppearanceTrackingOS)
-}
 
 module.exports = systemPreferences


### PR DESCRIPTION
* Removes the APIs added to track OS dark mode
* Add instructions on how to use the macOS replacement

Basically, these 2 APIs are not required, you can compile on < 10.14 SDK and still have macOS adjust the appearance of your app automatically for you.  You just need the `NSRequiresAquaSystemAppearance` key set to `false` in your app's `Info.plist`.  We can't set this by default in Electron because you should only set it if your app actually supports dark mode but we can [add support to `electron-packager`](https://github.com/electron-userland/electron-packager/pull/893) and document this keys behavior in our dark mode docs.

Refs: https://github.com/electron-userland/electron-packager/pull/893 . 
Refs: https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app

Notes: Simplified mojave dark mode APIs