### PR TITLE
fix: subclass of BrowserWindow cannot use dialog API

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -22,7 +22,7 @@ const messageBoxOptions = {
 }
 
 const parseArgs = function (window, options, callback, ...args) {
-  if (window != null && window.constructor !== BrowserWindow) {
+  if (window != null && !(window instanceof BrowserWindow)) {
     // Shift.
     [callback, options, window] = [options, window, null]
   }


### PR DESCRIPTION
#### Description of Change

Make subclass of BrowserWindow can use dialog API

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes
