### PR TITLE
feat: promisify win.capturePage()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1758,10 +1758,8 @@ v8::Local<v8::Promise> WebContents::CapturePage(mate::Arguments* args) {
   gfx::Rect rect;
   scoped_refptr<util::Promise> promise = new util::Promise(isolate());
 
-  if (args->Length() == 1 && !args->GetNext(&rect)) {
-    promise->RejectWithErrorMessage("Rect argument is required.");
-    return promise->GetHandle();
-  }
+  // get rect arguments if they exist
+  args->GetNext(&rect);
 
   auto* const view = web_contents()->GetRenderWidgetHostView();
   if (!view) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -226,7 +226,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Captures the page with |rect|, |callback| would be called when capturing is
   // done.
-  void CapturePage(mate::Arguments* args);
+  v8::Local<v8::Promise> CapturePage(mate::Arguments* args);
 
   // Methods for creating <webview>.
   bool IsGuest() const;

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -8,28 +8,6 @@ The `FIXME` string is used in code comments to denote things that should be fixe
 
 # Planned Breaking API Changes (5.0)
 
-## `[BrowserWindow, webContents, <webview>].capturePage([rect, ]callback)`
-
-The `capturePage` function on `BrowserWindow`, `webContents`, and `<webview>` taking a callback is being deprecated in favor of a version returning a Promise.
-
-```js
-// Deprecated
-const w = new BrowserWindow()
-w.capturePage(image => {
-  console.log(`image is ${image}`)
-})
-
-// Replace With
-const w = new BrowserWindow()
-w.capturePage().then(image => {
-  console.log(`image is ${image}`)
-})
-
-// Or
-const image = await w.capturePage()
-console.log(`image is ${image}`)
-```
-
 ## `new BrowserWindow({ webPreferences })`
 
 The following `webPreferences` option default values are deprecated in favor of the new defaults listed below.

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -8,6 +8,28 @@ The `FIXME` string is used in code comments to denote things that should be fixe
 
 # Planned Breaking API Changes (5.0)
 
+## `[BrowserWindow, webContents, <webview>].capturePage([rect, ]callback)`
+
+The `capturePage` function on `BrowserWindow`, `webContents`, and `<webview>` taking a callback is being deprecated in favor of a version returning a Promise.
+
+```js
+// Deprecated
+const w = new BrowserWindow()
+w.capturePage(image => {
+  console.log(`image is ${image}`)
+})
+
+// Replace With
+const w = new BrowserWindow()
+w.capturePage().then(image => {
+  console.log(`image is ${image}`)
+})
+
+// Or
+const image = await w.capturePage()
+console.log(`image is ${image}`)
+```
+
 ## `new BrowserWindow({ webPreferences })`
 
 The following `webPreferences` option default values are deprecated in favor of the new defaults listed below.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1206,6 +1206,13 @@ Returns `Boolean` - Whether the window's document has been edited.
 
 #### `win.blurWebView()`
 
+#### `win.capturePage([rect, ]callback)`
+
+* `callback` Function
+  * `image` [NativeImage](native-image.md)
+
+Same as `webContents.capturePage([rect, ]callback)`.
+
 #### `win.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1206,13 +1206,13 @@ Returns `Boolean` - Whether the window's document has been edited.
 
 #### `win.blurWebView()`
 
-#### `win.capturePage([rect, ]callback)`
+#### `win.capturePage(rect)`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
-* `callback` Function
-  * `image` [NativeImage](native-image.md)
 
-Same as `webContents.capturePage([rect, ]callback)`.
+* Returns `Promise<NativeImage>` - Returns [NativeImage](native-image.md)
+
+Same as `webContents.capturePage(rect)`.
 
 #### `win.loadURL(url[, options])`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1206,7 +1206,7 @@ Returns `Boolean` - Whether the window's document has been edited.
 
 #### `win.blurWebView()`
 
-#### `win.capturePage(rect)`
+#### `win.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1208,18 +1208,23 @@ Returns `Boolean` - Whether the window's document has been edited.
 
 #### `win.capturePage([rect, ]callback)`
 
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 * `callback` Function
   * `image` [NativeImage](native-image.md)
 
-Same as `webContents.capturePage([rect, ]callback)`.
+Captures a snapshot of the page within `rect`. Upon completion `callback` will
+be called with `callback(image)`. The `image` is an instance of [NativeImage](native-image.md)
+that stores data of the snapshot. Omitting `rect` will capture the whole visible page.
+
+**[Deprecated Soon](promisification.md)**
 
 #### `win.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 
-* Returns `Promise<NativeImage>` - Returns [NativeImage](native-image.md)
+* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
-Same as `webContents.capturePage(rect)`.
+Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
 #### `win.loadURL(url[, options])`
 

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -11,7 +11,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ ] [app.getFileIcon(path[, options], callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#getFileIcon)
 - [ ] [app.importCertificate(options, callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#importCertificate)
 - [ ] [win.hookWindowMessage(message, callback)](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#hookWindowMessage)
-- [ ] [win.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#capturePage)
 - [ ] [request.write(chunk[, encoding][, callback])](https://github.com/electron/electron/blob/master/docs/api/client-request.md#write)
 - [ ] [request.end([chunk][, encoding][, callback])](https://github.com/electron/electron/blob/master/docs/api/client-request.md#end)
 - [ ] [contentTracing.getCategories(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getCategories)
@@ -52,7 +51,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ ] [contents.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#executeJavaScript)
 - [ ] [contents.getZoomFactor(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#getZoomFactor)
 - [ ] [contents.getZoomLevel(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#getZoomLevel)
-- [ ] [contents.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#capturePage)
 - [ ] [contents.hasServiceWorker(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#hasServiceWorker)
 - [ ] [contents.unregisterServiceWorker(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#unregisterServiceWorker)
 - [ ] [contents.print([options], [callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#print)
@@ -63,8 +61,11 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ ] [webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-frame.md#executeJavaScriptInIsolatedWorld)
 - [ ] [webviewTag.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#executeJavaScript)
 - [ ] [webviewTag.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#printToPDF)
-- [ ] [webviewTag.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#capturePage)
 - [ ] [webviewTag.getZoomFactor(callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#getZoomFactor)
 - [ ] [webviewTag.getZoomLevel(callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#getZoomLevel)
 
 ### Converted Functions
+
+- [ ] [win.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#capturePage)
+- [ ] [webviewTag.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#capturePage)
+- [ ] [contents.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#capturePage)

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1048,15 +1048,24 @@ const requestId = webContents.findInPage('api')
 console.log(requestId)
 ```
 
+#### `contents.capturePage([rect, ]callback)`
+
+* `callback` Function
+  * `image` [NativeImage](native-image.md)
+
+Captures a snapshot of the page within `rect`. Upon completion `callback` will
+be called with `callback(image)`. The `image` is an instance of [NativeImage](native-image.md)
+that stores data of the snapshot. Omitting `rect` will capture the whole visible page.
+
 #### `contents.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
 * Returns `Promise<NativeImage>` - Returns [NativeImage](native-image.md)
 
-Captures a snapshot of the page within `rect`. The promise will will be resolved with an `image`, where `image` is an instance of
-[NativeImage](native-image.md) that stores data of the snapshot. Omitting
-`rect` will capture the whole visible page.
+Captures a snapshot of the page within `rect`. The promise will will be resolved with an `image`,
+where `image` is an instance of [NativeImage](native-image.md) that stores data of the snapshot.
+Omitting `rect` will capture the whole visible page.
 
 #### `contents.hasServiceWorker(callback)`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1050,6 +1050,7 @@ console.log(requestId)
 
 #### `contents.capturePage([rect, ]callback)`
 
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 * `callback` Function
   * `image` [NativeImage](native-image.md)
 
@@ -1057,15 +1058,15 @@ Captures a snapshot of the page within `rect`. Upon completion `callback` will
 be called with `callback(image)`. The `image` is an instance of [NativeImage](native-image.md)
 that stores data of the snapshot. Omitting `rect` will capture the whole visible page.
 
+**[Deprecated Soon](promisification.md)**
+
 #### `contents.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
-* Returns `Promise<NativeImage>` - Returns [NativeImage](native-image.md)
+* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
-Captures a snapshot of the page within `rect`. The promise will will be resolved with an `image`,
-where `image` is an instance of [NativeImage](native-image.md) that stores data of the snapshot.
-Omitting `rect` will capture the whole visible page.
+Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
 #### `contents.hasServiceWorker(callback)`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1048,14 +1048,13 @@ const requestId = webContents.findInPage('api')
 console.log(requestId)
 ```
 
-#### `contents.capturePage([rect, ]callback)`
+#### `contents.capturePage(rect)`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
-* `callback` Function
-  * `image` [NativeImage](native-image.md)
 
-Captures a snapshot of the page within `rect`. Upon completion `callback` will
-be called with `callback(image)`. The `image` is an instance of
+* Returns `Promise<NativeImage>` - Returns [NativeImage](native-image.md)
+
+Captures a snapshot of the page within `rect`. The promise will will be resolved with an `image`, where `image` is an instance of
 [NativeImage](native-image.md) that stores data of the snapshot. Omitting
 `rect` will capture the whole visible page.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1048,7 +1048,7 @@ const requestId = webContents.findInPage('api')
 console.log(requestId)
 ```
 
-#### `contents.capturePage(rect)`
+#### `contents.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -538,6 +538,13 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
 
+### `<webview>.capturePage([rect, ]callback)`
+
+* `callback` Function
+  * `image` [NativeImage](native-image.md)
+
+Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([rect, ]callback)`.
+
 ### `<webview>.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -538,7 +538,7 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
 
-### `<webview>.capturePage(rect)`
+### `<webview>.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -538,13 +538,13 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
 
-### `<webview>.capturePage([rect, ]callback)`
+### `<webview>.capturePage(rect)`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
-* `callback` Function
-  * `image` [NativeImage](native-image.md)
 
-Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([rect, ]callback)`.
+* Returns `Promise<NativeImage>` - Returns [NativeImage](native-image.md)
+
+Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage(rect)`.
 
 ### `<webview>.send(channel[, arg1][, arg2][, ...])`
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -540,18 +540,23 @@ Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, cal
 
 ### `<webview>.capturePage([rect, ]callback)`
 
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 * `callback` Function
   * `image` [NativeImage](native-image.md)
 
-Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([rect, ]callback)`.
+Captures a snapshot of the page within `rect`. Upon completion `callback` will
+be called with `callback(image)`. The `image` is an instance of [NativeImage](native-image.md)
+that stores data of the snapshot. Omitting `rect` will capture the whole visible page.
+
+**[Deprecated Soon](promisification.md)**
 
 ### `<webview>.capturePage([rect])`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
-* Returns `Promise<NativeImage>` - Returns [NativeImage](native-image.md)
+* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
-Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage(rect)`.
+Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
 ### `<webview>.send(channel[, arg1][, arg2][, ...])`
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -318,13 +318,19 @@ WebContents.prototype._init = function () {
   NavigationController.call(this, this)
 
   // Every remote callback from renderer process would add a listenter to the
-  // render-view-deleted event, so ignore the listenters warning.
+  // render-view-deleted event, so ignore the listeners warning.
   this.setMaxListeners(0)
+
+  const nativeCapturePage = this.capturePage
+  this.capturePage = function (rect, cb) {
+    return deprecate.promisify(nativeCapturePage.call(this, rect), cb)
+  }
 
   // Dispatch IPC messages to the ipc module.
   this.on('ipc-message', function (event, [channel, ...args]) {
     ipcMain.emit(channel, event, ...args)
   })
+
   this.on('ipc-message-sync', function (event, [channel, ...args]) {
     Object.defineProperty(event, 'returnValue', {
       set: function (value) {
@@ -338,6 +344,7 @@ WebContents.prototype._init = function () {
   this.on('ipc-internal-message', function (event, [channel, ...args]) {
     ipcMainInternal.emit(channel, event, ...args)
   })
+
   this.on('ipc-internal-message-sync', function (event, [channel, ...args]) {
     Object.defineProperty(event, 'returnValue', {
       set: function (value) {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -68,8 +68,8 @@ const deprecate = {
   },
 
   promisify: (promise, cb) => {
-    const oldName = `${promise.name} with callbacks`
-    const newName = `${promise.name} with Promises`
+    const oldName = `function with callbacks`
+    const newName = `function with Promises`
     const warn = warnOnce(oldName, newName)
 
     if (typeof cb !== 'function') return promise

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -490,15 +490,13 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.capturePage(rect, callback)', () => {
-    it('calls the callback with a Buffer', async () => {
-      const image = await new Promise((resolve) => {
-        w.capturePage({
-          x: 0,
-          y: 0,
-          width: 100,
-          height: 100
-        }, resolve)
+  describe('BrowserWindow.capturePage(rect)', () => {
+    it('returns a Promise with a Buffer', async () => {
+      const image = await w.capturePage({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100
       })
 
       expect(image.isEmpty()).to.be.true()
@@ -515,7 +513,7 @@ describe('BrowserWindow module', () => {
       await emittedOnce(w, 'ready-to-show')
       w.show()
 
-      const image = await new Promise((resolve) => w.capturePage(resolve))
+      const image = await w.capturePage()
       const imgBuffer = image.toPNG()
 
       // Check the 25th byte in the PNG.


### PR DESCRIPTION
#### Description of Change

This PR promisifies `win.capturePage`. 

Todo:
- [x] Docs
- [x] Specs

/cc @ckerr @deepak1556

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: promisify win.capturePage()

Co-authored-by: Charles Kerr <ckerr@github.com>