### PR TITLE
fix: get foreground color from GtkMenubar#menubar

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <set>
 #include <sstream>
-#include <string>
 
 #include "atom/browser/ui/views/submenu_button.h"
 #include "atom/common/keyboard_util.h"
@@ -268,13 +267,11 @@ void MenuBar::RefreshColorCache(const ui::NativeTheme* theme) {
     theme = ui::NativeTheme::GetInstanceForNativeUi();
   if (theme) {
 #if defined(USE_X11)
-    const std::string menubar_selector = "GtkMenuBar#menubar";
-    background_color_ = libgtkui::GetBgColor(menubar_selector);
-
-    enabled_color_ = theme->GetSystemColor(
-        ui::NativeTheme::kColorId_EnabledMenuItemForegroundColor);
-    disabled_color_ = theme->GetSystemColor(
-        ui::NativeTheme::kColorId_DisabledMenuItemForegroundColor);
+    background_color_ = libgtkui::GetBgColor("GtkMenuBar#menubar");
+    enabled_color_ = libgtkui::GetFgColor(
+        "GtkMenuBar#menubar GtkMenuItem#menuitem GtkLabel");
+    disabled_color_ = libgtkui::GetFgColor(
+        "GtkMenuBar#menubar GtkMenuItem#menuitem:disabled GtkLabel");
 #else
     background_color_ =
         theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);

--- a/patches/common/chromium/libgtkui_export.patch
+++ b/patches/common/chromium/libgtkui_export.patch
@@ -39,6 +39,15 @@ index d9f245070249f5f153bd8fe11e0a5e718c7d3629..a0f033c3e3f7f3996897f5f969b2a209
  
  // Gets the transient parent aura window for |dialog|.
  aura::Window* GetAuraTransientParent(GtkWidget* dialog);
+@@ -180,7 +181,7 @@ void ApplyCssToContext(GtkStyleContext* context, const std::string& css);
+ 
+ // Get the 'color' property from the style context created by
+ // GetStyleContextFromCss(|css_selector|).
+-SkColor GetFgColor(const std::string& css_selector);
++LIBGTKUI_EXPORT SkColor GetFgColor(const std::string& css_selector);
+ 
+ ScopedCssProvider GetCssProvider(const std::string& css);
+ 
 @@ -193,7 +194,7 @@ void RenderBackground(const gfx::Size& size,
  // Renders a background from the style context created by
  // GetStyleContextFromCss(|css_selector|) into a 24x24 bitmap and


### PR DESCRIPTION
#### Description of Change

Resolves #15194

This pulls the GTK menubar item's color from the theme's menubar item foreground. Previously, the menu item's color was used, which could cause issues with some themes (e.g., see the screenshot below using the Yaru theme, which is default in the latest version of Ubuntu):

![screenshot from 2018-11-29 11-28-14](https://user-images.githubusercontent.com/325102/49218066-ae215500-f3cf-11e8-919b-0d40cf98bb08.png)

![screenshot from 2018-11-29 11-28-03](https://user-images.githubusercontent.com/325102/49218070-b1b4dc00-f3cf-11e8-8a22-1e716dde0bc7.png)

cc @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: Fixes incorrect foreground color on GTK menubar