### PR TITLE
chore: 'breaking change' in PR body overrides commit type in relnotes

### DIFF
--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -522,9 +522,10 @@ const getNotes = async (fromRef, toRef, newVersion) => {
 
       // try to pull a release note from the pull comment
       const prParsed = parseCommitMessage(`${prData.data.title}\n\n${prData.data.body}`, pr.owner, pr.repo)
-      commit.note = commit.note || prParsed.note
-      commit.type = commit.type || prParsed.type
-      if (prParsed.type === 'breaking-change') {
+      if (!commit.note) {
+        commit.note = prParsed.note
+      }
+      if (!commit.type || prParsed.type === 'breaking-change') {
         commit.type = prParsed.type
       }
       prSubject = prSubject || prParsed.subject

--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -521,10 +521,12 @@ const getNotes = async (fromRef, toRef, newVersion) => {
       }
 
       // try to pull a release note from the pull comment
-      const prParsed = {}
-      parseCommitMessage(`${prData.data.title}\n\n${prData.data.body}`, pr.owner, pr.repo, prParsed)
+      const prParsed = parseCommitMessage(`${prData.data.title}\n\n${prData.data.body}`, pr.owner, pr.repo)
       commit.note = commit.note || prParsed.note
       commit.type = commit.type || prParsed.type
+      if (prParsed.type === 'breaking-change') {
+        commit.type = prParsed.type
+      }
       prSubject = prSubject || prParsed.subject
 
       pr = prParsed.pr && (prParsed.pr.number !== pr.number) ? prParsed.pr : null


### PR DESCRIPTION
#### Description of Change
This allows the line 'BREAKING CHANGE' in the PR body to override the commit type inferred from the semantic commit message. The reason for this is to allow post-editing the PR body to add 'BREAKING CHANGE' into commits that didn't have that tag to begin with.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes