### PR TITLE
Fixes to menu item example

### DIFF
--- a/docs/tutorial/keyboard-shortcuts.md
+++ b/docs/tutorial/keyboard-shortcuts.md
@@ -8,6 +8,7 @@ You can use the [Menu] module to configure keyboard shortcuts that will
 be triggered only when the app is focused. To do so, specify an
 [`accelerator`] property when creating a [MenuItem].
 
+This will create a new application menu with the 'Print' item.
 ```js
 const { Menu, MenuItem } = require('electron')
 const menu = new Menu()
@@ -17,6 +18,21 @@ menu.append(new MenuItem({
   accelerator: 'CmdOrCtrl+P',
   click: () => { console.log('time to print stuff') }
 }))
+
+Menu.setApplicationMenu(menu);
+```
+
+Use this to append to the existing application menu:
+```js
+const { Menu, MenuItem } = require('electron')
+
+Menu.getApplicationMenu().append(new MenuItem({
+  label: 'Print',
+  accelerator: 'CmdOrCtrl+P',
+  click: () => { console.log('time to print stuff') }
+}))
+
+Menu.setApplicationMenu(Menu.getApplicationMenu());
 ```
 
 You can configure different key combinations based on the user's operating system.


### PR DESCRIPTION
Previous example was not calling setApplicationMenu and thus was confusing as to why it wasn't working. I've corrected that and explained the difference between adding a menu item to the existing menu vs creating a menu with just one item (basically the original example).

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
