### PR TITLE
feat: add media access apis for mojave

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -595,6 +595,7 @@ if (is_mac) {
     sources = filenames.framework_sources
 
     libs = [
+      "AVFoundation.framework",
       "Carbon.framework",
       "QuartzCore.framework",
       "Quartz.framework",

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -89,6 +89,9 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::GetAppLevelAppearance)
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
+      .SetMethod("getMediaAccessStatus",
+                 &SystemPreferences::GetMediaAccessStatus)
+      .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)
 #endif
       .SetMethod("isInvertedColorScheme",
                  &SystemPreferences::IsInvertedColorScheme)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "atom/browser/api/event_emitter.h"
+#include "atom/common/promise_util.h"
 #include "base/callback.h"
 #include "base/values.h"
 #include "native_mate/handle.h"
@@ -89,6 +90,13 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
                       mate::Arguments* args);
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
+
+  // TODO(codebytere): Write tests for these methods once we
+  // are running tests on a Mojave machine
+  std::string GetMediaAccessStatus(const std::string& media_type,
+                                   mate::Arguments* args);
+  v8::Local<v8::Promise> AskForMediaAccess(v8::Isolate* isolate,
+                                           const std::string& media_type);
 
   // TODO(MarshallOfSound): Write tests for these methods once we
   // are running tests on a Mojave machine

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -6,12 +6,35 @@
 #include "base/mac/scoped_nsobject.h"
 #include "base/mac/scoped_sending_event.h"
 
-// Forward Declare Appareance APIs
+#import <AVFoundation/AVFoundation.h>
+
+// Forward Declare Appearance APIs
 @interface NSApplication (HighSierraSDK)
 @property(copy, readonly)
     NSAppearance* effectiveAppearance API_AVAILABLE(macosx(10.14));
 @property(copy, readonly) NSAppearance* appearance API_AVAILABLE(macosx(10.14));
 - (void)setAppearance:(NSAppearance*)appearance API_AVAILABLE(macosx(10.14));
+@end
+
+// forward declare Access APIs
+typedef NSString* AVMediaType NS_EXTENSIBLE_STRING_ENUM;
+
+AVF_EXPORT AVMediaType const AVMediaTypeVideo;
+AVF_EXPORT AVMediaType const AVMediaTypeAudio;
+
+typedef NS_ENUM(NSInteger, AVAuthorizationStatusMac) {
+  AVAuthorizationStatusNotDeterminedMac = 0,
+  AVAuthorizationStatusRestrictedMac = 1,
+  AVAuthorizationStatusDeniedMac = 2,
+  AVAuthorizationStatusAuthorizedMac = 3,
+};
+
+@interface AVCaptureDevice (MojaveSDK)
++ (void)requestAccessForMediaType:(AVMediaType)mediaType
+                completionHandler:(void (^)(BOOL granted))handler
+    API_AVAILABLE(macosx(10.14));
++ (AVAuthorizationStatusMac)authorizationStatusForMediaType:
+    (AVMediaType)mediaType API_AVAILABLE(macosx(10.14));
 @end
 
 extern "C" {

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -311,7 +311,6 @@ using `electron-packager` or `electron-forge` just set the `enableDarwinDarkMode
 packager option to `true`.  See the [Electron Packager API](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
 for more details.
 
-
 ### `systemPreferences.getAppLevelAppearance()` _macOS_
 
 Returns `String` | `null` - Can be `dark`, `light` or `unknown`.
@@ -326,3 +325,21 @@ You can use the `setAppLevelAppearance` API to set this value.
 
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
+
+### `systemPreferences.getMediaAccessStatus(mediaType)` _macOS_
+
+* `mediaType` String - `microphone` or `camera`.
+
+Returns `String` - Can be `not-determined`, `granted`, `denied`, `restricted` or `unknown`.
+
+This user consent was not required until macOS 10.14 Mojave, so this method will always return `granted` if your system is running 10.13 High Sierra or lower.
+
+### `systemPreferences.askForMediaAccess(mediaType)` _macOS_
+
+* `mediaType` String - the type of media being requested; can be `microphone`, `camera`.
+
+Returns `Promise<Boolean>` - A promise that resolves with `true` if consent was granted and `false` if it was denied. If an invalid `mediaType` is passed, the promise will be rejected. If an access request was denied and later is changed through the System Preferences pane, a restart of the app will be required for the new permissions to take effect. If access has already been requested and denied, it _must_ be changed through the preference pane; an alert will not pop up and the promise will resolve with the existing access status.
+
+**Important:** In order to properly leverage this API, you [must set](https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos?language=objc) the `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings in your app's `Info.plist` file. The values for these keys will be used to populate the permission dialogs so that the user will be properly informed as to the purpose of the permission request. See [Electron Application Distribution](https://electronjs.org/docs/tutorial/application-distribution#macos) for more information about how to set these in the context of Electron.
+
+This user consent was not required until macOS 10.14 Mojave, so this method will always return `true` if your system is running 10.13 High Sierra or lower.


### PR DESCRIPTION
#### Description of Change

This PR adds new APIs to control new media privacy and consent rules introduced in MacOS Mojave. Namely:

```
systemPreferences.getMediaAccessStatus(mediaType)
systemPreferences.askForMediaAccess(mediaType)
```

Apple Docs:
- [[AVCaptureDevice authorizationStatusForMediaType:]](https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624613-authorizationstatusformediatype?language=objc)
- [[AVCaptureDevice requestAccessForMediaType:completionHandler:]](https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624584-requestaccessformediatype?language=objc)
- [AVAuthorizationStatus](https://developer.apple.com/documentation/avfoundation/avauthorizationstatus?language=objc)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Added media access APIs for macOS Mojave