### PR TITLE
feat: add about panel customization on linux

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1290,6 +1290,11 @@ void App::BuildPrototype(v8::Isolate* isolate,
                  base::Bind(&Browser::InvalidateCurrentActivity, browser))
       .SetMethod("updateCurrentActivity",
                  base::Bind(&Browser::UpdateCurrentActivity, browser))
+      // TODO(juturu): Remove in 2.0, deprecate before then with warnings
+      .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
+      .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
+#endif
+#if defined(OS_MACOSX) || defined(OS_LINUX)
       .SetMethod("setAboutPanelOptions",
                  base::Bind(&Browser::SetAboutPanelOptions, browser))
       .SetMethod("showAboutPanel",
@@ -1329,11 +1334,6 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getAppMetrics", &App::GetAppMetrics)
       .SetMethod("getGPUFeatureStatus", &App::GetGPUFeatureStatus)
       .SetMethod("getGPUInfo", &App::GetGPUInfo)
-// TODO(juturu): Remove in 2.0, deprecate before then with warnings
-#if defined(OS_MACOSX)
-      .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
-      .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
-#endif
 #if defined(MAS_BUILD)
       .SetMethod("startAccessingSecurityScopedResource",
                  &App::StartAccessingSecurityScopedResource)

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -180,9 +180,12 @@ class Browser : public WindowListObserver {
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
 
+#endif  // defined(OS_MACOSX)
+
+#if defined(OS_MACOSX) || defined(OS_LINUX)
   void ShowAboutPanel();
   void SetAboutPanelOptions(const base::DictionaryValue& options);
-#endif  // defined(OS_MACOSX)
+#endif
 
 #if defined(OS_WIN)
   struct UserTask {
@@ -288,7 +291,7 @@ class Browser : public WindowListObserver {
 
   util::Promise* ready_promise_ = nullptr;
 
-#if defined(OS_MACOSX)
+#if defined(OS_LINUX) || defined(OS_MACOSX)
   base::DictionaryValue about_panel_options_;
 #endif
 

--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -142,4 +142,44 @@ bool Browser::IsUnityRunning() {
   return unity::IsRunning();
 }
 
+void Browser::ShowAboutPanel() {
+  std::string app_name, version, copyright, icon_path, website;
+
+  GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(gtk_about_dialog_new());
+
+  if (about_panel_options_.GetString("applicationName", &app_name))
+    gtk_about_dialog_set_program_name(dialog, app_name.c_str());
+  if (about_panel_options_.GetString("applicationVersion", &version))
+    gtk_about_dialog_set_version(dialog, version.c_str());
+  if (about_panel_options_.GetString("copyright", &copyright))
+    gtk_about_dialog_set_copyright(dialog, copyright.c_str());
+  if (about_panel_options_.GetString("website", &website))
+    gtk_about_dialog_set_website(dialog, website.c_str());
+  if (about_panel_options_.GetString("iconPath", &icon_path)) {
+    GError* error = nullptr;
+    GdkPixbuf* icon = gdk_pixbuf_new_from_file(icon_path.c_str(), &error);
+    if (error != nullptr) {
+      g_warning("%s", error->message);
+      g_clear_error(&error);
+    } else {
+      gtk_about_dialog_set_logo(dialog, icon);
+      g_clear_object(&icon);
+    }
+  }
+
+  gtk_dialog_run(GTK_DIALOG(dialog));
+  g_clear_object(&dialog);
+}
+
+void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
+  about_panel_options_.Clear();
+
+  for (const auto& pair : options) {
+    const std::string& key = pair.first;
+    const auto& val = pair.second;
+    if (!key.empty() && val->is_string())
+      about_panel_options_.SetString(key, val->GetString());
+  }
+}
+
 }  // namespace atom

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -392,13 +392,12 @@ void Browser::ShowAboutPanel() {
 void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
   about_panel_options_.Clear();
 
-  // Upper case option keys for orderFrontStandardAboutPanelWithOptions format
-  for (base::DictionaryValue::Iterator iter(options); !iter.IsAtEnd();
-       iter.Advance()) {
-    std::string key = iter.key();
-    if (!key.empty() && iter.value().is_string()) {
+  for (const auto& pair : options) {
+    std::string key = pair.first;
+    const auto& val = pair.second;
+    if (!key.empty() && val->is_string()) {
       key[0] = base::ToUpperASCII(key[0]);
-      about_panel_options_.SetString(key, iter.value().GetString());
+      about_panel_options_.SetString(key, val->GetString());
     }
   }
 }

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1064,22 +1064,23 @@ details. Disabled by default.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 
-### `app.showAboutPanel()` _macOS_
+### `app.showAboutPanel` _macOS_ _Linux_
 
-Show the about panel with the values defined in the app's
-`.plist` file or with the options set via `app.setAboutPanelOptions(options)`.
+Show the app's about panel options. These options can be overridden with `app.setAboutPanelOptions(options)`.
 
-### `app.setAboutPanelOptions(options)` _macOS_
+### `app.setAboutPanelOptions(options)` _macOS_ _Linux_
 
 * `options` Object
   * `applicationName` String (optional) - The app's name.
   * `applicationVersion` String (optional) - The app's version.
   * `copyright` String (optional) - Copyright information.
-  * `credits` String (optional) - Credit information.
-  * `version` String (optional) - The app's build version number.
+  * `version` String (optional) - The app's build version number. _macOS_
+  * `credits` String (optional) - Credit information. _macOS_
+  * `website` String (optional) - The app's website. _Linux_
+  * `iconPath` String (optional) - Path to the app's icon. _Linux_
 
 Set the about panel options. This will override the values defined in the app's
-`.plist` file. See the [Apple docs][about-panel-options] for more details.
+`.plist` file on MacOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.
 
 ### `app.startAccessingSecurityScopedResource(bookmarkData)` _macOS (mas)_
 


### PR DESCRIPTION
#### Description of Change

Refs: https://github.com/electron/electron/issues/15591.

Adds an about panel on Linux with options to customize via `setAboutPanelOptions`.

/cc @ckerr @sindresorhus

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: add about panel customization on linux