### PR TITLE
chore: fix missing \n at end of exported patches (#15579) (backport: 4-0-x)

### DIFF
--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -123,7 +123,7 @@ def main(argv):
     for patch in patches:
       filename = get_file_name(patch)
       with open(os.path.join(out_dir, filename), 'w') as f:
-        f.write('\n'.join(remove_patch_filename(patch)))
+        f.write('\n'.join(remove_patch_filename(patch)).rstrip('\n') + '\n')
       pl.write(filename + '\n')
 
 


### PR DESCRIPTION
Backport of #15579

See that PR for details.

Notes: no-notes