### PR TITLE
build: enable BIND_NOW when compiling Linux builds, fix #15149. (3-0-x)

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -257,6 +257,8 @@
             'ldflags': [
               # Build as Position-Independent Executable to mitigate exploitations.
               '-pie',
+              # Enable BIND_NOW to prevent GOT overwrite attacks.
+              '-Wl,-z,now',
             ],
           },
           'cflags_cc': [


### PR DESCRIPTION
#### Description of Change

[Corresponding 2-0-x's PR is here.](https://github.com/electron/electron/pull/15150)

**This should be merged after #15152.**

> build: enable BIND_NOW when compiling Linux builds, fix #15149.
>     
> We've hardened Linux builds by enabling PIE and RELRO,
> and should continue to try hardening Linux builds by
> enabling BIND_NOW. With both RELRO and BIND_NOW enabled,
> we can stop all GOT overwrite attacks. The same hardening
> option has been enabled in official Chrome/Chromium
> builds since more than five years ago.
>     
> This helps to improve the security of a whole range of
> applications built upon Electron, including sensetive ones
> such as Signal-Desktop.
>
> Signed-off-by: Tom Li <tomli@tomli.me>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Enable BIND_NOW when compiling Linux builds.