### PR TITLE
fix: incorrect view ordering for customButtonsOnHover (#15564)

### DIFF
--- a/atom/browser/api/atom_api_browser_window_mac.mm
+++ b/atom/browser/api/atom_api_browser_window_mac.mm
@@ -63,7 +63,12 @@ void BrowserWindow::OverrideNSWindowContentView(
   NSView* webView = iwc->GetView()->GetNativeView();
   NSView* contentView = [window()->GetNativeWindow() contentView];
   [webView setFrame:[contentView bounds]];
-  [contentView addSubview:webView];
+
+  // ensure that buttons view is floated to top of view hierarchy
+  NSArray* subviews = [contentView subviews];
+  NSView* last = subviews.lastObject;
+  [contentView addSubview:webView positioned:NSWindowBelow relativeTo:last];
+
   [contentView viewDidMoveToWindow];
 }
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -74,9 +74,7 @@
                                              forStyleMask:NSTitledWindowMask];
   NSButton* miniaturize_button =
       [NSWindow standardWindowButton:NSWindowMiniaturizeButton
-                        forStyleMask:NSTitledWindowMask];
-  NSButton* zoom_button = [NSWindow standardWindowButton:NSWindowZoomButton
-                                            forStyleMask:NSTitledWindowMask];
+                        forStyleMask:NSWindowStyleMaskTitled];
 
   CGFloat x = 0;
   const CGFloat space_between = 20;
@@ -89,11 +87,7 @@
   x += space_between;
   [self addSubview:miniaturize_button];
 
-  [zoom_button setFrameOrigin:NSMakePoint(x, 0)];
-  x += space_between;
-  [self addSubview:zoom_button];
-
-  const auto last_button_frame = zoom_button.frame;
+  const auto last_button_frame = miniaturize_button.frame;
   [self setFrameSize:NSMakeSize(last_button_frame.origin.x +
                                     last_button_frame.size.width,
                                 last_button_frame.size.height)];
@@ -1361,6 +1355,8 @@ void NativeWindowMac::AddContentViewLayers() {
     if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER) {
       buttons_view_.reset(
           [[CustomWindowButtonView alloc] initWithFrame:NSZeroRect]);
+      // NSWindowStyleMaskFullSizeContentView does not work with zoom button
+      SetFullScreenable(false);
       [[window_ contentView] addSubview:buttons_view_];
     } else {
       if (title_bar_style_ != NORMAL) {

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -222,11 +222,11 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       the top left.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-    * `customButtonsOnHover` Boolean (optional) - Draw custom close, minimize,
-      and full screen buttons on macOS frameless windows. These buttons will not
-      display unless hovered over in the top left of the window. These custom
-      buttons prevent issues with mouse events that occur with the standard
-      window toolbar buttons. **Note:** This option is currently experimental.
+    * `customButtonsOnHover` Boolean (optional) - Draw custom close,
+      and minimize buttons on macOS frameless windows. These buttons will not display
+      unless hovered over in the top left of the window. These custom buttons prevent
+      issues with mouse events that occur with the standard window toolbar buttons.
+      **Note:** This option is currently experimental.
   * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
     title bar in full screen mode on macOS for all `titleBarStyle` options.
     Default is `false`.

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -50,10 +50,12 @@ win.show()
 
 #### `customButtonsOnHover`
 
-Uses custom drawn close, miniaturize, and fullscreen buttons that display
-when hovering in the top left of the window. These custom buttons prevent issues
-with mouse events that occur with the standard window toolbar buttons. This
-option is only applicable for frameless windows.
+Uses custom drawn close, and miniaturize buttons that display
+when hovering in the top left of the window. The fullscreen button
+is not available due to restrictions of frameless windows as they
+interface with Apple's MacOS window masks. These custom buttons prevent
+issues with mouse events that occur with the standard window toolbar buttons.
+This option is only applicable for frameless windows.
 
 ```javascript
 const {BrowserWindow} = require('electron')


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/15564.

/cc @BinaryMuse 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: fix unclickable buttons when using `customButtonsOnHover`