### PR TITLE
refactor: eliminate duplicate code exposing process APIs

### DIFF
--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -17,6 +17,10 @@
 #include "uv.h"  // NOLINT(build/include)
 #include "v8/include/v8.h"
 
+namespace mate {
+class Dictionary;
+}
+
 namespace memory_instrumentation {
 class GlobalMemoryDump;
 }
@@ -43,8 +47,14 @@ class AtomBindings {
   // Should be called when a node::Environment has been destroyed.
   void EnvironmentDestroyed(node::Environment* env);
 
+  static void BindProcess(v8::Isolate* isolate,
+                          mate::Dictionary* process,
+                          base::ProcessMetrics* metrics);
+
   static void Log(const base::string16& message);
   static void Crash();
+
+ private:
   static void Hang();
   static v8::Local<v8::Value> GetHeapStatistics(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
@@ -57,7 +67,6 @@ class AtomBindings {
   static bool TakeHeapSnapshot(v8::Isolate* isolate,
                                const base::FilePath& file_path);
 
- private:
   void ActivateUVLoop(v8::Isolate* isolate);
 
   static void OnCallNextTick(uv_async_t* handle);

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -147,28 +147,12 @@ void AtomSandboxedRendererClient::InitializeBindings(
   mate::Dictionary process = mate::Dictionary::CreateEmpty(isolate);
   b.Set("process", process);
 
-  process.SetMethod("crash", AtomBindings::Crash);
-  process.SetMethod("hang", AtomBindings::Hang);
-  process.SetMethod("getHeapStatistics", &AtomBindings::GetHeapStatistics);
-  process.SetMethod("getSystemMemoryInfo", &AtomBindings::GetSystemMemoryInfo);
-  process.SetMethod(
-      "getCPUUsage",
-      base::Bind(&AtomBindings::GetCPUUsage, base::Unretained(metrics_.get())));
-  process.SetMethod("getIOCounters", &AtomBindings::GetIOCounters);
+  AtomBindings::BindProcess(isolate, &process, metrics_.get());
 
   process.Set("argv", base::CommandLine::ForCurrentProcess()->argv());
   process.SetReadOnly("pid", base::GetCurrentProcId());
   process.SetReadOnly("sandboxed", true);
   process.SetReadOnly("type", "renderer");
-
-#if defined(MAS_BUILD)
-  process.SetReadOnly("mas", true);
-#endif
-
-#if defined(OS_WIN)
-  if (IsRunningInDesktopBridge())
-    process.SetReadOnly("windowsStore", true);
-#endif
 
   // Pass in CLI flags needed to setup the renderer
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -13,6 +13,7 @@ It adds the following events, properties, and methods:
 In sandboxed renderers the `process` object contains only a subset of the APIs:
 - `crash()`
 - `hang()`
+- `getCreationTime()`
 - `getHeapStatistics()`
 - `getProcessMemoryInfo()`
 - `getSystemMemoryInfo()`


### PR DESCRIPTION
#### Description of Change
- Eliminate duplicate code exposing process APIs (sandboxed vs non-sandboxed renderer).
- Expose missing `process.getCreationTime()` in sandboxed renderers.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Missing `process.getCreationTime()` exposed in sandboxed renderers.