### PR TITLE
fix: On close trying to remove observer from an empty collection leads to an access violation

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -298,7 +298,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
     observers_.AddObserver(obs);
   }
   void RemoveObserver(ExtendedWebContentsObserver* obs) {
-    observers_.RemoveObserver(obs);
+    // Trying to remove from an empty collection leads to an access violation
+    if (observers_.might_have_observers())
+      observers_.RemoveObserver(obs);
   }
 
   bool EmitNavigationEvent(const std::string& event,


### PR DESCRIPTION
#### Description of Change

Closing Electron on Windows always causes a crash to me.
After debugging I've found that, on object cleanup during closing, when removes some observers, if the observers collection is empty the application crashes.
To avoid this I've added a condition with a call to 'observers_.might_have_observers()' to check if the collection is empty before trying to remove from it.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: no-notes