### PR TITLE
test: fix a possible race condition in sendInputEvent test

### DIFF
--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -313,8 +313,8 @@ describe('webContents module', () => {
 
   describe('sendInputEvent(event)', () => {
     beforeEach((done) => {
-      w.loadFile(path.join(fixtures, 'pages', 'key-events.html'))
       w.webContents.once('did-finish-load', () => done())
+      w.loadFile(path.join(fixtures, 'pages', 'key-events.html'))
     })
 
     it('can send keydown events', (done) => {


### PR DESCRIPTION
#### Description of Change
See flake in https://github.com/electron/electron/pull/15486/checks?check_run_id=27623861i:

webContents module sendInputEvent(event) "before each" hook for "can send char events"
Test failed
Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/vsts/agent/2.141.1/work/1/s/src/electron/spec/api-web-contents-spec.js)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes