### PR TITLE
chore: allow for callback => promise deprecation

### DIFF
--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -73,10 +73,10 @@ const deprecate = {
     const warn = warnOnce(oldName, newName)
 
     if (typeof cb !== 'function') return promise
+    warn()
     return promise
       .then(res => {
         process.nextTick(() => {
-          warn()
           cb(null, res)
         })
       }, err => {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -72,7 +72,7 @@ const deprecate = {
     const newName = `${promise.name} with Promises`
     const warn = warnOnce(oldName, newName)
 
-    if (cb == null || typeof cb !== 'function') return promise
+    if (typeof cb !== 'function') return promise
     return promise
       .then(res => {
         process.nextTick(() => {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -67,6 +67,25 @@ const deprecate = {
     })
   },
 
+  promisify: (promise, cb) => {
+    const oldName = `${promise.name} with callbacks`
+    const newName = `${promise.name} with Promises`
+    const warn = warnOnce(oldName, newName)
+
+    if (cb == null || typeof cb !== 'function') return promise
+    return promise
+      .then(res => {
+        process.nextTick(() => {
+          warn()
+          cb(null, res)
+        })
+      }, err => {
+        process.nextTick(() => {
+          cb(err)
+        })
+      })
+  },
+
   renameProperty: (o, oldName, newName) => {
     const warn = warnOnce(oldName, newName)
 


### PR DESCRIPTION
#### Description of Change

Allows for migrating the native promisification process through the deprecation cycle by temporarily allowing affected functions to use both promises and callbacks.

/cc @MarshallOfSound @ckerr

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes