### PR TITLE
chore: remove deprecated modules internally using remote.require in sandboxed renderer context

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -2,13 +2,10 @@
 
 > Retrieve information about screen size, displays, cursor position, etc.
 
-Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
+Process: [Main](../glossary.md#main-process)
 
 You cannot require or use this module until the `ready` event of the `app`
 module is emitted.
-
-In the renderer process context it depends on the [`remote`](remote.md) module,
-it is therefore not available when this module is disabled.
 
 `screen` is an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
 

--- a/filenames.gni
+++ b/filenames.gni
@@ -80,7 +80,6 @@ filenames = {
     "lib/renderer/api/ipc-renderer.js",
     "lib/renderer/api/module-list.js",
     "lib/renderer/api/remote.js",
-    "lib/renderer/api/screen.js",
     "lib/renderer/api/web-frame.js",
     "lib/renderer/extensions/event.js",
     "lib/renderer/extensions/i18n.js",

--- a/lib/renderer/api/module-list.js
+++ b/lib/renderer/api/module-list.js
@@ -16,6 +16,5 @@ module.exports = [
   },
   { name: 'ipcRenderer', file: 'ipc-renderer' },
   { name: 'remote', file: 'remote', enabled: enableRemoteModule },
-  { name: 'screen', file: 'screen' },
   { name: 'webFrame', file: 'web-frame' }
 ]

--- a/lib/renderer/api/screen.js
+++ b/lib/renderer/api/screen.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { deprecate } = require('electron')
-
-deprecate.warn(`electron.screen`, `electron.remote.screen`)
-
-const { getRemote } = require('@electron/internal/renderer/remote')
-module.exports = getRemote('screen')

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -37,13 +37,6 @@ process.isRemoteModuleEnabled = isRemoteModuleEnabled
 // The electron module depends on process.atomBinding
 const electron = require('electron')
 
-const remoteModules = new Set([
-  'child_process',
-  'fs',
-  'os',
-  'path'
-])
-
 const loadedModules = new Map([
   ['electron', electron],
   ['events', events],
@@ -91,16 +84,10 @@ Object.defineProperty(preloadProcess, 'noDeprecation', {
 
 process.on('exit', () => preloadProcess.emit('exit'))
 
-const { remoteRequire } = require('@electron/internal/renderer/remote')
-
 // This is the `require` function that will be visible to the preload script
 function preloadRequire (module) {
   if (loadedModules.has(module)) {
     return loadedModules.get(module)
-  }
-  if (remoteModules.has(module)) {
-    electron.deprecate.warn(`require('${module}')`, `remote.require('${module}')`)
-    return remoteRequire(module)
   }
   throw new Error('module not found')
 }


### PR DESCRIPTION
#### Description of Change
Remove APIs deprecated in https://github.com/electron/electron/pull/15145. Deprecations are in 5.0 release.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Removed deprecated modules internally using `remote.require` in sandboxed renderer context. Use `remote.require` explicitly instead (unless the remote module is disabled).