### PR TITLE
[WIP] fix: initialize renderer early to make first request behave correctly

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -376,6 +376,7 @@ WebContents::WebContents(v8::Isolate* isolate,
     guest_delegate_.reset(
         new WebViewGuestDelegate(embedder_->web_contents(), this));
     params.guest_delegate = guest_delegate_.get();
+    params.initialize_renderer = true;
 
 #if defined(ENABLE_OSR)
     if (embedder_ && embedder_->IsOffScreen()) {
@@ -398,6 +399,7 @@ WebContents::WebContents(v8::Isolate* isolate,
     content::WebContents::CreateParams params(session->browser_context());
     auto* view = new OffScreenWebContentsView(
         transparent, base::Bind(&WebContents::OnPaint, base::Unretained(this)));
+    params.initialize_renderer = true;
     params.view = view;
     params.delegate_view = view;
 
@@ -406,6 +408,7 @@ WebContents::WebContents(v8::Isolate* isolate,
 #endif
   } else {
     content::WebContents::CreateParams params(session->browser_context());
+    params.initialize_renderer = true;
     web_contents = content::WebContents::Create(params);
   }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This is a fix for #14908. Well, it's a working workaround at least, might give us a clue about the proper solution. Most likely `Plznavigate` related, /cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes <!-- One-line Change Summary Here-->