### PR TITLE
fix: pass result to chrome.tabs.executeScript callback

### DIFF
--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -150,14 +150,12 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
   }
 
   chrome.tabs = {
-    executeScript (tabId, details, callback) {
-      const requestId = ++originResultID
-      ipcRenderer.once(`CHROME_TABS_EXECUTESCRIPT_RESULT_${requestId}`, (event, result) => {
-        // Disabled due to false positive in StandardJS
-        // eslint-disable-next-line standard/no-callback-literal
-        callback([result])
-      })
-      ipcRenderer.send('CHROME_TABS_EXECUTESCRIPT', requestId, tabId, extensionId, details)
+    executeScript (tabId, details, resultCallback) {
+      if (resultCallback) {
+        ipcRenderer.once(`CHROME_TABS_EXECUTESCRIPT_RESULT_${originResultID}`, (event, result) => resultCallback([result]))
+      }
+      ipcRenderer.send('CHROME_TABS_EXECUTESCRIPT', originResultID, tabId, extensionId, details)
+      originResultID++
     },
 
     sendMessage (tabId, message, options, responseCallback) {

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -5,8 +5,6 @@ const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-inter
 const Event = require('@electron/internal/renderer/extensions/event')
 const url = require('url')
 
-let nextId = 0
-
 class Tab {
   constructor (tabId) {
     this.id = tabId
@@ -153,11 +151,11 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
 
   chrome.tabs = {
     executeScript (tabId, details, callback) {
-      const requestId = ++nextId
+      const requestId = ++originResultID
       ipcRenderer.once(`CHROME_TABS_EXECUTESCRIPT_RESULT_${requestId}`, (event, result) => {
         // Disabled due to false positive in StandardJS
         // eslint-disable-next-line standard/no-callback-literal
-        callback([event.result])
+        callback([result])
       })
       ipcRenderer.send('CHROME_TABS_EXECUTESCRIPT', requestId, tabId, extensionId, details)
     },


### PR DESCRIPTION
Fix for #16940

#### Checklist
- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes