### PR TITLE
feat: allow partial setting of window bounds

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -896,7 +896,21 @@ Closes the currently open [Quick Look][quick-look] panel.
 * `bounds` [Rectangle](structures/rectangle.md)
 * `animate` Boolean (optional) _macOS_
 
-Resizes and moves the window to the supplied bounds
+Resizes and moves the window to the supplied bounds. Also allows setting any of the `x`, `y`, `width`, or `height` properties, instead of setting them all at once. Properties that are not set will fall back to their current values.
+
+```javascript
+const { BrowserWindow } = require('electron')
+let win = new BrowserWindow()
+
+// set all bounds properties
+win.setBounds({ x: 440, y: 225, width: 800, height: 600 })
+
+// set a single bounds property
+win.setBounds({ width: 100 })
+
+// { x: 440, y: 225, width: 100, height: 600 }
+console.log(win.getBounds())
+```
 
 #### `win.getBounds()`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -896,7 +896,7 @@ Closes the currently open [Quick Look][quick-look] panel.
 * `bounds` [Rectangle](structures/rectangle.md)
 * `animate` Boolean (optional) _macOS_
 
-Resizes and moves the window to the supplied bounds. Also allows setting any of the `x`, `y`, `width`, or `height` properties, instead of setting them all at once. Properties that are not set will fall back to their current values.
+Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.
 
 ```javascript
 const { BrowserWindow } = require('electron')

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -900,7 +900,7 @@ Resizes and moves the window to the supplied bounds. Also allows setting any of 
 
 ```javascript
 const { BrowserWindow } = require('electron')
-let win = new BrowserWindow()
+const win = new BrowserWindow()
 
 // set all bounds properties
 win.setBounds({ x: 440, y: 225, width: 800, height: 600 })

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -18,12 +18,12 @@ BrowserWindow.prototype._init = function () {
   this.setContentView(new WebContentsView(this.webContents))
 
   const nativeSetBounds = this.setBounds
-  this.setBounds = (bounds, animate) => {
+  this.setBounds = (bounds, ...opts) => {
     bounds = {
       ...this.getBounds(),
       ...bounds
     }
-    nativeSetBounds.call(this, bounds, animate)
+    nativeSetBounds.call(this, bounds, ...opts)
   }
 
   // Make new windows requested by links behave like "window.open"

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -17,6 +17,15 @@ BrowserWindow.prototype._init = function () {
   // Create WebContentsView.
   this.setContentView(new WebContentsView(this.webContents))
 
+  const nativeSetBounds = this.setBounds
+  this.setBounds = (bounds, animate) => {
+    bounds = {
+      ...this.getBounds(),
+      ...bounds
+    }
+    nativeSetBounds.call(this, bounds, animate)
+  }
+
   // Make new windows requested by links behave like "window.open"
   this.webContents.on('-new-window', (event, url, frameName, disposition,
     additionalFeatures, postData,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -536,15 +536,11 @@ describe('BrowserWindow module', () => {
       const fullBounds = { x: 440, y: 225, width: 500, height: 400 }
       w.setBounds(fullBounds)
 
-      assertBoundsEqual(w.getBounds(), fullBounds)
+      const boundsUpdate = { width: 100 }
+      w.setBounds(boundsUpdate)
 
-      w.setBounds({ width: 100 })
-      assertBoundsEqual(w.getBounds(), {
-        x: 440,
-        y: 225,
-        width: 100, // updated bound
-        height: 400
-      })
+      const expectedBounds = Object.assign(fullBounds, boundsUpdate)
+      assertBoundsEqual(w.getBounds(), expectedBounds)
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -524,6 +524,30 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('BrowserWindow.setBounds(bounds[, animate])', () => {
+    it('sets the window bounds with full bounds', () => {
+      const fullBounds = { x: 440, y: 225, width: 500, height: 400 }
+      w.setBounds(fullBounds)
+
+      assertBoundsEqual(w.getBounds(), fullBounds)
+    })
+
+    it('sets the window bounds with partial bounds', () => {
+      const fullBounds = { x: 440, y: 225, width: 500, height: 400 }
+      w.setBounds(fullBounds)
+
+      assertBoundsEqual(w.getBounds(), fullBounds)
+
+      w.setBounds({ width: 100 })
+      assertBoundsEqual(w.getBounds(), {
+        x: 440,
+        y: 225,
+        width: 100, // updated bound
+        height: 400
+      })
+    })
+  })
+
   describe('BrowserWindow.setSize(width, height)', () => {
     it('sets the window size', async () => {
       const size = [300, 400]


### PR DESCRIPTION
#### Description of Change

This PR extends the existing `win.setBounds` functionality by allowing developers to partially update bounds without being forced to pass in all four [bounds values](https://electronjs.org/docs/api/structures/rectangle). No existing functionality is altered.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: allow partial setting of window bounds with win.setBounds()