### PR TITLE
refactor: simplify logic for enabling stack dumping

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -155,18 +155,9 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   // Logging with pid and timestamp.
   logging::SetLogItems(true, false, true, false);
 
-  // Enable convient stack printing.
-#if defined(DEBUG) && defined(OS_LINUX)
-  bool enable_stack_dumping = true;
-#else
-  bool enable_stack_dumping = env->HasVar("ELECTRON_ENABLE_STACK_DUMPING");
-#endif
-#if defined(ARCH_CPU_ARM_FAMILY) && defined(ARCH_CPU_32_BITS)
-  // For 32bit ARM enabling stack printing would end up crashing.
-  // https://github.com/electron/electron/pull/11230#issuecomment-363232482
-  enable_stack_dumping = false;
-#endif
-  if (enable_stack_dumping)
+  // Enable convient stack printing. This is enabled by default in non-official
+  // builds.
+  if (env->HasVar("ELECTRON_ENABLE_STACK_DUMPING"))
     base::debug::EnableInProcessStackDumping();
 
   chrome::RegisterPathProvider();


### PR DESCRIPTION
ref #15785

#### Description of Change
As of #15785, stack dumping is enabled by default in non-official builds. It's possible to disable it by passing the `--disable-in-process-stack-dumping` switch.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes