### PR TITLE
fix: don't construct submenu if it's invisible

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -220,7 +220,8 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
     NSMenu* submenu = [[NSMenu alloc] initWithTitle:label];
     [item setSubmenu:submenu];
     [NSApp setServicesMenu:submenu];
-  } else if (type == atom::AtomMenuModel::TYPE_SUBMENU) {
+  } else if (type == atom::AtomMenuModel::TYPE_SUBMENU &&
+             model->IsVisibleAt(index)) {
     // Recursively build a submenu from the sub-model at this index.
     [item setTarget:nil];
     [item setAction:nil];


### PR DESCRIPTION
#### Description of Change

Previously, if a submenu was specified in a template like the following:
```
const template = [
  { label: 'one' },
  {
    label: 'two',
    visible: false,
    submenu: [
      { label: 'three' },
      { label: 'four' }
    ]
  },
]
```

The `visible` property of the submenu would be ignored and the menu would be constructed regardless. This adds a check to `addItemToMenu` which matches Chromium's [current check](https://cs.chromium.org/chromium/src/ui/base/cocoa/menu_controller.mm?type=cs&dlp=chromium&dlf=src/ui/base/cocoa/menu_controller.mm&dlc=3c50480db92fe1220814910400ace4683a4d438a&dlr=51&dlgp=ui/base/cocoa/menu_controller.mm&dlgr=chromium/chromium/src&drp=chromium&drf=src/ui/base/cocoa/menu_controller.mm&drc=4a56f1eef016e40754e82f34e34dab999c4f53c4&drr=52&drgp=ui/base/cocoa/menu_controller.mm&drgr=chromium/chromium/src&g=0&l=167) in the selfsame method that chooses to _not_ create the submenu if it has `visible: false`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed submenus not responding to the `visible: false` `MenuItem` property.
