### PR TITLE
[wip] build: add v8_embedder_string to build args

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -4,6 +4,7 @@ root_extra_deps = [ "//electron" ]
 
 v8_promise_internal_field_count = 1
 v8_typed_array_max_size_in_heap = 0
+v8_embedder_string = "-electron.0"
 
 enable_cdm_host_verification = false
 enable_extensions = false


### PR DESCRIPTION
##### Description of Change
Set v8_embedder_string to append `-electron.N` to the version string. Node does this in [common.gypi](https://github.com/electron/node/blob/electron-node-v10.11.0/common.gypi#L30).

I'm unsure whether we should follow node and use `-node.N` or go with what I've done here, which is `-electron.N`, because I'm not sure what this version string is actually used for. I can see it's used in snapshot blobs, and accessible in `process.versions.v8`, but I'm not sure what the effects of changing this would be. I'd appreciate feedback from @ryzokuken and @codebytere on what the right path is here.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: v8 embedder version string changed from `-node.N` to `-electron.N`