### PR TITLE
fix: use gio as default linux trash impl

### DIFF
--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -16,7 +16,7 @@
 #include "url/gurl.h"
 
 #define ELECTRON_TRASH "ELECTRON_TRASH"
-#define ELECTRON_DEFAULT_TRASH "gvfs-trash"
+#define ELECTRON_DEFAULT_TRASH "gio"
 
 namespace {
 
@@ -126,12 +126,13 @@ bool MoveItemToTrash(const base::FilePath& full_path) {
   } else if (trash.compare("trash-cli") == 0) {
     argv.push_back("trash-put");
     argv.push_back(full_path.value());
-  } else if (trash.compare("gio") == 0) {
-    argv.push_back("gio");
-    argv.push_back("trash");
+  } else if (trash.compare("gvfs-trash") == 0) {
+    // retain support for deprecated gvfs-trash
+    argv.push_back("gvfs-trash");
     argv.push_back(full_path.value());
   } else {
     argv.push_back(ELECTRON_DEFAULT_TRASH);
+    argv.push_back("trash");
     argv.push_back(full_path.value());
   }
   return XDGUtilV(argv, true);

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -80,6 +80,16 @@ Don't attach to the current console session.
 
 Don't use the global menu bar on Linux.
 
+### `ELECTRON_TRASH` _Linux_
+
+Set the trash implementation on Linux. Default is `gio`.
+
+Options:
+* `gvfs-trash`
+* `trash-cli`
+* `kioclient5`
+* `kioclient`
+
 ## Development Variables
 
 The following environment variables are intended primarily for development and


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15011.

Switches the default trash implementation away from `gvfs-trash` to `gio trash` now that `gvfs-trash` has ben largely deprecated and is no longer appropriate as the default.

/cc @ckerr @eli-schwartz

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: fix default trash impl on linux to use gio