### PR TITLE
refactor: remove api::WebContents::CreateFrom

### DIFF
--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -26,7 +26,7 @@ bool IsWebContents(v8::Isolate* isolate, content::RenderProcessHost* process) {
   if (!web_contents)
     return false;
 
-  auto api_web_contents = WebContents::CreateFrom(isolate, web_contents);
+  auto api_web_contents = WebContents::FromOrCreate(isolate, web_contents);
   auto type = api_web_contents->GetType();
   return type == WebContents::Type::BROWSER_WINDOW ||
          type == WebContents::Type::WEB_VIEW;

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -82,18 +82,29 @@ class WebContents : public mate::TrackableObject<WebContents>,
   using PrintToPDFCallback =
       base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>)>;
 
-  // Create from an existing WebContents.
-  static mate::Handle<WebContents> CreateFrom(
-      v8::Isolate* isolate,
-      content::WebContents* web_contents);
-  static mate::Handle<WebContents> CreateFrom(
+  // Create a new WebContents and return the V8 wrapper of it.
+  static mate::Handle<WebContents> Create(v8::Isolate* isolate,
+                                          const mate::Dictionary& options);
+
+  // Create a new V8 wrapper for an existing |web_content|.
+  //
+  // The lifetime of |web_contents| will be managed by this class.
+  static mate::Handle<WebContents> CreateAndTake(
       v8::Isolate* isolate,
       content::WebContents* web_contents,
       Type type);
 
-  // Create a new WebContents.
-  static mate::Handle<WebContents> Create(v8::Isolate* isolate,
-                                          const mate::Dictionary& options);
+  // Get the V8 wrapper of |web_content|, return empty handle if not wrapped.
+  static mate::Handle<WebContents> From(v8::Isolate* isolate,
+                                        content::WebContents* web_content);
+
+  // Get the V8 wrapper of the |web_contents|, or create one if not existed.
+  //
+  // The lifetime of |web_contents| is NOT managed by this class, and the type
+  // of this wrapper is always REMOTE.
+  static mate::Handle<WebContents> FromOrCreate(
+      v8::Isolate* isolate,
+      content::WebContents* web_contents);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
@@ -281,9 +292,13 @@ class WebContents : public mate::TrackableObject<WebContents>,
                            content::NavigationHandle* navigation_handle);
 
  protected:
+  // Does not manage lifetime of |web_contents|.
+  WebContents(v8::Isolate* isolate, content::WebContents* web_contents);
+  // Takes over ownership of |web_contents|.
   WebContents(v8::Isolate* isolate,
               content::WebContents* web_contents,
               Type type);
+  // Creates a new content::WebContents.
   WebContents(v8::Isolate* isolate, const mate::Dictionary& options);
   ~WebContents() override;
 

--- a/atom/browser/atom_navigation_throttle.cc
+++ b/atom/browser/atom_navigation_throttle.cc
@@ -29,9 +29,9 @@ AtomNavigationThrottle::WillRedirectRequest() {
   }
 
   auto api_contents =
-      atom::api::WebContents::CreateFrom(v8::Isolate::GetCurrent(), contents);
+      atom::api::WebContents::From(v8::Isolate::GetCurrent(), contents);
   if (api_contents.IsEmpty()) {
-    NOTREACHED();
+    // No need to emit any event if the WebContents is not available in JS.
     return PROCEED;
   }
 

--- a/atom/common/native_mate_converters/content_converter.cc
+++ b/atom/common/native_mate_converters/content_converter.cc
@@ -206,7 +206,7 @@ v8::Local<v8::Value> Converter<content::WebContents*>::ToV8(
     content::WebContents* val) {
   if (!val)
     return v8::Null(isolate);
-  return atom::api::WebContents::CreateFrom(isolate, val).ToV8();
+  return atom::api::WebContents::FromOrCreate(isolate, val).ToV8();
 }
 
 // static


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Currently the `WebContents::CreateFrom` method can have 3 different kinds of behaviors depending on different conditions, and it is impossible to know which path it would go by simply looking at the code.

This PR separates it to 3 methods with different names, and makes the behavior explicit by name.

As a side effect we can avoid creating V8 wrapper for `WebContents` in some cases when the  `WebContents` is not accessed from JS.

This PR should not have any behavior change on existing code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: (refactor) Remove `api::WebContents::CreateFrom`.