### PR TITLE
fix: support chrome extensions in sandboxed renderer

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -151,7 +151,6 @@ void AtomSandboxedRendererClient::InitializeBindings(
   b.Set("process", process);
 
   AtomBindings::BindProcess(isolate, &process, metrics_.get());
-  AddRenderBindings(isolate, process.GetHandle());
 
   process.Set("argv", base::CommandLine::ForCurrentProcess()->argv());
   process.SetReadOnly("pid", base::GetCurrentProcId());
@@ -201,6 +200,7 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   auto* isolate = context->GetIsolate();
   auto binding = v8::Object::New(isolate);
   InitializeBindings(binding, context, render_frame->IsMainFrame());
+  AddRenderBindings(isolate, binding);
 
   std::vector<v8::Local<v8::String>> preload_bundle_params = {
       node::FIXED_ONE_BYTE_STRING(isolate, "binding")};

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -178,12 +178,10 @@ void AtomSandboxedRendererClient::RenderViewCreated(
 
 void AtomSandboxedRendererClient::RunScriptsAtDocumentStart(
     content::RenderFrame* render_frame) {
-  v8::HandleScope main_handle_scope(blink::MainThreadIsolate());
-  v8::Local<v8::Context> context =
-      render_frame->GetWebFrame()->MainWorldScriptContext();
-
-  auto* isolate = context->GetIsolate();
+  auto* isolate = blink::MainThreadIsolate();
   v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context =
+      GetContext(render_frame->GetWebFrame(), isolate);
   v8::Context::Scope context_scope(context);
   InvokeIpcCallback(context, "onDocumentStart",
                     std::vector<v8::Local<v8::Value>>());
@@ -191,12 +189,10 @@ void AtomSandboxedRendererClient::RunScriptsAtDocumentStart(
 
 void AtomSandboxedRendererClient::RunScriptsAtDocumentEnd(
     content::RenderFrame* render_frame) {
-  v8::HandleScope main_handle_scope(blink::MainThreadIsolate());
-  v8::Local<v8::Context> context =
-      render_frame->GetWebFrame()->MainWorldScriptContext();
-
-  auto* isolate = context->GetIsolate();
+  auto* isolate = blink::MainThreadIsolate();
   v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context =
+      GetContext(render_frame->GetWebFrame(), isolate);
   v8::Context::Scope context_scope(context);
   InvokeIpcCallback(context, "onDocumentEnd",
                     std::vector<v8::Local<v8::Value>>());

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -277,13 +277,6 @@ void AtomSandboxedRendererClient::WillReleaseScriptContext(
     return;
   injected_frames_.erase(render_frame);
 
-  // Only allow preload for the main frame
-  // Or for sub frames when explicitly enabled
-  if (!render_frame->IsMainFrame() &&
-      !base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kNodeIntegrationInSubFrames))
-    return;
-
   auto* isolate = context->GetIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -176,6 +176,32 @@ void AtomSandboxedRendererClient::RenderViewCreated(
   RendererClientBase::RenderViewCreated(render_view);
 }
 
+void AtomSandboxedRendererClient::RunScriptsAtDocumentStart(
+    content::RenderFrame* render_frame) {
+  v8::HandleScope main_handle_scope(blink::MainThreadIsolate());
+  v8::Local<v8::Context> context =
+      render_frame->GetWebFrame()->MainWorldScriptContext();
+
+  auto* isolate = context->GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(context);
+  InvokeIpcCallback(context, "onDocumentStart",
+                    std::vector<v8::Local<v8::Value>>());
+}
+
+void AtomSandboxedRendererClient::RunScriptsAtDocumentEnd(
+    content::RenderFrame* render_frame) {
+  v8::HandleScope main_handle_scope(blink::MainThreadIsolate());
+  v8::Local<v8::Context> context =
+      render_frame->GetWebFrame()->MainWorldScriptContext();
+
+  auto* isolate = context->GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(context);
+  InvokeIpcCallback(context, "onDocumentEnd",
+                    std::vector<v8::Local<v8::Value>>());
+}
+
 void AtomSandboxedRendererClient::DidCreateScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -151,6 +151,7 @@ void AtomSandboxedRendererClient::InitializeBindings(
   b.Set("process", process);
 
   AtomBindings::BindProcess(isolate, &process, metrics_.get());
+  AddRenderBindings(isolate, process.GetHandle());
 
   process.Set("argv", base::CommandLine::ForCurrentProcess()->argv());
   process.SetReadOnly("pid", base::GetCurrentProcId());
@@ -200,7 +201,6 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   auto* isolate = context->GetIsolate();
   auto binding = v8::Object::New(isolate);
   InitializeBindings(binding, context, render_frame->IsMainFrame());
-  AddRenderBindings(isolate, binding);
 
   std::vector<v8::Local<v8::String>> preload_bundle_params = {
       node::FIXED_ONE_BYTE_STRING(isolate, "binding")};

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -5,6 +5,7 @@
 #define ATOM_RENDERER_ATOM_SANDBOXED_RENDERER_CLIENT_H_
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -34,6 +34,8 @@ class AtomSandboxedRendererClient : public RendererClientBase {
   // content::ContentRendererClient:
   void RenderFrameCreated(content::RenderFrame*) override;
   void RenderViewCreated(content::RenderView*) override;
+  void RunScriptsAtDocumentStart(content::RenderFrame* render_frame) override;
+  void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;
 
  private:
   std::unique_ptr<base::ProcessMetrics> metrics_;

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -40,6 +40,11 @@ class AtomSandboxedRendererClient : public RendererClientBase {
  private:
   std::unique_ptr<base::ProcessMetrics> metrics_;
 
+  // Getting main script context from web frame would lazily initializes
+  // its script context. Doing so in a web page without scripts would trigger
+  // assertion, so we have to keep a book of injected web frames.
+  std::set<content::RenderFrame*> injected_frames_;
+
   DISALLOW_COPY_AND_ASSIGN(AtomSandboxedRendererClient);
 };
 

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -95,13 +95,15 @@ ipcRendererInternal.on('CHROME_TABS_EXECUTESCRIPT', function (
   ipcRendererInternal.sendToAll(senderWebContentsId, `CHROME_TABS_EXECUTESCRIPT_RESULT_${requestId}`, result)
 })
 
-// Read the renderer process preferences.
-const preferences = process.getRenderProcessPreferences()
-if (preferences) {
-  for (const pref of preferences) {
-    if (pref.contentScripts) {
-      for (const script of pref.contentScripts) {
-        injectContentScript(pref.extensionId, script)
+module.exports = (getRenderProcessPreferences) => {
+  // Read the renderer process preferences.
+  const preferences = getRenderProcessPreferences()
+  if (preferences) {
+    for (const pref of preferences) {
+      if (pref.contentScripts) {
+        for (const script of pref.contentScripts) {
+          injectContentScript(pref.extensionId, script)
+        }
       }
     }
   }

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -96,7 +96,7 @@ const injectContentScript = function (extensionId: string, script: Electron.Cont
 
 // Handle the request of chrome.tabs.executeJavaScript.
 ipcRendererInternal.on('CHROME_TABS_EXECUTESCRIPT', function (
-  event,
+  event: Electron.Event,
   senderWebContentsId: number,
   requestId: number,
   extensionId: string,
@@ -107,7 +107,7 @@ ipcRendererInternal.on('CHROME_TABS_EXECUTESCRIPT', function (
   ipcRendererInternal.sendToAll(senderWebContentsId, `CHROME_TABS_EXECUTESCRIPT_RESULT_${requestId}`, result)
 })
 
-module.exports = (getRenderProcessPreferences) => {
+module.exports = (getRenderProcessPreferences: typeof process.getRenderProcessPreferences) => {
   // Read the renderer process preferences.
   const preferences = getRenderProcessPreferences()
   if (preferences) {

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -86,7 +86,7 @@ switch (window.location.protocol) {
 
     // Inject content scripts.
     if (process.isMainFrame) {
-      require('@electron/internal/renderer/content-scripts-injector')
+      require('@electron/internal/renderer/content-scripts-injector')(process.getRenderProcessPreferences)
     }
   }
 }

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -115,7 +115,7 @@ switch (window.location.protocol) {
   }
   default: {
     // Inject content scripts.
-    require('@electron/internal/renderer/content-scripts-injector')
+    require('@electron/internal/renderer/content-scripts-injector')(binding.getRenderProcessPreferences)
   }
 }
 

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -110,6 +110,13 @@ switch (window.location.protocol) {
     require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, isBackgroundPage, window)
     break
   }
+  case 'chrome': {
+    break
+  }
+  default: {
+    // Inject content scripts.
+    require('@electron/internal/renderer/content-scripts-injector')
+  }
 }
 
 const guestInstanceId = binding.guestInstanceId && parseInt(binding.guestInstanceId)

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -69,7 +69,6 @@ ipcNative.onDocumentEnd = function () {
   process.emit('document-end')
 }
 
-
 const { webFrameInit } = require('@electron/internal/renderer/web-frame-init')
 webFrameInit()
 

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -61,6 +61,15 @@ ipcNative.onExit = function () {
   process.emit('exit')
 }
 
+ipcNative.onDocumentStart = function () {
+  process.emit('document-start')
+}
+
+ipcNative.onDocumentEnd = function () {
+  process.emit('document-end')
+}
+
+
 const { webFrameInit } = require('@electron/internal/renderer/web-frame-init')
 webFrameInit()
 

--- a/spec/content-script-spec.js
+++ b/spec/content-script-spec.js
@@ -12,6 +12,9 @@ describe('chrome content scripts', () => {
       let w
 
       beforeEach(async () => {
+        Object.keys(BrowserWindow.getExtensions()).map(extName => {
+          BrowserWindow.removeExtension(extName)
+        })
         await closeWindow(w)
         w = new BrowserWindow({
           show: false,

--- a/spec/content-script-spec.js
+++ b/spec/content-script-spec.js
@@ -1,0 +1,66 @@
+const { expect } = require('chai')
+const { remote } = require('electron')
+const path = require('path')
+
+const { closeWindow } = require('./window-helpers')
+
+const { BrowserWindow } = remote
+
+describe('chrome content scripts', () => {
+  const generateTests = (sandboxEnabled) => {
+    describe(`with sandbox ${sandboxEnabled ? 'enabled' : 'disabled'}`, () => {
+      let w
+
+      beforeEach(async () => {
+        await closeWindow(w)
+        w = new BrowserWindow({
+          show: false,
+          width: 400,
+          height: 400,
+          webPreferences: {
+            sandbox: sandboxEnabled
+          }
+        })
+      })
+
+      afterEach(() => {
+        return closeWindow(w).then(() => { w = null })
+      })
+
+      const addExtension = (name) => {
+        const extensionPath = path.join(__dirname, 'fixtures', 'extensions', name)
+        BrowserWindow.addExtension(extensionPath)
+      }
+
+      it('should run content script at document_start', (done) => {
+        addExtension('content-script-document-start')
+        w.loadURL('about:blank')
+        w.webContents.executeJavaScript('document.body.style.backgroundColor', (result) => {
+          expect(result).to.equal('red')
+          done()
+        })
+      })
+
+      it('should run content script at document_idle', (done) => {
+        addExtension('content-script-document-idle')
+        w.loadURL('about:blank')
+        w.webContents.executeJavaScript('document.body.style.backgroundColor', (result) => {
+          expect(result).to.equal('red')
+          done()
+        })
+      })
+
+      it('should run content script at document_end', (done) => {
+        addExtension('content-script-document-end')
+        w.loadURL('about:blank')
+        w.webContents.executeJavaScript('document.body.style.backgroundColor', (result) => {
+          expect(result).to.equal('red')
+          done()
+        })
+      })
+    })
+  }
+
+  generateTests(false)
+  generateTests(true)
+})

--- a/spec/content-script-spec.js
+++ b/spec/content-script-spec.js
@@ -7,8 +7,8 @@ const { closeWindow } = require('./window-helpers')
 const { BrowserWindow } = remote
 
 describe('chrome content scripts', () => {
-  const generateTests = (sandboxEnabled) => {
-    describe(`with sandbox ${sandboxEnabled ? 'enabled' : 'disabled'}`, () => {
+  const generateTests = (sandboxEnabled, contextIsolationEnabled) => {
+    describe(`with sandbox ${sandboxEnabled ? 'enabled' : 'disabled'} and context isolation ${contextIsolationEnabled ? 'enabled' : 'disabled'}`, () => {
       let w
 
       beforeEach(async () => {
@@ -18,6 +18,7 @@ describe('chrome content scripts', () => {
           width: 400,
           height: 400,
           webPreferences: {
+            contextIsolation: contextIsolationEnabled,
             sandbox: sandboxEnabled
           }
         })
@@ -61,6 +62,8 @@ describe('chrome content scripts', () => {
     })
   }
 
-  generateTests(false)
-  generateTests(true)
+  generateTests(false, false)
+  generateTests(false, true)
+  generateTests(true, false)
+  generateTests(true, true)
 })

--- a/spec/content-script-spec.js
+++ b/spec/content-script-spec.js
@@ -38,11 +38,13 @@ describe('chrome content scripts', () => {
 
       it('should run content script at document_start', (done) => {
         addExtension('content-script-document-start')
-        w.loadURL('about:blank')
-        w.webContents.executeJavaScript('document.body.style.backgroundColor', (result) => {
-          expect(result).to.equal('red')
-          done()
+        w.webContents.once('dom-ready', () => {
+          w.webContents.executeJavaScript('document.documentElement.style.backgroundColor', (result) => {
+            expect(result).to.equal('red')
+            done()
+          })
         })
+        w.loadURL('about:blank')
       })
 
       it('should run content script at document_idle', (done) => {
@@ -56,11 +58,13 @@ describe('chrome content scripts', () => {
 
       it('should run content script at document_end', (done) => {
         addExtension('content-script-document-end')
-        w.loadURL('about:blank')
-        w.webContents.executeJavaScript('document.body.style.backgroundColor', (result) => {
-          expect(result).to.equal('red')
-          done()
+        w.webContents.once('did-finish-load', () => {
+          w.webContents.executeJavaScript('document.documentElement.style.backgroundColor', (result) => {
+            expect(result).to.equal('red')
+            done()
+          })
         })
+        w.loadURL('about:blank')
       })
     })
   }

--- a/spec/content-script-spec.js
+++ b/spec/content-script-spec.js
@@ -12,9 +12,6 @@ describe('chrome content scripts', () => {
       let w
 
       beforeEach(async () => {
-        Object.keys(BrowserWindow.getExtensions()).map(extName => {
-          BrowserWindow.removeExtension(extName)
-        })
         await closeWindow(w)
         w = new BrowserWindow({
           show: false,
@@ -28,6 +25,9 @@ describe('chrome content scripts', () => {
       })
 
       afterEach(() => {
+        Object.keys(BrowserWindow.getExtensions()).map(extName => {
+          BrowserWindow.removeExtension(extName)
+        })
         return closeWindow(w).then(() => { w = null })
       })
 

--- a/spec/fixtures/extensions/content-script-document-end/end.js
+++ b/spec/fixtures/extensions/content-script-document-end/end.js
@@ -1,0 +1,1 @@
+document.documentElement.style.backgroundColor = 'red'

--- a/spec/fixtures/extensions/content-script-document-end/manifest.json
+++ b/spec/fixtures/extensions/content-script-document-end/manifest.json
@@ -1,0 +1,14 @@
+{
+    "name": "document-end",
+    "version": "1.0",
+    "description": "",
+    "content_scripts": [
+      {
+        "matches": ["*://*/*"],
+        "js": ["end.js"],
+        "run_at": "document_end"
+      }
+    ],
+    "manifest_version": 2
+  }
+  

--- a/spec/fixtures/extensions/content-script-document-end/manifest.json
+++ b/spec/fixtures/extensions/content-script-document-end/manifest.json
@@ -4,7 +4,7 @@
     "description": "",
     "content_scripts": [
       {
-        "matches": ["*://*/*"],
+        "matches": ["<all_urls>"],
         "js": ["end.js"],
         "run_at": "document_end"
       }

--- a/spec/fixtures/extensions/content-script-document-idle/idle.js
+++ b/spec/fixtures/extensions/content-script-document-idle/idle.js
@@ -1,0 +1,1 @@
+document.documentElement.style.backgroundColor = 'red'

--- a/spec/fixtures/extensions/content-script-document-idle/idle.js
+++ b/spec/fixtures/extensions/content-script-document-idle/idle.js
@@ -1,1 +1,1 @@
-document.documentElement.style.backgroundColor = 'red'
+document.body.style.backgroundColor = 'red'

--- a/spec/fixtures/extensions/content-script-document-idle/manifest.json
+++ b/spec/fixtures/extensions/content-script-document-idle/manifest.json
@@ -1,0 +1,14 @@
+{
+    "name": "document-idle",
+    "version": "1.0",
+    "description": "",
+    "content_scripts": [
+      {
+        "matches": ["*://*/*"],
+        "js": ["idle.js"],
+        "run_at": "document_idle"
+      }
+    ],
+    "manifest_version": 2
+  }
+  

--- a/spec/fixtures/extensions/content-script-document-idle/manifest.json
+++ b/spec/fixtures/extensions/content-script-document-idle/manifest.json
@@ -4,7 +4,7 @@
     "description": "",
     "content_scripts": [
       {
-        "matches": ["*://*/*"],
+        "matches": ["<all_urls>"],
         "js": ["idle.js"],
         "run_at": "document_idle"
       }

--- a/spec/fixtures/extensions/content-script-document-start/manifest.json
+++ b/spec/fixtures/extensions/content-script-document-start/manifest.json
@@ -1,0 +1,14 @@
+{
+    "name": "document-start",
+    "version": "1.0",
+    "description": "",
+    "content_scripts": [
+      {
+        "matches": ["*://*/*"],
+        "js": ["start.js"],
+        "run_at": "document_start"
+      }
+    ],
+    "manifest_version": 2
+  }
+  

--- a/spec/fixtures/extensions/content-script-document-start/manifest.json
+++ b/spec/fixtures/extensions/content-script-document-start/manifest.json
@@ -4,7 +4,7 @@
     "description": "",
     "content_scripts": [
       {
-        "matches": ["*://*/*"],
+        "matches": ["<all_urls>"],
         "js": ["start.js"],
         "run_at": "document_start"
       }

--- a/spec/fixtures/extensions/content-script-document-start/start.js
+++ b/spec/fixtures/extensions/content-script-document-start/start.js
@@ -1,0 +1,1 @@
+document.documentElement.style.backgroundColor = 'red'


### PR DESCRIPTION
#### Description of Change
The sandboxed renderer doesn't currently load any content scripts included with chrome extensions. A few changes were needed to fix this:
- Add `content-script-injector.js` to `lib/sandboxed_renderer/init.js`
- Use the correct reference to `getRenderProcessPreferences` in `content-script-injector.js` (not bound to `process` in sandboxed lib).
- Emit `document-start` and `document-end` events in sandboxed renderer.

Content scripts don't currently work in subframes when context isolation is enabled. #16804 will need to be fixed first.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Fixed Chrome extension content scripts not loading in sandboxed renderer.
