### PR TITLE
chore: remove duplicate code in spec/security-warnings-spec.js

### DIFF
--- a/spec/security-warnings-spec.js
+++ b/spec/security-warnings-spec.js
@@ -68,227 +68,129 @@ describe('security warnings', () => {
     w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
   })
 
-  it('should warn about disabled webSecurity', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        webSecurity: false,
-        nodeIntegration: false
-      }
+  const generateSpecs = (description, sandbox) => {
+    describe(description, () => {
+      it('should warn about disabled webSecurity', (done) => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            webSecurity: false,
+            nodeIntegration: false,
+            sandbox
+          }
+        })
+        w.webContents.once('console-message', (e, level, message) => {
+          assert(message.includes('Disabled webSecurity'), message)
+          done()
+        })
+
+        w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
+      })
+
+      it('should warn about insecure Content-Security-Policy', (done) => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nodeIntegration: false,
+            sandbox
+          }
+        })
+
+        w.webContents.once('console-message', (e, level, message) => {
+          assert(message.includes('Insecure Content-Security-Policy'), message)
+          done()
+        })
+
+        useCsp = false
+        w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
+      })
+
+      it('should warn about allowRunningInsecureContent', (done) => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            allowRunningInsecureContent: true,
+            nodeIntegration: false,
+            sandbox
+          }
+        })
+        w.webContents.once('console-message', (e, level, message) => {
+          assert(message.includes('allowRunningInsecureContent'), message)
+          done()
+        })
+
+        w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
+      })
+
+      it('should warn about experimentalFeatures', (done) => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            experimentalFeatures: true,
+            nodeIntegration: false,
+            sandbox
+          }
+        })
+        w.webContents.once('console-message', (e, level, message) => {
+          assert(message.includes('experimentalFeatures'), message)
+          done()
+        })
+
+        w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
+      })
+
+      it('should warn about enableBlinkFeatures', (done) => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            enableBlinkFeatures: ['my-cool-feature'],
+            nodeIntegration: false,
+            sandbox
+          }
+        })
+        w.webContents.once('console-message', (e, level, message) => {
+          assert(message.includes('enableBlinkFeatures'), message)
+          done()
+        })
+
+        w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
+      })
+
+      it('should warn about allowpopups', (done) => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nodeIntegration: false,
+            sandbox
+          }
+        })
+        w.webContents.once('console-message', (e, level, message) => {
+          assert(message.includes('allowpopups'), message)
+          done()
+        })
+
+        w.loadURL(`http://127.0.0.1:8881/webview-allowpopups.html`)
+      })
+
+      it('should warn about insecure resources', (done) => {
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nodeIntegration: false,
+            sandbox
+          }
+        })
+        w.webContents.once('console-message', (e, level, message) => {
+          assert(message.includes('Insecure Resources'), message)
+          done()
+        })
+
+        w.loadURL(`http://127.0.0.1:8881/insecure-resources.html`)
+        w.webContents.openDevTools()
+      })
     })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('Disabled webSecurity'), message)
-      done()
-    })
+  }
 
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about disabled webSecurity (sandboxed)', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        webSecurity: false,
-        sandbox: true
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('Disabled webSecurity'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about insecure Content-Security-Policy', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        nodeIntegration: false
-      }
-    })
-
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('Insecure Content-Security-Policy'), message)
-      done()
-    })
-
-    useCsp = false
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about insecure Content-Security-Policy (sandboxed)', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        sandbox: true
-      }
-    })
-
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('Insecure Content-Security-Policy'), message)
-      done()
-    })
-
-    useCsp = false
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about allowRunningInsecureContent', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        allowRunningInsecureContent: true,
-        nodeIntegration: false
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('allowRunningInsecureContent'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about allowRunningInsecureContent (sandboxed)', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        allowRunningInsecureContent: true,
-        sandbox: true
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('allowRunningInsecureContent'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about experimentalFeatures', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        experimentalFeatures: true,
-        nodeIntegration: false
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('experimentalFeatures'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about experimentalFeatures (sandboxed)', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        experimentalFeatures: true,
-        sandbox: true
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('experimentalFeatures'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about enableBlinkFeatures', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        enableBlinkFeatures: ['my-cool-feature'],
-        nodeIntegration: false
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('enableBlinkFeatures'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about enableBlinkFeatures (sandboxed)', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        enableBlinkFeatures: ['my-cool-feature'],
-        sandbox: true
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('enableBlinkFeatures'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/base-page-security.html`)
-  })
-
-  it('should warn about allowpopups', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        nodeIntegration: false
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('allowpopups'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/webview-allowpopups.html`)
-  })
-
-  it('should warn about allowpopups (sandboxed)', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        sandbox: true
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('allowpopups'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/webview-allowpopups.html`)
-  })
-
-  it('should warn about insecure resources', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        nodeIntegration: false
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('Insecure Resources'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/insecure-resources.html`)
-    w.webContents.openDevTools()
-  })
-
-  it('should warn about insecure resources (sandboxed)', (done) => {
-    w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        sandbox: true
-      }
-    })
-    w.webContents.once('console-message', (e, level, message) => {
-      assert(message.includes('Insecure Resources'), message)
-      done()
-    })
-
-    w.loadURL(`http://127.0.0.1:8881/insecure-resources.html`)
-    w.webContents.openDevTools()
-  })
+  generateSpecs('without sandbox', false)
+  generateSpecs('with sandbox', true)
 })


### PR DESCRIPTION
##### Description of Change
Use `generateSpecs` pattern to share test for non-sandboxed and sandboxed renderer.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: no-notes