### PR TITLE
docs: cancel is optional in OnHeadersReceivedResponse

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -32,7 +32,7 @@ const filter = {
 
 session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
   details.requestHeaders['User-Agent'] = 'MyAgent'
-  callback({ cancel: false, requestHeaders: details.requestHeaders })
+  callback({ requestHeaders: details.requestHeaders })
 })
 ```
 
@@ -130,7 +130,7 @@ response are visible by the time this listener is fired.
     * `responseHeaders` Object
   * `callback` Function
     * `response` Object
-      * `cancel` Boolean
+      * `cancel` Boolean (optional)
       * `responseHeaders` Object (optional) - When provided, the server is assumed
         to have responded with these headers.
       * `statusLine` String (optional) - Should be provided when overriding


### PR DESCRIPTION
#### Description of Change
The `cancel` property is optional for all responses, including `OnHeadersReceivedResponse` according to the code [atom/browser/net/atom_network_delegate.cc](https://github.com/electron/electron/blob/master/atom/browser/net/atom_network_delegate.cc#L530)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Documented the `cancel` property in `OnHeadersReceivedResponse` as optional.