### PR TITLE
refactor: enforce naming of ipcMainInternal

### DIFF
--- a/lib/browser/api/crash-reporter.js
+++ b/lib/browser/api/crash-reporter.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const CrashReporter = require('@electron/internal/common/crash-reporter')
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 
 class CrashReporterMain extends CrashReporter {
   sendSync (channel, ...args) {
     const event = {}
-    ipcMain.emit(channel, event, ...args)
+    ipcMainInternal.emit(channel, event, ...args)
     return event.returnValue
   }
 }

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -8,7 +8,7 @@ const url = require('url')
 const { app, ipcMain, session, deprecate } = electron
 
 const NavigationController = require('@electron/internal/browser/navigation-controller')
-const ipcMainInternal = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const errorUtils = require('@electron/internal/common/error-utils')
 
 // session is not used here, the purpose is to make sure session is initalized

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -3,7 +3,7 @@
 const { app, webContents, BrowserWindow } = require('electron')
 const { getAllWebContents } = process.atomBinding('web_contents')
 const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllWebContents()
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 
 const { Buffer } = require('buffer')
 const fs = require('fs')
@@ -149,7 +149,7 @@ const hookWebContentsEvents = function (webContents) {
 // Handle the chrome.* API messages.
 let nextId = 0
 
-ipcMain.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, connectInfo) {
+ipcMainInternal.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, connectInfo) {
   const page = backgroundPages[extensionId]
   if (!page) {
     console.error(`Connect to unknown extension ${extensionId}`)
@@ -166,12 +166,12 @@ ipcMain.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, connectInfo) 
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONCONNECT_${extensionId}`, event.sender.id, portId, connectInfo)
 })
 
-ipcMain.on('CHROME_I18N_MANIFEST', function (event, extensionId) {
+ipcMainInternal.on('CHROME_I18N_MANIFEST', function (event, extensionId) {
   event.returnValue = manifestMap[extensionId]
 })
 
 let resultID = 1
-ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, originResultID) {
+ipcMainInternal.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, originResultID) {
   const page = backgroundPages[extensionId]
   if (!page) {
     console.error(`Connect to unknown extension ${extensionId}`)
@@ -179,13 +179,13 @@ ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, 
   }
 
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, event.sender.id, message, resultID)
-  ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
+  ipcMainInternal.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
     event._replyInternal(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
 })
 
-ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBackgroundPage, message, originResultID) {
+ipcMainInternal.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBackgroundPage, message, originResultID) {
   const contents = webContents.fromId(tabId)
   if (!contents) {
     console.error(`Sending message to unknown tab ${tabId}`)
@@ -195,7 +195,7 @@ ipcMain.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extensionId, isBa
   const senderTabId = isBackgroundPage ? null : event.sender.id
 
   contents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, senderTabId, message, resultID)
-  ipcMain.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
+  ipcMainInternal.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
     event._replyInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
@@ -206,7 +206,7 @@ const isChromeExtension = function (pageURL) {
   return protocol === 'chrome-extension:'
 }
 
-ipcMain.on('CHROME_TABS_EXECUTESCRIPT', function (event, requestId, tabId, extensionId, details) {
+ipcMainInternal.on('CHROME_TABS_EXECUTESCRIPT', function (event, requestId, tabId, extensionId, details) {
   const pageURL = event.sender._getURL()
   if (!isChromeExtension(pageURL)) {
     console.error(`Blocked ${pageURL} from calling chrome.tabs.executeScript()`)

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 
 const { desktopCapturer } = process.atomBinding('desktop_capturer')
 const eventBinding = process.atomBinding('event')
@@ -13,7 +13,7 @@ let requestsQueue = []
 const electronSources = 'ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES'
 const capturerResult = (id) => `ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_${id}`
 
-ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize, fetchWindowIcons, id) => {
+ipcMainInternal.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize, fetchWindowIcons, id) => {
   const customEvent = eventBinding.createWithSender(event.sender)
   event.sender.emit('desktop-capturer-get-sources', customEvent)
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { webContents } = require('electron')
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const parseFeaturesString = require('@electron/internal/common/parse-features-string')
 const errorUtils = require('@electron/internal/common/error-utils')
 const {
@@ -341,7 +341,7 @@ const isWebViewTagEnabled = function (contents) {
 }
 
 const handleMessage = function (channel, handler) {
-  ipcMain.on(channel, (event, ...args) => {
+  ipcMainInternal.on(channel, (event, ...args) => {
     if (isWebViewTagEnabled(event.sender)) {
       handler(event, ...args)
     } else {
@@ -376,7 +376,7 @@ handleMessage('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, embed
 })
 
 // this message is sent by the actual <webview>
-ipcMain.on('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', function (event, focus, guestInstanceId) {
+ipcMainInternal.on('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', function (event, focus, guestInstanceId) {
   const guest = getGuest(guestInstanceId)
   if (guest === event.sender) {
     event.sender.emit('focus-change', {}, focus, guestInstanceId)

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -2,7 +2,7 @@
 
 const { BrowserWindow, webContents } = require('electron')
 const { isSameOrigin } = process.atomBinding('v8_util')
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const parseFeaturesString = require('@electron/internal/common/parse-features-string')
 
 const hasProp = {}.hasOwnProperty
@@ -173,7 +173,7 @@ const canAccessWindow = function (sender, target) {
 }
 
 // Routed window.open messages with raw options
-ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, frameName, features) => {
+ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, frameName, features) => {
   if (url == null || url === '') url = 'about:blank'
   if (frameName == null) frameName = ''
   if (features == null) features = ''
@@ -233,12 +233,12 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, frameName, 
   }
 
   const referrer = { url: '', policy: 'default' }
-  ipcMain.emit('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', event,
+  ipcMainInternal.emit('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', event,
     url, referrer, frameName, disposition, options, additionalFeatures)
 })
 
 // Routed window.open messages with fully parsed options
-ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', function (event, url, referrer,
+ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', function (event, url, referrer,
   frameName, disposition, options,
   additionalFeatures, postData) {
   options = mergeBrowserWindowOptions(event.sender, options)
@@ -260,7 +260,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', function (event
   }
 })
 
-ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function (event, guestId) {
+ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function (event, guestId) {
   const guestContents = webContents.fromId(guestId)
   if (guestContents == null) return
 
@@ -278,7 +278,7 @@ const windowMethods = new Set([
   'blur'
 ])
 
-ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guestId, method, ...args) {
+ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guestId, method, ...args) {
   const guestContents = webContents.fromId(guestId)
   if (guestContents == null) {
     event.returnValue = null
@@ -299,7 +299,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function (event, guest
   }
 })
 
-ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, guestId, message, targetOrigin, sourceOrigin) {
+ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function (event, guestId, message, targetOrigin, sourceOrigin) {
   if (targetOrigin == null) {
     targetOrigin = '*'
   }
@@ -321,7 +321,7 @@ const webContentsMethods = new Set([
   'executeJavaScript'
 ])
 
-ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event, guestId, method, ...args) {
+ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function (event, guestId, method, ...args) {
   const guestContents = webContents.fromId(guestId)
   if (guestContents == null) return
 
@@ -337,7 +337,7 @@ const webContentsSyncMethods = new Set([
   'loadURL'
 ])
 
-ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', function (event, guestId, method, ...args) {
+ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', function (event, guestId, method, ...args) {
   const guestContents = webContents.fromId(guestId)
   if (guestContents == null) {
     event.returnValue = null

--- a/lib/browser/ipc-main-internal-utils.js
+++ b/lib/browser/ipc-main-internal-utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const errorUtils = require('@electron/internal/common/error-utils')
 
 const callHandler = async function (handler, event, args, reply) {
@@ -13,7 +13,7 @@ const callHandler = async function (handler, event, args, reply) {
 }
 
 exports.handle = function (channel, handler) {
-  ipcMain.on(channel, (event, requestId, ...args) => {
+  ipcMainInternal.on(channel, (event, requestId, ...args) => {
     callHandler(handler, event, args, responseArgs => {
       event._replyInternal(`${channel}_RESPONSE_${requestId}`, ...responseArgs)
     })
@@ -21,7 +21,7 @@ exports.handle = function (channel, handler) {
 }
 
 exports.handleSync = function (channel, handler) {
-  ipcMain.on(channel, (event, ...args) => {
+  ipcMainInternal.on(channel, (event, ...args) => {
     callHandler(handler, event, args, responseArgs => {
       event.returnValue = responseArgs
     })

--- a/lib/browser/ipc-main-internal.js
+++ b/lib/browser/ipc-main-internal.js
@@ -7,4 +7,6 @@ const emitter = new EventEmitter()
 // Do not throw exception when channel name is "error".
 emitter.on('error', () => {})
 
-module.exports = emitter
+module.exports = {
+  ipcMainInternal: emitter
+}

--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -1,21 +1,21 @@
 'use strict'
 
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 
 // The history operation in renderer is redirected to browser.
-ipcMain.on('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK', function (event) {
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK', function (event) {
   event.sender.goBack()
 })
 
-ipcMain.on('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD', function (event) {
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD', function (event) {
   event.sender.goForward()
 })
 
-ipcMain.on('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', function (event, offset) {
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', function (event, offset) {
   event.sender.goToOffset(offset)
 })
 
-ipcMain.on('ELECTRON_NAVIGATION_CONTROLLER_LENGTH', function (event) {
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_LENGTH', function (event) {
   event.returnValue = event.sender.length()
 })
 

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -11,7 +11,7 @@ const eventBinding = process.atomBinding('event')
 
 const { isPromise } = electron
 
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const objectsRegistry = require('@electron/internal/browser/objects-registry')
 const guestViewManager = require('@electron/internal/browser/guest-view-manager')
 const bufferUtils = require('@electron/internal/common/buffer-utils')
@@ -266,7 +266,7 @@ const callFunction = function (event, contextId, func, caller, args) {
 }
 
 const handleRemoteCommand = function (channel, handler) {
-  ipcMain.on(channel, (event, contextId, ...args) => {
+  ipcMainInternal.on(channel, (event, contextId, ...args) => {
     let returnValue
     if (!event.sender._isRemoteModuleEnabled()) {
       event.returnValue = null
@@ -462,7 +462,7 @@ handleRemoteCommand('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, cont
 })
 
 // Implements window.close()
-ipcMain.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
+ipcMainInternal.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
   const window = event.sender.getOwnerBrowserWindow()
   if (window) {
     window.close()
@@ -518,19 +518,19 @@ const setReturnValue = function (event, getValue) {
   }
 }
 
-ipcMain.on('ELECTRON_CRASH_REPORTER_INIT', function (event, options) {
+ipcMainInternal.on('ELECTRON_CRASH_REPORTER_INIT', function (event, options) {
   setReturnValue(event, () => crashReporterInit(options))
 })
 
-ipcMain.on('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES', function (event) {
+ipcMainInternal.on('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES', function (event) {
   setReturnValue(event, () => event.sender.getLastWebPreferences())
 })
 
-ipcMain.on('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', function (event) {
+ipcMainInternal.on('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', function (event) {
   setReturnValue(event, () => electron.clipboard.readFindText())
 })
 
-ipcMain.on('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (event, text) {
+ipcMainInternal.on('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (event, text) {
   setReturnValue(event, () => electron.clipboard.writeFindText(text))
 })
 
@@ -547,7 +547,7 @@ const getPreloadScript = function (preloadPath) {
   return { preloadPath, preloadSrc, preloadError }
 }
 
-ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
+ipcMainInternal.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
   const preloadPaths = [
     ...(event.sender.session ? event.sender.session.getPreloads() : []),
     event.sender._getPreloadPath()
@@ -568,6 +568,6 @@ ipcMain.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
   }
 })
 
-ipcMain.on('ELECTRON_BROWSER_PRELOAD_ERROR', function (event, preloadPath, error) {
+ipcMainInternal.on('ELECTRON_BROWSER_PRELOAD_ERROR', function (event, preloadPath, error) {
   event.sender.emit('preload-error', event, preloadPath, errorUtils.deserialize(error))
 })


### PR DESCRIPTION
This PR changes `ipc-main-internal` to named export itself as `ipcMainInternal` so that any of our internals modules using it are *forced* to name it `ipcMainInternal`.  This to avoid the stumbling block we ran into recently where some of our internal logic was using the public `ipcMain` instead of the internal version.

cc @ckerr 

Notes: no-notes