### PR TITLE
fix: Backport of #14648

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -608,6 +608,7 @@ void NativeWindowViews::SetResizable(bool resizable) {
     // both the minimum and maximum size to the window size to achieve it.
     if (resizable) {
       SetContentSizeConstraints(old_size_constraints_);
+      SetMaximizable(maximizable_);
     } else {
       old_size_constraints_ = GetContentSizeConstraints();
       resizable_ = false;

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2349,9 +2349,15 @@ describe('BrowserWindow module', () => {
       // Only implemented on windows.
       if (process.platform !== 'win32') return
 
-      it('is set to false when resizable state is set to false', () => {
+      it('is reset to its former state', () => {
+        w.setMaximizable(false)
         w.setResizable(false)
+        w.setResizable(true)
         assert.equal(w.isMaximizable(), false)
+        w.setMaximizable(true)
+        w.setResizable(false)
+        w.setResizable(true)
+        assert.strictEqual(w.isMaximizable(), true)
       })
     })
 


### PR DESCRIPTION
##### Description of Change
Backport of #14648 to restore `maximizable` state of window when `setResizable` is toggled. 

##### Checklist
- [X] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [X] tests are [changed or added]
- [X] PR title follows semantic [commit guidelines]


##### Release Notes
Notes: Allows the window to be maximization status to be restored to previous value upon being resizable again.