### PR TITLE
chore: Deprecate options in webcontents.findInPage

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -2090,7 +2090,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("unselect", &WebContents::Unselect)
       .SetMethod("replace", &WebContents::Replace)
       .SetMethod("replaceMisspelling", &WebContents::ReplaceMisspelling)
-      .SetMethod("findInPage", &WebContents::FindInPage)
+      .SetMethod("_findInPage", &WebContents::FindInPage)
       .SetMethod("stopFindInPage", &WebContents::StopFindInPage)
       .SetMethod("focus", &WebContents::Focus)
       .SetMethod("isFocused", &WebContents::IsFocused)

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -22,6 +22,10 @@ The following `webPreferences` option default values are deprecated in favor of 
 
 Child windows opened with the `nativeWindowOpen` option will always have Node.js integration disabled.
 
+## `webContents.findInPage(text[, options])`
+
+`wordStart` and `medialCapitalAsWordStart` options are removed.
+
 # Planned Breaking API Changes (4.0)
 
 The following list includes the breaking API changes planned for Electron 4.0.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1016,9 +1016,9 @@ Inserts `text` to the focused element.
     defaults to `false`.
   * `matchCase` Boolean (optional) - Whether search should be case-sensitive,
     defaults to `false`.
-  * `wordStart` Boolean (optional) - Whether to look only at the start of words.
+  * `wordStart` Boolean (optional) (Deprecated) - Whether to look only at the start of words.
     defaults to `false`.
-  * `medialCapitalAsWordStart` Boolean (optional) - When combined with `wordStart`,
+  * `medialCapitalAsWordStart` Boolean (optional) (Deprecated) - When combined with `wordStart`,
     accepts a match in the middle of a word if the match begins with an
     uppercase letter followed by a lowercase or non-letter.
     Accepts several other intra-word matches, defaults to `false`.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -288,6 +288,13 @@ WebContents.prototype.getZoomFactor = function (callback) {
   })
 }
 
+WebContents.prototype.findInPage = function (text, options = {}) {
+  //TODO (nitsakh): Remove in 5.0
+  if (options.wordStart || options.medialCapitalAtWordStart)
+    deprecate.log('wordStart and medialCapitalAtWordStart options are deprecated')
+  this._findInPage(text, options)
+}
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.


### PR DESCRIPTION
#### Description of Change

`medialCapitalAsWordStart` and `wordStart` are removed upstream (https://github.com/electron/electron/commit/e6cb6f22a888d0c17a404072b6c4b747ea67ef1f).
So lets deprecate them in 4.x and remove in 5.x.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Deprecated `findInPage` options`wordStart` and `medialCapitalAsWordStart`