### PR TITLE
docs: fix app.setAppUserModelId link

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -37,7 +37,7 @@ Electron is used together with the installation and update framework Squirrel,
 [shortcuts will automatically be set correctly][squirrel-events]. Furthermore,
 Electron will detect that Squirrel was used and will automatically call
 `app.setAppUserModelId()` with the correct value. During development, you may have
-to call [`app.setAppUserModelId()`][[set-app-user-model-id]] yourself.
+to call [`app.setAppUserModelId()`][set-app-user-model-id] yourself.
 
 Furthermore, in Windows 8, the maximum length for the notification body is 250
 characters, with the Windows team recommending that notifications should be kept


### PR DESCRIPTION
#### Description of Change

The link had invalid Markdown. (Found while looking at https://github.com/electron/fiddle/pull/154.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes
