### PR TITLE
fix: don't expose `isolatedWorld` to global

### DIFF
--- a/lib/isolated_renderer/init.js
+++ b/lib/isolated_renderer/init.js
@@ -2,8 +2,6 @@
 
 /* global nodeProcess, isolatedWorld */
 
-window.isolatedWorld = isolatedWorld
-
 // Note: Don't use "process", as it will be replaced by browserify's one.
 const v8Util = nodeProcess.atomBinding('v8_util')
 


### PR DESCRIPTION
It is a leftover debugging assignment in https://github.com/electron/electron/pull/16067.

The `4-0-x` branch is fine since the assignment had been removed there.

Notes: no-notes