### PR TITLE
chore: update release scripts for cleanup (backport: 2-0-x)

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -179,11 +179,12 @@ async function createRelease (branchToTarget, isBeta) {
   }
   githubOpts.tag_name = newVersion
   githubOpts.target_commitish = newVersion.indexOf('nightly') !== -1 ? 'master' : branchToTarget
-  await github.repos.createRelease(githubOpts)
+  const release = await github.repos.createRelease(githubOpts)
     .catch(err => {
       console.log(`${fail} Error creating new release: `, err)
       process.exit(1)
     })
+  console.log(`Release has been created with id: ${release.data.id}.`)
   console.log(`${pass} Draft release for ${newVersion} has been created.`)
 }
 


### PR DESCRIPTION
#### Description of Change

Backport a handful of release- and sudowoodo-related scripts to enable proper failed release cleanup for `2-0-x`.

/cc @ckerr @BinaryMuse 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes

Notes: no-notes