### PR TITLE
fix: get foreground color from GtkMenuBar#menubar (4-0-x)

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -5,7 +5,6 @@
 #include "atom/browser/ui/views/menu_bar.h"
 
 #include <memory>
-#include <string>
 
 #include "atom/browser/ui/views/menu_delegate.h"
 #include "atom/browser/ui/views/submenu_button.h"
@@ -129,13 +128,11 @@ void MenuBar::RefreshColorCache(const ui::NativeTheme* theme) {
     theme = ui::NativeTheme::GetInstanceForNativeUi();
   if (theme) {
 #if defined(USE_X11)
-    const std::string menubar_selector = "GtkMenuBar#menubar";
-    background_color_ = libgtkui::GetBgColor(menubar_selector);
-
-    enabled_color_ = theme->GetSystemColor(
-        ui::NativeTheme::kColorId_EnabledMenuItemForegroundColor);
-    disabled_color_ = theme->GetSystemColor(
-        ui::NativeTheme::kColorId_DisabledMenuItemForegroundColor);
+    background_color_ = libgtkui::GetBgColor("GtkMenuBar#menubar");
+    enabled_color_ = libgtkui::GetFgColor(
+        "GtkMenuBar#menubar GtkMenuItem#menuitem GtkLabel");
+    disabled_color_ = libgtkui::GetFgColor(
+        "GtkMenuBar#menubar GtkMenuItem#menuitem:disabled GtkLabel");
 #else
     background_color_ =
         theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);

--- a/patches/common/chromium/libgtkui_export.patch
+++ b/patches/common/chromium/libgtkui_export.patch
@@ -81,6 +81,15 @@ index d9f245070249f5f153bd8fe11e0a5e718c7d3629..a0f033c3e3f7f3996897f5f969b2a209
  
  // Gets the transient parent aura window for |dialog|.
  aura::Window* GetAuraTransientParent(GtkWidget* dialog);
+@@ -180,7 +181,7 @@ void ApplyCssToContext(GtkStyleContext* context, const std::string& css);
+ 
+ // Get the 'color' property from the style context created by
+ // GetStyleContextFromCss(|css_selector|).
+-SkColor GetFgColor(const std::string& css_selector);
++LIBGTKUI_EXPORT SkColor GetFgColor(const std::string& css_selector);
+ 
+ ScopedCssProvider GetCssProvider(const std::string& css);
+ 
 @@ -193,7 +194,7 @@ void RenderBackground(const gfx::Size& size,
  // Renders a background from the style context created by
  // GetStyleContextFromCss(|css_selector|) into a 24x24 bitmap and


### PR DESCRIPTION
#### Description of Change
Backport of https://github.com/electron/electron/pull/15878 to `4-0-x`
/cc @inukshuk 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: Fixes incorrect foreground color on GTK menubar
