### PR TITLE
fix: registerStreamProtocol callback with large chunks

### DIFF
--- a/atom/browser/net/url_request_stream_job.cc
+++ b/atom/browser/net/url_request_stream_job.cc
@@ -141,6 +141,7 @@ void URLRequestStreamJob::StartAsync(
 }
 
 void URLRequestStreamJob::OnData(std::vector<char>&& buffer) {  // NOLINT
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
   if (write_buffer_.empty()) {
     // Quick branch without copying.
     write_buffer_ = std::move(buffer);
@@ -175,7 +176,7 @@ void URLRequestStreamJob::OnError(int error) {
 int URLRequestStreamJob::ReadRawData(net::IOBuffer* dest, int dest_size) {
   response_start_time_ = base::TimeTicks::Now();
 
-  if (ended_)
+  if (ended_ && write_buffer_.empty())
     return 0;
 
   // When write_buffer_ is empty, there is no data valable yet, we have to save

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -654,6 +654,30 @@ describe('protocol module', () => {
         })
       })
     })
+
+    it('can handle large responses', async () => {
+      const data = Buffer.alloc(128 * 1024)
+      const handler = (request, callback) => {
+        callback(getStream(data.length, data))
+      }
+      await new Promise((resolve, reject) => {
+        protocol.registerStreamProtocol(protocolName, handler, err => {
+          if (err) return reject(err)
+          resolve()
+        })
+      })
+      const r = await new Promise((resolve, reject) => {
+        $.ajax({
+          url: protocolName + '://fake-host',
+          cache: false,
+          success: resolve,
+          error: (xhr, errorType, error) => {
+            reject(error || new Error(`Request failed: ${xhr.status}`))
+          }
+        })
+      })
+      assert.strictEqual(r.length, data.length)
+    })
   })
 
   describe('protocol.isProtocolHandled', (done) => {


### PR DESCRIPTION
#### Description of Change
This fixes a bug in the registerStreamProtocol API that was introduced in Electron 4. The response was being closed before the data in the stream was exhausted.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fixed an issue where data streamed from registerStreamProtocol could be truncated before completion.