### PR TITLE
feat: add mac support to systemPrefs.getAccentColor()

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -55,8 +55,10 @@ void SystemPreferences::BuildPrototype(
     v8::Local<v8::FunctionTemplate> prototype) {
   prototype->SetClassName(mate::StringToV8(isolate, "SystemPreferences"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
-#if defined(OS_WIN)
+#if defined(OS_WIN) || defined(OS_MACOSX)
       .SetMethod("getAccentColor", &SystemPreferences::GetAccentColor)
+#endif
+#if defined(OS_WIN)
       .SetMethod("isAeroGlassEnabled", &SystemPreferences::IsAeroGlassEnabled)
       .SetMethod("getColor", &SystemPreferences::GetColor)
 #elif defined(OS_MACOSX)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -49,10 +49,13 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
+#if defined(OS_WIN) || defined(OS_MACOSX)
+  std::string GetAccentColor();
+#endif
+
 #if defined(OS_WIN)
   bool IsAeroGlassEnabled();
 
-  std::string GetAccentColor();
   std::string GetColor(const std::string& color, mate::Arguments* args);
 
   void InitializeWindow();

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -104,6 +104,17 @@ std::string ConvertAuthorizationStatus(AVAuthorizationStatusMac status) {
   }
 }
 
+// Convert color to RGBA value like "#ABCDEF"
+std::string ToRGBA(NSColor* color) {
+  NSString* rgbHex = [NSString
+      stringWithFormat:@"%02X%02X%02X%02X", (int)(color.redComponent * 0xFF),
+                       (int)(color.greenComponent * 0xFF),
+                       (int)(color.blueComponent * 0xFF),
+                       (int)(color.alphaComponent * 0xFF)];
+
+  return std::string([rgbHex UTF8String]);
+}
+
 }  // namespace
 
 void SystemPreferences::PostNotification(const std::string& name,
@@ -376,6 +387,14 @@ void SystemPreferences::SetUserDefault(const std::string& name,
     args->ThrowError("Invalid type: " + type);
     return;
   }
+}
+
+std::string SystemPreferences::GetAccentColor() {
+  NSColor* sysColor = nil;
+  if (@available(macOS 10.14, *))
+    sysColor = [NSColor controlAccentColor];
+
+  return ToRGBA(sysColor);
 }
 
 bool SystemPreferences::IsTrustedAccessibilityClient(bool prompt) {

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -227,7 +227,7 @@ if (browserOptions.transparent) {
 
 [dwm-composition]:https://msdn.microsoft.com/en-us/library/windows/desktop/aa969540.aspx
 
-### `systemPreferences.getAccentColor()` _Windows_
+### `systemPreferences.getAccentColor()` _Windows_ _macOS_
 
 Returns `String` - The users current system wide accent color preference in RGBA
 hexadecimal form.


### PR DESCRIPTION
#### Description of Change

Add MacOS support for `systemPreferences.getAccentColor()`.

/cc @miniak

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes

Notes: Add MacOS support for `systemPreferences.getAccentColor()`.
