### PR TITLE
fix: Menu accelerators not working Unity

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -873,14 +873,17 @@ void NativeWindowViews::SetFocusable(bool focusable) {
 
 void NativeWindowViews::SetMenu(AtomMenuModel* menu_model) {
 #if defined(USE_X11)
-  if (menu_model == nullptr)
+  if (menu_model == nullptr) {
     global_menu_bar_.reset();
+    root_view_->UnregisterAcceleratorsWithFocusManager();
+  }
 
   if (!global_menu_bar_ && ShouldUseGlobalMenuBar())
     global_menu_bar_.reset(new GlobalMenuBarX11(this));
 
   // Use global application menu bar when possible.
   if (global_menu_bar_ && global_menu_bar_->IsServerStarted()) {
+    root_view_->RegisterAcceleratorsWithFocusManager(menu_model);
     global_menu_bar_->SetMenu(menu_model);
     return;
   }

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -44,15 +44,14 @@ RootView::~RootView() {}
 void RootView::SetMenu(AtomMenuModel* menu_model) {
   if (menu_model == nullptr) {
     // Remove accelerators
-    accelerator_table_.clear();
-    GetFocusManager()->UnregisterAccelerators(this);
+    UnregisterAcceleratorsWithFocusManager();
     // and menu bar.
     SetMenuBarVisibility(false);
     menu_bar_.reset();
     return;
   }
 
-  RegisterAccelerators(menu_model);
+  RegisterAcceleratorsWithFocusManager(menu_model);
 
   // Do not show menu bar in frameless window.
   if (!window_->has_frame())
@@ -178,18 +177,23 @@ bool RootView::AcceleratorPressed(const ui::Accelerator& accelerator) {
                                                           accelerator);
 }
 
-void RootView::RegisterAccelerators(AtomMenuModel* menu_model) {
+void RootView::RegisterAcceleratorsWithFocusManager(AtomMenuModel* menu_model) {
   // Clear previous accelerators.
-  views::FocusManager* focus_manager = GetFocusManager();
-  accelerator_table_.clear();
-  focus_manager->UnregisterAccelerators(this);
+  UnregisterAcceleratorsWithFocusManager();
 
+  views::FocusManager* focus_manager = GetFocusManager();
   // Register accelerators with focus manager.
   accelerator_util::GenerateAcceleratorTable(&accelerator_table_, menu_model);
   for (const auto& iter : accelerator_table_) {
     focus_manager->RegisterAccelerator(
         iter.first, ui::AcceleratorManager::kNormalPriority, this);
   }
+}
+
+void RootView::UnregisterAcceleratorsWithFocusManager() {
+  views::FocusManager* focus_manager = GetFocusManager();
+  accelerator_table_.clear();
+  focus_manager->UnregisterAccelerators(this);
 }
 
 }  // namespace atom

--- a/atom/browser/ui/views/root_view.h
+++ b/atom/browser/ui/views/root_view.h
@@ -34,6 +34,9 @@ class RootView : public views::View {
   bool IsMenuBarVisible() const;
   void HandleKeyEvent(const content::NativeWebKeyboardEvent& event);
   void ResetAltState();
+  // Register/Unregister accelerators supported by the menu model.
+  void RegisterAcceleratorsWithFocusManager(AtomMenuModel* menu_model);
+  void UnregisterAcceleratorsWithFocusManager();
 
   // views::View:
   void Layout() override;
@@ -42,9 +45,6 @@ class RootView : public views::View {
   bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
 
  private:
-  // Register accelerators supported by the menu model.
-  void RegisterAccelerators(AtomMenuModel* menu_model);
-
   // Parent window, weak ref.
   NativeWindow* window_;
 


### PR DESCRIPTION
#### Description of Change
Manually backporting single commit from #15094, not backporting the test as it needs robotjs dependency.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Fixed bug that caused menu accelerators to stop working on some linux