### PR TITLE
chore: change return type of platform_util::SetLoginItemEnabled

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -278,7 +278,9 @@ void RemoveFromLoginItems() {
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 #if defined(MAS_BUILD)
-  platform_util::SetLoginItemEnabled(settings.open_at_login);
+  if (!platform_util::SetLoginItemEnabled(settings.open_at_login)) {
+    LOG(ERROR) << "Unable to set login item enabled on sandboxed app.";
+  }
 #else
   if (settings.open_at_login)
     base::mac::AddToLoginItems(settings.open_as_hidden);

--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -61,7 +61,7 @@ void Beep();
 
 #if defined(OS_MACOSX)
 bool GetLoginItemEnabled();
-void SetLoginItemEnabled(bool enabled);
+bool SetLoginItemEnabled(bool enabled);
 #endif
 
 #if defined(OS_LINUX)

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -199,9 +199,9 @@ bool GetLoginItemEnabled() {
   return enabled;
 }
 
-void SetLoginItemEnabled(bool enabled) {
+bool SetLoginItemEnabled(bool enabled) {
   NSString* identifier = GetLoginHelperBundleIdentifier();
-  SMLoginItemSetEnabled((__bridge CFStringRef)identifier, enabled);
+  return SMLoginItemSetEnabled((__bridge CFStringRef)identifier, enabled);
 }
 
 }  // namespace platform_util


### PR DESCRIPTION
#### Description of Change

Change the return type of `platform_util::SetLoginItemEnabled` from `void` to `bool` to hopefully give more clarity around the flakes experiences on MAS (sandboxed) builds of MacOS. Logs on failure to apply the requested LoginItem settings change.

/cc @nornagon

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes