### PR TITLE
chore: disable the remote module in devtools / chrome extension background scripts

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1959,6 +1959,9 @@ v8::Local<v8::Value> WebContents::GetLastWebPreferences(
 }
 
 bool WebContents::IsRemoteModuleEnabled() const {
+  if (web_contents()->GetVisibleURL().SchemeIs("chrome-devtools")) {
+    return false;
+  }
   if (auto* web_preferences = WebContentsPreferences::From(web_contents())) {
     return web_preferences->IsRemoteModuleEnabled();
   }

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -505,6 +505,7 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
     if (web_contents->GetVisibleURL().SchemeIs("chrome-devtools")) {
       command_line->AppendSwitch(service_manager::switches::kNoSandbox);
       command_line->AppendSwitch(::switches::kNoZygote);
+      command_line->AppendSwitch(switches::kDisableRemoteModule);
     }
     auto* web_preferences = WebContentsPreferences::From(web_contents);
     if (web_preferences)

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -128,6 +128,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
   SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
+  SetDefaultBoolIfUndefined(options::kEnableRemoteModule, true);
   SetDefaultBoolIfUndefined(options::kContextIsolation, false);
   SetDefaultBoolIfUndefined("javascript", true);
   SetDefaultBoolIfUndefined("images", true);

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -365,17 +365,6 @@ const addReturnValueToEvent = (event) => {
   })
 }
 
-const safeProtocols = new Set([
-  'chrome-devtools:',
-  'chrome-extension:'
-])
-
-const isWebContentsTrusted = function (contents) {
-  const pageURL = contents._getURL()
-  const { protocol } = url.parse(pageURL)
-  return safeProtocols.has(protocol)
-}
-
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.
@@ -435,9 +424,7 @@ WebContents.prototype._init = function () {
 
   for (const eventName of forwardedEvents) {
     this.on(eventName, (event, ...args) => {
-      if (!isWebContentsTrusted(event.sender)) {
-        app.emit(eventName, event, this, ...args)
-      }
+      app.emit(eventName, event, this, ...args)
     })
   }
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -91,7 +91,8 @@ const startBackgroundPages = function (manifest) {
   const contents = webContents.create({
     partition: 'persist:__chrome_extension',
     isBackgroundPage: true,
-    commandLineSwitches: ['--background-page']
+    commandLineSwitches: ['--background-page'],
+    enableRemoteModule: false
   })
   backgroundPages[manifest.extensionId] = { html: html, webContents: contents, name: name }
   contents.loadURL(url.format({

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -264,10 +264,20 @@ const callFunction = function (event, contextId, func, caller, args) {
   }
 }
 
+const isRemoteModuleEnabledCache = new WeakMap()
+
+const isRemoteModuleEnabled = function (contents) {
+  if (!isRemoteModuleEnabledCache.has(contents)) {
+    isRemoteModuleEnabledCache.set(contents, contents._isRemoteModuleEnabled())
+  }
+
+  return isRemoteModuleEnabledCache.get(contents)
+}
+
 const handleRemoteCommand = function (channel, handler) {
   ipcMainInternal.on(channel, (event, contextId, ...args) => {
     let returnValue
-    if (!event.sender._isRemoteModuleEnabled()) {
+    if (!isRemoteModuleEnabled(event.sender)) {
       event.returnValue = null
       return
     }
@@ -506,7 +516,7 @@ ipcMainInternal.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
 
   event.returnValue = {
     preloadScripts: preloadPaths.map(path => getPreloadScript(path)),
-    isRemoteModuleEnabled: event.sender._isRemoteModuleEnabled(),
+    isRemoteModuleEnabled: isRemoteModuleEnabled(event.sender),
     isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),
     process: {
       arch: process.arch,


### PR DESCRIPTION
#### Description of Change
- Disables the remote module in devtools / chrome extension background scripts
- Reverts https://github.com/electron/electron/pull/16565 as it's no longer necessary (remote related IPC are blocked by the `isRemoteModuleEnabled` check)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes