### PR TITLE
docs: fix referrer typedef in OnCompletedDetails

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -200,6 +200,7 @@ redirect is about to occur.
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `responseHeaders` Object
     * `fromCache` Boolean


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16660.

Add `referrer` typedef to `OnCompletedDetails`.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added missing `referrer` typedef in `OnCompletedDetails` documentation.
