### PR TITLE
perf: and refactor: Code Scope + Minor Performance Improvement.

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1154,8 +1154,9 @@ v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
 
 std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
   std::vector<mate::Dictionary> result;
+  result.reserve(app_metrics_.size());
   int processor_count = base::SysInfo::NumberOfProcessors();
-
+  
   for (const auto& process_metric : app_metrics_) {
     mate::Dictionary pid_dict = mate::Dictionary::CreateEmpty(isolate);
     mate::Dictionary cpu_dict = mate::Dictionary::CreateEmpty(isolate);

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1156,7 +1156,7 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
   std::vector<mate::Dictionary> result;
   result.reserve(app_metrics_.size());
   int processor_count = base::SysInfo::NumberOfProcessors();
-  
+
   for (const auto& process_metric : app_metrics_) {
     mate::Dictionary pid_dict = mate::Dictionary::CreateEmpty(isolate);
     mate::Dictionary cpu_dict = mate::Dictionary::CreateEmpty(isolate);

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -137,11 +137,12 @@ bool DesktopCapturer::ShouldScheduleNextRefresh(DesktopMediaList* list) {
 }
 
 void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
-  std::vector<DesktopCapturer::Source> window_sources;
   if (capture_window_ &&
       list->GetMediaListType() == content::DesktopMediaID::TYPE_WINDOW) {
     capture_window_ = false;
     const auto& media_list_sources = list->GetSources();
+    std::vector<DesktopCapturer::Source> window_sources;
+    window_sources.reserve(media_list_sources.size());
     for (const auto& media_list_source : media_list_sources) {
       window_sources.emplace_back(DesktopCapturer::Source{
           media_list_source, std::string(), fetch_window_icons_});
@@ -150,11 +151,12 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
               std::back_inserter(captured_sources_));
   }
 
-  std::vector<DesktopCapturer::Source> screen_sources;
   if (capture_screen_ &&
       list->GetMediaListType() == content::DesktopMediaID::TYPE_SCREEN) {
     capture_screen_ = false;
     const auto& media_list_sources = list->GetSources();
+    std::vector<DesktopCapturer::Source> screen_sources;
+    screen_sources.reserve(media_list_sources.size());
     for (const auto& media_list_source : media_list_sources) {
       screen_sources.emplace_back(
           DesktopCapturer::Source{media_list_source, std::string()});


### PR DESCRIPTION
Made two vectors scope narrower and reserved them because we know the size in advance. This helps save on allocation costs. 

"It's better to delay initialization until it is actually used".

notes: no-notes
