### PR TITLE
chore: dont log 100000000 chars of URL

### DIFF
--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -69,7 +69,7 @@ const NavigationController = (function () {
         resolve()
       }
       const rejectAndCleanup = (errorCode, errorDescription, url) => {
-        const err = new Error(`${errorDescription} (${errorCode}) loading '${url}'`)
+        const err = new Error(`${errorDescription} (${errorCode}) loading '${typeof url === 'string' ? url.substr(0, 2048) : url}'`)
         Object.assign(err, { errno: errorCode, code: errorDescription, url })
         removeListeners()
         reject(err)


### PR DESCRIPTION
Once of our tests was causing a VERRRYYY long URL to be logged to console, this made CI logs very hard to read (you had to download them and scroll past several pages of "A" before you could see the failure).

This changes that log to only log the first 2048 chars of a URL (should be plenty for 99% of use cases and most URLs are capped at this number anyway)

Notes: no-notes