### PR TITLE
fix: correctly handle IPC for promise-based methods

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -4,7 +4,11 @@ const { webContents } = require('electron')
 const ipcMain = require('@electron/internal/browser/ipc-main-internal')
 const parseFeaturesString = require('@electron/internal/common/parse-features-string')
 const errorUtils = require('@electron/internal/common/error-utils')
-const { syncMethods, asyncMethods } = require('@electron/internal/common/web-view-methods')
+const {
+  syncMethods,
+  asyncCallbackMethods,
+  asyncPromiseMethods
+} = require('@electron/internal/common/web-view-methods')
 
 // Doesn't exist in early initialization.
 let webViewManager = null
@@ -383,7 +387,7 @@ ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', function (event, focus, g
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL', function (event, requestId, guestInstanceId, method, args, hasCallback) {
   new Promise(resolve => {
     const guest = getGuestForWebContents(guestInstanceId, event.sender)
-    if (!asyncMethods.has(method)) {
+    if (!asyncCallbackMethods.has(method) && !asyncPromiseMethods.has(method)) {
       throw new Error(`Invalid method: ${method}`)
     }
     if (hasCallback) {

--- a/lib/common/web-view-methods.js
+++ b/lib/common/web-view-methods.js
@@ -50,18 +50,20 @@ exports.syncMethods = new Set([
   'setZoomLevel'
 ])
 
-exports.asyncMethods = new Set([
+exports.asyncCallbackMethods = new Set([
   'insertCSS',
   'insertText',
   'send',
   'sendInputEvent',
   'setLayoutZoomLevelLimits',
   'setVisualZoomLevelLimits',
-  // with callback
-  'capturePage',
-  'executeJavaScript',
   'getZoomFactor',
   'getZoomLevel',
   'print',
   'printToPDF'
+])
+
+exports.asyncPromiseMethods = new Set([
+  'capturePage',
+  'executeJavaScript'
 ])

--- a/lib/renderer/web-view/web-view-impl.js
+++ b/lib/renderer/web-view/web-view-impl.js
@@ -7,7 +7,11 @@ const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
 const guestViewInternal = require('@electron/internal/renderer/web-view/guest-view-internal')
 const webViewConstants = require('@electron/internal/renderer/web-view/web-view-constants')
 const errorUtils = require('@electron/internal/common/error-utils')
-const { syncMethods, asyncMethods } = require('@electron/internal/common/web-view-methods')
+const {
+  syncMethods,
+  asyncCallbackMethods,
+  asyncPromiseMethods
+} = require('@electron/internal/common/web-view-methods')
 
 // ID generator.
 let nextId = 0
@@ -254,8 +258,34 @@ const setupMethods = (WebViewElement) => {
       ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL', requestId, getGuestInstanceId(this), method, args, callback != null)
     }
   }
-  for (const method of asyncMethods) {
+
+  for (const method of asyncCallbackMethods) {
     WebViewElement.prototype[method] = createNonBlockHandler(method)
+  }
+
+  const createPromiseHandler = function (method) {
+    return function (...args) {
+      return new Promise((resolve, reject) => {
+        const callback = (typeof args[args.length - 1] === 'function') ? args.pop() : null
+        const requestId = getNextId()
+
+        ipcRenderer.once(`ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL_RESPONSE_${requestId}`, function (event, error, result) {
+          if (error == null) {
+            if (callback) {
+              callback(result)
+            }
+            resolve(result)
+          } else {
+            reject(errorUtils.deserialize(error))
+          }
+        })
+        ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL', requestId, getGuestInstanceId(this), method, args, callback != null)
+      })
+    }
+  }
+
+  for (const method of asyncPromiseMethods) {
+    WebViewElement.prototype[method] = createPromiseHandler(method)
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Pulling this PR out of https://github.com/electron/electron/pull/16410, since `zoomLevel` and `zoomFactor` no longer need to be retrieved in an async manner. This PR takes into account async methods that return a promise as separate entities from those that simply take callbacks, and ensures that they are appropriately handled by ipc. 

/cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with promise methods not resolving correctly over ipc in the renderer process.
