### PR TITLE
feat: allow registering multiple shortcuts

### DIFF
--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -39,8 +39,9 @@ void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
   accelerator_callback_map_[accelerator].Run();
 }
 
-bool GlobalShortcut::Register(const std::vector<ui::Accelerator>& accelerators,
-                              const base::Closure& callback) {
+bool GlobalShortcut::RegisterAll(
+    const std::vector<ui::Accelerator>& accelerators,
+    const base::Closure& callback) {
   for (auto& accelerator : accelerators) {
     GlobalShortcutListener* listener = GlobalShortcutListener::GetInstance();
     if (!listener->RegisterAccelerator(accelerator, this))
@@ -51,8 +52,8 @@ bool GlobalShortcut::Register(const std::vector<ui::Accelerator>& accelerators,
   return true;
 }
 
-bool GlobalShortcut::RegisterAccelerator(const ui::Accelerator& accelerator,
-                                         const base::Closure& callback) {
+bool GlobalShortcut::Register(const ui::Accelerator& accelerator,
+                              const base::Closure& callback) {
   if (!GlobalShortcutListener::GetInstance()->RegisterAccelerator(accelerator,
                                                                   this)) {
     return false;
@@ -90,8 +91,8 @@ void GlobalShortcut::BuildPrototype(v8::Isolate* isolate,
                                     v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "GlobalShortcut"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+      .SetMethod("registerAll", &GlobalShortcut::RegisterAll)
       .SetMethod("register", &GlobalShortcut::Register)
-      .SetMethod("registerAccelerator", &GlobalShortcut::RegisterAccelerator)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)
       .SetMethod("unregister", &GlobalShortcut::Unregister)
       .SetMethod("unregisterAll", &GlobalShortcut::UnregisterAll);

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -44,8 +44,11 @@ bool GlobalShortcut::RegisterAll(
     const base::Closure& callback) {
   for (auto& accelerator : accelerators) {
     GlobalShortcutListener* listener = GlobalShortcutListener::GetInstance();
-    if (!listener->RegisterAccelerator(accelerator, this))
+    if (!listener->RegisterAccelerator(accelerator, this)) {
+      // unregister all shortcuts if any failed
+      UnregisterAll();
       return false;
+    }
 
     accelerator_callback_map_[accelerator] = callback;
   }

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -42,14 +42,16 @@ void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
 bool GlobalShortcut::RegisterAll(
     const std::vector<ui::Accelerator>& accelerators,
     const base::Closure& callback) {
+  std::vector<ui::Accelerator> registered;
   for (auto& accelerator : accelerators) {
     GlobalShortcutListener* listener = GlobalShortcutListener::GetInstance();
     if (!listener->RegisterAccelerator(accelerator, this)) {
       // unregister all shortcuts if any failed
-      UnregisterAll();
+      UnregisterSome(registered);
       return false;
     }
 
+    registered.push_back(accelerator);
     accelerator_callback_map_[accelerator] = callback;
   }
   return true;
@@ -75,6 +77,13 @@ void GlobalShortcut::Unregister(const ui::Accelerator& accelerator) {
                                                                this);
 }
 
+void GlobalShortcut::UnregisterSome(
+    const std::vector<ui::Accelerator>& accelerators) {
+  for (auto& accelerator : accelerators) {
+    Unregister(accelerator);
+  }
+}
+
 bool GlobalShortcut::IsRegistered(const ui::Accelerator& accelerator) {
   return ContainsKey(accelerator_callback_map_, accelerator);
 }
@@ -98,6 +107,7 @@ void GlobalShortcut::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("register", &GlobalShortcut::Register)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)
       .SetMethod("unregister", &GlobalShortcut::Unregister)
+      .SetMethod("unregisterSome", &GlobalShortcut::UnregisterSome)
       .SetMethod("unregisterAll", &GlobalShortcut::UnregisterAll);
 }
 

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -107,7 +107,6 @@ void GlobalShortcut::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("register", &GlobalShortcut::Register)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)
       .SetMethod("unregister", &GlobalShortcut::Unregister)
-      .SetMethod("unregisterSome", &GlobalShortcut::UnregisterSome)
       .SetMethod("unregisterAll", &GlobalShortcut::UnregisterAll);
 }
 

--- a/atom/browser/api/atom_api_global_shortcut.h
+++ b/atom/browser/api/atom_api_global_shortcut.h
@@ -40,6 +40,7 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
                 const base::Closure& callback);
   bool IsRegistered(const ui::Accelerator& accelerator);
   void Unregister(const ui::Accelerator& accelerator);
+  void UnregisterSome(const std::vector<ui::Accelerator>& accelerators);
   void UnregisterAll();
 
   // GlobalShortcutListener::Observer implementation.

--- a/atom/browser/api/atom_api_global_shortcut.h
+++ b/atom/browser/api/atom_api_global_shortcut.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "atom/browser/api/trackable_object.h"
 #include "base/callback.h"
@@ -33,8 +34,10 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
  private:
   typedef std::map<ui::Accelerator, base::Closure> AcceleratorCallbackMap;
 
-  bool Register(const ui::Accelerator& accelerator,
+  bool Register(const std::vector<ui::Accelerator>& accelerators,
                 const base::Closure& callback);
+  bool RegisterAccelerator(const ui::Accelerator& accelerator,
+                           const base::Closure& callback);
   bool IsRegistered(const ui::Accelerator& accelerator);
   void Unregister(const ui::Accelerator& accelerator);
   void UnregisterAll();

--- a/atom/browser/api/atom_api_global_shortcut.h
+++ b/atom/browser/api/atom_api_global_shortcut.h
@@ -34,10 +34,10 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
  private:
   typedef std::map<ui::Accelerator, base::Closure> AcceleratorCallbackMap;
 
-  bool Register(const std::vector<ui::Accelerator>& accelerators,
+  bool RegisterAll(const std::vector<ui::Accelerator>& accelerators,
+                   const base::Closure& callback);
+  bool Register(const ui::Accelerator& accelerator,
                 const base::Closure& callback);
-  bool RegisterAccelerator(const ui::Accelerator& accelerator,
-                           const base::Closure& callback);
   bool IsRegistered(const ui::Accelerator& accelerator);
   void Unregister(const ui::Accelerator& accelerator);
   void UnregisterAll();

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -81,7 +81,7 @@ don't want applications to fight for global shortcuts.
 
 Unregisters the global shortcut of `accelerator`.
 
-### `globalShortcut.unregisterSome(accelerator)`
+### `globalShortcut.unregisterSome(accelerators)`
 
 * `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
 

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -81,12 +81,6 @@ don't want applications to fight for global shortcuts.
 
 Unregisters the global shortcut of `accelerator`.
 
-### `globalShortcut.unregisterSome(accelerators)`
-
-* `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
-
-Unregisters all shortcuts present in `accelerators`.
-
 ### `globalShortcut.unregisterAll()`
 
 Unregisters all of the global shortcuts.

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -81,6 +81,12 @@ don't want applications to fight for global shortcuts.
 
 Unregisters the global shortcut of `accelerator`.
 
+### `globalShortcut.unregisterSome(accelerator)`
+
+* `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
+
+Unregisters all shortcuts present in `accelerators`.
+
 ### `globalShortcut.unregisterAll()`
 
 Unregisters all of the global shortcuts.

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -44,6 +44,17 @@ The `globalShortcut` module has the following methods:
 
 ### `globalShortcut.register(accelerator, callback)`
 
+* `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
+* `callback` Function
+
+Registers a global shortcut of all `accelerator` items in `accelerators`. The `callback` is called when any of the registered shortcuts are pressed by the user.
+
+When a given accelerator is already taken by other applications, this call will
+silently fail. This behavior is intended by operating systems, since they don't
+want applications to fight for global shortcuts.
+
+### `globalShortcut.registerAccelerator(accelerator, callback)`
+
 * `accelerator` [Accelerator](accelerator.md)
 * `callback` Function
 

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -42,7 +42,7 @@ app.on('will-quit', () => {
 
 The `globalShortcut` module has the following methods:
 
-### `globalShortcut.register(accelerator, callback)`
+### `globalShortcut.registerAll(accelerator, callback)`
 
 * `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
 * `callback` Function
@@ -53,7 +53,7 @@ When a given accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
-### `globalShortcut.registerAccelerator(accelerator, callback)`
+### `globalShortcut.register(accelerator, callback)`
 
 * `accelerator` [Accelerator](accelerator.md)
 * `callback` Function

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -42,17 +42,6 @@ app.on('will-quit', () => {
 
 The `globalShortcut` module has the following methods:
 
-### `globalShortcut.registerAll(accelerator, callback)`
-
-* `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
-* `callback` Function
-
-Registers a global shortcut of all `accelerator` items in `accelerators`. The `callback` is called when any of the registered shortcuts are pressed by the user.
-
-When a given accelerator is already taken by other applications, this call will
-silently fail. This behavior is intended by operating systems, since they don't
-want applications to fight for global shortcuts.
-
 ### `globalShortcut.register(accelerator, callback)`
 
 * `accelerator` [Accelerator](accelerator.md)
@@ -62,6 +51,17 @@ Registers a global shortcut of `accelerator`. The `callback` is called when
 the registered shortcut is pressed by the user.
 
 When the accelerator is already taken by other applications, this call will
+silently fail. This behavior is intended by operating systems, since they don't
+want applications to fight for global shortcuts.
+
+### `globalShortcut.registerAll(accelerators, callback)`
+
+* `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
+* `callback` Function
+
+Registers a global shortcut of all `accelerator` items in `accelerators`. The `callback` is called when any of the registered shortcuts are pressed by the user.
+
+When a given accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 

--- a/spec/api-global-shortcut-spec.js
+++ b/spec/api-global-shortcut-spec.js
@@ -50,24 +50,4 @@ describe('globalShortcut module', () => {
     expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
     expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
   })
-
-  it('can register and unregister some accelerators', () => {
-    const accelerators = ['CmdOrCtrl+X', 'CmdOrCtrl+Y', 'CmdOrCtrl+Z']
-
-    expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
-    expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
-    expect(globalShortcut.isRegistered(accelerators[2])).to.be.false()
-
-    globalShortcut.registerAll(accelerators, () => {})
-
-    expect(globalShortcut.isRegistered(accelerators[0])).to.be.true()
-    expect(globalShortcut.isRegistered(accelerators[1])).to.be.true()
-    expect(globalShortcut.isRegistered(accelerators[2])).to.be.true()
-
-    globalShortcut.unregisterSome(['CmdOrCtrl+X', 'CmdOrCtrl+Y'])
-
-    expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
-    expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
-    expect(globalShortcut.isRegistered(accelerators[2])).to.be.true()
-  })
 })

--- a/spec/api-global-shortcut-spec.js
+++ b/spec/api-global-shortcut-spec.js
@@ -18,19 +18,36 @@ describe('globalShortcut module', () => {
     globalShortcut.unregisterAll()
   })
 
-  it('can register and unregister accelerators', () => {
+  it('can register and unregister single accelerators', () => {
     const accelerator = 'CommandOrControl+A+B+C'
 
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
-    globalShortcut.register(accelerator, () => {})
+    globalShortcut.registerAccelerator(accelerator, () => {})
     expect(globalShortcut.isRegistered(accelerator)).to.be.true()
     globalShortcut.unregister(accelerator)
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
 
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
-    globalShortcut.register(accelerator, () => {})
+    globalShortcut.registerAccelerator(accelerator, () => {})
     expect(globalShortcut.isRegistered(accelerator)).to.be.true()
     globalShortcut.unregisterAll()
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
+  })
+
+  it('can register andunregistermultiple accelerators', () => {
+    const accelerators = ['CommandOrControl+X', 'CommandOrControl+Y']
+
+    expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
+    expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
+
+    globalShortcut.register(accelerators, () => {})
+
+    expect(globalShortcut.isRegistered(accelerators[0])).to.be.true()
+    expect(globalShortcut.isRegistered(accelerators[1])).to.be.true()
+
+    globalShortcut.unregisterAll()
+
+    expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
+    expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
   })
 })

--- a/spec/api-global-shortcut-spec.js
+++ b/spec/api-global-shortcut-spec.js
@@ -22,25 +22,25 @@ describe('globalShortcut module', () => {
     const accelerator = 'CommandOrControl+A+B+C'
 
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
-    globalShortcut.registerAccelerator(accelerator, () => {})
+    globalShortcut.register(accelerator, () => {})
     expect(globalShortcut.isRegistered(accelerator)).to.be.true()
     globalShortcut.unregister(accelerator)
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
 
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
-    globalShortcut.registerAccelerator(accelerator, () => {})
+    globalShortcut.register(accelerator, () => {})
     expect(globalShortcut.isRegistered(accelerator)).to.be.true()
     globalShortcut.unregisterAll()
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
   })
 
-  it('can register andunregistermultiple accelerators', () => {
+  it('can register and unregister multiple accelerators', () => {
     const accelerators = ['CommandOrControl+X', 'CommandOrControl+Y']
 
     expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
     expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
 
-    globalShortcut.register(accelerators, () => {})
+    globalShortcut.registerAll(accelerators, () => {})
 
     expect(globalShortcut.isRegistered(accelerators[0])).to.be.true()
     expect(globalShortcut.isRegistered(accelerators[1])).to.be.true()

--- a/spec/api-global-shortcut-spec.js
+++ b/spec/api-global-shortcut-spec.js
@@ -19,7 +19,7 @@ describe('globalShortcut module', () => {
   })
 
   it('can register and unregister single accelerators', () => {
-    const accelerator = 'CommandOrControl+A+B+C'
+    const accelerator = 'CmdOrCtrl+A+B+C'
 
     expect(globalShortcut.isRegistered(accelerator)).to.be.false()
     globalShortcut.register(accelerator, () => {})
@@ -35,7 +35,7 @@ describe('globalShortcut module', () => {
   })
 
   it('can register and unregister multiple accelerators', () => {
-    const accelerators = ['CommandOrControl+X', 'CommandOrControl+Y']
+    const accelerators = ['CmdOrCtrl+X', 'CmdOrCtrl+Y']
 
     expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
     expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
@@ -49,5 +49,25 @@ describe('globalShortcut module', () => {
 
     expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
     expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
+  })
+
+  it('can register and unregister some accelerators', () => {
+    const accelerators = ['CmdOrCtrl+X', 'CmdOrCtrl+Y', 'CmdOrCtrl+Z']
+
+    expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
+    expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
+    expect(globalShortcut.isRegistered(accelerators[2])).to.be.false()
+
+    globalShortcut.registerAll(accelerators, () => {})
+
+    expect(globalShortcut.isRegistered(accelerators[0])).to.be.true()
+    expect(globalShortcut.isRegistered(accelerators[1])).to.be.true()
+    expect(globalShortcut.isRegistered(accelerators[2])).to.be.true()
+
+    globalShortcut.unregisterSome(['CmdOrCtrl+X', 'CmdOrCtrl+Y'])
+
+    expect(globalShortcut.isRegistered(accelerators[0])).to.be.false()
+    expect(globalShortcut.isRegistered(accelerators[1])).to.be.false()
+    expect(globalShortcut.isRegistered(accelerators[2])).to.be.true()
   })
 })


### PR DESCRIPTION
#### Description of Change

This PR allows for multiple global shortcuts to be registered such that triggering any of them calls the same callback. 

Ex.
```
const ret = globalShortcut.registerAll(['CmdOrCtrl+X', 'CmdOrCtrl+Y'], () => {
   console.log('did something!')
})
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: allow registering of multiple globalShortcuts