### PR TITLE
fix: explicitly set `windowsHide` to the old node default

### DIFF
--- a/npm/cli.js
+++ b/npm/cli.js
@@ -4,7 +4,7 @@ var electron = require('./')
 
 var proc = require('child_process')
 
-var child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit' })
+var child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit', windowsHide: false })
 child.on('close', function (code) {
   process.exit(code)
 })


### PR DESCRIPTION
Fixes #15467

Notes: fix Electron not being visible when launching in development mode on node v11