### PR TITLE
chore: add simple set/unset loginitem spec

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -486,6 +486,16 @@ describe('app module', () => {
       }, delay)
     })
 
+    it('correctly sets and unsets the LoginItem', function () {
+      expect(app.getLoginItemSettings().openAtLogin).to.be.false()
+
+      app.setLoginItemSettings({ openAtLogin: true })
+      expect(app.getLoginItemSettings().openAtLogin).to.be.true()
+
+      app.setLoginItemSettings({ openAtLogin: false })
+      expect(app.getLoginItemSettings().openAtLogin).to.be.false()
+    })
+
     it('correctly sets and unsets the LoginItem as hidden', function () {
       if (process.platform !== 'darwin' || process.mas) this.skip()
 


### PR DESCRIPTION
#### Description of Change

When natively implementing RemoveFromLoginItems a while back, i tested locally but forgot to include the most basic simple test: that it can simply set and unset the `LoginItem` with no other conditions. This should prevent regressions of that type from recurring.

/cc @nornagon

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes