### PR TITLE
feat: added process.electron to get the electron version in the forked process

### DIFF
--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -11,6 +11,7 @@
 #include "atom/browser/javascript_environment.h"
 #include "atom/browser/node_debugger.h"
 #include "atom/common/api/atom_bindings.h"
+#include "atom/common/atom_version.h"
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/node_bindings.h"
@@ -78,6 +79,11 @@ int NodeMain(int argc, char* argv[]) {
     auto reporter = mate::Dictionary::CreateEmpty(gin_env.isolate());
     reporter.SetMethod("start", &crash_reporter::CrashReporter::StartInstance);
     process.Set("crashReporter", reporter);
+
+    mate::Dictionary versions;
+    if (process.Get("versions", &versions)) {
+      versions.SetReadOnly(ATOM_PROJECT_NAME, ATOM_VERSION_STRING);
+    }
 
     node::LoadEnvironment(env);
 

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -111,6 +111,18 @@ describe('node feature', () => {
         })
         forked.send('hello')
       })
+
+      it('has the electron version in process.versions', (done) => {
+        const source = 'process.send(process.versions)'
+        const forked = ChildProcess.fork('--eval', [source])
+        forked.on('message', (message) => {
+          expect(message)
+            .to.have.own.property('electron')
+            .that.is.a('string')
+            .and.matches(/^\d+\.\d+\.\d+(\S*)?$/)
+          done()
+        })
+      })
     })
 
     describe('child_process.spawn', () => {


### PR DESCRIPTION
#### Description of Change
This change addresses #9058.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes
Notes: added `process.versions.electron` to get the electron version in the forked process