### PR TITLE
fix: electron could not open on node 11

### DIFF
--- a/npm/cli.js
+++ b/npm/cli.js
@@ -4,7 +4,7 @@ var electron = require('./')
 
 var proc = require('child_process')
 
-var options = parseInt(process.versions.node) >= 11 ? {stdio: 'inherit', windowsHide: false}: {stdio: 'inherit'};
+var options = parseInt(process.versions.node) >= 11 ? {stdio: 'inherit', windowsHide: false}: {stdio: 'inherit'}
 var child = proc.spawn(electron, process.argv.slice(2), options)
 child.on('close', function (code) {
   process.exit(code)

--- a/npm/cli.js
+++ b/npm/cli.js
@@ -4,7 +4,8 @@ var electron = require('./')
 
 var proc = require('child_process')
 
-var child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit' })
+var options = parseInt(process.versions.node) >= 11 ? {stdio: 'inherit', windowsHide: false}: {stdio: 'inherit'};
+var child = proc.spawn(electron, process.argv.slice(2), options)
 child.on('close', function (code) {
   process.exit(code)
 })


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
According to the latest documentation on https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options

 `windowsHide <boolean>` : Hide the subprocess console window that would normally be created on Windows systems. Default: true.

So If node used great than or equal to 11, then the option in spawn should contain `windowsHide: false` expicity.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
