### PR TITLE
feat: promisify app.getFileIcon()

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1126,15 +1126,14 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
 
 v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
                                         mate::Arguments* args) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
-  mate::Dictionary options;
-  IconLoader::IconSize icon_size;
-
   v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
+  v8::Isolate::Scope scope(isolate());
 
+  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
   base::FilePath normalized_path = path.NormalizePathSeparators();
 
+  IconLoader::IconSize icon_size;
+  mate::Dictionary options;
   if (!args->GetNext(&options)) {
     icon_size = IconLoader::IconSize::NORMAL;
   } else {

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1126,7 +1126,7 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
 v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
                                         mate::Arguments* args) {
   v8::Locker locker(isolate());
-  v8::HandleScope scope(isolate());
+  v8::HandleScope handle_scope(isolate());
 
   scoped_refptr<util::Promise> promise = new util::Promise(isolate());
   base::FilePath normalized_path = path.NormalizePathSeparators();

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1126,7 +1126,7 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
 v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
                                         mate::Arguments* args) {
   v8::Locker locker(isolate());
-  v8::Isolate::Scope scope(isolate());
+  v8::HandleScope scope(isolate());
 
   scoped_refptr<util::Promise> promise = new util::Promise(isolate());
   base::FilePath normalized_path = path.NormalizePathSeparators();

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -4,7 +4,6 @@
 
 #include "atom/browser/api/atom_api_app.h"
 
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -198,7 +198,8 @@ class App : public AtomBrowserClient::Delegate,
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);
 #endif
-  void GetFileIcon(const base::FilePath& path, mate::Arguments* args);
+  v8::Local<v8::Promise> GetFileIcon(const base::FilePath& path,
+                                     mate::Arguments* args);
 
   std::vector<mate::Dictionary> GetAppMetrics(v8::Isolate* isolate);
   v8::Local<v8::Value> GetGPUFeatureStatus(v8::Isolate* isolate);

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -533,6 +533,27 @@ You can request the following paths by the name:
 * `logs` Directory for your app's log folder.
 * `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
 
+### `app.getFileIcon(path[, options], callback)`
+
+* `path` String
+* `options` Object (optional)
+  * `size` String
+    * `small` - 16x16
+    * `normal` - 32x32
+    * `large` - 48x48 on _Linux_, 32x32 on _Windows_, unsupported on _macOS_.
+* `callback` Function
+  * `error` Error
+  * `icon` [NativeImage](native-image.md)
+
+Fetches a path's associated icon.
+
+On _Windows_, there a 2 kinds of icons:
+
+- Icons associated with certain file extensions, like `.mp3`, `.png`, etc.
+- Icons inside the file itself, like `.exe`, `.dll`, `.ico`.
+
+On _Linux_ and _macOS_, icons depend on the application associated with file mime type.
+
 ### `app.getFileIcon(path[, options])`
 
 * `path` String

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -533,7 +533,7 @@ You can request the following paths by the name:
 * `logs` Directory for your app's log folder.
 * `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
 
-### `app.getFileIcon(path[, options], callback)`
+### `app.getFileIcon(path[, options])`
 
 * `path` String
 * `options` Object (optional)
@@ -541,9 +541,8 @@ You can request the following paths by the name:
     * `small` - 16x16
     * `normal` - 32x32
     * `large` - 48x48 on _Linux_, 32x32 on _Windows_, unsupported on _macOS_.
-* `callback` Function
-  * `error` Error
-  * `icon` [NativeImage](native-image.md)
+
+Returns `Promise<icon>` - fulfilled with the app's icon, which is a [NativeImage](native-image.md).
 
 Fetches a path's associated icon.
 
@@ -552,8 +551,7 @@ On _Windows_, there a 2 kinds of icons:
 - Icons associated with certain file extensions, like `.mp3`, `.png`, etc.
 - Icons inside the file itself, like `.exe`, `.dll`, `.ico`.
 
-On _Linux_ and _macOS_, icons depend on the application associated with file
-mime type.
+On _Linux_ and _macOS_, icons depend on the application associated with file mime type.
 
 ### `app.setPath(name, path)`
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -542,7 +542,7 @@ You can request the following paths by the name:
     * `normal` - 32x32
     * `large` - 48x48 on _Linux_, 32x32 on _Windows_, unsupported on _macOS_.
 
-Returns `Promise<icon>` - fulfilled with the app's icon, which is a [NativeImage](native-image.md).
+Returns `Promise<NativeImage>` - fulfilled with the app's icon, which is a [NativeImage](native-image.md).
 
 Fetches a path's associated icon.
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -554,6 +554,8 @@ On _Windows_, there a 2 kinds of icons:
 
 On _Linux_ and _macOS_, icons depend on the application associated with file mime type.
 
+**[Deprecated Soon](promisification.md)**
+
 ### `app.getFileIcon(path[, options])`
 
 * `path` String

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -8,29 +8,6 @@ The `FIXME` string is used in code comments to denote things that should be fixe
 
 # Planned Breaking API Changes (5.0)
 
-## `app.getFileIcon(path[, options], callback)`
-
-The `getFileIcon` function on `app` taking a callback is being deprecated in favor of a version returning a Promise.
-
-```js
-const path = 'some/path/to/your/icon'
-// Deprecated
-app.getFileIcon(path, (err, icon) => {
-  if (err) {
-    console.log('oh no an error!', err)
-  } else {
-    console.log(icon)
-  }
-})
-// Replace With
-app.getFileIcon(path)
-  .then(icon => {
-    console.log(icon)
-  }).catch(err => {
-    console.log('oh no an error!', err)
-  })
-```
-
 ## `new BrowserWindow({ webPreferences })`
 
 The following `webPreferences` option default values are deprecated in favor of the new defaults listed below.

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -8,6 +8,29 @@ The `FIXME` string is used in code comments to denote things that should be fixe
 
 # Planned Breaking API Changes (5.0)
 
+## `app.getFileIcon(path[, options], callback)`
+
+The `getFileIcon` function on `app` taking a callback is being deprecated in favor of a version returning a Promise.
+
+```js
+const path = 'some/path/to/your/icon'
+// Deprecated
+app.getFileIcon(path, (err, icon) => {
+  if (err) {
+    console.log('oh no an error!', err)
+  } else {
+    console.log(icon)
+  }
+})
+// Replace With
+app.getFileIcon(path)
+  .then(icon => {
+    console.log(icon)
+  }).catch(err => {
+    console.log('oh no an error!', err)
+  })
+```
+
 ## `new BrowserWindow({ webPreferences })`
 
 The following `webPreferences` option default values are deprecated in favor of the new defaults listed below.

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -40,9 +40,14 @@ Object.assign(app, {
   }
 })
 
-const nativeFn = app.getAppMetrics
+const nativeGetFileIcon = app.getFileIcon
+app.getFileIcon = (path, options = {}, cb) => {
+  return deprecate.promisify(nativeGetFileIcon.call(app, path, options), cb)
+}
+
+const nativeAppMetrics = app.getAppMetrics
 app.getAppMetrics = () => {
-  const metrics = nativeFn.call(app)
+  const metrics = nativeAppMetrics.call(app)
   for (const metric of metrics) {
     if ('memory' in metric) {
       deprecate.removeProperty(metric, 'memory')

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -793,7 +793,6 @@ describe('app module', () => {
 
       it('fetches a normal icon', async () => {
         const icon = await app.getFileIcon(iconPath, { size: 'normal' })
-        console.log(icon)
         const size = icon.getSize()
 
         expect(size.height).to.equal(sizes.normal)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -769,61 +769,46 @@ describe('app module', () => {
       }
     })
 
-    it('fetches a non-empty icon', done => {
-      app.getFileIcon(iconPath, (err, icon) => {
-        expect(err).to.be.null()
-        expect(icon.isEmpty()).to.be.false()
-        done()
-      })
+    it('fetches a non-empty icon', async () => {
+      const icon = await app.getFileIcon(iconPath)
+      expect(icon.isEmpty()).to.be.false()
     })
 
-    it('fetches normal icon size by default', done => {
-      app.getFileIcon(iconPath, (err, icon) => {
-        const size = icon.getSize()
+    it('fetches normal icon size by default', async () => {
+      const icon = await app.getFileIcon(iconPath)
+      const size = icon.getSize()
 
-        expect(err).to.be.null()
-        expect(size.height).to.equal(sizes.normal)
-        expect(size.width).to.equal(sizes.normal)
-        done()
-      })
+      expect(size.height).to.equal(sizes.normal)
+      expect(size.width).to.equal(sizes.normal)
     })
 
     describe('size option', () => {
-      it('fetches a small icon', (done) => {
-        app.getFileIcon(iconPath, { size: 'small' }, (err, icon) => {
-          const size = icon.getSize()
-          expect(err).to.be.null()
-          expect(size.height).to.equal(sizes.small)
-          expect(size.width).to.equal(sizes.small)
-          done()
-        })
+      it('fetches a small icon', async () => {
+        const icon = await app.getFileIcon(iconPath, { size: 'small' })
+        const size = icon.getSize()
+
+        expect(size.height).to.equal(sizes.small)
+        expect(size.width).to.equal(sizes.small)
       })
 
-      it('fetches a normal icon', (done) => {
-        app.getFileIcon(iconPath, { size: 'normal' }, (err, icon) => {
-          const size = icon.getSize()
-          expect(err).to.be.null()
-          expect(size.height).to.equal(sizes.normal)
-          expect(size.width).to.equal(sizes.normal)
-          done()
-        })
+      it('fetches a normal icon', async () => {
+        const icon = await app.getFileIcon(iconPath, { size: 'normal' })
+        console.log(icon)
+        const size = icon.getSize()
+
+        expect(size.height).to.equal(sizes.normal)
+        expect(size.width).to.equal(sizes.normal)
       })
 
-      it('fetches a large icon', function (done) {
+      it('fetches a large icon', async () => {
         // macOS does not support large icons
-        if (process.platform === 'darwin') {
-          // FIXME(alexeykuzmin): Skip the test.
-          // this.skip()
-          return done()
-        }
+        if (process.platform === 'darwin') return
 
-        app.getFileIcon(iconPath, { size: 'large' }, (err, icon) => {
-          const size = icon.getSize()
-          expect(err).to.be.null()
-          expect(size.height).to.equal(sizes.large)
-          expect(size.width).to.equal(sizes.large)
-          done()
-        })
+        const icon = await app.getFileIcon(iconPath, { size: 'large' })
+        const size = icon.getSize()
+
+        expect(size.height).to.equal(sizes.large)
+        expect(size.width).to.equal(sizes.large)
       })
     })
   })


### PR DESCRIPTION
#### Description of Change

Promisifies `app.getFileIcon` natively.

Todo:
- [x] specs
- [x] docs

/cc @ckerr @deepak1556

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Promisifies `app.getFileIcon`

Co-authored-by: Charles Kerr <ckerr@github.com>