### PR TITLE
build: strip linux binaries for release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,13 @@ step-electron-build: &step-electron-build
       cd src
       ninja -C out/Default electron -j18
 
+step-electron-dist-strip: &step-electron-dist-strip
+  run:
+    name: Strip electron binaries
+    command: |
+      cd src
+      electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH"
+
 step-electron-dist-build: &step-electron-dist-build
   run:
     name: Build dist.zip
@@ -176,7 +183,9 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
       cd src
       # NOTE(alexeykuzmin): -j3 because chromedriver is currently built
       # on a smaller size machine and ninja mis-detects the number of CPUs available.
-      ninja -C out/Default electron:electron_chromedriver_zip -j3
+      ninja -C out/Default chrome/test/chromedriver -j3
+      electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/out/Default/chromedriver
+      ninja -C out/Default electron:electron_chromedriver_zip
 
 step-electron-chromedriver-store: &step-electron-chromedriver-store
   store_artifacts:
@@ -278,6 +287,15 @@ step-mksnapshot-build: &step-mksnapshot-build
     name: mksnapshot build
     command: |
       cd src
+      if [ "`uname`" != "Darwin" ]; then
+        if [ "$TARGET_ARCH" == "arm" ]; then
+          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot
+        elif [ "$TARGET_ARCH" == "arm64" ]; then
+          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x64_v8_arm64/mksnapshot
+        else
+          electron/script/strip-binaries.py --file $PWD/out/Default/mksnapshot
+        fi
+      fi
       # NOTE(jeremy): -j3 because mksnapshot is currently built on a smaller
       # machine size and ninja mis-detects the number of CPUs available.
       ninja -C out/Default electron:electron_mksnapshot_zip -j3
@@ -324,6 +342,17 @@ step-maybe-native-mksnapshot-build: &step-maybe-native-mksnapshot-build
         ninja -C out/native_mksnapshot electron:electron_mksnapshot_zip -j3
       else
         echo 'Skipping native mksnapshot build for non arm build'
+      fi
+
+step-maybe-native-mksnapshot-strip: &step-maybe-native-mksnapshot-strip
+  run:
+    name: Native mksnapshot binary strip (arm/arm64)
+    command: |
+      if [ "$BUILD_NATIVE_MKSNAPSHOT" == "1" ]; then
+        cd src
+        electron/script/strip-binaries.py --file $PWD/out/native_mksnapshot/mksnapshot --target-cpu="$TARGET_ARCH"
+      else
+        echo 'Skipping native mksnapshot binary strip'
       fi
 
 step-maybe-native-mksnapshot-store: &step-maybe-native-mksnapshot-store
@@ -394,7 +423,7 @@ steps-electron-build: &steps-electron-build
 
     # Node.js headers
     - *step-nodejs-headers-build
-    - *step-nodejs-headers-store    
+    - *step-nodejs-headers-store
 
     - *step-show-sccache-stats
 
@@ -440,6 +469,7 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
 
     # Electron app
     - *step-electron-build
+    - *step-electron-dist-strip
     - *step-electron-dist-build
     - *step-electron-dist-store
     - *step-generate-breakpad-symbols
@@ -451,6 +481,7 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
     # native_mksnapshot
     - *step-maybe-native-mksnapshot-gn-gen
     - *step-maybe-native-mksnapshot-build
+    - *step-maybe-native-mksnapshot-strip
     - *step-maybe-native-mksnapshot-store
 
     # chromedriver

--- a/build/zip.py
+++ b/build/zip.py
@@ -4,13 +4,6 @@ import subprocess
 import sys
 import zipfile
 
-LINUX_BINARIES_TO_STRIP = [
-  'chromedriver',
-  'electron',
-  'libffmpeg.so',
-  'libnode.so'
-]
-
 EXTENSIONS_TO_SKIP = [
   '.pdb'
 ]
@@ -29,22 +22,6 @@ def skip_path(dep):
   if should_skip:
     print("Skipping {}".format(dep))
   return should_skip
-
-def strip_binaries(target_cpu, dep):
-  for binary in LINUX_BINARIES_TO_STRIP:
-    if dep.endswith(binary):
-     strip_binary(dep, target_cpu)
-
-def strip_binary(binary_path, target_cpu):
-  if target_cpu == 'arm':
-    strip = 'arm-linux-gnueabihf-strip'
-  elif target_cpu == 'arm64':
-    strip = 'aarch64-linux-gnu-strip'
-  elif target_cpu == 'mips64el':
-    strip = 'mips64el-redhat-linux-strip'
-  else:
-    strip = 'strip'
-  execute([strip, binary_path])
 
 def execute(argv):
   try:
@@ -66,8 +43,6 @@ def main(argv):
   else:
     with zipfile.ZipFile(dist_zip, 'w', zipfile.ZIP_DEFLATED) as z:
       for dep in dist_files:
-        if target_os == 'linux':
-            strip_binaries(target_cpu, dep)
         if skip_path(dep):
           continue
         if os.path.isdir(dep):

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -62,14 +62,8 @@ async function circleCIcall (buildUrl, targetBranch, job, options) {
     }
   }
 
-  if (options.ghRelease) {
-    buildRequest.build_parameters.ELECTRON_RELEASE = 1
-  } else {
-    buildRequest.build_parameters.RUN_RELEASE_BUILD = 'true'
-  }
-
-  if (options.automaticRelease) {
-    buildRequest.build_parameters.AUTO_RELEASE = 'true'
+  if (!options.ghRelease) {
+    buildRequest.build_parameters.UPLOAD_TO_S3 = 1
   }
 
   const circleResponse = await makeRequest({
@@ -237,13 +231,13 @@ module.exports = runRelease
 
 if (require.main === module) {
   const args = require('minimist')(process.argv.slice(2), {
-    boolean: ['ghRelease', 'automaticRelease', 'armTest']
+    boolean: ['ghRelease', 'armTest']
   })
   const targetBranch = args._[0]
   if (args._.length < 1) {
     console.log(`Trigger CI to build release builds of electron.
     Usage: ci-release-build.js [--job=CI_JOB_NAME] [--ci=CircleCI|AppVeyor|VSTS]
-    [--ghRelease] [--automaticRelease] [--armTest] [--circleBuildNum=xxx] TARGET_BRANCH
+    [--ghRelease] [--armTest] [--circleBuildNum=xxx] TARGET_BRANCH
     `)
     process.exit(0)
   }

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+import argparse
+import os
+import sys
+
+from lib.util import execute, get_out_dir
+
+LINUX_BINARIES_TO_STRIP = [
+  'electron',
+  'libffmpeg.so',
+  'libGLESv2.so',
+  'libEGL.so'
+]
+
+def strip_binaries(directory, target_cpu):
+  for binary in LINUX_BINARIES_TO_STRIP:
+    binary_path = os.path.join(directory, binary)
+    if os.path.isfile(binary_path):
+      strip_binary(binary_path, target_cpu)
+
+def strip_binary(binary_path, target_cpu):
+  if target_cpu == 'arm':
+    strip = 'arm-linux-gnueabihf-strip'
+  elif target_cpu == 'arm64':
+    strip = 'aarch64-linux-gnu-strip'
+  elif target_cpu == 'mips64el':
+    strip = 'mips64el-redhat-linux-strip'
+  else:
+    strip = 'strip'
+  execute([strip, binary_path])
+
+def main():
+  args = parse_args()
+  print args
+  if args.file:
+    strip_binary(args.file, args.target_cpu)
+  else:
+    strip_binaries(args.directory, args.target_cpu)
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Strip linux binaries')
+  parser.add_argument('-d', '--directory',
+                      help='Path to the dir that contains files to strip.',
+                      default=get_out_dir(),
+                      required=False)
+  parser.add_argument('-f', '--file',
+                      help='Path to a specific file to strip.',
+                      required=False)
+  parser.add_argument('-v', '--verbose',
+                      action='store_true',
+                      help='Prints the output of the subprocesses')
+  parser.add_argument('--target-cpu',
+                      default='',
+                      required=False,
+                      help='Target cpu of binaries to strip')
+
+  return parser.parse_args()
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
##### Description of Change
This PR adds a new script to strip linux binaries before they are zipped into our distribution files.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes