### PR TITLE
fix: simpleFullscreen window should be on top of other OS X menu bars.

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -199,6 +199,7 @@ class NativeWindowMac : public NativeWindow {
   bool was_maximizable_ = false;
   bool was_movable_ = false;
   NSRect original_frame_;
+  NSInteger original_level_;
   NSUInteger simple_fullscreen_mask_;
 
   base::scoped_nsobject<NSColor> background_color_before_vibrancy_;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -469,6 +469,9 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   // Default content view.
   SetContentView(new views::View());
   AddContentViewLayers();
+
+  original_frame_ = [window_ frame];
+  original_level_ = [window_ level];
 }
 
 NativeWindowMac::~NativeWindowMac() {
@@ -859,8 +862,9 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
   if (simple_fullscreen && !is_simple_fullscreen_) {
     is_simple_fullscreen_ = true;
 
-    // Take note of the current window size
+    // Take note of the current window size and level
     original_frame_ = [window frame];
+    original_level_ = [window level];
 
     simple_fullscreen_options_ = [NSApp currentSystemPresentationOptions];
     simple_fullscreen_mask_ = [window styleMask];
@@ -876,6 +880,13 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     was_movable_ = IsMovable();
 
     NSRect fullscreenFrame = [window.screen frame];
+
+    // If our app has dock hidden, set the window level higher so another app's
+    // menu bar doesn't appear on top of our fullscreen app.
+    if ([[NSRunningApplication currentApplication] activationPolicy] !=
+        NSApplicationActivationPolicyRegular) {
+      window.level = NSPopUpMenuWindowLevel;
+    }
 
     if (!fullscreen_window_title()) {
       // Hide the titlebar
@@ -912,6 +923,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     }
 
     [window setFrame:original_frame_ display:YES animate:YES];
+    window.level = original_level_;
 
     [NSApp setPresentationOptions:simple_fullscreen_options_];
 


### PR DESCRIPTION
If an app has no menu bar (because `app.dock.hide()` has been called),
OS X will still render the menu bar of the previously-focused app.

This commit ensures simpleFullscreen windows will be drawn on top of
that menu bar by setting their level to NSPopUpMenuWindowLevel while
simpleFullscreen mode is active.

Ref: #11468

Backport requested by @codebytere: https://github.com/electron/electron/pull/14881#issuecomment-428444403

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: Fixed simpleFullscreen windows in hidden-dock apps from being drawn below OS X menu bar of previously-focused app.