### PR TITLE
feat: add process.getSystemVersion()

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -73,6 +73,8 @@ void AtomBindings::BindProcess(v8::Isolate* isolate,
   process->SetMethod("getHeapStatistics", &GetHeapStatistics);
   process->SetMethod("getProcessMemoryInfo", &GetProcessMemoryInfo);
   process->SetMethod("getSystemMemoryInfo", &GetSystemMemoryInfo);
+  process->SetMethod("getSystemVersion",
+                     &base::SysInfo::OperatingSystemVersion);
   process->SetMethod("getIOCounters", &GetIOCounters);
   process->SetMethod("getCPUUsage", base::Bind(&AtomBindings::GetCPUUsage,
                                                base::Unretained(metrics)));

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -17,6 +17,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 - `getHeapStatistics()`
 - `getProcessMemoryInfo()`
 - `getSystemMemoryInfo()`
+- `getSystemVersion()`
 - `getCPUUsage()`
 - `getIOCounters()`
 - `argv`
@@ -205,6 +206,17 @@ Returns `Object`:
 
 Returns an object giving memory usage statistics about the entire system. Note
 that all statistics are reported in Kilobytes.
+
+### `process.getSystemVersion()`
+
+Returns `String` - The version of the host operating system.
+
+Examples:
+- macOS: `10.13.6`
+- Windows: `10.0.17763`
+- Linux: `4.15.0-45-generic`
+
+**Note:** It returns the actual operating system version instead of kernel version on macOS unlike `os.release()`.
 
 ### `process.takeHeapSnapshot(filePath)`
 

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -59,6 +59,12 @@ describe('process module', () => {
     })
   })
 
+  describe('process.getSystemVersion()', () => {
+    it('returns a string', () => {
+      expect(process.getSystemVersion()).to.be.a('string')
+    })
+  })
+
   describe('process.getHeapStatistics()', () => {
     it('returns heap statistics object', () => {
       const heapStats = process.getHeapStatistics()


### PR DESCRIPTION
#### Description of Change
- available in sandboxed renderers
- returns the actual operating system version instead of kernel version on macOS

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `process.getSystemVersion()`, which is available in sandboxed renderers and returns the actual operating system version instead of kernel version on macOS.