### PR TITLE
fix: fix an original-fs regression introduced in 4.0 betas

### DIFF
--- a/lib/common/asar_init.js
+++ b/lib/common/asar_init.js
@@ -8,10 +8,6 @@
     // dependency. So to expose the unmodified Node 'fs' functionality here,
     // we have to copy both 'fs' *and* 'internal/fs/streams' and modify the
     // copies to depend on each other instead of on our asarified 'fs' code.
-    // source['original_fs'] = source.fs.replace(/'internal\/fs\/streams'/g, "'original_fs/internal/streams'")
-    // source['original_fs/internal/streams'] = source['internal/fs/streams'].replace(/'fs'/g, "'original_fs'")
-    // source['original-fs'] = source['original_fs']
-
     source['original-fs'] = source.fs.replace("require('internal/fs/streams')", "require('original-fs/streams')")
     source['original-fs/streams'] = source['internal/fs/streams'].replace("require('fs')", "require('original-fs')")
 

--- a/lib/common/asar_init.js
+++ b/lib/common/asar_init.js
@@ -3,7 +3,17 @@
 ;(function () { // eslint-disable-line
   return function (source, require, asarSource) {
     // Expose fs module without asar support.
-    source['original-fs'] = source.fs
+
+    // NB: Node's 'fs' and 'internal/fs/streams' have a lazy-loaded circular
+    // dependency. So to expose the unmodified Node 'fs' functionality here,
+    // we have to copy both 'fs' *and* 'internal/fs/streams' and modify the
+    // copies to depend on each other instead of on our asarified 'fs' code.
+    // source['original_fs'] = source.fs.replace(/'internal\/fs\/streams'/g, "'original_fs/internal/streams'")
+    // source['original_fs/internal/streams'] = source['internal/fs/streams'].replace(/'fs'/g, "'original_fs'")
+    // source['original-fs'] = source['original_fs']
+
+    source['original-fs'] = source.fs.replace("require('internal/fs/streams')", "require('original-fs/streams')")
+    source['original-fs/streams'] = source['internal/fs/streams'].replace("require('fs')", "require('original-fs')")
 
     // Make asar.js accessible via "require".
     source.ELECTRON_ASAR = asarSource


### PR DESCRIPTION
#### Description of Change

Fixes a 4.0.0-beta.X regression in `original-fs`. Node's `fs` and `internal/fs/streams` have a lazy-loaded circular dependency, so to expose the unmodified Node `fs` functionality, we have to copy both `fs` *and* `internal/fs/streams` and modify the copies to depend on each other instead of on our asarified 'fs' code.

Fixes #15543.

Discussion: an earlier draft of this code added a new `original_fs` module into atom/common/node-bindings so that multiple Node code that calls `process.binding('fs')` could also be swapped out with a `process.binding('fs_original')`. This more completely separates the asarified and original versions of `fs`, but it also requires more cloning and inter-dependencies, and is not required for #15543. This PR tries to KISS by replacing only what's clearly needed.

CC @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Fix 4-0-x regression that broke original-fs