### PR TITLE
feat: allow partial setting of window bounds

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -895,7 +895,18 @@ Closes the currently open [Quick Look][quick-look] panel.
 * `bounds` [Rectangle](structures/rectangle.md)
 * `animate` Boolean (optional) _macOS_
 
-Resizes and moves the window to the supplied bounds
+Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.
+
+```javascript
+const { BrowserWindow } = require('electron')
+const win = new BrowserWindow()
+ // set all bounds properties
+win.setBounds({ x: 440, y: 225, width: 800, height: 600 })
+ // set a single bounds property
+win.setBounds({ width: 200 })
+ // { x: 440, y: 225, width: 200, height: 600 }
+console.log(win.getBounds())
+```
 
 #### `win.getBounds()`
 

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -18,6 +18,15 @@ BrowserWindow.prototype._init = function () {
   // Create WebContentsView.
   this.setContentView(new WebContentsView(this.webContents))
 
+  const nativeSetBounds = this.setBounds
+  this.setBounds = (bounds, ...opts) => {
+    bounds = {
+      ...this.getBounds(),
+      ...bounds
+    }
+    nativeSetBounds.call(this, bounds, ...opts)
+  }
+
   // Make new windows requested by links behave like "window.open"
   this.webContents.on('-new-window', (event, url, frameName, disposition,
     additionalFeatures, postData,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -524,6 +524,25 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('BrowserWindow.setBounds(bounds[, animate])', () => {
+    it('sets the window bounds with full bounds', () => {
+      const fullBounds = { x: 440, y: 225, width: 500, height: 400 }
+      w.setBounds(fullBounds)
+      assertBoundsEqual(w.getBounds(), fullBounds)
+    })
+
+    it('sets the window bounds with partial bounds', () => {
+      const fullBounds = { x: 440, y: 225, width: 500, height: 400 }
+      w.setBounds(fullBounds)
+
+      const boundsUpdate = { width: 200 }
+      w.setBounds(boundsUpdate)
+
+      const expectedBounds = Object.assign(fullBounds, boundsUpdate)
+      assertBoundsEqual(w.getBounds(), expectedBounds)
+    })
+  })
+
   describe('BrowserWindow.setSize(width, height)', () => {
     it('sets the window size', async () => {
       const size = [300, 400]


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/15677.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: allow partial setting of window bounds