### PR TITLE
fix: check dbus response for null before use.

### DIFF
--- a/atom/browser/lib/power_observer_linux.h
+++ b/atom/browser/lib/power_observer_linux.h
@@ -19,6 +19,7 @@ namespace atom {
 class PowerObserverLinux : public base::PowerObserver {
  public:
   PowerObserverLinux();
+  ~PowerObserverLinux() override;
 
  protected:
   void BlockSleep();
@@ -39,7 +40,6 @@ class PowerObserverLinux : public base::PowerObserver {
 
   base::Callback<bool()> should_shutdown_;
 
-  scoped_refptr<dbus::Bus> bus_;
   scoped_refptr<dbus::ObjectProxy> logind_;
   std::string lock_owner_name_;
   base::ScopedFD sleep_lock_;


### PR DESCRIPTION
##### Description of Change

Fixes #14958.

Manual backport of #15030 to fix a pair of power-monitor bugs:
 * nullptr dereference in dbus response handling (14958)
 * redundant dbus signal subscriptions

cc @alexeykuzmin 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: Fixed crash when login1 manager dbus calls failed.
