### PR TITLE
feat: webContents.loadURL returns a promise

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1236,7 +1236,11 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
-Same as `webContents.loadURL(url[, options])`.
+Returns `Promise` - the promise will resolve when the page has finished loading
+(see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
+if the page fails to load (see [`did-fail-load`](web-contents.md#event-did-fail-load)).
+
+Same as [`webContents.loadURL(url[, options])`](web-contents.md#contentsloadurlurl-options).
 
 The `url` can be a remote address (e.g. `http://`) or a path to a local
 HTML file using the `file://` protocol.
@@ -1275,6 +1279,10 @@ win.loadURL('http://localhost:8000/post', {
   * `query` Object (optional) - Passed to `url.format()`.
   * `search` String (optional) - Passed to `url.format()`.
   * `hash` String (optional) - Passed to `url.format()`.
+
+Returns `Promise` - the promise will resolve when the page has finished loading
+(see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
+if the page fails to load (see [`did-fail-load`](web-contents.md#event-did-fail-load)).
 
 Same as `webContents.loadFile`, `filePath` should be a path to an HTML
 file relative to the root of your application.  See the `webContents` docs

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1236,7 +1236,7 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
-Returns `Promise` - the promise will resolve when the page has finished loading
+Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
 if the page fails to load (see [`did-fail-load`](web-contents.md#event-did-fail-load)).
 
@@ -1280,7 +1280,7 @@ win.loadURL('http://localhost:8000/post', {
   * `search` String (optional) - Passed to `url.format()`.
   * `hash` String (optional) - Passed to `url.format()`.
 
-Returns `Promise` - the promise will resolve when the page has finished loading
+Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
 if the page fails to load (see [`did-fail-load`](web-contents.md#event-did-fail-load)).
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -697,6 +697,11 @@ Custom value can be returned by setting `event.returnValue`.
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
+Returns `Promise` - the promise will resolve when the page has finished loading
+(see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
+if the page fails to load (see
+[`did-fail-load`](web-contents.md#event-did-fail-load)).
+
 Loads the `url` in the window. The `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`. If the load should bypass http cache then
 use the `pragma` header to achieve it.
@@ -714,6 +719,10 @@ webContents.loadURL('https://github.com', options)
   * `query` Object (optional) - Passed to `url.format()`.
   * `search` String (optional) - Passed to `url.format()`.
   * `hash` String (optional) - Passed to `url.format()`.
+
+Returns `Promise` - the promise will resolve when the page has finished loading
+(see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
+if the page fails to load (see [`did-fail-load`](web-contents.md#event-did-fail-load)).
 
 Loads the given file in the window, `filePath` should be a path to
 an HTML file relative to the root of your application.  For instance

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -697,7 +697,7 @@ Custom value can be returned by setting `event.returnValue`.
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
-Returns `Promise` - the promise will resolve when the page has finished loading
+Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
 if the page fails to load (see
 [`did-fail-load`](web-contents.md#event-did-fail-load)).
@@ -720,7 +720,7 @@ webContents.loadURL('https://github.com', options)
   * `search` String (optional) - Passed to `url.format()`.
   * `hash` String (optional) - Passed to `url.format()`.
 
-Returns `Promise` - the promise will resolve when the page has finished loading
+Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
 if the page fails to load (see [`did-fail-load`](web-contents.md#event-did-fail-load)).
 

--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -55,9 +55,33 @@ const NavigationController = (function () {
     if (options == null) {
       options = {}
     }
+    const p = new Promise((resolve, reject) => {
+      const finishListener = () => {
+        this.webContents.removeListener('did-fail-load', failListener)
+        resolve()
+      }
+      const failListener = (event, errorCode, errorDescription, validatedURL, isMainFrame, frameProcessId, frameRoutingId) => {
+        if (!isMainFrame) {
+          return
+        }
+        this.webContents.removeListener('did-finish-load', finishListener)
+        const err = new Error(`${errorDescription} (${errorCode}) loading '${validatedURL}'`)
+        Object.assign(err, {
+          errno: errorCode,
+          code: errorDescription,
+          validatedURL,
+          frameProcessId,
+          frameRoutingId
+        })
+        reject(err)
+      }
+      this.webContents.once('did-finish-load', finishListener)
+      this.webContents.once('did-fail-load', failListener)
+    })
     this.pendingIndex = -1
     this.webContents._loadURL(url, options)
-    return this.webContents.emit('load-url', url, options)
+    this.webContents.emit('load-url', url, options)
+    return p
   }
 
   NavigationController.prototype.getURL = function () {

--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -78,6 +78,8 @@ const NavigationController = (function () {
       this.webContents.once('did-finish-load', finishListener)
       this.webContents.once('did-fail-load', failListener)
     })
+    // Add a no-op rejection handler to silence the unhandled rejection error.
+    p.catch(() => {})
     this.pendingIndex = -1
     this.webContents._loadURL(url, options)
     this.webContents.emit('load-url', url, options)

--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -56,27 +56,58 @@ const NavigationController = (function () {
       options = {}
     }
     const p = new Promise((resolve, reject) => {
-      const finishListener = () => {
-        this.webContents.removeListener('did-fail-load', failListener)
+      const resolveAndCleanup = () => {
+        removeListeners()
         resolve()
       }
-      const failListener = (event, errorCode, errorDescription, validatedURL, isMainFrame, frameProcessId, frameRoutingId) => {
-        if (!isMainFrame) {
-          return
-        }
-        this.webContents.removeListener('did-finish-load', finishListener)
-        const err = new Error(`${errorDescription} (${errorCode}) loading '${validatedURL}'`)
-        Object.assign(err, {
-          errno: errorCode,
-          code: errorDescription,
-          validatedURL,
-          frameProcessId,
-          frameRoutingId
-        })
+      const rejectAndCleanup = (errorCode, errorDescription, url) => {
+        const err = new Error(`${errorDescription} (${errorCode}) loading '${url}'`)
+        Object.assign(err, { errno: errorCode, code: errorDescription, url })
+        removeListeners()
         reject(err)
       }
-      this.webContents.once('did-finish-load', finishListener)
-      this.webContents.once('did-fail-load', failListener)
+      const finishListener = () => {
+        resolveAndCleanup()
+      }
+      const failListener = (event, errorCode, errorDescription, validatedURL, isMainFrame, frameProcessId, frameRoutingId) => {
+        if (isMainFrame) {
+          rejectAndCleanup(errorCode, errorDescription, validatedURL)
+        }
+      }
+
+      let navigationStarted = false
+      const navigationListener = (event, url, isSameDocument, isMainFrame, frameProcessId, frameRoutingId, navigationId) => {
+        if (isMainFrame) {
+          if (navigationStarted) {
+            // the webcontents has started another unrelated navigation in the
+            // main frame (probably from the app calling `loadURL` again); reject
+            // the promise
+            return rejectAndCleanup(-3, 'ERR_ABORTED', url)
+          }
+          navigationStarted = true
+        }
+      }
+      const stopLoadingListener = () => {
+        // By the time we get here, either 'finish' or 'fail' should have fired
+        // if the navigation occurred. However, in some situations (e.g. when
+        // attempting to load a page with a bad scheme), loading will stop
+        // without emitting finish or fail. In this case, we reject the promise
+        // with a generic failure.
+        // TODO(jeremy): enumerate all the cases in which this can happen. If
+        // the only one is with a bad scheme, perhaps ERR_INVALID_ARGUMENT
+        // would be more appropriate.
+        rejectAndCleanup(-2, 'ERR_FAILED', url)
+      }
+      const removeListeners = () => {
+        this.webContents.removeListener('did-finish-load', finishListener)
+        this.webContents.removeListener('did-fail-load', failListener)
+        this.webContents.removeListener('did-start-navigation', navigationListener)
+        this.webContents.removeListener('did-stop-loading', stopLoadingListener)
+      }
+      this.webContents.on('did-finish-load', finishListener)
+      this.webContents.on('did-fail-load', failListener)
+      this.webContents.on('did-start-navigation', navigationListener)
+      this.webContents.on('did-stop-loading', stopLoadingListener)
     })
     // Add a no-op rejection handler to silence the unhandled rejection error.
     p.catch(() => {})

--- a/spec/api-ipc-renderer-spec.js
+++ b/spec/api-ipc-renderer-spec.js
@@ -5,7 +5,6 @@ const dirtyChai = require('dirty-chai')
 const http = require('http')
 const path = require('path')
 const { closeWindow } = require('./window-helpers')
-const { emittedOnce } = require('./events-helpers')
 
 const { expect } = chai
 chai.use(dirtyChai)
@@ -229,9 +228,7 @@ describe('ipc renderer module', () => {
   describe('ipcRenderer.on', () => {
     it('is not used for internals', async () => {
       w = new BrowserWindow({ show: false })
-      w.loadURL('about:blank')
-
-      await emittedOnce(w.webContents, 'did-finish-load')
+      await w.loadURL('about:blank')
 
       const script = `require('electron').ipcRenderer.eventNames()`
       const result = await w.webContents.executeJavaScript(script)

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -429,9 +429,10 @@ describe('remote module', () => {
     })
 
     it('emits unhandled rejection events in the renderer process', (done) => {
-      window.addEventListener('unhandledrejection', function (event) {
+      window.addEventListener('unhandledrejection', function handler (event) {
         event.preventDefault()
         assert.strictEqual(event.reason.message, 'rejected')
+        window.removeEventListener('unhandledrejection', handler)
         done()
       })
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -60,7 +60,7 @@ describe('webContents module', () => {
       expect(err).not.to.be.null()
       expect(err.code).to.eql('ERR_FILE_NOT_FOUND')
       expect(err.errno).to.eql(-6)
-      expect(err.validatedURL).to.eql(process.platform === 'win32' ? 'file://non-existent/' : 'file:///non-existent')
+      expect(err.url).to.eql(process.platform === 'win32' ? 'file://non-existent/' : 'file:///non-existent')
     })
 
     it('rejects when loading fails due to DNS not resolved', async () => {
@@ -73,7 +73,7 @@ describe('webContents module', () => {
       expect(err).not.to.be.undefined()
       expect(err.code).to.eql('ERR_NAME_NOT_RESOLVED')
       expect(err.errno).to.eql(-105)
-      expect(err.validatedURL).to.eql('https://err.name.not.resolved/')
+      expect(err.url).to.eql('https://err.name.not.resolved/')
     })
   })
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -60,7 +60,7 @@ describe('webContents module', () => {
       expect(err).not.to.be.null()
       expect(err.code).to.eql('ERR_FILE_NOT_FOUND')
       expect(err.errno).to.eql(-6)
-      expect(err.validatedURL).to.eql('file:///non-existent')
+      expect(err.validatedURL).to.eql(process.platform === 'win32' ? 'file://non-existent/' : 'file:///non-existent')
     })
 
     it('rejects when loading fails due to DNS not resolved', async () => {

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -39,6 +39,44 @@ describe('webContents module', () => {
 
   afterEach(() => closeWindow(w).then(() => { w = null }))
 
+  describe('loadURL() promise API', () => {
+    it('resolves when done loading', async () => {
+      await w.loadURL('about:blank')
+      // assert: no timeout, no exception.
+    })
+
+    it('resolves when done loading a file URL', async () => {
+      await w.loadFile(path.join(fixtures, 'pages', 'base-page.html'))
+      // assert: no timeout, no exception.
+    })
+
+    it('rejects when failing to load a file URL', async () => {
+      let err
+      try {
+        await w.loadURL('file:non-existent')
+      } catch (e) {
+        err = e
+      }
+      expect(err).not.to.be.null()
+      expect(err.code).to.eql('ERR_FILE_NOT_FOUND')
+      expect(err.errno).to.eql(-6)
+      expect(err.validatedURL).to.eql('file:///non-existent')
+    })
+
+    it('rejects when loading fails due to DNS not resolved', async () => {
+      let err
+      try {
+        await w.loadURL('https://err.name.not.resolved')
+      } catch (e) {
+        err = e
+      }
+      expect(err).not.to.be.undefined()
+      expect(err.code).to.eql('ERR_NAME_NOT_RESOLVED')
+      expect(err.errno).to.eql(-105)
+      expect(err.validatedURL).to.eql('https://err.name.not.resolved/')
+    })
+  })
+
   describe('getAllWebContents() API', () => {
     it('returns an array of web contents', (done) => {
       w.webContents.on('devtools-opened', () => {
@@ -899,9 +937,7 @@ describe('webContents module', () => {
         }
       })
 
-      const p = emittedOnce(w.webContents, 'did-finish-load')
-      w.loadURL('about:blank')
-      await p
+      await w.loadURL('about:blank')
 
       const filePath = path.join(remote.app.getPath('temp'), 'test.heapsnapshot')
 
@@ -931,9 +967,7 @@ describe('webContents module', () => {
         }
       })
 
-      const p = emittedOnce(w.webContents, 'did-finish-load')
-      w.loadURL('about:blank')
-      await p
+      await w.loadURL('about:blank')
 
       const promise = w.webContents.takeHeapSnapshot('')
       return expect(promise).to.be.eventually.rejectedWith(Error, 'takeHeapSnapshot failed')


### PR DESCRIPTION
#### Description of Change
Many tests use the following pattern to load a page in a WebContents and wait for the load to finish:

```js
async () => {
  webContents.loadFile('path/to/page.html')
  await emittedOnce(webContents, 'did-finish-load')
  // ... do something with the page
}
```

This is an aesthetic improvement over the callback method of `webContents.on('did-finish-load', ...)`, but is unfortunately flaky: it is sometimes possible that the `'did-finish-load'` event is emitted before the listener is registered (see #15853 for example, which fixes the flaky test described in #15095). This is to do with the fact that the tests use the `BrowserWindow` module via the `remote` API, so there is a short window of time after loading the URL but before the event listener is registered. If the event is fired during that window, it will be lost, and the test times out.

It's possible to eliminate the additional `emittedOnce` helper call, clean up the code, and remove the possibility of flakiness by having `loadURL` return a promise. The above could would be written as follows with this patch:

```js
async () => {
  await webContents.loadFile('path/to/page.html')
  // ... do something with the page
}
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: webContents.loadURL and loadFile now return a promise