### PR TITLE
docs: troubleshooting for 'DefaultDelegateCheckMode' for Electron Windows build

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -105,3 +105,7 @@ node.js has some [extremely long pathnames](https://github.com/electron/node/tre
 ```sh
 $ git config --system core.longpaths true
 ```
+
+### error: use of undeclared identifier 'DefaultDelegateCheckMode'
+
+This can happen during build, when Debugging Tools for Windows has been installed with Windows Driver Kit. Uninstall Windows Driver Kit and install Debugging Tools with steps described above.


### PR DESCRIPTION
#### Description of Change
Added one more section to Windows troubleshooting describing issue I have encountered when I have tried to build electron locally.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic commit guidelines
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes
