### PR TITLE
fix: prefer MessageEvent over Event for postMessage

### DIFF
--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -181,11 +181,8 @@ module.exports = (ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNative
   ipcRenderer.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (event, sourceId, message, sourceOrigin) {
     // Manually dispatch event instead of using postMessage because we also need to
     // set event.source.
-    event = document.createEvent('Event')
-    event.initEvent('message', false, false)
-    event.data = message
-    event.origin = sourceOrigin
-    event.source = getOrCreateProxy(ipcRenderer, sourceId)
+    event = new MessageEvent('message', { data: message, origin: sourceOrigin });
+    event.source = getOrCreateProxy(ipcRenderer, sourceId);
     window.dispatchEvent(event)
   })
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This commit fix allows us to catch up events through `$(window).on('message', ...)` which does not work with `Event` type. Backward and forward compatible.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes

