### PR TITLE
chore: remove unused catch bindings

### DIFF
--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -94,7 +94,7 @@ exports.checkForUpdate = function (updateURL, callback) {
       // Last line of output is the JSON details about the releases
       const json = stdout.trim().split('\n').pop()
       update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === 'function' ? ref1.pop() : void 0 : void 0 : void 0
-    } catch (jsonError) {
+    } catch {
       // Disabled for backwards compatibility:
       // eslint-disable-next-line standard/no-callback-literal
       return callback(`Invalid result:\n${stdout}`)
@@ -113,7 +113,7 @@ exports.supported = function () {
   try {
     fs.accessSync(updateExe, fs.R_OK)
     return true
-  } catch (error) {
+  } catch {
     return false
   }
 }

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -226,7 +226,7 @@ const getMessagesPath = (extensionId) => {
     const filename = path.join(localesDirectory, language, 'messages.json')
     fs.accessSync(filename, fs.constants.R_OK)
     return filename
-  } catch (err) {
+  } catch {
     const defaultLocale = metadata.default_locale || 'en'
     return path.join(localesDirectory, defaultLocale, 'messages.json')
   }
@@ -289,7 +289,7 @@ ipcMainUtils.handle('CHROME_STORAGE_WRITE', async function (event, storageType, 
 
   try {
     await mkdirp(path.dirname(filePath))
-  } catch (error) {
+  } catch {
     // we just ignore the errors of mkdir or mkdirp
   }
 
@@ -452,14 +452,14 @@ app.on('will-quit', function () {
     if (loadedDevToolsExtensions.length > 0) {
       try {
         fs.mkdirSync(path.dirname(loadedDevToolsExtensionsPath))
-      } catch (error) {
+      } catch {
         // Ignore error
       }
       fs.writeFileSync(loadedDevToolsExtensionsPath, JSON.stringify(loadedDevToolsExtensions))
     } else {
       fs.unlinkSync(loadedDevToolsExtensionsPath)
     }
-  } catch (error) {
+  } catch {
     // Ignore error
   }
 })

--- a/lib/browser/crash-reporter-init.js
+++ b/lib/browser/crash-reporter-init.js
@@ -8,7 +8,7 @@ const path = require('path')
 const getTempDirectory = function () {
   try {
     return app.getPath('temp')
-  } catch (error) {
+  } catch {
     return os.tmpdir()
   }
 }

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -107,13 +107,14 @@ require('@electron/internal/browser/guest-window-manager')
 let packagePath = null
 let packageJson = null
 const searchPaths = ['app', 'app.asar', 'default_app.asar']
+
 if (process.resourcesPath) {
   for (packagePath of searchPaths) {
     try {
       packagePath = path.join(process.resourcesPath, packagePath)
       packageJson = require(path.join(packagePath, 'package.json'))
       break
-    } catch (error) {
+    } catch {
       continue
     }
   }

--- a/lib/renderer/extensions/i18n.js
+++ b/lib/renderer/extensions/i18n.js
@@ -12,7 +12,7 @@ const getMessages = (extensionId) => {
   try {
     const data = ipcRendererUtils.invokeSync('CHROME_GET_MESSAGES', extensionId)
     return JSON.parse(data) || {}
-  } catch (error) {
+  } catch {
     return {}
   }
 }

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -68,7 +68,7 @@ const isUnsafeEvalEnabled = function () {
     webFrame.executeJavaScript(`(${(() => {
       try {
         new Function('') // eslint-disable-line no-new,no-new-func
-      } catch (err) {
+      } catch {
         return false
       }
       return true

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -19,7 +19,7 @@
 // - document.hidden
 // - document.visibilityState
 
-const { defineProperty, defineProperties } = Object
+const { defineProperty } = Object
 
 // Helper function to resolve relative url.
 const a = window.document.createElement('a')


### PR DESCRIPTION
#### Description of Change

Remove unused catch bindings in `lib`

Refs: https://github.com/nodejs/node/pull/24079

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none