### PR TITLE
security: block chrome.tabs.executeScript() for non chrome-extension: URLs

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -201,7 +201,18 @@ ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBa
   resultID++
 })
 
+const isChromeExtension = function (pageURL) {
+  const { protocol } = url.parse(pageURL)
+  return protocol === 'chrome-extension:'
+}
+
 ipcMain.on('CHROME_TABS_EXECUTESCRIPT', function (event, requestId, tabId, extensionId, details) {
+  const pageURL = event.sender._getURL()
+  if (!isChromeExtension(pageURL)) {
+    console.error(`Blocked ${pageURL} from calling chrome.tabs.executeScript()`)
+    return
+  }
+
   const contents = webContents.fromId(tabId)
   if (!contents) {
     console.error(`Sending message to unknown tab ${tabId}`)


### PR DESCRIPTION
#### Description of Change
Don't handle IPCs implementing Chrome Extension APIs if the sender is not an extension (URL needs to be `chrome-extension:` scheme). Similar to https://github.com/electron/electron/pull/15859.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes