### PR TITLE
feat: expose showAboutPanel for MacOS

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1292,6 +1292,8 @@ void App::BuildPrototype(v8::Isolate* isolate,
                  base::Bind(&Browser::UpdateCurrentActivity, browser))
       .SetMethod("setAboutPanelOptions",
                  base::Bind(&Browser::SetAboutPanelOptions, browser))
+      .SetMethod("showAboutPanel",
+                 base::Bind(&Browser::ShowAboutPanel, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks", base::Bind(&Browser::SetUserTasks, browser))

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1064,6 +1064,11 @@ details. Disabled by default.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 
+### `app.showAboutPanel()` _macOS_
+
+Show the about panel with the values defined in the app's
+`.plist` file or with the options set via `app.setAboutPanelOptions(options)`.
+
 ### `app.setAboutPanelOptions(options)` _macOS_
 
 * `options` Object


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15592.

Exposes and documents `showAboutPanel` for MacOS, allowing users to trigger the panel manually.

/cc @sindresorhus @MarshallOfSound

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: expose showAboutPanel for MacOS