### PR TITLE
feat: allow immediate MacOS notifications

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -114,9 +114,6 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   ~SystemPreferences() override;
 
 #if defined(OS_MACOSX)
-  void DoPostNotification(const std::string& name,
-                          const base::DictionaryValue& user_info,
-                          NotificationCenterKind kind);
   int DoSubscribeNotification(const std::string& name,
                               const NotificationCallback& callback,
                               NotificationCenterKind kind);

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -68,7 +68,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
       base::Callback<void(const std::string&, const base::DictionaryValue&)>;
 
   void PostNotification(const std::string& name,
-                        const base::DictionaryValue& user_info);
+                        const base::DictionaryValue& user_info,
+                        mate::Arguments* args);
   int SubscribeNotification(const std::string& name,
                             const NotificationCallback& callback);
   void UnsubscribeNotification(int id);

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -109,9 +109,8 @@ std::string ConvertAuthorizationStatus(AVAuthorizationStatusMac status) {
 void SystemPreferences::PostNotification(const std::string& name,
                                          const base::DictionaryValue& user_info,
                                          mate::Arguments* args) {
-  bool immediate;
-  if (!args->GetNext(&immediate))
-    immediate = false;
+  bool immediate = false;
+  args->GetNext(&immediate);
 
   NSDistributedNotificationCenter* center =
       [NSDistributedNotificationCenter defaultCenter];

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -106,10 +106,19 @@ std::string ConvertAuthorizationStatus(AVAuthorizationStatusMac status) {
 
 }  // namespace
 
-void SystemPreferences::PostNotification(
-    const std::string& name,
-    const base::DictionaryValue& user_info) {
-  DoPostNotification(name, user_info, kNSDistributedNotificationCenter);
+void SystemPreferences::PostNotification(const std::string& name,
+                                         const base::DictionaryValue& user_info,
+                                         mate::Arguments* args) {
+  bool immediate;
+  if (!args->GetNext(&immediate))
+    immediate = false;
+
+  NSDistributedNotificationCenter* center =
+      [NSDistributedNotificationCenter defaultCenter];
+  [center postNotificationName:base::SysUTF8ToNSString(name)
+                        object:nil
+                      userInfo:DictionaryValueToNSDictionary(user_info)
+            deliverImmediately:immediate];
 }
 
 int SystemPreferences::SubscribeNotification(
@@ -126,7 +135,10 @@ void SystemPreferences::UnsubscribeNotification(int request_id) {
 void SystemPreferences::PostLocalNotification(
     const std::string& name,
     const base::DictionaryValue& user_info) {
-  DoPostNotification(name, user_info, kNSNotificationCenter);
+  NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
+  [center postNotificationName:base::SysUTF8ToNSString(name)
+                        object:nil
+                      userInfo:DictionaryValueToNSDictionary(user_info)];
 }
 
 int SystemPreferences::SubscribeLocalNotification(
@@ -142,7 +154,11 @@ void SystemPreferences::UnsubscribeLocalNotification(int request_id) {
 void SystemPreferences::PostWorkspaceNotification(
     const std::string& name,
     const base::DictionaryValue& user_info) {
-  DoPostNotification(name, user_info, kNSWorkspaceNotificationCenter);
+  NSNotificationCenter* center =
+      [[NSWorkspace sharedWorkspace] notificationCenter];
+  [center postNotificationName:base::SysUTF8ToNSString(name)
+                        object:nil
+                      userInfo:DictionaryValueToNSDictionary(user_info)];
 }
 
 int SystemPreferences::SubscribeWorkspaceNotification(
@@ -154,29 +170,6 @@ int SystemPreferences::SubscribeWorkspaceNotification(
 
 void SystemPreferences::UnsubscribeWorkspaceNotification(int request_id) {
   DoUnsubscribeNotification(request_id, kNSWorkspaceNotificationCenter);
-}
-
-void SystemPreferences::DoPostNotification(
-    const std::string& name,
-    const base::DictionaryValue& user_info,
-    NotificationCenterKind kind) {
-  NSNotificationCenter* center;
-  switch (kind) {
-    case kNSDistributedNotificationCenter:
-      center = [NSDistributedNotificationCenter defaultCenter];
-      break;
-    case kNSNotificationCenter:
-      center = [NSNotificationCenter defaultCenter];
-      break;
-    case kNSWorkspaceNotificationCenter:
-      center = [[NSWorkspace sharedWorkspace] notificationCenter];
-      break;
-    default:
-      break;
-  }
-  [center postNotificationName:base::SysUTF8ToNSString(name)
-                        object:nil
-                      userInfo:DictionaryValueToNSDictionary(user_info)];
 }
 
 int SystemPreferences::DoSubscribeNotification(

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -63,7 +63,7 @@ Returns `Boolean` - Whether the Swipe between pages setting is on.
 
 * `event` String
 * `userInfo` Object
-* `deliverImmediately` Boolean (optional) - `true` to post notifications immediately regardless of whether or not the subscribing app is active or not.
+* `deliverImmediately` Boolean (optional) - `true` to post notifications immediately regardless of whether or not the subscribing app is active or not. Defaults to `false`. See [NSDistributedNotificationCenter documentation](https://developer.apple.com/documentation/foundation/nsdistributednotificationcenter/1418360-postnotificationname) for details.
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -63,7 +63,7 @@ Returns `Boolean` - Whether the Swipe between pages setting is on.
 
 * `event` String
 * `userInfo` Object
-* `deliverImmediately` Boolean (optional) - `true` to post notifications immediately regardless of whether or not the subscribing app is active or not. Defaults to `false`. See [NSDistributedNotificationCenter documentation](https://developer.apple.com/documentation/foundation/nsdistributednotificationcenter/1418360-postnotificationname) for details.
+* `deliverImmediately` Boolean (optional) - `true` to post notifications immediately even when the subscribing app is inactive.
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -59,10 +59,11 @@ Returns `Boolean` - Whether the system is in Dark Mode.
 
 Returns `Boolean` - Whether the Swipe between pages setting is on.
 
-### `systemPreferences.postNotification(event, userInfo)` _macOS_
+### `systemPreferences.postNotification(event, userInfo[, deliverImmediately])` _macOS_
 
 * `event` String
 * `userInfo` Object
+* `deliverImmediately` Boolean (optional) - `true` to post notifications immediately regardless of whether or not the subscribing app is active or not.
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/15789.

Refactors notification posting on MacOS to allow for some notifications to deliver immediately regardless of whether or not the subscribing app is active or not. 

Only `NSDistributedNotificationCenter` has access to the `deliverImmediate` selector, so I split out the `DoPostNotification` helper into the calling functions as it now make more sense for each to just call the methods themselves rather than call out to a helper. `deliverImmediate` was also added as an optional new param so as to maintain backwards compat.

/cc @ckerr

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: allow for MacOS notifications to be immediately delivered 