### PR TITLE
fix: bypass CORB when web security is disabled (#15737)

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -172,28 +172,34 @@ bool AtomBrowserClient::ShouldCreateNewSiteInstance(
 void AtomBrowserClient::AddProcessPreferences(
     int process_id,
     AtomBrowserClient::ProcessPreferences prefs) {
+  base::AutoLock auto_lock(process_preferences_lock_);
   process_preferences_[process_id] = prefs;
 }
 
 void AtomBrowserClient::RemoveProcessPreferences(int process_id) {
+  base::AutoLock auto_lock(process_preferences_lock_);
   process_preferences_.erase(process_id);
 }
 
 bool AtomBrowserClient::IsProcessObserved(int process_id) {
+  base::AutoLock auto_lock(process_preferences_lock_);
   return process_preferences_.find(process_id) != process_preferences_.end();
 }
 
 bool AtomBrowserClient::IsRendererSandboxed(int process_id) {
+  base::AutoLock auto_lock(process_preferences_lock_);
   auto it = process_preferences_.find(process_id);
   return it != process_preferences_.end() && it->second.sandbox;
 }
 
 bool AtomBrowserClient::RendererUsesNativeWindowOpen(int process_id) {
+  base::AutoLock auto_lock(process_preferences_lock_);
   auto it = process_preferences_.find(process_id);
   return it != process_preferences_.end() && it->second.native_window_open;
 }
 
 bool AtomBrowserClient::RendererDisablesPopups(int process_id) {
+  base::AutoLock auto_lock(process_preferences_lock_);
   auto it = process_preferences_.find(process_id);
   return it != process_preferences_.end() && it->second.disable_popups;
 }
@@ -217,6 +223,8 @@ void AtomBrowserClient::RenderProcessWillLaunch(
     prefs.native_window_open =
         web_preferences->IsEnabled(options::kNativeWindowOpen);
     prefs.disable_popups = web_preferences->IsEnabled("disablePopups");
+    prefs.web_security = web_preferences->IsEnabled(options::kWebSecurity,
+                                                    true /* default value */);
   }
   AddProcessPreferences(host->GetID(), prefs);
   // ensure the ProcessPreferences is removed later
@@ -654,6 +662,13 @@ AtomBrowserClient::CreateThrottlesForNavigation(
   std::vector<std::unique_ptr<content::NavigationThrottle>> throttles;
   throttles.push_back(std::make_unique<AtomNavigationThrottle>(handle));
   return throttles;
+}
+
+bool AtomBrowserClient::ShouldBypassCORB(int render_process_id) {
+  // This is called on the network thread.
+  base::AutoLock auto_lock(process_preferences_lock_);
+  auto it = process_preferences_.find(render_process_id);
+  return it != process_preferences_.end() && !it->second.web_security;
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -11,7 +11,9 @@
 #include <string>
 #include <vector>
 
+#include "base/synchronization/lock.h"
 #include "brightray/browser/browser_client.h"
+#include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/render_process_host_observer.h"
 #include "net/ssl/client_cert_identity.h"
 
@@ -124,6 +126,7 @@ class AtomBrowserClient : public brightray::BrowserClient,
   void WebNotificationAllowed(
       int render_process_id,
       const base::Callback<void(bool, bool)>& callback) override;
+  bool ShouldBypassCORB(int render_process_id) override;
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;
@@ -145,6 +148,7 @@ class AtomBrowserClient : public brightray::BrowserClient,
     bool sandbox = false;
     bool native_window_open = false;
     bool disable_popups = false;
+    bool web_security = true;
   };
 
   bool ShouldCreateNewSiteInstance(content::RenderFrameHost* render_frame_host,
@@ -161,7 +165,6 @@ class AtomBrowserClient : public brightray::BrowserClient,
   // pending_render_process => web contents.
   std::map<int, content::WebContents*> pending_processes_;
 
-  std::map<int, ProcessPreferences> process_preferences_;
   std::map<int, base::ProcessId> render_process_host_pids_;
 
   // list of site per affinity. weak_ptr to prevent instance locking
@@ -171,6 +174,9 @@ class AtomBrowserClient : public brightray::BrowserClient,
       resource_dispatcher_host_delegate_;
 
   Delegate* delegate_ = nullptr;
+
+  base::Lock process_preferences_lock_;
+  std::map<int, ProcessPreferences> process_preferences_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserClient);
 };

--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -80,3 +80,4 @@ dump_syms.patch
 web_preferences.patch
 verbose_generate_breakpad_symbols.patch
 fix_zoom_display.patch
+cross_site_document_resource_handler.patch

--- a/patches/common/chromium/cross_site_document_resource_handler.patch
+++ b/patches/common/chromium/cross_site_document_resource_handler.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: deepak1556 <hop2deep@gmail.com>
+Date: Thu, 15 Nov 2018 22:04:34 +0530
+Subject: cross_site_document_resource_handler.patch
+
+Add a content layer hook to disable CORB for a renderer process,
+this patch can be removed once we switch to network service,
+where the embedders have a chance to design their URLLoaders.
+
+diff --git a/content/browser/loader/cross_site_document_resource_handler.cc b/content/browser/loader/cross_site_document_resource_handler.cc
+index 907922701280b589bf11691342de0ec95cdec6a1..eaf8bac18f8e3a2735ce7ded606199092a3746d3 100644
+--- a/content/browser/loader/cross_site_document_resource_handler.cc
++++ b/content/browser/loader/cross_site_document_resource_handler.cc
+@@ -593,6 +593,9 @@ bool CrossSiteDocumentResourceHandler::ShouldBlockBasedOnHeaders(
+     return false;
+   }
+ 
++  if (GetContentClient()->browser()->ShouldBypassCORB(info->GetChildID()))
++    return false;
++
+   return true;
+ }
+ 
+diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
+index bb54b89bef5c6f32e7b4a056336c85494e2a04de..f069dfc4d2823b22eb0d90d28bc20236aeeddd04 100644
+--- a/content/public/browser/content_browser_client.cc
++++ b/content/public/browser/content_browser_client.cc
+@@ -47,6 +47,10 @@ void OverrideOnBindInterface(const service_manager::BindSourceInfo& remote_info,
+                                                          handle);
+ }
+ 
++bool ContentBrowserClient::ShouldBypassCORB(int render_process_id) {
++  return false;
++}
++
+ BrowserMainParts* ContentBrowserClient::CreateBrowserMainParts(
+     const MainFunctionParams& parameters) {
+   return nullptr;
+diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
+index 2c22cb1cfe0dddc97c00e5f4ff89de6b18bc232f..a7b59095a887d566af9e74a646443fb49ea23bfc 100644
+--- a/content/public/browser/content_browser_client.h
++++ b/content/public/browser/content_browser_client.h
+@@ -205,6 +205,9 @@ class CONTENT_EXPORT ContentBrowserClient {
+       SiteInstance* candidate_site_instance,
+       SiteInstance** new_instance) {}
+ 
++  // Electron: Allows bypassing CORB checks for a renderer process.
++  virtual bool ShouldBypassCORB(int render_process_id);
++
+   // Allows the embedder to set any number of custom BrowserMainParts
+   // implementations for the browser startup code. See comments in
+   // browser_main_parts.h.


### PR DESCRIPTION
#### Description of Change

Manual backport of `web_security_corb_patch` from `master`. See https://github.com/electron/electron/pull/15737 for details.

CC @deepak1556 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Disable CORB checks when web security preference is disabled