### PR TITLE
feat: add mac support to systemPrefs.getColor()

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -56,11 +56,12 @@ void SystemPreferences::BuildPrototype(
   prototype->SetClassName(mate::StringToV8(isolate, "SystemPreferences"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
 #if defined(OS_WIN) || defined(OS_MACOSX)
+      .SetMethod("getColor", &SystemPreferences::GetColor)
       .SetMethod("getAccentColor", &SystemPreferences::GetAccentColor)
 #endif
+
 #if defined(OS_WIN)
       .SetMethod("isAeroGlassEnabled", &SystemPreferences::IsAeroGlassEnabled)
-      .SetMethod("getColor", &SystemPreferences::GetColor)
 #elif defined(OS_MACOSX)
       .SetMethod("postNotification", &SystemPreferences::PostNotification)
       .SetMethod("subscribeNotification",

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -51,12 +51,10 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
 #if defined(OS_WIN) || defined(OS_MACOSX)
   std::string GetAccentColor();
+  std::string GetColor(const std::string& color, mate::Arguments* args);
 #endif
-
 #if defined(OS_WIN)
   bool IsAeroGlassEnabled();
-
-  std::string GetColor(const std::string& color, mate::Arguments* args);
 
   void InitializeWindow();
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -442,6 +442,96 @@ bool SystemPreferences::IsTrustedAccessibilityClient(bool prompt) {
   return AXIsProcessTrustedWithOptions((CFDictionaryRef)options);
 }
 
+std::string SystemPreferences::GetColor(const std::string& color,
+                                        mate::Arguments* args) {
+  NSColor* sysColor = nil;
+  if (color == "alternate-selected-control-text") {
+    sysColor = [NSColor alternateSelectedControlTextColor];
+  } else if (color == "control-background") {
+    sysColor = [NSColor controlBackgroundColor];
+  } else if (color == "control") {
+    sysColor = [NSColor controlColor];
+  } else if (color == "control-text") {
+    sysColor = [NSColor controlTextColor];
+  } else if (color == "disabled-control") {
+    sysColor = [NSColor disabledControlTextColor];
+  } else if (color == "find-highlight") {
+    if (@available(macOS 10.14, *))
+      sysColor = [NSColor findHighlightColor];
+  } else if (color == "grid") {
+    sysColor = [NSColor gridColor];
+  } else if (color == "header-text") {
+    sysColor = [NSColor headerTextColor];
+  } else if (color == "highlight") {
+    sysColor = [NSColor highlightColor];
+  } else if (color == "keyboard-focus-indicator") {
+    sysColor = [NSColor keyboardFocusIndicatorColor];
+  } else if (color == "label") {
+    if (@available(macOS 10.10, *))
+      sysColor = [NSColor labelColor];
+  } else if (color == "link") {
+    if (@available(macOS 10.10, *))
+      sysColor = [NSColor linkColor];
+  } else if (color == "placeholder-text") {
+    if (@available(macOS 10.10, *))
+      sysColor = [NSColor placeholderTextColor];
+  } else if (color == "quaternary-label") {
+    if (@available(macOS 10.10, *))
+      sysColor = [NSColor quaternaryLabelColor];
+  } else if (color == "scrubber-textured-background") {
+    if (@available(macOS 10.12.2, *))
+      sysColor = [NSColor scrubberTexturedBackgroundColor];
+  } else if (color == "secondary-label") {
+    if (@available(macOS 10.10, *))
+      sysColor = [NSColor secondaryLabelColor];
+  } else if (color == "selected-content-background") {
+    if (@available(macOS 10.14, *))
+      sysColor = [NSColor selectedContentBackgroundColor];
+  } else if (color == "selected-control") {
+    sysColor = [NSColor selectedControlColor];
+  } else if (color == "selected-control-text") {
+    sysColor = [NSColor selectedControlTextColor];
+  } else if (color == "selected-menu-item-text") {
+    sysColor = [NSColor selectedMenuItemTextColor];
+  } else if (color == "selected-text-background") {
+    sysColor = [NSColor selectedTextBackgroundColor];
+  } else if (color == "selected-text") {
+    sysColor = [NSColor selectedTextColor];
+  } else if (color == "separator") {
+    if (@available(macOS 10.14, *))
+      sysColor = [NSColor separatorColor];
+  } else if (color == "shadow") {
+    sysColor = [NSColor shadowColor];
+  } else if (color == "tertiary-label") {
+    if (@available(macOS 10.10, *))
+      sysColor = [NSColor tertiaryLabelColor];
+  } else if (color == "text-background") {
+    sysColor = [NSColor textBackgroundColor];
+  } else if (color == "text") {
+    sysColor = [NSColor textColor];
+  } else if (color == "under-page-background") {
+    sysColor = [NSColor underPageBackgroundColor];
+  } else if (color == "unemphasized-selected-content-background") {
+    if (@available(macOS 10.14, *))
+      sysColor = [NSColor unemphasizedSelectedContentBackgroundColor];
+  } else if (color == "unemphasized-selected-text-background") {
+    if (@available(macOS 10.14, *))
+      sysColor = [NSColor unemphasizedSelectedTextBackgroundColor];
+  } else if (color == "unemphasized-selected-text") {
+    if (@available(macOS 10.14, *))
+      sysColor = [NSColor unemphasizedSelectedTextColor];
+  } else if (color == "window-background") {
+    sysColor = [NSColor windowBackgroundColor];
+  } else if (color == "window-frame-text") {
+    sysColor = [NSColor windowFrameTextColor];
+  } else {
+    args->ThrowError("Unknown color: " + color);
+    return "";
+  }
+
+  return ToRGBHex(sysColor);
+}
+
 std::string SystemPreferences::GetMediaAccessStatus(
     const std::string& media_type,
     mate::Arguments* args) {

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -60,6 +60,26 @@ typedef NS_ENUM(NSInteger, AVAuthorizationStatusMac) {
     NSColor* systemRedColor API_AVAILABLE(macosx(10.10));
 @property(class, strong, readonly)
     NSColor* systemYellowColor API_AVAILABLE(macosx(10.10));
+
+// misc dynamic colors declarations
+@property(class, strong, readonly)
+    NSColor* linkColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* placeholderTextColor API_AVAILABLE(macosx(10.10));
+@property(class, strong, readonly)
+    NSColor* findHighlightColor API_AVAILABLE(macosx(10.13));
+@property(class, strong, readonly)
+    NSColor* separatorColor API_AVAILABLE(macosx(10.14));
+@property(class, strong, readonly)
+    NSColor* selectedContentBackgroundColor API_AVAILABLE(macosx(10.14));
+@property(class, strong, readonly)
+    NSColor* unemphasizedSelectedContentBackgroundColor API_AVAILABLE(
+        macosx(10.14));
+@property(class, strong, readonly)
+    NSColor* unemphasizedSelectedTextBackgroundColor API_AVAILABLE(macosx(10.14)
+    );
+@property(class, strong, readonly)
+    NSColor* unemphasizedSelectedTextColor API_AVAILABLE(macosx(10.14));
 @end
 
 extern "C" {

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -242,54 +242,90 @@ const alpha = color.substr(6, 2) // "dd"
 
 This API is only available on macOS 10.14 Mojave or newer.
 
-### `systemPreferences.getColor(color)` _Windows_
+### `systemPreferences.getColor(color)` _Windows_ _macOS_
 
 * `color` String - One of the following values:
-  * `3d-dark-shadow` - Dark shadow for three-dimensional display elements.
-  * `3d-face` - Face color for three-dimensional display elements and for dialog
-    box backgrounds.
-  * `3d-highlight` - Highlight color for three-dimensional display elements.
-  * `3d-light` - Light color for three-dimensional display elements.
-  * `3d-shadow` - Shadow color for three-dimensional display elements.
-  * `active-border` - Active window border.
-  * `active-caption` - Active window title bar. Specifies the left side color in
-    the color gradient of an active window's title bar if the gradient effect is
-    enabled.
-  * `active-caption-gradient` - Right side color in the color gradient of an
-    active window's title bar.
-  * `app-workspace` - Background color of multiple document interface (MDI)
-    applications.
-  * `button-text` - Text on push buttons.
-  * `caption-text` - Text in caption, size box, and scroll bar arrow box.
-  * `desktop` - Desktop background color.
-  * `disabled-text` - Grayed (disabled) text.
-  * `highlight` - Item(s) selected in a control.
-  * `highlight-text` - Text of item(s) selected in a control.
-  * `hotlight` - Color for a hyperlink or hot-tracked item.
-  * `inactive-border` - Inactive window border.
-  * `inactive-caption` - Inactive window caption. Specifies the left side color
-    in the color gradient of an inactive window's title bar if the gradient
-    effect is enabled.
-  * `inactive-caption-gradient` - Right side color in the color gradient of an
-    inactive window's title bar.
-  * `inactive-caption-text` - Color of text in an inactive caption.
-  * `info-background` - Background color for tooltip controls.
-  * `info-text` - Text color for tooltip controls.
-  * `menu` - Menu background.
-  * `menu-highlight` - The color used to highlight menu items when the menu
-    appears as a flat menu.
-  * `menubar` - The background color for the menu bar when menus appear as flat
-    menus.
-  * `menu-text` - Text in menus.
-  * `scrollbar` - Scroll bar gray area.
-  * `window` - Window background.
-  * `window-frame` - Window frame.
-  * `window-text` - Text in windows.
+  * On **Windows**:
+    * `3d-dark-shadow` - Dark shadow for three-dimensional display elements.
+    * `3d-face` - Face color for three-dimensional display elements and for dialog
+      box backgrounds.
+    * `3d-highlight` - Highlight color for three-dimensional display elements.
+    * `3d-light` - Light color for three-dimensional display elements.
+    * `3d-shadow` - Shadow color for three-dimensional display elements.
+    * `active-border` - Active window border.
+    * `active-caption` - Active window title bar. Specifies the left side color in
+      the color gradient of an active window's title bar if the gradient effect is
+      enabled.
+    * `active-caption-gradient` - Right side color in the color gradient of an
+      active window's title bar.
+    * `app-workspace` - Background color of multiple document interface (MDI)
+      applications.
+    * `button-text` - Text on push buttons.
+    * `caption-text` - Text in caption, size box, and scroll bar arrow box.
+    * `desktop` - Desktop background color.
+    * `disabled-text` - Grayed (disabled) text.
+    * `highlight` - Item(s) selected in a control.
+    * `highlight-text` - Text of item(s) selected in a control.
+    * `hotlight` - Color for a hyperlink or hot-tracked item.
+    * `inactive-border` - Inactive window border.
+    * `inactive-caption` - Inactive window caption. Specifies the left side color
+      in the color gradient of an inactive window's title bar if the gradient
+      effect is enabled.
+    * `inactive-caption-gradient` - Right side color in the color gradient of an
+      inactive window's title bar.
+    * `inactive-caption-text` - Color of text in an inactive caption.
+    * `info-background` - Background color for tooltip controls.
+    * `info-text` - Text color for tooltip controls.
+    * `menu` - Menu background.
+    * `menu-highlight` - The color used to highlight menu items when the menu
+      appears as a flat menu.
+    * `menubar` - The background color for the menu bar when menus appear as flat
+      menus.
+    * `menu-text` - Text in menus.
+    * `scrollbar` - Scroll bar gray area.
+    * `window` - Window background.
+    * `window-frame` - Window frame.
+    * `window-text` - Text in windows.
+  * On **macOS**
+    * `alternate-selected-control-text` - The text on a selected surface in a list or table.
+    * `control-background` - The background of a large interface element, such as a browser or table.
+    * `control` - The surface of a control.
+    * `control-text` -The text of a control that isn’t disabled.
+    * `disabled-control-text` - The text of a control that’s disabled.
+    * `find-highlight` - The color of a find indicator.
+    * `grid` - The gridlines of an interface element such as a table.
+    * `header-text` - The text of a header cell in a table.
+    * `highlight` - The virtual light source onscreen.
+    * `keyboard-focus-indicator` - The ring that appears around the currently focused control when using the keyboard for interface navigation.
+    * `label` - The text of a label containing primary content.
+    * `link` - A link to other content.
+    * `placeholder-text` -  A placeholder string in a control or text view.
+    * `quaternary-label` - The text of a label of lesser importance than a tertiary label such as watermark text.
+    * `scrubber-textured-background` - The background of a scrubber in the Touch Bar.
+    * `secondary-label` - The text of a label of lesser importance than a normal label such as a label used to represent a subheading or additional information.
+    * `selected-content-background` - The background for selected content in a key window or view.
+    * `selected-control` - The surface of a selected control.
+    * `selected-control-text` - The text of a selected control.
+    * `selected-menu-item` - The text of a selected menu.
+    * `selected-text-background` - The background of selected text.
+    * `selected-text` - Selected text.
+    * `separator` - A separator between different sections of content.
+    * `shadow` - The virtual shadow cast by a raised object onscreen.
+    * `tertiary-label` - The text of a label of lesser importance than a secondary label such as a label used to represent disabled text.
+    * `text-background` - Text background.
+    * `text` -  The text in a document.
+    * `under-page-background` -  The background behind a document's content.
+    * `unemphasized-selected-content-background` - The selected content in a non-key window or view.
+    * `unemphasized-selected-text-background` - A background for selected text in a non-key window or view.
+    * `unemphasized-selected-text` - Selected text in a non-key window or view.
+    * `window-background` - The background of a window.
+    * `window-frame-text` - The text in the window's titlebar area.	
 
 Returns `String` - The system color setting in RGB hexadecimal form (`#ABCDEF`).
-See the [Windows docs][windows-colors] for more details.
+See the [Windows docs][windows-colors] and the [MacOS docs][macos-colors] for more details.
 
 [windows-colors]:https://msdn.microsoft.com/en-us/library/windows/desktop/ms724371(v=vs.85).aspx
+[macos-colors]:https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color#dynamic-system-colors
 
 ### `systemPreferences.getSystemColor(color)` _macOS_
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16246. Adds MacOS support to `systemPreferences.getColor()`.

**TODO**
- [x] documentation updates 
- [x] `@available` wrapping around newer apis

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes

Notes: Added macOS support to `systemPreferences.getColor()`.
