### PR TITLE
chore: warn memory leak when using nativeWindowOpen with nodeIntegration (2-0-x)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -125,6 +125,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetIgnoreMenuShortcuts(bool ignore);
   void SetAudioMuted(bool muted);
   bool IsAudioMuted();
+  bool IsDOMReady() const;
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   void SetEmbedder(const WebContents* embedder);
@@ -429,6 +430,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Whether to enable devtools.
   bool enable_devtools_;
+
+  // Whether page's document is ready.
+  bool is_dom_ready_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -49,6 +49,15 @@ BrowserWindow.prototype._init = function () {
       return
     }
 
+    if (webContents.getLastWebPreferences().nodeIntegration === true) {
+      const message =
+        'Enabling Node.js integration in child windows opened with the ' +
+        '"nativeWindowOpen" option will cause memory leaks, please turn off ' +
+        'the "nodeIntegration" option.\\n' +
+        'See https://github.com/electron/electron/pull/15076 for more.'
+      this.webContents.executeJavaScript(`console.warn('${message}')`)
+    }
+
     let {url, frameName} = urlFrameName
     v8Util.deleteHiddenValue(webContents, 'url-framename')
     const options = {

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -55,7 +55,13 @@ BrowserWindow.prototype._init = function () {
         '"nativeWindowOpen" option will cause memory leaks, please turn off ' +
         'the "nodeIntegration" option.\\n' +
         'See https://github.com/electron/electron/pull/15076 for more.'
-      this.webContents.executeJavaScript(`console.warn('${message}')`)
+      // console is only available after DOM is created.
+      const printWarning = () => this.webContents.executeJavaScript(`console.warn('${message}')`)
+      if (this.webContents.isDomReady()) {
+        printWarning()
+      } else {
+        this.webContents.once('dom-ready', printWarning)
+      }
     }
 
     let {url, frameName} = urlFrameName


### PR DESCRIPTION
Backport https://github.com/electron/electron/pull/15192 to 2-0-x.

Notes: Print a memory leak warning when the child windows opened with nativeWindowOpen option have node integration.
