### PR TITLE
fix: ensure webcontents is destroyed before its associated browser context

### DIFF
--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -209,14 +209,15 @@ void CommonWebContentsDelegate::ResetManagedWebContents(bool async) {
     // this is guaranteed in the sync mode by the order of declaration,
     // in the async version we maintain a reference until the WebContents
     // is destroyed.
+    // //electron/patches/common/chromium/content_browser_main_loop.patch
+    // is required to get the right quit closure for the main message loop.
     base::ThreadTaskRunnerHandle::Get()->PostNonNestableTask(
         FROM_HERE,
-        base::BindOnce(
-            [](scoped_refptr<AtomBrowserContext> browser_context,
-               void* web_contents) {
-              delete static_cast<content::WebContents*>(web_contents);
-            },
-            base::RetainedRef(browser_context_), web_contents_.release()));
+        base::BindOnce([](scoped_refptr<AtomBrowserContext> browser_context,
+                          std::unique_ptr<brightray::InspectableWebContents>
+                              web_contents) { web_contents.reset(); },
+                       base::RetainedRef(browser_context_),
+                       std::move(web_contents_)));
   } else {
     web_contents_.reset();
   }

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -482,4 +482,5 @@ patches:
   file: content_browser_main_loop.patch
   description: |
     Pass idle quit closure for main message loop, so that pending tasks are
-    run before shutdown.
+    run before shutdown. This is required to cleanup WebContents asynchronously
+    in atom::CommonWebContentsDelegate::ResetManageWebContents.


### PR DESCRIPTION
##### Description of Change

Fixes https://github.com/orgs/electron/projects/24#card-13558526
Fixes https://github.com/electron/electron/issues/12594

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: no-notes