### PR TITLE
fix:  correct windowMenu role on MacOS

### DIFF
--- a/default_app/menu.js
+++ b/default_app/menu.js
@@ -69,15 +69,7 @@ const setDefaultApplicationMenu = () => {
       ]
     },
     {
-      role: 'window',
-      submenu: [
-        {
-          role: 'minimize'
-        },
-        {
-          role: 'close'
-        }
-      ]
+      role: 'windowMenu'
     },
     {
       role: 'help',
@@ -158,23 +150,6 @@ const setDefaultApplicationMenu = () => {
         }
       ]
     })
-    template[3].submenu = [
-      {
-        role: 'close'
-      },
-      {
-        role: 'minimize'
-      },
-      {
-        role: 'zoom'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'front'
-      }
-    ]
   } else {
     template.unshift({
       label: 'File',

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -216,17 +216,23 @@ const roles = {
         role: 'minimize'
       },
       {
-        role: 'close'
+        role: 'zoom'
       },
-
+      process.platform !== 'darwin' ? {
+        label: 'close'
+      } : null,
       process.platform === 'darwin' ? {
         type: 'separator'
       } : null,
-
       process.platform === 'darwin' ? {
         role: 'front'
+      } : null,
+      process.platform === 'darwin' ? {
+        type: 'separator'
+      } : null,
+      process.platform === 'darwin' ? {
+        role: 'window'
       } : null
-
     ]
   }
 }

--- a/spec/api-menu-item-spec.js
+++ b/spec/api-menu-item-spec.js
@@ -349,11 +349,14 @@ describe('MenuItems', () => {
 
       expect(item.label).to.equal('Window')
       expect(item.submenu.items[0].role).to.equal('minimize')
-      expect(item.submenu.items[1].role).to.equal('close')
+      expect(item.submenu.items[1].role).to.equal('zoom')
 
       if (process.platform === 'darwin') {
         expect(item.submenu.items[2].type).to.equal('separator')
         expect(item.submenu.items[3].role).to.equal('front')
+
+        expect(item.submenu.items[4].type).to.equal('separator')
+        expect(item.submenu.items[5].role).to.equal('window')
       }
     })
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15912.

Updates `windowMenu` MenuItem role to more accurately reflect the default window menu on MacOS. Also updates the default app to use this role.

/cc @sindresorhus @BinaryMuse

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: correct windowMenu MenuItem role on MacOS