### PR TITLE
chore: add 'use strict' to default app sources

### DIFF
--- a/default_app/.eslintrc
+++ b/default_app/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "parserOptions": {
+    "sourceType": "script"
+  },
+  "rules": {
+    "strict": ["error", "global"]
+  }
+}

--- a/default_app/default_app.js
+++ b/default_app/default_app.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { app, BrowserWindow } = require('electron')
 const path = require('path')
 

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { app, dialog } = require('electron')
 
 const fs = require('fs')

--- a/default_app/menu.js
+++ b/default_app/menu.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { shell, Menu } = require('electron')
 
 const isMac = process.platform === 'darwin'

--- a/default_app/renderer.js
+++ b/default_app/renderer.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { remote, shell } = require('electron')
 const fs = require('fs')
 const path = require('path')


### PR DESCRIPTION
Follow up to https://github.com/electron/electron/pull/14721

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes