### PR TITLE
chore: re-enable DCHECK in node_debugger

### DIFF
--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -58,9 +58,8 @@ void NodeDebugger::Start() {
   }
 
   const char* path = "";
-  inspector->Start(path, options);
-  // FIXME
-  // DCHECK(env_->inspector_agent()->IsListening());
+  if (inspector->Start(path, options))
+    DCHECK(env_->inspector_agent()->IsListening());
 }
 
 }  // namespace atom


### PR DESCRIPTION
Did this in a PR that got dropped, this change should still go in though 👍 

Notes: no-notes