### PR TITLE
fix: natively implement LoginItem functions (backport: 2-0-x)

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -215,6 +215,65 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings(
   return settings;
 }
 
+// copied from GetLoginItemForApp in base/mac/mac_util.mm
+LSSharedFileListItemRef GetLoginItemForApp() {
+  base::ScopedCFTypeRef<LSSharedFileListRef> login_items(
+      LSSharedFileListCreate(NULL, kLSSharedFileListSessionLoginItems, NULL));
+  if (!login_items.get()) {
+    LOG(ERROR) << "Couldn't get a Login Items list.";
+    return NULL;
+  }
+  base::scoped_nsobject<NSArray> login_items_array(
+      base::mac::CFToNSCast(LSSharedFileListCopySnapshot(login_items, NULL)));
+  NSURL* url = [NSURL fileURLWithPath:[base::mac::MainBundle() bundlePath]];
+  for (NSUInteger i = 0; i < [login_items_array count]; ++i) {
+    LSSharedFileListItemRef item =
+        reinterpret_cast<LSSharedFileListItemRef>(login_items_array[i]);
+    CFURLRef item_url_ref = NULL;
+    if (LSSharedFileListItemResolve(item, 0, &item_url_ref, NULL) == noErr &&
+        item_url_ref) {
+      base::ScopedCFTypeRef<CFURLRef> item_url(item_url_ref);
+      if (CFEqual(item_url, url)) {
+        CFRetain(item);
+        return item;
+      }
+    }
+  }
+  return NULL;
+}
+
+void RemoveFromLoginItems() {
+  base::ScopedCFTypeRef<LSSharedFileListRef> list(
+      LSSharedFileListCreate(NULL, kLSSharedFileListSessionLoginItems, NULL));
+  if (!list) {
+    LOG(ERROR) << "Unable to access shared file list";
+    return;
+  }
+
+  if (GetLoginItemForApp() != NULL) {
+    base::scoped_nsobject<NSArray> login_items_array(
+        base::mac::CFToNSCast(LSSharedFileListCopySnapshot(list, NULL)));
+
+    if (!login_items_array) {
+      LOG(ERROR) << "No items in list of auto-loaded apps";
+      return;
+    }
+
+    for (NSUInteger i = 0; i < [login_items_array count]; ++i) {
+      LSSharedFileListItemRef item =
+          reinterpret_cast<LSSharedFileListItemRef>(login_items_array[i]);
+      CFURLRef url_ref = NULL;
+      if (LSSharedFileListItemResolve(item, 0, &url_ref, NULL) == noErr &&
+          item) {
+        base::ScopedCFTypeRef<CFURLRef> url(url_ref);
+        if ([[base::mac::CFToNSCast(url.get()) path]
+                hasPrefix:[[NSBundle mainBundle] bundlePath]])
+          LSSharedFileListItemRemove(list, item);
+      }
+    }
+  }
+}
+
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 #if defined(MAS_BUILD)
   platform_util::SetLoginItemEnabled(settings.open_at_login);
@@ -222,7 +281,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
   if (settings.open_at_login)
     base::mac::AddToLoginItems(settings.open_as_hidden);
   else
-    base::mac::RemoveFromLoginItems();
+    RemoveFromLoginItems();
 #endif
 }
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -422,7 +422,7 @@ describe('app module', () => {
       // Wait because login item settings are not applied immediately in MAS build
       const delay = process.mas ? 150 : 0
       setTimeout(() => {
-        assert.equal(app.getLoginItemSettings(), {
+        assert.deepEqual(app.getLoginItemSettings(), {
           openAtLogin: true,
           openAsHidden: false,
           wasOpenedAtLogin: false,
@@ -435,7 +435,7 @@ describe('app module', () => {
 
     it('adds a login item that loads in hidden mode', () => {
       app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
-      assert.equal(app.getLoginItemSettings(), {
+      assert.deepEqual(app.getLoginItemSettings(), {
         openAtLogin: true,
         openAsHidden: process.platform === 'darwin' && !process.mas, // Only available on macOS
         wasOpenedAtLogin: false,

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -417,31 +417,13 @@ describe('app module', () => {
       app.setLoginItemSettings({openAtLogin: false, path: updateExe, args: processStartArgs})
     })
 
-    it('returns the login item status of the app', (done) => {
-      app.setLoginItemSettings({openAtLogin: true})
-      assert.deepEqual(app.getLoginItemSettings(), {
-        openAtLogin: true,
-        openAsHidden: false,
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false
-      })
-
-      app.setLoginItemSettings({openAtLogin: true, openAsHidden: true})
-      assert.deepEqual(app.getLoginItemSettings(), {
-        openAtLogin: true,
-        openAsHidden: process.platform === 'darwin' && !process.mas, // Only available on macOS
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false
-      })
-
-      app.setLoginItemSettings({})
+    it('sets and returns the app as a login item', done => {
+      app.setLoginItemSettings({ openAtLogin: true })
       // Wait because login item settings are not applied immediately in MAS build
-      const delay = process.mas ? 100 : 0
+      const delay = process.mas ? 150 : 0
       setTimeout(() => {
-        assert.deepEqual(app.getLoginItemSettings(), {
-          openAtLogin: false,
+        assert.equal(app.getLoginItemSettings(), {
+          openAtLogin: true,
           openAsHidden: false,
           wasOpenedAtLogin: false,
           wasOpenedAsHidden: false,
@@ -449,6 +431,32 @@ describe('app module', () => {
         })
         done()
       }, delay)
+    })
+
+    it('adds a login item that loads in hidden mode', () => {
+      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
+      assert.equal(app.getLoginItemSettings(), {
+        openAtLogin: true,
+        openAsHidden: process.platform === 'darwin' && !process.mas, // Only available on macOS
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
+        restoreState: false
+      })
+    })
+
+    it('correctly sets and unsets the LoginItem as hidden', function () {
+      if (process.platform !== 'darwin' || process.mas) this.skip()
+
+      assert.equal(app.getLoginItemSettings().openAtLogin, false)
+      assert.equal(app.getLoginItemSettings().openAsHidden, false)
+
+      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
+      assert.equal(app.getLoginItemSettings().openAtLogin, true)
+      assert.equal(app.getLoginItemSettings().openAsHidden, true)
+
+      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: false })
+      assert.equal(app.getLoginItemSettings().openAtLogin, true)
+      assert.equal(app.getLoginItemSettings().openAsHidden, false)
     })
 
     it('allows you to pass a custom executable and arguments', function () {


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/15010.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: fixes issue with setting and unsetting an app as a LoginItem