### PR TITLE
fix: default_app incorrect loading by url

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -155,7 +155,11 @@ if (option.file && !option.webdriver) {
   if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:' || protocol === 'chrome:') {
     loadApplicationByUrl(file)
   } else if (extension === '.html' || extension === '.htm') {
-    loadApplicationByUrl('file://' + path.resolve(file))
+    loadApplicationByUrl(url.format({
+      protocol: 'file:',
+      slashes: true,
+      pathname: path.resolve(file)
+    }))
   } else {
     loadApplicationPackage(file)
   }


### PR DESCRIPTION
##### Description of Change

Resolves https://github.com/electron/electron/issues/10311.

Uses `url.format` to remove the case where, when there is a # in a folder path, loading will fail because the # will not be escaped and the path will be treated as a anchor tag.

/cc @MarshallOfSound 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes