### PR TITLE
fix: correctly package Login Helper in mas builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -678,7 +678,7 @@ if (is_mac) {
       "$root_out_dir/$electron_login_helper_name.app",
     ]
     outputs = [
-      "{{bundle_contents_dir}}/Library/LoginItems",
+      "{{bundle_contents_dir}}/Library/LoginItems/{{source_file_part}}",
     ]
   }
 


### PR DESCRIPTION
#### Description of Change
The Login Helper app structure was missing a directory in MAS builds. Before:

```
out/Testing-mas/Electron.app/Contents/Library
└── LoginItems
    └── Contents
        ├── Info.plist
        ├── MacOS
        │   └── Electron\ Login\ Helper
        └── PkgInfo
```

after:

```
out/Testing-mas/Electron.app/Contents/Library
└── LoginItems
    └── Electron\ Login\ Helper.app
        └── Contents
            ├── Info.plist
            ├── MacOS
            │   └── Electron\ Login\ Helper
            └── PkgInfo
```

Fixes #15567

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fixed issue with incorrectly packaged Login Helper app, which caused issues with signing apps