### PR TITLE
chore: fix electron.d.ts file upload

### DIFF
--- a/script/upload-to-github.js
+++ b/script/upload-to-github.js
@@ -21,7 +21,8 @@ const getHeaders = (filePath, fileName) => {
   const options = {
     'json': 'text/json',
     'zip': 'application/zip',
-    'txt': 'text/plain'
+    'txt': 'text/plain',
+    'ts': 'application/typescript'
   }
 
   return {


### PR DESCRIPTION
#### Description of Change

A mapping for `electron.d.ts` was accidentally omitted from `getHeaders()` in `upload-to-github.js`, resulting in `undefined` being returned. This fixes that.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
