### PR TITLE
add width to webview iframe

### DIFF
--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -47,6 +47,7 @@ class WebViewImpl {
   createInternalElement () {
     const iframeElement = document.createElement('iframe')
     iframeElement.style.flex = '1 1 auto'
+    iframeElement.style.width = '100%'
     iframeElement.style.border = '0'
     v8Util.setHiddenValue(iframeElement, 'internal', this)
     return iframeElement


### PR DESCRIPTION
#### Description of Change
Without the width set, the minimum width of the iframe element is 300px, regardless of the width of the parent webview element.  If the webview width is set to a value less than 300px, this will cause the child iframe to not be larger than the parent.

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes