### PR TITLE
docs: mention the limits of nativeWindowOpen (4-0-x)

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -351,8 +351,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       Console tab. **Note:** This option is currently experimental and may
       change or be removed in future Electron releases.
     * `nativeWindowOpen` Boolean (optional) - Whether to use native
-      `window.open()`. Defaults to `false`. **Note:** This option is currently
-      experimental.
+      `window.open()`. If set to `true`, the `webPreferences` of child window
+      will always be the same with parent window, regardless of the parameters
+      passed to `window.open()`. Defaults to `false`. **Note:** This option is
+      currently experimental.
     * `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
       Defaults to the value of the `nodeIntegration` option. **Note:** The
       `preload` script configured for the `<webview>` will have node integration


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Mention the limits of `nativeWindowOpen`  in documentation, close #15666.

Note that from 5.x there will be new limitations for `nativeWindowOpen` (that `nodeIntegration` will always be `false`) and it has already been documented in `master` branch. This PR just explicitly documents existing limits of `nativeWindowOpen` in 4.x and does not make any change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Update limitations of `nativeWindowOpen` option in documentation.