### PR TITLE
docs: document how setAsDefaultProtocolClient works in Windows Store

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -725,6 +725,11 @@ your app's `info.plist`, which can not be modified at runtime. You can however
 change the file with a simple text editor or script during build time.
 Please refer to [Apple's documentation][CFBundleURLTypes] for details.
 
+**Note:** In a Windows Store environment (when packaged as an `appx`) this API
+will return `true` for all calls but the registry key it sets won't be accessible
+by other applications.  In order to register your Windows Store application
+as a default protocol handler you must [declare the protocol in your manifest](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-protocol).
+
 The API uses the Windows Registry and LSSetDefaultHandlerForURLScheme internally.
 
 ### `app.removeAsDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_


### PR DESCRIPTION
Closes #16852

Notes: Documented the behavior of `setAsDefaultProtocolClient` in a Windows Store environment.
