### PR TITLE
build: fix the build with enable_run_as_node disabled

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -53,7 +53,7 @@ namespace {
 const char kRunAsNode[] = "ELECTRON_RUN_AS_NODE";
 #endif
 
-bool IsEnvSet(const char* name) {
+ALLOW_UNUSED_TYPE bool IsEnvSet(const char* name) {
 #if defined(OS_WIN)
   size_t required_size;
   getenv_s(&required_size, nullptr, 0, name);

--- a/atom/common/api/features.cc
+++ b/atom/common/api/features.cc
@@ -23,6 +23,10 @@ bool IsPDFViewerEnabled() {
   return BUILDFLAG(ENABLE_PDF_VIEWER);
 }
 
+bool IsRunAsNodeEnabled() {
+  return BUILDFLAG(ENABLE_RUN_AS_NODE);
+}
+
 bool IsFakeLocationProviderEnabled() {
   return BUILDFLAG(OVERRIDE_LOCATION_PROVIDER);
 }
@@ -47,6 +51,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isDesktopCapturerEnabled", &IsDesktopCapturerEnabled);
   dict.SetMethod("isOffscreenRenderingEnabled", &IsOffscreenRenderingEnabled);
   dict.SetMethod("isPDFViewerEnabled", &IsPDFViewerEnabled);
+  dict.SetMethod("isRunAsNodeEnabled", &IsRunAsNodeEnabled);
   dict.SetMethod("isFakeLocationProviderEnabled",
                  &IsFakeLocationProviderEnabled);
   dict.SetMethod("isViewApiEnabled", &IsViewApiEnabled);

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -12,6 +12,8 @@ const remote = require('electron').remote
 
 const { ipcMain, BrowserWindow } = remote
 
+const features = process.atomBinding('features')
+
 describe('asar package', function () {
   const fixtures = path.join(__dirname, 'fixtures')
 
@@ -844,6 +846,12 @@ describe('asar package', function () {
     })
 
     describe('child_process.fork', function () {
+      before(function () {
+        if (!features.isRunAsNodeEnabled()) {
+          this.skip()
+        }
+      })
+
       it('opens a normal js file', function (done) {
         const child = ChildProcess.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'))
         child.on('message', function (msg) {
@@ -1040,6 +1048,12 @@ describe('asar package', function () {
     })
 
     describe('process.env.ELECTRON_NO_ASAR', function () {
+      before(function () {
+        if (!features.isRunAsNodeEnabled()) {
+          this.skip()
+        }
+      })
+
       it('disables asar support in forked processes', function (done) {
         const forked = ChildProcess.fork(path.join(__dirname, 'fixtures', 'module', 'no-asar.js'), [], {
           env: {
@@ -1205,6 +1219,11 @@ describe('asar package', function () {
     })
 
     it('is available in forked scripts', function (done) {
+      if (!features.isRunAsNodeEnabled()) {
+        this.skip()
+        done()
+      }
+
       const child = ChildProcess.fork(path.join(fixtures, 'module', 'original-fs.js'))
       child.on('message', function (msg) {
         assert.strictEqual(msg, 'object')

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const { remote } = require('electron')
 const { BrowserWindow } = remote
 const { closeWindow } = require('./window-helpers')
+const features = process.atomBinding('features')
 
 const nativeModulesEnabled = remote.getGlobal('nativeModulesEnabled')
 
@@ -17,7 +18,12 @@ describe('modules support', () => {
         require('runas')
       })
 
-      it('can be required in node binary', (done) => {
+      it('can be required in node binary', function (done) {
+        if (!features.isRunAsNodeEnabled()) {
+          this.skip()
+          done()
+        }
+
         const runas = path.join(fixtures, 'module', 'runas.js')
         const child = require('child_process').fork(runas)
         child.on('message', (msg) => {

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -6,6 +6,7 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 const { ipcRenderer, remote } = require('electron')
+const features = process.atomBinding('features')
 
 const isCI = remote.getGlobal('isCi')
 chai.use(dirtyChai)
@@ -14,6 +15,12 @@ describe('node feature', () => {
   const fixtures = path.join(__dirname, 'fixtures')
 
   describe('child_process', () => {
+    beforeEach(function () {
+      if (!features.isRunAsNodeEnabled()) {
+        this.skip()
+      }
+    })
+
     describe('child_process.fork', () => {
       it('works in current process', (done) => {
         const child = ChildProcess.fork(path.join(fixtures, 'module', 'ping.js'))
@@ -208,6 +215,12 @@ describe('node feature', () => {
   describe('inspector', () => {
     let child = null
 
+    beforeEach(function () {
+      if (!features.isRunAsNodeEnabled()) {
+        this.skip()
+      }
+    })
+
     afterEach(() => {
       if (child !== null) child.kill()
     })
@@ -299,7 +312,7 @@ describe('node feature', () => {
 
   describe('net.connect', () => {
     before(function () {
-      if (process.platform !== 'darwin') {
+      if (!features.isRunAsNodeEnabled() || process.platform !== 'darwin') {
         this.skip()
       }
     })


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Fix the build with `enable_run_as_node = false` on Mac and Linux.

Builds with `enable_run_as_node = false` _before_ the change:
 -  ✘ [linux-x64-debug](https://circleci.com/gh/electron/electron/98065?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
 - ✘ [electron-osx-testing](https://github.visualstudio.com/electron/_build/results?buildId=21793&view=logs)
 - ✓ [electron-x64-testing](https://windows-ci.electronjs.org/project/AppVeyor/electron-i8wjp/build/1.0.3234) _build is fine, there are only test failures_

Builds with `enable_run_as_node = false` _after_ the change:
 - ✓ https://circleci.com/workflow-run/494a774c-4120-467f-9fa0-d22bc6274a52
 - ✓ [electron-x64-testing](https://windows-ci.electronjs.org/project/AppVeyor/electron-i8wjp/build/1.0.4500)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no notes