### PR TITLE
fix: correctly destroy spellcheck client 

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -4,6 +4,8 @@
 
 #include "atom/renderer/api/atom_api_web_frame.h"
 
+#include <utility>
+
 #include "atom/common/api/api_messages.h"
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/blink_converter.h"
@@ -135,6 +137,22 @@ class FrameSpellChecker : public content::RenderFrameVisitor {
 
 }  // namespace
 
+class AtomWebFrameObserver : public content::RenderFrameObserver {
+ public:
+  explicit AtomWebFrameObserver(
+      content::RenderFrame* render_frame,
+      std::unique_ptr<SpellCheckClient> spell_check_client)
+      : content::RenderFrameObserver(render_frame),
+        spell_check_client_(std::move(spell_check_client)) {}
+  ~AtomWebFrameObserver() final {}
+
+  // RenderFrameObserver implementation.
+  void OnDestruct() final { spell_check_client_.reset(nullptr); }
+
+ private:
+  std::unique_ptr<SpellCheckClient> spell_check_client_;
+};
+
 WebFrame::WebFrame(v8::Isolate* isolate)
     : web_frame_(blink::WebLocalFrame::FrameForCurrentContext()) {
   Init(isolate);
@@ -226,11 +244,13 @@ void WebFrame::SetSpellCheckProvider(mate::Arguments* args,
       language, auto_spell_correct_turned_on, args->isolate(), provider);
   // Set spellchecker for all live frames in the same process or
   // in the sandbox mode for all live sub frames to this WebFrame.
-  FrameSpellChecker spell_checker(
-      client.get(), content::RenderFrame::FromWebFrame(web_frame_));
+  auto* render_frame = content::RenderFrame::FromWebFrame(web_frame_);
+  FrameSpellChecker spell_checker(client.get(), render_frame);
   content::RenderFrame::ForEach(&spell_checker);
   spell_check_client_.swap(client);
   web_frame_->SetSpellCheckPanelHostClient(spell_check_client_.get());
+  web_frame_observer_.reset(
+      new AtomWebFrameObserver(render_frame, std::move(spell_check_client_)));
 }
 
 void WebFrame::RegisterURLSchemeAsBypassingCSP(const std::string& scheme) {

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -27,6 +27,7 @@ namespace atom {
 namespace api {
 
 class SpellCheckClient;
+class AtomWebFrameObserver;
 
 class WebFrame : public mate::Wrappable<WebFrame> {
  public:
@@ -100,6 +101,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   v8::Local<v8::Value> RoutingId() const;
 
   std::unique_ptr<SpellCheckClient> spell_check_client_;
+  std::unique_ptr<AtomWebFrameObserver> web_frame_observer_;
 
   blink::WebLocalFrame* web_frame_;
 

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -26,9 +26,6 @@ namespace atom {
 
 namespace api {
 
-class SpellCheckClient;
-class AtomWebFrameObserver;
-
 class WebFrame : public mate::Wrappable<WebFrame> {
  public:
   static mate::Handle<WebFrame> Create(v8::Isolate* isolate);
@@ -99,9 +96,6 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   v8::Local<v8::Value> FindFrameByName(const std::string& name) const;
   v8::Local<v8::Value> FindFrameByRoutingId(int routing_id) const;
   v8::Local<v8::Value> RoutingId() const;
-
-  std::unique_ptr<SpellCheckClient> spell_check_client_;
-  std::unique_ptr<AtomWebFrameObserver> web_frame_observer_;
 
   blink::WebLocalFrame* web_frame_;
 


### PR DESCRIPTION
#### Description of Change
Backport of https://github.com/electron/electron/pull/16448.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fixed memory leak caused by webFrame.setSpellCheckProvider.