### PR TITLE
fix: folder open not working in devtools

### DIFF
--- a/atom/browser/ui/inspectable_web_contents_impl.cc
+++ b/atom/browser/ui/inspectable_web_contents_impl.cc
@@ -512,8 +512,9 @@ void InspectableWebContentsImpl::ShowItemInFolder(
     const std::string& file_system_path) {
   if (file_system_path.empty())
     return;
+
   base::FilePath path = base::FilePath::FromUTF8Unsafe(file_system_path);
-  platform_util::ShowItemInFolder(path);
+  platform_util::OpenItem(path);
 }
 
 void InspectableWebContentsImpl::SaveToFile(const std::string& url,

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -4,8 +4,17 @@ window.onload = function () {
   // Use menu API to show context menu.
   window.InspectorFrontendHost.showContextMenuAtPoint = createMenu
 
+  // correct for Chromium returning undefined for filesystem
+  window.Persistence.FileSystemWorkspaceBinding.completeURL = completeURL
+
   // Use dialog API to override file chooser dialog.
   window.UI.createFileSelectorElement = createFileSelectorElement
+}
+
+// Extra / is needed as a result of MacOS requiring absolute paths
+function completeURL (project, path) {
+  project = 'file:///'
+  return `${project}${path}`
 }
 
 window.confirm = function (message, title) {


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15360.

The root of this issue lies [here](https://cs.chromium.org/chromium/src/third_party/blink/renderer/devtools/front_end/persistence/FileSystemWorkspaceBinding.js?type=cs&q=completeURL&sq=package:chromium&g=0&l=110); `fsProject._fileSystemBaseURL` should be returning `file://` and instead was returning `undefined`. This meant that [this](https://cs.chromium.org/chromium/src/third_party/blink/renderer/devtools/front_end/common/ParsedURL.js?q=urlToPlatformPath&sq=package:chromium&l=100) function would return `edpath/to/your/source`, because it was originally `undefinedyour/path/to/source` but the `undefin` got shaved off. Then, `InspectorFrontendHost.showItemInFolder`, which mapped to [our function here](https://github.com/electron/electron/blob/master/atom/browser/ui/inspectable_web_contents_impl.cc#L511) would try to call `platform_util::ShowItemInFolder`, which can only be called on the main thread (hence the original DCHECK crash) and which actually needs to be `platform_util::OpenItem`. 

However! `platform_util::OpenItem` would try to take that mangled path and open it as an absolute path, so we actually need to inject into `window.Persistence.FileSystemWorkspaceBinding.completeURL` and force the prefix to be `file://`/`file:///` (mac/win)  instead of `undefined`.

/cc @MarshallOfSound @pronebird

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fix crash when showing source folder in devtools