### PR TITLE
refactor: Improve accessibility of menus

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -202,6 +202,12 @@ const char* MenuBar::GetClassName() const {
   return kViewClassName;
 }
 
+void MenuBar::RequestFocus() {
+  if (!HasFocus()) {
+    views::AccessiblePaneView::RequestFocus();
+  }
+}
+
 void MenuBar::OnMenuButtonClicked(views::MenuButton* source,
                                   const gfx::Point& point,
                                   const ui::Event* event) {

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -6,6 +6,9 @@
 #define ATOM_BROWSER_UI_VIEWS_MENU_BAR_H_
 
 #include "atom/browser/ui/atom_menu_model.h"
+#include "atom/browser/ui/views/menu_delegate.h"
+#include "atom/browser/ui/views/root_view.h"
+#include "ui/views/accessible_pane_view.h"
 #include "ui/views/controls/button/menu_button_listener.h"
 #include "ui/views/focus/focus_manager.h"
 #include "ui/views/view.h"
@@ -16,15 +19,13 @@ class MenuButton;
 
 namespace atom {
 
-class MenuDelegate;
-
-class MenuBar : public views::View,
+class MenuBar : public views::AccessiblePaneView,
                 public views::MenuButtonListener,
-                public views::FocusChangeListener {
+                public atom::MenuDelegate::Observer {
  public:
   static const char kViewClassName[];
 
-  explicit MenuBar(views::View* window);
+  explicit MenuBar(RootView* window);
   ~MenuBar() override;
 
   // Replaces current menu with a new one.
@@ -47,6 +48,10 @@ class MenuBar : public views::View,
                                     AtomMenuModel** menu_model,
                                     views::MenuButton** button);
 
+  void OnBeforeExecuteCommand() override;
+
+  bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
+
  protected:
   // views::View:
   const char* GetClassName() const override;
@@ -59,7 +64,6 @@ class MenuBar : public views::View,
 
   // views::FocusChangeListener:
   void OnDidChangeFocus(View* focused_before, View* focused_now) override;
-  void OnWillChangeFocus(View* focused_before, View* focused_now) override {}
 
  private:
   void RebuildChildren();
@@ -72,7 +76,7 @@ class MenuBar : public views::View,
   SkColor disabled_color_;
 #endif
 
-  views::View* window_ = nullptr;
+  RootView* window_ = nullptr;
   AtomMenuModel* menu_model_ = nullptr;
 
   View* FindAccelChild(base::char16 key);

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -57,9 +57,6 @@ class MenuBar : public views::AccessiblePaneView,
   bool SetPaneFocus(views::View* initial_focus) override;
   void RemovePaneFocus() override;
 
-  // views::View:
-  void RequestFocus() override;
-
  protected:
   // views::View:
   const char* GetClassName() const override;

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -48,9 +48,14 @@ class MenuBar : public views::AccessiblePaneView,
                                     AtomMenuModel** menu_model,
                                     views::MenuButton** button);
 
+  // atom::MenuDelegate::Observer
   void OnBeforeExecuteCommand() override;
+  void OnMenuClosed() override;
 
+  // views::AccessiblePaneView
   bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
+  bool SetPaneFocus(views::View* initial_focus) override;
+  void RemovePaneFocus() override;
 
  protected:
   // views::View:

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -48,14 +48,17 @@ class MenuBar : public views::AccessiblePaneView,
                                     AtomMenuModel** menu_model,
                                     views::MenuButton** button);
 
-  // atom::MenuDelegate::Observer
+  // atom::MenuDelegate::Observer:
   void OnBeforeExecuteCommand() override;
   void OnMenuClosed() override;
 
-  // views::AccessiblePaneView
+  // views::AccessiblePaneView:
   bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
   bool SetPaneFocus(views::View* initial_focus) override;
   void RemovePaneFocus() override;
+
+  // views::View:
+  void RequestFocus() override;
 
  protected:
   // views::View:

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_UI_VIEWS_MENU_BAR_H_
 #define ATOM_BROWSER_UI_VIEWS_MENU_BAR_H_
 
+#include <memory>
+
 #include "atom/browser/ui/atom_menu_model.h"
 #include "atom/browser/ui/views/menu_delegate.h"
 #include "atom/browser/ui/views/root_view.h"

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -19,6 +19,20 @@ class MenuButton;
 
 namespace atom {
 
+class MenuBarColorUpdater : public views::FocusChangeListener {
+ public:
+  explicit MenuBarColorUpdater(MenuBar* menu_bar);
+  ~MenuBarColorUpdater() override;
+
+  void OnDidChangeFocus(views::View* focused_before,
+                        views::View* focused_now) override;
+  void OnWillChangeFocus(views::View* focused_before,
+                         views::View* focused_now) override {}
+
+ private:
+  MenuBar* menu_bar_;
+};
+
 class MenuBar : public views::AccessiblePaneView,
                 public views::MenuButtonListener,
                 public atom::MenuDelegate::Observer {
@@ -67,10 +81,9 @@ class MenuBar : public views::AccessiblePaneView,
                            const ui::Event* event) override;
   void OnNativeThemeChanged(const ui::NativeTheme* theme) override;
 
-  // views::FocusChangeListener:
-  void OnDidChangeFocus(View* focused_before, View* focused_now) override;
-
  private:
+  friend class MenuBarColorUpdater;
+
   void RebuildChildren();
   void UpdateViewColors();
 
@@ -87,6 +100,8 @@ class MenuBar : public views::AccessiblePaneView,
   View* FindAccelChild(base::char16 key);
 
   bool has_focus_ = true;
+
+  std::unique_ptr<MenuBarColorUpdater> color_updater_;
 
   DISALLOW_COPY_AND_ASSIGN(MenuBar);
 };

--- a/atom/browser/ui/views/menu_delegate.cc
+++ b/atom/browser/ui/views/menu_delegate.cc
@@ -99,6 +99,9 @@ void MenuDelegate::WillHideMenu(views::MenuItemView* menu) {
 }
 
 void MenuDelegate::OnMenuClosed(views::MenuItemView* menu) {
+  for (Observer& obs : observers_)
+    obs.OnMenuClosed();
+
   // Only switch to new menu when current menu is closed.
   if (button_to_open_)
     button_to_open_->Activate(nullptr);

--- a/atom/browser/ui/views/menu_delegate.h
+++ b/atom/browser/ui/views/menu_delegate.h
@@ -31,6 +31,7 @@ class MenuDelegate : public views::MenuDelegate {
   class Observer {
    public:
     virtual void OnBeforeExecuteCommand() = 0;
+    virtual void OnMenuClosed() = 0;
   };
 
   void AddObserver(Observer* obs) { observers_.AddObserver(obs); }

--- a/atom/browser/ui/views/menu_delegate.h
+++ b/atom/browser/ui/views/menu_delegate.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "atom/browser/ui/atom_menu_model.h"
+#include "base/observer_list.h"
 #include "ui/views/controls/menu/menu_delegate.h"
 
 namespace views {
@@ -23,7 +24,18 @@ class MenuDelegate : public views::MenuDelegate {
   explicit MenuDelegate(MenuBar* menu_bar);
   ~MenuDelegate() override;
 
-  void RunMenu(AtomMenuModel* model, views::MenuButton* button);
+  void RunMenu(AtomMenuModel* model,
+               views::MenuButton* button,
+               ui::MenuSourceType source_type);
+
+  class Observer {
+   public:
+    virtual void OnBeforeExecuteCommand() = 0;
+  };
+
+  void AddObserver(Observer* obs) { observers_.AddObserver(obs); }
+
+  void RemoveObserver(const Observer* obs) { observers_.RemoveObserver(obs); }
 
  protected:
   // views::MenuDelegate:
@@ -55,6 +67,9 @@ class MenuDelegate : public views::MenuDelegate {
 
   // The menu button to switch to.
   views::MenuButton* button_to_open_ = nullptr;
+  bool hold_first_switch_;
+
+  base::ObserverList<Observer> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(MenuDelegate);
 };

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -130,9 +130,6 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
     return;
   }
 
-  if (!menu_bar_autohide_)
-    return;
-
   // Toggle the menu bar only when a single Alt is released.
   if (event.GetType() == blink::WebInputEvent::kRawKeyDown && IsAltKey(event)) {
     // When a single Alt is pressed:
@@ -141,7 +138,8 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
              IsAltKey(event) && menu_bar_alt_pressed_) {
     // When a single Alt is released right after a Alt is pressed:
     menu_bar_alt_pressed_ = false;
-    SetMenuBarVisibility(!menu_bar_visible_);
+    if (menu_bar_autohide_)
+      SetMenuBarVisibility(!menu_bar_visible_);
     View* focused_view = GetFocusManager()->GetFocusedView();
     last_focused_view_tracker_->SetView(focused_view);
     menu_bar_->RequestFocus();

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -91,10 +91,6 @@ void RootView::SetMenuBarVisibility(bool visible) {
   if (!window_->content_view() || !menu_bar_ || menu_bar_visible_ == visible)
     return;
 
-  // Always show the accelerator when the auto-hide menu bar shows.
-  if (menu_bar_autohide_)
-    menu_bar_->SetAcceleratorVisibility(visible);
-
   menu_bar_visible_ = visible;
   if (visible) {
     DCHECK_EQ(child_count(), 1);
@@ -126,6 +122,10 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
     if (!menu_bar_visible_ &&
         (menu_bar_->HasAccelerator(event.windows_key_code)))
       SetMenuBarVisibility(true);
+
+    View* focused_view = GetFocusManager()->GetFocusedView();
+    last_focused_view_tracker_->SetView(focused_view);
+    menu_bar_->RequestFocus();
     menu_bar_->ActivateAccelerator(event.windows_key_code);
     return;
   }
@@ -140,9 +140,12 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
     menu_bar_alt_pressed_ = false;
     if (menu_bar_autohide_)
       SetMenuBarVisibility(!menu_bar_visible_);
+
     View* focused_view = GetFocusManager()->GetFocusedView();
     last_focused_view_tracker_->SetView(focused_view);
     menu_bar_->RequestFocus();
+    // Show accelerators when menu bar is focused
+    menu_bar_->SetAcceleratorVisibility(true);
   } else {
     // When any other keys except single Alt have been pressed/released:
     menu_bar_alt_pressed_ = false;

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -119,14 +119,17 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
   // Show the submenu when "Alt+Key" is pressed.
   if (event.GetType() == blink::WebInputEvent::kRawKeyDown &&
       !IsAltKey(event) && IsAltModifier(event)) {
-    if (!menu_bar_visible_ &&
-        (menu_bar_->HasAccelerator(event.windows_key_code)))
-      SetMenuBarVisibility(true);
+    if (menu_bar_->HasAccelerator(event.windows_key_code)) {
+      if (!menu_bar_visible_) {
+        SetMenuBarVisibility(true);
 
-    View* focused_view = GetFocusManager()->GetFocusedView();
-    last_focused_view_tracker_->SetView(focused_view);
-    menu_bar_->RequestFocus();
-    menu_bar_->ActivateAccelerator(event.windows_key_code);
+        View* focused_view = GetFocusManager()->GetFocusedView();
+        last_focused_view_tracker_->SetView(focused_view);
+        menu_bar_->RequestFocus();
+      }
+
+      menu_bar_->ActivateAccelerator(event.windows_key_code);
+    }
     return;
   }
 

--- a/atom/browser/ui/views/root_view.h
+++ b/atom/browser/ui/views/root_view.h
@@ -9,6 +9,7 @@
 
 #include "atom/browser/ui/accelerator_util.h"
 #include "ui/views/view.h"
+#include "ui/views/view_tracker.h"
 
 namespace content {
 struct NativeWebKeyboardEvent;
@@ -34,6 +35,7 @@ class RootView : public views::View {
   bool IsMenuBarVisible() const;
   void HandleKeyEvent(const content::NativeWebKeyboardEvent& event);
   void ResetAltState();
+  void RestoreFocus();
 
   // views::View:
   void Layout() override;
@@ -56,6 +58,8 @@ class RootView : public views::View {
 
   // Map from accelerator to menu item's command id.
   accelerator_util::AcceleratorTable accelerator_table_;
+
+  std::unique_ptr<views::ViewTracker> last_focused_view_tracker_;
 
   DISALLOW_COPY_AND_ASSIGN(RootView);
 };

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -71,6 +71,11 @@ void SubmenuButton::SetUnderlineColor(SkColor color) {
   underline_color_ = color;
 }
 
+void SubmenuButton::GetAccessibleNodeData(ui::AXNodeData* node_data) {
+  node_data->SetName(accessible_name());
+  node_data->role = ax::mojom::Role::kPopUpButton;
+}
+
 void SubmenuButton::PaintButtonContents(gfx::Canvas* canvas) {
   views::MenuButton::PaintButtonContents(canvas);
 

--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -80,11 +80,12 @@ void SubmenuButton::PaintButtonContents(gfx::Canvas* canvas) {
   views::MenuButton::PaintButtonContents(canvas);
 
   if (show_underline_ && (underline_start_ != underline_end_)) {
-    int padding = (width() - text_width_) / 2;
-    int underline_height = (height() + text_height_) / 2 - 2;
-    canvas->DrawLine(gfx::Point(underline_start_ + padding, underline_height),
-                     gfx::Point(underline_end_ + padding, underline_height),
-                     underline_color_);
+    float padding = (width() - text_width_) / 2;
+    float underline_height = (height() + text_height_) / 2 - 2;
+    canvas->DrawSharpLine(
+        gfx::PointF(underline_start_ + padding, underline_height),
+        gfx::PointF(underline_end_ + padding, underline_height),
+        underline_color_);
   }
 }
 

--- a/atom/browser/ui/views/submenu_button.h
+++ b/atom/browser/ui/views/submenu_button.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "ui/accessibility/ax_node_data.h"
 #include "ui/views/animation/ink_drop_highlight.h"
 #include "ui/views/controls/button/menu_button.h"
 
@@ -24,6 +25,8 @@ class SubmenuButton : public views::MenuButton {
   void SetUnderlineColor(SkColor color);
 
   base::char16 accelerator() const { return accelerator_; }
+
+  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
 
   // views::MenuButton:
   void PaintButtonContents(gfx::Canvas* canvas) override;

--- a/atom/browser/ui/win/notify_icon.h
+++ b/atom/browser/ui/win/notify_icon.h
@@ -15,6 +15,7 @@
 #include "atom/browser/ui/tray_icon.h"
 #include "base/compiler_specific.h"
 #include "base/macros.h"
+#include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 
 namespace gfx {
@@ -23,7 +24,8 @@ class Point;
 
 namespace views {
 class MenuRunner;
-}
+class Widget;
+}  // namespace views
 
 namespace atom {
 
@@ -63,6 +65,7 @@ class NotifyIcon : public TrayIcon {
 
  private:
   void InitIconData(NOTIFYICONDATA* icon_data);
+  void OnContextMenuClosed();
 
   // The tray that owns us.  Weak.
   NotifyIconHost* host_;
@@ -84,6 +87,12 @@ class NotifyIcon : public TrayIcon {
 
   // Context menu associated with this icon (if any).
   std::unique_ptr<views::MenuRunner> menu_runner_;
+
+  // Temporary widget for the context menu, needed for keyboard event capture.
+  std::unique_ptr<views::Widget> widget_;
+
+  // WeakPtrFactory for CloseClosure safety.
+  base::WeakPtrFactory<NotifyIcon> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(NotifyIcon);
 };

--- a/atom/common/keyboard_util.cc
+++ b/atom/common/keyboard_util.cc
@@ -14,8 +14,94 @@ namespace atom {
 
 namespace {
 
-// Return key code of the char, and also determine whether the SHIFT key is
-// pressed.
+// Return key code represented by |str|.
+ui::KeyboardCode KeyboardCodeFromKeyIdentifier(const std::string& s,
+                                               bool* shifted) {
+  std::string str = base::ToLowerASCII(s);
+  if (str == "ctrl" || str == "control") {
+    return ui::VKEY_CONTROL;
+  } else if (str == "super" || str == "cmd" || str == "command" ||
+             str == "meta") {
+    return ui::VKEY_COMMAND;
+  } else if (str == "commandorcontrol" || str == "cmdorctrl") {
+#if defined(OS_MACOSX)
+    return ui::VKEY_COMMAND;
+#else
+    return ui::VKEY_CONTROL;
+#endif
+  } else if (str == "alt" || str == "option") {
+    return ui::VKEY_MENU;
+  } else if (str == "shift") {
+    return ui::VKEY_SHIFT;
+  } else if (str == "altgr") {
+    return ui::VKEY_ALTGR;
+  } else if (str == "plus") {
+    *shifted = true;
+    return ui::VKEY_OEM_PLUS;
+  } else if (str == "tab") {
+    return ui::VKEY_TAB;
+  } else if (str == "space") {
+    return ui::VKEY_SPACE;
+  } else if (str == "backspace") {
+    return ui::VKEY_BACK;
+  } else if (str == "delete") {
+    return ui::VKEY_DELETE;
+  } else if (str == "insert") {
+    return ui::VKEY_INSERT;
+  } else if (str == "enter" || str == "return") {
+    return ui::VKEY_RETURN;
+  } else if (str == "up") {
+    return ui::VKEY_UP;
+  } else if (str == "down") {
+    return ui::VKEY_DOWN;
+  } else if (str == "left") {
+    return ui::VKEY_LEFT;
+  } else if (str == "right") {
+    return ui::VKEY_RIGHT;
+  } else if (str == "home") {
+    return ui::VKEY_HOME;
+  } else if (str == "end") {
+    return ui::VKEY_END;
+  } else if (str == "pageup") {
+    return ui::VKEY_PRIOR;
+  } else if (str == "pagedown") {
+    return ui::VKEY_NEXT;
+  } else if (str == "esc" || str == "escape") {
+    return ui::VKEY_ESCAPE;
+  } else if (str == "volumemute") {
+    return ui::VKEY_VOLUME_MUTE;
+  } else if (str == "volumeup") {
+    return ui::VKEY_VOLUME_UP;
+  } else if (str == "volumedown") {
+    return ui::VKEY_VOLUME_DOWN;
+  } else if (str == "medianexttrack") {
+    return ui::VKEY_MEDIA_NEXT_TRACK;
+  } else if (str == "mediaprevioustrack") {
+    return ui::VKEY_MEDIA_PREV_TRACK;
+  } else if (str == "mediastop") {
+    return ui::VKEY_MEDIA_STOP;
+  } else if (str == "mediaplaypause") {
+    return ui::VKEY_MEDIA_PLAY_PAUSE;
+  } else if (str == "printscreen") {
+    return ui::VKEY_SNAPSHOT;
+  } else if (str.size() > 1 && str[0] == 'f') {
+    // F1 - F24.
+    int n;
+    if (base::StringToInt(str.c_str() + 1, &n) && n > 0 && n < 25) {
+      return static_cast<ui::KeyboardCode>(ui::VKEY_F1 + n - 1);
+    } else {
+      LOG(WARNING) << str << "is not available on keyboard";
+      return ui::VKEY_UNKNOWN;
+    }
+  } else {
+    if (str.size() > 2)
+      LOG(WARNING) << "Invalid accelerator token: " << str;
+    return ui::VKEY_UNKNOWN;
+  }
+}
+
+}  // namespace
+
 ui::KeyboardCode KeyboardCodeFromCharCode(base::char16 c, bool* shifted) {
   c = base::ToLowerASCII(c);
   *shifted = false;
@@ -197,94 +283,6 @@ ui::KeyboardCode KeyboardCodeFromCharCode(base::char16 c, bool* shifted) {
       return ui::VKEY_UNKNOWN;
   }
 }
-
-// Return key code represented by |str|.
-ui::KeyboardCode KeyboardCodeFromKeyIdentifier(const std::string& s,
-                                               bool* shifted) {
-  std::string str = base::ToLowerASCII(s);
-  if (str == "ctrl" || str == "control") {
-    return ui::VKEY_CONTROL;
-  } else if (str == "super" || str == "cmd" || str == "command" ||
-             str == "meta") {
-    return ui::VKEY_COMMAND;
-  } else if (str == "commandorcontrol" || str == "cmdorctrl") {
-#if defined(OS_MACOSX)
-    return ui::VKEY_COMMAND;
-#else
-    return ui::VKEY_CONTROL;
-#endif
-  } else if (str == "alt" || str == "option") {
-    return ui::VKEY_MENU;
-  } else if (str == "shift") {
-    return ui::VKEY_SHIFT;
-  } else if (str == "altgr") {
-    return ui::VKEY_ALTGR;
-  } else if (str == "plus") {
-    *shifted = true;
-    return ui::VKEY_OEM_PLUS;
-  } else if (str == "tab") {
-    return ui::VKEY_TAB;
-  } else if (str == "space") {
-    return ui::VKEY_SPACE;
-  } else if (str == "backspace") {
-    return ui::VKEY_BACK;
-  } else if (str == "delete") {
-    return ui::VKEY_DELETE;
-  } else if (str == "insert") {
-    return ui::VKEY_INSERT;
-  } else if (str == "enter" || str == "return") {
-    return ui::VKEY_RETURN;
-  } else if (str == "up") {
-    return ui::VKEY_UP;
-  } else if (str == "down") {
-    return ui::VKEY_DOWN;
-  } else if (str == "left") {
-    return ui::VKEY_LEFT;
-  } else if (str == "right") {
-    return ui::VKEY_RIGHT;
-  } else if (str == "home") {
-    return ui::VKEY_HOME;
-  } else if (str == "end") {
-    return ui::VKEY_END;
-  } else if (str == "pageup") {
-    return ui::VKEY_PRIOR;
-  } else if (str == "pagedown") {
-    return ui::VKEY_NEXT;
-  } else if (str == "esc" || str == "escape") {
-    return ui::VKEY_ESCAPE;
-  } else if (str == "volumemute") {
-    return ui::VKEY_VOLUME_MUTE;
-  } else if (str == "volumeup") {
-    return ui::VKEY_VOLUME_UP;
-  } else if (str == "volumedown") {
-    return ui::VKEY_VOLUME_DOWN;
-  } else if (str == "medianexttrack") {
-    return ui::VKEY_MEDIA_NEXT_TRACK;
-  } else if (str == "mediaprevioustrack") {
-    return ui::VKEY_MEDIA_PREV_TRACK;
-  } else if (str == "mediastop") {
-    return ui::VKEY_MEDIA_STOP;
-  } else if (str == "mediaplaypause") {
-    return ui::VKEY_MEDIA_PLAY_PAUSE;
-  } else if (str == "printscreen") {
-    return ui::VKEY_SNAPSHOT;
-  } else if (str.size() > 1 && str[0] == 'f') {
-    // F1 - F24.
-    int n;
-    if (base::StringToInt(str.c_str() + 1, &n) && n > 0 && n < 25) {
-      return static_cast<ui::KeyboardCode>(ui::VKEY_F1 + n - 1);
-    } else {
-      LOG(WARNING) << str << "is not available on keyboard";
-      return ui::VKEY_UNKNOWN;
-    }
-  } else {
-    if (str.size() > 2)
-      LOG(WARNING) << "Invalid accelerator token: " << str;
-    return ui::VKEY_UNKNOWN;
-  }
-}
-
-}  // namespace
 
 ui::KeyboardCode KeyboardCodeFromStr(const std::string& str, bool* shifted) {
   if (str.size() == 1)

--- a/atom/common/keyboard_util.h
+++ b/atom/common/keyboard_util.h
@@ -7,9 +7,14 @@
 
 #include <string>
 
+#include "base/strings/string16.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
 namespace atom {
+
+// Return key code of the char, and also determine whether the SHIFT key is
+// pressed.
+ui::KeyboardCode KeyboardCodeFromCharCode(base::char16 c, bool* shifted);
 
 // Return key code of the |str|, and also determine whether the SHIFT key is
 // pressed.

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -19,6 +19,12 @@ The `menu` class has the following static methods:
 Sets `menu` as the application menu on macOS. On Windows and Linux, the
 `menu` will be set as each window's top menu.
 
+Also on Windows and Linux, you can use a `&` in the top-level item name to
+indicate which letter should get a generated accelerator. For example, using
+`&File` for the file menu would result in a generated `Alt-F` accelerator that
+opens the associated menu. The indicated character in the button label gets an
+underline. The `&` character is not displayed on the button label.
+
 Passing `null` will remove the menu bar on Windows and Linux but has no
 effect on macOS.
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

There are a couple of accessibility problems related to menus that I've found:
 - The `Windows Narrator` couldn't announce any menu items
 - The menu bar on `Windows` (and I guess `Linux` too) was not accessible by keyboard
 - #11587

The first fix was given to us by the `Chromium 69` upgrade, which allowed the `Windows Narrator` to read the menus. This is because chromium's `UIAutomation` API implementation is not yet complete, and that's what the narrator uses on `Windows` (but the implementation progressed from 68 to 69 to allow the menus to be read).

The menu bar was not accessible because we basically didn't `focus` the `View`, which in turn didn't give it keyboard events. This was done because some commands in the menu (like copy) depend on the actual content being focused, instead of the bar. I fixed this by returning the focus before the command executes. Also, focusing the menu bar was not enough, since we used a plain `View` for the bar, which didn't implement any keyboard navigation of it's items. I changed the base class to `AccessiblePaneView`, which implements that navigation (should fix #2504).

![electron-acc-1](https://user-images.githubusercontent.com/1690458/47253178-3d8e2c80-d450-11e8-9c0f-76bf17415ecd.gif)

#11587 was caused by the fact that the tray icon's context menu was spawned without a `Widget`, since it's not necessary to have a `BrowserWindow` to have an icon in the tray. The `Widget` is important because that's what actually captures keyboard events, and the menus leech off their parent `Widgets` for those events. I added a temporary non-visual `Widget` to the menu that gets destroyed when the menu closes, which fixed the issue.

![electron-acc-2](https://user-images.githubusercontent.com/1690458/47253182-41ba4a00-d450-11e8-9ea0-f263d99f35f7.gif)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: <!-- One-line Change Summary Here--> improved tray icon context menu and menu bar accessibility