### PR TITLE
feat: promisify app.dock.show()

### DIFF
--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -171,7 +171,7 @@ class Browser : public WindowListObserver {
 
   // Hide/Show dock.
   void DockHide();
-  void DockShow();
+  v8::Local<v8::Promise> DockShow(v8::Isolate* isolate);
   bool DockIsVisible();
 
   // Set docks' menu.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1295,13 +1295,11 @@ Hides the dock icon.
 
 ### `app.dock.show()` _macOS_
 
-Shows the dock icon.
+Returns `Promise<void>` - Resolves when the dock icon is shown.
 
 ### `app.dock.isVisible()` _macOS_
 
 Returns `Boolean` - Whether the dock icon is visible.
-The `app.dock.show()` call is asynchronous so this method might not
-return true immediately after that call.
 
 ### `app.dock.setMenu(menu)` _macOS_
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -1110,17 +1110,29 @@ describe('app module', () => {
     })
   })
 
-  describe('dock.setMenu', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip()
-      }
+  describe('dock APIs', () => {
+    describe('dock.setMenu()', () => {
+      it('keeps references to the menu', function () {
+        if (process.platform !== 'darwin') this.skip()
+
+        app.dock.setMenu(new Menu())
+        const v8Util = process.atomBinding('v8_util')
+        v8Util.requestGarbageCollectionForTesting()
+      })
     })
 
-    it('keeps references to the menu', () => {
-      app.dock.setMenu(new Menu())
-      const v8Util = process.atomBinding('v8_util')
-      v8Util.requestGarbageCollectionForTesting()
+    describe('dock.show()', () => {
+      before(function () {
+        if (process.platform !== 'darwin') this.skip()
+      })
+
+      it('returns a Promise', () => {
+        expect(app.dock.show()).to.be.a('promise')
+      })
+
+      it('eventually fulfills', () => {
+        expect(app.dock.show()).to.be.eventually.fulfilled()
+      })
     })
   })
 
@@ -1131,7 +1143,7 @@ describe('app module', () => {
 
     it('becomes fulfilled if the app is already ready', () => {
       expect(app.isReady()).to.be.true()
-      return expect(app.whenReady()).to.be.eventually.fulfilled
+      expect(app.whenReady()).to.be.eventually.fulfilled()
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/13047.

`app.dock.show()` was previously an asynchronous function that did _not_ take a callback, so devs needed to employ unsavory timeouts and other things in order to give deterministic behavior to their users. This converts that method to return a Promise, which ameliorates that issue and also serves the modernization initiative.

cc @miniak @deepak1556 @ckerr @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `app.dock.show()` such that it now returns a Promise.