### PR TITLE
fix: make certain values on `process` read-only

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -72,19 +72,18 @@ void AtomBindings::BindTo(v8::Isolate* isolate, v8::Local<v8::Object> process) {
                                               base::Unretained(this)));
 
 #if defined(MAS_BUILD)
-  dict.Set("mas", true);
+  dict.SetReadOnly("mas", true);
 #endif
 
 #if defined(OS_WIN)
   if (IsRunningInDesktopBridge())
-    dict.Set("windowsStore", true);
+    dict.SetReadOnly("windowsStore", true);
 #endif
 
   mate::Dictionary versions;
   if (dict.Get("versions", &versions)) {
-    // TODO(kevinsawicki): Make read-only in 2.0 to match node
-    versions.Set(ATOM_PROJECT_NAME, ATOM_VERSION_STRING);
-    versions.Set("chrome", CHROME_VERSION_STRING);
+    versions.SetReadOnly(ATOM_PROJECT_NAME, ATOM_VERSION_STRING);
+    versions.SetReadOnly("chrome", CHROME_VERSION_STRING);
   }
 }
 

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -339,7 +339,7 @@ node::Environment* NodeBindings::CreateEnvironment(
   }
 
   mate::Dictionary process(context->GetIsolate(), env->process_object());
-  process.Set("type", process_type);
+  process.SetReadOnly("type", process_type);
   process.Set("resourcesPath", resources_path);
   // Do not set DOM globals for renderer process.
   if (browser_env_ != BROWSER)

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -158,18 +158,18 @@ void AtomSandboxedRendererClient::InitializeBindings(
 
   process.Set("argv", base::CommandLine::ForCurrentProcess()->argv());
   process.Set("execPath", GetExecPath());
-  process.Set("pid", base::GetCurrentProcId());
+  process.SetReadOnly("pid", base::GetCurrentProcId());
   process.Set("resourcesPath", NodeBindings::GetHelperResourcesPath());
-  process.Set("sandboxed", true);
-  process.Set("type", "renderer");
+  process.SetReadOnly("sandboxed", true);
+  process.SetReadOnly("type", "renderer");
 
 #if defined(MAS_BUILD)
-  process.Set("mas", true);
+  process.SetReadOnly("mas", true);
 #endif
 
 #if defined(OS_WIN)
   if (IsRunningInDesktopBridge())
-    process.Set("windowsStore", true);
+    process.SetReadOnly("windowsStore", true);
 #endif
 
   // Pass in CLI flags needed to setup the renderer

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -103,7 +103,7 @@ A `Boolean` that controls whether or not process warnings printed to `stderr` in
 
 ### `process.type`
 
-A `String` representing the current process's type, can be `"browser"` (i.e. main process) or `"renderer"`.
+A `String` representing the current process's type, can be `"browser"` (i.e. main process), `"renderer"`, or `"worker"` (i.e. web worker).
 
 ### `process.versions.chrome`
 


### PR DESCRIPTION
#### Description of Change

Certain values on the `process` object should be read-only, either to match similar values (e.g. `process.versions.x`) or because it doesn't make sense for the values to be changed (because they represent some condition that cannot be changed).

Part of this change was slated for v2.0, but the change was not made in that version.

The values that I've made read-only are:

* `process.mas`
* `process.windowsStore`
* `process.versions.electron`
* `process.versions.chrome`
* `process.type`
* `process.pid`
* `process.sandboxed`

I'm fairly certain there's no good reason for any of these values to *not* be read-only, but please comment if I've missed something.

Fixes https://github.com/electron/electron/issues/8083

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: fix: make certain values on `process` read-only