### PR TITLE
fix: trim app name and productName

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -127,9 +127,9 @@ if (packageJson.version != null) {
 
 // Set application's name.
 if (packageJson.productName != null) {
-  app.setName(packageJson.productName)
+  app.setName(`${packageJson.productName}`.trim())
 } else if (packageJson.name != null) {
-  app.setName(packageJson.name)
+  app.setName(`${packageJson.name}`.trim())
 }
 
 // Set application's desktop name.


### PR DESCRIPTION
Fixes #15245

Notes: handle app name and productName have trailing whitespace