### PR TITLE
fix: resolve printing related bugs on 3-0-x

### DIFF
--- a/chromium_src/chrome/browser/printing/print_view_manager_base.cc
+++ b/chromium_src/chrome/browser/printing/print_view_manager_base.cc
@@ -165,7 +165,6 @@ void PrintViewManagerBase::OnDidPrintPage(
         reinterpret_cast<const unsigned char*>(shared_buf.memory()),
         params.data_size);
 
-    document->DebugDumpData(bytes.get(), FILE_PATH_LITERAL(".pdf"));
     print_job_->StartPdfToEmfConversion(
         bytes, params.page_size, params.content_area, print_text_with_gdi);
   }

--- a/chromium_src/chrome/renderer/printing/print_web_view_helper_pdf_win.cc
+++ b/chromium_src/chrome/renderer/printing/print_web_view_helper_pdf_win.cc
@@ -106,7 +106,9 @@ bool PrintWebViewHelper::PrintPagesNative(blink::WebLocalFrame* frame,
     printed_page_params.content_area = content_area_in_dpi[i];
     Send(new PrintHostMsg_DidPrintPage(routing_id(), printed_page_params));
     // Send the rest of the pages with an invalid metafile handle.
-    printed_page_params.metafile_data_handle.Close();
+    if (printed_page_params.metafile_data_handle.IsValid()) {
+      printed_page_params.metafile_data_handle.Close();
+    }
     printed_page_params.metafile_data_handle = base::SharedMemoryHandle();
   }
   return true;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

I tried to fix #14705 but ended up fixing #15036 too.

This is all related to outdated sources in `chromium_src`, the shared memory handles now trigger a `DCHECK` if you close one that's already invalid, and the printing debug dump call created junk files, and was also triggering a breakpoint, which I guess shouldn't happen.

With this I can print to `pdf` with the Microsoft Print To PDF thing twice in a row, without crash.
#14260 might be related, might be fixed by this, since I can see all pages when I print to PDF.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fixed printing related bugs on Windows <!-- One-line Change Summary Here-->