### PR TITLE
ci: move mac release tests to nightly cron job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,28 +1303,6 @@ workflows:
           requires:
             - osx-testing
 
-      - osx-release:
-          requires:
-            - mac-checkout
-      - osx-release-tests:
-          requires:
-            - osx-release
-      - osx-verify-ffmpeg:
-          requires:
-            - osx-release
-      - osx-verify-mksnapshot:
-          requires:
-            - osx-release
-      - osx-chromedriver:
-          requires:
-            - mac-checkout
-      - osx-release-summary:
-          requires:
-          - osx-release
-          - osx-release-tests
-          - osx-verify-ffmpeg
-          - osx-chromedriver
-
       - mas-testing:
           requires:
             - mac-checkout
@@ -1333,29 +1311,7 @@ workflows:
           requires:
             - mas-testing
 
-      - mas-release:
-          requires:
-            - mac-checkout
-      - mas-release-tests:
-          requires:
-            - mas-release
-      - mas-verify-ffmpeg:
-          requires:
-            - mas-release
-      - mas-verify-mksnapshot:
-          requires:
-            - mas-release
-      - mas-chromedriver:
-          requires:
-            - mac-checkout
-      - mas-release-summary:
-          requires:
-          - mas-release
-          - mas-release-tests
-          - mas-verify-ffmpeg
-          - mas-chromedriver
-
-  nightly-release-test:
+  nightly-linux-release-test:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -1440,6 +1396,62 @@ workflows:
             - linux-arm64-release
             - linux-arm64-chromedriver
             - linux-arm64-native-mksnapshot
+
+  nightly-mac-release-test:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - *chromium-upgrade-branches
+    jobs:
+      - mac-checkout
+
+      - osx-release:
+          requires:
+            - mac-checkout
+      - osx-release-tests:
+          requires:
+            - osx-release
+      - osx-verify-ffmpeg:
+          requires:
+            - osx-release
+      - osx-verify-mksnapshot:
+          requires:
+            - osx-release
+      - osx-chromedriver:
+          requires:
+            - mac-checkout
+      - osx-release-summary:
+          requires:
+          - osx-release
+          - osx-release-tests
+          - osx-verify-ffmpeg
+          - osx-chromedriver
+
+      - mas-release:
+          requires:
+            - mac-checkout
+      - mas-release-tests:
+          requires:
+            - mas-release
+      - mas-verify-ffmpeg:
+          requires:
+            - mas-release
+      - mas-verify-mksnapshot:
+          requires:
+            - mas-release
+      - mas-chromedriver:
+          requires:
+            - mac-checkout
+      - mas-release-summary:
+          requires:
+          - mas-release
+          - mas-release-tests
+          - mas-verify-ffmpeg
+          - mas-chromedriver
 
   # Various slow and non-essential checks we run only nightly.
   # Sanitizer jobs should be added here.


### PR DESCRIPTION
#### Description of Change
When #16552 was merged it accidentally included a change that ran mac release tests on every build.  This PR changes the CircleCI config to only run those jobs on a nightly basis like we do for our linux builds
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
