### PR TITLE
fix: remove semi-transparent line rendered above frameless window on macOS Mojave

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -322,6 +322,9 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   }
 
   NSUInteger styleMask = NSWindowStyleMaskTitled;
+  if (!has_frame() && title_bar_style_ == NORMAL) {
+    styleMask = NSWindowStyleMaskBorderless;
+  }
   if (@available(macOS 10.10, *)) {
     if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER &&
         (!useStandardWindow || transparent() || !has_frame())) {

--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -229,8 +229,10 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (void)performClose:(id)sender {
-  if (shell_->title_bar_style() ==
-      atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER) {
+  if ((!shell_->has_frame() &&
+       shell_->title_bar_style() == atom::NativeWindowMac::NORMAL) ||
+      shell_->title_bar_style() ==
+          atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER) {
     [[self delegate] windowShouldClose:self];
   } else if (shell_->IsSimpleFullScreen()) {
     if ([[self delegate] respondsToSelector:@selector(windowShouldClose:)]) {


### PR DESCRIPTION
The new appearance of `NSWindow` on macOS Mojave was revamped with the thin semi-transparent line rendered over the titlebar. Regardless if the titlebar is invisible, the line is still rendered over it, which leads to visual defects on frameless windows.

I was able to get rid of the pesky line by using the `NSWindowStyleMaskBorderless` style for window, instead of `NSWindowStyleMaskTitled`.

Frameless windows by definition do not contain any chrome, so it makes sense to entirely get rid of titlebar in that case. For all other use cases `titleBarStyle` should suffice.

That's the snapshot made with current electron 4.0 nightly, same look with electron 3.0 stable:

<img width="363" alt="screenshot 2018-10-07 at 16 43 14" src="https://user-images.githubusercontent.com/704044/46587502-c76fea00-ca8d-11e8-860d-49c26f496689.png">

After applying the patch the window looks normal once again.

<img width="386" alt="screenshot 2018-10-08 at 00 10 39" src="https://user-images.githubusercontent.com/704044/46587566-a78cf600-ca8e-11e8-91f1-c70c82098d04.png">

Related issue: https://github.com/electron/electron/issues/15008

##### TODO

Test on macOS High Sierra 👷 🔨 💻 

##### Description of Change

The change itself is small and only swaps `NSWindowStyleMaskTitled ` for `NSWindowStyleMaskBorderless` when using frameless window configuration `{ frame: false }`. 

There are few exceptions though, the `NSWindowStyleMaskTitled` is still used when `titleBarStyle` is not default (`NORMAL`) because the "semaphore" buttons seem to be a part of titlebar and no chrome is rendered when borderless style is used.

I have a few concerns about the simple fullscreen mode though which actually attempts to restore the `NSWindowStyleMaskTitled` but to be fair, when entering the fullscreen mode programmatically, the titlebar was rendered without any buttons so there was no way to leave it 😄 Not sure it's worth fixing at this point.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Remove semi-transparent line rendered above frameless window on macOS Mojave