### PR TITLE
feat: make zoomLevel/zoomFactor sync

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -2159,9 +2159,9 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
 #endif
       .SetMethod("invalidate", &WebContents::Invalidate)
       .SetMethod("setZoomLevel", &WebContents::SetZoomLevel)
-      .SetMethod("_getZoomLevel", &WebContents::GetZoomLevel)
+      .SetMethod("getZoomLevel", &WebContents::GetZoomLevel)
       .SetMethod("setZoomFactor", &WebContents::SetZoomFactor)
-      .SetMethod("_getZoomFactor", &WebContents::GetZoomFactor)
+      .SetMethod("getZoomFactor", &WebContents::GetZoomFactor)
       .SetMethod("getType", &WebContents::GetType)
       .SetMethod("_getPreloadPath", &WebContents::GetPreloadPath)
       .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -41,8 +41,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ses.getBlobData(identifier, callback)](https://github.com/electron/electron/blob/master/docs/api/session.md#getBlobData)
 - [ses.clearAuthCache(options[, callback])](https://github.com/electron/electron/blob/master/docs/api/session.md#clearAuthCache)
 - [contents.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#executeJavaScript)
-- [contents.getZoomFactor(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#getZoomFactor)
-- [contents.getZoomLevel(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#getZoomLevel)
 - [contents.hasServiceWorker(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#hasServiceWorker)
 - [contents.unregisterServiceWorker(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#unregisterServiceWorker)
 - [contents.print([options], [callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#print)
@@ -52,8 +50,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-frame.md#executeJavaScriptInIsolatedWorld)
 - [webviewTag.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#executeJavaScript)
 - [webviewTag.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#printToPDF)
-- [webviewTag.getZoomFactor(callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#getZoomFactor)
-- [webviewTag.getZoomLevel(callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#getZoomLevel)
 
 ### Converted Functions
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -977,13 +977,9 @@ Returns `Boolean` - Whether audio is currently playing.
 Changes the zoom factor to the specified factor. Zoom factor is
 zoom percent divided by 100, so 300% = 3.0.
 
-#### `contents.getZoomFactor(callback)`
+#### `contents.getZoomFactor()`
 
-* `callback` Function
-  * `zoomFactor` Number
-
-Sends a request to get current zoom factor, the `callback` will be called with
-`callback(zoomFactor)`.
+Returns `Number` - the current zoom factor.
 
 #### `contents.setZoomLevel(level)`
 
@@ -994,13 +990,9 @@ increment above or below represents zooming 20% larger or smaller to default
 limits of 300% and 50% of original size, respectively. The formula for this is
 `scale := 1.2 ^ level`.
 
-#### `contents.getZoomLevel(callback)`
+#### `contents.getZoomLevel()`
 
-* `callback` Function
-  * `zoomLevel` Number
-
-Sends a request to get current zoom level, the `callback` will be called with
-`callback(zoomLevel)`.
+Returns `Number` - the current zoom level.
 
 #### `contents.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -595,21 +595,13 @@ increment above or below represents zooming 20% larger or smaller to default
 limits of 300% and 50% of original size, respectively. The formula for this is
 `scale := 1.2 ^ level`.
 
-### `<webview>.getZoomFactor(callback)`
+### `<webview>.getZoomFactor()`
 
-* `callback` Function
-  * `zoomFactor` Number
+Returns `Number` - the current zoom factor.
 
-Sends a request to get current zoom factor, the `callback` will be called with
-`callback(zoomFactor)`.
+### `<webview>.getZoomLevel()`
 
-### `<webview>.getZoomLevel(callback)`
-
-* `callback` Function
-  * `zoomLevel` Number
-
-Sends a request to get current zoom level, the `callback` will be called with
-`callback(zoomLevel)`.
+Returns `Number` - the current zoom level.
 
 ### `<webview>.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -156,9 +156,8 @@ const roles = {
     accelerator: 'CommandOrControl+Plus',
     nonNativeMacOSRole: true,
     webContentsMethod: (webContents) => {
-      webContents.getZoomLevel((zoomLevel) => {
-        webContents.setZoomLevel(zoomLevel + 0.5)
-      })
+      const zoomLevel = webContents.getZoomLevel()
+      webContents.setZoomLevel(zoomLevel + 0.5)
     }
   },
   zoomout: {
@@ -166,9 +165,8 @@ const roles = {
     accelerator: 'CommandOrControl+-',
     nonNativeMacOSRole: true,
     webContentsMethod: (webContents) => {
-      webContents.getZoomLevel((zoomLevel) => {
-        webContents.setZoomLevel(zoomLevel - 0.5)
-      })
+      const zoomLevel = webContents.getZoomLevel()
+      webContents.setZoomLevel(zoomLevel - 0.5)
     }
   },
   // App submenu should be used for Mac only

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -111,6 +111,7 @@ WebContents.prototype.send = function (channel, ...args) {
 
   return this._send(internal, sendToAll, channel, args)
 }
+
 WebContents.prototype.sendToAll = function (channel, ...args) {
   if (typeof channel !== 'string') {
     throw new Error('Missing required channel argument')
@@ -209,6 +210,30 @@ WebContents.prototype.executeJavaScript = function (code, hasUserGesture, callba
   }
 }
 
+// TODO(codebytere): remove when promisifications is complete
+const nativeZoomLevel = WebContents.prototype.getZoomLevel
+WebContents.prototype.getZoomLevel = function (callback) {
+  if (callback == null) {
+    return nativeZoomLevel.call(this)
+  } else {
+    process.nextTick(() => {
+      callback(nativeZoomLevel.call(this))
+    })
+  }
+}
+
+// TODO(codebytere): remove when promisifications is complete
+const nativeZoomFactor = WebContents.prototype.getZoomFactor
+WebContents.prototype.getZoomFactor = function (callback) {
+  if (callback == null) {
+    return nativeZoomFactor.call(this)
+  } else {
+    process.nextTick(() => {
+      callback(nativeZoomFactor.call(this))
+    })
+  }
+}
+
 WebContents.prototype.takeHeapSnapshot = function (filePath) {
   return new Promise((resolve, reject) => {
     const channel = `ELECTRON_TAKE_HEAP_SNAPSHOT_RESULT_${getNextId()}`
@@ -289,16 +314,6 @@ WebContents.prototype.getPrinters = function () {
   }
 }
 
-WebContents.prototype.getZoomLevel = function (callback) {
-  if (typeof callback !== 'function') {
-    throw new Error('Must pass function as an argument')
-  }
-  process.nextTick(() => {
-    const zoomLevel = this._getZoomLevel()
-    callback(zoomLevel)
-  })
-}
-
 WebContents.prototype.loadFile = function (filePath, options = {}) {
   if (typeof filePath !== 'string') {
     throw new Error('Must pass filePath as a string')
@@ -313,16 +328,6 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
     search,
     hash
   }))
-}
-
-WebContents.prototype.getZoomFactor = function (callback) {
-  if (typeof callback !== 'function') {
-    throw new Error('Must pass function as an argument')
-  }
-  process.nextTick(() => {
-    const zoomFactor = this._getZoomFactor()
-    callback(zoomFactor)
-  })
 }
 
 // Add JavaScript wrappers for WebContents class.

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -212,7 +212,7 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
     nodeIntegration: params.nodeintegration != null ? params.nodeintegration : false,
     enableRemoteModule: params.enableremotemodule,
     plugins: params.plugins,
-    zoomFactor: embedder._getZoomFactor(),
+    zoomFactor: embedder.getZoomFactor(),
     webSecurity: !params.disablewebsecurity,
     enableBlinkFeatures: params.blinkfeatures,
     disableBlinkFeatures: params.disableblinkfeatures

--- a/lib/common/web-view-methods.js
+++ b/lib/common/web-view-methods.js
@@ -46,6 +46,8 @@ exports.syncMethods = new Set([
   'downloadURL',
   'inspectServiceWorker',
   'showDefinitionForSelection',
+  'getZoomFactor',
+  'getZoomLevel',
   'setZoomFactor',
   'setZoomLevel'
 ])
@@ -57,8 +59,6 @@ exports.asyncCallbackMethods = new Set([
   'sendInputEvent',
   'setLayoutZoomLevelLimits',
   'setVisualZoomLevelLimits',
-  'getZoomFactor',
-  'getZoomLevel',
   'print',
   'printToPDF'
 ])

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dotenv-safe": "^4.0.4",
     "dugite": "^1.45.0",
     "electron-docs-linter": "^2.4.0",
-    "electron-typescript-definitions": "^3.0.0",
+    "electron-typescript-definitions": "^4.0.0",
     "eslint": "^5.6.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-mocha": "^5.2.0",

--- a/spec/fixtures/pages/webview-custom-zoom-level.html
+++ b/spec/fixtures/pages/webview-custom-zoom-level.html
@@ -10,17 +10,15 @@
     if (!finalNavigation && !view.canGoBack()) {
       view.setZoomLevel(2.0)
     }
-    view.getZoomLevel((zoomLevel) => {
-      view.getZoomFactor((zoomFactor) => {
-        ipcRenderer.send('webview-zoom-level', zoomLevel, zoomFactor, view.canGoBack(), finalNavigation)
-        if (!view.canGoBack() && !finalNavigation) {
-          view.src = 'zoom://host2'
-        } else if (!finalNavigation) {
-          finalNavigation = true
-          view.goBack()
-        }
-      })
-    })
+    const zoomLevel = view.getZoomLevel()
+    const zoomFactor = view.getZoomFactor()
+    ipcRenderer.send('webview-zoom-level', zoomLevel, zoomFactor, view.canGoBack(), finalNavigation)
+    if (!view.canGoBack() && !finalNavigation) {
+      view.src = 'zoom://host2'
+    } else if (!finalNavigation) {
+      finalNavigation = true
+      view.goBack()
+    }
   })
 </script>
 </html>

--- a/spec/fixtures/pages/webview-in-page-navigate.html
+++ b/spec/fixtures/pages/webview-in-page-navigate.html
@@ -8,12 +8,10 @@
   let finalNavigation = false
   function SendZoomLevel() {
     return new Promise((resolve, reject) => {
-      view.getZoomLevel((zoomLevel) => {
-        view.getZoomFactor((zoomFactor) => {
-          ipcRenderer.send('webview-zoom-in-page', zoomLevel, zoomFactor, finalNavigation)
-          resolve()
-        })
-      })
+      const zoomLevel = view.getZoomLevel()
+      const zoomFactor = view.getZoomFactor()
+      ipcRenderer.send('webview-zoom-in-page', zoomLevel, zoomFactor, finalNavigation)
+      resolve()
     })
   }
   view.addEventListener('dom-ready', () => {

--- a/spec/fixtures/pages/webview-origin-zoom-level.html
+++ b/spec/fixtures/pages/webview-origin-zoom-level.html
@@ -13,8 +13,7 @@
     document.body.appendChild(view2)
   })
   view2.addEventListener('dom-ready', () => {
-    view2.getZoomLevel((level) => {
-      ipcRenderer.send('webview-origin-zoom-level', level)
-    })
+    const zoomLevel = view2.getZoomLevel()
+    ipcRenderer.send('webview-origin-zoom-level', zoomLevel)
   })
 </script>


### PR DESCRIPTION
#### Description of Change

Convert `webContents` `getZoomLevel` and `getZoomFactor` to be sync methods.

cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `zoomLevel()` and `zoomFactor()` for `webContents` and `<webview>` to return a promise instead taking a callback.
