### PR TITLE
fix: don't register some shortcuts without accessibility 

### DIFF
--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -10,12 +10,15 @@
 #include "atom/browser/api/atom_api_system_preferences.h"
 #include "atom/common/native_mate_converters/accelerator_converter.h"
 #include "atom/common/native_mate_converters/callback.h"
-#include "base/mac/mac_util.h"
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "native_mate/dictionary.h"
 
 #include "atom/common/node_includes.h"
+
+#if defined(OS_MACOSX)
+#include "base/mac/mac_util.h"
+#endif
 
 using extensions::GlobalShortcutListener;
 

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -24,9 +24,9 @@ namespace {
 #if defined(OS_MACOSX)
 bool RegisteringMediaKeyForUntrustedClient(const ui::Accelerator& accelerator) {
   if (base::mac::IsAtLeastOS10_14()) {
-    constexpr ui::KeyboardCode mediaKeys[] = {ui::VKEY_MEDIA_PLAY_PAUSE,
-                                              ui::VKEY_MEDIA_NEXT_TRACK,
-                                              ui::VKEY_MEDIA_PREV_TRACK};
+    constexpr ui::KeyboardCode mediaKeys[] = {
+        ui::VKEY_MEDIA_PLAY_PAUSE, ui::VKEY_MEDIA_NEXT_TRACK,
+        ui::VKEY_MEDIA_PREV_TRACK, ui::VKEY_MEDIA_STOP};
 
     if (std::find(std::begin(mediaKeys), std::end(mediaKeys),
                   accelerator.key_code()) != std::end(mediaKeys)) {

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -95,7 +95,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   std::string GetSystemColor(const std::string& color, mate::Arguments* args);
 
-  bool IsTrustedAccessibilityClient(bool prompt);
+  static bool IsTrustedAccessibilityClient(bool prompt);
 
   // TODO(codebytere): Write tests for these methods once we
   // are running tests on a Mojave machine

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -437,6 +437,7 @@ std::string SystemPreferences::GetSystemColor(const std::string& color,
   }
 }
 
+// static
 bool SystemPreferences::IsTrustedAccessibilityClient(bool prompt) {
   NSDictionary* options = @{(id)kAXTrustedCheckOptionPrompt : @(prompt)};
   return AXIsProcessTrustedWithOptions((CFDictionaryRef)options);

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -60,6 +60,7 @@ the app has been authorizes as a trusted accessibility client:
 * "Media Play/Pause"
 * "Media Next Track"
 * "Media Previous Track"
+* "Media Stop"
 
 ### `globalShortcut.registerAll(accelerators, callback)`
 
@@ -78,6 +79,7 @@ the app has been authorizes as a trusted accessibility client:
 * "Media Play/Pause"
 * "Media Next Track"
 * "Media Previous Track"
+* "Media Stop"
 
 ### `globalShortcut.isRegistered(accelerator)`
 

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -55,7 +55,7 @@ silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
 The following accelerators will not be registered successfully on macOS 10.14 Mojave unless
-the app has been authorizes as a trusted accessibility client:
+the app has been authorized as a [trusted accessibility client](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html):
 
 * "Media Play/Pause"
 * "Media Next Track"
@@ -74,7 +74,7 @@ silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
 The following accelerators will not be registered successfully on macOS 10.14 Mojave unless
-the app has been authorizes as a trusted accessibility client:
+the app has been authorized as a [trusted accessibility client](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html):
 
 * "Media Play/Pause"
 * "Media Next Track"

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -54,7 +54,7 @@ When the accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
-The following accelerators will not be registered successfully on MacOS 10.14 Mojave unless
+The following accelerators will not be registered successfully on macOS 10.14 Mojave unless
 the app has been authorizes as a trusted accessibility client:
 
 * "Media Play/Pause"
@@ -73,7 +73,7 @@ When a given accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
-The following accelerators will not be registered successfully on MacOS 10.14 Mojave unless
+The following accelerators will not be registered successfully on macOS 10.14 Mojave unless
 the app has been authorizes as a trusted accessibility client:
 
 * "Media Play/Pause"

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -54,6 +54,13 @@ When the accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
+The following accelerators will not be registered successfully on MacOS 10.14 Mojave unless
+the app has been authorizes as a trusted accessibility client:
+
+* "Media Play/Pause"
+* "Media Next Track"
+* "Media Previous Track"
+
 ### `globalShortcut.registerAll(accelerators, callback)`
 
 * `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
@@ -64,6 +71,13 @@ Registers a global shortcut of all `accelerator` items in `accelerators`. The `c
 When a given accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
+
+The following accelerators will not be registered successfully on MacOS 10.14 Mojave unless
+the app has been authorizes as a trusted accessibility client:
+
+* "Media Play/Pause"
+* "Media Next Track"
+* "Media Previous Track"
 
 ### `globalShortcut.isRegistered(accelerator)`
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/14837. 

/cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes

Notes: Fixed crash on macOS when using `globalShortcut` for media keys when accessibility access is not granted.
