### PR TITLE
fix: remove event monitor before destroying window (3-0-x)

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -472,7 +472,8 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
 }
 
 NativeWindowMac::~NativeWindowMac() {
-  [NSEvent removeMonitor:wheel_event_monitor_];
+  if (wheel_event_monitor_)
+    [NSEvent removeMonitor:wheel_event_monitor_];
 }
 
 void NativeWindowMac::SetContentView(views::View* view) {
@@ -509,6 +510,13 @@ void NativeWindowMac::Close() {
 }
 
 void NativeWindowMac::CloseImmediately() {
+  // Remove event monitor before destroying window, otherwise the monitor may
+  // call its callback after window has been destroyed.
+  if (wheel_event_monitor_) {
+    [NSEvent removeMonitor:wheel_event_monitor_];
+    wheel_event_monitor_ = nil;
+  }
+
   // Retain the child window before closing it. If the last reference to the
   // NSWindow goes away inside -[NSWindow close], then bad stuff can happen.
   // See e.g. http://crbug.com/616701.


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/commit/d1f0d6c1846f6949fe6f5d102c35d342750eebf3

Fixes https://github.com/electron/electron/issues/15725

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: Fix crash with mouse wheel event monitor on app quit in macOS