### PR TITLE
test: run tests without sandbox on arm

### DIFF
--- a/script/verify-ffmpeg.py
+++ b/script/verify-ffmpeg.py
@@ -45,7 +45,10 @@ def main():
     env['ELECTRON_ENABLE_STACK_DUMPING'] = 'true'
     # FIXME: Enable after ELECTRON_ENABLE_LOGGING works again
     # env['ELECTRON_ENABLE_LOGGING'] = 'true'
-    subprocess.check_call([electron, test_path] + sys.argv[1:], env=env)
+    extra_args = []
+    if args.no_sandbox:
+      extra_args.append('--no-sandbox')
+    subprocess.check_call([electron, test_path] + extra_args, env=env)
   except subprocess.CalledProcessError as e:
     returncode = e.returncode
   except KeyboardInterrupt:
@@ -86,6 +89,9 @@ def parse_args():
                           Relative to the --source-root.',
                       default=None,
                       required=True)
+  parser.add_argument('--no-sandbox',
+                      help='Run electron without sandbox.',
+                      action='store_true')
   return parser.parse_args()
 
 if __name__ == '__main__':

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -55,7 +55,10 @@ def main():
       else:
         electron = os.path.join(app_path, PROJECT_NAME)
 
-      subprocess.check_call([electron, test_path])
+      extra_args = []
+      if args.no_sandbox:
+        extra_args.append('--no-sandbox')
+      subprocess.check_call([electron, test_path] + extra_args)
       print 'ok successfully used custom snapshot.'
   except subprocess.CalledProcessError as e:
     print 'not ok an error was encountered while testing mksnapshot.'
@@ -96,6 +99,8 @@ def parse_args():
   parser.add_argument('--source-root',
                       default=SOURCE_ROOT,
                       required=False)
+  parser.add_argument('--no-sandbox',
+                      action='store_True')
   return parser.parse_args()
 
 if __name__ == '__main__':

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -100,7 +100,7 @@ def parse_args():
                       default=SOURCE_ROOT,
                       required=False)
   parser.add_argument('--no-sandbox',
-                      action='store_True')
+                      action='store_true')
   return parser.parse_args()
 
 if __name__ == '__main__':

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -73,7 +73,7 @@ steps:
 
 - bash: |
     cd src
-    python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
+    python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --no-sandbox
   displayName: Verify mksnapshot
   timeoutInMinutes: 5
 

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -67,7 +67,7 @@ steps:
 
 - bash: |
     cd src
-    python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
+    python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg --no-sandbox
   displayName: Verify non proprietary ffmpeg
   timeoutInMinutes: 5
 
@@ -79,7 +79,7 @@ steps:
 
 - bash: |
    cd src
-   ./out/Default/electron electron/spec --ci --enable-logging
+   ./out/Default/electron electron/spec --ci --enable-logging --no-sandbox
   displayName: 'Run Electron tests'
   timeoutInMinutes: 10
 


### PR DESCRIPTION
#### Description of Change
On ARM, we run our tests in docker, which conflicts with Chromium's sandboxing strategy. For now, just run the tests without the sandbox.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes