### PR TITLE
fix: improved event flow management related to 'will-resize' event on Windows

### DIFF
--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -194,6 +194,7 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       if (prevent_default) {
         ::GetWindowRect(GetAcceleratedWidget(),
                         reinterpret_cast<RECT*>(l_param));
+        return true;  // Tells Windows that the Sizing is handled.
       }
       return false;
     }


### PR DESCRIPTION
#### Description of Change

This is change improve the compliance with Windows event management flow for the `WM_SIZING` event.
When we use the `event.preventDefault()` function we need to return true into the Windows event queue in order to signal to Windows that the event has been managed.
The solution is to add the missing 'return true' into the 'prevent default' condition.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: no-notes