### PR TITLE
docs: update list of events webview doesn't allow listening for

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -73,7 +73,7 @@ examples:
 
 * When clicking into a `webview`, the page focus will move from the embedder
   frame to `webview`.
-* You can not add keyboard event listeners to `webview`.
+* You can not add keyboard, mouse, and scroll event listeners to `webview`.
 * All reactions between the embedder frame and `webview` are asynchronous.
 
 ## CSS Styling Notes


### PR DESCRIPTION
#### Description of Change
Added Mouse and Scroll to list of events that webview can't have event listeners for in "/docs/api/webview-tag"

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders 
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
Notes: no-notes