### PR TITLE
chore: make macOS release builds higher priority to skip the queue

### DIFF
--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -177,7 +177,8 @@ async function buildVSTS (targetBranch, options) {
 async function callVSTSBuild (build, targetBranch, environmentVariables) {
   const buildBody = {
     definition: build,
-    sourceBranch: targetBranch
+    sourceBranch: targetBranch,
+    priority: 'high'
   }
   if (Object.keys(environmentVariables).length !== 0) {
     buildBody.parameters = JSON.stringify(environmentVariables)


### PR DESCRIPTION
Release builds should be run before branch builds on our limited macOS
infra.

Refs: https://docs.microsoft.com/en-us/rest/api/vsts/build/builds/queue?view=vsts-rest-4.1#queuepriority

Notes: no-notes