### PR TITLE
chore: add deprecation warning for contextIsolation default change

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -100,6 +100,8 @@ WebContentsPreferences::WebContentsPreferences(
 
   preference_.SetKey(options::kNodeIntegrationWasExplicitlyEnabled,
                      base::Value(IsEnabled(options::kNodeIntegration)));
+  preference_.SetKey(options::kContextIsolationWasExplicitlyDisabled,
+                     base::Value(!IsEnabled(options::kContextIsolation, true)));
 
   // Set WebPreferences defaults onto the JS object
   SetDefaultBoolIfUndefined(options::kPlugins, false);

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -123,6 +123,13 @@ const char kEnableRemoteModule[] = "enableRemoteModule";
 // Enable context isolation of Electron APIs and preload script
 const char kContextIsolation[] = "contextIsolation";
 
+// Whether context isolation was explicitly enabled.
+// This is to support the change from default-disabled to default-enabled in
+// Electron 5 (with a warning message in 4). This option and its usages
+// can be removed in Electron 5.
+const char kContextIsolationWasExplicitlyDisabled[] =
+    "contextIsolationWasExplicitlyDisabled";
+
 // Instance ID of guest WebContents.
 const char kGuestInstanceID[] = "guestInstanceId";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -61,6 +61,7 @@ extern const char kNodeIntegration[];
 extern const char kNodeIntegrationWasExplicitlyEnabled[];
 extern const char kEnableRemoteModule[];
 extern const char kContextIsolation[];
+extern const char kContextIsolationWasExplicitlyDisabled[];
 extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kOpenerID[];

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -262,11 +262,13 @@ const warnAboutNodeIntegrationDefault = function (webPreferences) {
 
 const warnAboutContextIsolationDefault = function (webPreferences) {
   if (webPreferences.preload && !webPreferences.contextIsolation && !webPreferences.contextIsolationWasExplicitlyDisabled) {
+    const url = 'https://electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content'
     const warning = `This window has context isolation disabled by default. In ` +
         `Electron 5.0.0, context isolation will be enabled by default. To prepare ` +
         `for this change, set {contextIsolation: false} in the webPreferences for ` +
         `this window, or ensure that this window does not rely on context ` +
-        `isolation being disabled, and set {contextIsolation: true}.`
+        `isolation being disabled, and set {contextIsolation: true}.\n\n` +
+        `For more information, see ${url}`
     console.warn('%cElectron Deprecation Warning (contextIsolation default change)', 'font-weight: bold;', warning)
   }
 }

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -254,8 +254,20 @@ const warnAboutNodeIntegrationDefault = function (webPreferences) {
     const warning = `This window has node integration enabled by default. In ` +
         `Electron 5.0.0, node integration will be disabled by default. To prepare ` +
         `for this change, set {nodeIntegration: true} in the webPreferences for ` +
-        `this window.`
+        `this window, or ensure that this window does not rely on node integration ` +
+        `and set {nodeIntegration: false}.`
     console.warn('%cElectron Deprecation Warning (nodeIntegration default change)', 'font-weight: bold;', warning)
+  }
+}
+
+const warnAboutContextIsolationDefault = function (webPreferences) {
+  if (webPreferences.preload && !webPreferences.contextIsolation && !webPreferences.contextIsolationWasExplicitlyDisabled) {
+    const warning = `This window has context isolation disabled by default. In ` +
+        `Electron 5.0.0, context isolation will be enabled by default. To prepare ` +
+        `for this change, set {contextIsolation: false} in the webPreferences for ` +
+        `this window, or ensure that this window does not rely on context ` +
+        `isolation being disabled, and set {contextIsolation: true}.`
+    console.warn('%cElectron Deprecation Warning (contextIsolation default change)', 'font-weight: bold;', warning)
   }
 }
 
@@ -272,6 +284,7 @@ const logSecurityWarnings = function (webPreferences, nodeIntegration) {
   warnAboutInsecureCSP()
   warnAboutAllowedPopups()
   warnAboutNodeIntegrationDefault(webPreferences)
+  warnAboutContextIsolationDefault(webPreferences)
 }
 
 const getWebPreferences = function () {


### PR DESCRIPTION
#### Description of Change
In 5.0, the default for `contextIsolation` will be `true`. This only affects you if you're using the `preload` option to interact directly with globals on the `window` or `document` objects.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes