### PR TITLE
feat: allow setting autoplayPolicy in webPreferences

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -73,6 +73,29 @@ bool GetAsInteger(const base::Value* val,
   return false;
 }
 
+bool GetAsAutoplayPolicy(const base::Value* val,
+                         const base::StringPiece& path,
+                         content::AutoplayPolicy* out) {
+  std::string policy_str;
+  if (GetAsString(val, path, &policy_str)) {
+    if (policy_str == "no-user-gesture-required") {
+      *out = content::AutoplayPolicy::kNoUserGestureRequired;
+      return true;
+    } else if (policy_str == "user-gesture-required") {
+      *out = content::AutoplayPolicy::kUserGestureRequired;
+      return true;
+    } else if (policy_str == "user-gesture-required-for-cross-origin") {
+      *out = content::AutoplayPolicy::kUserGestureRequiredForCrossOrigin;
+      return true;
+    } else if (policy_str == "document-user-activation-required") {
+      *out = content::AutoplayPolicy::kDocumentUserActivationRequired;
+      return true;
+    }
+    return false;
+  }
+  return false;
+}
+
 }  // namespace
 
 namespace atom {
@@ -361,6 +384,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   prefs->navigate_on_drag_drop =
       IsEnabled("navigateOnDragDrop", false /* default_value */);
   prefs->autoplay_policy = content::AutoplayPolicy::kNoUserGestureRequired;
+  GetAsAutoplayPolicy(&preference_, "autoplayPolicy", &prefs->autoplay_policy);
 
   // Check if webgl should be enabled.
   bool is_webgl_enabled = IsEnabled("webgl", true /* default_value */);

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -383,8 +383,9 @@ void WebContentsPreferences::OverrideWebkitPrefs(
       IsEnabled("textAreasAreResizable", true /* default_value */);
   prefs->navigate_on_drag_drop =
       IsEnabled("navigateOnDragDrop", false /* default_value */);
-  prefs->autoplay_policy = content::AutoplayPolicy::kNoUserGestureRequired;
-  GetAsAutoplayPolicy(&preference_, "autoplayPolicy", &prefs->autoplay_policy);
+  if (!GetAsAutoplayPolicy(&preference_, "autoplayPolicy", &prefs->autoplay_policy)) {
+    prefs->autoplay_policy = content::AutoplayPolicy::kNoUserGestureRequired;
+  }
 
   // Check if webgl should be enabled.
   bool is_webgl_enabled = IsEnabled("webgl", true /* default_value */);

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -371,6 +371,18 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       English and not localized.
     * `navigateOnDragDrop` Boolean (optional) - Whether dragging and dropping a
       file or link onto the page causes a navigation. Default is `false`.
+    * `autoplayPolicy` String (optional) - Autoplay policy to apply to
+      content in the window. Defaults to `'no-user-gesture-required'`. Valid
+      values are:
+      * `'no-user-gesture-required'` - no user gesture is required before
+        playing media on a page. This is the default behavior in Electron.
+      * `'user-gesture-required'` - user gesture is required before autoplaying
+        media.
+      * `'user-gesture-required-for-cross-origin'` - user gesture is required
+        for cross-origin iframes before allowing them to autoplay media.
+      * `'document-user-activation-required'` - document user activation is
+        required before autoplaying media. This is the default behavior in
+        Chromium.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -372,17 +372,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `navigateOnDragDrop` Boolean (optional) - Whether dragging and dropping a
       file or link onto the page causes a navigation. Default is `false`.
     * `autoplayPolicy` String (optional) - Autoplay policy to apply to
-      content in the window. Defaults to `'no-user-gesture-required'`. Valid
-      values are:
-      * `'no-user-gesture-required'` - no user gesture is required before
-        playing media on a page. This is the default behavior in Electron.
-      * `'user-gesture-required'` - user gesture is required before autoplaying
-        media.
-      * `'user-gesture-required-for-cross-origin'` - user gesture is required
-        for cross-origin iframes before allowing them to autoplay media.
-      * `'document-user-activation-required'` - document user activation is
-        required before autoplaying media. This is the default behavior in
-        Chromium.
+      content in the window, can be `no-user-gesture-required`,
+      `user-gesture-required`, `user-gesture-required-for-cross-origin`,
+      `document-user-activation-required`. Defaults to
+      `no-user-gesture-required`.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from


### PR DESCRIPTION
#### Description of Change
Chrome 71 shipped with the autoplay policy set to require user gesture by default. I don't think this default makes sense for electron, so I've made the default in electron be kNoUserGestureRequired, but I can imagine app devs wanting to set a different option. This exposes that API as `{autoplayPolicy: "user-gesture-required"}` in webPreferences.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Allowed configuring of media autoplay policy via webPreferences.