### PR TITLE
fix: UAF with http auth preferences (3-1-x)

### DIFF
--- a/atom/browser/net/url_request_context_getter.h
+++ b/atom/browser/net/url_request_context_getter.h
@@ -24,8 +24,9 @@ class RequireCTDelegate;
 }  // namespace brightray
 
 namespace net {
+class HttpAuthPreferences;
 class NetLog;
-}
+}  // namespace net
 
 namespace atom {
 
@@ -100,6 +101,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
 
   std::unique_ptr<brightray::RequireCTDelegate> ct_delegate_;
   std::unique_ptr<AtomURLRequestJobFactory> top_job_factory_;
+  std::unique_ptr<net::HttpAuthPreferences> http_auth_preferences_;
   std::unique_ptr<network::mojom::NetworkContext> network_context_;
 
   net::NetLog* net_log_;


### PR DESCRIPTION
#### Description of Change

Since we manage the custom auth preferences, they need to live for the lifetime of request context. This is not required for 4.x and higher because the lifetime is managed by the network service.

Fixes https://github.com/electron/electron/issues/16131

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Fix crash when using negotiate auth requests
