### PR TITLE
fix: Remove `statSyncNoException` for good

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -292,10 +292,9 @@
       process.nextTick(() => fs.lstat(pathArgument, callback))
     }
 
-    const { statSyncNoException } = fs
     fs.statSyncNoException = pathArgument => {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return statSyncNoException(pathArgument)
+      if (!isAsar) return fs.statSyncNoException(pathArgument)
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) return false

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -294,7 +294,13 @@
 
     fs.statSyncNoException = pathArgument => {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return fs.statSyncNoException(pathArgument)
+      if (!isAsar) {
+        try {
+          return statSync(pathArgument)
+        } catch (error) {
+          return false
+        }
+      }
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) return false

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -292,25 +292,6 @@
       process.nextTick(() => fs.lstat(pathArgument, callback))
     }
 
-    fs.statSyncNoException = pathArgument => {
-      const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) {
-        try {
-          return statSync(pathArgument)
-        } catch (error) {
-          return false
-        }
-      }
-
-      const archive = getOrCreateArchive(asarPath)
-      if (!archive) return false
-
-      const stats = archive.stat(filePath)
-      if (!stats) return false
-
-      return asarStatsToFsStats(stats)
-    }
-
     const { realpathSync } = fs
     fs.realpathSync = function (pathArgument) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)


### PR DESCRIPTION
##### Description of Change
~The existing code throws if an `asar` is used. This simply changes the assignment, ensuring that the correct object is returned.~

New plan: Let's just cut `fs.statSyncNoException` for real.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
Notes: Fix "TypeError: statSyncNoException is not a function" when asar is used