### PR TITLE
fix: do not create node environment in child window if node integration is not enabled (2-0-x)

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -336,6 +336,11 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   std::string encoding;
   if (self->web_preferences_.GetString("defaultEncoding", &encoding))
     prefs->default_encoding = encoding;
+
+  bool node_integration = false;
+  self->web_preferences_.GetBoolean(options::kNodeIntegration,
+                                    &node_integration);
+  prefs->node_integration = node_integration;
 }
 
 bool WebContentsPreferences::GetInteger(const std::string& attributeName,

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -17,6 +17,7 @@
 #include "atom/renderer/atom_render_frame_observer.h"
 #include "atom/renderer/web_worker_observer.h"
 #include "base/command_line.h"
+#include "content/public/common/web_preferences.h"
 #include "content/public/renderer/render_frame.h"
 #include "native_mate/dictionary.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
@@ -87,6 +88,15 @@ void AtomRendererClient::DidCreateScriptContext(
   // Only allow node integration for the main frame, unless it is a devtools
   // extension page.
   if (!render_frame->IsMainFrame() && !IsDevToolsExtension(render_frame))
+    return;
+
+  // Don't allow node integration if this is a child window and it does not have
+  // node integration enabled.  Otherwise we would have memory leak in the child
+  // window since we don't clean up node environments.
+  //
+  // TODO(zcbenz): We shouldn't allow node integration even for the top frame.
+  if (!render_frame->GetWebkitPreferences().node_integration &&
+      render_frame->GetWebFrame()->Opener())
     return;
 
   // Prepare the node bindings.


### PR DESCRIPTION
Backport https://github.com/electron/electron/pull/15076 to 2-0-x.

Notes: Partially fix the memory leak when opening child windows with `nativeWindowOpen`.
