### PR TITLE
feat: Support response headers in File protocol handler

### DIFF
--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -73,11 +73,15 @@ void URLRequestAsyncAsarJob::StartAsync(std::unique_ptr<base::Value> options,
   std::string file_path;
   response_headers_ = new net::HttpResponseHeaders("HTTP/1.1 200 OK");
   if (options->is_dict()) {
-    base::DictionaryValue* headersValue = nullptr;
     base::DictionaryValue* dict =
         static_cast<base::DictionaryValue*>(options.get());
-    dict->GetString("path", &file_path);
-    dict->GetDictionary("headers", &headersValue);
+    base::Value* pathValue =
+        dict->FindKeyOfType("path", base::Value::Type::STRING);
+    if (pathValue) {
+      file_path = pathValue->GetString();
+    }
+    base::Value* headersValue =
+        dict->FindKeyOfType("headers", base::Value::Type::DICTIONARY);
     if (headersValue) {
       for (const auto& iter : headersValue->DictItems()) {
         response_headers_->AddHeader(iter.first + ": " +

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -71,14 +71,20 @@ void URLRequestAsyncAsarJob::StartAsync(std::unique_ptr<base::Value> options,
   }
 
   std::string file_path;
+  response_headers_ = new net::HttpResponseHeaders("HTTP/1.1 200 OK");
   if (options->is_dict()) {
-    auto* path_value =
-        options->FindKeyOfType("path", base::Value::Type::STRING);
-    if (path_value)
-      file_path = path_value->GetString();
+    base::DictionaryValue* headersValue = nullptr;
+    base::DictionaryValue* dict =
+        static_cast<base::DictionaryValue*>(options.get());
+    dict->GetString("path", &file_path);
+    dict->GetDictionary("headers", &headersValue);
+    for (const auto& iter : headersValue->DictItems()) {
+      response_headers_->AddHeader(iter.first + ": " + iter.second.GetString());
+    }
   } else if (options->is_string()) {
     file_path = options->GetString();
   }
+  response_headers_->AddHeader(kCORSHeader);
 
   if (file_path.empty()) {
     NotifyStartError(net::URLRequestStatus(net::URLRequestStatus::FAILED,
@@ -103,11 +109,7 @@ void URLRequestAsyncAsarJob::Kill() {
 }
 
 void URLRequestAsyncAsarJob::GetResponseInfo(net::HttpResponseInfo* info) {
-  std::string status("HTTP/1.1 200 OK");
-  auto* headers = new net::HttpResponseHeaders(status);
-
-  headers->AddHeader(kCORSHeader);
-  info->headers = headers;
+  info->headers = response_headers_;
 }
 
 }  // namespace atom

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -78,8 +78,11 @@ void URLRequestAsyncAsarJob::StartAsync(std::unique_ptr<base::Value> options,
         static_cast<base::DictionaryValue*>(options.get());
     dict->GetString("path", &file_path);
     dict->GetDictionary("headers", &headersValue);
-    for (const auto& iter : headersValue->DictItems()) {
-      response_headers_->AddHeader(iter.first + ": " + iter.second.GetString());
+    if (headersValue) {
+      for (const auto& iter : headersValue->DictItems()) {
+        response_headers_->AddHeader(iter.first + ": " +
+                                     iter.second.GetString());
+      }
     }
   } else if (options->is_string()) {
     file_path = options->GetString();

--- a/atom/browser/net/url_request_async_asar_job.h
+++ b/atom/browser/net/url_request_async_asar_job.h
@@ -26,6 +26,7 @@ class URLRequestAsyncAsarJob : public asar::URLRequestAsarJob, public JsAsker {
   void Kill() override;
 
  private:
+  scoped_refptr<net::HttpResponseHeaders> response_headers_;
   base::WeakPtrFactory<URLRequestAsyncAsarJob> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(URLRequestAsyncAsarJob);

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -99,7 +99,9 @@ going to be created with `scheme`. `completion` will be called with
 
 To handle the `request`, the `callback` should be called with either the file's
 path or an object that has a `path` property, e.g. `callback(filePath)` or
-`callback({ path: filePath })`.
+`callback({ path: filePath })`. The object may also have a `headers` property
+which gives a list of strings for the response headers, e.g.
+`callback({ path: filePath, headers: ["Content-Security-Policy: default-src 'none'"]})`.
 
 When `callback` is called with nothing, a number, or an object that has an
 `error` property, the `request` will fail with the `error` number you

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -323,7 +323,7 @@ describe('protocol module', () => {
     it('sets custom headers', (done) => {
       const handler = (request, callback) => callback({
         path: filePath,
-        headers: ['X-Great-Header: sogreat']
+        headers: { 'X-Great-Header': 'sogreat' }
       })
       protocol.registerFileProtocol(protocolName, handler, (error) => {
         if (error) return done(error)

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -320,6 +320,28 @@ describe('protocol module', () => {
       })
     })
 
+    it('sets custom headers', (done) => {
+      const handler = (request, callback) => callback({
+        path: filePath,
+        headers: ['X-Great-Header: sogreat']
+      })
+      protocol.registerFileProtocol(protocolName, handler, (error) => {
+        if (error) return done(error)
+        $.ajax({
+          url: protocolName + '://fake-host',
+          cache: false,
+          success: (data, status, request) => {
+            assert.strictEqual(data, String(fileContent))
+            assert.strictEqual(request.getResponseHeader('X-Great-Header'), 'sogreat')
+            done()
+          },
+          error: (xhr, errorType, error) => {
+            done(error)
+          }
+        })
+      })
+    })
+
     it('sends object as response', (done) => {
       const handler = (request, callback) => callback({ path: filePath })
       protocol.registerFileProtocol(protocolName, handler, (error) => {


### PR DESCRIPTION
#### Description of Change
This adds support for response headers to `protocol.registerFileProtocol` to match `protocol.registerStreamProtocol`.

My specific use case for this is to set a CSP for pages served from local content rather than HTTPS: setting the header by intercepting the request with the `webRequest` module doesn't work because `URLRequestAsarJob` doesn't call the network_delegate methods (see https://github.com/electron/electron/issues/16030). In any case, this seems like a more direct way of setting the header.

I've also changed how this works a little to make it more consistent (hopefully) with the other handlers (ie. convert the dict to a `base::DictionaryValue` and use `base::DictionaryValue::GetFoo()`).

Note that I've documented this in the text as the callback param in the list has `filePath` as a string. This could be changed so the `callback` taking an object is in the main docs: I'm happy to make this change.

Stakeholders: @zcbenz & @paulcbetts appear to have last made major changes here. cc @MarshallOfSound as you kindly helped on the issue I filed.

Test failures don't appear to be related to my changes: one of them is:
```
AssertionError: exit signal should be null, if you see this please tag @MarshallOfSound: expected 'SIGSEGV' to equal null
```
(so, cc @MarshallOfSound)

#### Checklist
- [X] PR description included and stakeholders cc'd
- [x] `npm test` passes: failures appear unrelated to my changes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
Notes: Add response header support to `protocol.registerFileProtocol` to match `protocol.registerStreamProtocol`.