### PR TITLE
fix: correctly display zoom in accelerator on mac (backport: 4-0-x)

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -79,3 +79,4 @@ content_browser_main_loop.patch
 dump_syms.patch
 web_preferences.patch
 verbose_generate_breakpad_symbols.patch
+fix_zoom_display.patch

--- a/patches/common/chromium/fix_zoom_display.patch
+++ b/patches/common/chromium/fix_zoom_display.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Web Oct 31 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Web, 31 Oct 2018 09:08:02 -0700
+Subject: fix_zoom_display.patch
+
+This patch was released in 70.0.3512.0.
+
+diff --git a/ui/base/accelerators/platform_accelerator_cocoa.mm b/ui/base/accelerators/platform_accelerator_cocoa.mm
+index 9786168be893..3c177060453a 100644
+--- a/ui/base/accelerators/platform_accelerator_cocoa.mm
++++ b/ui/base/accelerators/platform_accelerator_cocoa.mm
+@@ -25,9 +25,16 @@ void GetKeyEquivalentAndModifierMaskFromAccelerator(
+   if (accelerator.IsCmdDown())
+     cocoa_modifiers |= NSEventModifierFlagCommand;
+   unichar shifted_character;
++  unichar character;
+   int result = ui::MacKeyCodeForWindowsKeyCode(
+-      accelerator.key_code(), cocoa_modifiers, &shifted_character, nullptr);
+-  DCHECK(result != -1);
++      accelerator.key_code(), cocoa_modifiers, &shifted_character, &character);
++  DCHECK_NE(result, -1);
++
++  // If the key equivalent is itself shifted, then drop Shift from the modifier
++  // flags, otherwise Shift will be required. E.g., curly braces and plus are
++  // both inherently shifted, so the key equivalents shouldn't require Shift.
++  if (shifted_character != character)
++    cocoa_modifiers &= ~NSEventModifierFlagShift;
+   *key_equivalent = [NSString stringWithFormat:@"%C", shifted_character];
+   *modifier_mask = cocoa_modifiers;
+ }

--- a/patches/common/chromium/fix_zoom_display.patch
+++ b/patches/common/chromium/fix_zoom_display.patch
@@ -3,6 +3,7 @@ From: Shelley Vohr <shelley.vohr@gmail.com>
 Date: Web, 31 Oct 2018 09:08:02 -0700
 Subject: fix_zoom_display.patch
 
+Backport of https://chromium-review.googlesource.com/c/chromium/src/+/1157224. 
 This patch was released in 70.0.3512.0.
 
 diff --git a/ui/base/accelerators/platform_accelerator_cocoa.mm b/ui/base/accelerators/platform_accelerator_cocoa.mm


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/15502.

/cc @alexeykuzmin

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: fix incorrect display of 'zoom in' accelerator on mac