### PR TITLE
fix: prevent bluetooth device list from growing without bound

### DIFF
--- a/atom/browser/lib/bluetooth_chooser.h
+++ b/atom/browser/lib/bluetooth_chooser.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_BROWSER_LIB_BLUETOOTH_CHOOSER_H_
 #define ATOM_BROWSER_LIB_BLUETOOTH_CHOOSER_H_
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -33,10 +34,10 @@ class BluetoothChooser : public content::BluetoothChooser {
                          bool is_gatt_connected,
                          bool is_paired,
                          int signal_strength_level) override;
-  void RemoveDevice(const std::string& device_id);
+  std::vector<DeviceInfo> GetDeviceList();
 
  private:
-  std::vector<DeviceInfo> device_list_;
+  std::map<std::string, base::string16> device_map_;
   api::WebContents* api_web_contents_;
   EventHandler event_handler_;
   int num_retries_ = 0;

--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -148,11 +148,13 @@ template("electron_paks") {
       "${root_gen_dir}/content/app/strings/content_strings_",
       "${root_gen_dir}/ui/strings/app_locale_settings_",
       "${root_gen_dir}/ui/strings/ui_strings_",
+      "${root_gen_dir}/device/bluetooth/strings/bluetooth_strings_",
     ]
     deps = [
       "//chrome/app/resources:platform_locale_settings",
       "//components/strings:components_strings",
       "//content/app/strings",
+      "//device/bluetooth/strings",
       "//ui/strings:app_locale_settings",
       "//ui/strings:ui_strings",
     ]


### PR DESCRIPTION
#### Description of Change

This PR changes the internal data structure that Electron uses to collect Bluetooth devices from a vector to a map in order to prevent duplicate entries with the same device ID.

This PR also changes the `select-bluetooth-device` event to only fire if a new device was detected or if an existing device was updated. Internally, `BluetoothChooser::AddOrUpdateDevice` is called many times, but few of those calls actually update relevant data, especially once several seconds have elapsed.

Finally, I removed `atom::BluetoothChooser::RemoveDevice` as it's not a member of `content::BluetoothChooser` and I could find no instance of it being used in the Electron codebase.

Fixes https://github.com/electron/electron/issues/15603 (see https://github.com/electron/electron/issues/15603#issuecomment-439492729 for actual issue description)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: fix: prevent bluetooth device list from growing without bound