### PR TITLE
docs: instructions to get Notifications working on Win 10 Update added

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -23,9 +23,8 @@ While code and user experience across operating systems are similar, there
 are subtle differences.
 
 ## Windows
-
 * On Windows 10, a shortcut to your app with an [Application User
-Model ID][app-user-model-id] must be installed to the Start Menu.
+Model ID][app-user-model-id] must be installed to the Start Menu. This can be overkill during development, so adding `node_modules\electron\dist\electron.exe` to your Start Menu also does the trick. Navigate to the file in Explorer, right-click and 'Pin to Start Menu'. You will then need to add the line `app.setAppUserModelId(process.execPath)` to your main process to see notifications.
 * On Windows 8.1 and Windows 8, a shortcut to your app with an [Application User
 Model ID][app-user-model-id] must be installed to the Start screen. Note,
 however, that it does not need to be pinned to the Start screen.


### PR DESCRIPTION
#### Description of Change
Updated docs only. Notifications fail silently and was frustratingly hard to know why. Hope this saves a lot of people time. It's because Windows expects only known apps to be able to send notifications.

#### Checklist
- [X] PR description included and stakeholders cc'd
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Added instructions on getting Notification API to work in Windows 10
