### PR TITLE
build: Enable PIE when compiling Linux builds, fix #14961. (3-0-x)

### DIFF
--- a/brightray/brightray.gyp
+++ b/brightray/brightray.gyp
@@ -84,6 +84,8 @@
           },
           'cflags': [
             '<!@(<(pkg-config) --cflags <(linux_system_libraries))',
+            # Needed for PIE
+            '-fPIC',
           ],
           'direct_dependent_settings': {
             'cflags': [

--- a/common.gypi
+++ b/common.gypi
@@ -263,6 +263,7 @@
           ['OS=="linux"', {
             'cflags': [
               '-Wno-empty-body',
+              '-fPIC',
             ],
           }],  # OS=="linux"
           ['OS=="win"', {

--- a/electron.gyp
+++ b/electron.gyp
@@ -253,6 +253,16 @@
               ],
             },
           ],
+          'link_settings': {
+            'ldflags': [
+              # Build as Position-Independent Executable to mitigate exploitations.
+              '-pie',
+            ],
+          },
+          'cflags_cc': [
+            # Needed for PIE
+            '-fPIC',
+          ]
         }],  # OS=="linux"
       ],
     },  # target <(project_name)
@@ -441,6 +451,7 @@
           # Required settings of using breakpad.
           'cflags_cc': [
             '-Wno-empty-body',
+            '-fPIC',
           ],
           'include_dirs': [
             'vendor/breakpad/src',


### PR DESCRIPTION
#### Description of Change

[Corresponding 2-0-x's PR is here.](https://github.com/electron/electron/pull/15148)

> build: Enable PIE when compiling Linux builds, fix #14961. (3-0-x)
>
> PIE allows an application to utilize the full benefits of ASLR
> to prevent itself from exploitations, but it was disabled for
> all released versions of Electron (3.0 and prior).
> 
> Currently, PIE is already enabled since 9294fac but enabling it
> for all released version is still an ongoing work (#14961). This
> patch backports PIE to the 3.0.x branch.
> 
> Signed-off-by: Tom Li <tomli@tomli.me>
> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Enable PIE when compiling Linux builds.