### PR TITLE
chore: simplify require for modules internally using remote.require in sandbox

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -62,14 +62,6 @@ npm_action("atom_browserify_sandbox") {
     "lib/sandboxed_renderer/init.js",
     "-r",
     "./lib/sandboxed_renderer/api/exports/electron.js:electron",
-    "-r",
-    "./lib/sandboxed_renderer/api/exports/fs.js:fs",
-    "-r",
-    "./lib/sandboxed_renderer/api/exports/os.js:os",
-    "-r",
-    "./lib/sandboxed_renderer/api/exports/path.js:path",
-    "-r",
-    "./lib/sandboxed_renderer/api/exports/child_process.js:child_process",
     "-t",
     "aliasify",
   ]
@@ -80,10 +72,6 @@ npm_action("atom_browserify_sandbox") {
     # Use a script to generate all dependencies and put them here.
     "lib/sandboxed_renderer/init.js",
     "lib/sandboxed_renderer/api/exports/electron.js",
-    "lib/sandboxed_renderer/api/exports/fs.js",
-    "lib/sandboxed_renderer/api/exports/os.js",
-    "lib/sandboxed_renderer/api/exports/path.js",
-    "lib/sandboxed_renderer/api/exports/child_process.js",
   ]
   outputs = [
     "$target_gen_dir/js2c/preload_bundle.js",

--- a/lib/renderer/remote.js
+++ b/lib/renderer/remote.js
@@ -9,16 +9,16 @@ exports.getRemote = function (name) {
   return remote[name]
 }
 
-exports.getRemoteFor = function (usage) {
+exports.remoteRequire = function (name) {
   if (!remote) {
-    throw new Error(`${usage} requires remote, which is not enabled`)
+    throw new Error(`${name} requires remote, which is not enabled`)
   }
-  return remote
+  return remote.require(name)
 }
 
 exports.potentiallyRemoteRequire = function (name) {
   if (process.sandboxed) {
-    return exports.getRemoteFor(name).require(name)
+    return exports.remoteRequire(name)
   } else {
     return require(name)
   }

--- a/lib/sandboxed_renderer/api/exports/child_process.js
+++ b/lib/sandboxed_renderer/api/exports/child_process.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { deprecate } = require('electron')
-
-deprecate.warn(`require('child_process')`, `remote.require('child_process')`)
-
-const { getRemoteFor } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteFor('child_process').require('child_process')

--- a/lib/sandboxed_renderer/api/exports/fs.js
+++ b/lib/sandboxed_renderer/api/exports/fs.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { deprecate } = require('electron')
-
-deprecate.warn(`require('fs')`, `remote.require('fs')`)
-
-const { getRemoteFor } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteFor('fs').require('fs')

--- a/lib/sandboxed_renderer/api/exports/os.js
+++ b/lib/sandboxed_renderer/api/exports/os.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { deprecate } = require('electron')
-
-deprecate.warn(`require('os')`, `remote.require('os')`)
-
-const { getRemoteFor } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteFor('os').require('os')

--- a/lib/sandboxed_renderer/api/exports/path.js
+++ b/lib/sandboxed_renderer/api/exports/path.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { deprecate } = require('electron')
-
-deprecate.warn(`require('path')`, `remote.require('path')`)
-
-const { getRemoteFor } = require('@electron/internal/renderer/remote')
-module.exports = getRemoteFor('path').require('path')

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -91,13 +91,16 @@ Object.defineProperty(preloadProcess, 'noDeprecation', {
 
 process.on('exit', () => preloadProcess.emit('exit'))
 
+const { remoteRequire } = require('@electron/internal/renderer/remote')
+
 // This is the `require` function that will be visible to the preload script
 function preloadRequire (module) {
   if (loadedModules.has(module)) {
     return loadedModules.get(module)
   }
   if (remoteModules.has(module)) {
-    return require(module)
+    electron.deprecate.warn(`require('${module}')`, `remote.require('${module}')`)
+    return remoteRequire(module)
   }
   throw new Error('module not found')
 }


### PR DESCRIPTION
#### Description of Change
We are loading all these modules via `potentiallyRemoteRequire`, which fails with appropriate error when the `remote` module is not enabled. There is no reason to expose them via browserified require. Also, as these are deprecated, will be removed by https://github.com/electron/electron/pull/15957.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes