### PR TITLE
fix: <webview> not working with contextIsolation + sandbox

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -29,7 +29,7 @@ class AtomSandboxedRendererClient : public RendererClientBase {
   void WillReleaseScriptContext(v8::Handle<v8::Context> context,
                                 content::RenderFrame* render_frame) override;
   void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
-                               content::RenderFrame* render_frame) override {}
+                               content::RenderFrame* render_frame) override;
   // content::ContentRendererClient:
   void RenderFrameCreated(content::RenderFrame*) override;
   void RenderViewCreated(content::RenderView*) override;

--- a/filenames.gni
+++ b/filenames.gni
@@ -74,6 +74,7 @@ filenames = {
     "lib/renderer/web-view/web-view-constants.js",
     "lib/renderer/web-view/web-view-element.js",
     "lib/renderer/web-view/web-view-impl.js",
+    "lib/renderer/web-view/web-view-init.js",
     "lib/renderer/api/exports/electron.js",
     "lib/renderer/api/crash-reporter.js",
     "lib/renderer/api/ipc-renderer.js",

--- a/lib/isolated_renderer/init.js
+++ b/lib/isolated_renderer/init.js
@@ -2,11 +2,11 @@
 
 /* global nodeProcess, isolatedWorld */
 
-// Note: Don't use "process", as it will be replaced by browserify's one.
-const v8Util = nodeProcess.atomBinding('v8_util')
+const atomBinding = require('@electron/internal/common/atom-binding-setup')(nodeProcess.binding, 'renderer')
 
-const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
-const { webViewImpl, ipcRenderer, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+const v8Util = atomBinding('v8_util')
+
+const webViewImpl = v8Util.getHiddenValue(isolatedWorld, 'web-view-impl')
 
 if (webViewImpl) {
   // Must setup the WebView element in main world.
@@ -14,4 +14,9 @@ if (webViewImpl) {
   setupWebView(v8Util, webViewImpl)
 }
 
-require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
+
+if (isolatedWorldArgs) {
+  const { ipcRenderer, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+  require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+}

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -58,32 +58,28 @@ if (preloadScript) {
   preloadScripts.push(preloadScript)
 }
 
-if (window.location.protocol === 'chrome-devtools:') {
-  // Override some inspector APIs.
-  require('@electron/internal/renderer/inspector')
-} else if (window.location.protocol === 'chrome-extension:') {
-  // Add implementations of chrome API.
-  require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, isBackgroundPage, window)
-} else if (window.location.protocol === 'chrome:') {
-  // Disable node integration for chrome UI scheme.
-} else {
-  // Override default web functions.
-  require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+switch (window.location.protocol) {
+  case 'chrome-devtools:': {
+    // Override some inspector APIs.
+    require('@electron/internal/renderer/inspector')
+    break
+  }
+  case 'chrome-extension:': {
+    // Inject the chrome.* APIs that chrome extensions require
+    require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, isBackgroundPage, window)
+    break
+  }
+  default: {
+    // Override default web functions.
+    require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 
-  // Inject content scripts.
-  require('@electron/internal/renderer/content-scripts-injector')
-
-  // Load webview tag implementation.
-  if (webviewTag && guestInstanceId == null) {
-    const webViewImpl = require('@electron/internal/renderer/web-view/web-view-impl')
-    if (contextIsolation) {
-      Object.assign(isolatedWorldArgs, { webViewImpl })
-    } else {
-      const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element')
-      setupWebView(v8Util, webViewImpl)
-    }
+    // Inject content scripts.
+    require('@electron/internal/renderer/content-scripts-injector')
   }
 }
+
+// Load webview tag implementation.
+require('@electron/internal/renderer/web-view/web-view-init')(contextIsolation, webviewTag, guestInstanceId)
 
 // Pass the arguments to isolatedWorld.
 if (contextIsolation) {
@@ -163,15 +159,3 @@ for (const preloadScript of preloadScripts) {
 
 // Warn about security issues
 require('@electron/internal/renderer/security-warnings')(nodeIntegration)
-
-// Report focus/blur events of webview to browser.
-// Note that while Chromium content APIs have observer for focus/blur, they
-// unfortunately do not work for webview.
-if (guestInstanceId) {
-  window.addEventListener('focus', () => {
-    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', true, guestInstanceId)
-  })
-  window.addEventListener('blur', () => {
-    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', false, guestInstanceId)
-  })
-}

--- a/lib/renderer/web-view/web-view-init.js
+++ b/lib/renderer/web-view/web-view-init.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
+const v8Util = process.atomBinding('v8_util')
+
+function handleFocusBlur (guestInstanceId) {
+  // Note that while Chromium content APIs have observer for focus/blur, they
+  // unfortunately do not work for webview.
+
+  window.addEventListener('focus', () => {
+    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', true, guestInstanceId)
+  })
+
+  window.addEventListener('blur', () => {
+    ipcRenderer.send('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', false, guestInstanceId)
+  })
+}
+
+module.exports = function (contextIsolation, webviewTag, guestInstanceId) {
+  // Load webview tag implementation.
+  if (webviewTag && guestInstanceId == null) {
+    const webViewImpl = require('@electron/internal/renderer/web-view/web-view-impl')
+    if (contextIsolation) {
+      v8Util.setHiddenValue(window, 'web-view-impl', webViewImpl)
+    } else {
+      const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element')
+      setupWebView(v8Util, webViewImpl)
+    }
+  }
+
+  if (guestInstanceId) {
+    // Report focus/blur events of webview to browser.
+    handleFocusBlur(guestInstanceId)
+  }
+}

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -105,7 +105,11 @@ function preloadRequire (module) {
   throw new Error('module not found')
 }
 
+// Process command line arguments.
 const { hasSwitch } = process.atomBinding('command_line')
+
+const isBackgroundPage = hasSwitch('background-page')
+const contextIsolation = hasSwitch('context-isolation')
 
 switch (window.location.protocol) {
   case 'chrome-devtools:': {
@@ -115,22 +119,15 @@ switch (window.location.protocol) {
   }
   case 'chrome-extension:': {
     // Inject the chrome.* APIs that chrome extensions require
-    const isBackgroundPage = hasSwitch('background-page')
     require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, isBackgroundPage, window)
     break
   }
 }
 
-if (binding.guestInstanceId) {
-  process.guestInstanceId = parseInt(binding.guestInstanceId)
-}
+const guestInstanceId = binding.guestInstanceId && parseInt(binding.guestInstanceId)
 
-// Don't allow recursive `<webview>`.
-if (!process.guestInstanceId && isWebViewTagEnabled) {
-  const webViewImpl = require('@electron/internal/renderer/web-view/web-view-impl')
-  const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element')
-  setupWebView(v8Util, webViewImpl)
-}
+// Load webview tag implementation.
+require('@electron/internal/renderer/web-view/web-view-init')(contextIsolation, isWebViewTagEnabled, guestInstanceId)
 
 const errorUtils = require('@electron/internal/common/error-utils')
 


### PR DESCRIPTION
#### Description of Change
- The `isolated_renderer/init.js` script was not being injected into the main world context of sandboxed renderers
- The code for forwarding the `focus` event was missing in `lib/sandboxed_renderer/init.js`.

/cc @nornagon @MarshallOfSound

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `<webview>` not working with `contextIsolation` + `sandbox`.
Fixed `focus` event not emitted when `<webview>` is sandboxed.