### PR TITLE
test: ensure legacy callback functions work

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -33,7 +33,7 @@ Object.assign(app, {
   }
 })
 
-app.getFileIcon = deprecate.promisify(app.getFileIcon, 2)
+app.getFileIcon = deprecate.promisify(app.getFileIcon, 3)
 
 const nativeAppMetrics = app.getAppMetrics
 app.getAppMetrics = () => {

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -20,6 +20,6 @@ Object.setPrototypeOf(Session.prototype, EventEmitter.prototype)
 Object.setPrototypeOf(Cookies.prototype, EventEmitter.prototype)
 
 Session.prototype._init = function () {
-  this.protocol.isProtocolHandled = deprecate.promisify(this.protocol.isProtocolHandled, 1)
+  this.protocol.isProtocolHandled = deprecate.promisify(this.protocol.isProtocolHandled, 2)
   app.emit('session-created', this)
 }

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -334,7 +334,7 @@ WebContents.prototype._init = function () {
   // render-view-deleted event, so ignore the listeners warning.
   this.setMaxListeners(0)
 
-  this.capturePage = deprecate.promisify(this.capturePage, 1)
+  this.capturePage = deprecate.promisify(this.capturePage, 2)
 
   // Dispatch IPC messages to the ipc module.
   this.on('ipc-message', function (event, [channel, ...args]) {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -836,7 +836,7 @@ describe('app module', () => {
     })
   })
 
-  describe('getFileIcon() API', () => {
+  describe('getFileIcon() API', (done) => {
     const iconPath = path.join(__dirname, 'fixtures/assets/icon.ico')
     const sizes = {
       small: 16,
@@ -858,12 +858,31 @@ describe('app module', () => {
       expect(icon.isEmpty()).to.be.false()
     })
 
+    // TODO(codebytere): remove when promisification is complete
+    it('fetches a non-empty icon (callback)', () => {
+      app.getFileIcon(iconPath, (icon) => {
+        expect(icon.isEmpty()).to.be.false()
+        done()
+      })
+    })
+
     it('fetches normal icon size by default', async () => {
       const icon = await app.getFileIcon(iconPath)
       const size = icon.getSize()
 
       expect(size.height).to.equal(sizes.normal)
       expect(size.width).to.equal(sizes.normal)
+    })
+
+    // TODO(codebytere): remove when promisification is complete
+    it('fetches normal icon size by default (callback)', () => {
+      app.getFileIcon(iconPath, (icon) => {
+        const size = icon.getSize()
+
+        expect(size.height).to.equal(sizes.normal)
+        expect(size.width).to.equal(sizes.normal)
+        done()
+      })
     })
 
     describe('size option', () => {
@@ -881,6 +900,17 @@ describe('app module', () => {
 
         expect(size.height).to.equal(sizes.normal)
         expect(size.width).to.equal(sizes.normal)
+      })
+
+      // TODO(codebytere): remove when promisification is complete
+      it('fetches a normal icon (callback)', () => {
+        app.getFileIcon(iconPath, { size: 'normal' }, (icon) => {
+          const size = icon.getSize()
+
+          expect(size.height).to.equal(sizes.normal)
+          expect(size.width).to.equal(sizes.normal)
+          done()
+        })
       })
 
       it('fetches a large icon', async () => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -539,6 +539,7 @@ describe('BrowserWindow module', () => {
       expect(imgBuffer[25]).to.equal(6)
     })
 
+    // TODO(codebytere): remove when promisification is complete
     it('preserves transparency (callback)', async (done) => {
       const w = await openTheWindow({
         show: false,

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -483,7 +483,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.getFocusedWindow()', (done) => {
+  describe('BrowserWindow.getFocusedWindow()', () => {
     it('returns the opener window when dev tools window is focused', (done) => {
       w.show()
       w.webContents.once('devtools-focused', () => {
@@ -506,6 +506,19 @@ describe('BrowserWindow module', () => {
       expect(image.isEmpty()).to.be.true()
     })
 
+    // TODO(codebytere): remove when promisification is complete
+    it('returns a Promise with a Buffer (callback)', (done) => {
+      w.capturePage({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100
+      }, (image) => {
+        expect(image.isEmpty()).to.be.true()
+        done()
+      })
+    })
+
     it('preserves transparency', async () => {
       const w = await openTheWindow({
         show: false,
@@ -524,6 +537,27 @@ describe('BrowserWindow module', () => {
       // Check the 25th byte in the PNG.
       // Values can be 0,2,3,4, or 6. We want 6, which is RGB + Alpha
       expect(imgBuffer[25]).to.equal(6)
+    })
+
+    it('preserves transparency (callback)', async (done) => {
+      const w = await openTheWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        transparent: true
+      })
+      const p = emittedOnce(w, 'ready-to-show')
+      w.loadURL('data:text/html,<html><body background-color: rgba(255,255,255,0)></body></html>')
+      await p
+      w.show()
+
+      w.capturePage((image) => {
+        const imgBuffer = image.toPNG()
+        // Check the 25th byte in the PNG.
+        // Values can be 0,2,3,4, or 6. We want 6, which is RGB + Alpha
+        expect(imgBuffer[25]).to.equal(6)
+        done()
+      })
     })
   })
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -494,7 +494,7 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.capturePage(rect)', () => {
+  describe('BrowserWindow.capturePage(rect)', (done) => {
     it('returns a Promise with a Buffer', async () => {
       const image = await w.capturePage({
         x: 0,
@@ -507,7 +507,7 @@ describe('BrowserWindow module', () => {
     })
 
     // TODO(codebytere): remove when promisification is complete
-    it('returns a Promise with a Buffer (callback)', (done) => {
+    it('returns a Promise with a Buffer (callback)', () => {
       w.capturePage({
         x: 0,
         y: 0,
@@ -540,7 +540,7 @@ describe('BrowserWindow module', () => {
     })
 
     // TODO(codebytere): remove when promisification is complete
-    it('preserves transparency (callback)', async (done) => {
+    it('preserves transparency (callback)', async () => {
       const w = await openTheWindow({
         show: false,
         width: 400,

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -656,15 +656,29 @@ describe('protocol module', () => {
     })
   })
 
-  describe('protocol.isProtocolHandled', () => {
+  describe('protocol.isProtocolHandled', (done) => {
     it('returns true for about:', async () => {
       const result = await protocol.isProtocolHandled('about')
       assert.strictEqual(result, true)
     })
 
+    it('returns true for about: (callback)', () => {
+      protocol.isProtocolHandled('about', (result) => {
+        assert.strictEqual(result, true)
+        done()
+      })
+    })
+
     it('returns true for file:', async () => {
       const result = await protocol.isProtocolHandled('file')
       assert.strictEqual(result, true)
+    })
+
+    it('returns true for file: (callback)', () => {
+      protocol.isProtocolHandled('file', (result) => {
+        assert.strictEqual(result, true)
+        done()
+      })
     })
 
     it('returns true for http:', async () => {
@@ -682,7 +696,7 @@ describe('protocol module', () => {
       assert.strictEqual(result, false)
     })
 
-    it('returns true for custom protocol', (done) => {
+    it('returns true for custom protocol', () => {
       const emptyHandler = (request, callback) => callback()
       protocol.registerStringProtocol(protocolName, emptyHandler, async (error) => {
         assert.strictEqual(error, null)
@@ -692,13 +706,35 @@ describe('protocol module', () => {
       })
     })
 
-    it('returns true for intercepted protocol', (done) => {
+    it('returns true for custom protocol (callback)', () => {
+      const emptyHandler = (request, callback) => callback()
+      protocol.registerStringProtocol(protocolName, emptyHandler, (error) => {
+        assert.strictEqual(error, null)
+        protocol.isProtocolHandled(protocolName, (result) => {
+          assert.strictEqual(result, true)
+          done()
+        })
+      })
+    })
+
+    it('returns true for intercepted protocol', () => {
       const emptyHandler = (request, callback) => callback()
       protocol.interceptStringProtocol('http', emptyHandler, async (error) => {
         assert.strictEqual(error, null)
         const result = await protocol.isProtocolHandled('http')
         assert.strictEqual(result, true)
         done()
+      })
+    })
+
+    it('returns true for intercepted protocol (callback)', () => {
+      const emptyHandler = (request, callback) => callback()
+      protocol.interceptStringProtocol('http', emptyHandler, (error) => {
+        assert.strictEqual(error, null)
+        protocol.isProtocolHandled('http', (result) => {
+          assert.strictEqual(result, true)
+          done()
+        })
       })
     })
   })

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -662,6 +662,7 @@ describe('protocol module', () => {
       assert.strictEqual(result, true)
     })
 
+    // TODO(codebytere): remove when promisification is complete
     it('returns true for about: (callback)', () => {
       protocol.isProtocolHandled('about', (result) => {
         assert.strictEqual(result, true)
@@ -674,6 +675,7 @@ describe('protocol module', () => {
       assert.strictEqual(result, true)
     })
 
+    // TODO(codebytere): remove when promisification is complete
     it('returns true for file: (callback)', () => {
       protocol.isProtocolHandled('file', (result) => {
         assert.strictEqual(result, true)
@@ -706,6 +708,7 @@ describe('protocol module', () => {
       })
     })
 
+    // TODO(codebytere): remove when promisification is complete
     it('returns true for custom protocol (callback)', () => {
       const emptyHandler = (request, callback) => callback()
       protocol.registerStringProtocol(protocolName, emptyHandler, (error) => {
@@ -727,6 +730,7 @@ describe('protocol module', () => {
       })
     })
 
+    // TODO(codebytere): remove when promisification is complete
     it('returns true for intercepted protocol (callback)', () => {
       const emptyHandler = (request, callback) => callback()
       protocol.interceptStringProtocol('http', emptyHandler, (error) => {


### PR DESCRIPTION
#### Description of Change

Ensure legacy callback functions remain tested to prevent regressions as the promisification initiative continues.

cc @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added legacy callback function tests to prevent regressions as the promisification initiative continues.
