### PR TITLE
feat: add app.enableSandbox()

### DIFF
--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -203,6 +203,7 @@ class App : public AtomBrowserClient::Delegate,
   v8::Local<v8::Value> GetGPUFeatureStatus(v8::Isolate* isolate);
   v8::Local<v8::Promise> GetGPUInfo(v8::Isolate* isolate,
                                     const std::string& info_type);
+  void EnableSandbox(mate::Arguments* args);
   void EnableMixedSandbox(mate::Arguments* args);
 
 #if defined(OS_MACOSX)

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1089,6 +1089,12 @@ correctly.
 
 **Note:** This will not affect `process.argv`.
 
+### `app.enableSandbox()` _Experimental_ _macOS_ _Windows_
+
+Enables full sandbox mode on the app.
+
+This method can only be called before app is ready.
+
 ### `app.enableMixedSandbox()` _Experimental_ _macOS_ _Windows_
 
 Enables mixed sandbox mode on the app.

--- a/spec/fixtures/api/mixed-sandbox-app/main.js
+++ b/spec/fixtures/api/mixed-sandbox-app/main.js
@@ -6,7 +6,11 @@ process.on('uncaughtException', () => {
   app.exit(1)
 })
 
-if (!process.argv.includes('--enable-mixed-sandbox')) {
+if (process.argv.includes('--app-enable-sandbox')) {
+  app.enableSandbox()
+}
+
+if (process.argv.includes('--app-enable-mixed-sandbox')) {
   app.enableMixedSandbox()
 }
 


### PR DESCRIPTION
##### Description of Change
Add `app.enableSandbox()` to allow turning on full sandbox without having to run the app with `--enable-sandbox` switch.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
Notes: Added `app.enableSandbox()` API