### PR TITLE
docs: document webContents.getOwnerBrowserWindow()

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -29,6 +29,11 @@ const { webContents } = require('electron')
 console.log(webContents)
 ```
 
+### `webContents.getOwnerBrowserWindow()`
+
+Returns `BrowserWindow | null` - The BrowserWindow that owns the given `webContents`
+or `null` if the contents are not owned by a BrowserWindow.
+
 ### `webContents.getAllWebContents()`
 
 Returns `WebContents[]` - An array of all `WebContents` instances. This will contain web contents


### PR DESCRIPTION
#### Description of Change
Document `webContents.getOwnerBrowserWindow()`, which seems quite useful for applications.
Is there any reason keeping it hidden?

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Documented `webContents.getOwnerBrowserWindow()`

cc @zcbenz