### PR TITLE
feat: promisify debugger.sendCommand()

### DIFF
--- a/atom/browser/api/atom_api_debugger.h
+++ b/atom/browser/api/atom_api_debugger.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "atom/browser/api/trackable_object.h"
+#include "atom/common/promise_util.h"
 #include "base/callback.h"
 #include "base/values.h"
 #include "content/public/browser/devtools_agent_host_client.h"
@@ -32,9 +33,6 @@ class Debugger : public mate::TrackableObject<Debugger>,
                  public content::DevToolsAgentHostClient,
                  public content::WebContentsObserver {
  public:
-  using SendCommandCallback =
-      base::Callback<void(const base::Value&, const base::Value&)>;
-
   static mate::Handle<Debugger> Create(v8::Isolate* isolate,
                                        content::WebContents* web_contents);
 
@@ -56,12 +54,12 @@ class Debugger : public mate::TrackableObject<Debugger>,
                               content::RenderFrameHost* new_rfh) override;
 
  private:
-  using PendingRequestMap = std::map<int, SendCommandCallback>;
+  using PendingRequestMap = std::map<int, scoped_refptr<atom::util::Promise>>;
 
   void Attach(mate::Arguments* args);
   bool IsAttached();
   void Detach();
-  void SendCommand(mate::Arguments* args);
+  v8::Local<v8::Promise> SendCommand(mate::Arguments* args);
   void ClearPendingRequests();
 
   content::WebContents* web_contents_;  // Weak Reference.

--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -60,6 +60,20 @@ Detaches the debugger from the `webContents`.
 
 Send given command to the debugging target.
 
+**[Deprecated Soon](promisification.md)**
+
+#### `debugger.sendCommand(method[, commandParams])`
+
+* `method` String - Method name, should be one of the methods defined by the
+   [remote debugging protocol][rdp].
+* `commandParams` Object (optional) - JSON object with request parameters.
+
+Returns `Promise<any>` - A promise that resolves with the response defined by
+the 'returns' attribute of the command description in the remote debugging protocol
+or is rejected indicating the failure of the command.
+
+Send given command to the debugging target.
+
 ### Instance Events
 
 #### Event: 'detach'

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -51,4 +51,3 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [webviewTag.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#capturePage)
 - [webviewTag.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#printToPDF)
 - [win.capturePage([rect, ]callback)](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#capturePage)
-- [desktopCapturer.getSources(options, callback)](https://github.com/electron/electron/blob/master/docs/api/desktop-capturer.md#getSources)

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -10,7 +10,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 
 - [app.importCertificate(options, callback)](https://github.com/electron/electron/blob/master/docs/api/app.md#importCertificate)
 - [contentTracing.getTraceBufferUsage(callback)](https://github.com/electron/electron/blob/master/docs/api/content-tracing.md#getTraceBufferUsage)
-- [debugger.sendCommand(method[, commandParams, callback])](https://github.com/electron/electron/blob/master/docs/api/debugger.md#sendCommand)
 - [dialog.showOpenDialog([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showOpenDialog)
 - [dialog.showSaveDialog([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showSaveDialog)
 - [dialog.showMessageBox([browserWindow, ]options[, callback])](https://github.com/electron/electron/blob/master/docs/api/dialog.md#showMessageBox)
@@ -45,6 +44,7 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [cookies.get(filter, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#get)
 - [cookies.remove(url, name, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#remove)
 - [cookies.set(details, callback)](https://github.com/electron/electron/blob/master/docs/api/cookies.md#set)
+- [debugger.sendCommand(method[, commandParams, callback])](https://github.com/electron/electron/blob/master/docs/api/debugger.md#sendCommand)
 - [desktopCapturer.getSources(options, callback)](https://github.com/electron/electron/blob/master/docs/api/desktop-capturer.md#getSources)
 - [protocol.isProtocolHandled(scheme, callback)](https://github.com/electron/electron/blob/master/docs/api/protocol.md#isProtocolHandled)
 - [shell.openExternal(url[, options, callback])](https://github.com/electron/electron/blob/master/docs/api/shell.md#openExternal)

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -483,6 +483,8 @@ WebContents.prototype._init = function () {
 // JavaScript wrapper of Debugger.
 const { Debugger } = process.atomBinding('debugger')
 
+Debugger.prototype.sendCommand = deprecate.promisify(Debugger.prototype.sendCommand)
+
 Object.setPrototypeOf(Debugger.prototype, EventEmitter.prototype)
 
 // Public APIs.

--- a/spec/api-debugger-spec.js
+++ b/spec/api-debugger-spec.js
@@ -2,6 +2,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const http = require('http')
 const path = require('path')
+const { emittedOnce } = require('./events-helpers')
 const { closeWindow } = require('./window-helpers')
 const { BrowserWindow } = require('electron').remote
 
@@ -102,7 +103,21 @@ describe('debugger module', () => {
       }
     })
 
-    it('returns response', done => {
+    it('returns response', async () => {
+      w.webContents.loadURL('about:blank')
+      w.webContents.debugger.attach()
+
+      const params = { 'expression': '4+2' }
+      const res = await w.webContents.debugger.sendCommand('Runtime.evaluate', params)
+
+      expect(res.wasThrown).to.be.undefined()
+      expect(res.result.value).to.equal(6)
+
+      w.webContents.debugger.detach()
+    })
+
+    // TODO(miniak): remove when promisification is complete
+    it('returns response (callback)', done => {
       w.webContents.loadURL('about:blank')
       try {
         w.webContents.debugger.attach()
@@ -123,7 +138,24 @@ describe('debugger module', () => {
       w.webContents.debugger.sendCommand('Runtime.evaluate', params, callback)
     })
 
-    it('returns response when devtools is opened', done => {
+    it('returns response when devtools is opened', async () => {
+      w.webContents.loadURL('about:blank')
+      w.webContents.debugger.attach()
+
+      w.webContents.openDevTools()
+      await emittedOnce(w.webContents, 'devtools-opened')
+
+      const params = { 'expression': '4+2' }
+      const res = await w.webContents.debugger.sendCommand('Runtime.evaluate', params)
+
+      expect(res.wasThrown).to.be.undefined()
+      expect(res.result.value).to.equal(6)
+
+      w.webContents.debugger.detach()
+    })
+
+    // TODO(miniak): remove when promisification is complete
+    it('returns response when devtools is opened (callback)', done => {
       w.webContents.loadURL('about:blank')
       try {
         w.webContents.debugger.attach()
@@ -169,7 +201,18 @@ describe('debugger module', () => {
       w.webContents.debugger.sendCommand('Console.enable')
     })
 
-    it('returns error message when command fails', done => {
+    it('returns error message when command fails', async () => {
+      w.webContents.loadURL('about:blank')
+      w.webContents.debugger.attach()
+
+      const promise = w.webContents.debugger.sendCommand('Test')
+      await expect(promise).to.be.eventually.rejectedWith(Error, "'Test' wasn't found")
+
+      w.webContents.debugger.detach()
+    })
+
+    // TODO(miniak): remove when promisification is complete
+    it('returns error message when command fails (callback)', done => {
       w.webContents.loadURL('about:blank')
       try {
         w.webContents.debugger.attach()
@@ -177,9 +220,8 @@ describe('debugger module', () => {
         done(`unexpected error : ${err}`)
       }
 
-      w.webContents.debugger.sendCommand('Test', err => {
-        expect(err).to.not.be.null()
-        expect(err.message).to.equal("'Test' wasn't found")
+      w.webContents.debugger.sendCommand('Test', (err, res) => {
+        expect(err).to.be.an.instanceOf(Error).with.property('message', "'Test' wasn't found")
         w.webContents.debugger.detach()
         done()
       })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1515,11 +1515,7 @@ describe('font fallback', () => {
     try {
       await w.loadURL(`data:text/html,${html}`)
       w.webContents.debugger.attach()
-      const sendCommand = (...args) => new Promise((resolve, reject) => {
-        w.webContents.debugger.sendCommand(...args, (e, r) => {
-          if (e) { reject(e) } else { resolve(r) }
-        })
-      })
+      const sendCommand = (...args) => w.webContents.debugger.sendCommand(...args)
       const { nodeId } = (await sendCommand('DOM.getDocument')).root.children[0]
       await sendCommand('CSS.enable')
       const { fonts } = await sendCommand('CSS.getPlatformFontsForNode', { nodeId })


### PR DESCRIPTION
#### Description of Change

This PR promisifies `debugger.sendCommand()`

/cc @codebytere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Converted `debugger.sendCommand()` to return a Promise instead of taking a callback.