### PR TITLE
chore: disable bump-version on arm32

### DIFF
--- a/spec/version-bump-spec.js
+++ b/spec/version-bump-spec.js
@@ -6,7 +6,7 @@ describe('bump-version script', () => {
   const betaPattern = /[0-9.]*(-beta[0-9.]*)/g
 
   before(function () {
-    if (process.platform === 'linux' && process.arch === 'arm32') {
+    if (process.platform === 'linux' && process.arch === 'arm') {
       this.skip()
     }
   })

--- a/spec/version-bump-spec.js
+++ b/spec/version-bump-spec.js
@@ -5,6 +5,12 @@ describe('bump-version script', () => {
   const nightlyPattern = /[0-9.]*(-nightly.(\d{4})(\d{2})(\d{2}))$/g
   const betaPattern = /[0-9.]*(-beta[0-9.]*)/g
 
+  before(function () {
+    if (process.platform === 'linux' && process.arch === 'arm32') {
+      this.skip()
+    }
+  })
+
   it('bumps to nightly from stable', async () => {
     const version = 'v2.0.0'
     const next = await nextVersion('nightly', version)


### PR DESCRIPTION
#### Description of Change

Dugite doesn't work on arm32, and we don't run bump-version on arm32 anyway so we can disable the associated tests on that arch.

/cc @jkleinsc 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes