### PR TITLE
fix: moveTop window not works, if electron process do not have focus

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -627,11 +627,10 @@ void NativeWindowViews::SetResizable(bool resizable) {
 
 #if defined(OS_WIN)
 void NativeWindowViews::MoveTop() {
-  gfx::Point pos = GetPosition();
-  gfx::Size size = GetSize();
-  ::SetWindowPos(GetAcceleratedWidget(), HWND_TOP, pos.x(), pos.y(),
-                 size.width(), size.height(),
+  ::SetWindowPos(GetAcceleratedWidget(), HWND_TOPMOST, 0, 0, 0, 0,
                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+  ::SetWindowPos(GetAcceleratedWidget(), HWND_NOTOPMOST, 0, 0, 0, 0,
+                 SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
 }
 #endif
 


### PR DESCRIPTION
#### Description of Change
BrowserWindow moveTop API bug fix. 
if electron process do not have focus, this api do not works. 

@KiranNiranjan
#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
Notes: in windows os, BrowserWindow moveTop API not works if electron process do not have focus. so fix this bug. in moveTop function, call SetWindowPos twice. first move top most with always top most flag, second cancel always top most flag