### PR TITLE
fix: use NSURL path for receipt url

### DIFF
--- a/atom/browser/mac/in_app_purchase.mm
+++ b/atom/browser/mac/in_app_purchase.mm
@@ -167,7 +167,7 @@ void FinishTransactionByDate(const std::string& date) {
 std::string GetReceiptURL() {
   NSURL* receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
   if (receiptURL != nil) {
-    return [[receiptURL absoluteString] UTF8String];
+    return std::string([[receiptURL path] UTF8String]);
   } else {
     return "";
   }


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15140.

Return the  in-app purchase receipt url using `path` instead of `absoluteString`.

/cc @MarshallOfSound @semireg

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fix: incorrect path returned by IAP getReceiptURL()