### PR TITLE
fix: get foreground color from GtkMenuBar#menubar (3-1-x)

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -5,7 +5,6 @@
 #include "atom/browser/ui/views/menu_bar.h"
 
 #include <memory>
-#include <string>
 
 #include "atom/browser/ui/views/menu_delegate.h"
 #include "atom/browser/ui/views/submenu_button.h"
@@ -129,13 +128,11 @@ void MenuBar::RefreshColorCache(const ui::NativeTheme* theme) {
     theme = ui::NativeTheme::GetInstanceForNativeUi();
   if (theme) {
 #if defined(USE_X11)
-    const std::string menubar_selector = "GtkMenuBar#menubar";
-    background_color_ = libgtkui::GetBgColor(menubar_selector);
-
-    enabled_color_ = theme->GetSystemColor(
-        ui::NativeTheme::kColorId_EnabledMenuItemForegroundColor);
-    disabled_color_ = theme->GetSystemColor(
-        ui::NativeTheme::kColorId_DisabledMenuItemForegroundColor);
+    background_color_ = libgtkui::GetBgColor("GtkMenuBar#menubar");
+    enabled_color_ = libgtkui::GetFgColor(
+        "GtkMenuBar#menubar GtkMenuItem#menuitem GtkLabel");
+    disabled_color_ = libgtkui::GetFgColor(
+        "GtkMenuBar#menubar GtkMenuItem#menuitem:disabled GtkLabel");
 #else
     background_color_ =
         theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);


### PR DESCRIPTION
#### Description of Change
Backport of https://github.com/electron/electron/pull/15878 to `3-1-x`
Depends on https://github.com/electron/libchromiumcontent/pull/742
/cc @inukshuk 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: Fixed incorrect foreground color on GTK menubar.
