### PR TITLE
fix: register accelerator if role has no registerAccelerator

### DIFF
--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -254,7 +254,8 @@ exports.getDefaultAccelerator = (role) => {
 }
 
 exports.shouldRegisterAccelerator = (role) => {
-  return roles.hasOwnProperty(role) ? roles[role].registerAccelerator : true
+  const hasRoleRegister = roles.hasOwnProperty(role) && roles[role].registerAccelerator
+  return hasRoleRegister ? roles[role].registerAccelerator : true
 }
 
 exports.getDefaultSubmenu = (role) => {

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -254,7 +254,7 @@ exports.getDefaultAccelerator = (role) => {
 }
 
 exports.shouldRegisterAccelerator = (role) => {
-  const hasRoleRegister = roles.hasOwnProperty(role) && roles[role].registerAccelerator
+  const hasRoleRegister = roles.hasOwnProperty(role) && roles[role].registerAccelerator !== undefined
   return hasRoleRegister ? roles[role].registerAccelerator : true
 }
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16303.

Previously, `registerAccelerator` defaulted to `true` only if there was no role for the menu item. If there is a role set, it instead used the `registerAccelerator` property for that role; however many of the roles had an `undefined` `registerAccelerator`. 

This therefore changes behavior such that a `MenuItem` will only be set to `roles[role].registerAccelerator` if it has a role AND that role has a defined `registerAccelerator` property. 

/cc @brenca

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue whereby `registerAccelerator` was being set to the `registerAccelerator` property of its role even when `registerAccelerator` was `undefined`.
