### PR TITLE
refactor: remove LaunchServices from LoginItem api

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -321,7 +321,6 @@ struct Converter<Browser::LoginItemSettings> {
       return false;
 
     dict.Get("openAtLogin", &(out->open_at_login));
-    dict.Get("openAsHidden", &(out->open_as_hidden));
     dict.Get("path", &(out->path));
     dict.Get("args", &(out->args));
     return true;
@@ -331,10 +330,6 @@ struct Converter<Browser::LoginItemSettings> {
                                    Browser::LoginItemSettings val) {
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
     dict.Set("openAtLogin", val.open_at_login);
-    dict.Set("openAsHidden", val.open_as_hidden);
-    dict.Set("restoreState", val.restore_state);
-    dict.Set("wasOpenedAtLogin", val.opened_at_login);
-    dict.Set("wasOpenedAsHidden", val.opened_as_hidden);
     return dict.GetHandle();
   }
 };

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -96,10 +96,6 @@ class Browser : public WindowListObserver {
   // Set/Get the login item settings of the app
   struct LoginItemSettings {
     bool open_at_login = false;
-    bool open_as_hidden = false;
-    bool restore_state = false;
-    bool opened_at_login = false;
-    bool opened_as_hidden = false;
     base::string16 path;
     std::vector<base::string16> args;
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1089,27 +1089,12 @@ need to pass the same arguments here for `openAtLogin` to be set correctly.
 Returns `Object`:
 
 * `openAtLogin` Boolean - `true` if the app is set to open at login.
-* `openAsHidden` Boolean _macOS_ - `true` if the app is set to open as hidden at login.
-  This setting is not available on [MAS builds][mas-builds].
-* `wasOpenedAtLogin` Boolean _macOS_ - `true` if the app was opened at login
-  automatically. This setting is not available on [MAS builds][mas-builds].
-* `wasOpenedAsHidden` Boolean _macOS_ - `true` if the app was opened as a hidden login
-  item. This indicates that the app should not open any windows at startup.
-  This setting is not available on [MAS builds][mas-builds].
-* `restoreState` Boolean _macOS_ - `true` if the app was opened as a login item that
-  should restore the state from the previous session. This indicates that the
-  app should restore the windows that were open the last time the app was
-  closed. This setting is not available on [MAS builds][mas-builds].
 
 ### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
 
 * `settings` Object
   * `openAtLogin` Boolean (optional) - `true` to open the app at login, `false` to remove
     the app as a login item. Defaults to `false`.
-  * `openAsHidden` Boolean (optional) _macOS_ - `true` to open the app as hidden. Defaults to
-    `false`. The user can edit this setting from the System Preferences so
-    `app.getLoginItemSettings().wasOpenedAsHidden` should be checked when the app
-    is opened to know the current value. This setting is not available on [MAS builds][mas-builds].
   * `path` String (optional) _Windows_ - The executable to launch at login.
     Defaults to `process.execPath`.
   * `args` String[] (optional) _Windows_ - The command-line arguments to pass to

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -536,7 +536,7 @@ describe('app module', () => {
     ]
 
     before(function () {
-      if (process.platform === 'linux' || process.mas) this.skip()
+      if (process.platform !== 'win32') this.skip()
     })
 
     beforeEach(() => {
@@ -551,25 +551,7 @@ describe('app module', () => {
 
     it('sets and returns the app as a login item', done => {
       app.setLoginItemSettings({ openAtLogin: true })
-      expect(app.getLoginItemSettings()).to.deep.equal({
-        openAtLogin: true,
-        openAsHidden: false,
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false
-      })
-      done()
-    })
-
-    it('adds a login item that loads in hidden mode', done => {
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
-      expect(app.getLoginItemSettings()).to.deep.equal({
-        openAtLogin: true,
-        openAsHidden: process.platform === 'darwin' && !process.mas, // Only available on macOS
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false
-      })
+      expect(app.getLoginItemSettings()).to.deep.equal({ openAtLogin: true })
       done()
     })
 
@@ -581,21 +563,6 @@ describe('app module', () => {
 
       app.setLoginItemSettings({ openAtLogin: false })
       expect(app.getLoginItemSettings().openAtLogin).to.be.false()
-    })
-
-    it('correctly sets and unsets the LoginItem as hidden', function () {
-      if (process.platform !== 'darwin') this.skip()
-
-      expect(app.getLoginItemSettings().openAtLogin).to.be.false()
-      expect(app.getLoginItemSettings().openAsHidden).to.be.false()
-
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
-      expect(app.getLoginItemSettings().openAtLogin).to.be.true()
-      expect(app.getLoginItemSettings().openAsHidden).to.be.true()
-
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: false })
-      expect(app.getLoginItemSettings().openAtLogin).to.be.true()
-      expect(app.getLoginItemSettings().openAsHidden).to.be.false()
     })
 
     it('allows you to pass a custom executable and arguments', function () {

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -307,8 +307,7 @@ if (app.isUnityRunning()) {
 if (app.isAccessibilitySupportEnabled()) {
   console.log('a11y running')
 }
-app.setLoginItemSettings({ openAtLogin: true, openAsHidden: false })
-console.log(app.getLoginItemSettings().wasOpenedAtLogin)
+
 app.setAboutPanelOptions({
   applicationName: 'Test',
   version: '1.2.3'


### PR DESCRIPTION
#### Description of Change

Previously, we had two different means of setting a login item on Mac: Launch Services and ServiceManagement. The Launch Services APIs are almost [entirely deprecated](https://developer.apple.com/documentation/coreservices/launch_services?language=objc), and often failed as what remained of them was rather buggy. This removes all traces of the LaunchServices APIs in favor of the ServiceManagement APIs. This means that macOS users will no longer be able to set login items as hidden, but this brings the API more in line with the Windows.

Requires https://github.com/electron/electron-typescript-definitions/pull/128.

cc @deepak1556 @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed deprecated LaunchServices from LoginItem APIs.
