### PR TITLE
refactor: promise_util promise creation

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -533,12 +533,8 @@ int ImportIntoCertStore(CertificateManagerModel* model,
 }
 #endif
 
-void OnIconDataAvailable(v8::Isolate* isolate,
-                         scoped_refptr<util::Promise> promise,
+void OnIconDataAvailable(scoped_refptr<util::Promise> promise,
                          gfx::Image* icon) {
-  v8::Locker locker(isolate);
-  v8::HandleScope handle_scope(isolate);
-
   if (icon && !icon->IsEmpty()) {
     promise->Resolve(*icon);
   } else {
@@ -1130,9 +1126,6 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
 
 v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
                                         mate::Arguments* args) {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
-
   scoped_refptr<util::Promise> promise = new util::Promise(isolate());
   base::FilePath normalized_path = path.NormalizePathSeparators();
 
@@ -1153,7 +1146,7 @@ v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
     promise->Resolve(*icon);
   } else {
     icon_manager->LoadIcon(normalized_path, icon_size,
-                           base::Bind(&OnIconDataAvailable, isolate(), promise),
+                           base::Bind(&OnIconDataAvailable, promise),
                            &cancelable_task_tracker_);
   }
   return promise->GetHandle();

--- a/atom/common/api/atom_api_shell.cc
+++ b/atom/common/api/atom_api_shell.cc
@@ -44,17 +44,8 @@ struct Converter<base::win::ShortcutOperation> {
 
 namespace {
 
-void OnOpenExternalFinished(const v8::Global<v8::Context>& context,
-                            scoped_refptr<atom::util::Promise> promise,
+void OnOpenExternalFinished(scoped_refptr<atom::util::Promise> promise,
                             const std::string& error) {
-  v8::Isolate* isolate = promise->isolate();
-  mate::Locker locker(isolate);
-  v8::HandleScope handle_scope(isolate);
-  v8::MicrotasksScope script_scope(isolate,
-                                   v8::MicrotasksScope::kRunMicrotasks);
-  v8::Context::Scope context_scope(
-      v8::Local<v8::Context>::New(isolate, context));
-
   if (error.empty())
     promise->Resolve();
   else
@@ -99,11 +90,8 @@ v8::Local<v8::Promise> OpenExternal(
     }
   }
 
-  v8::Global<v8::Context> context(args->isolate(),
-                                  args->isolate()->GetCurrentContext());
-  platform_util::OpenExternal(
-      url, options,
-      base::Bind(&OnOpenExternalFinished, std::move(context), promise));
+  platform_util::OpenExternal(url, options,
+                              base::Bind(&OnOpenExternalFinished, promise));
 
   return promise->GetHandle();
 }

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -22,6 +22,7 @@ Promise::Promise(v8::Isolate* isolate) {
       v8::Local<v8::Context>::New(isolate, context));
 
   auto resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
+  context_ = context;
   isolate_ = isolate;
   resolver_.Reset(isolate, resolver);
 }

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -14,13 +14,6 @@ namespace util {
 Promise::Promise(v8::Isolate* isolate) {
   auto context = isolate->GetCurrentContext();
 
-  mate::Locker locker(isolate);
-  v8::HandleScope handle_scope(isolate);
-  v8::MicrotasksScope script_scope(isolate,
-                                   v8::MicrotasksScope::kRunMicrotasks);
-  v8::Context::Scope context_scope(
-      v8::Local<v8::Context>::New(isolate, context));
-
   auto resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
   context_ = context;
   isolate_ = isolate;

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "atom/common/promise_util.h"
-
 #include <string>
+
+#include "atom/common/api/locker.h"
+#include "atom/common/promise_util.h"
 
 namespace atom {
 
@@ -12,6 +13,14 @@ namespace util {
 
 Promise::Promise(v8::Isolate* isolate) {
   auto context = isolate->GetCurrentContext();
+
+  mate::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
+  v8::MicrotasksScope script_scope(isolate,
+                                   v8::MicrotasksScope::kRunMicrotasks);
+  v8::Context::Scope context_scope(
+      v8::Local<v8::Context>::New(isolate, context));
+
   auto resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
   isolate_ = isolate;
   resolver_.Reset(isolate, resolver);

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -13,7 +13,6 @@ namespace util {
 
 Promise::Promise(v8::Isolate* isolate) {
   auto context = isolate->GetCurrentContext();
-
   auto resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
   isolate_ = isolate;
 
@@ -24,6 +23,12 @@ Promise::Promise(v8::Isolate* isolate) {
 Promise::~Promise() = default;
 
 v8::Maybe<bool> Promise::RejectWithErrorMessage(const std::string& string) {
+  v8::HandleScope handle_scope(isolate());
+  v8::MicrotasksScope script_scope(isolate(),
+                                   v8::MicrotasksScope::kRunMicrotasks);
+  v8::Context::Scope context_scope(
+      v8::Local<v8::Context>::New(isolate(), GetContext()));
+
   v8::Local<v8::String> error_message =
       v8::String::NewFromUtf8(isolate(), string.c_str());
   v8::Local<v8::Value> error = v8::Exception::Error(error_message);

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -15,8 +15,9 @@ Promise::Promise(v8::Isolate* isolate) {
   auto context = isolate->GetCurrentContext();
 
   auto resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
-  context_ = context;
   isolate_ = isolate;
+
+  context_.Reset(isolate, context);
   resolver_.Reset(isolate, resolver);
 }
 


### PR DESCRIPTION
#### Description of Change

Move code to enter the js env inside the promise helper, and refactor other code accordingly. Fixes an issue with `getFileIcon()` crashing locally.

/cc @zcbenz @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
