### PR TITLE
ci: cleanup Electron dirs before running tests

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -85,14 +85,16 @@ jobs:
       if pgrep Electron; then
         killall Electron
       fi
+      rm -rf ~/Library/Saved\ Application\ State/com.github.electron.savedState
+      rm -rf ~/Library/Application\ Support/Electron
     displayName: Make sure Electron isn't running from previous tests
-# FIXME(alexeykuzmin)
-#  - bash: |
-#      cd src
-#      python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
-#    displayName: Verify non proprietary ffmpeg
-#    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
-#    timeoutInMinutes: 5
+
+  - bash: |
+      cd src
+      python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
+    displayName: Verify non proprietary ffmpeg
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], '1'))
+    timeoutInMinutes: 5
 
   - bash: |
       cd src


### PR DESCRIPTION
##### Description of Change
This PR makes sure that directories from previous Electron builds are removed before testing.  This resolves the issue of ffmpeg/electron hanging when testing.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes