### PR TITLE
chore: make crash-reporter specs not use URL module

### DIFF
--- a/spec/fixtures/api/crash-restart.html
+++ b/spec/fixtures/api/crash-restart.html
@@ -2,7 +2,7 @@
 <body>
 <script type="text/javascript" charset="utf-8">
 
-const {port} = require('url').parse(window.location.href, true).query
+const port = (new URLSearchParams(location.search)).get('port')
 const {crashReporter, ipcRenderer} = require('electron')
 
 crashReporter.start({

--- a/spec/fixtures/api/crash.html
+++ b/spec/fixtures/api/crash.html
@@ -2,9 +2,9 @@
 
 <body>
   <script type="text/javascript" charset="utf-8">
-    const url = require('url').parse(window.location.href, true);
-    const uploadToServer = !url.query.skipUpload;
-    const port = url.query.port;
+    const query = new URLSearchParams(location.search)
+    const port = query.get('port')
+    const uploadToServer = !query.has('skipUpload')
     const {crashReporter, ipcRenderer} = require('electron');
 
     crashReporter.start({


### PR DESCRIPTION
These specs fail 100% locally (no idea how they sometimes pass on CI) because the `url` module is not available to sandboxed renderers.

This updates the specs to use standard web APIs to do URl parsing instead of `url`.

These tests are responsible for almost 30% of the flakes in the last 30 days 👍 

Notes: no-notes