### PR TITLE
feat: add contents.ipc (EventEmitter), which allows handling messages for given webContents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1617,6 +1617,11 @@ when the page becomes backgrounded. This also affects the Page Visibility API.
 
 A `Integer` representing the unique ID of this WebContents.
 
+#### `contents.ipc`
+
+An [`EventEmitter`](https://nodejs.org/api/events.html#events_class_events_eventemitter),
+which allows handling IPC messages for this `contents` only.
+
 #### `contents.session`
 
 A [`Session`](session.md) used by this webContents.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -337,7 +337,13 @@ WebContents.prototype._init = function () {
   this.capturePage = deprecate.promisify(this.capturePage, 1)
 
   // Dispatch IPC messages to the ipc module.
+  const ipc = new EventEmitter()
+  Object.defineProperty(this, 'ipc', {
+    get: () => ipc
+  })
+
   this.on('ipc-message', function (event, [channel, ...args]) {
+    ipc.emit(channel, event, ...args)
     ipcMain.emit(channel, event, ...args)
   })
 
@@ -348,6 +354,7 @@ WebContents.prototype._init = function () {
       },
       get: function () {}
     })
+    ipc.emit(channel, event, ...args)
     ipcMain.emit(channel, event, ...args)
   })
 


### PR DESCRIPTION
#### Description of Change
- The motivation is to simplify application code, when messages only from a particular `webContents` instance are being handled. 
- This is especially handy when using `once`, where doing the `event.sender === someWebContents` check can't be done in the listener, as it would be unregistered even if we don't handle the message.
- We cannot just emit the IPC events on the `webContents` directly as it could clash with existing events.
- It allows to use `webContents.ipc.removeAllListeners()`, which is safe(r) unlike `ipcMain.removeAllListeners()`

example
```js
const win = new BrowserWindow()
...

// this does not work properly
ipcMain.once('ready', (event) => {
  if (event.sender === win.webContents) {
    console.log('ready')
  }
})

// this is annoying
ipcMain.on('ready', function handler (event) => {
  if (event.sender === win.webContents) {
    console.log('ready')
    ipcMain.removeListener('ready', handler)
  }
})

// this is much better
win.webContents.ipc.once('ready', () => {
  console.log('ready')
})
```

#### Checklist
- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `contents.ipc` (`EventEmitter`), which allows handling messages for given `webContents`