### PR TITLE
chore: remove the process 'exit' event in renderers

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -120,6 +120,21 @@ class AtomSandboxedRenderFrameObserver : public AtomRenderFrameObserver {
   DISALLOW_COPY_AND_ASSIGN(AtomSandboxedRenderFrameObserver);
 };
 
+v8::Local<v8::Value> GetHiddenValue(v8::Local<v8::Context> context,
+                                    const base::StringPiece& key) {
+  v8::Isolate* isolate = context->GetIsolate();
+  v8::Local<v8::Private> privateKey =
+      v8::Private::ForApi(isolate, mate::StringToV8(isolate, key));
+  v8::Local<v8::Value> value;
+  v8::Local<v8::Object> object = context->Global();
+  v8::Maybe<bool> result = object->HasPrivate(context, privateKey);
+  if (!(result.IsJust() && result.FromJust()))
+    return v8::Local<v8::Value>();
+  if (object->GetPrivate(context, privateKey).ToLocal(&value))
+    return value;
+  return v8::Local<v8::Value>();
+}
+
 }  // namespace
 
 AtomSandboxedRendererClient::AtomSandboxedRendererClient() {
@@ -223,10 +238,23 @@ void AtomSandboxedRendererClient::WillReleaseScriptContext(
   if (!render_frame->IsMainFrame())
     return;
 
-  auto* isolate = context->GetIsolate();
-  v8::HandleScope handle_scope(isolate);
-  v8::Context::Scope context_scope(context);
-  InvokeIpcCallback(context, "onExit", std::vector<v8::Local<v8::Value>>());
+  // Notify the main process when current context is going to be released.
+  // Note that when the renderer process is destroyed, the message may not be
+  // sent, we also listen to the "render-view-deleted" event in the main process
+  // to guard that situation.
+  auto contextId = GetHiddenValue(context, "contextId");
+  std::string contextIdValue;
+  if (mate::ConvertFromV8(context->GetIsolate(), contextId, &contextIdValue)) {
+    base::ListValue release_arguments;
+    release_arguments.GetList().emplace_back(
+        "ELECTRON_BROWSER_CONTEXT_RELEASE");
+    release_arguments.GetList().emplace_back(contextIdValue);
+    base::ListValue result;
+    IPC::SyncMessage* message = new AtomFrameHostMsg_Message_Sync(
+        render_frame->GetRoutingID(), "ipc-internal-message-sync",
+        release_arguments, &result);
+    render_frame->Send(message);
+  }
 }
 
 void AtomSandboxedRendererClient::InvokeIpcCallback(

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -15,15 +15,6 @@ const remoteObjectCache = v8Util.createIDWeakMap()
 // An unique ID that can represent current context.
 const contextId = v8Util.getHiddenValue(global, 'contextId')
 
-// Notify the main process when current context is going to be released.
-// Note that when the renderer process is destroyed, the message may not be
-// sent, we also listen to the "render-view-deleted" event in the main process
-// to guard that situation.
-process.on('exit', () => {
-  const command = 'ELECTRON_BROWSER_CONTEXT_RELEASE'
-  ipcRenderer.sendSync(command, contextId)
-})
-
 // Convert the arguments object into an array of meta data.
 function wrapArgs (args, visited = new Set()) {
   const valueToMeta = (value) => {

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -44,7 +44,7 @@ const loadedModules = new Map([
 ])
 
 // AtomSandboxedRendererClient will look for the "ipcNative" hidden object when
-// invoking the `onMessage`/`onExit` callbacks.
+// invoking the `onMessage`/`onInternalMessage` callbacks.
 const ipcNative = process.atomBinding('ipc')
 v8Util.setHiddenValue(global, 'ipcNative', ipcNative)
 
@@ -56,10 +56,6 @@ ipcNative.onInternalMessage = function (channel, args, senderId) {
 
 ipcNative.onMessage = function (channel, args, senderId) {
   electron.ipcRenderer.emit(channel, { sender: electron.ipcRenderer, senderId }, ...args)
-}
-
-ipcNative.onExit = function () {
-  process.emit('exit')
 }
 
 const {
@@ -89,8 +85,6 @@ Object.assign(preloadProcess, processProps)
 
 Object.assign(process, binding.process)
 Object.assign(process, processProps)
-
-process.on('exit', () => preloadProcess.emit('exit'))
 
 // This is the `require` function that will be visible to the preload script
 function preloadRequire (module) {


### PR DESCRIPTION
#### Description of Change
This is so that we can remove [this patch](https://github.com/electron/electron/blob/51cb36fa9b2c9c829050b6612bc6770f048db245/patches/common/chromium/blink_local_frame.patch).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: removed the `process.on('exit')` event