### PR TITLE
chore: correctly capitalize releaseID

### DIFF
--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -5,8 +5,8 @@ require('colors')
 const pass = '\u2713'.green
 const fail = '\u2717'.red
 const args = require('minimist')(process.argv.slice(2), {
-  string: ['tag', 'releaseId'],
-  default: { releaseId: '' }
+  string: ['tag', 'releaseID'],
+  default: { releaseID: '' }
 })
 const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
@@ -82,7 +82,7 @@ async function deleteTag (tag, targetRepo) {
 }
 
 async function cleanReleaseArtifacts () {
-  const releaseId = args.releaseId.length > 0 ? args.releaseId : null
+  const releaseId = args.releaseID.length > 0 ? args.releaseID : null
   const isNightly = args.tag.includes('nightly')
 
   if (releaseId) {


### PR DESCRIPTION
#### Description of Change

![1464638210_there_was_an_attempt](https://user-images.githubusercontent.com/2036040/50028198-b2d73300-ffa3-11e8-8436-f550e3af6d24.png)

We were waiting to receive a `releaseId` argument in [`release-artifact-cleanup.js`](https://github.com/electron/electron/blob/master/script/release-artifact-cleanup.js#L85), but passing it a `releaseID` argument in [`clean-release-artifacts.ts`](https://github.com/electron/sudowoodo/blob/master/src/operations/clean-release-artifacts.ts#L21).

/cc @BinaryMuse 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: none