### PR TITLE
fix: send NSView* as the response to getNativeWindowHandle() instead of a null handle

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -691,8 +691,11 @@ void TopLevelWindow::SetBrowserView(v8::Local<v8::Value> value) {
 }
 
 v8::Local<v8::Value> TopLevelWindow::GetNativeWindowHandle() {
-  gfx::AcceleratedWidget handle = window_->GetAcceleratedWidget();
-  return ToBuffer(isolate(), static_cast<void*>(&handle), sizeof(handle));
+  // TODO(MarshallOfSound): Replace once
+  // https://chromium-review.googlesource.com/c/chromium/src/+/1253094/ has
+  // landed
+  auto handle = window_->GetNativeWindowHandlePointer();
+  return ToBuffer(isolate(), std::get<0>(handle), std::get<1>(handle));
 }
 
 void TopLevelWindow::SetProgressBar(double progress, mate::Arguments* args) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "atom/browser/native_window_observer.h"
@@ -152,6 +153,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::NativeView GetNativeView() const = 0;
   virtual gfx::NativeWindow GetNativeWindow() const = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() const = 0;
+  virtual std::tuple<void*, int> GetNativeWindowHandlePointer() const = 0;
 
   // Taskbar/Dock APIs.
   enum ProgressState {

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "atom/browser/native_window.h"
@@ -106,6 +107,7 @@ class NativeWindowMac : public NativeWindow {
   gfx::NativeView GetNativeView() const override;
   gfx::NativeWindow GetNativeWindow() const override;
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
+  std::tuple<void*, int> GetNativeWindowHandlePointer() const override;
   void SetProgressBar(double progress, const ProgressState state) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1104,6 +1104,11 @@ gfx::AcceleratedWidget NativeWindowMac::GetAcceleratedWidget() const {
   return gfx::kNullAcceleratedWidget;
 }
 
+std::tuple<void*, int> NativeWindowMac::GetNativeWindowHandlePointer() const {
+  NSView* view = [window_ contentView];
+  return std::make_tuple(static_cast<void*>(view), sizeof(view));
+}
+
 void NativeWindowMac::SetProgressBar(double progress,
                                      const NativeWindow::ProgressState state) {
   NSDockTile* dock_tile = [NSApp dockTile];

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -10,6 +10,7 @@
 #endif
 
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -1050,6 +1051,11 @@ bool NativeWindowViews::IsVisibleOnAllWorkspaces() {
 
 gfx::AcceleratedWidget NativeWindowViews::GetAcceleratedWidget() const {
   return GetNativeWindow()->GetHost()->GetAcceleratedWidget();
+}
+
+std::tuple<void*, int> NativeWindowViews::GetNativeWindowHandlePointer() const {
+  gfx::AcceleratedWidget handle = GetAcceleratedWidget();
+  return std::make_tuple(static_cast<void*>(&handle), sizeof(handle));
 }
 
 gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <tuple>
 
 #include "ui/views/widget/widget_observer.h"
 
@@ -128,6 +129,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsVisibleOnAllWorkspaces() override;
 
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
+  std::tuple<void*, int> GetNativeWindowHandlePointer() const override;
 
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;


### PR DESCRIPTION
Fixes #15489

Notes: Fixed issue where `getNativeWindowHandle()` would return an empty buffer on macOS

Originally caused by https://github.com/electron/electron/commit/4068a62fa629e6de3eea0ce64c425977ea320a28 which was caused by https://chromium-review.googlesource.com/c/chromium/src/+/792295

This re-implements the API on macOS without using `gfx::AcceleratedWidget`

cc @deepak1556 