### PR TITLE
fix: prevent double-destroy of window

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -182,7 +182,14 @@ bool BrowserWindow::OnMessageReceived(const IPC::Message& message,
 }
 
 void BrowserWindow::OnCloseContents() {
-  DCHECK(web_contents());
+  // On some machines it may happen that the window gets destroyed for twice,
+  // checking web_contents() can effectively guard against that.
+  // https://github.com/electron/electron/issues/16202.
+  //
+  // TODO(zcbenz): We should find out the root cause and improve the closing
+  // procedure of BrowserWindow.
+  if (!web_contents())
+    return;
 
   // Close all child windows before closing current window.
   v8::Locker locker(isolate());


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fix https://github.com/electron/electron/issues/16202.

On some machines it may happen that the window gets destroyed for twice, and checking web_contents() can effectively guard against that.

I could not find out the root cause as I could not reproduce the crash on my machine, but as discussed in the original issue, this fix can solve the crash, and I don't see any bad side effect. 

#### Release Notes

Notes: Fix crash when closing popup windows.