### PR TITLE
fix: correct reversed logic in NativeWindowMac::SetEnabled (2-0-x)

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1155,12 +1155,12 @@ bool NativeWindowMac::IsEnabled() {
 
 void NativeWindowMac::SetEnabled(bool enable) {
   if (enable) {
+    [window_ endSheet: [window_ attachedSheet]];
+  } else {
     [window_ beginSheet: window_ completionHandler:^(NSModalResponse returnCode) {
        NSLog(@"modal enabled");
        return;
     }];
-  } else {
-    [window_ endSheet: [window_ attachedSheet]];
   }
 }
 


### PR DESCRIPTION
Manual backport of #15257

Notes: fix: correct reversed logic in BrowserWindow#setEnabled on macOS