### PR TITLE
feat: make ipc-message and ipc-message-sync events public

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -673,6 +673,26 @@ Returns:
 
 Emitted when the preload script `preloadPath` throws an unhandled exception `error`.
 
+#### Event: 'ipc-message'
+
+Returns:
+
+* `event` Event
+* `channel` String
+* `...args` any[]
+
+Emitted when the renderer process sends an asynchronous message via `ipcRenderer.send()`.
+
+#### Event: 'ipc-message-sync'
+
+Returns:
+
+* `event` Event
+* `channel` String
+* `...args` any[]
+
+Emitted when the renderer process sends a synchronous message via `ipcRenderer.sendSync()`.
+
 #### Event: 'desktop-capturer-get-sources'
 
 Returns:

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -342,17 +342,19 @@ WebContents.prototype._init = function () {
   this.capturePage = deprecate.promisify(this.capturePage, 2)
 
   // Dispatch IPC messages to the ipc module.
-  this.on('ipc-message', function (event, [channel, ...args]) {
+  this.on('-ipc-message', function (event, [channel, ...args]) {
+    this.emit('ipc-message', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
 
-  this.on('ipc-message-sync', function (event, [channel, ...args]) {
+  this.on('-ipc-message-sync', function (event, [channel, ...args]) {
     Object.defineProperty(event, 'returnValue', {
       set: function (value) {
         return event.sendReply([value])
       },
       get: function () {}
     })
+    this.emit('ipc-message-sync', event, channel, ...args)
     ipcMain.emit(channel, event, ...args)
   })
 

--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -8,11 +8,11 @@ const ipcRenderer = v8Util.getHiddenValue(global, 'ipc')
 const internal = false
 
 ipcRenderer.send = function (...args) {
-  return binding.send('ipc-message', args)
+  return binding.send('-ipc-message', args)
 }
 
 ipcRenderer.sendSync = function (...args) {
-  return binding.sendSync('ipc-message-sync', args)[0]
+  return binding.sendSync('-ipc-message-sync', args)[0]
 }
 
 ipcRenderer.sendToHost = function (...args) {

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -995,6 +995,34 @@ describe('webContents module', () => {
     })
   })
 
+  describe('ipc-message event', () => {
+    it('emits when the renderer process sends an asynchronous message', async () => {
+      const webContents = remote.getCurrentWebContents()
+      const promise = emittedOnce(webContents, 'ipc-message')
+
+      ipcRenderer.send('message', 'Hello World!')
+
+      const [, channel, message] = await promise
+      expect(channel).to.equal('message')
+      expect(message).to.equal('Hello World!')
+    })
+  })
+
+  describe('ipc-message-sync event', () => {
+    it('emits when the renderer process sends a synchronous message', async () => {
+      const webContents = remote.getCurrentWebContents()
+      const promise = emittedOnce(webContents, 'ipc-message-sync')
+
+      ipcRenderer.send('handle-next-ipc-message-sync', 'foobar')
+      const result = ipcRenderer.sendSync('message', 'Hello World!')
+
+      const [, channel, message] = await promise
+      expect(channel).to.equal('message')
+      expect(message).to.equal('Hello World!')
+      expect(result).to.equal('foobar')
+    })
+  })
+
   describe('referrer', () => {
     it('propagates referrer information to new target=_blank windows', (done) => {
       const server = http.createServer((req, res) => {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -235,6 +235,12 @@ app.on('ready', function () {
   })
 })
 
+ipcMain.on('handle-next-ipc-message-sync', function (event, returnValue) {
+  event.sender.once('ipc-message-sync', (event, channel, args) => {
+    event.returnValue = returnValue
+  })
+})
+
 for (const eventName of [
   'remote-require',
   'remote-get-global',

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -651,7 +651,7 @@ describe('<webview> tag', function () {
   })
 
   describe('ipc-message event', () => {
-    it('emits when guest sends a ipc message to browser', async () => {
+    it('emits when guest sends an ipc message to browser', async () => {
       loadWebView(webview, {
         nodeintegration: 'on',
         src: `file://${fixtures}/pages/ipc-message.html`


### PR DESCRIPTION
#### Description of Change
- Allows handling IPC messages for particular `webContents`.
- Both `ipc-message` and `ipc-message-sync` on `webContents` are refactored to make the arguments easier to handle.

/cc @MarshallOfSound, @nornagon

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `ipc-message` and `ipc-message-sync` events to `webContents`.