### PR TITLE
fix: execute session preload scripts in sandboxed renderers

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -534,8 +534,7 @@ ipcMain.on('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (event, text) 
   setReturnValue(event, () => electron.clipboard.writeFindText(text))
 })
 
-ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
-  const preloadPath = event.sender._getPreloadPath()
+const getPreloadScript = function (preloadPath) {
   let preloadSrc = null
   let preloadError = null
   if (preloadPath) {
@@ -545,10 +544,17 @@ ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
       preloadError = errorUtils.serialize(err)
     }
   }
+  return { preloadPath, preloadSrc, preloadError }
+}
+
+ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
+  const preloadPaths = [
+    ...(event.sender.session ? event.sender.session.getPreloads() : []),
+    event.sender._getPreloadPath()
+  ]
+
   event.returnValue = {
-    preloadPath,
-    preloadSrc,
-    preloadError,
+    preloadScripts: preloadPaths.map(path => getPreloadScript(path)),
     isRemoteModuleEnabled: event.sender._isRemoteModuleEnabled(),
     isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),
     process: {

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -29,7 +29,7 @@ Object.setPrototypeOf(process, EventEmitter.prototype)
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
 
 const {
-  preloadPath, preloadSrc, preloadError, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
+  preloadScripts, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
 } = ipcRenderer.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 process.isRemoteModuleEnabled = isRemoteModuleEnabled
@@ -151,17 +151,19 @@ function runPreloadScript (preloadSrc) {
   preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate, clearImmediate)
 }
 
-try {
-  if (preloadSrc) {
-    runPreloadScript(preloadSrc)
-  } else if (preloadError) {
-    throw errorUtils.deserialize(preloadError)
-  }
-} catch (error) {
-  console.error(`Unable to load preload script: ${preloadPath}`)
-  console.error(`${error}`)
+for (const { preloadPath, preloadSrc, preloadError } of preloadScripts) {
+  try {
+    if (preloadSrc) {
+      runPreloadScript(preloadSrc)
+    } else if (preloadError) {
+      throw errorUtils.deserialize(preloadError)
+    }
+  } catch (error) {
+    console.error(`Unable to load preload script: ${preloadPath}`)
+    console.error(`${error}`)
 
-  ipcRenderer.send('ELECTRON_BROWSER_PRELOAD_ERROR', preloadPath, errorUtils.serialize(error))
+    ipcRenderer.send('ELECTRON_BROWSER_PRELOAD_ERROR', preloadPath, errorUtils.serialize(error))
+  }
 }
 
 // Warn about security issues

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1382,23 +1382,29 @@ describe('BrowserWindow module', () => {
         assert.deepStrictEqual(defaultSession.getPreloads(), preloads)
       })
 
-      it('loads the script before other scripts in window including normal preloads', function (done) {
-        ipcMain.once('vars', function (event, preload1, preload2, preload3) {
-          assert.strictEqual(preload1, 'preload-1')
-          assert.strictEqual(preload2, 'preload-1-2')
-          assert.strictEqual(preload3, 'preload-1-2-3')
-          done()
+      const generateSpecs = (description, sandbox) => {
+        describe(description, () => {
+          it('loads the script before other scripts in window including normal preloads', function (done) {
+            ipcMain.once('vars', function (event, preload1, preload2) {
+              assert.strictEqual(preload1, 'preload-1')
+              assert.strictEqual(preload2, 'preload-1-2')
+              done()
+            })
+            w.destroy()
+            w = new BrowserWindow({
+              show: false,
+              webPreferences: {
+                sandbox,
+                preload: path.join(fixtures, 'module', 'get-global-preload.js')
+              }
+            })
+            w.loadURL('about:blank')
+          })
         })
-        w.destroy()
-        w = new BrowserWindow({
-          show: false,
-          webPreferences: {
-            nodeIntegration: true,
-            preload: path.join(fixtures, 'module', 'set-global-preload-3.js')
-          }
-        })
-        w.loadFile(path.join(fixtures, 'api', 'preloads.html'))
-      })
+      }
+
+      generateSpecs('without sandbox', false)
+      generateSpecs('with sandbox', true)
     })
 
     describe('"additionalArguments" option', () => {

--- a/spec/fixtures/module/get-global-preload.js
+++ b/spec/fixtures/module/get-global-preload.js
@@ -1,0 +1,1 @@
+require('electron').ipcRenderer.send('vars', window.preload1, window.preload2)

--- a/spec/fixtures/module/set-global-preload-3.js
+++ b/spec/fixtures/module/set-global-preload-3.js
@@ -1,1 +1,0 @@
-window.preload3 = window.preload2 + '-3'


### PR DESCRIPTION
#### Description of Change
The code to execute session preload scripts in sandboxed renderers was missing.

/cc @MarshallOfSound, @zcbenz, @tarruda

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed session preload scripts not being executed in sandboxed renderers.
