### PR TITLE
fix: don't call ReadRawDataComplete if it's not necessary

### DIFF
--- a/atom/browser/net/url_request_stream_job.cc
+++ b/atom/browser/net/url_request_stream_job.cc
@@ -153,13 +153,17 @@ void URLRequestStreamJob::OnData(std::vector<char>&& buffer) {  // NOLINT
   if (pending_buf_) {
     int len = BufferCopy(&write_buffer_, pending_buf_.get(), pending_buf_size_);
     write_buffer_.erase(write_buffer_.begin(), write_buffer_.begin() + len);
+    pending_buf_ = nullptr;
+    pending_buf_size_ = 0;
     ReadRawDataComplete(len);
   }
 }
 
 void URLRequestStreamJob::OnEnd() {
   ended_ = true;
-  ReadRawDataComplete(0);
+  if (pending_buf_) {
+    ReadRawDataComplete(0);
+  }
 }
 
 void URLRequestStreamJob::OnError(int error) {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
We shouldn't call `ReadRawDataComplete` when `OnEnd` is called. This causes a possible crash in release builds, because [chromium started using `OnceCallback`s](https://chromium.googlesource.com/chromium/src/+/5f11548b7ddf26564dbb1bbf5ebf001db48ac6ac%5E%21/#F13) in this part of the code, so when `ReadRawDataComplete` is called when no prior `ReadRawData` call has returned `net::ERR_IO_PENDING` (and thus no callback was set by chromium), we would be calling a `null` callback.

Also, reset `pending_buf_`, since that fixes a failed `DCHECK` [here](https://cs.chromium.org/chromium/src/net/url_request/url_request_job.cc?dr=CSs&g=0&l=509). My best guess is that this check might get triggered when two `OnData` calls arrive between `ReadRawData` calls.

Possibly fixes #15121

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: <!-- One-line Change Summary Here--> fixes crash when using stream protocols