### PR TITLE
chore: return release blob during prepare-release 

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -93,7 +93,7 @@ async function createRelease (branchToTarget, isBeta) {
   console.log(`Checking for existing draft release.`)
   const releases = await github.repos.getReleases(githubOpts)
     .catch(err => {
-      console.log('$fail} Could not get releases.  Error was', err)
+      console.log(`${fail} Could not get releases. Error was: `, err)
     })
   const drafts = releases.data.filter(release => release.draft &&
     release.tag_name === newVersion)
@@ -124,12 +124,13 @@ async function createRelease (branchToTarget, isBeta) {
   }
   githubOpts.tag_name = newVersion
   githubOpts.target_commitish = newVersion.indexOf('nightly') !== -1 ? 'master' : branchToTarget
-  await github.repos.createRelease(githubOpts)
+  const release = await github.repos.createRelease(githubOpts)
     .catch(err => {
       console.log(`${fail} Error creating new release: `, err)
       process.exit(1)
     })
-  console.log(`${pass} Draft release for ${newVersion} has been created.`)
+  console.log(`Release has been created with id: ${release.id}.`)
+  console.log(`${pass} Draft release for ${newVersion} successful.`)
 }
 
 async function pushRelease (branch) {

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -50,13 +50,14 @@ async function revertBumpCommit (tag) {
   }
 }
 
-async function deleteDraft (tag, targetRepo) {
+async function deleteDraft (releaseId, targetRepo) {
   try {
-    const result = await github.repos.getReleaseByTag({
+    const result = await github.repos.getRelease({
       owner: 'electron',
       repo: targetRepo,
-      tag
+      id: parseInt(releaseId, 10)
     })
+    console.log(result)
     if (!result.draft) {
       console.log(`Published releases cannot be deleted.`)
       process.exit(1)
@@ -67,9 +68,9 @@ async function deleteDraft (tag, targetRepo) {
         release_id: result.id
       })
     }
-    console.log(`Successfully deleted draft with tag ${tag} from ${targetRepo}`)
+    console.log(`Successfully deleted draft with id ${releaseId} from ${targetRepo}`)
   } catch (err) {
-    console.error(`Couldn't delete draft with tag ${tag} from ${targetRepo}: `, err)
+    console.error(`Couldn't delete draft with id ${releaseId} from ${targetRepo}: `, err)
     process.exit(1)
   }
 }
@@ -89,18 +90,19 @@ async function deleteTag (tag, targetRepo) {
 }
 
 async function cleanReleaseArtifacts () {
-  const tag = args.tag
+  const releaseId = args.releaseId
   const isNightly = args.tag.includes('nightly')
 
   if (isNightly) {
-    await deleteDraft(tag, 'nightlies')
-    await deleteTag(tag, 'nightlies')
+    await deleteDraft(releaseId, 'nightlies')
+    await deleteTag(args.tag, 'nightlies')
   } else {
-    await deleteDraft(tag, 'electron')
+    console.log('we are here')
+    await deleteDraft(releaseId, 'electron')
   }
 
-  await deleteTag(tag, 'electron')
-  await revertBumpCommit(tag)
+  await deleteTag(args.tag, 'electron')
+  await revertBumpCommit(args.tag)
 
   console.log('Failed release artifact cleanup complete')
 }


### PR DESCRIPTION
#### Description of Change

Alters `prepare-release` script such that it returns the blob response created when the new release is drafted. Will be used with sudowoodo so that the cleanup script finds the new release by id instead of by tag, which the API disallows.

TODO:
- [x] update cleanup-release-script to take release id to find draft release

/cc @MarshallOfSound

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes