### PR TITLE
ci: fix breakpad symbols generation on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,14 +290,16 @@ step-mksnapshot-store: &step-mksnapshot-store
 step-generate-breakpad-symbols: &step-generate-breakpad-symbols
   run:
     name: Generate breakpad symbols
+    environment:
+      # TODO(alexeykuzmin): Explicitly pass an out folder path to the scripts.
+      ELECTRON_OUT_DIR: Default
     command: |
       cd src
+
       # Build needed dump_syms executable
       ninja -C out/Default third_party/breakpad:dump_syms
-      electron/script/dump-symbols.py -d "$PWD/out/Default/electron.breakpad.syms"
 
-      # TODO(alexeykuzmin): Explicitly pass an out folder path to the "zip-symbols.py" script.
-      export ELECTRON_OUT_DIR=Default
+      electron/script/dump-symbols.py -d "$PWD/out/Default/electron.breakpad.syms"
       electron/script/zip-symbols.py
 
 step-maybe-native-mksnapshot-gn-gen: &step-maybe-native-mksnapshot-gn-gen


### PR DESCRIPTION
##### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
A failed build example https://circleci.com/gh/electron/electron/78458
The same problem on Mac was fixed in #15004.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` 
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no notes