### PR TITLE
fix: enable autofill popups on mac

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -397,8 +397,6 @@ static_library("electron_lib") {
       "*_views.cc",
       "*_views.h",
       "*\bviews/*",
-      "*/autofill_popup.cc",
-      "*/autofill_popup.h",
     ]
   }
 
@@ -422,6 +420,10 @@ static_library("electron_lib") {
     deps += [
       "//third_party/crashpad/crashpad/client",
       "//ui/accelerated_widget_mac",
+    ]
+    sources += [
+      "atom/browser/ui/views/autofill_popup_view.cc",
+      "atom/browser/ui/views/autofill_popup_view.h",
     ]
     include_dirs += [
       # NOTE(nornagon): other chromium files use the full path to include

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -586,7 +586,7 @@ void WebContents::SetContentsBounds(content::WebContents* source,
 
 void WebContents::CloseContents(content::WebContents* source) {
   Emit("close");
-#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
+#if defined(TOOLKIT_VIEWS)
   HideAutofillPopup();
 #endif
   if (managed_web_contents())
@@ -1015,7 +1015,7 @@ void WebContents::DevToolsClosed() {
   Emit("devtools-closed");
 }
 
-#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
+#if defined(TOOLKIT_VIEWS)
 void WebContents::ShowAutofillPopup(content::RenderFrameHost* frame_host,
                                     const gfx::RectF& bounds,
                                     const std::vector<base::string16>& values,
@@ -1063,7 +1063,7 @@ bool WebContents::OnMessageReceived(const IPC::Message& message,
         FrameDispatchHelper::OnSetTemporaryZoomLevel)
     IPC_MESSAGE_FORWARD_DELAY_REPLY(AtomFrameHostMsg_GetZoomLevel, &helper,
                                     FrameDispatchHelper::OnGetZoomLevel)
-#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
+#if defined(TOOLKIT_VIEWS)
     IPC_MESSAGE_HANDLER(AtomAutofillFrameHostMsg_ShowPopup, ShowAutofillPopup)
     IPC_MESSAGE_HANDLER(AtomAutofillFrameHostMsg_HidePopup, HideAutofillPopup)
 #endif

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -629,7 +629,6 @@ void CommonWebContentsDelegate::ShowAutofillPopup(
   if (!owner_window())
     return;
 
-  // auto* window = static_cast<NativeWindow*>(owner_window());
   autofill_popup_->CreateView(frame_host, embedder_frame_host, offscreen,
                               owner_window()->content_view(), bounds);
   autofill_popup_->SetItems(values, labels);

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -206,7 +206,7 @@ void CommonWebContentsDelegate::SetOwnerWindow(
     NativeWindow* owner_window) {
   if (owner_window) {
     owner_window_ = owner_window->GetWeakPtr();
-#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
+#if defined(TOOLKIT_VIEWS)
     autofill_popup_.reset(new AutofillPopup());
 #endif
     NativeWindowRelay::CreateForWebContents(web_contents,
@@ -617,6 +617,27 @@ void CommonWebContentsDelegate::SetHtmlApiFullscreen(bool enter_fullscreen) {
   owner_window_->SetFullScreen(enter_fullscreen);
   html_fullscreen_ = enter_fullscreen;
   native_fullscreen_ = false;
+}
+
+void CommonWebContentsDelegate::ShowAutofillPopup(
+    content::RenderFrameHost* frame_host,
+    content::RenderFrameHost* embedder_frame_host,
+    bool offscreen,
+    const gfx::RectF& bounds,
+    const std::vector<base::string16>& values,
+    const std::vector<base::string16>& labels) {
+  if (!owner_window())
+    return;
+
+  // auto* window = static_cast<NativeWindow*>(owner_window());
+  autofill_popup_->CreateView(frame_host, embedder_frame_host, offscreen,
+                              owner_window()->content_view(), bounds);
+  autofill_popup_->SetItems(values, labels);
+}
+
+void CommonWebContentsDelegate::HideAutofillPopup() {
+  if (autofill_popup_)
+    autofill_popup_->Hide();
 }
 
 }  // namespace atom

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -18,7 +18,7 @@
 #include "content/public/browser/web_contents_delegate.h"
 #include "electron/buildflags/buildflags.h"
 
-#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
+#if defined(TOOLKIT_VIEWS)
 #include "atom/browser/ui/autofill_popup.h"
 #endif
 
@@ -105,7 +105,7 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
       const content::NativeWebKeyboardEvent& event) override;
 
   // Autofill related events.
-#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
+#if defined(TOOLKIT_VIEWS)
   void ShowAutofillPopup(content::RenderFrameHost* frame_host,
                          content::RenderFrameHost* embedder_frame_host,
                          bool offscreen,
@@ -175,7 +175,7 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
   bool native_fullscreen_ = false;
 
   // UI related helper classes.
-#if defined(TOOLKIT_VIEWS) && !defined(OS_MACOSX)
+#if defined(TOOLKIT_VIEWS)
   std::unique_ptr<AutofillPopup> autofill_popup_;
 #endif
   std::unique_ptr<WebDialogHelper> web_dialog_helper_;

--- a/atom/browser/common_web_contents_delegate_views.cc
+++ b/atom/browser/common_web_contents_delegate_views.cc
@@ -41,27 +41,6 @@ bool CommonWebContentsDelegate::HandleKeyboardEvent(
   return false;
 }
 
-void CommonWebContentsDelegate::ShowAutofillPopup(
-    content::RenderFrameHost* frame_host,
-    content::RenderFrameHost* embedder_frame_host,
-    bool offscreen,
-    const gfx::RectF& bounds,
-    const std::vector<base::string16>& values,
-    const std::vector<base::string16>& labels) {
-  if (!owner_window())
-    return;
-
-  auto* window = static_cast<NativeWindowViews*>(owner_window());
-  autofill_popup_->CreateView(frame_host, embedder_frame_host, offscreen,
-                              window->content_view(), bounds);
-  autofill_popup_->SetItems(values, labels);
-}
-
-void CommonWebContentsDelegate::HideAutofillPopup() {
-  if (autofill_popup_)
-    autofill_popup_->Hide();
-}
-
 gfx::ImageSkia CommonWebContentsDelegate::GetDevToolsWindowIcon() {
   if (!owner_window())
     return gfx::ImageSkia();

--- a/atom/browser/ui/autofill_popup.cc
+++ b/atom/browser/ui/autofill_popup.cc
@@ -25,20 +25,6 @@
 #include "atom/browser/osr/osr_view_proxy.h"
 #endif
 
-namespace chrome {
-struct Browser;
-
-Browser* FindBrowserWithWindow(gfx::NativeWindow window) {
-  return NULL;
-}
-}  // namespace chrome
-
-namespace platform_util {
-gfx::NativeWindow GetTopLevel(gfx::NativeView view) {
-  return NULL;
-}
-}  // namespace platform_util
-
 namespace atom {
 
 class PopupViewCommon : public autofill::PopupViewCommon {

--- a/atom/browser/ui/autofill_popup.cc
+++ b/atom/browser/ui/autofill_popup.cc
@@ -43,7 +43,7 @@ namespace atom {
 
 class PopupViewCommon : public autofill::PopupViewCommon {
  public:
-  PopupViewCommon(const gfx::Rect& window_bounds)
+  explicit PopupViewCommon(const gfx::Rect& window_bounds)
       : window_bounds_(window_bounds) {}
 
   gfx::Rect GetWindowBounds(gfx::NativeView container_view) override {

--- a/atom/browser/ui/cocoa/views_delegate_mac.mm
+++ b/atom/browser/ui/cocoa/views_delegate_mac.mm
@@ -27,7 +27,7 @@ void ViewsDelegateMac::OnBeforeWidgetInit(
       return;
   }
 
-  // By returning null Widget creates the default NativeWidget implementation.
+  // Setting null here causes Widget to create the default NativeWidget implementation.
   params->native_widget = nullptr;
 }
 

--- a/atom/browser/ui/cocoa/views_delegate_mac.mm
+++ b/atom/browser/ui/cocoa/views_delegate_mac.mm
@@ -27,6 +27,7 @@ void ViewsDelegateMac::OnBeforeWidgetInit(
       return;
   }
 
+  // By returning null Widget creates the default NativeWidget implementation.
   params->native_widget = nullptr;
 }
 

--- a/atom/browser/ui/cocoa/views_delegate_mac.mm
+++ b/atom/browser/ui/cocoa/views_delegate_mac.mm
@@ -16,7 +16,18 @@ ViewsDelegateMac::~ViewsDelegateMac() {}
 void ViewsDelegateMac::OnBeforeWidgetInit(
     views::Widget::InitParams* params,
     views::internal::NativeWidgetDelegate* delegate) {
-  DCHECK(params->native_widget);
+  // If we already have a native_widget, we don't have to try to come
+  // up with one.
+  if (params->native_widget)
+    return;
+
+  if (!native_widget_factory().is_null()) {
+    params->native_widget = native_widget_factory().Run(*params, delegate);
+    if (params->native_widget)
+      return;
+  }
+
+  params->native_widget = nullptr;
 }
 
 ui::ContextFactory* ViewsDelegateMac::GetContextFactory() {

--- a/atom/browser/ui/views/autofill_popup_view.cc
+++ b/atom/browser/ui/views/autofill_popup_view.cc
@@ -56,10 +56,7 @@ AutofillPopupView::~AutofillPopupView() {
 }
 
 void AutofillPopupView::Show() {
-  if (!popup_)
-    return;
-
-  if (!parent_widget_->IsVisible() || parent_widget_->IsClosed())
+  if (!popup_ || !parent_widget_->IsVisible() || parent_widget_->IsClosed())
     return;
 
   const bool initialize_widget = !GetWidget();

--- a/atom/browser/ui/views/autofill_popup_view.cc
+++ b/atom/browser/ui/views/autofill_popup_view.cc
@@ -59,16 +59,12 @@ void AutofillPopupView::Show() {
   if (!popup_)
     return;
 
+  if (!parent_widget_->IsVisible() || parent_widget_->IsClosed())
+    return;
+
   const bool initialize_widget = !GetWidget();
   if (initialize_widget) {
     parent_widget_->AddObserver(this);
-    views::FocusManager* focus_manager = parent_widget_->GetFocusManager();
-    focus_manager->RegisterAccelerator(
-        ui::Accelerator(ui::VKEY_RETURN, ui::EF_NONE),
-        ui::AcceleratorManager::kNormalPriority, this);
-    focus_manager->RegisterAccelerator(
-        ui::Accelerator(ui::VKEY_ESCAPE, ui::EF_NONE),
-        ui::AcceleratorManager::kNormalPriority, this);
 
     // The widget is destroyed by the corresponding NativeWidget, so we use
     // a weak pointer to hold the reference and don't have to worry about
@@ -487,7 +483,6 @@ void AutofillPopupView::ClearSelection() {
 }
 
 void AutofillPopupView::RemoveObserver() {
-  parent_widget_->GetFocusManager()->UnregisterAccelerators(this);
   parent_widget_->RemoveObserver(this);
   views::WidgetFocusManager::GetInstance()->RemoveFocusChangeListener(this);
 }

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -41,6 +41,8 @@ static_library("chrome") {
     "//chrome/browser/net/proxy_service_factory.h",
     "//chrome/browser/ssl/security_state_tab_helper.cc",
     "//chrome/browser/ssl/security_state_tab_helper.h",
+    "//chrome/browser/ui/autofill/popup_view_common.cc",
+    "//chrome/browser/ui/autofill/popup_view_common.h",
     "//chrome/browser/win/chrome_process_finder.cc",
     "//chrome/browser/win/chrome_process_finder.h",
     "//extensions/browser/app_window/size_constraints.cc",
@@ -51,6 +53,7 @@ static_library("chrome") {
   ]
   deps = [
     "//chrome/common",
+    "//components/feature_engagement:buildflags",
     "//components/keyed_service/content",
     "//components/proxy_config",
     "//components/security_state/content",

--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -70,3 +70,4 @@ support_mixed_sandbox_with_zygote.patch
 disable_color_correct_rendering.patch
 disable_time_ticks_dcheck.patch
 fix_test_compilation_error.patch
+autofill_size_calculation.patch

--- a/patches/common/chromium/autofill_size_calculation.patch
+++ b/patches/common/chromium/autofill_size_calculation.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Heilig Benedek <benecene@gmail.com>
+Date: Wed, 30 Jan 2019 17:04:33 +0100
+Subject: don't call into chrome internals for autofill popup size calculations
+
+The default GetWindowBounds calls into chrome internal functions to
+find out the size of the window - this can be overridden but even
+then some methods call into the original. Let's just return an empty
+gfx::Rect and do the actual job in the subclass.
+
+diff --git a/chrome/browser/ui/autofill/popup_view_common.cc b/chrome/browser/ui/autofill/popup_view_common.cc
+index 004e9cb86bee7c10f6a68cdf6ceb60bf39627e1d..ddd54707e7ffce7c88511c25cf7ca5311bbad9c2 100644
+--- a/chrome/browser/ui/autofill/popup_view_common.cc
++++ b/chrome/browser/ui/autofill/popup_view_common.cc
+@@ -172,17 +172,17 @@ gfx::Rect PopupViewCommon::GetWindowBounds(gfx::NativeView container_view) {
+ #if defined(OS_ANDROID)
+   return container_view->GetWindowAndroid()->bounds();
+ #else
+-  views::Widget* widget =
+-      views::Widget::GetTopLevelWidgetForNativeView(container_view);
+-  if (widget)
+-    return widget->GetWindowBoundsInScreen();
++  // views::Widget* widget =
++  //     views::Widget::GetTopLevelWidgetForNativeView(container_view);
++  // if (widget)
++  //   return widget->GetWindowBoundsInScreen();
+
+   // If the widget is null, try to get these bounds from a browser window. This
+   // is common on Mac when the window is drawn using Cocoa.
+-  gfx::NativeWindow window = platform_util::GetTopLevel(container_view);
+-  Browser* browser = chrome::FindBrowserWithWindow(window);
+-  if (browser)
+-    return browser->window()->GetBounds();
++  // gfx::NativeWindow window = platform_util::GetTopLevel(container_view);
++  // Browser* browser = chrome::FindBrowserWithWindow(window);
++  // if (browser)
++  //   return browser->window()->GetBounds();
+
+   // If the browser is null, simply return an empty rect. The most common reason
+   // to end up here is that the NativeView has been destroyed externally, which

--- a/patches/common/chromium/autofill_size_calculation.patch
+++ b/patches/common/chromium/autofill_size_calculation.patch
@@ -9,32 +9,23 @@ then some methods call into the original. Let's just return an empty
 gfx::Rect and do the actual job in the subclass.
 
 diff --git a/chrome/browser/ui/autofill/popup_view_common.cc b/chrome/browser/ui/autofill/popup_view_common.cc
-index 004e9cb86bee7c10f6a68cdf6ceb60bf39627e1d..ddd54707e7ffce7c88511c25cf7ca5311bbad9c2 100644
+index 004e9cb86bee7c10f6a68cdf6ceb60bf39627e1d..c6da9a8f5c14615bf22192f540b6fd95fa1ccb0e 100644
 --- a/chrome/browser/ui/autofill/popup_view_common.cc
 +++ b/chrome/browser/ui/autofill/popup_view_common.cc
-@@ -172,17 +172,17 @@ gfx::Rect PopupViewCommon::GetWindowBounds(gfx::NativeView container_view) {
- #if defined(OS_ANDROID)
-   return container_view->GetWindowAndroid()->bounds();
- #else
--  views::Widget* widget =
--      views::Widget::GetTopLevelWidgetForNativeView(container_view);
--  if (widget)
--    return widget->GetWindowBoundsInScreen();
-+  // views::Widget* widget =
-+  //     views::Widget::GetTopLevelWidgetForNativeView(container_view);
-+  // if (widget)
-+  //   return widget->GetWindowBoundsInScreen();
-
+@@ -176,14 +176,14 @@ gfx::Rect PopupViewCommon::GetWindowBounds(gfx::NativeView container_view) {
+       views::Widget::GetTopLevelWidgetForNativeView(container_view);
+   if (widget)
+     return widget->GetWindowBoundsInScreen();
+-
++#if 0
    // If the widget is null, try to get these bounds from a browser window. This
    // is common on Mac when the window is drawn using Cocoa.
--  gfx::NativeWindow window = platform_util::GetTopLevel(container_view);
--  Browser* browser = chrome::FindBrowserWithWindow(window);
--  if (browser)
--    return browser->window()->GetBounds();
-+  // gfx::NativeWindow window = platform_util::GetTopLevel(container_view);
-+  // Browser* browser = chrome::FindBrowserWithWindow(window);
-+  // if (browser)
-+  //   return browser->window()->GetBounds();
-
+   gfx::NativeWindow window = platform_util::GetTopLevel(container_view);
+   Browser* browser = chrome::FindBrowserWithWindow(window);
+   if (browser)
+     return browser->window()->GetBounds();
+-
++#endif
    // If the browser is null, simply return an empty rect. The most common reason
    // to end up here is that the NativeView has been destroyed externally, which
+   // can happen at any time. This happens fairly commonly on Windows (e.g., at


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Pretty much what the label says, it looks like shuffling some code around was enough to enable autofill popups on Mac. This PR also fixes the positioning (the popup appeared below the autofilled element before, now it matches chrome (if there is no space, it appears above the element)).

Resolves #360

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Enabled autofill popups on Mac.
