### PR TITLE
chore: avoid appending git version to the exported patches

### DIFF
--- a/patches/common/chromium/accelerator.patch
+++ b/patches/common/chromium/accelerator.patch
@@ -97,6 +97,3 @@ index 7e55ef366ac8320f730cdcb268453b1fa2710887..c3fb98b426cd7c12f66eaaf358f4ff18
    parts.push_back(base::string16(IsCmdDown() ? kCommandSymbol : kNoSymbol));
    parts.push_back(shortcut);
    return base::StrCat(parts);
--- 
-2.17.0
-

--- a/patches/common/chromium/add_atomic_lib_to_dependencies_even_for_sysroot_builds.patch
+++ b/patches/common/chromium/add_atomic_lib_to_dependencies_even_for_sysroot_builds.patch
@@ -17,6 +17,3 @@ index 7fb93868d6e009323eceb2ba0f1ff9c506dc5f3b..53c5744953da460c02b43de1bfd184cd
        host_toolchain != "//build/toolchain/cros:host") {
      libs += [ "atomic" ]
    }
--- 
-2.17.0
-

--- a/patches/common/chromium/add_realloc.patch
+++ b/patches/common/chromium/add_realloc.patch
@@ -81,6 +81,3 @@ index 809229caa872789345218538d945f3ed6a871adc..6248ad32d6b045fbd4c863cbdbeb859a
    static void FreeMemory(void*);
    static DataHandle CreateDataHandle(size_t, InitializationPolicy);
    static void Initialize(
--- 
-2.17.0
-

--- a/patches/common/chromium/allow_nested_error_trackers.patch
+++ b/patches/common/chromium/allow_nested_error_trackers.patch
@@ -32,6 +32,3 @@ index af031de356c5e0938fd3b84a494e48dc9a0e0476..2a5c18dc473a4f88fc0427bec6914291
    g_handler = this;
    XSync(GetXDisplay(), False);
    old_handler_ = XSetErrorHandler(X11ErrorHandler);
--- 
-2.17.0
-

--- a/patches/common/chromium/allow_webview_file_url.patch
+++ b/patches/common/chromium/allow_webview_file_url.patch
@@ -18,6 +18,3 @@ index 061ad189c46d5f0f1afb09052cc21aeb7e60a744..d64ba4f20d49a57b29e1ad5bc7ac5361
    if (is_shutdown_ || non_web_url_in_guest) {
      url_loader_client->OnComplete(
          network::URLLoaderCompletionStatus(net::ERR_ABORTED));
--- 
-2.17.0
-

--- a/patches/common/chromium/app_indicator_icon_menu.patch
+++ b/patches/common/chromium/app_indicator_icon_menu.patch
@@ -17,6 +17,3 @@ index 40399a35f8d2c70827adec732c898a5be09cf69b..1d3a0da948dca3fef3af53256d23e8ae
      ExecuteCommand(model, id);
  }
  
--- 
-2.17.0
-

--- a/patches/common/chromium/blink-worker-enable-csp-in-file-scheme.patch
+++ b/patches/common/chromium/blink-worker-enable-csp-in-file-scheme.patch
@@ -16,6 +16,3 @@ index 6e803af108f310b6df0ff0f3e2f0ddb0cce3cae3..94a72b37ae8ebf7f142b5dfdd0226122
        !response.Url().ProtocolIs("filesystem")) {
      content_security_policy_ = ContentSecurityPolicy::Create();
      content_security_policy_->SetOverrideURLForSelf(response.Url());
--- 
-2.17.0
-

--- a/patches/common/chromium/blink_file_path.patch
+++ b/patches/common/chromium/blink_file_path.patch
@@ -32,6 +32,3 @@ index a74beceda3e769aaf5673cabc6663bb883f54705..7196fd5f5f9e51616d49c09142247c83
      readonly attribute long long lastModified;
  
      // Non-standard APIs
--- 
-2.17.0
-

--- a/patches/common/chromium/blink_fix_prototype_assert.patch
+++ b/patches/common/chromium/blink_fix_prototype_assert.patch
@@ -27,6 +27,3 @@ index 87f2176ce897583b6682e8f49d1e4cac1392aacb..ce3d9ce19bff686640be08776a7dc573
  
      prototype_object = prototype_value.As<v8::Object>();
      if (prototype_object->InternalFieldCount() ==
--- 
-2.17.0
-

--- a/patches/common/chromium/blink_initialization_order.patch
+++ b/patches/common/chromium/blink_initialization_order.patch
@@ -26,6 +26,3 @@ index cbd9f811d97855e8bf083cbb2dd9ebcbcab0a1a5..160e5bc7d57ad18619a4c912d57b6b07
    if (World().IsMainWorld()) {
      GetFrame()->Loader().DispatchDidClearWindowObjectInMainWorld();
    }
--- 
-2.17.0
-

--- a/patches/common/chromium/blink_local_frame.patch
+++ b/patches/common/chromium/blink_local_frame.patch
@@ -39,6 +39,3 @@ index 52810bba03b0c2916ae84d5b1642740cc2d7a2e6..65575d432df5e8e27f8285dcf6dd77e4
  
    // TODO(crbug.com/729196): Trace why LocalFrameView::DetachFromLayout crashes.
    CHECK(!view_->IsAttached());
--- 
-2.17.0
-

--- a/patches/common/chromium/blink_world_context.patch
+++ b/patches/common/chromium/blink_world_context.patch
@@ -49,6 +49,3 @@ index feb4b14bc8e52c8335e93d133506ecd6226c051d..95d1cc2c91ca01ec95dc3f63aa5f2546
    v8::Local<v8::Object> GlobalProxy() const override;
    void StartReload(WebFrameLoadType) override;
    void ReloadImage(const WebNode&) override;
--- 
-2.17.0
-

--- a/patches/common/chromium/boringssl_build_gn.patch
+++ b/patches/common/chromium/boringssl_build_gn.patch
@@ -24,6 +24,3 @@ index d31a9f29fa9c12e753708b2a1e75c33b70924300..dea5a6403f4c32f94bb58198c467bc7c
  
  # Windows' assembly is built with Yasm. The other platforms use the platform
  # assembler.
--- 
-2.17.0
-

--- a/patches/common/chromium/browser_compositor_mac.patch
+++ b/patches/common/chromium/browser_compositor_mac.patch
@@ -42,6 +42,3 @@ index 92afcc77910610e53378f55adc003cc1bdf3109a..42bd6fd7c169de36c775471c68b456f1
  DelegatedFrameHost* BrowserCompositorMac::GetDelegatedFrameHost() {
    DCHECK(delegated_frame_host_);
    return delegated_frame_host_.get();
--- 
-2.17.0
-

--- a/patches/common/chromium/browser_plugin_guest.patch
+++ b/patches/common/chromium/browser_plugin_guest.patch
@@ -22,6 +22,3 @@ index f56ce93c3d5b1b46b706800a12a21f29cabafb33..19c302c2714fb8ce89b261dd44d9939d
  }
  
  base::WeakPtr<BrowserPluginGuest> BrowserPluginGuest::AsWeakPtr() {
--- 
-2.17.0
-

--- a/patches/common/chromium/browser_plugin_wheel.patch
+++ b/patches/common/chromium/browser_plugin_wheel.patch
@@ -29,6 +29,3 @@ index 4d8251069ae9a45e1be22fa03f23b3196116b612..fbd5cc8099629971d670d087fdee8920
  
    if (blink::WebInputEvent::IsGestureEventType(event.GetType())) {
      auto gesture_event = static_cast<const blink::WebGestureEvent&>(event);
--- 
-2.17.0
-

--- a/patches/common/chromium/build_gn.patch
+++ b/patches/common/chromium/build_gn.patch
@@ -26,6 +26,3 @@ index fcc00ee0e49f101cb1b10629747c4c4fa521776d..3232a0360e94e78621f7f672e3de4bdc
  ]
  
  if (is_win) {
--- 
-2.17.0
-

--- a/patches/common/chromium/can_create_window.patch
+++ b/patches/common/chromium/can_create_window.patch
@@ -235,6 +235,3 @@ index fa458cf0c92d6f75ecd71e296ba1af88ace400dc..cdd95a1d88e582a31aca43cd2fc90011
                         bool user_gesture,
                         bool opener_suppressed,
                         bool* no_javascript_access) override;
--- 
-2.17.0
-

--- a/patches/common/chromium/chrome_key_systems.patch
+++ b/patches/common/chromium/chrome_key_systems.patch
@@ -35,6 +35,3 @@ index 5c38d0b1ce7c6d395126b6cc428467d31bb3c0a5..4ffaf2a3301eec188b1b40b06b2152f1
  
    if (!supported_by_the_cdm) {
      DVLOG(2) << __func__ << ": Not supported by the CDM.";
--- 
-2.17.0
-

--- a/patches/common/chromium/color_chooser.patch
+++ b/patches/common/chromium/color_chooser.patch
@@ -88,6 +88,3 @@ index 06381ef0e5ca34d141363213a846e5a9baa5fd8a..acb3a6e9e6476d9d2e3f445237246e6a
    current_color_chooser_ = NULL;
    if (web_contents_)
      web_contents_->DidEndColorChooser();
--- 
-2.17.0
-

--- a/patches/common/chromium/command-ismediakey.patch
+++ b/patches/common/chromium/command-ismediakey.patch
@@ -117,6 +117,3 @@ index cd595b0c017d6e36a5d94f7c99fe0a098a52b067..941c1a76a1c3ebe542aebcc9dc301d19
      return event;
    }
  
--- 
-2.17.0
-

--- a/patches/common/chromium/compositor_delegate.patch
+++ b/patches/common/chromium/compositor_delegate.patch
@@ -78,6 +78,3 @@ index e0ec33400b179a600d95501fb93826075ffc52eb..29ba88a504c33d850c7a3425bd7d874a
    // The root of the Layer tree drawn by this compositor.
    Layer* root_layer_ = nullptr;
  
--- 
-2.17.0
-

--- a/patches/common/chromium/content_browser_main_loop.patch
+++ b/patches/common/chromium/content_browser_main_loop.patch
@@ -20,6 +20,3 @@ index eb942391306e86e8ee8dc2584c63440b10ec76bd..9111cf18b7fc8fb67e7ee65e3cd76bd1
    run_loop.Run();
  #endif
  }
--- 
-2.17.0
-

--- a/patches/common/chromium/crashpad_http_status.patch
+++ b/patches/common/chromium/crashpad_http_status.patch
@@ -84,6 +84,3 @@ index 18d343ccef0396ee6679f4b5fd8316c3109003f4..2919bc11d0ba4bf84a11e146bf2961b8
      LOG(ERROR) << base::StringPrintf("HTTP status %lu", status_code);
      return false;
    }
--- 
-2.17.0
-

--- a/patches/common/chromium/dcheck.patch
+++ b/patches/common/chromium/dcheck.patch
@@ -267,6 +267,3 @@ index 57bbe16c15ea442963a53f89b009e2c99c7b090a..07725187c595784d9e5f49d45a8835da
  }
  
  if (is_android) {
--- 
-2.17.0
-

--- a/patches/common/chromium/desktop_media_list.patch
+++ b/patches/common/chromium/desktop_media_list.patch
@@ -298,6 +298,3 @@ index e6f0e17b05ee4dc45827dc2dd00d484201f74646..75c9ca04ce481ab79615515da948c29d
    std::unique_ptr<Worker> worker_;
  
  #if defined(USE_AURA)
--- 
-2.17.0
-

--- a/patches/common/chromium/disable-redraw-lock.patch
+++ b/patches/common/chromium/disable-redraw-lock.patch
@@ -74,6 +74,3 @@ index 1b2d98a857385d31b5f401d685fd9524da228726..dd080180aebda193ef885bf7f4158780
    // Returns who we want to be drawing the frame. Either the system (Windows)
    // will handle it or Chrome will custom draw it.
    virtual FrameMode GetFrameMode() const = 0;
--- 
-2.17.0
-

--- a/patches/common/chromium/disable_detach_webview_frame.patch
+++ b/patches/common/chromium/disable_detach_webview_frame.patch
@@ -26,6 +26,3 @@ index b06a4b9242d30869f9b37fee1dc3ecbe7dcc06d4..b7793aaa094ad342fa15491653baac26
      // Only main frame proxy can detach for inner WebContents.
      DCHECK(frame_tree_node_->IsMainFrame());
      frame_tree_node_->render_manager()->RemoveOuterDelegateFrame();
--- 
-2.17.0
-

--- a/patches/common/chromium/disable_hidden.patch
+++ b/patches/common/chromium/disable_hidden.patch
@@ -32,6 +32,3 @@ index 4af5870e7c40056b98e67f71c2c037490f2634f2..f2e19fe92e56d5d98a3ea0491a719c89
    void set_hung_renderer_delay(const base::TimeDelta& delay) {
      hung_renderer_delay_ = delay;
    }
--- 
-2.17.0
-

--- a/patches/common/chromium/disable_user_gesture_requirement_for_beforeunload_dialogs.patch
+++ b/patches/common/chromium/disable_user_gesture_requirement_for_beforeunload_dialogs.patch
@@ -20,6 +20,3 @@ index 5bfe30b8b88073b83c8128b889298bd9af5938f3..70129284e60b20258b2e5d3506f93600
    }
  
    if (did_allow_navigation) {
--- 
-2.17.0
-

--- a/patches/common/chromium/dom_storage_map.patch
+++ b/patches/common/chromium/dom_storage_map.patch
@@ -21,6 +21,3 @@ index fd088fb170bead6452ded14016f21f0c29659e03..a9e4b3375e9b614ed1e8b737a30f4436
  
    (*map_type)[key] = value;
    ResetKeyIterator();
--- 
-2.17.0
-

--- a/patches/common/chromium/dump_syms.patch
+++ b/patches/common/chromium/dump_syms.patch
@@ -20,6 +20,3 @@ index 2032f1991ada8669a393838c57b2fd054a81a3e1..58646a10591a1d3e7c2dd1782c3642b9
    return deps
  
  
--- 
-2.17.0
-

--- a/patches/common/chromium/enable_osr_components.patch
+++ b/patches/common/chromium/enable_osr_components.patch
@@ -26,6 +26,3 @@ index 305095fc420e1732bdf089dfeee7672f69d85167..f5ca4eda4a663b9297ce69e6a455d755
   public:
    MouseWheelPhaseHandler(RenderWidgetHostViewBase* const host_view);
    ~MouseWheelPhaseHandler() {}
--- 
-2.17.0
-

--- a/patches/common/chromium/enable_widevine.patch
+++ b/patches/common/chromium/enable_widevine.patch
@@ -20,6 +20,3 @@ index 82a93622585a424f56c3567050f9ba4822de6c1e..cbd10bed9f3bdbeb61ec5daa2f8d0e15
  }
  
  enable_widevine_cdm_host_verification =
--- 
-2.17.0
-

--- a/patches/common/chromium/exclude-a-few-test-files-from-build.patch
+++ b/patches/common/chromium/exclude-a-few-test-files-from-build.patch
@@ -19,6 +19,3 @@ index d5d8e48305ba20926415a3e94f8732baf327a14b..070c6be426f4affcfb3a08199f8f1bd7
      "graphics/paint/paint_chunk_test.cc",
      "graphics/paint/paint_chunker_test.cc",
      "graphics/paint/paint_controller_test.cc",
--- 
-2.17.0
-

--- a/patches/common/chromium/expose-net-observer-api.patch
+++ b/patches/common/chromium/expose-net-observer-api.patch
@@ -27,6 +27,3 @@ index 7a2dcd9de423cca8e39f84e7f6839eefd86c11ae..494526c843b9e39eba46785618960c3e
  
    // OnDestruct is used to ensure deletion on the thread on which the request
    // IO happens.
--- 
-2.17.0
-

--- a/patches/common/chromium/frame_host_manager.patch
+++ b/patches/common/chromium/frame_host_manager.patch
@@ -87,6 +87,3 @@ index 3be31602689cb93b965729cc4e35cf6d23a8ec2f..2c22cb1cfe0dddc97c00e5f4ff89de6b
    // Allows the embedder to set any number of custom BrowserMainParts
    // implementations for the browser startup code. See comments in
    // browser_main_parts.h.
--- 
-2.17.0
-

--- a/patches/common/chromium/gin_enable_disable_v8_platform.patch
+++ b/patches/common/chromium/gin_enable_disable_v8_platform.patch
@@ -70,6 +70,3 @@ index 6f3265ba4d06e70930630432bf739f89847d0b3c..29f28bebbdcde5a7f1c7b31a625d30f1
  
    // Get address and size information for currently loaded snapshot.
    // If no snapshot is loaded, the return values are null for addresses
--- 
-2.17.0
-

--- a/patches/common/chromium/gritsettings_resource_ids.patch
+++ b/patches/common/chromium/gritsettings_resource_ids.patch
@@ -21,6 +21,3 @@ index efa6e5c90b88c25f412ad4e49c94f82a87f0f456..a40476bb9c8794f1db05b930e80ad483
    # END "everything else" section.
    # Everything but chrome/, components/, content/, and ios/
  
--- 
-2.17.0
-

--- a/patches/common/chromium/gtk_visibility.patch
+++ b/patches/common/chromium/gtk_visibility.patch
@@ -6,7 +6,7 @@ Subject: gtk_visibility.patch
 Allow electron to depend on GTK in the GN build.
 
 diff --git a/build/config/linux/gtk/BUILD.gn b/build/config/linux/gtk/BUILD.gn
-index deae4d3455a8..5f5db2fd6e5e 100644
+index deae4d3455a8b54292dd3abc0a316f9ca60b4104..5f5db2fd6e5ee8532e5fa796988ea4ed58265b0d 100644
 --- a/build/config/linux/gtk/BUILD.gn
 +++ b/build/config/linux/gtk/BUILD.gn
 @@ -18,6 +18,7 @@ group("gtk") {
@@ -17,6 +17,3 @@ index deae4d3455a8..5f5db2fd6e5e 100644
      "//examples:peerconnection_client",
      "//gpu/gles2_conform_support:gles2_conform_test_windowless",
      "//remoting/host",
--- 
-2.17.0
-

--- a/patches/common/chromium/ignore_rc_check.patch
+++ b/patches/common/chromium/ignore_rc_check.patch
@@ -23,6 +23,3 @@ index cb0393ecd507b865169e9d7c3037d7d5523ae30e..34eebb06295b38dfa0b567f66780ce14
      return rc_exe_exit_code
  
    def ExecActionWrapper(self, arch, rspfile, *dirname):
--- 
-2.17.0
-

--- a/patches/common/chromium/isolate_holder.patch
+++ b/patches/common/chromium/isolate_holder.patch
@@ -48,6 +48,3 @@ index 84cf66e6e9cdbfcdc3d8f0a1f0c122e5994ef1c2..cc0d65e4e4be5818d526c0a46a60e116
    ~IsolateHolder();
  
    // Should be invoked once before creating IsolateHolder instances to
--- 
-2.17.0
-

--- a/patches/common/chromium/leveldb_ssize_t.patch
+++ b/patches/common/chromium/leveldb_ssize_t.patch
@@ -23,6 +23,3 @@ index a7c449eba19c3e3f46eec9c428fb497f6b1a7852..acbce7efd582e226419054cf80e1c27f
  #endif
  
  namespace leveldb {
--- 
-2.17.0
-

--- a/patches/common/chromium/libgtkui_export.patch
+++ b/patches/common/chromium/libgtkui_export.patch
@@ -139,6 +139,3 @@ index 8d67e1460837c7f8adb151adea131cc6440659a3..95fbb27b6a81e4d73d239e94f5105078
  
  }  // namespace unity
  
--- 
-2.17.0
-

--- a/patches/common/chromium/mas-audiodeviceduck.patch
+++ b/patches/common/chromium/mas-audiodeviceduck.patch
@@ -33,6 +33,3 @@ index 53586b888d82b9602e3f76b84072a1e6a7df1ec0..c1d750dbf32d9c56d557e5bf5ff5d63a
  }
  
  }  // namespace
--- 
-2.17.0
-

--- a/patches/common/chromium/mas-cfisobjc.patch
+++ b/patches/common/chromium/mas-cfisobjc.patch
@@ -37,6 +37,3 @@ index 15fc15ba307e18f438852f00f41b2f5ecf7ff85f..7ca4e0ec5ca87f34e0baa22ba0b704e2
    id<NSObject> ns_val = reinterpret_cast<id>(const_cast<void*>(cf_val));
    if ([ns_val isKindOfClass:[NSFont class]]) {
      return (CTFontRef)(cf_val);
--- 
-2.17.0
-

--- a/patches/common/chromium/mas-cgdisplayusesforcetogray.patch
+++ b/patches/common/chromium/mas-cgdisplayusesforcetogray.patch
@@ -27,6 +27,3 @@ index 99a128511250d594cdac79ebf9b291823db18962..7200a5df74e168b817f7e7598b7fce8b
  
    // CGDisplayRotation returns a double. Display::SetRotationAsDegree will
    // handle the unexpected situations were the angle is not a multiple of 90.
--- 
-2.17.0
-

--- a/patches/common/chromium/mas-lssetapplicationlaunchservicesserverconnectionstatus.patch
+++ b/patches/common/chromium/mas-lssetapplicationlaunchservicesserverconnectionstatus.patch
@@ -21,6 +21,3 @@ index f14c045d47add3159e9099a8bdb511b233a2911b..9c8751a6fe0bcd0c69cc47dbbcf4fcc8
  #else
      main_message_loop.reset(
          new base::MessageLoop(base::MessageLoop::TYPE_DEFAULT));
--- 
-2.17.0
-

--- a/patches/common/chromium/mas_blink_no_private_api.patch
+++ b/patches/common/chromium/mas_blink_no_private_api.patch
@@ -118,6 +118,3 @@ index 7a1260db0a139f9f3f8a823af2c220f36162812a..bf9cf7046e2fc9cdfee5b92f2a348185
    return false;
  }
  
--- 
-2.17.0
-

--- a/patches/common/chromium/mas_no_private_api.patch
+++ b/patches/common/chromium/mas_no_private_api.patch
@@ -442,6 +442,3 @@ index 69c5f1f44d7e39e8480319b3da02725b5cb89eea..8841b59f6b70ac4687adfde61a1fba14
  namespace {
  constexpr auto kUIPaintTimeout = base::TimeDelta::FromSeconds(5);
  }  // namespace
--- 
-2.17.0
-

--- a/patches/common/chromium/net_url_request_job.patch
+++ b/patches/common/chromium/net_url_request_job.patch
@@ -16,6 +16,3 @@ index 7a223958751012b2042a91edf85578b00702d565..08a3940915c61746c7bf80d244008750
    // Called to read raw (pre-filtered) data from this Job. Reads at most
    // |buf_size| bytes into |buf|.
    // Possible return values:
--- 
-2.17.0
-

--- a/patches/common/chromium/no_cache_storage_check.patch
+++ b/patches/common/chromium/no_cache_storage_check.patch
@@ -19,6 +19,3 @@ index d91b54a4d2a15f4d48f6e82488e0c27c68c5abdb..7f946a5a04c97635f783aeecebc13fc2
    }
  
    virtual ~CacheLoader() {}
--- 
-2.17.0
-

--- a/patches/common/chromium/no_stack_dumping.patch
+++ b/patches/common/chromium/no_stack_dumping.patch
@@ -17,6 +17,3 @@ index 8d789ef1b9f76aacbf1bc8c13b79de04618b9141..034fdcad958cb25780c304d184b2fbb7
  #if defined(OS_WIN)
      bool should_enable_stack_dump = !process_type.empty();
  #else
--- 
-2.17.0
-

--- a/patches/common/chromium/notification_provenance.patch
+++ b/patches/common/chromium/notification_provenance.patch
@@ -162,6 +162,3 @@ index baf24f9effc9569f070757832681a82e62322d30..98a128e5d24933fbf98a5cfdda90b061
        BrowserContext* browser_context,
        const std::string& notification_id,
        const GURL& origin,
--- 
-2.17.0
-

--- a/patches/common/chromium/out_of_process_instance.patch
+++ b/patches/common/chromium/out_of_process_instance.patch
@@ -19,6 +19,3 @@ index 0358d15fb45bb57111ee2af0f791cd99f6f27f70..101763db35d129097bda50af1bfa9f6f
      return false;
  
    // Check if the plugin is full frame. This is passed in from JS.
--- 
-2.17.0
-

--- a/patches/common/chromium/pepper_flash.patch
+++ b/patches/common/chromium/pepper_flash.patch
@@ -489,6 +489,3 @@ index e021c964da3d467530775164a67d5cadaf6dc741..e035f0fb9e2baa6a9148b43765b09c52
   public:
    explicit PepperHelper(content::RenderFrame* render_frame);
    ~PepperHelper() override;
--- 
-2.17.0
-

--- a/patches/common/chromium/printing.patch
+++ b/patches/common/chromium/printing.patch
@@ -997,6 +997,3 @@ index 283c0ff81954bb9e777b1e0007a735ec0ad4901e..231873a456442856c43d643e41c1bb22
  // Use for debug only, because output is not completely consistent with format
  // of |PrintSettingsFromJobSettings| input.
  void PrintSettingsToJobSettingsDebug(const PrintSettings& settings,
--- 
-2.17.0
-

--- a/patches/common/chromium/proxy_config_monitor.patch
+++ b/patches/common/chromium/proxy_config_monitor.patch
@@ -89,6 +89,3 @@ index b783ab18d2d77cb2d443eed36a508f1eac77c04d..4475b58756dbf686cf78f6e317e55bc1
    mojo::BindingSet<network::mojom::ProxyConfigPollerClient> binding_set_;
  
    mojo::InterfacePtrSet<network::mojom::ProxyConfigClient>
--- 
-2.17.0
-

--- a/patches/common/chromium/render_widget_host_view_base.patch
+++ b/patches/common/chromium/render_widget_host_view_base.patch
@@ -74,6 +74,3 @@ index 8ed6ffd3a284fe58fe5e80a473f6d22f6b5bf8f7..dd7fdbbdee59658d674f93d3a5b769b6
    // Transform a point that is in the coordinate space of a Surface that is
    // embedded within the RenderWidgetHostViewBase's Surface to the
    // coordinate space of an embedding, or embedded, Surface. Typically this
--- 
-2.17.0
-

--- a/patches/common/chromium/render_widget_host_view_mac.patch
+++ b/patches/common/chromium/render_widget_host_view_mac.patch
@@ -77,6 +77,3 @@ index 0703dd02c90106a541acf173ec770e18e01c8841..7186a054cf559c64bb6ed410adcba724
  
  using blink::WebInputEvent;
  using blink::WebMouseEvent;
--- 
-2.17.0
-

--- a/patches/common/chromium/resource_file_conflict.patch
+++ b/patches/common/chromium/resource_file_conflict.patch
@@ -32,6 +32,3 @@ index a47af42a5a5afc1560f11ee0ccfa5fc177745caa..db8311121e755eb955ff05dee61a9706
  
  repack("browser_tests_pak") {
    sources = [
--- 
-2.17.0
-

--- a/patches/common/chromium/scoped_clipboard_writer.patch
+++ b/patches/common/chromium/scoped_clipboard_writer.patch
@@ -61,6 +61,3 @@ index 385900eb67dee499afc8591e6acf0c6b5957df7e..cf1f803ec1233c173d11295be05ba085
    // Adds arbitrary pickled data to clipboard.
    void WritePickledData(const base::Pickle& pickle,
                          const Clipboard::FormatType& format);
--- 
-2.17.0
-

--- a/patches/common/chromium/scroll_bounce_flag.patch
+++ b/patches/common/chromium/scroll_bounce_flag.patch
@@ -18,6 +18,3 @@ index c078565cef71d6a27f276b7a34dd9d060ea079d4..5c31ab7654d0168d232e9974105573fa
  }
  
  bool RenderThreadImpl::IsUseZoomForDSFEnabled() {
--- 
-2.17.0
-

--- a/patches/common/chromium/ssl_security_state_tab_helper.patch
+++ b/patches/common/chromium/ssl_security_state_tab_helper.patch
@@ -142,6 +142,3 @@ index 3319df136d4d32aad066fe98bfadacfb3c05322a..fbc6eea480d23e7158bbbfb8dc779268
    return schemes;
  }
  
--- 
-2.17.0
-

--- a/patches/common/chromium/stream_resource_handler.patch
+++ b/patches/common/chromium/stream_resource_handler.patch
@@ -25,6 +25,3 @@ index b6f51bba48cd145d6bccaff649d7875cf0520b7d..1ee88dfacee3e9bf3e4393a32ebd7192
   public:
    // |origin| will be used to construct the URL for the Stream. See
    // WebCore::BlobURL and and WebCore::SecurityOrigin in Blink to understand
--- 
-2.17.0
-

--- a/patches/common/chromium/sysroot.patch
+++ b/patches/common/chromium/sysroot.patch
@@ -33,6 +33,3 @@ index 58f09950d844f4fa4f8d46718852c4f2c490c391..55dd50187714b596e6ded4f2b302fb49
    sysroots = json.load(open(sysroots_file))
    sysroot_key = '%s_%s' % (target_platform, target_arch)
    if sysroot_key not in sysroots:
--- 
-2.17.0
-

--- a/patches/common/chromium/thread_capabilities.patch
+++ b/patches/common/chromium/thread_capabilities.patch
@@ -25,6 +25,3 @@ index ad0714a7f5edad1784d5e055a392519f750973cc..1406e1d53f2f13bbbcc5b96a1681b9ec
    return 0;
  }
  
--- 
-2.17.0
-

--- a/patches/common/chromium/tts.patch
+++ b/patches/common/chromium/tts.patch
@@ -173,6 +173,3 @@ index cc9e2806b5c3942472785bf3a3a32e23d859971d..d21fb42f1aca2906b8d8968bd1a46721
  
    DISALLOW_COPY_AND_ASSIGN(TtsMessageFilter);
  };
--- 
-2.17.0
-

--- a/patches/common/chromium/use_transparent_window.patch
+++ b/patches/common/chromium/use_transparent_window.patch
@@ -52,6 +52,3 @@ index 4308bbed939898323f26a747330937b7009f11b4..a7cafcfccdffd1b63858d2fc7650eba7
    void AddObserver(GpuSwitchingObserver* observer);
    void RemoveObserver(GpuSwitchingObserver* observer);
  
--- 
-2.17.0
-

--- a/patches/common/chromium/v8_context_snapshot_generator.patch
+++ b/patches/common/chromium/v8_context_snapshot_generator.patch
@@ -18,6 +18,3 @@ index b119ec095c7b1b55277a8d6784be35508ac37094..47df8af5ef68bf8e3fb4fa4f22f7d008
      ]
    }
  }
--- 
-2.17.0
-

--- a/patches/common/chromium/verbose_generate_breakpad_symbols.patch
+++ b/patches/common/chromium/verbose_generate_breakpad_symbols.patch
@@ -82,6 +82,3 @@ index 58646a10591a1d3e7c2dd1782c3642b9cbe06738..0ae9c3c8ae27ca5684ebcb4f6a87f014
            if symbol_info == binary_info:
              mkdir_p(os.path.dirname(output_path))
              shutil.copyfile(potential_symbol_file, output_path)
--- 
-2.17.0
-

--- a/patches/common/chromium/web_contents.patch
+++ b/patches/common/chromium/web_contents.patch
@@ -119,6 +119,3 @@ index 0f82f91e437c495b92662c9816225687430ec8a4..0deb4d93fffbd7392cc1a391d9503946
      // Sandboxing flags set on the new WebContents.
      blink::WebSandboxFlags starting_sandbox_flags;
  
--- 
-2.17.0
-

--- a/patches/common/chromium/webgl_context_attributes.patch
+++ b/patches/common/chromium/webgl_context_attributes.patch
@@ -115,6 +115,3 @@ index 38ca0f6b6a0c4bcb042887cd168ba8040435875d..90cfe8497daf2db6c3022826b5f1ab4e
      boolean failIfMajorPerformanceCaveat = false;
      [OriginTrialEnabled=WebXR] XRDevice compatibleXRDevice = null;
  };
--- 
-2.17.0
-

--- a/patches/common/chromium/webui_in_subframes.patch
+++ b/patches/common/chromium/webui_in_subframes.patch
@@ -5,7 +5,7 @@ Subject: webui_in_subframes.patch
 
 
 diff --git a/content/browser/frame_host/render_frame_host_delegate.cc b/content/browser/frame_host/render_frame_host_delegate.cc
-index 26b8eec2bb76..fb3843168f14 100644
+index 26b8eec2bb763c6a1e29309abe34c4c068eee609..fb3843168f14fa7b584e2ec52f1c1495aa7dd070 100644
 --- a/content/browser/frame_host/render_frame_host_delegate.cc
 +++ b/content/browser/frame_host/render_frame_host_delegate.cc
 @@ -99,7 +99,9 @@ RenderFrameHostDelegate::GetFocusedFrameIncludingInnerWebContents() {
@@ -20,7 +20,7 @@ index 26b8eec2bb76..fb3843168f14 100644
  }
  
 diff --git a/content/browser/frame_host/render_frame_host_delegate.h b/content/browser/frame_host/render_frame_host_delegate.h
-index 7919ac1e5795..03f331915213 100644
+index 7919ac1e579592815fa96e88f30537c51b110fa9..03f33191521354031357a4886fe7ef3417ba17b6 100644
 --- a/content/browser/frame_host/render_frame_host_delegate.h
 +++ b/content/browser/frame_host/render_frame_host_delegate.h
 @@ -278,7 +278,8 @@ class CONTENT_EXPORT RenderFrameHostDelegate {
@@ -34,7 +34,7 @@ index 7919ac1e5795..03f331915213 100644
    // Called by |frame| to notify that it has received an update on focused
    // element. |bounds_in_root_view| is the rectangle containing the element that
 diff --git a/content/browser/frame_host/render_frame_host_impl.cc b/content/browser/frame_host/render_frame_host_impl.cc
-index 783dc705f748..9fa14c824032 100644
+index 783dc705f748bc6c9d3b8630ce12ad39ff2fd7d2..9fa14c824032463cedbbf5db41f1dbe3490c4a69 100644
 --- a/content/browser/frame_host/render_frame_host_impl.cc
 +++ b/content/browser/frame_host/render_frame_host_impl.cc
 @@ -26,6 +26,7 @@
@@ -71,7 +71,7 @@ index 783dc705f748..9fa14c824032 100644
        pending_web_ui_type_ = new_web_ui_type;
  
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
-index 64ad6ca91d93..88211169a7d7 100644
+index 64ad6ca91d9331a09d09f7e29b7c24a0c12852a2..88211169a7d731cb805f34c48ae4caf2fdcd1c84 100644
 --- a/content/browser/web_contents/web_contents_impl.cc
 +++ b/content/browser/web_contents/web_contents_impl.cc
 @@ -788,6 +788,25 @@ RenderFrameHostManager* WebContentsImpl::GetRenderManagerForTesting() {
@@ -127,7 +127,7 @@ index 64ad6ca91d93..88211169a7d7 100644
  
  NavigationEntry*
 diff --git a/content/browser/web_contents/web_contents_impl.h b/content/browser/web_contents/web_contents_impl.h
-index d16a99122772..907738e0bf80 100644
+index d16a99122772385e6fcdb13a8080c82ee0695232..907738e0bf80e4a34c5f068e67a6ba15d5d8338d 100644
 --- a/content/browser/web_contents/web_contents_impl.h
 +++ b/content/browser/web_contents/web_contents_impl.h
 @@ -542,7 +542,8 @@ class CONTENT_EXPORT WebContentsImpl : public WebContents,
@@ -140,6 +140,3 @@ index d16a99122772..907738e0bf80 100644
    void SetFocusedFrame(FrameTreeNode* node, SiteInstance* source) override;
    void DidCallFocus() override;
    RenderFrameHost* GetFocusedFrameIncludingInnerWebContents() override;
--- 
-2.17.0
-

--- a/patches/common/chromium/webview_cross_drag.patch
+++ b/patches/common/chromium/webview_cross_drag.patch
@@ -28,6 +28,3 @@ index cec3bd8a97b8b9bcab176a9bd2c296ec12aba838..7a2b4462bd44176e8e8389499f8c3d5f
    return targetRWH->GetProcess()->GetID() == dragStartProcessID_ ||
           GetRenderViewHostID(webContents_->GetRenderViewHost()) !=
               dragStartViewID_;
--- 
-2.17.0
-

--- a/patches/common/chromium/webview_reattach.patch
+++ b/patches/common/chromium/webview_reattach.patch
@@ -7,7 +7,7 @@ Backports https://chromium-review.googlesource.com/c/chromium/src/+/1161391
 Fixes webview not working after renderer process restarted.
 
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
-index 64ad6ca91d9331a09d09f7e29b7c24a0c12852a2..ec3d1ccbad7e3e4184205f87b6b3fb7dcd4c07f2 100644
+index 88211169a7d731cb805f34c48ae4caf2fdcd1c84..7b2715aea2afb9e939a6d5cf7fa7ec23f330194a 100644
 --- a/content/browser/web_contents/web_contents_impl.cc
 +++ b/content/browser/web_contents/web_contents_impl.cc
 @@ -4906,6 +4906,12 @@ void WebContentsImpl::NotifyViewSwapped(RenderViewHost* old_host,
@@ -23,6 +23,3 @@ index 64ad6ca91d9331a09d09f7e29b7c24a0c12852a2..ec3d1ccbad7e3e4184205f87b6b3fb7d
    // Ensure that the associated embedder gets cleared after a RenderViewHost
    // gets swapped, so we don't reuse the same embedder next time a
    // RenderViewHost is attached to this WebContents.
--- 
-2.17.0
-

--- a/patches/common/chromium/windows_cc_wrapper.patch
+++ b/patches/common/chromium/windows_cc_wrapper.patch
@@ -32,7 +32,7 @@ index eb3e2b2b377dde31e062be46837bf509ecab0325..5c014b190e121619056aa2eb7301887d
  }
  
  # Copy the VS runtime DLL for the default toolchain to the root build directory
-@@ -404,7 +411,7 @@ if (win_build_host_cpu != "x64") {
+@@ -392,7 +399,7 @@ if (win_build_host_cpu != "x64") {
    msvc_toolchain("win_clang_" + win_build_host_cpu) {
      environment = "environment." + win_build_host_cpu
      prefix = rebase_path("$clang_base_path/bin", root_build_dir)
@@ -41,7 +41,7 @@ index eb3e2b2b377dde31e062be46837bf509ecab0325..5c014b190e121619056aa2eb7301887d
      sys_include_flags = "${build_cpu_toolchain_data.include_flags_imsvc}"
      if (host_os != "win") {
        # For win cross build.
-@@ -453,7 +460,7 @@ template("win_x64_toolchains") {
+@@ -441,7 +448,7 @@ template("win_x64_toolchains") {
    msvc_toolchain("win_clang_" + target_name) {
      environment = "environment.x64"
      prefix = rebase_path("$clang_base_path/bin", root_build_dir)
@@ -50,6 +50,3 @@ index eb3e2b2b377dde31e062be46837bf509ecab0325..5c014b190e121619056aa2eb7301887d
      sys_include_flags = "${x64_toolchain_data.include_flags_imsvc}"
      if (host_os != "win") {
        # For win cross build
--- 
-2.17.0
-

--- a/patches/common/chromium/worker_context_will_destroy.patch
+++ b/patches/common/chromium/worker_context_will_destroy.patch
@@ -78,6 +78,3 @@ index 6b4a2ce05520c19c77fa3ddf135e83ef8783b3be..2ba97d5ec53ac4693024bb047e6c256d
    GetWorkerReportingProxy().WillDestroyWorkerGlobalScope();
  
    probe::AllAsyncTasksCanceled(GlobalScope());
--- 
-2.17.0
-

--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -29,6 +29,11 @@ def format_patch(repo, since):
     '--no-stat',
     '--stdout',
 
+    # Per RFC 3676 the signature is separated from the body by a line with
+    # '-- ' on it. If the signature option is omitted the signature defaults
+    # to the Git version number.
+    '--no-signature',
+
     # The name of the parent commit object isn't useful information in this
     # context, so zero it out to avoid needless patch-file churn.
     '--zero-commit',


### PR DESCRIPTION
#### Description of Change
The git version appended currently to all exported git patches depends on the machine and causes unnecessary changes.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes