### PR TITLE
ci: use ubuntu 18.04 for arm testing

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:16.04
+FROM arm32v7/ubuntu:18.04
 
 RUN groupadd --gid 1000 builduser \
   && useradd --uid 1000 --gid builduser --shell /bin/bash --create-home builduser

--- a/vsts-arm32v7.yml
+++ b/vsts-arm32v7.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm32v7-test-container
-    image: electronbuilds/arm32v7:0.0.1
+    image: electronbuilds/arm32v7:0.0.2
 
 jobs:
 - job: Test_Arm32v7


### PR DESCRIPTION
##### Description of Change
Our arm tests are failing because of the version of glibc install on our docker container:
```./out/Default/electron: /lib/arm-linux-gnueabihf/libc.so.6: version 'GLIBC_2.27' not found (required by ./out/Default/electron)```.

This PR updates our docker container for arm to Ubuntu 18.04
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes