### PR TITLE
fix: enable FixAltGraph to fix Ctrl+Alt accelerators on Windows

### DIFF
--- a/brightray/browser/browser_main_parts.cc
+++ b/brightray/browser/browser_main_parts.cc
@@ -181,8 +181,15 @@ void OverrideAppLogsPath() {
 
 void BrowserMainParts::InitializeFeatureList() {
   auto* cmd_line = base::CommandLine::ForCurrentProcess();
-  const auto enable_features =
+  auto enable_features =
       cmd_line->GetSwitchValueASCII(switches::kEnableFeatures);
+#if defined(OS_WIN)
+  // On Windows, when you set an accelerator with Ctrl and Alt both added as
+  // a modifier, it screws with the event modifiers, and also sets AltGr as
+  // enabled. There is a fix for this in chromium, but it's not enabled by
+  // default in 3-0-x. http://crbug.com/25503
+  enable_features += std::string(",FixAltGraph");
+#endif
   auto disable_features =
       cmd_line->GetSwitchValueASCII(switches::kDisableFeatures);
   auto feature_list = std::make_unique<base::FeatureList>();


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Windows treats `Ctrl+Alt` as `AltGr`, and this causes confusion when checking if an accelerator was pressed or not. There is a fix in `chromium`, but in C66 it's behind a flag, so we must enable it to use those accelerators.

This is only required on `3-0-x`. Fixes #14674.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fixes `Ctrl+Alt+<x>` accelerators on Windows <!-- One-line Change Summary Here-->