### PR TITLE
fix: return after handling Esc for fullscreen in WebContentsDelegate

### DIFF
--- a/atom/browser/common_web_contents_delegate_mac.mm
+++ b/atom/browser/common_web_contents_delegate_mac.mm
@@ -25,8 +25,10 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
     return;
 
   // Escape exits tabbed fullscreen mode.
-  if (event.windows_key_code == ui::VKEY_ESCAPE && is_html_fullscreen())
+  if (event.windows_key_code == ui::VKEY_ESCAPE && is_html_fullscreen()) {
     ExitFullscreenModeForTab(source);
+    return;
+  }
 
   // Check if the webContents has preferences and to ignore shortcuts
   auto* web_preferences = WebContentsPreferences::From(source);

--- a/atom/browser/common_web_contents_delegate_views.cc
+++ b/atom/browser/common_web_contents_delegate_views.cc
@@ -21,8 +21,10 @@ void CommonWebContentsDelegate::HandleKeyboardEvent(
     content::WebContents* source,
     const content::NativeWebKeyboardEvent& event) {
   // Escape exits tabbed fullscreen mode.
-  if (event.windows_key_code == ui::VKEY_ESCAPE && is_html_fullscreen())
+  if (event.windows_key_code == ui::VKEY_ESCAPE && is_html_fullscreen()) {
     ExitFullscreenModeForTab(source);
+    return;
+  }
 
   // Check if the webContents has preferences and to ignore shortcuts
   auto* web_preferences = WebContentsPreferences::From(source);


### PR DESCRIPTION
#### Description of Change
It doesn't seem to me like we should be continuing to handle the key event after exiting fullscreen. I'm not sure what behaviour that might result in, though, so here's a PR to discuss it!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes