### PR TITLE
build: make make_locale_dirs idempotent

### DIFF
--- a/build/mac/make_locale_dirs.py
+++ b/build/mac/make_locale_dirs.py
@@ -13,7 +13,14 @@ import sys
 
 def main(args):
   for dirname in args:
-    os.makedirs(dirname)
+    try:
+      os.makedirs(dirname)
+    except OSError as e:
+      if e.errno == os.errno.EEXIST:
+        # It's OK if it already exists
+        pass
+      else:
+        raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Description of Change
this script was throwing `OSError: File exists` errors when re-running the build on my local machine after previously having built electron.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes