### PR TITLE
refactor: use ipcRendererUtils.invokeSync / ipcMainUtils.handleSync for clipboard / getLastWebPreferences()

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -469,28 +469,20 @@ ipcMainInternal.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
   event.returnValue = null
 })
 
-const setReturnValue = function (event, getValue) {
-  try {
-    event.returnValue = [null, getValue()]
-  } catch (error) {
-    event.returnValue = [errorUtils.serialize(error)]
-  }
-}
-
 ipcMainUtils.handleSync('ELECTRON_CRASH_REPORTER_INIT', function (event, options) {
   return crashReporterInit(options)
 })
 
-ipcMainInternal.on('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES', function (event) {
-  setReturnValue(event, () => event.sender.getLastWebPreferences())
+ipcMainUtils.handleSync('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES', function (event) {
+  return event.sender.getLastWebPreferences()
 })
 
-ipcMainInternal.on('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', function (event) {
-  setReturnValue(event, () => electron.clipboard.readFindText())
+ipcMainUtils.handleSync('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', function (event) {
+  return electron.clipboard.readFindText()
 })
 
-ipcMainInternal.on('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (event, text) {
-  setReturnValue(event, () => electron.clipboard.writeFindText(text))
+ipcMainUtils.handleSync('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (event, text) {
+  return electron.clipboard.writeFindText(text)
 })
 
 const getPreloadScript = function (preloadPath) {

--- a/lib/common/api/clipboard.js
+++ b/lib/common/api/clipboard.js
@@ -10,21 +10,10 @@ if (process.platform === 'linux' && process.type === 'renderer') {
   // Read/write to find pasteboard over IPC since only main process is notified
   // of changes
   if (process.platform === 'darwin' && process.type === 'renderer') {
-    const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-    const errorUtils = require('@electron/internal/common/error-utils')
+    const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
-    const invoke = function (command, ...args) {
-      const [ error, result ] = ipcRenderer.sendSync(command, ...args)
-
-      if (error) {
-        throw errorUtils.deserialize(error)
-      } else {
-        return result
-      }
-    }
-
-    clipboard.readFindText = (...args) => invoke('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', ...args)
-    clipboard.writeFindText = (...args) => invoke('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', ...args)
+    clipboard.readFindText = (...args) => ipcRendererUtils.invokeSync('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', ...args)
+    clipboard.writeFindText = (...args) => ipcRendererUtils.invokeSync('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', ...args)
   }
 
   module.exports = clipboard

--- a/lib/renderer/security-warnings.js
+++ b/lib/renderer/security-warnings.js
@@ -264,16 +264,13 @@ const logSecurityWarnings = function (webPreferences, nodeIntegration) {
 }
 
 const getWebPreferences = function () {
-  const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-  const errorUtils = require('@electron/internal/common/error-utils')
+  const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
-  const [ error, result ] = ipcRenderer.sendSync('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES')
-
-  if (error) {
-    console.warn(`getLastWebPreferences() failed: ${errorUtils.deserialize(error)}`)
+  try {
+    return ipcRendererUtils.invokeSync('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES')
+  } catch (error) {
+    console.warn(`getLastWebPreferences() failed: ${error}`)
     return null
-  } else {
-    return result
   }
 }
 


### PR DESCRIPTION
#### Description of Change
- Use `ipcRendererUtils.invokeSync` / `ipcMainUtils.handleSync` to eliminate duplicate code.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes