### PR TITLE
chore: release notes should be an object

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -56,7 +56,7 @@ async function getNewVersion (dryRun) {
 
 async function getReleaseNotes (currentBranch) {
   if (bumpType === 'nightly') {
-    return 'Nightlies do not get release notes, please compare tags for info'
+    return { text: 'Nightlies do not get release notes, please compare tags for info.' }
   }
   console.log(`Generating release notes for ${currentBranch}.`)
   const releaseNotes = await releaseNotesGenerator(currentBranch)


### PR DESCRIPTION
#### Description of Change
 
When we kick out a nightly, we return a string: `'Nightlies do not get release notes, please compare tags for info.'`, but  the release body looks for 

```
`Note: This is a beta release.  Please file new issues ` +
        `for any bugs you find in it.\n \n This release is published to npm ` +
        `under the beta tag and can be installed via npm install electron@beta, ` +
        `or npm i electron@${newVersion.substr(1)}.\n \n ${releaseNotes.text}`
```

thus resulting in a faulty `undefined` where `releaseNotes.text` should be. This fixes that.

/cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
