### PR TITLE
fix: export zlib symbols

### DIFF
--- a/patches/common/zlib/.patches.yaml
+++ b/patches/common/zlib/.patches.yaml
@@ -1,0 +1,7 @@
+repo: src
+patches:
+-
+  author: Andy Dill <adill@discordapp.com>
+  file: fix-export_zlib_symbols.patch
+  description: |
+    Set ZLIB_DLL so that we export zlib symbols.

--- a/patches/common/zlib/fix-export_zlib_symbols.patch
+++ b/patches/common/zlib/fix-export_zlib_symbols.patch
@@ -1,0 +1,15 @@
+diff --git a/third_party/zlib/BUILD.gn b/third_party/zlib/BUILD.gn
+index 902e287f8a0a..c08a187ca968 100644
+--- a/third_party/zlib/BUILD.gn
++++ b/third_party/zlib/BUILD.gn
+@@ -265,6 +265,10 @@ static_library("zlib") {
+   defines = []
+   deps = []
+
++  if (is_win) {
++    defines += [ "ZLIB_DLL" ]
++  }
++
+   if (!is_ios && (current_cpu == "x86" || current_cpu == "x64")) {
+     deps += [ ":zlib_crc32_simd" ]
+


### PR DESCRIPTION
##### Description of Change

Previous to 4.0.0 electron's `node.lib` included symbols for zlib; this restores that behavior. We've got one native module that was directly using the bundled zlib but I don't imagine we are the only ones?

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: export zlib symbols