### PR TITLE
chore: warn memory leak when using nativeWindowOpen with nodeIntegration (3-0-x)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -806,8 +806,10 @@ void WebContents::DidChangeThemeColor(SkColor theme_color) {
 
 void WebContents::DocumentLoadedInFrame(
     content::RenderFrameHost* render_frame_host) {
-  if (!render_frame_host->GetParent())
+  if (!render_frame_host->GetParent()) {
+    is_dom_ready_ = true;
     Emit("dom-ready");
+  }
 }
 
 void WebContents::DidFinishLoad(content::RenderFrameHost* render_frame_host,
@@ -834,6 +836,7 @@ void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
 }
 
 void WebContents::DidStartLoading() {
+  is_dom_ready_ = false;
   Emit("did-start-loading");
 }
 
@@ -1405,6 +1408,10 @@ void WebContents::SetAudioMuted(bool muted) {
 
 bool WebContents::IsAudioMuted() {
   return web_contents()->IsAudioMuted();
+}
+
+bool WebContents::IsDOMReady() const {
+  return is_dom_ready_;
 }
 
 void WebContents::Print(mate::Arguments* args) {
@@ -2002,6 +2009,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setIgnoreMenuShortcuts", &WebContents::SetIgnoreMenuShortcuts)
       .SetMethod("setAudioMuted", &WebContents::SetAudioMuted)
       .SetMethod("isAudioMuted", &WebContents::IsAudioMuted)
+      .SetMethod("isDomReady", &WebContents::IsDOMReady)
       .SetMethod("undo", &WebContents::Undo)
       .SetMethod("redo", &WebContents::Redo)
       .SetMethod("cut", &WebContents::Cut)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -142,6 +142,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetIgnoreMenuShortcuts(bool ignore);
   void SetAudioMuted(bool muted);
   bool IsAudioMuted();
+  bool IsDOMReady() const;
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   void SetEmbedder(const WebContents* embedder);
@@ -461,6 +462,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether to enable devtools.
   bool enable_devtools_ = true;
+
+  // Whether page's document is ready.
+  bool is_dom_ready_ = false;
 
   // Observers of this WebContents.
   base::ObserverList<ExtendedWebContentsObserver> observers_;

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -54,7 +54,13 @@ BrowserWindow.prototype._init = function () {
         '"nativeWindowOpen" option will cause memory leaks, please turn off ' +
         'the "nodeIntegration" option.\\n' +
         'See https://github.com/electron/electron/pull/15076 for more.'
-      this.webContents.executeJavaScript(`console.warn('${message}')`)
+      // console is only available after DOM is created.
+      const printWarning = () => this.webContents.executeJavaScript(`console.warn('${message}')`)
+      if (this.webContents.isDomReady()) {
+        printWarning()
+      } else {
+        this.webContents.once('dom-ready', printWarning)
+      }
     }
 
     let {url, frameName} = urlFrameName

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -48,6 +48,15 @@ BrowserWindow.prototype._init = function () {
       return
     }
 
+    if (webContents.getLastWebPreferences().nodeIntegration === true) {
+      const message =
+        'Enabling Node.js integration in child windows opened with the ' +
+        '"nativeWindowOpen" option will cause memory leaks, please turn off ' +
+        'the "nodeIntegration" option.\\n' +
+        'See https://github.com/electron/electron/pull/15076 for more.'
+      this.webContents.executeJavaScript(`console.warn('${message}')`)
+    }
+
     let {url, frameName} = urlFrameName
     v8Util.deleteHiddenValue(webContents, 'url-framename')
     const options = {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Print a memory leak warning when the child windows opened with `nativeWindowOpen`  option have node integration.

Refs https://github.com/electron/electron/issues/12634, https://github.com/electron/electron/pull/15076#issuecomment-429225532.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Print a memory leak warning when the child windows opened with `nativeWindowOpen`  option have node integration.