### PR TITLE
docs: remove unnecessary space

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -251,8 +251,7 @@ document.addEventListener('DOMContentLoaded', () => {
 ## 4) Handle Session Permission Requests From Remote Content
 
 You may have seen permission requests while using Chrome: They pop up whenever
-the website attempts to use a feature that the user has to manually approve (
-like notifications).
+the website attempts to use a feature that the user has to manually approve (like notifications).
 
 The API is based on the [Chromium permissions API](https://developer.chrome.com/extensions/permissions)
 and implements the same types of permissions.


### PR DESCRIPTION
#### Description of Change

I removed the newline within the Markdown file to avoid this unnecessary space character:

![space](https://user-images.githubusercontent.com/469989/50368353-2078f580-0588-11e9-9d5a-a02fc7d57841.png)

The bug is currently visible here:
- https://electronjs.org/docs/tutorial/security#4-handle-session-permission-requests-from-remote-content

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Fixed typo in security tutorial.
