### PR TITLE
fix: auth_info lifetime in loginhandler

### DIFF
--- a/atom/browser/login_handler.cc
+++ b/atom/browser/login_handler.cc
@@ -22,7 +22,7 @@ LoginHandler::LoginHandler(
     net::AuthCredentials* credentials,
     const content::ResourceRequestInfo* resource_request_info)
     : credentials_(credentials),
-      auth_info_(auth_info),
+      auth_info_(&auth_info),
       auth_callback_(std::move(callback)),
       weak_factory_(this) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -40,7 +40,7 @@ class LoginHandler : public base::RefCountedThreadSafe<LoginHandler> {
   // thread.
   content::WebContents* GetWebContents() const;
 
-  const net::AuthChallengeInfo* auth_info() const { return &*auth_info_; }
+  const net::AuthChallengeInfo* auth_info() const { return auth_info_.get(); }
 
  private:
   friend class base::RefCountedThreadSafe<LoginHandler>;

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -40,7 +40,7 @@ class LoginHandler : public base::RefCountedThreadSafe<LoginHandler> {
   // thread.
   content::WebContents* GetWebContents() const;
 
-  const net::AuthChallengeInfo* auth_info() const { return &auth_info_; }
+  const net::AuthChallengeInfo* auth_info() const { return &*auth_info_; }
 
  private:
   friend class base::RefCountedThreadSafe<LoginHandler>;
@@ -56,7 +56,7 @@ class LoginHandler : public base::RefCountedThreadSafe<LoginHandler> {
   net::AuthCredentials* credentials_;
 
   // Who/where/what asked for the authentication.
-  const net::AuthChallengeInfo& auth_info_;
+  scoped_refptr<const net::AuthChallengeInfo> auth_info_;
 
   // WebContents associated with the login request.
   content::ResourceRequestInfo::WebContentsGetter web_contents_getter_;


### PR DESCRIPTION
##### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
The login handler takes the `auth_info` by const reference. However, the object is created as a `scoped_refptr` before the call to `NotifyAuthRequired` and but is passed as `const &` all through 
until we get into the loginhandler constructor. The login handler object also maintains a const reference to the same underlying object without copying.
This original auth_info will be invalid (out of scope) after the login handler constructor, and hence the const reference will have invalid data.

This change tries to address that.
One solution would've been to pass in the scoped_refptr through the chain of functions, so that the refcount could've incremented appropriately until the login handler exists. This involves patching all the functions involved and corresponding function calls.
Another solution is for login handler to copy the object. Because the object is originally not meant to be copied, this change creates a new one and copies the attributes individually.
The new `NetworkServiceClient` properly passes the `AuthChallengeInfo` as a `scoped_refptr`.

Suggestions for better approach are welcome.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Fixed crash when using proxy with login credentials