### PR TITLE
test: add test for argument handling in node_debugger.cc

### DIFF
--- a/spec/fixtures/module/noop.js
+++ b/spec/fixtures/module/noop.js
@@ -1,0 +1,1 @@
+process.exit(0)

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -239,6 +239,24 @@ describe('node feature', () => {
       child.stdout.on('data', outDataHandler)
     })
 
+    it('does not start the v8 inspector when --inspect is after a -- argument', (done) => {
+      child = ChildProcess.spawn(remote.process.execPath, [path.join(__dirname, 'fixtures', 'module', 'noop.js'), '--', '--inspect'])
+
+      let output = ''
+      function dataListener (data) {
+        output += data
+      }
+      child.stderr.on('data', dataListener)
+      child.stdout.on('data', dataListener)
+      child.on('exit', () => {
+        if (output.trim().startsWith('Debugger listening on ws://')) {
+          done(new Error('Inspector was started when it should not have been'))
+        } else {
+          done()
+        }
+      })
+    })
+
     it('supports js binding', (done) => {
       child = ChildProcess.spawn(process.execPath, ['--inspect', path.join(__dirname, 'fixtures', 'module', 'inspector-binding.js')], {
         env: {


### PR DESCRIPTION
This adds a spec to ensure no regressions in our node inspector argument handling

Notes: no-notes