### PR TITLE
ci: set MAS_BUILD=true on mas builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ env-arm64: &env-arm64
 
 env-mas: &env-mas
   GN_EXTRA_ARGS: 'is_mas_build = true'
+  MAS_BUILD: 'true'
 
 # Misc build configuration options.
 env-enable-sccache: &env-enable-sccache


### PR DESCRIPTION
#### Description of Change

In VSTS we defined `MAS_BUILD`, and on CircleCI we forgot to do so. This thus fixes MAS releases not being built correctly and published to releases on GitHub.

#### Release Notes

Notes: no-notes