### PR TITLE
security: allow to block desktopCapturer.getSources() calls

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.h
+++ b/atom/browser/api/atom_api_desktop_capturer.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "atom/browser/api/event_emitter.h"
+#include "atom/browser/api/trackable_object.h"
 #include "chrome/browser/media/webrtc/desktop_media_list_observer.h"
 #include "chrome/browser/media/webrtc/native_desktop_media_list.h"
 #include "native_mate/handle.h"
@@ -18,7 +18,7 @@ namespace atom {
 
 namespace api {
 
-class DesktopCapturer : public mate::EventEmitter<DesktopCapturer>,
+class DesktopCapturer : public mate::TrackableObject<DesktopCapturer>,
                         public DesktopMediaListObserver {
  public:
   struct Source {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -401,6 +401,16 @@ gets emitted.
 **Note:** Extra command line arguments might be added by Chromium,
 such as `--original-process-start-time`.
 
+### Event: 'desktop-capturer-get-sources'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+
+Emitted when `desktopCapturer.getSources()` is called in the renderer process of `webContents`.
+Calling `event.preventDefault()` will make it throw an error.
+
 ### Event: 'remote-require'
 
 Returns:

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -409,7 +409,7 @@ Returns:
 * `webContents` [WebContents](web-contents.md)
 
 Emitted when `desktopCapturer.getSources()` is called in the renderer process of `webContents`.
-Calling `event.preventDefault()` will make it throw an error.
+Calling `event.preventDefault()` will make it return empty sources.
 
 ### Event: 'remote-require'
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -663,6 +663,15 @@ Returns:
 Emitted when the associated window logs a console message. Will not be emitted
 for windows with *offscreen rendering* enabled.
 
+#### Event: 'desktop-capturer-get-sources'
+
+Returns:
+
+* `event` Event
+
+Emitted when `desktopCapturer.getSources()` is called in the renderer process.
+Calling `event.preventDefault()` will make it throw an error.
+
 #### Event: 'remote-require'
 
 Returns:

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -670,7 +670,7 @@ Returns:
 * `event` Event
 
 Emitted when `desktopCapturer.getSources()` is called in the renderer process.
-Calling `event.preventDefault()` will make it throw an error.
+Calling `event.preventDefault()` will make it return empty sources.
 
 #### Event: 'remote-require'
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -377,6 +377,10 @@ WebContents.prototype._init = function () {
     })
   })
 
+  this.on('desktop-capturer-get-sources', (event, ...args) => {
+    app.emit('desktop-capturer-get-sources', event, this, ...args)
+  })
+
   this.on('remote-require', (event, ...args) => {
     app.emit('remote-require', event, this, ...args)
   })

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -1,7 +1,10 @@
 'use strict'
 
 const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const errorUtils = require('@electron/internal/common/error-utils')
+
 const { desktopCapturer } = process.atomBinding('desktop_capturer')
+const eventBinding = process.atomBinding('event')
 
 const deepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b)
 
@@ -12,6 +15,15 @@ const electronSources = 'ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES'
 const capturerResult = (id) => `ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`
 
 ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize, fetchWindowIcons, id) => {
+  const customEvent = eventBinding.createWithSender(event.sender)
+  event.sender.emit('desktop-capturer-get-sources', customEvent)
+
+  if (customEvent.defaultPrevented) {
+    const error = new Error('desktopCapturer.getSources() blocked')
+    event.sender._sendInternal(capturerResult(id), errorUtils.serialize(error))
+    return
+  }
+
   const request = {
     id,
     options: {
@@ -51,7 +63,7 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   })
 
   if (handledWebContents) {
-    handledWebContents._sendInternal(capturerResult(handledRequest.id), result)
+    handledWebContents._sendInternal(capturerResult(handledRequest.id), null, result)
   }
 
   // Check the queue to see whether there is another identical request & handle
@@ -59,7 +71,7 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
     const webContents = request.webContents
     if (deepEqual(handledRequest.options, request.options)) {
       if (webContents) {
-        webContents._sendInternal(capturerResult(request.id), result)
+        webContents._sendInternal(capturerResult(request.id), null, result)
       }
     } else {
       unhandledRequestsQueue.push(request)

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const ipcMain = require('@electron/internal/browser/ipc-main-internal')
-const errorUtils = require('@electron/internal/common/error-utils')
 
 const { desktopCapturer } = process.atomBinding('desktop_capturer')
 const eventBinding = process.atomBinding('event')
@@ -19,8 +18,7 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
   event.sender.emit('desktop-capturer-get-sources', customEvent)
 
   if (customEvent.defaultPrevented) {
-    const error = new Error('desktopCapturer.getSources() blocked')
-    event.sender._sendInternal(capturerResult(id), errorUtils.serialize(error))
+    event.sender._sendInternal(capturerResult(id), [])
     return
   }
 
@@ -63,7 +61,7 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   })
 
   if (handledWebContents) {
-    handledWebContents._sendInternal(capturerResult(handledRequest.id), null, result)
+    handledWebContents._sendInternal(capturerResult(handledRequest.id), result)
   }
 
   // Check the queue to see whether there is another identical request & handle
@@ -71,7 +69,7 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
     const webContents = request.webContents
     if (deepEqual(handledRequest.options, request.options)) {
       if (webContents) {
-        webContents._sendInternal(capturerResult(request.id), null, result)
+        webContents._sendInternal(capturerResult(request.id), result)
       }
     } else {
       unhandledRequestsQueue.push(request)

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const { nativeImage } = require('electron')
-
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-const errorUtils = require('@electron/internal/common/error-utils')
 
 const includes = [].includes
 let currentId = 0
@@ -46,11 +44,11 @@ exports.getSources = function (options, callback) {
 
   const id = incrementId()
   ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, options.fetchWindowIcons, id)
-  return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, error, sources) => {
-    if (error) {
-      callback(errorUtils.deserialize(error))
-    } else {
+  return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, sources) => {
+    try {
       callback(null, mapSources(sources))
+    } catch (error) {
+      callback(error)
     }
   })
 }

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const { nativeImage } = require('electron')
+
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
+const errorUtils = require('@electron/internal/common/error-utils')
 
 const includes = [].includes
 let currentId = 0
@@ -15,6 +17,16 @@ const incrementId = () => {
 function isValid (options) {
   const types = options ? options.types : undefined
   return Array.isArray(types)
+}
+
+function mapSources (sources) {
+  return sources.map(source => ({
+    id: source.id,
+    name: source.name,
+    thumbnail: nativeImage.createFromDataURL(source.thumbnail),
+    display_id: source.display_id,
+    appIcon: source.appIcon ? nativeImage.createFromDataURL(source.appIcon) : null
+  }))
 }
 
 exports.getSources = function (options, callback) {
@@ -34,19 +46,11 @@ exports.getSources = function (options, callback) {
 
   const id = incrementId()
   ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, options.fetchWindowIcons, id)
-  return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, sources) => {
-    callback(null, (() => {
-      const results = []
-      sources.forEach(source => {
-        results.push({
-          id: source.id,
-          name: source.name,
-          thumbnail: nativeImage.createFromDataURL(source.thumbnail),
-          display_id: source.display_id,
-          appIcon: source.appIcon ? nativeImage.createFromDataURL(source.appIcon) : null
-        })
-      })
-      return results
-    })())
+  return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, error, sources) => {
+    if (error) {
+      callback(errorUtils.deserialize(error))
+    } else {
+      callback(null, mapSources(sources))
+    }
   })
 }

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -370,6 +370,16 @@ describe('app module', () => {
       w = new BrowserWindow({ show: false })
     })
 
+    it('should emit desktop-capturer-get-sources event when desktopCapturer.getSources() is invoked', (done) => {
+      app.once('desktop-capturer-get-sources', (event, webContents) => {
+        expect(webContents).to.equal(w.webContents)
+        done()
+      })
+      w = new BrowserWindow({ show: false })
+      w.loadURL('about:blank')
+      w.webContents.executeJavaScript(`require('electron').desktopCapturer.getSources({ types: ['screen'] }, () => {})`)
+    })
+
     it('should emit remote-require event when remote.require() is invoked', (done) => {
       app.once('remote-require', (event, webContents, moduleName) => {
         expect(webContents).to.equal(w.webContents)

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -39,15 +39,6 @@ describe('desktopCapturer', () => {
     })
   })
 
-  it('throws an error when blocked', done => {
-    ipcRenderer.send('handle-next-desktop-capturer-get-sources')
-    desktopCapturer.getSources({ types: ['screen'] }, (error, sources) => {
-      expect(error.message).to.equal('desktopCapturer.getSources() blocked')
-      expect(sources).to.be.undefined()
-      done()
-    })
-  })
-
   it('does not throw an error when called more than once (regression)', (done) => {
     let callCount = 0
     const callback = (error, sources) => {
@@ -107,6 +98,15 @@ describe('desktopCapturer', () => {
         expect(sources[i].display_id).to.equal(displays[i].id.toString())
       }
       done()
+    })
+
+    it('returns empty sources when blocked', done => {
+      ipcRenderer.send('handle-next-desktop-capturer-get-sources')
+      desktopCapturer.getSources({ types: ['screen'] }, (error, sources) => {
+        expect(error).to.be.null()
+        expect(sources).to.be.empty()
+        done()
+      })
     })
   })
 })

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -1,6 +1,6 @@
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
-const { desktopCapturer, remote } = require('electron')
+const { desktopCapturer, ipcRenderer, remote } = require('electron')
 const { screen } = remote
 const features = process.atomBinding('features')
 
@@ -35,6 +35,15 @@ describe('desktopCapturer', () => {
   it('throws an error for invalid options', done => {
     desktopCapturer.getSources(['window', 'screen'], error => {
       expect(error.message).to.equal('Invalid options')
+      done()
+    })
+  })
+
+  it('throws an error when blocked', done => {
+    ipcRenderer.send('handle-next-desktop-capturer-get-sources')
+    desktopCapturer.getSources({ types: ['screen'] }, (error, sources) => {
+      expect(error.message).to.equal('desktopCapturer.getSources() blocked')
+      expect(sources).to.be.undefined()
       done()
     })
   })

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -233,6 +233,12 @@ app.on('ready', function () {
   })
 })
 
+ipcMain.on('handle-next-desktop-capturer-get-sources', function (event) {
+  event.sender.once('desktop-capturer-get-sources', (event) => {
+    event.preventDefault()
+  })
+})
+
 ipcMain.on('handle-next-remote-require', function (event, modulesMap = {}) {
   event.sender.once('remote-require', (event, moduleName) => {
     event.preventDefault()


### PR DESCRIPTION
#### Description of Change
Allows blocking of `desktopCapturer.getSources()` calls by handling the `desktop-capturer-get-sources` event.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Allowed blocking of `desktopCapturer.getSources()` calls by handling the `desktop-capturer-get-sources` event.