### PR TITLE
feat: promisify desktopCapturer.getSources

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -12,32 +12,30 @@ title is `Electron`:
 // In the renderer process.
 const { desktopCapturer } = require('electron')
 
-desktopCapturer.getSources({ types: ['window', 'screen'] }, async (error, sources) => {
-  if (error) throw error
-  for (const source of sources) {
-    if (source.name === 'Electron') {
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({
-          audio: false,
-          video: {
-            mandatory: {
-              chromeMediaSource: 'desktop',
-              chromeMediaSourceId: source.id,
-              minWidth: 1280,
-              maxWidth: 1280,
-              minHeight: 720,
-              maxHeight: 720
-            }
+const sources = await desktopCapturer.getSources({ types: ['window', 'screen'] })
+for (const source of sources) {
+  if (source.name === 'Electron') {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: {
+          mandatory: {
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: source.id,
+            minWidth: 1280,
+            maxWidth: 1280,
+            minHeight: 720,
+            maxHeight: 720
           }
-        })
-        handleStream(stream)
-      } catch (e) {
-        handleError(e)
-      }
-      return
+        }
+      })
+      handleStream(stream)
+    } catch (e) {
+      handleError(e)
     }
+    return
   }
-})
+}
 
 function handleStream (stream) {
   const video = document.querySelector('video')
@@ -97,5 +95,20 @@ and calls `callback(error, sources)` when finished.
 `sources` is an array of [`DesktopCapturerSource`](structures/desktop-capturer-source.md)
 objects, each `DesktopCapturerSource` represents a screen or an individual window that can be
 captured.
+
+[`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
+
+### `desktopCapturer.getSources(options)`
+
+* `options` Object
+  * `types` String[] - An array of Strings that lists the types of desktop sources
+    to be captured, available types are `screen` and `window`.
+  * `thumbnailSize` [Size](structures/size.md) (optional) - The size that the media source thumbnail
+    should be scaled to. Default is `150` x `150`.
+  * `fetchWindowIcons` Boolean (optional) - Set to true to enable fetching window icons. The default
+    value is false. When false the appIcon property of the sources return null. Same if a source has
+    the type screen.
+
+Returns `Promise<sources>` - Resolves with an array of [`DesktopCapturerSource`](structures/desktop-capturer-source.md) objects, each `DesktopCapturerSource` represents a screen or an individual window that can be captured.
 
 [`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -23,7 +23,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ ] [cookies.remove(url, name, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#remove)
 - [ ] [cookies.flushStore(callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#flushStore)
 - [ ] [debugger.sendCommand(method[, commandParams, callback])](https://github.com/electron/electron/blob/master/docs/api/debugger.md#sendCommand)
-- [ ] [desktopCapturer.getSources(options, callback)](https://github.com/electron/electron/blob/master/docs/api/desktop-capturer.md#getSources)
 - [ ] [dialog.showOpenDialog([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showOpenDialog)
 - [ ] [dialog.showSaveDialog([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showSaveDialog)
 - [ ] [dialog.showMessageBox([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showMessageBox)
@@ -62,3 +61,4 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ ] [contents.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#capturePage)
 - [ ] [app.getFileIcon(path[, options], callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#getFileIcon)
 - [ ] [shell.openExternal(url[, options, callback])](https://github.com/electron/electron/blob/master/docs/api/shell.md#openExternal)
+- [ ] [desktopCapturer.getSources(options, callback)](https://github.com/electron/electron/blob/master/docs/api/desktop-capturer.md#getSources)

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -27,28 +27,33 @@ function mapSources (sources) {
   }))
 }
 
-exports.getSources = function (options, callback) {
-  if (!isValid(options)) return callback(new Error('Invalid options'))
-  const captureWindow = includes.call(options.types, 'window')
-  const captureScreen = includes.call(options.types, 'screen')
-
-  if (options.thumbnailSize == null) {
-    options.thumbnailSize = {
-      width: 150,
-      height: 150
+exports.getSources = (options) => {
+  return new Promise((resolve, reject) => {
+    if (!isValid(options)) {
+      reject(new Error('Invalid options'))
     }
-  }
-  if (options.fetchWindowIcons == null) {
-    options.fetchWindowIcons = false
-  }
 
-  const id = incrementId()
-  ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, options.fetchWindowIcons, id)
-  return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, sources) => {
-    try {
-      callback(null, mapSources(sources))
-    } catch (error) {
-      callback(error)
+    const captureWindow = includes.call(options.types, 'window')
+    const captureScreen = includes.call(options.types, 'screen')
+
+    if (options.thumbnailSize == null) {
+      options.thumbnailSize = {
+        width: 150,
+        height: 150
+      }
     }
+    if (options.fetchWindowIcons == null) {
+      options.fetchWindowIcons = false
+    }
+
+    const id = incrementId()
+    ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, options.fetchWindowIcons, id)
+    return ipcRenderer.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, sources) => {
+      try {
+        resolve(mapSources(sources))
+      } catch (error) {
+        reject(new Error(error))
+      }
+    })
   })
 }

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -1,11 +1,13 @@
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
+const chaiAsPromised = require('chai-as-promised')
 const { desktopCapturer, ipcRenderer, remote } = require('electron')
 const { screen } = remote
 const features = process.atomBinding('features')
 
 const { expect } = chai
 chai.use(dirtyChai)
+chai.use(chaiAsPromised)
 
 const isCI = remote.getGlobal('isCi')
 
@@ -22,91 +24,62 @@ describe('desktopCapturer', () => {
     }
   })
 
-  it('should return a non-empty array of sources', done => {
-    desktopCapturer.getSources({
-      types: ['window', 'screen']
-    }, (error, sources) => {
-      expect(error).to.be.null()
-      expect(sources).to.be.an('array').that.is.not.empty()
-      done()
-    })
+  it('should return a non-empty array of sources', async () => {
+    const sources = await desktopCapturer.getSources({ types: ['window', 'screen'] })
+    expect(sources).to.be.an('array').that.is.not.empty()
   })
 
-  it('throws an error for invalid options', done => {
-    desktopCapturer.getSources(['window', 'screen'], error => {
-      expect(error.message).to.equal('Invalid options')
-      done()
-    })
+  it('throws an error for invalid options', async () => {
+    const promise = desktopCapturer.getSources(['window', 'screen'])
+    expect(promise).to.be.eventually.rejectedWith(Error, 'Invalid options')
   })
 
-  it('does not throw an error when called more than once (regression)', (done) => {
-    let callCount = 0
-    const callback = (error, sources) => {
-      callCount++
-      expect(error).to.be.null()
-      expect(sources).to.be.an('array').that.is.not.empty()
-      if (callCount === 2) done()
-    }
+  it('does not throw an error when called more than once (regression)', async () => {
+    const sources1 = await desktopCapturer.getSources({ types: ['window', 'screen'] })
+    expect(sources1).to.be.an('array').that.is.not.empty()
 
-    desktopCapturer.getSources({ types: ['window', 'screen'] }, callback)
-    desktopCapturer.getSources({ types: ['window', 'screen'] }, callback)
+    const sources2 = await desktopCapturer.getSources({ types: ['window', 'screen'] })
+    expect(sources2).to.be.an('array').that.is.not.empty()
   })
 
-  it('responds to subsequent calls of different options', done => {
-    let callCount = 0
-    const callback = (error, sources) => {
-      callCount++
-      expect(error).to.be.null()
-      if (callCount === 2) done()
-    }
+  it('responds to subsequent calls of different options', async () => {
+    const sources1 = await desktopCapturer.getSources({ types: ['window'] })
+    expect(sources1).to.be.an('array').that.is.not.empty()
 
-    desktopCapturer.getSources({ types: ['window'] }, callback)
-    desktopCapturer.getSources({ types: ['screen'] }, callback)
+    const sources2 = await desktopCapturer.getSources({ types: ['screen'] })
+    expect(sources2).to.be.an('array').that.is.not.empty()
   })
 
-  it('returns an empty display_id for window sources on Windows and Mac', done => {
+  it('returns an empty display_id for window sources on Windows and Mac', async () => {
     // Linux doesn't return any window sources.
-    if (process.platform !== 'win32' && process.platform !== 'darwin') {
-      return done()
-    }
+    if (process.platform !== 'win32' && process.platform !== 'darwin') return
 
     const { BrowserWindow } = remote
     const w = new BrowserWindow({ width: 200, height: 200 })
 
-    desktopCapturer.getSources({ types: ['window'] }, (error, sources) => {
-      w.destroy()
-      expect(error).to.be.null()
-      expect(sources).to.be.an('array').that.is.not.empty()
-      for (const { display_id: displayId } of sources) {
-        expect(displayId).to.be.a('string').and.be.empty()
-      }
-      done()
-    })
+    const sources = await desktopCapturer.getSources({ types: ['window'] })
+    w.destroy()
+    expect(sources).to.be.an('array').that.is.not.empty()
+    for (const { display_id: displayId } of sources) {
+      expect(displayId).to.be.a('string').and.be.empty()
+    }
   })
 
-  it('returns display_ids matching the Screen API on Windows and Mac', done => {
-    if (process.platform !== 'win32' && process.platform !== 'darwin') {
-      return done()
-    }
+  it('returns display_ids matching the Screen API on Windows and Mac', async () => {
+    if (process.platform !== 'win32' && process.platform !== 'darwin') return
 
     const displays = screen.getAllDisplays()
-    desktopCapturer.getSources({ types: ['screen'] }, (error, sources) => {
-      expect(error).to.be.null()
-      expect(sources).to.be.an('array').of.length(displays.length)
+    const sources = await desktopCapturer.getSources({ types: ['screen'] })
+    expect(sources).to.be.an('array').of.length(displays.length)
 
-      for (let i = 0; i < sources.length; i++) {
-        expect(sources[i].display_id).to.equal(displays[i].id.toString())
-      }
-      done()
-    })
+    for (let i = 0; i < sources.length; i++) {
+      expect(sources[i].display_id).to.equal(displays[i].id.toString())
+    }
 
-    it('returns empty sources when blocked', done => {
+    it('returns empty sources when blocked', async () => {
       ipcRenderer.send('handle-next-desktop-capturer-get-sources')
-      desktopCapturer.getSources({ types: ['screen'] }, (error, sources) => {
-        expect(error).to.be.null()
-        expect(sources).to.be.empty()
-        done()
-      })
+      const sources = await desktopCapturer.getSources({ types: ['screen'] })
+      expect(sources).to.be.empty()
     })
   })
 })


### PR DESCRIPTION
#### Description of Change

Promisify `desktopCapturer.getSources(options)`.

cc @ckerr @miniak @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `desktopCapturer.getSources(options)` to return a promise instead taking a callback.
