### PR TITLE
fix: expose ripemd160 hash from boringssl

### DIFF
--- a/patches/common/boringssl/.patches
+++ b/patches/common/boringssl/.patches
@@ -1,2 +1,3 @@
 add_ec_group_order_bits_for_openssl_compatibility.patch
 add_ec_key_key2buf_for_openssl_compatibility.patch
+expose_ripemd160.patch

--- a/patches/common/boringssl/expose_ripemd160.patch
+++ b/patches/common/boringssl/expose_ripemd160.patch
@@ -1,0 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Fri, 18 Jan 2019 13:56:52 -0800
+Subject: expose ripemd160
+
+This adds references to the decrepit/ module from non-decrepit source,
+which is not allowed in upstream. Until upstream has a way to interface
+with node.js that allows exposing additional digests without patching,
+this patch is required to provide ripemd160 support in the nodejs crypto
+module.
+
+diff --git a/crypto/digest_extra/digest_extra.c b/crypto/digest_extra/digest_extra.c
+index 4b4bb38135e6089eaf6f47afda0199567a2397ef..43b7eca808b82a032055f56ce726ce4f38c5f2c5 100644
+--- a/crypto/digest_extra/digest_extra.c
++++ b/crypto/digest_extra/digest_extra.c
+@@ -81,6 +81,7 @@ static const struct nid_to_digest nid_to_digest_mapping[] = {
+     {NID_sha384, EVP_sha384, SN_sha384, LN_sha384},
+     {NID_sha512, EVP_sha512, SN_sha512, LN_sha512},
+     {NID_md5_sha1, EVP_md5_sha1, SN_md5_sha1, LN_md5_sha1},
++    {NID_ripemd160, EVP_ripemd160, SN_ripemd160, LN_ripemd160},
+     // As a remnant of signing |EVP_MD|s, OpenSSL returned the corresponding
+     // hash function when given a signature OID. To avoid unintended lax parsing
+     // of hash OIDs, this is no longer supported for lookup by OID or NID.
+diff --git a/crypto/fipsmodule/digest/digests.c b/crypto/fipsmodule/digest/digests.c
+index f2fa349c2b32ae88766624af3109ece4b1d69909..bcaed59c5401bef071acba9b9919d9069e3ccd4d 100644
+--- a/crypto/fipsmodule/digest/digests.c
++++ b/crypto/fipsmodule/digest/digests.c
+@@ -63,6 +63,7 @@
+ #include <openssl/md5.h>
+ #include <openssl/nid.h>
+ #include <openssl/sha.h>
++#include <openssl/ripemd.h>
+ 
+ #include "internal.h"
+ #include "../delocate.h"
+@@ -277,4 +278,27 @@ DEFINE_METHOD_FUNCTION(EVP_MD, EVP_md5_sha1) {
+   out->ctx_size = sizeof(MD5_SHA1_CTX);
+ }
+ 
++static void ripemd160_init(EVP_MD_CTX *ctx) {
++  CHECK(RIPEMD160_Init(ctx->md_data));
++}
++
++static void ripemd160_update(EVP_MD_CTX *ctx, const void *data, size_t count) {
++  CHECK(RIPEMD160_Update(ctx->md_data, data, count));
++}
++
++static void ripemd160_final(EVP_MD_CTX *ctx, uint8_t *md) {
++  CHECK(RIPEMD160_Final(md, ctx->md_data));
++}
++
++DEFINE_METHOD_FUNCTION(EVP_MD, EVP_ripemd160) {
++  out->type = NID_ripemd160;
++  out->md_size = RIPEMD160_DIGEST_LENGTH;
++  out->flags = 0;
++  out->init = ripemd160_init;
++  out->update = ripemd160_update;
++  out->final = ripemd160_final;
++  out->block_size = 64;
++  out->ctx_size = sizeof(RIPEMD160_CTX);
++}
++
+ #undef CHECK
+diff --git a/decrepit/evp/evp_do_all.c b/decrepit/evp/evp_do_all.c
+index 38b8f9f78f76050174096740596ac59a0fe18757..acc4719b7e9c4c4461fc6142f2ae9156b407915b 100644
+--- a/decrepit/evp/evp_do_all.c
++++ b/decrepit/evp/evp_do_all.c
+@@ -66,6 +66,7 @@ void EVP_MD_do_all_sorted(void (*callback)(const EVP_MD *cipher,
+   callback(EVP_sha256(), "SHA256", NULL, arg);
+   callback(EVP_sha384(), "SHA384", NULL, arg);
+   callback(EVP_sha512(), "SHA512", NULL, arg);
++  callback(EVP_ripemd160(), "RIPEMD160", NULL, arg);
+ 
+   callback(EVP_md4(), "md4", NULL, arg);
+   callback(EVP_md5(), "md5", NULL, arg);
+@@ -74,4 +75,5 @@ void EVP_MD_do_all_sorted(void (*callback)(const EVP_MD *cipher,
+   callback(EVP_sha256(), "sha256", NULL, arg);
+   callback(EVP_sha384(), "sha384", NULL, arg);
+   callback(EVP_sha512(), "sha512", NULL, arg);
++  callback(EVP_ripemd160(), "ripemd160", NULL, arg);
+ }
+diff --git a/include/openssl/digest.h b/include/openssl/digest.h
+index 1a1ca29732afae317c8e8740c629e8922fc83093..48ebdd1eb93b3febecddbc2545b7aae583f21525 100644
+--- a/include/openssl/digest.h
++++ b/include/openssl/digest.h
+@@ -88,6 +88,9 @@ OPENSSL_EXPORT const EVP_MD *EVP_sha512(void);
+ // MD5 and SHA-1, as used in TLS 1.1 and below.
+ OPENSSL_EXPORT const EVP_MD *EVP_md5_sha1(void);
+ 
++// EVP_ripemd160 is in decrepit and not available by default.
++OPENSSL_EXPORT const EVP_MD *EVP_ripemd160(void);
++
+ // EVP_get_digestbynid returns an |EVP_MD| for the given NID, or NULL if no
+ // such digest is known.
+ OPENSSL_EXPORT const EVP_MD *EVP_get_digestbynid(int nid);

--- a/patches/common/chromium/boringssl_build_gn.patch
+++ b/patches/common/chromium/boringssl_build_gn.patch
@@ -1,16 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jeremy Apthorp <nornagon@nornagon.net>
 Date: Thu, 20 Sep 2018 17:48:05 -0700
-Subject: boringssl_build_gn.patch
+Subject: boringssl BUILD.gn
 
-Build BoringSSL with some extra functions that nodejs needs. Only affects
-the GN build; with the GYP build, nodejs is still built with OpenSSL.
+Build BoringSSL with some extra functions that nodejs needs.
 
 diff --git a/third_party/boringssl/BUILD.gn b/third_party/boringssl/BUILD.gn
-index 6e4fc85f124ed6dd4a7ac1812686fa59c4e50cdf..2fbd44c0ac71bbd84706ef50dd0d98b2466d4295 100644
+index 6e4fc85f124ed6dd4a7ac1812686fa59c4e50cdf..fd45cfcb50fb659ff8d5a07b06aeecc8f0ecd3ee 100644
 --- a/third_party/boringssl/BUILD.gn
 +++ b/third_party/boringssl/BUILD.gn
-@@ -45,6 +45,13 @@ config("no_asm_config") {
+@@ -45,6 +45,19 @@ config("no_asm_config") {
  
  all_sources = crypto_sources + ssl_sources
  all_headers = crypto_headers + ssl_headers
@@ -19,6 +18,12 @@ index 6e4fc85f124ed6dd4a7ac1812686fa59c4e50cdf..2fbd44c0ac71bbd84706ef50dd0d98b2
 +  all_sources += [
 +    "src/decrepit/evp/evp_do_all.c",
 +    "src/decrepit/xts/xts.c",
++  ]
++
++  all_sources += [
++    "src/decrepit/ripemd/internal.h",
++    "src/decrepit/ripemd/ripemd.c",
++    "src/decrepit/cfb/cfb.c",
 +  ]
 +}
  

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -428,6 +428,18 @@ describe('node feature', () => {
     })
   })
 
+  describe('crypto', () => {
+    it('should list the ripemd160 hash in getHashes', () => {
+      expect(require('crypto').getHashes()).to.include('ripemd160')
+    })
+
+    it('should be able to create a ripemd160 hash and use it', () => {
+      const hash = require('crypto').createHash('ripemd160')
+      hash.update('electron-ripemd160')
+      expect(hash.digest('hex')).to.equal('fa7fec13c624009ab126ebb99eda6525583395fe')
+    })
+  })
+
   it('includes the electron version in process.versions', () => {
     expect(process.versions)
       .to.have.own.property('electron')


### PR DESCRIPTION
Ref #16195

ripemd160 is available in openssl by default, but boringssl does not build it by default. This adds a patch to expose it from boringssl.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Restored support for RIPEMD160 digest, which was lost when switching from OpenSSL to BoringSSL.
