### PR TITLE
chore: fix V8 deprecation warnings

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -287,8 +287,12 @@ static_library("electron_lib") {
     "//third_party/blink/renderer",
   ]
 
-  defines = []
+  defines = [ "V8_DEPRECATION_WARNINGS" ]
   libs = []
+
+  if (is_linux) {
+    defines += [ "GDK_DISABLE_DEPRECATION_WARNINGS" ]
+  }
 
   extra_source_filters = []
   if (!is_linux) {

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -68,8 +68,8 @@ class GtkMessageBox : public NativeWindowObserver {
       GtkWidget* w = gtk_image_new_from_pixbuf(scaled_pixbuf);
       gtk_message_dialog_set_image(GTK_MESSAGE_DIALOG(dialog_), w);
       gtk_widget_show(w);
-      g_clear_pointer(&scaled_pixbuf, gdk_pixbuf_unref);
-      g_clear_pointer(&pixbuf, gdk_pixbuf_unref);
+      g_clear_pointer(&scaled_pixbuf, g_object_unref);
+      g_clear_pointer(&pixbuf, g_object_unref);
     }
 
     if (!checkbox_label.empty()) {

--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -122,9 +122,10 @@ void InitAsarSupport(v8::Isolate* isolate,
                      v8::Local<v8::Value> process,
                      v8::Local<v8::Value> require) {
   // Evaluate asar_init.js.
-  v8::Local<v8::Script> asar_init =
-      v8::Script::Compile(node::asar_init_value.ToStringChecked(isolate));
-  v8::Local<v8::Value> result = asar_init->Run();
+  auto context = isolate->GetCurrentContext();
+  auto source = node::asar_init_value.ToStringChecked(isolate);
+  auto asar_init = v8::Script::Compile(context, source).ToLocalChecked();
+  auto result = asar_init->Run(context).ToLocalChecked();
 
   // Initialize asar support.
   if (result->IsFunction()) {

--- a/atom/common/native_mate_converters/string16_converter.h
+++ b/atom/common/native_mate_converters/string16_converter.h
@@ -24,7 +24,7 @@ struct Converter<base::string16> {
     if (!val->IsString())
       return false;
 
-    v8::String::Value s(val);
+    v8::String::Value s(isolate, val);
     out->assign(reinterpret_cast<const base::char16*>(*s), s.length());
     return true;
   }

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -11,8 +11,10 @@ namespace atom {
 namespace util {
 
 Promise::Promise(v8::Isolate* isolate) {
+  auto context = isolate->GetCurrentContext();
+  auto resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
   isolate_ = isolate;
-  resolver_.Reset(isolate, v8::Promise::Resolver::New(isolate));
+  resolver_.Reset(isolate, resolver);
 }
 
 Promise::~Promise() = default;

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -198,10 +198,11 @@ void AtomRendererClient::SetupMainWorldOverrides(
   // an argument.
   std::string left = "(function (binding, require) {\n";
   std::string right = "\n})";
-  auto script = v8::Script::Compile(v8::String::Concat(
+  auto source = v8::String::Concat(
       mate::ConvertToV8(isolate, left)->ToString(),
       v8::String::Concat(node::isolated_bundle_value.ToStringChecked(isolate),
-                         mate::ConvertToV8(isolate, right)->ToString())));
+                         mate::ConvertToV8(isolate, right)->ToString()));
+  auto script = v8::Script::Compile(context, source).ToLocalChecked();
   auto func =
       v8::Handle<v8::Function>::Cast(script->Run(context).ToLocalChecked());
 

--- a/native_mate/BUILD.gn
+++ b/native_mate/BUILD.gn
@@ -1,7 +1,5 @@
 config("native_mate_config") {
   include_dirs = [ "." ]
-  cflags_cc = [ "-Wno-deprecated-declarations" ]
-  cflags_objcc = cflags_cc
 }
 
 source_set("native_mate") {


### PR DESCRIPTION
#### Description of Change
- add `V8_DEPRECATION_WARNINGS` to defines
- remove `-Wno-deprecated-declarations` from compiler options
- fix deprecation warnings

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes