### PR TITLE
fix: send `chrome.runtime/tabs.sendMessage` result to correct sender

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -186,7 +186,7 @@ ipcMainInternal.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, m
   }
 
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, event.sender.id, message, resultID)
-  ipcMainInternal.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
+  ipcMainInternal.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (resultEvent, result) => {
     event._replyInternal(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++
@@ -202,7 +202,7 @@ ipcMainInternal.on('CHROME_TABS_SEND_MESSAGE', function (event, tabId, extension
   const senderTabId = isBackgroundPage ? null : event.sender.id
 
   contents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, senderTabId, message, resultID)
-  ipcMainInternal.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (event, result) => {
+  ipcMainInternal.once(`CHROME_RUNTIME_ONMESSAGE_RESULT_${resultID}`, (resultEvent, result) => {
     event._replyInternal(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, result)
   })
   resultID++

--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -132,14 +132,14 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
       } else if (args.length === 2) {
         // A case of not provide extension-id: (message, responseCallback)
         if (typeof args[1] === 'function') {
-          ipcRenderer.on(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, (event, result) => args[1](result))
+          ipcRenderer.once(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, (event, result) => args[1](result))
           message = args[0]
         } else {
           [targetExtensionId, message] = args
         }
       } else {
         console.error('options is not supported')
-        ipcRenderer.on(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, (event, result) => args[2](result))
+        ipcRenderer.once(`CHROME_RUNTIME_SENDMESSAGE_RESULT_${originResultID}`, (event, result) => args[2](result))
       }
 
       ipcRenderer.send('CHROME_RUNTIME_SENDMESSAGE', targetExtensionId, message, originResultID)
@@ -164,7 +164,7 @@ exports.injectTo = function (extensionId, isBackgroundPage, context) {
 
     sendMessage (tabId, message, options, responseCallback) {
       if (responseCallback) {
-        ipcRenderer.on(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, (event, result) => responseCallback(result))
+        ipcRenderer.once(`CHROME_TABS_SEND_MESSAGE_RESULT_${originResultID}`, (event, result) => responseCallback(result))
       }
       ipcRenderer.send('CHROME_TABS_SEND_MESSAGE', tabId, extensionId, isBackgroundPage, message, originResultID)
       originResultID++


### PR DESCRIPTION
Fix for #16394 

#### Checklist
- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes