### PR TITLE
docs: more natural language in Mac app store guide

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -4,7 +4,7 @@ Since v0.34.0, Electron allows submitting packaged apps to the Mac App Store
 (MAS). This guide provides information on: how to submit your app and the
 limitations of the MAS build.
 
-**Note:** Submitting an app to Mac App Store requires enrolling [Apple Developer
+**Note:** Submitting an app to Mac App Store requires enrolling in the [Apple Developer
 Program][developer-program], which costs money.
 
 ## How to Submit Your App
@@ -33,7 +33,7 @@ After finishing the preparation work, you can package your app by following
 signing your app.
 
 First, you have to add a `ElectronTeamID` key to your app's `Info.plist`, which
-has your Team ID as value:
+has your Team ID as its value:
 
 ```xml
 <plist version="1.0">
@@ -149,7 +149,7 @@ Also note that native modules may have intermediate files produced which should
 not be included (as they would also need to be signed). If you use
 [electron-packager][electron-packager] before version 8.1.0, add
 `--ignore=.+\.o$` to your build step to ignore these files. Versions 8.1.0 and
-later ignores those files by default.
+later ignore those files by default.
 
 ### Upload Your App
 


### PR DESCRIPTION
#### Description of Change
Very minor grammatical changes to the Mac App Store docs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes