### PR TITLE
docs: contextIsolation is no longer experimental

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -347,8 +347,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       This option uses the same technique used by [Chrome Content Scripts][chrome-content-scripts].
       You can access this context in the dev tools by selecting the
       'Electron Isolated Context' entry in the combo box at the top of the
-      Console tab. **Note:** This option is currently experimental and may
-      change or be removed in future Electron releases.
+      Console tab.
     * `nativeWindowOpen` Boolean (optional) - Whether to use native
       `window.open()`. Defaults to `false`. Child windows will always have node
       integration disabled. **Note:** This option is currently


### PR DESCRIPTION
#### Description of Change

This removes the note from the `BrowserWindow` docs that says that `contextIsolation` is experimental in preparation for the 4.0 release.

Should we also reword the explanation of the default since it's changing for 5.0?

/cc @nornagon @electron/docs 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes