### PR TITLE
fix: set NSResizableWindowMask at init time

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -341,6 +341,9 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   if (!useStandardWindow || transparent() || !has_frame()) {
     styleMask |= NSTexturedBackgroundWindowMask;
   }
+  if (resizable_) {
+    styleMask |= NSResizableWindowMask;
+  }
 
   // Create views::Widget and assign window_ with it.
   // TODO(zcbenz): Get rid of the window_ in future.


### PR DESCRIPTION
##### Description of Change

I belive this was erroneously removed in https://github.com/electron/electron/commit/39242c978f8bbc8ec3cda9f3c6e75aaa62b775f4. The only side-effect that I observed, however, was that some window managers (namely [Magnet](http://magnet.crowdcafe.com/)) no longer function (until you go in & out of fullscreen, which sets the flag.)

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes

Notes: fix: set NSResizableWindowMask at init time