### PR TITLE
[wip] feat: promisify cookies API

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -353,8 +353,7 @@ v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
       base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), std::move(copy),
                      promise));
 
-  v8::Local<v8::Promise> handle = promise->GetHandle();
-  return handle;
+  return promise->GetHandle();
 }
 
 void Cookies::FlushStore(const base::Closure& callback) {

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -185,7 +185,13 @@ void SettleSetPromiseOnUI(scoped_refptr<util::Promise> promise, bool success) {
       << __FILE__ << ':' << __LINE__ << ' '
       << "SettlesSetPromiseOnUI enter -- resolving promise with success flag: "
       << success << std::endl;
-  promise->Resolve(success ? Cookies::SUCCESS : Cookies::FAILED);
+  if (success) {
+    std::cerr << __FILE__ << ':' << __LINE__ << " resolving" << std::endl;
+    promise->Resolve();
+  } else {
+    std::cerr << __FILE__ << ':' << __LINE__ << " rejecting" << std::endl;
+    promise->RejectWithErrorMessage("Setting cookie failed");
+  }
   std::cerr << __FILE__ << ':' << __LINE__ << ' '
             << "SettlesSetPromiseOnUI exit" << std::endl;
 }

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -10,6 +10,7 @@
 
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/net/cookie_details.h"
+#include "atom/common/promise_util.h"
 #include "base/callback_list.h"
 #include "native_mate/handle.h"
 #include "net/cookies/canonical_cookie.h"
@@ -35,6 +36,9 @@ class Cookies : public mate::TrackableObject<Cookies> {
     FAILED,
   };
 
+  using GetCallback = base::Callback<void(Error, const net::CookieList&)>;
+  using SetCallback = base::Callback<void(Error)>;
+
   static mate::Handle<Cookies> Create(v8::Isolate* isolate,
                                       AtomBrowserContext* browser_context);
 
@@ -46,11 +50,12 @@ class Cookies : public mate::TrackableObject<Cookies> {
   Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context);
   ~Cookies() override;
 
-  v8::Local<v8::Promise> Get(const base::DictionaryValue& filter);
-  v8::Local<v8::Promise> Remove(const GURL& url,
-              const std::string& name);
+  void Get(const base::DictionaryValue& filter, const GetCallback& callback);
+  void Remove(const GURL& url,
+              const std::string& name,
+              const base::Closure& callback);
   v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
-  v8::Local<v8::Promise> FlushStore();
+  void FlushStore(const base::Closure& callback);
 
   // CookieChangeNotifier subscription:
   void OnCookieChanged(const CookieDetails*);

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -37,7 +37,6 @@ class Cookies : public mate::TrackableObject<Cookies> {
   };
 
   using GetCallback = base::Callback<void(Error, const net::CookieList&)>;
-  using SetCallback = base::Callback<void(Error)>;
 
   static mate::Handle<Cookies> Create(v8::Isolate* isolate,
                                       AtomBrowserContext* browser_context);
@@ -50,7 +49,7 @@ class Cookies : public mate::TrackableObject<Cookies> {
   Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context);
   ~Cookies() override;
 
-  void Get(const base::DictionaryValue& filter, const GetCallback& callback);
+  v8::Local<v8::Promise> Get(const base::DictionaryValue& filter);
   v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
   v8::Local<v8::Promise> Remove(const GURL& url, const std::string& name);
   void FlushStore(const base::Closure& callback);

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -51,10 +51,8 @@ class Cookies : public mate::TrackableObject<Cookies> {
   ~Cookies() override;
 
   void Get(const base::DictionaryValue& filter, const GetCallback& callback);
-  void Remove(const GURL& url,
-              const std::string& name,
-              const base::Closure& callback);
   v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
+  v8::Local<v8::Promise> Remove(const GURL& url, const std::string& name);
   void FlushStore(const base::Closure& callback);
 
   // CookieChangeNotifier subscription:

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -35,9 +35,6 @@ class Cookies : public mate::TrackableObject<Cookies> {
     FAILED,
   };
 
-  using GetCallback = base::Callback<void(Error, const net::CookieList&)>;
-  using SetCallback = base::Callback<void(Error)>;
-
   static mate::Handle<Cookies> Create(v8::Isolate* isolate,
                                       AtomBrowserContext* browser_context);
 
@@ -49,12 +46,11 @@ class Cookies : public mate::TrackableObject<Cookies> {
   Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context);
   ~Cookies() override;
 
-  void Get(const base::DictionaryValue& filter, const GetCallback& callback);
-  void Remove(const GURL& url,
-              const std::string& name,
-              const base::Closure& callback);
-  void Set(const base::DictionaryValue& details, const SetCallback& callback);
-  void FlushStore(const base::Closure& callback);
+  v8::Local<v8::Promise> Get(const base::DictionaryValue& filter);
+  v8::Local<v8::Promise> Remove(const GURL& url,
+              const std::string& name);
+  v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
+  v8::Local<v8::Promise> FlushStore();
 
   // CookieChangeNotifier subscription:
   void OnCookieChanged(const CookieDetails*);

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -52,7 +52,7 @@ class Cookies : public mate::TrackableObject<Cookies> {
   v8::Local<v8::Promise> Get(const base::DictionaryValue& filter);
   v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
   v8::Local<v8::Promise> Remove(const GURL& url, const std::string& name);
-  void FlushStore(const base::Closure& callback);
+  v8::Local<v8::Promise> FlushStore();
 
   // CookieChangeNotifier subscription:
   void OnCookieChanged(const CookieDetails*);

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -4,6 +4,7 @@
 
 #include "atom/common/promise_util.h"
 
+#include <iostream>
 #include <string>
 
 namespace atom {
@@ -11,13 +12,18 @@ namespace atom {
 namespace util {
 
 Promise::Promise(v8::Isolate* isolate) {
+  std::cerr << __FILE__ << ':' << __LINE__ << " Promise::Promise(), this is "
+            << this << std::endl;
   auto context = isolate->GetCurrentContext();
   auto resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
   isolate_ = isolate;
   resolver_.Reset(isolate, resolver);
 }
 
-Promise::~Promise() = default;
+Promise::~Promise() {
+  std::cerr << __FILE__ << ':' << __LINE__ << " Promise::~Promise(), this is "
+            << this << std::endl;
+}
 
 v8::Maybe<bool> Promise::RejectWithErrorMessage(const std::string& string) {
   v8::Local<v8::String> error_message =

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -25,8 +25,12 @@ session.defaultSession.cookies.get({ url: 'http://www.github.com' }, (error, coo
 // Set a cookie with the given cookie data;
 // may overwrite equivalent cookies if they exist.
 const cookie = { url: 'http://www.github.com', name: 'dummy_name', value: 'dummy' }
-session.defaultSession.cookies.set(cookie, (error) => {
-  if (error) console.error(error)
+session.defaultSession.cookies.set(cookie)
+  .then(() => {
+    // success
+  }, (error) => {
+    console.error(error)
+  })
 })
 ```
 
@@ -55,7 +59,7 @@ expired.
 
 The following methods are available on instances of `Cookies`:
 
-#### `cookies.get(filter, callback)`
+#### `cookies.get(filter)`
 
 * `filter` Object
   * `url` String (optional) - Retrieves cookies which are associated with
@@ -66,14 +70,13 @@ The following methods are available on instances of `Cookies`:
   * `path` String (optional) - Retrieves cookies whose path matches `path`.
   * `secure` Boolean (optional) - Filters cookies by their Secure property.
   * `session` Boolean (optional) - Filters out session or persistent cookies.
-* `callback` Function
-  * `error` Error
-  * `cookies` [Cookie[]](structures/cookie.md) - an array of cookie objects.
 
-Sends a request to get all cookies matching `filter`, `callback` will be called
-with `callback(error, cookies)` on complete.
+* Returns `Promise<Cookie[]>` - A promise which resolves an array of cookie objects.
 
-#### `cookies.set(details, callback)`
+Sends a request to get all cookies matching `filter`, and resolves a promise with
+the response.
+
+#### `cookies.set(details)`
 
 * `details` Object
   * `url` String - The url to associate the cookie with.
@@ -88,23 +91,22 @@ with `callback(error, cookies)` on complete.
   * `expirationDate` Double (optional) - The expiration date of the cookie as the number of
     seconds since the UNIX epoch. If omitted then the cookie becomes a session
     cookie and will not be retained between sessions.
-* `callback` Function
-  * `error` Error
 
-Sets a cookie with `details`, `callback` will be called with `callback(error)`
-on complete.
+* Returns `Promise<void>` - A promise which resolves when the cookie has been set
 
-#### `cookies.remove(url, name, callback)`
+Sets a cookie with `details`.
+
+#### `cookies.remove(url, name)`
 
 * `url` String - The URL associated with the cookie.
 * `name` String - The name of cookie to remove.
-* `callback` Function
 
-Removes the cookies matching `url` and `name`, `callback` will called with
-`callback()` on complete.
+* Returns `Promise<void>` - A promise which resolves when the cookie has been removed
 
-#### `cookies.flushStore(callback)`
+Removes the cookies matching `url` and `name`
 
-* `callback` Function
+#### `cookies.flushStore()`
+
+* Returns `Promise<void>` - A promise which resolves when the cookie store has been flushed
 
 Writes any unwritten cookies data to disk.

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -13,14 +13,20 @@ For example:
 const { session } = require('electron')
 
 // Query all cookies.
-session.defaultSession.cookies.get({}, (error, cookies) => {
-  console.log(error, cookies)
-})
+session.defaultSession.cookies.get({})
+  .then((cookies) => {
+    // success
+  }).catch((error) => {
+    console.log(error)
+  })
 
 // Query all cookies associated with a specific url.
-session.defaultSession.cookies.get({ url: 'http://www.github.com' }, (error, cookies) => {
-  console.log(error, cookies)
-})
+session.defaultSession.cookies.get({ url: 'http://www.github.com' })
+  .then((cookies) => {
+    // success
+  }).catch((error) => {
+    console.log(error)
+  })
 
 // Set a cookie with the given cookie data;
 // may overwrite equivalent cookies if they exist.
@@ -31,7 +37,6 @@ session.defaultSession.cookies.set(cookie)
   }, (error) => {
     console.error(error)
   })
-})
 ```
 
 ### Instance Events

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -8,7 +8,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 
 ### Candidate Functions
 
-- [ ] [app.getFileIcon(path[, options], callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#getFileIcon)
 - [ ] [app.importCertificate(options, callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#importCertificate)
 - [ ] [request.write(chunk[, encoding][, callback])](https://github.com/electron/electron/blob/master/docs/api/client-request.md#write)
 - [ ] [request.end([chunk][, encoding][, callback])](https://github.com/electron/electron/blob/master/docs/api/client-request.md#end)
@@ -19,10 +18,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ ] [contentTracing.stopMonitoring(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#stopMonitoring)
 - [ ] [contentTracing.captureMonitoringSnapshot(resultFilePath, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#captureMonitoringSnapshot)
 - [ ] [contentTracing.getTraceBufferUsage(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getTraceBufferUsage)
-- [ ] [cookies.get(filter, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#get)
-- [ ] [cookies.set(details, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#set)
-- [ ] [cookies.remove(url, name, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#remove)
-- [ ] [cookies.flushStore(callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#flushStore)
 - [ ] [debugger.sendCommand(method[, commandParams, callback])](https://github.com/electron/electron/blob/master/docs/api/debugger.md#sendCommand)
 - [ ] [desktopCapturer.getSources(options, callback)](https://github.com/electron/electron/blob/master/docs/api/desktop-capturer.md#getSources)
 - [ ] [dialog.showOpenDialog([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showOpenDialog)
@@ -59,6 +54,11 @@ When a majority of affected functions are migrated, this flag will be enabled by
 
 ### Converted Functions
 
+- [ ] [app.getFileIcon(path[, options], callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#getFileIcon)
+- [ ] [contents.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#capturePage)
+- [ ] [cookies.get(filter, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#get)
+- [ ] [cookies.set(details, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#set)
+- [ ] [cookies.remove(url, name, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#remove)
+- [ ] [cookies.flushStore(callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#flushStore)
 - [ ] [win.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#capturePage)
 - [ ] [webviewTag.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#capturePage)
-- [ ] [contents.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#capturePage)

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -9,6 +9,8 @@ const wrappedSymbol = Symbol('wrapped-deprecate')
 const fromPartition = (partition) => {
   const session = realFromPartition(partition)
   if (!session[wrappedSymbol]) {
+    session.cookies.get = deprecate.promisify(session.cookies.get, 1)
+    session.cookies.remove = deprecate.promisify(session.cookies.remove, 2)
     session.cookies.set = deprecate.promisify(session.cookies.set, 1)
     session[wrappedSymbol] = true
   }

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -1,8 +1,19 @@
 'use strict'
 
 const { EventEmitter } = require('events')
-const { app } = require('electron')
-const { fromPartition, Session, Cookies } = process.atomBinding('session')
+const { app, deprecate } = require('electron')
+const { Session, Cookies } = process.atomBinding('session')
+const realFromPartition = process.atomBinding('session').fromPartition
+
+const wrappedSymbol = Symbol('wrapped-deprecate')
+const fromPartition = (partition) => {
+  const session = realFromPartition(partition)
+  if (!session[wrappedSymbol]) {
+    session.cookies.set = deprecate.promisify(session.cookies.set, 1)
+    session[wrappedSymbol] = true
+  }
+  return session
+}
 
 // Public API.
 Object.defineProperties(exports, {

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { EventEmitter } = require('events')
-const { app, deprecate } = require('electron')
+const { app } = require('electron')
 const { fromPartition, Session, Cookies } = process.atomBinding('session')
 
 // Public API.
@@ -18,11 +18,6 @@ Object.defineProperties(exports, {
 
 Object.setPrototypeOf(Session.prototype, EventEmitter.prototype)
 Object.setPrototypeOf(Cookies.prototype, EventEmitter.prototype)
-
-const nativeCookieSet = Cookies.set
-Cookies.set = function (details, callback) {
-  return deprecate.promisify(nativeCookieSet.call(this, details), callback)
-}
 
 Session.prototype._init = function () {
   app.emit('session-created', this)

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -9,10 +9,12 @@ const wrappedSymbol = Symbol('wrapped-deprecate')
 const fromPartition = (partition) => {
   const session = realFromPartition(partition)
   if (!session[wrappedSymbol]) {
-    session.cookies.get = deprecate.promisify(session.cookies.get, 1)
-    session.cookies.remove = deprecate.promisify(session.cookies.remove, 2)
-    session.cookies.set = deprecate.promisify(session.cookies.set, 1)
     session[wrappedSymbol] = true
+    const { cookies } = session
+    cookies.flushStore = deprecate.promisify(cookies.flushStore, 0)
+    cookies.get = deprecate.promisify(cookies.get, 1)
+    cookies.remove = deprecate.promisify(cookies.remove, 2)
+    cookies.set = deprecate.promisify(cookies.set, 1)
   }
   return session
 }

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { EventEmitter } = require('events')
-const { app } = require('electron')
+const { app, deprecate } = require('electron')
 const { fromPartition, Session, Cookies } = process.atomBinding('session')
 
 // Public API.
@@ -18,6 +18,11 @@ Object.defineProperties(exports, {
 
 Object.setPrototypeOf(Session.prototype, EventEmitter.prototype)
 Object.setPrototypeOf(Cookies.prototype, EventEmitter.prototype)
+
+const nativeCookieSet = Cookies.set
+Cookies.set = function (details, callback) {
+  return deprecate.promisify(nativeCookieSet.call(this, details), callback)
+}
 
 Session.prototype._init = function () {
   app.emit('session-created', this)

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -31,7 +31,7 @@ const deprecate = {
     } else if (process.traceDeprecation) {
       return console.trace(message)
     } else {
-      return console.warn(`(electron) ${message}`)
+      return console.log(`(electron) ${message}`)
     }
   },
 
@@ -78,7 +78,6 @@ const deprecate = {
     return function (...params) {
       const cb = params.splice(cbParamIndex, 1)[0]
       const promise = fn.apply(this, params)
-
       if (typeof cb !== 'function') return promise
       if (process.enablePromiseAPIs) warn()
       return promise

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -550,12 +550,12 @@ describe('net module', () => {
             handleUnexpectedURL(request, response)
         }
       })
+
       customSession.cookies.set({
         url: `${server.url}`,
         name: 'test',
         value: '11111'
-      }, (error) => {
-        if (error) return done(error)
+      }).then(() => { // resolved
         const urlRequest = net.request({
           method: 'GET',
           url: `${server.url}${requestUrl}`,
@@ -575,6 +575,8 @@ describe('net module', () => {
         assert.strictEqual(urlRequest.getHeader(cookieHeaderName),
           cookieHeaderValue)
         urlRequest.end()
+      }, (error) => {
+        done(error)
       })
     })
 

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -151,7 +151,7 @@ describe('session module', () => {
         name: '2',
         value: '2'
       }).then(() => {
-        session.defaultSession.cookies.remove(url, '2')
+        return session.defaultSession.cookies.remove(url, '2')
       }).then(() => {
         session.defaultSession.cookies.get({ url }, (error, list) => {
           if (error) return done(error)
@@ -217,17 +217,18 @@ describe('session module', () => {
       })
     })
 
-    describe('ses.cookies.flushStore(callback)', () => {
+    describe('ses.cookies.flushStore()', (done) => {
       it('flushes the cookies to disk and invokes the callback when done', (done) => {
         session.defaultSession.cookies.set({
           url: url,
           name: 'foo',
           value: 'bar'
-        }, (error) => {
-          if (error) return done(error)
-          session.defaultSession.cookies.flushStore(() => {
-            done()
-          })
+        }).then(() => {
+          return session.defaultSession.cookies.flushStore()
+        }).then(() => {
+          done()
+        }).catch((error) => {
+          done(error)
         })
       })
     })

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -127,7 +127,7 @@ describe('session module', () => {
       expect(error).to.have.property('message').which.equals('Setting cookie failed')
     })
 
-    it('should over-write the existent cookie', (done) => {
+    it('should overwrite the existent cookie', (done) => {
       session.defaultSession.cookies.set({
         url,
         name: '1',
@@ -156,18 +156,19 @@ describe('session module', () => {
         url: url,
         name: '2',
         value: '2'
-      }, (error) => {
-        if (error) return done(error)
-        session.defaultSession.cookies.remove(url, '2', () => {
-          session.defaultSession.cookies.get({ url }, (error, list) => {
-            if (error) return done(error)
-            for (let i = 0; i < list.length; i++) {
-              const cookie = list[i]
-              if (cookie.name === '2') return done('Cookie not deleted')
-            }
-            done()
-          })
+      }).then(() => {
+        session.defaultSession.cookies.remove(url, '2')
+      }).then(() => {
+        session.defaultSession.cookies.get({ url }, (error, list) => {
+          if (error) return done(error)
+          for (let i = 0; i < list.length; i++) {
+            const cookie = list[i]
+            if (cookie.name === '2') return done('Cookie not deleted')
+          }
+          done()
         })
+      }).catch((error) => {
+        return done(error)
       })
     })
 

--- a/spec/fixtures/api/cookie-app/main.js
+++ b/spec/fixtures/api/cookie-app/main.js
@@ -5,19 +5,11 @@ app.on('ready', async function () {
   const persistentSession = session.fromPartition('persist:ence-test')
 
   const set = () => {
-    return new Promise((resolve, reject) => {
-      persistentSession.cookies.set({
-        url,
-        name: 'test',
-        value: 'true',
-        expirationDate: Date.now() + 60000
-      }, error => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve()
-        }
-      })
+    return persistentSession.cookies.set({
+      url,
+      name: 'test',
+      value: 'true',
+      expirationDate: Date.now() + 60000
     })
   }
 


### PR DESCRIPTION
#### Description of Change

Promisifies the Cookie API.

TODO:
- [x] promisify FlushStore
- [x] wrap `flushStore()` with `deprecate.promisfy()`
- [x] finish updating tests
- [ ] remove the excess tracer `LOG(INFO)` statements in `atom_api_cookies.cc`
- [ ] other cleanup: currently has unnecessary exploratory code that shouldn't go into prod
- [x] update documentation for all four methods

CC @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: Updated Cookies API to use Promises.