### PR TITLE
feat: disable fetching thumbnails if thumbnailSize is 0

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -82,7 +82,9 @@ The `desktopCapturer` module has the following methods:
   * `types` String[] - An array of Strings that lists the types of desktop sources
     to be captured, available types are `screen` and `window`.
   * `thumbnailSize` [Size](structures/size.md) (optional) - The size that the media source thumbnail
-    should be scaled to. Default is `150` x `150`.
+    should be scaled to. Default is `150` x `150`. Set width or height to 0 when you do not need
+    the thumbnails. This will save the processing time required for capturing the content of each
+    window and screen.
   * `fetchWindowIcons` Boolean (optional) - Set to true to enable fetching window icons. The default
     value is false. When false the appIcon property of the sources return null. Same if a source has
     the type screen.
@@ -107,7 +109,9 @@ captured.
   * `types` String[] - An array of Strings that lists the types of desktop sources
     to be captured, available types are `screen` and `window`.
   * `thumbnailSize` [Size](structures/size.md) (optional) - The size that the media source thumbnail
-    should be scaled to. Default is `150` x `150`.
+    should be scaled to. Default is `150` x `150`. Set width or height to 0 when you do not need
+    the thumbnails. This will save the processing time required for capturing the content of each
+    window and screen.
   * `fetchWindowIcons` Boolean (optional) - Set to true to enable fetching window icons. The default
     value is false. When false the appIcon property of the sources return null. Same if a source has
     the type screen.


### PR DESCRIPTION
#### Description of Change

Refs: https://github.com/electron/electron/issues/14872.

Capturing window thumbnails is expensive as it actually use the
window capturer and record one full frame per window and then
downscale then to the default size 150x150. When only interested
in the app icons we do not need all of this.

Example: `desktopCapturer.getSources({thumbnailSize: {width: 0, height: 0}}, ...)`

#### Release Notes

Notes: Added ability disable fetching thumbnails for in  `desktopCapturer.getSources()`