### PR TITLE
chore: remove accidental octokit introduction

### DIFF
--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -6,15 +6,16 @@ const os = require('os')
 const path = require('path')
 
 const { GitProcess } = require('dugite')
-const octokit = require('@octokit/rest')()
+const GitHub = require('github')
 const semver = require('semver')
 
 const CACHE_DIR = path.resolve(__dirname, '.cache')
 const NO_NOTES = 'No notes'
 const FOLLOW_REPOS = [ 'electron/electron', 'electron/libchromiumcontent', 'electron/node' ]
+const github = new GitHub()
 const gitDir = path.resolve(__dirname, '..', '..')
 
-octokit.authenticate({ type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN })
+github.authenticate({ type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN })
 
 const breakTypes = new Set(['breaking-change'])
 const docTypes = new Set(['doc', 'docs'])
@@ -283,7 +284,7 @@ const getPullRequest = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}`
   return checkCache(name, async () => {
     try {
-      return await octokit.pulls.get({ number, owner, repo })
+      return await github.pullRequests.get({ number, owner, repo })
     } catch (error) {
       // Silently eat 404s.
       // We can get a bad pull number if someone manually lists


### PR DESCRIPTION
#### Description of Change

Fix accidental introduction of `@octokit/rest` in https://github.com/electron/electron/pull/16343.

cc @BinaryMuse 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none