### PR TITLE
fix: do not create node environment in child window if node integration is not enabled (3-0-x)

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -331,6 +331,10 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   std::string encoding;
   if (dict_.GetString("defaultEncoding", &encoding))
     prefs->default_encoding = encoding;
+
+  bool node_integration = false;
+  dict_.GetBoolean(options::kNodeIntegration, &node_integration);
+  prefs->node_integration = node_integration;
 }
 
 bool WebContentsPreferences::GetInteger(const base::StringPiece& attribute_name,


### PR DESCRIPTION
Backport https://github.com/electron/electron/pull/15076 to 3-0-x.

Notes: Partially fix the memory leak when opening child windows with `nativeWindowOpen`.
