### PR TITLE
fix: backport patch to sync exposed crypto

### DIFF
--- a/patches/common/boringssl/.patches
+++ b/patches/common/boringssl/.patches
@@ -2,3 +2,4 @@ add_ec_group_order_bits_for_openssl_compatibility.patch
 add_ec_key_key2buf_for_openssl_compatibility.patch
 expose_ripemd160.patch
 expose_aes-cfb.patch
+sync_sorted_ciphers.patch

--- a/patches/common/boringssl/sync_sorted_ciphers.patch
+++ b/patches/common/boringssl/sync_sorted_ciphers.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Thurs, 7 Feb 2019 11:11:35 -0800
+Subject: sync EVP_get_cipherbyname with EVP_do_all_sorted
+
+EVP_get_cipherbyname should work on everything that EVP_do_all_sorted
+lists, and conversely, there should be nothing that
+EVP_get_cipherbyname works on that EVP_do_all_sorted doesn't list.
+This thus does that.
+
+diff --git a/crypto/cipher_extra/cipher_extra.c b/crypto/cipher_extra/cipher_extra.c
+index be7ef07b2..588a47734 100644
+--- a/crypto/cipher_extra/cipher_extra.c
++++ b/crypto/cipher_extra/cipher_extra.c
+@@ -133,6 +133,14 @@ const EVP_CIPHER *EVP_get_cipherbyname(const char *name) {
+     return EVP_aes_192_ofb();
+   } else if (OPENSSL_strcasecmp(name, "aes-256-ofb") == 0) {
+     return EVP_aes_256_ofb();
++  } else if (OPENSSL_strcasecmp(name, "des-ecb") == 0) {
++    return EVP_des_ecb();
++  } else if (OPENSSL_strcasecmp(name, "des-ede") == 0) {
++    return EVP_des_ede();
++  } else if (OPENSSL_strcasecmp(name, "des-ede-cbc") == 0) {
++    return EVP_des_ede_cbc();
++  } else if (OPENSSL_strcasecmp(name, "rc2-cbc") == 0) {
++    return EVP_rc2_cbc();
+   }
+ 
+   return NULL;
+diff --git a/decrepit/evp/evp_do_all.c b/decrepit/evp/evp_do_all.c
+index 8b008a401..3e88b29cb 100644
+--- a/decrepit/evp/evp_do_all.c
++++ b/decrepit/evp/evp_do_all.c
+@@ -21,15 +21,21 @@ void EVP_CIPHER_do_all_sorted(void (*callback)(const EVP_CIPHER *cipher,
+                               void *arg) {
+   callback(EVP_aes_128_cbc(), "AES-128-CBC", NULL, arg);
+   callback(EVP_aes_128_cfb128(), "AES-128-CFB", NULL, arg);
+-  callback(EVP_aes_128_ctr(), "AES-128-CTR", NULL, arg);
+-  callback(EVP_aes_128_ecb(), "AES-128-ECB", NULL, arg);
+-  callback(EVP_aes_128_ofb(), "AES-128-OFB", NULL, arg);
++  callback(EVP_aes_192_cbc(), "AES-192-CBC", NULL, arg);
+   callback(EVP_aes_256_cbc(), "AES-256-CBC", NULL, arg);
++  callback(EVP_aes_128_ctr(), "AES-128-CTR", NULL, arg);
++  callback(EVP_aes_192_ctr(), "AES-192-CTR", NULL, arg);
+   callback(EVP_aes_256_cfb128(), "AES-256-CFB", NULL, arg);
+   callback(EVP_aes_256_ctr(), "AES-256-CTR", NULL, arg);
++  callback(EVP_aes_128_ecb(), "AES-128-ECB", NULL, arg);
++  callback(EVP_aes_192_ecb(), "AES-192-ECB", NULL, arg);
+   callback(EVP_aes_256_ecb(), "AES-256-ECB", NULL, arg);
++  callback(EVP_aes_128_ofb(), "AES-128-OFB", NULL, arg);
++  callback(EVP_aes_192_ofb(), "AES-192-OFB", NULL, arg);
+   callback(EVP_aes_256_ofb(), "AES-256-OFB", NULL, arg);
+-  callback(EVP_aes_256_xts(), "AES-256-XTS", NULL, arg);
++  callback(EVP_aes_128_gcm(), "AES-128-GCM", NULL, arg);
++  callback(EVP_aes_192_gcm(), "AES-192-GCM", NULL, arg);
++  callback(EVP_aes_256_gcm(), "AES-256-GCM", NULL, arg);
+   callback(EVP_des_cbc(), "DES-CBC", NULL, arg);
+   callback(EVP_des_ecb(), "DES-ECB", NULL, arg);
+   callback(EVP_des_ede(), "DES-EDE", NULL, arg);
+@@ -41,15 +47,21 @@ void EVP_CIPHER_do_all_sorted(void (*callback)(const EVP_CIPHER *cipher,
+   // OpenSSL returns everything twice, the second time in lower case.
+   callback(EVP_aes_128_cbc(), "aes-128-cbc", NULL, arg);
+   callback(EVP_aes_128_cfb128(), "aes-128-cfb", NULL, arg);
+-  callback(EVP_aes_128_ctr(), "aes-128-ctr", NULL, arg);
+-  callback(EVP_aes_128_ecb(), "aes-128-ecb", NULL, arg);
+-  callback(EVP_aes_128_ofb(), "aes-128-ofb", NULL, arg);
++  callback(EVP_aes_192_cbc(), "aes-192-cbc", NULL, arg);
+   callback(EVP_aes_256_cbc(), "aes-256-cbc", NULL, arg);
++  callback(EVP_aes_128_ctr(), "aes-128-ctr", NULL, arg);
++  callback(EVP_aes_192_ctr(), "aes-192-ctr", NULL, arg);
+   callback(EVP_aes_256_cfb128(), "aes-256-cfb", NULL, arg);
+   callback(EVP_aes_256_ctr(), "aes-256-ctr", NULL, arg);
++  callback(EVP_aes_128_ecb(), "aes-128-ecb", NULL, arg);
++  callback(EVP_aes_192_ecb(), "aes-192-ecb", NULL, arg);
+   callback(EVP_aes_256_ecb(), "aes-256-ecb", NULL, arg);
++  callback(EVP_aes_128_ofb(), "aes-128-ofb", NULL, arg);
++  callback(EVP_aes_192_ofb(), "aes-192-ofb", NULL, arg);
+   callback(EVP_aes_256_ofb(), "aes-256-ofb", NULL, arg);
+-  callback(EVP_aes_256_xts(), "aes-256-xts", NULL, arg);
++  callback(EVP_aes_128_gcm(), "aes-128-gcm", NULL, arg);
++  callback(EVP_aes_192_gcm(), "aes-192-gcm", NULL, arg);
++  callback(EVP_aes_256_gcm(), "aes-256-gcm", NULL, arg);
+   callback(EVP_des_cbc(), "des-cbc", NULL, arg);
+   callback(EVP_des_ecb(), "des-ecb", NULL, arg);
+   callback(EVP_des_ede(), "des-ede", NULL, arg);

--- a/patches/common/boringssl/sync_sorted_ciphers.patch
+++ b/patches/common/boringssl/sync_sorted_ciphers.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shelley Vohr <shelley.vohr@gmail.com>
-Date: Thurs, 7 Feb 2019 11:11:35 -0800
+Date: Thu, 7 Feb 2019 11:11:35 -0800
 Subject: sync EVP_get_cipherbyname with EVP_do_all_sorted
 
 EVP_get_cipherbyname should work on everything that EVP_do_all_sorted
@@ -9,7 +9,7 @@ EVP_get_cipherbyname works on that EVP_do_all_sorted doesn't list.
 This thus does that.
 
 diff --git a/crypto/cipher_extra/cipher_extra.c b/crypto/cipher_extra/cipher_extra.c
-index be7ef07b2..588a47734 100644
+index be7ef07b2c188a76890deb0f305cf92fcc57a64e..588a4773437c311877f275bf3679f9688cda3c46 100644
 --- a/crypto/cipher_extra/cipher_extra.c
 +++ b/crypto/cipher_extra/cipher_extra.c
 @@ -133,6 +133,14 @@ const EVP_CIPHER *EVP_get_cipherbyname(const char *name) {
@@ -28,7 +28,7 @@ index be7ef07b2..588a47734 100644
  
    return NULL;
 diff --git a/decrepit/evp/evp_do_all.c b/decrepit/evp/evp_do_all.c
-index 8b008a401..3e88b29cb 100644
+index 8b008a401ec2f2d0673f6876609dd5786cace4c2..3e88b29cb599730d2e8682070aaa4be38d06ed80 100644
 --- a/decrepit/evp/evp_do_all.c
 +++ b/decrepit/evp/evp_do_all.c
 @@ -21,15 +21,21 @@ void EVP_CIPHER_do_all_sorted(void (*callback)(const EVP_CIPHER *cipher,

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -462,6 +462,14 @@ describe('node feature', () => {
     it('should be able to create an aes-256-cfb cipher', () => {
       require('crypto').createCipheriv('aes-256-cfb', '0123456789abcdef0123456789abcdef', '0123456789abcdef')
     })
+
+    it('should list des-ede-cbc in getCiphers', () => {
+      expect(require('crypto').getCiphers()).to.include('des-ede-cbc')
+    })
+
+    it('should be able to create an des-ede-cbc cipher', () => {
+      require('crypto').createCipheriv('des-ede-cbc', '0123456789abcdeff1e0d3c2b5a49786', 'fedcba9876543210')
+    })
   })
 
   it('includes the electron version in process.versions', () => {

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -468,7 +468,9 @@ describe('node feature', () => {
     })
 
     it('should be able to create an des-ede-cbc cipher', () => {
-      require('crypto').createCipheriv('des-ede-cbc', '0123456789abcdeff1e0d3c2b5a49786', 'fedcba9876543210')
+      const key = Buffer.from('0123456789abcdeff1e0d3c2b5a49786', 'hex')
+      const iv = Buffer.from('fedcba9876543210', 'hex')
+      require('crypto').createCipheriv('des-ede-cbc', key, iv)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/16812.

Backports https://boringssl-review.googlesource.com/c/boringssl/+/33984 to our patch set in order to correctly enumerate and instantiate ciphers. Also adds a test to ensure that `DES-EDE-CBC` actually works.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Added a patch to fix incorrect enumeration and instantiation of Node.js ciphers in the Crypto module.
