### PR TITLE
fix: registerStreamProtocol callback with large chunks (backport: 4-0-x)

### DIFF
--- a/atom/browser/net/url_request_stream_job.cc
+++ b/atom/browser/net/url_request_stream_job.cc
@@ -139,6 +139,7 @@ void URLRequestStreamJob::StartAsync(
 }
 
 void URLRequestStreamJob::OnData(std::vector<char>&& buffer) {  // NOLINT
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
   if (write_buffer_.empty()) {
     // Quick branch without copying.
     write_buffer_ = std::move(buffer);
@@ -173,7 +174,7 @@ void URLRequestStreamJob::OnError(int error) {
 int URLRequestStreamJob::ReadRawData(net::IOBuffer* dest, int dest_size) {
   response_start_time_ = base::TimeTicks::Now();
 
-  if (ended_)
+  if (ended_ && write_buffer_.empty())
     return 0;
 
   // When write_buffer_ is empty, there is no data valable yet, we have to save

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -602,6 +602,30 @@ describe('protocol module', () => {
         })
       })
     })
+
+    it('can handle large responses', async () => {
+      const data = Buffer.alloc(128 * 1024)
+      const handler = (request, callback) => {
+        callback(getStream(data.length, data))
+      }
+      await new Promise((resolve, reject) => {
+        protocol.registerStreamProtocol(protocolName, handler, err => {
+          if (err) return reject(err)
+          resolve()
+        })
+      })
+      const r = await new Promise((resolve, reject) => {
+        $.ajax({
+          url: protocolName + '://fake-host',
+          cache: false,
+          success: resolve,
+          error: (xhr, errorType, error) => {
+            reject(error || new Error(`Request failed: ${xhr.status}`))
+          }
+        })
+      })
+      assert.strictEqual(r.length, data.length)
+    })
   })
 
   describe('protocol.isProtocolHandled', () => {


### PR DESCRIPTION
#### Description of Change
Backports #16532 to 4-0-x. See that PR for details.

Notes: Fixed an issue where data streamed from registerStreamProtocol could be truncated before completion.