### PR TITLE
fix: ability to fetch separators by id (backport: 3-0-x)

### DIFF
--- a/lib/browser/api/menu-utils.js
+++ b/lib/browser/api/menu-utils.js
@@ -15,10 +15,15 @@ function splitArray (arr, predicate) {
   return result
 }
 
-function joinArrays (arrays, joiner) {
+function joinArrays (arrays, joinIDs) {
   return arrays.reduce((joined, arr, i) => {
     if (i > 0 && arr.length) {
-      joined.push(joiner)
+      if (joinIDs.length > 0) {
+        joined.push(joinIDs[0])
+        joinIDs.splice(0, 1)
+      } else {
+        joined.push({ type: 'separator' })
+      }
     }
     return joined.concat(arr)
   }, [])
@@ -154,6 +159,7 @@ function sortGroups (groups) {
 
 function sortMenuItems (menuItems) {
   const isSeparator = (item) => item.type === 'separator'
+  const separators = menuItems.filter(i => i.type === 'separator')
 
   // Split the items into their implicit groups based upon separators.
   const groups = splitArray(menuItems, isSeparator)
@@ -161,7 +167,7 @@ function sortMenuItems (menuItems) {
   const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
   const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
 
-  const joined = joinArrays(sortedGroups, { type: 'separator' })
+  const joined = joinArrays(sortedGroups, separators)
   return joined
 }
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -570,6 +570,26 @@ describe('Menu module', () => {
       const fsc = menu.getMenuItemById('fullScreen')
       assert.equal(menu.items[0].submenu.items[0], fsc)
     })
+
+    it('should return the separator with the given id', () => {
+      const menu = Menu.buildFromTemplate([
+        {
+          label: 'Item 1',
+          id: 'item_1'
+        },
+        {
+          id: 'separator',
+          type: 'separator'
+        },
+        {
+          label: 'Item 2',
+          id: 'item_2'
+        }
+      ])
+      const separator = menu.getMenuItemById('separator')
+      assert.equal(typeof separator, 'object')
+      assert.equal(separator, menu.items[1])
+    })
   })
 
   describe('Menu.insert', () => {


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/15290.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fixes ability to fetch separators menu items by id