### PR TITLE
fix: honor properties.showHiddenFiles on Linux

### DIFF
--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -94,10 +94,14 @@ class FileChooserDialog {
   }
 
   void SetupProperties(int properties) {
-    if (properties & FILE_DIALOG_MULTI_SELECTIONS)
-      gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog()), TRUE);
-    if (properties & FILE_DIALOG_SHOW_HIDDEN_FILES)
-      g_object_set(dialog(), "show-hidden", TRUE, NULL);
+    const auto hasProp = [properties](FileDialogProperty prop) {
+      return gboolean((properties & prop) != 0);
+    };
+    auto* file_chooser = GTK_FILE_CHOOSER(dialog());
+    gtk_file_chooser_set_select_multiple(file_chooser,
+                                         hasProp(FILE_DIALOG_MULTI_SELECTIONS));
+    gtk_file_chooser_set_show_hidden(file_chooser,
+                                     hasProp(FILE_DIALOG_SHOW_HIDDEN_FILES));
   }
 
   void RunAsynchronous() {


### PR DESCRIPTION
#### Description of Change

Previously the code only set the GtkFileChooser's property if `properties.showHiddenFiles` was set.

This PR unconditionally sets the GtkFileChooser's property so that hidden files will be hidden if `properties.showHiddenFiles` was not set.

CC @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Honor `properties.showHiddenFiles` in `dialog.showOpenDialog()` on Linux