### PR TITLE
 fix: enable inputpane virtual keyboard by default

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -90,3 +90,4 @@ sqlite_upgrade_from_3_24_to_3_26.patch
 sqlite_update_api_3_26.patch
 tts.patch
 do_not_allow_impl_side_invalidations_until_frame_sink_is_fully_active.patch
+enable_inputpane_virtual_keyboard_functionality_by_default.patch

--- a/patches/common/chromium/enable_inputpane_virtual_keyboard_functionality_by_default.patch
+++ b/patches/common/chromium/enable_inputpane_virtual_keyboard_functionality_by_default.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dave Tapuska <dtapuska@chromium.org>
+Date: Mon, 11 Jun 2018 19:26:48 +0000
+Subject: Enable InputPane virtual keyboard functionality by default.
+
+Flip feature flag on. New functionality is used for Windows 10 RS4 and
+later.
+
+BUG=817501
+
+Change-Id: I3c45ac35f925a3b72f2ff50d5f8fdad4895b3cfd
+Reviewed-on: https://chromium-review.googlesource.com/946928
+Commit-Queue: Dave Tapuska <dtapuska@chromium.org>
+Reviewed-by: Scott Violet <sky@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#566102}
+
+diff --git a/ui/base/ui_base_features.cc b/ui/base/ui_base_features.cc
+index a2431e836940c4a1fc7fc95f128a2e2d5aab1b02..80add9507320a8e0dfb42f024095870faa7b3e3c 100644
+--- a/ui/base/ui_base_features.cc
++++ b/ui/base/ui_base_features.cc
+@@ -97,7 +97,7 @@ const base::Feature kUiCompositorScrollWithLayers = {
+ #if defined(OS_WIN)
+ // Enables InputPane API for controlling on screen keyboard.
+ const base::Feature kInputPaneOnScreenKeyboard = {
+-    "InputPaneOnScreenKeyboard", base::FEATURE_DISABLED_BY_DEFAULT};
++    "InputPaneOnScreenKeyboard", base::FEATURE_ENABLED_BY_DEFAULT};
+ 
+ // Enables using WM_POINTER instead of WM_TOUCH for touch events.
+ const base::Feature kPointerEventsForTouch = {"PointerEventsForTouch",


### PR DESCRIPTION
#### Description of Change
First commit here is just running `git-import-patches` followed by `git-export-patches`. The second commit backports https://chromium-review.googlesource.com/c/chromium/src/+/946928 to enable the inputpane virtual keyboard by default, which should fix some scenarios in Windows 10 RS4 and later in which the virtual keyboard wasn't showing when it should have.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fixed an issue on Windows 10 RS4 and later that was causing the virtual keyboard not to appear when focusing some input fields.
