### PR TITLE
chore: backport cleanup changes to 3-1-x

### DIFF
--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -10,7 +10,6 @@ const args = require('minimist')(process.argv.slice(2), {
 })
 const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
-const { getCurrentBranch } = require('./lib/utils.js')
 
 const GitHub = require('github')
 const path = require('path')
@@ -22,6 +21,18 @@ github.authenticate({
   type: 'token',
   token: process.env.ELECTRON_GITHUB_TOKEN
 })
+
+async function getCurrentBranch (gitDir) {
+  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
+  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
+  if (branchDetails.exitCode === 0) {
+    return branchDetails.stdout.trim()
+  }
+
+  const error = GitProcess.parseError(branchDetails.stderr)
+  console.error(`Couldn't get current branch: `, error)
+  process.exit(1)
+}
 
 function getLastBumpCommit (tag) {
   const data = execSync(`git log -n1 --grep "Bump ${tag}" --format='format:{"hash": "%H", "message": "%s"}'`).toString()
@@ -47,7 +58,7 @@ async function deleteDraft (releaseId, targetRepo) {
     const result = await github.repos.getRelease({
       owner: 'electron',
       repo: targetRepo,
-      release_id: parseInt(releaseId, 10)
+      id: parseInt(releaseId, 10)
     })
     console.log(result)
     if (!result.data.draft) {
@@ -70,7 +81,7 @@ async function deleteDraft (releaseId, targetRepo) {
 
 async function deleteTag (tag, targetRepo) {
   try {
-    await github.gitdata.deleteRef({
+    await github.gitdata.deleteReference({
       owner: 'electron',
       repo: targetRepo,
       ref: `tags/${tag}`

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -96,6 +96,9 @@ async function cleanReleaseArtifacts () {
   const releaseId = args.releaseID.length > 0 ? args.releaseID : null
   const isNightly = args.tag.includes('nightly')
 
+  // try to revert commit regardless of tag and draft deletion status
+  await revertBumpCommit(args.tag)
+
   if (releaseId) {
     if (isNightly) {
       const deletedNightlyDraft = await deleteDraft(releaseId, 'nightlies')
@@ -114,9 +117,6 @@ async function cleanReleaseArtifacts () {
       }
     }
   }
-
-  // try to revert commit regardless of tag and draft deletion status
-  await revertBumpCommit(args.tag)
 
   console.log(`${pass} failed release artifact cleanup complete`)
 }

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -2,17 +2,21 @@
 
 if (!process.env.CI) require('dotenv-safe').load()
 require('colors')
+const pass = '\u2713'.green
+const fail = '\u2717'.red
 const args = require('minimist')(process.argv.slice(2), {
-  string: ['tag']
+  string: ['tag', 'releaseID'],
+  default: { releaseID: '' }
 })
 const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
+const { getCurrentBranch } = require('./lib/utils.js')
 
 const GitHub = require('github')
 const path = require('path')
 
-const github = new GitHub()
 const gitDir = path.resolve(__dirname, '..')
+const github = new GitHub()
 
 github.authenticate({
   type: 'token',
@@ -24,87 +28,86 @@ function getLastBumpCommit (tag) {
   return JSON.parse(data)
 }
 
-async function getCurrentBranch (gitDir) {
-  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
-  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
-  if (branchDetails.exitCode === 0) {
-    return branchDetails.stdout.trim()
-  }
-
-  const error = GitProcess.parseError(branchDetails.stderr)
-  console.error(`Couldn't get current branch: `, error)
-  process.exit(1)
-}
-
 async function revertBumpCommit (tag) {
   const branch = await getCurrentBranch()
   const commitToRevert = getLastBumpCommit(tag).hash
   await GitProcess.exec(['revert', commitToRevert], gitDir)
   const pushDetails = await GitProcess.exec(['push', 'origin', `HEAD:${branch}`, '--follow-tags'], gitDir)
   if (pushDetails.exitCode === 0) {
-    console.log(`Successfully reverted release commit.`)
+    console.log(`${pass} successfully reverted release commit.`)
   } else {
     const error = GitProcess.parseError(pushDetails.stderr)
-    console.error(`Failed to push release commit: `, error)
+    console.error(`${fail} could not push release commit: `, error)
     process.exit(1)
   }
 }
 
-async function deleteDraft (releaseID, targetRepo) {
+async function deleteDraft (releaseId, targetRepo) {
   try {
     const result = await github.repos.getRelease({
       owner: 'electron',
       repo: targetRepo,
-      id: parseInt(releaseID, 10)
+      release_id: parseInt(releaseId, 10)
     })
     console.log(result)
-    if (!result.draft) {
-      console.log(`Published releases cannot be deleted.`)
-      process.exit(1)
+    if (!result.data.draft) {
+      console.log(`${fail} published releases cannot be deleted.`)
+      return false
     } else {
       await github.repos.deleteRelease({
         owner: 'electron',
         repo: targetRepo,
-        release_id: result.id
+        release_id: result.data.id
       })
     }
-    console.log(`Successfully deleted draft with id ${releaseID} from ${targetRepo}`)
+    console.log(`${pass} successfully deleted draft with id ${releaseId} from ${targetRepo}`)
+    return true
   } catch (err) {
-    console.error(`Couldn't delete draft with id ${releaseID} from ${targetRepo}: `, err)
-    process.exit(1)
+    console.error(`${fail} couldn't delete draft with id ${releaseId} from ${targetRepo}: `, err)
+    return false
   }
 }
 
 async function deleteTag (tag, targetRepo) {
   try {
-    await github.gitdata.deleteReference({
+    await github.gitdata.deleteRef({
       owner: 'electron',
       repo: targetRepo,
       ref: `tags/${tag}`
     })
-    console.log(`Successfully deleted tag ${tag} from ${targetRepo}`)
+    console.log(`${pass} successfully deleted tag ${tag} from ${targetRepo}`)
   } catch (err) {
-    console.log(`Couldn't delete tag ${tag} from ${targetRepo}: `, err)
-    process.exit(1)
+    console.log(`${fail} couldn't delete tag ${tag} from ${targetRepo}: `, err)
   }
 }
 
 async function cleanReleaseArtifacts () {
-  const releaseID = args.releaseID
+  const releaseId = args.releaseID.length > 0 ? args.releaseID : null
   const isNightly = args.tag.includes('nightly')
 
-  if (isNightly) {
-    await deleteDraft(releaseID, 'nightlies')
-    await deleteTag(args.tag, 'nightlies')
-  } else {
-    console.log('we are here')
-    await deleteDraft(releaseID, 'electron')
+  if (releaseId) {
+    if (isNightly) {
+      const deletedNightlyDraft = await deleteDraft(releaseId, 'nightlies')
+      // don't delete tag unless draft deleted successfully
+      if (deletedNightlyDraft) {
+        await Promise.all([
+          deleteTag(args.tag, 'electron'),
+          deleteTag(args.tag, 'nightlies')
+        ])
+      }
+    } else {
+      const deletedElectronDraft = await deleteDraft(releaseId, 'electron')
+      // don't delete tag unless draft deleted successfully
+      if (deletedElectronDraft) {
+        await deleteTag(args.tag, 'electron')
+      }
+    }
   }
 
-  await deleteTag(args.tag, 'electron')
+  // try to revert commit regardless of tag and draft deletion status
   await revertBumpCommit(args.tag)
 
-  console.log('Failed release artifact cleanup complete')
+  console.log(`${pass} failed release artifact cleanup complete`)
 }
 
 cleanReleaseArtifacts()

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -22,6 +22,11 @@ github.authenticate({
   token: process.env.ELECTRON_GITHUB_TOKEN
 })
 
+function getLastBumpCommit (tag) {
+  const data = execSync(`git log -n1 --grep "Bump ${tag}" --format='format:{"hash": "%H", "message": "%s"}'`).toString()
+  return JSON.parse(data)
+}
+
 async function getCurrentBranch (gitDir) {
   const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
   const branchDetails = await GitProcess.exec(gitArgs, gitDir)
@@ -32,11 +37,6 @@ async function getCurrentBranch (gitDir) {
   const error = GitProcess.parseError(branchDetails.stderr)
   console.error(`Couldn't get current branch: `, error)
   process.exit(1)
-}
-
-function getLastBumpCommit (tag) {
-  const data = execSync(`git log -n1 --grep "Bump ${tag}" --format='format:{"hash": "%H", "message": "%s"}'`).toString()
-  return JSON.parse(data)
 }
 
 async function revertBumpCommit (tag) {


### PR DESCRIPTION
#### Description of Change

Backport cleanup changes to cleanup script to `3-1-x`.

cc @BinaryMuse

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
