### PR TITLE
ci: make sure brew installed node is available in path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ step-install-nodejs-on-mac: &step-install-nodejs-on-mac
       if [ "`uname`" == "Darwin" ]; then
         brew update
         brew install node@10
+        echo 'export PATH="/usr/local/opt/node@10/bin:$PATH"' >> $BASH_ENV
       fi
 
 step-gn-gen-default: &step-gn-gen-default


### PR DESCRIPTION
#### Description of Change
Fixes CircleCI issue where mac builds were not working because node wasn't available (port of #15374 for master)
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes