### PR TITLE
docs: fix protocol.isProtocolHandled documentation

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -267,7 +267,7 @@ Unregisters the custom protocol of `scheme`.
 
 * `scheme` String
 * `callback` Function
-  * `error` Error
+  * `handled` Boolean
 
 The `callback` will be called with a boolean that indicates whether there is
 already a handler for `scheme`.


### PR DESCRIPTION
Fix to make the listed parameters for callback align with the written description. Feel free to change the parameter name 'handled' to anything else.

Notes: no-notes