### PR TITLE
feat: add app.commandLine.hasSwitch() / app.commandLine.getSwitchValue()

### DIFF
--- a/atom/common/api/atom_api_command_line.cc
+++ b/atom/common/api/atom_api_command_line.cc
@@ -36,9 +36,9 @@ void AppendSwitch(const std::string& switch_string, mate::Arguments* args) {
     return;
   }
 
-  std::string value;
+  base::CommandLine::StringType value;
   if (args->GetNext(&value))
-    command_line->AppendSwitchASCII(switch_string, value);
+    command_line->AppendSwitchNative(switch_string, value);
   else
     command_line->AppendSwitch(switch_string);
 }

--- a/atom/common/api/atom_api_command_line.cc
+++ b/atom/common/api/atom_api_command_line.cc
@@ -2,10 +2,14 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/strings/string_util.h"
 #include "native_mate/converter.h"
 #include "native_mate/dictionary.h"
+#include "services/network/public/cpp/network_switches.h"
 
 #include "atom/common/node_includes.h"
 
@@ -20,13 +24,36 @@ base::CommandLine::StringType GetSwitchValue(const std::string& name) {
       name.c_str());
 }
 
+void AppendSwitch(const std::string& switch_string, mate::Arguments* args) {
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+
+  if (base::EndsWith(switch_string, "-path",
+                     base::CompareCase::INSENSITIVE_ASCII) ||
+      switch_string == network::switches::kLogNetLog) {
+    base::FilePath path;
+    args->GetNext(&path);
+    command_line->AppendSwitchPath(switch_string, path);
+    return;
+  }
+
+  std::string value;
+  if (args->GetNext(&value))
+    command_line->AppendSwitchASCII(switch_string, value);
+  else
+    command_line->AppendSwitch(switch_string);
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   mate::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("hasSwitch", &HasSwitch);
   dict.SetMethod("getSwitchValue", &GetSwitchValue);
+  dict.SetMethod("appendSwitch", &AppendSwitch);
+  dict.SetMethod("appendArgument", base::Bind(&base::CommandLine::AppendArg,
+                                              base::Unretained(command_line)));
 }
 
 }  // namespace

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1159,6 +1159,20 @@ correctly.
 
 **Note:** This will not affect `process.argv`.
 
+### `app.commandLine.hasSwitch(switch)`
+
+* `switch` String - A command-line switch
+
+Returns `Boolean` - Whether the command-line switch is present.
+
+### `app.commandLine.getSwitchValue(switch)`
+
+* `switch` String - A command-line switch
+
+Returns `String` - The command-line switch value.
+
+**Note:** When the switch is not present, it returns empty string.
+
 ### `app.enableSandbox()` _Experimental_ _macOS_ _Windows_
 
 Enables full sandbox mode on the app.

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const bindings = process.atomBinding('app')
+const commandLine = process.atomBinding('command_line')
 const path = require('path')
 const { app, App } = bindings
 
@@ -17,6 +18,12 @@ let dockMenu = null
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 EventEmitter.call(app)
 
+const castArgs = function (args) {
+  return args.map((arg) => {
+    return typeof arg !== 'string' ? `${arg}` : arg
+  })
+}
+
 Object.assign(app, {
   setApplicationMenu (menu) {
     return Menu.setApplicationMenu(menu)
@@ -25,19 +32,10 @@ Object.assign(app, {
     return Menu.getApplicationMenu()
   },
   commandLine: {
-    ...process.atomBinding('command_line'),
-    appendSwitch (...args) {
-      const castedArgs = args.map((arg) => {
-        return typeof arg !== 'string' ? `${arg}` : arg
-      })
-      return bindings.appendSwitch(...castedArgs)
-    },
-    appendArgument (...args) {
-      const castedArgs = args.map((arg) => {
-        return typeof arg !== 'string' ? `${arg}` : arg
-      })
-      return bindings.appendArgument(...castedArgs)
-    }
+    hasSwitch: (...args) => commandLine.hasSwitch(...castArgs(args)),
+    getSwitchValue: (...args) => commandLine.getSwitchValue(...castArgs(args)),
+    appendSwitch: (...args) => commandLine.appendSwitch(...castArgs(args)),
+    appendArgument: (...args) => commandLine.appendArgument(...castArgs(args))
   }
 })
 

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -18,12 +18,6 @@ let dockMenu = null
 Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 EventEmitter.call(app)
 
-const castArgs = function (args) {
-  return args.map((arg) => {
-    return typeof arg !== 'string' ? `${arg}` : arg
-  })
-}
-
 Object.assign(app, {
   setApplicationMenu (menu) {
     return Menu.setApplicationMenu(menu)
@@ -32,10 +26,10 @@ Object.assign(app, {
     return Menu.getApplicationMenu()
   },
   commandLine: {
-    hasSwitch: (...args) => commandLine.hasSwitch(...castArgs(args)),
-    getSwitchValue: (...args) => commandLine.getSwitchValue(...castArgs(args)),
-    appendSwitch: (...args) => commandLine.appendSwitch(...castArgs(args)),
-    appendArgument: (...args) => commandLine.appendArgument(...castArgs(args))
+    hasSwitch: (...args) => commandLine.hasSwitch(...args.map(String)),
+    getSwitchValue: (...args) => commandLine.getSwitchValue(...args.map(String)),
+    appendSwitch: (...args) => commandLine.appendSwitch(...args.map(String)),
+    appendArgument: (...args) => commandLine.appendArgument(...args.map(String))
   }
 })
 

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -25,6 +25,7 @@ Object.assign(app, {
     return Menu.getApplicationMenu()
   },
   commandLine: {
+    ...process.atomBinding('command_line'),
     appendSwitch (...args) {
       const castedArgs = args.map((arg) => {
         return typeof arg !== 'string' ? `${arg}` : arg

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -1118,8 +1118,8 @@ describe('app module', () => {
 
   describe('commandLine.getSwitchValue', () => {
     it('returns the value when present', () => {
-      app.commandLine.appendSwitch('foobar', 'test')
-      expect(app.commandLine.getSwitchValue('foobar')).to.equal('test')
+      app.commandLine.appendSwitch('foobar', 'æøåü')
+      expect(app.commandLine.getSwitchValue('foobar')).to.equal('æøåü')
     })
 
     it('returns an empty string when present without value', () => {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -6,6 +6,7 @@ const https = require('https')
 const net = require('net')
 const fs = require('fs')
 const path = require('path')
+const cp = require('child_process')
 const { ipcRenderer, remote } = require('electron')
 const { emittedOnce } = require('./events-helpers')
 const { closeWindow } = require('./window-helpers')
@@ -1103,6 +1104,18 @@ describe('app module', () => {
     })
   })
 
+  describe('commandLine.hasSwitch (existing argv)', () => {
+    it('returns true when present', async () => {
+      const { hasSwitch } = await runCommandLineTestApp('--foobar')
+      expect(hasSwitch).to.be.true()
+    })
+
+    it('returns false when not present', async () => {
+      const { hasSwitch } = await runCommandLineTestApp()
+      expect(hasSwitch).to.be.false()
+    })
+  })
+
   describe('commandLine.getSwitchValue', () => {
     it('returns the value when present', () => {
       app.commandLine.appendSwitch('foobar', 'test')
@@ -1118,4 +1131,34 @@ describe('app module', () => {
       expect(app.commandLine.getSwitchValue('foobar2')).to.equal('')
     })
   })
+
+  describe('commandLine.getSwitchValue (existing argv)', () => {
+    it('returns the value when present', async () => {
+      const { getSwitchValue } = await runCommandLineTestApp('--foobar=test')
+      expect(getSwitchValue).to.equal('test')
+    })
+
+    it('returns an empty string when present without value', async () => {
+      const { getSwitchValue } = await runCommandLineTestApp('--foobar')
+      expect(getSwitchValue).to.equal('')
+    })
+
+    it('returns an empty string when not present', async () => {
+      const { getSwitchValue } = await runCommandLineTestApp()
+      expect(getSwitchValue).to.equal('')
+    })
+  })
+
+  async function runCommandLineTestApp (...args) {
+    const appPath = path.join(__dirname, 'fixtures', 'api', 'command-line')
+    const electronPath = remote.getGlobal('process').execPath
+    const appProcess = cp.spawn(electronPath, [appPath, ...args])
+
+    let output = ''
+    appProcess.stdout.on('data', (data) => { output += data })
+
+    await emittedOnce(appProcess.stdout, 'end')
+
+    return JSON.parse(output)
+  }
 })

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -1091,4 +1091,31 @@ describe('app module', () => {
       return expect(app.whenReady()).to.be.eventually.fulfilled
     })
   })
+
+  describe('commandLine.hasSwitch', () => {
+    it('returns true when present', () => {
+      app.commandLine.appendSwitch('foobar1')
+      expect(app.commandLine.hasSwitch('foobar1')).to.be.true()
+    })
+
+    it('returns false when not present', () => {
+      expect(app.commandLine.hasSwitch('foobar2')).to.be.false()
+    })
+  })
+
+  describe('commandLine.getSwitchValue', () => {
+    it('returns the value when present', () => {
+      app.commandLine.appendSwitch('foobar', 'test')
+      expect(app.commandLine.getSwitchValue('foobar')).to.equal('test')
+    })
+
+    it('returns an empty string when present without value', () => {
+      app.commandLine.appendSwitch('foobar1')
+      expect(app.commandLine.getSwitchValue('foobar1')).to.equal('')
+    })
+
+    it('returns an empty string when not present', () => {
+      expect(app.commandLine.getSwitchValue('foobar2')).to.equal('')
+    })
+  })
 })

--- a/spec/fixtures/api/command-line/main.js
+++ b/spec/fixtures/api/command-line/main.js
@@ -1,0 +1,15 @@
+const { app } = require('electron')
+
+app.on('ready', () => {
+  const payload = {
+    hasSwitch: app.commandLine.hasSwitch('foobar'),
+    getSwitchValue: app.commandLine.getSwitchValue('foobar')
+  }
+
+  process.stdout.write(JSON.stringify(payload))
+  process.stdout.end()
+
+  setImmediate(() => {
+    app.quit()
+  })
+})

--- a/spec/fixtures/api/command-line/package.json
+++ b/spec/fixtures/api/command-line/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "command-line",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change
Expose the following APIs, which we are already using internally in [lib/renderer/init.js](https://github.com/electron/electron/blob/9cc3fbabf73cdb2d59fd492cb1fb39a9b24f1bb3/lib/renderer/init.js#L34)
- `app.commandLine.hasSwitch()`
- `app.commandLine.getSwitchValue()`

These methods are useful for parsing command-line options in robust way without having to use external libraries.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `app.commandLine.hasSwitch()` / `app.commandLine.getSwitchValue()`