### PR TITLE
refactor: remove 10.9 specific window conditions

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1360,9 +1360,8 @@ views::View* NativeWindowMac::GetContentsView() {
 
 void NativeWindowMac::AddContentViewLayers() {
   // Make sure the bottom corner is rounded for non-modal windows:
-  // http://crbug.com/396264. But do not enable it on OS X 10.9 for transparent
-  // window, otherwise a semi-transparent frame would show.
-  if (!(transparent() && base::mac::IsOS10_9()) && !is_modal()) {
+  // http://crbug.com/396264.
+  if (!is_modal()) {
     // For normal window, we need to explicitly set layer for contentView to
     // make setBackgroundColor work correctly.
     // There is no need to do so for frameless window, and doing so would make
@@ -1399,14 +1398,8 @@ void NativeWindowMac::AddContentViewLayers() {
           [[CustomWindowButtonView alloc] initWithFrame:NSZeroRect]);
       [[window_ contentView] addSubview:buttons_view_];
     } else {
-      if (title_bar_style_ != NORMAL) {
-        if (base::mac::IsOS10_9()) {
-          ShowWindowButton(NSWindowZoomButton);
-          ShowWindowButton(NSWindowMiniaturizeButton);
-          ShowWindowButton(NSWindowCloseButton);
-        }
+      if (title_bar_style_ != NORMAL)
         return;
-      }
 
       // Hide the window buttons.
       [[window_ standardWindowButton:NSWindowZoomButton] setHidden:YES];


### PR DESCRIPTION
#### Description of Change

Per https://github.com/electron/electron/pull/15357, we support a minimum MacOS version 10.10. This thus removes some code remnants specific to MacOS 10.9 present in `native_window_mac`.

/cc @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes