### PR TITLE
feat: Add new powerMonitor synchronous API 

### DIFF
--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -50,6 +50,9 @@ class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
                             int idle_threshold,
                             const ui::IdleCallback& callback);
   void QuerySystemIdleTime(const ui::IdleTimeCallback& callback);
+  v8::Local<v8::Value> GetSystemIdleState(v8::Isolate* isolate,
+                                          int idle_threshold);
+  int GetSystemIdleTime();
 
 #if defined(OS_WIN)
   // Static callback invoked when a message comes in to our messaging window.

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -77,7 +77,7 @@ A new API, `protocol.registerSchemesAsPrivileged` has been added and should be u
 // Deprecated
 powerMonitor.querySystemIdleState(threshold, callback)
 // Replace with synchronous API
-idleState = getSystemIdleState(threshold)
+const idleState = getSystemIdleState(threshold)
 ```
 
 ## `powerMonitor.querySystemIdleTime`
@@ -86,7 +86,7 @@ idleState = getSystemIdleState(threshold)
 // Deprecated
 powerMonitor.querySystemIdleTime(callback)
 // Replace with synchronous API
-idleTime = getSystemIdleTime()
+const idleTime = getSystemIdleTime()
 ```
 
 # Planned Breaking API Changes (4.0)

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -71,6 +71,24 @@ Child windows opened with the `nativeWindowOpen` option will always have Node.js
 Renderer process APIs `webFrame.setRegisterURLSchemeAsPrivileged` and `webFrame.registerURLSchemeAsBypassingCSP` as well as browser process API `protocol.registerStandardSchemes` have been removed.
 A new API, `protocol.registerSchemesAsPrivileged` has been added and should be used for registering custom schemes with the required privileges. Custom schemes are required to be registered before app ready.
 
+## `powerMonitor.querySystemIdleState`
+
+```js
+// Deprecated
+powerMonitor.querySystemIdleState(threshold, callback)
+// Replace with synchronous API
+idleState = getSystemIdleState(threshold)
+```
+
+## `powerMonitor.querySystemIdleTime`
+
+```js
+// Deprecated
+powerMonitor.querySystemIdleTime(callback)
+// Replace with synchronous API
+idleTime = getSystemIdleTime()
+```
+
 # Planned Breaking API Changes (4.0)
 
 The following list includes the breaking API changes made in Electron 4.0.

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -59,7 +59,7 @@ Emitted as soon as the systems screen is unlocked.
 
 The `powerMonitor` module has the following methods:
 
-#### `powerMonitor.querySystemIdleState(idleThreshold, callback)`
+#### `powerMonitor.querySystemIdleState(idleThreshold, callback)` _(Deprecated)_
 
 * `idleThreshold` Integer
 * `callback` Function
@@ -70,9 +70,24 @@ before considered idle. `callback` will be called synchronously on some systems
 and with an `idleState` argument that describes the system's state. `locked` is
 available on supported systems only.
 
-#### `powerMonitor.querySystemIdleTime(callback)`
+#### `powerMonitor.querySystemIdleTime(callback)` _(Deprecated)_
 
 * `callback` Function
   * `idleTime` Integer - Idle time in seconds
+
+Calculate system idle time in seconds.
+
+#### `powerMonitor.getSystemIdleState(idleThreshold)`
+
+* `idleThreshold` Integer
+
+Returns `String` - The system's current state. Can be `active`, `idle`, `locked` or `unknown`.
+
+Calculate the system idle state. `idleThreshold` is the amount of time (in seconds)
+before considered idle.  `locked` is available on supported systems only.
+
+#### `powerMonitor.getSystemIdleTime()`
+
+Returns `Integer` - Idle time in seconds
 
 Calculate system idle time in seconds.

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -2,6 +2,7 @@
 
 const { EventEmitter } = require('events')
 const { powerMonitor, PowerMonitor } = process.atomBinding('power_monitor')
+const { deprecate } = require('electron')
 
 // PowerMonitor is an EventEmitter.
 Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
@@ -20,6 +21,17 @@ if (process.platform === 'linux') {
       powerMonitor.unblockShutdown()
     }
   })
+}
+
+// TODO(nitsakh): Remove for electron 6.
+PowerMonitor.prototype.querySystemIdleState = (idleThreshold, callback) => {
+  deprecate.warn('powerMonitor.querySystemIdleState', 'powerMonitor.getSystemIdleState')
+  powerMonitor._querySystemIdleState(idleThreshold, callback)
+}
+
+PowerMonitor.prototype.querySystemIdleTime = (callback) => {
+  deprecate.warn('powerMonitor.querySystemIdleTime', 'powerMonitor.getSystemIdleTime')
+  powerMonitor._querySystemIdleTime(callback)
 }
 
 module.exports = powerMonitor

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -179,15 +179,15 @@ describe('powerMonitor', () => {
       it('does not accept non positive integer threshold', () => {
         expect(() => {
           powerMonitor.getSystemIdleState(-1)
-        }).to.throw()
+        }).to.throw(/must be greater than 0/)
 
         expect(() => {
           powerMonitor.getSystemIdleState(NaN)
-        }).to.throw()
+        }).to.throw(/conversion failure/)
 
         expect(() => {
           powerMonitor.getSystemIdleState('a')
-        }).to.throw()
+        }).to.throw(/conversion failure/)
       })
     })
 

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -128,6 +128,7 @@ describe('powerMonitor', () => {
       powerMonitor = require('electron').remote.powerMonitor
     })
 
+    // TODO(nitsakh): Remove in 6.0
     describe('powerMonitor.querySystemIdleState', () => {
       it('notify current system idle state', done => {
         // this function is not mocked out, so we can test the result's
@@ -155,12 +156,45 @@ describe('powerMonitor', () => {
       })
     })
 
+    // TODO(nitsakh): Remove in 6.0
     describe('powerMonitor.querySystemIdleTime', () => {
       it('notify current system idle time', done => {
         powerMonitor.querySystemIdleTime(idleTime => {
           expect(idleTime).to.be.at.least(0)
           done()
         })
+      })
+    })
+
+    describe('powerMonitor.getSystemIdleState', () => {
+      it('gets current system idle state', () => {
+        // this function is not mocked out, so we can test the result's
+        // form and type but not its value.
+        const idleState = powerMonitor.getSystemIdleState(1)
+        expect(idleState).to.be.a('string')
+        const validIdleStates = [ 'active', 'idle', 'locked', 'unknown' ]
+        expect(validIdleStates).to.include(idleState)
+      })
+
+      it('does not accept non positive integer threshold', () => {
+        expect(() => {
+          powerMonitor.getSystemIdleState(-1)
+        }).to.throw()
+
+        expect(() => {
+          powerMonitor.getSystemIdleState(NaN)
+        }).to.throw()
+
+        expect(() => {
+          powerMonitor.getSystemIdleState('a')
+        }).to.throw()
+      })
+    })
+
+    describe('powerMonitor.getSystemIdleTime', () => {
+      it('notify current system idle time', () => {
+        const idleTime = powerMonitor.getSystemIdleTime()
+        expect(idleTime).to.be.at.least(0)
       })
     })
   })


### PR DESCRIPTION
#### Description of Change
`powerMonitor.querySystemIdleState` and `powerMonitor.querySystemIdleTime` had async backing APIs in chromium (https://chromium-review.googlesource.com/c/chromium/src/+/1379183). However, that has changed in ch73. So, this PR deprecates the old async APIs and adds new sync APIs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Replaced `powerMonitor` `querySystemIdleState` and `querySystemIdleTime` with synchronous APIs.
