### PR TITLE
fix: add default media usage strings to info.plist

### DIFF
--- a/atom/browser/resources/mac/Info.plist
+++ b/atom/browser/resources/mac/Info.plist
@@ -32,5 +32,9 @@
   <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSMicrophoneUsageDescription</key>
+	<string></string>
+  <key>NSCameraUsageDescription</key>
+	<string></string>
 </dict>
 </plist>

--- a/atom/browser/resources/mac/Info.plist
+++ b/atom/browser/resources/mac/Info.plist
@@ -33,8 +33,8 @@
   <key>NSHighResolutionCapable</key>
   <true/>
   <key>NSMicrophoneUsageDescription</key>
-  <string></string>
+  <string>This app needs access to the microphone</string>
   <key>NSCameraUsageDescription</key>
-  <string></string>
+  <string>This app needs access to the camera</string>
 </dict>
 </plist>

--- a/atom/browser/resources/mac/Info.plist
+++ b/atom/browser/resources/mac/Info.plist
@@ -33,8 +33,8 @@
   <key>NSHighResolutionCapable</key>
   <true/>
   <key>NSMicrophoneUsageDescription</key>
-	<string></string>
+  <string></string>
   <key>NSCameraUsageDescription</key>
-	<string></string>
+  <string></string>
 </dict>
 </plist>


### PR DESCRIPTION
#### Description of Change

This PR adds default keys to Info.plist for `NSMicrophoneUsageDescription` and `NSCameraUsageDescription`. This will simplify usage of the [media access apis](https://github.com/electron/electron/pull/15624) added for MacOS Mojave.

/cc @nornagon @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes

Notes: Added default `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` keys to Info.plist.
