### PR TITLE
Fix missing remote object error when calling remote function created in preload script

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -152,9 +152,10 @@ const throwRPCError = function (message) {
   throw error
 }
 
-const removeRemoteListenersAndLogWarning = (sender, meta, callIntoRenderer) => {
+const removeRemoteListenersAndLogWarning = (sender, callIntoRenderer) => {
+  const location = v8Util.getHiddenValue(callIntoRenderer, 'location')
   let message = `Attempting to call a function in a renderer window that has been closed or released.` +
-    `\nFunction provided here: ${meta.location}`
+    `\nFunction provided here: ${location}`
 
   if (sender instanceof EventEmitter) {
     const remoteEvents = sender.eventNames().filter((eventName) => {
@@ -214,14 +215,14 @@ const unwrapArgs = function (sender, contextId, args) {
           return rendererFunctions.get(objectId)
         }
 
-        const processId = sender.getProcessId()
         const callIntoRenderer = function (...args) {
-          if (!sender.isDestroyed() && processId === sender.getProcessId()) {
+          if (!sender.isDestroyed()) {
             sender._sendInternal('ELECTRON_RENDERER_CALLBACK', contextId, meta.id, valueToMeta(sender, contextId, args))
           } else {
-            removeRemoteListenersAndLogWarning(this, meta, callIntoRenderer)
+            removeRemoteListenersAndLogWarning(this, callIntoRenderer)
           }
         }
+        v8Util.setHiddenValue(callIntoRenderer, 'location', meta.location)
         Object.defineProperty(callIntoRenderer, 'length', { value: meta.length })
 
         v8Util.setRemoteCallbackFreer(callIntoRenderer, contextId, meta.id, sender)
@@ -280,6 +281,15 @@ const handleRemoteCommand = function (channel, handler) {
     }
   })
 }
+
+handleRemoteCommand('ELECTRON_BROWSER_WRONG_CONTEXT_ERROR', function (event, contextId, passedContextId, id) {
+  const objectId = [passedContextId, id]
+  if (!rendererFunctions.has(objectId)) {
+    // Do nothing if the error has already been reported before.
+    return
+  }
+  removeRemoteListenersAndLogWarning(event.sender, rendererFunctions.get(objectId))
+})
 
 handleRemoteCommand('ELECTRON_BROWSER_REQUIRE', function (event, contextId, moduleName) {
   const customEvent = eventBinding.createWithSender(event.sender)

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -270,9 +270,12 @@ function metaToPlainObject (meta) {
 }
 
 function handleMessage (channel, handler) {
-  ipcRenderer.on(channel, (event, passedContextId, ...args) => {
+  ipcRenderer.on(channel, (event, passedContextId, id, ...args) => {
     if (passedContextId === contextId) {
-      handler(...args)
+      handler(id, ...args)
+    } else {
+      // Message sent to an un-exist context, notify the error to main process.
+      ipcRenderer.send('ELECTRON_BROWSER_WRONG_CONTEXT_ERROR', contextId, passedContextId, id)
     }
   })
 }

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -8,6 +8,7 @@ const { closeWindow } = require('./window-helpers')
 const { resolveGetters } = require('./assert-helpers')
 
 const { remote, ipcRenderer } = require('electron')
+const { ipcMain, BrowserWindow } = remote
 const { expect } = chai
 
 chai.use(dirtyChai)
@@ -510,6 +511,25 @@ describe('remote module', () => {
         assert.ok(error.from)
         assert.deepStrictEqual(error.cause, ...resolveGetters(err))
       }
+    })
+  })
+
+  describe('remote function in renderer', () => {
+    afterEach(() => {
+      ipcMain.removeAllListeners('done')
+    })
+
+    it('works when created in preload script', (done) => {
+      ipcMain.once('done', () => w.close())
+      const preload = path.join(fixtures, 'module', 'preload-remote-function.js')
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          preload: preload
+        }
+      })
+      w.once('closed', () => done())
+      w.loadURL('about:blank')
     })
   })
 })

--- a/spec/fixtures/module/preload-remote-function.js
+++ b/spec/fixtures/module/preload-remote-function.js
@@ -1,0 +1,5 @@
+const { remote, ipcRenderer } = require('electron')
+remote.getCurrentWindow().rendererFunc = () => {
+  ipcRenderer.send('done')
+}
+remote.getCurrentWindow().rendererFunc()

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -350,26 +350,21 @@ ipcMain.on('disable-preload-on-next-will-attach-webview', (event, id) => {
 
 ipcMain.on('try-emit-web-contents-event', (event, id, eventName) => {
   const consoleWarn = console.warn
-  let warningMessage = null
   const contents = webContents.fromId(id)
   const listenerCountBefore = contents.listenerCount(eventName)
 
-  try {
-    console.warn = (message) => {
-      warningMessage = message
-    }
-    contents.emit(eventName, { sender: contents })
-  } finally {
+  console.warn = (warningMessage) => {
     console.warn = consoleWarn
+
+    const listenerCountAfter = contents.listenerCount(eventName)
+    event.returnValue = {
+      warningMessage,
+      listenerCountBefore,
+      listenerCountAfter
+    }
   }
 
-  const listenerCountAfter = contents.listenerCount(eventName)
-
-  event.returnValue = {
-    warningMessage,
-    listenerCountBefore,
-    listenerCountAfter
-  }
+  contents.emit(eventName, { sender: contents })
 })
 
 ipcMain.on('handle-uncaught-exception', (event, message) => {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Previously we were using `sender.getProcessId()` to determine whether the context of a remote function still lives. But since `sender.getProcessId()` may still return the ID of previous page when the new page is still loading, we will wrongly report "missing remote object error" when the remote function is created in preload script.

This PR removes the check of `sender.getProcessId()` in the main process, and instead checks the `contextId` in the renderer process which is reliable.

Close https://github.com/electron/electron/issues/14965.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Fix missing remote object error when calling remote function created in preload script