### PR TITLE
refactor: pass isWebViewTagEnabled via ELECTRON_BROWSER_SANDBOX_LOAD

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -328,8 +328,8 @@ const isWebViewTagEnabledCache = new WeakMap()
 
 const isWebViewTagEnabled = function (contents) {
   if (!isWebViewTagEnabledCache.has(contents)) {
-    const value = contents.getLastWebPreferences().webviewTag
-    isWebViewTagEnabledCache.set(contents, value)
+    const webPreferences = contents.getLastWebPreferences() || {}
+    isWebViewTagEnabledCache.set(contents, !!webPreferences.webviewTag)
   }
 
   return isWebViewTagEnabledCache.get(contents)
@@ -437,3 +437,4 @@ const getEmbedder = function (guestInstanceId) {
 }
 
 exports.getGuestForWebContents = getGuestForWebContents
+exports.isWebViewTagEnabled = isWebViewTagEnabled

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -504,6 +504,7 @@ ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
     preloadSrc,
     preloadError,
     isRemoteModuleEnabled: event.sender._isRemoteModuleEnabled(),
+    isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),
     process: {
       arch: process.arch,
       platform: process.platform,

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -29,7 +29,7 @@ Object.setPrototypeOf(process, EventEmitter.prototype)
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
 
 const {
-  preloadSrc, preloadError, isRemoteModuleEnabled, process: processProps
+  preloadSrc, preloadError, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
 } = ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 process.isRemoteModuleEnabled = isRemoteModuleEnabled
@@ -125,7 +125,7 @@ if (binding.guestInstanceId) {
   process.guestInstanceId = parseInt(binding.guestInstanceId)
 }
 
-if (!process.guestInstanceId && hasSwitch('webview-tag')) {
+if (!process.guestInstanceId && isWebViewTagEnabled) {
   // don't allow recursive `<webview>`
   require('@electron/internal/renderer/web-view/web-view').setupWebView(window)
 }


### PR DESCRIPTION
#### Description of Change
Passing options via command-line to a sandboxed renderer process is not safe as the process can be shared between multiple webContents.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
