### PR TITLE
refactor: merge event._replyInternal into event.reply

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -342,20 +342,14 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
   }))
 }
 
-const addReplyToEvent = (event) => {
+const addReplyToEvent = (event, internal) => {
   event.reply = (...args) => {
-    event.sender.sendToFrame(event.frameId, ...args)
-  }
-}
-
-const addReplyInternalToEvent = (event) => {
-  Object.defineProperty(event, '_replyInternal', {
-    configurable: false,
-    enumerable: false,
-    value: (...args) => {
+    if (internal) {
       event.sender._sendToFrameInternal(event.frameId, ...args)
+    } else {
+      event.sender.sendToFrame(event.frameId, ...args)
     }
-  })
+  }
 }
 
 const addReturnValueToEvent = (event) => {
@@ -379,11 +373,10 @@ WebContents.prototype._init = function () {
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, internal, channel, args) {
+    addReplyToEvent(event, internal)
     if (internal) {
-      addReplyInternalToEvent(event)
       ipcMainInternal.emit(channel, event, ...args)
     } else {
-      addReplyToEvent(event)
       this.emit('ipc-message', event, channel, ...args)
       ipcMain.emit(channel, event, ...args)
     }
@@ -391,11 +384,10 @@ WebContents.prototype._init = function () {
 
   this.on('-ipc-message-sync', function (event, internal, channel, args) {
     addReturnValueToEvent(event)
+    addReplyToEvent(event, internal)
     if (internal) {
-      addReplyInternalToEvent(event)
       ipcMainInternal.emit(channel, event, ...args)
     } else {
-      addReplyToEvent(event)
       this.emit('ipc-message-sync', event, channel, ...args)
       ipcMain.emit(channel, event, ...args)
     }

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -180,7 +180,7 @@ ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, 
 
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, event.sender.id, message, resultID)
   ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
-    event._replyInternal(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
+    event.reply(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
 })
@@ -196,7 +196,7 @@ ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBa
 
   contents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, senderTabId, message, resultID)
   ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
-    event._replyInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
+    event.reply(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
 })

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -18,7 +18,7 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
   event.sender.emit('desktop-capturer-get-sources', customEvent)
 
   if (customEvent.defaultPrevented) {
-    event._replyInternal(capturerResult(id), [])
+    event.reply(capturerResult(id), [])
     return
   }
 
@@ -60,7 +60,7 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   })
 
   if (handledRequest.event) {
-    handledRequest.event._replyInternal(capturerResult(handledRequest.id), result)
+    handledRequest.event.reply(capturerResult(handledRequest.id), result)
   }
 
   // Check the queue to see whether there is another identical request & handle
@@ -68,7 +68,7 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
     const event = request.event
     if (deepEqual(handledRequest.options, request.options)) {
       if (event) {
-        event._replyInternal(capturerResult(request.id), result)
+        event.reply(capturerResult(request.id), result)
       }
     } else {
       unhandledRequestsQueue.push(request)

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -351,7 +351,7 @@ const handleMessage = function (channel, handler) {
 }
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params, requestId) {
-  event._replyInternal(`ELECTRON_RESPONSE_${requestId}`, createGuest(event.sender, params))
+  event.reply(`ELECTRON_RESPONSE_${requestId}`, createGuest(event.sender, params))
 })
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST_SYNC', function (event, params) {
@@ -401,7 +401,7 @@ handleMessage('ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL', function (event, request
   }, error => {
     return [errorUtils.serialize(error)]
   }).then(responseArgs => {
-    event._replyInternal(`ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL_RESPONSE_${requestId}`, ...responseArgs)
+    event.reply(`ELECTRON_GUEST_VIEW_MANAGER_ASYNC_CALL_RESPONSE_${requestId}`, ...responseArgs)
   })
 })
 


### PR DESCRIPTION
#### Description of Change
Have a single `event.reply()`, which calls either `sendToFrame()` or `_sendToFrameInternal()` accordingly. The is also only a single `event.returnValue` property.

/cc @MarshallOfSound

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes