### PR TITLE
fix: pass url to contents.hasServiceWorker()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1447,6 +1447,11 @@ v8::Local<v8::Promise> WebContents::HasServiceWorker(const GURL& url) {
     return promise->GetHandle();
   }
 
+  if (!url.is_valid()) {
+    promise->RejectWithErrorMessage("URL is invalid.");
+    return promise->GetHandle();
+  }
+
   context->CheckHasServiceWorker(
       url, url, base::BindOnce(&OnServiceWorkerCheckDone, promise));
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1439,17 +1439,11 @@ void OnServiceWorkerCheckDone(scoped_refptr<util::Promise> promise,
                    content::ServiceWorkerCapability::NO_SERVICE_WORKER);
 }
 
-v8::Local<v8::Promise> WebContents::HasServiceWorker() {
+v8::Local<v8::Promise> WebContents::HasServiceWorker(const GURL& url) {
   scoped_refptr<util::Promise> promise = new util::Promise(isolate());
   auto* context = GetServiceWorkerContext(web_contents());
   if (!context) {
     promise->RejectWithErrorMessage("Unable to get ServiceWorker context.");
-    return promise->GetHandle();
-  }
-
-  GURL url = web_contents()->GetLastCommittedURL();
-  if (!url.is_valid()) {
-    promise->RejectWithErrorMessage("URL invalid or not yet loaded.");
     return promise->GetHandle();
   }
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -161,7 +161,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DisableDeviceEmulation();
   void InspectElement(int x, int y);
   void InspectServiceWorker();
-  v8::Local<v8::Promise> HasServiceWorker();
+  v8::Local<v8::Promise> HasServiceWorker(const GURL& url);
   void UnregisterServiceWorker(const base::Callback<void(bool)>&);
   void SetIgnoreMenuShortcuts(bool ignore);
   void SetAudioMuted(bool muted);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1156,8 +1156,9 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
-#### `contents.hasServiceWorker(callback)`
+#### `contents.hasServiceWorker(url, callback)`
 
+* `url` String
 * `callback` Function
   * `hasWorker` Boolean
 
@@ -1168,7 +1169,9 @@ response to `callback`.
 
 #### `contents.hasServiceWorker()`
 
-Returns `Promise<Boolean>` - Resolves with a boolean depending on whether or not the current `webContents` has a registered ServiceWorker
+* `url` String
+
+Returns `Promise<Boolean>` - Resolves with a boolean depending on whether or not the file loaded into the current `webContents` has a registered ServiceWorker.
 
 #### `contents.unregisterServiceWorker(callback)`
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -229,20 +229,17 @@ describe('webContents module', () => {
   })
 
   describe('ServiceWorker APIs', () => {
+    const filePath = path.join(fixtures, 'api', 'service-worker', 'service-worker.html')
+
     it('can successfully check for presence of a ServiceWorker', async () => {
-      await w.loadFile(path.join(fixtures, 'api', 'service-worker', 'service-worker.html'))
-      const hasSW = await w.webContents.hasServiceWorker()
+      await w.loadFile(filePath)
+      const hasSW = await w.webContents.hasServiceWorker(`file://${filePath}`)
       expect(hasSW).to.be.true()
     })
 
-    it('throws properly for invalid url', async () => {
-      const promise = w.webContents.hasServiceWorker()
-      return expect(promise).to.be.eventually.rejectedWith(Error, 'URL invalid or not yet loaded.')
-    })
-
     it('can successfully check for presence of a ServiceWorker (callback)', (done) => {
-      w.loadFile(path.join(fixtures, 'api', 'service-worker', 'service-worker.html')).then(() => {
-        w.webContents.hasServiceWorker(hasSW => {
+      w.loadFile(path.join(path.join(fixtures, 'api', 'service-worker', 'service-worker.html'))).then(() => {
+        w.webContents.hasServiceWorker(`file://${filePath}`, hasSW => {
           expect(hasSW).to.be.true()
           done()
         })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -229,16 +229,29 @@ describe('webContents module', () => {
   })
 
   describe('ServiceWorker APIs', () => {
-    const filePath = path.join(fixtures, 'api', 'service-worker', 'service-worker.html')
-
-    it('can successfully check for presence of a ServiceWorker', async () => {
+    it('can successfully check when a ServiceWorker is present', async () => {
+      const filePath = path.join(fixtures, 'api', 'service-worker', 'service-worker.html')
       await w.loadFile(filePath)
       const hasSW = await w.webContents.hasServiceWorker(`file://${filePath}`)
       expect(hasSW).to.be.true()
     })
 
+    it('can successfully check when a ServiceWorker is not present', async () => {
+      const filePath = path.join(fixtures, 'pages', 'a.html')
+      await w.loadFile(filePath)
+      const hasSW = await w.webContents.hasServiceWorker(`file://${filePath}`)
+      expect(hasSW).to.be.false()
+    })
+
+    it('hasServiceWorker should reject on a malformed or nonexistent url', async () => {
+      const filePath = path.join(fixtures, 'api', 'service-worker', 'service-worker.html')
+      await w.loadFile(filePath)
+      expect(w.webContents.hasServiceWorker(`bad-file-bad`)).to.eventually.be.rejectedWith('URL is invalid.')
+    })
+
     it('can successfully check for presence of a ServiceWorker (callback)', (done) => {
-      w.loadFile(path.join(path.join(fixtures, 'api', 'service-worker', 'service-worker.html'))).then(() => {
+      const filePath = path.join(fixtures, 'api', 'service-worker', 'service-worker.html')
+      w.loadFile(filePath).then(() => {
         w.webContents.hasServiceWorker(`file://${filePath}`, hasSW => {
           expect(hasSW).to.be.true()
           done()

--- a/spec/package-lock.json
+++ b/spec/package-lock.json
@@ -228,7 +228,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -267,7 +267,7 @@
     },
     "dbus-native": {
       "version": "0.2.5",
-      "resolved": "http://registry.npmjs.org/dbus-native/-/dbus-native-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.2.5.tgz",
       "integrity": "sha512-ocxMKCV7QdiNhzhFSeEMhj258OGtvpANSb3oWGiotmI5h1ZIse0TMPcSLiXSpqvbYvQz2Y5RsYPMNYLWhg9eBw==",
       "dev": true,
       "requires": {
@@ -358,7 +358,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -512,7 +512,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -753,7 +753,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -761,7 +761,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -958,7 +958,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -1000,7 +1000,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1018,7 +1018,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -1139,7 +1139,7 @@
     },
     "rimraf": {
       "version": "2.2.8",
-      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
     },
@@ -1321,7 +1321,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -1391,7 +1391,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -1486,7 +1486,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
#### Description of Change

A bug was present in the original API, wherein the API assumed that the loaded page has a previously committed url and thus would DCHECK when a new page was loaded. Thus, for this to actually work properly we need to pass in the url to check as a new parameter. This PR thus does that and updates the associated tests and documentation.

cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `webContents.hasServiceWorker` by adding a parameter for the url to test for its presence.
