### PR TITLE
feat: add Touch ID authentication support for macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -689,6 +689,7 @@ if (is_mac) {
 
     libs = [
       "AVFoundation.framework",
+      "LocalAuthentication.framework",
       "Carbon.framework",
       "QuartzCore.framework",
       "Quartz.framework",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -689,8 +689,8 @@ if (is_mac) {
 
     libs = [
       "AVFoundation.framework",
-      "LocalAuthentication.framework",
       "Carbon.framework",
+      "LocalAuthentication.framework",
       "QuartzCore.framework",
       "Quartz.framework",
       "Security.framework",

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -93,6 +93,7 @@ void SystemPreferences::BuildPrototype(
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
       .SetMethod("getSystemColor", &SystemPreferences::GetSystemColor)
+      .SetMethod("isTouchIDAvailable", &SystemPreferences::IsTouchIDAvailable)
       .SetMethod("promptTouchID", &SystemPreferences::PromptTouchID)
       .SetMethod("isTrustedAccessibilityClient",
                  &SystemPreferences::IsTrustedAccessibilityClient)

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -93,6 +93,7 @@ void SystemPreferences::BuildPrototype(
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
       .SetMethod("getSystemColor", &SystemPreferences::GetSystemColor)
+      .SetMethod("promptTouchID", &SystemPreferences::PromptTouchID)
       .SetMethod("isTrustedAccessibilityClient",
                  &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("getMediaAccessStatus",

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -93,7 +93,7 @@ void SystemPreferences::BuildPrototype(
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
       .SetMethod("getSystemColor", &SystemPreferences::GetSystemColor)
-      .SetMethod("isTouchIDAvailable", &SystemPreferences::IsTouchIDAvailable)
+      .SetMethod("canPromptTouchID", &SystemPreferences::CanPromptTouchID)
       .SetMethod("promptTouchID", &SystemPreferences::PromptTouchID)
       .SetMethod("isTrustedAccessibilityClient",
                  &SystemPreferences::IsTrustedAccessibilityClient)

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -95,6 +95,9 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   std::string GetSystemColor(const std::string& color, mate::Arguments* args);
 
+  v8::Local<v8::Promise> PromptTouchID(v8::Isolate* isolate,
+                                       const std::string& reason);
+
   static bool IsTrustedAccessibilityClient(bool prompt);
 
   // TODO(codebytere): Write tests for these methods once we

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -95,6 +95,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   std::string GetSystemColor(const std::string& color, mate::Arguments* args);
 
+  bool IsTouchIDAvailable();
   v8::Local<v8::Promise> PromptTouchID(v8::Isolate* isolate,
                                        const std::string& reason);
 

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -95,7 +95,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   std::string GetSystemColor(const std::string& color, mate::Arguments* args);
 
-  bool IsTouchIDAvailable();
+  bool CanPromptTouchID();
   v8::Local<v8::Promise> PromptTouchID(v8::Isolate* isolate,
                                        const std::string& reason);
 

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -443,6 +443,16 @@ std::string SystemPreferences::GetSystemColor(const std::string& color,
   }
 }
 
+bool SystemPreferences::IsTouchIDAvailable() {
+  if (@available(macOS 10.12.2, *)) {
+    base::scoped_nsobject<LAContext> context([[LAContext alloc] init]);
+    return [context
+        canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+                    error:nil];
+  }
+  return false;
+}
+
 void OnTouchIDCompleted(scoped_refptr<util::Promise> promise, bool success) {
   promise->Resolve(success);
 }
@@ -451,7 +461,7 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
     v8::Isolate* isolate,
     const std::string& reason) {
   scoped_refptr<util::Promise> promise = new util::Promise(isolate);
-  if (@available(macOS 10.12.1, *)) {
+  if (@available(macOS 10.12.2, *)) {
     base::scoped_nsobject<LAContext> context([[LAContext alloc] init]);
     base::ScopedCFTypeRef<SecAccessControlRef> access_control =
         base::ScopedCFTypeRef<SecAccessControlRef>(
@@ -481,7 +491,7 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
                         }];
   } else {
     promise->RejectWithErrorMessage(
-        "This API is not available on macOS versions older than 10.12.1");
+        "This API is not available on macOS versions older than 10.12.2");
   }
   return promise->GetHandle();
 }

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -470,13 +470,18 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
                     operation:LAAccessControlOperationUseKeySign
               localizedReason:[NSString stringWithUTF8String:reason.c_str()]
                         reply:^(BOOL success, NSError* error) {
-                          runner->PostTask(FROM_HERE,
-                                           base::BindOnce(&OnTouchIDCompleted,
+                          if (!success) {
+                            promise->RejectWithErrorMessage(std::string(
+                                [error.localizedDescription UTF8String]));
+                          } else {
+                            runner->PostTask(
+                                FROM_HERE, base::BindOnce(&OnTouchIDCompleted,
                                                           promise, !!success));
+                          }
                         }];
   } else {
     promise->RejectWithErrorMessage(
-        "This API is not available on macOS older than 10.12");
+        "This API is not available on macOS versions older than 10.12.1");
   }
   return promise->GetHandle();
 }

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -443,12 +443,16 @@ std::string SystemPreferences::GetSystemColor(const std::string& color,
   }
 }
 
-bool SystemPreferences::IsTouchIDAvailable() {
+bool SystemPreferences::CanPromptTouchID() {
   if (@available(macOS 10.12.2, *)) {
     base::scoped_nsobject<LAContext> context([[LAContext alloc] init]);
-    return [context
-        canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
-                    error:nil];
+    if (![context
+            canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+                        error:nil])
+      return false;
+    if (@available(macOS 10.13.2, *))
+      return [context biometryType] == LABiometryTypeTouchID;
+    return true;
   }
   return false;
 }

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -16,6 +16,22 @@
 - (void)setAppearance:(NSAppearance*)appearance API_AVAILABLE(macosx(10.14));
 @end
 
+#if !defined(MAC_OS_X_VERSION_10_13_2)
+
+// forward declare Touch ID APIs
+typedef NS_ENUM(NSInteger, LABiometryType) {
+  LABiometryTypeNone = 0,
+  LABiometryTypeFaceID = 1,
+  LABiometryTypeTouchID = 2,
+};
+
+@interface LAContext (HighSierraSDK)
+@property(copy, readonly)
+    LABiometryType biometryType API_AVAILABLE(macosx(10.13.2));
+@end
+
+#endif
+
 // forward declare Access APIs
 typedef NSString* AVMediaType NS_EXTENSIBLE_STRING_ENUM;
 

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -7,6 +7,7 @@
 #include "base/mac/scoped_sending_event.h"
 
 #import <AVFoundation/AVFoundation.h>
+#import <LocalAuthentication/LocalAuthentication.h>
 
 // Forward Declare Appearance APIs
 @interface NSApplication (HighSierraSDK)
@@ -23,10 +24,10 @@ typedef NS_ENUM(NSInteger, LABiometryType) {
   LABiometryTypeNone = 0,
   LABiometryTypeFaceID = 1,
   LABiometryTypeTouchID = 2,
-};
+} API_AVAILABLE(macosx(10.13.2));
 
-@interface LAContext (HighSierraSDK)
-@property(copy, readonly)
+@interface LAContext (HighSierraPointTwoSDK)
+@property(nonatomic, readonly)
     LABiometryType biometryType API_AVAILABLE(macosx(10.13.2));
 @end
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -380,11 +380,11 @@ You can use the `setAppLevelAppearance` API to set this value.
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
 
-### `systemPreferences.isTouchIDAvailable()` _macOS_
+### `systemPreferences.canPromptTouchID()` _macOS_
 
 Returns `Boolean` - whether or not this device has the ability to use Touch ID.
 
-**NOTE:** This API is only available on macOS Sierra 10.12.2 or newer.
+**NOTE:** This API will return `false` for systems older than macOS Sierra 10.12.2, due to restrictions on the underlying macOS API.
 
 ### `systemPreferences.promptTouchID(reason)` _macOS_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -384,7 +384,7 @@ system default and override the value of `getEffectiveAppearance`.
 
 Returns `Boolean` - whether or not this device has the ability to use Touch ID.
 
-**NOTE:** This API will return `false` on systems older than macOS Sierra 10.12.2.
+**NOTE:** This API will return `false` on macOS systems older than Sierra 10.12.2.
 
 ### `systemPreferences.promptTouchID(reason)` _macOS_
 
@@ -404,7 +404,7 @@ systemPreferences.promptTouchID('To get consent for a Security-Gated Thing').the
 
 This API itself will not protect your user data; rather, it is a mechanism to allow you to do so. Native apps will need to set [Access Control Constants](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags?language=objc) like [`kSecAccessControlUserPresence`](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/ksecaccesscontroluserpresence?language=objc) on the their keychain entry so that reading it would auto-prompt for Touch ID biometric consent. This could be done with [`node-keytar`](https://github.com/atom/node-keytar), such that one would store an encryption key with `node-keytar` and only fetch it if `promptTouchID()` resolves.
 
-**NOTE:** This API is only available on macOS Sierra 10.12.2 or newer.
+**NOTE:** This API will return a rejected Promise on macOS systems older than Sierra 10.12.2.
 
 ### `systemPreferences.isTrustedAccessibilityClient(prompt)` _macOS_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -380,6 +380,20 @@ You can use the `setAppLevelAppearance` API to set this value.
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
 
+### `systemPreferences.promptTouchID(reason)` _macOS_
+
+* `reason` String - The reason you are asking for Touch ID authentication
+
+Returns `Promise<Boolean>` - whether ot not the user has successfully authenticated with Touch ID.
+
+```javascript
+const { systemPreferences } = require('electron')
+
+systemPreferences.promptTouchID('To get consent for In-App Purchase').then(success => {
+  console.log('You have successfully authenticated with Touch ID!')
+})
+```
+
 ### `systemPreferences.isTrustedAccessibilityClient(prompt)` _macOS_
 
 * `prompt` Boolean - whether or not the user will be informed via prompt if the current process is untrusted.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -384,7 +384,7 @@ system default and override the value of `getEffectiveAppearance`.
 
 Returns `Boolean` - whether or not this device has the ability to use Touch ID.
 
-**NOTE:** This API will return `false` for systems older than macOS Sierra 10.12.2, due to restrictions on the underlying macOS API.
+**NOTE:** This API will return `false` on systems older than macOS Sierra 10.12.2.
 
 ### `systemPreferences.promptTouchID(reason)` _macOS_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -380,6 +380,12 @@ You can use the `setAppLevelAppearance` API to set this value.
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
 
+### `systemPreferences.isTouchIDAvailable()` _macOS_
+
+Returns `Boolean` - whether or not this device has the ability to use Touch ID.
+
+**NOTE:** This API is only available on macOS Sierra 10.12.2 or newer.
+
 ### `systemPreferences.promptTouchID(reason)` _macOS_
 
 * `reason` String - The reason you are asking for Touch ID authentication
@@ -389,10 +395,14 @@ Returns `Promise<Boolean>` - whether ot not the user has successfully authentica
 ```javascript
 const { systemPreferences } = require('electron')
 
-systemPreferences.promptTouchID('To get consent for In-App Purchase').then(success => {
+systemPreferences.promptTouchID('To get consent for a Security-Gated Thing').then(success => {
   console.log('You have successfully authenticated with Touch ID!')
 })
 ```
+
+This API itself will not protect your user data; rather, it is a mechanism to allow you to do so. Native apps will need to set [Access Control Constants](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags?language=objc) like [`kSecAccessControlUserPresence`](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/ksecaccesscontroluserpresence?language=objc) on the their keychain entry so that reading it would auto-prompt for Touch ID biometric consent. This could be done with [`node-keytar`](https://github.com/atom/node-keytar), such that one would store an encryption key with `node-keytar` and only fetch it if `promptTouchID()` resolves with `true`.
+
+**NOTE:** This API is only available on macOS Sierra 10.12.2 or newer.
 
 ### `systemPreferences.isTrustedAccessibilityClient(prompt)` _macOS_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -390,17 +390,19 @@ Returns `Boolean` - whether or not this device has the ability to use Touch ID.
 
 * `reason` String - The reason you are asking for Touch ID authentication
 
-Returns `Promise<Boolean>` - whether ot not the user has successfully authenticated with Touch ID.
+Returns `Promise<void>` - resolves if the user has successfully authenticated with Touch ID.
 
 ```javascript
 const { systemPreferences } = require('electron')
 
 systemPreferences.promptTouchID('To get consent for a Security-Gated Thing').then(success => {
   console.log('You have successfully authenticated with Touch ID!')
+}).catch(err => {
+  console.log(err)
 })
 ```
 
-This API itself will not protect your user data; rather, it is a mechanism to allow you to do so. Native apps will need to set [Access Control Constants](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags?language=objc) like [`kSecAccessControlUserPresence`](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/ksecaccesscontroluserpresence?language=objc) on the their keychain entry so that reading it would auto-prompt for Touch ID biometric consent. This could be done with [`node-keytar`](https://github.com/atom/node-keytar), such that one would store an encryption key with `node-keytar` and only fetch it if `promptTouchID()` resolves with `true`.
+This API itself will not protect your user data; rather, it is a mechanism to allow you to do so. Native apps will need to set [Access Control Constants](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags?language=objc) like [`kSecAccessControlUserPresence`](https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/ksecaccesscontroluserpresence?language=objc) on the their keychain entry so that reading it would auto-prompt for Touch ID biometric consent. This could be done with [`node-keytar`](https://github.com/atom/node-keytar), such that one would store an encryption key with `node-keytar` and only fetch it if `promptTouchID()` resolves.
 
 **NOTE:** This API is only available on macOS Sierra 10.12.2 or newer.
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16699.

This PR adds Touch ID authentication support for macOS with two new `SystemPreferences` methods. 

1. `systemPreferences.promptForTouchID()` returns a Promise that resolves with `true` if successful and rejects with an error message if authentication could not be completed.
2. `systemPreferences.isTouchIDAvailable()` returns a Boolean that's `true` if this device is a Mac running a supported OS that has the necessary hardware for Touch ID and `false` otherwise.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added native Touch ID authentication support for macOS.
