### PR TITLE
fix: navigator.languages to use OS preferred languages

### DIFF
--- a/atom/app/atom_main_delegate.h
+++ b/atom/app/atom_main_delegate.h
@@ -35,6 +35,7 @@ class AtomMainDelegate : public content::ContentMainDelegate {
 #if defined(OS_MACOSX)
   bool ShouldSendMachPort(const std::string& process_type) override;
   bool DelaySandboxInitialization(const std::string& process_type) override;
+  std::string GetSystemPreferredLanguage();
 #endif
   bool ShouldLockSchemeRegistry() override;
   bool ShouldCreateFeatureList() override;

--- a/atom/app/atom_main_delegate_mac.mm
+++ b/atom/app/atom_main_delegate_mac.mm
@@ -61,6 +61,11 @@ void AtomMainDelegate::SetUpBundleOverrides() {
   base::mac::SetBaseBundleID(base_bundle_id.c_str());
 }
 
+std::string AtomMainDelegate::GetSystemPreferredLanguage() {
+  return base::SysNSStringToUTF8(
+      [[NSLocale preferredLanguages] objectAtIndex:0]);
+}
+
 void RegisterAtomCrApp() {
   // Force the NSApplication subclass to be used.
   [AtomApplication sharedApplication];

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -405,7 +405,7 @@ void WebContents::InitWithSessionAndOptions(
   managed_web_contents()->GetView()->SetDelegate(this);
 
   auto* prefs = web_contents()->GetMutableRendererPrefs();
-  prefs->accept_languages = g_browser_process->GetApplicationLocale();
+  SetAcceptLanguages(prefs);
 
 #if defined(OS_LINUX) || defined(OS_WIN)
   // Update font settings.

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -35,6 +35,10 @@ namespace blink {
 struct WebDeviceEmulationParams;
 }
 
+namespace content {
+struct RendererPreferences;
+}
+
 namespace mate {
 class Arguments;
 class Dictionary;
@@ -514,6 +518,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   void InitZoomController(content::WebContents* web_contents,
                           const mate::Dictionary& options);
+  // Update the accept_languages pref
+  void SetAcceptLanguages(content::RendererPreferences* prefs);
 
   v8::Global<v8::Value> session_;
   v8::Global<v8::Value> devtools_web_contents_;

--- a/atom/browser/api/atom_api_web_contents_linux.cc
+++ b/atom/browser/api/atom_api_web_contents_linux.cc
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/api/atom_api_web_contents.h"
+
+#include "chrome/browser/browser_process.h"
+#include "content/public/common/renderer_preferences.h"
+
+namespace atom {
+
+namespace api {
+
+void WebContents::SetAcceptLanguages(content::RendererPreferences* prefs) {
+  prefs->accept_languages = g_browser_process->GetApplicationLocale();
+}
+
+}  // namespace api
+
+}  // namespace atom

--- a/atom/browser/api/atom_api_web_contents_mac.mm
+++ b/atom/browser/api/atom_api_web_contents_mac.mm
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 #include "atom/browser/api/atom_api_web_contents.h"
+#include "base/strings/sys_string_conversions.h"
 #include "content/public/browser/render_widget_host_view.h"
+#include "content/public/common/renderer_preferences.h"
 
 #import <Cocoa/Cocoa.h>
 
@@ -25,6 +27,11 @@ bool WebContents::IsFocused() const {
   }
 
   return view->HasFocus();
+}
+
+void WebContents::SetAcceptLanguages(content::RendererPreferences* prefs) {
+  prefs->accept_languages = base::SysNSStringToUTF8(
+      [[NSLocale preferredLanguages] componentsJoinedByString:@","]);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_web_contents_win.cc
+++ b/atom/browser/api/atom_api_web_contents_win.cc
@@ -1,0 +1,28 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/api/atom_api_web_contents.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "base/win/i18n.h"
+#include "content/public/common/renderer_preferences.h"
+
+namespace atom {
+
+namespace api {
+
+void WebContents::SetAcceptLanguages(content::RendererPreferences* prefs) {
+  std::vector<base::string16> languages;
+  base::win::i18n::GetThreadPreferredUILanguageList(&languages);
+  std::string accept_langs;
+  for (const auto& s16 : languages) {
+    accept_langs += base::SysWideToUTF8(s16) + ',';
+  }
+  accept_langs.pop_back();
+  prefs->accept_languages = accept_langs;
+}
+
+}  // namespace api
+
+}  // namespace atom

--- a/filenames.gni
+++ b/filenames.gni
@@ -188,6 +188,8 @@ filenames = {
     "atom/browser/api/atom_api_web_contents.h",
     "atom/browser/api/atom_api_web_contents_impl.cc",
     "atom/browser/api/atom_api_web_contents_mac.mm",
+    "atom/browser/api/atom_api_web_contents_linux.cc",
+    "atom/browser/api/atom_api_web_contents_win.cc",
     "atom/browser/api/atom_api_web_contents_view.cc",
     "atom/browser/api/atom_api_web_contents_view.h",
     "atom/browser/api/atom_api_web_request.cc",

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -200,10 +200,11 @@ describe('chromium feature', () => {
   })
 
   describe('navigator.languages', (done) => {
-    it('should return the system locale only', () => {
+    it('should return the system locales', () => {
       const appLocale = app.getLocale()
-      assert.strictEqual(navigator.languages.length, 1)
-      assert.strictEqual(navigator.languages[0], appLocale)
+      expect(navigator.languages.length).greaterThan(0)
+      // compare only the language not the region as appLocale provides that
+      expect(navigator.languages[0].split('-')[0]).equal(appLocale.split('-')[0])
     })
   })
 

--- a/spec/package-lock.json
+++ b/spec/package-lock.json
@@ -75,7 +75,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "optional": true,
       "requires": {
@@ -231,7 +231,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -363,7 +363,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -781,7 +781,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -789,7 +789,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -975,7 +975,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "optional": true
     },
@@ -1040,7 +1040,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1058,7 +1058,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -1357,7 +1357,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1373,7 +1373,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -1442,7 +1442,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -1537,7 +1537,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
#### Description of Change
Until recent versions of chrome (i.e. for electron version < 4.x), `navigator.language` returned the system language, and the first item in `navigator.languages` array, was also the same system locale.
However, this behaviour has changed, (it also follows the HTML spec). The language preferences are obtained through the preferences list that chrome maintains. The user has to set these language preferences manually, through the settings menu.
For an electron app, there's no way to set these preferences. Besides, being a desktop app, it seems reasonable for the app to follow the users desktop language preferences.
This change makes the needed changes to set the right OS languages. This also fixes `app.getLocale` which always returned `en-US`.
Adding a spec for this would be difficult, as the os language preferences need to be changed to see the difference.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Fixed behaviour of navigator.language/s and app.getLocale to use OS locale