### PR TITLE
docs: http protocol handlers can access headers

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -169,6 +169,7 @@ should be called with either a `String` or an object that has the `data`,
 * `handler` Function
   * `request` Object
     * `url` String
+    * `headers` Object
     * `referrer` String
     * `method` String
     * `uploadData` [UploadData[]](structures/upload-data.md)
@@ -329,6 +330,7 @@ which sends a `Buffer` as a response.
 * `handler` Function
   * `request` Object
     * `url` String
+    * `headers` Object
     * `referrer` String
     * `method` String
     * `uploadData` [UploadData[]](structures/upload-data.md)

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -475,6 +475,19 @@ describe('protocol module', () => {
         })
       })
     })
+
+    it('can access request headers', (done) => {
+      const handler = (request) => {
+        assert.ok('headers' in request)
+        done()
+      }
+      protocol.registerHttpProtocol(protocolName, handler, () => {
+        $.ajax({
+          url: protocolName + '://fake-host',
+          cache: false
+        })
+      })
+    })
   })
 
   describe('protocol.registerStreamProtocol', () => {
@@ -895,6 +908,16 @@ describe('protocol module', () => {
           customSession.webRequest.onBeforeRequest(null)
           done()
         })
+      })
+    })
+
+    it('can access request headers', (done) => {
+      const handler = (request) => {
+        assert.ok('headers' in request)
+        done()
+      }
+      protocol.interceptHttpProtocol('http', handler, () => {
+        fetch('http://fake-host')
       })
     })
   })


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

HTTP protocol handlers are provided headers, but this wasn't documented, only that stream protocol handlers got them. Updated documentation and added tests to ensure it stays true.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes