### PR TITLE
test: fix flaky takeHeapSnapshot test

### DIFF
--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -879,8 +879,9 @@ describe('webContents module', () => {
         }
       })
 
+      const p = emittedOnce(w.webContents, 'did-finish-load')
       w.loadURL('about:blank')
-      await emittedOnce(w.webContents, 'did-finish-load')
+      await p
 
       const filePath = path.join(remote.app.getPath('temp'), 'test.heapsnapshot')
 
@@ -910,8 +911,9 @@ describe('webContents module', () => {
         }
       })
 
+      const p = emittedOnce(w.webContents, 'did-finish-load')
       w.loadURL('about:blank')
-      await emittedOnce(w.webContents, 'did-finish-load')
+      await p
 
       const promise = w.webContents.takeHeapSnapshot('')
       return expect(promise).to.be.eventually.rejectedWith(Error, 'takeHeapSnapshot failed')


### PR DESCRIPTION
My suspicion is that the 'load' event is getting emitted before we start waiting for it.

Fixes #15095

Notes: no-notes