### PR TITLE
fix: improve the way frameless windows are handled on Windows

### DIFF
--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -68,6 +68,9 @@ void BrowserView::Init(v8::Isolate* isolate,
   api_web_contents_ = web_contents.get();
   Observe(web_contents->web_contents());
 
+  mate::Dictionary(isolate, web_contents->GetWrapper())
+      .Set("browserWindowOptions", options);
+
   view_.reset(
       NativeBrowserView::Create(api_web_contents_->managed_web_contents()));
 

--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -68,9 +68,6 @@ void BrowserView::Init(v8::Isolate* isolate,
   api_web_contents_ = web_contents.get();
   Observe(web_contents->web_contents());
 
-  mate::Dictionary(isolate, web_contents->GetWrapper())
-      .Set("browserWindowOptions", options);
-
   view_.reset(
       NativeBrowserView::Create(api_web_contents_->managed_web_contents()));
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -82,8 +82,13 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   } else if (options.Get(options::kCenter, &center) && center) {
     Center();
   }
+
+  bool use_content_size = false;
+  options.Get(options::kUseContentSize, &use_content_size);
+
   // On Linux and Window we may already have maximum size defined.
-  extensions::SizeConstraints size_constraints(GetContentSizeConstraints());
+  extensions::SizeConstraints size_constraints(
+      use_content_size ? GetContentSizeConstraints() : GetSizeConstraints());
   int min_height = 0, min_width = 0;
   if (options.Get(options::kMinHeight, &min_height) |
       options.Get(options::kMinWidth, &min_width)) {
@@ -94,8 +99,6 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
       options.Get(options::kMaxWidth, &max_width)) {
     size_constraints.set_maximum_size(gfx::Size(max_width, max_height));
   }
-  bool use_content_size = false;
-  options.Get(options::kUseContentSize, &use_content_size);
   if (use_content_size) {
     SetContentSizeConstraints(size_constraints);
   } else {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -32,6 +32,7 @@
 #include "ui/aura/window_tree_host.h"
 #include "ui/base/hit_test.h"
 #include "ui/gfx/image/image.h"
+#include "ui/gfx/native_widget_types.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/controls/webview/webview.h"
@@ -1100,7 +1101,7 @@ gfx::AcceleratedWidget NativeWindowViews::GetAcceleratedWidget() const {
   if (GetNativeWindow() && GetNativeWindow()->GetHost())
     return GetNativeWindow()->GetHost()->GetAcceleratedWidget();
   else
-    return nullptr;
+    return gfx::kNullAcceleratedWidget;
 }
 
 NativeWindowHandle NativeWindowViews::GetNativeWindowHandle() const {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -259,7 +259,6 @@ NativeWindowViews::NativeWindowViews(const mate::Dictionary& options,
   if (!has_frame()) {
     // Set Window style so that we get a minimize and maximize animation when
     // frameless.
-    // DWORD frame_style = WS_CAPTION | WS_OVERLAPPED | WS_SYSMENU;
     DWORD frame_style = WS_CAPTION | WS_OVERLAPPED;
     if (resizable_)
       frame_style |= WS_THICKFRAME;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -244,6 +244,8 @@ class NativeWindowViews : public NativeWindow,
 
   ui::WindowShowState last_window_state_;
 
+  gfx::Rect last_normal_placement_bounds_;
+
   // There's an issue with restore on Windows, that sometimes causes the Window
   // to receive the wrong size (#2498). To circumvent that, we keep tabs on the
   // size of the window while in the normal state (not maximized, minimized or

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -4,8 +4,8 @@
 
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window_views.h"
-#include "atom/common/atom_constants.h"
 #include "atom/browser/ui/views/root_view.h"
+#include "atom/common/atom_constants.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "ui/base/win/accessibility_misc_utils.h"
 #include "ui/display/win/screen_win.h"
@@ -195,8 +195,9 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       // previously on (but the leftmost one instead). We restore the position
       // of the window during the restore operation, this way chromium can
       // use the proper display to calculate the scale factor to use.
-      if(!last_normal_placement_bounds_.IsEmpty() && GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
-        last_normal_placement_bounds_.set_size(gfx::Size(0,0));
+      if (!last_normal_placement_bounds_.IsEmpty() &&
+          GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
+        last_normal_placement_bounds_.set_size(gfx::Size(0, 0));
         wp.rcNormalPosition = last_normal_placement_bounds_.ToRECT();
         SetWindowPlacement(GetAcceleratedWidget(), &wp);
 
@@ -207,12 +208,14 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
     }
     case WM_NCCALCSIZE: {
       if (!has_frame() && w_param == TRUE) {
-        NCCALCSIZE_PARAMS* params = (NCCALCSIZE_PARAMS*)l_param;
+        NCCALCSIZE_PARAMS* params =
+            reinterpret_cast<NCCALCSIZE_PARAMS*>(l_param);
         RECT PROPOSED = params->rgrc[0];
         RECT BEFORE = params->rgrc[1];
 
         // We need to call the default to have cascade and tile windows
-        // working (https://github.com/rossy/borderless-window/blob/master/borderless-window.c#L239),
+        // working
+        // (https://github.com/rossy/borderless-window/blob/master/borderless-window.c#L239),
         // but we need to provide the proposed original value as suggested in
         // https://blogs.msdn.microsoft.com/wpfsdk/2008/09/08/custom-window-chrome-in-wpf/
         DefWindowProcW(GetAcceleratedWidget(), WM_NCCALCSIZE, w_param, l_param);
@@ -330,7 +333,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
       WINDOWPLACEMENT wp;
       wp.length = sizeof(WINDOWPLACEMENT);
 
-      if(GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
+      if (GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
         last_normal_placement_bounds_ = gfx::Rect(wp.rcNormalPosition);
       }
 

--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -173,14 +173,18 @@ void RootView::Layout() {
     return;
 
   const auto menu_bar_bounds =
-      menu_bar_visible_ ? gfx::Rect(0, 0, size().width(), kMenuBarHeight)
-                        : gfx::Rect();
+      menu_bar_visible_
+          ? gfx::Rect(insets_.left(), insets_.top(),
+                      size().width() - insets_.width(), kMenuBarHeight)
+          : gfx::Rect();
   if (menu_bar_)
     menu_bar_->SetBoundsRect(menu_bar_bounds);
 
   window_->content_view()->SetBoundsRect(
-      gfx::Rect(0, menu_bar_bounds.height(), size().width(),
-                size().height() - menu_bar_bounds.height()));
+      gfx::Rect(insets_.left(),
+                menu_bar_visible_ ? menu_bar_bounds.bottom() : insets_.top(),
+                size().width() - insets_.width(),
+                size().height() - menu_bar_bounds.height() - insets_.height()));
 }
 
 gfx::Size RootView::GetMinimumSize() const {
@@ -215,6 +219,13 @@ void RootView::UnregisterAcceleratorsWithFocusManager() {
   views::FocusManager* focus_manager = GetFocusManager();
   accelerator_table_.clear();
   focus_manager->UnregisterAccelerators(this);
+}
+
+void RootView::SetInsets(const gfx::Insets& insets) {
+  if (insets != insets_) {
+    insets_ = insets;
+    Layout();
+  }
 }
 
 }  // namespace atom

--- a/atom/browser/ui/views/root_view.h
+++ b/atom/browser/ui/views/root_view.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "atom/browser/ui/accelerator_util.h"
+#include "ui/gfx/geometry/insets.h"
 #include "ui/views/view.h"
 #include "ui/views/view_tracker.h"
 
@@ -39,6 +40,8 @@ class RootView : public views::View {
   // Register/Unregister accelerators supported by the menu model.
   void RegisterAcceleratorsWithFocusManager(AtomMenuModel* menu_model);
   void UnregisterAcceleratorsWithFocusManager();
+  void SetInsets(const gfx::Insets& insets);
+  gfx::Insets insets() const { return insets_; }
 
   // views::View:
   void Layout() override;
@@ -55,6 +58,8 @@ class RootView : public views::View {
   bool menu_bar_autohide_ = false;
   bool menu_bar_visible_ = false;
   bool menu_bar_alt_pressed_ = false;
+
+  gfx::Insets insets_;
 
   // Map from accelerator to menu item's command id.
   accelerator_util::AcceleratorTable accelerator_table_;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes #15816.

Most of the ideas implemented here come from [this post](https://blogs.msdn.microsoft.com/wpfsdk/2008/09/08/custom-window-chrome-in-wpf/), which is mentioned in several comments. Particularly the idea to use insets on the `RootView` comes from this part:

> When the window is maximized, Windows will clip out the border on the app’s behalf if a clipping region hasn’t been applied. In this scenario there’s no reason to have done that, but the thing to watch out for is if glass isn’t extended as deeply into the borders as Windows would have (SM_CXFRAME (+ SM_CXPADDEDBORDER on Vista)) then a maximized window will clip the edges of your client region. The simplest way to work around this is to just place a Border around the window’s content that has a thickness of clipping region, and make its Visibility collapsed when not maximized.

I also took inspiration from [this repo](https://github.com/rossy/borderless-window/blob/master/borderless-window.c), but decided to not mess with undocumented events.

I tested these changes when I put this PR together on Windows 10, 8.1, and 7.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Improved the way frameless windows are handled on Windows.