### PR TITLE
docs: change examples in docs to use for..of and async/await (#14842)

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -12,28 +12,34 @@ title is `Electron`:
 // In the renderer process.
 const { desktopCapturer } = require('electron')
 
-desktopCapturer.getSources({ types: ['window', 'screen'] }, (error, sources) => {
+desktopCapturer.getSources({ types: ['window', 'screen'] }, async (error, sources) => {
   if (error) throw error
-  for (let i = 0; i < sources.length; ++i) {
-    if (sources[i].name === 'Electron') {
-      navigator.mediaDevices.getUserMedia({
-        audio: false,
-        video: {
-          mandatory: {
-            chromeMediaSource: 'desktop',
-            chromeMediaSourceId: sources[i].id,
-            minWidth: 1280,
-            maxWidth: 1280,
-            minHeight: 720,
-            maxHeight: 720
+  for (const source in sources) {
+    if(source.name=='Electron'){
+      try{
+        const stream = await navigator.mediDevices.getUserMedia({
+          audio:false,
+          video:{
+            mandatory:{
+              chromeMediaSource: 'desktop',
+              chromeMediaSourceId: source.id,
+              minWidth: 1280,
+              maxWidth: 1280,
+              minHeight: 720,
+              maxHeight: 720
+            }
           }
-        }
-      }).then((stream) => handleStream(stream))
-        .catch((e) => handleError(e))
+        })
+        handleStream(stream)
+      }
+      catch(e){
+        handleError(e)
+      }
       return
     }
   }
 })
+
 
 function handleStream (stream) {
   const video = document.querySelector('video')

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -17,7 +17,7 @@ desktopCapturer.getSources({ types: ['window', 'screen'] }, async (error, source
   for (const source in sources) {
     if(source.name=='Electron'){
       try{
-        const stream = await navigator.mediDevices.getUserMedia({
+        const stream = await navigator.mediaDevices.getUserMedia({
           audio:false,
           video:{
             mandatory:{

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -14,7 +14,7 @@ const { desktopCapturer } = require('electron')
 
 desktopCapturer.getSources({ types: ['window', 'screen'] }, async (error, sources) => {
   if (error) throw error
-  for (const source in sources) {
+  for (const source of sources) {
     if (source.name === 'Electron') {
       try {
         const stream = await navigator.mediaDevices.getUserMedia({

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -15,12 +15,12 @@ const { desktopCapturer } = require('electron')
 desktopCapturer.getSources({ types: ['window', 'screen'] }, async (error, sources) => {
   if (error) throw error
   for (const source in sources) {
-    if(source.name=='Electron'){
-      try{
+    if (source.name === 'Electron') {
+      try {
         const stream = await navigator.mediaDevices.getUserMedia({
-          audio:false,
-          video:{
-            mandatory:{
+          audio: false,
+          video: {
+            mandatory: {
               chromeMediaSource: 'desktop',
               chromeMediaSourceId: source.id,
               minWidth: 1280,
@@ -31,15 +31,13 @@ desktopCapturer.getSources({ types: ['window', 'screen'] }, async (error, source
           }
         })
         handleStream(stream)
-      }
-      catch(e){
+      } catch (e) {
         handleError(e)
       }
       return
     }
   }
 })
-
 
 function handleStream (stream) {
   const video = document.querySelector('video')

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -27,25 +27,26 @@ var app = new Application({
   path: '/Applications/MyApp.app/Contents/MacOS/MyApp'
 })
 
-app.start().then(function () {
-  // Check if the window is visible
-  return app.browserWindow.isVisible()
-}).then(function (isVisible) {
-  // Verify the window is visible
-  assert.strictEqual(isVisible, true)
-}).then(function () {
-  // Get the window's title
-  return app.client.getTitle()
-}).then(function (title) {
-  // Verify the window's title
-  assert.strictEqual(title, 'My App')
-}).catch(function (error) {
-  // Log any failures
-  console.error('Test failed', error.message)
-}).then(function () {
-  // Stop the application
-  return app.stop()
-})
+(
+  async ()=>{
+    await app.start()
+    try{
+      // Check if the window is visible
+      const isVisible = await app.browserWindow.isVisible()
+      // Verify the window is visible
+      assert.strictEqual(isVisible, true)
+      // Get the window's title
+      const title = await app.client.getTitle()
+      // Verify the window's title
+      assert.strictEqual(title, 'My App')
+    }
+    catch(error){
+      console.error('Test failed', error.message)
+    }
+    // Stop the application
+    await app.stop()
+  }
+)()
 ```
 
 ## Setting up with WebDriverJs

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -25,28 +25,25 @@ var assert = require('assert')
 
 var app = new Application({
   path: '/Applications/MyApp.app/Contents/MacOS/MyApp'
-})
+});
 
-(
-  async ()=>{
-    await app.start()
-    try{
-      // Check if the window is visible
-      const isVisible = await app.browserWindow.isVisible()
-      // Verify the window is visible
-      assert.strictEqual(isVisible, true)
-      // Get the window's title
-      const title = await app.client.getTitle()
-      // Verify the window's title
-      assert.strictEqual(title, 'My App')
-    }
-    catch(error){
-      console.error('Test failed', error.message)
-    }
-    // Stop the application
-    await app.stop()
+(async () => {
+  await app.start()
+  try {
+    // Check if the window is visible
+    const isVisible = await app.browserWindow.isVisible()
+    // Verify the window is visible
+    assert.strictEqual(isVisible, true)
+    // Get the window's title
+    const title = await app.client.getTitle()
+    // Verify the window's title
+    assert.strictEqual(title, 'My App')
+  } catch (error) {
+    console.error('Test failed', error.message)
   }
-)()
+  // Stop the application
+  await app.stop()
+})()
 ```
 
 ## Setting up with WebDriverJs

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -20,14 +20,14 @@ $ npm install --save-dev spectron
 
 ```javascript
 // A simple test to verify a visible window is opened with a title
-var Application = require('spectron').Application
-var assert = require('assert')
+const Application = require('spectron').Application
+const assert = require('assert')
 
-var app = new Application({
+const myApp = new Application({
   path: '/Applications/MyApp.app/Contents/MacOS/MyApp'
-});
+})
 
-(async () => {
+const verifyWindowIsVisibleWithTitle = async (app) => {
   await app.start()
   try {
     // Check if the window is visible
@@ -39,11 +39,14 @@ var app = new Application({
     // Verify the window's title
     assert.strictEqual(title, 'My App')
   } catch (error) {
+    // Log any failures
     console.error('Test failed', error.message)
   }
   // Stop the application
   await app.stop()
-})()
+}
+
+verifyWindowIsVisibleWithTitle(myApp)
 ```
 
 ## Setting up with WebDriverJs


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Changed code examples in desktop-capturer.md and using-selenium-and-webdriver.md to use for..of and async/await instead of normal for loop and Promises.
CC @ckerr @codebytere 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: docs: update some examples in documentation to use async/await and for..of