### PR TITLE
chore: add miniak to troppers

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -50,6 +50,7 @@ authorizedUsers:
   - deepak1556
   - jkleinsc
   - MarshallOfSound
+  - miniak
   - nitsakh
   - nornagon
   - zcbenz


### PR DESCRIPTION
#### Description of Change

I would like to be able to run trop backports manually.

/cc @codebytere, @ckerr

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes