### PR TITLE
build: skip pyproto/ resources in zip.py

### DIFF
--- a/build/zip.py
+++ b/build/zip.py
@@ -13,6 +13,11 @@ PATHS_TO_SKIP = [
   'swiftshader', #Skipping because it is an output of //ui/gl that we don't need
   './libVkLayer_', #Skipping because these are outputs that we don't need
   './VkLayerLayer_', #Skipping because these are outputs that we don't need
+
+  # //chrome/browser:resources depends on this via
+  # //chrome/browser/resources/ssl/ssl_error_assistant, but we don't need to
+  # ship it.
+  'pyproto',
 ]
 
 def skip_path(dep):


### PR DESCRIPTION
#### Description of Change
Fixes #15347. It looks like these python files are listed as data deps to support python-only targets which GN doesn't understand, and we're picking them up by accident.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: removed unneeded `pyproto` files from release archives