### PR TITLE
chore: update pr template for no-notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-##### Description of Change
+#### Description of Change
 <!--
 Thank you for your Pull Request. Please provide a description above and review
 the requirements below.
@@ -6,7 +6,7 @@ the requirements below.
 Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
 -->
 
-##### Checklist
+#### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] PR description included and stakeholders cc'd
@@ -16,7 +16,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 - [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
 
 
-##### Release Notes
-<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->
+#### Release Notes
+<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->
 
 Notes: <!-- One-line Change Summary Here-->


### PR DESCRIPTION
#### Description of Change

Better indicate what devs should put when their PR has no user-facing changes.

/cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. See https://github.com/electron/clerk/blob/master/README.md for details. -->

Notes: no-notes