### PR TITLE
docs: current guide stop `console.log` output.

### DIFF
--- a/docs/tutorial/debugging-main-process-vscode.md
+++ b/docs/tutorial/debugging-main-process-vscode.md
@@ -22,7 +22,8 @@ $ code electron-quick-start
       "windows": {
         "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
       },
-      "args" : ["."]
+      "args" : ["."],
+      "outputCapture": "std"
     }
   ]
 }


### PR DESCRIPTION
#### Description of Change
docs: 

current guide stop `console.log` output.
add `"outputCapture": "std"` in `.vscode/launch.json` is fix this.

> console.log() not printing to terminal when debugging Electron apps.
[github.com/Microsoft/vscode-recipes/issues/49](https://github.com/Microsoft/vscode-recipes/issues/49#issuecomment-354367330)
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes