### PR TITLE
test: increase MAS timeout for login items

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -457,7 +457,7 @@ describe('app module', () => {
     it('sets and returns the app as a login item', done => {
       app.setLoginItemSettings({ openAtLogin: true })
       // Wait because login item settings are not applied immediately in MAS build
-      const delay = process.mas ? 150 : 0
+      const delay = process.mas ? 250 : 0
       setTimeout(() => {
         expect(app.getLoginItemSettings()).to.deep.equal({
           openAtLogin: true,
@@ -470,15 +470,20 @@ describe('app module', () => {
       }, delay)
     })
 
-    it('adds a login item that loads in hidden mode', () => {
+    it('adds a login item that loads in hidden mode', done => {
       app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
-      expect(app.getLoginItemSettings()).to.deep.equal({
-        openAtLogin: true,
-        openAsHidden: process.platform === 'darwin' && !process.mas, // Only available on macOS
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false
-      })
+      // Wait because login item settings are not applied immediately in MAS build
+      const delay = process.mas ? 250 : 0
+      setTimeout(() => {
+        expect(app.getLoginItemSettings()).to.deep.equal({
+          openAtLogin: true,
+          openAsHidden: process.platform === 'darwin' && !process.mas, // Only available on macOS
+          wasOpenedAtLogin: false,
+          wasOpenedAsHidden: false,
+          restoreState: false
+        })
+        done()
+      }, delay)
     })
 
     it('correctly sets and unsets the LoginItem as hidden', function () {


### PR DESCRIPTION
#### Description of Change

Still seeing some timeouts in release branches for LoginItems on `mas` builds, which is a result of slow application of LoginItem settings. This PR increases that timeout and adds a delay for the `adds a login item that loads in hidden mode` spec as well.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes