### PR TITLE
feat: add --vanilla command-line option to default_app

### DIFF
--- a/default_app/default_app.js
+++ b/default_app/default_app.js
@@ -1,12 +1,16 @@
 const { app, BrowserWindow } = require('electron')
 const path = require('path')
 
+const { setDefaultApplicationMenu } = require('./menu')
+
 let mainWindow = null
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   app.quit()
 })
+
+setDefaultApplicationMenu()
 
 exports.load = async (appUrl) => {
   await app.whenReady()

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -13,6 +13,7 @@ const argv = process.argv.slice(1)
 const option = {
   file: null,
   noHelp: Boolean(process.env.ELECTRON_NO_HELP),
+  vanilla: false,
   version: null,
   webdriver: null,
   modules: []
@@ -44,6 +45,9 @@ for (const arg of argv) {
   } else if (arg === '--no-help') {
     option.noHelp = true
     continue
+  } else if (arg === '--vanilla') {
+    option.vanilla = true
+    continue
   } else if (arg[0] === '-') {
     continue
   } else {
@@ -57,17 +61,19 @@ if (nextArgIsRequire) {
   process.exit(1)
 }
 
-// Quit when all windows are closed and no other one is listening to this.
-app.on('window-all-closed', () => {
-  if (app.listeners('window-all-closed').length === 1 && !option.interactive) {
-    app.quit()
-  }
-})
+if (!option.vanilla) {
+  // Quit when all windows are closed and no other one is listening to this.
+  app.on('window-all-closed', () => {
+    if (app.listeners('window-all-closed').length === 1 && !option.interactive) {
+      app.quit()
+    }
+  })
 
-// Create default menu.
-app.once('ready', () => {
-  setDefaultApplicationMenu()
-})
+  // Create default menu.
+  app.once('ready', () => {
+    setDefaultApplicationMenu()
+  })
+}
 
 // Set up preload modules
 if (option.modules.length > 0) {
@@ -188,7 +194,9 @@ Options:
   -i, --interactive     Open a REPL to the main process.
   -r, --require         Module to preload (option can be repeated).
   -v, --version         Print the version.
-  -a, --abi             Print the Node ABI version.`
+  -a, --abi             Print the Node ABI version.
+  --no-help             Don't print this usage documentation.
+  --vanilla             Don't change behavior (default menu, etc.) when running a packaged app.`
 
     console.log(welcomeMessage)
   }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
- [ ] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `--vanilla` command-line option to default_app allowing to prevent changing behavior (default menu, etc.) when running a packaged app.