### PR TITLE
chore: simplify promisify helper

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -40,10 +40,7 @@ Object.assign(app, {
   }
 })
 
-const nativeGetFileIcon = app.getFileIcon
-app.getFileIcon = (path, options = {}, cb) => {
-  return deprecate.promisify(nativeGetFileIcon.call(app, path, options), cb)
-}
+app.getFileIcon = deprecate.promisify(app.getFileIcon)
 
 const nativeAppMetrics = app.getAppMetrics
 app.getAppMetrics = () => {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -40,7 +40,7 @@ Object.assign(app, {
   }
 })
 
-app.getFileIcon = deprecate.promisify(app.getFileIcon)
+app.getFileIcon = deprecate.promisify(app.getFileIcon, 2)
 
 const nativeAppMetrics = app.getAppMetrics
 app.getAppMetrics = () => {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -318,14 +318,11 @@ WebContents.prototype._init = function () {
   // The navigation controller.
   NavigationController.call(this, this)
 
-  // Every remote callback from renderer process would add a listenter to the
+  // Every remote callback from renderer process would add a listener to the
   // render-view-deleted event, so ignore the listeners warning.
   this.setMaxListeners(0)
 
-  const nativeCapturePage = this.capturePage
-  this.capturePage = function (rect, cb) {
-    return deprecate.promisify(nativeCapturePage.call(this, rect), cb)
-  }
+  this.capturePage = deprecate.promisify(this.capturePage, 1)
 
   // Dispatch IPC messages to the ipc module.
   this.on('ipc-message', function (event, [channel, ...args]) {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -69,23 +69,28 @@ const deprecate = {
     })
   },
 
-  promisify: (promise, cb) => {
-    const oldName = `function with callbacks`
-    const newName = `function with Promises`
-    const warn = warnOnce(oldName, newName)
+  promisify: (fn, numArgs) => {
+    return function (...args) {
+      const promise = fn.apply(this, args.splice(0, numArgs))
+      const cb = args[numArgs]
 
-    if (typeof cb !== 'function') return promise
-    if (process.enablePromiseAPIs) warn()
-    return promise
-      .then(res => {
-        process.nextTick(() => {
-          cb(null, res)
+      const oldName = `function with callbacks`
+      const newName = `function with Promises`
+      const warn = warnOnce(oldName, newName)
+
+      if (typeof cb !== 'function') return promise
+      if (process.enablePromiseAPIs) warn()
+      return promise
+        .then(res => {
+          process.nextTick(() => {
+            cb(null, res)
+          })
+        }, err => {
+          process.nextTick(() => {
+            cb(err)
+          })
         })
-      }, err => {
-        process.nextTick(() => {
-          cb(err)
-        })
-      })
+    }
   },
 
   renameProperty: (o, oldName, newName) => {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -69,14 +69,14 @@ const deprecate = {
     })
   },
 
-  promisify: (fn, numArgs) => {
+  promisify: (fn, cbParamIndex) => {
     const oldName = `function with callbacks`
     const newName = `function with Promises`
     const warn = warnOnce(oldName, newName)
 
-    return function (...args) {
-      const promise = fn.apply(this, args.splice(0, numArgs))
-      const cb = args[numArgs]
+    return function (...params) {
+      const cb = params.splice(cbParamIndex, 1)[0]
+      const promise = fn.apply(this, params)
 
       if (typeof cb !== 'function') return promise
       if (process.enablePromiseAPIs) warn()

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -70,13 +70,13 @@ const deprecate = {
   },
 
   promisify: (fn, numArgs) => {
+    const oldName = `function with callbacks`
+    const newName = `function with Promises`
+    const warn = warnOnce(oldName, newName)
+
     return function (...args) {
       const promise = fn.apply(this, args.splice(0, numArgs))
       const cb = args[numArgs]
-
-      const oldName = `function with callbacks`
-      const newName = `function with Promises`
-      const warn = warnOnce(oldName, newName)
 
       if (typeof cb !== 'function') return promise
       if (process.enablePromiseAPIs) warn()

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -70,8 +70,9 @@ const deprecate = {
   },
 
   promisify: (fn, cbParamIndex) => {
-    const oldName = `function with callbacks`
-    const newName = `function with Promises`
+    const fnName = fn.name || 'function'
+    const oldName = `${fnName} with callbacks`
+    const newName = `${fnName} with Promises`
     const warn = warnOnce(oldName, newName)
 
     return function (...params) {


### PR DESCRIPTION
#### Description of Change

Simplifies callbackification of methods that have been converted to promises so as to avoid excessive proliferation of:

```
const nativefn = this.fn
this.fn = function (arg, cb) {
  return deprecate.promisify(nativeFn.call(this, arg), cb)
}
```

/cc @miniak 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: none