### PR TITLE
chore: improve existing error preservation in promisify

### DIFF
--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -89,7 +89,9 @@ const deprecate = {
             cb.length === 2 ? cb(null, res) : cb(res)
           })
         }, err => {
-          process.nextTick(() => cb(err))
+          if (cb.length === 2) {
+            process.nextTick(() => cb(err))
+          }
         })
     }
   },

--- a/lib/common/api/deprecate.js
+++ b/lib/common/api/deprecate.js
@@ -89,9 +89,9 @@ const deprecate = {
             cb.length === 2 ? cb(null, res) : cb(res)
           })
         }, err => {
-          if (cb.length === 2) {
-            process.nextTick(() => cb(err))
-          }
+          process.nextTick(() => {
+            cb.length === 2 ? cb(err) : cb()
+          })
         })
     }
   },

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -145,6 +145,24 @@ describe('deprecations', () => {
       expect(warnings).to.have.lengthOf(0)
     })
 
+    it('only calls back an error if the callback is called with (err, data)', (done) => {
+      enableCallbackWarnings()
+      let erringPromiseFunc = () => new Promise((resolve, reject) => {
+        reject(new Error('fail'))
+      })
+      erringPromiseFunc = deprecate.promisify(erringPromiseFunc)
+
+      erringPromiseFunc((err, data) => {
+        expect(data).to.be.an('undefined')
+        expect(err).to.be.an.instanceOf(Error).with.property('message', 'fail')
+        erringPromiseFunc(data => {
+          expect(data).to.not.be.an.instanceOf(Error)
+          expect(data).to.be.an('undefined')
+          done()
+        })
+      })
+    })
+
     it('warns exactly once for callback-based invocations', (done) => {
       enableCallbackWarnings()
       promiseFunc = deprecate.promisify(promiseFunc)


### PR DESCRIPTION
#### Description of Change

This PR better preserves existing behavior in `deprecate.promisify()` in the cases where the promise fails. Previously, if a callback was only called with `data` instead of `err, data` and the promise was rejected, `data` would be populated with `err`, which could be confusing to users. This makes it such that `err` is called back on promise rejection if a callback is called with `err, data` a la Node.js

cc @miniak 
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
