### PR TITLE
chore: improve docs for new docs parser, fixes errors caught by the new parser

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1105,7 +1105,7 @@ This API must be called after the `ready` event is emitted.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 
-### `app.showAboutPanel` _macOS_ _Linux_
+### `app.showAboutPanel()` _macOS_ _Linux_
 
 Show the app's about panel options. These options can be overridden with `app.setAboutPanelOptions(options)`.
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -9,8 +9,6 @@ A `BrowserView` can be used to embed additional web content into a
 relative to its owning window. It is meant to be an alternative to the
 `webview` tag.
 
-## Example
-
 ```javascript
 // In the main process.
 const { BrowserView, BrowserWindow } = require('electron')

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1225,7 +1225,7 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 
-* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
+Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 

--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -51,7 +51,7 @@ A `String` representing the HTTP status message.
 
 #### `response.headers`
 
-An `Object` representing the response HTTP headers. The `headers` object is
+A `Record<string, string[]>` (an Object) representing the response HTTP headers. The `headers` object is
 formatted as follows:
 
 * All header names are lowercased.

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -201,7 +201,7 @@ process.
 
 ### `remote.process`
 
-The `process` object in the main process. This is the same as
+A `NodeJS.Process` object in the main process. This is the same as
 `remote.getGlobal('process')` but is cached.
 
 [rmi]: https://en.wikipedia.org/wiki/Java_remote_method_invocation

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -430,15 +430,15 @@ The following properties are available on instances of `Session`:
 
 #### `ses.cookies`
 
-A [Cookies](cookies.md) object for this session.
+A [`Cookies`](cookies.md) object for this session.
 
 #### `ses.webRequest`
 
-A [WebRequest](web-request.md) object for this session.
+A [`WebRequest`](web-request.md) object for this session.
 
 #### `ses.protocol`
 
-A [Protocol](protocol.md) object for this session.
+A [`Protocol`](protocol.md) object for this session.
 
 ```javascript
 const { app, session } = require('electron')
@@ -457,7 +457,7 @@ app.on('ready', function () {
 
 #### `ses.netLog`
 
-A [NetLog](net-log.md) object for this session.
+A [`NetLog`](net-log.md) object for this session.
 
 ```javascript
 const { app, session } = require('electron')

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1088,7 +1088,7 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
-* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
+Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
@@ -1592,6 +1592,6 @@ when the DevTools has been closed.
 
 #### `contents.debugger`
 
-A [Debugger](debugger.md) instance for this webContents.
+A [`Debugger`](debugger.md) instance for this webContents.
 
 [keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -554,7 +554,7 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
-* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
+Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 


### PR DESCRIPTION
Fixes a few weird docs syntax issues that the new parser did not approve of (do not follow our guidelines / standard)

Notes: no-notes