### PR TITLE
docs: note that visual zoom is disabled by default

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -948,6 +948,12 @@ Sends a request to get current zoom level, the `callback` will be called with
 
 Sets the maximum and minimum pinch-to-zoom level.
 
+> **NOTE**: Visual zoom is disabled by default in Electron. To re-enable it, call:
+>
+> ```js
+> contents.setVisualZoomLevelLimits(1, 3)
+> ```
+
 #### `contents.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
 
 * `minimumLevel` Number

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -50,6 +50,12 @@ Returns `Number` - The current zoom level.
 
 Sets the maximum and minimum pinch-to-zoom level.
 
+> **NOTE**: Visual zoom is disabled by default in Electron. To re-enable it, call:
+>
+> ```js
+> webFrame.setVisualZoomLevelLimits(1, 3)
+> ```
+
 ### `webFrame.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
 
 * `minimumLevel` Number


### PR DESCRIPTION
#### Description of Change
This behaviour is confusing for some app developers and this seems like a good place to document it.

Ref #12631

#### Release Notes

Notes: none