### PR TITLE
fix: use a new Electron dedicated ABI number for Electron 4.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '69.0.3497.106',
   'node_version':
-    '4d44266b78256449dd6ae86e419e3ec07257b569',
+    '8bc5d171a0873c0ba49f9433798bc8b67399788c',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',


### PR DESCRIPTION
This is the outcome of https://github.com/nodejs/TSC/issues/651 and should fix everyone having issues building / using native modules on Electron 4 with strange ABI mis-match issues.

Brings in: https://github.com/electron/node/commit/8bc5d171a0873c0ba49f9433798bc8b67399788c

Notes: Change the `NODE_MODULE_VERSION` to 69