### PR TITLE
fix: use sendToAll method correctly in chrome-api

### DIFF
--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -43,12 +43,12 @@ class Port {
   disconnect () {
     if (this.disconnected) return
 
-    ipcRenderer._sendInternalToAll(this.tabId, `CHROME_PORT_DISCONNECT_${this.portId}`)
+    ipcRenderer.sendToAll(this.tabId, `CHROME_PORT_DISCONNECT_${this.portId}`)
     this._onDisconnect()
   }
 
   postMessage (message) {
-    ipcRenderer._sendInternalToAll(this.tabId, `CHROME_PORT_POSTMESSAGE_${this.portId}`, message)
+    ipcRenderer.sendToAll(this.tabId, `CHROME_PORT_POSTMESSAGE_${this.portId}`, message)
   }
 
   _onDisconnect () {


### PR DESCRIPTION
Fixes #15495

Notes: Fix exceptions being thrown in Electrons Chrome API implementation