### PR TITLE
view: add ResizeArea class

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -165,6 +165,7 @@ asar("js2asar") {
       "lib/browser/api/views/label-button.js",
       "lib/browser/api/views/layout-manager.js",
       "lib/browser/api/views/md-text-button.js",
+      "lib/browser/api/views/resize-area.js",
       "lib/browser/api/views/text-field.js",
     ]
   }
@@ -459,6 +460,8 @@ static_library("electron_lib") {
       "atom/browser/api/views/atom_api_layout_manager.h",
       "atom/browser/api/views/atom_api_md_text_button.cc",
       "atom/browser/api/views/atom_api_md_text_button.h",
+      "atom/browser/api/views/atom_api_resize_area.cc",
+      "atom/browser/api/views/atom_api_resize_area.h",
       "atom/browser/api/views/atom_api_text_field.cc",
       "atom/browser/api/views/atom_api_text_field.h",
     ]

--- a/atom/browser/api/views/atom_api_resize_area.cc
+++ b/atom/browser/api/views/atom_api_resize_area.cc
@@ -1,0 +1,60 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/api/views/atom_api_resize_area.h"
+
+#include "atom/common/api/constructor.h"
+#include "native_mate/dictionary.h"
+
+#include "atom/common/node_includes.h"
+
+namespace atom {
+
+namespace api {
+
+ResizeArea::ResizeArea() : View(new views::ResizeArea(this)) {
+  view()->set_owned_by_client();
+}
+
+ResizeArea::~ResizeArea() {}
+
+void ResizeArea::OnResize(int resize_amount, bool done_resizing) {
+  Emit("resize", resize_amount, done_resizing);
+}
+
+// static
+mate::WrappableBase* ResizeArea::New(mate::Arguments* args) {
+  // Constructor call.
+  auto* view = new ResizeArea();
+  view->InitWith(args->isolate(), args->GetThis());
+  return view;
+}
+
+// static
+void ResizeArea::BuildPrototype(v8::Isolate* isolate,
+                                v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "ResizeArea"));
+}
+
+}  // namespace api
+
+}  // namespace atom
+
+namespace {
+
+using atom::api::ResizeArea;
+
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
+  v8::Isolate* isolate = context->GetIsolate();
+  mate::Dictionary dict(isolate, exports);
+  dict.Set("ResizeArea", mate::CreateConstructor<ResizeArea>(
+                             isolate, base::Bind(&ResizeArea::New)));
+}
+
+}  // namespace
+
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_resize_area, Initialize)

--- a/atom/browser/api/views/atom_api_resize_area.h
+++ b/atom/browser/api/views/atom_api_resize_area.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_API_VIEWS_ATOM_API_RESIZE_AREA_H_
+#define ATOM_BROWSER_API_VIEWS_ATOM_API_RESIZE_AREA_H_
+
+#include "atom/browser/api/atom_api_view.h"
+#include "native_mate/handle.h"
+#include "ui/views/controls/resize_area.h"
+#include "ui/views/controls/resize_area_delegate.h"
+
+namespace atom {
+
+namespace api {
+
+class ResizeArea : public View, protected views::ResizeAreaDelegate {
+ public:
+  static mate::WrappableBase* New(mate::Arguments* args);
+
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::FunctionTemplate> prototype);
+
+ protected:
+  void OnResize(int resize_amount, bool done_resizing) override;
+
+ private:
+  ResizeArea();
+  ~ResizeArea() override;
+
+  views::ResizeArea* resize_area() const {
+    return static_cast<views::ResizeArea*>(view());
+  }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ResizeArea);
+};
+
+}  // namespace api
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_API_VIEWS_ATOM_API_RESIZE_AREA_H_

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -74,6 +74,7 @@
   V(atom_browser_label_button)   \
   V(atom_browser_layout_manager) \
   V(atom_browser_md_text_button) \
+  V(atom_browser_resize_area)    \
   V(atom_browser_text_field)
 
 #define ELECTRON_DESKTOP_CAPTURER_MODULE(V) V(atom_browser_desktop_capturer)

--- a/lib/browser/api/module-list.js
+++ b/lib/browser/api/module-list.js
@@ -42,6 +42,7 @@ if (features.isViewApiEnabled()) {
     { name: 'LabelButton', file: 'views/label-button' },
     { name: 'LayoutManager', file: 'views/layout-manager' },
     { name: 'MdTextButton', file: 'views/md-text-button' },
+    { name: 'ResizeArea', file: 'views/resize-area' },
     { name: 'TextField', file: 'views/text-field' }
   )
 }

--- a/lib/browser/api/views/resize-area.js
+++ b/lib/browser/api/views/resize-area.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const electron = require('electron')
+
+const { View } = electron
+const { ResizeArea } = process.atomBinding('resize_area')
+
+Object.setPrototypeOf(ResizeArea.prototype, View.prototype)
+
+ResizeArea.prototype._init = function () {
+  // Call parent class's _init.
+  View.prototype._init.call(this)
+}
+
+module.exports = ResizeArea


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Add JS bindings for the `views::ResizeArea` class:
https://cs.chromium.org/chromium/src/ui/views/controls/resize_area.h?sq=package:chromium&g=0&l=18

Hidden by the `enable_view_api` flag.

Notes: (Unpublished change.)