### PR TITLE
fix: schedule a paint after BrowserView's background is set

### DIFF
--- a/atom/browser/native_browser_view_views.cc
+++ b/atom/browser/native_browser_view_views.cc
@@ -29,6 +29,7 @@ void NativeBrowserViewViews::SetBounds(const gfx::Rect& bounds) {
 void NativeBrowserViewViews::SetBackgroundColor(SkColor color) {
   auto* view = GetInspectableWebContentsView()->GetView();
   view->SetBackground(views::CreateSolidBackground(color));
+  view->SchedulePaint();
 }
 
 // static


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

As per the comment [here](https://cs.chromium.org/chromium/src/chrome/browser/ui/views/frame/contents_web_view.cc?type=cs&sq=package:chromium&g=0&l=82), we need to schedule a paint for the background color to take effect.

Fixes #15778.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fixed an issue that prevented setting the `BrowserView`'s background color after the first paint