### PR TITLE
fix:webframe spellcheck client leak for sandbox mode

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -264,8 +264,7 @@ void WebFrame::SetSpellCheckProvider(mate::Arguments* args,
   FrameSpellChecker spell_checker(spell_check_client.get(), render_frame);
   content::RenderFrame::ForEach(&spell_checker);
   web_frame_->SetSpellCheckPanelHostClient(spell_check_client.get());
-  web_frame_observer_.reset(
-      new AtomWebFrameObserver(render_frame, std::move(spell_check_client)));
+  new AtomWebFrameObserver(render_frame, std::move(spell_check_client));
 }
 
 void WebFrame::InsertText(const std::string& text) {

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -26,6 +26,8 @@ namespace atom {
 
 namespace api {
 
+class AtomWebFrameObserver;
+
 class WebFrame : public mate::Wrappable<WebFrame> {
  public:
   static mate::Handle<WebFrame> Create(v8::Isolate* isolate);
@@ -92,7 +94,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   v8::Local<v8::Value> RoutingId() const;
 
   blink::WebLocalFrame* web_frame_;
-
+  std::unique_ptr<AtomWebFrameObserver> web_frame_observer_;
   DISALLOW_COPY_AND_ASSIGN(WebFrame);
 };
 

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -26,8 +26,6 @@ namespace atom {
 
 namespace api {
 
-class AtomWebFrameObserver;
-
 class WebFrame : public mate::Wrappable<WebFrame> {
  public:
   static mate::Handle<WebFrame> Create(v8::Isolate* isolate);
@@ -94,7 +92,7 @@ class WebFrame : public mate::Wrappable<WebFrame> {
   v8::Local<v8::Value> RoutingId() const;
 
   blink::WebLocalFrame* web_frame_;
-  std::unique_ptr<AtomWebFrameObserver> web_frame_observer_;
+
   DISALLOW_COPY_AND_ASSIGN(WebFrame);
 };
 


### PR DESCRIPTION
#### Description of Change
RenderFrameObserver OnDestruct method is only called in non sandbox mode. So spellcheck client was destroyed only in non sandbox mode.
This fixes that and moves the spellcheck client destruction to `WillReleaseScriptContext` which will be called in both sandbox and non-sandbox mode.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fixed webframe spellcheck provider memory leak for sandbox mode
