### PR TITLE
chore: improve granular release cleanup

### DIFF
--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -5,7 +5,8 @@ require('colors')
 const pass = '\u2713'.green
 const fail = '\u2717'.red
 const args = require('minimist')(process.argv.slice(2), {
-  string: ['tag', 'releaseId']
+  string: ['tag', 'releaseId'],
+  default: { releaseId: '' }
 })
 const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
@@ -100,8 +101,10 @@ async function cleanReleaseArtifacts () {
       const deletedNightlyDraft = await deleteDraft(releaseId, 'nightlies')
       // don't delete tag unless draft deleted successfully
       if (deletedNightlyDraft) {
-        await deleteTag(args.tag, 'electron')
-        await deleteTag(args.tag, 'nightlies')
+        await Promise.all([
+          deleteTag(args.tag, 'electron'),
+          deleteTag(args.tag, 'nightlies')
+        ])
       }
     } else {
       const deletedElectronDraft = await deleteDraft(releaseId, 'electron')

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -2,8 +2,10 @@
 
 if (!process.env.CI) require('dotenv-safe').load()
 require('colors')
+const pass = '\u2713'.green
+const fail = '\u2717'.red
 const args = require('minimist')(process.argv.slice(2), {
-  string: ['tag']
+  string: ['tag', 'releaseId']
 })
 const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
@@ -32,7 +34,7 @@ async function getCurrentBranch (gitDir) {
   }
 
   const error = GitProcess.parseError(branchDetails.stderr)
-  console.error(`Couldn't get current branch: `, error)
+  console.error(`${fail} couldn't get current branch: `, error)
   process.exit(1)
 }
 
@@ -42,10 +44,10 @@ async function revertBumpCommit (tag) {
   await GitProcess.exec(['revert', commitToRevert], gitDir)
   const pushDetails = await GitProcess.exec(['push', 'origin', `HEAD:${branch}`, '--follow-tags'], gitDir)
   if (pushDetails.exitCode === 0) {
-    console.log(`Successfully reverted release commit.`)
+    console.log(`${pass} successfully reverted release commit.`)
   } else {
     const error = GitProcess.parseError(pushDetails.stderr)
-    console.error(`Failed to push release commit: `, error)
+    console.error(`${fail} could not push release commit: `, error)
     process.exit(1)
   }
 }
@@ -59,8 +61,8 @@ async function deleteDraft (releaseId, targetRepo) {
     })
     console.log(result)
     if (!result.draft) {
-      console.log(`Published releases cannot be deleted.`)
-      process.exit(1)
+      console.log(`${fail} published releases cannot be deleted.`)
+      return false
     } else {
       await github.repos.deleteRelease({
         owner: 'electron',
@@ -68,10 +70,11 @@ async function deleteDraft (releaseId, targetRepo) {
         release_id: result.id
       })
     }
-    console.log(`Successfully deleted draft with id ${releaseId} from ${targetRepo}`)
+    console.log(`${pass} successfully deleted draft with id ${releaseId} from ${targetRepo}`)
+    return true
   } catch (err) {
-    console.error(`Couldn't delete draft with id ${releaseId} from ${targetRepo}: `, err)
-    process.exit(1)
+    console.error(`${fail} couldn't delete draft with id ${releaseId} from ${targetRepo}: `, err)
+    return false
   }
 }
 
@@ -82,29 +85,37 @@ async function deleteTag (tag, targetRepo) {
       repo: targetRepo,
       ref: tag
     })
-    console.log(`Successfully deleted tag ${tag} from ${targetRepo}`)
+    console.log(`${pass} successfully deleted tag ${tag} from ${targetRepo}`)
   } catch (err) {
-    console.log(`Couldn't delete tag ${tag} from ${targetRepo}: `, err)
-    process.exit(1)
+    console.log(`${fail} couldn't delete tag ${tag} from ${targetRepo}: `, err)
   }
 }
 
 async function cleanReleaseArtifacts () {
-  const releaseId = args.releaseId
+  const releaseId = args.releaseId.length > 0 ? args.releaseId : null
   const isNightly = args.tag.includes('nightly')
 
-  if (isNightly) {
-    await deleteDraft(releaseId, 'nightlies')
-    await deleteTag(args.tag, 'nightlies')
-  } else {
-    console.log('we are here')
-    await deleteDraft(releaseId, 'electron')
+  if (releaseId) {
+    if (isNightly) {
+      const deletedNightlyDraft = await deleteDraft(releaseId, 'nightlies')
+      // don't delete tag unless draft deleted successfully
+      if (deletedNightlyDraft) {
+        await deleteTag(args.tag, 'electron')
+        await deleteTag(args.tag, 'nightlies')
+      }
+    } else {
+      const deletedElectronDraft = await deleteDraft(releaseId, 'electron')
+      // don't delete tag unless draft deleted successfully
+      if (deletedElectronDraft) {
+        await deleteTag(args.tag, 'electron')
+      }
+    }
   }
 
-  await deleteTag(args.tag, 'electron')
+  // try to revert commit regardless of tag and draft deletion status
   await revertBumpCommit(args.tag)
 
-  console.log('Failed release artifact cleanup complete')
+  console.log(`${pass} failed release artifact cleanup complete`)
 }
 
 cleanReleaseArtifacts()


### PR DESCRIPTION
#### Description of Change

Adapts the release cleanup script to account for the case where a commit is pushed to the release branch but a tag and draft is not created by removing the interdependence of these functions. Also ensures that tags are not deleted unless drafts are deleted, so that a tag is never accidentally removed from a published draft.

/cc @MarshallOfSound @ckerr @BinaryMuse

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes