### PR TITLE
chore: pass dryRun arg correctly

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -35,8 +35,9 @@ async function getNewVersion (dryRun) {
   }
   const bumpScript = path.join(__dirname, 'bump-version.js')
   const scriptArgs = ['node', bumpScript, `--bump=${bumpType}`]
-  if (dryRun) scriptArgs.push('--dry-run')
+  if (dryRun) scriptArgs.push('--dryRun')
   try {
+    console.log(scriptArgs.join(' '))
     let bumpVersion = execSync(scriptArgs.join(' '), { encoding: 'UTF-8' })
     bumpVersion = bumpVersion.substr(bumpVersion.indexOf(':') + 1).trim()
     const newVersion = `v${bumpVersion}`

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -37,7 +37,6 @@ async function getNewVersion (dryRun) {
   const scriptArgs = ['node', bumpScript, `--bump=${bumpType}`]
   if (dryRun) scriptArgs.push('--dryRun')
   try {
-    console.log(scriptArgs.join(' '))
     let bumpVersion = execSync(scriptArgs.join(' '), { encoding: 'UTF-8' })
     bumpVersion = bumpVersion.substr(bumpVersion.indexOf(':') + 1).trim()
     const newVersion = `v${bumpVersion}`


### PR DESCRIPTION
#### Description of Change

We were passing `--dry-run` instead of `--dryRun`

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
