### PR TITLE
chore: fix json parsing for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "asar": "asar",
     "browserify": "browserify",
-    "bump-version": "./script/bump-version.py",
+    "bump-version": "./script/bump-version.js",
     "check-tls": "python ./script/tls.py",
     "clang-format": "find atom/ chromium_src/ -iname *.h -o -iname *.cc -o -iname *.mm | xargs clang-format -i",
     "lint": "node ./script/lint.js && npm run lint:clang-format && npm run lint:docs",

--- a/script/publish-to-npm.js
+++ b/script/publish-to-npm.js
@@ -120,7 +120,7 @@ new Promise((resolve, reject) => {
         npmTag = `nightly-${currentBranch}`
       }
 
-      const currentJson = JSON.stringify(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf8'))
+      const currentJson = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf8'))
       currentJson.name = 'electron-nightly'
       rootPackageJson.name = 'electron-nightly'
 


### PR DESCRIPTION
#### Description of Change

Fixes json parsing in our `publish-to-npm` script. Also updates our `bump-version` command.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
