### PR TITLE
ci: Cleanup build dirs on Azure Devops 

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -234,7 +234,9 @@ jobs:
     timeoutInMinutes: 1
 
   - bash: |
+      ls -la
       rm -rf *
+      ls -la
     condition: always()
     displayName: 'Cleanup directories'
 

--- a/vsts.yml
+++ b/vsts.yml
@@ -234,9 +234,7 @@ jobs:
     timeoutInMinutes: 1
 
   - bash: |
-      ls -la
-      rm -rf *
-      ls -la
+      rm -rf ..?* .[!.]* *
     condition: always()
     displayName: 'Cleanup directories'
 

--- a/vsts.yml
+++ b/vsts.yml
@@ -233,8 +233,10 @@ jobs:
     condition: and(failed(), eq(variables['NOTIFY_SLACK'], '1'))
     timeoutInMinutes: 1
 
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
+  - bash: |
+      rm -rf src
+    condition: always()
+    displayName: 'Cleanup source directories'
 
 - job: run_tests
   displayName: Run Tests

--- a/vsts.yml
+++ b/vsts.yml
@@ -233,6 +233,9 @@ jobs:
     condition: and(failed(), eq(variables['NOTIFY_SLACK'], '1'))
     timeoutInMinutes: 1
 
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+
 - job: run_tests
   displayName: Run Tests
   dependsOn: build

--- a/vsts.yml
+++ b/vsts.yml
@@ -234,9 +234,9 @@ jobs:
     timeoutInMinutes: 1
 
   - bash: |
-      rm -rf src
+      rm -rf *
     condition: always()
-    displayName: 'Cleanup source directories'
+    displayName: 'Cleanup directories'
 
 - job: run_tests
   displayName: Run Tests


### PR DESCRIPTION
#### Description of Change
Azure Devops (aks VSTS) was not properly cleaning up directories after builds which meant our CI VMs were running out of disk space.  This PR ensures that the directories are deleted after the build.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes