### PR TITLE
[WIP] refactor: split setLoginItemSettings into a getter and setter

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -316,7 +316,7 @@ struct Converter<Browser::LoginItemSettings> {
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
 
-    dict.Get("openAtLogin", &(out->open_at_login));
+    dict.Get("isLoginItem", &(out->is_login_item));
     dict.Get("openAsHidden", &(out->open_as_hidden));
     dict.Get("path", &(out->path));
     dict.Get("args", &(out->args));
@@ -326,7 +326,7 @@ struct Converter<Browser::LoginItemSettings> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    Browser::LoginItemSettings val) {
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
-    dict.Set("openAtLogin", val.open_at_login);
+    dict.Set("isLoginItem", val.is_login_item);
     dict.Set("openAsHidden", val.open_as_hidden);
     dict.Set("restoreState", val.restore_state);
     dict.Set("wasOpenedAtLogin", val.opened_at_login);
@@ -1257,8 +1257,10 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setBadgeCount", base::Bind(&Browser::SetBadgeCount, browser))
       .SetMethod("getBadgeCount", base::Bind(&Browser::GetBadgeCount, browser))
       .SetMethod("getLoginItemSettings", &App::GetLoginItemSettings)
-      .SetMethod("setLoginItemSettings",
-                 base::Bind(&Browser::SetLoginItemSettings, browser))
+      .SetMethod("addToLoginItems",
+                 base::Bind(&Browser::AddToLoginItems, browser))
+      .SetMethod("removeFromLoginItems",
+                 base::Bind(&Browser::RemoveFromLoginItems, browser))
 #if defined(OS_MACOSX)
       .SetMethod("hide", base::Bind(&Browser::Hide, browser))
       .SetMethod("show", base::Bind(&Browser::Show, browser))

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -95,7 +95,7 @@ class Browser : public WindowListObserver {
 
   // Set/Get the login item settings of the app
   struct LoginItemSettings {
-    bool open_at_login = false;
+    bool is_login_item = false;
     bool open_as_hidden = false;
     bool restore_state = false;
     bool opened_at_login = false;
@@ -107,7 +107,8 @@ class Browser : public WindowListObserver {
     ~LoginItemSettings();
     LoginItemSettings(const LoginItemSettings&);
   };
-  void SetLoginItemSettings(LoginItemSettings settings);
+  void AddToLoginItems(LoginItemSettings settings);
+  void RemoveFromLoginItems();
   LoginItemSettings GetLoginItemSettings(const LoginItemSettings& options);
 
 #if defined(OS_MACOSX)

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -123,7 +123,8 @@ bool Browser::SetBadgeCount(int count) {
   }
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {}
+void Browser::AddToLoginItems(LoginItemSettings settings) {}
+void Browser::RemoveFromLoginItems() {}
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -292,18 +292,21 @@ bool Browser::SetBadgeCount(int count) {
   return false;
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+void Browser::AddToLoginItems(LoginItemSettings settings) {
   base::string16 keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
   base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
 
-  if (settings.open_at_login) {
-    base::string16 exe = settings.path;
-    if (FormatCommandLineString(&exe, settings.args)) {
-      key.WriteValue(GetAppUserModelID(), exe.c_str());
-    }
-  } else {
-    key.DeleteValue(GetAppUserModelID());
+  base::string16 exe = settings.path;
+  if (FormatCommandLineString(&exe, settings.args)) {
+    key.WriteValue(GetAppUserModelID(), exe.c_str());
   }
+}
+
+void Browser::RemoveFromLoginItems() {
+  base::string16 keyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
+
+  key.DeleteValue(GetAppUserModelID());
 }
 
 Browser::LoginItemSettings Browser::GetLoginItemSettings(
@@ -316,7 +319,7 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings(
   if (!FAILED(key.ReadValue(GetAppUserModelID(), &keyVal))) {
     base::string16 exe = options.path;
     if (FormatCommandLineString(&exe, options.args)) {
-      settings.open_at_login = keyVal == exe;
+      settings.is_login_item = keyVal == exe;
     }
   }
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -965,57 +965,37 @@ Returns `Boolean` - Whether the current desktop environment is Unity launcher.
 ### `app.getLoginItemSettings([options])` _macOS_ _Windows_
 
 * `options` Object (optional)
-  * `path` String (optional) _Windows_ - The executable path to compare against.
-    Defaults to `process.execPath`.
-  * `args` String[] (optional) _Windows_ - The command-line arguments to compare
-    against. Defaults to an empty array.
+  * `path` String (optional) _Windows_ - The executable path to compare against. Defaults to `process.execPath`.
+  * `args` String[] (optional) _Windows_ - The command-line arguments to compare against. Defaults to an empty array.
 
-If you provided `path` and `args` options to `app.setLoginItemSettings` then you
-need to pass the same arguments here for `openAtLogin` to be set correctly.
+If you provided `path` and `args` options to `app.addToLoginItems` then you need to pass the same arguments here for `isLoginItem` to be set correctly.
 
 Returns `Object`:
 
-* `openAtLogin` Boolean - `true` if the app is set to open at login.
-* `openAsHidden` Boolean _macOS_ - `true` if the app is set to open as hidden at login.
-  This setting is not available on [MAS builds][mas-builds].
-* `wasOpenedAtLogin` Boolean _macOS_ - `true` if the app was opened at login
-  automatically. This setting is not available on [MAS builds][mas-builds].
-* `wasOpenedAsHidden` Boolean _macOS_ - `true` if the app was opened as a hidden login
-  item. This indicates that the app should not open any windows at startup.
-  This setting is not available on [MAS builds][mas-builds].
-* `restoreState` Boolean _macOS_ - `true` if the app was opened as a login item that
-  should restore the state from the previous session. This indicates that the
-  app should restore the windows that were open the last time the app was
-  closed. This setting is not available on [MAS builds][mas-builds].
+* `isLoginItem` Boolean - `true` if the app is set to open at login.
+* `openAsHidden` Boolean _macOS_ - `true` if the app is set to open as hidden at login. This setting is not available on [MAS builds][mas-builds].
+* `wasOpenedAtLogin` Boolean _macOS_ - `true` if the app was opened at login automatically. This setting is not available on [MAS builds][mas-builds].
+* `wasOpenedAsHidden` Boolean _macOS_ - `true` if the app was opened as a hidden login item. This indicates that the app should not open any windows at startup. This setting is not available on [MAS builds][mas-builds].
+* `restoreState` Boolean _macOS_ - `true` if the app was opened as a login item that should restore the state from the previous session. This indicates that the app should restore the windows that were open the last time the app was closed. This setting is not available on [MAS builds][mas-builds].
 
-### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
+### `app.addToLoginItems(settings)` _macOS_ _Windows_
 
 * `settings` Object
-  * `openAtLogin` Boolean (optional) - `true` to open the app at login, `false` to remove
-    the app as a login item. Defaults to `false`.
-  * `openAsHidden` Boolean (optional) _macOS_ - `true` to open the app as hidden. Defaults to
-    `false`. The user can edit this setting from the System Preferences so
-    `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
-    is opened to know the current value. This setting is not available on [MAS builds][mas-builds].
+  * `openAsHidden` Boolean (optional) _macOS_ - `true` to open the app as hidden. Defaults to `false`. The user can edit this setting from the System Preferences so `app.getLoginItemSettings().wasOpenedAsHidden` should be checked when the app is opened to know the current value. This setting is not available on [MAS builds][mas-builds].
   * `path` String (optional) _Windows_ - The executable to launch at login.
     Defaults to `process.execPath`.
-  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to
-    the executable. Defaults to an empty array. Take care to wrap paths in
-    quotes.
+  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to the executable. Defaults to an empty array. Take care to wrap paths in quotes.
 
-Set the app's login item settings.
+Add the app to login items. If you want to change a given app's login item status from visible to hidden, call `app.addToLoginItems()` with `openAsHidden` set to the desired new setting.
 
-To work with Electron's `autoUpdater` on Windows, which uses [Squirrel][Squirrel-Windows],
-you'll want to set the launch path to Update.exe, and pass arguments that specify your
-application name. For example:
+To work with Electron's `autoUpdater` on Windows, which uses [Squirrel][Squirrel-Windows], you'll want to set the launch path to Update.exe, and pass arguments that specify your application name. For example:
 
 ``` javascript
 const appFolder = path.dirname(process.execPath)
 const updateExe = path.resolve(appFolder, '..', 'Update.exe')
 const exeName = path.basename(process.execPath)
 
-app.setLoginItemSettings({
-  openAtLogin: true,
+app.addToLoginItems({
   path: updateExe,
   args: [
     '--processStart', `"${exeName}"`,
@@ -1023,6 +1003,10 @@ app.setLoginItemSettings({
   ]
 })
 ```
+
+### `app.removeFromLoginItems()` _macOS_ _Windows_
+
+Removes the app from login items.
 
 ### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -409,7 +409,7 @@ describe('app module', () => {
     })
   })
 
-  describe('app.get/setLoginItemSettings API', () => {
+  describe('LoginItemSettings API', () => {
     const updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe')
     const processStartArgs = [
       '--processStart', `"${path.basename(process.execPath)}"`,
@@ -422,41 +422,34 @@ describe('app module', () => {
       }
     })
 
-    beforeEach(() => {
-      app.setLoginItemSettings({ openAtLogin: false })
-      app.setLoginItemSettings({ openAtLogin: false, path: updateExe, args: processStartArgs })
-    })
-
-    afterEach(() => {
-      app.setLoginItemSettings({ openAtLogin: false })
-      app.setLoginItemSettings({ openAtLogin: false, path: updateExe, args: processStartArgs })
-    })
+    beforeEach(() => app.removeFromLoginItems())
+    afterEach(() => app.removeFromLoginItems())
 
     it('returns the login item status of the app', done => {
-      app.setLoginItemSettings({ openAtLogin: true })
+      app.addToLoginItems({ openAsHidden: false })
       expect(app.getLoginItemSettings()).to.deep.equal({
-        openAtLogin: true,
+        isLoginItem: true,
         openAsHidden: false,
         wasOpenedAtLogin: false,
         wasOpenedAsHidden: false,
         restoreState: false
       })
 
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
+      app.addToLoginItems({ openAsHidden: true })
       expect(app.getLoginItemSettings()).to.deep.equal({
-        openAtLogin: true,
+        isLoginItem: true,
         openAsHidden: process.platform === 'darwin' && !process.mas, // Only available on macOS
         wasOpenedAtLogin: false,
         wasOpenedAsHidden: false,
         restoreState: false
       })
 
-      app.setLoginItemSettings({})
       // Wait because login item settings are not applied immediately in MAS build
+      app.removeFromLoginItems()
       const delay = process.mas ? 100 : 0
       setTimeout(() => {
         expect(app.getLoginItemSettings()).to.deep.equal({
-          openAtLogin: false,
+          isLoginItem: false,
           openAsHidden: false,
           wasOpenedAtLogin: false,
           wasOpenedAsHidden: false,
@@ -473,13 +466,12 @@ describe('app module', () => {
         return
       }
 
-      app.setLoginItemSettings({ openAtLogin: true, path: updateExe, args: processStartArgs })
-
-      expect(app.getLoginItemSettings().openAtLogin).to.be.false()
+      app.addToLoginItems({ path: updateExe, args: processStartArgs })
+      expect(app.getLoginItemSettings().isLoginItem).to.be.false()
       expect(app.getLoginItemSettings({
         path: updateExe,
         args: processStartArgs
-      }).openAtLogin).to.be.true()
+      }).isLoginItem).to.be.true()
     })
   })
 


### PR DESCRIPTION
##### Description of Change

Potentially resolves https://github.com/electron/electron/issues/10880.

This PR splits `setLoginItemSettings` into two new methods: `addToLoginItems` and `removeFromLoginItems`.

Needs https://github.com/electron/electron-typescript-definitions/pull/117.

Here there (may) be 🐉 

/cc @MarshallOfSound

**TODO:**
- [x] Documentation
- [x] Cross-plat compatibility confirmation
- [x] Update and add new specs 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes:  split setLoginItemSettings into a getter and setter