### PR TITLE
ci: cache brew update result

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,6 +458,11 @@ step-maybe-generate-typescript-defs: &step-maybe-generate-typescript-defs
 # Lists of steps.
 steps-checkout: &steps-checkout
   steps:
+    - restore_cache:
+        paths:
+          - /usr/local/Homebrew
+        keys:
+          - v1-brew-cache-{{ arch }}
     - *step-checkout-electron
     - *step-depot-tools-get
     - *step-depot-tools-add-to-path
@@ -481,6 +486,10 @@ steps-checkout: &steps-checkout
         paths:
           - ~/.gclient-cache
         key: v1-gclient-cache-{{ arch }}-{{ checksum "src/electron/DEPS" }}
+    - save_cache:
+        paths:
+          - /usr/local/Homebrew
+        key: v1-brew-cache-{{ arch }}
 
     - run:
         name: Remove some unused data to avoid storing it in the workspace


### PR DESCRIPTION
This is a secondary attempt to make macOS CI faster by targeting the low-hanging-fruit of "why does it take 6 minutes to install node 10".

Turns out it's `brew update`, if we cache the result of `brew update` we drop from 6 minutes --> 30 seconds + 10 second cache restore.

This change should save us ~15 minutes for an end-to-end macOS CI run

Notes: no-notes