### PR TITLE
chore: warn when nodeIntegration's default is relied on

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -98,6 +98,9 @@ WebContentsPreferences::WebContentsPreferences(
 
   instances_.push_back(this);
 
+  preference_.SetKey(options::kNodeIntegrationWasExplicitlyEnabled,
+                     base::Value(IsEnabled(options::kNodeIntegration)));
+
   // Set WebPreferences defaults onto the JS object
   SetDefaultBoolIfUndefined(options::kPlugins, false);
   SetDefaultBoolIfUndefined(options::kExperimentalFeatures, false);

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -110,6 +110,13 @@ const char kPreloadURL[] = "preloadURL";
 // Enable the node integration.
 const char kNodeIntegration[] = "nodeIntegration";
 
+// Whether node integration was explicitly enabled.
+// This is to support the change from default-enabled to default-disabled in
+// Electron 5 (with a warning message in 4). This option and its usages
+// can be removed in Electron 5.
+const char kNodeIntegrationWasExplicitlyEnabled[] =
+    "nodeIntegrationWasExplicitlyEnabled";
+
 // Enable the remote module
 const char kEnableRemoteModule[] = "enableRemoteModule";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -58,6 +58,7 @@ extern const char kZoomFactor[];
 extern const char kPreloadScript[];
 extern const char kPreloadURL[];
 extern const char kNodeIntegration[];
+extern const char kNodeIntegrationWasExplicitlyEnabled[];
 extern const char kEnableRemoteModule[];
 extern const char kContextIsolation[];
 extern const char kGuestInstanceID[];

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -249,6 +249,16 @@ const warnAboutAllowedPopups = function () {
   }
 }
 
+const warnAboutNodeIntegrationDefault = function (webPreferences) {
+  if (webPreferences.nodeIntegration && !webPreferences.nodeIntegrationWasExplicitlyEnabled) {
+    const warning = `This window has node integration enabled by default. In ` +
+        `Electron 5.0.0, node integration will be disabled by default. To prepare ` +
+        `for this change, set {nodeIntegration: true} in the webPreferences for ` +
+        `this window.`
+    console.warn('%cElectron Deprecation Warning (nodeIntegration default change)', 'font-weight: bold;', warning)
+  }
+}
+
 // Currently missing since we can't easily programmatically check for it:
 //   #12WebViews: Verify the options and params of all `<webview>` tags
 
@@ -261,6 +271,7 @@ const logSecurityWarnings = function (webPreferences, nodeIntegration) {
   warnAboutEnableBlinkFeatures(webPreferences)
   warnAboutInsecureCSP()
   warnAboutAllowedPopups()
+  warnAboutNodeIntegrationDefault(webPreferences)
 }
 
 const getWebPreferences = function () {


### PR DESCRIPTION
#### Description of Change
`nodeIntegration` will be [disabled by default in Electron 5.0](/docs/api/breaking-changes.md#planned-breaking-api-changes-50). This adds a warning for users of 4.0 to help prepare for the change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: in Electron 5.0, the default for nodeIntegration will change from true to false. Electron 4 will log a warning in the renderer when nodeIntegration is enabled by default.