### PR TITLE
feat: add window removeMenu() method

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -659,6 +659,13 @@ void TopLevelWindow::SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   }
 }
 
+void TopLevelWindow::RemoveMenu() {
+  mate::Handle<Menu> menu;
+
+  menu_.Reset();
+  window_->SetMenu(nullptr);
+}
+
 void TopLevelWindow::SetParentWindow(v8::Local<v8::Value> value,
                                      mate::Arguments* args) {
   if (IsModal()) {
@@ -1103,6 +1110,7 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setContentProtection", &TopLevelWindow::SetContentProtection)
       .SetMethod("setFocusable", &TopLevelWindow::SetFocusable)
       .SetMethod("setMenu", &TopLevelWindow::SetMenu)
+      .SetMethod("removeMenu", &TopLevelWindow::RemoveMenu)
       .SetMethod("setParentWindow", &TopLevelWindow::SetParentWindow)
       .SetMethod("setBrowserView", &TopLevelWindow::SetBrowserView)
       .SetMethod("addBrowserView", &TopLevelWindow::AddBrowserView)

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -165,6 +165,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void SetContentProtection(bool enable);
   void SetFocusable(bool focusable);
   void SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> menu);
+  void RemoveMenu();
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
   virtual void SetBrowserView(v8::Local<v8::Value> value);
   virtual void AddBrowserView(v8::Local<v8::Value> value);

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1308,8 +1308,11 @@ Same as `webContents.reload`.
 
 * `menu` Menu | null
 
-Sets the `menu` as the window's menu bar, setting it to `null` will remove the
-menu bar.
+Sets the `menu` as the window's menu bar, setting it to `null` will remove the menu bar.
+
+#### `win.removeMenu()` _Linux_ _Windows_
+
+Remove the window's menu bar.
 
 #### `win.setProgressBar(progress[, options])`
 


### PR DESCRIPTION
#### Description of Change

This PR adds `win.removeMenu()` as an alternative for `win.setMenu(null)`, which is less intuitive and a bit of an antipattern for modern JS.

cc @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `win.removeMenu()` to remove application menus instead of using `win.setMenu(null)`.
