### PR TITLE
fix: load the chrome.* API on chrome-extension pages in sandbox mode

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -38,6 +38,11 @@ bool IsDevTools(content::RenderFrame* render_frame) {
       "chrome-devtools");
 }
 
+bool IsDevToolsExtension(content::RenderFrame* render_frame) {
+  return render_frame->GetWebFrame()->GetDocument().Url().ProtocolIs(
+      "chrome-extension");
+}
+
 v8::Local<v8::Object> GetModuleCache(v8::Isolate* isolate) {
   mate::Dictionary global(isolate, isolate->GetCurrentContext()->Global());
   v8::Local<v8::Value> cache;
@@ -197,7 +202,8 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
 
   // Only allow preload for the main frame or
   // For devtools we still want to run the preload_bundle script
-  if (!render_frame->IsMainFrame() && !IsDevTools(render_frame))
+  if (!render_frame->IsMainFrame() && !IsDevTools(render_frame) &&
+      !IsDevToolsExtension(render_frame))
     return;
 
   auto* isolate = context->GetIsolate();

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -103,16 +103,25 @@ function preloadRequire (module) {
   throw new Error('module not found')
 }
 
-if (window.location.protocol === 'chrome-devtools:') {
-  // Override some inspector APIs.
-  require('@electron/internal/renderer/inspector')
+switch (window.location.protocol) {
+  case 'chrome-devtools:': {
+    // Override some inspector APIs.
+    require('@electron/internal/renderer/inspector')
+    break
+  }
+  case 'chrome-extension:': {
+    // Inject the chrome.* APIs that chrome extensions require
+    const isBackgroundPage = preloadProcess.argv.includes('--background-page')
+    require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, isBackgroundPage, window)
+    break
+  }
 }
 
 if (binding.guestInstanceId) {
   process.guestInstanceId = parseInt(binding.guestInstanceId)
 }
 
-if (!process.guestInstanceId && preloadProcess.argv.indexOf('--webview-tag=true') !== -1) {
+if (!process.guestInstanceId && preloadProcess.argv.includes('--webview-tag=true')) {
   // don't allow recursive `<webview>`
   require('@electron/internal/renderer/web-view/web-view')
   require('@electron/internal/renderer/web-view/web-view-attributes')


### PR DESCRIPTION
With mixed sandbox enabled we need to load the chrome.* APIs in the
sandbox init.js so that chrome extensions load correctly.

This mirrors the equivilant impl in `atom_renderer_client.cc`

Refs: https://github.com/electron/electron/blob/master/atom/renderer/atom_renderer_client.cc#L84-L98

Fixes #15561

Notes: fix loading chrome devtools extensions with sandbox enabled