### PR TITLE
fix: release-notes interop with clerk

### DIFF
--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -56,6 +56,7 @@ const getNoteFromClerk = async (number, owner, repo) => {
   if (!comments || !comments.data) return
 
   const CLERK_LOGIN = 'release-clerk[bot]'
+  const CLERK_NO_NOTES = '**No Release Notes**'
   const PERSIST_LEAD = '**Release Notes Persisted**\n\n'
   const QUOTE_LEAD = '> '
 
@@ -63,18 +64,19 @@ const getNoteFromClerk = async (number, owner, repo) => {
     if (comment.user.login !== CLERK_LOGIN) {
       continue
     }
-    if (!comment.body.startsWith(PERSIST_LEAD)) {
-      continue
+    if (comment.body === CLERK_NO_NOTES) {
+      return NO_NOTES
     }
-    const note = comment.body
-      .slice(PERSIST_LEAD.length).trim() // remove PERSIST_LEAD
-      .split('\r?\n') // break into lines
-      .map(line => line.trim())
-      .filter(line => line.startsWith(QUOTE_LEAD)) // notes are quoted
-      .map(line => line.slice(QUOTE_LEAD.length)) // unquote the lines
-      .join(' ') // join the note lines
-      .trim()
-    return note
+    if (comment.body.startsWith(PERSIST_LEAD)) {
+      return comment.body
+        .slice(PERSIST_LEAD.length).trim() // remove PERSIST_LEAD
+        .split('\r?\n') // break into lines
+        .map(line => line.trim())
+        .filter(line => line.startsWith(QUOTE_LEAD)) // notes are quoted
+        .map(line => line.slice(QUOTE_LEAD.length)) // unquote the lines
+        .join(' ') // join the note lines
+        .trim()
+    }
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Explicitly look not just for Clerk's "notes persisted" message but also its "no release notes" message.

CC @codebytere 
FYI @nornagon 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes