### PR TITLE
feat: implement 'app-command' events for browser history navigation keys on Linux

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -267,7 +267,7 @@ void TopLevelWindow::OnWindowAlwaysOnTopChanged() {
   Emit("always-on-top-changed", IsAlwaysOnTop());
 }
 
-void TopLevelWindow::OnExecuteWindowsCommand(const std::string& command_name) {
+void TopLevelWindow::OnExecuteAppCommand(const std::string& command_name) {
   Emit("app-command", command_name);
 }
 
@@ -279,10 +279,6 @@ void TopLevelWindow::OnTouchBarItemResult(
 
 void TopLevelWindow::OnNewWindowForTab() {
   Emit("new-window-for-tab");
-}
-
-void TopLevelWindow::OnHistoryAction(const std::string& action) {
-  Emit("history-action", action);
 }
 
 #if defined(OS_WIN)

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -281,6 +281,10 @@ void TopLevelWindow::OnNewWindowForTab() {
   Emit("new-window-for-tab");
 }
 
+void TopLevelWindow::OnHistoryAction(const std::string& action) {
+  Emit("history-action", action);
+}
+
 #if defined(OS_WIN)
 void TopLevelWindow::OnWindowMessage(UINT message,
                                      WPARAM w_param,

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -78,11 +78,10 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnWindowEnterHtmlFullScreen() override;
   void OnWindowLeaveHtmlFullScreen() override;
   void OnWindowAlwaysOnTopChanged() override;
-  void OnExecuteWindowsCommand(const std::string& command_name) override;
+  void OnExecuteAppCommand(const std::string& command_name) override;
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;
   void OnNewWindowForTab() override;
-  void OnHistoryAction(const std::string& action) override;
 #if defined(OS_WIN)
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
 #endif

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -82,6 +82,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;
   void OnNewWindowForTab() override;
+  void OnHistoryAction(const std::string& action) override;
 #if defined(OS_WIN)
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
 #endif

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -558,6 +558,11 @@ void NativeWindow::NotifyNewWindowForTab() {
     observer.OnNewWindowForTab();
 }
 
+void NativeWindow::NotifyHistoryAction(const std::string& action) {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnHistoryAction(action);
+}
+
 #if defined(OS_WIN)
 void NativeWindow::NotifyWindowMessage(UINT message,
                                        WPARAM w_param,

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -540,10 +540,9 @@ void NativeWindow::NotifyWindowAlwaysOnTopChanged() {
     observer.OnWindowAlwaysOnTopChanged();
 }
 
-void NativeWindow::NotifyWindowExecuteWindowsCommand(
-    const std::string& command) {
+void NativeWindow::NotifyWindowExecuteAppCommand(const std::string& command) {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnExecuteWindowsCommand(command);
+    observer.OnExecuteAppCommand(command);
 }
 
 void NativeWindow::NotifyTouchBarItemInteraction(
@@ -556,11 +555,6 @@ void NativeWindow::NotifyTouchBarItemInteraction(
 void NativeWindow::NotifyNewWindowForTab() {
   for (NativeWindowObserver& observer : observers_)
     observer.OnNewWindowForTab();
-}
-
-void NativeWindow::NotifyHistoryAction(const std::string& action) {
-  for (NativeWindowObserver& observer : observers_)
-    observer.OnHistoryAction(action);
 }
 
 #if defined(OS_WIN)

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -261,6 +261,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      const base::DictionaryValue& details);
   void NotifyNewWindowForTab();
+  void NotifyHistoryAction(const std::string& action);
 
 #if defined(OS_WIN)
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -38,11 +38,6 @@ class Dictionary;
 class PersistentDictionary;
 }  // namespace mate
 
-namespace appCommand {
-const char kBrowserForward[] = "browser-forward";
-const char kBrowserBackward[] = "browser-backward";
-}  // namespace appCommand
-
 namespace atom {
 
 class AtomMenuModel;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -257,11 +257,10 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowEnterHtmlFullScreen();
   void NotifyWindowLeaveHtmlFullScreen();
   void NotifyWindowAlwaysOnTopChanged();
-  void NotifyWindowExecuteWindowsCommand(const std::string& command);
+  void NotifyWindowExecuteAppCommand(const std::string& command);
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      const base::DictionaryValue& details);
   void NotifyNewWindowForTab();
-  void NotifyHistoryAction(const std::string& action);
 
 #if defined(OS_WIN)
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -38,6 +38,11 @@ class Dictionary;
 class PersistentDictionary;
 }  // namespace mate
 
+namespace appCommand {
+const char kBrowserForward[] = "browser-forward";
+const char kBrowserBackward[] = "browser-backward";
+}  // namespace appCommand
+
 namespace atom {
 
 class AtomMenuModel;

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -88,7 +88,6 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictionaryValue& details) {}
   virtual void OnNewWindowForTab() {}
-  virtual void OnHistoryAction(const std::string& action) {}
 
 // Called when window message received
 #if defined(OS_WIN)
@@ -96,7 +95,8 @@ class NativeWindowObserver : public base::CheckedObserver {
 #endif
 
   // Called on Windows when App Commands arrive (WM_APPCOMMAND)
-  virtual void OnExecuteWindowsCommand(const std::string& command_name) {}
+  // Some commands are implemented on on other platforms as well
+  virtual void OnExecuteAppCommand(const std::string& command_name) {}
 };
 
 }  // namespace atom

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -88,6 +88,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictionaryValue& details) {}
   virtual void OnNewWindowForTab() {}
+  virtual void OnHistoryAction(const std::string& action) {}
 
 // Called when window message received
 #if defined(OS_WIN)

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -287,6 +287,12 @@ NativeWindowViews::NativeWindowViews(const mate::Dictionary& options,
     last_window_state_ = ui::SHOW_STATE_NORMAL;
   last_normal_bounds_ = GetBounds();
 #endif
+
+#if defined(OS_LINUX)
+  aura::Window* window = GetNativeWindow();
+  if (window)
+    window->AddPreTargetHandler(this);
+#endif
 }
 
 NativeWindowViews::~NativeWindowViews() {
@@ -295,6 +301,12 @@ NativeWindowViews::~NativeWindowViews() {
 #if defined(OS_WIN)
   // Disable mouse forwarding to relinquish resources, should any be held.
   SetForwardMouseMessages(false);
+#endif
+
+#if defined(OS_LINUX)
+  aura::Window* window = GetNativeWindow();
+  if (window)
+    window->RemovePreTargetHandler(this);
 #endif
 }
 
@@ -1278,6 +1290,18 @@ void NativeWindowViews::HandleKeyboardEvent(
                                                root_view_->GetFocusManager());
   root_view_->HandleKeyEvent(event);
 }
+
+#if defined(OS_LINUX)
+void NativeWindowViews::OnMouseEvent(ui::MouseEvent* event) {
+  if (event->type() != ui::ET_MOUSE_PRESSED)
+    return;
+
+  if (event->changed_button_flags() == ui::EF_BACK_MOUSE_BUTTON)
+    NotifyHistoryAction("backward");
+  if (event->changed_button_flags() == ui::EF_FORWARD_MOUSE_BUTTON)
+    NotifyHistoryAction("forward");
+}
+#endif
 
 ui::WindowShowState NativeWindowViews::GetRestoredState() {
   if (IsMaximized())

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -22,6 +22,7 @@
 #include "atom/browser/web_contents_preferences.h"
 #include "atom/browser/web_view_manager.h"
 #include "atom/browser/window_list.h"
+#include "atom/common/atom_constants.h"
 #include "atom/common/draggable_region.h"
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/options_switches.h"
@@ -289,6 +290,7 @@ NativeWindowViews::NativeWindowViews(const mate::Dictionary& options,
 #endif
 
 #if defined(OS_LINUX)
+  // Listen to move events.
   aura::Window* window = GetNativeWindow();
   if (window)
     window->AddPreTargetHandler(this);
@@ -1288,9 +1290,9 @@ void NativeWindowViews::HandleKeyboardEvent(
     const content::NativeWebKeyboardEvent& event) {
 #if defined(OS_LINUX)
   if (event.windows_key_code == ui::VKEY_BROWSER_BACK)
-    NotifyWindowExecuteAppCommand(appCommand::kBrowserBackward);
-  if (event.windows_key_code == ui::VKEY_BROWSER_FORWARD)
-    NotifyWindowExecuteAppCommand(appCommand::kBrowserForward);
+    NotifyWindowExecuteAppCommand(kBrowserBackward);
+  else if (event.windows_key_code == ui::VKEY_BROWSER_FORWARD)
+    NotifyWindowExecuteAppCommand(kBrowserForward);
 #endif
 
   keyboard_event_handler_->HandleKeyboardEvent(event,
@@ -1304,9 +1306,9 @@ void NativeWindowViews::OnMouseEvent(ui::MouseEvent* event) {
     return;
 
   if (event->changed_button_flags() == ui::EF_BACK_MOUSE_BUTTON)
-    NotifyWindowExecuteAppCommand(appCommand::kBrowserBackward);
-  if (event->changed_button_flags() == ui::EF_FORWARD_MOUSE_BUTTON)
-    NotifyWindowExecuteAppCommand(appCommand::kBrowserForward);
+    NotifyWindowExecuteAppCommand(kBrowserBackward);
+  else if (event->changed_button_flags() == ui::EF_FORWARD_MOUSE_BUTTON)
+    NotifyWindowExecuteAppCommand(kBrowserForward);
 }
 #endif
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1289,15 +1289,15 @@ void NativeWindowViews::HandleKeyboardEvent(
 #if defined(OS_MACOSX)
   if (event.GetModifiers() == blink::WebInputEvent::kMetaKey) {
     if (event.windows_key_code == ui::VKEY_OEM_4)
-      NotifyHistoryAction("backward");
+      NotifyWindowExecuteAppCommand("browser-backward");
     if (event.windows_key_code == ui::VKEY_OEM_6)
-      NotifyHistoryAction("forward");
+      NotifyWindowExecuteAppCommand("browser-forward");
   }
 #elif defined(OS_LINUX)
   if (event.windows_key_code == ui::VKEY_BROWSER_BACK)
-    NotifyHistoryAction("backward");
+    NotifyWindowExecuteAppCommand("browser-backward");
   if (event.windows_key_code == ui::VKEY_BROWSER_FORWARD)
-    NotifyHistoryAction("forward");
+    NotifyWindowExecuteAppCommand("browser-forward");
 #endif
 
   keyboard_event_handler_->HandleKeyboardEvent(event,
@@ -1311,9 +1311,9 @@ void NativeWindowViews::OnMouseEvent(ui::MouseEvent* event) {
     return;
 
   if (event->changed_button_flags() == ui::EF_BACK_MOUSE_BUTTON)
-    NotifyHistoryAction("backward");
+    NotifyWindowExecuteAppCommand("browser-backward");
   if (event->changed_button_flags() == ui::EF_FORWARD_MOUSE_BUTTON)
-    NotifyHistoryAction("forward");
+    NotifyWindowExecuteAppCommand("browser-forward");
 }
 #endif
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1286,18 +1286,11 @@ void NativeWindowViews::OnWidgetMove() {
 void NativeWindowViews::HandleKeyboardEvent(
     content::WebContents*,
     const content::NativeWebKeyboardEvent& event) {
-#if defined(OS_MACOSX)
-  if (event.GetModifiers() == blink::WebInputEvent::kMetaKey) {
-    if (event.windows_key_code == ui::VKEY_OEM_4)
-      NotifyWindowExecuteAppCommand("browser-backward");
-    if (event.windows_key_code == ui::VKEY_OEM_6)
-      NotifyWindowExecuteAppCommand("browser-forward");
-  }
-#elif defined(OS_LINUX)
+#if defined(OS_LINUX)
   if (event.windows_key_code == ui::VKEY_BROWSER_BACK)
-    NotifyWindowExecuteAppCommand("browser-backward");
+    NotifyWindowExecuteAppCommand(appCommand::kBrowserBackward);
   if (event.windows_key_code == ui::VKEY_BROWSER_FORWARD)
-    NotifyWindowExecuteAppCommand("browser-forward");
+    NotifyWindowExecuteAppCommand(appCommand::kBrowserForward);
 #endif
 
   keyboard_event_handler_->HandleKeyboardEvent(event,
@@ -1311,9 +1304,9 @@ void NativeWindowViews::OnMouseEvent(ui::MouseEvent* event) {
     return;
 
   if (event->changed_button_flags() == ui::EF_BACK_MOUSE_BUTTON)
-    NotifyWindowExecuteAppCommand("browser-backward");
+    NotifyWindowExecuteAppCommand(appCommand::kBrowserBackward);
   if (event->changed_button_flags() == ui::EF_FORWARD_MOUSE_BUTTON)
-    NotifyWindowExecuteAppCommand("browser-forward");
+    NotifyWindowExecuteAppCommand(appCommand::kBrowserForward);
 }
 #endif
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1286,6 +1286,20 @@ void NativeWindowViews::OnWidgetMove() {
 void NativeWindowViews::HandleKeyboardEvent(
     content::WebContents*,
     const content::NativeWebKeyboardEvent& event) {
+#if defined(OS_MACOSX)
+  if (event.GetModifiers() == blink::WebInputEvent::kMetaKey) {
+    if (event.windows_key_code == ui::VKEY_OEM_4)
+      NotifyHistoryAction("backward");
+    if (event.windows_key_code == ui::VKEY_OEM_6)
+      NotifyHistoryAction("forward");
+  }
+#elif defined(OS_LINUX)
+  if (event.windows_key_code == ui::VKEY_BROWSER_BACK)
+    NotifyHistoryAction("backward");
+  if (event.windows_key_code == ui::VKEY_BROWSER_FORWARD)
+    NotifyHistoryAction("forward");
+#endif
+
   keyboard_event_handler_->HandleKeyboardEvent(event,
                                                root_view_->GetFocusManager());
   root_view_->HandleKeyEvent(event);

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -40,7 +40,8 @@ class NativeWindowViews : public NativeWindow,
 #if defined(OS_WIN)
                           public MessageHandlerDelegate,
 #endif
-                          public views::WidgetObserver {
+                          public views::WidgetObserver,
+                          public ui::EventHandler {
  public:
   NativeWindowViews(const mate::Dictionary& options, NativeWindow* parent);
   ~NativeWindowViews() override;
@@ -203,6 +204,11 @@ class NativeWindowViews : public NativeWindow,
   void HandleKeyboardEvent(
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) override;
+
+#if defined(OS_LINUX)
+  // EventHandler:
+  void OnMouseEvent(ui::MouseEvent* event) override;
+#endif
 
   // Returns the restore state for the window.
   ui::WindowShowState GetRestoredState();

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -206,7 +206,7 @@ class NativeWindowViews : public NativeWindow,
       const content::NativeWebKeyboardEvent& event) override;
 
 #if defined(OS_LINUX)
-  // EventHandler:
+  // ui::EventHandler:
   void OnMouseEvent(ui::MouseEvent* event) override;
 #endif
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -143,6 +143,13 @@ bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {
   std::string command = AppCommandToString(command_id);
   NotifyWindowExecuteWindowsCommand(command);
 
+  if (command_id == APPCOMMAND_BROWSER_BACKWARD) {
+    NotifyHistoryAction("backward");
+  }
+  if (command_id == APPCOMMAND_BROWSER_FORWARD) {
+    NotifyHistoryAction("forward");
+  }
+
   return false;
 }
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -18,9 +18,9 @@ namespace {
 const char* AppCommandToString(int command_id) {
   switch (command_id) {
     case APPCOMMAND_BROWSER_BACKWARD:
-      return "browser-backward";
+      return appCommand::kBrowserBackward;
     case APPCOMMAND_BROWSER_FORWARD:
-      return "browser-forward";
+      return appCommand::kBrowserForward;
     case APPCOMMAND_BROWSER_REFRESH:
       return "browser-refresh";
     case APPCOMMAND_BROWSER_STOP:

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window_views.h"
+#include "atom/common/atom_constants.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "ui/base/win/accessibility_misc_utils.h"
 
@@ -18,9 +19,9 @@ namespace {
 const char* AppCommandToString(int command_id) {
   switch (command_id) {
     case APPCOMMAND_BROWSER_BACKWARD:
-      return appCommand::kBrowserBackward;
+      return kBrowserBackward;
     case APPCOMMAND_BROWSER_FORWARD:
-      return appCommand::kBrowserForward;
+      return kBrowserForward;
     case APPCOMMAND_BROWSER_REFRESH:
       return "browser-refresh";
     case APPCOMMAND_BROWSER_STOP:

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -141,14 +141,7 @@ HHOOK NativeWindowViews::mouse_hook_ = NULL;
 
 bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {
   std::string command = AppCommandToString(command_id);
-  NotifyWindowExecuteWindowsCommand(command);
-
-  if (command_id == APPCOMMAND_BROWSER_BACKWARD) {
-    NotifyHistoryAction("backward");
-  }
-  if (command_id == APPCOMMAND_BROWSER_FORWARD) {
-    NotifyHistoryAction("forward");
-  }
+  NotifyWindowExecuteAppCommand(command);
 
   return false;
 }

--- a/atom/common/atom_constants.cc
+++ b/atom/common/atom_constants.cc
@@ -6,6 +6,9 @@
 
 namespace atom {
 
+const char kBrowserForward[] = "browser-forward";
+const char kBrowserBackward[] = "browser-backward";
+
 const char kCORSHeader[] = "Access-Control-Allow-Origin: *";
 
 const char kSHA1Certificate[] = "SHA-1 Certificate";

--- a/atom/common/atom_constants.h
+++ b/atom/common/atom_constants.h
@@ -9,6 +9,10 @@
 
 namespace atom {
 
+// The app-command in NativeWindow.
+extern const char kBrowserForward[];
+extern const char kBrowserBackward[];
+
 // Header to ignore CORS.
 extern const char kCORSHeader[];
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -562,7 +562,7 @@ Returns:
 * `command` String
 
 Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx)
-is invoked on Windows. These are typically related to keyboard media keys or browser
+is invoked. These are typically related to keyboard media keys or browser
 commands, as well as the "Back" button built into some mice on Windows.
 
 Commands are lowercased, underscores are replaced with hyphens, and the

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -580,7 +580,7 @@ win.on('app-command', (e, cmd) => {
 })
 ```
 
-The following app commands are explictly supported on Linux and macOS
+The following app commands are explictly supported on Linux
 
 * `browser-backward`
 * `browser-forward`

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -554,7 +554,7 @@ Returns:
 
 Emitted when the window is set or unset to show always on top of other windows.
 
-#### Event: 'app-command' _Windows_
+#### Event: 'app-command' _Windows_ _Linux_
 
 Returns:
 
@@ -562,7 +562,7 @@ Returns:
 * `command` String
 
 Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx)
-is invoked. These are typically related to keyboard media keys or browser
+is invoked on Windows. These are typically related to keyboard media keys or browser
 commands, as well as the "Back" button built into some mice on Windows.
 
 Commands are lowercased, underscores are replaced with hyphens, and the

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -613,6 +613,16 @@ Emitted when the window has closed a sheet.
 
 Emitted when the native new tab button is clicked.
 
+#### Event: 'history-action'
+
+Returns:
+
+* `event` Event
+* `action` String
+
+Emitted when a browser history navigation key is pressed, such as the back button on some mice.
+Possible actions are `forward` and `backward`.
+
 ### Static Methods
 
 The `BrowserWindow` class has the following static methods:

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -580,6 +580,11 @@ win.on('app-command', (e, cmd) => {
 })
 ```
 
+The following app commands are explictly supported on Linux and macOS
+
+* `browser-backward`
+* `browser-forward`
+
 #### Event: 'scroll-touch-begin' _macOS_
 
 Emitted when scroll wheel event phase has begun.
@@ -612,16 +617,6 @@ Emitted when the window has closed a sheet.
 #### Event: 'new-window-for-tab' _macOS_
 
 Emitted when the native new tab button is clicked.
-
-#### Event: 'history-action'
-
-Returns:
-
-* `event` Event
-* `action` String
-
-Emitted when a browser history navigation key is pressed, such as the back button on some mice.
-Possible actions are `forward` and `backward`.
 
 ### Static Methods
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -580,7 +580,7 @@ win.on('app-command', (e, cmd) => {
 })
 ```
 
-The following app commands are explictly supported on Linux
+The following app commands are explictly supported on Linux:
 
 * `browser-backward`
 * `browser-forward`


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Implemented the `browser-backward` and `browser-forward` `app-command` events on Linux.

For issue #6996.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: The `browser-backward` and `browser-forward` `app-command` events events available in BrowserWindow now work on Linux