### PR TITLE
ci: Use VSTS checkout of electron

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -3,6 +3,12 @@ jobs:
   displayName: Build Electron via GN
   timeoutInMinutes: 120
   steps:
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: src/electron'
+    inputs:
+      TargetFolder: src/electron
+
   - bash: |
       export PATH="$PATH:/Users/electron/depot_tools"
       echo "##vso[task.setvariable variable=PATH]$PATH"
@@ -12,14 +18,6 @@ jobs:
         --name "src/electron" \
         --unmanaged \
         "https://github.com/electron/electron"
-      mkdir src
-      git clone https://github.com/electron/electron src/electron
-      # TODO: there's a subtle race condition here in that if you push two
-      # commits to $BUILD_SOURCEBRANCH in quick succession, it's possible that
-      # fetching the BUILD_SOURCEBRANCH ref will not actually fetch the
-      # BUILD_SOURCEVERSION commit, and so the checkout will fail. Find a
-      # better solution for checking out the commit to be built.
-      (cd src/electron; git fetch origin +"${BUILD_SOURCEBRANCH}"; git checkout "${BUILD_SOURCEVERSION}")
       gclient sync --with_branch_heads --with_tags
       cd src
       export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools


### PR DESCRIPTION
##### Description of Change
This PR changes out Mac VSTS builds to use VSTS's checkout of electron instead of relying on checking it out ourselves.  This resolves the occasional issue we were experiencing where VSTS builds were failing at checkout
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes