### PR TITLE
fix: display empty menu item for non-visible submenus

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -17,6 +17,7 @@
 #include "ui/base/l10n/l10n_util_mac.h"
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/gfx/image/image.h"
+#include "ui/strings/grit/ui_strings.h"
 
 using content::BrowserThread;
 
@@ -73,11 +74,10 @@ bool MenuHasVisibleItems(const atom::AtomMenuModel* model) {
 // "(empty)" into the submenu. Matches Windows behavior.
 NSMenu* MakeEmptySubmenu() {
   base::scoped_nsobject<NSMenu> submenu([[NSMenu alloc] initWithTitle:@""]);
-  base::string16 empty_menu_title = base::ASCIIToUTF16("(empty)");
-  NSString* empty_menu_label =
-      l10n_util::FixUpWindowsStyleLabel(empty_menu_title);
+  NSString* empty_menu_title =
+      l10n_util::GetNSString(IDS_APP_MENU_EMPTY_SUBMENU);
 
-  [submenu addItemWithTitle:empty_menu_label action:NULL keyEquivalent:@""];
+  [submenu addItemWithTitle:empty_menu_title action:NULL keyEquivalent:@""];
   [[submenu itemAtIndex:0] setEnabled:NO];
   return submenu.autorelease();
 }


### PR DESCRIPTION
#### Description of Change

Previously, when a context menu was created with a submenu that had no visible `MenuItems`, the menu item would display and not show anything on hover, which i don't believe to be the most user-friendly behavior:

![screen shot 2019-02-08 at 9 42 46 am](https://user-images.githubusercontent.com/2036040/52495591-1043c680-2b86-11e9-811a-57d1e906afb0.png)

This PR improves the UX of that scenario by first checking if a submenu has any visible `MenuItems`, and in the case that it doesn't, it creates a localized `MenuItem` to indicate that the submenu does not currently have any items with which the user may interact:

![screen shot 2019-02-08 at 9 46 37 am](https://user-images.githubusercontent.com/2036040/52495736-74ff2100-2b86-11e9-8c50-f1beda2ef9b8.png)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed issue whereby a user was not well informed when interacting with a menu submenu that did not have any visible `MenuItems`.
