### PR TITLE
feat: add ELECTRON_DISABLE_SANDBOX env var

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -164,6 +164,9 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   if (env->HasVar("ELECTRON_ENABLE_STACK_DUMPING"))
     base::debug::EnableInProcessStackDumping();
 
+  if (env->HasVar("ELECTRON_DISABLE_SANDBOX"))
+    command_line->AppendSwitch(service_manager::switches::kNoSandbox);
+
   chrome::RegisterPathProvider();
 
 #if defined(OS_MACOSX)

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -70,18 +70,24 @@ steps:
     python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
   displayName: Verify non proprietary ffmpeg
   timeoutInMinutes: 5
+  env:
+    ELECTRON_DISABLE_SANDBOX: 1
 
 - bash: |
     cd src
     python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default
   displayName: Verify mksnapshot
   timeoutInMinutes: 5
+  env:
+    ELECTRON_DISABLE_SANDBOX: 1
 
 - bash: |
    cd src
    ./out/Default/electron electron/spec --ci --enable-logging
   displayName: 'Run Electron tests'
   timeoutInMinutes: 10
+  env:
+    ELECTRON_DISABLE_SANDBOX: 1
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'


### PR DESCRIPTION
#### Description of Change
This is to support easy disabling of sandboxing in CI environments, particularly on Linux where running CI inside docker is common, and Chrome's sandboxing technique conflicts with docker's default seccomp profile.

There have been concerns raised over whether this is a potential attack vector (e.g. an attacker who had control over the app's environment could set this variable to permit escalation), but I think there exist other easier routes to escalation if you have control over the environment, e.g. `LD_PRELOAD` or `PATH`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Added ELECTRON_DISABLE_SANDBOX environment variable to make it easier to disable sandboxing in Docker-based Linux CI environments.