### PR TITLE
refactor: Port getRemote to TypeScript

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -69,7 +69,7 @@ filenames = {
     "lib/renderer/inspector.js",
     "lib/renderer/ipc-renderer-internal-utils.js",
     "lib/renderer/ipc-renderer-internal.js",
-    "lib/renderer/remote.js",
+    "lib/renderer/remote.ts",
     "lib/renderer/security-warnings.js",
     "lib/renderer/web-frame-init.js",
     "lib/renderer/window-setup.js",

--- a/lib/renderer/remote.ts
+++ b/lib/renderer/remote.ts
@@ -1,6 +1,6 @@
-import { remote, Remote } from 'electron'
+import { remote } from 'electron'
 
-export function getRemote (name: keyof Remote) {
+export function getRemote (name: keyof Electron.Remote) {
   if (!remote) {
     throw new Error(`${name} requires remote, which is not enabled`)
   }

--- a/lib/renderer/remote.ts
+++ b/lib/renderer/remote.ts
@@ -1,8 +1,6 @@
-'use strict'
+import { remote, Remote } from 'electron'
 
-const { remote } = require('electron')
-
-exports.getRemote = function (name) {
+export function getRemote (name: keyof Remote) {
   if (!remote) {
     throw new Error(`${name} requires remote, which is not enabled`)
   }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
   "aliasify": {
     "replacements": {
       "@electron/internal/(.+)": "./lib/$1"
+    },
+    "appliesTo": {
+      "includeExtensions": [".js", ".ts"]
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Another chunk of TypeScript conversion, this time around for `web-frame-init`.

Notes: no-notes