### PR TITLE
refactor: use ipcRendererUtils.invoke / ipcMainUtils.handle for desktopCapturer.getSources()

### DIFF
--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
+const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 
 const { desktopCapturer } = process.atomBinding('desktop_capturer')
 const eventBinding = process.atomBinding('event')
@@ -10,37 +10,34 @@ const deepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b)
 // A queue for holding all requests from renderer process.
 let requestsQueue = []
 
-const electronSources = 'ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES'
-const capturerResult = (id) => `ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`
-
-ipcMainInternal.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize, fetchWindowIcons, id) => {
+ipcMainUtils.handle('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', (event, captureWindow, captureScreen, thumbnailSize, fetchWindowIcons) => {
   const customEvent = eventBinding.createWithSender(event.sender)
   event.sender.emit('desktop-capturer-get-sources', customEvent)
 
   if (customEvent.defaultPrevented) {
-    event._replyInternal(capturerResult(id), [])
-    return
+    return []
   }
 
-  const request = {
-    id,
-    options: {
-      captureWindow,
-      captureScreen,
-      thumbnailSize,
-      fetchWindowIcons
-    },
-    event
-  }
-  requestsQueue.push(request)
-  if (requestsQueue.length === 1) {
-    desktopCapturer.startHandling(captureWindow, captureScreen, thumbnailSize, fetchWindowIcons)
-  }
+  return new Promise((resolve, reject) => {
+    const request = {
+      options: {
+        captureWindow,
+        captureScreen,
+        thumbnailSize,
+        fetchWindowIcons
+      },
+      resolve
+    }
+    requestsQueue.push(request)
+    if (requestsQueue.length === 1) {
+      desktopCapturer.startHandling(captureWindow, captureScreen, thumbnailSize, fetchWindowIcons)
+    }
 
-  // If the WebContents is destroyed before receiving result, just remove the
-  // reference from requestsQueue to make the module not send the result to it.
-  event.sender.once('destroyed', () => {
-    request.event = null
+    // If the WebContents is destroyed before receiving result, just remove the
+    // reference from requestsQueue to make the module not send the result to it.
+    event.sender.once('destroyed', () => {
+      request.resolve = null
+    })
   })
 })
 
@@ -59,16 +56,15 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
     }
   })
 
-  if (handledRequest.event) {
-    handledRequest.event._replyInternal(capturerResult(handledRequest.id), result)
+  if (handledRequest.resolve) {
+    handledRequest.resolve(result)
   }
 
   // Check the queue to see whether there is another identical request & handle
   requestsQueue.forEach(request => {
-    const event = request.event
     if (deepEqual(handledRequest.options, request.options)) {
-      if (event) {
-        event._replyInternal(capturerResult(request.id), result)
+      if (request.resolve) {
+        request.resolve(result)
       }
     } else {
       unhandledRequestsQueue.push(request)

--- a/lib/renderer/api/desktop-capturer.js
+++ b/lib/renderer/api/desktop-capturer.js
@@ -1,15 +1,7 @@
 'use strict'
 
 const { nativeImage, deprecate } = require('electron')
-const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal')
-
-const includes = [].includes
-let currentId = 0
-
-const incrementId = () => {
-  currentId += 1
-  return currentId
-}
+const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
 // |options.types| can't be empty and must be an array
 function isValid (options) {
@@ -31,8 +23,8 @@ const getSources = (options) => {
   return new Promise((resolve, reject) => {
     if (!isValid(options)) throw new Error('Invalid options')
 
-    const captureWindow = includes.call(options.types, 'window')
-    const captureScreen = includes.call(options.types, 'screen')
+    const captureWindow = options.types.includes('window')
+    const captureScreen = options.types.includes('screen')
 
     if (options.thumbnailSize == null) {
       options.thumbnailSize = {
@@ -44,15 +36,8 @@ const getSources = (options) => {
       options.fetchWindowIcons = false
     }
 
-    const id = incrementId()
-    ipcRendererInternal.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, options.fetchWindowIcons, id)
-    return ipcRendererInternal.once(`ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`, (event, sources) => {
-      try {
-        resolve(mapSources(sources))
-      } catch (error) {
-        reject(error)
-      }
-    })
+    ipcRendererUtils.invoke('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, options.thumbnailSize, options.fetchWindowIcons)
+      .then(sources => resolve(mapSources(sources)), reject)
   })
 }
 


### PR DESCRIPTION
#### Description of Change
- Use `ipcRendererUtils.invoke` / `ipcMainUtils.handle` to eliminate duplicate code.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes