### PR TITLE
fix: power observer dbus crash

### DIFF
--- a/atom/browser/lib/power_observer_linux.cc
+++ b/atom/browser/lib/power_observer_linux.cc
@@ -123,8 +123,10 @@ void PowerObserverLinux::SetShutdownHandler(base::Callback<bool()> handler) {
 
 void PowerObserverLinux::OnInhibitResponse(base::ScopedFD* scoped_fd,
                                            dbus::Response* response) {
-  dbus::MessageReader reader(response);
-  reader.PopFileDescriptor(scoped_fd);
+  if (response != nullptr) {
+    dbus::MessageReader reader(response);
+    reader.PopFileDescriptor(scoped_fd);
+  }
 }
 
 void PowerObserverLinux::OnPrepareForSleep(dbus::Signal* signal) {

--- a/atom/browser/lib/power_observer_linux.cc
+++ b/atom/browser/lib/power_observer_linux.cc
@@ -161,7 +161,7 @@ void PowerObserverLinux::OnPrepareForShutdown(dbus::Signal* signal) {
   }
 }
 
-void PowerObserverLinux::OnSignalConnected(const std::string& interface,
+void PowerObserverLinux::OnSignalConnected(const std::string& /*interface*/,
                                            const std::string& signal,
                                            bool success) {
   LOG_IF(WARNING, !success) << "Failed to connect to " << signal;

--- a/atom/browser/lib/power_observer_linux.cc
+++ b/atom/browser/lib/power_observer_linux.cc
@@ -81,10 +81,10 @@ void PowerObserverLinux::BlockSleep() {
   inhibit_writer.AppendString(lock_owner_name_);                      // who
   inhibit_writer.AppendString("Application cleanup before suspend");  // why
   inhibit_writer.AppendString("delay");                               // mode
-  logind_->CallMethod(&sleep_inhibit_call,
-                      dbus::ObjectProxy::TIMEOUT_USE_DEFAULT,
-                      base::Bind(&PowerObserverLinux::OnInhibitResponse,
-                                 weak_ptr_factory_.GetWeakPtr(), &sleep_lock_));
+  logind_->CallMethod(
+      &sleep_inhibit_call, dbus::ObjectProxy::TIMEOUT_USE_DEFAULT,
+      base::BindOnce(&PowerObserverLinux::OnInhibitResponse,
+                     weak_ptr_factory_.GetWeakPtr(), &sleep_lock_));
 }
 
 void PowerObserverLinux::UnblockSleep() {
@@ -104,8 +104,8 @@ void PowerObserverLinux::BlockShutdown() {
   inhibit_writer.AppendString("delay");                    // mode
   logind_->CallMethod(
       &shutdown_inhibit_call, dbus::ObjectProxy::TIMEOUT_USE_DEFAULT,
-      base::Bind(&PowerObserverLinux::OnInhibitResponse,
-                 weak_ptr_factory_.GetWeakPtr(), &shutdown_lock_));
+      base::BindOnce(&PowerObserverLinux::OnInhibitResponse,
+                     weak_ptr_factory_.GetWeakPtr(), &shutdown_lock_));
 }
 
 void PowerObserverLinux::UnblockShutdown() {

--- a/atom/browser/lib/power_observer_linux.h
+++ b/atom/browser/lib/power_observer_linux.h
@@ -40,7 +40,6 @@ class PowerObserverLinux : public base::PowerObserver {
 
   base::Callback<bool()> should_shutdown_;
 
-  scoped_refptr<dbus::Bus> bus_;
   scoped_refptr<dbus::ObjectProxy> logind_;
   std::string lock_owner_name_;
   base::ScopedFD sleep_lock_;

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -131,8 +131,8 @@ describe('powerMonitor', () => {
 
     describe('powerMonitor.querySystemIdleState', () => {
       it('notify current system idle state', done => {
-        // this funtion is just a wrapper around ui::CalculateIdleState,
-        // so this test checks for form and type, but not state
+        // this function is not mocked out, so we can test the result's
+        // form and type but not its value.
         powerMonitor.querySystemIdleState(1, idleState => {
           expect(idleState).to.be.a('string')
           const validIdleStates = [ 'active', 'idle', 'locked', 'unknown' ]

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -17,7 +17,7 @@ chai.use(dirtyChai)
 const skip = process.platform !== 'linux' || !process.env.DBUS_SYSTEM_BUS_ADDRESS
 
 // TODO(alexeykuzmin): [Ch66] Crashes on Linux ia32. Fix it and enable back.
-xdescribe('powerMonitor', () => {
+describe('powerMonitor', () => {
   let logindMock, dbusMockPowerMonitor, getCalls, emitSignal, reset
 
   if (!skip) {
@@ -31,7 +31,9 @@ xdescribe('powerMonitor', () => {
       reset = Promise.promisify(logindMock.Reset, { context: logindMock })
     })
 
-    after(reset)
+    after(async () => {
+      await reset()
+    })
   }
 
   (skip ? describe.skip : describe)('when powerMonitor module is loaded with dbus mock', () => {
@@ -129,8 +131,12 @@ xdescribe('powerMonitor', () => {
 
     describe('powerMonitor.querySystemIdleState', () => {
       it('notify current system idle state', done => {
+        // this funtion is just a wrapper around ui::CalculateIdleState,
+        // so this test checks for form and type, but not state
         powerMonitor.querySystemIdleState(1, idleState => {
-          expect(idleState).to.be.true()
+          expect(idleState).to.be.a('string')
+          const validIdleStates = [ 'active', 'idle', 'locked', 'unknown' ]
+          expect(validIdleStates).to.include(idleState)
           done()
         })
       })

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -16,7 +16,6 @@ chai.use(dirtyChai)
 
 const skip = process.platform !== 'linux' || !process.env.DBUS_SYSTEM_BUS_ADDRESS
 
-// TODO(alexeykuzmin): [Ch66] Crashes on Linux ia32. Fix it and enable back.
 describe('powerMonitor', () => {
   let logindMock, dbusMockPowerMonitor, getCalls, emitSignal, reset
 


### PR DESCRIPTION
##### Description of Change

Fixes #14958 by testing for a valid dbus response before trying to use it.

Also fixes registering for login1 signals once rather than once per service appearance, since the registration isn't bound to a specific instance.

Lastly, I found & fixed a few issues in the tests, so I'm marking as [WIP] and re-enabling them to see if this has any effect on the ia32 CI issues we've had in the past with dbus tests.

cc: @alexeykuzmin 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added]
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Fixed crash when login1 manager dbus calls failed.