### PR TITLE
chore: fix window width in spec for win

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -538,7 +538,7 @@ describe('BrowserWindow module', () => {
       const fullBounds = { x: 440, y: 225, width: 500, height: 400 }
       w.setBounds(fullBounds)
 
-      const boundsUpdate = { width: 100 }
+      const boundsUpdate = { width: 200 }
       w.setBounds(boundsUpdate)
 
       const expectedBounds = Object.assign(fullBounds, boundsUpdate)


### PR DESCRIPTION
#### Description of Change

Windows, it seems, will not let you make windows less than 140px wide.

/cc @alexeykuzmin

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes