### PR TITLE
chore: add helper to wait for a window to load in a remote-safe way

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -9,7 +9,7 @@ const url = require('url')
 const ChildProcess = require('child_process')
 const { ipcRenderer, remote } = require('electron')
 const { emittedOnce } = require('./events-helpers')
-const { closeWindow } = require('./window-helpers')
+const { closeWindow, waitForWebContentsToLoad } = require('./window-helpers')
 const { resolveGetters } = require('./assert-helpers')
 const { app, BrowserWindow, ipcMain, protocol, session, webContents } = remote
 const isCI = remote.getGlobal('isCi')
@@ -525,7 +525,7 @@ describe('chromium feature', () => {
       const w = window.open()
       try {
         const [, { webContents }] = await browserWindowCreated
-        await emittedOnce(webContents, 'did-finish-load')
+        await waitForWebContentsToLoad(webContents)
         assert.strictEqual(w.location.href, 'about:blank')
       } finally {
         w.close()
@@ -537,7 +537,7 @@ describe('chromium feature', () => {
       const w = window.open('')
       try {
         const [, { webContents }] = await browserWindowCreated
-        await emittedOnce(webContents, 'did-finish-load')
+        await waitForWebContentsToLoad(webContents)
         assert.strictEqual(w.location.href, 'about:blank')
       } finally {
         w.close()

--- a/spec/window-helpers.js
+++ b/spec/window-helpers.js
@@ -17,3 +17,10 @@ exports.closeWindow = async (window = null,
     expect(BrowserWindow.getAllWindows()).to.have.lengthOf(1)
   }
 }
+
+exports.waitForWebContentsToLoad = async (webContents) => {
+  const didFinishLoadPromise = emittedOnce(webContents, 'did-finish-load')
+  if (webContents.isLoadingMainFrame()) {
+    await didFinishLoadPromise
+  }
+}


### PR DESCRIPTION
This test has flaked a fair bit of the last 2-3 weeks, I think the race condition is the window already being loaded before we get a chance to listen to the load event.  This helper will check if the window is actually already loaded before `await`'ing an event that may never come

Notes: no-notes