### PR TITLE
fix: match Chrome's font fallback behavior

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -208,6 +208,7 @@ static_library("electron_lib") {
     "//base",
     "//base:base_static",
     "//base:i18n",
+    "//chrome/app/resources:platform_locale_settings",
     "//chrome/common",
     "//components/certificate_transparency",
     "//components/net_log",

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -21,6 +21,7 @@
 #include "atom/browser/atom_resource_dispatcher_host_delegate.h"
 #include "atom/browser/atom_speech_recognition_manager_delegate.h"
 #include "atom/browser/child_web_contents_tracker.h"
+#include "atom/browser/font_defaults.h"
 #include "atom/browser/io_thread.h"
 #include "atom/browser/media/media_capture_devices_dispatcher.h"
 #include "atom/browser/native_window.h"
@@ -300,6 +301,8 @@ void AtomBrowserClient::OverrideWebkitPrefs(content::RenderViewHost* host,
   prefs->default_minimum_page_scale_factor = 1.f;
   prefs->default_maximum_page_scale_factor = 1.f;
   prefs->navigate_on_drag_drop = false;
+
+  SetFontDefaults(prefs);
 
   // Custom preferences of guest page.
   auto* web_contents = content::WebContents::FromRenderViewHost(host);

--- a/atom/browser/font_defaults.cc
+++ b/atom/browser/font_defaults.cc
@@ -1,0 +1,149 @@
+// Copyright (c) 2018 Slack Technologies, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/font_defaults.h"
+
+#include <string>
+
+#include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
+#include "chrome/common/pref_names.h"
+#include "chrome/grit/platform_locale_settings.h"
+#include "content/public/common/web_preferences.h"
+#include "ui/base/l10n/l10n_util.h"
+
+namespace {
+
+struct FontDefault {
+  const char* pref_name;
+  int resource_id;
+};
+
+// Font pref defaults.  The prefs that have defaults vary by platform, since not
+// all platforms have fonts for all scripts for all generic families.
+// TODO(falken): add proper defaults when possible for all
+// platforms/scripts/generic families.
+const FontDefault kFontDefaults[] = {
+    {prefs::kWebKitStandardFontFamily, IDS_STANDARD_FONT_FAMILY},
+    {prefs::kWebKitFixedFontFamily, IDS_FIXED_FONT_FAMILY},
+    {prefs::kWebKitSerifFontFamily, IDS_SERIF_FONT_FAMILY},
+    {prefs::kWebKitSansSerifFontFamily, IDS_SANS_SERIF_FONT_FAMILY},
+    {prefs::kWebKitCursiveFontFamily, IDS_CURSIVE_FONT_FAMILY},
+    {prefs::kWebKitFantasyFontFamily, IDS_FANTASY_FONT_FAMILY},
+    {prefs::kWebKitPictographFontFamily, IDS_PICTOGRAPH_FONT_FAMILY},
+#if defined(OS_CHROMEOS) || defined(OS_MACOSX) || defined(OS_WIN)
+    {prefs::kWebKitStandardFontFamilyJapanese,
+     IDS_STANDARD_FONT_FAMILY_JAPANESE},
+    {prefs::kWebKitFixedFontFamilyJapanese, IDS_FIXED_FONT_FAMILY_JAPANESE},
+    {prefs::kWebKitSerifFontFamilyJapanese, IDS_SERIF_FONT_FAMILY_JAPANESE},
+    {prefs::kWebKitSansSerifFontFamilyJapanese,
+     IDS_SANS_SERIF_FONT_FAMILY_JAPANESE},
+    {prefs::kWebKitStandardFontFamilyKorean, IDS_STANDARD_FONT_FAMILY_KOREAN},
+    {prefs::kWebKitSerifFontFamilyKorean, IDS_SERIF_FONT_FAMILY_KOREAN},
+    {prefs::kWebKitSansSerifFontFamilyKorean,
+     IDS_SANS_SERIF_FONT_FAMILY_KOREAN},
+    {prefs::kWebKitStandardFontFamilySimplifiedHan,
+     IDS_STANDARD_FONT_FAMILY_SIMPLIFIED_HAN},
+    {prefs::kWebKitSerifFontFamilySimplifiedHan,
+     IDS_SERIF_FONT_FAMILY_SIMPLIFIED_HAN},
+    {prefs::kWebKitSansSerifFontFamilySimplifiedHan,
+     IDS_SANS_SERIF_FONT_FAMILY_SIMPLIFIED_HAN},
+    {prefs::kWebKitStandardFontFamilyTraditionalHan,
+     IDS_STANDARD_FONT_FAMILY_TRADITIONAL_HAN},
+    {prefs::kWebKitSerifFontFamilyTraditionalHan,
+     IDS_SERIF_FONT_FAMILY_TRADITIONAL_HAN},
+    {prefs::kWebKitSansSerifFontFamilyTraditionalHan,
+     IDS_SANS_SERIF_FONT_FAMILY_TRADITIONAL_HAN},
+#endif
+#if defined(OS_MACOSX) || defined(OS_WIN)
+    {prefs::kWebKitCursiveFontFamilySimplifiedHan,
+     IDS_CURSIVE_FONT_FAMILY_SIMPLIFIED_HAN},
+    {prefs::kWebKitCursiveFontFamilyTraditionalHan,
+     IDS_CURSIVE_FONT_FAMILY_TRADITIONAL_HAN},
+#endif
+#if defined(OS_CHROMEOS)
+    {prefs::kWebKitStandardFontFamilyArabic, IDS_STANDARD_FONT_FAMILY_ARABIC},
+    {prefs::kWebKitSerifFontFamilyArabic, IDS_SERIF_FONT_FAMILY_ARABIC},
+    {prefs::kWebKitSansSerifFontFamilyArabic,
+     IDS_SANS_SERIF_FONT_FAMILY_ARABIC},
+    {prefs::kWebKitFixedFontFamilyKorean, IDS_FIXED_FONT_FAMILY_KOREAN},
+    {prefs::kWebKitFixedFontFamilySimplifiedHan,
+     IDS_FIXED_FONT_FAMILY_SIMPLIFIED_HAN},
+    {prefs::kWebKitFixedFontFamilyTraditionalHan,
+     IDS_FIXED_FONT_FAMILY_TRADITIONAL_HAN},
+#elif defined(OS_WIN)
+    {prefs::kWebKitFixedFontFamilyArabic, IDS_FIXED_FONT_FAMILY_ARABIC},
+    {prefs::kWebKitSansSerifFontFamilyArabic,
+     IDS_SANS_SERIF_FONT_FAMILY_ARABIC},
+    {prefs::kWebKitStandardFontFamilyCyrillic,
+     IDS_STANDARD_FONT_FAMILY_CYRILLIC},
+    {prefs::kWebKitFixedFontFamilyCyrillic, IDS_FIXED_FONT_FAMILY_CYRILLIC},
+    {prefs::kWebKitSerifFontFamilyCyrillic, IDS_SERIF_FONT_FAMILY_CYRILLIC},
+    {prefs::kWebKitSansSerifFontFamilyCyrillic,
+     IDS_SANS_SERIF_FONT_FAMILY_CYRILLIC},
+    {prefs::kWebKitStandardFontFamilyGreek, IDS_STANDARD_FONT_FAMILY_GREEK},
+    {prefs::kWebKitFixedFontFamilyGreek, IDS_FIXED_FONT_FAMILY_GREEK},
+    {prefs::kWebKitSerifFontFamilyGreek, IDS_SERIF_FONT_FAMILY_GREEK},
+    {prefs::kWebKitSansSerifFontFamilyGreek, IDS_SANS_SERIF_FONT_FAMILY_GREEK},
+    {prefs::kWebKitFixedFontFamilyKorean, IDS_FIXED_FONT_FAMILY_KOREAN},
+    {prefs::kWebKitCursiveFontFamilyKorean, IDS_CURSIVE_FONT_FAMILY_KOREAN},
+    {prefs::kWebKitFixedFontFamilySimplifiedHan,
+     IDS_FIXED_FONT_FAMILY_SIMPLIFIED_HAN},
+    {prefs::kWebKitFixedFontFamilyTraditionalHan,
+     IDS_FIXED_FONT_FAMILY_TRADITIONAL_HAN},
+#endif
+};
+const size_t kFontDefaultsLength = arraysize(kFontDefaults);
+
+std::string GetDefaultFontForPref(const char* pref_name) {
+  for (size_t i = 0; i < kFontDefaultsLength; ++i) {
+    FontDefault pref = kFontDefaults[i];
+    if (strcmp(pref.pref_name, pref_name) == 0) {
+      return l10n_util::GetStringUTF8(pref.resource_id);
+    }
+  }
+  return std::string();
+}
+
+base::string16 FetchFont(const char* script, const char* map_name) {
+  std::string pref_name = base::StringPrintf("%s.%s", map_name, script);
+  std::string font = GetDefaultFontForPref(pref_name.c_str());
+  base::string16 font16 = base::UTF8ToUTF16(font);
+
+  return font16;
+}
+
+void FillFontFamilyMap(const char* map_name,
+                       content::ScriptFontFamilyMap* map) {
+  for (size_t i = 0; i < prefs::kWebKitScriptsForFontFamilyMapsLength; ++i) {
+    const char* script = prefs::kWebKitScriptsForFontFamilyMaps[i];
+    base::string16 result = FetchFont(script, map_name);
+    if (!result.empty()) {
+      (*map)[script] = result;
+    }
+  }
+}
+
+}  // namespace
+
+namespace atom {
+
+void SetFontDefaults(content::WebPreferences* prefs) {
+  FillFontFamilyMap(prefs::kWebKitStandardFontFamilyMap,
+                    &prefs->standard_font_family_map);
+  FillFontFamilyMap(prefs::kWebKitFixedFontFamilyMap,
+                    &prefs->fixed_font_family_map);
+  FillFontFamilyMap(prefs::kWebKitSerifFontFamilyMap,
+                    &prefs->serif_font_family_map);
+  FillFontFamilyMap(prefs::kWebKitSansSerifFontFamilyMap,
+                    &prefs->sans_serif_font_family_map);
+  FillFontFamilyMap(prefs::kWebKitCursiveFontFamilyMap,
+                    &prefs->cursive_font_family_map);
+  FillFontFamilyMap(prefs::kWebKitFantasyFontFamilyMap,
+                    &prefs->fantasy_font_family_map);
+  FillFontFamilyMap(prefs::kWebKitPictographFontFamilyMap,
+                    &prefs->pictograph_font_family_map);
+}
+
+}  // namespace atom

--- a/atom/browser/font_defaults.cc
+++ b/atom/browser/font_defaults.cc
@@ -16,6 +16,14 @@
 
 namespace {
 
+// The following list of font defaults was copied from
+// https://chromium.googlesource.com/chromium/src/+/69.0.3497.106/chrome/browser/ui/prefs/prefs_tab_helper.cc#152
+//
+// The only updates that should be made to this list are copying updates that
+// were made in Chromium.
+//
+// vvvvv DO NOT EDIT vvvvv
+
 struct FontDefault {
   const char* pref_name;
   int resource_id;
@@ -97,6 +105,8 @@ const FontDefault kFontDefaults[] = {
 };
 const size_t kFontDefaultsLength = arraysize(kFontDefaults);
 
+// ^^^^^ DO NOT EDIT ^^^^^
+
 std::string GetDefaultFontForPref(const char* pref_name) {
   for (size_t i = 0; i < kFontDefaultsLength; ++i) {
     FontDefault pref = kFontDefaults[i];
@@ -115,6 +125,8 @@ using ScriptFontMap = std::unordered_map<const char*, base::string16>;
 // Key comparison uses pointer equality.
 using FontFamilyMap = std::unordered_map<const char*, ScriptFontMap>;
 
+// A lookup table mapping (font-family, script) -> font-name
+// e.g. ("sans-serif", "Zyyy") -> "Arial"
 FontFamilyMap g_font_cache;
 
 base::string16 FetchFont(const char* script, const char* map_name) {

--- a/atom/browser/font_defaults.h
+++ b/atom/browser/font_defaults.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2018 Slack Technologies, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_FONT_DEFAULTS_H_
+#define ATOM_BROWSER_FONT_DEFAULTS_H_
+
+namespace content {
+struct WebPreferences;
+}  // namespace content
+
+namespace atom {
+
+void SetFontDefaults(content::WebPreferences* prefs);
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_FONT_DEFAULTS_H_

--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -143,12 +143,14 @@ template("electron_paks") {
     }
 
     source_patterns = [
+      "${root_gen_dir}/chrome/platform_locale_settings_",
       "${root_gen_dir}/components/strings/components_strings_",
       "${root_gen_dir}/content/app/strings/content_strings_",
       "${root_gen_dir}/ui/strings/app_locale_settings_",
       "${root_gen_dir}/ui/strings/ui_strings_",
     ]
     deps = [
+      "//chrome/app/resources:platform_locale_settings",
       "//components/strings:components_strings",
       "//content/app/strings",
       "//ui/strings:app_locale_settings",

--- a/filenames.gni
+++ b/filenames.gni
@@ -120,6 +120,8 @@ filenames = {
     "atom/app/uv_task_runner.cc",
     "atom/app/uv_task_runner.h",
     "atom/browser/api/atom_api_app.cc",
+    "atom/browser/font_defaults.cc",
+    "atom/browser/font_defaults.h",
     "atom/browser/api/atom_api_app.h",
     "atom/browser/api/atom_api_auto_updater.cc",
     "atom/browser/api/atom_api_auto_updater.h",

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1344,7 +1344,7 @@ describe('font fallback', () => {
     expect(fonts[0].familyName).to.equal({
       'win32': 'Arial',
       'darwin': 'Helvetica',
-      'linux': 'Arial'
+      'linux': 'DejaVu Sans' // I think this depends on the distro? We don't specify a default.
     }[process.platform])
   })
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1336,8 +1336,8 @@ describe('font fallback', () => {
     }
   }
 
-  it('should use Helvetica for sans-serif on mac, and Arial on windows and linux', async () => {
-    const html = `<span style="font-family: sans-serif">test</body>`
+  it('should use Helvetica for sans-serif on Mac, and Arial on Windows and Linux', async () => {
+    const html = `<body style="font-family: sans-serif">test</body>`
     const fonts = await getRenderedFonts(html)
     expect(fonts).to.be.an('array')
     expect(fonts).to.have.length(1)
@@ -1348,7 +1348,7 @@ describe('font fallback', () => {
     }[process.platform])
   })
 
-  it('should fall back to non-PingFang SC font for sans-serif japanese script', async () => {
+  it('should fall back to Japanese font for sans-serif Japanese script', async function () {
     if (process.platform === 'linux') {
       return this.skip()
     }


### PR DESCRIPTION
This PR sets up blink's default fonts (`serif`, `sans-serif`, etc.) to match Chrome's behavior, which includes per-[script](https://en.wikipedia.org/wiki/Script_(Unicode)) fallbacks.

Fixes #15481.

TODO:
- [x] tests. There's one test for japanese script, but it needs a couple more to make sure the mechanism is working correctly.
- [x] Chromium uses a [cache](https://chromium.googlesource.com/chromium/src/+/69.0.3497.106/chrome/browser/font_family_cache.cc) and claims that iterating the whole list every time adds significantly to renderer startup time. That doesn't intuitively seem true to me, but I haven't measured. It needs to be measured, and possibly we should build a cache.
- [x] ~Evaluate the possibility of directly using `font_family_cache.cc` from Chrome.~ Its use of `Profile` doesn't match the needs of Electron.
- [x] ~Evaluate the possibility of splitting out `kFontDefaults` in upstream Chromium (defined [here](https://chromium.googlesource.com/chromium/src/+/69.0.3497.106/chrome/browser/ui/prefs/prefs_tab_helper.cc#157)) so we can include them without patching.~ This would be difficult currently, these defaults are embedded pretty deep into Chromium's preference system and it'd be a challenge to refactor them to a common place in a way that would make sense to upstream to Chromium. The lists change quite infrequently though: the last change was [in 2016](https://chromium.googlesource.com/chromium/src/+blame/master/chrome/browser/ui/prefs/prefs_tab_helper.cc#125), so I think it's OK to copy/paste them.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fixed default font fallback for non-latin scripts