### PR TITLE
feat: preloads and nodeIntegration in iframes

### DIFF
--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -56,9 +56,10 @@ v8::Local<v8::Object> CreateJSEvent(v8::Isolate* isolate,
   } else {
     event = CreateEventObject(isolate);
   }
-  mate::Dictionary(isolate, event).Set("sender", object);
+  mate::Dictionary dict(isolate, event);
+  dict.Set("sender", object);
   if (sender)
-    mate::Dictionary(isolate, event).Set("frameId", sender->GetRoutingID());
+    dict.Set("frameId", sender->GetRoutingID());
   return event;
 }
 

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -100,7 +100,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kPlugins, false);
   SetDefaultBoolIfUndefined(options::kExperimentalFeatures, false);
   SetDefaultBoolIfUndefined(options::kNodeIntegration, false);
-  SetDefaultBoolIfUndefined(options::kNodeSupportInSubFrames, false);
+  SetDefaultBoolIfUndefined(options::kNodeIntegrationInSubFrames, false);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
@@ -347,8 +347,8 @@ void WebContentsPreferences::AppendCommandLineSwitches(
     }
   }
 
-  if (IsEnabled(options::kNodeSupportInSubFrames))
-    command_line->AppendSwitch(switches::kNodeSupportInSubFrames);
+  if (IsEnabled(options::kNodeIntegrationInSubFrames))
+    command_line->AppendSwitch(switches::kNodeIntegrationInSubFrames);
 
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -100,6 +100,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kPlugins, false);
   SetDefaultBoolIfUndefined(options::kExperimentalFeatures, false);
   SetDefaultBoolIfUndefined(options::kNodeIntegration, false);
+  SetDefaultBoolIfUndefined(options::kNodeSupportInSubFrames, false);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
@@ -345,6 +346,9 @@ void WebContentsPreferences::AppendCommandLineSwitches(
       }
     }
   }
+
+  if (IsEnabled(options::kNodeSupportInSubFrames))
+    command_line->AppendSwitch(switches::kNodeSupportInSubFrames);
 
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -154,6 +154,8 @@ const char kAllowRunningInsecureContent[] = "allowRunningInsecureContent";
 
 const char kOffscreen[] = "offscreen";
 
+const char kNodeSupportInSubFrames[] = "nodeSupportInSubFrames";
+
 }  // namespace options
 
 namespace switches {
@@ -207,6 +209,10 @@ const char kWebviewTag[] = "webview-tag";
 
 // Command switch passed to renderer process to control nodeIntegration.
 const char kNodeIntegrationInWorker[] = "node-integration-in-worker";
+
+// Command switch passed to renderer process to control whether node
+// environments will be created in sub-frames.
+const char kNodeSupportInSubFrames[] = "node-support-in-subframes";
 
 // Widevine options
 // Path to Widevine CDM binaries.

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -154,7 +154,7 @@ const char kAllowRunningInsecureContent[] = "allowRunningInsecureContent";
 
 const char kOffscreen[] = "offscreen";
 
-const char kNodeSupportInSubFrames[] = "nodeSupportInSubFrames";
+const char kNodeIntegrationInSubFrames[] = "nodeIntegrationInSubFrames";
 
 }  // namespace options
 
@@ -212,7 +212,7 @@ const char kNodeIntegrationInWorker[] = "node-integration-in-worker";
 
 // Command switch passed to renderer process to control whether node
 // environments will be created in sub-frames.
-const char kNodeSupportInSubFrames[] = "node-support-in-subframes";
+const char kNodeIntegrationInSubFrames[] = "node-integration-in-subframes";
 
 // Widevine options
 // Path to Widevine CDM binaries.

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -75,6 +75,7 @@ extern const char kSandbox[];
 extern const char kWebSecurity[];
 extern const char kAllowRunningInsecureContent[];
 extern const char kOffscreen[];
+extern const char kNodeSupportInSubFrames[];
 
 }  // namespace options
 
@@ -107,6 +108,7 @@ extern const char kHiddenPage[];
 extern const char kNativeWindowOpen[];
 extern const char kNodeIntegrationInWorker[];
 extern const char kWebviewTag[];
+extern const char kNodeSupportInSubFrames[];
 
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -75,7 +75,7 @@ extern const char kSandbox[];
 extern const char kWebSecurity[];
 extern const char kAllowRunningInsecureContent[];
 extern const char kOffscreen[];
-extern const char kNodeSupportInSubFrames[];
+extern const char kNodeIntegrationInSubFrames[];
 
 }  // namespace options
 
@@ -108,7 +108,7 @@ extern const char kHiddenPage[];
 extern const char kNativeWindowOpen[];
 extern const char kNodeIntegrationInWorker[];
 extern const char kWebviewTag[];
-extern const char kNodeSupportInSubFrames[];
+extern const char kNodeIntegrationInSubFrames[];
 
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -187,7 +187,7 @@ void AtomRenderFrameObserver::OnBrowserMessage(bool internal,
     return;
 
   blink::WebLocalFrame* frame = render_frame_->GetWebFrame();
-  if (!frame || !render_frame_->IsMainFrame())
+  if (!frame)
     return;
 
   EmitIPCEvent(frame, internal, channel, args, sender_id);

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -96,7 +96,8 @@ void AtomRendererClient::DidCreateScriptContext(
 
   // If this is the first environment we are creating, prepare the node
   // bindings.
-  if (environments_.size() == 0) {
+  if (!node_integration_initialized_) {
+    node_integration_initialized_ = true;
     node_bindings_->Initialize();
     node_bindings_->PrepareMessageLoop();
   }

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -53,6 +53,9 @@ class AtomRendererClient : public RendererClientBase {
 
   node::Environment* GetEnvironment(content::RenderFrame* frame) const;
 
+  // Whether the node integration has been initialized.
+  bool node_integration_initialized_ = false;
+
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<AtomBindings> atom_bindings_;
 

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -53,9 +53,6 @@ class AtomRendererClient : public RendererClientBase {
 
   node::Environment* GetEnvironment(content::RenderFrame* frame) const;
 
-  // Whether the node integration has been initialized.
-  bool node_integration_initialized_ = false;
-
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<AtomBindings> atom_bindings_;
 

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -183,10 +183,15 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   // Only allow preload for the main frame or
   // For devtools we still want to run the preload_bundle script
   // Or when nodeSupport is explicitly enabled in sub frames
-  if (!render_frame->IsMainFrame() && !IsDevTools(render_frame) &&
-      !IsDevToolsExtension(render_frame) &&
-      !base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kNodeSupportInSubFrames))
+  bool is_main_frame = render_frame->IsMainFrame();
+  bool is_devtools =
+      IsDevTools(render_frame) || IsDevToolsExtension(render_frame);
+  bool allow_node_in_sub_frames =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kNodeIntegrationInSubFrames);
+  bool should_load_preload =
+      is_main_frame || is_devtools || allow_node_in_sub_frames;
+  if (!should_load_preload)
     return;
 
   // Wrap the bundle into a function that receives the binding object as
@@ -237,7 +242,7 @@ void AtomSandboxedRendererClient::WillReleaseScriptContext(
   // Or for sub frames when explicitly enabled
   if (!render_frame->IsMainFrame() &&
       !base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kNodeSupportInSubFrames))
+          switches::kNodeIntegrationInSubFrames))
     return;
 
   auto* isolate = context->GetIsolate();

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -139,7 +139,8 @@ AtomSandboxedRendererClient::~AtomSandboxedRendererClient() {}
 
 void AtomSandboxedRendererClient::InitializeBindings(
     v8::Local<v8::Object> binding,
-    v8::Local<v8::Context> context) {
+    v8::Local<v8::Context> context,
+    bool is_main_frame) {
   auto* isolate = context->GetIsolate();
   mate::Dictionary b(isolate, binding);
   b.SetMethod("get", GetBinding);
@@ -154,6 +155,7 @@ void AtomSandboxedRendererClient::InitializeBindings(
   process.SetReadOnly("pid", base::GetCurrentProcId());
   process.SetReadOnly("sandboxed", true);
   process.SetReadOnly("type", "renderer");
+  process.SetReadOnly("isMainFrame", is_main_frame);
 
   // Pass in CLI flags needed to setup the renderer
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
@@ -180,15 +182,18 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
 
   // Only allow preload for the main frame or
   // For devtools we still want to run the preload_bundle script
+  // Or when nodeSupport is explicitly enabled in sub frames
   if (!render_frame->IsMainFrame() && !IsDevTools(render_frame) &&
-      !IsDevToolsExtension(render_frame))
+      !IsDevToolsExtension(render_frame) &&
+      !base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kNodeSupportInSubFrames))
     return;
 
   // Wrap the bundle into a function that receives the binding object as
   // argument.
   auto* isolate = context->GetIsolate();
   auto binding = v8::Object::New(isolate);
-  InitializeBindings(binding, context);
+  InitializeBindings(binding, context, render_frame->IsMainFrame());
   AddRenderBindings(isolate, binding);
 
   std::vector<v8::Local<v8::String>> preload_bundle_params = {
@@ -229,7 +234,10 @@ void AtomSandboxedRendererClient::WillReleaseScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {
   // Only allow preload for the main frame
-  if (!render_frame->IsMainFrame())
+  // Or for sub frames when explicitly enabled
+  if (!render_frame->IsMainFrame() &&
+      !base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kNodeSupportInSubFrames))
     return;
 
   auto* isolate = context->GetIsolate();

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -19,7 +19,8 @@ class AtomSandboxedRendererClient : public RendererClientBase {
   ~AtomSandboxedRendererClient() override;
 
   void InitializeBindings(v8::Local<v8::Object> binding,
-                          v8::Local<v8::Context> context);
+                          v8::Local<v8::Context> context,
+                          bool is_main_frame);
   void InvokeIpcCallback(v8::Handle<v8::Context> context,
                          const std::string& callback_name,
                          std::vector<v8::Handle<v8::Value>> args);

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -371,6 +371,14 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       English and not localized.
     * `navigateOnDragDrop` Boolean (optional) - Whether dragging and dropping a
       file or link onto the page causes a navigation. Default is `false`.
+    * `nodeSupportInSubFrames` Boolean (optional) - Experimental option for
+      enabling NodeJS support in sub-frames such as iframes.  This may have
+      an increased chance of memory leaks.  All your preloads will load for
+      every iframe, you can use `process.isMainFrame` to determine if you are
+      in the main frame or not.  If you have `nodeIntegration=false` and
+      `nodeSupportInSubFrames=true` your preloads will still run in iframes
+      with node enabled but nodeIntegration will be disabled for all iframe
+      content just like your main frame.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -255,6 +255,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `nodeIntegrationInWorker` Boolean (optional) - Whether node integration is
       enabled in web workers. Default is `false`. More about this can be found
       in [Multithreading](../tutorial/multithreading.md).
+    * `nodeIntegrationInSubFrames` Boolean (optional) - Experimental option for
+      enabling NodeJS support in sub-frames such as iframes. All your preloads will load for
+      every iframe, you can use `process.isMainFrame` to determine if you are
+      in the main frame or not.
     * `preload` String (optional) - Specifies a script that will be loaded before other
       scripts run in the page. This script will always have access to node APIs
       no matter whether node integration is turned on or off. The value should
@@ -371,14 +375,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       English and not localized.
     * `navigateOnDragDrop` Boolean (optional) - Whether dragging and dropping a
       file or link onto the page causes a navigation. Default is `false`.
-    * `nodeSupportInSubFrames` Boolean (optional) - Experimental option for
-      enabling NodeJS support in sub-frames such as iframes.  This may have
-      an increased chance of memory leaks.  All your preloads will load for
-      every iframe, you can use `process.isMainFrame` to determine if you are
-      in the main frame or not.  If you have `nodeIntegration=false` and
-      `nodeSupportInSubFrames=true` your preloads will still run in iframes
-      with node enabled but nodeIntegration will be disabled for all iframe
-      content just like your main frame.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -19,7 +19,7 @@ process, see [webContents.send][web-contents-send] for more information.
 * To reply to a synchronous message, you need to set `event.returnValue`.
 * To send an asynchronous message back to the sender, you can use
   `event.reply(...)`.  This helper method will automatically handle messages
-  coming from frames that aren't the main frame (E.g. IFrames) whereas
+  coming from frames that aren't the main frame (e.g. iframes) whereas
   `event.sender.send(...)` will always send to the main frame.
 
 An example of sending and handling messages between the render and main

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -18,7 +18,9 @@ process, see [webContents.send][web-contents-send] for more information.
 * When sending a message, the event name is the `channel`.
 * To reply to a synchronous message, you need to set `event.returnValue`.
 * To send an asynchronous message back to the sender, you can use
-  `event.sender.send(...)`.
+  `event.reply(...)`.  This helper method will automatically handle messages
+  coming from frames that aren't the main frame (E.g. IFrames) whereas
+  `event.sender.send(...)` will always send to the main frame.
 
 An example of sending and handling messages between the render and main
 processes:
@@ -28,7 +30,7 @@ processes:
 const { ipcMain } = require('electron')
 ipcMain.on('asynchronous-message', (event, arg) => {
   console.log(arg) // prints "ping"
-  event.sender.send('asynchronous-reply', 'pong')
+  event.reply('asynchronous-reply', 'pong')
 })
 
 ipcMain.on('synchronous-message', (event, arg) => {
@@ -86,6 +88,10 @@ Removes listeners of the specified `channel`.
 
 The `event` object passed to the `callback` has the following methods:
 
+### `event.frameId`
+
+An `Integer` representing the ID of the renderer frame that sent this message.
+
 ### `event.returnValue`
 
 Set this to the value to be returned in a synchronous message.
@@ -97,3 +103,10 @@ Returns the `webContents` that sent the message, you can call
 [webContents.send][web-contents-send] for more information.
 
 [web-contents-send]: web-contents.md#contentssendchannel-arg1-arg2-
+
+### `event.reply`
+
+A function that will send an IPC message to the renderer frane that sent
+the original message that you are currently handling.  You should use this
+method to "reply" to the sent message in order to guaruntee the reply will go
+to the correct process and frame.

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -59,6 +59,11 @@ process.once('loaded', () => {
 A `Boolean`. When app is started by being passed as parameter to the default app, this
 property is `true` in the main process, otherwise it is `undefined`.
 
+### `process.isMainFrame`
+
+A `Boolean`.  Set to `true` when the current renderer context is the "main" renderer
+frame.  If you want the ID of the current frame you should use `webFrame.routingId`.
+
 ### `process.mas`
 
 A `Boolean`. For Mac App Store build, this property is `true`, for other builds it is

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -61,7 +61,7 @@ property is `true` in the main process, otherwise it is `undefined`.
 
 ### `process.isMainFrame`
 
-A `Boolean`.  Set to `true` when the current renderer context is the "main" renderer
+A `Boolean`, `true` when the current renderer context is the "main" renderer
 frame.  If you want the ID of the current frame you should use `webFrame.routingId`.
 
 ### `process.mas`

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -62,7 +62,7 @@ property is `true` in the main process, otherwise it is `undefined`.
 ### `process.isMainFrame`
 
 A `Boolean`, `true` when the current renderer context is the "main" renderer
-frame.  If you want the ID of the current frame you should use `webFrame.routingId`.
+frame. If you want the ID of the current frame you should use `webFrame.routingId`.
 
 ### `process.mas`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1427,8 +1427,8 @@ app.on('ready', () => {
 * `...args` any[]
 
 Send an asynchronous message to a specific frame in a renderer process via
-`channel`, you can also send arbitrary arguments. Arguments will be serialized
-in JSON internally and hence no functions or prototype chain will be included.
+`channel`. Arguments will be serialized
+as JSON internally and as such no functions or prototype chains will be included.
 
 The renderer process can handle the message by listening to `channel` with the
 [`ipcRenderer`](ipc-renderer.md) module.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1420,6 +1420,36 @@ app.on('ready', () => {
 </html>
 ```
 
+#### `contents.sendToFrame(frameId, channel[, arg1][, arg2][, ...])`
+
+* `frameId` Integer
+* `channel` String
+* `...args` any[]
+
+Send an asynchronous message to a specific frame in a renderer process via
+`channel`, you can also send arbitrary arguments. Arguments will be serialized
+in JSON internally and hence no functions or prototype chain will be included.
+
+The renderer process can handle the message by listening to `channel` with the
+[`ipcRenderer`](ipc-renderer.md) module.
+
+If you want to get the `frameId` of a given renderer context you should use
+the `webFrame.routingId` value.  E.g.
+
+```js
+// In a renderer process
+console.log('My frameId is:', require('electron').webFrame.routingId)
+```
+
+You can also read `frameId` from all incoming IPC messages in the main process.
+
+```js
+// In the main process
+ipcMain.on('ping', (event) => {
+  console.info('Message came from frameId:', event.frameId)
+})
+```
+
 #### `contents.enableDeviceEmulation(parameters)`
 
 * `parameters` Object

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -352,20 +352,20 @@ WebContents.prototype.getZoomFactor = function (callback) {
   })
 }
 
-const wrapEventWithReply = (event, internal) => {
-  if (!internal) {
-    event.reply = (...args) => {
-      event.sender.sendToFrame(event.frameId, ...args)
-    }
-  } else {
-    Object.defineProperty(event, '_replyInternal', {
-      configurable: false,
-      enumerable: false,
-      value: (...args) => {
-        event.sender._sendToFrameInternal(event.frameId, ...args)
-      }
-    })
+const wrapEventWithReply = (event) => {
+  event.reply = (...args) => {
+    event.sender.sendToFrame(event.frameId, ...args)
   }
+}
+
+const wrapEventWithReplyInternal = (event) => {
+  Object.defineProperty(event, '_replyInternal', {
+    configurable: false,
+    enumerable: false,
+    value: (...args) => {
+      event.sender._sendToFrameInternal(event.frameId, ...args)
+    }
+  })
 }
 
 // Add JavaScript wrappers for WebContents class.
@@ -381,7 +381,7 @@ WebContents.prototype._init = function () {
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, [channel, ...args]) {
-    wrapEventWithReply(event, false)
+    wrapEventWithReply(event)
     this.emit('ipc-message', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
@@ -393,13 +393,13 @@ WebContents.prototype._init = function () {
       },
       get: function () {}
     })
-    wrapEventWithReply(event, false)
+    wrapEventWithReply(event)
     this.emit('ipc-message-sync', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
 
   this.on('ipc-internal-message', function (event, [channel, ...args]) {
-    wrapEventWithReply(event, true)
+    wrapEventWithReplyInternal(event)
     ipcMainInternal.emit(channel, event, ...args)
   })
 
@@ -410,7 +410,7 @@ WebContents.prototype._init = function () {
       },
       get: function () {}
     })
-    wrapEventWithReply(event, true)
+    wrapEventWithReplyInternal(event)
     ipcMainInternal.emit(channel, event, ...args)
   })
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -342,6 +342,32 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
   }))
 }
 
+WebContents.prototype.getZoomFactor = function (callback) {
+  if (typeof callback !== 'function') {
+    throw new Error('Must pass function as an argument')
+  }
+  process.nextTick(() => {
+    const zoomFactor = this._getZoomFactor()
+    callback(zoomFactor)
+  })
+}
+
+const wrapEventWithReply = (event, internal) => {
+  if (!internal) {
+    event.reply = (...args) => {
+      event.sender.sendToFrame(event.frameId, ...args)
+    }
+  } else {
+    Object.defineProperty(event, '_replyInternal', {
+      configurable: false,
+      enumerable: false,
+      value: (...args) => {
+        event.sender._sendToFrameInternal(event.frameId, ...args)
+      }
+    })
+  }
+}
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.
@@ -355,16 +381,7 @@ WebContents.prototype._init = function () {
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, [channel, ...args]) {
-    event.reply = (...args) => {
-      event.sender.sendToFrame(event.frameId, ...args)
-    }
-    Object.defineProperty(event, '_replyInternal', {
-      configurable: false,
-      enumerable: false,
-      value: (...args) => {
-        event.sender._sendToFrameInternal(event.frameId, ...args)
-      }
-    })
+    wrapEventWithReply(event, false)
     this.emit('ipc-message', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
@@ -376,11 +393,13 @@ WebContents.prototype._init = function () {
       },
       get: function () {}
     })
+    wrapEventWithReply(event, false)
     this.emit('ipc-message-sync', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
 
   this.on('ipc-internal-message', function (event, [channel, ...args]) {
+    wrapEventWithReply(event, true)
     ipcMainInternal.emit(channel, event, ...args)
   })
 
@@ -391,6 +410,7 @@ WebContents.prototype._init = function () {
       },
       get: function () {}
     })
+    wrapEventWithReply(event, true)
     ipcMainInternal.emit(channel, event, ...args)
   })
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -342,16 +342,6 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
   }))
 }
 
-WebContents.prototype.getZoomFactor = function (callback) {
-  if (typeof callback !== 'function') {
-    throw new Error('Must pass function as an argument')
-  }
-  process.nextTick(() => {
-    const zoomFactor = this._getZoomFactor()
-    callback(zoomFactor)
-  })
-}
-
 const wrapEventWithReply = (event) => {
   event.reply = (...args) => {
     event.sender.sendToFrame(event.frameId, ...args)

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -143,6 +143,18 @@ WebContents.prototype._sendInternalToAll = function (channel, ...args) {
 
   return this._send(internal, sendToAll, channel, args)
 }
+WebContents.prototype.sendToFrame = function (frameId, channel, ...args) {
+  if (typeof channel !== 'string') {
+    throw new Error('Missing required channel argument')
+  } else if (typeof frameId !== 'number') {
+    throw new Error('Missing required frameId argument')
+  }
+
+  const internal = false
+  const sendToAll = false
+
+  return this._sendToFrame(internal, sendToAll, frameId, channel, args)
+}
 WebContents.prototype._sendToFrameInternal = function (frameId, channel, ...args) {
   if (typeof channel !== 'string') {
     throw new Error('Missing required channel argument')
@@ -343,6 +355,16 @@ WebContents.prototype._init = function () {
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, [channel, ...args]) {
+    event.reply = (...args) => {
+      event.sender.sendToFrame(event.frameId, ...args)
+    }
+    Object.defineProperty(event, '_replyInternal', {
+      configurable: false,
+      enumerable: false,
+      value: (...args) => {
+        event.sender._sendToFrameInternal(event.frameId, ...args)
+      }
+    })
     this.emit('ipc-message', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -342,13 +342,13 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
   }))
 }
 
-const wrapEventWithReply = (event) => {
+const addReplyToEvent = (event) => {
   event.reply = (...args) => {
     event.sender.sendToFrame(event.frameId, ...args)
   }
 }
 
-const wrapEventWithReplyInternal = (event) => {
+const addReplyInternalToEvent = (event) => {
   Object.defineProperty(event, '_replyInternal', {
     configurable: false,
     enumerable: false,
@@ -371,7 +371,7 @@ WebContents.prototype._init = function () {
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, [channel, ...args]) {
-    wrapEventWithReply(event)
+    addReplyToEvent(event)
     this.emit('ipc-message', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
@@ -383,13 +383,13 @@ WebContents.prototype._init = function () {
       },
       get: function () {}
     })
-    wrapEventWithReply(event)
+    addReplyToEvent(event)
     this.emit('ipc-message-sync', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
 
   this.on('ipc-internal-message', function (event, [channel, ...args]) {
-    wrapEventWithReplyInternal(event)
+    addReplyInternalToEvent(event)
     ipcMainInternal.emit(channel, event, ...args)
   })
 
@@ -400,7 +400,7 @@ WebContents.prototype._init = function () {
       },
       get: function () {}
     })
-    wrapEventWithReplyInternal(event)
+    addReplyInternalToEvent(event)
     ipcMainInternal.emit(channel, event, ...args)
   })
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -180,7 +180,7 @@ ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, 
 
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, event.sender.id, message, resultID)
   ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
-    event.sender._replyInternal(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
+    event._replyInternal(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
 })
@@ -196,7 +196,7 @@ ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBa
 
   contents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, senderTabId, message, resultID)
   ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
-    event.sender._replyInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
+    event._replyInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
 })

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -180,7 +180,7 @@ ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, 
 
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, event.sender.id, message, resultID)
   ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
-    event.sender._sendInternal(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
+    event.sender._replyInternal(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
 })
@@ -196,7 +196,7 @@ ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBa
 
   contents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, senderTabId, message, resultID)
   ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
-    event.sender._sendInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
+    event.sender._replyInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
 })

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -18,7 +18,7 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
   event.sender.emit('desktop-capturer-get-sources', customEvent)
 
   if (customEvent.defaultPrevented) {
-    event.sender._replyInternal(capturerResult(id), [])
+    event._replyInternal(capturerResult(id), [])
     return
   }
 

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -18,7 +18,7 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
   event.sender.emit('desktop-capturer-get-sources', customEvent)
 
   if (customEvent.defaultPrevented) {
-    event.sender._sendInternal(capturerResult(id), [])
+    event.sender._replyInternal(capturerResult(id), [])
     return
   }
 
@@ -30,7 +30,7 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
       thumbnailSize,
       fetchWindowIcons
     },
-    webContents: event.sender
+    event
   }
   requestsQueue.push(request)
   if (requestsQueue.length === 1) {
@@ -40,14 +40,14 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
   // If the WebContents is destroyed before receiving result, just remove the
   // reference from requestsQueue to make the module not send the result to it.
   event.sender.once('destroyed', () => {
-    request.webContents = null
+    request.event = null
   })
 })
 
 desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   // Receiving sources result from main process, now send them back to renderer.
   const handledRequest = requestsQueue.shift()
-  const handledWebContents = handledRequest.webContents
+  const handledWebContents = handledRequest.event ? handledRequest.event.sender : null
   const unhandledRequestsQueue = []
 
   const result = sources.map(source => {
@@ -61,15 +61,15 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   })
 
   if (handledWebContents) {
-    handledWebContents._sendInternal(capturerResult(handledRequest.id), result)
+    handledRequest.event._replyInternal(capturerResult(handledRequest.id), result)
   }
 
   // Check the queue to see whether there is another identical request & handle
   requestsQueue.forEach(request => {
-    const webContents = request.webContents
+    const event = request.event
     if (deepEqual(handledRequest.options, request.options)) {
-      if (webContents) {
-        webContents._sendInternal(capturerResult(request.id), result)
+      if (event) {
+        event._replyInternal(capturerResult(request.id), result)
       }
     } else {
       unhandledRequestsQueue.push(request)

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -47,7 +47,6 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
 desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   // Receiving sources result from main process, now send them back to renderer.
   const handledRequest = requestsQueue.shift()
-  const handledWebContents = handledRequest.event ? handledRequest.event.sender : null
   const unhandledRequestsQueue = []
 
   const result = sources.map(source => {
@@ -60,7 +59,7 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
     }
   })
 
-  if (handledWebContents) {
+  if (handledRequest.event) {
     handledRequest.event._replyInternal(capturerResult(handledRequest.id), result)
   }
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -351,7 +351,7 @@ const handleMessage = function (channel, handler) {
 }
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params, requestId) {
-  event.sender._replyInternal(`ELECTRON_RESPONSE_${requestId}`, createGuest(event.sender, params))
+  event._replyInternal(`ELECTRON_RESPONSE_${requestId}`, createGuest(event.sender, params))
 })
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST_SYNC', function (event, params) {
@@ -401,7 +401,7 @@ handleMessage('ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL', function (event, request
   }, error => {
     return [errorUtils.serialize(error)]
   }).then(responseArgs => {
-    event.sender._replyInternal(`ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL_RESPONSE_${requestId}`, ...responseArgs)
+    event._replyInternal(`ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL_RESPONSE_${requestId}`, ...responseArgs)
   })
 })
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -247,7 +247,7 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
     ['nodeIntegration', false],
     ['enableRemoteModule', false],
     ['sandbox', true],
-    ['kNodeSupportInSubFrames', false]
+    ['nodeIntegrationInSubFrames', false]
   ])
 
   // Inherit certain option values from embedder

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -246,7 +246,8 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
     ['nativeWindowOpen', true],
     ['nodeIntegration', false],
     ['enableRemoteModule', false],
-    ['sandbox', true]
+    ['sandbox', true],
+    ['kNodeSupportInSubFrames', false]
   ])
 
   // Inherit certain option values from embedder
@@ -350,7 +351,7 @@ const handleMessage = function (channel, handler) {
 }
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params, requestId) {
-  event.sender._sendInternal(`ELECTRON_RESPONSE_${requestId}`, createGuest(event.sender, params))
+  event.sender._replyInternal(`ELECTRON_RESPONSE_${requestId}`, createGuest(event.sender, params))
 })
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST_SYNC', function (event, params) {
@@ -400,7 +401,7 @@ handleMessage('ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL', function (event, request
   }, error => {
     return [errorUtils.serialize(error)]
   }).then(responseArgs => {
-    event.sender._sendInternal(`ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL_RESPONSE_${requestId}`, ...responseArgs)
+    event.sender._replyInternal(`ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL_RESPONSE_${requestId}`, ...responseArgs)
   })
 })
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -17,7 +17,7 @@ const inheritedWebPreferences = new Map([
   ['enableRemoteModule', false],
   ['sandbox', true],
   ['webviewTag', false],
-  ['kNodeSupportInSubFrames', false]
+  ['nodeIntegrationInSubFrames', false]
 ])
 
 // Copy attribute of |parent| to |child| if it is not defined in |child|.

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -16,7 +16,8 @@ const inheritedWebPreferences = new Map([
   ['nodeIntegration', false],
   ['enableRemoteModule', false],
   ['sandbox', true],
-  ['webviewTag', false]
+  ['webviewTag', false],
+  ['kNodeSupportInSubFrames', false]
 ])
 
 // Copy attribute of |parent| to |child| if it is not defined in |child|.

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -1,8 +1,5 @@
 'use strict'
 
-console.info(`Is Main Frame: ${process.isMainFrame ? 'YES' : 'NO'}`)
-console.log(JSON.stringify(process.argv))
-
 const { EventEmitter } = require('events')
 const path = require('path')
 const Module = require('module')

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -1,5 +1,8 @@
 'use strict'
 
+console.info(`Is Main Frame: ${process.isMainFrame ? 'YES' : 'NO'}`)
+console.log(JSON.stringify(process.argv))
+
 const { EventEmitter } = require('events')
 const path = require('path')
 const Module = require('module')
@@ -74,12 +77,16 @@ switch (window.location.protocol) {
     require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 
     // Inject content scripts.
-    require('@electron/internal/renderer/content-scripts-injector')
+    if (process.isMainFrame) {
+      require('@electron/internal/renderer/content-scripts-injector')
+    }
   }
 }
 
 // Load webview tag implementation.
-require('@electron/internal/renderer/web-view/web-view-init')(contextIsolation, webviewTag, guestInstanceId)
+if (process.isMainFrame) {
+  require('@electron/internal/renderer/web-view/web-view-init')(contextIsolation, webviewTag, guestInstanceId)
+}
 
 // Pass the arguments to isolatedWorld.
 if (contextIsolation) {
@@ -158,4 +165,6 @@ for (const preloadScript of preloadScripts) {
 }
 
 // Warn about security issues
-require('@electron/internal/renderer/security-warnings')(nodeIntegration)
+if (process.isMainFrame) {
+  require('@electron/internal/renderer/security-warnings')(nodeIntegration)
+}

--- a/lib/renderer/window-setup.js
+++ b/lib/renderer/window-setup.js
@@ -26,7 +26,7 @@
 const { defineProperty, defineProperties } = Object
 
 // Helper function to resolve relative url.
-const a = window.top.document.createElement('a')
+const a = window.document.createElement('a')
 const resolveURL = function (url) {
   a.href = url
   return a.href

--- a/spec/api-subframe-spec.js
+++ b/spec/api-subframe-spec.js
@@ -58,7 +58,6 @@ describe('renderer nodeSupportInSubFrames', () => {
         const pongPromise = emittedOnce(remote.ipcMain, 'preload-pong')
         event1[0].reply('preload-ping')
         const details = await pongPromise
-        console.log(details, event1[0].frameId)
         expect(details[1]).to.equal(event1[0].frameId)
       })
 

--- a/spec/api-subframe-spec.js
+++ b/spec/api-subframe-spec.js
@@ -1,0 +1,89 @@
+const { expect } = require('chai')
+const { remote } = require('electron')
+const path = require('path')
+
+const { emittedNTimes, emittedOnce } = require('./events-helpers')
+const { closeWindow } = require('./window-helpers')
+
+const { BrowserWindow } = remote
+
+describe('renderer nodeSupportInSubFrames', () => {
+  const generateTests = (sandboxEnabled) => {
+    describe(`with sandbox ${sandboxEnabled ? 'enabled' : 'disabled'}`, () => {
+      let w
+
+      beforeEach(async () => {
+        await closeWindow(w)
+        w = new BrowserWindow({
+          show: false,
+          width: 400,
+          height: 400,
+          webPreferences: {
+            sandbox: sandboxEnabled,
+            preload: path.resolve(__dirname, 'fixtures/sub-frames/preload.js'),
+            nodeSupportInSubFrames: true
+          }
+        })
+      })
+
+      afterEach(() => {
+        return closeWindow(w).then(() => { w = null })
+      })
+
+      it('should load preload scripts in top level iframes', async () => {
+        const detailsPromise = emittedNTimes(remote.ipcMain, 'preload-ran', 2)
+        w.loadFile(path.resolve(__dirname, 'fixtures/sub-frames/frame-container.html'))
+        const [event1, event2] = await detailsPromise
+        expect(event1[0].frameId).to.not.equal(event2[0].frameId)
+        expect(event1[0].frameId).to.equal(event1[2])
+        expect(event2[0].frameId).to.equal(event2[2])
+      })
+
+      it('should load preload scripts in nested iframes', async () => {
+        const detailsPromise = emittedNTimes(remote.ipcMain, 'preload-ran', 3)
+        w.loadFile(path.resolve(__dirname, 'fixtures/sub-frames/frame-with-frame-container.html'))
+        const [event1, event2, event3] = await detailsPromise
+        expect(event1[0].frameId).to.not.equal(event2[0].frameId)
+        expect(event1[0].frameId).to.not.equal(event3[0].frameId)
+        expect(event2[0].frameId).to.not.equal(event3[0].frameId)
+        expect(event1[0].frameId).to.equal(event1[2])
+        expect(event2[0].frameId).to.equal(event2[2])
+        expect(event3[0].frameId).to.equal(event3[2])
+      })
+
+      it('should correctly reply to the main frame with using event.reply', async () => {
+        const detailsPromise = emittedNTimes(remote.ipcMain, 'preload-ran', 2)
+        w.loadFile(path.resolve(__dirname, 'fixtures/sub-frames/frame-container.html'))
+        const [event1] = await detailsPromise
+        const pongPromise = emittedOnce(remote.ipcMain, 'preload-pong')
+        event1[0].reply('preload-ping')
+        const details = await pongPromise
+        console.log(details, event1[0].frameId)
+        expect(details[1]).to.equal(event1[0].frameId)
+      })
+
+      it('should correctly reply to the sub-frames with using event.reply', async () => {
+        const detailsPromise = emittedNTimes(remote.ipcMain, 'preload-ran', 2)
+        w.loadFile(path.resolve(__dirname, 'fixtures/sub-frames/frame-container.html'))
+        const [, event2] = await detailsPromise
+        const pongPromise = emittedOnce(remote.ipcMain, 'preload-pong')
+        event2[0].reply('preload-ping')
+        const details = await pongPromise
+        expect(details[1]).to.equal(event2[0].frameId)
+      })
+
+      it('should correctly reply to the nested sub-frames with using event.reply', async () => {
+        const detailsPromise = emittedNTimes(remote.ipcMain, 'preload-ran', 3)
+        w.loadFile(path.resolve(__dirname, 'fixtures/sub-frames/frame-with-frame-container.html'))
+        const [,, event3] = await detailsPromise
+        const pongPromise = emittedOnce(remote.ipcMain, 'preload-pong')
+        event3[0].reply('preload-ping')
+        const details = await pongPromise
+        expect(details[1]).to.equal(event3[0].frameId)
+      })
+    })
+  }
+
+  generateTests(false)
+  generateTests(true)
+})

--- a/spec/api-subframe-spec.js
+++ b/spec/api-subframe-spec.js
@@ -7,7 +7,7 @@ const { closeWindow } = require('./window-helpers')
 
 const { BrowserWindow } = remote
 
-describe('renderer nodeSupportInSubFrames', () => {
+describe('renderer nodeIntegrationInSubFrames', () => {
   const generateTests = (sandboxEnabled) => {
     describe(`with sandbox ${sandboxEnabled ? 'enabled' : 'disabled'}`, () => {
       let w
@@ -21,7 +21,7 @@ describe('renderer nodeSupportInSubFrames', () => {
           webPreferences: {
             sandbox: sandboxEnabled,
             preload: path.resolve(__dirname, 'fixtures/sub-frames/preload.js'),
-            nodeSupportInSubFrames: true
+            nodeIntegrationInSubFrames: true
           }
         })
       })

--- a/spec/events-helpers.js
+++ b/spec/events-helpers.js
@@ -20,10 +20,23 @@ const waitForEvent = (target, eventName) => {
  * @return {!Promise<!Array>} With Event as the first item.
  */
 const emittedOnce = (emitter, eventName) => {
+  return emittedNTimes(emitter, eventName, 1).then(([result]) => result)
+}
+
+const emittedNTimes = (emitter, eventName, times) => {
+  const events = []
   return new Promise(resolve => {
-    emitter.once(eventName, (...args) => resolve(args))
+    const handler = (...args) => {
+      events.push(args)
+      if (events.length === times) {
+        emitter.removeListener(eventName, handler)
+        resolve(events)
+      }
+    }
+    emitter.on(eventName, handler)
   })
 }
 
 exports.emittedOnce = emittedOnce
+exports.emittedNTimes = emittedNTimes
 exports.waitForEvent = waitForEvent

--- a/spec/fixtures/sub-frames/frame-container.html
+++ b/spec/fixtures/sub-frames/frame-container.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  This is the root page
+  <iframe src="./frame.html"></iframe>
+</body>
+</html>

--- a/spec/fixtures/sub-frames/frame-with-frame-container.html
+++ b/spec/fixtures/sub-frames/frame-with-frame-container.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  This is the root page
+  <iframe src="./frame-with-frame.html"></iframe>
+</body>
+</html>

--- a/spec/fixtures/sub-frames/frame-with-frame.html
+++ b/spec/fixtures/sub-frames/frame-with-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  This is a frame, is has one child
+  <iframe src="./frame.html"></iframe>
+</body>
+</html>

--- a/spec/fixtures/sub-frames/frame.html
+++ b/spec/fixtures/sub-frames/frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  This is a frame, it has no children
+</body>
+</html>

--- a/spec/fixtures/sub-frames/preload.js
+++ b/spec/fixtures/sub-frames/preload.js
@@ -1,0 +1,7 @@
+const { ipcRenderer, webFrame } = require('electron')
+
+ipcRenderer.send('preload-ran', window.location.href, webFrame.routingId)
+
+ipcRenderer.on('preload-ping', () => {
+  ipcRenderer.send('preload-pong', webFrame.routingId)
+})


### PR DESCRIPTION
#### Description of Change

This adds support for running preload scripts and nodeIntegration in sub-frames (iframes)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Added support for running preload scripts and nodeIntegration in iframes
