### PR TITLE
fix: Disable new fade animation for BrowserViews

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1058,6 +1058,9 @@ void NativeWindowMac::SetContentProtection(bool enable) {
 }
 
 void NativeWindowMac::SetBrowserView(NativeBrowserView* view) {
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+
   if (browser_view()) {
     [browser_view()->GetInspectableWebContentsView()->GetNativeView()
             removeFromSuperview];
@@ -1065,6 +1068,7 @@ void NativeWindowMac::SetBrowserView(NativeBrowserView* view) {
   }
 
   if (!view) {
+    [CATransaction commit];
     return;
   }
 
@@ -1074,6 +1078,8 @@ void NativeWindowMac::SetBrowserView(NativeBrowserView* view) {
                          positioned:NSWindowAbove
                          relativeTo:nil];
   native_view.hidden = NO;
+
+  [CATransaction commit];
 }
 
 void NativeWindowMac::SetParentWindow(NativeWindow* parent) {


### PR DESCRIPTION
##### Description of Change
With `3.x`, we switched to a newer version of the macOS SDK. With that came a subtle change: An implicit animation is applied to BrowserViews, since they're added `NSView` `subviews`. I didn't think much of it at the time, but our designers did not appreciate the surprise change – and I can understand why 😁 

This PR ensures that we don't show a cross-fade animation while adding or removing a `BrowserView`, ensuring that `BrowserViews` behave just like they have in Electron `2.x`.

Closes #14909 

##### Before
![actual](https://user-images.githubusercontent.com/1426799/46320745-a6daf800-c594-11e8-9d6e-e7f3ffcc8579.gif)

##### After
![expected](https://user-images.githubusercontent.com/1426799/46320756-b0646000-c594-11e8-816d-898580b5e24a.gif)

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines]

##### Release Notes
Notes: Removed an accidentially added fade animation to `BrowserViews`