### PR TITLE
feat: allow Menu.buildFromTemplate() to accept MenuItems

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -52,15 +52,14 @@ for more information on macOS' native actions.
 
 #### `Menu.buildFromTemplate(template)`
 
-* `template` MenuItemConstructorOptions[]
+* `template` MenuItemConstructorOptions[] | MenuItem[]
 
 Returns `Menu`
 
 Generally, the `template` is an array of `options` for constructing a
 [MenuItem](menu-item.md). The usage can be referenced above.
 
-You can also attach other fields to the element of the `template` and they
-will become properties of the constructed menu items.
+You can also attach other fields to the element of the `template` and they will become properties of the constructed menu items.
 
 ### Instance Methods
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -52,7 +52,7 @@ for more information on macOS' native actions.
 
 #### `Menu.buildFromTemplate(template)`
 
-* `template` MenuItemConstructorOptions[] | MenuItem[]
+* `template` (MenuItemConstructorOptions | MenuItem)[]
 
 Returns `Menu`
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -168,7 +168,13 @@ Menu.buildFromTemplate = function (template) {
   const sorted = sortTemplate(filtered)
 
   const menu = new Menu()
-  sorted.forEach((item) => menu.append(new MenuItem(item)))
+  sorted.forEach(item => {
+    if (item instanceof MenuItem) {
+      menu.append(item)
+    } else {
+      menu.append(new MenuItem(item))
+    }
+  })
 
   return menu
 }
@@ -178,7 +184,11 @@ Menu.buildFromTemplate = function (template) {
 // validate the template against having the wrong attribute
 function areValidTemplateItems (template) {
   return template.every(item =>
-    item != null && typeof item === 'object' && (item.hasOwnProperty('label') || item.hasOwnProperty('role') || item.type === 'separator'))
+    item != null &&
+    typeof item === 'object' &&
+    (item.hasOwnProperty('label') ||
+     item.hasOwnProperty('role') ||
+     item.type === 'separator'))
 }
 
 function sortTemplate (template) {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -30,6 +30,19 @@ describe('Menu module', () => {
       expect(menu.items[1].label).to.equal('two')
     })
 
+    it('should be able to accept only MenuItems in a submenu', () => {
+      const menu = Menu.buildFromTemplate([
+        {
+          label: 'one',
+          submenu: [
+            new MenuItem({ label: 'two' })
+          ]
+        }
+      ])
+      expect(menu.items[0].label).to.equal('one')
+      expect(menu.items[0].submenu.items[0].label).to.equal('two')
+    })
+
     it('should be able to accept MenuItems and plain objects', () => {
       const menu = Menu.buildFromTemplate([
         new MenuItem({ label: 'one' }),

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -109,30 +109,16 @@ describe('Menu module', () => {
         })
 
         it('does a simple sort with MenuItems', () => {
-          const items = [
-            new MenuItem({
-              label: 'two',
-              id: '2',
-              afterGroupContaining: ['1'] }),
-            new MenuItem({ type: 'separator' }),
-            new MenuItem({
-              id: '1',
-              label: 'one'
-            })
-          ].map(item => delete item.commandId)
+          const firstItem = new MenuItem({ id: '1', label: 'one' })
+          const secondItem = new MenuItem({
+            label: 'two',
+            id: '2',
+            afterGroupContaining: ['1']
+          })
+          const sep = new MenuItem({ type: 'separator' })
 
-          const expected = [
-            new MenuItem({
-              id: '1',
-              label: 'one'
-            }),
-            new MenuItem({ type: 'separator' }),
-            new MenuItem({
-              id: '2',
-              label: 'two',
-              afterGroupContaining: ['1']
-            })
-          ].map(item => delete item.commandId)
+          const items = [ secondItem, sep, firstItem ]
+          const expected = [ firstItem, sep, secondItem ]
 
           expect(sortMenuItems(items)).to.deep.equal(expected)
         })
@@ -610,6 +596,34 @@ describe('Menu module', () => {
             label: 'one',
             before: ['2']
           }
+        ])
+
+        expect(menu.items[0].label).to.equal('one')
+        expect(menu.items[1].label).to.equal('two')
+        expect(menu.items[2].label).to.equal('three')
+        expect(menu.items[3].label).to.equal('four')
+        expect(menu.items[4].label).to.equal('five')
+      })
+
+      it('should continue inserting MenuItems at next index when no specifier is present', () => {
+        const menu = Menu.buildFromTemplate([
+          new MenuItem({
+            id: '2',
+            label: 'two'
+          }), new MenuItem({
+            id: '3',
+            label: 'three'
+          }), new MenuItem({
+            id: '4',
+            label: 'four'
+          }), new MenuItem({
+            id: '5',
+            label: 'five'
+          }), new MenuItem({
+            id: '1',
+            label: 'one',
+            before: ['2']
+          })
         ])
 
         expect(menu.items[0].label).to.equal('one')

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -21,6 +21,24 @@ describe('Menu module', () => {
       expect(menu.items[0].extra).to.equal('field')
     })
 
+    it('should be able to accept only MenuItems', () => {
+      const menu = Menu.buildFromTemplate([
+        new MenuItem({ label: 'one' }),
+        new MenuItem({ label: 'two' })
+      ])
+      expect(menu.items[0].label).to.equal('one')
+      expect(menu.items[1].label).to.equal('two')
+    })
+
+    it('should be able to accept MenuItems and plain objects', () => {
+      const menu = Menu.buildFromTemplate([
+        new MenuItem({ label: 'one' }),
+        { label: 'two' }
+      ])
+      expect(menu.items[0].label).to.equal('one')
+      expect(menu.items[1].label).to.equal('two')
+    })
+
     it('does not modify the specified template', () => {
       const template = [{ label: 'text', submenu: [{ label: 'sub' }] }]
       const result = ipcRenderer.sendSync('eval', `const template = [{label: 'text', submenu: [{label: 'sub'}]}]\nrequire('electron').Menu.buildFromTemplate(template)\ntemplate`)
@@ -86,6 +104,35 @@ describe('Menu module', () => {
               afterGroupContaining: ['1']
             }
           ]
+
+          expect(sortMenuItems(items)).to.deep.equal(expected)
+        })
+
+        it('does a simple sort with MenuItems', () => {
+          const items = [
+            new MenuItem({
+              label: 'two',
+              id: '2',
+              afterGroupContaining: ['1'] }),
+            new MenuItem({ type: 'separator' }),
+            new MenuItem({
+              id: '1',
+              label: 'one'
+            })
+          ].map(item => delete item.commandId)
+
+          const expected = [
+            new MenuItem({
+              id: '1',
+              label: 'one'
+            }),
+            new MenuItem({ type: 'separator' }),
+            new MenuItem({
+              id: '2',
+              label: 'two',
+              afterGroupContaining: ['1']
+            })
+          ].map(item => delete item.commandId)
 
           expect(sortMenuItems(items)).to.deep.equal(expected)
         })


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16645.

Augment `Menu.buildFromTemplate()` to allow for MenuItem instances to be passed in either in place of or alongside plain objects.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Updated `Menu.buildFromTemplate()` to allow it to accept `MenuItem`s in addition to plain objects.
