### PR TITLE
perf: optimize invocation of promisifed functions / methods via the remote module

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -63,6 +63,7 @@ filenames = {
     "lib/common/init.ts",
     "lib/common/parse-features-string.js",
     "lib/common/path-utils.ts",
+    "lib/common/promise-utils.ts",
     "lib/common/reset-search-paths.ts",
     "lib/common/web-view-methods.js",
     "lib/renderer/callbacks-registry.js",

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -3,6 +3,8 @@ import * as path from 'path'
 import * as electron from 'electron'
 import { EventEmitter } from 'events'
 
+import { markPromisified } from '@electron/internal/common/promise-utils'
+
 const bindings = process.electronBinding('app')
 const commandLine = process.electronBinding('command_line')
 const { app, App } = bindings
@@ -46,6 +48,10 @@ Object.defineProperty(app, 'applicationMenu', {
   }
 })
 
+// Mark promisifed APIs
+markPromisified(app.getFileIcon)
+markPromisified(app.getGPUInfo)
+
 app.isPackaged = (() => {
   const execFile = path.basename(process.execPath).toLowerCase()
   if (process.platform === 'win32') {
@@ -76,6 +82,9 @@ if (process.platform === 'darwin') {
     setDockMenu(menu)
   }
   app.dock.getMenu = () => dockMenu
+
+  // Mark promisifed APIs
+  markPromisified(app.dock.show)
 }
 
 // Routes the events to webContents.

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -4,6 +4,8 @@ const electron = require('electron')
 const { WebContentsView, TopLevelWindow } = electron
 const { BrowserWindow } = process.electronBinding('window')
 
+const { markPromisified } = require('@electron/internal/common/promise-utils')
+
 Object.setPrototypeOf(BrowserWindow.prototype, TopLevelWindow.prototype)
 
 BrowserWindow.prototype._init = function () {
@@ -190,5 +192,9 @@ Object.assign(BrowserWindow.prototype, {
     this.webContents.setBackgroundThrottling(allowed)
   }
 })
+
+markPromisified(BrowserWindow.prototype.capturePage)
+markPromisified(BrowserWindow.prototype.loadURL)
+markPromisified(BrowserWindow.prototype.loadFile)
 
 module.exports = BrowserWindow

--- a/lib/browser/api/content-tracing.js
+++ b/lib/browser/api/content-tracing.js
@@ -1,5 +1,11 @@
 'use strict'
 const { deprecate } = require('electron')
-const contentTracing =
+const { markPromisified } = require('@electron/internal/common/promise-utils')
 
 module.exports = process.electronBinding('content_tracing')
+
+// Mark promisifed APIs
+markPromisified(module.exports.getCategories)
+markPromisified(module.exports.startRecording)
+markPromisified(module.exports.stopRecording)
+markPromisified(module.exports.getTraceBufferUsage)

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -4,6 +4,8 @@ const { app, BrowserWindow, deprecate } = require('electron')
 const binding = process.electronBinding('dialog')
 const v8Util = process.electronBinding('v8_util')
 
+const { markPromisified } = require('@electron/internal/common/promise-utils')
+
 const fileDialogProperties = {
   openFile: 1 << 0,
   openDirectory: 1 << 1,
@@ -216,3 +218,9 @@ module.exports = {
     return binding.showCertificateTrustDialog(window, certificate, message)
   }
 }
+
+// Mark promisifed APIs
+markPromisified(module.exports.showMessageBox)
+markPromisified(module.exports.showOpenDialog)
+markPromisified(module.exports.showSaveDialog)
+markPromisified(module.exports.showCertificateTrustDialog)

--- a/lib/browser/api/in-app-purchase.js
+++ b/lib/browser/api/in-app-purchase.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { deprecate } = require('electron')
+const { markPromisified } = require('@electron/internal/common/promise-utils')
 
 if (process.platform === 'darwin') {
   const { EventEmitter } = require('events')
@@ -20,3 +21,7 @@ if (process.platform === 'darwin') {
     getReceiptURL: () => ''
   }
 }
+
+// Mark promisifed APIs
+markPromisified(module.exports.purchaseProduct)
+markPromisified(module.exports.getProducts)

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -4,6 +4,8 @@ const { EventEmitter } = require('events')
 const { app, deprecate } = require('electron')
 const { fromPartition, Session, Cookies, NetLog, Protocol } = process.electronBinding('session')
 
+const { markPromisified } = require('@electron/internal/common/promise-utils')
+
 // Public API.
 Object.defineProperties(exports, {
   defaultSession: {
@@ -22,3 +24,22 @@ Object.setPrototypeOf(Cookies.prototype, EventEmitter.prototype)
 Session.prototype._init = function () {
   app.emit('session-created', this)
 }
+
+// Mark promisifed APIs
+markPromisified(Session.prototype.clearStorageData)
+markPromisified(Session.prototype.clearHostResolverCache)
+markPromisified(Session.prototype.resolveProxy)
+markPromisified(Session.prototype.setProxy)
+markPromisified(Session.prototype.getCacheSize)
+markPromisified(Session.prototype.clearCache)
+markPromisified(Session.prototype.clearAuthCache)
+markPromisified(Session.prototype.getBlobData)
+
+markPromisified(Cookies.prototype.flushStore)
+markPromisified(Cookies.prototype.get)
+markPromisified(Cookies.prototype.remove)
+markPromisified(Cookies.prototype.set)
+
+markPromisified(NetLog.prototype.stopLogging)
+
+markPromisified(Protocol.prototype.isProtocolHandled)

--- a/lib/browser/api/system-preferences.js
+++ b/lib/browser/api/system-preferences.js
@@ -2,9 +2,14 @@
 
 const { EventEmitter } = require('events')
 const { systemPreferences, SystemPreferences } = process.electronBinding('system_preferences')
+const { markPromisified } = require('@electron/internal/common/promise-utils')
 
 // SystemPreferences is an EventEmitter.
 Object.setPrototypeOf(SystemPreferences.prototype, EventEmitter.prototype)
 EventEmitter.call(systemPreferences)
 
 module.exports = systemPreferences
+
+// Mark promisifed APIs
+markPromisified(systemPreferences.askForMediaAccess)
+markPromisified(systemPreferences.promptTouchID)

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -11,6 +11,7 @@ const NavigationController = require('@electron/internal/browser/navigation-cont
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
+const { markPromisified } = require('@electron/internal/common/promise-utils')
 
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
@@ -282,6 +283,15 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
   }))
 }
 
+// Mark promisifed APIs
+markPromisified(WebContents.prototype.capturePage)
+markPromisified(WebContents.prototype.executeJavaScript)
+markPromisified(WebContents.prototype.loadURL)
+markPromisified(WebContents.prototype.loadFile)
+markPromisified(WebContents.prototype.printToPDF)
+markPromisified(WebContents.prototype.savePage)
+markPromisified(WebContents.prototype.takeHeapSnapshot)
+
 const addReplyToEvent = (event) => {
   event.reply = (...args) => {
     event.sender.sendToFrame(event.frameId, ...args)
@@ -407,6 +417,10 @@ WebContents.prototype._init = function () {
 
 // JavaScript wrapper of Debugger.
 const { Debugger } = process.electronBinding('debugger')
+
+// Mark promisifed APIs
+markPromisified(Debugger.prototype.sendCommand)
+
 Object.setPrototypeOf(Debugger.prototype, EventEmitter.prototype)
 
 // Public APIs.

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -21,6 +21,7 @@ const bufferUtils = require('@electron/internal/common/buffer-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
 const clipboardUtils = require('@electron/internal/common/clipboard-utils')
 const { isParentDir } = require('@electron/internal/common/path-utils')
+const { isPromisified } = require('@electron/internal/common/promise-utils')
 
 const hasProp = {}.hasOwnProperty
 
@@ -49,6 +50,9 @@ const getObjectMembers = function (object) {
     const member = { name, enumerable: descriptor.enumerable, writable: false }
     if (descriptor.get === undefined && typeof object[name] === 'function') {
       member.type = 'method'
+      if (isPromisified(object[name])) {
+        member.promisified = true
+      }
     } else {
       if (descriptor.set || descriptor.writable) member.writable = true
       member.type = 'get'
@@ -106,6 +110,9 @@ const valueToMeta = function (sender, contextId, value, optimizeSimpleObject = f
     meta.id = objectsRegistry.add(sender, contextId, value)
     meta.members = getObjectMembers(value)
     meta.proto = getObjectPrototype(value)
+    if (isPromisified(value)) {
+      meta.promisified = true
+    }
   } else if (meta.type === 'buffer') {
     meta.value = bufferUtils.bufferToMeta(value)
   } else if (meta.type === 'promise') {
@@ -244,6 +251,15 @@ const unwrapArgs = function (sender, frameId, contextId, args) {
   return args.map(metaToValue)
 }
 
+const callbackFunctions = new WeakMap()
+
+const callbackify = function (func) {
+  if (!callbackFunctions.has(func)) {
+    callbackFunctions.set(func, util.callbackify(func))
+  }
+  return callbackFunctions.get(func)
+}
+
 const isRemoteModuleEnabledCache = new WeakMap()
 
 const isRemoteModuleEnabled = function (contents) {
@@ -375,10 +391,14 @@ handleRemoteCommand('ELECTRON_BROWSER_CONSTRUCTOR', function (event, contextId, 
 
 handleRemoteCommand('ELECTRON_BROWSER_FUNCTION_CALL', function (event, contextId, id, args) {
   args = unwrapArgs(event.sender, event.frameId, contextId, args)
-  const func = objectsRegistry.get(id)
+  let func = objectsRegistry.get(id)
 
   if (func == null) {
     throwRPCError(`Cannot call function on missing remote object ${id}`)
+  }
+
+  if (isPromisified(func)) {
+    func = callbackify(func)
   }
 
   try {
@@ -398,7 +418,13 @@ handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', function (event, cont
     throwRPCError(`Cannot call constructor '${method}' on missing remote object ${id}`)
   }
 
-  return valueToMeta(event.sender, contextId, new object[method](...args))
+  const func = object[method]
+
+  if (func == null) {
+    throwRPCError(`Invalid constructor '${method}' on remote object ${id}`)
+  }
+
+  return valueToMeta(event.sender, contextId, Reflect.construct(func, args))
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CALL', function (event, contextId, id, method, args) {
@@ -409,8 +435,18 @@ handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CALL', function (event, contextId, 
     throwRPCError(`Cannot call method '${method}' on missing remote object ${id}`)
   }
 
+  let func = object[method]
+
+  if (func == null) {
+    throwRPCError(`Invalid method '${method}' on remote object ${id}`)
+  }
+
+  if (isPromisified(func)) {
+    func = callbackify(func)
+  }
+
   try {
-    return valueToMeta(event.sender, contextId, object[method](...args), true)
+    return valueToMeta(event.sender, contextId, Reflect.apply(func, object, args), true)
   } catch (error) {
     const err = new Error(`Could not call remote method '${method}'. Check that the method signature is correct. Underlying error: ${error.message}\nUnderlying stack: ${error.stack}\n`)
     err.cause = error

--- a/lib/common/api/shell.js
+++ b/lib/common/api/shell.js
@@ -1,3 +1,8 @@
 'use strict'
 
+const { markPromisified } = require('@electron/internal/common/promise-utils')
+
 module.exports = process.electronBinding('shell')
+
+// Mark promisifed APIs
+markPromisified(module.exports.openExternal)

--- a/lib/common/promise-utils.ts
+++ b/lib/common/promise-utils.ts
@@ -1,0 +1,13 @@
+'use strict'
+
+const v8Util = process.electronBinding('v8_util')
+
+export function isPromisified (func: Function) {
+  return v8Util.getHiddenValue<boolean>(func, 'promisified') === true
+}
+
+export function markPromisified (func: Function) {
+  if (func) {
+    v8Util.setHiddenValue(func, 'promisified', true)
+  }
+}

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -115,17 +115,7 @@ function setObjectMembers (ref, object, metaId, members) {
 
     const descriptor = { enumerable: member.enumerable }
     if (member.type === 'method') {
-      const remoteMemberFunction = function (...args) {
-        let command
-        if (this && this.constructor === remoteMemberFunction) {
-          command = 'ELECTRON_BROWSER_MEMBER_CONSTRUCTOR'
-        } else {
-          command = 'ELECTRON_BROWSER_MEMBER_CALL'
-        }
-        const ret = ipcRendererInternal.sendSync(command, contextId, metaId, member.name, wrapArgs(args))
-        return metaToValue(ret)
-      }
-
+      const remoteMemberFunction = makeRemoteMemberFunction(metaId, member)
       let descriptorFunction = proxyFunctionProperties(remoteMemberFunction, metaId, member.name)
 
       descriptor.get = () => {
@@ -233,17 +223,7 @@ function metaToValue (meta) {
 
     // A shadow class to represent the remote function object.
     if (meta.type === 'function') {
-      const remoteFunction = function (...args) {
-        let command
-        if (this && this.constructor === remoteFunction) {
-          command = 'ELECTRON_BROWSER_CONSTRUCTOR'
-        } else {
-          command = 'ELECTRON_BROWSER_FUNCTION_CALL'
-        }
-        const obj = ipcRendererInternal.sendSync(command, contextId, meta.id, wrapArgs(args))
-        return metaToValue(obj)
-      }
-      ret = remoteFunction
+      ret = makeRemoteFunction(meta)
     } else {
       ret = {}
     }
@@ -258,6 +238,58 @@ function metaToValue (meta) {
     v8Util.addRemoteObjectRef(contextId, meta.id)
     remoteObjectCache.set(meta.id, ret)
     return ret
+  }
+}
+
+function makeRemoteMemberFunction (metaId, member) {
+  return function remoteMemberFunction (...args) {
+    const isConstructCall = this && this.constructor === remoteMemberFunction
+    const command = isConstructCall
+      ? 'ELECTRON_BROWSER_MEMBER_CONSTRUCTOR'
+      : 'ELECTRON_BROWSER_MEMBER_CALL'
+
+    if (!isConstructCall && member.promisified) {
+      return new Promise((resolve, reject) => {
+        args.push((error, result) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        })
+
+        ipcRendererInternal.send(command, contextId, metaId, member.name, wrapArgs(args))
+      })
+    }
+
+    const result = ipcRendererInternal.sendSync(command, contextId, metaId, member.name, wrapArgs(args))
+    return metaToValue(result)
+  }
+}
+
+function makeRemoteFunction (meta) {
+  return function remoteFunction (...args) {
+    const isConstructCall = this && this.constructor === remoteFunction
+    const command = isConstructCall
+      ? 'ELECTRON_BROWSER_CONSTRUCTOR'
+      : 'ELECTRON_BROWSER_FUNCTION_CALL'
+
+    if (!isConstructCall && meta.promisified) {
+      return new Promise((resolve, reject) => {
+        args.push((error, result) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        })
+
+        ipcRendererInternal.send(command, contextId, meta.id, wrapArgs(args))
+      })
+    }
+
+    const result = ipcRendererInternal.sendSync(command, contextId, meta.id, wrapArgs(args))
+    return metaToValue(result)
   }
 }
 

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -413,16 +413,16 @@ describe('remote module', () => {
     })
 
     it('handles rejections via catch(onRejected)', (done) => {
-      const promise = remote.require(path.join(fixtures, 'module', 'rejected-promise.js'))
-      promise.reject(Promise.resolve(1234)).catch((error) => {
+      const promise = remote.require(path.join(fixtures, 'module', 'promise.js'))
+      promise.rejectPromise(Promise.resolve(1234)).catch((error) => {
         assert.strictEqual(error.message, 'rejected')
         done()
       })
     })
 
     it('handles rejections via then(onFulfilled, onRejected)', (done) => {
-      const promise = remote.require(path.join(fixtures, 'module', 'rejected-promise.js'))
-      promise.reject(Promise.resolve(1234)).then(() => {}, (error) => {
+      const promise = remote.require(path.join(fixtures, 'module', 'promise.js'))
+      promise.rejectPromise(Promise.resolve(1234)).then(() => {}, (error) => {
         assert.strictEqual(error.message, 'rejected')
         done()
       })
@@ -433,7 +433,7 @@ describe('remote module', () => {
         done(reason)
       })
 
-      const promise = remote.require(path.join(fixtures, 'module', 'unhandled-rejection.js'))
+      const promise = remote.require(path.join(fixtures, 'module', 'promise.js'))
       promise.reject().then(() => {
         done(new Error('Promise was not rejected'))
       }).catch((error) => {
@@ -450,7 +450,7 @@ describe('remote module', () => {
         done()
       })
 
-      const promise = remote.require(path.join(fixtures, 'module', 'unhandled-rejection.js'))
+      const promise = remote.require(path.join(fixtures, 'module', 'promise.js'))
       promise.reject().then(() => {
         done(new Error('Promise was not rejected'))
       })

--- a/spec/fixtures/module/promise.js
+++ b/spec/fixtures/module/promise.js
@@ -1,5 +1,25 @@
+const v8Util = process.electronBinding('v8_util')
+
 exports.twicePromise = function (promise) {
   return promise.then(function (value) {
     return value * 2
   })
 }
+
+exports.rejectPromise = function (promise) {
+  return promise.then(function () {
+    throw Error('rejected')
+  })
+}
+
+exports.reject = function () {
+  return Promise.reject(new Error('rejected'))
+}
+
+function markPromisified (func) {
+  v8Util.setHiddenValue(func, 'promisified', true)
+}
+
+markPromisified(exports.twicePromise)
+markPromisified(exports.rejectPromise)
+markPromisified(exports.reject)

--- a/spec/fixtures/module/rejected-promise.js
+++ b/spec/fixtures/module/rejected-promise.js
@@ -1,5 +1,0 @@
-exports.reject = function (promise) {
-  return promise.then(function () {
-    throw Error('rejected')
-  })
-}

--- a/spec/fixtures/module/unhandled-rejection.js
+++ b/spec/fixtures/module/unhandled-rejection.js
@@ -1,3 +1,0 @@
-exports.reject = function () {
-  return Promise.reject(new Error('rejected'))
-}


### PR DESCRIPTION
#### Description of Change
Instead of 2 sync IPCs only 1 async IPC is needed to invoke functions / methods returning promises. The trick is to convert a promisifed function to callback based in the main process (`rpc-server.js`) when invoking over IPC and then transparently wrap it back to Promise on the renderer side (`remote.js`).

before:
- `ipcRenderer.sendSync` to invoke method -> returns proxy `Promise`
- `ipcRenderer.sendSync` to invoke `then` on the `Promise` instance

after:
- `ipcRenderer.send` (async) to invoke method

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Optimized invocation of promisifed functions / methods via the `remote` module