### PR TITLE
fix: move NativeWindow tracking to OSR WCV (backport: 4-0-x)

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -51,7 +51,7 @@ class WebViewGuestDelegate;
 class FrameSubscriber;
 
 #if BUILDFLAG(ENABLE_OSR)
-class OffScreenWebContentsView;
+class OffScreenRenderWidgetHostView;
 #endif
 
 namespace api {
@@ -439,9 +439,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   uint32_t GetNextRequestId() { return ++request_id_; }
 
 #if BUILDFLAG(ENABLE_OSR)
-  OffScreenWebContentsView* GetOffScreenWebContentsView() const;
-  OffScreenRenderWidgetHostView* GetOffScreenRenderWidgetHostView()
-      const override;
+  OffScreenWebContentsView* GetOffScreenWebContentsView() const override;
+  OffScreenRenderWidgetHostView* GetOffScreenRenderWidgetHostView() const;
 #endif
 
   // Called when we receive a CursorChange message from chromium.

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -41,7 +41,7 @@
 #include "storage/browser/fileapi/isolated_context.h"
 
 #if BUILDFLAG(ENABLE_OSR)
-#include "atom/browser/osr/osr_render_widget_host_view.h"
+#include "atom/browser/osr/osr_web_contents_view.h"
 #endif
 
 using content::BrowserThread;
@@ -207,9 +207,9 @@ void CommonWebContentsDelegate::SetOwnerWindow(
         NativeWindowRelay::kNativeWindowRelayUserDataKey);
   }
 #if BUILDFLAG(ENABLE_OSR)
-  auto* osr_rwhv = GetOffScreenRenderWidgetHostView();
-  if (osr_rwhv)
-    osr_rwhv->SetNativeWindow(owner_window);
+  auto* osr_wcv = GetOffScreenWebContentsView();
+  if (osr_wcv)
+    osr_wcv->SetNativeWindow(owner_window);
 #endif
 }
 
@@ -247,8 +247,8 @@ content::WebContents* CommonWebContentsDelegate::GetDevToolsWebContents()
 }
 
 #if BUILDFLAG(ENABLE_OSR)
-OffScreenRenderWidgetHostView*
-CommonWebContentsDelegate::GetOffScreenRenderWidgetHostView() const {
+OffScreenWebContentsView*
+CommonWebContentsDelegate::GetOffScreenWebContentsView() const {
   return nullptr;
 }
 #endif

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -33,7 +33,7 @@ class NativeWindow;
 class WebDialogHelper;
 
 #if BUILDFLAG(ENABLE_OSR)
-class OffScreenRenderWidgetHostView;
+class OffScreenWebContentsView;
 #endif
 
 class CommonWebContentsDelegate
@@ -71,8 +71,7 @@ class CommonWebContentsDelegate
 
  protected:
 #if BUILDFLAG(ENABLE_OSR)
-  virtual OffScreenRenderWidgetHostView* GetOffScreenRenderWidgetHostView()
-      const;
+  virtual OffScreenWebContentsView* GetOffScreenWebContentsView() const;
 #endif
 
   // content::WebContentsDelegate:

--- a/atom/browser/osr/osr_render_widget_host_view.h
+++ b/atom/browser/osr/osr_render_widget_host_view.h
@@ -14,8 +14,6 @@
 #include <windows.h>
 #endif
 
-#include "atom/browser/native_window.h"
-#include "atom/browser/native_window_observer.h"
 #include "atom/browser/osr/osr_output_device.h"
 #include "atom/browser/osr/osr_view_proxy.h"
 #include "base/process/kill.h"
@@ -75,7 +73,6 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
 #if !defined(OS_MACOSX)
                                       public content::DelegatedFrameHostClient,
 #endif
-                                      public NativeWindowObserver,
                                       public OffscreenViewProxyObserver {
  public:
   OffScreenRenderWidgetHostView(bool transparent,
@@ -84,7 +81,7 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
                                 const OnPaintCallback& callback,
                                 content::RenderWidgetHost* render_widget_host,
                                 OffScreenRenderWidgetHostView* parent_host_view,
-                                NativeWindow* native_window);
+                                gfx::Size initial_size);
   ~OffScreenRenderWidgetHostView() override;
 
   content::BrowserAccessibilityManager* CreateBrowserAccessibilityManager(
@@ -205,10 +202,6 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
 
   bool InstallTransparency();
 
-  // NativeWindowObserver:
-  void OnWindowResize() override;
-  void OnWindowClosed() override;
-
   void OnBeginFrameTimerTick();
   void SendBeginFrame(base::TimeTicks frame_time, base::TimeDelta vsync_period);
 
@@ -268,8 +261,7 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   content::RenderWidgetHostImpl* render_widget_host() const {
     return render_widget_host_;
   }
-  void SetNativeWindow(NativeWindow* window);
-  NativeWindow* window() const { return native_window_; }
+
   gfx::Size size() const { return size_; }
 
   void set_popup_host_view(OffScreenRenderWidgetHostView* popup_view) {
@@ -306,7 +298,6 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   std::set<OffScreenRenderWidgetHostView*> guest_host_views_;
   std::set<OffscreenViewProxy*> proxy_views_;
 
-  NativeWindow* native_window_;
   OffScreenOutputDevice* software_output_device_ = nullptr;
 
   const bool transparent_;

--- a/atom/browser/osr/osr_web_contents_view.h
+++ b/atom/browser/osr/osr_web_contents_view.h
@@ -5,6 +5,9 @@
 #ifndef ATOM_BROWSER_OSR_OSR_WEB_CONTENTS_VIEW_H_
 #define ATOM_BROWSER_OSR_OSR_WEB_CONTENTS_VIEW_H_
 
+#include "atom/browser/native_window.h"
+#include "atom/browser/native_window_observer.h"
+
 #include "atom/browser/osr/osr_render_widget_host_view.h"
 #include "content/browser/renderer_host/render_view_host_delegate_view.h"
 #include "content/browser/web_contents/web_contents_view.h"
@@ -21,12 +24,20 @@ class OffScreenView;
 namespace atom {
 
 class OffScreenWebContentsView : public content::WebContentsView,
-                                 public content::RenderViewHostDelegateView {
+                                 public content::RenderViewHostDelegateView,
+                                 public NativeWindowObserver {
  public:
   OffScreenWebContentsView(bool transparent, const OnPaintCallback& callback);
   ~OffScreenWebContentsView() override;
 
   void SetWebContents(content::WebContents*);
+  void SetNativeWindow(NativeWindow* window);
+
+  // NativeWindowObserver:
+  void OnWindowResize() override;
+  void OnWindowClosed() override;
+
+  gfx::Size GetSize();
 
   // content::WebContentsView:
   gfx::NativeView GetNativeView() const override;
@@ -83,6 +94,8 @@ class OffScreenWebContentsView : public content::WebContentsView,
 #endif
 
   OffScreenRenderWidgetHostView* GetView() const;
+
+  NativeWindow* native_window_;
 
   const bool transparent_;
   bool painting_ = true;


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/15585. See that PR for details.

/cc @sofianguy @adill 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: move NativeWindow tracking to OSR WCV