### PR TITLE
test: skip test for not supported setLoginItemSettings on mas platform

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -450,7 +450,7 @@ describe('app module', () => {
     ]
 
     before(function () {
-      if (process.platform === 'linux') {
+      if (process.platform === 'linux' || process.mas) {
         this.skip()
       }
     })


### PR DESCRIPTION
#### Description of Change
The `Browser::SetLoginItemSettings` is not supported on mas and tests that are executed on this feature always fails.
To avoid this I've disabled the `Browser::SetLoginItemSettings` related tests on mas platform.
This is the `Browser::SetLoginItemSettings` function source code inside `electron/atom/browser/browser_mac.mm` on line 279:
```
void Browser::SetLoginItemSettings(LoginItemSettings settings) {
#if defined(MAS_BUILD)
  if (!platform_util::SetLoginItemEnabled(settings.open_at_login)) {
    LOG(ERROR) << "Unable to set login item enabled on sandboxed app.";
  }
#else
  if (settings.open_at_login)
    base::mac::AddToLoginItems(settings.open_as_hidden);
  else {
    RemoveFromLoginItems();
  }
#endif
}
```

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: no-notes