### PR TITLE
test: fix a bunch of flaky tests related to emittedOnce

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -360,7 +360,6 @@ describe('BrowserWindow module', () => {
 
     it('is emitted after will-navigate on redirects', (done) => {
       let navigateCalled = false
-      w.loadURL(`${server.url}/navigate-302`)
       w.webContents.on('will-navigate', () => {
         navigateCalled = true
       })
@@ -368,6 +367,7 @@ describe('BrowserWindow module', () => {
         expect(navigateCalled).to.equal(true, 'should have called will-navigate first')
         done()
       })
+      w.loadURL(`${server.url}/navigate-302`)
     })
 
     it('is emitted before did-stop-loading on redirects', (done) => {
@@ -509,8 +509,9 @@ describe('BrowserWindow module', () => {
         height: 400,
         transparent: true
       })
+      const p = emittedOnce(w, 'ready-to-show')
       w.loadURL('data:text/html,<html><body background-color: rgba(255,255,255,0)></body></html>')
-      await emittedOnce(w, 'ready-to-show')
+      await p
       w.show()
 
       const image = await w.capturePage()
@@ -1312,8 +1313,9 @@ describe('BrowserWindow module', () => {
             preload: preload
           }
         })
+        const p = emittedOnce(ipcMain, 'answer')
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
-        const [, test] = await emittedOnce(ipcMain, 'answer')
+        const [, test] = await p
         expect(test).to.be.an('object')
         expect(test.atPreload).to.be.an('array')
         expect(test.atLoad).to.be.an('array')
@@ -1428,8 +1430,9 @@ describe('BrowserWindow module', () => {
                 sandbox
               }
             })
+            const p = emittedOnce(ipcMain, 'remote')
             w.loadFile(path.join(fixtures, 'api', 'blank.html'))
-            const [, remote] = await emittedOnce(ipcMain, 'remote')
+            const [, remote] = await p
             expect(remote).to.equal('object')
           })
 
@@ -1443,8 +1446,9 @@ describe('BrowserWindow module', () => {
                 enableRemoteModule: false
               }
             })
+            const p = emittedOnce(ipcMain, 'remote')
             w.loadFile(path.join(fixtures, 'api', 'blank.html'))
-            const [, remote] = await emittedOnce(ipcMain, 'remote')
+            const [, remote] = await p
             expect(remote).to.equal('undefined')
           })
         })
@@ -1533,7 +1537,6 @@ describe('BrowserWindow module', () => {
         })
         const htmlPath = path.join(fixtures, 'api', 'sandbox.html?exit-event')
         const pageUrl = 'file://' + htmlPath
-        w.loadURL(pageUrl)
         ipcMain.once('answer', function (event, url) {
           let expectedUrl = pageUrl
           if (process.platform === 'win32') {
@@ -1542,6 +1545,7 @@ describe('BrowserWindow module', () => {
           assert.strictEqual(url, expectedUrl)
           done()
         })
+        w.loadURL(pageUrl)
       })
 
       it('should open windows in same domain with cross-scripting enabled', (done) => {
@@ -1556,7 +1560,6 @@ describe('BrowserWindow module', () => {
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
         const htmlPath = path.join(fixtures, 'api', 'sandbox.html?window-open')
         const pageUrl = 'file://' + htmlPath
-        w.loadURL(pageUrl)
         w.webContents.once('new-window', (e, url, frameName, disposition, options) => {
           let expectedUrl = pageUrl
           if (process.platform === 'win32') {
@@ -1571,6 +1574,7 @@ describe('BrowserWindow module', () => {
             done()
           })
         })
+        w.loadURL(pageUrl)
       })
 
       it('should open windows in another domain with cross-scripting disabled', async () => {
@@ -1583,24 +1587,27 @@ describe('BrowserWindow module', () => {
         })
 
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
+        const browserWindowCreated = emittedOnce(app, 'browser-window-created')
+        const childLoaded = emittedOnce(ipcMain, 'child-loaded')
         w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), { search: 'window-open-external' })
         const expectedPopupUrl = 'http://www.google.com/#q=electron' // Set in the "sandbox.html".
 
         // The page is going to open a popup that it won't be able to close.
         // We have to close it from here later.
         // XXX(alexeykuzmin): It will leak if the test fails too soon.
-        const [, popupWindow] = await emittedOnce(app, 'browser-window-created')
+        const [, popupWindow] = await browserWindowCreated
 
         // Wait for a message from the popup's preload script.
-        const [, openerIsNull, html, locationHref] = await emittedOnce(ipcMain, 'child-loaded')
+        const [, openerIsNull, html, locationHref] = await childLoaded
         expect(openerIsNull).to.be.true('window.opener is not null')
         expect(html).to.equal(`<h1>${expectedPopupUrl}</h1>`,
           'looks like a http: request has not been intercepted locally')
         expect(locationHref).to.equal(expectedPopupUrl)
 
         // Ask the page to access the popup.
+        const answer = emittedOnce(ipcMain, 'answer')
         w.webContents.send('touch-the-popup')
-        const [, exceptionMessage] = await emittedOnce(ipcMain, 'answer')
+        const [, exceptionMessage] = await answer
 
         // We don't need the popup anymore, and its parent page can't close it,
         // so let's close it from here before we run any checks.
@@ -1860,10 +1867,12 @@ describe('BrowserWindow module', () => {
             webviewTag: true
           }
         })
+        const didAttachWebview = emittedOnce(w.webContents, 'did-attach-webview')
+        const webviewDomReady = emittedOnce(ipcMain, 'webview-dom-ready')
         w.loadFile(path.join(fixtures, 'pages', 'webview-did-attach-event.html'))
 
-        const [, webContents] = await emittedOnce(w.webContents, 'did-attach-webview')
-        const [, id] = await emittedOnce(ipcMain, 'webview-dom-ready')
+        const [, webContents] = await didAttachWebview
+        const [, id] = await webviewDomReady
         expect(webContents.id).to.equal(id)
       })
     })
@@ -3197,13 +3206,13 @@ describe('BrowserWindow module', () => {
 
       showLastDevToolsPanel()
 
-      w.loadURL('about:blank')
-      w.webContents.openDevTools({ mode: 'bottom' })
-
       ipcMain.once('answer', function (event, message) {
         assert.strictEqual(message.runtimeId, 'foo')
         done()
       })
+
+      w.loadURL('about:blank')
+      w.webContents.openDevTools({ mode: 'bottom' })
     })
 
     it('serializes the registered extensions on quit', () => {
@@ -3417,32 +3426,39 @@ describe('BrowserWindow module', () => {
     })
 
     it('separates the page context from the Electron/preload context', async () => {
+      const p = emittedOnce(ipcMain, 'isolated-world')
       iw.loadFile(path.join(fixtures, 'api', 'isolated.html'))
-      const [, data] = await emittedOnce(ipcMain, 'isolated-world')
+      const [, data] = await p
       assert.deepStrictEqual(data, expectedContextData)
     })
     it('recreates the contexts on reload', async () => {
+      const loaded = emittedOnce(iw.webContents, 'did-finish-load')
       iw.loadFile(path.join(fixtures, 'api', 'isolated.html'))
-      await emittedOnce(iw.webContents, 'did-finish-load')
+      await loaded
+      const isolatedWorld = emittedOnce(ipcMain, 'isolated-world')
       iw.webContents.reload()
-      const [, data] = await emittedOnce(ipcMain, 'isolated-world')
+      const [, data] = await isolatedWorld
       assert.deepStrictEqual(data, expectedContextData)
     })
     it('enables context isolation on child windows', async () => {
+      const browserWindowCreated = emittedOnce(app, 'browser-window-created')
       iw.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
-      const [, window] = await emittedOnce(app, 'browser-window-created')
+      const [, window] = await browserWindowCreated
       assert.ok(window.webContents.getLastWebPreferences().contextIsolation)
     })
     it('separates the page context from the Electron/preload context with sandbox on', async () => {
+      const p = emittedOnce(ipcMain, 'isolated-world')
       ws.loadFile(path.join(fixtures, 'api', 'isolated.html'))
-      const [, data] = await emittedOnce(ipcMain, 'isolated-world')
+      const [, data] = await p
       assert.deepStrictEqual(data, expectedContextData)
     })
     it('recreates the contexts on reload with sandbox on', async () => {
+      const loaded = emittedOnce(ws.webContents, 'did-finish-load')
       ws.loadFile(path.join(fixtures, 'api', 'isolated.html'))
-      await emittedOnce(ws.webContents, 'did-finish-load')
+      await loaded
+      const isolatedWorld = emittedOnce(ipcMain, 'isolated-world')
       ws.webContents.reload()
-      const [, data] = await emittedOnce(ipcMain, 'isolated-world')
+      const [, data] = await isolatedWorld
       assert.deepStrictEqual(data, expectedContextData)
     })
     it('supports fetch api', async () => {
@@ -3453,12 +3469,14 @@ describe('BrowserWindow module', () => {
           preload: path.join(fixtures, 'api', 'isolated-fetch-preload.js')
         }
       })
+      const p = emittedOnce(ipcMain, 'isolated-fetch-error')
       fetchWindow.loadURL('about:blank')
-      const [, error] = await emittedOnce(ipcMain, 'isolated-fetch-error')
+      const [, error] = await p
       fetchWindow.destroy()
       assert.strictEqual(error, 'Failed to fetch')
     })
     it('doesn\'t break ipc serialization', async () => {
+      const p = emittedOnce(ipcMain, 'isolated-world')
       iw.loadURL('about:blank')
       iw.webContents.executeJavaScript(`
         const opened = window.open()
@@ -3466,7 +3484,7 @@ describe('BrowserWindow module', () => {
         opened.close()
         window.postMessage({openedLocation}, '*')
       `)
-      const [, data] = await emittedOnce(ipcMain, 'isolated-world')
+      const [, data] = await p
       assert.strictEqual(data.pageContext.openedLocation, '')
     })
   })


### PR DESCRIPTION
#### Description of Change

It seems that a common source of test flake is events firing before listeners are registered, in particular with `loadURL` and `did-finish-load`. It's not clear to me how those events could be getting fired early, but they are, and this fixes it, hopefully.

Relatedly: #15855

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes