### PR TITLE
chore: re-enable devtools renderer sandbox

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -71,7 +71,6 @@
 #include "services/device/public/cpp/geolocation/location_provider.h"
 #include "services/network/public/cpp/resource_request_body.h"
 #include "services/proxy_resolver/public/mojom/proxy_resolver.mojom.h"
-#include "services/service_manager/sandbox/switches.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "v8/include/v8.h"
@@ -496,15 +495,7 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
 
   content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);
   if (web_contents) {
-    // devtools processes must be launched unsandboxed in order for the remote
-    // API to work in devtools extensions. This is due to the fact that the
-    // remote API assumes that it will only be used from the main frame, but
-    // devtools extensions are loaded from an iframe.
-    // It would be possible to sandbox devtools extensions processes by default
-    // if we made the remote API work with multiple frames.
     if (web_contents->GetVisibleURL().SchemeIs("chrome-devtools")) {
-      command_line->AppendSwitch(service_manager::switches::kNoSandbox);
-      command_line->AppendSwitch(::switches::kNoZygote);
       command_line->AppendSwitch(switches::kDisableRemoteModule);
     }
     auto* web_preferences = WebContentsPreferences::From(web_contents);

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -92,6 +92,7 @@ const startBackgroundPages = function (manifest) {
     partition: 'persist:__chrome_extension',
     isBackgroundPage: true,
     commandLineSwitches: ['--background-page'],
+    sandbox: true,
     enableRemoteModule: false
   })
   backgroundPages[manifest.extensionId] = { html: html, webContents: contents, name: name }


### PR DESCRIPTION
#### Description of Change
- Re-enable sandboxing of devtools renderers, which was disabled in https://github.com/electron/electron/pull/15894/files#diff-fb76da0c9cc2defc5c9fa23dd04d5327R508
- Enable sandbox for chrome extension background script host renderers

/cc @nornagon, @deepak1556

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Enabled sandboxing of devtools and chrome extension background script host renderers.