### PR TITLE
refactor: use helpers when using the remote module in sandboxed renderers

### DIFF
--- a/lib/common/api/clipboard.js
+++ b/lib/common/api/clipboard.js
@@ -2,8 +2,8 @@
 
 if (process.platform === 'linux' && process.type === 'renderer') {
   // On Linux we could not access clipboard in renderer process.
-  const { getRemoteForUsage } = require('@electron/internal/renderer/remote')
-  module.exports = getRemoteForUsage('clipboard').clipboard
+  const { getRemote } = require('@electron/internal/renderer/remote')
+  module.exports = getRemote('clipboard')
 } else {
   const clipboard = process.atomBinding('clipboard')
 

--- a/lib/renderer/api/screen.js
+++ b/lib/renderer/api/screen.js
@@ -4,5 +4,5 @@ const { deprecate } = require('electron')
 
 deprecate.warn(`electron.screen`, `electron.remote.screen`)
 
-const { getRemoteForUsage } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteForUsage('screen').screen
+const { getRemote } = require('@electron/internal/renderer/remote')
+module.exports = getRemote('screen')

--- a/lib/renderer/extensions/i18n.js
+++ b/lib/renderer/extensions/i18n.js
@@ -6,9 +6,10 @@
 // Does not implement predefined messages:
 // https://developer.chrome.com/extensions/i18n#overview-predefined
 
+const { nativeRequire } = require('@electron/internal/renderer/remote')
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-const fs = require('fs')
-const path = require('path')
+const fs = nativeRequire('fs')
+const path = nativeRequire('path')
 
 let metadata
 

--- a/lib/renderer/extensions/storage.js
+++ b/lib/renderer/extensions/storage.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
-const { remote } = require('electron')
-const { app } = remote
+const { getRemote, nativeRequire } = require('@electron/internal/renderer/remote')
+const fs = nativeRequire('fs')
+const path = nativeRequire('path')
+const app = getRemote('app')
 
 const getChromeStoragePath = (storageType, extensionId) => {
   return path.join(

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { getRemote, nativeRequire } = require('@electron/internal/renderer/remote')
+
 window.onload = function () {
   // Use menu API to show context menu.
   window.InspectorFrontendHost.showContextMenuAtPoint = createMenu
@@ -18,7 +20,7 @@ function completeURL (project, path) {
 }
 
 window.confirm = function (message, title) {
-  const { dialog } = require('electron').remote
+  const dialog = getRemote('dialog')
   if (title == null) {
     title = ''
   }
@@ -62,8 +64,7 @@ const convertToMenuTemplate = function (items) {
 }
 
 const createMenu = function (x, y, items) {
-  const { remote } = require('electron')
-  const { Menu } = remote
+  const Menu = getRemote('Menu')
 
   let template = convertToMenuTemplate(items)
   if (useEditMenuItems(x, y, template)) {
@@ -73,7 +74,8 @@ const createMenu = function (x, y, items) {
 
   // The menu is expected to show asynchronously.
   setTimeout(function () {
-    menu.popup({ window: remote.getCurrentWindow() })
+    const getCurrentWindow = getRemote('getCurrentWindow')
+    menu.popup({ window: getCurrentWindow() })
   })
 }
 
@@ -116,7 +118,7 @@ const getEditMenuItems = function () {
 }
 
 const showFileChooserDialog = function (callback) {
-  const { dialog } = require('electron').remote
+  const dialog = getRemote('dialog')
   const files = dialog.showOpenDialog({})
   if (files != null) {
     callback(pathToHtml5FileObject(files[0]))
@@ -124,7 +126,7 @@ const showFileChooserDialog = function (callback) {
 }
 
 const pathToHtml5FileObject = function (path) {
-  const fs = require('fs')
+  const fs = nativeRequire('fs')
   const blob = new Blob([fs.readFileSync(path)])
   blob.name = path
   return blob

--- a/lib/renderer/remote.js
+++ b/lib/renderer/remote.js
@@ -2,9 +2,24 @@
 
 const { remote } = require('electron')
 
-exports.getRemoteForUsage = function (usage) {
+exports.getRemote = function (name) {
+  if (!remote) {
+    throw new Error(`${name} requires remote, which is not enabled`)
+  }
+  return remote[name]
+}
+
+exports.getRemoteFor = function (usage) {
   if (!remote) {
     throw new Error(`${usage} requires remote, which is not enabled`)
   }
   return remote
+}
+
+exports.nativeRequire = function (name) {
+  if (process.sandboxed) {
+    return exports.getRemoteFor(name).require(name)
+  } else {
+    return require(name)
+  }
 }

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -274,13 +274,13 @@ const registerWebViewElement = function () {
 
   // WebContents associated with this webview.
   proto.getWebContents = function () {
-    const { getRemoteForUsage } = require('@electron/internal/renderer/remote')
-    const remote = getRemoteForUsage('getWebContents()')
+    const { getRemote } = require('@electron/internal/renderer/remote')
+    const getGuestWebContents = getRemote('getGuestWebContents')
     const internal = v8Util.getHiddenValue(this, 'internal')
     if (!internal.guestInstanceId) {
       internal.createGuestSync()
     }
-    return remote.getGuestWebContents(internal.guestInstanceId)
+    return getGuestWebContents(internal.guestInstanceId)
   }
 
   // Focusing the webview should move page focus to the underlying iframe.

--- a/lib/sandboxed_renderer/api/exports/child_process.js
+++ b/lib/sandboxed_renderer/api/exports/child_process.js
@@ -4,5 +4,5 @@ const { deprecate } = require('electron')
 
 deprecate.warn(`require('child_process')`, `remote.require('child_process')`)
 
-const { getRemoteForUsage } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteForUsage('child_process').require('child_process')
+const { getRemoteFor } = require('@electron/internal/renderer/remote')
+module.exports = getRemoteFor('child_process').require('child_process')

--- a/lib/sandboxed_renderer/api/exports/fs.js
+++ b/lib/sandboxed_renderer/api/exports/fs.js
@@ -4,5 +4,5 @@ const { deprecate } = require('electron')
 
 deprecate.warn(`require('fs')`, `remote.require('fs')`)
 
-const { getRemoteForUsage } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteForUsage('fs').require('fs')
+const { getRemoteFor } = require('@electron/internal/renderer/remote')
+module.exports = getRemoteFor('fs').require('fs')

--- a/lib/sandboxed_renderer/api/exports/os.js
+++ b/lib/sandboxed_renderer/api/exports/os.js
@@ -4,5 +4,5 @@ const { deprecate } = require('electron')
 
 deprecate.warn(`require('os')`, `remote.require('os')`)
 
-const { getRemoteForUsage } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteForUsage('os').require('os')
+const { getRemoteFor } = require('@electron/internal/renderer/remote')
+module.exports = getRemoteFor('os').require('os')

--- a/lib/sandboxed_renderer/api/exports/path.js
+++ b/lib/sandboxed_renderer/api/exports/path.js
@@ -4,5 +4,5 @@ const { deprecate } = require('electron')
 
 deprecate.warn(`require('path')`, `remote.require('path')`)
 
-const { getRemoteForUsage } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteForUsage('path').require('path')
+const { getRemoteFor } = require('@electron/internal/renderer/remote')
+module.exports = getRemoteFor('path').require('path')


### PR DESCRIPTION
#### Description of Change
Use helpers for any remaining uses of modules, which are using `remote.remote` internally or the `remote` module itself, as it can be disabled.

Follow up to https://github.com/electron/electron/pull/13028.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes