### PR TITLE
chore: only rely on render-view-deleted in remote

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -403,11 +403,6 @@ handleRemoteCommand('ELECTRON_BROWSER_DEREFERENCE', function (event, contextId, 
   objectsRegistry.remove(event.sender, contextId, id)
 })
 
-handleRemoteCommand('ELECTRON_BROWSER_CONTEXT_RELEASE', (event, contextId) => {
-  objectsRegistry.clear(event.sender, contextId)
-  return null
-})
-
 handleRemoteCommand('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, contextId, guestInstanceId) {
   const guestViewManager = require('@electron/internal/browser/guest-view-manager')
   return valueToMeta(event.sender, contextId, guestViewManager.getGuest(guestInstanceId))

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -15,15 +15,6 @@ const remoteObjectCache = v8Util.createIDWeakMap()
 // An unique ID that can represent current context.
 const contextId = v8Util.getHiddenValue(global, 'contextId')
 
-// Notify the main process when current context is going to be released.
-// Note that when the renderer process is destroyed, the message may not be
-// sent, we also listen to the "render-view-deleted" event in the main process
-// to guard that situation.
-process.on('exit', () => {
-  const command = 'ELECTRON_BROWSER_CONTEXT_RELEASE'
-  ipcRenderer.sendSync(command, contextId)
-})
-
 // Convert the arguments object into an array of meta data.
 function wrapArgs (args, visited = new Set()) {
   const valueToMeta = (value) => {


### PR DESCRIPTION
I think the extra message is redundant and unnecessary, as well as unreliable? `render-view-deleted` should be enough, and should be more reliable.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes