### PR TITLE
chore: add --fix option to lint:cpp

### DIFF
--- a/atom/browser/atom_permission_manager.h
+++ b/atom/browser/atom_permission_manager.h
@@ -49,13 +49,12 @@ class AtomPermissionManager : public content::PermissionControllerDelegate {
       bool user_gesture,
       const base::Callback<void(blink::mojom::PermissionStatus)>& callback)
       override;
-  int RequestPermissionWithDetails(
-      content::PermissionType permission,
-      content::RenderFrameHost* render_frame_host,
-      const GURL& requesting_origin,
-      bool user_gesture,
-      const base::DictionaryValue* details,
-      const StatusCallback& callback);
+  int RequestPermissionWithDetails(content::PermissionType permission,
+                                   content::RenderFrameHost* render_frame_host,
+                                   const GURL& requesting_origin,
+                                   bool user_gesture,
+                                   const base::DictionaryValue* details,
+                                   const StatusCallback& callback);
   int RequestPermissions(
       const std::vector<content::PermissionType>& permissions,
       content::RenderFrameHost* render_frame_host,

--- a/atom/browser/web_contents_permission_helper.h
+++ b/atom/browser/web_contents_permission_helper.h
@@ -25,9 +25,8 @@ class WebContentsPermissionHelper
 
   // Asynchronous Requests
   void RequestFullscreenPermission(const base::Callback<void(bool)>& callback);
-  void RequestMediaAccessPermission(
-      const content::MediaStreamRequest& request,
-      content::MediaResponseCallback callback);
+  void RequestMediaAccessPermission(const content::MediaStreamRequest& request,
+                                    content::MediaResponseCallback callback);
   void RequestWebNotificationPermission(
       const base::Callback<void(bool)>& callback);
   void RequestPointerLockPermission(bool user_gesture);


### PR DESCRIPTION
##### Description of Change
uses the `-i` option to clang-format.

also fixes the patches generated by lint:cpp's invocation of `run-clang-format.py` to be relative instead of absolute.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes