### PR TITLE
docs: fix web-request.md listener signatures in electron.d.ts

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -73,24 +73,23 @@ The `callback` has to be called with an `response` object.
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `webContentsId` Integer (optional)
+    * `resourceType` String
+    * `timestamp` Double
+    * `requestHeaders` Object
+  * `callback` Function
+    * `response` Object
+      * `cancel` Boolean (optional)
+      * `requestHeaders` Object (optional) - When provided, request will be made
+  with these headers.
 
 The `listener` will be called with `listener(details, callback)` before sending
 an HTTP request, once the request headers are available. This may occur after a
 TCP connection is made to the server, but before any http data is sent.
-
-* `details` Object
-  * `id` Integer
-  * `url` String
-  * `method` String
-  * `webContentsId` Integer (optional)
-  * `resourceType` String
-  * `timestamp` Double
-  * `requestHeaders` Object
-* `callback` Function
-  * `response` Object
-    * `cancel` Boolean (optional)
-    * `requestHeaders` Object (optional) - When provided, request will be made
-      with these headers.
 
 The `callback` has to be called with an `response` object.
 
@@ -119,28 +118,27 @@ response are visible by the time this listener is fired.
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `webContentsId` Integer (optional)
+    * `resourceType` String
+    * `timestamp` Double
+    * `statusLine` String
+    * `statusCode` Integer
+    * `responseHeaders` Object
+  * `callback` Function
+    * `response` Object
+      * `cancel` Boolean
+      * `responseHeaders` Object (optional) - When provided, the server is assumed
+        to have responded with these headers.
+      * `statusLine` String (optional) - Should be provided when overriding
+        `responseHeaders` to change header status otherwise original response
+        header's status will be used.
 
 The `listener` will be called with `listener(details, callback)` when HTTP
 response headers of a request have been received.
-
-* `details` Object
-  * `id` Integer
-  * `url` String
-  * `method` String
-  * `webContentsId` Integer (optional)
-  * `resourceType` String
-  * `timestamp` Double
-  * `statusLine` String
-  * `statusCode` Integer
-  * `responseHeaders` Object
-* `callback` Function
-  * `response` Object
-    * `cancel` Boolean
-    * `responseHeaders` Object (optional) - When provided, the server is assumed
-      to have responded with these headers.
-    * `statusLine` String (optional) - Should be provided when overriding
-      `responseHeaders` to change header status otherwise original response
-      header's status will be used.
 
 The `callback` has to be called with an `response` object.
 


### PR DESCRIPTION
#### Description of Change
Fixes `listener` being generated as `Function` for `onBeforeSendHeaders` and `onHeadersReceived`.

/cc @alexeykuzmin, @codebytere 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `onBeforeSendHeaders` / `onSendHeaders` listener signatures in `electron.d.ts`.
