### PR TITLE
refactor: implement chrome.i18n.getMessage() without the remote module

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -4,9 +4,11 @@ const { app, webContents, BrowserWindow } = require('electron')
 const { getAllWebContents } = process.atomBinding('web_contents')
 const renderProcessPreferences = process.atomBinding('render_process_preferences').forAllWebContents()
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
+const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 
 const { Buffer } = require('buffer')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const url = require('url')
 
@@ -166,10 +168,6 @@ ipcMainInternal.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, conne
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONCONNECT_${extensionId}`, event.sender.id, portId, connectInfo)
 })
 
-ipcMainInternal.on('CHROME_I18N_MANIFEST', function (event, extensionId) {
-  event.returnValue = manifestMap[extensionId]
-})
-
 let resultID = 1
 ipcMainInternal.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, originResultID) {
   const page = backgroundPages[extensionId]
@@ -199,6 +197,34 @@ ipcMainInternal.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extension
     event._replyInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
+})
+
+const getMessagesPath = (extensionId, language) => {
+  const metadata = manifestMap[extensionId]
+  if (!metadata) {
+    throw new Error(`Invalid extensionId: ${extensionId}`)
+  }
+
+  const isSafe = path.dirname(path.resolve(os.tmpdir(), language)) === os.tmpdir()
+  if (!isSafe) {
+    throw new Error(`Invalid language: ${language}`)
+  }
+
+  const localesDirectory = path.join(metadata.srcDirectory, '_locales')
+
+  try {
+    const filename = path.join(localesDirectory, language, 'messages.json')
+    fs.accessSync(filename, fs.constants.R_OK)
+    return filename
+  } catch (err) {
+    const defaultLocale = metadata.default_locale || 'en'
+    return path.join(localesDirectory, defaultLocale, 'messages.json')
+  }
+}
+
+ipcMainUtils.handleSync('CHROME_GET_MESSAGES', function (event, extensionId, language) {
+  const messagesPath = getMessagesPath(extensionId, language)
+  return fs.readFileSync(messagesPath)
 })
 
 const isChromeExtension = function (pageURL) {

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -8,7 +8,6 @@ const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils
 
 const { Buffer } = require('buffer')
 const fs = require('fs')
-const os = require('os')
 const path = require('path')
 const url = require('url')
 
@@ -199,18 +198,18 @@ ipcMainInternal.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extension
   resultID++
 })
 
-const getMessagesPath = (extensionId, language) => {
+const getLanguage = () => {
+  return app.getLocale().replace(/-.*$/, '').toLowerCase()
+}
+
+const getMessagesPath = (extensionId) => {
   const metadata = manifestMap[extensionId]
   if (!metadata) {
     throw new Error(`Invalid extensionId: ${extensionId}`)
   }
 
-  const isSafe = path.dirname(path.resolve(os.tmpdir(), language)) === os.tmpdir()
-  if (!isSafe) {
-    throw new Error(`Invalid language: ${language}`)
-  }
-
   const localesDirectory = path.join(metadata.srcDirectory, '_locales')
+  const language = getLanguage()
 
   try {
     const filename = path.join(localesDirectory, language, 'messages.json')
@@ -222,8 +221,8 @@ const getMessagesPath = (extensionId, language) => {
   }
 }
 
-ipcMainUtils.handleSync('CHROME_GET_MESSAGES', function (event, extensionId, language) {
-  const messagesPath = getMessagesPath(extensionId, language)
+ipcMainUtils.handleSync('CHROME_GET_MESSAGES', function (event, extensionId) {
+  const messagesPath = getMessagesPath(extensionId)
   return fs.readFileSync(messagesPath)
 })
 

--- a/lib/renderer/extensions/i18n.js
+++ b/lib/renderer/extensions/i18n.js
@@ -8,17 +8,13 @@
 
 const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
-const getMessages = (extensionId, language) => {
+const getMessages = (extensionId) => {
   try {
-    const data = ipcRendererUtils.invokeSync('CHROME_GET_MESSAGES', extensionId, language)
+    const data = ipcRendererUtils.invokeSync('CHROME_GET_MESSAGES', extensionId)
     return JSON.parse(data) || {}
   } catch (error) {
     return {}
   }
-}
-
-const getLanguage = () => {
-  return navigator.language.replace(/-.*$/, '').toLowerCase()
 }
 
 const replaceNumberedSubstitutions = (message, substitutions) => {
@@ -48,7 +44,7 @@ const replacePlaceholders = (message, placeholders, substitutions) => {
 }
 
 const getMessage = (extensionId, messageName, substitutions) => {
-  const messages = getMessages(extensionId, getLanguage())
+  const messages = getMessages(extensionId)
   if (messages.hasOwnProperty(messageName)) {
     const { message, placeholders } = messages[messageName]
     return replacePlaceholders(message, placeholders, substitutions)

--- a/lib/renderer/extensions/i18n.js
+++ b/lib/renderer/extensions/i18n.js
@@ -6,37 +6,12 @@
 // Does not implement predefined messages:
 // https://developer.chrome.com/extensions/i18n#overview-predefined
 
-const { potentiallyRemoteRequire } = require('@electron/internal/renderer/remote')
-const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-const fs = potentiallyRemoteRequire('fs')
-const path = potentiallyRemoteRequire('path')
-
-let metadata
-
-const getExtensionMetadata = (extensionId) => {
-  if (!metadata) {
-    metadata = ipcRenderer.sendSync('CHROME_I18N_MANIFEST', extensionId)
-  }
-  return metadata
-}
-
-const getMessagesPath = (extensionId, language) => {
-  const metadata = getExtensionMetadata(extensionId)
-  const localesDirectory = path.join(metadata.srcDirectory, '_locales')
-  try {
-    const filename = path.join(localesDirectory, language, 'messages.json')
-    fs.accessSync(filename, fs.constants.R_OK)
-    return filename
-  } catch (err) {
-    const defaultLocale = metadata.default_locale || 'en'
-    return path.join(localesDirectory, defaultLocale, 'messages.json')
-  }
-}
+const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
 const getMessages = (extensionId, language) => {
   try {
-    const messagesPath = getMessagesPath(extensionId, language)
-    return JSON.parse(fs.readFileSync(messagesPath)) || {}
+    const data = ipcRendererUtils.invokeSync('CHROME_GET_MESSAGES', extensionId, language)
+    return JSON.parse(data) || {}
   } catch (error) {
     return {}
   }


### PR DESCRIPTION
#### Description of Change
- Follow up to [refactor: implement inspector APIs without the remote module](https://github.com/electron/electron/pull/16607).
- Eliminates usage of the `remote` module in `chrome.i18n.getMessage()` implementation (`i18n.js`).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes