### PR TITLE
chore: make spec runner build headers and node.lib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,6 +682,7 @@ steps-tests: &steps-tests
         command: |
           cd src
           export ELECTRON_OUT_DIR=Default
+          export ELECTRON_SPEC_NO_HEADER_BUILD=1
           (cd electron && npm run test -- --ci)
     - run:
         name: Check test results existence

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,10 +84,7 @@ test_script:
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
   - if "%RUN_TESTS%"=="true" ( echo Verifying mksnapshot & python electron\script\verify-mksnapshot.py --build-dir out\Default --source-root %cd% )
   - ps: >-
-      if ($env:RUN_TESTS -eq 'true') {
-        New-Item .\out\Default\gen\node_headers\Release -Type directory
-        Copy-Item -path .\out\Default\electron.lib -destination .\out\Default\gen\node_headers\Release\node.lib
-      } else {
+      if (-Not $env:RUN_TESTS -eq 'true') {
         echo "Skipping tests for $env:GN_CONFIG build"
       }
   - cd electron


### PR DESCRIPTION
Annoying that we have to run these manually (I always forget to copy the lib file on windows)

Notes: no-notes