### PR TITLE
chore: disable nodeIntegration / webviewTag by default

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -99,9 +99,9 @@ WebContentsPreferences::WebContentsPreferences(
   // Set WebPreferences defaults onto the JS object
   SetDefaultBoolIfUndefined(options::kPlugins, false);
   SetDefaultBoolIfUndefined(options::kExperimentalFeatures, false);
-  bool node = SetDefaultBoolIfUndefined(options::kNodeIntegration, true);
+  SetDefaultBoolIfUndefined(options::kNodeIntegration, false);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
-  SetDefaultBoolIfUndefined(options::kWebviewTag, node);
+  SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
   SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
   SetDefaultBoolIfUndefined(options::kContextIsolation, false);

--- a/default_app/default_app.js
+++ b/default_app/default_app.js
@@ -18,7 +18,6 @@ exports.load = async (appUrl) => {
     backgroundColor: '#FFFFFF',
     webPreferences: {
       contextIsolation: true,
-      nodeIntegration: false,
       preload: path.resolve(__dirname, 'renderer.js'),
       webviewTag: false
     },

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -20,11 +20,7 @@ win.on('closed', () => {
   win = null
 })
 
-let view = new BrowserView({
-  webPreferences: {
-    nodeIntegration: false
-  }
-})
+let view = new BrowserView()
 win.setBrowserView(view)
 view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
 view.webContents.loadURL('https://electronjs.org')

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -250,8 +250,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     `new-window-for-tab` event.
   * `webPreferences` Object (optional) - Settings of web page's features.
     * `devTools` Boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
-    * `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default
-      is `true`.
+    * `nodeIntegration` Boolean (optional) - Whether node integration is enabled.
+      Default is `false`.
     * `nodeIntegrationInWorker` Boolean (optional) - Whether node integration is
       enabled in web workers. Default is `false`. More about this can be found
       in [Multithreading](../tutorial/multithreading.md).
@@ -353,7 +353,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       integration disabled. **Note:** This option is currently
       experimental.
     * `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
-      Defaults to the value of the `nodeIntegration` option. **Note:** The
+      Defaults to `false`. **Note:** The
       `preload` script configured for the `<webview>` will have node integration
       enabled when it is executed so you should ensure remote/untrusted content
       is not able to create a `<webview>` tag with a possibly malicious `preload`
@@ -1603,7 +1603,7 @@ removed in future Electron releases.
 
 * `browserView` [BrowserView](browser-view.md). Attach browserView to win.
 If there is some other browserViews was attached they will be removed from
-this window.  
+this window.
 
 #### `win.getBrowserView()` _Experimental_
 

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -38,7 +38,7 @@ const parseOption = function (name, defaultValue, converter = value => value) {
 }
 
 const contextIsolation = hasSwitch('context-isolation')
-let nodeIntegration = hasSwitch('node-integration')
+const nodeIntegration = hasSwitch('node-integration')
 const webviewTag = hasSwitch('webview-tag')
 const isHiddenPage = hasSwitch('hidden-page')
 const isBackgroundPage = hasSwitch('background-page')
@@ -64,14 +64,11 @@ if (contextIsolation) {
 if (window.location.protocol === 'chrome-devtools:') {
   // Override some inspector APIs.
   require('@electron/internal/renderer/inspector')
-  nodeIntegration = false
 } else if (window.location.protocol === 'chrome-extension:') {
   // Add implementations of chrome API.
   require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, isBackgroundPage, window)
-  nodeIntegration = false
 } else if (window.location.protocol === 'chrome:') {
   // Disable node integration for chrome UI scheme.
-  nodeIntegration = false
 } else {
   // Override default web functions.
   require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -32,7 +32,10 @@ describe('electron module', () => {
       window = new BrowserWindow({
         show: false,
         width: 400,
-        height: 400
+        height: 400,
+        webPreferences: {
+          nodeIntegration: true
+        }
       })
     })
 
@@ -298,7 +301,12 @@ describe('app module', () => {
         password: 'electron'
       }
 
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       w.webContents.on('did-finish-load', () => {
         expect(w.webContents.getTitle()).to.equal('authorized')
@@ -375,7 +383,12 @@ describe('app module', () => {
         expect(webContents).to.equal(w.webContents)
         done()
       })
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       w.loadURL('about:blank')
       w.webContents.executeJavaScript(`require('electron').desktopCapturer.getSources({ types: ['screen'] }, () => {})`)
     })
@@ -386,7 +399,12 @@ describe('app module', () => {
         expect(moduleName).to.equal('test')
         done()
       })
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       w.loadURL('about:blank')
       w.webContents.executeJavaScript(`require('electron').remote.require('test')`)
     })
@@ -397,7 +415,12 @@ describe('app module', () => {
         expect(globalName).to.equal('test')
         done()
       })
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       w.loadURL('about:blank')
       w.webContents.executeJavaScript(`require('electron').remote.getGlobal('test')`)
     })
@@ -590,6 +613,7 @@ describe('app module', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
+          nodeIntegration: true,
           partition: 'empty-certificate'
         }
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -34,7 +34,8 @@ describe('BrowserWindow module', () => {
     width: 400,
     height: 400,
     webPreferences: {
-      backgroundThrottling: false
+      backgroundThrottling: false,
+      nodeIntegration: true
     }
   }
 
@@ -1283,7 +1284,10 @@ describe('BrowserWindow module', () => {
         w.destroy()
         w = new BrowserWindow({
           show: false,
-          webPreferences: { preload }
+          webPreferences: {
+            nodeIntegration: true,
+            preload
+          }
         })
         const p = emittedOnce(ipcMain, 'answer')
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
@@ -1296,7 +1300,8 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            preload: preload
+            nodeIntegration: true,
+            preload
           }
         })
         const p = emittedOnce(ipcMain, 'answer')
@@ -1308,7 +1313,10 @@ describe('BrowserWindow module', () => {
         const preload = path.join(fixtures, 'module', 'access-blink-apis.js')
         const w = await openTheWindow({
           show: false,
-          webPreferences: { preload }
+          webPreferences: {
+            nodeIntegration: true,
+            preload
+          }
         })
         const p = emittedOnce(ipcMain, 'answer')
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
@@ -1350,6 +1358,7 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
+            nodeIntegration: true,
             preload: path.join(fixtures, 'module', 'set-global-preload-3.js')
           }
         })
@@ -1368,7 +1377,8 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            preload: preload,
+            nodeIntegration: true,
+            preload,
             additionalArguments: ['--my-magic-arg']
           }
         })
@@ -1385,7 +1395,8 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            preload: preload,
+            nodeIntegration: true,
+            preload,
             additionalArguments: ['--my-magic-arg=foo']
           }
         })
@@ -1394,7 +1405,7 @@ describe('BrowserWindow module', () => {
     })
 
     describe('"node-integration" option', () => {
-      it('disables node integration when specified to false', (done) => {
+      it('disables node integration by default', (done) => {
         const preload = path.join(fixtures, 'module', 'send-later.js')
         ipcMain.once('answer', (event, typeofProcess, typeofBuffer) => {
           assert.strictEqual(typeofProcess, 'undefined')
@@ -1405,8 +1416,7 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            preload: preload,
-            nodeIntegration: false
+            preload
           }
         })
         w.loadFile(path.join(fixtures, 'api', 'blank.html'))
@@ -1422,7 +1432,6 @@ describe('BrowserWindow module', () => {
             const w = await openTheWindow({
               show: false,
               webPreferences: {
-                nodeIntegration: false,
                 preload,
                 sandbox
               }
@@ -1437,7 +1446,6 @@ describe('BrowserWindow module', () => {
             const w = await openTheWindow({
               show: false,
               webPreferences: {
-                nodeIntegration: false,
                 preload,
                 sandbox,
                 enableRemoteModule: false
@@ -1476,8 +1484,9 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
+            nodeIntegration: true,
             sandbox: true,
-            preload: preload
+            preload
           }
         })
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
@@ -1493,6 +1502,7 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
+            nodeIntegration: true,
             sandbox: true,
             preload: preloadSpecialChars
           }
@@ -1505,8 +1515,9 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
+            nodeIntegration: true,
             sandbox: true,
-            preload: preload
+            preload
           }
         })
         const htmlPath = path.join(fixtures, 'api', 'sandbox.html?exit-event')
@@ -1527,8 +1538,9 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
+            nodeIntegration: true,
             sandbox: true,
-            preload: preload
+            preload
           }
         })
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
@@ -1653,7 +1665,7 @@ describe('BrowserWindow module', () => {
           show: false,
           webPreferences: {
             sandbox: true,
-            preload: preload
+            preload
           }
         })
         ipcRenderer.send('set-web-preferences-on-next-new-window', w.webContents.id, 'preload', preload)
@@ -1738,7 +1750,7 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            preload: preload,
+            preload,
             sandbox: true
           }
         })
@@ -1761,7 +1773,7 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            preload: preload,
+            preload,
             sandbox: true
           }
         })
@@ -1794,7 +1806,7 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            preload: preload,
+            preload,
             sandbox: true
           }
         })
@@ -1843,7 +1855,7 @@ describe('BrowserWindow module', () => {
           show: false,
           webPreferences: {
             sandbox: true,
-            preload: preload
+            preload
           }
         })
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
@@ -1855,7 +1867,7 @@ describe('BrowserWindow module', () => {
           show: false,
           webPreferences: {
             sandbox: true,
-            preload: preload,
+            preload,
             webviewTag: true
           }
         })
@@ -1875,6 +1887,7 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
+            nodeIntegration: true,
             nativeWindowOpen: true
           }
         })
@@ -1962,7 +1975,6 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: true,
           webPreferences: {
-            nodeIntegration: false,
             nativeWindowOpen: true
           }
         })
@@ -2093,7 +2105,14 @@ describe('BrowserWindow module', () => {
     afterEach(() => { ipcMain.removeAllListeners('pong') })
 
     it('visibilityState is initially visible despite window being hidden', (done) => {
-      w = new BrowserWindow({ show: false, width: 100, height: 100 })
+      w = new BrowserWindow({
+        show: false,
+        width: 100,
+        height: 100,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       let readyToShow = false
       w.once('ready-to-show', () => {
@@ -2111,7 +2130,13 @@ describe('BrowserWindow module', () => {
       w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState changes when window is hidden', (done) => {
-      w = new BrowserWindow({ width: 100, height: 100 })
+      w = new BrowserWindow({
+        width: 100,
+        height: 100,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       onNextVisibilityChange((visibilityState, hidden) => {
         assert.strictEqual(visibilityState, 'visible')
@@ -2129,7 +2154,13 @@ describe('BrowserWindow module', () => {
       w.loadFile(path.join(fixtures, 'pages', 'visibilitychange.html'))
     })
     it('visibilityState changes when window is shown', (done) => {
-      w = new BrowserWindow({ width: 100, height: 100 })
+      w = new BrowserWindow({
+        width: 100,
+        height: 100,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       onNextVisibilityChange((visibilityState, hidden) => {
         onVisibilityChange((visibilityState, hidden) => {
@@ -2155,7 +2186,13 @@ describe('BrowserWindow module', () => {
         return done()
       }
 
-      w = new BrowserWindow({ width: 100, height: 100 })
+      w = new BrowserWindow({
+        width: 100,
+        height: 100,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       onNextVisibilityChange((visibilityState, hidden) => {
         onVisibilityChange((visibilityState, hidden) => {
@@ -2181,7 +2218,13 @@ describe('BrowserWindow module', () => {
         return done()
       }
 
-      w = new BrowserWindow({ width: 100, height: 100 })
+      w = new BrowserWindow({
+        width: 100,
+        height: 100,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       onNextVisibilityChange((visibilityState, hidden) => {
         assert.strictEqual(visibilityState, 'visible')
@@ -2204,7 +2247,8 @@ describe('BrowserWindow module', () => {
         width: 100,
         height: 100,
         webPreferences: {
-          backgroundThrottling: false
+          backgroundThrottling: false,
+          nodeIntegration: true
         }
       })
 
@@ -3189,6 +3233,7 @@ describe('BrowserWindow module', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
+          nodeIntegration: true,
           partition: 'temp'
         }
       })

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -10,7 +10,7 @@ const url = require('url')
 const { closeWindow } = require('./window-helpers')
 
 const { remote } = require('electron')
-const { app, BrowserWindow, crashReporter } = remote.require('electron')
+const { app, BrowserWindow, crashReporter } = remote
 
 describe('crashReporter module', () => {
   if (process.mas || process.env.DISABLE_CRASH_REPORTER_TESTS) return
@@ -188,7 +188,11 @@ describe('crashReporter module', () => {
     })
   }
 
-  generateSpecs('without sandbox', {})
+  generateSpecs('without sandbox', {
+    webPreferences: {
+      nodeIntegration: true
+    }
+  })
   generateSpecs('with sandbox', {
     webPreferences: {
       sandbox: true,
@@ -197,6 +201,7 @@ describe('crashReporter module', () => {
   })
   generateSpecs('with remote module disabled', {
     webPreferences: {
+      nodeIntegration: true,
       enableRemoteModule: false
     }
   })

--- a/spec/api-ipc-main-spec.js
+++ b/spec/api-ipc-main-spec.js
@@ -24,7 +24,12 @@ describe('ipc main module', () => {
     afterEach(() => { ipcMain.removeAllListeners('send-sync-message') })
 
     it('does not crash when reply is not sent and browser is destroyed', (done) => {
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       ipcMain.once('send-sync-message', (event) => {
         event.returnValue = null
         done()
@@ -33,7 +38,12 @@ describe('ipc main module', () => {
     })
 
     it('does not crash when reply is sent by multiple listeners', (done) => {
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       ipcMain.on('send-sync-message', (event) => {
         event.returnValue = null
       })
@@ -59,7 +69,12 @@ describe('ipc main module', () => {
 
   describe('remote objects registry', () => {
     it('does not dereference until the render view is deleted (regression)', (done) => {
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       ipcMain.once('error-message', (event, message) => {
         const correctMsgStart = message.startsWith('Cannot call function \'getURL\' on missing remote object')

--- a/spec/api-ipc-renderer-spec.js
+++ b/spec/api-ipc-renderer-spec.js
@@ -199,7 +199,12 @@ describe('ipc renderer module', () => {
 
   describe('remote listeners', () => {
     it('detaches listeners subscribed to destroyed renderers, and shows a warning', (done) => {
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
 
       w.webContents.once('did-finish-load', () => {
         w.webContents.once('did-finish-load', () => {
@@ -227,7 +232,12 @@ describe('ipc renderer module', () => {
 
   describe('ipcRenderer.on', () => {
     it('is not used for internals', async () => {
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       await w.loadURL('about:blank')
 
       const script = `require('electron').ipcRenderer.eventNames()`

--- a/spec/api-notification-dbus-spec.js
+++ b/spec/api-notification-dbus-spec.js
@@ -11,7 +11,7 @@ const dbus = require('dbus-native')
 const Promise = require('bluebird')
 
 const { remote } = require('electron')
-const { app } = remote.require('electron')
+const { app } = remote
 
 const skip = process.platform !== 'linux' ||
              process.arch === 'ia32' ||

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -1045,7 +1045,12 @@ describe('protocol module', () => {
     let success = null
 
     beforeEach(() => {
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       success = false
     })
 

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -526,7 +526,7 @@ describe('remote module', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
-          preload: preload
+          preload
         }
       })
       w.once('closed', () => done())

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -26,7 +26,10 @@ describe('session module', () => {
     w = new BrowserWindow({
       show: false,
       width: 400,
-      height: 400
+      height: 400,
+      webPreferences: {
+        nodeIntegration: true
+      }
     })
   })
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -32,7 +32,9 @@ describe('webContents module', () => {
       width: 400,
       height: 400,
       webPreferences: {
-        backgroundThrottling: false
+        backgroundThrottling: false,
+        nodeIntegration: true,
+        webviewTag: true
       }
     })
   })

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -146,7 +146,12 @@ describe('webFrame module', function () {
   })
 
   it('calls a spellcheck provider', async () => {
-    w = new BrowserWindow({ show: false })
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        nodeIntegration: true
+      }
+    })
     await w.loadFile(path.join(fixtures, 'pages', 'webframe-spell-check.html'))
     w.focus()
     await w.webContents.executeJavaScript('document.querySelector("input").focus()', true)

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -10,8 +10,7 @@ const { closeWindow } = require('./window-helpers')
 const nativeImage = require('electron').nativeImage
 const remote = require('electron').remote
 
-const ipcMain = remote.require('electron').ipcMain
-const BrowserWindow = remote.require('electron').BrowserWindow
+const { ipcMain, BrowserWindow } = remote
 
 describe('asar package', function () {
   const fixtures = path.join(__dirname, 'fixtures')
@@ -1134,7 +1133,10 @@ describe('asar package', function () {
       w = new BrowserWindow({
         show: false,
         width: 400,
-        height: 400
+        height: 400,
+        webPreferences: {
+          nodeIntegration: true
+        }
       })
       const p = path.resolve(fixtures, 'asar', 'web.asar', 'index.html')
       ipcMain.once('dirname', function (event, dirname) {
@@ -1152,7 +1154,10 @@ describe('asar package', function () {
       w = new BrowserWindow({
         show: false,
         width: 400,
-        height: 400
+        height: 400,
+        webPreferences: {
+          nodeIntegration: true
+        }
       })
       const p = path.resolve(fixtures, 'asar', 'script.asar', 'index.html')
       w.loadFile(p)
@@ -1172,7 +1177,10 @@ describe('asar package', function () {
       w = new BrowserWindow({
         show: false,
         width: 400,
-        height: 400
+        height: 400,
+        webPreferences: {
+          nodeIntegration: true
+        }
       })
       const p = path.resolve(fixtures, 'asar', 'video.asar', 'index.html')
       w.loadFile(p)

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -112,12 +112,7 @@ describe('chromium feature', () => {
 
   describe('loading jquery', () => {
     it('does not crash', (done) => {
-      w = new BrowserWindow({
-        show: false,
-        webPreferences: {
-          nodeIntegration: false
-        }
-      })
+      w = new BrowserWindow({ show: false })
       w.webContents.once('did-finish-load', () => { done() })
       w.webContents.once('crashed', () => done(new Error('WebContents crashed.')))
       w.loadFile(path.join(fixtures, 'pages', 'jquery.html'))
@@ -176,6 +171,7 @@ describe('chromium feature', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
+          nodeIntegration: true,
           session: ses
         }
       })
@@ -216,6 +212,7 @@ describe('chromium feature', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
+          nodeIntegration: true,
           partition: 'sw-file-scheme-spec'
         }
       })
@@ -253,7 +250,10 @@ describe('chromium feature', () => {
 
       w = new BrowserWindow({
         show: false,
-        webPreferences: { session: customSession }
+        webPreferences: {
+          nodeIntegration: true,
+          session: customSession
+        }
       })
       w.webContents.on('ipc-message', (event, args) => {
         if (args[0] === 'reload') {
@@ -294,6 +294,7 @@ describe('chromium feature', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
+          nodeIntegration: true,
           partition: 'geolocation-spec'
         }
       })
@@ -382,26 +383,6 @@ describe('chromium feature', () => {
         protocol: 'file',
         query: {
           p: `${fixtures}/pages/window-opener-node.html`
-        },
-        slashes: true
-      })
-      b = window.open(windowUrl, '', 'nodeIntegration=no,show=no')
-    })
-
-    it('disables webviewTag when node integration is disabled on the parent window', (done) => {
-      let b = null
-      listener = (event) => {
-        assert.strictEqual(event.data.isWebViewUndefined, true)
-        b.close()
-        done()
-      }
-      window.addEventListener('message', listener)
-
-      const windowUrl = require('url').format({
-        pathname: `${fixtures}/pages/window-opener-no-web-view-tag.html`,
-        protocol: 'file',
-        query: {
-          p: `${fixtures}/pages/window-opener-web-view.html`
         },
         slashes: true
       })
@@ -604,7 +585,12 @@ describe('chromium feature', () => {
   describe('window.opener', () => {
     const url = `file://${fixtures}/pages/window-opener.html`
     it('is null for main window', (done) => {
-      w = new BrowserWindow({ show: false })
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       w.webContents.once('ipc-message', (event, args) => {
         assert.deepStrictEqual(args, ['opener', null])
         done()
@@ -1008,7 +994,9 @@ describe('chromium feature', () => {
       })
 
       beforeEach(() => {
-        contents = webContents.create({})
+        contents = webContents.create({
+          nodeIntegration: true
+        })
       })
 
       afterEach(() => {
@@ -1102,8 +1090,10 @@ describe('chromium feature', () => {
 
       const testLocalStorageAfterXSiteRedirect = (testTitle, extraPreferences = {}) => {
         it(testTitle, (done) => {
-          const webPreferences = { show: false, ...extraPreferences }
-          w = new BrowserWindow(webPreferences)
+          w = new BrowserWindow({
+            show: false,
+            ...extraPreferences
+          })
           let redirected = false
           w.webContents.on('crashed', () => {
             assert.fail('renderer crashed / was killed')
@@ -1417,7 +1407,11 @@ describe('chromium feature', () => {
 
     beforeEach(async () => {
       w = new BrowserWindow({
-        show: true
+        show: true,
+        webPreferences: {
+          nodeIntegration: true,
+          webviewTag: true
+        }
       })
 
       const webviewReady = emittedOnce(w.webContents, 'did-attach-webview')

--- a/spec/fixtures/no-proprietary-codecs.js
+++ b/spec/fixtures/no-proprietary-codecs.js
@@ -14,7 +14,10 @@ let window
 
 app.once('ready', () => {
   window = new BrowserWindow({
-    show: false
+    show: false,
+    webPreferences: {
+      nodeIntegration: true
+    }
   })
 
   window.webContents.on('crashed', (event, killed) => {

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -162,7 +162,12 @@ describe('modules support', () => {
       let w
 
       beforeEach(() => {
-        w = new BrowserWindow({ show: false })
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nodeIntegration: true
+          }
+        })
       })
 
       afterEach(async () => {

--- a/spec/security-warnings-spec.js
+++ b/spec/security-warnings-spec.js
@@ -59,7 +59,12 @@ describe('security warnings', () => {
   })
 
   it('should warn about Node.js integration with remote content', (done) => {
-    w = new BrowserWindow({ show: false })
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        nodeIntegration: true
+      }
+    })
     w.webContents.once('console-message', (e, level, message) => {
       assert(message.includes('Node.js Integration with Remote Content'), message)
       done()
@@ -75,7 +80,6 @@ describe('security warnings', () => {
           show: false,
           webPreferences: {
             webSecurity: false,
-            nodeIntegration: false,
             ...webPreferences
           }
         })
@@ -90,10 +94,7 @@ describe('security warnings', () => {
       it('should warn about insecure Content-Security-Policy', (done) => {
         w = new BrowserWindow({
           show: false,
-          webPreferences: {
-            nodeIntegration: false,
-            ...webPreferences
-          }
+          webPreferences
         })
 
         w.webContents.once('console-message', (e, level, message) => {
@@ -110,7 +111,6 @@ describe('security warnings', () => {
           show: false,
           webPreferences: {
             allowRunningInsecureContent: true,
-            nodeIntegration: false,
             ...webPreferences
           }
         })
@@ -127,7 +127,6 @@ describe('security warnings', () => {
           show: false,
           webPreferences: {
             experimentalFeatures: true,
-            nodeIntegration: false,
             ...webPreferences
           }
         })
@@ -144,7 +143,6 @@ describe('security warnings', () => {
           show: false,
           webPreferences: {
             enableBlinkFeatures: ['my-cool-feature'],
-            nodeIntegration: false,
             ...webPreferences
           }
         })
@@ -159,10 +157,7 @@ describe('security warnings', () => {
       it('should warn about allowpopups', (done) => {
         w = new BrowserWindow({
           show: false,
-          webPreferences: {
-            nodeIntegration: false,
-            ...webPreferences
-          }
+          webPreferences
         })
         w.webContents.once('console-message', (e, level, message) => {
           assert(message.includes('allowpopups'), message)
@@ -175,10 +170,7 @@ describe('security warnings', () => {
       it('should warn about insecure resources', (done) => {
         w = new BrowserWindow({
           show: false,
-          webPreferences: {
-            nodeIntegration: false,
-            ...webPreferences
-          }
+          webPreferences
         })
         w.webContents.once('console-message', (e, level, message) => {
           assert(message.includes('Insecure Resources'), message)

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -124,7 +124,9 @@ app.on('ready', function () {
     width: 800,
     height: 600,
     webPreferences: {
-      backgroundThrottling: false
+      backgroundThrottling: false,
+      nodeIntegration: true,
+      webviewTag: true
     }
   })
   window.loadFile('static/index.html', {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -65,7 +65,13 @@ describe('<webview> tag', function () {
   })
 
   it('works without script tag in page', async () => {
-    const w = await openTheWindow({ show: false })
+    const w = await openTheWindow({
+      show: false,
+      webPreferences: {
+        webviewTag: true,
+        nodeIntegration: true
+      }
+    })
     w.loadFile(path.join(fixtures, 'pages', 'webview-no-script.html'))
     await emittedOnce(ipcMain, 'pong')
   })
@@ -75,6 +81,7 @@ describe('<webview> tag', function () {
       show: false,
       webPreferences: {
         webviewTag: true,
+        nodeIntegration: true,
         contextIsolation: true
       }
     })
@@ -82,12 +89,12 @@ describe('<webview> tag', function () {
     await emittedOnce(ipcMain, 'pong')
   })
 
-  it('is disabled when nodeIntegration is disabled', async () => {
+  it('is disabled by default', async () => {
     const w = await openTheWindow({
       show: false,
       webPreferences: {
-        nodeIntegration: false,
-        preload: path.join(fixtures, 'module', 'preload-webview.js')
+        preload: path.join(fixtures, 'module', 'preload-webview.js'),
+        nodeIntegration: true
       }
     })
 
@@ -95,22 +102,6 @@ describe('<webview> tag', function () {
     const [, type] = await emittedOnce(ipcMain, 'webview')
 
     expect(type).to.equal('undefined', 'WebView still exists')
-  })
-
-  it('is enabled when the webviewTag option is enabled and the nodeIntegration option is disabled', async () => {
-    const w = await openTheWindow({
-      show: false,
-      webPreferences: {
-        nodeIntegration: false,
-        preload: path.join(fixtures, 'module', 'preload-webview.js'),
-        webviewTag: true
-      }
-    })
-
-    w.loadFile(path.join(fixtures, 'pages', 'webview-no-script.html'))
-    const [, type] = await emittedOnce(ipcMain, 'webview')
-
-    expect(type).to.not.equal('undefined', 'WebView is not created')
   })
 
   describe('src attribute', () => {
@@ -1289,7 +1280,13 @@ describe('<webview> tag', function () {
 
   describe('did-attach-webview event', () => {
     it('is emitted when a webview has been attached', async () => {
-      const w = await openTheWindow({ show: false })
+      const w = await openTheWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true
+        }
+      })
       w.loadFile(path.join(fixtures, 'pages', 'webview-did-attach-event.html'))
 
       const [, webContents] = await emittedOnce(w.webContents, 'did-attach-webview')
@@ -1299,7 +1296,13 @@ describe('<webview> tag', function () {
   })
 
   it('loads devtools extensions registered on the parent window', async () => {
-    const w = await openTheWindow({ show: false })
+    const w = await openTheWindow({
+      show: false,
+      webPreferences: {
+        webviewTag: true,
+        nodeIntegration: true
+      }
+    })
     BrowserWindow.removeDevToolsExtension('foo')
 
     const extensionPath = path.join(__dirname, 'fixtures', 'devtools-extensions', 'foo')
@@ -1391,6 +1394,8 @@ describe('<webview> tag', function () {
       const w = await openTheWindow({
         show: false,
         webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
           zoomFactor: 1.2
         }
       })
@@ -1405,6 +1410,8 @@ describe('<webview> tag', function () {
       return openTheWindow({
         show: false,
         webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
           zoomFactor: 1.2
         }
       }).then((w) => {
@@ -1434,6 +1441,8 @@ describe('<webview> tag', function () {
       return openTheWindow({
         show: false,
         webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
           zoomFactor: 1.2
         }
       }).then((w) => {
@@ -1458,6 +1467,8 @@ describe('<webview> tag', function () {
       const w = await openTheWindow({
         show: false,
         webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
           zoomFactor: 1.2
         }
       })


### PR DESCRIPTION
#### Description of Change
The previous default values have been deprecated in Electron 4.0. Follow up to https://github.com/electron/electron/pull/15045 and https://github.com/electron/electron/pull/16004.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes
Notes: The default values of `nodeIntegration` and `webviewTag` are now `false` to improve security.