### PR TITLE
chore: remove deprecated touch-bar API

### DIFF
--- a/lib/browser/api/touch-bar.js
+++ b/lib/browser/api/touch-bar.js
@@ -31,12 +31,6 @@ class TouchBar extends EventEmitter {
 
     let { items, escapeItem } = options
 
-    // FIXME Support array as first argument, remove in 2.0
-    if (Array.isArray(options)) {
-      items = options
-      escapeItem = null
-    }
-
     if (!Array.isArray(items)) {
       items = []
     }


### PR DESCRIPTION
This was marked for removal way back in the `1.6.x` days --> https://github.com/electron/electron/commit/414540bfcb28cf6c79b35616a48485f265db7378

Seems about time we should remove it 😆 

Notes: Removed support for deprecated construction of a TouchBar with an array of items, use an options object instead