### PR TITLE
feat: add evt listeners for SetAlwaysOnTop

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -262,6 +262,14 @@ void TopLevelWindow::OnWindowLeaveHtmlFullScreen() {
   Emit("leave-html-full-screen");
 }
 
+void TopLevelWindow::OnWindowEnterAlwaysOnTop() {
+  Emit("enter-always-on-top");
+}
+
+void TopLevelWindow::OnWindowLeaveAlwaysOnTop() {
+  Emit("leave-always-on-top");
+}
+
 void TopLevelWindow::OnExecuteWindowsCommand(const std::string& command_name) {
   Emit("app-command", command_name);
 }

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -262,12 +262,8 @@ void TopLevelWindow::OnWindowLeaveHtmlFullScreen() {
   Emit("leave-html-full-screen");
 }
 
-void TopLevelWindow::OnWindowEnterAlwaysOnTop() {
-  Emit("enter-always-on-top");
-}
-
-void TopLevelWindow::OnWindowLeaveAlwaysOnTop() {
-  Emit("leave-always-on-top");
+void TopLevelWindow::OnWindowAlwaysOnTopChange() {
+  Emit("always-on-top-change", IsAlwaysOnTop());
 }
 
 void TopLevelWindow::OnExecuteWindowsCommand(const std::string& command_name) {

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -262,8 +262,8 @@ void TopLevelWindow::OnWindowLeaveHtmlFullScreen() {
   Emit("leave-html-full-screen");
 }
 
-void TopLevelWindow::OnWindowAlwaysOnTopChange() {
-  Emit("always-on-top-change", IsAlwaysOnTop());
+void TopLevelWindow::OnWindowAlwaysOnTopChanged() {
+  Emit("always-on-top-changed", IsAlwaysOnTop());
 }
 
 void TopLevelWindow::OnExecuteWindowsCommand(const std::string& command_name) {

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -77,6 +77,8 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;
   void OnWindowLeaveHtmlFullScreen() override;
+  void OnWindowEnterAlwaysOnTop() override;
+  void OnWindowLeaveAlwaysOnTop() override;
   void OnExecuteWindowsCommand(const std::string& command_name) override;
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -77,8 +77,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;
   void OnWindowLeaveHtmlFullScreen() override;
-  void OnWindowEnterAlwaysOnTop() override;
-  void OnWindowLeaveAlwaysOnTop() override;
+  void OnWindowAlwaysOnTopChange() override;
   void OnExecuteWindowsCommand(const std::string& command_name) override;
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -77,7 +77,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;
   void OnWindowLeaveHtmlFullScreen() override;
-  void OnWindowAlwaysOnTopChange() override;
+  void OnWindowAlwaysOnTopChanged() override;
   void OnExecuteWindowsCommand(const std::string& command_name) override;
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -537,6 +537,16 @@ void NativeWindow::NotifyWindowLeaveHtmlFullScreen() {
     observer.OnWindowLeaveHtmlFullScreen();
 }
 
+void NativeWindow::NotifyWindowEnterAlwaysOnTop() {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowEnterAlwaysOnTop();
+}
+
+void NativeWindow::NotifyWindowLeaveAlwaysOnTop() {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowLeaveAlwaysOnTop();
+}
+
 void NativeWindow::NotifyWindowExecuteWindowsCommand(
     const std::string& command) {
   for (NativeWindowObserver& observer : observers_)

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -537,14 +537,9 @@ void NativeWindow::NotifyWindowLeaveHtmlFullScreen() {
     observer.OnWindowLeaveHtmlFullScreen();
 }
 
-void NativeWindow::NotifyWindowEnterAlwaysOnTop() {
+void NativeWindow::NotifyWindowAlwaysOnTopChange() {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowEnterAlwaysOnTop();
-}
-
-void NativeWindow::NotifyWindowLeaveAlwaysOnTop() {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowLeaveAlwaysOnTop();
+    observer.OnWindowAlwaysOnTopChange();
 }
 
 void NativeWindow::NotifyWindowExecuteWindowsCommand(

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -537,9 +537,9 @@ void NativeWindow::NotifyWindowLeaveHtmlFullScreen() {
     observer.OnWindowLeaveHtmlFullScreen();
 }
 
-void NativeWindow::NotifyWindowAlwaysOnTopChange() {
+void NativeWindow::NotifyWindowAlwaysOnTopChanged() {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowAlwaysOnTopChange();
+    observer.OnWindowAlwaysOnTopChanged();
 }
 
 void NativeWindow::NotifyWindowExecuteWindowsCommand(

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -254,6 +254,8 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();
   void NotifyWindowLeaveHtmlFullScreen();
+  void NotifyWindowEnterAlwaysOnTop();
+  void NotifyWindowLeaveAlwaysOnTop();
   void NotifyWindowExecuteWindowsCommand(const std::string& command);
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      const base::DictionaryValue& details);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -254,7 +254,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();
   void NotifyWindowLeaveHtmlFullScreen();
-  void NotifyWindowAlwaysOnTopChange();
+  void NotifyWindowAlwaysOnTopChanged();
   void NotifyWindowExecuteWindowsCommand(const std::string& command);
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      const base::DictionaryValue& details);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -254,8 +254,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();
   void NotifyWindowLeaveHtmlFullScreen();
-  void NotifyWindowEnterAlwaysOnTop();
-  void NotifyWindowLeaveAlwaysOnTop();
+  void NotifyWindowAlwaysOnTopChange();
   void NotifyWindowExecuteWindowsCommand(const std::string& command);
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      const base::DictionaryValue& details);

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -83,6 +83,8 @@ class NativeWindowObserver {
   virtual void OnWindowLeaveFullScreen() {}
   virtual void OnWindowEnterHtmlFullScreen() {}
   virtual void OnWindowLeaveHtmlFullScreen() {}
+  virtual void OnWindowEnterAlwaysOnTop() {}
+  virtual void OnWindowLeaveAlwaysOnTop() {}
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictionaryValue& details) {}
   virtual void OnNewWindowForTab() {}

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -83,8 +83,7 @@ class NativeWindowObserver {
   virtual void OnWindowLeaveFullScreen() {}
   virtual void OnWindowEnterHtmlFullScreen() {}
   virtual void OnWindowLeaveHtmlFullScreen() {}
-  virtual void OnWindowEnterAlwaysOnTop() {}
-  virtual void OnWindowLeaveAlwaysOnTop() {}
+  virtual void OnWindowAlwaysOnTopChange() {}
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictionaryValue& details) {}
   virtual void OnNewWindowForTab() {}

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -83,7 +83,7 @@ class NativeWindowObserver {
   virtual void OnWindowLeaveFullScreen() {}
   virtual void OnWindowEnterHtmlFullScreen() {}
   virtual void OnWindowLeaveHtmlFullScreen() {}
-  virtual void OnWindowAlwaysOnTopChange() {}
+  virtual void OnWindowAlwaysOnTopChanged() {}
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictionaryValue& details) {}
   virtual void OnNewWindowForTab() {}

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -706,12 +706,7 @@ void NativeWindowViews::SetAlwaysOnTop(bool top,
                                        const std::string& level,
                                        int relativeLevel,
                                        std::string* error) {
-  if (top) {
-    NativeWindow::NotifyWindowEnterAlwaysOnTop();
-  } else {
-    NativeWindow::NotifyWindowLeaveAlwaysOnTop();
-  }
-
+  NativeWindow::NotifyWindowAlwaysOnTopChange();
   widget()->SetAlwaysOnTop(top);
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -707,7 +707,7 @@ void NativeWindowViews::SetAlwaysOnTop(bool top,
                                        int relativeLevel,
                                        std::string* error) {
   if (top != widget()->IsAlwaysOnTop())
-    NativeWindow::NotifyWindowAlwaysOnTopChange();
+    NativeWindow::NotifyWindowAlwaysOnTopChanged();
 
   widget()->SetAlwaysOnTop(top);
 }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -706,7 +706,9 @@ void NativeWindowViews::SetAlwaysOnTop(bool top,
                                        const std::string& level,
                                        int relativeLevel,
                                        std::string* error) {
-  NativeWindow::NotifyWindowAlwaysOnTopChange();
+  if (top != widget()->IsAlwaysOnTop())
+    NativeWindow::NotifyWindowAlwaysOnTopChange();
+
   widget()->SetAlwaysOnTop(top);
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -706,6 +706,12 @@ void NativeWindowViews::SetAlwaysOnTop(bool top,
                                        const std::string& level,
                                        int relativeLevel,
                                        std::string* error) {
+  if (top) {
+    NativeWindow::NotifyWindowEnterAlwaysOnTop();
+  } else {
+    NativeWindow::NotifyWindowLeaveAlwaysOnTop();
+  }
+
   widget()->SetAlwaysOnTop(top);
 }
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -542,7 +542,12 @@ Emitted when the window enters a full-screen state triggered by HTML API.
 
 Emitted when the window leaves a full-screen state triggered by HTML API.
 
-#### Event: 'always-on-top-change' _macOS_
+#### Event: 'always-on-top-changed' _macOS_
+
+Returns:
+
+* `event` Event
+* `isAlwaysOnTop` Boolean
 
 Emitted when the window is set or unset to show always on top of other windows.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -542,6 +542,10 @@ Emitted when the window enters a full-screen state triggered by HTML API.
 
 Emitted when the window leaves a full-screen state triggered by HTML API.
 
+#### Event: 'always-on-top-change' _macOS_
+
+Emitted when the window is set or unset to show always on top of other windows.
+
 #### Event: 'app-command' _Windows_
 
 Returns:


### PR DESCRIPTION
##### Description of Change

Resolves https://github.com/electron/electron/issues/12466.

Adds new event listener for `SetAlwaysOnTop`: **"always-on-top-change"**

/cc @ckerr @MarshallOfSound 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Add new event listener for window `SetAlwaysOnTop`