### PR TITLE
fix: enable use of NODE_OPTIONS env var

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '69.0.3497.106',
   'node_version':
-    'f14ddf9d7e07739dc1dc0cbe2f7a5ba8b44906d1',
+    '4d44266b78256449dd6ae86e419e3ec07257b569',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "atom/common/api/event_emitter_caller.h"
@@ -18,6 +19,7 @@
 #include "base/environment.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
+#include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "base/trace_event/trace_event.h"
@@ -213,19 +215,69 @@ void NodeBindings::Initialize() {
   // Explicitly register electron's builtin modules.
   RegisterBuiltinModules();
 
-  // Init node.
-  // (we assume node::Init would not modify the parameters under embedded mode).
-  // NOTE: If you change this line, please ping @codebytere or @MarshallOfSound
-  int argc = 0;
+  // pass non-null program name to argv so it doesn't crash
+  // trying to index into a nullptr
+  int argc = 1;
   int exec_argc = 0;
-  const char** argv = nullptr;
+  const char* prog_name = "electron";
+  const char** argv = &prog_name;
   const char** exec_argv = nullptr;
+
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  if (env->HasVar("NODE_OPTIONS")) {
+    base::FilePath exe_path;
+    base::PathService::Get(base::FILE_EXE, &exe_path);
+    std::string path = exe_path.value();
+    std::transform(path.begin(), path.end(), path.begin(), ::tolower);
+
+#if defined(OS_WIN)
+    const bool is_packaged_app = path == "electron.exe";
+#else
+    const bool is_packaged_app = path == "electron";
+#endif
+
+    // explicitly disallow NODE_OPTIONS in packaged apps
+    if (is_packaged_app) {
+      LOG(WARNING) << "NODE_OPTIONs are not supported in packaged apps";
+      env->SetVar("NODE_OPTIONS", "");
+    } else {
+      const std::vector<std::string> disallowed = {
+          "--openssl-config", "--use-bundled-ca", "--use-openssl-ca",
+          "--force-fips", "--enable-fips"};
+
+      std::string options;
+      env->GetVar("NODE_OPTIONS", &options);
+      std::vector<std::string> parts = base::SplitString(
+          options, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+
+      // parse passed options for unsupported options
+      // and remove them from the options list
+      std::string new_options = options;
+      for (const auto& disallow : disallowed) {
+        for (const auto& part : parts) {
+          if (part.find(disallow) != std::string::npos) {
+            LOG(WARNING) << "The NODE_OPTION" << disallow
+                         << "is not supported in Electron";
+            new_options.erase(new_options.find(part), part.length());
+            break;
+          }
+        }
+      }
+
+      // overwrite new NODE_OPTIONS without unsupported variables
+      if (new_options != options)
+        env->SetVar("NODE_OPTIONS", new_options);
+    }
+  }
+
+  // TODO(codebytere): this is going to be deprecated in the near future
+  // in favor of Init(std::vector<std::string>* argv,
+  //        std::vector<std::string>* exec_argv)
   node::Init(&argc, argv, &exec_argc, &exec_argv);
 
 #if defined(OS_WIN)
   // uv_init overrides error mode to suppress the default crash dialog, bring
   // it back if user wants to show it.
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
   if (browser_env_ == BROWSER || env->HasVar("ELECTRON_DEFAULT_ERROR_MODE"))
     SetErrorMode(GetErrorMode() & ~SEM_NOGPFAULTERRORBOX);
 #endif

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -24,6 +24,28 @@ Windows console example:
 The following environment variables are intended primarily for use at runtime
 in packaged Electron applications.
 
+### `NODE_OPTIONS`
+
+Electron includes support for a subset of Node's [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#cli_node_options_options). The majority are supported with the exception of those which conflict with Chromium's use of BoringSSL.
+
+Example:
+
+```sh
+export NODE_OPTIONS="--no-warnings --max-old-space-size=2048"
+```
+
+Unsupported options are:
+
+```sh
+--use-bundled-ca
+--force-fips
+--enable-fips
+--openssl-config
+--use-openssl-ca
+```
+
+`NODE_OPTIONS` are explicitly disallowed in packaged apps.
+
 ### `GOOGLE_API_KEY`
 
 Electron includes a hardcoded API key for making requests to Google's geocoding


### PR DESCRIPTION
#### Description of Change

Enables use of `NODE_OPTIONS` environment variable in Electron. 

Depends on https://github.com/electron/node/pull/76.

Potential concerns: options relating to V8 that may cause collisions should they misalign with Blink's V8 usage.

/cc @deepak1556

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Enable use of NODE_OPTIONS env var