### PR TITLE
feat: promisify contentTracing.getTraceBufferUsage()

### DIFF
--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -115,11 +115,10 @@ v8::Local<v8::Promise> StartTracing(
   return promise->GetHandle();
 }
 
-void OnTraceBufferUsageAvailable(v8::Isolate* isolate,
-                                 scoped_refptr<atom::util::Promise> promise,
+void OnTraceBufferUsageAvailable(scoped_refptr<atom::util::Promise> promise,
                                  float percent_full,
                                  size_t approximate_count) {
-  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise->isolate());
   dict.Set("percentage", percent_full);
   dict.Set("value", approximate_count);
 
@@ -129,12 +128,10 @@ void OnTraceBufferUsageAvailable(v8::Isolate* isolate,
 v8::Local<v8::Promise> GetTraceBufferUsage(v8::Isolate* isolate) {
   scoped_refptr<atom::util::Promise> promise = new atom::util::Promise(isolate);
   bool success = TracingController::GetInstance()->GetTraceBufferUsage(
-      base::BindOnce(&OnTraceBufferUsageAvailable, isolate, promise));
+      base::BindOnce(&OnTraceBufferUsageAvailable, promise));
 
-  if (!success) {
+  if (!success)
     promise->RejectWithErrorMessage("Could not get trace buffer usage.");
-    return promise->GetHandle();
-  }
 
   return promise->GetHandle();
 }

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -17,6 +17,19 @@ win.setMenu(null)
 win.removeMenu()
 ```
 
+## `contentTracing.getTraceBufferUsage()`
+
+```js
+// Deprecated
+contentTracing.getTraceBufferUsage((percentage, value) => {
+  // do something
+})
+// Replace with
+contentTracing.getTraceBufferUsage().then(infoObject => {
+  // infoObject has percentage and value fields
+})
+```
+
 ## `electron.screen` in renderer process
 
 ```js

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -122,9 +122,19 @@ temporary file.
 ### `contentTracing.getTraceBufferUsage(callback)`
 
 * `callback` Function
-  * `value` Number
-  * `percentage` Number
+  * Object
+    * `value` Number
+    * `percentage` Number
 
 Get the maximum usage across processes of trace buffer as a percentage of the
 full state. When the TraceBufferUsage value is determined the `callback` is
 called.
+
+**[Deprecated Soon](promisification.md)**
+
+### `contentTracing.getTraceBufferUsage()`
+
+Returns `Promise<Object>` - Resolves with an object containing the `value` and `percentage` of trace buffer maximum usage
+
+Get the maximum usage across processes of trace buffer as a percentage of the
+full state.

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -9,7 +9,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 ### Candidate Functions
 
 - [app.importCertificate(options, callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#importCertificate)
-- [contentTracing.getTraceBufferUsage(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getTraceBufferUsage)
 - [dialog.showOpenDialog([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showOpenDialog)
 - [dialog.showSaveDialog([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showSaveDialog)
 - [dialog.showMessageBox([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showMessageBox)
@@ -40,6 +39,7 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [contentTracing.getCategories(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getCategories)
 - [contentTracing.startRecording(options, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#startRecording)
 - [contentTracing.stopRecording(resultFilePath, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#stopRecording)
+- [contentTracing.getTraceBufferUsage(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getTraceBufferUsage)
 - [cookies.flushStore(callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#flushStore)
 - [cookies.get(filter, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#get)
 - [cookies.remove(url, name, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#remove)

--- a/lib/browser/api/content-tracing.js
+++ b/lib/browser/api/content-tracing.js
@@ -5,5 +5,6 @@ const contentTracing = process.atomBinding('content_tracing')
 contentTracing.getCategories = deprecate.promisify(contentTracing.getCategories)
 contentTracing.startRecording = deprecate.promisify(contentTracing.startRecording)
 contentTracing.stopRecording = deprecate.promisify(contentTracing.stopRecording)
+contentTracing.getTraceBufferUsage = deprecate.promisify(contentTracing.getTraceBufferUsage)
 
 module.exports = contentTracing

--- a/lib/browser/api/content-tracing.js
+++ b/lib/browser/api/content-tracing.js
@@ -5,6 +5,6 @@ const contentTracing = process.atomBinding('content_tracing')
 contentTracing.getCategories = deprecate.promisify(contentTracing.getCategories)
 contentTracing.startRecording = deprecate.promisify(contentTracing.startRecording)
 contentTracing.stopRecording = deprecate.promisify(contentTracing.stopRecording)
-contentTracing.getTraceBufferUsage = deprecate.promisify(contentTracing.getTraceBufferUsage)
+contentTracing.getTraceBufferUsage = deprecate.promisifyMultiArg(contentTracing.getTraceBufferUsage)
 
 module.exports = contentTracing

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -104,6 +104,32 @@ const deprecate = {
     }
   },
 
+  promisifyMultiArg: (fn) => {
+    const fnName = fn.name || 'function'
+    const oldName = `${fnName} with callbacks`
+    const newName = `${fnName} with Promises`
+    const warn = warnOnce(oldName, newName)
+
+    return function (...params) {
+      let cb
+      if (params.length > 0 && typeof params[params.length - 1] === 'function') {
+        cb = params.pop()
+      }
+      const promise = fn.apply(this, params)
+      if (!cb) return promise
+      if (process.enablePromiseAPIs) warn()
+      return promise
+        .then(res => {
+          process.nextTick(() => {
+            // eslint-disable-next-line standard/no-callback-literal
+            cb.length > 2 ? cb(null, ...res) : cb(...res)
+          })
+        }, err => {
+          process.nextTick(() => cb(err))
+        })
+    }
+  },
+
   renameProperty: (o, oldName, newName) => {
     const warn = warnOnce(oldName, newName)
 


### PR DESCRIPTION
#### Description of Change

Promisify `contentTracing.getTraceBufferUsage()`.

**NB**: this PR required backwards-incompatible changes and thus cannot be backported to `5-0-x`.

cc @ckerr @deepak1556

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `contentTracing.getTraceBufferUsage()` to return a Promise instead of taking a callback.
