### PR TITLE
chore: no need to expose Initialize of ipc module

### DIFF
--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -78,18 +78,22 @@ void SendTo(mate::Arguments* args,
     args->ThrowError("Unable to send AtomFrameHostMsg_Message_To");
 }
 
+}  // namespace api
+
+}  // namespace atom
+
+namespace {
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
-  dict.SetMethod("send", &Send);
-  dict.SetMethod("sendSync", &SendSync);
-  dict.SetMethod("sendTo", &SendTo);
+  dict.SetMethod("send", &atom::api::Send);
+  dict.SetMethod("sendSync", &atom::api::SendSync);
+  dict.SetMethod("sendTo", &atom::api::SendTo);
 }
 
-}  // namespace api
+}  // namespace
 
-}  // namespace atom
-
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_renderer_ipc, atom::api::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_renderer_ipc, Initialize)

--- a/atom/renderer/api/atom_api_renderer_ipc.h
+++ b/atom/renderer/api/atom_api_renderer_ipc.h
@@ -29,11 +29,6 @@ void SendTo(mate::Arguments* args,
             const std::string& channel,
             const base::ListValue& arguments);
 
-void Initialize(v8::Local<v8::Object> exports,
-                v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context,
-                void* priv);
-
 }  // namespace api
 
 }  // namespace atom


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

There is no more need to make the `Initialize` of renderer_ipc public after #16046.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes