### PR TITLE
fix: update fs methods for options param

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -301,7 +301,7 @@
     }
 
     const { realpathSync } = fs
-    fs.realpathSync = function (pathArgument) {
+    fs.realpathSync = function (pathArgument, options) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
       if (!isAsar) return realpathSync.apply(this, arguments)
 
@@ -315,10 +315,10 @@
         throw createError(AsarError.NOT_FOUND, { asarPath, filePath })
       }
 
-      return path.join(realpathSync(asarPath), fileRealPath)
+      return path.join(realpathSync(asarPath, options), fileRealPath)
     }
 
-    fs.realpathSync.native = function (pathArgument) {
+    fs.realpathSync.native = function (pathArgument, options) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
       if (!isAsar) return realpathSync.native.apply(this, arguments)
 
@@ -332,17 +332,17 @@
         throw createError(AsarError.NOT_FOUND, { asarPath, filePath })
       }
 
-      return path.join(realpathSync.native(asarPath), fileRealPath)
+      return path.join(realpathSync.native(asarPath, options), fileRealPath)
     }
 
     const { realpath } = fs
-    fs.realpath = function (pathArgument, cache, callback) {
+    fs.realpath = function (pathArgument, options, callback) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
       if (!isAsar) return realpath.apply(this, arguments)
 
-      if (typeof cache === 'function') {
-        callback = cache
-        cache = undefined
+      if (arguments.length < 3) {
+        callback = options
+        options = {}
       }
 
       const archive = getOrCreateArchive(asarPath)
@@ -359,7 +359,7 @@
         return
       }
 
-      realpath(asarPath, (error, archiveRealPath) => {
+      realpath(asarPath, options, (error, archiveRealPath) => {
         if (error === null) {
           const fullPath = path.join(archiveRealPath, fileRealPath)
           callback(null, fullPath)
@@ -369,13 +369,13 @@
       })
     }
 
-    fs.realpath.native = function (pathArgument, cache, callback) {
+    fs.realpath.native = function (pathArgument, options, callback) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
       if (!isAsar) return realpath.native.apply(this, arguments)
 
-      if (typeof cache === 'function') {
-        callback = cache
-        cache = undefined
+      if (arguments.length < 3) {
+        callback = options
+        options = {}
       }
 
       const archive = getOrCreateArchive(asarPath)
@@ -392,7 +392,7 @@
         return
       }
 
-      realpath.native(asarPath, (error, archiveRealPath) => {
+      realpath.native(asarPath, options, (error, archiveRealPath) => {
         if (error === null) {
           const fullPath = path.join(archiveRealPath, fileRealPath)
           callback(null, fullPath)
@@ -610,8 +610,12 @@
     }
 
     const { readdir } = fs
-    fs.readdir = function (pathArgument, callback) {
+    fs.readdir = function (pathArgument, options, callback) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
       if (!isAsar) return readdir.apply(this, arguments)
 
       const archive = getOrCreateArchive(asarPath)
@@ -632,7 +636,7 @@
     }
 
     const { readdirSync } = fs
-    fs.readdirSync = function (pathArgument) {
+    fs.readdirSync = function (pathArgument, options) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
       if (!isAsar) return readdirSync.apply(this, arguments)
 
@@ -692,14 +696,12 @@
 
     // Calling mkdir for directory inside asar archive should throw ENOTDIR
     // error, but on Windows it throws ENOENT.
-    // This is to work around the recursive looping bug of mkdirp since it is
-    // widely used.
     if (process.platform === 'win32') {
       const { mkdir } = fs
-      fs.mkdir = (pathArgument, mode, callback) => {
-        if (typeof mode === 'function') {
-          callback = mode
-          mode = undefined
+      fs.mkdir = (pathArgument, options, callback) => {
+        if (typeof options === 'function') {
+          callback = options
+          options = {}
         }
 
         const { isAsar, filePath } = splitPath(pathArgument)
@@ -709,14 +711,14 @@
           return
         }
 
-        mkdir(pathArgument, mode, callback)
+        mkdir(pathArgument, options, callback)
       }
 
       const { mkdirSync } = fs
-      fs.mkdirSync = function (pathArgument, mode) {
+      fs.mkdirSync = function (pathArgument, options) {
         const { isAsar, filePath } = splitPath(pathArgument)
         if (isAsar && filePath.length) throw createError(AsarError.NOT_DIR)
-        return mkdirSync(pathArgument, mode)
+        return mkdirSync(pathArgument, options)
       }
     }
 

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -238,9 +238,9 @@
     }
 
     const { lstatSync } = fs
-    fs.lstatSync = pathArgument => {
+    fs.lstatSync = (pathArgument, options) => {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return lstatSync(pathArgument)
+      if (!isAsar) return lstatSync(pathArgument, options)
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) throw createError(AsarError.INVALID_ARCHIVE, { asarPath })
@@ -252,9 +252,13 @@
     }
 
     const { lstat } = fs
-    fs.lstat = (pathArgument, callback) => {
+    fs.lstat = function (pathArgument, options, callback) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return lstat(pathArgument, callback)
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+      if (!isAsar) return lstat(pathArgument, options, callback)
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {
@@ -275,21 +279,25 @@
     }
 
     const { statSync } = fs
-    fs.statSync = pathArgument => {
+    fs.statSync = (pathArgument, options) => {
       const { isAsar } = splitPath(pathArgument)
-      if (!isAsar) return statSync(pathArgument)
+      if (!isAsar) return statSync(pathArgument, options)
 
       // Do not distinguish links for now.
-      return fs.lstatSync(pathArgument)
+      return fs.lstatSync(pathArgument, options)
     }
 
     const { stat } = fs
-    fs.stat = (pathArgument, callback) => {
+    fs.stat = (pathArgument, options, callback) => {
       const { isAsar } = splitPath(pathArgument)
-      if (!isAsar) return stat(pathArgument, callback)
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+      if (!isAsar) return stat(pathArgument, options, callback)
 
       // Do not distinguish links for now.
-      process.nextTick(() => fs.lstat(pathArgument, callback))
+      process.nextTick(() => fs.lstat(pathArgument, options, callback))
     }
 
     const { realpathSync } = fs

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -192,6 +192,15 @@ describe('asar package', function () {
         assert.strictEqual(stats.size, 0)
       })
 
+      it('returns information of root with stats as bigint', function () {
+        const p = path.join(fixtures, 'asar', 'a.asar')
+        const stats = fs.lstatSync(p, { bigint: false })
+        assert.strictEqual(stats.isFile(), false)
+        assert.strictEqual(stats.isDirectory(), true)
+        assert.strictEqual(stats.isSymbolicLink(), false)
+        assert.strictEqual(stats.size, 0)
+      })
+
       it('returns information of a normal file', function () {
         const ref2 = ['file1', 'file2', 'file3', path.join('dir1', 'file1'), path.join('link2', 'file1')]
         for (let j = 0, len = ref2.length; j < len; j++) {
@@ -266,6 +275,18 @@ describe('asar package', function () {
       it('returns information of root', function (done) {
         const p = path.join(fixtures, 'asar', 'a.asar')
         fs.lstat(p, function (err, stats) {
+          assert.strictEqual(err, null)
+          assert.strictEqual(stats.isFile(), false)
+          assert.strictEqual(stats.isDirectory(), true)
+          assert.strictEqual(stats.isSymbolicLink(), false)
+          assert.strictEqual(stats.size, 0)
+          done()
+        })
+      })
+
+      it('returns information of root with stats as bigint', function (done) {
+        const p = path.join(fixtures, 'asar', 'a.asar')
+        fs.lstat(p, { bigint: false }, function (err, stats) {
           assert.strictEqual(err, null)
           assert.strictEqual(stats.isFile(), false)
           assert.strictEqual(stats.isDirectory(), true)


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15314.
Updates our overwrite of `fs.stat` and `fs.statSync` to take an optional `options` param.

/cc @BinaryMuse

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: update `fs.stat/fs.statSync` for new `options` param