### PR TITLE
[wip] feat: show when primary display changes

### DIFF
--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -49,6 +49,8 @@ std::vector<std::string> MetricsToArray(uint32_t metrics) {
     array.push_back("scaleFactor");
   if (metrics & display::DisplayObserver::DISPLAY_METRIC_ROTATION)
     array.push_back("rotation");
+  if (metrics & display::DisplayObserver::DISPLAY_METRIC_PRIMARY)
+    array.push_back("primary");
   return array;
 }
 


### PR DESCRIPTION
#### Description of Change

This PR adds a new metric to be emitted in `OnDisplayMetricsChanged`, `primary`, so that users can know when the primary display has changed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add a new display metric for changes in primary `Display`.
