### PR TITLE
fix: shutdown after message loop is ready

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -455,7 +455,7 @@ bool AtomBrowserMainParts::MainMessageLoopRun(int* result_code) {
 
 void AtomBrowserMainParts::PreDefaultMainMessageLoopRun(
     base::OnceClosure quit_closure) {
-  Browser::SetMainMessageLoopQuitClosure(std::move(quit_closure));
+  Browser::Get()->SetMainMessageLoopQuitClosure(std::move(quit_closure));
 }
 
 void AtomBrowserMainParts::PostMainMessageLoopStart() {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -244,7 +244,7 @@ class Browser : public WindowListObserver {
 
   // Stores the supplied |quit_closure|, to be run when the last Browser
   // instance is destroyed.
-  static void SetMainMessageLoopQuitClosure(base::OnceClosure quit_closure);
+  void SetMainMessageLoopQuitClosure(base::OnceClosure quit_closure);
 
   void AddObserver(BrowserObserver* obs) { observers_.AddObserver(obs); }
 
@@ -286,6 +286,9 @@ class Browser : public WindowListObserver {
 
   // The browser is being shutdown.
   bool is_shutdown_ = false;
+
+  // Null until/unless the default main message loop is running.
+  base::OnceClosure quit_main_message_loop_;
 
   int badge_count_ = 0;
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -1211,13 +1211,6 @@ describe('default behavior', () => {
   })
 
   describe('window-all-closed', () => {
-    before(function () {
-      // FIXME(jkleinsc): Test is consistently failing on Windows 32 bit.
-      if (process.arch === 'ia32') {
-        this.skip()
-      }
-    })
-
     it('quits when the app does not handle the event', async () => {
       const result = await runTestApp('window-all-closed')
       expect(result).to.equal(false)

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -228,13 +228,6 @@ describe('BrowserView module', () => {
   })
 
   describe('new BrowserView()', () => {
-    before(function () {
-      // FIXME(jkleinsc): Test is consistently failing on Windows 32 bit.
-      if (process.arch === 'ia32') {
-        this.skip()
-      }
-    })
-
     it('does not crash on exit', async () => {
       const appPath = path.join(fixtures, 'api', 'leak-exit-browserview.js')
       const electronPath = remote.getGlobal('process').execPath

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -916,13 +916,6 @@ describe('webContents module', () => {
   })
 
   describe('create()', () => {
-    before(function () {
-      // FIXME(jkleinsc): Test is consistently failing on Windows 32 bit.
-      if (process.arch === 'ia32') {
-        this.skip()
-      }
-    })
-
     it('does not crash on exit', async () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'leak-exit-webcontents.js')
       const electronPath = remote.getGlobal('process').execPath

--- a/spec/api-web-contents-view-spec.js
+++ b/spec/api-web-contents-view-spec.js
@@ -34,13 +34,6 @@ describe('WebContentsView', () => {
   })
 
   describe('new WebContentsView()', () => {
-    before(function () {
-      // FIXME(jkleinsc): Test is consistently failing on Windows 32 bit.
-      if (process.arch === 'ia32') {
-        this.skip()
-      }
-    })
-
     it('does not crash on exit', async () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'leak-exit-webcontentsview.js')
       const electronPath = remote.getGlobal('process').execPath


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

When `app.quit()` is called while the message loop is not fully started, do not shutdown until message loop is ready.

Quitting too early would break Chromium's shutdown code, and leave a few defunct processes behind.

Close https://github.com/electron/electron/issues/16632.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fix defunct processes after quitting.