### PR TITLE
fix: send NSView* as the response to getNativeWindowHandle() instead of a null handle (backport: 3-0-x)

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -664,8 +664,11 @@ void TopLevelWindow::SetBrowserView(v8::Local<v8::Value> value) {
 }
 
 v8::Local<v8::Value> TopLevelWindow::GetNativeWindowHandle() {
-  gfx::AcceleratedWidget handle = window_->GetAcceleratedWidget();
-  return ToBuffer(isolate(), static_cast<void*>(&handle), sizeof(handle));
+  // TODO(MarshallOfSound): Replace once
+  // https://chromium-review.googlesource.com/c/chromium/src/+/1253094/ has
+  // landed
+  auto handle = window_->GetNativeWindowHandlePointer();
+  return ToBuffer(isolate(), std::get<0>(handle), std::get<1>(handle));
 }
 
 void TopLevelWindow::SetProgressBar(double progress, mate::Arguments* args) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "atom/browser/native_window_observer.h"
@@ -150,6 +151,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::NativeView GetNativeView() const = 0;
   virtual gfx::NativeWindow GetNativeWindow() const = 0;
   virtual gfx::AcceleratedWidget GetAcceleratedWidget() const = 0;
+  virtual std::tuple<void*, int> GetNativeWindowHandlePointer() const = 0;
 
   // Taskbar/Dock APIs.
   enum ProgressState {

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -8,6 +8,7 @@
 #import <Cocoa/Cocoa.h>
 
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "atom/browser/native_window.h"
@@ -103,6 +104,7 @@ class NativeWindowMac : public NativeWindow {
   gfx::NativeView GetNativeView() const override;
   gfx::NativeWindow GetNativeWindow() const override;
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
+  std::tuple<void*, int> GetNativeWindowHandlePointer() const override;
   void SetProgressBar(double progress, const ProgressState state) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1079,6 +1079,11 @@ gfx::AcceleratedWidget NativeWindowMac::GetAcceleratedWidget() const {
   return gfx::kNullAcceleratedWidget;
 }
 
+std::tuple<void*, int> NativeWindowMac::GetNativeWindowHandlePointer() const {
+  NSView* view = [window_ contentView];
+  return std::make_tuple(static_cast<void*>(view), sizeof(view));
+}
+
 void NativeWindowMac::SetProgressBar(double progress,
                                      const NativeWindow::ProgressState state) {
   NSDockTile* dock_tile = [NSApp dockTile];

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -9,6 +9,7 @@
 #include <wrl/client.h>
 #endif
 
+#include <tuple>
 #include <vector>
 
 #include "atom/browser/api/atom_api_web_contents.h"
@@ -1044,6 +1045,11 @@ bool NativeWindowViews::IsVisibleOnAllWorkspaces() {
 
 gfx::AcceleratedWidget NativeWindowViews::GetAcceleratedWidget() const {
   return GetNativeWindow()->GetHost()->GetAcceleratedWidget();
+}
+
+std::tuple<void*, int> NativeWindowViews::GetNativeWindowHandlePointer() const {
+  gfx::AcceleratedWidget handle = GetAcceleratedWidget();
+  return std::make_tuple(static_cast<void*>(&handle), sizeof(handle));
 }
 
 gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -9,6 +9,7 @@
 
 #include <set>
 #include <string>
+#include <tuple>
 
 #include "ui/views/widget/widget_observer.h"
 
@@ -123,6 +124,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsVisibleOnAllWorkspaces() override;
 
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
+  std::tuple<void*, int> GetNativeWindowHandlePointer() const override;
 
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/15521 to 3.0
Same as https://github.com/electron/electron/pull/15644 for 4.0

cc @MarshallOfSound 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

- [x] `npm test` passes

#### Release Notes

Notes: Fixed issue where `getNativeWindowHandle()` would return an empty buffer on macOS
