### PR TITLE
build: add temporary debugging to generate_breakpad_symbols.py

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -380,7 +380,7 @@ patches:
   file: allow_nested_error_trackers.patch
   description: |
     Only one X11ErrorTracker should exist at a time, but upstream has a bug
-    where two can exist if running in headless mode -- 
+    where two can exist if running in headless mode --
       ui::(anonymous namespace)::SupportsEWMH() [inner tracker is created]
       ui::WmSupportsHint()
       ui::IsX11WindowFullScreen()
@@ -500,3 +500,9 @@ patches:
 
     This is required by the nativeWindowOpen option, which put multiple main
     frames in one renderer process.
+-
+  author: John Kleinschmidt <jkleinsc@github.com>
+  file: verbose_generate_breakpad_symbols.patch
+  description:  |
+    Temporarily add additional debugging statements to
+    generate_breakpad_symbols.py to determine why it is hanging.

--- a/patches/common/chromium/verbose_generate_breakpad_symbols.patch
+++ b/patches/common/chromium/verbose_generate_breakpad_symbols.patch
@@ -1,0 +1,76 @@
+diff --git a/components/crash/content/tools/generate_breakpad_symbols.py b/components/crash/content/tools/generate_breakpad_symbols.py
+index 58646a1..8bf830b 100755
+--- a/components/crash/content/tools/generate_breakpad_symbols.py
++++ b/components/crash/content/tools/generate_breakpad_symbols.py
+@@ -59,7 +59,10 @@ def Resolve(path, exe_path, loader_path, rpaths):
+   return path
+ 
+ 
+-def GetSharedLibraryDependenciesLinux(binary):
++def GetSharedLibraryDependenciesLinux(binary, options):
++  if options.verbose:  
++    print "GetSharedLibraryDependencies for %s" % binary
++
+   """Return absolute paths to all shared library dependecies of the binary.
+ 
+   This implementation assumes that we're running on a Linux system."""
+@@ -73,6 +76,9 @@ def GetSharedLibraryDependenciesLinux(binary):
+     m = lib_re.match(line)
+     if m:
+       result.append(m.group(1))
++  if options.verbose:  
++    print "Done GetSharedLibraryDependencies for %s" % binary      
++    print result
+   return result
+ 
+ 
+@@ -167,7 +173,7 @@ def GetSharedLibraryDependencies(options, binary, exe_path):
+   """Return absolute paths to all shared library dependecies of the binary."""
+   deps = []
+   if sys.platform.startswith('linux'):
+-    deps = GetSharedLibraryDependenciesLinux(binary)
++    deps = GetSharedLibraryDependenciesLinux(binary, options)
+   elif sys.platform == 'darwin':
+     deps = GetSharedLibraryDependenciesMac(binary, exe_path)
+   else:
+@@ -204,7 +210,8 @@ def GetBinaryInfoFromHeaderInfo(header_info):
+ 
+ def GenerateSymbols(options, binaries):
+   """Dumps the symbols of binary and places them in the given directory."""
+-
++  if options.verbose:          
++    print "Generating symbols for %s " % (' '.join(binaries))
+   queue = Queue.Queue()
+   print_lock = threading.Lock()
+ 
+@@ -224,8 +231,15 @@ def GenerateSymbols(options, binaries):
+           reason = "Could not locate dump_syms executable."
+           break
+ 
++        if options.verbose:
++          with print_lock:
++            print "GetBinaryInfoFromHeaderInfo for %s" % (binary)
+         binary_info = GetBinaryInfoFromHeaderInfo(
+             subprocess.check_output([dump_syms, '-i', binary]).splitlines()[0])
++        if options.verbose:
++          with print_lock:
++            print "Done GetBinaryInfoFromHeaderInfo for %s: %s (%s)" % (binary, binary_info.name, binary_info.hash)
++
+         if not binary_info:
+           should_dump_syms = False
+           reason = "Could not obtain binary information."
+@@ -242,8 +256,14 @@ def GenerateSymbols(options, binaries):
+         # See if there is a symbol file already found next to the binary
+         potential_symbol_files = glob.glob('%s.breakpad*' % binary)
+         for potential_symbol_file in potential_symbol_files:
++          if options.verbose:
++            with print_lock:
++              print "Looking at %s as a potential symbol file." % (potential_symbol_file)
+           with open(potential_symbol_file, 'rt') as f:
+             symbol_info = GetBinaryInfoFromHeaderInfo(f.readline())
++            if options.verbose:
++              with print_lock:
++                print "Got symbol_info for %s." % (potential_symbol_file)
+           if symbol_info == binary_info:
+             mkdir_p(os.path.dirname(output_path))
+             shutil.copyfile(potential_symbol_file, output_path)


### PR DESCRIPTION
#### Description of Change
Manual backport of #15176 to 4-0-x.
This PR temporarily add additional debugging statements to generate_breakpad_symbols.py to determine why it is hanging. I can't reproduce the hang but if it does happen again, we should now have more information as to why it is happening.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes