### PR TITLE
fix: bypass CORB when web security is disabled

### DIFF
--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/synchronization/lock.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/render_process_host_observer.h"
 #include "net/ssl/client_cert_identity.h"
@@ -143,6 +144,7 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   GetSystemSharedURLLoaderFactory() override;
   void OnNetworkServiceCreated(
       network::mojom::NetworkService* network_service) override;
+  bool ShouldBypassCORB(int render_process_id) override;
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;
@@ -164,6 +166,7 @@ class AtomBrowserClient : public content::ContentBrowserClient,
     bool sandbox = false;
     bool native_window_open = false;
     bool disable_popups = false;
+    bool web_security = true;
   };
 
   bool ShouldCreateNewSiteInstance(content::RenderFrameHost* render_frame_host,
@@ -180,7 +183,6 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   // pending_render_process => web contents.
   std::map<int, content::WebContents*> pending_processes_;
 
-  std::map<int, ProcessPreferences> process_preferences_;
   std::map<int, base::ProcessId> render_process_host_pids_;
 
   // list of site per affinity. weak_ptr to prevent instance locking
@@ -193,6 +195,9 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   std::unique_ptr<NotificationPresenter> notification_presenter_;
 
   Delegate* delegate_ = nullptr;
+
+  base::Lock process_preferences_lock_;
+  std::map<int, ProcessPreferences> process_preferences_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserClient);
 };

--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -75,3 +75,4 @@ verbose_generate_breakpad_symbols.patch
 fix_zoom_display.patch
 chrome_process_finder.patch
 customizable_app_indicator_id_prefix.patch
+cross_site_document_resource_handler.patch

--- a/patches/common/chromium/cross_site_document_resource_handler.patch
+++ b/patches/common/chromium/cross_site_document_resource_handler.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: deepak1556 <hop2deep@gmail.com>
+Date: Thu, 15 Nov 2018 22:04:34 +0530
+Subject: cross_site_document_resource_handler.patch
+
+Add a content layer hook to disable CORB for a renderer process,
+this patch can be removed once we switch to network service,
+where the embedders have a chance to design their URLLoaders.
+
+diff --git a/content/browser/loader/cross_site_document_resource_handler.cc b/content/browser/loader/cross_site_document_resource_handler.cc
+index 907922701280b589bf11691342de0ec95cdec6a1..eaf8bac18f8e3a2735ce7ded606199092a3746d3 100644
+--- a/content/browser/loader/cross_site_document_resource_handler.cc
++++ b/content/browser/loader/cross_site_document_resource_handler.cc
+@@ -593,6 +593,9 @@ bool CrossSiteDocumentResourceHandler::ShouldBlockBasedOnHeaders(
+     return false;
+   }
+ 
++  if (GetContentClient()->browser()->ShouldBypassCORB(info->GetChildID()))
++    return false;
++
+   return true;
+ }
+ 
+diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
+index bb54b89bef5c6f32e7b4a056336c85494e2a04de..f069dfc4d2823b22eb0d90d28bc20236aeeddd04 100644
+--- a/content/public/browser/content_browser_client.cc
++++ b/content/public/browser/content_browser_client.cc
+@@ -47,6 +47,10 @@ void OverrideOnBindInterface(const service_manager::BindSourceInfo& remote_info,
+                                                          handle);
+ }
+ 
++bool ContentBrowserClient::ShouldBypassCORB(int render_process_id) {
++  return false;
++}
++
+ BrowserMainParts* ContentBrowserClient::CreateBrowserMainParts(
+     const MainFunctionParams& parameters) {
+   return nullptr;
+diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
+index 2c22cb1cfe0dddc97c00e5f4ff89de6b18bc232f..a7b59095a887d566af9e74a646443fb49ea23bfc 100644
+--- a/content/public/browser/content_browser_client.h
++++ b/content/public/browser/content_browser_client.h
+@@ -205,6 +205,9 @@ class CONTENT_EXPORT ContentBrowserClient {
+       SiteInstance* candidate_site_instance,
+       SiteInstance** new_instance) {}
+ 
++  // Electron: Allows bypassing CORB checks for a renderer process.
++  virtual bool ShouldBypassCORB(int render_process_id);
++
+   // Allows the embedder to set any number of custom BrowserMainParts
+   // implementations for the browser startup code. See comments in
+   // browser_main_parts.h.


### PR DESCRIPTION
#### Description of Change

This temporarily adds a patch for disabling CORB checks for pre network service code path, things would be easier to solve once we get to implement [ContentBrowserClient::CreateURLLoaderFactoryForNetworkRequests](https://cs.chromium.org/chromium/src/content/public/browser/content_browser_client.h?l=344)

Fixes https://github.com/electron/electron/issues/15132

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: Disable CORB checks when web security preference is disabled