### PR TITLE
chore: fix tag cleanup

### DIFF
--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -72,7 +72,7 @@ async function deleteTag (tag, targetRepo) {
     await octokit.git.deleteRef({
       owner: 'electron',
       repo: targetRepo,
-      ref: tag
+      ref: `tags/${tag}`
     })
     console.log(`${pass} successfully deleted tag ${tag} from ${targetRepo}`)
   } catch (err) {


### PR DESCRIPTION
#### Description of Change

`ref` is not automatically inferred to be the tag; it must be explicitly set with `tags/${tag}` instead of just `tag`.

cc @BinaryMuse

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
