### PR TITLE
fix: enable property having no effect on submenus

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -246,6 +246,11 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
     [NSApp setServicesMenu:submenu];
   } else if (type == atom::AtomMenuModel::TYPE_SUBMENU &&
              model->IsVisibleAt(index)) {
+    // We need to specifically check that the submenu top-level item has been
+    // enabled as it's not validated by validateUserInterfaceItem
+    if (!model->IsEnabledAt(index))
+      [item setEnabled:NO];
+
     // Recursively build a submenu from the sub-model at this index.
     [item setTarget:nil];
     [item setAction:nil];


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16821.

We need to specifically check that the submenu top-level item has been enabled on macOS, as it's not validated by `validateUserInterfaceItem`.

Before Change: 

![screen shot 2019-02-08 at 10 20 17 am](https://user-images.githubusercontent.com/2036040/52497522-24d68d80-2b8b-11e9-85f6-175e3a8426be.png)

After Change:
![screen shot 2019-02-08 at 10 18 30 am](https://user-images.githubusercontent.com/2036040/52497536-2d2ec880-2b8b-11e9-8c09-9d0b26f3dfa5.png)

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the `enable` property having no effect for top-level submenu `MenuItems`.
