### PR TITLE
fix: Fix window close

### DIFF
--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -9,6 +9,7 @@
 #include "atom/browser/ui/cocoa/atom_preview_item.h"
 #include "atom/browser/ui/cocoa/atom_touch_bar.h"
 #include "base/mac/mac_util.h"
+#include "ui/views/cocoa/bridged_native_widget.h"
 #include "ui/views/widget/native_widget_mac.h"
 
 @implementation AtomNSWindowDelegate
@@ -246,7 +247,10 @@
   // Clears the delegate when window is going to be closed, since EL Capitan it
   // is possible that the methods of delegate would get called after the window
   // has been closed.
-  [shell_->GetNativeWindow() setDelegate:nil];
+  views::BridgedNativeWidget* bridged_view =
+      views::NativeWidgetMac::GetBridgeForNativeWindow(
+          shell_->GetNativeWindow());
+  bridged_view->OnWindowWillClose();
 }
 
 - (BOOL)windowShouldClose:(id)window {


### PR DESCRIPTION
#### Description of Change
Window close was causing a crash because of a notification on the window delegate which has already gone away.
This calls the `BridgedNativeWidget`s on close handler which takes care of the cleanup.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Fixed potential crash when closing windows on macOS 10.10 and10.11