### PR TITLE
ci: Fix timeout when generating breakpad symbols

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,9 +328,9 @@ step-generate-breakpad-symbols: &step-generate-breakpad-symbols
       export DEST_PATH="$BUILD_PATH/electron.breakpad.syms"
       electron/script/dump-symbols.py -b $BUILD_PATH -d $DEST_PATH -v
 
-step-zip-breakpad-symbols: &step-zip-breakpad-symbols
+step-zip-symbols: &step-zip-symbols
   run:
-    name: Generate breakpad symbols
+    name: Zip symbols
     command: |
       cd src
       export BUILD_PATH="$PWD/out/Default"
@@ -470,7 +470,7 @@ steps-electron-build-for-tests: &steps-electron-build-for-tests
     # TODO(alexeykuzmin): We should do it only in nightly builds.
     - *step-build-dump-syms
     - *step-generate-breakpad-symbols
-    - *step-zip-breakpad-symbols
+    - *step-zip-symbols
 
     # Trigger tests on arm hardware if needed
     - *step-maybe-trigger-arm-test
@@ -493,7 +493,7 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
     - *step-electron-dist-store
     - *step-build-dump-syms
     - *step-generate-breakpad-symbols
-    - *step-zip-breakpad-symbols
+    - *step-zip-symbols
 
     # mksnapshot
     - *step-mksnapshot-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,20 +311,30 @@ step-mksnapshot-store: &step-mksnapshot-store
     path: src/out/Default/mksnapshot.zip
     destination: mksnapshot.zip
 
-step-generate-breakpad-symbols: &step-generate-breakpad-symbols
+step-build-dump-syms: &step-build-dump-syms
   run:
-    name: Generate breakpad symbols
-    environment:
-      # TODO(alexeykuzmin): Explicitly pass an out folder path to the scripts.
-      ELECTRON_OUT_DIR: Default
+    name: Build dump_syms binary
     command: |
       cd src
-
       # Build needed dump_syms executable
       ninja -C out/Default third_party/breakpad:dump_syms
 
-      electron/script/dump-symbols.py -d "$PWD/out/Default/electron.breakpad.syms"
-      electron/script/zip-symbols.py
+step-generate-breakpad-symbols: &step-generate-breakpad-symbols
+  run:
+    name: Generate breakpad symbols
+    command: |
+      cd src
+      export BUILD_PATH="$PWD/out/Default"
+      export DEST_PATH="$BUILD_PATH/electron.breakpad.syms"
+      electron/script/dump-symbols.py -b $BUILD_PATH -d $DEST_PATH -v
+
+step-zip-breakpad-symbols: &step-zip-breakpad-symbols
+  run:
+    name: Generate breakpad symbols
+    command: |
+      cd src
+      export BUILD_PATH="$PWD/out/Default"
+      electron/script/zip-symbols.py -b $BUILD_PATH
 
 step-maybe-native-mksnapshot-gn-gen: &step-maybe-native-mksnapshot-gn-gen
   run:
@@ -458,7 +468,9 @@ steps-electron-build-for-tests: &steps-electron-build-for-tests
 
     # Breakpad symbols.
     # TODO(alexeykuzmin): We should do it only in nightly builds.
+    - *step-build-dump-syms
     - *step-generate-breakpad-symbols
+    - *step-zip-breakpad-symbols
 
     # Trigger tests on arm hardware if needed
     - *step-maybe-trigger-arm-test
@@ -479,7 +491,9 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
     - *step-maybe-electron-dist-strip
     - *step-electron-dist-build
     - *step-electron-dist-store
+    - *step-build-dump-syms
     - *step-generate-breakpad-symbols
+    - *step-zip-breakpad-symbols
 
     # mksnapshot
     - *step-mksnapshot-build

--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -78,8 +78,7 @@ def generate_posix_symbols(binary, source_root, build_dir, destination):
 def parse_args():
   parser = argparse.ArgumentParser(description='Create breakpad symbols')
   parser.add_argument('-b', '--build-dir',
-                      help='Path to an Electron build folder. \
-                          Relative to the --source-root.',
+                      help='Path to an Electron build folder.',
                       default=RELEASE_PATH,
                       required=False)
   parser.add_argument('-d', '--destination',

--- a/script/zip-symbols.py
+++ b/script/zip-symbols.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import glob
 import os
 import sys
@@ -17,29 +18,38 @@ def main():
   if get_target_arch() == 'mips64el':
     return
 
+  args = parse_args()
   dist_name = 'symbols.zip'
-  zip_file = os.path.join(OUT_DIR, dist_name)
+  zip_file = os.path.join(args.build_dir, dist_name)
   licenses = ['LICENSE', 'LICENSES.chromium.html', 'version']
 
-  with scoped_cwd(OUT_DIR):
+  with scoped_cwd(args.build_dir):
     dirs = ['{0}.breakpad.syms'.format(PROJECT_NAME)]
     print('Making symbol zip: ' + zip_file)
     make_zip(zip_file, licenses, dirs)
 
   if PLATFORM == 'darwin':
     dsym_name = 'dsym.zip'
-    with scoped_cwd(OUT_DIR):
+    with scoped_cwd(args.build_dir):
       dsyms = glob.glob('*.dSYM')
-      dsym_zip_file = os.path.join(OUT_DIR, dsym_name)
+      dsym_zip_file = os.path.join(args.build_dir, dsym_name)
       print('Making dsym zip: ' + dsym_zip_file)
       make_zip(dsym_zip_file, licenses, dsyms)
   elif PLATFORM == 'win32':
     pdb_name = 'pdb.zip'
-    with scoped_cwd(OUT_DIR):
+    with scoped_cwd(args.build_dir):
       pdbs = glob.glob('*.pdb')
-      pdb_zip_file = os.path.join(OUT_DIR, pdb_name)
+      pdb_zip_file = os.path.join(args.build_dir, pdb_name)
       print('Making pdb zip: ' + pdb_zip_file)
       make_zip(pdb_zip_file, pdbs + licenses, [])
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Zip symbols')
+  parser.add_argument('-b', '--build-dir',
+                      help='Path to an Electron build folder.',
+                      default=OUT_DIR,
+                      required=False)
+  return parser.parse_args()
 
 if __name__ == '__main__':
   sys.exit(main())


### PR DESCRIPTION
##### Description of Change
As #15054 states we are seeing timeouts on release builds when generating breakpad symbols.  This PR breaks out the steps for generating breakpad symbols into separate steps so that we can further isolate where this process is timing out. Additionally the dump-symbols script is now running in verbose mode.  On my testing of the release builds, it did not timeout so tentatively this resolves #15054, or at least gives us a better understanding where it is actually failing.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes