### PR TITLE
fix: failed "creates offscreen window with correct size" spec on Mac with Retina display

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -3632,8 +3632,9 @@ describe('BrowserWindow module', () => {
       w.webContents.once('paint', function (event, rect, data) {
         assert.notStrictEqual(data.length, 0)
         const size = data.getSize()
-        assertWithinDelta(size.width, 100, 2, 'width')
-        assertWithinDelta(size.height, 100, 2, 'height')
+        const scale = process.platform === 'darwin' ? devicePixelRatio : 1
+        assertWithinDelta(size.width, 100 * scale, 2, 'width')
+        assertWithinDelta(size.height, 100 * scale, 2, 'height')
         done()
       })
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'))


### PR DESCRIPTION
#### Description of Change
Fixes the following spec:
<img width="912" alt="screen shot 2019-02-11 at 2 47 47 am" src="https://user-images.githubusercontent.com/1281234/52543149-8115f900-2da7-11e9-8184-e5b8edf1f9a9.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes