### PR TITLE
feat: support capslock  and numlock as accelerators

### DIFF
--- a/atom/common/keyboard_util.cc
+++ b/atom/common/keyboard_util.cc
@@ -38,6 +38,8 @@ ui::KeyboardCode KeyboardCodeFromKeyIdentifier(const std::string& s,
   } else if (str == "plus") {
     *shifted = true;
     return ui::VKEY_OEM_PLUS;
+  } else if (str == "capslock") {
+    return ui::VKEY_CAPITAL;
   } else if (str == "tab") {
     return ui::VKEY_TAB;
   } else if (str == "num0") {

--- a/atom/common/keyboard_util.cc
+++ b/atom/common/keyboard_util.cc
@@ -40,6 +40,8 @@ ui::KeyboardCode KeyboardCodeFromKeyIdentifier(const std::string& s,
     return ui::VKEY_OEM_PLUS;
   } else if (str == "capslock") {
     return ui::VKEY_CAPITAL;
+  } else if (str == "numlock") {
+    return ui::VKEY_NUMLOCK;
   } else if (str == "tab") {
     return ui::VKEY_TAB;
   } else if (str == "num0") {

--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -58,6 +58,7 @@ The `Super` key is mapped to the `Windows` key on Windows and Linux and
 * `Plus`
 * `Space`
 * `Tab`
+* `Capslock`
 * `Backspace`
 * `Delete`
 * `Insert`

--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -59,6 +59,7 @@ The `Super` key is mapped to the `Windows` key on Windows and Linux and
 * `Space`
 * `Tab`
 * `Capslock`
+* `Numlock`
 * `Backspace`
 * `Delete`
 * `Insert`


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16714.

Add numlock and capslock as keyboard modifiers.

cc @brenca 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add caps lock and numlock as keyboard accelerator modifiers.
