### PR TITLE
feat: add new components to Display structure

### DIFF
--- a/atom/common/native_mate_converters/gfx_converter.cc
+++ b/atom/common/native_mate_converters/gfx_converter.cc
@@ -151,6 +151,7 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
   dict.Set("workAreaSize", val.work_area_size());
   dict.Set("scaleFactor", val.device_scale_factor());
   dict.Set("rotation", val.RotationAsDegree());
+  dict.Set("internal", val.IsInternal());
   dict.Set("touchSupport", val.touch_support());
   return dict.GetHandle();
 }

--- a/atom/common/native_mate_converters/gfx_converter.cc
+++ b/atom/common/native_mate_converters/gfx_converter.cc
@@ -146,6 +146,7 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
   dict.Set("workArea", val.work_area());
   dict.Set("accelerometerSupport", val.accelerometer_support());
   dict.Set("monochrome", val.is_monochrome());
+  dict.Set("colorDepth", val.color_depth());
   dict.Set("depthPerComponent", val.depth_per_component());
   dict.Set("size", val.size());
   dict.Set("workAreaSize", val.work_area_size());

--- a/atom/common/native_mate_converters/gfx_converter.cc
+++ b/atom/common/native_mate_converters/gfx_converter.cc
@@ -106,6 +106,22 @@ bool Converter<gfx::Rect>::FromV8(v8::Isolate* isolate,
 }
 
 template <>
+struct Converter<display::Display::AccelerometerSupport> {
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      const display::Display::AccelerometerSupport& val) {
+    switch (val) {
+      case display::Display::AccelerometerSupport::AVAILABLE:
+        return StringToV8(isolate, "available");
+      case display::Display::AccelerometerSupport::UNAVAILABLE:
+        return StringToV8(isolate, "unavailable");
+      default:
+        return StringToV8(isolate, "unknown");
+    }
+  }
+};
+
+template <>
 struct Converter<display::Display::TouchSupport> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const display::Display::TouchSupport& val) {
@@ -128,6 +144,9 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
   dict.Set("id", val.id());
   dict.Set("bounds", val.bounds());
   dict.Set("workArea", val.work_area());
+  dict.Set("accelerometerSupport", val.accelerometer_support());
+  dict.Set("monochrome", val.is_monochrome());
+  dict.Set("depthPerComponent", val.depth_per_component());
   dict.Set("size", val.size());
   dict.Set("workAreaSize", val.work_area_size());
   dict.Set("scaleFactor", val.device_scale_factor());

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -7,6 +7,7 @@
 * `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
 * `monochrome` Boolean - Whether or not the display is a monochrome display.
 * `accelerometerSupport` String - Can be `available`, `unavailable`, `unknown`.
+* `colorDepth` Number - The number of bits per pixel.
 * `depthPerComponent` Number - The number of bits per color component.
 * `bounds` [Rectangle](rectangle.md)
 * `size` [Size](size.md)

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -12,6 +12,7 @@
 * `size` [Size](size.md)
 * `workArea` [Rectangle](rectangle.md)
 * `workAreaSize` [Size](size.md)
+* `internal` Boolean - `true` for an internal display and `false` for an external display
 
 The `Display` object represents a physical display connected to the system. A
 fake `Display` may exist on a headless system, or a `Display` may correspond to

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -5,6 +5,9 @@
   clock-wise degrees.
 * `scaleFactor` Number - Output device's pixel scale factor.
 * `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
+* `monochrome` Boolean - Whether or not the display is a monochrome display.
+* `accelerometerSupport` String - Can be `available`, `unavailable`, `unknown`.
+* `depthPerComponent` Number - The number of bits per color component.
 * `bounds` [Rectangle](rectangle.md)
 * `size` [Size](size.md)
 * `workArea` [Rectangle](rectangle.md)

--- a/spec/api-screen-spec.js
+++ b/spec/api-screen-spec.js
@@ -1,21 +1,77 @@
-const assert = require('assert')
+const { expect } = require('chai')
 const { screen } = require('electron').remote
 
 describe('screen module', () => {
   describe('screen.getCursorScreenPoint()', () => {
     it('returns a point object', () => {
       const point = screen.getCursorScreenPoint()
-      assert.strictEqual(typeof point.x, 'number')
-      assert.strictEqual(typeof point.y, 'number')
+      expect(point.x).to.be.a('number')
+      expect(point.y).to.be.a('number')
     })
   })
 
   describe('screen.getPrimaryDisplay()', () => {
     it('returns a display object', () => {
       const display = screen.getPrimaryDisplay()
-      assert.strictEqual(typeof display.scaleFactor, 'number')
-      assert(display.size.width > 0)
-      assert(display.size.height > 0)
+      expect(display).to.be.an('object')
+    })
+
+    it('has the correct non-object properties', function () {
+      if (process.platform === 'linux') this.skip()
+      const display = screen.getPrimaryDisplay()
+
+      expect(display).to.have.a.property('scaleFactor').that.is.a('number')
+      expect(display).to.have.a.property('id').that.is.a('number')
+      expect(display).to.have.a.property('rotation').that.is.a('number')
+      expect(display).to.have.a.property('touchSupport').that.is.a('string')
+      expect(display).to.have.a.property('accelerometerSupport').that.is.a('string')
+      expect(display).to.have.a.property('internal').that.is.a('boolean')
+      expect(display).to.have.a.property('monochrome').that.is.a('boolean')
+      expect(display).to.have.a.property('depthPerComponent').that.is.a('number')
+      expect(display).to.have.a.property('colorDepth').that.is.a('number')
+    })
+
+    it('has a size object property', function () {
+      if (process.platform === 'linux') this.skip()
+      const display = screen.getPrimaryDisplay()
+
+      expect(display).to.have.a.property('size').that.is.an('object')
+      const size = display.size
+      expect(size).to.have.a.property('width').that.is.greaterThan(0)
+      expect(size).to.have.a.property('height').that.is.greaterThan(0)
+    })
+
+    it('has a workAreaSize object property', function () {
+      if (process.platform === 'linux') this.skip()
+      const display = screen.getPrimaryDisplay()
+
+      expect(display).to.have.a.property('workAreaSize').that.is.an('object')
+      const workAreaSize = display.workAreaSize
+      expect(workAreaSize).to.have.a.property('width').that.is.greaterThan(0)
+      expect(workAreaSize).to.have.a.property('height').that.is.greaterThan(0)
+    })
+
+    it('has a bounds object property', function () {
+      if (process.platform === 'linux') this.skip()
+      const display = screen.getPrimaryDisplay()
+
+      expect(display).to.have.a.property('bounds').that.is.an('object')
+      const bounds = display.bounds
+      expect(bounds).to.have.a.property('x').that.is.a('number')
+      expect(bounds).to.have.a.property('y').that.is.a('number')
+      expect(bounds).to.have.a.property('width').that.is.greaterThan(0)
+      expect(bounds).to.have.a.property('height').that.is.greaterThan(0)
+    })
+
+    it('has a workArea object property', function () {
+      const display = screen.getPrimaryDisplay()
+
+      expect(display).to.have.a.property('workArea').that.is.an('object')
+      const workArea = display.workArea
+      expect(workArea).to.have.a.property('x').that.is.a('number')
+      expect(workArea).to.have.a.property('y').that.is.a('number')
+      expect(workArea).to.have.a.property('width').that.is.greaterThan(0)
+      expect(workArea).to.have.a.property('height').that.is.greaterThan(0)
     })
   })
 })


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16078.

In the years since we added the [`Display`](https://github.com/electron/electron/blob/master/docs/api/structures/display.md) API structure, Chromium has added several new fields (and accessors for the them) to it: `monochrome`, `accelerometerEnabled`, `internal`, and `depthPerComponent`. This PR thus adds these three new fields to our own Display structure.

cc @ckerr @MarshallOfSound @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added new `monochrome`, `internal`, `acceleratorEnabled`, `colorDepth` and `depthPerComponent` properties to the Display API Structure.
