### PR TITLE
build: remove duplicate cursor resource configs

### DIFF
--- a/atom/browser/resources/win/atom.rc
+++ b/atom/browser/resources/win/atom.rc
@@ -1,12 +1,6 @@
 // Microsoft Visual C++ generated resource script.
 //
-#include "ui\\resources\\grit\\ui_unscaled_resources.h"
 #include "resource.h"
-#include <winresrc.h>
-#ifdef IDC_STATIC
-#undef IDC_STATIC
-#endif
-#define IDC_STATIC (-1)
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -110,30 +104,4 @@ END
 //
 
 IDR_MAINFRAME           ICON                    "atom.ico"
-/////////////////////////////////////////////////////////////////////////////
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Cursors
-//
-IDC_ALIAS          CURSOR             "ui\\resources\\cursors\\aliasb.cur"
-IDC_CELL           CURSOR             "ui\\resources\\cursors\\cell.cur"
-IDC_COLRESIZE      CURSOR             "ui\\resources\\cursors\\col_resize.cur"
-IDC_COPYCUR        CURSOR             "ui\\resources\\cursors\\copy.cur"
-IDC_CURSOR_NONE    CURSOR             "ui\\resources\\cursors\\none.cur"
-IDC_HAND_GRAB      CURSOR             "ui\\resources\\cursors\\hand_grab.cur"
-IDC_HAND_GRABBING  CURSOR             "ui\\resources\\cursors\\hand_grabbing.cur"
-IDC_PAN_EAST       CURSOR             "ui\\resources\\cursors\\pan_east.cur"
-IDC_PAN_MIDDLE     CURSOR             "ui\\resources\\cursors\\pan_middle.cur"
-IDC_PAN_NORTH      CURSOR             "ui\\resources\\cursors\\pan_north.cur"
-IDC_PAN_NORTH_EAST CURSOR             "ui\\resources\\cursors\\pan_north_east.cur"
-IDC_PAN_NORTH_WEST CURSOR             "ui\\resources\\cursors\\pan_north_west.cur"
-IDC_PAN_SOUTH      CURSOR             "ui\\resources\\cursors\\pan_south.cur"
-IDC_PAN_SOUTH_EAST CURSOR             "ui\\resources\\cursors\\pan_south_east.cur"
-IDC_PAN_SOUTH_WEST CURSOR             "ui\\resources\\cursors\\pan_south_west.cur"
-IDC_PAN_WEST       CURSOR             "ui\\resources\\cursors\\pan_west.cur"
-IDC_ROWRESIZE      CURSOR             "ui\\resources\\cursors\\row_resize.cur"
-IDC_VERTICALTEXT   CURSOR             "ui\\resources\\cursors\\vertical_text.cur"
-IDC_ZOOMIN         CURSOR             "ui\\resources\\cursors\\zoom_in.cur"
-IDC_ZOOMOUT        CURSOR             "ui\\resources\\cursors\\zoom_out.cur"
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
##### Description of Change

Addresses https://github.com/electron/electron/projects/12#card-13268369

It was originally added in https://github.com/electron/electron/pull/2131, the values are already available from `$target_gen_dir/ui/resources/ui_unsclaed_resources.rc`. This PR removes the duplicate config we maintain.

```sh
$ gn analyze out/Testing input_analyze.json output_analyze.json
$ cat input_analyze.json
{
  "files": [
    "//out/Testing/gen/ui/resources/ui_unscaled_resources.rc"
  ],
  "test_targets": [
    "//electron:electron_lib",
  ],
  "additional_compile_targets": [
    "//ui/resources"
  ]
}
$ cat output_analyze.json
{
  "compile_targets": [
    "//ui/resources:ui_unscaled_resources_grd"
   ],
  "status": "Found dependency",
  "test_targets": [
    "//electron:electron_lib"
   ]
}
```

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: no-notes