### PR TITLE
fix: correctly destroy spellcheck client

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -149,7 +149,11 @@ class AtomWebFrameObserver : public content::RenderFrameObserver {
   ~AtomWebFrameObserver() final {}
 
   // RenderFrameObserver implementation.
-  void OnDestruct() final { spell_check_client_.reset(nullptr); }
+  void OnDestruct() final {
+    spell_check_client_.reset();
+    // Frame observers should delete themselves
+    delete this;
+  }
 
  private:
   std::unique_ptr<SpellCheckClient> spell_check_client_;
@@ -245,17 +249,15 @@ void WebFrame::SetSpellCheckProvider(mate::Arguments* args,
     return;
   }
 
-  auto client =
+  auto spell_check_client =
       std::make_unique<SpellCheckClient>(language, args->isolate(), provider);
   // Set spellchecker for all live frames in the same process or
   // in the sandbox mode for all live sub frames to this WebFrame.
   auto* render_frame = content::RenderFrame::FromWebFrame(web_frame_);
-  FrameSpellChecker spell_checker(client.get(), render_frame);
+  FrameSpellChecker spell_checker(spell_check_client.get(), render_frame);
   content::RenderFrame::ForEach(&spell_checker);
-  spell_check_client_.swap(client);
-  web_frame_->SetSpellCheckPanelHostClient(spell_check_client_.get());
-  web_frame_observer_.reset(
-      new AtomWebFrameObserver(render_frame, std::move(spell_check_client_)));
+  web_frame_->SetSpellCheckPanelHostClient(spell_check_client.get());
+  new AtomWebFrameObserver(render_frame, std::move(spell_check_client));
 }
 
 void WebFrame::RegisterURLSchemeAsBypassingCSP(const std::string& scheme) {

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -27,6 +27,7 @@ namespace atom {
 namespace api {
 
 class SpellCheckClient;
+class AtomWebFrameObserver;
 
 class WebFrame : public mate::Wrappable<WebFrame> {
  public:
@@ -98,6 +99,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   v8::Local<v8::Value> RoutingId() const;
 
   std::unique_ptr<SpellCheckClient> spell_check_client_;
+  std::unique_ptr<AtomWebFrameObserver> web_frame_observer_;
 
   blink::WebLocalFrame* web_frame_;
 

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -26,9 +26,6 @@ namespace atom {
 
 namespace api {
 
-class SpellCheckClient;
-class AtomWebFrameObserver;
-
 class WebFrame : public mate::Wrappable<WebFrame> {
  public:
   static mate::Handle<WebFrame> Create(v8::Isolate* isolate);
@@ -97,9 +94,6 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   v8::Local<v8::Value> FindFrameByName(const std::string& name) const;
   v8::Local<v8::Value> FindFrameByRoutingId(int routing_id) const;
   v8::Local<v8::Value> RoutingId() const;
-
-  std::unique_ptr<SpellCheckClient> spell_check_client_;
-  std::unique_ptr<AtomWebFrameObserver> web_frame_observer_;
 
   blink::WebLocalFrame* web_frame_;
 


### PR DESCRIPTION
#### Description of Change
This change addresses https://github.com/electron/electron/issues/15459.
The spellcheck client wasn't destroyed when the renderer goes away.
This change adds an observer which takes care of the destruction.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fixed `webFrame.setSpellCheckProvider` memory leak
