### PR TITLE
feat: expose systemPreferences.getSystemColor()

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -91,6 +91,7 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::GetAppLevelAppearance)
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
+      .SetMethod("getSystemColor", &SystemPreferences::GetSystemColor)
       .SetMethod("isTrustedAccessibilityClient",
                  &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("getMediaAccessStatus",

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -95,6 +95,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 
+  std::string GetSystemColor(const std::string& color, mate::Arguments* args);
+
   bool IsTrustedAccessibilityClient(bool prompt);
 
   // TODO(codebytere): Write tests for these methods once we

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -105,12 +105,19 @@ std::string ConvertAuthorizationStatus(AVAuthorizationStatusMac status) {
   }
 }
 
-// Convert color to RGBA value like "#ABCDEF"
+// Convert color to RGBA value like "aabbccdd"
 std::string ToRGBA(NSColor* color) {
   return base::StringPrintf(
       "%02X%02X%02X%02X", (int)(color.redComponent * 0xFF),
       (int)(color.greenComponent * 0xFF), (int)(color.blueComponent * 0xFF),
       (int)(color.alphaComponent * 0xFF));
+}
+
+// Convert color to RGB hex value like "#ABCDEF"
+std::string ToRGBHex(NSColor* color) {
+  return base::StringPrintf("#%02X%02X%02X", (int)(color.redComponent * 0xFF),
+                            (int)(color.greenComponent * 0xFF),
+                            (int)(color.blueComponent * 0xFF));
 }
 
 }  // namespace
@@ -393,6 +400,41 @@ std::string SystemPreferences::GetAccentColor() {
     sysColor = [NSColor controlAccentColor];
 
   return ToRGBA(sysColor);
+}
+
+std::string SystemPreferences::GetSystemColor(const std::string& color,
+                                              mate::Arguments* args) {
+  if (@available(macOS 10.10, *)) {
+    NSColor* sysColor;
+    if (color == "blue") {
+      sysColor = [NSColor systemBlueColor];
+    } else if (color == "brown") {
+      sysColor = [NSColor systemBrownColor];
+    } else if (color == "gray") {
+      sysColor = [NSColor systemGrayColor];
+    } else if (color == "green") {
+      sysColor = [NSColor systemGreenColor];
+    } else if (color == "orange") {
+      sysColor = [NSColor systemOrangeColor];
+    } else if (color == "pink") {
+      sysColor = [NSColor systemPinkColor];
+    } else if (color == "purple") {
+      sysColor = [NSColor systemPurpleColor];
+    } else if (color == "red") {
+      sysColor = [NSColor systemRedColor];
+    } else if (color == "yellow") {
+      sysColor = [NSColor systemYellowColor];
+    } else {
+      args->ThrowError("Unknown system color: " + color);
+      return "";
+    }
+
+    return ToRGBHex(sysColor);
+  } else {
+    args->ThrowError(
+        "This api is not available on MacOS version 10.9 or lower.");
+    return "";
+  }
 }
 
 bool SystemPreferences::IsTrustedAccessibilityClient(bool prompt) {

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -40,6 +40,26 @@ typedef NS_ENUM(NSInteger, AVAuthorizationStatusMac) {
 @interface NSColor (MojaveSDK)
 @property(class, strong, readonly)
     NSColor* controlAccentColor API_AVAILABLE(macosx(10.14));
+
+// macOS system colors
+@property(class, strong, readonly)
+    NSColor* systemBlueColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemBrownColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemGrayColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemGreenColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemOrangeColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemPinkColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemPurpleColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemRedColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* systemYellowColor API_AVAILABLE(macosx(10.10));
 @end
 
 extern "C" {

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -291,6 +291,21 @@ See the [Windows docs][windows-colors] for more details.
 
 [windows-colors]:https://msdn.microsoft.com/en-us/library/windows/desktop/ms724371(v=vs.85).aspx
 
+### `systemPreferences.getSystemColor(color)` _macOS_
+
+* `color` String - One of the following values:
+  * `blue`
+  * `brown`
+  * `gray`
+  * `green`
+  * `orange`
+  * `pink`
+  * `purple`
+  * `red`
+  * `yellow`
+
+Returns one of several standard system colors that automatically adapt to vibrancy and changes in accessibility settings like 'Increase contrast' and 'Reduce transparency'. See [Apple Documentation](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color#system-colors) for  more details.
+
 ### `systemPreferences.isInvertedColorScheme()` _Windows_
 
 Returns `Boolean` - `true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is active, `false` otherwise.


### PR DESCRIPTION
#### Description of Change

Partially resolves https://github.com/electron/electron/issues/16246. There will be a second follow-up PR that adds MacOS support for [Dynamic Colors](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color#dynamic-system-colors) to the existing `systemPreferences.getColor()` method that already exists for Windows.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes

Notes: Add a way to query for system colors on MacOS via `systemPreferences.getSystemColor()`.
