### PR TITLE
build: add v8_context_snapshot_generator to mksnapshot zip

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -912,6 +912,7 @@ dist_zip("electron_chromedriver_zip") {
 dist_zip("electron_mksnapshot_zip") {
   data_deps = [
     "//v8:mksnapshot($v8_snapshot_toolchain)",
+    "//tools/v8_context_snapshot:v8_context_snapshot_generator",
     ":licenses",
   ]
   outputs = [


### PR DESCRIPTION
#### Description of Change
v8_context_snapshot_generator is needed when creating custom snapshots with mksnapshot, so this PR adds that binary to the mksnapshot.zip
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: added v8_context_snapshot_generator to mksnapshot.zip