### PR TITLE
refactor: deprecate ServiceWorker APIs

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -379,6 +379,8 @@ WebContents.prototype._init = function () {
   this.setMaxListeners(0)
 
   this.capturePage = deprecate.promisify(this.capturePage)
+  this.hasServiceWorker = deprecate.function(this.hasServiceWorker)
+  this.unregisterServiceWorker = deprecate.function(this.unregisterServiceWorker)
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, [channel, ...args]) {

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -69,6 +69,16 @@ const deprecate = {
     })
   },
 
+  function: (fn, newName) => {
+    // if newName is left blank, a removal warning will be displayed
+    const warn = warnOnce(fn.name, newName)
+
+    return function () {
+      if (!process.noDeprecation) warn()
+      return fn.apply(this, arguments)
+    }
+  },
+
   promisify: (fn) => {
     const fnName = fn.name || 'function'
     const oldName = `${fnName} with callbacks`


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/16717: deprecate ServiceWorker APIs on the WebContents module before their removal in 6.0

cc @deepak1556 @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Deprecated `ServiceWorker` APIs on `WebContents` in preparation for their removal.
