### PR TITLE
docs: fix protocol.registerSchemesAsPrivileged generation

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -28,10 +28,9 @@ of the `app` module gets emitted.
 
 The `protocol` module has the following methods:
 
-### `protocol.registerSchemesAsPrivileged(schemes[, options])`
+### `protocol.registerSchemesAsPrivileged(schemes)`
 
-* `custom_schemes` [CustomScheme[]](structures/custom-scheme.md)
-
+* `schemes` [CustomScheme[]](structures/custom-scheme.md)
 
 **Note:** This method can only be used before the `ready` event of the `app`
 module gets emitted and can be called only once.

--- a/docs/api/structures/custom-scheme-options.md
+++ b/docs/api/structures/custom-scheme-options.md
@@ -1,0 +1,8 @@
+# CustomSchemeOptions Object
+
+* `standard` Boolean (optional) - Default false.
+* `secure` Boolean (optional) - Default false.
+* `bypassCSP` Boolean (optional) - Default false.
+* `allowServiceWorkers` Boolean (optional) - Default false.
+* `supportFetchAPI` Boolean (optional) - Default false.
+* `corsEnabled` Boolean (optional) - Default false.

--- a/docs/api/structures/custom-scheme.md
+++ b/docs/api/structures/custom-scheme.md
@@ -1,10 +1,4 @@
 # CustomScheme Object
 
 * `scheme` String - Custom schemes to be registered with options.
-* `options` Object (optional)
-  * `standard` Boolean (optional) - Default false.
-  * `secure` Boolean (optional) - Default false.
-  * `bypassCSP` Boolean (optional) - Default false.
-  * `allowServiceWorkers` Boolean (optional) - Default false.
-  * `supportFetchAPI` Boolean (optional) - Default false.
-  * `corsEnabled` Boolean (optional) - Default false.
+* `options` [CustomSchemeOptions](custom-scheme-options.md) (optional)


### PR DESCRIPTION
#### Description of Change
Fix `electron.d.ts` generation errors introduced by https://github.com/electron/electron/pull/16416

/cc @nitsakh

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `electron.d.ts` generation for `protocol.registerSchemesAsPrivileged()`.