### PR TITLE
chore: bump minimum supported macOS version to 10.10 (backport: 4-0-x)

### DIFF
--- a/atom/browser/resources/mac/Info.plist
+++ b/atom/browser/resources/mac/Info.plist
@@ -23,7 +23,7 @@
   <key>LSApplicationCategoryType</key>
   <string>public.app-category.developer-tools</string>
   <key>LSMinimumSystemVersion</key>
-  <string>10.9.0</string>
+  <string>10.10.0</string>
   <key>NSMainNibFile</key>
   <string>MainMenu</string>
   <key>NSPrincipalClass</key>

--- a/atom/common/node_includes.h
+++ b/atom/common/node_includes.h
@@ -30,7 +30,7 @@
 #undef NO_RETURN
 #undef LIKELY
 #undef arraysize
-#undef debug_string  // This is defined in macOS 10.9 SDK in AssertMacros.h.
+#undef debug_string  // This is defined in macOS SDK in AssertMacros.h.
 #include "env-inl.h"
 #include "env.h"
 #include "node.h"

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -21,11 +21,10 @@ win.show()
 
 ### Alternatives on macOS
 
-On macOS 10.9 Mavericks and newer, there's an alternative way to specify
-a chromeless window. Instead of setting `frame` to `false` which disables
-both the titlebar and window controls, you may want to have the title bar
-hidden and your content extend to the full window size, yet still preserve
-the window controls ("traffic lights") for standard window actions.
+There's an alternative way to specify a chromeless window.
+Instead of setting `frame` to `false` which disables both the titlebar and window controls,
+you may want to have the title bar hidden and your content extend to the full window size,
+yet still preserve the window controls ("traffic lights") for standard window actions.
 You can do so by specifying the `titleBarStyle` option:
 
 #### `hidden`

--- a/docs/tutorial/development-environment.md
+++ b/docs/tutorial/development-environment.md
@@ -7,7 +7,7 @@ rudimentary understanding of your operating system's command line client.
 
 ## Setting up macOS
 
-> Electron supports Mac OS X 10.9 (and all versions named macOS) and up. Apple
+> Electron supports macOS 10.10 (Yosemite) and up. Apple
 does not allow running macOS in virtual machines unless the host computer is
 already an Apple computer, so if you find yourself in need of a Mac, consider
 using a cloud service that rents access to Macs (like [MacInCloud][macincloud]

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -61,7 +61,7 @@ Following platforms are supported by Electron:
 ### macOS
 
 Only 64bit binaries are provided for macOS, and the minimum macOS version
-supported is macOS 10.9.
+supported is macOS 10.10 (Yosemite).
 
 ### Windows
 
@@ -79,7 +79,7 @@ Ubuntu 12.04, the `armv7l` binary is built against ARM v7 with hard-float ABI an
 NEON for Debian Wheezy.
 
 [Until the release of Electron 2.0][arm-breaking-change], Electron will also
-continue to release the `armv7l` binary with a simple `arm` suffix. Both binaries 
+continue to release the `armv7l` binary with a simple `arm` suffix. Both binaries
 are identical.
 
 Whether the prebuilt binary can run on a distribution depends on whether the


### PR DESCRIPTION
Backport of #15357

See that PR for details.


Notes: Dropped support for macOS 10.9 (OS X Mavericks).