### PR TITLE
build: make it possible to pass a "--directory" arg to "git am"

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -40,11 +40,13 @@ def get_repo_root(path):
   return get_repo_root(parent_path)
 
 
-def am(repo, patch_data, threeway=False,
+def am(repo, patch_data, threeway=False, directory=None,
     committer_name=None, committer_email=None):
   args = []
   if threeway:
     args += ['--3way']
+  if directory is not None:
+    args += ['--directory', directory]
   root_args = ['-C', repo]
   if committer_name is not None:
     root_args += ['-c', 'user.name=' + committer_name]


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
We really need this stuff for Microsoft internal builds.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no notes