### PR TITLE
build: include needed bin files for v8_context_snapshot_generator

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -86,6 +86,8 @@ V8_SNAPSHOT_BINARIES = {
     'libicuuc.dylib',
     'libv8.dylib',
     'v8_context_snapshot_generator',
+    'natives_blob.bin',
+    'snapshot_blob.bin',
   ],
   'linux': [
     'libffmpeg.so',
@@ -93,6 +95,8 @@ V8_SNAPSHOT_BINARIES = {
     'libicuuc.so',
     'libv8.so',
     'v8_context_snapshot_generator',
+    'natives_blob.bin',
+    'snapshot_blob.bin',
   ],
   'win32': [
     'ffmpeg.dll',
@@ -100,6 +104,8 @@ V8_SNAPSHOT_BINARIES = {
     'icuuc.dll',
     'v8.dll',
     'v8_context_snapshot_generator.exe',
+    'natives_blob.bin',
+    'snapshot_blob.bin',
   ],
 }
 


### PR DESCRIPTION
#### Description of Change
This PR adds `natives_blob.bin` and `snapshot_blob.bin` to the mksnapshot.zip dist file.  These files are needed for the `v8_context_generator` binary.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Add needed .bin files for v8_context_generator.