### PR TITLE
fix: allow 2 threads for CreateIoCompletionPort on single-core to prevent busy looping

### DIFF
--- a/atom/common/node_bindings_win.cc
+++ b/atom/common/node_bindings_win.cc
@@ -7,6 +7,7 @@
 #include <windows.h>
 
 #include "base/logging.h"
+#include "base/sys_info.h"
 
 namespace atom {
 
@@ -14,8 +15,7 @@ NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env)
     : NodeBindings(browser_env) {
   // on single-core the io comp port NumberOfConcurrentThreads needs to be 2
   // to avoid cpu pegging likely caused by a busy loop in PollEvents
-  char* numProcessors = getenv("NUMBER_OF_PROCESSORS");
-  if (numProcessors && strcmp(numProcessors, "1") == 0) {
+  if (base::SysInfo::NumberOfProcessors() == 1) {
     if (uv_loop_->iocp && uv_loop_->iocp != INVALID_HANDLE_VALUE)
       CloseHandle(uv_loop_->iocp);
     uv_loop_->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 2);

--- a/atom/common/node_bindings_win.cc
+++ b/atom/common/node_bindings_win.cc
@@ -16,6 +16,11 @@ NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env)
   // on single-core the io comp port NumberOfConcurrentThreads needs to be 2
   // to avoid cpu pegging likely caused by a busy loop in PollEvents
   if (base::SysInfo::NumberOfProcessors() == 1) {
+    // the expectation is the uv_loop_ has just been initialized
+    // which makes iocp replacement safe
+    CHECK_EQ(0u, uv_loop_->active_handles);
+    CHECK_EQ(0u, uv_loop_->active_reqs.count);
+
     if (uv_loop_->iocp && uv_loop_->iocp != INVALID_HANDLE_VALUE)
       CloseHandle(uv_loop_->iocp);
     uv_loop_->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 2);

--- a/atom/common/node_bindings_win.cc
+++ b/atom/common/node_bindings_win.cc
@@ -11,7 +11,16 @@
 namespace atom {
 
 NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env)
-    : NodeBindings(browser_env) {}
+    : NodeBindings(browser_env) {
+  // on single-core the io comp port NumberOfConcurrentThreads needs to be 2
+  // to avoid cpu pegging likely caused by a busy loop in PollEvents
+  char* numProcessors = getenv("NUMBER_OF_PROCESSORS");
+  if (numProcessors && strcmp(numProcessors, "1") == 0) {
+    if (uv_loop_->iocp && uv_loop_->iocp != INVALID_HANDLE_VALUE)
+      CloseHandle(uv_loop_->iocp);
+    uv_loop_->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 2);
+  }
+}
 
 NodeBindingsWin::~NodeBindingsWin() {}
 


### PR DESCRIPTION
#### Description of Change

Electron on single-core windows has a problem with cpu pegging when it should be idle, triggered by (among other things) async io.

- electron/electron#12026
- electron/electron#11699
- electron/electron#14319

There are related issues in downstream projects like vscode.

This fix replaces the I/O completion port created by libuv with one with 2 concurrent threads, on single core.

Original idea came from #12026.
@refack recommended to do the iocp override in electron code.
CCing @zcbenz for review

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Fixes cpu pegging on single-core windows. 