### PR TITLE
feat: Add API to inspect a Shared Worker

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1416,6 +1416,23 @@ void WebContents::InspectElement(int x, int y) {
   managed_web_contents()->InspectElement(x, y);
 }
 
+void WebContents::InspectSharedWorker() {
+  if (type_ == REMOTE)
+    return;
+
+  if (!enable_devtools_)
+    return;
+
+  for (const auto& agent_host : content::DevToolsAgentHost::GetOrCreateAll()) {
+    if (agent_host->GetType() ==
+        content::DevToolsAgentHost::kTypeSharedWorker) {
+      OpenDevTools(nullptr);
+      managed_web_contents()->AttachTo(agent_host);
+      break;
+    }
+  }
+}
+
 void WebContents::InspectServiceWorker() {
   if (type_ == REMOTE)
     return;
@@ -2178,6 +2195,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("unregisterServiceWorker",
                  &WebContents::UnregisterServiceWorker)
       .SetMethod("inspectServiceWorker", &WebContents::InspectServiceWorker)
+      .SetMethod("inspectSharedWorker", &WebContents::InspectSharedWorker)
 #if BUILDFLAG(ENABLE_PRINTING)
       .SetMethod("_print", &WebContents::Print)
       .SetMethod("_getPrinters", &WebContents::GetPrinterList)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -160,6 +160,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void EnableDeviceEmulation(const blink::WebDeviceEmulationParams& params);
   void DisableDeviceEmulation();
   void InspectElement(int x, int y);
+  void InspectSharedWorker();
   void InspectServiceWorker();
   v8::Local<v8::Promise> HasServiceWorker();
   void UnregisterServiceWorker(const base::Callback<void(bool)>&);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1381,6 +1381,10 @@ Toggles the developer tools.
 
 Starts inspecting element at position (`x`, `y`).
 
+#### `contents.inspectSharedWorker()`
+
+Opens the developer tools for the shared worker context.
+
 #### `contents.inspectServiceWorker()`
 
 Opens the developer tools for the service worker context.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -408,6 +408,10 @@ Returns `Boolean` - Whether DevTools window of guest page is focused.
 
 Starts inspecting element at position (`x`, `y`) of guest page.
 
+### `<webview>.inspectSharedWorker()`
+
+Opens the DevTools for the shared worker context present in the guest page.
+
 ### `<webview>.inspectServiceWorker()`
 
 Opens the DevTools for the service worker context present in the guest page.

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -171,6 +171,9 @@ Object.assign(BrowserWindow.prototype, {
   inspectElement (...args) {
     return this.webContents.inspectElement(...args)
   },
+  inspectSharedWorker () {
+    return this.webContents.inspectSharedWorker()
+  },
   inspectServiceWorker () {
     return this.webContents.inspectServiceWorker()
   },

--- a/lib/common/web-view-methods.js
+++ b/lib/common/web-view-methods.js
@@ -44,6 +44,7 @@ exports.syncMethods = new Set([
   'findInPage',
   'stopFindInPage',
   'downloadURL',
+  'inspectSharedWorker',
   'inspectServiceWorker',
   'showDefinitionForSelection',
   'getZoomFactor',


### PR DESCRIPTION
#### Description of Change
This change adds a new inspectSharedWorker() API to enable opening devtools for a shared worker. 

#### Checklist
- [x] PR description included and stakeholders cc'd
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

notes: Added new inspectSharedWorker() API to enable opening devtools for a shared worker.
