### PR TITLE
fix: support ASAR in fs.copyFile

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -748,6 +748,12 @@
       }
     }
 
+    // Strictly implementing the flags of fs.copyFile is hard, just do a simple
+    // implementation for now. Doing 2 copies won't spend much time more as OS
+    // has filesystem caching.
+    overrideAPI(fs, 'copyFile')
+    overrideAPISync(fs, 'copyFileSync')
+
     overrideAPI(fs, 'open')
     overrideAPI(childProcess, 'execFile')
     overrideAPISync(process, 'dlopen', 1)

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -3,6 +3,7 @@ const ChildProcess = require('child_process')
 const { expect } = require('chai')
 const fs = require('fs')
 const path = require('path')
+const temp = require('temp').track()
 const util = require('util')
 const { closeWindow } = require('./window-helpers')
 
@@ -134,6 +135,44 @@ describe('asar package', function () {
           assert.strictEqual(err.code, 'ENOENT')
           done()
         })
+      })
+    })
+
+    describe('fs.copyFile', function () {
+      it('copies a normal file', function (done) {
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const dest = temp.path()
+        fs.copyFile(p, dest, function (err) {
+          assert.strictEqual(err, null)
+          assert(fs.readFileSync(p).equals(fs.readFileSync(dest)))
+          done()
+        })
+      })
+
+      it('copies a unpacked file', function (done) {
+        const p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
+        const dest = temp.path()
+        fs.copyFile(p, dest, function (err) {
+          assert.strictEqual(err, null)
+          assert(fs.readFileSync(p).equals(fs.readFileSync(dest)))
+          done()
+        })
+      })
+    })
+
+    describe('fs.copyFileSync', function () {
+      it('copies a normal file', function () {
+        const p = path.join(fixtures, 'asar', 'a.asar', 'file1')
+        const dest = temp.path()
+        fs.copyFileSync(p, dest)
+        assert(fs.readFileSync(p).equals(fs.readFileSync(dest)))
+      })
+
+      it('copies a unpacked file', function () {
+        const p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt')
+        const dest = temp.path()
+        fs.copyFileSync(p, dest)
+        assert(fs.readFileSync(p).equals(fs.readFileSync(dest)))
       })
     })
 


### PR DESCRIPTION
##### Description of Change

Close https://github.com/electron/electron/issues/14320.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: Fix `fs.copyFile` not working with ASAR archives.