### PR TITLE
chore: remove FileChooser AddExtensionForFilename

### DIFF
--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -129,20 +129,18 @@ class FileChooserDialog {
 
   base::FilePath GetFileName() const {
     gchar* filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog_));
-    base::FilePath path = AddExtensionForFilename(filename);
+    const base::FilePath path(filename);
     g_free(filename);
     return path;
   }
 
   std::vector<base::FilePath> GetFileNames() const {
     std::vector<base::FilePath> paths;
-    GSList* filenames =
-        gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog_));
-    for (GSList* iter = filenames; iter != NULL; iter = g_slist_next(iter)) {
-      base::FilePath path =
-          AddExtensionForFilename(static_cast<char*>(iter->data));
-      g_free(iter->data);
-      paths.push_back(path);
+    auto* filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog_));
+    for (auto* iter = filenames; iter != NULL; iter = iter->next) {
+      auto* filename = static_cast<char*>(iter->data);
+      paths.emplace_back(filename);
+      g_free(filename);
     }
     g_slist_free(filenames);
     return paths;
@@ -154,7 +152,6 @@ class FileChooserDialog {
 
  private:
   void AddFilters(const Filters& filters);
-  base::FilePath AddExtensionForFilename(const gchar* filename) const;
 
   atom::NativeWindowViews* parent_;
   atom::UnresponsiveSuppressor unresponsive_suppressor_;
@@ -203,31 +200,6 @@ void FileChooserDialog::AddFilters(const Filters& filters) {
     gtk_file_filter_set_name(gtk_filter, filter.first.c_str());
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog_), gtk_filter);
   }
-}
-
-base::FilePath FileChooserDialog::AddExtensionForFilename(
-    const gchar* filename) const {
-  base::FilePath path(filename);
-  GtkFileFilter* selected_filter =
-      gtk_file_chooser_get_filter(GTK_FILE_CHOOSER(dialog_));
-  if (!selected_filter)
-    return path;
-
-  GSList* filters = gtk_file_chooser_list_filters(GTK_FILE_CHOOSER(dialog_));
-  size_t i = g_slist_index(filters, selected_filter);
-  g_slist_free(filters);
-  if (i >= filters_.size())
-    return path;
-
-  const auto& extensions = filters_[i].second;
-  for (const auto& extension : extensions) {
-    if (extension == "*" ||
-        base::EndsWith(path.value(), "." + extension,
-                       base::CompareCase::INSENSITIVE_ASCII))
-      return path;
-  }
-
-  return path.ReplaceExtension(extensions[0]);
 }
 
 }  // namespace


### PR DESCRIPTION
#### Description of Change

Remove code that was added in https://github.com/electron/electron/commit/81a16b424f5760f091885d7ec3d2708d91aa2cf9 for issue #4634.

As described in that issue, the use case is:

> If the showSaveDialog is called with the file name hello.foo and then there's a filter for an extension called bar, the dialog should update the file name to hello.bar so the user can get a proper feedback to what type of file is he saving to.

### Problem 1: The current code doesn't work

Perhaps GTK+ behaved differently when this code was written, but what I'm seeing in testing is:

a) if the user selects `filename.foo` and then changes the filter from `foo` to `bar`, then the file is deselected because `filename.foo` doesn't match filter `bar`. So `AddExtensionForFilename()` effectively only ever runs on things that already match the filter, e.g. renaming `filename.foo` to `filename.foo` :stuck_out_tongue: 

b) if the user types the filename instead, e.g. typing `filename.foo` into the text entry, then changes the filter from `foo` to `bar`, the filename remains unchanged in the entry.

### Problem 2: We'd have to write our own file chooser to do it right

For example, there is no signal we can connect to for listening to filter changes. If we want to update the text entry field when the filter changes, we'd have to write our own filters so that we could have hooks in them.

The two Linux apps cited in #4634 -- GIMP and Inkscape -- both have written their own file dialogs to handle their specific needs. IMO this is out-of-scope for Electron's general purpose dialog.

Even if we decide to write this behavior into a custom file chooser, it's not consistent with most apps on Linux and not consistent with the way Electron behaves on Mac / Win.

That's why I'd like to remove this code.

CC @zcbenz 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: <!-- One-line Change Summary Here-->