### PR TITLE
docs: deprecation warning for using nativeWindowOpen with nodeIntegration (4-0-x)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -814,8 +814,10 @@ void WebContents::DidChangeThemeColor(SkColor theme_color) {
 
 void WebContents::DocumentLoadedInFrame(
     content::RenderFrameHost* render_frame_host) {
-  if (!render_frame_host->GetParent())
+  if (!render_frame_host->GetParent()) {
+    is_dom_ready_ = true;
     Emit("dom-ready");
+  }
 }
 
 void WebContents::DidFinishLoad(content::RenderFrameHost* render_frame_host,
@@ -842,6 +844,7 @@ void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
 }
 
 void WebContents::DidStartLoading() {
+  is_dom_ready_ = false;
   Emit("did-start-loading");
 }
 
@@ -1420,6 +1423,10 @@ bool WebContents::IsAudioMuted() {
 
 bool WebContents::IsCurrentlyAudible() {
   return web_contents()->IsCurrentlyAudible();
+}
+
+bool WebContents::IsDOMReady() const {
+  return is_dom_ready_;
 }
 
 void WebContents::Print(mate::Arguments* args) {
@@ -2019,6 +2026,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setAudioMuted", &WebContents::SetAudioMuted)
       .SetMethod("isAudioMuted", &WebContents::IsAudioMuted)
       .SetMethod("isCurrentlyAudible", &WebContents::IsCurrentlyAudible)
+      .SetMethod("isDomReady", &WebContents::IsDOMReady)
       .SetMethod("undo", &WebContents::Undo)
       .SetMethod("redo", &WebContents::Redo)
       .SetMethod("cut", &WebContents::Cut)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -141,6 +141,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetAudioMuted(bool muted);
   bool IsAudioMuted();
   bool IsCurrentlyAudible();
+  bool IsDOMReady() const;
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   void SetEmbedder(const WebContents* embedder);
@@ -490,6 +491,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether to enable devtools.
   bool enable_devtools_ = true;
+
+  // Whether page's document is ready.
+  bool is_dom_ready_ = false;
 
   // Observers of this WebContents.
   base::ObserverList<ExtendedWebContentsObserver> observers_;

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -18,6 +18,9 @@ The following `webPreferences` option default values are deprecated in favor of 
 | `nodeIntegration` | `true` | `false` |
 | `webviewTag` | `nodeIntegration` if set else `true` | `false` |
 
+## `nativeWindowOpen`
+
+Child windows opened with the `nativeWindowOpen` option will always have Node.js integration disabled.
 
 # Planned Breaking API Changes (4.0)
 

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -57,7 +57,13 @@ BrowserWindow.prototype._init = function () {
         'From 5.x child windows opened with the "nativeWindowOpen" option ' +
         'will always have Node.js integration disabled.\\n' +
         'See https://github.com/electron/electron/pull/15076 for more.'
-      this.webContents.executeJavaScript(`console.warn('${message}')`)
+      // console is only available after DOM is created.
+      const printWarning = () => this.webContents.executeJavaScript(`console.warn('${message}')`)
+      if (this.webContents.isDomReady()) {
+        printWarning()
+      } else {
+        this.webContents.once('dom-ready', printWarning)
+      }
     }
 
     const { url, frameName } = urlFrameName

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -49,6 +49,17 @@ BrowserWindow.prototype._init = function () {
       return
     }
 
+    if (webContents.getLastWebPreferences().nodeIntegration === true) {
+      const message =
+        'Enabling Node.js integration in child windows opened with the ' +
+        '"nativeWindowOpen" option will cause memory leaks, please turn off ' +
+        'the "nodeIntegration" option.\\n' +
+        'From 5.x child windows opened with the "nativeWindowOpen" option ' +
+        'will always have Node.js integration disabled.\\n' +
+        'See https://github.com/electron/electron/pull/15076 for more.'
+      this.webContents.executeJavaScript(`console.warn('${message}')`)
+    }
+
     const { url, frameName } = urlFrameName
     v8Util.deleteHiddenValue(webContents, 'url-framename')
     const options = {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Print a deprecation warning when the child windows opened with `nativeWindowOpen`  option have node integration.

Refs https://github.com/electron/electron/issues/12634, https://github.com/electron/electron/pull/15076#issuecomment-429225532.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Print a deprecation warning when the child windows opened with `nativeWindowOpen`  option have node integration.