### PR TITLE
ci: combine linux-*-checkout into one step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,12 @@ env-ia32: &env-ia32
   TARGET_ARCH: ia32
 
 env-arm: &env-arm
-  GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True'
   GN_EXTRA_ARGS: 'target_cpu = "arm"'
   MKSNAPSHOT_TOOLCHAIN: //build/toolchain/linux:clang_arm
   BUILD_NATIVE_MKSNAPSHOT: 1
   TARGET_ARCH: arm
 
 env-arm64: &env-arm64
-  GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm64=True'
   GN_EXTRA_ARGS: 'target_cpu = "arm64" fatal_linker_warnings = false enable_linux_installer = false'
   MKSNAPSHOT_TOOLCHAIN: //build/toolchain/linux:clang_arm64
   BUILD_NATIVE_MKSNAPSHOT: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,18 +598,8 @@ jobs:
   # Layer 1: Checkout.
   linux-checkout:
     <<: *machine-linux-2xlarge
-    <<: *steps-checkout
-
-  linux-arm-checkout:
-    <<: *machine-linux-2xlarge
     environment:
-      <<: *env-arm
-    <<: *steps-checkout
-
-  linux-arm64-checkout:
-    <<: *machine-linux-2xlarge
-    environment:
-      <<: *env-arm64
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-checkout
 
   # Layer 2: Builds.
@@ -863,8 +853,6 @@ workflows:
   build-linux:
     jobs:
       - linux-checkout
-      - linux-arm-checkout
-      - linux-arm64-checkout
 
       - linux-x64-debug:
           requires:
@@ -902,29 +890,29 @@ workflows:
 
       - linux-arm-debug:
           requires:
-            - linux-arm-checkout
+            - linux-checkout
       - linux-arm-testing:
           requires:
-            - linux-arm-checkout
+            - linux-checkout
       - linux-arm-ffmpeg:
            requires:
-             - linux-arm-checkout
+             - linux-checkout
       - linux-arm-native-mksnapshot:
           requires:
-            - linux-arm-checkout
+            - linux-checkout
 
       - linux-arm64-debug:
           requires:
-            - linux-arm64-checkout
+            - linux-checkout
       - linux-arm64-testing:
           requires:
-            - linux-arm64-checkout
+            - linux-checkout
       - linux-arm64-ffmpeg:
            requires:
-             - linux-arm64-checkout
+             - linux-checkout
       - linux-arm64-native-mksnapshot:
           requires:
-            - linux-arm64-checkout
+            - linux-checkout
 
   build-mac-fork-prs:
     jobs:
@@ -953,8 +941,6 @@ workflows:
                 - /chromium\-upgrade\/[0-9]+/
     jobs:
       - linux-checkout
-      - linux-arm-checkout
-      - linux-arm64-checkout
 
       # TODO(alexeykuzmin): Enable it back.
       # Tons of crashes right now, see
@@ -996,20 +982,20 @@ workflows:
 
       - linux-arm-release:
           requires:
-            - linux-arm-checkout
+            - linux-checkout
       - linux-arm-ffmpeg:
            requires:
-             - linux-arm-checkout
+             - linux-checkout
       - linux-arm-native-mksnapshot:
           requires:
-            - linux-arm-checkout
+            - linux-checkout
 
       - linux-arm64-release:
           requires:
-            - linux-arm64-checkout
+            - linux-checkout
       - linux-arm64-ffmpeg:
            requires:
-             - linux-arm64-checkout
+             - linux-checkout
       - linux-arm64-native-mksnapshot:
           requires:
-            - linux-arm64-checkout
+            - linux-checkout


### PR DESCRIPTION
this was already merged to the m68 branch and works fine there. saves some machine time.

Notes: no-notes