### PR TITLE
build: use different directory for generated breakpad symbols

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ step-generate-breakpad-symbols: &step-generate-breakpad-symbols
     command: |
       cd src
       export BUILD_PATH="$PWD/out/Default"
-      export DEST_PATH="$BUILD_PATH/electron.breakpad.syms"
+      export DEST_PATH="$BUILD_PATH/breakpad_symbols"
       electron/script/dump-symbols.py -b $BUILD_PATH -d $DEST_PATH -v
 
 step-zip-symbols: &step-zip-symbols

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ build_script:
       if ($env:GN_CONFIG -eq 'release') {
         ninja -C out/Default third_party/breakpad:dump_syms
       }
-  - if "%GN_CONFIG%"=="release" ( python electron\script\dump-symbols.py -d %cd%\out\Default\electron.breakpad.syms -v)
+  - if "%GN_CONFIG%"=="release" ( python electron\script\dump-symbols.py -d %cd%\out\Default\breakpad_symbols -v)
   - ps: >-
       if ($env:GN_CONFIG -eq 'release') {
         python electron\script\zip-symbols.py

--- a/script/dump-symbols.py
+++ b/script/dump-symbols.py
@@ -72,7 +72,7 @@ def generate_posix_symbols(binary, source_root, build_dir, destination):
     '--binary={0}'.format(binary),
   ]
   if is_verbose_mode():
-    args += ['-v']
+    args += ['--verbose']
   execute([sys.executable, generate_breakpad_symbols] + args)
 
 def parse_args():

--- a/script/upload-symbols.py
+++ b/script/upload-symbols.py
@@ -14,9 +14,7 @@ RELEASE_DIR = get_out_dir()
 
 PROJECT_NAME = get_electron_branding()['project_name']
 PRODUCT_NAME = get_electron_branding()['product_name']
-SYMBOLS_DIR = os.path.join(
-  RELEASE_DIR, '{0}.breakpad.syms'.format(PROJECT_NAME)
-)
+SYMBOLS_DIR = os.path.join(RELEASE_DIR, 'breakpad_symbols')
 
 PDB_LIST = [
   os.path.join(RELEASE_DIR, '{0}.exe.pdb'.format(PROJECT_NAME))

--- a/script/zip-symbols.py
+++ b/script/zip-symbols.py
@@ -24,7 +24,7 @@ def main():
   licenses = ['LICENSE', 'LICENSES.chromium.html', 'version']
 
   with scoped_cwd(args.build_dir):
-    dirs = ['{0}.breakpad.syms'.format(PROJECT_NAME)]
+    dirs = ['breakpad_symbols']
     print('Making symbol zip: ' + zip_file)
     make_zip(zip_file, licenses, dirs)
 

--- a/vsts.yml
+++ b/vsts.yml
@@ -110,7 +110,7 @@ jobs:
       # TODO(alexeykuzmin): Explicitly pass an out folder path to the scripts.
       export ELECTRON_OUT_DIR=Default
 
-      electron/script/dump-symbols.py -d "$PWD/out/Default/electron.breakpad.syms"
+      electron/script/dump-symbols.py -d "$PWD/out/Default/breakpad_symbols"
       electron/script/zip-symbols.py
     displayName: Collect symbols
     condition: and(succeeded(), eq(variables['ELECTRON_RELEASE'], '1'))


### PR DESCRIPTION
#### Description of Change
Fixes #15054.

Our CI was timing out on generating breakpad symbols.  It turns out it was erroring out on trying to read the destination directory electron.breakpad.syms as a file here:
https://cs.chromium.org/chromium/src/components/crash/content/tools/generate_breakpad_symbols.py?q=potential_symbol_files&sq=package:chromium&g=0&l=245
This is because of this line which happens to match our directory name:
https://cs.chromium.org/chromium/src/components/crash/content/tools/generate_breakpad_symbols.py?q=potential_symbol_files&sq=package:chromium&g=0&l=243

This PR fixes the issue by changing what directory we save the breakpad symbols to.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes