### PR TITLE
chore: clean up FIXME and TODO comments in our tests

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -14,6 +14,8 @@ const { closeWindow } = require('./window-helpers')
 const { expect } = chai
 const { app, BrowserWindow, Menu, ipcMain } = remote
 
+const isCI = remote.getGlobal('isCi')
+
 chai.use(chaiAsPromised)
 chai.use(dirtyChai)
 
@@ -753,27 +755,9 @@ describe('app module', () => {
       large: process.platform === 'win32' ? 32 : 48
     }
 
-<<<<<<< HEAD
-    // (alexeykuzmin): `.skip()` called in `before`
-    // doesn't affect nested `describe`s.
-    beforeEach(function () {
-      // FIXME Get these specs running on Linux CI
-      if (process.platform === 'linux' && isCI) {
-        this.skip()
-      }
-    })
-
     it('fetches a non-empty icon', async () => {
       const icon = await app.getFileIcon(iconPath)
       expect(icon.isEmpty()).to.be.false()
-=======
-    it('fetches a non-empty icon', done => {
-      app.getFileIcon(iconPath, (err, icon) => {
-        expect(err).to.be.null()
-        expect(icon.isEmpty()).to.be.false()
-        done()
-      })
->>>>>>> chore: remove FIXME test skips to see what passes
     })
 
     it('fetches normal icon size by default', async () => {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -8,12 +8,11 @@ const fs = require('fs')
 const path = require('path')
 const { ipcRenderer, remote } = require('electron')
 const { emittedOnce } = require('./events-helpers')
+const { platformIt } = require('./test-helpers')
 const { closeWindow } = require('./window-helpers')
 
 const { expect } = chai
 const { app, BrowserWindow, Menu, ipcMain } = remote
-
-const isCI = remote.getGlobal('isCi')
 
 chai.use(chaiAsPromised)
 chai.use(dirtyChai)
@@ -522,13 +521,7 @@ describe('app module', () => {
       expect(app.getLoginItemSettings().openAsHidden).to.be.false()
     })
 
-    it('allows you to pass a custom executable and arguments', function () {
-      if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
+    platformIt('allows you to pass a custom executable and arguments', ['win32'], function () {
       app.setLoginItemSettings({ openAtLogin: true, path: updateExe, args: processStartArgs })
 
       expect(app.getLoginItemSettings().openAtLogin).to.be.false()
@@ -760,6 +753,7 @@ describe('app module', () => {
       large: process.platform === 'win32' ? 32 : 48
     }
 
+<<<<<<< HEAD
     // (alexeykuzmin): `.skip()` called in `before`
     // doesn't affect nested `describe`s.
     beforeEach(function () {
@@ -772,6 +766,14 @@ describe('app module', () => {
     it('fetches a non-empty icon', async () => {
       const icon = await app.getFileIcon(iconPath)
       expect(icon.isEmpty()).to.be.false()
+=======
+    it('fetches a non-empty icon', done => {
+      app.getFileIcon(iconPath, (err, icon) => {
+        expect(err).to.be.null()
+        expect(icon.isEmpty()).to.be.false()
+        done()
+      })
+>>>>>>> chore: remove FIXME test skips to see what passes
     })
 
     it('fetches normal icon size by default', async () => {
@@ -799,10 +801,7 @@ describe('app module', () => {
         expect(size.width).to.equal(sizes.normal)
       })
 
-      it('fetches a large icon', async () => {
-        // macOS does not support large icons
-        if (process.platform === 'darwin') return
-
+      platformIt('fetches a large icon', ['linux', 'win32'], async () => {
         const icon = await app.getFileIcon(iconPath, { size: 'large' })
         const size = icon.getSize()
 

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -69,14 +69,8 @@ describe('autoUpdater module', function () {
       })
     })
 
-    describe('on Mac', function () {
+    platformDescribe('on Mac', ['darwin'], function () {
       const isServerTypeError = (err) => err.message.includes('Expected serverType to be \'default\' or \'json\'')
-
-      before(function () {
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
-      })
 
       it('emits an error when the application is unsigned', done => {
         ipcRenderer.once('auto-updater-error', (event, message) => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -19,6 +19,8 @@ const { expect } = chai
 const isCI = remote.getGlobal('isCi')
 const nativeModulesEnabled = remote.getGlobal('nativeModulesEnabled')
 
+const { platformIt } = require('./test-helpers')
+
 chai.use(dirtyChai)
 
 describe('BrowserWindow module', () => {
@@ -797,16 +799,7 @@ describe('BrowserWindow module', () => {
       w.setAlwaysOnTop(true)
       assert.strictEqual(w.isAlwaysOnTop(), true)
     })
-    it('raises an error when relativeLevel is out of bounds', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test instead of marking it as passed.
-        // afterEach hook won't be run if a test is skipped dynamically.
-        // If afterEach isn't run current window won't be destroyed
-        // and the next test will fail on assertion in `closeWindow()`.
-        // this.skip()
-        return
-      }
-
+    platformIt('raises an error when relativeLevel is out of bounds', ['darwin'], function () {
       assert.throws(() => {
         w.setAlwaysOnTop(true, '', -2147483644)
       })
@@ -2157,15 +2150,6 @@ describe('BrowserWindow module', () => {
       w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState changes when window is shown inactive', function (done) {
-      if (isCI && process.platform === 'win32') {
-        // FIXME(alexeykuzmin): Skip the test instead of marking it as passed.
-        // afterEach hook won't be run if a test is skipped dynamically.
-        // If afterEach isn't run current window won't be destroyed
-        // and the next test will fail on assertion in `closeWindow()`.
-        // this.skip()
-        return done()
-      }
-
       w = new BrowserWindow({ width: 100, height: 100 })
 
       onNextVisibilityChange((visibilityState, hidden) => {
@@ -2182,16 +2166,7 @@ describe('BrowserWindow module', () => {
 
       w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
-    it('visibilityState changes when window is minimized', function (done) {
-      if (isCI && process.platform === 'linux') {
-        // FIXME(alexeykuzmin): Skip the test instead of marking it as passed.
-        // afterEach hook won't be run if a test is skipped dynamically.
-        // If afterEach isn't run current window won't be destroyed
-        // and the next test will fail on assertion in `closeWindow()`.
-        // this.skip()
-        return done()
-      }
-
+    platformIt('visibilityState changes when window is minimized', ['win32', 'darwin'], function (done) {
       w = new BrowserWindow({ width: 100, height: 100 })
 
       onNextVisibilityChange((visibilityState, hidden) => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -19,7 +19,7 @@ const { expect } = chai
 const isCI = remote.getGlobal('isCi')
 const nativeModulesEnabled = remote.getGlobal('nativeModulesEnabled')
 
-const { platformIt } = require('./test-helpers')
+const { platformIt, platformDescribe } = require('./test-helpers')
 
 chai.use(dirtyChai)
 
@@ -413,9 +413,7 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow.show()', () => {
     before(function () {
-      if (isCI) {
-        this.skip()
-      }
+      if (isCI) this.skip()
     })
 
     it('should focus on window', () => {
@@ -437,9 +435,7 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow.hide()', () => {
     before(function () {
-      if (isCI) {
-        this.skip()
-      }
+      if (isCI) this.skip()
     })
 
     it('should defocus on window', () => {
@@ -671,9 +667,7 @@ describe('BrowserWindow module', () => {
     })
     describe(`Maximized state`, () => {
       before(function () {
-        if (isCI) {
-          this.skip()
-        }
+        if (isCI) this.skip()
       })
       it(`checks normal bounds when maximized`, (done) => {
         const bounds = w.getBounds()
@@ -699,9 +693,7 @@ describe('BrowserWindow module', () => {
     })
     describe(`Minimized state`, () => {
       before(function () {
-        if (isCI) {
-          this.skip()
-        }
+        if (isCI) this.skip()
       })
       it(`checks normal bounds when minimized`, (done) => {
         const bounds = w.getBounds()
@@ -712,6 +704,7 @@ describe('BrowserWindow module', () => {
         w.show()
         w.minimize()
       })
+
       it(`checks normal bounds when restored`, (done) => {
         const bounds = w.getBounds()
         w.once('minimize', () => {
@@ -725,15 +718,11 @@ describe('BrowserWindow module', () => {
         w.minimize()
       })
     })
-    describe(`Fullscreen state`, () => {
+    platformDescribe(`Fullscreen state`, ['win32', 'linux'], () => {
       before(function () {
-        if (isCI) {
-          this.skip()
-        }
-        if (process.platform === 'darwin') {
-          this.skip()
-        }
+        if (isCI) this.skip()
       })
+
       it(`checks normal bounds when fullscreen'ed`, (done) => {
         const bounds = w.getBounds()
         w.once('enter-full-screen', () => {
@@ -743,11 +732,10 @@ describe('BrowserWindow module', () => {
         w.show()
         w.setFullScreen(true)
       })
+
       it(`checks normal bounds when unfullscreen'ed`, (done) => {
         const bounds = w.getBounds()
-        w.once('enter-full-screen', () => {
-          w.setFullScreen(false)
-        })
+        w.once('enter-full-screen', () => w.setFullScreen(false))
         w.once('leave-full-screen', () => {
           assertBoundsEqual(w.getNormalBounds(), bounds)
           done()
@@ -810,13 +798,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.alwaysOnTop() resets level on minimize', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.alwaysOnTop() resets level on minimize', ['darwin'], () => {
     it('resets the windows level on minimize', () => {
       assert.strictEqual(w.isAlwaysOnTop(), false)
       w.setAlwaysOnTop(true, 'screen-saver')
@@ -829,13 +811,7 @@ describe('BrowserWindow module', () => {
   })
 
   describe('BrowserWindow.setAutoHideCursor(autoHide)', () => {
-    describe('on macOS', () => {
-      before(function () {
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('on macOS', ['darwin'], () => {
       it('allows changing cursor auto-hiding', () => {
         assert.doesNotThrow(() => {
           w.setAutoHideCursor(false)
@@ -844,26 +820,14 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('on non-macOS platforms', () => {
-      before(function () {
-        if (process.platform === 'darwin') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('on non-macOS platforms', ['win32', 'linux'], () => {
       it('is not available', () => {
         assert.ok(!w.setAutoHideCursor)
       })
     })
   })
 
-  describe('BrowserWindow.selectPreviousTab()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.selectPreviousTab()', ['darwin'], () => {
     it('does not throw', () => {
       assert.doesNotThrow(() => {
         w.selectPreviousTab()
@@ -871,13 +835,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.selectNextTab()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.selectNextTab()', ['darwin'], () => {
     it('does not throw', () => {
       assert.doesNotThrow(() => {
         w.selectNextTab()
@@ -885,13 +843,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.mergeAllWindows()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.mergeAllWindows()', ['darwin'], () => {
     it('does not throw', () => {
       assert.doesNotThrow(() => {
         w.mergeAllWindows()
@@ -899,13 +851,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.moveTabToNewWindow()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.moveTabToNewWindow()', ['darwin'], () => {
     it('does not throw', () => {
       assert.doesNotThrow(() => {
         w.moveTabToNewWindow()
@@ -913,13 +859,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.toggleTabBar()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.toggleTabBar()', ['darwin'], () => {
     it('does not throw', () => {
       assert.doesNotThrow(() => {
         w.toggleTabBar()
@@ -927,13 +867,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.addTabbedWindow()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.addTabbedWindow()', ['darwin'], () => {
     it('does not throw', (done) => {
       const tabbedWindow = new BrowserWindow({})
       assert.doesNotThrow(() => {
@@ -955,13 +889,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.setWindowButtonVisibility()', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.setWindowButtonVisibility()', ['darwin'], () => {
     it('does not throw', () => {
       assert.doesNotThrow(() => {
         w.setWindowButtonVisibility(true)
@@ -994,13 +922,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.setAppDetails(options)', () => {
-    before(function () {
-      if (process.platform !== 'win32') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('BrowserWindow.setAppDetails(options)', ['win32'], () => {
     it('supports setting the app details', () => {
       const iconPath = path.join(fixtures, 'assets', 'icon.ico')
 
@@ -1035,9 +957,7 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow.fromWebContents(webContents)', () => {
     let contents = null
-
     beforeEach(() => { contents = webContents.create({}) })
-
     afterEach(() => { contents.destroy() })
 
     it('returns the window with the webContents', () => {
@@ -1048,9 +968,7 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow.fromDevToolsWebContents(webContents)', () => {
     let contents = null
-
     beforeEach(() => { contents = webContents.create({}) })
-
     afterEach(() => { contents.destroy() })
 
     it('returns the window with the webContents', (done) => {
@@ -1165,12 +1083,8 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('"titleBarStyle" option', () => {
+  platformDescribe('"titleBarStyle" option', ['darwin'], () => {
     before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-
       if (parseInt(os.release().split('.')[0]) < 14) {
         this.skip()
       }
@@ -1200,13 +1114,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('enableLargerThanScreen" option', () => {
-    before(function () {
-      if (process.platform === 'linux') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('enableLargerThanScreen" option', ['darwin', 'win32'], () => {
     beforeEach(() => {
       w.destroy()
       w = new BrowserWindow({
@@ -1223,6 +1131,7 @@ describe('BrowserWindow module', () => {
       assert.strictEqual(after[0], -10)
       assert.strictEqual(after[1], -10)
     })
+
     it('can set the window larger than screen', () => {
       const size = screen.getPrimaryDisplay().size
       size.width += 100
@@ -1232,13 +1141,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('"zoomToPageWidth" option', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('"zoomToPageWidth" option', ['darwin'], () => {
     it('sets the window width to the page width when used', () => {
       w.destroy()
       w = new BrowserWindow({
@@ -2290,14 +2193,8 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('sheet-begin event', () => {
+  platformDescribe('sheet-begin event', ['darwin'], () => {
     let sheet = null
-
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
 
     afterEach(() => {
       return closeWindow(sheet, { assertSingleWindow: false }).then(() => { sheet = null })
@@ -2316,14 +2213,8 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('sheet-end event', () => {
+  platformDescribe('sheet-end event', ['darwin'], () => {
     let sheet = null
-
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
 
     afterEach(() => {
       return closeWindow(sheet, { assertSingleWindow: false }).then(() => { sheet = null })
@@ -2343,9 +2234,7 @@ describe('BrowserWindow module', () => {
   describe('beginFrameSubscription method', () => {
     before(function () {
       // This test is too slow, only test it on CI.
-      if (!isCI) {
-        this.skip()
-      }
+      if (!isCI) this.skip()
 
       // FIXME These specs crash on Linux when run in a docker container
       if (isCI && process.platform === 'linux') {
@@ -2663,14 +2552,7 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('fullscreenable state', () => {
-      before(function () {
-        // Only implemented on macOS.
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('fullscreenable state', ['darwin'], () => {
       it('can be changed with fullscreenable option', () => {
         w.destroy()
         w = new BrowserWindow({ show: false, fullscreenable: false })
@@ -2686,14 +2568,7 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('kiosk state', () => {
-      before(function () {
-        // Only implemented on macOS.
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('kiosk state', ['darwin'], () => {
       it('can be changed with setKiosk method', (done) => {
         w.destroy()
         w = new BrowserWindow()
@@ -2710,14 +2585,7 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('fullscreen state with resizable set', () => {
-      before(function () {
-        // Only implemented on macOS.
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('fullscreen state with resizable set', ['darwin'], () => {
       it('resizable flag should be set to true and restored', (done) => {
         w.destroy()
         w = new BrowserWindow({ resizable: false })
@@ -2733,14 +2601,7 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('fullscreen state', () => {
-      before(function () {
-        // Only implemented on macOS.
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('fullscreen state', ['darwin'], () => {
       it('can be changed with setFullScreen method', (done) => {
         w.destroy()
         w = new BrowserWindow()
@@ -2839,14 +2700,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.setFullScreen(false)', () => {
-    before(function () {
-      // only applicable to windows: https://github.com/electron/electron/issues/6036
-      if (process.platform !== 'win32') {
-        this.skip()
-      }
-    })
-
+  describe('BrowserWindow.setFullScreen(false)', ['win32'], () => {
     it('should restore a normal visible window from a fullscreen startup state', (done) => {
       w.webContents.once('did-finish-load', () => {
         // start fullscreen and hidden
@@ -2861,6 +2715,7 @@ describe('BrowserWindow module', () => {
       })
       w.loadURL('about:blank')
     })
+
     it('should keep window hidden if already in hidden state', (done) => {
       w.webContents.once('did-finish-load', () => {
         w.once('leave-full-screen', () => {
@@ -2874,13 +2729,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.setFullScreen(false) when HTML fullscreen', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  describe('BrowserWindow.setFullScreen(false) when HTML fullscreen', ['darwin'], () => {
     it('exits HTML fullscreen when window leaves fullscreen', (done) => {
       w.destroy()
       w = new BrowserWindow()
@@ -2931,13 +2780,7 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('win.setParentWindow(parent)', () => {
-      before(function () {
-        if (process.platform === 'win32') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('win.setParentWindow(parent)', ['darwin', 'linux'], () => {
       beforeEach(() => {
         if (c != null) c.destroy()
         c = new BrowserWindow({ show: false })
@@ -2968,14 +2811,7 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('modal option', () => {
-      before(function () {
-        // The isEnabled API is not reliable on macOS.
-        if (process.platform === 'darwin') {
-          this.skip()
-        }
-      })
-
+    platformDescribe('modal option', ['win32', 'linux'], () => {
       beforeEach(() => {
         if (c != null) c.destroy()
         c = new BrowserWindow({ show: false, parent: w, modal: true })
@@ -3334,13 +3170,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('previewFile', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('previewFile', ['darwin'], () => {
     it('opens the path in Quick Look on macOS', () => {
       assert.doesNotThrow(() => {
         w.previewFile(__filename)

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -4,6 +4,8 @@ const { Buffer } = require('buffer')
 
 const { clipboard, nativeImage } = require('electron')
 
+const { platformIt } = require('./test-helpers')
+
 describe('clipboard module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures')
 
@@ -104,15 +106,15 @@ describe('clipboard module', () => {
   })
 
   describe('clipboard.writeBuffer(format, buffer)', () => {
-    it('writes a Buffer for the specified format', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
+    platformIt('writes a Buffer for the specified format', ['darwin'], function () {
       const buffer = Buffer.from('writeBuffer', 'utf8')
       clipboard.writeBuffer('public.utf8-plain-text', buffer)
+      expect(clipboard.readText()).to.equal('writeBuffer')
+    })
+
+    platformIt('writes a Buffer for the specified format', ['linux'], function () {
+      const buffer = Buffer.from('writeBuffer', 'utf8')
+      clipboard.writeBuffer('text/plain', buffer)
       expect(clipboard.readText()).to.equal('writeBuffer')
     })
 

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -4,7 +4,7 @@ const { Buffer } = require('buffer')
 
 const { clipboard, nativeImage } = require('electron')
 
-const { platformIt } = require('./test-helpers')
+const { platformIt, platformDescribe } = require('./test-helpers')
 
 describe('clipboard module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures')
@@ -43,13 +43,7 @@ describe('clipboard module', () => {
     })
   })
 
-  describe('clipboard.readBookmark', () => {
-    before(function () {
-      if (process.platform === 'linux') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('clipboard.readBookmark', ['win32', 'darwin'], () => {
     it('returns title and url', () => {
       clipboard.writeBookmark('a title', 'https://electronjs.org')
       expect(clipboard.readBookmark()).to.deep.equal({
@@ -92,13 +86,7 @@ describe('clipboard module', () => {
     })
   })
 
-  describe('clipboard.read/writeFindText(text)', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('clipboard.read/writeFindText(text)', ['darwin'], () => {
     it('reads and write text to the find pasteboard', () => {
       clipboard.writeFindText('find this')
       expect(clipboard.readFindText()).to.equal('find this')
@@ -106,13 +94,13 @@ describe('clipboard module', () => {
   })
 
   describe('clipboard.writeBuffer(format, buffer)', () => {
-    platformIt('writes a Buffer for the specified format', ['darwin'], function () {
+    platformIt('writes a Buffer for the specified format', ['darwin'], () => {
       const buffer = Buffer.from('writeBuffer', 'utf8')
       clipboard.writeBuffer('public.utf8-plain-text', buffer)
       expect(clipboard.readText()).to.equal('writeBuffer')
     })
 
-    platformIt('writes a Buffer for the specified format', ['linux'], function () {
+    platformIt('writes a Buffer for the specified format', ['linux'], () => {
       const buffer = Buffer.from('writeBuffer', 'utf8')
       clipboard.writeBuffer('text/plain', buffer)
       expect(clipboard.readText()).to.equal('writeBuffer')
@@ -126,13 +114,7 @@ describe('clipboard module', () => {
   })
 
   describe('clipboard.readBuffer(format)', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
-    it('returns a Buffer of the content for the specified format', () => {
+    platformIt('returns a Buffer of the content for the specified format', ['darwin'], () => {
       const buffer = Buffer.from('this is binary', 'utf8')
       clipboard.writeText(buffer.toString())
       expect(buffer.equals(clipboard.readBuffer('public.utf8-plain-text'))).to.equal(true)

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -286,12 +286,6 @@ describe('crashReporter module', () => {
       assert.throws(() => require('electron').crashReporter.getUploadToServer())
     })
     it('returns true when uploadToServer is set to true', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
       crashReporter.start({
         companyName: 'Umbrella Corporation',
         submitURL: 'http://127.0.0.1/crashes',
@@ -300,12 +294,6 @@ describe('crashReporter module', () => {
       assert.strictEqual(crashReporter.getUploadToServer(), true)
     })
     it('returns false when uploadToServer is set to false', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
       crashReporter.start({
         companyName: 'Umbrella Corporation',
         submitURL: 'http://127.0.0.1/crashes',
@@ -321,12 +309,6 @@ describe('crashReporter module', () => {
       assert.throws(() => require('electron').crashReporter.setUploadToServer('arg'))
     })
     it('sets uploadToServer false when called with false', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
       crashReporter.start({
         companyName: 'Umbrella Corporation',
         submitURL: 'http://127.0.0.1/crashes',
@@ -336,12 +318,6 @@ describe('crashReporter module', () => {
       assert.strictEqual(crashReporter.getUploadToServer(), false)
     })
     it('sets uploadToServer true when called with true', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
       crashReporter.start({
         companyName: 'Umbrella Corporation',
         submitURL: 'http://127.0.0.1/crashes',
@@ -363,12 +339,6 @@ describe('crashReporter module', () => {
       assert(typeof parameters === 'object')
     })
     it('adds a parameter to current parameters', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
       crashReporter.start({
         companyName: 'Umbrella Corporation',
         submitURL: 'http://127.0.0.1/crashes'
@@ -378,12 +348,6 @@ describe('crashReporter module', () => {
       assert('hello' in crashReporter.getParameters())
     })
     it('removes a parameter from current parameters', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
       crashReporter.start({
         companyName: 'Umbrella Corporation',
         submitURL: 'http://127.0.0.1/crashes'

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -5,6 +5,8 @@ const dirtyChai = require('dirty-chai')
 const { nativeImage } = require('electron')
 const path = require('path')
 
+const { platformIt } = require('./test-helpers')
+
 const { expect } = chai
 chai.use(dirtyChai)
 
@@ -300,13 +302,7 @@ describe('nativeImage module', () => {
       expect(image.getSize()).to.deep.equal({ width: 538, height: 190 })
     })
 
-    it('Gets an NSImage pointer on macOS', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
+    platformIt('Gets an NSImage pointer on macOS', ['darwin'], () => {
       const imagePath = `${path.join(__dirname, 'fixtures', 'api')}${path.sep}..${path.sep}${path.join('assets', 'logo.png')}`
       const image = nativeImage.createFromPath(imagePath)
       const nsimage = image.getNativeHandle()
@@ -318,13 +314,7 @@ describe('nativeImage module', () => {
       expect(allBytesAreNotNull)
     })
 
-    it('loads images from .ico files on Windows', function () {
-      if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
+    platformIt('loads images from .ico files on Windows', ['win32'], () => {
       const imagePath = path.join(__dirname, 'fixtures', 'assets', 'icon.ico')
       const image = nativeImage.createFromPath(imagePath)
       expect(image.isEmpty()).to.be.false()
@@ -338,35 +328,17 @@ describe('nativeImage module', () => {
       expect(image.isEmpty())
     })
 
-    it('returns empty on non-darwin platforms', function () {
-      if (process.platform === 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
+    platformIt('returns empty on non-darwin platforms', ['win32', 'linux'], function () {
       const image = nativeImage.createFromNamedImage('NSActionTemplate')
       expect(image.isEmpty())
     })
 
-    it('returns a valid image on darwin', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
+    platformIt('returns a valid image on darwin', ['darwin'], function () {
       const image = nativeImage.createFromNamedImage('NSActionTemplate')
       expect(image.isEmpty()).to.be.false()
     })
 
-    it('returns allows an HSL shift for a valid image on darwin', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
-
+    platformIt('returns allows an HSL shift for a valid image on darwin', ['darwin'], function () {
       const image = nativeImage.createFromNamedImage('NSActionTemplate', [0.5, 0.2, 0.8])
       expect(image.isEmpty()).to.be.false()
     })

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { expect } = require('chai')
+const { platformDescribe } = require('./test-helpers')
 
 describe('process module', () => {
   describe('process.getCreationTime()', () => {
@@ -20,13 +21,7 @@ describe('process module', () => {
     })
   })
 
-  describe('process.getIOCounters()', () => {
-    before(function () {
-      if (process.platform === 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('process.getIOCounters()', ['win32', 'linux'], () => {
     it('returns an io counters object', () => {
       const ioCounters = process.getIOCounters()
       expect(ioCounters.readOperationCount).to.be.a('number')

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -426,12 +426,6 @@ describe('session module', () => {
     })
 
     it('can generate a default filename', function (done) {
-      if (process.env.APPVEYOR === 'True') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
-      }
-
       downloadServer.listen(0, '127.0.0.1', () => {
         const port = downloadServer.address().port
         ipcRenderer.sendSync('set-download-option', true, false)

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -4,7 +4,9 @@ const path = require('path')
 const os = require('os')
 const { shell } = require('electron')
 
-describe('shell module', () => {
+const { platformDescribe } = require('./test-helpers')
+
+platformDescribe('shell module', ['win32'], () => {
   const fixtures = path.resolve(__dirname, 'fixtures')
   const shortcutOptions = {
     target: 'C:\\target',
@@ -15,13 +17,6 @@ describe('shell module', () => {
     icon: 'icon',
     iconIndex: 1
   }
-
-  // (alexeykuzmin): `.skip()` in `before` doesn't work for nested `describe`s.
-  beforeEach(function () {
-    if (process.platform !== 'win32') {
-      this.skip()
-    }
-  })
 
   describe('shell.readShortcutLink(shortcutPath)', () => {
     it('throws when failed', () => {

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -2,14 +2,10 @@ const assert = require('assert')
 const { remote } = require('electron')
 const { systemPreferences } = remote
 
-describe('systemPreferences module', () => {
-  describe('systemPreferences.getAccentColor', () => {
-    before(function () {
-      if (process.platform !== 'win32') {
-        this.skip()
-      }
-    })
+const { platformDescribe } = require('./test-helpers')
 
+describe('systemPreferences module', () => {
+  platformDescribe('systemPreferences.getAccentColor', ['win32'], () => {
     it('should return a non-empty string', () => {
       const accentColor = systemPreferences.getAccentColor()
       assert.notStrictEqual(accentColor, null)
@@ -17,13 +13,7 @@ describe('systemPreferences module', () => {
     })
   })
 
-  describe('systemPreferences.getColor(id)', () => {
-    before(function () {
-      if (process.platform !== 'win32') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('systemPreferences.getColor(id)', ['win32'], () => {
     it('throws an error when the id is invalid', () => {
       assert.throws(() => {
         systemPreferences.getColor('not-a-color')
@@ -35,13 +25,7 @@ describe('systemPreferences module', () => {
     })
   })
 
-  describe('systemPreferences.registerDefaults(defaults)', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('systemPreferences.registerDefaults(defaults)', ['darwin'], () => {
     it('registers defaults', () => {
       const defaultsMap = [
         { key: 'one', type: 'string', value: 'ONE' },
@@ -77,13 +61,7 @@ describe('systemPreferences module', () => {
     })
   })
 
-  describe('systemPreferences.getUserDefault(key, type)', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('systemPreferences.getUserDefault(key, type)', ['darwin'], () => {
     it('returns values for known user defaults', () => {
       const locale = systemPreferences.getUserDefault('AppleLocale', 'string')
       assert.strictEqual(typeof locale, 'string')
@@ -107,7 +85,7 @@ describe('systemPreferences module', () => {
     })
   })
 
-  describe('systemPreferences.setUserDefault(key, type, value)', () => {
+  platformDescribe('systemPreferences.setUserDefault(key, type, value)', ['darwin'], () => {
     const KEY = 'SystemPreferencesTest'
     const TEST_CASES = [
       ['string', 'abc'],
@@ -119,12 +97,6 @@ describe('systemPreferences module', () => {
       ['array', [1, 2, 3]],
       ['dictionary', { 'a': 1, 'b': 2 }]
     ]
-
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
 
     it('sets values', () => {
       for (const [type, value] of TEST_CASES) {
@@ -149,13 +121,7 @@ describe('systemPreferences module', () => {
     })
   })
 
-  describe('systemPreferences.setUserDefault(key, type, value)', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('systemPreferences.setUserDefault(key, type, value)', ['darwin'], () => {
     it('removes keys', () => {
       const KEY = 'SystemPreferencesTest'
       systemPreferences.setUserDefault(KEY, 'string', 'foo')

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -948,10 +948,7 @@ describe('webContents module', () => {
         { name: 'dom-ready', url: `${server.url}/200` },
         { name: 'did-stop-loading', url: `${server.url}/200` },
         { name: 'did-finish-load', url: `${server.url}/200` },
-        // FIXME: Multiple Emit calls inside an observer assume that object
-        // will be alive till end of the observer. Synchronous `destroy` api
-        // violates this contract and crashes.
-        // { name: 'did-frame-finish-load', url: `${server.url}/200` },
+        { name: 'did-frame-finish-load', url: `${server.url}/200` },
         { name: 'did-fail-load', url: `${server.url}/404` }
       ]
       const responseEvent = 'webcontents-destroyed'

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -6,6 +6,7 @@ const path = require('path')
 const temp = require('temp').track()
 const util = require('util')
 const { closeWindow } = require('./window-helpers')
+const { platformDescribe } = require('./test-helpers')
 
 const nativeImage = require('electron').nativeImage
 const remote = require('electron').remote
@@ -883,36 +884,30 @@ describe('asar package', function () {
       })
     })
 
-    describe('child_process.execSync', function () {
+    describe('child_process.execSync', () => {
       const echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
-      it('should not try to extract the command if there is a reference to a file inside an .asar', function (done) {
+      it('should not try to extract the command if there is a reference to a file inside an .asar', (done) => {
         const stdout = ChildProcess.execSync('echo ' + echo + ' foo bar')
         assert.strictEqual(stdout.toString().replace(/\r/g, ''), echo + ' foo bar\n')
         done()
       })
     })
 
-    describe('child_process.execFile', function () {
+    platformDescribe('child_process.execFile', ['darwin'], () => {
       const execFile = ChildProcess.execFile
       const execFileSync = ChildProcess.execFileSync
       const echo = path.join(fixtures, 'asar', 'echo.asar', 'echo')
 
-      before(function () {
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
-      })
-
-      it('executes binaries', function (done) {
-        execFile(echo, ['test'], function (error, stdout) {
+      it('executes binaries', (done) => {
+        execFile(echo, ['test'], (error, stdout) => {
           assert.strictEqual(error, null)
           assert.strictEqual(stdout, 'test\n')
           done()
         })
       })
 
-      it('execFileSync executes binaries', function () {
+      it('execFileSync executes binaries', () => {
         const output = execFileSync(echo, ['test'])
         assert.strictEqual(String(output), 'test\n')
       })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -18,6 +18,8 @@ const features = process.atomBinding('features')
 const { expect } = chai
 chai.use(dirtyChai)
 
+const { platformIt } = require('./test-helpers')
+
 /* Most of the APIs here don't use standard callbacks */
 /* eslint-disable standard/no-callback-literal */
 
@@ -1441,10 +1443,7 @@ describe('font fallback', () => {
     }[process.platform])
   })
 
-  it('should fall back to Japanese font for sans-serif Japanese script', async function () {
-    if (process.platform === 'linux') {
-      return this.skip()
-    }
+  platformIt('should fall back to Japanese font for sans-serif Japanese script', ['win32', 'darwin'], async function () {
     const html = `
     <html lang="ja-JP">
       <head>

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -855,9 +855,12 @@ describe('chromium feature', () => {
   })
 
   describe('webgl', () => {
-    it('can be get as context in canvas', () => {
+    it('can be get as context in canvas', function () {
       // WebGL doesn't work on ia32 linux in CI
-      if (process.platform === 'linux' && process.arch === 'ia32' && isCI) return;
+      if (process.platform === 'linux' && process.arch === 'ia32' && isCI) {
+        this.skip()
+        return
+      }
 
       const webgl = document.createElement('canvas').getContext('webgl')
       assert.notStrictEqual(webgl, null)

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -855,18 +855,9 @@ describe('chromium feature', () => {
   })
 
   describe('webgl', () => {
-    before(function () {
-      if (isCI && process.platform === 'win32') {
-        this.skip()
-      }
-    })
-
     it('can be get as context in canvas', () => {
-      if (process.platform === 'linux') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
+      // WebGL doesn't work on ia32 linux in CI
+      if (process.platform === 'linux' && process.arch === 'ia32' && isCI) return;
 
       const webgl = document.createElement('canvas').getContext('webgl')
       assert.notStrictEqual(webgl, null)

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -10,6 +10,8 @@ const { ipcRenderer, remote } = require('electron')
 const isCI = remote.getGlobal('isCi')
 chai.use(dirtyChai)
 
+const { platformDescribe } = require('./test-helpers')
+
 describe('node feature', () => {
   const fixtures = path.join(__dirname, 'fixtures')
 
@@ -297,13 +299,7 @@ describe('node feature', () => {
     })
   })
 
-  describe('net.connect', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
-    })
-
+  platformDescribe('net.connect', ['darwin'], () => {
     it('emit error when connect to a socket path without listeners', (done) => {
       const socketPath = path.join(os.tmpdir(), 'atom-shell-test.sock')
       const script = path.join(fixtures, 'module', 'create_socket.js')

--- a/spec/test-helpers.js
+++ b/spec/test-helpers.js
@@ -14,7 +14,19 @@ const platformIt = (name, platforms, fn) => {
   return platformDependent(platforms, [it, it.skip], [name, fn])
 }
 
+// eslint-disable standard/no-unused-vars
+const xplatformDescribe = (name, platforms, fn) => {
+  return xdescribe([name, fn])
+}
+
+// eslint-disable standard/no-unused-vars
+const xplatformIt = (name, platforms, fn) => {
+  return xit([name, fn])
+}
+
 module.exports = {
   platformDescribe,
-  platformIt
+  xplatformDescribe,
+  platformIt,
+  xplatformIt
 }

--- a/spec/test-helpers.js
+++ b/spec/test-helpers.js
@@ -1,18 +1,24 @@
 const platformDependent = ([goodPlatformFn, skipFn, onlyFn]) => {
   const resultFn = (goodFn, badFn) => (name, platforms, testFn) => {
     let fn = goodPlatformFn
-    if (!platforms.includes(process.platform)) {
-      fn = skipFn
+    const validArch = platforms.includes(process.arch)
+    let validPlatform
+    if (validArch) {
+      validPlatform = validArch && platforms.includes(process.platform)
+    } else {
+      validPlatform = platforms.includes(process.platform)
     }
-    return fn(name, testFn);
+
+    if (!validPlatform) fn = skipFn
+    return fn(name, testFn)
   }
-  const returnFn = resultFn(goodPlatformFn, skipFn);
-  returnFn.skip = resultFn(skipFn, skipFn);
-  returnFn.only = resultFn(onlyFn, skipFn);
-  return returnFn;
+  const returnFn = resultFn(goodPlatformFn, skipFn)
+  returnFn.skip = resultFn(skipFn, skipFn)
+  returnFn.only = resultFn(onlyFn, skipFn)
+  return returnFn
 }
 
-const platformDescribe =  platformDependent([describe, describe.skip, describe.only])
+const platformDescribe = platformDependent([describe, describe.skip, describe.only])
 
 const platformIt = platformDependent([it, it.skip, it.only])
 

--- a/spec/test-helpers.js
+++ b/spec/test-helpers.js
@@ -1,0 +1,20 @@
+const platformDependent = (platforms, [goodPlatformFn, badPlatformFn], args) => {
+  let fn = goodPlatformFn
+  if (!platforms.includes(process.platform)) {
+    fn = badPlatformFn
+  }
+  return fn(...args)
+}
+
+const platformDescribe = (name, platforms, fn) => {
+  return platformDependent(platforms, [describe, describe.skip], [name, fn])
+}
+
+const platformIt = (name, platforms, fn) => {
+  return platformDependent(platforms, [it, it.skip], [name, fn])
+}
+
+module.exports = {
+  platformDescribe,
+  platformIt
+}

--- a/spec/test-helpers.js
+++ b/spec/test-helpers.js
@@ -1,28 +1,26 @@
-const platformDependent = (platforms, [goodPlatformFn, badPlatformFn], args) => {
-  let fn = goodPlatformFn
-  if (!platforms.includes(process.platform)) {
-    fn = badPlatformFn
+const platformDependent = ([goodPlatformFn, skipFn, onlyFn]) => {
+  const resultFn = (goodFn, badFn) => (name, platforms, testFn) => {
+    let fn = goodPlatformFn
+    if (!platforms.includes(process.platform)) {
+      fn = skipFn
+    }
+    return fn(name, testFn);
   }
-  return fn(...args)
+  const returnFn = resultFn(goodPlatformFn, skipFn);
+  returnFn.skip = resultFn(skipFn, skipFn);
+  returnFn.only = resultFn(onlyFn, skipFn);
+  return returnFn;
 }
 
-const platformDescribe = (name, platforms, fn) => {
-  return platformDependent(platforms, [describe, describe.skip], [name, fn])
-}
+const platformDescribe =  platformDependent([describe, describe.skip, describe.only])
 
-const platformIt = (name, platforms, fn) => {
-  return platformDependent(platforms, [it, it.skip], [name, fn])
-}
-
-// eslint-disable standard/no-unused-vars
-const xplatformDescribe = (name, platforms, fn) => {
-  return xdescribe([name, fn])
-}
+const platformIt = platformDependent([it, it.skip, it.only])
 
 // eslint-disable standard/no-unused-vars
-const xplatformIt = (name, platforms, fn) => {
-  return xit([name, fn])
-}
+const xplatformDescribe = platformDescribe.skip
+
+// eslint-disable standard/no-unused-vars
+const xplatformIt = platformIt.skip
 
 module.exports = {
   platformDescribe,

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -167,12 +167,6 @@ describe('<webview> tag', function () {
     })
 
     it('loads node symbols after POST navigation when set', async function () {
-      // FIXME Figure out why this is timing out on AppVeyor
-      if (process.env.APPVEYOR === 'True') {
-        this.skip()
-        return
-      }
-
       const message = await startLoadingWebViewAndWaitForMessage(webview, {
         nodeintegration: 'on',
         src: `file://${fixtures}/pages/post.html`


### PR DESCRIPTION
Clean up the `FIXME` and `TODO` comments in our tests

This enables a few tests and establishes a better pattern for platform-dependently skipping tests.

Notes: no-notes