### PR TITLE
chore: fix missing \n at end of exported patches

### DIFF
--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -123,7 +123,7 @@ def main(argv):
     for patch in patches:
       filename = get_file_name(patch)
       with open(os.path.join(out_dir, filename), 'w') as f:
-        f.write('\n'.join(remove_patch_filename(patch)))
+        f.write('\n'.join(remove_patch_filename(patch)).rstrip('\n') + '\n')
       pl.write(filename + '\n')
 
 


### PR DESCRIPTION
#### Description of Change
`git-export-patches` was failing to append a `\n` to the last exported patch, without which the patch was failing to apply.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes