### PR TITLE
refactor: simplify isRemoteModuleEnabled handling in sandboxed renderers

### DIFF
--- a/lib/sandboxed_renderer/api/exports/electron.js
+++ b/lib/sandboxed_renderer/api/exports/electron.js
@@ -6,7 +6,6 @@ for (const {
   name,
   load,
   enabled = true,
-  configurable = false,
   private: isPrivate = false
 } of moduleList) {
   if (!enabled) {
@@ -14,7 +13,6 @@ for (const {
   }
 
   Object.defineProperty(exports, name, {
-    configurable,
     enumerable: !isPrivate,
     get: load
   })

--- a/lib/sandboxed_renderer/api/module-list.js
+++ b/lib/sandboxed_renderer/api/module-list.js
@@ -22,8 +22,8 @@ module.exports = [
   },
   {
     name: 'remote',
-    configurable: true, // will be configured in init.js
-    load: () => require('@electron/internal/renderer/api/remote')
+    load: () => require('@electron/internal/renderer/api/remote'),
+    enabled: process.isRemoteModuleEnabled
   },
   {
     name: 'webFrame',

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -7,9 +7,6 @@ const { EventEmitter } = events
 
 process.atomBinding = require('@electron/internal/common/atom-binding-setup')(binding.get, 'renderer')
 
-// The electron module depends on process.atomBinding
-const electron = require('electron')
-
 const v8Util = process.atomBinding('v8_util')
 // Expose browserify Buffer as a hidden value. This is used by C++ code to
 // deserialize Buffer instances sent from browser process.
@@ -28,6 +25,17 @@ for (const prop of Object.keys(EventEmitter.prototype)) {
   }
 }
 Object.setPrototypeOf(process, EventEmitter.prototype)
+
+const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
+
+const {
+  preloadSrc, preloadError, isRemoteModuleEnabled, process: processProps
+} = ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD')
+
+process.isRemoteModuleEnabled = isRemoteModuleEnabled
+
+// The electron module depends on process.atomBinding
+const electron = require('electron')
 
 const remoteModules = new Set([
   'child_process',
@@ -48,8 +56,6 @@ const loadedModules = new Map([
 const ipcNative = process.atomBinding('ipc')
 v8Util.setHiddenValue(global, 'ipcNative', ipcNative)
 
-const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-
 ipcNative.onInternalMessage = function (channel, args, senderId) {
   ipcRenderer.emit(channel, { sender: ipcRenderer, senderId }, ...args)
 }
@@ -60,22 +66,6 @@ ipcNative.onMessage = function (channel, args, senderId) {
 
 ipcNative.onExit = function () {
   process.emit('exit')
-}
-
-const {
-  preloadSrc, preloadError, isRemoteModuleEnabled, process: processProps
-} = ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD')
-
-const makePropertyNonConfigurable = function (object, name) {
-  const descriptor = Object.getOwnPropertyDescriptor(electron, name)
-  descriptor.configurable = false
-  Object.defineProperty(electron, name, descriptor)
-}
-
-if (isRemoteModuleEnabled) {
-  makePropertyNonConfigurable(electron, 'remote')
-} else {
-  delete electron.remote
 }
 
 require('@electron/internal/renderer/web-frame-init')()


### PR DESCRIPTION
#### Description of Change
Remove hacky code re-configuring the `electron.remote` property, inject `isRemoteModuleEnabled` into `features` before initializing the `electron` exports.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes