### PR TITLE
build: use async remove method to handle errors better

### DIFF
--- a/script/gn-asar.js
+++ b/script/gn-asar.js
@@ -46,14 +46,18 @@ try {
   }
 } catch (err) {
   console.error('Unexpected error while generating ASAR', err)
-  fs.removeSync(tmpPath)
-  process.exit(1)
+  fs.remove(tmpPath)
+    .then(() => process.exit(1))
+    .catch(() => process.exit(1))
+  return
 }
 
 // Create the ASAR archive
 asar.createPackageWithOptions(tmpPath, out[0], {})
   .catch(err => {
-    fs.removeSync(tmpPath)
-    console.error('Unexpected error while generating ASAR', err)
-    process.exit(1)
+    const exit = () => {
+      console.error('Unexpected error while generating ASAR', err)
+      process.exit(1)
+    }
+    fs.remove(tmpPath).then(exit).catch(exit)
   }).then(() => fs.remove(tmpPath))


### PR DESCRIPTION
On windows removeSync randomly seems to fail with DIRNOTEMPTY. By using
the async version fs-extra will do some back-off-retry logic to
hopefully get this dir deleted

Notes: no-notes