### PR TITLE
ci: re-enable logging on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ steps-tests: &steps-tests
         command: |
           cd src
           export ELECTRON_OUT_DIR=Default
-          (cd electron && npm run test -- --ci)
+          (cd electron && npm run test -- --ci --enable-logging)
     - run:
         name: Check test results existence
         command: |

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -79,7 +79,7 @@ steps:
 
 - bash: |
    cd src
-   ./out/Default/electron electron/spec --ci
+   ./out/Default/electron electron/spec --ci --enable-logging
   displayName: 'Run Electron tests'
   timeoutInMinutes: 10
 

--- a/vsts.yml
+++ b/vsts.yml
@@ -360,7 +360,7 @@ jobs:
 
   - bash: |
       export ELECTRON_OUT_DIR=Default
-      (cd src/electron && npm run test -- --ci)
+      (cd src/electron && npm run test -- --ci --enable-logging)
     displayName: Run Electron test suite
     timeoutInMinutes: 10
 


### PR DESCRIPTION
This reverts commit a5c3091c34efdadd388e09d003e57e8e88d6c6a9.

Hoping that the underlying issue was fixed by #15555

Notes: no-notes