### PR TITLE
[WIP] chore: deprecate webFrame.registerURLSchemeAsPrivileged

### DIFF
--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -74,9 +74,42 @@ Protocol::Protocol(v8::Isolate* isolate, AtomBrowserContext* browser_context)
 
 Protocol::~Protocol() {}
 
-void Protocol::RegisterServiceWorkerSchemes(
-    const std::vector<std::string>& schemes) {
-  atom::AtomBrowserClient::SetCustomServiceWorkerSchemes(schemes);
+void Protocol::RegisterSchemesAsPrivileged(
+    const std::vector<std::string>& schemes,
+    mate::Arguments* args) {
+  bool secure = true;
+  bool bypassCSP = true;
+  bool allowServiceWorkers = true;
+  bool supportFetchAPI = true;
+  bool corsEnabled = true;
+  if (args->Length() == 2) {
+    mate::Dictionary options;
+    if (args->GetNext(&options)) {
+      options.Get("secure", &secure);
+      options.Get("bypassCSP", &bypassCSP);
+      options.Get("allowServiceWorkers", &allowServiceWorkers);
+      options.Get("supportFetchAPI", &supportFetchAPI);
+      options.Get("corsEnabled", &corsEnabled);
+    }
+  }
+  for (const auto& scheme : schemes) {
+    // Register scheme to privileged list (https, wss, data, chrome-extension)
+    if (secure) {
+      url::AddSecureScheme(scheme.c_str());
+    }
+    if (bypassCSP) {
+      url::AddCSPBypassingScheme(scheme.c_str());
+    }
+    if (allowServiceWorkers) {
+      atom::AtomBrowserClient::SetCustomServiceWorkerSchemes({scheme});
+    }
+    if (supportFetchAPI) {
+      // NYI
+    }
+    if (corsEnabled) {
+      url::AddCORSEnabledScheme(scheme.c_str());
+    }
+  }
 }
 
 void Protocol::UnregisterProtocol(const std::string& scheme,
@@ -188,8 +221,8 @@ void Protocol::BuildPrototype(v8::Isolate* isolate,
                               v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "Protocol"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
-      .SetMethod("registerServiceWorkerSchemes",
-                 &Protocol::RegisterServiceWorkerSchemes)
+      .SetMethod("registerSchemesAsPrivileged",
+                 &Protocol::RegisterSchemesAsPrivileged)
       .SetMethod("registerStringProtocol",
                  &Protocol::RegisterProtocol<URLRequestStringJob>)
       .SetMethod("registerBufferProtocol",

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -92,9 +92,8 @@ class Protocol : public mate::TrackableObject<Protocol> {
     DISALLOW_COPY_AND_ASSIGN(CustomProtocolHandler);
   };
 
-  // Register schemes that can handle service worker.
-  void RegisterServiceWorkerSchemes(const std::vector<std::string>& schemes);
-
+  void RegisterSchemesAsPrivileged(const std::vector<std::string>& schemes,
+                                   mate::Arguments* args);
   // Register the protocol with certain request job.
   template <typename RequestJob>
   void RegisterProtocol(const std::string& scheme,

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -493,9 +493,9 @@ void WebFrame::BuildPrototype(v8::Isolate* isolate,
                  &WebFrame::RegisterEmbedderCustomElement)
       .SetMethod("getWebFrameId", &WebFrame::GetWebFrameId)
       .SetMethod("setSpellCheckProvider", &WebFrame::SetSpellCheckProvider)
-      .SetMethod("registerURLSchemeAsBypassingCSP",
+      .SetMethod("_registerURLSchemeAsBypassingCSP",
                  &WebFrame::RegisterURLSchemeAsBypassingCSP)
-      .SetMethod("registerURLSchemeAsPrivileged",
+      .SetMethod("_registerURLSchemeAsPrivileged",
                  &WebFrame::RegisterURLSchemeAsPrivileged)
       .SetMethod("insertText", &WebFrame::InsertText)
       .SetMethod("insertCSS", &WebFrame::InsertCSS)

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -26,6 +26,12 @@ Child windows opened with the `nativeWindowOpen` option will always have Node.js
 
 `wordStart` and `medialCapitalAsWordStart` options are removed.
 
+## `webFrame.registerURLSchemeAsBypassingCSP(scheme)` and `webFrame.registerURLSchemeAsPrivileged(scheme[, options])`
+
+These APIs have been deprecated. Starting in 5.0 this functionality can only be used per app, and not separtely for each webframe.
+Use `app.registerURLSchemeAsPrivileged(scheme[, options])` instead.
+
+
 # Planned Breaking API Changes (4.0)
 
 The following list includes the breaking API changes planned for Electron 4.0.

--- a/lib/renderer/api/web-frame.js
+++ b/lib/renderer/api/web-frame.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { EventEmitter } = require('events')
+const { deprecate } = require('electron')
 const { webFrame, WebFrame } = process.atomBinding('web_frame')
 
 // WebFrame is an EventEmitter.
@@ -9,5 +10,19 @@ EventEmitter.call(webFrame)
 
 // Lots of webview would subscribe to webFrame's events.
 webFrame.setMaxListeners(0)
+
+WebFrame.prototype.registerURLSchemeAsBypassingCSP = function (scheme) {
+  // TODO (nitsakh): Remove in 5.0
+  deprecate.log('webFrame.registerURLSchemeAsBypassingCSP is deprecated. Use app api starting in 5.0')
+
+  return this._registerURLSchemeAsBypassingCSP(scheme)
+}
+
+WebFrame.prototype.registerURLSchemeAsPrivileged = function (scheme, options) {
+  // TODO (nitsakh): Remove in 5.0
+  deprecate.log('webFrame.registerURLSchemeAsPrivileged is deprecated. Use app api starting in 5.0')
+
+  return this._registerURLSchemeAsPrivileged(scheme, options)
+}
 
 module.exports = webFrame


### PR DESCRIPTION
#### Description of Change
This API is being deprecated for 4.x and another app API that'll run in the browser process will be set up. https://github.com/electron/electron/pull/15423#issuecomment-434219676

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Deprecate API webFrame.registerURLSchemeAsPrivileged