### PR TITLE
refactor: deprecate.promisify prototype methods

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -61,7 +61,6 @@
 
 #include "atom/common/node_includes.h"
 
-using atom::api::Cookies;
 using content::BrowserThread;
 using content::StoragePartition;
 
@@ -785,6 +784,8 @@ void Session::BuildPrototype(v8::Isolate* isolate,
 
 namespace {
 
+using atom::api::Cookies;
+using atom::api::Protocol;
 using atom::api::Session;
 
 v8::Local<v8::Value> FromPartition(const std::string& partition,
@@ -810,6 +811,9 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.Set(
       "Cookies",
       Cookies::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());
+  dict.Set(
+      "Protocol",
+      Protocol::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());
   dict.SetMethod("fromPartition", &FromPartition);
 }
 

--- a/lib/browser/api/net-log.js
+++ b/lib/browser/api/net-log.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // TODO(deepak1556): Deprecate and remove standalone netLog module,
-// it is now a property of sessio module.
+// it is now a property of session module.
 const { app, session } = require('electron')
 
 // Fallback to default session.

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -2,22 +2,7 @@
 
 const { EventEmitter } = require('events')
 const { app, deprecate } = require('electron')
-const { Session, Cookies } = process.atomBinding('session')
-const realFromPartition = process.atomBinding('session').fromPartition
-
-const wrappedSymbol = Symbol('wrapped-deprecate')
-const fromPartition = (partition) => {
-  const session = realFromPartition(partition)
-  if (!session[wrappedSymbol]) {
-    session[wrappedSymbol] = true
-    const { cookies } = session
-    cookies.flushStore = deprecate.promisify(cookies.flushStore)
-    cookies.get = deprecate.promisify(cookies.get)
-    cookies.remove = deprecate.promisify(cookies.remove)
-    cookies.set = deprecate.promisify(cookies.set)
-  }
-  return session
-}
+const { fromPartition, Session, Cookies, Protocol } = process.atomBinding('session')
 
 // Public API.
 Object.defineProperties(exports, {
@@ -35,6 +20,12 @@ Object.setPrototypeOf(Session.prototype, EventEmitter.prototype)
 Object.setPrototypeOf(Cookies.prototype, EventEmitter.prototype)
 
 Session.prototype._init = function () {
-  this.protocol.isProtocolHandled = deprecate.promisify(this.protocol.isProtocolHandled)
   app.emit('session-created', this)
 }
+
+Cookies.prototype.flushStore = deprecate.promisify(Cookies.prototype.flushStore)
+Cookies.prototype.get = deprecate.promisify(Cookies.prototype.get)
+Cookies.prototype.remove = deprecate.promisify(Cookies.prototype.remove)
+Cookies.prototype.set = deprecate.promisify(Cookies.prototype.set)
+
+Protocol.prototype.isProtocolHandled = deprecate.promisify(Protocol.prototype.isProtocolHandled)


### PR DESCRIPTION
#### Description of Change
We should `deprecate.promisify` the prototype methods for better API compatibility.

/cc @codebytere 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
