### PR TITLE
fix: allow 2 threads for CreateIoCompletionPort on single-core to prevent busy looping (backport: 2-0-x)

### DIFF
--- a/atom/common/node_bindings_win.cc
+++ b/atom/common/node_bindings_win.cc
@@ -7,6 +7,7 @@
 #include <windows.h>
 
 #include "base/logging.h"
+#include "base/sys_info.h"
 
 extern "C" {
 #include "vendor/node/deps/uv/src/win/internal.h"
@@ -16,6 +17,17 @@ namespace atom {
 
 NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env)
     : NodeBindings(browser_env) {
+  // on single-core the io comp port NumberOfConcurrentThreads needs to be 2
+  // to avoid cpu pegging likely caused by a busy loop in PollEvents
+  if (base::SysInfo::NumberOfProcessors() == 1) {
+    // the expectation is the uv_loop_ has just been initialized
+    // which makes iocp replacement safe
+    CHECK_EQ(0u, uv_loop_->active_handles);
+
+    if (uv_loop_->iocp && uv_loop_->iocp != INVALID_HANDLE_VALUE)
+      CloseHandle(uv_loop_->iocp);
+    uv_loop_->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 2);
+  }
 }
 
 NodeBindingsWin::~NodeBindingsWin() {


### PR DESCRIPTION
Backport of #15975

See that PR for details.

Notes: Fixes cpu pegging on single-core windows. 