### PR TITLE
docs: Remove redundant 'Instance Events' Headline

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -107,7 +107,7 @@ Inserts the `menuItem` to the `pos` position of the menu.
 
 ### Instance Events
 
-Objects created with `new Menu` emit the following events:
+Objects created with `new Menu` or returned by `Menu.buildFromTemplate` emit the following events:
 
 **Note:** Some events are only available on specific operating systems and are
 labeled as such.
@@ -138,11 +138,6 @@ A `MenuItem[]` array containing the menu's items.
 
 Each `Menu` consists of multiple [`MenuItem`](menu-item.md)s and each `MenuItem`
 can have a submenu.
-
-### Instance Events
-
-Objects created with `new Menu` or returned by `Menu.buildFromTemplate` emit
-the following events:
 
 ## Examples
 


### PR DESCRIPTION
#### Description of Change
Remove redundant 'Instance Events' Headline

#### Checklist
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes
Notes: In the [Menu Docs](https://electronjs.org/docs/api/menu) 'Instance Events' Headline is wrongly repeated.