### PR TITLE
chore: re-export chromium patches

### DIFF
--- a/patches/common/chromium/dcheck.patch
+++ b/patches/common/chromium/dcheck.patch
@@ -17,7 +17,7 @@ only one or two specific checks fail. Then it's better to simply comment out the
 failing checks and allow the rest of the target to have them enabled.
 
 diff --git a/content/browser/frame_host/navigation_controller_impl.cc b/content/browser/frame_host/navigation_controller_impl.cc
-index 4c3c16176f2dced3f7f2e586594d9e368b358d37..9511aefc5cf61497fb98bb9bae028e67be41973c 100644
+index 6dfe29cb33f494228c254ca4a1890626af68e2d7..30fa308bca29c77e4708b108d17a7e5e94092181 100644
 --- a/content/browser/frame_host/navigation_controller_impl.cc
 +++ b/content/browser/frame_host/navigation_controller_impl.cc
 @@ -1101,8 +1101,10 @@ NavigationType NavigationControllerImpl::ClassifyNavigation(

--- a/patches/common/chromium/disable-redraw-lock.patch
+++ b/patches/common/chromium/disable-redraw-lock.patch
@@ -15,7 +15,7 @@ the redraw locking mechanism, which fixes these issues. The electron issue
 can be found at https://github.com/electron/electron/issues/1821
 
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index b3c01542f183a247df30e5b96bbba8298d828153..8fe7e1142cb79cb3abf3cbc1cabc73b27695a63a 100644
+index 322315fb109b6260fcc9a243c910e789ee0a666c..27b9b8a1ea25559eb2fa45023085ddde6da3b719 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
 @@ -288,6 +288,10 @@ const int kSynthesizedMouseMessagesTimeDifference = 500;
@@ -37,7 +37,7 @@ index b3c01542f183a247df30e5b96bbba8298d828153..8fe7e1142cb79cb3abf3cbc1cabc73b2
                       (!(GetWindowLong(hwnd_, GWL_STYLE) & WS_CAPTION) ||
                        !ui::win::IsAeroGlassEnabled())) {
      if (should_lock_)
-@@ -940,6 +945,10 @@ bool HWNDMessageHandler::HasChildRenderingWindow() {
+@@ -941,6 +946,10 @@ bool HWNDMessageHandler::HasChildRenderingWindow() {
        hwnd());
  }
  
@@ -49,7 +49,7 @@ index b3c01542f183a247df30e5b96bbba8298d828153..8fe7e1142cb79cb3abf3cbc1cabc73b2
  // HWNDMessageHandler, gfx::WindowImpl overrides:
  
 diff --git a/ui/views/win/hwnd_message_handler.h b/ui/views/win/hwnd_message_handler.h
-index 2efafcdba85f2f8c940bb5fc2b07f1ec1abdb3c9..ce3fdf8ec003f0b18fe94368b18f6efca5d6d7b4 100644
+index c0f8d689ffdfaa52ef28de0b5344739f27f57eb1..5a376f06e2bcca0875f30ea37cc9a1feaf521ad5 100644
 --- a/ui/views/win/hwnd_message_handler.h
 +++ b/ui/views/win/hwnd_message_handler.h
 @@ -182,6 +182,8 @@ class VIEWS_EXPORT HWNDMessageHandler : public gfx::WindowImpl,
@@ -62,7 +62,7 @@ index 2efafcdba85f2f8c940bb5fc2b07f1ec1abdb3c9..ce3fdf8ec003f0b18fe94368b18f6efc
    HICON GetDefaultWindowIcon() const override;
    HICON GetSmallWindowIcon() const override;
 diff --git a/ui/views/win/hwnd_message_handler_delegate.h b/ui/views/win/hwnd_message_handler_delegate.h
-index 17907e675bb1d9cf4bf2bff1d0668d36fdf42df0..0ca9cb470df588bb952faada6c658335dc76ed06 100644
+index 690bc7aedd2893a017c13decc847b7ab9a203ccf..529f08d6321bbc91767a60b6be2fae6efdd585c2 100644
 --- a/ui/views/win/hwnd_message_handler_delegate.h
 +++ b/ui/views/win/hwnd_message_handler_delegate.h
 @@ -45,6 +45,8 @@ class VIEWS_EXPORT HWNDMessageHandlerDelegate {

--- a/patches/common/chromium/disable_time_ticks_dcheck.patch
+++ b/patches/common/chromium/disable_time_ticks_dcheck.patch
@@ -6,7 +6,7 @@ Subject: disable_time_ticks_dcheck.patch
 The DCHECK is failing for some reason.
 
 diff --git a/content/common/inter_process_time_ticks_converter.cc b/content/common/inter_process_time_ticks_converter.cc
-index 128abab37eb8..4d8e5e9c05b1 100644
+index 128abab37eb8a96535ef92ebf11a463e863cc485..4d8e5e9c05b11083a69537d5badc85924b6fbae2 100644
 --- a/content/common/inter_process_time_ticks_converter.cc
 +++ b/content/common/inter_process_time_ticks_converter.cc
 @@ -55,13 +55,13 @@ LocalTimeTicks InterProcessTimeTicksConverter::ToLocalTimeTicks(

--- a/patches/common/chromium/fix_test_compilation_error.patch
+++ b/patches/common/chromium/fix_test_compilation_error.patch
@@ -1,14 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Xianzhu Wang <wangxianzhu@chromium.org>
-Date: Thu Dec 6 02:00:06 2018 +0000
-
-Backport dedab04b5256f88ec4dbbbae9492941e8cf1221a which fixes
-compilation error for the test files.
+Date: Thu, 6 Dec 2018 02:00:06 +0000
+Subject: Backport dedab04b5256f88ec4dbbbae9492941e8cf1221a which fixes
+ compilation error for the test files.
 
 This patch can be removed after updating to Chrome 73.
 
 diff --git a/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator_test.cc b/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator_test.cc
-index 97ffe553cd1e..771392a0137b 100644
+index 97ffe553cd1e620152126639a1589621abaad00e..771392a0137b3eeb465651a228201e4fa5fa7b8f 100644
 --- a/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator_test.cc
 +++ b/third_party/blink/renderer/platform/graphics/paint/display_item_raster_invalidator_test.cc
 @@ -8,13 +8,15 @@
@@ -177,7 +176,7 @@ index 97ffe553cd1e..771392a0137b 100644
    GraphicsContext context(GetPaintController());
  
 diff --git a/third_party/blink/renderer/platform/graphics/paint/raster_invalidator_test.cc b/third_party/blink/renderer/platform/graphics/paint/raster_invalidator_test.cc
-index 7f8306e2703e..4cecc2c3c41f 100644
+index 13cbaaab2ea04726d0a2461fbd8e78e865443ce4..6a7e25139ad4848e14cb1548105eff2cdfdb94a1 100644
 --- a/third_party/blink/renderer/platform/graphics/paint/raster_invalidator_test.cc
 +++ b/third_party/blink/renderer/platform/graphics/paint/raster_invalidator_test.cc
 @@ -8,13 +8,15 @@


### PR DESCRIPTION
this is the changeset from running import-patches && export-patches. should be idempotent now.
Notes: no-notes