### PR TITLE
[wip] refactor: implement isRemoteModuleEnabled() using getLastWebPreferences()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1942,13 +1942,6 @@ v8::Local<v8::Value> WebContents::GetLastWebPreferences(
   return mate::ConvertToV8(isolate, *web_preferences->last_preference());
 }
 
-bool WebContents::IsRemoteModuleEnabled() const {
-  if (auto* web_preferences = WebContentsPreferences::From(web_contents())) {
-    return web_preferences->IsRemoteModuleEnabled();
-  }
-  return true;
-}
-
 v8::Local<v8::Value> WebContents::GetOwnerBrowserWindow() const {
   if (owner_window())
     return BrowserWindow::From(isolate(), owner_window());
@@ -2121,7 +2114,6 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("_getPreloadPath", &WebContents::GetPreloadPath)
       .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)
       .SetMethod("getLastWebPreferences", &WebContents::GetLastWebPreferences)
-      .SetMethod("_isRemoteModuleEnabled", &WebContents::IsRemoteModuleEnabled)
       .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
       .SetMethod("hasServiceWorker", &WebContents::HasServiceWorker)
       .SetMethod("unregisterServiceWorker",

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -273,8 +273,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate) const;
   v8::Local<v8::Value> GetLastWebPreferences(v8::Isolate* isolate) const;
 
-  bool IsRemoteModuleEnabled() const;
-
   // Returns the owner window.
   v8::Local<v8::Value> GetOwnerBrowserWindow() const;
 

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -106,6 +106,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kWebviewTag, node);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
   SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
+  SetDefaultBoolIfUndefined(options::kEnableRemoteModule, true);
   SetDefaultBoolIfUndefined(options::kContextIsolation, false);
   SetDefaultBoolIfUndefined("javascript", true);
   SetDefaultBoolIfUndefined("images", true);
@@ -169,10 +170,6 @@ void WebContentsPreferences::Clear() {
 bool WebContentsPreferences::GetPreference(const base::StringPiece& name,
                                            std::string* value) const {
   return GetAsString(&preference_, name, value);
-}
-
-bool WebContentsPreferences::IsRemoteModuleEnabled() const {
-  return IsEnabled(options::kEnableRemoteModule, true);
 }
 
 bool WebContentsPreferences::GetPreloadPath(
@@ -272,7 +269,7 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   }
 
   // Whether to enable the remote module
-  if (!IsRemoteModuleEnabled())
+  if (!IsEnabled(options::kEnableRemoteModule))
     command_line->AppendSwitch(switches::kDisableRemoteModule);
 
   // Run Electron APIs and preload script in isolated world

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -55,9 +55,6 @@ class WebContentsPreferences
   // Return true if the particular preference value exists.
   bool GetPreference(const base::StringPiece& name, std::string* value) const;
 
-  // Whether to enable the remote module
-  bool IsRemoteModuleEnabled() const;
-
   // Returns the preload script path.
   bool GetPreloadPath(base::FilePath::StringType* path) const;
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -262,10 +262,21 @@ const callFunction = function (event, contextId, func, caller, args) {
   }
 }
 
+const isRemoteModuleEnabledCache = new WeakMap()
+
+const isRemoteModuleEnabled = function (contents) {
+  if (!isRemoteModuleEnabledCache.has(contents)) {
+    const value = contents.getLastWebPreferences().enableRemoteModule
+    isRemoteModuleEnabledCache.set(contents, value)
+  }
+
+  return isRemoteModuleEnabledCache.get(contents)
+}
+
 const handleRemoteCommand = function (channel, handler) {
   ipcMain.on(channel, (event, contextId, ...args) => {
     let returnValue
-    if (!event.sender._isRemoteModuleEnabled()) {
+    if (!isRemoteModuleEnabled(event.sender)) {
       event.returnValue = null
       return
     }
@@ -534,7 +545,7 @@ ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
   event.returnValue = {
     preloadSrc,
     preloadError,
-    isRemoteModuleEnabled: event.sender._isRemoteModuleEnabled(),
+    isRemoteModuleEnabled: isRemoteModuleEnabled(event.sender),
     process: {
       arch: process.arch,
       platform: process.platform,


### PR DESCRIPTION
#### Description of Change
Implement `isRemoteModuleEnabled()` using `getLastWebPreferences()`.
Simplifies the native code.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes