### PR TITLE
fix: update accelerator patch to handle recent chromium fixes

### DIFF
--- a/patches/common/chromium/accelerator.patch
+++ b/patches/common/chromium/accelerator.patch
@@ -20,14 +20,12 @@ index a6756c2..5352958 100644
  
  namespace ui {
  
-@@ -145,7 +144,17 @@ base::string16 Accelerator::GetShortcutText() const {
+@@ -145,7 +144,15 @@ base::string16 Accelerator::GetShortcutText() const {
    shortcut = KeyCodeToName(key_code_);
  #endif
  
 +  unsigned int flags = 0;
    if (shortcut.empty()) {
-+    if (IsShiftDown())
-+      flags = ui::EF_SHIFT_DOWN;
 +    const uint16_t c = DomCodeToUsLayoutCharacter(
 +        UsLayoutKeyboardCodeToDomCode(key_code_), flags);
 +    if (c != 0) {
@@ -38,7 +36,7 @@ index a6756c2..5352958 100644
  #if defined(OS_WIN)
      // Our fallback is to try translate the key code to a regular character
      // unless it is one of digits (VK_0 to VK_9). Some keyboard
-@@ -154,17 +163,20 @@ base::string16 Accelerator::GetShortcutText() const {
+@@ -154,17 +161,20 @@ base::string16 Accelerator::GetShortcutText() const {
      // accent' for '0'). For display in the menu (e.g. Ctrl-0 for the
      // default zoom level), we leave VK_[0-9] alone without translation.
      wchar_t key;
@@ -69,13 +67,13 @@ index a6756c2..5352958 100644
  #endif
    }
  
-@@ -221,15 +233,12 @@ base::string16 Accelerator::GetShortcutText() const {
+@@ -221,15 +231,15 @@ base::string16 Accelerator::GetShortcutText() const {
  
  base::string16 Accelerator::ApplyLongFormModifiers(
      base::string16 shortcut) const {
--  if (IsShiftDown())
--    shortcut = l10n_util::GetStringFUTF16(IDS_APP_SHIFT_MODIFIER, shortcut);
--
+  if (IsShiftDown())
+    shortcut = l10n_util::GetStringFUTF16(IDS_APP_SHIFT_MODIFIER, shortcut);
+
    // Note that we use 'else-if' in order to avoid using Ctrl+Alt as a shortcut.
    // See http://blogs.msdn.com/oldnewthing/archive/2004/03/29/101121.aspx for
    // more information.
@@ -86,7 +84,7 @@ index a6756c2..5352958 100644
      shortcut = l10n_util::GetStringFUTF16(IDS_APP_ALT_MODIFIER, shortcut);
  
    if (IsCmdDown()) {
-@@ -249,14 +258,12 @@ base::string16 Accelerator::ApplyShortFormModifiers(
+@@ -249,14 +256,12 @@ base::string16 Accelerator::ApplyShortFormModifiers(
      base::string16 shortcut) const {
    const base::char16 kCommandSymbol[] = {0x2318, 0};
    const base::char16 kCtrlSymbol[] = {0x2303, 0};


### PR DESCRIPTION
Closes #14501

This will need to be manually backported into libcc electron-3-0-x

Notes: fix shift based accelerators not rendering correctly