### PR TITLE
chore: don't explicitly destroy asar archives

### DIFF
--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -39,8 +39,7 @@ class Archive : public mate::Wrappable<Archive> {
         .SetMethod("readdir", &Archive::Readdir)
         .SetMethod("realpath", &Archive::Realpath)
         .SetMethod("copyFileOut", &Archive::CopyFileOut)
-        .SetMethod("getFd", &Archive::GetFD)
-        .SetMethod("destroy", &Archive::Destroy);
+        .SetMethod("getFd", &Archive::GetFD);
   }
 
  protected:
@@ -112,9 +111,6 @@ class Archive : public mate::Wrappable<Archive> {
       return -1;
     return archive_->GetFD();
   }
-
-  // Free the resources used by archive.
-  void Destroy() { archive_.reset(); }
 
  private:
   std::unique_ptr<asar::Archive> archive_;

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -37,14 +37,6 @@
     return newArchive
   }
 
-  // Clean cache on quit.
-  process.on('exit', () => {
-    for (const archive of cachedArchives.values()) {
-      archive.destroy()
-    }
-    cachedArchives.clear()
-  })
-
   const ASAR_EXTENSION = '.asar'
 
   // Separate asar package's path from full path.


### PR DESCRIPTION
#### Description of Change
`Wrappable` objects are automatically destroyed during GC, so there's no reason to explicitly destroy them on process exit.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes