### PR TITLE
fix: beep on Ubuntu

### DIFF
--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -140,11 +140,14 @@ bool MoveItemToTrash(const base::FilePath& full_path) {
 
 void Beep() {
   // echo '\a' > /dev/console
-  FILE* console = fopen("/dev/console", "r");
-  if (console == NULL)
-    return;
-  fprintf(console, "\a");
-  fclose(console);
+  FILE* fp = fopen("/dev/console", "a");
+  if (fp == nullptr) {
+    fp = fopen("/dev/tty", "a");
+  }
+  if (fp != nullptr) {
+    fprintf(fp, "\a");
+    fclose(fp);
+  }
 }
 
 bool GetDesktopName(std::string* setme) {


### PR DESCRIPTION
#### Description of Change

The `shell.beep()` implementation for Linux works by writing BEL to `/dev/console`. However, `/dev/console` requires elevated permissions on Ubuntu. So if opening `/dev/console` fails, use `/dev/tty` as a fallback.

There's no particular stakeholder for this, but CC'ing @BinaryMuse as she was participating in the Linux Beep discussion earlier

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `shell.beep()` on Ubuntu.