### PR TITLE
chore: disable get/setLoginItemSettings specs on MAS

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -539,7 +539,7 @@ describe('app module', () => {
     ]
 
     before(function () {
-      if (process.platform === 'linux') this.skip()
+      if (process.platform === 'linux' || process.mas) this.skip()
     })
 
     beforeEach(() => {


### PR DESCRIPTION
These tests have all kinds of asynchronous issues on MAS CI.  We disabled them on master here --> https://github.com/electron/electron/pull/16552/files#diff-6428a7ecb6a3a2831eae23aee7efeac5R539

To reduce CI "flakes" this test should be disabled all the way back to 2-0-x 👍 

Notes: no-notes