### PR TITLE
chore: update PR template to request better release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 
 #### Release Notes
-<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->
 
-Notes: <!-- One-line Change Summary Here-->
+<!-- The note that you write here will be communicated to Electron users in the release notes when this change is released. Write something short but descriptive that explains what, if anything, this change means for a developer building an app with Electron. -->
+
+Notes: <!-- Short, descriptive end-user-facing change summary here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
 - [ ] relevant documentation is changed or added
 - [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
-- [ ] PR release notes describes the change in a user-centric way
+- [ ] PR release notes describe the change in a way relevant to app-developers
 
 
 #### Release Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 - [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
 - [ ] relevant documentation is changed or added
 - [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
+- [ ] PR release notes describes the change in a user-centric way
 
 
 #### Release Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,8 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 #### Release Notes
 
-<!-- The note that you write here will be communicated to Electron app developers in the release notes when this change is released. Write something short but descriptive (one sentence to a couple paragraphs, if appropriate) that explains what, if anything, this change means for a developer building an app with Electron. Use `no-notes` for things like chores, internal fixes, and the like. -->
+<!-- A one-line description for the release notes. Please make this
+understandable to end users. Examples and help on special cases: 
+https://github.com/electron/clerk/blob/master/README.md#examples -->
 
 Notes: <!-- Short, descriptive app-developer-relevant change summary here, or `no-notes` if no app-developer-relevant changes. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 #### Release Notes
 
 <!-- A one-line description for the release notes. Please make this
-understandable to end users. Examples and help on special cases: 
-https://github.com/electron/clerk/blob/master/README.md#examples -->
+understandable to end users (Electron app developers). Examples and help
+on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
 
 Notes: <!-- Short, descriptive app-developer-relevant change summary here, or `no-notes` if no app-developer-relevant changes. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,9 +19,4 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 #### Release Notes
 
-<!-- A one-line description for the release notes. Please make this
-understandable to end users (Electron app developers). Examples and help
-on special cases: https://github.com/electron/clerk/blob/master/README.md#examples
--->
-
-Notes: <!-- Short, descriptive change summary here, or `no-notes` if no app developer facing changes -->
+Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 <!-- The note that you write here will be communicated to Electron users in the release notes when this change is released. Write something short but descriptive that explains what, if anything, this change means for a developer building an app with Electron. -->
 
-Notes: <!-- Short, descriptive end-user-facing change summary here -->
+Notes: <!-- Short, descriptive end-user-facing change summary here, or `no-notes` if no user-facing changes -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 #### Release Notes
 
-<!-- The note that you write here will be communicated to Electron users in the release notes when this change is released. Write something short but descriptive that explains what, if anything, this change means for a developer building an app with Electron. -->
+<!-- The note that you write here will be communicated to Electron app developers in the release notes when this change is released. Write something short but descriptive (one sentence to a couple paragraphs, if appropriate) that explains what, if anything, this change means for a developer building an app with Electron. Use `no-notes` for things like chores, internal fixes, and the like. -->
 
-Notes: <!-- Short, descriptive end-user-facing change summary here, or `no-notes` if no user-facing changes -->
+Notes: <!-- Short, descriptive app-developer-relevant change summary here, or `no-notes` if no app-developer-relevant changes. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 <!-- A one-line description for the release notes. Please make this
 understandable to end users (Electron app developers). Examples and help
-on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
+on special cases: https://github.com/electron/clerk/blob/master/README.md#examples
+-->
 
-Notes: <!-- Short, descriptive app-developer-relevant change summary here, or `no-notes` if no app-developer-relevant changes. -->
+Notes: <!-- Short, descriptive change summary here, or `no-notes` if no app developer facing changes -->


### PR DESCRIPTION
#### Description of Change

The release notes for our releases aren't great; in particular, we tend to use Electron-developer-oriented descriptions for the `Notes:` sections on PRs. Now that the release notes and the semantic commit messages are decoupled, we could do better to use the `Notes:` section to describe to the *end user* (people building apps with Electron) what the change is and how it affects their development with Electron. Folks should be able to peruse the release notes for a release and have a relatively good understanding of what changed for them.

To this end, this PR updates the PR template to better describe the kind of notes we're looking for here. Open to suggestions and improvements on wording that would be most likely to get the kind of notes we want.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes