### PR TITLE
docs: fix extra closing parenthesis

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -253,7 +253,7 @@ const { remote } = require('electron')
 const { Menu, MenuItem } = remote
 
 const menu = new Menu()
-menu.append(new MenuItem({ label: 'MenuItem1', click() { console.log('item 1 clicked') } })))
+menu.append(new MenuItem({ label: 'MenuItem1', click() { console.log('item 1 clicked') } }))
 menu.append(new MenuItem({ type: 'separator' }))
 menu.append(new MenuItem({ label: 'MenuItem2', type: 'checkbox', checked: true }))
 


### PR DESCRIPTION
#### Description of Change
There was an extra closing parenthesis in the example of creating a menu dynamically in a web page https://electronjs.org/docs/api/menu#render-process 

#### Checklist
- [x] relevant documentation is changed or added

#### Release Notes
Notes: `no-notes`