### PR TITLE
chore: allow bumping stable => beta

### DIFF
--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -72,7 +72,7 @@ def main():
     if args.bump == 'nightly':
       version = get_next_nightly(curr_version)
     elif args.bump == 'beta':
-      raise Exception("You can\'t bump to a beta from stable")
+      version = get_next_beta(curr_version)
     elif args.bump == 'stable':
       version = get_next_stable_from_stable(curr_version)
     else:


### PR DESCRIPTION
#### Description of Change

We had a flow check such that one cannot bump from stable to beta; the first time we ever ran it it died on that. We then created a `v3.1.0-beta.0` so it wouldn’t hit that check, but thennn that meant there were no new commits between `3-1-x` and `beta.0` so it died on `Error checking for commits from 3.1.0-beta.0 to 3-1-x`. This allows for `stable` => `beta` bumping.

Tested locally.

/cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes