### PR TITLE
chore: restore WTF::StringImpl dchecks

### DIFF
--- a/patches/common/chromium/dcheck.patch
+++ b/patches/common/chromium/dcheck.patch
@@ -45,35 +45,6 @@ index 6dfe29cb33f494228c254ca4a1890626af68e2d7..30fa308bca29c77e4708b108d17a7e5e
    // The browser requested to clear the session history when it initiated the
    // navigation. Now we know that the renderer has updated its state accordingly
    // and it is safe to also clear the browser side history.
-diff --git a/third_party/blink/renderer/platform/wtf/text/string_impl.h b/third_party/blink/renderer/platform/wtf/text/string_impl.h
-index 3073b0856d29e442f8905041350a2bb196aa24ce..e997f094c75e055b44ce4a31c359c31cb1f25a14 100644
---- a/third_party/blink/renderer/platform/wtf/text/string_impl.h
-+++ b/third_party/blink/renderer/platform/wtf/text/string_impl.h
-@@ -258,21 +258,21 @@ class WTF_EXPORT StringImpl {
-   }
- 
-   ALWAYS_INLINE bool HasOneRef() const {
--#if DCHECK_IS_ON()
-+#if 0
-     DCHECK(IsStatic() || verifier_.IsSafeToUse()) << AsciiForDebugging();
- #endif
-     return ref_count_ == 1;
-   }
- 
-   ALWAYS_INLINE void AddRef() const {
--#if DCHECK_IS_ON()
-+#if 0
-     DCHECK(IsStatic() || verifier_.OnRef(ref_count_)) << AsciiForDebugging();
- #endif
-     ++ref_count_;
-   }
- 
-   ALWAYS_INLINE void Release() const {
--#if DCHECK_IS_ON()
-+#if 0
-     DCHECK(IsStatic() || verifier_.OnDeref(ref_count_))
-         << AsciiForDebugging() << " " << CurrentThread();
- #endif
 diff --git a/ui/base/clipboard/clipboard_win.cc b/ui/base/clipboard/clipboard_win.cc
 index 1857bfa07ce3d8656105e696363a760889794e77..c25d8c241907fb166218670533a3b6e1e2f32769 100644
 --- a/ui/base/clipboard/clipboard_win.cc


### PR DESCRIPTION
Restore commented-out DCHECKS in WTF::StringImpl

Notes: no-notes