### PR TITLE
 feat: add chrome.runtime.getManifest

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -168,6 +168,10 @@ ipcMainInternal.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, conne
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONCONNECT_${extensionId}`, event.sender.id, portId, connectInfo)
 })
 
+ipcMainInternal.on('CHROME_EXTENSION_MANIFEST', function (event, extensionId) {
+  event.returnValue = manifestMap[extensionId]
+})
+
 let resultID = 1
 ipcMainInternal.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, originResultID) {
   const page = backgroundPages[extensionId]

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -168,8 +168,12 @@ ipcMainInternal.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, conne
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONCONNECT_${extensionId}`, event.sender.id, portId, connectInfo)
 })
 
-ipcMainInternal.on('CHROME_EXTENSION_MANIFEST', function (event, extensionId) {
-  event.returnValue = manifestMap[extensionId]
+ipcMainUtils.handleSync('CHROME_EXTENSION_MANIFEST', function (event, extensionId) {
+  const manifest = manifestMap[extensionId]
+  if (!manifest) {
+    throw new Error(`Invalid extensionId: ${extensionId}`)
+  }
+  return manifest
 })
 
 let resultID = 1

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -93,6 +93,11 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
       })
     },
 
+    getManifest: function () {
+      const manifest = ipcRenderer.sendSync('CHROME_EXTENSION_MANIFEST', extensionId)
+      return manifest
+    },
+
     connect (...args) {
       if (isBackgroundPage) {
         console.error('chrome.runtime.connect is not supported in background page')

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
+const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 const Event = require('@electron/internal/renderer/extensions/event')
 const url = require('url')
 
@@ -94,7 +95,7 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
     },
 
     getManifest: function () {
-      const manifest = ipcRenderer.sendSync('CHROME_EXTENSION_MANIFEST', extensionId)
+      const manifest = ipcRendererUtils.invokeSync('CHROME_EXTENSION_MANIFEST', extensionId)
       return manifest
     },
 

--- a/spec/chrome-api-spec.js
+++ b/spec/chrome-api-spec.js
@@ -1,0 +1,48 @@
+const fs = require('fs')
+const path = require('path')
+
+const { expect } = require('chai')
+const { remote } = require('electron')
+
+const { closeWindow } = require('./window-helpers')
+const { emittedOnce } = require('./events-helpers')
+
+const { BrowserWindow } = remote
+
+describe('chrome api', () => {
+  const fixtures = path.resolve(__dirname, 'fixtures')
+  let w
+
+  before(() => {
+    BrowserWindow.addExtension(path.join(fixtures, 'extensions/chrome-api'))
+  })
+
+  after(() => {
+    BrowserWindow.removeExtension('chrome-api')
+  })
+
+  beforeEach(() => {
+    w = new BrowserWindow({
+      show: false
+    })
+  })
+
+  afterEach(() => closeWindow(w).then(() => { w = null }))
+
+  it('runtime.getManifest returns extension manifest', async () => {
+    const actualManifest = (() => {
+      const data = fs.readFileSync(path.join(fixtures, 'extensions/chrome-api/manifest.json'), 'utf-8')
+      return JSON.parse(data)
+    })()
+
+    w.loadURL('about:blank')
+
+    const p = emittedOnce(w.webContents, 'console-message')
+    w.webContents.executeJavaScript(`window.postMessage('getManifest', '*')`)
+    const [,, manifestString] = await p
+    const manifest = JSON.parse(manifestString)
+
+    expect(manifest.name).to.equal(actualManifest.name)
+    expect(manifest.content_scripts.length).to.equal(actualManifest.content_scripts.length)
+  })
+})

--- a/spec/fixtures/extensions/chrome-api/main.js
+++ b/spec/fixtures/extensions/chrome-api/main.js
@@ -1,0 +1,15 @@
+/* global chrome */
+
+const testMap = {
+  getManifest () {
+    const manifest = chrome.runtime.getManifest()
+    console.log(JSON.stringify(manifest))
+  }
+}
+
+const dispatchTest = (event) => {
+  const testName = event.data
+  const test = testMap[testName]
+  test()
+}
+window.addEventListener('message', dispatchTest, false)

--- a/spec/fixtures/extensions/chrome-api/manifest.json
+++ b/spec/fixtures/extensions/chrome-api/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "chrome-api",
+  "version": "1.0",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["main.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "manifest_version": 2
+}


### PR DESCRIPTION
#### Description of Change
Implements [`chrome.runtime.getManifest`](https://developer.chrome.com/extensions/runtime#method-getManifest) API.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Added [`chrome.runtime.getManifest`](https://developer.chrome.com/extensions/runtime#method-getManifest) API for Chrome extensions.