### PR TITLE
chore: DCHECK that events are only emitted on the UI thread

### DIFF
--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "atom/common/api/event_emitter_caller.h"
+#include "content/public/browser/browser_thread.h"
 #include "native_mate/wrappable.h"
 
 namespace content {
@@ -77,6 +78,7 @@ class EventEmitter : public Wrappable<T> {
                       content::RenderFrameHost* sender,
                       IPC::Message* message,
                       const Args&... args) {
+    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
     v8::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
     v8::Local<v8::Object> wrapper = GetWrapper();

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -78,7 +78,6 @@ class EventEmitter : public Wrappable<T> {
                       content::RenderFrameHost* sender,
                       IPC::Message* message,
                       const Args&... args) {
-    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
     v8::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
     v8::Local<v8::Object> wrapper = GetWrapper();
@@ -99,6 +98,7 @@ class EventEmitter : public Wrappable<T> {
   bool EmitWithEvent(const base::StringPiece& name,
                      v8::Local<v8::Object> event,
                      const Args&... args) {
+    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
     v8::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
     EmitEvent(isolate(), GetWrapper(), name, event, args...);

--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "atom/common/native_mate_converters/callback.h"
+#include "content/public/browser/browser_thread.h"
 
 namespace atom {
 

--- a/atom/common/native_mate_converters/callback.cc
+++ b/atom/common/native_mate_converters/callback.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "atom/common/native_mate_converters/callback.h"
+#include "content/public/browser/browser_thread.h"
 
 #include "native_mate/dictionary.h"
 

--- a/atom/common/native_mate_converters/callback.h
+++ b/atom/common/native_mate_converters/callback.h
@@ -12,7 +12,6 @@
 #include "base/callback.h"
 #include "base/memory/weak_ptr.h"
 #include "base/message_loop/message_loop.h"
-#include "content/public/browser/browser_thread.h"
 #include "native_mate/function_template.h"
 #include "native_mate/scoped_persistent.h"
 


### PR DESCRIPTION
#### Description of Change
Emitting events on non-UI threads is a Very Bad Idea

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes