### PR TITLE
[WIP] ci: enable logging that was disable during 69 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,7 +609,7 @@ steps-tests: &steps-tests
         command: |
           cd src
           export ELECTRON_OUT_DIR=Default
-          (cd electron && npm run test -- --ci)
+          (cd electron && npm run test -- --ci --enable-logging)
     - run:
         name: Check test results existence
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,6 +682,104 @@ filter-only-prs-from-forks: &filter-only-prs-from-forks
 chromium-upgrade-branches: &chromium-upgrade-branches
   /chromium\-upgrade\/[0-9]+/
 
+# List of jobs for workflows.
+jobs-release-checks: &jobs-release-checks
+  jobs:
+    - linux-checkout:
+        filters:
+          branches:
+            only:
+              - master
+              - linux-release-checks  # FIXME
+              - 69_enable_logging  # FIXME
+              - *chromium-upgrade-branches
+
+    - linux-x64-release:
+        requires:
+          - linux-checkout
+    - linux-x64-release-tests:
+        requires:
+          - linux-x64-release
+    - linux-x64-ffmpeg:
+        requires:
+          - linux-checkout
+    - linux-x64-verify-ffmpeg:
+        requires:
+          - linux-x64-release
+          - linux-x64-ffmpeg
+    - linux-x64-chromedriver:
+        requires:
+          - linux-checkout
+    - linux-x64-release-summary:
+        requires:
+          - linux-x64-release
+          - linux-x64-release-tests
+          - linux-x64-ffmpeg
+          - linux-x64-verify-ffmpeg
+          - linux-x64-chromedriver
+
+    - linux-ia32-release:
+        requires:
+          - linux-checkout
+    - linux-ia32-release-tests:
+        requires:
+          - linux-ia32-release
+    - linux-ia32-ffmpeg:
+        requires:
+          - linux-checkout
+    - linux-ia32-verify-ffmpeg:
+        requires:
+          - linux-ia32-release
+          - linux-ia32-ffmpeg
+    - linux-ia32-chromedriver:
+        requires:
+          - linux-checkout
+    - linux-ia32-release-summary:
+        requires:
+          - linux-ia32-release
+          - linux-ia32-release-tests
+          - linux-ia32-ffmpeg
+          - linux-ia32-verify-ffmpeg
+          - linux-ia32-chromedriver
+
+    - linux-arm-release:
+        requires:
+          - linux-checkout
+    - linux-arm-ffmpeg:
+         requires:
+           - linux-checkout
+    - linux-arm-native-mksnapshot:
+        requires:
+          - linux-checkout
+    - linux-arm-chromedriver:
+        requires:
+          - linux-checkout
+    - linux-arm-release-summary:
+        requires:
+          - linux-arm-release
+          - linux-arm-ffmpeg
+          - linux-arm-chromedriver
+          - linux-arm-native-mksnapshot
+
+    - linux-arm64-release:
+        requires:
+          - linux-checkout
+    - linux-arm64-ffmpeg:
+         requires:
+           - linux-checkout
+    - linux-arm64-native-mksnapshot:
+        requires:
+          - linux-checkout
+    - linux-arm64-chromedriver:
+        requires:
+          - linux-checkout
+    - linux-arm64-release-summary:
+        requires:
+          - linux-arm64-release
+          - linux-arm64-ffmpeg
+          - linux-arm64-chromedriver
+          - linux-arm64-native-mksnapshot
+
 # List of all jobs.
 version: 2
 jobs:
@@ -1085,6 +1183,10 @@ workflows:
           requires:
             - mas-testing
 
+  # Build Electron and side products in release configuration.
+  linux-release-checks:
+    <<: *jobs-release-checks
+
   nightly-release-test:
     triggers:
       - schedule:
@@ -1094,94 +1196,7 @@ workflows:
               only:
                 - master
                 - *chromium-upgrade-branches
-    jobs:
-      - linux-checkout
-
-      - linux-x64-release:
-          requires:
-            - linux-checkout
-      - linux-x64-release-tests:
-          requires:
-            - linux-x64-release
-      - linux-x64-ffmpeg:
-          requires:
-            - linux-checkout
-      - linux-x64-verify-ffmpeg:
-          requires:
-            - linux-x64-release
-            - linux-x64-ffmpeg
-      - linux-x64-chromedriver:
-          requires:
-            - linux-checkout
-      - linux-x64-release-summary:
-          requires:
-            - linux-x64-release
-            - linux-x64-release-tests
-            - linux-x64-ffmpeg
-            - linux-x64-verify-ffmpeg
-            - linux-x64-chromedriver
-
-      - linux-ia32-release:
-          requires:
-            - linux-checkout
-      - linux-ia32-release-tests:
-          requires:
-            - linux-ia32-release
-      - linux-ia32-ffmpeg:
-          requires:
-            - linux-checkout
-      - linux-ia32-verify-ffmpeg:
-          requires:
-            - linux-ia32-release
-            - linux-ia32-ffmpeg
-      - linux-ia32-chromedriver:
-          requires:
-            - linux-checkout
-      - linux-ia32-release-summary:
-          requires:
-            - linux-ia32-release
-            - linux-ia32-release-tests
-            - linux-ia32-ffmpeg
-            - linux-ia32-verify-ffmpeg
-            - linux-ia32-chromedriver
-
-      - linux-arm-release:
-          requires:
-            - linux-checkout
-      - linux-arm-ffmpeg:
-           requires:
-             - linux-checkout
-      - linux-arm-native-mksnapshot:
-          requires:
-            - linux-checkout
-      - linux-arm-chromedriver:
-          requires:
-            - linux-checkout
-      - linux-arm-release-summary:
-          requires:
-            - linux-arm-release
-            - linux-arm-ffmpeg
-            - linux-arm-chromedriver
-            - linux-arm-native-mksnapshot
-
-      - linux-arm64-release:
-          requires:
-            - linux-checkout
-      - linux-arm64-ffmpeg:
-           requires:
-             - linux-checkout
-      - linux-arm64-native-mksnapshot:
-          requires:
-            - linux-checkout
-      - linux-arm64-chromedriver:
-          requires:
-            - linux-checkout
-      - linux-arm64-release-summary:
-          requires:
-            - linux-arm64-release
-            - linux-arm64-ffmpeg
-            - linux-arm64-chromedriver
-            - linux-arm64-native-mksnapshot
+    <<: *jobs-release-checks
 
   # Various slow and non-essential checks we run only nightly.
   # Sanitizer jobs should be added here.

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -15,3 +15,7 @@ rtc_use_h264 = proprietary_codecs
 # who have an LGPL requirement to ship ffmpeg as a dynamically linked library,
 # we build ffmpeg as a shared library.
 is_component_ffmpeg = true
+
+# FIXME: Temporary args for debugging
+dcheck_always_on = true
+symbol_level = 1

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -19,3 +19,4 @@ is_component_ffmpeg = true
 # FIXME: Temporary args for debugging
 dcheck_always_on = true
 symbol_level = 1
+enable_swiftshader = false

--- a/build/zip.py
+++ b/build/zip.py
@@ -41,7 +41,8 @@ def main(argv):
   if sys.platform == 'darwin':
     execute(['zip', '-r', '-y', dist_zip] + list(dist_files))
   else:
-    with zipfile.ZipFile(dist_zip, 'w', zipfile.ZIP_DEFLATED) as z:
+    with zipfile.ZipFile(dist_zip, mode='w', compression=zipfile.ZIP_DEFLATED,
+                         allowZip64=True) as z:
       for dep in dist_files:
         if skip_path(dep):
           continue

--- a/script/verify-ffmpeg.py
+++ b/script/verify-ffmpeg.py
@@ -43,8 +43,7 @@ def main():
         'no-proprietary-codecs.js')
     env = dict(os.environ)
     env['ELECTRON_ENABLE_STACK_DUMPING'] = 'true'
-    # FIXME: Enable after ELECTRON_ENABLE_LOGGING works again
-    # env['ELECTRON_ENABLE_LOGGING'] = 'true'
+    env['ELECTRON_ENABLE_LOGGING'] = 'true'
     subprocess.check_call([electron, test_path] + sys.argv[1:], env=env)
   except subprocess.CalledProcessError as e:
     returncode = e.returncode

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -46,7 +46,7 @@ steps:
 
 - bash: |
    cd src
-   ./out/Default/electron electron/spec --ci
+   ./out/Default/electron electron/spec --ci --enable-logging
   displayName: 'Run Electron tests'
   timeoutInMinutes: 10
 

--- a/vsts.yml
+++ b/vsts.yml
@@ -293,7 +293,7 @@ jobs:
 
   - bash: |
       export ELECTRON_OUT_DIR=Default
-      (cd src/electron && npm run test -- --ci)
+      (cd src/electron && npm run test -- --ci --enable-logging)
     displayName: Run Electron test suite
     timeoutInMinutes: 10
 


### PR DESCRIPTION
##### Description of Change

Lets identify the root cause and fix it.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes

Notes: no-notes