### PR TITLE
fix: Memory > Profiles > Load in DevTools

### DIFF
--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -5,8 +5,7 @@ window.onload = function () {
   window.InspectorFrontendHost.showContextMenuAtPoint = createMenu
 
   // Use dialog API to override file chooser dialog.
-  // Note: It will be moved to UI after Chrome 57.
-  window.Bindings.createFileSelectorElement = createFileSelectorElement
+  window.UI.createFileSelectorElement = createFileSelectorElement
 }
 
 window.confirm = function (message, title) {


### PR DESCRIPTION
#### Description of Change
Address comment in `inspector.js`:
```
// Use dialog API to override file chooser dialog.
// Note: It will be moved to UI after Chrome 57.
```
Chromium now calls `UI.createFileSelectorElement` in [ProfilesPanel.js](https://cs.chromium.org/chromium/src/third_party/blink/renderer/devtools/front_end/profiler/ProfilesPanel.js?type=cs&q=createFileSelectorElement&sq=package:chromium&g=0&l=127)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Fixed Memory > Profiles > Load in DevTools