### PR TITLE
docs: we don't emit an event object for session-created

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -369,7 +369,6 @@ details.
 
 Returns:
 
-* `event` Event
 * `session` [Session](session.md)
 
 Emitted when Electron has created a new `session`.


### PR DESCRIPTION
Closes #15203 

Notes: fixed documentation for the session-created event