### PR TITLE
fix: use url::AddCORSEnabledScheme

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -12,6 +12,7 @@
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/renderer/api/atom_api_spell_check_client.h"
 #include "base/memory/memory_pressure_listener.h"
+#include "content/common/url_util.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "content/public/renderer/render_frame_visitor.h"
@@ -276,9 +277,7 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme,
         privileged_scheme);
   }
   if (corsEnabled) {
-    // FIXME: blink::SchemeRegistry::RegisterURLSchemeAsCORSEnabled
-    // is removed with C70
-    // https://chromium-review.googlesource.com/c/chromium/src/+/1157364
+    url::AddCORSEnabledScheme(privileged_scheme.c_str());
   }
 }
 


### PR DESCRIPTION
#### Description of Change

`blink::SchemeRegistry::RegisterURLSchemeAsCORSEnabled` was removed in M70, and it was `cors_enabled_schemes` was originally populated using `url::GetCORSEnabledSchemes()`. This thus switches us to use `url::AddCORSEnabledScheme()` from `url_util`.

/cc @deepak1556 @nornagon @MarshallOfSound

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes