### PR TITLE
feat: enable standalone cut/copy/paste in devtools

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -45,7 +45,7 @@ returns `null`.
 
 Returns `WebContents` - A WebContents instance with the given ID.
 
-### `webContents.enableEditHotkeys()`
+### `webContents.enableEditHotkeys()` _MacOS_
 
 Enables `cut`, `copy`, and `paste` shortcuts for a given `webContents`. 
 Useful in differenting shortcuts between different `webContents`, such as devtools vs. primary

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -45,6 +45,12 @@ returns `null`.
 
 Returns `WebContents` - A WebContents instance with the given ID.
 
+### `webContents.enableEditHotkeys()`
+
+Enables `cut`, `copy`, and `paste` shortcuts for a given `webContents`. 
+Useful in differenting shortcuts between different `webContents`, such as devtools vs. primary
+app `webContents`.
+
 ## Class: WebContents
 
 > Render and control the contents of a BrowserWindow instance.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -280,6 +280,22 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
   }))
 }
 
+WebContents.prototype.enableEditHotkeys = function () {
+  if (process.platform === 'darwin') {
+    this.executeJavaScript(`
+      window.addEventListener('keydown', function (e) {
+        if (e.keyCode === 67 && e.metaKey) {
+          document.execCommand('copy')
+        } else if (e.keyCode === 86 && e.metaKey) {
+          document.execCommand('paste')
+        } else if (e.keyCode === 88 && e.metaKey) {
+          document.execCommand('cut')
+        }
+      })`
+    )
+  }
+}
+
 WebContents.prototype.getZoomFactor = function (callback) {
   if (typeof callback !== 'function') {
     throw new Error('Must pass function as an argument')

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -281,19 +281,18 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
 }
 
 WebContents.prototype.enableEditHotkeys = function () {
-  if (process.platform === 'darwin') {
-    this.executeJavaScript(`
-      window.addEventListener('keydown', function (e) {
-        if (e.keyCode === 67 && e.metaKey) {
-          document.execCommand('copy')
-        } else if (e.keyCode === 86 && e.metaKey) {
-          document.execCommand('paste')
-        } else if (e.keyCode === 88 && e.metaKey) {
-          document.execCommand('cut')
-        }
-      })`
-    )
-  }
+  // metakey is ⌘ on MacOS, ctrl on linux/win
+  this.executeJavaScript(`
+    window.addEventListener('keydown', function (e) {
+      if (e.keyCode === 67 && e.metaKey) {
+        document.execCommand('copy')
+      } else if (e.keyCode === 86 && e.metaKey) {
+        document.execCommand('paste')
+      } else if (e.keyCode === 88 && e.metaKey) {
+        document.execCommand('cut')
+      }
+    })`
+  )
 }
 
 WebContents.prototype.getZoomFactor = function (callback) {


### PR DESCRIPTION
#### Description of Change

Attempt to resolve https://github.com/electron/electron/issues/11998.

A little sketchy imo but i'm not sure a cleaner way to approach this conceptually. Would be invoked as `mainWin.webContents.devToolsWebContents.enableEditHotkeys()` although it could technically be used on any `webContents`. 

I'll add documentation once we've settled on an impl!

/cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: add enableEditHotkeys function for webContents