### PR TITLE
build: ensure that the uploaded symbol path is correct for our symbol server

### DIFF
--- a/script/upload-symbols.py
+++ b/script/upload-symbols.py
@@ -29,6 +29,11 @@ def main():
     files = glob.glob(SYMBOLS_DIR + '/*.pdb/*/*.pdb')
   else:
     files = glob.glob(SYMBOLS_DIR + '/*/*/*.sym')
+
+  # The file upload needs to be atom-shell/symbols/:symbol_name/:hash/:symbol
+  os.chdir(SYMBOLS_DIR)
+  files = [os.path.relpath(f, os.getcwd()) for f in files]
+
   # The symbol server needs lowercase paths, it will fail otherwise
   # So lowercase all the file paths here
   files = [f.lower() for f in files]


### PR DESCRIPTION
The symbols for >= 3.0.0 have been fixed on S3 by @jkleinsc and I.  This script change should fix the upload script for future releases.  Tested locally by printing paths, have not tested an actual upload so the first nightly will test this change.

Closes #15834
Fixes #10105

cc @jkleinsc 

Notes: no-notes