### PR TITLE
chore: fix pre passing to atom.rc

### DIFF
--- a/script/bump-version.js
+++ b/script/bump-version.js
@@ -12,6 +12,12 @@ const minimist = require('minimist')
 const writeFile = promisify(fs.writeFile)
 const readFile = promisify(fs.readFile)
 
+const preTypes = {
+  NONE: 'none',
+  PARTIAL: 'partial',
+  FULL: 'full'
+}
+
 function parseCommandLine () {
   let help
   const opts = minimist(process.argv.slice(2), {
@@ -164,8 +170,8 @@ async function updateWinRC (components) {
   const arr = data.split('\n')
   arr.forEach((line, idx) => {
     if (line.includes('FILEVERSION')) {
-      arr[idx] = ` FILEVERSION ${utils.makeVersion(components, ',', true)}`
-      arr[idx + 1] = ` PRODUCTVERSION ${utils.makeVersion(components, ',', true)}`
+      arr[idx] = ` FILEVERSION ${utils.makeVersion(components, ',', preTypes.PARTIAL)}`
+      arr[idx + 1] = ` PRODUCTVERSION ${utils.makeVersion(components, ',', preTypes.PARTIAL)}`
     } else if (line.includes('FileVersion')) {
       arr[idx] = `            VALUE "FileVersion", "${utils.makeVersion(components, '.')}"`
       arr[idx + 5] = `            VALUE "ProductVersion", "${utils.makeVersion(components, '.')}"`

--- a/script/bump-version.js
+++ b/script/bump-version.js
@@ -12,7 +12,7 @@ const minimist = require('minimist')
 const writeFile = promisify(fs.writeFile)
 const readFile = promisify(fs.readFile)
 
-const preTypes = {
+const preType = {
   NONE: 'none',
   PARTIAL: 'partial',
   FULL: 'full'
@@ -170,8 +170,8 @@ async function updateWinRC (components) {
   const arr = data.split('\n')
   arr.forEach((line, idx) => {
     if (line.includes('FILEVERSION')) {
-      arr[idx] = ` FILEVERSION ${utils.makeVersion(components, ',', preTypes.PARTIAL)}`
-      arr[idx + 1] = ` PRODUCTVERSION ${utils.makeVersion(components, ',', preTypes.PARTIAL)}`
+      arr[idx] = ` FILEVERSION ${utils.makeVersion(components, ',', preType.PARTIAL)}`
+      arr[idx + 1] = ` PRODUCTVERSION ${utils.makeVersion(components, ',', preType.PARTIAL)}`
     } else if (line.includes('FileVersion')) {
       arr[idx] = `            VALUE "FileVersion", "${utils.makeVersion(components, '.')}"`
       arr[idx + 5] = `            VALUE "ProductVersion", "${utils.makeVersion(components, '.')}"`

--- a/script/lib/version-utils.js
+++ b/script/lib/version-utils.js
@@ -8,7 +8,7 @@ const { promisify } = require('util')
 const readFile = promisify(fs.readFile)
 const gitDir = path.resolve(__dirname, '..', '..')
 
-const preTypes = {
+const preType = {
   NONE: 'none',
   PARTIAL: 'partial',
   FULL: 'full'
@@ -29,11 +29,11 @@ const isStable = v => {
   return !!(parsed && parsed.prerelease.length === 0)
 }
 
-const makeVersion = (components, delim, preType = preTypes.NONE) => {
+const makeVersion = (components, delim, pre = preType.NONE) => {
   let version = [components.major, components.minor, components.patch].join(delim)
-  if (preType === preTypes.PARTIAL) {
+  if (pre === preType.PARTIAL) {
     version += `${delim}${components.pre[1]}`
-  } else if (preType === preTypes.FULL) {
+  } else if (pre === preType.FULL) {
     version += `-${components.pre[0]}${delim}${components.pre[1]}`
   }
   return version

--- a/script/lib/version-utils.js
+++ b/script/lib/version-utils.js
@@ -8,6 +8,12 @@ const { promisify } = require('util')
 const readFile = promisify(fs.readFile)
 const gitDir = path.resolve(__dirname, '..', '..')
 
+const preTypes = {
+  NONE: 'none',
+  PARTIAL: 'partial',
+  FULL: 'full'
+}
+
 const getCurrentDate = () => {
   const d = new Date()
   const dd = `${d.getDate()}`.padStart(2, '0')
@@ -23,9 +29,11 @@ const isStable = v => {
   return !!(parsed && parsed.prerelease.length === 0)
 }
 
-const makeVersion = (components, delim, withPre = false) => {
+const makeVersion = (components, delim, preType = preTypes.NONE) => {
   let version = [components.major, components.minor, components.patch].join(delim)
-  if (withPre) {
+  if (preType === preTypes.PARTIAL) {
+    version += `${delim}${components.pre[1]}`
+  } else if (preType === preTypes.FULL) {
     version += `-${components.pre[0]}${delim}${components.pre[1]}`
   }
   return version


### PR DESCRIPTION
#### Description of Change

Updates `version-utils` to allow more nuance for contructing version with either partial or full `pre` values. Fixes an issue whereby `atom.rc` was getting incorrectly updated.

/cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
