### PR TITLE
feat: convenience command to apply all formatter patches

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -281,6 +281,8 @@ def main():
         njobs = multiprocessing.cpu_count() + 1
     njobs = min(len(files), njobs)
 
+    patch_filenames = []
+
     if njobs == 1:
         # execute directly instead of in a pool,
         # less overhead, simpler stacktraces
@@ -321,8 +323,15 @@ def main():
                     patch_file.write('\n')
                     print("\nTo apply this patch, run:\n$ git apply {}\n"
                           .format(patch_file.name))
+                    patch_filenames.append(patch_file.name)
             if retcode == ExitStatus.SUCCESS:
                 retcode = ExitStatus.DIFF
+
+    if len(patch_filenames) > 1:
+      print("\nTo apply all patches, run:\n"
+            "$ for file in {}; do git apply $file; done"
+            .format(' '.join(patch_filenames)))
+
     return retcode
 
 

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -281,7 +281,8 @@ def main():
         njobs = multiprocessing.cpu_count() + 1
     njobs = min(len(files), njobs)
 
-    patch_filenames = []
+    patch_file = tempfile.NamedTemporaryFile(delete=False,
+                                             prefix='electron-format-')
 
     if njobs == 1:
         # execute directly instead of in a pool,
@@ -317,20 +318,17 @@ def main():
                 continue
             if not args.quiet:
                 print_diff(outs, use_color=colored_stdout)
-                with tempfile.NamedTemporaryFile(delete=False) as patch_file:
-                    for line in outs:
-                        patch_file.write(line)
-                    patch_file.write('\n')
-                    print("\nTo apply this patch, run:\n$ git apply {}\n"
-                          .format(patch_file.name))
-                    patch_filenames.append(patch_file.name)
+                for line in outs:
+                    patch_file.write(line)
+                patch_file.write('\n')
             if retcode == ExitStatus.SUCCESS:
                 retcode = ExitStatus.DIFF
 
-    if len(patch_filenames) > 1:
-      print("\nTo apply all patches, run:\n"
-            "$ for file in {}; do git apply $file; done"
-            .format(' '.join(patch_filenames)))
+    if patch_file.tell() == 0:
+      os.unlink(patch_file.name)
+    else:
+      print("\nTo patch these files, run:\n$ git apply {}\n"
+            .format(patch_file.name))
 
     return retcode
 


### PR DESCRIPTION
##### Description of Change

run-clang-format.py can create multiple patchfiles. This change puts all diffs into a single file so that it will be easier to fix everything in a batch.

cc @codebytere @nornagon 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: no-notes