### PR TITLE
[wip] build: do not run ci for changes to some dirs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,3 +107,8 @@ deploy_script:
           & python script\upload.py
         }
       }
+skip_commits:
+  files:
+    - docs/*
+    - script/*
+    - tools/*

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gn-typescript-definitions": "npm run create-typescript-definitions && cp electron.d.ts",
     "preinstall": "node -e 'process.exit(0)'",
     "precommit": "lint-staged",
-    "commitmsg": "script/check-skip-circle-ci", 
+    "preparecommitmsg": "script/check-skip-circle-ci", 
     "prepack": "check-for-leaks",
     "prepush": "check-for-leaks",
     "repl": "node ./script/start.js --interactive",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gn-typescript-definitions": "npm run create-typescript-definitions && cp electron.d.ts",
     "preinstall": "node -e 'process.exit(0)'",
     "precommit": "lint-staged",
+    "commitmsg": "script/check-skip-circle-ci", 
     "prepack": "check-for-leaks",
     "prepush": "check-for-leaks",
     "repl": "node ./script/start.js --interactive",

--- a/script/check-skip-circle-ci
+++ b/script/check-skip-circle-ci
@@ -18,9 +18,8 @@ do
 done
 
 if [[ ${#changes[@]} -gt 0 ]]; then
-	# if still changes left leave the commit alone.
 	exit
 fi
 
 # Prefix the commit message with "[skip ci]"
-echo "[skip ci] $(cat $commit_file)" > $commit_file
+sed -i.bak -e "1s/^/[skip ci] /" "$GIT_DIR/COMMIT_EDITMSG"

--- a/script/check-skip-circle-ci
+++ b/script/check-skip-circle-ci
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Load in every file that will be changed via this commit into an array
+changes=( `git diff --name-only --cached` )
+commit_file="../.git/COMMIT_EDITMSG"
+
+# Load the dir patterns to skip into an array
+declare -a blacklist=("script/*" "tools/*" "docs/*")
+
+for i in "${blacklist[@]}"
+do
+	# Remove the current pattern from the list of changes
+	changes=( ${changes[@]/$i/} )
+
+	if [[ ${#changes[@]} -eq 0 ]]; then
+		break
+	fi
+done
+
+if [[ ${#changes[@]} -gt 0 ]]; then
+	# if still changes left leave the commit alone.
+	exit
+fi
+
+# Prefix the commit message with "[skip ci]"
+echo "[skip ci] $(cat $commit_file)" > $commit_file

--- a/script/check-skip-circle-ci
+++ b/script/check-skip-circle-ci
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
 
-# Load in every file that will be changed via this commit into an array
-changes=( `git diff --name-only --cached` )
-commit_file="../.git/COMMIT_EDITMSG"
-
-# Load the dir patterns to skip into an array
-declare -a blacklist=("script/*" "tools/*" "docs/*")
-
-for i in "${blacklist[@]}"
-do
-	# Remove the current pattern from the list of changes
-	changes=( ${changes[@]/$i/} )
-
-	if [[ ${#changes[@]} -eq 0 ]]; then
-		break
-	fi
-done
+# Get all changes that are not in omitted folders
+changes=( `git diff --name-only --cached ':!docs' ':!script' ':!tools'` )
 
 if [[ ${#changes[@]} -gt 0 ]]; then
 	exit


### PR DESCRIPTION
#### Description of Change

The success of changes to `docs/`, `script/` and `tools/` would never be reflected in debug build output from appveyor, so per [these settings](https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only), configure appveyor not to run if all of the files modified in push’s head commit are in any of these folders.

This PR also adds a `preparecommitmsg` hook on CircleCI that accomplishes the same goal, as circle does not have the same convenient `skip_commit` option.

cc @jkleinsc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
