### PR TITLE
fix: reject with error when url not loaded

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1444,12 +1444,17 @@ v8::Local<v8::Promise> WebContents::HasServiceWorker() {
   auto* context = GetServiceWorkerContext(web_contents());
   if (!context) {
     promise->RejectWithErrorMessage("Unable to get ServiceWorker context.");
+    return promise->GetHandle();
+  }
+
+  GURL url = web_contents()->GetLastCommittedURL();
+  if (!url.is_valid()) {
+    promise->RejectWithErrorMessage("URL invalid or not yet loaded.");
+    return promise->GetHandle();
   }
 
   context->CheckHasServiceWorker(
-      web_contents()->GetLastCommittedURL(),
-      web_contents()->GetLastCommittedURL(),
-      base::BindOnce(&OnServiceWorkerCheckDone, promise));
+      url, url, base::BindOnce(&OnServiceWorkerCheckDone, promise));
 
   return promise->GetHandle();
 }

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -229,7 +229,7 @@ describe('webContents module', () => {
   })
 
   describe('ServiceWorker APIs', () => {
-    it('can successfully register a ServiceWorker', async () => {
+    it('can successfully check for presence of a ServiceWorker', async () => {
       await w.loadFile(path.join(fixtures, 'api', 'service-worker', 'service-worker.html'))
       const hasSW = await w.webContents.hasServiceWorker()
       expect(hasSW).to.be.true()
@@ -240,7 +240,7 @@ describe('webContents module', () => {
       return expect(promise).to.be.eventually.rejectedWith(Error, 'URL invalid or not yet loaded.')
     })
 
-    it('can successfully register a ServiceWorker (callback)', (done) => {
+    it('can successfully check for presence of a ServiceWorker (callback)', (done) => {
       w.loadFile(path.join(fixtures, 'api', 'service-worker', 'service-worker.html')).then(() => {
         w.webContents.hasServiceWorker(hasSW => {
           expect(hasSW).to.be.true()

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -235,6 +235,11 @@ describe('webContents module', () => {
       expect(hasSW).to.be.true()
     })
 
+    it('throws properly for invalid url', async () => {
+      const promise = w.webContents.hasServiceWorker()
+      return expect(promise).to.be.eventually.rejectedWith(Error, 'URL invalid or not yet loaded.')
+    })
+
     it('can successfully register a ServiceWorker (callback)', (done) => {
       w.loadFile(path.join(fixtures, 'api', 'service-worker', 'service-worker.html')).then(() => {
         w.webContents.hasServiceWorker(hasSW => {


### PR DESCRIPTION
#### Description of Change

When a user tried to call `webContents.hasServiceWorker()`on a `webContents` that hadn't yet loaded a valid URL, a DCHECK would get triggered. This prevents unexplained behavior for the end user by clearly rejecting with an error when `webContents.hasServiceWorker()` is called and there is no valid file or url in which to check for the presence of a ServiceWorker.

cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Ensured that `webContents.hasServiceWorker()` rejects with an error for invalid URLs.
