### PR TITLE
chore: warn when people attempt to use the Electron module to do Electron things but from node

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -15,4 +15,20 @@ function getElectronPath () {
   }
 }
 
-module.exports = getElectronPath()
+// A list of the main modules the people will attempt to use from the Electron API, this is not a complete list but should cover most
+// use cases.
+var electronModuleNames = ['app', 'autoUpdater', 'BrowserWindow', 'ipcMain', 'Menu', 'net', 'Notification', 'systemPreferences', 'Tray']
+var electronPath = new String(getElectronPath())
+
+electronModuleNames.forEach(function warnOnElectronAPIAccess (apiKey) {
+  Object.defineProperty(electronPath, apiKey, {
+    enumerable: false,
+    configurable: false,
+    get: function getElectronAPI () {
+      console.warn('WARNING: You are attempting to access an Electron API from a node environment.\n\n' +
+      'You need to use the "electron" command to run your app. E.g. "electron ./myapp.js"')
+    }
+  })
+})
+
+module.exports = electronPath

--- a/npm/index.js
+++ b/npm/index.js
@@ -26,7 +26,7 @@ electronModuleNames.forEach(function warnOnElectronAPIAccess (apiKey) {
     configurable: false,
     get: function getElectronAPI () {
       console.warn('WARNING: You are attempting to access an Electron API from a node environment.\n\n' +
-      'You need to use the "electron" command to run your app. E.g. "electron ./myapp.js"')
+      'You need to use the "electron" command to run your app. E.g. "npx electron ./myapp.js"')
     }
   })
 })


### PR DESCRIPTION
#### Description of Change

A common first-time user issue I've seen is people running `node myapp.js` and then requiring Electron and wondering why it's a string.  This is something we can easily catch and point people in the right direction.

E.g. https://twitter.com/polotek/status/1068972979097264128

#### Release Notes

Notes: Warn if you try to use Electron APIs from a non-electron environment

Co-authored-by: Shelley Vohr shelley.vohr@gmail.com