### PR TITLE
chore: fix 'browserView' typo

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -451,7 +451,7 @@ WebContents.prototype._init = function () {
   })
 
   // Handle window.open for BrowserWindow and BrowserView.
-  if (['browserview', 'window'].includes(this.getType())) {
+  if (['browserView', 'window'].includes(this.getType())) {
     // Make new windows requested by links behave like "window.open".
     this.on('-new-window', (event, url, frameName, disposition,
       additionalFeatures, postData,


### PR DESCRIPTION
#### Description of Change

Fix a typo when looking for browserView.

CC @codebytere @MarshallOfSound @alexeykuzmin 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes