### PR TITLE
feat: add support for unsafe origin switch

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -46,6 +46,7 @@
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/printing/printing_message_filter.h"
+#include "chrome/common/chrome_switches.h"
 #include "components/net_log/chrome_net_log.h"
 #include "content/public/browser/browser_ppapi_host.h"
 #include "content/public/browser/client_certificate_delegate.h"
@@ -385,9 +386,10 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
     return;
 
   // Copy following switches to child process.
-  static const char* const kCommonSwitchNames[] = {switches::kStandardSchemes,
-                                                   switches::kEnableSandbox,
-                                                   switches::kSecureSchemes};
+  static const char* const kCommonSwitchNames[] = {
+      switches::kStandardSchemes, switches::kEnableSandbox,
+      switches::kSecureSchemes,
+      ::switches::kUnsafelyTreatInsecureOriginAsSecure};
   command_line->CopySwitchesFrom(*base::CommandLine::ForCurrentProcess(),
                                  kCommonSwitchNames,
                                  arraysize(kCommonSwitchNames));

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -19,6 +19,7 @@
 #include "base/command_line.h"
 #include "base/strings/string_split.h"
 #include "base/strings/stringprintf.h"
+#include "chrome/common/secure_origin_whitelist.h"
 #include "content/public/common/content_constants.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/renderer/render_frame.h"
@@ -163,6 +164,13 @@ void RendererClientBase::RenderThreadStarted() {
   for (const std::string& scheme : secure_schemes_list)
     blink::SchemeRegistry::RegisterURLSchemeAsSecure(
         WTF::String::FromUTF8(scheme.data(), scheme.length()));
+
+  // Parse --unsafely-treat-insecure-origin-as-secure
+  for (auto& origin_or_hostname_pattern :
+       secure_origin_whitelist::GetWhitelist()) {
+    blink::WebSecurityPolicy::AddOriginTrustworthyWhiteList(
+        blink::WebString::FromUTF8(origin_or_hostname_pattern));
+  }
 
   // Allow file scheme to handle service worker by default.
   // FIXME(zcbenz): Can this be moved elsewhere?


### PR DESCRIPTION
Fixes #15448

Notes: Add support for the `--unsafely-treat-insecure-origin-as-secure` switch