### PR TITLE
fix: ref-count threading issue in cookie api

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -305,7 +305,7 @@ v8::Local<v8::Promise> Cookies::Get(const base::DictionaryValue& filter) {
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
       base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter), std::move(copy),
-                     promise));
+                     std::move(promise)));
 
   return promise->GetHandle();
 }
@@ -318,7 +318,7 @@ v8::Local<v8::Promise> Cookies::Remove(const GURL& url,
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
       base::BindOnce(RemoveCookieOnIO, base::RetainedRef(getter), url, name,
-                     promise));
+                     std::move(promise)));
 
   return promise->GetHandle();
 }
@@ -332,7 +332,7 @@ v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
       base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), std::move(copy),
-                     promise));
+                     std::move(promise)));
 
   return promise->GetHandle();
 }
@@ -341,9 +341,10 @@ v8::Local<v8::Promise> Cookies::FlushStore() {
   scoped_refptr<util::Promise> promise = new util::Promise(isolate());
 
   auto* getter = browser_context_->GetRequestContext();
-  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::IO},
-                           base::BindOnce(FlushCookieStoreOnIOThread,
-                                          base::RetainedRef(getter), promise));
+  base::PostTaskWithTraits(
+      FROM_HERE, {BrowserThread::IO},
+      base::BindOnce(FlushCookieStoreOnIOThread, base::RetainedRef(getter),
+                     std::move(promise)));
 
   return promise->GetHandle();
 }


### PR DESCRIPTION
#### Description of Change
Hopefully fixes the following crash:

```
[395:0206/134010.588774:FATAL:ref_counted.h(63)] Check failed: CalledOnValidSequence(). 
#0 0x55f624bed01f base::debug::StackTrace::StackTrace()
#1 0x55f624b1bb37 logging::LogMessage::~LogMessage()
#2 0x55f621d72527 base::subtle::RefCountedBase::AddRef()
#3 0x55f6249f0ca9 _ZN4base8internal7InvokerINS0_9BindStateIPFvNSt3__110unique_ptrINS_15DictionaryValueENS3_14default_deleteIS5_EEEE13scoped_refptrIN4atom4util7PromiseEERKNS3_6vectorIN3net15CanonicalCookieENS3_9allocatorISG_EEEEEJNS0_13PassedWrapperIS8_EESD_EEEFvSL_EE7RunImplIRKSN_RKNS3_5tupleIJSP_SD_EEEJLm0ELm1EEEEvOT_OT0_NS3_16integer_sequenceImJXspT1_EEEESL_
#4 0x55f624cfc212 net::CookieMonster::GetCookieListWithOptions()
#5 0x55f624d02f45 _ZN4base8internal7InvokerINS0_9BindStateIMN3net13CookieMonsterEFvRK4GURLRKNS3_13CookieOptionsENS_12OnceCallbackIFvRKNSt3__16vectorINS3_15CanonicalCookieENSC_9allocatorISE_EEEEEEEEJNS0_17UnretainedWrapperIS4_EES5_S8_SL_EEEFvvEE7RunOnceEPNS0_13BindStateBaseE
#6 0x55f624d02627 _ZN4base8internal7InvokerINS0_9BindStateIZN12_GLOBAL__N_130InstrumentGetCookieListClosureENS_12OnceCallbackIFvvEEEE3$_0JNSt3__110unique_ptrINS_12ElapsedTimerENS8_14default_deleteISA_EEEES6_EEES5_E7RunOnceEPNS0_13BindStateBaseE
#7 0x55f624cfb215 net::CookieMonster::DoCookieCallbackForHostOrDomain()
#8 0x55f624cfc028 net::CookieMonster::GetCookieListWithOptionsAsync()
#9 0x55f624d07307 net::CookieStore::GetAllCookiesForURLAsync()
#10 0x55f6249ef094 atom::api::(anonymous namespace)::GetCookiesOnIO()
[...]
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes