### PR TITLE
fix: properly determine if WebContents is offscreen in WebContentsDelegate

### DIFF
--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -187,7 +187,7 @@ void CommonWebContentsDelegate::InitWithWebContents(
   // Determien whether the WebContents is offscreen.
   auto* web_preferences = WebContentsPreferences::From(web_contents);
   offscreen_ =
-      !web_preferences || web_preferences->IsEnabled(options::kOffscreen);
+      web_preferences && web_preferences->IsEnabled(options::kOffscreen);
 
   // Create InspectableWebContents.
   web_contents_.reset(InspectableWebContents::Create(


### PR DESCRIPTION
#### Description of Change

`WebContentsDelegate::InitWithWebContents` previously used the following code to set `offscreen_`:

```c++
  // Determien whether the WebContents is offscreen.
  auto* web_preferences = WebContentsPreferences::From(web_contents);
  offscreen_ =
      !web_preferences || web_preferences->IsEnabled(options::kOffscreen);
```

However, `options::kOffscreen` defaults to `false` when its not set, so when `web_preferences` was `null`, `offscreen_` would be set to `true`. The most immediate result of this is that `RunModalDialog` would have `settings.force_detached` set in the following code, causing the dialog to be shown as a regular modal instead of a sheet:

```objectivec
// Run modal dialog with parent window and return user's choice.
int RunModalDialog(NSSavePanel* dialog, const DialogSettings& settings) {
  __block int chosen = NSFileHandlingPanelCancelButton;
  if (!settings.parent_window || !settings.parent_window->GetNativeWindow() ||
      settings.force_detached) {
    chosen = [dialog runModal];
  } else {
    NSWindow* window = settings.parent_window->GetNativeWindow();

    [dialog beginSheetModalForWindow:window
                   completionHandler:^(NSInteger c) {
                     chosen = c;
                     [NSApp stopModal];
                   }];
    [NSApp runModalForWindow:window];
  }

  return chosen;
}
```

This change defaults `offscreen_` to false when `web_preferences` is `null`.

/cc @VishwasShashidhar

Fixes #16300 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Changed the file dialog presented by inputs with the type `file` to use sheets on macOS instead of detached modals.