### PR TITLE
feat: add custom platform_util::GetLinuxDistro(), which works on more distros

### DIFF
--- a/atom/common/crash_reporter/crash_reporter_linux.cc
+++ b/atom/common/crash_reporter/crash_reporter_linux.cc
@@ -10,6 +10,7 @@
 
 #include <string>
 
+#include "atom/common/platform_util.h"
 #include "base/debug/crash_logging.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -46,7 +47,7 @@ CrashReporterLinux::CrashReporterLinux() : pid_(getpid()) {
   }
 
   // Make base::g_linux_distro work.
-  base::SetLinuxDistro(base::GetLinuxDistro());
+  base::SetLinuxDistro(platform_util::GetLinuxDistro());
 }
 
 CrashReporterLinux::~CrashReporterLinux() {}

--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -68,6 +68,14 @@ bool SetLoginItemEnabled(bool enabled);
 // Returns a success flag.
 // Unlike libgtkui, does *not* use "chromium-browser.desktop" as a fallback.
 bool GetDesktopName(std::string* setme);
+
+// Returns the name of the current Linux distribution, or "Unknown"
+// if not available. This function is different from Chromium's
+// `base::GetLinuxDistro` in that it retrieves the information from
+// /etc/os-release as opposed to running `lsb_release -d`. This way works on
+// more distros (e.g. Ubuntu, Fedora, CentOS).
+//
+std::string GetLinuxDistro();
 #endif
 
 }  // namespace platform_util


### PR DESCRIPTION
#### Description of Change
Adding custom implementation of base::GetLinuxDistro(), which works on more Linux distros to improve crash reporting feedback.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added better Linux distro detection for crash reporting.
