### PR TITLE
feat: expose app accessibility status api

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -89,6 +89,8 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::GetAppLevelAppearance)
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
+      .SetMethod("isTrustedAccessibilityClient",
+                 &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("getMediaAccessStatus",
                  &SystemPreferences::GetMediaAccessStatus)
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -92,6 +92,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 
+  bool IsTrustedAccessibilityClient(bool prompt);
+
   // TODO(codebytere): Write tests for these methods once we
   // are running tests on a Mojave machine
   std::string GetMediaAccessStatus(const std::string& media_type,

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -379,12 +379,7 @@ void SystemPreferences::SetUserDefault(const std::string& name,
 }
 
 bool SystemPreferences::IsTrustedAccessibilityClient(bool prompt) {
-  NSDictionary* options;
-  if (prompt)
-    options = @{(id)kAXTrustedCheckOptionPrompt : @YES};
-  else
-    options = @{(id)kAXTrustedCheckOptionPrompt : @YES};
-
+  NSDictionary* options = @{(id)kAXTrustedCheckOptionPrompt : @(prompt)};
   return AXIsProcessTrustedWithOptions((CFDictionaryRef)options);
 }
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -378,6 +378,16 @@ void SystemPreferences::SetUserDefault(const std::string& name,
   }
 }
 
+bool SystemPreferences::IsTrustedAccessibilityClient(bool prompt) {
+  NSDictionary* options;
+  if (prompt)
+    options = @{(id)kAXTrustedCheckOptionPrompt : @YES};
+  else
+    options = @{(id)kAXTrustedCheckOptionPrompt : @YES};
+
+  return AXIsProcessTrustedWithOptions((CFDictionaryRef)options);
+}
+
 std::string SystemPreferences::GetMediaAccessStatus(
     const std::string& media_type,
     mate::Arguments* args) {

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -327,6 +327,12 @@ You can use the `setAppLevelAppearance` API to set this value.
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
 
+### `systemPreferences.isTrustedAccessibilityClient(prompt)` _macOS_
+
+* `prompt` Boolean - whether or not the user will be informed via prompt if the current process is untrusted.
+
+Returns `Boolean` - `true` if the current process is a trusted accessibility client and `false` if it is not.
+
 ### `systemPreferences.getMediaAccessStatus(mediaType)` _macOS_
 
 * `mediaType` String - `microphone` or `camera`.


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16090.

Exposes an api through System Preferences allowing an app to determine whether or not it's been designated a [trusted accessibility client](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/), where that means an app that is allowed to modify the way users interact with their computer.

This API takes a prompt argument; if `false` is passed then the result will be returned silently, and if `true` is passed then a dialog (like the one below) will be shown.

<img width="462" alt="screen shot 2018-12-17 at 8 32 33 pm" src="https://user-images.githubusercontent.com/2036040/50130540-52622300-023b-11e9-9223-579141850366.png">

/cc @miniak @4ndv

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes

Notes: Exposes an API to allow apps to determine their status as a trusted accessibility client.
