### PR TITLE
fix: SetSize() should honor minSize (#13994)

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -450,9 +450,11 @@ gfx::Rect Window::GetContentBounds() {
 }
 
 void Window::SetSize(int width, int height, mate::Arguments* args) {
+  gfx::Size size = window_->GetMinimumSize();
+  size.SetToMax(gfx::Size(width, height));
   bool animate = false;
   args->GetNext(&animate);
-  window_->SetSize(gfx::Size(width, height), animate);
+  window_->SetSize(size, animate);
 }
 
 std::vector<int> Window::GetSize() {

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -870,7 +870,9 @@ Disable or enable the window.
 * `height` Integer
 * `animate` Boolean (optional) _macOS_
 
-Resizes the window to `width` and `height`.
+Resizes the window to `width` and `height`. If `width` or `height`
+are below any set minimum size constraints the window will snap to
+its minimum size.
 
 #### `win.getSize()`
 


### PR DESCRIPTION
##### Description of Change

Manual backport of #14931 to fix #13994, enforcing window minimum height/width

@Kthulu120 @nornagon 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: setSize() now honors minimum size constraints.