### PR TITLE
fix: error if a11y support changed before ready

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1022,7 +1022,14 @@ bool App::IsAccessibilitySupportEnabled() {
   return ax_state->IsAccessibleBrowser();
 }
 
-void App::SetAccessibilitySupportEnabled(bool enabled) {
+void App::SetAccessibilitySupportEnabled(bool enabled, mate::Arguments* args) {
+  if (!Browser::Get()->is_ready()) {
+    args->ThrowError(
+        "app.setAccessibilitySupportEnabled() can only be called "
+        "after app is ready");
+    return;
+  }
+
   auto* ax_state = content::BrowserAccessibilityState::GetInstance();
   if (enabled) {
     ax_state->OnScreenReaderDetected();

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -192,7 +192,7 @@ class App : public AtomBrowserClient::Delegate,
   void DisableHardwareAcceleration(mate::Arguments* args);
   void DisableDomainBlockingFor3DAPIs(mate::Arguments* args);
   bool IsAccessibilitySupportEnabled();
-  void SetAccessibilitySupportEnabled(bool enabled);
+  void SetAccessibilitySupportEnabled(bool enabled, mate::Arguments* args);
   Browser::LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1098,8 +1098,10 @@ details.
 
 * `enabled` Boolean - Enable or disable [accessibility tree](https://developers.google.com/web/fundamentals/accessibility/semantics-builtin/the-accessibility-tree) rendering
 
-Manually enables Chrome's accessibility support, allowing to expose accessibility switch to users in application settings. https://www.chromium.org/developers/design-documents/accessibility for more
+Manually enables Chrome's accessibility support, allowing to expose accessibility switch to users in application settings. See [Chromium's accessibility docs](https://www.chromium.org/developers/design-documents/accessibility) for more
 details. Disabled by default.
+
+This API must be called after the `ready` event is emitted.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16256.

Starting with `v4.0.0`, `app.setAccessibilitySupportEnabled()` can only be called after the `ready` event is emitted. This clarifies that in documentation and ensures that an error is thrown so the method does not crash.

/cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Throw an error if `app.setAccessibilitySupportEnabled()` is called before the `ready` event is emitted.
