### PR TITLE
fix: respect the user's active app focus

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -28,7 +28,7 @@ void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
 }
 
 void Browser::Focus() {
-  [[AtomApplication sharedApplication] activateIgnoringOtherApps:YES];
+  [[AtomApplication sharedApplication] activateIgnoringOtherApps:NO];
 }
 
 void Browser::Hide() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -532,7 +532,7 @@ void NativeWindowMac::Focus(bool focus) {
     return;
 
   if (focus) {
-    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+    [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];
     [window_ makeKeyAndOrderFront:nil];
   } else {
     [window_ orderBack:nil];

--- a/atom/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/atom/browser/ui/cocoa/atom_bundle_mover.mm
@@ -48,7 +48,7 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
   // Activate app -- work-around for focus issues related to "scary file from
   // internet" OS dialog.
   if (![NSApp isActive]) {
-    [NSApp activateIgnoringOtherApps:false];
+    [NSApp activateIgnoringOtherApps:true];
   }
 
   // Move to applications folder

--- a/atom/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/atom/browser/ui/cocoa/atom_bundle_mover.mm
@@ -48,7 +48,7 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
   // Activate app -- work-around for focus issues related to "scary file from
   // internet" OS dialog.
   if (![NSApp isActive]) {
-    [NSApp activateIgnoringOtherApps:true];
+    [NSApp activateIgnoringOtherApps:false];
   }
 
   // Move to applications folder


### PR DESCRIPTION
Apple recommends not setting this to true, and this behaviour is non-standard (not to mention annoying when someone is actively focused on another app, like writing) https://developer.apple.com/documentation/appkit/nsapplication/1428468-activateignoringotherapps?language=objc

cc @zcbenz 

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Focus methods no longer steal focus when users are active on other apps
