### PR TITLE
fix: ensure that file descriptors 0/1/2 are opened at startup

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -25,9 +25,13 @@
 #include "content/public/app/sandbox_helper_win.h"
 #include "sandbox/win/src/sandbox_types.h"
 #elif defined(OS_LINUX)                   // defined(OS_WIN)
+#include <unistd.h>
+#include <cstdio>
 #include "atom/app/atom_main_delegate.h"  // NOLINT
 #include "content/public/app/content_main.h"
 #else  // defined(OS_LINUX)
+#include <unistd.h>
+#include <cstdio>
 #include "atom/app/atom_library_main.h"
 #endif  // defined(OS_MACOSX)
 
@@ -53,6 +57,25 @@ bool IsEnvSet(const char* name) {
   return indicator && indicator[0] != '\0';
 #endif
 }
+
+#if defined(OS_POSIX)
+void FixStdioStreams() {
+  // libuv may mark stdin/stdout/stderr as close-on-exec, which interferes
+  // with chromium's subprocess spawning. As a workaround, we detect if these
+  // streams are closed on startup, and reopen them as /dev/null if necessary.
+  // Otherwise, an unrelated file descriptor will be assigned as stdout/stderr
+  // which may cause various errors when attempting to write to them.
+  //
+  // For details see https://github.com/libuv/libuv/issues/2062
+  struct stat st;
+  if (fstat(STDIN_FILENO, &st) < 0 && errno == EBADF)
+    freopen("/dev/null", "r", stdin);
+  if (fstat(STDOUT_FILENO, &st) < 0 && errno == EBADF)
+    freopen("/dev/null", "w", stdout);
+  if (fstat(STDERR_FILENO, &st) < 0 && errno == EBADF)
+    freopen("/dev/null", "w", stderr);
+}
+#endif
 
 }  // namespace
 
@@ -155,6 +178,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
 #elif defined(OS_LINUX)  // defined(OS_WIN)
 
 int main(int argc, char* argv[]) {
+  FixStdioStreams();
+
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
   if (IsEnvSet(kRunAsNode)) {
     base::i18n::InitializeICU();
@@ -174,6 +199,8 @@ int main(int argc, char* argv[]) {
 #else  // defined(OS_LINUX)
 
 int main(int argc, char* argv[]) {
+  FixStdioStreams();
+
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
   if (IsEnvSet(kRunAsNode)) {
     return AtomInitializeICUandStartNode(argc, argv);

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -24,7 +24,7 @@
 #include "base/win/windows_version.h"
 #include "content/public/app/sandbox_helper_win.h"
 #include "sandbox/win/src/sandbox_types.h"
-#elif defined(OS_LINUX)                   // defined(OS_WIN)
+#elif defined(OS_LINUX)  // defined(OS_WIN)
 #include <unistd.h>
 #include <cstdio>
 #include "atom/app/atom_main_delegate.h"  // NOLINT


### PR DESCRIPTION
#### Description of Change
Libuv has a nasty mis-feature (https://github.com/libuv/libuv/issues/2062), where it marks the standard input/output/error tty streams with the close-on-exec flag. In effect, when the chromium gpu process is spawned, it starts with the fd's 0,1,2 closed. These are reused for other purposes, and if any message is output on stdout/stderr, it ends up in an unrelated socket, pipe or file which generally messes things up. This is the root cause of at least two issues: https://github.com/electron/electron/issues/14246 and https://github.com/electron/electron/issues/12937, and possibly these (duplicates) as well: https://github.com/electron/electron/issues/13415, https://github.com/electron/electron/issues/14954, https://github.com/electron/electron/issues/14697

The proper place to fix this would be in libuv, but the upstream developers insist that the current behaviour is right. My change introduces a workaround which checks the standard fds at startup, and reopens them as /dev/null if missing. Feel free to point me to a better solution.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

In my environment, npm test on the 3-0-x branch fails on 5 tests.
My commit doesn't introduce any more failures.

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Fixed a freeze when using the GPU in some configurations.