### PR TITLE
fix: do not print an error when browser extension isn't found on disk

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -427,7 +427,7 @@ app.once('ready', function () {
       }
     }
   } catch (error) {
-    if (process.env.ELECTRON_ENABLE_LOGGING) {
+    if (process.env.ELECTRON_ENABLE_LOGGING && error.code !== 'ENOENT') {
       console.error('Failed to load browser extensions from directory:', loadedDevToolsExtensionsPath)
       console.error(error)
     }


### PR DESCRIPTION
#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: do not print an error about devtools extensions when folder does not exist.