### PR TITLE
fix: set release notes body to a string

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -120,7 +120,7 @@ async function createRelease (branchToTarget, isBeta) {
     githubOpts.name = `${githubOpts.name}`
     githubOpts.prerelease = true
   } else {
-    githubOpts.body = releaseNotes
+    githubOpts.body = releaseNotes.text
   }
   githubOpts.tag_name = newVersion
   githubOpts.target_commitish = newVersion.indexOf('nightly') !== -1 ? 'master' : branchToTarget


### PR DESCRIPTION
#### Description of Change

Fixes

```
Error creating new release:  { [Error: {"message":"Invalid request.\n\nFor 'properties/body', {\"text\"=>\"...\"} is not a string.","documentation_url":"https://developer.github.com/v3/repos/releases/#create-a-release"}] 
```

during release.

#### Release Notes

Notes: no-notes