### PR TITLE
chore: bump version number in electron.gyp

### DIFF
--- a/electron.gyp
+++ b/electron.gyp
@@ -4,7 +4,7 @@
     'product_name%': 'Electron',
     'company_name%': 'GitHub, Inc',
     'company_abbr%': 'github',
-    'version%': '3.0.10',
+    'version%': '3.1.0-beta.0',
     'js2c_input_dir': '<(SHARED_INTERMEDIATE_DIR)/js2c',
   },
   'includes': [


### PR DESCRIPTION
Notes: no-notes

cc @felixrieseberg 