### PR TITLE
fix: check guest view's devtools window size

### DIFF
--- a/brightray/browser/inspectable_web_contents_impl.cc
+++ b/brightray/browser/inspectable_web_contents_impl.cc
@@ -215,8 +215,6 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
       is_guest_(is_guest),
       view_(CreateInspectableContentsView(this)),
       weak_factory_(this) {
-  if (is_guest)
-    return;
   auto* bounds_dict = pref_service_->GetDictionary(kDevToolsBoundsPref);
   if (bounds_dict) {
     DictionaryToRect(*bounds_dict, &devtools_bounds_);
@@ -227,7 +225,7 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
     }
     if (!IsPointInScreen(devtools_bounds_.origin())) {
       gfx::Rect display;
-      if (web_contents->GetNativeView()) {
+      if (!is_guest && web_contents->GetNativeView()) {
         display = display::Screen::GetScreen()
                       ->GetDisplayNearestView(web_contents->GetNativeView())
                       .bounds();


### PR DESCRIPTION
##### Description of Change

Fix the devtools window of webview being too small.
 
Close #14383.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Fix the devtools window of webview being too small.
