### PR TITLE
fix: ignore unused freopen result

### DIFF
--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -69,11 +69,11 @@ void FixStdioStreams() {
   // For details see https://github.com/libuv/libuv/issues/2062
   struct stat st;
   if (fstat(STDIN_FILENO, &st) < 0 && errno == EBADF)
-    freopen("/dev/null", "r", stdin);
+    ignore_result(freopen("/dev/null", "r", stdin));
   if (fstat(STDOUT_FILENO, &st) < 0 && errno == EBADF)
-    freopen("/dev/null", "w", stdout);
+    ignore_result(freopen("/dev/null", "w", stdout));
   if (fstat(STDERR_FILENO, &st) < 0 && errno == EBADF)
-    freopen("/dev/null", "w", stderr);
+    ignore_result(freopen("/dev/null", "w", stderr));
 }
 #endif
 


### PR DESCRIPTION
#### Description of Change

The `freopen`s introduced in https://github.com/electron/electron/pull/15555 were erroring on release builds a result of their return values being unused. This wraps them in a macro to mitigate that error.

/cc @deepak1556 @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes