### PR TITLE
fix: honor dialog.showMessageBox()'s Icon argument on Linux

### DIFF
--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -40,7 +40,8 @@ class GtkMessageBox : public NativeWindowObserver {
                 const std::string& message,
                 const std::string& detail,
                 const std::string& checkbox_label,
-                bool checkbox_checked)
+                bool checkbox_checked,
+                const gfx::ImageSkia& icon)
       : cancel_id_(cancel_id),
         parent_(static_cast<NativeWindow*>(parent_window)) {
     // Create dialog.
@@ -55,6 +56,21 @@ class GtkMessageBox : public NativeWindowObserver {
                                                "%s", detail.c_str());
     if (!title.empty())
       gtk_window_set_title(GTK_WINDOW(dialog_), title.c_str());
+
+    if (!icon.isNull()) {
+      // No easy way to obtain this programmatically, but GTK+'s docs
+      // define GTK_ICON_SIZE_DIALOG to be 48 pixels
+      static constexpr int pixel_width = 48;
+      static constexpr int pixel_height = 48;
+      GdkPixbuf* pixbuf = libgtkui::GdkPixbufFromSkBitmap(*icon.bitmap());
+      GdkPixbuf* scaled_pixbuf = gdk_pixbuf_scale_simple(
+          pixbuf, pixel_width, pixel_height, GDK_INTERP_BILINEAR);
+      GtkWidget* w = gtk_image_new_from_pixbuf(scaled_pixbuf);
+      gtk_message_dialog_set_image(GTK_MESSAGE_DIALOG(dialog_), w);
+      gtk_widget_show(w);
+      g_clear_pointer(&scaled_pixbuf, gdk_pixbuf_unref);
+      g_clear_pointer(&pixbuf, gdk_pixbuf_unref);
+    }
 
     if (!checkbox_label.empty()) {
       GtkWidget* message_area =
@@ -195,9 +211,9 @@ int ShowMessageBox(NativeWindow* parent,
                    const std::string& title,
                    const std::string& message,
                    const std::string& detail,
-                   const gfx::ImageSkia& /*icon*/) {
+                   const gfx::ImageSkia& icon) {
   return GtkMessageBox(parent, type, buttons, default_id, cancel_id, title,
-                       message, detail, "", false)
+                       message, detail, "", false, icon)
       .RunSynchronous();
 }
 
@@ -212,10 +228,10 @@ void ShowMessageBox(NativeWindow* parent,
                     const std::string& detail,
                     const std::string& checkbox_label,
                     bool checkbox_checked,
-                    const gfx::ImageSkia& /*icon*/,
+                    const gfx::ImageSkia& icon,
                     const MessageBoxCallback& callback) {
   (new GtkMessageBox(parent, type, buttons, default_id, cancel_id, title,
-                     message, detail, checkbox_label, checkbox_checked))
+                     message, detail, checkbox_label, checkbox_checked, icon))
       ->RunAsynchronous(callback);
 }
 
@@ -223,7 +239,8 @@ void ShowErrorBox(const base::string16& title, const base::string16& content) {
   if (Browser::Get()->is_ready()) {
     GtkMessageBox(nullptr, MESSAGE_BOX_TYPE_ERROR, {"OK"}, -1, 0, "Error",
                   base::UTF16ToUTF8(title).c_str(),
-                  base::UTF16ToUTF8(content).c_str(), "", false)
+                  base::UTF16ToUTF8(content).c_str(), "", false,
+                  gfx::ImageSkia())
         .RunSynchronous();
   } else {
     fprintf(stderr,

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -70,12 +70,11 @@ class GtkMessageBox : public NativeWindowObserver {
     }
 
     // Add buttons.
+    GtkDialog* dialog = GTK_DIALOG(dialog_);
     for (size_t i = 0; i < buttons.size(); ++i) {
-      GtkWidget* button = gtk_dialog_add_button(
-          GTK_DIALOG(dialog_), TranslateToStock(i, buttons[i]), i);
-      if (static_cast<int>(i) == default_id)
-        gtk_widget_grab_focus(button);
+      gtk_dialog_add_button(dialog, TranslateToStock(i, buttons[i]), i);
     }
+    gtk_dialog_set_default_response(dialog, default_id);
 
     // Parent window.
     if (parent_) {

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -66,6 +66,7 @@ class GtkMessageBox : public NativeWindowObserver {
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_button),
                                    checkbox_checked);
       gtk_container_add(GTK_CONTAINER(message_area), check_button);
+      gtk_widget_show(check_button);
     }
 
     // Add buttons.
@@ -122,7 +123,7 @@ class GtkMessageBox : public NativeWindowObserver {
   }
 
   void Show() {
-    gtk_widget_show_all(dialog_);
+    gtk_widget_show(dialog_);
     // We need to call gtk_window_present after making the widgets visible to
     // make sure window gets correctly raised and gets focus.
     int time = ui::X11EventSource::GetInstance()->GetTimestamp();


### PR DESCRIPTION
#### Description of Change

Fixes #15317.

A two-part fix:
 - [x] In the GTK+ messagebox code, don't show a broken icon when no icon is set.
  (Screenshot of this bug at #15317)
 - [x] On GTK+, support the `icon` argument to `ShowMessageBox`. Previously this argument was discarded.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Honor dialog.showMessageBox()'s `icon` argument on Linux