### PR TITLE
fix: improve release notes

### DIFF
--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -50,12 +50,12 @@ async function getNewVersion (dryRun) {
   }
 }
 
-async function getReleaseNotes (currentBranch) {
+async function getReleaseNotes (currentBranch, newVersion) {
   if (bumpType === 'nightly') {
     return { text: 'Nightlies do not get release notes, please compare tags for info.' }
   }
   console.log(`Generating release notes for ${currentBranch}.`)
-  const releaseNotes = await releaseNotesGenerator(currentBranch)
+  const releaseNotes = await releaseNotesGenerator(currentBranch, newVersion)
   if (releaseNotes.warning) {
     console.warn(releaseNotes.warning)
   }
@@ -64,7 +64,7 @@ async function getReleaseNotes (currentBranch) {
 
 async function createRelease (branchToTarget, isBeta) {
   const newVersion = await getNewVersion()
-  const releaseNotes = await getReleaseNotes(newVersion)
+  const releaseNotes = await getReleaseNotes(branchToTarget, newVersion)
   await tagRelease(newVersion)
 
   console.log(`Checking for existing draft release.`)
@@ -194,7 +194,8 @@ async function prepareRelease (isBeta, notesOnly) {
   } else {
     const currentBranch = (args.branch) ? args.branch : await getCurrentBranch(gitDir)
     if (notesOnly) {
-      const releaseNotes = await getReleaseNotes(currentBranch)
+      const newVersion = await getNewVersion(true)
+      const releaseNotes = await getReleaseNotes(currentBranch, newVersion)
       console.log(`Draft release notes are: \n${releaseNotes.text}`)
     } else {
       const changes = await changesToRelease(currentBranch)

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -63,8 +63,8 @@ async function getReleaseNotes (currentBranch) {
 }
 
 async function createRelease (branchToTarget, isBeta) {
-  const releaseNotes = await getReleaseNotes(branchToTarget)
   const newVersion = await getNewVersion()
+  const releaseNotes = await getReleaseNotes(newVersion)
   await tagRelease(newVersion)
 
   console.log(`Checking for existing draft release.`)

--- a/script/release-notes/index.js
+++ b/script/release-notes/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { GitProcess } = require('dugite')
+const minimist = require('minimist')
 const path = require('path')
 const semver = require('semver')
 
@@ -120,13 +121,17 @@ const getPreviousPoint = async (point) => {
   }
 }
 
-async function getReleaseNotes (range, explicitLinks) {
+async function getReleaseNotes (range, newVersion, explicitLinks) {
   const rangeList = range.split('..') || ['HEAD']
   const to = rangeList.pop()
   const from = rangeList.pop() || (await getPreviousPoint(to))
-  console.log(`Generating release notes between ${from} and ${to}`)
 
-  const notes = await notesGenerator.get(from, to)
+  if (!newVersion) {
+    newVersion = to
+  }
+
+  console.log(`Generating release notes between ${from} and ${to} for version ${newVersion}`)
+  const notes = await notesGenerator.get(from, to, newVersion)
   const ret = {
     text: notesGenerator.render(notes, explicitLinks)
   }
@@ -139,15 +144,31 @@ async function getReleaseNotes (range, explicitLinks) {
 }
 
 async function main () {
-  // TODO: minimist/commander
-  const explicitLinks = process.argv.slice(2).some(arg => arg === '--explicit-links')
-  if (process.argv.length > 4) {
-    console.log('Use: script/release-notes/index.js [--explicit-links] [tag | tag1..tag2]')
-    return 1
+  const opts = minimist(process.argv.slice(2), {
+    boolean: [ 'explicit-links', 'help' ],
+    string: [ 'version' ]
+  })
+  opts.range = opts._.shift()
+  if (opts.help || !opts.range) {
+    const name = path.basename(process.argv[1])
+    console.log(`
+easy usage: ${name} version
+
+full usage: ${name} [begin..]end [--version version] [--explicit-links]
+ * 'begin' and 'end' are two git references -- tags, branches, etc -- from
+   which the release notes are generated.
+ * if omitted, 'begin' defaults to the previous tag before 'end.'
+ * if omitted, 'version' defaults to 'end'. An explicit version is
+   useful for making notes on a new version that hasn't yet been tagged.
+
+For example, these invocations are equivalent:
+  ${process.argv[1]} v4.0.1
+  ${process.argv[1]} v4.0.0..v4.0.1 --version v4.0.1
+`)
+    return 0
   }
 
-  const range = process.argv[2] || 'HEAD'
-  const notes = await getReleaseNotes(range, explicitLinks)
+  const notes = await getReleaseNotes(opts.range, opts.version, opts['explicit-links'])
   console.log(notes.text)
   if (notes.warning) {
     throw new Error(notes.warning)

--- a/script/release-notes/index.js
+++ b/script/release-notes/index.js
@@ -155,11 +155,13 @@ async function main () {
 easy usage: ${name} version
 
 full usage: ${name} [begin..]end [--version version] [--explicit-links]
- * 'begin' and 'end' are two git references -- tags, branches, etc -- from
-   which the release notes are generated.
- * if omitted, 'begin' defaults to the previous tag before 'end.'
- * if omitted, 'version' defaults to 'end'. An explicit version is
-   useful for making notes on a new version that hasn't yet been tagged.
+
+ * 'begin' and 'end' are two git references -- tags, branches, etc --
+   from which the release notes are generated.
+ * if omitted, 'begin' defaults to the previous tag in end's branch.
+ * if omitted, 'version' defaults to 'end'. Specifying a version is
+   useful if you're making notes on a new version that isn't tagged yet.
+ * 'explicit-links' makes every note's issue, commit, or pull an MD link
 
 For example, these invocations are equivalent:
   ${process.argv[1]} v4.0.1

--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -63,6 +63,18 @@ const setPullRequest = (commit, owner, repo, number) => {
   }
 }
 
+// copied from https://github.com/electron/clerk/blob/master/src/index.ts#L4-L13
+const OMIT_FROM_RELEASE_NOTES_KEYS = [
+  'no-notes',
+  'no notes',
+  'no_notes',
+  'none',
+  'no',
+  'nothing',
+  'empty',
+  'blank'
+]
+
 const getNoteFromBody = body => {
   if (!body) {
     return null
@@ -83,13 +95,8 @@ const getNoteFromBody = body => {
       .trim()
   }
 
-  if (note) {
-    if (note.match(/^[Nn]o[ _-][Nn]otes\.?$/)) {
-      return NO_NOTES
-    }
-    if (note.match(/^[Nn]one\.?$/)) {
-      return NO_NOTES
-    }
+  if (note && OMIT_FROM_RELEASE_NOTES_KEYS.includes(note.toLowerCase())) {
+    return NO_NOTES
   }
 
   return note

--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -467,7 +467,7 @@ const getNotes = async (fromRef, toRef, newVersion) => {
     commit.note = commit.note || prSubject
   }
 
-  // remove procedural commits
+  // remove non-user-facing commits
   pool.commits = pool.commits
     .filter(commit => commit.note !== NO_NOTES)
     .filter(commit => !((commit.note || commit.subject).match(/^[Bb]ump v\d+\.\d+\.\d+/)))

--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -513,7 +513,7 @@ const getNotes = async (fromRef, toRef, newVersion) => {
   }
 
   const notes = {
-    breaks: [],
+    breaking: [],
     docs: [],
     feat: [],
     fix: [],
@@ -527,7 +527,7 @@ const getNotes = async (fromRef, toRef, newVersion) => {
     if (!str) {
       notes.unknown.push(commit)
     } else if (breakTypes.has(str)) {
-      notes.breaks.push(commit)
+      notes.breaking.push(commit)
     } else if (docTypes.has(str)) {
       notes.docs.push(commit)
     } else if (featTypes.has(str)) {
@@ -634,7 +634,7 @@ const renderNotes = (notes, explicitLinks) => {
     rendered.push(...lines.sort(), '\n')
   }
 
-  renderSection('Breaking Changes', notes.breaks)
+  renderSection('Breaking Changes', notes.breaking)
   renderSection('Features', notes.feat)
   renderSection('Fixes', notes.fix)
   renderSection('Other Changes', notes.other)

--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -137,8 +137,11 @@ const parseCommitMessage = (commitMessage, owner, repo, commit = {}) => {
 
   // if the subject begins with 'word:', treat it as a semantic commit
   if ((match = subject.match(/^(\w+):\s(.*)$/))) {
-    commit.type = match[1].toLocaleLowerCase()
-    subject = match[2]
+    const type = match[1].toLocaleLowerCase()
+    if (knownTypes.has(type)) {
+      commit.type = type
+      subject = match[2]
+    }
   }
 
   // Check for GitHub commit message that indicates a PR

--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -76,10 +76,9 @@ const getNoteFromBody = body => {
     .find(paragraph => paragraph.startsWith(NOTE_PREFIX))
 
   if (note) {
-    const placeholder = '<!-- One-line Change Summary Here-->'
     note = note
       .slice(NOTE_PREFIX.length)
-      .replace(placeholder, '')
+      .replace(/<!--.*-->/, '') // '<!-- change summary here-->'
       .replace(/\r?\n/, ' ') // remove newlines
       .trim()
   }


### PR DESCRIPTION
#### Description of Change

Addresses some of the release-notes script issues that we found during the 4.0.0 rollout:

* if we're making a stable release, omit notes that have already been released in older branches
* sniff semantic commit types from PR subjects, not just from commit messages
* don't honor unrecognized semantic commit types
* add an option to specify the version name to be shown in the notes

also, some housekeeping:

* Don't hardcode the release-notes' placeholder comment
* Update prepare-release.js to pass in the target version number

@codebytere @BinaryMuse 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes