### PR TITLE
chore: move getCurrentBranch to a util file

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -1,6 +1,11 @@
 const OUT_DIR = process.env.ELECTRON_OUT_DIR || 'Debug'
 
+const { GitProcess } = require('dugite')
 const path = require('path')
+
+require('colors')
+const pass = '\u2713'.green
+const fail = '\u2717'.red
 
 function getElectronExec () {
   switch (process.platform) {
@@ -19,7 +24,22 @@ function getAbsoluteElectronExec () {
   return path.resolve(__dirname, '../../..', getElectronExec())
 }
 
+async function getCurrentBranch (gitDir) {
+  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
+  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
+  if (branchDetails.exitCode === 0) {
+    const currentBranch = branchDetails.stdout.trim()
+    console.log(`${pass} current git branch is: ${currentBranch}`)
+    return currentBranch
+  } else {
+    const error = GitProcess.parseError(branchDetails.stderr)
+    console.log(`${fail} couldn't get details current branch: `, error)
+    process.exit(1)
+  }
+}
+
 module.exports = {
+  getCurrentBranch,
   getElectronExec,
   getAbsoluteElectronExec,
   OUT_DIR

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -1,21 +1,24 @@
 #!/usr/bin/env node
 
 if (!process.env.CI) require('dotenv-safe').load()
-require('colors')
 const args = require('minimist')(process.argv.slice(2), {
   boolean: ['automaticRelease', 'notesOnly', 'stable']
 })
 const ciReleaseBuild = require('./ci-release-build')
-const { execSync } = require('child_process')
-const fail = '\u2717'.red
-const { GitProcess } = require('dugite')
 const GitHub = require('github')
-const pass = '\u2713'.green
+const { execSync } = require('child_process')
+const { GitProcess } = require('dugite')
+
 const path = require('path')
 const readline = require('readline')
 const releaseNotesGenerator = require('./release-notes/index.js')
+const { getCurrentBranch } = require('../lib/utils.js')
 const versionType = args._[0]
 const targetRepo = versionType === 'nightly' ? 'nightlies' : 'electron'
+
+require('colors')
+const pass = '\u2713'.green
+const fail = '\u2717'.red
 
 // TODO (future) automatically determine version based on conventional commits
 // via conventional-recommended-bump
@@ -50,23 +53,6 @@ async function getNewVersion (dryRun) {
   } catch (err) {
     console.log(`${fail} Could not bump version, error was:`, err)
     throw err
-  }
-}
-
-async function getCurrentBranch (gitDir) {
-  console.log(`Determining current git branch`)
-  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
-  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
-  if (branchDetails.exitCode === 0) {
-    const currentBranch = branchDetails.stdout.trim()
-    console.log(`${pass} Successfully determined current git branch is ` +
-      `${currentBranch}`)
-    return currentBranch
-  } else {
-    const error = GitProcess.parseError(branchDetails.stderr)
-    console.log(`${fail} Could not get details for the current branch,
-      error was ${branchDetails.stderr}`, error)
-    process.exit(1)
   }
 }
 

--- a/script/publish-to-npm.js
+++ b/script/publish-to-npm.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const childProcess = require('child_process')
 const GitHubApi = require('github')
-const { GitProcess } = require('dugite')
+const { getCurrentBranch } = require('../lib/utils.js')
 const request = require('request')
 const semver = require('semver')
 const rootPackageJson = require('../package.json')
@@ -162,21 +162,3 @@ new Promise((resolve, reject) => {
     console.error(`Error: ${err}`)
     process.exit(1)
   })
-
-async function getCurrentBranch () {
-  const gitDir = path.resolve(__dirname, '..')
-  console.log(`Determining current git branch`)
-  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
-  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
-  if (branchDetails.exitCode === 0) {
-    const currentBranch = branchDetails.stdout.trim()
-    console.log(`Successfully determined current git branch is ` +
-      `${currentBranch}`)
-    return currentBranch
-  } else {
-    const error = GitProcess.parseError(branchDetails.stderr)
-    console.log(`Could not get details for the current branch,
-      error was ${branchDetails.stderr}`, error)
-    process.exit(1)
-  }
-}

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -10,6 +10,7 @@ const args = require('minimist')(process.argv.slice(2), {
 })
 const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
+const { getCurrentBranch } = require('../lib/utils.js')
 
 const GitHub = require('github')
 const path = require('path')
@@ -25,18 +26,6 @@ github.authenticate({
 function getLastBumpCommit (tag) {
   const data = execSync(`git log -n1 --grep "Bump ${tag}" --format='format:{"hash": "%H", "message": "%s"}'`).toString()
   return JSON.parse(data)
-}
-
-async function getCurrentBranch (gitDir) {
-  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
-  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
-  if (branchDetails.exitCode === 0) {
-    return branchDetails.stdout.trim()
-  }
-
-  const error = GitProcess.parseError(branchDetails.stderr)
-  console.error(`${fail} couldn't get current branch: `, error)
-  process.exit(1)
 }
 
 async function revertBumpCommit (tag) {


### PR DESCRIPTION
#### Description of Change

`getCurrentBranch` is used in the same manner across several release files; to DRY it out this PR moves it to a utils file.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes