### PR TITLE
fix: do not increase ref-counting in wrong thread

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -195,7 +195,7 @@ void RemoveCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                       const std::string& name,
                       scoped_refptr<util::Promise> promise) {
   GetCookieStore(getter)->DeleteCookieAsync(
-      url, name, base::BindOnce(ResolvePromiseInUI, promise));
+      url, name, base::BindOnce(ResolvePromiseInUI, std::move(promise)));
 }
 
 // Resolves/rejects the |promise| in UI thread.
@@ -219,7 +219,7 @@ void FlushCookieStoreOnIOThread(
     scoped_refptr<net::URLRequestContextGetter> getter,
     scoped_refptr<util::Promise> promise) {
   GetCookieStore(getter)->FlushStore(
-      base::BindOnce(ResolvePromiseInUI, promise));
+      base::BindOnce(ResolvePromiseInUI, std::move(promise)));
 }
 
 // Sets cookie with |details| in IO thread.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Avoiding copying `scoped_refptr` when passing from IO thread to UI thread, as it would encounter an DCHECK asserting `CalledOnValidSequence`.

This fixes the CI failure like:
https://circleci.com/api/v1.1/project/github/electron/electron/127426/output/107/0?file=true

```
[391:0205/065229.893931:FATAL:ref_counted.h(63)] Check failed: CalledOnValidSequence(). 
#0 0x55831deea02f base::debug::StackTrace::StackTrace()
#1 0x55831de18b47 logging::LogMessage::~LogMessage()
#2 0x55831b06f527 base::subtle::RefCountedBase::AddRef()
#3 0x55831dcee620 _ZN4base8internal9BindStateIPFv13scoped_refptrIN4atom4util7PromiseEEEJS6_EE6CreateIRS7_JRS6_EEEPS9_PFvvEOT_DpOT0_
#4 0x55831dcec41f atom::api::(anonymous namespace)::RemoveCookieOnIO()
#5 0x55831dceef12 _ZN4base8internal7InvokerINS0_9BindStateIPFv13scoped_refptrIN3net23URLRequestContextGetterEERK4GURLRKNSt3__112basic_stringIcNSA_11char_traitsIcEENSA_9allocatorIcEEEES3_IN4atom4util7PromiseEEEJNS0_18RetainedRefWrapperIS5_EES7_SG_SM_EEEFvvEE7RunOnceEPNS0_13BindStateBaseE
#6 0x55831de038b9 base::debug::TaskAnnotator::RunTask()
#7 0x55831de33def base::MessageLoopImpl::RunTask()
```

To prevent errors like this from happening in future, I think we should convert `Promise` from `RefCounted` to move-only. I'll try it in another PR.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes