### PR TITLE
feat: promisify contentTracing.getCategories()

### DIFF
--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -8,6 +8,7 @@
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/promise_util.h"
 #include "base/bind.h"
 #include "base/files/file_util.h"
 #include "content/public/browser/tracing_controller.h"
@@ -71,11 +72,22 @@ void StopRecording(const base::FilePath& path,
       GetTraceDataEndpoint(path, callback));
 }
 
-bool GetCategories(
-    const base::RepeatingCallback<void(const std::set<std::string>&)>&
-        callback) {
-  return TracingController::GetInstance()->GetCategories(
-      base::BindOnce(callback));
+void OnCategoriesAvailable(scoped_refptr<atom::util::Promise> promise,
+                           const std::set<std::string>& categories) {
+  promise->Resolve(categories);
+}
+
+v8::Local<v8::Promise> GetCategories(v8::Isolate* isolate) {
+  scoped_refptr<atom::util::Promise> promise = new atom::util::Promise(isolate);
+  bool success = TracingController::GetInstance()->GetCategories(
+      base::BindOnce(&OnCategoriesAvailable, promise));
+
+  if (!success) {
+    promise->RejectWithErrorMessage("Could not get categories.");
+    return promise->GetHandle();
+  }
+
+  return promise->GetHandle();
 }
 
 bool StartTracing(const base::trace_event::TraceConfig& trace_config,

--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -82,10 +82,8 @@ v8::Local<v8::Promise> GetCategories(v8::Isolate* isolate) {
   bool success = TracingController::GetInstance()->GetCategories(
       base::BindOnce(&OnCategoriesAvailable, promise));
 
-  if (!success) {
+  if (!success)
     promise->RejectWithErrorMessage("Could not get categories.");
-    return promise->GetHandle();
-  }
 
   return promise->GetHandle();
 }

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -43,11 +43,18 @@ The `contentTracing` module has the following methods:
 * `callback` Function
   * `categories` String[]
 
-Get a set of category groups. The category groups can change as new code paths
-are reached.
+Get a set of category groups. The category groups can change as new code paths are reached.
 
-Once all child processes have acknowledged the `getCategories` request the
-`callback` is invoked with an array of category groups.
+Once all child processes have acknowledged the `getCategories` request the `callback` is invoked with an array of category groups.
+
+**[Deprecated Soon](promisification.md)**
+
+### `contentTracing.getCategories()`
+
+Returns `Promise<String[]>` - resolves with an array of category groups once all child processes have acknowledged the `getCategories` request
+
+Get a set of category groups. The category groups can change as new code paths are reached.
+
 
 ### `contentTracing.startRecording(options, callback)`
 

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -11,7 +11,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [app.importCertificate(options, callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#importCertificate)
 - [request.write(chunk[, encoding][, callback])](https://github.com/electron/electron/blob/master/docs/api/client-request.md#write)
 - [request.end([chunk][, encoding][, callback])](https://github.com/electron/electron/blob/master/docs/api/client-request.md#end)
-- [contentTracing.getCategories(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getCategories)
 - [contentTracing.startRecording(options, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#startRecording)
 - [contentTracing.stopRecording(resultFilePath, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#stopRecording)
 - [contentTracing.startMonitoring(options, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#startMonitoring)
@@ -48,6 +47,7 @@ When a majority of affected functions are migrated, this flag will be enabled by
 
 - [app.getFileIcon(path[, options], callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#getFileIcon)
 - [contents.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#capturePage)
+- [contentTracing.getCategories(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getCategories)
 - [cookies.flushStore(callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#flushStore)
 - [cookies.get(filter, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#get)
 - [cookies.remove(url, name, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#remove)

--- a/lib/browser/api/content-tracing.js
+++ b/lib/browser/api/content-tracing.js
@@ -1,3 +1,7 @@
 'use strict'
+const { deprecate } = require('electron')
+const contentTracing = process.atomBinding('content_tracing')
 
-module.exports = process.atomBinding('content_tracing')
+contentTracing.getCategories = deprecate.promisify(contentTracing.getCategories)
+
+module.exports = contentTracing


### PR DESCRIPTION
#### Description of Change

Promisify `contentTracing.getCategories()`.

cc @ckerr @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `contentTracing.getCategories()` to return a promise instead taking a callback.
