### PR TITLE
[wip] chore: restore clipboard_win.cc dchecks

### DIFF
--- a/patches/common/chromium/dcheck.patch
+++ b/patches/common/chromium/dcheck.patch
@@ -45,19 +45,3 @@ index a28b7c8a3947371a9a17b3094f0b33fd3c03aba9..63929875aef3525e20ade2dcb5dcb1d7
    // The browser requested to clear the session history when it initiated the
    // navigation. Now we know that the renderer has updated its state accordingly
    // and it is safe to also clear the browser side history.
-diff --git a/ui/base/clipboard/clipboard_win.cc b/ui/base/clipboard/clipboard_win.cc
-index 49654c95675e0240d82232eb971f85ab3611ab29..8f0737841f70144770dc4dfd7353f7bdba3ffcfd 100644
---- a/ui/base/clipboard/clipboard_win.cc
-+++ b/ui/base/clipboard/clipboard_win.cc
-@@ -726,9 +726,9 @@ void ClipboardWin::WriteBitmapFromHandle(HBITMAP source_hbitmap,
- }
- 
- void ClipboardWin::WriteToClipboard(unsigned int format, HANDLE handle) {
--  DCHECK(clipboard_owner_->hwnd() != NULL);
-+  // DCHECK(clipboard_owner_->hwnd() != NULL);
-   if (handle && !::SetClipboardData(format, handle)) {
--    DCHECK(ERROR_CLIPBOARD_NOT_OPEN != GetLastError());
-+    // DCHECK(ERROR_CLIPBOARD_NOT_OPEN != GetLastError());
-     FreeData(format, handle);
-   }
- }


### PR DESCRIPTION
Restore commented-out DCHECKs in clipboard_win.cc

Notes: no-notes