### PR TITLE
build: fix native_mksnapshot build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,7 +370,7 @@ step-maybe-native-mksnapshot-gn-gen: &step-maybe-native-mksnapshot-gn-gen
     command: |
       if [ "$BUILD_NATIVE_MKSNAPSHOT" == "1" ]; then
         cd src
-        gn gen out/native_mksnapshot --args='import("//electron/build/args/native_mksnapshot.gn") cc_wrapper="'"$SCCACHE_PATH"'" v8_snapshot_toolchain="'"$MKSNAPSHOT_TOOLCHAIN"'"'" $GN_EXTRA_ARGS"
+        gn gen out/native_mksnapshot --args='import("'$GN_CONFIG'") cc_wrapper="'"$SCCACHE_PATH"'" v8_snapshot_toolchain="'"$MKSNAPSHOT_TOOLCHAIN"'"'" $GN_EXTRA_ARGS"
       else
         echo 'Skipping native mksnapshot GN gen for non arm build'
       fi
@@ -919,6 +919,7 @@ jobs:
     executor: linux-medium
     environment:
       <<: *env-arm
+      <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
     <<: *steps-native-mksnapshot-build
@@ -978,6 +979,7 @@ jobs:
     executor: linux-medium
     environment:
       <<: *env-arm64
+      <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
     <<: *steps-native-mksnapshot-build

--- a/build/args/native_mksnapshot.gn
+++ b/build/args/native_mksnapshot.gn
@@ -1,2 +1,0 @@
-import("release.gn")
-v8_enable_i18n_support = false

--- a/build/zip.py
+++ b/build/zip.py
@@ -20,6 +20,12 @@ PATHS_TO_SKIP = [
 ]
 
 def skip_path(dep, dist_zip, target_cpu):
+  # Skip specific paths and extensions as well as the following special case:
+  # snapshot_blob.bin is a dependency of mksnapshot.zip because
+  # v8_context_generator needs it, but this file does not get generated for arm
+  # and arm 64 binaries of mksnapshot since they are built on x64 hardware.
+  # Consumers of arm and arm64 mksnapshot can generate snapshot_blob.bin
+  # themselves by running mksnapshot.
   should_skip = (
     any(dep.startswith(path) for path in PATHS_TO_SKIP) or
     any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP) or

--- a/build/zip.py
+++ b/build/zip.py
@@ -19,10 +19,11 @@ PATHS_TO_SKIP = [
   'pyproto',
 ]
 
-def skip_path(dep):
+def skip_path(dep, dist_zip, target_cpu):
   should_skip = (
     any(dep.startswith(path) for path in PATHS_TO_SKIP) or
-    any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP))
+    any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP) or
+    ('arm' in target_cpu and dist_zip == 'mksnapshot.zip' and dep == 'snapshot_blob.bin'))
   if should_skip:
     print("Skipping {}".format(dep))
   return should_skip
@@ -47,7 +48,7 @@ def main(argv):
   else:
     with zipfile.ZipFile(dist_zip, 'w', zipfile.ZIP_DEFLATED) as z:
       for dep in dist_files:
-        if skip_path(dep):
+        if skip_path(dep, dist_zip, target_cpu):
           continue
         if os.path.isdir(dep):
           for root, dirs, files in os.walk(dep):

--- a/patches/common/v8/.patches
+++ b/patches/common/v8/.patches
@@ -18,3 +18,4 @@ dcheck.patch
 disable-warning-win.patch
 expose_mksnapshot.patch
 build-torque-with-x64-toolchain-on-arm.patch
+do_not_run_arm_arm64_mksnapshot_binaries.patch

--- a/patches/common/v8/do_not_run_arm_arm64_mksnapshot_binaries.patch
+++ b/patches/common/v8/do_not_run_arm_arm64_mksnapshot_binaries.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Kleinschmidt <jkleinsc@github.com>
+Date: Mon, 19 Nov 2018 18:33:56 -0500
+Subject: Do not run arm/arm64 mksnapshot binaries
+
+For arm and arm64 target_arches, Chromium builds mksnapshot as an x64 binary and
+as part of that build mksnapshot is executed to produce snapshot_blob.bin.  
+Chromium does not build native arm and arm64 binaries of mksnapshot, but 
+Electron does, so this patch makes sure that the build doesn't try to run 
+the mksnapshot binary if it was built for arm or arm64.
+
+diff --git a/BUILD.gn b/BUILD.gn
+index b1194e4b828e66d8d09fac57481efe313031f3ac..c256945650c24324c28a2e17fb299a1d0c2dcd19 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -1247,9 +1247,19 @@ if (v8_use_snapshot && v8_use_external_startup_data) {
+     ]
+     public_deps = [
+       ":natives_blob",
+-      ":run_mksnapshot_default",
+     ]
+ 
++    if (v8_snapshot_toolchain == "//build/toolchain/linux:clang_arm" ||
++        v8_snapshot_toolchain == "//build/toolchain/linux:clang_arm64") {
++      public_deps += [
++        ":mksnapshot($v8_snapshot_toolchain)",
++      ]
++    } else {
++      public_deps += [
++        ":run_mksnapshot_default",
++      ]
++    }
++
+     if (v8_use_multi_snapshots) {
+       public_deps += [ ":run_mksnapshot_trusted" ]
+     }


### PR DESCRIPTION
When we changed our electron_mksnapshot_zip target to include the v8_context_snapshot_generator, this dependency made the `run_mksnapshot` target run which was trying to run an arm/arm64 binary on x64 hardware.  This PR changes our native_mksnapshot build to not try to run that binary.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes