### PR TITLE
chore: mark browserview api as not-experimental

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -2,9 +2,6 @@
 
 > Create and control views.
 
-**Note:** The BrowserView API is currently experimental and may change or be
-removed in future Electron releases.
-
 Process: [Main](../glossary.md#main-process)
 
 A `BrowserView` can be used to embed additional web content into a


### PR DESCRIPTION
I think it's safe to say this API has been around long enough to be considered past the experimental phase 👍

Notes: removed the experimental tag from the `BrowserView` API docs