### PR TITLE
fix: incorrect view ordering for customButtonsOnHover

### DIFF
--- a/atom/browser/api/atom_api_browser_window_mac.mm
+++ b/atom/browser/api/atom_api_browser_window_mac.mm
@@ -62,7 +62,12 @@ void BrowserWindow::OverrideNSWindowContentView(InspectableWebContents* iwc) {
   NSView* webView = iwc->GetView()->GetNativeView();
   NSView* contentView = [window()->GetNativeWindow() contentView];
   [webView setFrame:[contentView bounds]];
-  [contentView addSubview:webView];
+
+  // ensure that buttons view is floated to top of view hierarchy
+  NSArray* subviews = [contentView subviews];
+  NSView* last = subviews.lastObject;
+  [contentView addSubview:webView positioned:NSWindowBelow relativeTo:last];
+
   [contentView viewDidMoveToWindow];
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1405,6 +1405,8 @@ void NativeWindowMac::AddContentViewLayers() {
     if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER) {
       buttons_view_.reset(
           [[CustomWindowButtonView alloc] initWithFrame:NSZeroRect]);
+      // NSWindowStyleMaskFullSizeContentView does not work with zoom button
+      SetFullScreenable(false);
       [[window_ contentView] addSubview:buttons_view_];
     } else {
       if (title_bar_style_ != NORMAL)

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -76,9 +76,6 @@
   NSButton* miniaturize_button =
       [NSWindow standardWindowButton:NSWindowMiniaturizeButton
                         forStyleMask:NSWindowStyleMaskTitled];
-  NSButton* zoom_button =
-      [NSWindow standardWindowButton:NSWindowZoomButton
-                        forStyleMask:NSWindowStyleMaskTitled];
 
   CGFloat x = 0;
   const CGFloat space_between = 20;
@@ -91,11 +88,7 @@
   x += space_between;
   [self addSubview:miniaturize_button];
 
-  [zoom_button setFrameOrigin:NSMakePoint(x, 0)];
-  x += space_between;
-  [self addSubview:zoom_button];
-
-  const auto last_button_frame = zoom_button.frame;
+  const auto last_button_frame = miniaturize_button.frame;
   [self setFrameSize:NSMakeSize(last_button_frame.origin.x +
                                     last_button_frame.size.width,
                                 last_button_frame.size.height)];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -222,11 +222,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       the top left.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-    * `customButtonsOnHover` Boolean (optional) - Draw custom close, minimize,
-      and full screen buttons on macOS frameless windows. These buttons will not
-      display unless hovered over in the top left of the window. These custom
-      buttons prevent issues with mouse events that occur with the standard
-      window toolbar buttons. **Note:** This option is currently experimental.
+    * `customButtonsOnHover` Boolean (optional) - Draw custom close,
+      and minimize buttons on macOS frameless windows. These buttons will not display unless hovered over in the top left of the window. These custom buttons prevent issues with mouse events that occur with the standard window toolbar buttons. **Note:** This option is currently experimental.
   * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
     title bar in full screen mode on macOS for all `titleBarStyle` options.
     Default is `false`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -223,7 +223,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
     * `customButtonsOnHover` Boolean (optional) - Draw custom close,
-      and minimize buttons on macOS frameless windows. These buttons will not display unless hovered over in the top left of the window. These custom buttons prevent issues with mouse events that occur with the standard window toolbar buttons. **Note:** This option is currently experimental.
+      and minimize buttons on macOS frameless windows. These buttons will not display
+      unless hovered over in the top left of the window. These custom buttons prevent
+      issues with mouse events that occur with the standard window toolbar buttons.
+      **Note:** This option is currently experimental.
   * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
     title bar in full screen mode on macOS for all `titleBarStyle` options.
     Default is `false`.

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -50,7 +50,11 @@ win.show()
 #### `customButtonsOnHover`
 
 Uses custom drawn close, and miniaturize buttons that display
-when hovering in the top left of the window. The fullscreen button is not available due to restrictions of frameless windows as they interface with Apple's MacOS window masks. These custom buttons prevent issues with mouse events that occur with the standard window toolbar buttons. This option is only applicable for frameless windows.
+when hovering in the top left of the window. The fullscreen button
+is not available due to restrictions of frameless windows as they
+interface with Apple's MacOS window masks. These custom buttons prevent
+issues with mouse events that occur with the standard window toolbar buttons.
+This option is only applicable for frameless windows.
 
 ```javascript
 const { BrowserWindow } = require('electron')

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -49,10 +49,8 @@ win.show()
 
 #### `customButtonsOnHover`
 
-Uses custom drawn close, miniaturize, and fullscreen buttons that display
-when hovering in the top left of the window. These custom buttons prevent issues
-with mouse events that occur with the standard window toolbar buttons. This
-option is only applicable for frameless windows.
+Uses custom drawn close, and miniaturize buttons that display
+when hovering in the top left of the window. The fullscreen button is not available due to restrictions of frameless windows as they interface with Apple's MacOS window masks. These custom buttons prevent issues with mouse events that occur with the standard window toolbar buttons. This option is only applicable for frameless windows.
 
 ```javascript
 const { BrowserWindow } = require('electron')


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/14412.

`BrowserWindow::OverrideNSWindowContentView()` calls `NativeWindowMac::OverrideNSWindowContentView()`, which calls `AddContentViewLayers()`,  which adds the `CustomWindowButtonView`. `BrowserWindow::OverrideNSWindowContentView()` then later on adds the `webView`, which meant that the `CustomWindowButtonView` no longer existed at the top of the view hierarchy and was therefore rendered unclickable.

This PR ensures that the buttons view is always floated to the top of the view hierarchy.

https://github.com/electron/electron/issues/15704 also requires us to disable fullscreen capabilities, which i've also done in this PR.

/cc @MarshallOfSound

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: fix unclickable buttons when using `customButtonsOnHover`