### PR TITLE
fix: split out LoginItem tests to account for delay in MAS api

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -432,16 +432,23 @@ describe('app module', () => {
       app.setLoginItemSettings({ openAtLogin: false, path: updateExe, args: processStartArgs })
     })
 
-    it('returns the login item status of the app', done => {
+    it('sets and returns the app as a login item', done => {
       app.setLoginItemSettings({ openAtLogin: true })
-      expect(app.getLoginItemSettings()).to.deep.equal({
-        openAtLogin: true,
-        openAsHidden: false,
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false
-      })
+      // Wait because login item settings are not applied immediately in MAS build
+      const delay = process.mas ? 150 : 0
+      setTimeout(() => {
+        expect(app.getLoginItemSettings()).to.deep.equal({
+          openAtLogin: true,
+          openAsHidden: false,
+          wasOpenedAtLogin: false,
+          wasOpenedAsHidden: false,
+          restoreState: false
+        })
+        done()
+      }, delay)
+    })
 
+    it('adds a login item that loads in hidden mode', () => {
       app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: true,
@@ -450,20 +457,6 @@ describe('app module', () => {
         wasOpenedAsHidden: false,
         restoreState: false
       })
-
-      app.setLoginItemSettings({})
-      // Wait because login item settings are not applied immediately in MAS build
-      const delay = process.mas ? 100 : 0
-      setTimeout(() => {
-        expect(app.getLoginItemSettings()).to.deep.equal({
-          openAtLogin: false,
-          openAsHidden: false,
-          wasOpenedAtLogin: false,
-          wasOpenedAsHidden: false,
-          restoreState: false
-        })
-        done()
-      }, delay)
     })
 
     it('correctly sets and unsets the LoginItem as hidden', function () {


### PR DESCRIPTION
##### Description of Change

Resolves flaky LoginItem tests on MAS builds. 
Unrelated to LoginItem CI failure beginning 10.13.

/cc @MarshallOfSound @alexeykuzmin 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes