### PR TITLE
docs: clarify menu item properties not available top-level

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -108,6 +108,8 @@ When specifying a `role` on macOS, `label` and `accelerator` are the only
 options that will affect the menu item. All other options will be ignored.
 Lowercase `role`, e.g. `toggledevtools`, is still supported.
 
+**Nota Bene:** The `enabled` and `visibility` properties are not available for top-level menu items in the tray on MacOS.
+
 ### Instance Properties
 
 The following properties are available on instances of `MenuItem`:


### PR DESCRIPTION
#### Description of Change

Document the fact that top-level menu items (those on the tray) don't follow the same pattern as submenu items and therefore are not subject to the `enabled` and `visible` properties.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: update docs to reflect top-level menu item property issues