### PR TITLE
fix: Linux empty menu model handling

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -894,7 +894,6 @@ void NativeWindowViews::SetMenu(AtomMenuModel* menu_model) {
   if (menu_model == nullptr) {
     global_menu_bar_.reset();
     root_view_->UnregisterAcceleratorsWithFocusManager();
-    return;
   }
 
   if (!global_menu_bar_ && ShouldUseGlobalMenuBar())

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -178,10 +178,10 @@ bool RootView::AcceleratorPressed(const ui::Accelerator& accelerator) {
 }
 
 void RootView::RegisterAcceleratorsWithFocusManager(AtomMenuModel* menu_model) {
-  // Clear previous accelerators.
-  UnregisterAcceleratorsWithFocusManager();
   if (!menu_model)
     return;
+  // Clear previous accelerators.
+  UnregisterAcceleratorsWithFocusManager();
   views::FocusManager* focus_manager = GetFocusManager();
   // Register accelerators with focus manager.
   accelerator_util::GenerateAcceleratorTable(&accelerator_table_, menu_model);

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -180,7 +180,8 @@ bool RootView::AcceleratorPressed(const ui::Accelerator& accelerator) {
 void RootView::RegisterAcceleratorsWithFocusManager(AtomMenuModel* menu_model) {
   // Clear previous accelerators.
   UnregisterAcceleratorsWithFocusManager();
-
+  if (!menu_model)
+    return;
   views::FocusManager* focus_manager = GetFocusManager();
   // Register accelerators with focus manager.
   accelerator_util::GenerateAcceleratorTable(&accelerator_table_, menu_model);


### PR DESCRIPTION
#### Description of Change
Folks, I caused #15601 with a previous menu change. Didn't realise `null` menu should clear the menu on linux. This PR fixes that.
We cannot have test for that in 3.0, but with the currently running master PR (#15094), tests should cover this scenario.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Empty menu now clears the menu on linux like before