### PR TITLE
fix: support async child process methods without callback in asar

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -171,9 +171,6 @@
       if (!isAsar) return old.apply(this, arguments)
 
       const callback = arguments[arguments.length - 1]
-      if (typeof callback !== 'function') {
-        return overrideAPISync(module, name, pathArgumentIndex)
-      }
 
       const archive = getOrCreateArchive(asarPath)
       if (!archive) {

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -912,6 +912,18 @@ describe('asar package', function () {
         })
       })
 
+      it('executes binaries without callback', function (done) {
+        const process = execFile(echo, ['test'])
+        process.on('close', function (code) {
+          assert.strictEqual(code, 0)
+          done()
+        })
+        process.on('error', function () {
+          assert.fail()
+          done()
+        })
+      })
+
       it('execFileSync executes binaries', function () {
         const output = execFileSync(echo, ['test'])
         assert.strictEqual(String(output), 'test\n')


### PR DESCRIPTION
#### Description of Change

In Node land, async child process methods do not require a callback to be provided. In Electron land in the packaged asar environment, there's a bug which means if you don't provide a callback the method does not run — it runs synchronously and blocks execution when a long running child process is launched. I saw this with `execFile`, I had to add a callback to make the child process run.

In development, original Node is used, but in production, Electron's Node (with changes) is used. This means there is a discrepancy between development and production environments and will catch users out, as it did to me. As it is a silent failure, it's quite difficult to spot.

This change no longer branches to call the synchronous method but continues to use the async method as requested and makes this flow work. I added a new asar test and all asar tests pass.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: support async child process methods without callback in asar