### PR TITLE
fix: do not create node environment in child window if node integration is not enabled

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -405,6 +405,8 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   std::string encoding;
   if (GetAsString(&preference_, "defaultEncoding", &encoding))
     prefs->default_encoding = encoding;
+
+  prefs->node_integration = IsEnabled(options::kNodeIntegration);
 }
 
 }  // namespace atom

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -16,6 +16,7 @@
 #include "atom/renderer/atom_render_frame_observer.h"
 #include "atom/renderer/web_worker_observer.h"
 #include "base/command_line.h"
+#include "content/public/common/web_preferences.h"
 #include "content/public/renderer/render_frame.h"
 #include "native_mate/dictionary.h"
 #include "third_party/blink/public/web/web_document.h"
@@ -84,6 +85,15 @@ void AtomRendererClient::DidCreateScriptContext(
   // Only allow node integration for the main frame, unless it is a devtools
   // extension page.
   if (!render_frame->IsMainFrame() && !IsDevToolsExtension(render_frame))
+    return;
+
+  // Don't allow node integration if this is a child window and it does not have
+  // node integration enabled.  Otherwise we would have memory leak in the child
+  // window since we don't clean up node environments.
+  //
+  // TODO(zcbenz): We shouldn't allow node integration even for the top frame.
+  if (!render_frame->GetWebkitPreferences().node_integration &&
+      render_frame->GetWebFrame()->Opener())
     return;
 
   injected_frames_.insert(render_frame);

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -536,3 +536,12 @@ patches:
   description:  |
     Temporarily add additional debugging statements to
     generate_breakpad_symbols.py to determine why it is hanging.
+-
+  author: zcbenz <zcbenz@gmail.com>
+  file: web_preferences.patch
+  description: |
+    Add a node_integration field to WebPreferences so we can determine whether
+    a frame has node integration in renderer process.
+
+    This is required by the nativeWindowOpen option, which put multiple main
+    frames in one renderer process.

--- a/patches/common/chromium/web_preferences.patch
+++ b/patches/common/chromium/web_preferences.patch
@@ -1,0 +1,26 @@
+diff --git a/content/public/common/common_param_traits_macros.h b/content/public/common/common_param_traits_macros.h
+index 57f03dc..7c4409e 100644
+--- a/content/public/common/common_param_traits_macros.h
++++ b/content/public/common/common_param_traits_macros.h
+@@ -198,6 +198,7 @@ IPC_STRUCT_TRAITS_BEGIN(content::WebPreferences)
+   IPC_STRUCT_TRAITS_MEMBER(animation_policy)
+   IPC_STRUCT_TRAITS_MEMBER(user_gesture_required_for_presentation)
+   IPC_STRUCT_TRAITS_MEMBER(text_track_margin_percentage)
++  IPC_STRUCT_TRAITS_MEMBER(node_integration)
+   IPC_STRUCT_TRAITS_MEMBER(save_previous_document_resources)
+   IPC_STRUCT_TRAITS_MEMBER(text_autosizing_enabled)
+   IPC_STRUCT_TRAITS_MEMBER(double_tap_to_zoom_enabled)
+diff --git a/content/public/common/web_preferences.h b/content/public/common/web_preferences.h
+index 78cbf5f..b33ac28 100644
+--- a/content/public/common/web_preferences.h
++++ b/content/public/common/web_preferences.h
+@@ -222,6 +222,9 @@ struct CONTENT_EXPORT WebPreferences {
+   // Cues will not be placed in this margin area.
+   float text_track_margin_percentage;
+ 
++  // Electron: Whether the frame has node integration.
++  bool node_integration = false;
++
+   bool immersive_mode_enabled;
+ 
+   bool text_autosizing_enabled;


### PR DESCRIPTION
##### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Since we don't release Node environments (to avoid crashes), child windows opened with `nativeWindowOpen` option will have their V8 contexts leaks. This PR avoids creating Node environment in child windows if the node integration is not enabled there.

So this PR serves as a partial fix for https://github.com/electron/electron/issues/12634, users should make sure node integration is not enabled in the child windows to avoid memory leaks.

As a complete fix for this problem, I propose:

1. For 4.x, disabling Node integration for child windows opened by `nativeWindowOpen`.
2. For 2.x and 3.x, print an error in console notifying users there is leak of memory, and recommend them turning off Node integration.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: Partially fix the memory leak when opening child windows with `nativeWindowOpen`.