### PR TITLE
test: fix remote-debugging-port test calling done twice

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -64,6 +64,7 @@ describe('chromium feature', () => {
           output += data
           const m = /DevTools listening on ws:\/\/127.0.0.1:(\d+)\//.exec(output)
           if (m) {
+            appProcess.stderr.removeAllListeners('data')
             const port = m[1]
             http.get(`http://127.0.0.1:${port}`, (res) => {
               res.destroy()


### PR DESCRIPTION
Fixes flake when `stderr.on('data')` fires more than once and `done` ends up being called multiple times

Notes: no-notes