### PR TITLE
fix: update docs for protocol API

### DIFF
--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -59,7 +59,7 @@ struct Converter<CustomScheme> {
       return false;
     mate::Dictionary opt;
     // options are optional. Default values specified in SchemeOptions are used
-    if (dict.Get("options", &opt)) {
+    if (dict.Get("privileges", &opt)) {
       opt.Get("standard", &(out->options.standard));
       opt.Get("supportFetchAPI", &(out->options.supportFetchAPI));
       opt.Get("secure", &(out->options.secure));

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -28,9 +28,9 @@ of the `app` module gets emitted.
 
 The `protocol` module has the following methods:
 
-### `protocol.registerSchemesAsPrivileged(schemes[, options])`
+### `protocol.registerSchemesAsPrivileged(customSchemes)`
 
-* `custom_schemes` [CustomScheme[]](structures/custom-scheme.md)
+* `customSchemes` [CustomScheme[]](structures/custom-scheme.md)
 
 
 **Note:** This method can only be used before the `ready` event of the `app`
@@ -39,13 +39,13 @@ module gets emitted and can be called only once.
 Registers the `scheme` as standard, secure, bypasses content security policy for resources,
 allows registering ServiceWorker and supports fetch API.
 
-Specify an option with the value of `true` to enable the capability.
+Specify a privilege with the value of `true` to enable the capability.
 An example of registering a privileged scheme, with bypassing Content Security Policy:
 
 ```javascript
 const { protocol } = require('electron')
 protocol.registerSchemesAsPrivileged([
-  { scheme: 'foo', options: { bypassCSP: true } }
+  { scheme: 'foo', privileges: { bypassCSP: true } }
 ])
 ```
 

--- a/docs/api/structures/custom-scheme.md
+++ b/docs/api/structures/custom-scheme.md
@@ -1,7 +1,7 @@
 # CustomScheme Object
 
 * `scheme` String - Custom schemes to be registered with options.
-* `options` Object (optional)
+* `privileges` Object (optional)
   * `standard` Boolean (optional) - Default false.
   * `secure` Boolean (optional) - Default false.
   * `bypassCSP` Boolean (optional) - Default false.

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,6 +313,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1550,7 +1551,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clang-format": {
@@ -2270,7 +2271,8 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
       "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -2932,9 +2934,9 @@
       }
     },
     "electron-typescript-definitions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/electron-typescript-definitions/-/electron-typescript-definitions-4.0.0.tgz",
-      "integrity": "sha512-UekaKgK8omivfj37xs1G09j5MctHCFSyPYvW67j30xYHVCvgjDLur1Vqd7CaaJCDuaYLsHjsmms4QjG8uOFb4A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/electron-typescript-definitions/-/electron-typescript-definitions-6.0.0.tgz",
+      "integrity": "sha512-W2CHJ1bUtbDXXzIAEbQ+s2XewpSdUUqNECJmhniV0GbPoIhwjAg90++BkMxH6wPBxHWOxesvUMipUEeJN9+wlQ==",
       "dev": true,
       "requires": {
         "@types/node": "^7.0.18",
@@ -4147,7 +4149,7 @@
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
       "dev": true
     },
     "find-up": {
@@ -5235,7 +5237,7 @@
     "gunzip-maybe": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
-      "integrity": "sha1-Occu2J0bSbpwjhh3ZQBIiQKlICc=",
+      "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
       "dev": true,
       "requires": {
         "browserify-zlib": "^0.1.4",
@@ -7398,7 +7400,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -10287,7 +10290,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "optional": true
     },
@@ -10793,7 +10796,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
         "through": "2"
@@ -10811,7 +10814,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
         "through2": "^2.0.2"
@@ -13070,9 +13073,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dotenv-safe": "^4.0.4",
     "dugite": "^1.45.0",
     "electron-docs-linter": "^2.4.0",
-    "electron-typescript-definitions": "^4.0.0",
+    "electron-typescript-definitions": "^6.0.0",
     "eslint": "^5.6.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-mocha": "^5.2.0",

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -98,12 +98,12 @@ global.nativeModulesEnabled = !process.env.ELECTRON_SKIP_NATIVE_MODULE_TESTS
 global.standardScheme = 'app'
 global.zoomScheme = 'zoom'
 protocol.registerSchemesAsPrivileged([
-  { scheme: global.standardScheme, options: { standard: true, secure: true } },
-  { scheme: global.zoomScheme, options: { standard: true, secure: true } },
-  { scheme: 'cors', options: { corsEnabled: true, supportFetchAPI: true } },
-  { scheme: 'cors-blob', options: { corsEnabled: true, supportFetchAPI: true } },
-  { scheme: 'no-cors', options: { supportFetchAPI: true } },
-  { scheme: 'no-fetch', options: { corsEnabled: true } }
+  { scheme: global.standardScheme, privileges: { standard: true, secure: true } },
+  { scheme: global.zoomScheme, privileges: { standard: true, secure: true } },
+  { scheme: 'cors', privileges: { corsEnabled: true, supportFetchAPI: true } },
+  { scheme: 'cors-blob', privileges: { corsEnabled: true, supportFetchAPI: true } },
+  { scheme: 'no-cors', privileges: { supportFetchAPI: true } },
+  { scheme: 'no-fetch', privileges: { corsEnabled: true } }
 ])
 
 app.on('window-all-closed', function () {


### PR DESCRIPTION
#### Description of Change
Update protocol API docs and the api options key.
Also update electron-typescript-definitions.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Updated the `protocol.registerSchemesAsPrivileged` API options key