### PR TITLE
fix: no longer require submenu for services menuitem

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -208,7 +208,17 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
 
   base::string16 role = model->GetRoleAt(index);
   atom::AtomMenuModel::ItemType type = model->GetTypeAt(index);
-  if (type == atom::AtomMenuModel::TYPE_SUBMENU) {
+
+  if (role == base::ASCIIToUTF16("services")) {
+    base::string16 title = base::ASCIIToUTF16("Services");
+    NSString* label = l10n_util::FixUpWindowsStyleLabel(title);
+
+    [item setTarget:nil];
+    [item setAction:nil];
+    NSMenu* submenu = [[NSMenu alloc] initWithTitle:label];
+    [item setSubmenu:submenu];
+    [NSApp setServicesMenu:submenu];
+  } else if (type == atom::AtomMenuModel::TYPE_SUBMENU) {
     // Recursively build a submenu from the sub-model at this index.
     [item setTarget:nil];
     [item setAction:nil];
@@ -223,8 +233,6 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
       [NSApp setWindowsMenu:submenu];
     else if (role == base::ASCIIToUTF16("help"))
       [NSApp setHelpMenu:submenu];
-    else if (role == base::ASCIIToUTF16("services"))
-      [NSApp setServicesMenu:submenu];
     else if (role == base::ASCIIToUTF16("recentdocuments"))
       [self replaceSubmenuShowingRecentDocuments:item];
   } else {

--- a/default_app/menu.js
+++ b/default_app/menu.js
@@ -123,8 +123,7 @@ const setDefaultApplicationMenu = () => {
           type: 'separator'
         },
         {
-          role: 'services',
-          submenu: []
+          role: 'services'
         },
         {
           type: 'separator'

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -210,7 +210,7 @@ if (process.platform === 'darwin') {
     submenu: [
       { role: 'about' },
       { type: 'separator' },
-      { role: 'services', submenu: [] },
+      { role: 'services' },
       { type: 'separator' },
       { role: 'hide' },
       { role: 'hideothers' },


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15653.

Adds a condition such that a submenu is automatically created and populated for the `Services` MenuItem role if none is provided by the user. For backwards compatibility, `Services` MenuItems will still correctly be created if a submenu is provided.

/cc @sindresorhus @brenca (for menu stuff)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no longer require submenu for services menuitem