### PR TITLE
chore: improve linting on CI

### DIFF
--- a/.vsts/lint.yml
+++ b/.vsts/lint.yml
@@ -1,8 +1,3 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 pool:
   vmImage: 'Ubuntu 16.04'
 
@@ -10,10 +5,11 @@ steps:
 - bash: |
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "${AGENT_BUILDDIRECTORY}/third_party/depot_tools"
     echo "##vso[task.setvariable variable=PATH]$PATH:${AGENT_BUILDDIRECTORY}/depot_tools"
-  name: Setup_depot_tools
+  displayName: Setup Depot Tools
 
 - bash: |
     export PATH="$PATH:${AGENT_BUILDDIRECTORY}/third_party/depot_tools"
     echo "##vso[task.setvariable variable=PATH]$PATH"
     npm install
     npm run lint
+  displayName: Run Lint


### PR DESCRIPTION
* Gives the tasks human readable names
* ~Output eslint failures to junit and collect them for good test reporting~ Tried this, it didn't look great and it passes on VSTS with lint failures

![image](https://user-images.githubusercontent.com/6634592/46325955-0e00b700-c63e-11e8-9053-163ed55966d1.png)

Notes: no-notes