### PR TITLE
chore: rename nativeRequire to potentiallyRemoteRequire

### DIFF
--- a/lib/renderer/extensions/i18n.js
+++ b/lib/renderer/extensions/i18n.js
@@ -6,10 +6,10 @@
 // Does not implement predefined messages:
 // https://developer.chrome.com/extensions/i18n#overview-predefined
 
-const { nativeRequire } = require('@electron/internal/renderer/remote')
+const { potentiallyRemoteRequire } = require('@electron/internal/renderer/remote')
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-const fs = nativeRequire('fs')
-const path = nativeRequire('path')
+const fs = potentiallyRemoteRequire('fs')
+const path = potentiallyRemoteRequire('path')
 
 let metadata
 

--- a/lib/renderer/extensions/storage.js
+++ b/lib/renderer/extensions/storage.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { getRemote, nativeRequire } = require('@electron/internal/renderer/remote')
-const fs = nativeRequire('fs')
-const path = nativeRequire('path')
+const { getRemote, potentiallyRemoteRequire } = require('@electron/internal/renderer/remote')
+const fs = potentiallyRemoteRequire('fs')
+const path = potentiallyRemoteRequire('path')
 const app = getRemote('app')
 
 const getChromeStoragePath = (storageType, extensionId) => {

--- a/lib/renderer/inspector.js
+++ b/lib/renderer/inspector.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { getRemote, nativeRequire } = require('@electron/internal/renderer/remote')
+const { getRemote, potentiallyRemoteRequire } = require('@electron/internal/renderer/remote')
 
 window.onload = function () {
   // Use menu API to show context menu.
@@ -126,7 +126,7 @@ const showFileChooserDialog = function (callback) {
 }
 
 const pathToHtml5FileObject = function (path) {
-  const fs = nativeRequire('fs')
+  const fs = potentiallyRemoteRequire('fs')
   const blob = new Blob([fs.readFileSync(path)])
   blob.name = path
   return blob

--- a/lib/renderer/remote.js
+++ b/lib/renderer/remote.js
@@ -16,7 +16,7 @@ exports.getRemoteFor = function (usage) {
   return remote
 }
 
-exports.nativeRequire = function (name) {
+exports.potentiallyRemoteRequire = function (name) {
   if (process.sandboxed) {
     return exports.getRemoteFor(name).require(name)
   } else {


### PR DESCRIPTION
#### Description of Change
Rename helper to better name as suggested by @nornagon in https://github.com/electron/electron/pull/15960

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes