### PR TITLE
docs: update mojave-dark-mode-guide.md

### DIFF
--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -24,8 +24,7 @@ to set the `NSRequiresAquaSystemAppearance` key in your app's `Info.plist` file 
 </plist>
 ```
 
-If you are using [`electron-packager` >= 12.2.0](https://github.com/electron-userland/electron-packager) or
-[`electron-forge` >= 6](https://github.com/electron-userland/electron-forge) you can set the
+If you are using [`electron-packager` >= 12.2.0](https://github.com/electron-userland/electron-packager), [`electron-forge` >= 6](https://github.com/electron-userland/electron-forge) or [`electron-builder` >= 20.37.0](https://github.com/electron-userland/electron-builder) you can set the
 [`darwinDarkModeSupport`](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
 option when packaging and this key will be set for you.
 

--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -24,11 +24,12 @@ to set the `NSRequiresAquaSystemAppearance` key in your app's `Info.plist` file 
 </plist>
 ```
 
-If you are using [`electron-packager` >= 12.2.0](https://github.com/electron-userland/electron-packager),
-[`electron-forge` >= 6](https://github.com/electron-userland/electron-forge) or
-[`electron-builder` >= 20.37.0](https://github.com/electron-userland/electron-builder) you can set the
+If you are using [`electron-packager` >= 12.2.0](https://github.com/electron-userland/electron-packager) or
+[`electron-forge` >= 6](https://github.com/electron-userland/electron-forge) you can set the
 [`darwinDarkModeSupport`](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
 option when packaging and this key will be set for you.
+
+If you are using [`electron-builder` >= 20.37.0](https://github.com/electron-userland/electron-builder) you can set the [`darkModeSupport`](https://www.electron.build/configuration/mac.html) option.
 
 ## Automatically updating your own interfaces
 

--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -24,7 +24,9 @@ to set the `NSRequiresAquaSystemAppearance` key in your app's `Info.plist` file 
 </plist>
 ```
 
-If you are using [`electron-packager` >= 12.2.0](https://github.com/electron-userland/electron-packager), [`electron-forge` >= 6](https://github.com/electron-userland/electron-forge) or [`electron-builder` >= 20.37.0](https://github.com/electron-userland/electron-builder) you can set the
+If you are using [`electron-packager` >= 12.2.0](https://github.com/electron-userland/electron-packager),
+[`electron-forge` >= 6](https://github.com/electron-userland/electron-forge) or
+[`electron-builder` >= 20.37.0](https://github.com/electron-userland/electron-builder) you can set the
 [`darwinDarkModeSupport`](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
 option when packaging and this key will be set for you.
 


### PR DESCRIPTION
Add info about dark mode support in electron-builder

#### Description of Change
Add info about dark mode support in electron-builder in `mojave-dark-mode-guide.md`

Release Notes
Notes: Add info about dark mode support in electron-builder in mojave-dark-mode-guide.md