### PR TITLE
fix: don't register some shortcuts without accessibility

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -83,6 +83,8 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::GetAppLevelAppearance)
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
+      .SetMethod("isTrustedAccessibilityClient",
+                 &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("getMediaAccessStatus",
                  &SystemPreferences::GetMediaAccessStatus)
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -91,6 +91,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 
+  static bool IsTrustedAccessibilityClient(bool prompt);
+
   // TODO(codebytere): Write tests for these methods once we
   // are running tests on a Mojave machine
   std::string GetMediaAccessStatus(const std::string& media_type,

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -386,6 +386,12 @@ void SystemPreferences::SetUserDefault(const std::string& name,
   }
 }
 
+// static
+bool SystemPreferences::IsTrustedAccessibilityClient(bool prompt) {
+  NSDictionary* options = @{(id)kAXTrustedCheckOptionPrompt : @(prompt)};
+  return AXIsProcessTrustedWithOptions((CFDictionaryRef)options);
+}
+
 std::string SystemPreferences::GetMediaAccessStatus(
     const std::string& media_type,
     mate::Arguments* args) {

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -54,6 +54,14 @@ When the accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
+The following accelerators will not be registered successfully on macOS 10.14 Mojave unless
+the app has been authorized as a [trusted accessibility client](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html):
+
+* "Media Play/Pause"
+* "Media Next Track"
+* "Media Previous Track"
+* "Media Stop"
+
 ### `globalShortcut.isRegistered(accelerator)`
 
 * `accelerator` [Accelerator](accelerator.md)

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -317,6 +317,12 @@ You can use the `setAppLevelAppearance` API to set this value.
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
 
+### `systemPreferences.isTrustedAccessibilityClient(prompt)` _macOS_
+
+* `prompt` Boolean - whether or not the user will be informed via prompt if the current process is untrusted.
+
+Returns `Boolean` - `true` if the current process is a trusted accessibility client and `false` if it is not.
+
 ### `systemPreferences.getMediaAccessStatus(mediaType)` _macOS_
 
 * `mediaType` String - `microphone` or `camera`.


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/16125 to `4-0-x`. Also backports https://github.com/electron/electron/pull/16119, as it's required for the fix impl.

See those PRs for more details.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash on macOS when using `globalShortcut` for media keys when accessibility access is not granted.
