### PR TITLE
test: allow retries for flaky mas loginitem specs

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -528,7 +528,10 @@ describe('app module', () => {
     })
   })
 
-  describe('app.get/setLoginItemSettings API', () => {
+  describe('app.get/setLoginItemSettings API', function () {
+    // allow up to three retries to account for flaky mas results
+    this.retries(3)
+
     const updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe')
     const processStartArgs = [
       '--processStart', `"${path.basename(process.execPath)}"`,
@@ -536,9 +539,7 @@ describe('app module', () => {
     ]
 
     before(function () {
-      if (process.platform === 'linux') {
-        this.skip()
-      }
+      if (process.platform === 'linux') this.skip()
     })
 
     beforeEach(() => {
@@ -609,11 +610,7 @@ describe('app module', () => {
     })
 
     it('allows you to pass a custom executable and arguments', function () {
-      if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
-      }
+      if (process.platform !== 'win32') this.skip()
 
       app.setLoginItemSettings({ openAtLogin: true, path: updateExe, args: processStartArgs })
 


### PR DESCRIPTION
#### Description of Change

Use Mocha's ability to [retry specs](https://mochajs.org/#retry-tests) to make the consistently flaky LoginItem specs on mas builds a little more fault-tolerant.

cc @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
