### PR TITLE
fix: use white background for non-OSR renderer by default (3-0-x)

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -213,8 +213,13 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
   // --background-color.
   std::string s;
-  if (dict_.GetString(options::kBackgroundColor, &s))
+  if (dict_.GetString(options::kBackgroundColor, &s)) {
     command_line->AppendSwitchASCII(switches::kBackgroundColor, s);
+  } else if (!(dict_.GetBoolean(options::kOffscreen, &b) && b)) {
+    // For non-OSR WebContents, we expect to have white background, see
+    // https://github.com/electron/electron/issues/13764 for more.
+    command_line->AppendSwitchASCII(switches::kBackgroundColor, "#fff");
+  }
 
   // --guest-instance-id, which is used to identify guest WebContents.
   int guest_instance_id = 0;


### PR DESCRIPTION
Backport #14932 to 3-0-x.

Notes: Fix subpixel AA fonts not working on Linux.