### PR TITLE
chore: electron alias should be defined with public_deps

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -919,7 +919,7 @@ dist_zip("electron_mksnapshot_zip") {
 }
 
 group("electron") {
-  deps = [
+  public_deps = [
     ":electron_app",
   ]
 }


### PR DESCRIPTION
#### Description of Change
This makes `gn path` work properly when pathing from `//electron` instead of `//electron:electron_app`, for example.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes