### PR TITLE
chore: add deprecation warning about new webviewTag default

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -102,6 +102,10 @@ WebContentsPreferences::WebContentsPreferences(
                      base::Value(IsEnabled(options::kNodeIntegration)));
   preference_.SetKey(options::kContextIsolationWasExplicitlyDisabled,
                      base::Value(!IsEnabled(options::kContextIsolation, true)));
+  preference_.SetKey(
+      options::kWebviewTagWasExplicitlyEnabled,
+      base::Value(IsEnabled(options::kWebviewTag,
+                            IsEnabled(options::kNodeIntegration))));
 
   // Set WebPreferences defaults onto the JS object
   SetDefaultBoolIfUndefined(options::kPlugins, false);

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -123,7 +123,7 @@ const char kEnableRemoteModule[] = "enableRemoteModule";
 // Enable context isolation of Electron APIs and preload script
 const char kContextIsolation[] = "contextIsolation";
 
-// Whether context isolation was explicitly enabled.
+// Whether context isolation was explicitly disabled.
 // This is to support the change from default-disabled to default-enabled in
 // Electron 5 (with a warning message in 4). This option and its usages
 // can be removed in Electron 5.
@@ -153,6 +153,12 @@ const char kNodeIntegrationInWorker[] = "nodeIntegrationInWorker";
 
 // Enable the web view tag.
 const char kWebviewTag[] = "webviewTag";
+
+// Whether the webview tag was explicitly enabled.
+// This is to support the change from default-disabled to default-enabled in
+// Electron 5 (with a warning message in 4). This option and its usages
+// can be removed in Electron 5.
+const char kWebviewTagWasExplicitlyEnabled[] = "webviewTagWasExplicitlyEnabled";
 
 const char kNativeWindowOpen[] = "nativeWindowOpen";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -70,6 +70,7 @@ extern const char kEnableBlinkFeatures[];
 extern const char kDisableBlinkFeatures[];
 extern const char kNodeIntegrationInWorker[];
 extern const char kWebviewTag[];
+extern const char kWebviewTagWasExplicitlyEnabled[];
 extern const char kNativeWindowOpen[];
 extern const char kCustomArgs[];
 extern const char kPlugins[];

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -273,6 +273,27 @@ const warnAboutContextIsolationDefault = function (webPreferences) {
   }
 }
 
+const warnAboutDeprecatedWebviewTagDefault = function (webPreferences) {
+  if (webPreferences.webviewTagWasExplicitlyEnabled) {
+    return
+  }
+  if (!document || !document.getElementsByTagName) {
+    return
+  }
+  const webviews = document.getElementsByTagName('webview')
+  if (webviews && webviews.length > 0) {
+    const url = 'https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#new-browserwindow-webpreferences-'
+    const warning = `This window has the <webview> tag enabled by default. In ` +
+      `Electron 5.0.0, <webview> tags will be disabled by default. To prepare ` +
+      `for this change, set {webviewTag: true} in the webPreferences for ` +
+      `this window.\n\n` +
+      `For more information, see ${url}`
+
+    console.warn('%cElectron Deprecation Warning (webviewTag default change)',
+      'font-weight: bold;', warning)
+  }
+}
+
 // Currently missing since we can't easily programmatically check for it:
 //   #12WebViews: Verify the options and params of all `<webview>` tags
 
@@ -287,6 +308,7 @@ const logSecurityWarnings = function (webPreferences, nodeIntegration) {
   warnAboutAllowedPopups()
   warnAboutNodeIntegrationDefault(webPreferences)
   warnAboutContextIsolationDefault(webPreferences)
+  warnAboutDeprecatedWebviewTagDefault(webPreferences)
 }
 
 const getWebPreferences = function () {


### PR DESCRIPTION
#### Description of Change
Per https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#new-browserwindow-webpreferences-

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes