### PR TITLE
fix: Lifetime of auth_info_ in login handler

### DIFF
--- a/atom/browser/login_handler.cc
+++ b/atom/browser/login_handler.cc
@@ -25,7 +25,7 @@ LoginHandler::LoginHandler(
     net::AuthCredentials* credentials,
     const content::ResourceRequestInfo* resource_request_info)
     : credentials_(credentials),
-      auth_info_(auth_info),
+      auth_info_(&auth_info),
       auth_callback_(std::move(callback)),
       weak_factory_(this) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -40,7 +40,7 @@ class LoginHandler : public base::RefCountedThreadSafe<LoginHandler> {
   // thread.
   content::WebContents* GetWebContents() const;
 
-  const net::AuthChallengeInfo* auth_info() const { return &auth_info_; }
+  const net::AuthChallengeInfo* auth_info() const { return auth_info_.get(); }
 
  private:
   friend class base::RefCountedThreadSafe<LoginHandler>;
@@ -56,7 +56,7 @@ class LoginHandler : public base::RefCountedThreadSafe<LoginHandler> {
   net::AuthCredentials* credentials_;
 
   // Who/where/what asked for the authentication.
-  const net::AuthChallengeInfo& auth_info_;
+  scoped_refptr<const net::AuthChallengeInfo> auth_info_;
 
   // WebContents associated with the login request.
   content::ResourceRequestInfo::WebContentsGetter web_contents_getter_;


### PR DESCRIPTION
##### Description of Change
Please refer to #15002 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Fixed crash in proxy login handler