### PR TITLE
 refactor: Port renderer-internal-utils to TypeScript 

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -67,7 +67,7 @@ filenames = {
     "lib/renderer/content-scripts-injector.js",
     "lib/renderer/init.js",
     "lib/renderer/inspector.js",
-    "lib/renderer/ipc-renderer-internal-utils.js",
+    "lib/renderer/ipc-renderer-internal-utils.ts",
     "lib/renderer/ipc-renderer-internal.js",
     "lib/renderer/remote.js",
     "lib/renderer/security-warnings.js",

--- a/lib/renderer/ipc-renderer-internal-utils.ts
+++ b/lib/renderer/ipc-renderer-internal-utils.ts
@@ -1,14 +1,14 @@
-'use strict'
-
-const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
-const errorUtils = require('@electron/internal/common/error-utils')
+import * as ipcRenderer from '@electron/internal/renderer/ipc-renderer-internal'
+import * as errorUtils from '@electron/internal/common/error-utils'
 
 let nextId = 0
 
-exports.invoke = function (command, ...args) {
+export function invoke (command: string, ...args: any[]) {
   return new Promise((resolve, reject) => {
     const requestId = ++nextId
-    ipcRenderer.once(`${command}_RESPONSE_${requestId}`, (event, error, result) => {
+    ipcRenderer.once(`${command}_RESPONSE_${requestId}`, (
+      _event: Electron.Event, error: Electron.SerializedError, result: any
+    ) => {
       if (error) {
         reject(errorUtils.deserialize(error))
       } else {
@@ -19,7 +19,7 @@ exports.invoke = function (command, ...args) {
   })
 }
 
-exports.invokeSync = function (command, ...args) {
+export function invokeSync (command: string, ...args: any[]) {
   const [ error, result ] = ipcRenderer.sendSync(command, ...args)
 
   if (error) {

--- a/lib/renderer/ipc-renderer-internal-utils.ts
+++ b/lib/renderer/ipc-renderer-internal-utils.ts
@@ -3,8 +3,8 @@ import * as errorUtils from '@electron/internal/common/error-utils'
 
 let nextId = 0
 
-export function invoke (command: string, ...args: any[]) {
-  return new Promise((resolve, reject) => {
+export function invoke<T> (command: string, ...args: any[]) {
+  return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId
     ipcRenderer.once(`${command}_RESPONSE_${requestId}`, (
       _event: Electron.Event, error: Electron.SerializedError, result: any
@@ -19,7 +19,7 @@ export function invoke (command: string, ...args: any[]) {
   })
 }
 
-export function invokeSync (command: string, ...args: any[]) {
+export function invokeSync<T> (command: string, ...args: any[]): T {
   const [ error, result ] = ipcRenderer.sendSync(command, ...args)
 
   if (error) {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
   "aliasify": {
     "replacements": {
       "@electron/internal/(.+)": "./lib/$1"
+    },
+    "appliesTo": {
+      "includeExtensions": [".js", ".ts"]
     }
   },
   "lint-staged": {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -6,9 +6,24 @@
  */
 
 declare namespace Electron {
+  enum ProcessType {
+    browser = 'browser',
+    renderer = 'renderer',
+    worker = 'worker'
+  }
+
   interface App {
     setVersion(version: string): void;
     setDesktopName(name: string): void;
     setAppPath(path: string | null): void;
+  }
+
+  interface SerializedError {
+    message: string;
+    stack?: string,
+    name: string,
+    from: Electron.ProcessType,
+    cause: SerializedError,
+    __ELECTRON_SERIALIZED_ERROR__: true
   }
 }


### PR DESCRIPTION
Another chunk of TypeScript conversion, this time around for `renderer-internal-utils`. We're importing things as `*` that are becoming named exports in other PRs, but opening these PRs in small chunks is probably still the best way to ensure that I'm not just opening one 10k line change monster 😅 

Notes: no-notes