### PR TITLE
fix: use white background for non-OSR renderer by default

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -272,8 +272,13 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
   // --background-color.
   std::string s;
-  if (GetAsString(&preference_, options::kBackgroundColor, &s))
+  if (GetAsString(&preference_, options::kBackgroundColor, &s)) {
     command_line->AppendSwitchASCII(switches::kBackgroundColor, s);
+  } else if (!IsEnabled(options::kOffscreen)) {
+    // For non-OSR WebContents, we expect to have white background, see
+    // https://github.com/electron/electron/issues/13764 for more.
+    command_line->AppendSwitchASCII(switches::kBackgroundColor, "#fff");
+  }
 
   // --guest-instance-id, which is used to identify guest WebContents.
   int guest_instance_id = 0;


### PR DESCRIPTION
##### Description of Change

Fix https://github.com/electron/electron/issues/13764 without  breaking https://github.com/electron/electron/pull/11956.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: Fix subpixel AA fonts not working on Linux.