### PR TITLE
fix: don't forward IPC filtering events to app for dev-tools and extensions

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -365,6 +365,17 @@ const addReturnValueToEvent = (event) => {
   })
 }
 
+const safeProtocols = new Set([
+  'chrome-devtools:',
+  'chrome-extension:'
+])
+
+const isWebContentsTrusted = function (contents) {
+  const pageURL = contents._getURL()
+  const { protocol } = url.parse(pageURL)
+  return safeProtocols.has(protocol)
+}
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.
@@ -425,7 +436,9 @@ WebContents.prototype._init = function () {
 
   for (const eventName of forwardedEvents) {
     this.on(eventName, (event, ...args) => {
-      app.emit(eventName, event, this, ...args)
+      if (!isWebContentsTrusted(event.sender)) {
+        app.emit(eventName, event, this, ...args)
+      }
     })
   }
 


### PR DESCRIPTION
Allowing apps to filter the `remote` module for Chrome dev-tools and/or extensions is not a good idea as it can prevent them from working properly (such as context menu not working)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Electron no longer forwards IPC filtering events to `app` for dev-tools and extensions.