### PR TITLE
chore: fix falsy comments edge case in release notes

### DIFF
--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -65,9 +65,7 @@ const setPullRequest = (commit, owner, repo, number) => {
 
 const getNoteFromClerk = async (number, owner, repo) => {
   const comments = await getComments(number, owner, repo)
-  if (!comments && !comments.data) {
-    return
-  }
+  if (!comments || !comments.data) return
 
   const CLERK_LOGIN = 'release-clerk[bot]'
   const PERSIST_LEAD = '**Release Notes Persisted**\n\n'


### PR DESCRIPTION
#### Description of Change

Address issue whereby code to fetch notes from Clerk comments would throw if `comments` was falsy.

cc @BinaryMuse @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: none
