### PR TITLE
fix: disable Chromium sandbox v2 in MAS builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -717,8 +717,10 @@ if (is_mac) {
     output_name = electron_helper_name
     deps = [
       ":electron_framework+link",
-      "//sandbox/mac:seatbelt",
     ]
+    if (!is_mas_build) {
+      deps += [ "//sandbox/mac:seatbelt" ]
+    }
     defines = [ "HELPER_EXECUTABLE" ]
     sources = filenames.app_sources
     include_dirs = [ "." ]

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -43,9 +43,9 @@
 #include "base/i18n/icu_util.h"
 #include "electron/buildflags/buildflags.h"
 
-#if defined(HELPER_EXECUTABLE)
+#if defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
 #include "sandbox/mac/seatbelt_exec.h"  // nogncheck
-#endif                                  // defined(HELPER_EXECUTABLE)
+#endif
 
 namespace {
 
@@ -213,7 +213,7 @@ int main(int argc, char* argv[]) {
   }
 #endif
 
-#if defined(HELPER_EXECUTABLE)
+#if defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
   uint32_t exec_path_size = 0;
   int rv = _NSGetExecutablePath(NULL, &exec_path_size);
   if (rv != -1) {
@@ -240,7 +240,7 @@ int main(int argc, char* argv[]) {
       abort();
     }
   }
-#endif
+#endif  // defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
 
   return AtomMain(argc, argv);
 }


### PR DESCRIPTION
#### Description of Change
Fixes https://github.com/electron/electron/issues/16919

/cc @nornagon

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed Chromium sandbox v2 related crashes in MAS builds.