### PR TITLE
fix: correct reversed logic in NativeWindowMac::SetEnabled

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -585,13 +585,13 @@ bool NativeWindowMac::IsEnabled() {
 
 void NativeWindowMac::SetEnabled(bool enable) {
   if (enable) {
+    [window_ endSheet:[window_ attachedSheet]];
+  } else {
     [window_ beginSheet:window_
         completionHandler:^(NSModalResponse returnCode) {
           NSLog(@"modal enabled");
           return;
         }];
-  } else {
-    [window_ endSheet:[window_ attachedSheet]];
   }
 }
 


### PR DESCRIPTION
#### Description of Change

The logic in `NativeWindowMac::SetEnabled` is reversed. This PR simply switches it around.

![](https://media.giphy.com/media/mjCaQoS4O7jEs/giphy.gif)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fix: correct reversed logic in BrowserWindow#setEnabled on macOS