### PR TITLE
docs: Corrected first sample code so it runs

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -6,21 +6,26 @@ Process: [Main](../glossary.md#main-process)
 
 ```javascript
 // In the main process.
-const { BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
 // Or use `remote` from the renderer process.
 // const { BrowserWindow } = require('electron').remote
 
-let win = new BrowserWindow({ width: 800, height: 600 })
-win.on('closed', () => {
+let win
+
+app.on('ready', () => {
+  win = new BrowserWindow({ width: 800, height: 600 })
+
+  // Load a remote URL
+  win.loadURL('https://github.com')
+
+  // Or load a local HTML file
+  win.loadURL(`file://${__dirname}/app/index.html`)
+
+  win.on('closed', () => {
   win = null
+  })
 })
-
-// Load a remote URL
-win.loadURL('https://github.com')
-
-// Or load a local HTML file
-win.loadURL(`file://${__dirname}/app/index.html`)
 ```
 
 ## Frameless window

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -20,7 +20,7 @@ app.on('ready', () => {
     win.loadURL('https://github.com')
 
     // Or load a local HTML file
-    win.loadURL(`file://${__dirname}/app/index.html`)
+    win.loadFile(`index.html`)
 
     win.on('closed', () => {
     win = null

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -14,17 +14,17 @@ const { app, BrowserWindow } = require('electron')
 let win
 
 app.on('ready', () => {
-  win = new BrowserWindow({ width: 800, height: 600 })
+    win = new BrowserWindow({ width: 800, height: 600 })
 
-  // Load a remote URL
-  win.loadURL('https://github.com')
+    // Load a remote URL
+    win.loadURL('https://github.com')
 
-  // Or load a local HTML file
-  win.loadURL(`file://${__dirname}/app/index.html`)
+    // Or load a local HTML file
+    win.loadURL(`file://${__dirname}/app/index.html`)
 
-  win.on('closed', () => {
-  win = null
-  })
+    win.on('closed', () => {
+    win = null
+    })
 })
 ```
 


### PR DESCRIPTION
The first sample code won't run because it tries to create the browser window before app is ready.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: no-notes https://github.com/electron/clerk/blob/master/README.md#examples -->
