### PR TITLE
ci: Renable ffmpeg and mksnapshot tests on Azure Devops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,6 +493,17 @@ steps-electron-build-for-tests: &steps-electron-build-for-tests
     - *step-mksnapshot-build
     - *step-mksnapshot-store
 
+    # native_mksnapshot
+    - *step-maybe-native-mksnapshot-gn-gen
+    - *step-maybe-native-mksnapshot-build
+    - *step-maybe-native-mksnapshot-strip
+    - *step-maybe-native-mksnapshot-store
+
+    # ffmpeg
+    - *step-ffmpeg-gn-gen
+    - *step-ffmpeg-build
+    - *step-ffmpeg-store
+
     # Save all data needed for a further tests run.
     - *step-persist-data-for-tests
 

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -11,12 +11,33 @@ steps:
 
 - bash: |
     export ZIP_DEST=$PWD/src/out/Default
+    echo "##vso[task.setvariable variable=ZIP_DEST]$ZIP_DEST"
     mkdir -p $ZIP_DEST
     cd src/electron
     node script/download-circleci-artifacts.js --buildNum=$CIRCLE_BUILD_NUM --name=dist.zip --dest=$ZIP_DEST
     cd $ZIP_DEST
     unzip -o dist.zip
   displayName: 'Download and unzip dist files for test'
+  env:
+    CIRCLE_TOKEN: $(CIRCLECI_TOKEN)
+
+- bash: |
+    export FFMPEG_ZIP_DEST=$PWD/src/out/ffmpeg
+    mkdir -p $FFMPEG_ZIP_DEST
+    cd src/electron
+    node script/download-circleci-artifacts.js --buildNum=$CIRCLE_BUILD_NUM --name=ffmpeg.zip --dest=$FFMPEG_ZIP_DEST
+    cd $FFMPEG_ZIP_DEST
+    unzip -o ffmpeg.zip
+  displayName: 'Download and unzip ffmpeg for test'
+  env:
+    CIRCLE_TOKEN: $(CIRCLECI_TOKEN)
+
+- bash: |
+    cd src/electron
+    node script/download-circleci-artifacts.js --buildNum=$CIRCLE_BUILD_NUM --name=native_mksnapshot.zip --dest=$ZIP_DEST
+    cd $ZIP_DEST
+    unzip -o native_mksnapshot.zip
+  displayName: 'Download and unzip native_mksnapshot.zip for test'
   env:
     CIRCLE_TOKEN: $(CIRCLECI_TOKEN)
 
@@ -43,6 +64,18 @@ steps:
   displayName: Setup for headless testing
   env:
     DISPLAY: ":99.0"
+
+- bash: |
+    cd src
+    python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
+  displayName: Verify non proprietary ffmpeg
+  timeoutInMinutes: 5
+
+- bash: |
+    cd src
+    python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
+  displayName: Verify mksnapshot
+  timeoutInMinutes: 5
 
 - bash: |
    cd src

--- a/vsts.yml
+++ b/vsts.yml
@@ -124,20 +124,6 @@ jobs:
 
   - bash: |
       cd src
-      python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
-    displayName: Verify non proprietary ffmpeg
-    condition: and(eq('DISABLED', 'breaking consistently'), and(succeeded(), eq(variables['RUN_TESTS'], '1')))
-    timeoutInMinutes: 5
-
-  - bash: |
-      cd src
-      python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
-    displayName: Verify mksnapshot
-    condition: and(eq('DISABLED', 'breaking sometimes?'), and(succeeded(), eq(variables['RUN_TESTS'], '1')))
-    timeoutInMinutes: 5
-
-  - bash: |
-      cd src
       ninja -C out/Default electron:electron_dist_zip
     displayName: Build dist zip
     timeoutInMinutes: 2  # Usually takes less than 20 seconds.
@@ -206,6 +192,13 @@ jobs:
     displayName: Publish Build Artifacts (mksnapshot.zip)
     inputs:
       PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/Default/mksnapshot.zip'
+      ArtifactName: Default
+    timeoutInMinutes: 1
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts (ffmpeg.zip)
+    inputs:
+      PathtoPublish: '$(System.DefaultWorkingDirectory)/src/out/ffmpeg/ffmpeg.zip'
       ArtifactName: Default
     timeoutInMinutes: 1
 
@@ -299,6 +292,20 @@ jobs:
     timeoutInMinutes: 1
 
   - task: ExtractFiles@1
+    displayName: Extract ffmpeg
+    inputs:
+      archiveFilePatterns: $(System.ArtifactsDirectory)/Default/ffmpeg.zip
+      destinationFolder: src/out/ffmpeg
+    timeoutInMinutes: 1
+
+  - task: ExtractFiles@1
+    displayName: Extract mksnapshot
+    inputs:
+      archiveFilePatterns: $(System.ArtifactsDirectory)/Default/mksnapshot.zip
+      destinationFolder: src/out/Default
+    timeoutInMinutes: 1
+
+  - task: ExtractFiles@1
     displayName: Extract Node.js headers
     inputs:
       archiveFilePatterns: $(System.ArtifactsDirectory)/Default/node_headers.tar.gz
@@ -316,6 +323,18 @@ jobs:
       npm install
     displayName: Install Node.js modules
     timeoutInMinutes: 4  # Should take about 30 seconds.
+
+  - bash: |
+      cd src
+      python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
+    displayName: Verify non proprietary ffmpeg
+    timeoutInMinutes: 5
+
+  - bash: |
+      cd src
+      python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
+    displayName: Verify mksnapshot
+    timeoutInMinutes: 5
 
   - bash: |
       if pgrep Electron; then

--- a/vsts.yml
+++ b/vsts.yml
@@ -326,6 +326,8 @@ jobs:
 
   - bash: |
       cd src
+      echo "$PWD"/out/Default
+      ls -la "$PWD"/out/Default
       python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
     displayName: Verify non proprietary ffmpeg
     timeoutInMinutes: 5

--- a/vsts.yml
+++ b/vsts.yml
@@ -302,8 +302,15 @@ jobs:
     displayName: Extract mksnapshot
     inputs:
       archiveFilePatterns: $(System.ArtifactsDirectory)/Default/mksnapshot.zip
-      destinationFolder: src/out/Default
-      cleanDestinationFolder: false
+      destinationFolder: src/out/mksnapshot
+    timeoutInMinutes: 1
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: src/out/Default'
+    inputs:
+      SourceFolder: src/out/mksnapshot
+      TargetFolder: src/out/Default
+      OverWrite: true
     timeoutInMinutes: 1
 
   - task: ExtractFiles@1

--- a/vsts.yml
+++ b/vsts.yml
@@ -303,6 +303,7 @@ jobs:
     inputs:
       archiveFilePatterns: $(System.ArtifactsDirectory)/Default/mksnapshot.zip
       destinationFolder: src/out/Default
+      cleanDestinationFolder: false
     timeoutInMinutes: 1
 
   - task: ExtractFiles@1
@@ -326,8 +327,6 @@ jobs:
 
   - bash: |
       cd src
-      echo "$PWD"/out/Default
-      ls -la "$PWD"/out/Default
       python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
     displayName: Verify non proprietary ffmpeg
     timeoutInMinutes: 5


### PR DESCRIPTION
This PR addresses the issue that was causing verify-ffmpeg and verify-mksnapshot to timeout on Azure Devops.  Those tests were disabled via #15732.  The issue was that on the CI machines there were previously crashed Electron instances that were causing this dialog to appear:
![crashed_electron](https://user-images.githubusercontent.com/609052/48867375-f9ba7a00-eda3-11e8-8b73-c4573344e52e.png). In order to resolve this issue, verify-ffmpeg and verify-mksnapshot now run with the Electron spec tests on a different dynamic VM.

This PR also adds testing of ffmpeg and native_mksnapshot on arm/arm64

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes