### PR TITLE
fix: make feature strings more robust to whitespace

### DIFF
--- a/lib/common/parse-features-string.js
+++ b/lib/common/parse-features-string.js
@@ -4,12 +4,12 @@
 // - `features` input string
 // - `emit` function(key, value) - called for each parsed KV
 module.exports = function parseFeaturesString (features, emit) {
-  features = `${features}`
+  features = `${features}`.trim()
   // split the string by ','
-  features.split(/,\s*/).forEach((feature) => {
+  features.split(/\s*,\s*/).forEach((feature) => {
     // expected form is either a key by itself or a key/value pair in the form of
     // 'key=value'
-    let [key, value] = feature.split(/\s*=/)
+    let [key, value] = feature.split(/\s*=\s*/)
     if (!key) return
 
     // interpret the value as a boolean, if possible

--- a/spec/internal-spec.js
+++ b/spec/internal-spec.js
@@ -1,0 +1,23 @@
+const chai = require('chai')
+const { expect } = chai
+
+describe('feature-string parsing', () => {
+  it('is indifferent to whitespace around keys and values', () => {
+    const parseFeaturesString = require('@electron/internal/common/parse-features-string')
+    const checkParse = (string, parsed) => {
+      const features = {}
+      parseFeaturesString(string, (k, v) => { features[k] = v })
+      expect(features).to.deep.equal(parsed)
+    }
+    checkParse('a=yes,c=d', { a: true, c: 'd' })
+    checkParse('a=yes ,c=d', { a: true, c: 'd' })
+    checkParse('a=yes, c=d', { a: true, c: 'd' })
+    checkParse('a=yes , c=d', { a: true, c: 'd' })
+    checkParse(' a=yes , c=d', { a: true, c: 'd' })
+    checkParse(' a= yes , c=d', { a: true, c: 'd' })
+    checkParse(' a = yes , c=d', { a: true, c: 'd' })
+    checkParse(' a = yes , c =d', { a: true, c: 'd' })
+    checkParse(' a = yes , c = d', { a: true, c: 'd' })
+    checkParse(' a = yes , c = d ', { a: true, c: 'd' })
+  })
+})


### PR DESCRIPTION
Fixes #15594

The algorithm was already _slightly_ lenient about whitespace, but surprisingly so. This makes it ignore all whitespace around `,` and `=` (and at beginning/end of the feature string).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: be more lenient about whitespace in webview's "webpreferences" feature string