### PR TITLE
fix: security warnings misfiring in devtools webcontents

### DIFF
--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -250,7 +250,7 @@ const warnAboutAllowedPopups = function () {
 }
 
 const warnAboutNodeIntegrationDefault = function (webPreferences) {
-  if (webPreferences.nodeIntegration && !webPreferences.nodeIntegrationWasExplicitlyEnabled) {
+  if (webPreferences && webPreferences.nodeIntegration && !webPreferences.nodeIntegrationWasExplicitlyEnabled) {
     const warning = `This window has node integration enabled by default. In ` +
         `Electron 5.0.0, node integration will be disabled by default. To prepare ` +
         `for this change, set {nodeIntegration: true} in the webPreferences for ` +
@@ -261,7 +261,7 @@ const warnAboutNodeIntegrationDefault = function (webPreferences) {
 }
 
 const warnAboutContextIsolationDefault = function (webPreferences) {
-  if (webPreferences.preload && !webPreferences.contextIsolation && !webPreferences.contextIsolationWasExplicitlyDisabled) {
+  if (webPreferences && webPreferences.preload && !webPreferences.contextIsolation && !webPreferences.contextIsolationWasExplicitlyDisabled) {
     const url = 'https://electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content'
     const warning = `This window has context isolation disabled by default. In ` +
         `Electron 5.0.0, context isolation will be enabled by default. To prepare ` +
@@ -274,6 +274,9 @@ const warnAboutContextIsolationDefault = function (webPreferences) {
 }
 
 const warnAboutDeprecatedWebviewTagDefault = function (webPreferences) {
+  if (!webPreferences) {
+    return
+  }
   if (webPreferences.webviewTagWasExplicitlyEnabled) {
     return
   }


### PR DESCRIPTION
#### Description of Change
Fixes #16114 

Notes: fix "Uncaught TypeError: Cannot read property 'nodeIntegration' of null" when opening devtools