### PR TITLE
chore: enable -pie for linux builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -722,6 +722,8 @@ if (is_mac) {
       ]
     }
     if (is_linux) {
+      ldflags = [ "-pie" ]
+
       if (!is_component_build && is_component_ffmpeg) {
         configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
       }


### PR DESCRIPTION
Closes #14961 

RELRO appears to be enabled on the GN build already (inherited somewhere)

![screenshot from 2018-10-04 11-54-07](https://user-images.githubusercontent.com/6634592/46448915-b17fd200-c7cc-11e8-935c-37631b5d86a1.png)

Notes: Enabled "-pie" when linking on Linux