### PR TITLE
fix: Check minSize constraints before resizing

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -401,7 +401,7 @@ void TopLevelWindow::SetSize(int width, int height, mate::Arguments* args) {
   gfx::Size size = window_->GetMinimumSize();
   size.SetToMax(gfx::Size(width, height));
   args->GetNext(&animate);
-  window_->SetSize(size, animate); 
+  window_->SetSize(size, animate);
 }
 
 std::vector<int> TopLevelWindow::GetSize() {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -399,13 +399,9 @@ gfx::Rect TopLevelWindow::GetContentBounds() {
 void TopLevelWindow::SetSize(int width, int height, mate::Arguments* args) {
   bool animate = false;
   gfx::Size size = window_->GetMinimumSize();
-  if ((size.height() <= height) | (size.width() <= width)) {
-    args->GetNext(&animate);
-    window_->SetSize(gfx::Size(width, height), animate);
-  } else {
-    args->GetNext(&animate);
-    window_->SetSize(gfx::Size(size.width(), size.height()), animate);
-  }
+  size.SetToMax(gfx::Size(width, height));
+  args->GetNext(&animate);
+  window_->SetSize(size, animate); 
 }
 
 std::vector<int> TopLevelWindow::GetSize() {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -402,6 +402,9 @@ void TopLevelWindow::SetSize(int width, int height, mate::Arguments* args) {
   if ((size.height() <= height) | (size.width() <= width)) {
     args->GetNext(&animate);
     window_->SetSize(gfx::Size(width, height), animate);
+  } else {
+    args->GetNext(&animate);
+    window_->SetSize(gfx::Size(size.width(), size.height()), animate);
   }
 }
 

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -399,12 +399,10 @@ gfx::Rect TopLevelWindow::GetContentBounds() {
 void TopLevelWindow::SetSize(int width, int height, mate::Arguments* args) {
   bool animate = false;
   gfx::Size size = window_->GetMinimumSize();
-  if ((size.height() <= height) |
-      (size.width() <= width)) {
+  if ((size.height() <= height) | (size.width() <= width)) {
     args->GetNext(&animate);
     window_->SetSize(gfx::Size(width, height), animate);
   }
-  
 }
 
 std::vector<int> TopLevelWindow::GetSize() {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -398,6 +398,11 @@ gfx::Rect TopLevelWindow::GetContentBounds() {
 
 void TopLevelWindow::SetSize(int width, int height, mate::Arguments* args) {
   bool animate = false;
+  gfx::Size size = window_->GetSize();
+  if ((size.height() <= height) |
+      (size.width() <= width)) {
+    //throw dev warning
+  }
   args->GetNext(&animate);
   window_->SetSize(gfx::Size(width, height), animate);
 }

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -398,13 +398,13 @@ gfx::Rect TopLevelWindow::GetContentBounds() {
 
 void TopLevelWindow::SetSize(int width, int height, mate::Arguments* args) {
   bool animate = false;
-  gfx::Size size = window_->GetSize();
+  gfx::Size size = window_->GetMinimumSize();
   if ((size.height() <= height) |
       (size.width() <= width)) {
-    //throw dev warning
+    args->GetNext(&animate);
+    window_->SetSize(gfx::Size(width, height), animate);
   }
-  args->GetNext(&animate);
-  window_->SetSize(gfx::Size(width, height), animate);
+  
 }
 
 std::vector<int> TopLevelWindow::GetSize() {

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -911,7 +911,7 @@ Disable or enable the window.
 * `height` Integer
 * `animate` Boolean (optional) _macOS_
 
-Resizes the window to `width` and `height`.
+Resizes the window to `width` and `height`. If `width` or `height` are below any set minimum size constraints the window will snap to its minimum size.
 
 #### `win.getSize()`
 


### PR DESCRIPTION
fixes #13994

Currently, when developers sets an initial Minimum Height or Minimum Width the expected functionality is that the windows size cannot be changed manually unless the `minHeight` or `minWidth` is changed. this PR sets enforcement of the the boundaries (if any)  defined by the developer.

##### Checklist
- [X] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added]
- [x] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines]


##### Release Notes
Notes: Snap to minimum size possible when `setSize` is called below size constraints