### PR TITLE
fix: correctly enable and disable windows on Windows and Linux

### DIFF
--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -149,6 +149,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetMenu(AtomMenuModel* menu);
   virtual void SetParentWindow(NativeWindow* parent);
   virtual void SetBrowserView(NativeBrowserView* browser_view) = 0;
+  virtual void SetHasChildModal(bool has_modal) = 0;
   virtual gfx::NativeView GetNativeView() const = 0;
   virtual gfx::NativeWindow GetNativeWindow() const = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() const = 0;
@@ -284,6 +285,10 @@ class NativeWindow : public base::SupportsUserData,
 
  protected:
   NativeWindow(const mate::Dictionary& options, NativeWindow* parent);
+
+  // Whether or not this window has a modal child;
+  // used to determine enabled state
+  bool has_child_modal_ = false;
 
   // views::WidgetDelegate:
   views::Widget* GetWidget() override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -112,6 +112,7 @@ class NativeWindowViews : public NativeWindow,
   void SetMenu(AtomMenuModel* menu_model) override;
   void SetBrowserView(NativeBrowserView* browser_view) override;
   void SetParentWindow(NativeWindow* parent) override;
+  void SetHasChildModal(bool has_modal) override;
   gfx::NativeView GetNativeView() const override;
   gfx::NativeWindow GetNativeWindow() const override;
   void SetOverlayIcon(const gfx::Image& overlay,
@@ -189,6 +190,10 @@ class NativeWindowViews : public NativeWindow,
                                         WPARAM w_param,
                                         LPARAM l_param);
 #endif
+
+  // Enable/disable:
+  bool ShouldBeEnabled();
+  void SetEnabledInternal(bool enabled);
 
   // NativeWindow:
   void HandleKeyboardEvent(
@@ -273,8 +278,8 @@ class NativeWindowViews : public NativeWindow,
   // has to been explicitly provided.
   std::unique_ptr<SkRegion> draggable_region_;  // used in custom drag.
 
-  // How many times the Disable has been called.
-  int disable_count_ = 0;
+  // Whether the window should be enabled based on user calls to SetEnabled()
+  bool is_enabled_ = true;
 
   bool use_content_size_ = false;
   bool movable_ = true;


### PR DESCRIPTION
#### Description of Change

Fixes #14632

Currently, we keep track of the number of calls to `NativeWindowViews::SetEnabled()` to determine when to actually enable or disable a Window; here's some additional information, taken from [this comment](https://github.com/electron/electron/issues/14632#issuecomment-428290004):

> On Windows and Linux, when you create a new modal window using `new BrowserWindow({ parent, modal: true })`, we [disable the parent window while the child window is shown](https://github.com/electron/electron/blob/d678d9ee7521d93e7a269f02966332151122c42a/atom/browser/native_window_views.cc#L344-L347). When the child window is hidden, we [re-enable the parent window](https://github.com/electron/electron/blob/d678d9ee7521d93e7a269f02966332151122c42a/atom/browser/native_window_views.cc#L370-L372). If the parent window was *already* disabled when the child window was shown, then this would be a bug (we would not want to re-enable the parent window unless it was enabled in the first place). The `disable_count_` check seems to be a mechanism to ensure that every call to `SetEnabled(false)` needs to be matched with a call to `SetEnabled(true)`, preventing this bug. Similarly, if we show more than one child modal, we only want to re-enable the parent window after *all* the modal windows have been closed.

Because users can also call `NativeWindowViews::SetEnabled` (via `BrowserWindow#setEnabled`), this count can get out of sync and cause strange issues (like `setEnabled(true)` not actually enabling the window).

This PR removes the count and replaces it with two boolean flags: the first tracks whether the window should be enabled based on (user) calls to `setEnabled()`, and the second keeps track of whether the window has any modal children. Any time these flags change, we recompute whether the window should *actually* be enabled and modify it accordingly.

This PR *also* fixes a bug where calling `setEnabled(false)` twice in a row segfaults on Linux.

Current test code for this feature sets two modal children on a window and keeps track of whether or not the parent window is enabled. However, windows with multiple modals are not well supported on Linux (the UI gets a bit weird), so I wonder if we should explicitly either disallow that or log a warning if a window already has a modal and the user is adding a second one.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: fix: correctly enable and disable windows on Windows and Linux