### PR TITLE
feat: flexible autoresize for BrowserViews

### DIFF
--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -37,6 +37,14 @@ struct Converter<atom::AutoResizeFlags> {
     if (params.Get("height", &height) && height) {
       flags |= atom::kAutoResizeHeight;
     }
+    bool horizontal = false;
+    if (params.Get("horizontal", &horizontal) && horizontal) {
+      flags |= atom::kAutoResizeHorizontal;
+    }
+    bool vertical = false;
+    if (params.Get("vertical", &vertical) && vertical) {
+      flags |= atom::kAutoResizeVertical;
+    }
 
     *auto_resize_flags = static_cast<atom::AutoResizeFlags>(flags);
     return true;

--- a/atom/browser/native_browser_view.h
+++ b/atom/browser/native_browser_view.h
@@ -21,6 +21,8 @@ namespace atom {
 enum AutoResizeFlags {
   kAutoResizeWidth = 0x1,
   kAutoResizeHeight = 0x2,
+  kAutoResizeHorizontal = 0x4,
+  kAutoResizeVertical = 0x8,
 };
 
 class InspectableWebContents;

--- a/atom/browser/native_browser_view_mac.mm
+++ b/atom/browser/native_browser_view_mac.mm
@@ -175,6 +175,14 @@ void NativeBrowserViewMac::SetAutoResizeFlags(uint8_t flags) {
   if (flags & kAutoResizeHeight) {
     autoresizing_mask |= NSViewHeightSizable;
   }
+  if (flags & kAutoResizeHorizontal) {
+    autoresizing_mask |=
+        NSViewMaxXMargin | NSViewMinXMargin | NSViewWidthSizable;
+  }
+  if (flags & kAutoResizeVertical) {
+    autoresizing_mask |=
+        NSViewMaxYMargin | NSViewMinYMargin | NSViewHeightSizable;
+  }
 
   auto* view =
       GetInspectableWebContentsView()->GetNativeView().GetNativeNSView();

--- a/atom/browser/native_browser_view_views.cc
+++ b/atom/browser/native_browser_view_views.cc
@@ -13,17 +13,90 @@ namespace atom {
 
 NativeBrowserViewViews::NativeBrowserViewViews(
     InspectableWebContents* inspectable_web_contents)
-    : NativeBrowserView(inspectable_web_contents) {}
+    : NativeBrowserView(inspectable_web_contents),
+      auto_resize_flags_(0),
+      auto_horizontal_proportion_set_(false),
+      auto_vertical_proportion_set_(false) {}
 
 NativeBrowserViewViews::~NativeBrowserViewViews() {}
 
 void NativeBrowserViewViews::SetAutoResizeFlags(uint8_t flags) {
   auto_resize_flags_ = flags;
+  ResetAutoResizeProportions();
+}
+
+void NativeBrowserViewViews::SetAutoResizeProportions(gfx::Size window_size) {
+  if ((auto_resize_flags_ & AutoResizeFlags::kAutoResizeHorizontal) &&
+      !auto_horizontal_proportion_set_) {
+    auto* view = GetInspectableWebContentsView()->GetView();
+    auto view_bounds = view->bounds();
+    auto_horizontal_proportion_width_ =
+        static_cast<float>(window_size.width()) /
+        static_cast<float>(view_bounds.width());
+    auto_horizontal_proportion_left_ = static_cast<float>(window_size.width()) /
+                                       static_cast<float>(view_bounds.x());
+    auto_horizontal_proportion_set_ = true;
+  }
+  if ((auto_resize_flags_ & AutoResizeFlags::kAutoResizeVertical) &&
+      !auto_vertical_proportion_set_) {
+    auto* view = GetInspectableWebContentsView()->GetView();
+    auto view_bounds = view->bounds();
+    auto_vertical_proportion_height_ =
+        static_cast<float>(window_size.height()) /
+        static_cast<float>(view_bounds.height());
+    auto_vertical_proportion_top_ = static_cast<float>(window_size.height()) /
+                                    static_cast<float>(view_bounds.y());
+    auto_vertical_proportion_set_ = true;
+  }
+}
+
+void NativeBrowserViewViews::AutoResize(const gfx::Rect& new_window,
+                                        int width_delta,
+                                        int height_delta) {
+  auto* view = GetInspectableWebContentsView()->GetView();
+  const auto flags = GetAutoResizeFlags();
+  if (!(flags & kAutoResizeWidth)) {
+    width_delta = 0;
+  }
+  if (!(flags & kAutoResizeHeight)) {
+    height_delta = 0;
+  }
+  if (height_delta || width_delta) {
+    auto new_view_size = view->size();
+    new_view_size.set_width(new_view_size.width() + width_delta);
+    new_view_size.set_height(new_view_size.height() + height_delta);
+    view->SetSize(new_view_size);
+  }
+  auto new_view_bounds = view->bounds();
+  if (flags & kAutoResizeHorizontal) {
+    new_view_bounds.set_width(new_window.width() /
+                              auto_horizontal_proportion_width_);
+    new_view_bounds.set_x(new_window.width() /
+                          auto_horizontal_proportion_left_);
+  }
+  if (flags & kAutoResizeVertical) {
+    new_view_bounds.set_height(new_window.height() /
+                               auto_vertical_proportion_height_);
+    new_view_bounds.set_y(new_window.height() / auto_vertical_proportion_top_);
+  }
+  if ((flags & kAutoResizeHorizontal) || (flags & kAutoResizeVertical)) {
+    view->SetBoundsRect(new_view_bounds);
+  }
+}
+
+void NativeBrowserViewViews::ResetAutoResizeProportions() {
+  if (auto_resize_flags_ & AutoResizeFlags::kAutoResizeHorizontal) {
+    auto_horizontal_proportion_set_ = false;
+  }
+  if (auto_resize_flags_ & AutoResizeFlags::kAutoResizeVertical) {
+    auto_vertical_proportion_set_ = false;
+  }
 }
 
 void NativeBrowserViewViews::SetBounds(const gfx::Rect& bounds) {
   auto* view = GetInspectableWebContentsView()->GetView();
   view->SetBoundsRect(bounds);
+  ResetAutoResizeProportions();
 }
 
 void NativeBrowserViewViews::SetBackgroundColor(SkColor color) {

--- a/atom/browser/native_browser_view_views.cc
+++ b/atom/browser/native_browser_view_views.cc
@@ -13,10 +13,7 @@ namespace atom {
 
 NativeBrowserViewViews::NativeBrowserViewViews(
     InspectableWebContents* inspectable_web_contents)
-    : NativeBrowserView(inspectable_web_contents),
-      auto_resize_flags_(0),
-      auto_horizontal_proportion_set_(false),
-      auto_vertical_proportion_set_(false) {}
+    : NativeBrowserView(inspectable_web_contents) {}
 
 NativeBrowserViewViews::~NativeBrowserViewViews() {}
 
@@ -25,7 +22,8 @@ void NativeBrowserViewViews::SetAutoResizeFlags(uint8_t flags) {
   ResetAutoResizeProportions();
 }
 
-void NativeBrowserViewViews::SetAutoResizeProportions(gfx::Size window_size) {
+void NativeBrowserViewViews::SetAutoResizeProportions(
+    const gfx::Size& window_size) {
   if ((auto_resize_flags_ & AutoResizeFlags::kAutoResizeHorizontal) &&
       !auto_horizontal_proportion_set_) {
     auto* view = GetInspectableWebContentsView()->GetView();

--- a/atom/browser/native_browser_view_views.h
+++ b/atom/browser/native_browser_view_views.h
@@ -15,25 +15,29 @@ class NativeBrowserViewViews : public NativeBrowserView {
       InspectableWebContents* inspectable_web_contents);
   ~NativeBrowserViewViews() override;
 
-  uint8_t GetAutoResizeFlags() { return auto_resize_flags_; }
-  void SetAutoResizeFlags(uint8_t flags) override;
-  void SetAutoResizeProportions(gfx::Size window_size);
+  void SetAutoResizeProportions(const gfx::Size& window_size);
   void AutoResize(const gfx::Rect& new_window,
                   int width_delta,
                   int height_delta);
+  uint8_t GetAutoResizeFlags() { return auto_resize_flags_; }
+
+  // NativeBrowserView:
+  void SetAutoResizeFlags(uint8_t flags) override;
   void SetBounds(const gfx::Rect& bounds) override;
   void SetBackgroundColor(SkColor color) override;
 
  private:
-  uint8_t auto_resize_flags_;
-
-  bool auto_horizontal_proportion_set_;
-  float auto_horizontal_proportion_width_;
-  float auto_horizontal_proportion_left_;
-  bool auto_vertical_proportion_set_;
-  float auto_vertical_proportion_height_;
-  float auto_vertical_proportion_top_;
   void ResetAutoResizeProportions();
+
+  uint8_t auto_resize_flags_ = 0;
+
+  bool auto_horizontal_proportion_set_ = false;
+  float auto_horizontal_proportion_width_ = 0.;
+  float auto_horizontal_proportion_left_ = 0.;
+
+  bool auto_vertical_proportion_set_ = false;
+  float auto_vertical_proportion_height_ = 0.;
+  float auto_vertical_proportion_top_ = 0.;
 
   DISALLOW_COPY_AND_ASSIGN(NativeBrowserViewViews);
 };

--- a/atom/browser/native_browser_view_views.h
+++ b/atom/browser/native_browser_view_views.h
@@ -17,11 +17,23 @@ class NativeBrowserViewViews : public NativeBrowserView {
 
   uint8_t GetAutoResizeFlags() { return auto_resize_flags_; }
   void SetAutoResizeFlags(uint8_t flags) override;
+  void SetAutoResizeProportions(gfx::Size window_size);
+  void AutoResize(const gfx::Rect& new_window,
+                  int width_delta,
+                  int height_delta);
   void SetBounds(const gfx::Rect& bounds) override;
   void SetBackgroundColor(SkColor color) override;
 
  private:
   uint8_t auto_resize_flags_;
+
+  bool auto_horizontal_proportion_set_;
+  float auto_horizontal_proportion_width_;
+  float auto_horizontal_proportion_left_;
+  bool auto_vertical_proportion_set_;
+  float auto_vertical_proportion_height_;
+  float auto_vertical_proportion_top_;
+  void ResetAutoResizeProportions();
 
   DISALLOW_COPY_AND_ASSIGN(NativeBrowserViewViews);
 };

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1189,7 +1189,7 @@ void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
     int height_delta = new_bounds.height() - widget_size_.height();
     for (NativeBrowserView* item : browser_views()) {
       NativeBrowserViewViews* native_view =
-          dynamic_cast<NativeBrowserViewViews*>(item);
+          static_cast<NativeBrowserViewViews*>(item);
       native_view->SetAutoResizeProportions(widget_size_);
       native_view->AutoResize(new_bounds, width_delta, height_delta);
     }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1176,26 +1176,6 @@ void NativeWindowViews::OnWidgetActivationChanged(views::Widget* changed_widget,
   root_view_->ResetAltState();
 }
 
-void NativeWindowViews::AutoresizeBrowserView(int width_delta,
-                                              int height_delta,
-                                              NativeBrowserView* browser_view) {
-  const auto flags =
-      static_cast<NativeBrowserViewViews*>(browser_view)->GetAutoResizeFlags();
-  if (!(flags & kAutoResizeWidth)) {
-    width_delta = 0;
-  }
-  if (!(flags & kAutoResizeHeight)) {
-    height_delta = 0;
-  }
-  if (height_delta || width_delta) {
-    auto* view = browser_view->GetInspectableWebContentsView()->GetView();
-    auto new_view_size = view->size();
-    new_view_size.set_width(new_view_size.width() + width_delta);
-    new_view_size.set_height(new_view_size.height() + height_delta);
-    view->SetSize(new_view_size);
-  }
-}
-
 void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
                                               const gfx::Rect& bounds) {
   if (changed_widget != widget())
@@ -1208,7 +1188,10 @@ void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
     int width_delta = new_bounds.width() - widget_size_.width();
     int height_delta = new_bounds.height() - widget_size_.height();
     for (NativeBrowserView* item : browser_views()) {
-      AutoresizeBrowserView(width_delta, height_delta, item);
+      NativeBrowserViewViews* native_view =
+          dynamic_cast<NativeBrowserViewViews*>(item);
+      native_view->SetAutoResizeProportions(widget_size_);
+      native_view->AutoResize(new_bounds, width_delta, height_delta);
     }
 
     NotifyWindowResize();

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -158,10 +158,8 @@ class NativeWindowViews : public NativeWindow,
   void OnWidgetActivationChanged(views::Widget* widget, bool active) override;
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& bounds) override;
-  void AutoresizeBrowserView(int width_delta,
-                             int height_delta,
-                             NativeBrowserView* browser_view);
   void OnWidgetDestroying(views::Widget* widget) override;
+
   // views::WidgetDelegate:
   void DeleteDelegate() override;
   views::View* GetInitiallyFocusedView() override;

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -83,6 +83,10 @@ Returns `Boolean` - Whether the view is destroyed.
     with the window. `false` by default.
   * `height` Boolean - If `true`, the view's height will grow and shrink
     together with the window. `false` by default.
+  * `horizontal` Boolean - If `true`, the view's x position and width will grow
+    and shrink proportionly with the window. `false` by default.
+  * `vertical` Boolean - If `true`, the view's y position and height will grow
+    and shrink proportinaly with the window. `false` by default.
 
 #### `view.setBounds(bounds)` _Experimental_
 


### PR DESCRIPTION
#### Flexible autoresize for BrowserViews in BrowserWindow

As support for multy BrowserView in BrowserWIndow added in PR #16148. How current autoresize options work is not always suitable to what app developer can need when some browser views resize together. It is because `width` and `height` autoresize modes change view by same amount what windows changed. 

This commit add two new options `horizontal` and `vertical`. With this options enabled, a browserview will autoresize not only dimensions but position on window too. And in a way that keep proportions the same. 

For example we add two views. 
`view1 x:100 width:100` and `view2 x:200 width:200` in window with width 400. 
And if user change window width to 800 then autoresize updates views to `view1 x:200 width:200` and `view2 x:400 width:400` 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Added flexible autoresize option for `BrowserView`s in `BrowserWindow`.
