### PR TITLE
feat: promisify webContents.printToPDF()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1499,11 +1499,12 @@ std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {
   return printers;
 }
 
-void WebContents::PrintToPDF(
-    const base::DictionaryValue& settings,
-    const PrintPreviewMessageHandler::PrintToPDFCallback& callback) {
+v8::Local<v8::Promise> WebContents::PrintToPDF(
+    const base::DictionaryValue& settings) {
+  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
   PrintPreviewMessageHandler::FromWebContents(web_contents())
-      ->PrintToPDF(settings, callback);
+      ->PrintToPDF(settings, promise);
+  return promise->GetHandle();
 }
 #endif
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -174,9 +174,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   // Print current page as PDF.
-  void PrintToPDF(
-      const base::DictionaryValue& settings,
-      const PrintPreviewMessageHandler::PrintToPDFCallback& callback);
+  v8::Local<v8::Promise> PrintToPDF(const base::DictionaryValue& settings);
 #endif
 
   // DevTools workspace api.

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -28,17 +28,16 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ses.clearAuthCache(options[, callback])](https://github.com/electron/electron/blob/master/docs/api/session.md#clearAuthCache)
 - [contents.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#executeJavaScript)
 - [contents.print([options], [callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#print)
-- [contents.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#printToPDF)
 - [contents.savePage(fullPath, saveType, callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#savePage)
 - [webFrame.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-frame.md#executeJavaScript)
 - [webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-frame.md#executeJavaScriptInIsolatedWorld)
 - [webviewTag.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#executeJavaScript)
-- [webviewTag.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#printToPDF)
 
 ### Converted Functions
 
 - [app.getFileIcon(path[, options], callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#getFileIcon)
 - [contents.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#capturePage)
+- [contents.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#printToPDF)
 - [contentTracing.getCategories(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getCategories)
 - [contentTracing.startRecording(options, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#startRecording)
 - [contentTracing.stopRecording(resultFilePath, callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#stopRecording)
@@ -50,5 +49,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [protocol.isProtocolHandled(scheme, callback)](https://github.com/electron/electron/blob/master/docs/api/protocol.md#isProtocolHandled)
 - [shell.openExternal(url[, options, callback])](https://github.com/electron/electron/blob/master/docs/api/shell.md#openExternal)
 - [webviewTag.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#capturePage)
+- [webviewTag.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#printToPDF)
 - [win.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#capturePage)
 - [desktopCapturer.getSources(options, callback)](https://github.com/electron/electron/blob/master/docs/api/desktop-capturer.md#getSources)

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1202,6 +1202,25 @@ settings.
 The `callback` will be called with `callback(error, data)` on completion. The
 `data` is a `Buffer` that contains the generated PDF data.
 
+**[Deprecated Soon](promisification.md)**
+
+#### `contents.printToPDF(options)`
+
+* `options` Object
+  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
+    default margin, 1 for no margin, and 2 for minimum margin.
+  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
+    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
+    and `width` in microns.
+  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
+  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+
+* Returns `Promise<Buffer>` - Resolves with the generated PDF data.
+
+Prints window's web page as PDF with Chromium's preview printing custom
+settings.
+
 The `landscape` will be ignored if `@page` CSS at-rule is used in the web page.
 
 By default, an empty `options` will be regarded as:

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -542,6 +542,24 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
 
+**[Deprecated Soon](promisification.md)**
+
+### `<webview>.printToPDF(options)`
+
+* `options` Object
+  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
+    default margin, 1 for no margin, and 2 for minimum margin.
+  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
+    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
+    and `width` in microns.
+  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
+  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+
+* Returns `Promise<Buffer>` - Resolves with the generated PDF data.
+
+Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options)`.
+
 ### `<webview>.capturePage([rect, ]callback)`
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -263,7 +263,7 @@ WebContents.prototype.takeHeapSnapshot = function (filePath) {
 }
 
 // Translate the options of printToPDF.
-WebContents.prototype.printToPDF = function (options, callback) {
+WebContents.prototype.printToPDF = function (options) {
   const printingSetting = Object.assign({}, defaultPrintingSetting)
   if (options.landscape) {
     printingSetting.landscape = options.landscape
@@ -282,7 +282,7 @@ WebContents.prototype.printToPDF = function (options, callback) {
     const pageSize = options.pageSize
     if (typeof pageSize === 'object') {
       if (!pageSize.height || !pageSize.width) {
-        return callback(new Error('Must define height and width for pageSize'))
+        return Promise.reject(new Error('Must define height and width for pageSize'))
       }
       // Dimensions in Microns
       // 1 meter = 10^6 microns
@@ -295,7 +295,7 @@ WebContents.prototype.printToPDF = function (options, callback) {
     } else if (PDFPageSizes[pageSize]) {
       printingSetting.mediaSize = PDFPageSizes[pageSize]
     } else {
-      return callback(new Error(`Does not support pageSize with ${pageSize}`))
+      return Promise.reject(new Error(`Does not support pageSize with ${pageSize}`))
     }
   } else {
     printingSetting.mediaSize = PDFPageSizes['A4']
@@ -304,9 +304,9 @@ WebContents.prototype.printToPDF = function (options, callback) {
   // Chromium expects this in a 0-100 range number, not as float
   printingSetting.scaleFactor *= 100
   if (features.isPrintingEnabled()) {
-    this._printToPDF(printingSetting, callback)
+    return this._printToPDF(printingSetting)
   } else {
-    console.error('Error: Printing feature is disabled.')
+    return Promise.reject(new Error('Printing feature is disabled'))
   }
 }
 
@@ -341,6 +341,9 @@ WebContents.prototype.loadFile = function (filePath, options = {}) {
     hash
   }))
 }
+
+WebContents.prototype.capturePage = deprecate.promisify(WebContents.prototype.capturePage)
+WebContents.prototype.printToPDF = deprecate.promisify(WebContents.prototype.printToPDF)
 
 const addReplyToEvent = (event) => {
   event.reply = (...args) => {
@@ -384,8 +387,6 @@ WebContents.prototype._init = function () {
   // Every remote callback from renderer process would add a listener to the
   // render-view-deleted event, so ignore the listeners warning.
   this.setMaxListeners(0)
-
-  this.capturePage = deprecate.promisify(this.capturePage)
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, internal, channel, args) {

--- a/lib/common/web-view-methods.js
+++ b/lib/common/web-view-methods.js
@@ -60,11 +60,11 @@ exports.asyncCallbackMethods = new Set([
   'sendInputEvent',
   'setLayoutZoomLevelLimits',
   'setVisualZoomLevelLimits',
-  'print',
-  'printToPDF'
+  'print'
 ])
 
 exports.asyncPromiseMethods = new Set([
   'capturePage',
-  'executeJavaScript'
+  'executeJavaScript',
+  'printToPDF'
 ])

--- a/lib/renderer/web-view/web-view-impl.js
+++ b/lib/renderer/web-view/web-view-impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { webFrame } = require('electron')
+const { webFrame, deprecate } = require('electron')
 
 const v8Util = process.atomBinding('v8_util')
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
@@ -287,6 +287,8 @@ const setupMethods = (WebViewElement) => {
   for (const method of asyncPromiseMethods) {
     WebViewElement.prototype[method] = createPromiseHandler(method)
   }
+
+  WebViewElement.prototype.printToPDF = deprecate.promisify(WebViewElement.prototype.printToPDF)
 }
 
 module.exports = { setupAttributes, setupMethods, guestViewInternal, webFrame, WebViewImpl }

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -1268,7 +1268,22 @@ describe('webContents module', () => {
       }
     })
 
-    it('can print to PDF', (done) => {
+    it('can print to PDF', async () => {
+      w.destroy()
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          sandbox: true
+        }
+      })
+      await w.loadURL('data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E')
+      const data = await w.webContents.printToPDF({})
+      assert.strictEqual(data instanceof Buffer, true)
+      assert.notStrictEqual(data.length, 0)
+    })
+
+    // TODO(miniak): remove when promisification is complete
+    it('can print to PDF (callback)', (done) => {
       w.destroy()
       w = new BrowserWindow({
         show: false,


### PR DESCRIPTION
#### Description of Change

This PR promisifies `webContents.printToPDF()`

/cc @codebytere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Converted `webContents.printToPDF()` to return a Promise instead of taking a callback.