### PR TITLE
fix: allow renaming electron.exe

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -731,6 +731,16 @@ if (is_mac) {
         "/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll",
         "/DELAYLOAD:api-ms-win-core-winrt-string-l1-1-0.dll",
       ]
+
+      # This is to support renaming of electron.exe. node-gyp has hard-coded
+      # executable names which it will recognise as node. This module definition
+      # file claims that the electron executable is in fact named "node.exe",
+      # which is one of the executable names that node-gyp recognizes.
+      # See https://github.com/nodejs/node-gyp/commit/52ceec3a6d15de3a8f385f43dbe5ecf5456ad07a
+      ldflags += [ "/DEF:" + rebase_path("build/electron.def", root_build_dir) ]
+      inputs = [
+        "build/electron.def",
+      ]
     }
     if (is_linux) {
       ldflags = [ "-pie" ]

--- a/build/electron.def
+++ b/build/electron.def
@@ -1,0 +1,6 @@
+; This is to support renaming of electron.exe. node-gyp has hard-coded
+; executable names which it will recognise as node. This module definition
+; file claims that the electron executable is in fact named "node.exe",
+; which is one of the executable names that node-gyp recognizes.
+; See https://github.com/nodejs/node-gyp/commit/52ceec3a6d15de3a8f385f43dbe5ecf5456ad07a
+NAME node.exe


### PR DESCRIPTION
#### Description of Change
Fixes #15147

See also nodejs/node-gyp#1566, which fixes this problem in node-gyp upstream, but until that's merged and released this workaround is needed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fix an issue preventing the electron.exe executable from being renamed on Windows when using native modules