### PR TITLE
fix: hiddenInset titleBar console spam

### DIFF
--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -232,6 +232,7 @@
     // Turn off the style for toolbar.
     if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
       shell_->SetStyleMask(false, NSWindowStyleMaskFullSizeContentView);
+      [window setTitlebarAppearsTransparent:YES];
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

Set `[window setTitlebarAppearsTransparent:YES];` for `hiddenInset`. Should fix some of the remaining console spam users see:

```
2018-10-02 12:06:59.730 Electron[34332:825632] *** WARNING: Textured window <AtomNSWindow: 0x7fa08cd74cb0> is getting an implicitly transparent titlebar. This will break when linking against newer SDKs. Use NSWindow's -titlebarAppearsTransparent=YES instead.
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fix: hiddenInset titleBar console spam