### PR TITLE
fix: simpleFullscreen window should be on top of other OS X menu bars.

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -213,6 +213,7 @@ class NativeWindowMac : public NativeWindow,
   bool was_maximizable_;
   bool was_movable_;
   NSRect original_frame_;
+  NSInteger original_level_;
   NSUInteger simple_fullscreen_mask_;
 
   base::scoped_nsobject<NSColor> background_color_before_vibrancy_;


### PR DESCRIPTION
If an app has no menu bar (because `app.dock.hide()` has been called),
OS X will still render the menu bar of the previously-focused app.

This commit ensures simpleFullscreen windows will be drawn on top of
that menu bar by setting their level to NSPopUpMenuWindowLevel while
simpleFullscreen mode is active.

Ref: #11468

Backport requested by @codebytere: https://github.com/electron/electron/pull/14881#issuecomment-428444403

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: Fixed simpleFullscreen windows in hidden-dock apps from being drawn below OS X menu bar of previously-focused app.