### PR TITLE
ci: Refactor mksnapshot test so that it doesn't stall.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,6 +92,9 @@ test_script:
   - if "%RUN_TESTS%"=="true" ( echo Running test suite & npm run test -- --ci --enable-logging)
   - cd ..
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
+  - echo "About to verify mksnapshot"
+  - if "%RUN_TESTS%"=="true" ( echo Verifying mksnapshot & python electron\script\verify-mksnapshot.py --build-dir out\Default --source-root %cd% )
+  - echo "Done verifying mksnapshot"
 deploy_script:
   - cd electron
   - ps: >-

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -39,7 +39,7 @@ def main():
             + context_snapshot
 
       test_path = os.path.join(SOURCE_ROOT, 'spec', 'fixtures', \
-                               'snapshot-items-available.js')
+                               'snapshot-items-available')
 
       if sys.platform == 'darwin':
         bin_files = glob.glob(os.path.join(app_path, '*.bin'))
@@ -64,7 +64,7 @@ def main():
   except KeyboardInterrupt:
     print 'Other error'
     returncode = 0
-
+  print 'Returning with error code: {0}'.format(returncode)
   return returncode
 
 

--- a/spec/fixtures/snapshot-items-available/main.js
+++ b/spec/fixtures/snapshot-items-available/main.js
@@ -2,19 +2,25 @@
 
 const { app } = require('electron')
 
-app.once('ready', () => {
+app.on('ready', () => {
+  let returnCode = 0
   try {
     const testValue = f() // eslint-disable-line no-undef
     if (testValue === 86) {
       console.log('ok test snapshot successfully loaded.')
-      app.exit(0)
     } else {
       console.log('not ok test snapshot could not be successfully loaded.')
-      app.exit(1)
+      returnCode = 1
     }
-    return
   } catch (ex) {
     console.log('Error running custom snapshot', ex)
-    app.exit(1)
+    returnCode = 1
   }
+  setImmediate(function () {
+    app.exit(returnCode)
+  })
+})
+
+process.on('exit', function (code) {
+  console.log('test snapshot exited with code: ' + code)
 })

--- a/spec/fixtures/snapshot-items-available/package.json
+++ b/spec/fixtures/snapshot-items-available/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "snapshot-items-available",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change
The CI step to verify mksnapshot on Windows was hanging.  This PR refactors that test so that it no longer hangs on Windows.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
