### PR TITLE
fix: close patch_file before deleting it

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -325,6 +325,7 @@ def main():
                 retcode = ExitStatus.DIFF
 
     if patch_file.tell() == 0:
+      patch_file.close()
       os.unlink(patch_file.name)
     else:
       print("\nTo patch these files, run:\n$ git apply {}\n"


### PR DESCRIPTION
##### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

`run_clang_format.py` failed on `Windows` (in `PowerShell`) for me with the following:
```
Traceback (most recent call last):
  File "script/run-clang-format.py", line 337, in <module>
    sys.exit(main())
  File "script/run-clang-format.py", line 328, in main
    os.unlink(patch_file.name)
WindowsError: [Error 32] The process cannot access the file because it is being used by another process: u'c:\\users\\benec\\appdata\\local\\temp\\electron-format-wb6cw_'"Code not formatted correctly."
```

I added a `.close()` call, and it seems to have fixed the issue, which is weird because `Windows` complained that "another process" was using the file, but whatever.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: none <!-- One-line Change Summary Here-->