### PR TITLE
docs: add more links to the devtools protocol docs

### DIFF
--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -51,7 +51,7 @@ Detaches the debugger from the `webContents`.
 #### `debugger.sendCommand(method[, commandParams, callback])`
 
 * `method` String - Method name, should be one of the methods defined by the
-   remote debugging protocol.
+   [remote debugging protocol][rdp].
 * `commandParams` Object (optional) - JSON object with request parameters.
 * `callback` Function (optional) - Response
   * `error` Object - Error message indicating the failure of the command.
@@ -79,5 +79,5 @@ Emitted when debugging session is terminated. This happens either when
 
 Emitted whenever debugging target issues instrumentation event.
 
-[rdp]: https://developer.chrome.com/devtools/docs/debugger-protocol
+[rdp]: https://chromedevtools.github.io/devtools-protocol/
 [`webContents.findInPage`]: web-contents.md#contentsfindinpagetext-options


### PR DESCRIPTION
I missed the link at the top when I was skimming this documentation

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes