### PR TITLE
fix: takeHeapSnapshot() using public IPC channel for internal implementation

### DIFF
--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -216,7 +216,7 @@ void AtomRenderFrameObserver::OnTakeHeapSnapshot(
   args.AppendBoolean(success);
 
   render_frame_->Send(new AtomFrameHostMsg_Message(
-      render_frame_->GetRoutingID(), "ipc-message", args));
+      render_frame_->GetRoutingID(), "ipc-internal-message", args));
 }
 
 void AtomRenderFrameObserver::EmitIPCEvent(blink::WebLocalFrame* frame,

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -237,7 +237,7 @@ WebContents.prototype.getZoomFactor = function (callback) {
 WebContents.prototype.takeHeapSnapshot = function (filePath) {
   return new Promise((resolve, reject) => {
     const channel = `ELECTRON_TAKE_HEAP_SNAPSHOT_RESULT_${getNextId()}`
-    ipcMain.once(channel, (event, success) => {
+    ipcMainInternal.once(channel, (event, success) => {
       if (success) {
         resolve()
       } else {
@@ -245,7 +245,7 @@ WebContents.prototype.takeHeapSnapshot = function (filePath) {
       }
     })
     if (!this._takeHeapSnapshot(filePath, channel)) {
-      ipcMain.emit(channel, false)
+      ipcMainInternal.emit(channel, false)
     }
   })
 }


### PR DESCRIPTION
#### Description of Change
Make it use the internal IPC channel.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
