### PR TITLE
fix: renderer hang in cc BeginMainFrame

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -89,3 +89,4 @@ disable_color_correct_rendering.patch
 sqlite_upgrade_from_3_24_to_3_26.patch
 sqlite_update_api_3_26.patch
 tts.patch
+do_not_allow_impl_side_invalidations_until_frame_sink_is_fully_active.patch

--- a/patches/common/chromium/allow_new_privs.patch
+++ b/patches/common/chromium/allow_new_privs.patch
@@ -1,11 +1,11 @@
-From 3a68808c9e49e9a249ee9056015e30543747cd00 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ales Pergl <alpergl@microsoft.com>
 Date: Thu, 20 Sep 2018 17:44:49 -0700
 Subject: allow_new_privs.patch
 
 
 diff --git a/base/process/launch.h b/base/process/launch.h
-index 7a2def2ef436..50afeaf5553a 100644
+index 7a2def2ef4365ee3dba0752fca46a6f7aa33ad81..50afeaf5553a1a4ae14ca30aa95ab65c258a0322 100644
 --- a/base/process/launch.h
 +++ b/base/process/launch.h
 @@ -180,7 +180,7 @@ struct BASE_EXPORT LaunchOptions {

--- a/patches/common/chromium/boringssl_build_gn.patch
+++ b/patches/common/chromium/boringssl_build_gn.patch
@@ -6,10 +6,10 @@ Subject: boringssl BUILD.gn
 Build BoringSSL with some extra functions that nodejs needs.
 
 diff --git a/third_party/boringssl/BUILD.gn b/third_party/boringssl/BUILD.gn
-index d31a9f29fa9c12e753708b2a1e75c33b70924300..fd45cfcb50fb659ff8d5a07b06aeecc8f0ecd3ee 100644
+index d31a9f29fa9c12e753708b2a1e75c33b70924300..12c0a84a39f4707f0120922aa64c813e5b2a7b0c 100644
 --- a/third_party/boringssl/BUILD.gn
 +++ b/third_party/boringssl/BUILD.gn
-@@ -45,6 +45,19 @@ config("no_asm_config") {
+@@ -46,6 +46,19 @@ config("no_asm_config") {
  
  all_sources = crypto_sources + ssl_sources
  all_headers = crypto_headers + ssl_headers

--- a/patches/common/chromium/build_gn.patch
+++ b/patches/common/chromium/build_gn.patch
@@ -27,7 +27,7 @@ index fcc00ee0e49f101cb1b10629747c4c4fa521776d..3232a0360e94e78621f7f672e3de4bdc
  
  if (is_win) {
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index 959a59231746..48f1285c4657 100644
+index 959a592317462abb07eefbf03853e1610034c5f3..48f1285c465797bfba37cf2a86cfe21d78c533e6 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
 @@ -634,12 +634,12 @@ config("compiler") {

--- a/patches/common/chromium/build_toolchain_win_patch.patch
+++ b/patches/common/chromium/build_toolchain_win_patch.patch
@@ -1,4 +1,4 @@
-From 88c91c7f60e6251c35fdb3549a5dd7fc66cfdf3b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anonymous <anonymous@electronjs.org>
 Date: Wed, 19 Sep 2018 18:55:58 -0700
 Subject: build_toolchain_win_patch.patch
@@ -18,7 +18,7 @@ For example, instead of generating `obj/ui/base/base_cc.pdb` the
 build will now generate `obj/ui/base/obj_ui_base_base_cc.pdb`.
 
 diff --git a/build/toolchain/win/BUILD.gn b/build/toolchain/win/BUILD.gn
-index eb3e2b2b377d..fdffcdbdbbfe 100644
+index eb3e2b2b377dde31e062be46837bf509ecab0325..fdffcdbdbbfe1280f50c5b8401b117e24ea5267f 100644
 --- a/build/toolchain/win/BUILD.gn
 +++ b/build/toolchain/win/BUILD.gn
 @@ -173,6 +173,12 @@ template("msvc_toolchain") {
@@ -48,7 +48,7 @@ index eb3e2b2b377d..fdffcdbdbbfe 100644
  
      tool("rc") {
 diff --git a/build/toolchain/win/tool_wrapper.py b/build/toolchain/win/tool_wrapper.py
-index cb0393ecd507..ee21eb4b194b 100644
+index cb0393ecd507b865169e9d7c3037d7d5523ae30e..ee21eb4b194b35576883b31c94c9a1f56075e89b 100644
 --- a/build/toolchain/win/tool_wrapper.py
 +++ b/build/toolchain/win/tool_wrapper.py
 @@ -247,6 +247,25 @@ class WinTool(object):

--- a/patches/common/chromium/desktop_screen_win.patch
+++ b/patches/common/chromium/desktop_screen_win.patch
@@ -1,11 +1,11 @@
-From 0dbac64c4877f7783726d3bc04f332a1491285b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anonymous <anonymous@electronjs.org>
 Date: Thu, 20 Sep 2018 17:45:44 -0700
 Subject: desktop_screen_win.patch
 
 
 diff --git a/ui/views/widget/desktop_aura/desktop_screen_win.cc b/ui/views/widget/desktop_aura/desktop_screen_win.cc
-index f772f64d656e..7d13f9f81b6c 100644
+index f772f64d656e88cd2631e388f92e00a845f84f16..7d13f9f81b6c4a9b2ac5ce7e54e6a0c58225517c 100644
 --- a/ui/views/widget/desktop_aura/desktop_screen_win.cc
 +++ b/ui/views/widget/desktop_aura/desktop_screen_win.cc
 @@ -32,6 +32,8 @@ display::Display DesktopScreenWin::GetDisplayMatching(

--- a/patches/common/chromium/disable_color_correct_rendering.patch
+++ b/patches/common/chromium/disable_color_correct_rendering.patch
@@ -19,7 +19,7 @@ to deal with color spaces. That is being tracked at
 https://crbug.com/634542 and https://crbug.com/711107.
 
 diff --git a/cc/trees/layer_tree_host_impl.cc b/cc/trees/layer_tree_host_impl.cc
-index f51e30c0d2a55f104ca0912e487484102e443c85..fbec9767bdefc3b90335ecc423ffd4ea31bf914d 100644
+index 507ece40522fc29a56908d9a6532947a7f67db35..1659c05bfeecbf8ef4264f946aa045d58beb2775 100644
 --- a/cc/trees/layer_tree_host_impl.cc
 +++ b/cc/trees/layer_tree_host_impl.cc
 @@ -1578,6 +1578,10 @@ void LayerTreeHostImpl::SetIsLikelyToRequireADraw(
@@ -34,7 +34,7 @@ index f51e30c0d2a55f104ca0912e487484102e443c85..fbec9767bdefc3b90335ecc423ffd4ea
    // The pending tree will have the most recently updated color space, so
    // prefer that.
 diff --git a/cc/trees/layer_tree_settings.h b/cc/trees/layer_tree_settings.h
-index e124035096b02e82d526d7dfd0e70d4cf73819be..4f182c826a8d08a8674e3ca2f0bf833aa49a1309 100644
+index 736df815a2815484b561bdc4828dbb8592a43d3a..b9b624e475bc244154febb214d88c63aaba5bbab 100644
 --- a/cc/trees/layer_tree_settings.h
 +++ b/cc/trees/layer_tree_settings.h
 @@ -98,6 +98,8 @@ class CC_EXPORT LayerTreeSettings {
@@ -47,7 +47,7 @@ index e124035096b02e82d526d7dfd0e70d4cf73819be..4f182c826a8d08a8674e3ca2f0bf833a
    // Image Decode Service and raster tiles without images until the decode is
    // ready.
 diff --git a/components/viz/common/display/renderer_settings.h b/components/viz/common/display/renderer_settings.h
-index 1327e8607c5192f2440341a33fc210aecd47ced5..543d6937a908560270c6bba431a255436b522608 100644
+index 740cb2ab71cfad11f51418f011ad8a68764c51f4..8c882d58a70a8f6c8f5d4ea861a38b24ffdd4573 100644
 --- a/components/viz/common/display/renderer_settings.h
 +++ b/components/viz/common/display/renderer_settings.h
 @@ -18,6 +18,7 @@ class VIZ_COMMON_EXPORT RendererSettings {
@@ -80,7 +80,7 @@ index eca6020535249e51b428de9dd6454273e6c9dd71..e190d2fb2e2cc41135c119485c2d4475
        !command_line->HasSwitch(switches::kUIDisablePartialSwap);
  #if defined(OS_WIN)
 diff --git a/components/viz/service/display/gl_renderer.cc b/components/viz/service/display/gl_renderer.cc
-index a9ba5ca388b8d0979a1235a0d976b8cb3277f6d3..574deb6ad7d1b088eea43d87b8fe4637b980139b 100644
+index f37adb85d10e344ec9251334b0f46809428cd87a..4d26492492da3ddff0a2529a5e52e5506560a31c 100644
 --- a/components/viz/service/display/gl_renderer.cc
 +++ b/components/viz/service/display/gl_renderer.cc
 @@ -77,6 +77,9 @@
@@ -237,10 +237,10 @@ index 0544d031b60d38279104a4ca9c6dc25126dea185..1acb3dfa55f39b8ecb9fccaa4627ac25
    base::Optional<skia::OpacityFilterCanvas> opacity_canvas;
    if (needs_transparency || disable_image_filtering) {
 diff --git a/components/viz/service/display/software_renderer.cc b/components/viz/service/display/software_renderer.cc
-index 5c41958ed259b1d3ae076312b97a802746897c98..4cb9801a859c12dae03e03073085ff82ea0e4a32 100644
+index b72323450524eb53e2ae1938da4e9410d456417f..bba0fd17ac0f95879e77c8112cb8f4da7b49e3ee 100644
 --- a/components/viz/service/display/software_renderer.cc
 +++ b/components/viz/service/display/software_renderer.cc
-@@ -334,9 +334,11 @@ void SoftwareRenderer::DrawPictureQuad(const PictureDrawQuad* quad) {
+@@ -333,9 +333,11 @@ void SoftwareRenderer::DrawPictureQuad(const PictureDrawQuad* quad) {
  
    std::unique_ptr<SkCanvas> color_transform_canvas;
    // TODO(enne): color transform needs to be replicated in gles2_cmd_decoder
@@ -256,10 +256,10 @@ index 5c41958ed259b1d3ae076312b97a802746897c98..4cb9801a859c12dae03e03073085ff82
    base::Optional<skia::OpacityFilterCanvas> opacity_canvas;
    if (needs_transparency || disable_image_filtering) {
 diff --git a/content/browser/gpu/gpu_process_host.cc b/content/browser/gpu/gpu_process_host.cc
-index 9511100e6077b6788abfead4b1962773a22ae40b..db2d8a4fc979b20810776cf2a31018d197cdba7d 100644
+index bdecceea7e66605869548efc15181d88cfb8a438..844790266cecd6f7dcfbd4f25e73fc16749f77dd 100644
 --- a/content/browser/gpu/gpu_process_host.cc
 +++ b/content/browser/gpu/gpu_process_host.cc
-@@ -193,6 +193,7 @@ GpuTerminationStatus ConvertToGpuTerminationStatus(
+@@ -192,6 +192,7 @@ GpuTerminationStatus ConvertToGpuTerminationStatus(
  
  // Command-line switches to propagate to the GPU process.
  static const char* const kSwitchNames[] = {
@@ -268,10 +268,10 @@ index 9511100e6077b6788abfead4b1962773a22ae40b..db2d8a4fc979b20810776cf2a31018d1
      service_manager::switches::kGpuSandboxAllowSysVShm,
      service_manager::switches::kGpuSandboxFailuresFatal,
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index 1f2897aabf94124f108a0f0449e4d687b084f1a4..4f88e4425ceada8af6b412b087ac134572222824 100644
+index 05e0ee79e5ada8eee03b2bff9c127b4f11610c17..35fdb9d351db5a6bdaa61742ec49dc75fe70cfa4 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
-@@ -218,6 +218,7 @@
+@@ -213,6 +213,7 @@
  #include "ui/base/ui_base_switches.h"
  #include "ui/base/ui_base_switches_util.h"
  #include "ui/display/display_switches.h"
@@ -279,7 +279,7 @@ index 1f2897aabf94124f108a0f0449e4d687b084f1a4..4f88e4425ceada8af6b412b087ac1345
  #include "ui/gl/gl_switches.h"
  #include "ui/gl/gpu_switching_manager.h"
  #include "ui/native_theme/native_theme_features.h"
-@@ -2931,6 +2932,7 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
+@@ -2779,6 +2780,7 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
    // Propagate the following switches to the renderer command line (along
    // with any associated values) if present in the browser command line.
    static const char* const kSwitchNames[] = {
@@ -288,10 +288,10 @@ index 1f2897aabf94124f108a0f0449e4d687b084f1a4..4f88e4425ceada8af6b412b087ac1345
      service_manager::switches::kDisableInProcessStackTraces,
      service_manager::switches::kDisableSeccompFilterSandbox,
 diff --git a/content/renderer/render_widget.cc b/content/renderer/render_widget.cc
-index 6d0580d5b0b76109bbaf0d058ce4201dc970adf0..f0271310ec6112ca7276c5af13ee6677d393109e 100644
+index 560c7caaa74c295a203bfa53c1acc63f1eb4283f..c10f893e1734e59f3102c8d862ccdaca01a3d73f 100644
 --- a/content/renderer/render_widget.cc
 +++ b/content/renderer/render_widget.cc
-@@ -2565,6 +2565,9 @@ cc::LayerTreeSettings RenderWidget::GenerateLayerTreeSettings(
+@@ -2458,6 +2458,9 @@ cc::LayerTreeSettings RenderWidget::GenerateLayerTreeSettings(
    settings.main_frame_before_activation_enabled =
        cmd.HasSwitch(cc::switches::kEnableMainFrameBeforeActivation);
  

--- a/patches/common/chromium/disable_extensions_gn.patch
+++ b/patches/common/chromium/disable_extensions_gn.patch
@@ -1,4 +1,4 @@
-From 790e1e19af133252e95e3a4de8c8e7a3a011bf02 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: deepak1556 <hop2deep@gmail.com>
 Date: Thu, 20 Sep 2018 17:50:48 -0700
 Subject: disable_extensions_gn.patch
@@ -6,7 +6,7 @@ Subject: disable_extensions_gn.patch
 Fix build files generation when chrome extensions are disabled.
 
 diff --git a/chrome/browser/apps/app_shim/BUILD.gn b/chrome/browser/apps/app_shim/BUILD.gn
-index f8a6d1868788..350c3572ec54 100644
+index f8a6d1868788d0a984e70b23b6522cf9b74827da..350c3572ec54d85c2195555877d27486a1300273 100644
 --- a/chrome/browser/apps/app_shim/BUILD.gn
 +++ b/chrome/browser/apps/app_shim/BUILD.gn
 @@ -1,6 +1,7 @@
@@ -46,7 +46,7 @@ index f8a6d1868788..350c3572ec54 100644
 +  }
  }
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
-index 1b14d628a63b..00401612c191 100644
+index 1b14d628a63b90532bf25251d0bec6c3f1c7a723..00401612c191836043eb0343d3ee3d42acbd5ea4 100644
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
 @@ -2570,7 +2570,10 @@ split_static_library("ui") {

--- a/patches/common/chromium/disable_scroll_begin_dcheck.patch
+++ b/patches/common/chromium/disable_scroll_begin_dcheck.patch
@@ -1,4 +1,4 @@
-From 56f1078f33969f1d3c097b398a10d251ea774add Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cheng Zhao <zcbenz@gmail.com>
 Date: Thu, 20 Sep 2018 17:48:27 -0700
 Subject: disable_scroll_begin_dcheck.patch
@@ -8,7 +8,7 @@ these assertions. I grouped them together since they are all related to the
 ScrollBegin event.
 
 diff --git a/content/browser/renderer_host/input/mouse_wheel_event_queue.cc b/content/browser/renderer_host/input/mouse_wheel_event_queue.cc
-index 702915772e4f..71fb66a7401c 100644
+index 702915772e4f150b473d3092d5d3a217d0a14602..71fb66a7401c3d46156dbfa7bc443d7e0b6192e1 100644
 --- a/content/browser/renderer_host/input/mouse_wheel_event_queue.cc
 +++ b/content/browser/renderer_host/input/mouse_wheel_event_queue.cc
 @@ -295,7 +295,7 @@ void MouseWheelEventQueue::SendScrollEnd(WebGestureEvent update_event,
@@ -21,7 +21,7 @@ index 702915772e4f..71fb66a7401c 100644
    WebGestureEvent scroll_begin(gesture_update);
    scroll_begin.SetType(WebInputEvent::kGestureScrollBegin);
 diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
-index 28879dc5e9bb..222b5d7e91ec 100644
+index 28879dc5e9bb3f391513da6a7ad829244b39799d..222b5d7e91ec07c3a471299a0d33e2c901b582fd 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc
 +++ b/content/browser/renderer_host/render_widget_host_impl.cc
 @@ -1321,8 +1321,8 @@ void RenderWidgetHostImpl::ForwardGestureEventWithLatencyInfo(

--- a/patches/common/chromium/do_not_allow_impl_side_invalidations_until_frame_sink_is_fully_active.patch
+++ b/patches/common/chromium/do_not_allow_impl_side_invalidations_until_frame_sink_is_fully_active.patch
@@ -1,0 +1,128 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sunny Sachanandani <sunnyps@chromium.org>
+Date: Fri, 18 Jan 2019 03:51:46 +0000
+Subject: Do not allow impl side invalidations until frame sink is fully active
+
+Impl side invalidations can fill up the pipeline blocking main thread
+commit, but draw is blocked for the first commit and activation after
+a new frame sink is created causing a hang in BeginMainFrame.
+
+In the repro, |has_pending_tree_| and |active_tree_needs_first_draw_|
+are both true while |layer_tree_frame_sink_state_| is
+WAITING_FOR_COMMIT.  This means the first invalidation activated and the
+second one created a pending tree, but draw is blocked because the frame
+sink hasn't produced first commit and activation.  It's also possible
+that only one invalidation would trigger this bug because the main
+thread commit won't be able to activate and draw would be blocked again.
+
+With this change, impl side invalidations are blocked until the first
+commit and activation for a frame sink have gone through.
+
+Reproduced using an internal test page (b/122271331) and verified that
+it's fixed.  Also verified that included test fails before this change.
+
+Hopefully this fixes all instances of this long standing hang.
+
+Bug: 622080
+Change-Id: I4b6835e0487f1e48244f41805e63897c9661e674
+Reviewed-on: https://chromium-review.googlesource.com/c/1419132
+Commit-Queue: Sunny Sachanandani <sunnyps@chromium.org>
+Commit-Queue: Khushal <khushalsagar@chromium.org>
+Reviewed-by: Khushal <khushalsagar@chromium.org>
+Auto-Submit: Sunny Sachanandani <sunnyps@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#623998}
+
+diff --git a/cc/scheduler/scheduler_state_machine.cc b/cc/scheduler/scheduler_state_machine.cc
+index a81baa256eab487995faae4f7242266f4c922190..588aa6b6cac770656384cef86b56d5445644dd48 100644
+--- a/cc/scheduler/scheduler_state_machine.cc
++++ b/cc/scheduler/scheduler_state_machine.cc
+@@ -712,8 +712,12 @@ bool SchedulerStateMachine::CouldCreatePendingTree() const {
+   if (begin_frame_source_paused_)
+     return false;
+ 
+-  // Don't create a pending tree till a frame sink is initialized.
+-  if (!HasInitializedLayerTreeFrameSink())
++  // Don't create a pending tree till a frame sink is fully initialized.  Check
++  // for the ACTIVE state explicitly instead of calling
++  // HasInitializedLayerTreeFrameSink() because that only checks if frame sink
++  // has been recreated, but doesn't check if we're waiting for first commit or
++  // activation.
++  if (layer_tree_frame_sink_state_ != LayerTreeFrameSinkState::ACTIVE)
+     return false;
+ 
+   return true;
+diff --git a/cc/scheduler/scheduler_state_machine_unittest.cc b/cc/scheduler/scheduler_state_machine_unittest.cc
+index aa742f8a8a2bf98a5d3a810d4164a44772719530..26d3adafda6236aebbfe8686c38bfa4181e9e470 100644
+--- a/cc/scheduler/scheduler_state_machine_unittest.cc
++++ b/cc/scheduler/scheduler_state_machine_unittest.cc
+@@ -2310,24 +2310,63 @@ TEST(SchedulerStateMachineTest,
+       SchedulerStateMachine::Action::PERFORM_IMPL_SIDE_INVALIDATION);
+ }
+ 
+-TEST(SchedulerStateMachineTest,
+-     NoImplSideInvalidationWithoutLayerTreeFrameSink) {
++TEST(SchedulerStateMachineTest, NoImplSideInvalidationUntilFrameSinkActive) {
+   SchedulerSettings settings;
+   StateMachine state(settings);
+-  SET_UP_STATE(state);
++  SET_UP_STATE(state)
++
++  // Prefer impl side invalidation over begin main frame.
++  state.set_should_defer_invalidation_for_fast_main_frame(false);
+ 
+-  // Impl-side invalidations should not be triggered till the frame sink is
+-  // initialized.
+   state.DidLoseLayerTreeFrameSink();
++
++  // Create new frame sink but don't commit or activate yet.
+   EXPECT_ACTION_UPDATE_STATE(
+       SchedulerStateMachine::Action::BEGIN_LAYER_TREE_FRAME_SINK_CREATION);
+-  EXPECT_ACTION_UPDATE_STATE(SchedulerStateMachine::Action::NONE);
+ 
+-  // No impl-side invalidations should be performed during frame sink creation.
++  state.DidCreateAndInitializeLayerTreeFrameSink();
++  state.SetNeedsBeginMainFrame();
++
+   bool needs_first_draw_on_activation = true;
+   state.SetNeedsImplSideInvalidation(needs_first_draw_on_activation);
++
++  state.IssueNextBeginImplFrame();
++  EXPECT_ACTION_UPDATE_STATE(
++      SchedulerStateMachine::Action::SEND_BEGIN_MAIN_FRAME);
++  // No impl side invalidation because we're still waiting for first commit.
++  EXPECT_ACTION_UPDATE_STATE(SchedulerStateMachine::Action::NONE);
++
++  state.NotifyBeginMainFrameStarted();
++  state.NotifyReadyToCommit();
++  EXPECT_ACTION_UPDATE_STATE(SchedulerStateMachine::Action::COMMIT);
++
++  state.OnBeginImplFrameDeadline();
++  state.OnBeginImplFrameIdle();
++  EXPECT_ACTION_UPDATE_STATE(SchedulerStateMachine::Action::NONE);
++
++  state.SetNeedsImplSideInvalidation(needs_first_draw_on_activation);
++
+   state.IssueNextBeginImplFrame();
++  // No impl side invalidation because we're still waiting for first activation.
+   EXPECT_ACTION_UPDATE_STATE(SchedulerStateMachine::Action::NONE);
++
++  state.NotifyReadyToActivate();
++  EXPECT_ACTION_UPDATE_STATE(SchedulerStateMachine::Action::ACTIVATE_SYNC_TREE);
++
++  state.OnBeginImplFrameDeadline();
++  EXPECT_ACTION_UPDATE_STATE(SchedulerStateMachine::Action::DRAW_IF_POSSIBLE);
++  state.OnBeginImplFrameIdle();
++
++  state.SetNeedsBeginMainFrame();
++  state.SetNeedsImplSideInvalidation(needs_first_draw_on_activation);
++
++  state.IssueNextBeginImplFrame();
++  EXPECT_ACTION_UPDATE_STATE(
++      SchedulerStateMachine::Action::SEND_BEGIN_MAIN_FRAME);
++  // Impl side invalidation only after receiving first commit and activation for
++  // new frame sink.
++  EXPECT_ACTION_UPDATE_STATE(
++      SchedulerStateMachine::Action::PERFORM_IMPL_SIDE_INVALIDATION);
+ }
+ 
+ TEST(SchedulerStateMachineTest, ImplSideInvalidationWhenPendingTreeExists) {

--- a/patches/common/chromium/dom_storage_limits.patch
+++ b/patches/common/chromium/dom_storage_limits.patch
@@ -32,36 +32,36 @@ for a given `BrowserWindow` via a `webPreferences` option,
 similar to [`nodeIntegration`](https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content).
 
 diff --git a/content/common/dom_storage/dom_storage_map.cc b/content/common/dom_storage/dom_storage_map.cc
-index fd088fb170be..b90b6cf9132d 100644
+index fd088fb170bead6452ded14016f21f0c29659e03..b90b6cf9132d16bc3b2076c3fa313916e2b5ea7d 100644
 --- a/content/common/dom_storage/dom_storage_map.cc
 +++ b/content/common/dom_storage/dom_storage_map.cc
 @@ -185,10 +185,12 @@ bool DOMStorageMap::SetItemInternal(MapType* map_type,
    size_t new_item_size = size_in_storage(key, value);
    size_t new_storage_used = storage_used_ - old_item_size + new_item_size;
-
+ 
 +#if 0
    // Only check quota if the size is increasing, this allows
    // shrinking changes to pre-existing files that are over budget.
    if (new_item_size > old_item_size && new_storage_used > quota_)
      return false;
 +#endif
-
+ 
    (*map_type)[key] = value;
    ResetKeyIterator();
 diff --git a/content/common/dom_storage/dom_storage_types.h b/content/common/dom_storage/dom_storage_types.h
-index e87afe5b8ee0..61c9a0dfff60 100644
+index e87afe5b8ee07f7038a7cc9c40832b6cd27884da..61c9a0dfff60f79c7b36ff5c7d741c06dca03ada 100644
 --- a/content/common/dom_storage/dom_storage_types.h
 +++ b/content/common/dom_storage/dom_storage_types.h
 @@ -21,6 +21,7 @@ typedef std::map<base::string16, base::NullableString16> DOMStorageValuesMap;
-
+ 
  // The quota for each storage area.
  // This value is enforced in renderer processes and the browser process.
 +// However, Electron's dom_storage_limits.patch removes the code that checks this limit.
  const size_t kPerStorageAreaQuota = 10 * 1024 * 1024;
-
+ 
  // In the browser process we allow some overage to
 diff --git a/content/renderer/dom_storage/dom_storage_cached_area.cc b/content/renderer/dom_storage/dom_storage_cached_area.cc
-index 402c27727ff1..f5908a1c55f9 100644
+index 402c27727ff13f634e7e4d9a0fc714795f52b8c0..f5908a1c55f95f41ee532ccfdcbc2e2670a01d4b 100644
 --- a/content/renderer/dom_storage/dom_storage_cached_area.cc
 +++ b/content/renderer/dom_storage/dom_storage_cached_area.cc
 @@ -53,11 +53,13 @@ bool DOMStorageCachedArea::SetItem(int connection_id,
@@ -75,11 +75,11 @@ index 402c27727ff1..f5908a1c55f9 100644
        kPerStorageAreaQuota)
      return false;
 +#endif
-
+ 
    PrimeIfNeeded(connection_id);
    base::NullableString16 old_value;
 diff --git a/content/renderer/dom_storage/local_storage_cached_area.cc b/content/renderer/dom_storage/local_storage_cached_area.cc
-index ffa21c9200d0..0edbd6152292 100644
+index ffa21c9200d0488db57eb598235e730d6aaa3687..0edbd615229238203fa1a3593802e712e3bfee4e 100644
 --- a/content/renderer/dom_storage/local_storage_cached_area.cc
 +++ b/content/renderer/dom_storage/local_storage_cached_area.cc
 @@ -141,11 +141,13 @@ bool LocalStorageCachedArea::SetItem(const base::string16& key,
@@ -93,6 +93,6 @@ index ffa21c9200d0..0edbd6152292 100644
        kPerStorageAreaQuota)
      return false;
 +#endif
-
+ 
    EnsureLoaded();
    bool result = false;

--- a/patches/common/chromium/ensure_cookie_store.patch
+++ b/patches/common/chromium/ensure_cookie_store.patch
@@ -15,7 +15,7 @@ index 55df34044af7bafb55521738a6581410877494c0..56da4a1012a6bcf7a500c0e600a08776
 +++ b/chrome/browser/io_thread.cc
 @@ -360,6 +360,11 @@ void IOThread::Init() {
  #endif
-
+ 
    ConstructSystemRequestContext();
 +
 +  // Prevent DCHECK failures when a NetworkContext is created with an encrypted
@@ -23,7 +23,7 @@ index 55df34044af7bafb55521738a6581410877494c0..56da4a1012a6bcf7a500c0e600a08776
 +  if (!base::FeatureList::IsEnabled(network::features::kNetworkService))
 +    content::GetNetworkServiceImpl()->set_os_crypt_is_configured();
  }
-
+ 
  void IOThread::CleanUp() {
 diff --git a/chrome/browser/profiles/off_the_record_profile_io_data.cc b/chrome/browser/profiles/off_the_record_profile_io_data.cc
 index ebb7e95151156209aae7234de0e17ef9241335a7..de61d90917a40d0d64bb7c15daad0fd2c1147247 100644
@@ -32,7 +32,7 @@ index ebb7e95151156209aae7234de0e17ef9241335a7..de61d90917a40d0d64bb7c15daad0fd2
 @@ -215,14 +215,6 @@ void OffTheRecordProfileIOData::InitializeInternal(
        std::make_unique<net::ChannelIDService>(
            new net::DefaultChannelIDStore(nullptr)));
-
+ 
 -  using content::CookieStoreConfig;
 -  std::unique_ptr<net::CookieStore> cookie_store(CreateCookieStore(
 -      CookieStoreConfig(base::FilePath(), false, false, nullptr)));
@@ -51,7 +51,7 @@ index 6dd54b7d045f38195c3858699dbd4ac5ad877277..c4038dc1e9cd5c13e946919ef5747357
 @@ -450,49 +450,6 @@ void ProfileImplIOData::InitializeInternal(
    IOThread* const io_thread = profile_params->io_thread;
    IOThread::Globals* const io_thread_globals = io_thread->globals();
-
+ 
 -  // This check is needed because with the network service the cookies are used
 -  // in a different process. See the bottom of
 -  // ProfileNetworkContextService::SetUpProfileIODataMainContext.
@@ -96,7 +96,7 @@ index 6dd54b7d045f38195c3858699dbd4ac5ad877277..c4038dc1e9cd5c13e946919ef5747357
 -  }
 -
    AddProtocolHandlersToBuilder(builder, protocol_handlers);
-
+ 
    // Install the Offline Page Interceptor.
 diff --git a/services/network/network_context.cc b/services/network/network_context.cc
 index 50b4f60a47c046796f2452a7454e2ed821113d3c..ec799409ac3597c2437d38a8686efcb8448255b8 100644
@@ -120,12 +120,12 @@ index 50b4f60a47c046796f2452a7454e2ed821113d3c..ec799409ac3597c2437d38a8686efcb8
 -      &session_cleanup_cookie_store, &session_cleanup_channel_id_store);
 +  url_request_context_owner_ = MakeURLRequestContext();
    url_request_context_ = url_request_context_owner_.url_request_context.get();
-
+ 
    network_service_->RegisterNetworkContext(this);
 @@ -323,10 +321,6 @@ NetworkContext::NetworkContext(
    binding_.set_connection_error_handler(base::BindOnce(
        &NetworkContext::OnConnectionError, base::Unretained(this)));
-
+ 
 -  cookie_manager_ = std::make_unique<CookieManager>(
 -      url_request_context_->cookie_store(), session_cleanup_cookie_store,
 -      session_cleanup_channel_id_store,
@@ -135,7 +135,7 @@ index 50b4f60a47c046796f2452a7454e2ed821113d3c..ec799409ac3597c2437d38a8686efcb8
    resource_scheduler_ =
 @@ -348,9 +342,6 @@ NetworkContext::NetworkContext(
    url_request_context_ = url_request_context_owner_.url_request_context.get();
-
+ 
    network_service_->RegisterNetworkContext(this);
 -  cookie_manager_ = std::make_unique<CookieManager>(
 -      url_request_context_->cookie_store(), nullptr, nullptr,
@@ -146,7 +146,7 @@ index 50b4f60a47c046796f2452a7454e2ed821113d3c..ec799409ac3597c2437d38a8686efcb8
 @@ -819,6 +810,61 @@ URLRequestContextOwner NetworkContext::ApplyContextParamsToBuilder(
          network_service_->network_quality_estimator());
    }
-
+ 
 +  scoped_refptr<network::SessionCleanupCookieStore>
 +      session_cleanup_cookie_store;
 +  scoped_refptr<SessionCleanupChannelIDStore> session_cleanup_channel_id_store;
@@ -208,7 +208,7 @@ index 50b4f60a47c046796f2452a7454e2ed821113d3c..ec799409ac3597c2437d38a8686efcb8
 @@ -1065,6 +1111,12 @@ URLRequestContextOwner NetworkContext::ApplyContextParamsToBuilder(
  #endif
    }
-
+ 
 +  cookie_manager_ = std::make_unique<CookieManager>(
 +      result.url_request_context->cookie_store(),
 +      std::move(session_cleanup_cookie_store),
@@ -217,11 +217,11 @@ index 50b4f60a47c046796f2452a7454e2ed821113d3c..ec799409ac3597c2437d38a8686efcb8
 +
    return result;
  }
-
+ 
 @@ -1098,71 +1150,11 @@ void NetworkContext::OnConnectionError() {
      std::move(on_connection_close_callback_).Run(this);
  }
-
+ 
 -URLRequestContextOwner NetworkContext::MakeURLRequestContext(
 -    SessionCleanupCookieStore** session_cleanup_cookie_store,
 -    SessionCleanupChannelIDStore** session_cleanup_channel_id_store) {
@@ -229,7 +229,7 @@ index 50b4f60a47c046796f2452a7454e2ed821113d3c..ec799409ac3597c2437d38a8686efcb8
    URLRequestContextBuilderMojo builder;
    const base::CommandLine* command_line =
        base::CommandLine::ForCurrentProcess();
-
+ 
 -  // The cookie configuration is in this method, which is only used by the
 -  // network process, and not ApplyContextParamsToBuilder which is used by the
 -  // browser as well. This is because this code path doesn't handle encryption
@@ -305,7 +305,7 @@ index 83459ab0f23ea0190bae410921391ca9d11c5aa9..4b25717b4be3a21249d177f0c7caca61
  #include "services/network/public/mojom/network_context.mojom.h"
 @@ -51,6 +50,7 @@ class TreeStateTracker;
  }  // namespace certificate_transparency
-
+ 
  namespace network {
 +class CookieManager;
  class ExpectCTReporter;
@@ -314,14 +314,14 @@ index 83459ab0f23ea0190bae410921391ca9d11c5aa9..4b25717b4be3a21249d177f0c7caca61
 @@ -233,9 +233,7 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkContext
    // On connection errors the NetworkContext destroys itself.
    void OnConnectionError();
-
+ 
 -  URLRequestContextOwner MakeURLRequestContext(
 -      SessionCleanupCookieStore** session_cleanup_cookie_store,
 -      SessionCleanupChannelIDStore** session_cleanup_channel_id_store);
 +  URLRequestContextOwner MakeURLRequestContext();
-
+ 
    NetworkService* const network_service_;
-
+ 
 diff --git a/services/network/network_context_unittest.cc b/services/network/network_context_unittest.cc
 index c756789a39f3d265c536a69d899512e816708344..88cdcc0b5433087c15edad4e6a977bb2a127f834 100644
 --- a/services/network/network_context_unittest.cc
@@ -341,7 +341,7 @@ index c4df8eceaad173b580c8fa91aca6cfdced5f571b..a91a9f4b5866c11ae76e2d173a92579f
 @@ -169,6 +169,10 @@ NetworkService::~NetworkService() {
    DCHECK(network_contexts_.empty());
  }
-
+ 
 +void NetworkService::set_os_crypt_is_configured() {
 +  os_crypt_config_set_ = true;
 +}
@@ -362,9 +362,9 @@ index 839a5da98be9adaa836a3881f5a42fde069c860c..a686fd84e0cf61219289d6f5ee9c700e
 --- a/services/network/network_service.h
 +++ b/services/network/network_service.h
 @@ -62,6 +62,11 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkService
-
+ 
    ~NetworkService() override;
-
+ 
 +  // Call to inform the NetworkService that OSCrypt::SetConfig() has already
 +  // been invoked, so OSCrypt::SetConfig() does not need to be called before
 +  // encrypted storage can be used.

--- a/patches/common/chromium/fix_trackpad_scrolling.patch
+++ b/patches/common/chromium/fix_trackpad_scrolling.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cheng Zhao <zcbenz@gmail.com>
-Date: Mon Nov 26 09:32:14 2018 +0900
+Date: Mon, 26 Nov 2018 09:32:14 +0900
 Subject: fix_trackpad_scrolling.patch
 
 Backport https://chromium-review.googlesource.com/c/chromium/src/+/1299342.
@@ -9,7 +9,7 @@ This patch fixes https://github.com/electron/electron/issues/8960, and can be
 removed after upgraded to Chrome 72.
 
 diff --git a/gpu/ipc/service/child_window_win.cc b/gpu/ipc/service/child_window_win.cc
-index d531234..3cce23e 100644
+index d531234e480e8b67582f69105de9ec42d857d840..3cce23ef71563a8106b35dcbdf561acd33c22625 100644
 --- a/gpu/ipc/service/child_window_win.cc
 +++ b/gpu/ipc/service/child_window_win.cc
 @@ -9,7 +9,6 @@
@@ -20,7 +20,7 @@ index d531234..3cce23e 100644
  #include "base/win/scoped_hdc.h"
  #include "base/win/wrapped_window_proc.h"
  #include "gpu/ipc/common/gpu_messages.h"
-@@ -21,49 +20,11 @@
+@@ -21,48 +20,10 @@
  
  namespace gpu {
  
@@ -38,7 +38,7 @@ index d531234..3cce23e 100644
  
  ATOM g_window_class;
  
- // This runs on the window owner thread.
+-// This runs on the window owner thread.
 -LRESULT CALLBACK IntermediateWindowProc(HWND window,
 -                                        UINT message,
 -                                        WPARAM w_param,
@@ -66,10 +66,9 @@ index d531234..3cce23e 100644
 -  }
 -}
 -
--// This runs on the window owner thread.
+ // This runs on the window owner thread.
  void InitializeWindowClass() {
    if (g_window_class)
-     return;
 @@ -71,9 +32,9 @@ void InitializeWindowClass() {
    WNDCLASSEX intermediate_class;
    base::win::InitializeWindowClass(
@@ -189,7 +188,7 @@ index d531234..3cce23e 100644
  
  }  // namespace gpu
 diff --git a/gpu/ipc/service/child_window_win.h b/gpu/ipc/service/child_window_win.h
-index c11202b..2b29fc6 100644
+index c11202b12da8fc540a78c3b13f731fc33d2d63b3..2b29fc641a810d2b521fa14e40da5bffb42ad722 100644
 --- a/gpu/ipc/service/child_window_win.h
 +++ b/gpu/ipc/service/child_window_win.h
 @@ -7,14 +7,13 @@
@@ -227,7 +226,7 @@ index c11202b..2b29fc6 100644
    HWND parent_window_;
    HWND window_;
 diff --git a/gpu/ipc/service/direct_composition_surface_win.cc b/gpu/ipc/service/direct_composition_surface_win.cc
-index e6ac830..2fc7cd93 100644
+index e6ac8301cffe14cc55445a89d2013b61739d7e1f..2fc7cd93d82acf377391fa727d3fdfbb31d304f6 100644
 --- a/gpu/ipc/service/direct_composition_surface_win.cc
 +++ b/gpu/ipc/service/direct_composition_surface_win.cc
 @@ -1541,8 +1541,6 @@ gfx::SwapResult DirectCompositionSurfaceWin::SwapBuffers(

--- a/patches/common/chromium/fix_zoom_display.patch
+++ b/patches/common/chromium/fix_zoom_display.patch
@@ -1,13 +1,13 @@
-From 0000000000000000000000000000000000000000 Web Oct 31 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shelley Vohr <shelley.vohr@gmail.com>
-Date: Web, 31 Oct 2018 09:08:02 -0700
+Date: Wed, 31 Oct 2018 09:08:02 -0700
 Subject: fix_zoom_display.patch
 
-Backport of https://chromium-review.googlesource.com/c/chromium/src/+/1157224. 
+Backport of https://chromium-review.googlesource.com/c/chromium/src/+/1157224.
 This patch was released in 70.0.3512.0.
 
 diff --git a/ui/base/accelerators/platform_accelerator_cocoa.mm b/ui/base/accelerators/platform_accelerator_cocoa.mm
-index 9786168be893..3c177060453a 100644
+index 9786168be893dc756bca02f962f4ef0806e63ff3..3c177060453a4c01cc00cf36784eb336bd901e5e 100644
 --- a/ui/base/accelerators/platform_accelerator_cocoa.mm
 +++ b/ui/base/accelerators/platform_accelerator_cocoa.mm
 @@ -25,9 +25,16 @@ void GetKeyEquivalentAndModifierMaskFromAccelerator(

--- a/patches/common/chromium/gtk_visibility.patch
+++ b/patches/common/chromium/gtk_visibility.patch
@@ -6,7 +6,7 @@ Subject: gtk_visibility.patch
 Allow electron and brightray to depend on GTK in the GN build.
 
 diff --git a/build/config/linux/gtk/BUILD.gn b/build/config/linux/gtk/BUILD.gn
-index deae4d3455a8..fd5d906b98b0 100644
+index deae4d3455a8b54292dd3abc0a316f9ca60b4104..fd5d906b98b047b245824a4b3d6f0c528c96ee1b 100644
 --- a/build/config/linux/gtk/BUILD.gn
 +++ b/build/config/linux/gtk/BUILD.gn
 @@ -18,6 +18,8 @@ group("gtk") {

--- a/patches/common/chromium/ignore_rc_check.patch
+++ b/patches/common/chromium/ignore_rc_check.patch
@@ -7,7 +7,7 @@ Dont compare RC.exe and RC.py output.
 FIXME: It has to be reverted once the script is fixed.
 
 diff --git a/build/toolchain/win/tool_wrapper.py b/build/toolchain/win/tool_wrapper.py
-index cb0393ecd507b865169e9d7c3037d7d5523ae30e..34eebb06295b38dfa0b567f66780ce144b6b5f34 100644
+index ee21eb4b194b35576883b31c94c9a1f56075e89b..ab98a033a61c7a7cb4d5f0968c7a6178c13e3117 100644
 --- a/build/toolchain/win/tool_wrapper.py
 +++ b/build/toolchain/win/tool_wrapper.py
 @@ -231,7 +231,11 @@ class WinTool(object):

--- a/patches/common/chromium/libgtkui_export.patch
+++ b/patches/common/chromium/libgtkui_export.patch
@@ -48,7 +48,7 @@ index e4e0da40981ca58964dfdcbd3fc0f730c9c09ec1..af028715ada9b8023f0ff7cf60e0f7e7
    Gtk2StatusIcon(const gfx::ImageSkia& image, const base::string16& tool_tip);
    ~Gtk2StatusIcon() override;
 diff --git a/chrome/browser/ui/libgtkui/gtk_util.h b/chrome/browser/ui/libgtkui/gtk_util.h
-index d9f245070249f5f153bd8fe11e0a5e718c7d3629..a0f033c3e3f7f3996897f5f969b2a209d7d5cf3f 100644
+index d9f245070249f5f153bd8fe11e0a5e718c7d3629..05875b9ca744b6bf7e0891bca3b193f36a98b19d 100644
 --- a/chrome/browser/ui/libgtkui/gtk_util.h
 +++ b/chrome/browser/ui/libgtkui/gtk_util.h
 @@ -11,6 +11,7 @@

--- a/patches/common/chromium/mac_fix_form_control_rendering_on_10_14_mojave.patch
+++ b/patches/common/chromium/mac_fix_form_control_rendering_on_10_14_mojave.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: deepak1556 <hop2deep@gmail.com>
 Date: Tue, 27 Nov 2018 04:32:18 +0530
-Subject: [Mac] Fix form control rendering on 10.14 Mojave.
+Subject: Fix form control rendering on 10.14 Mojave.
 
 Backports https://crrev.com/c/1106298/ and https://crrev.com/c/1130163/
 with changes required for v1 sandbox on macOS.
@@ -56,7 +56,7 @@ diff --git a/services/service_manager/sandbox/mac/sandbox_mac.mm b/services/serv
 index d69fcc0d4c5c2471163280c03a9fd9366e05031d..cdd7b7f6723162d6875c4d11379837708bdde79d 100644
 --- a/services/service_manager/sandbox/mac/sandbox_mac.mm
 +++ b/services/service_manager/sandbox/mac/sandbox_mac.mm
-@@ -81,6 +81,21 @@
+@@ -81,6 +81,21 @@ static_assert(arraysize(kDefaultSandboxTypeToResourceIDMapping) ==
                    size_t(SANDBOX_TYPE_AFTER_LAST_TYPE),
                "sandbox type to resource id mapping incorrect");
  
@@ -78,7 +78,7 @@ index d69fcc0d4c5c2471163280c03a9fd9366e05031d..cdd7b7f6723162d6875c4d1137983770
  }  // namespace
  
  // Static variable declarations.
-@@ -242,6 +257,9 @@
+@@ -242,6 +257,9 @@ bool SandboxMac::Enable(SandboxType sandbox_type) {
    if (!compiler.InsertBooleanParam(kSandboxMacOS1013, macos_1013))
      return false;
  

--- a/patches/common/chromium/statically_build_power_save_blocker.patch
+++ b/patches/common/chromium/statically_build_power_save_blocker.patch
@@ -1,11 +1,11 @@
-From a99c5f94fd02a391cde00aedfd613937cb72d558 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aleksei Kuzmin <alkuzmin@microsoft.com>
 Date: Thu, 20 Sep 2018 17:47:22 -0700
 Subject: statically_build_power_save_blocker.patch
 
 
 diff --git a/services/device/wake_lock/power_save_blocker/BUILD.gn b/services/device/wake_lock/power_save_blocker/BUILD.gn
-index dfce90f6b791..a2f7f776f4d8 100644
+index dfce90f6b791bd75603eecb2e22eb708ab24f754..a2f7f776f4d8ee2f34a74810fc8c746551e91b01 100644
 --- a/services/device/wake_lock/power_save_blocker/BUILD.gn
 +++ b/services/device/wake_lock/power_save_blocker/BUILD.gn
 @@ -9,7 +9,7 @@ if (is_android) {

--- a/patches/common/chromium/tts.patch
+++ b/patches/common/chromium/tts.patch
@@ -1,5 +1,11 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andy Dill <andy@discordapp.com>
+Date: Wed, 23 Jan 2019 10:33:55 -0800
+Subject: move text-to-speech out of chromium_src
+
+
 diff --git a/chrome/browser/speech/tts_controller_impl.cc b/chrome/browser/speech/tts_controller_impl.cc
-index 2ca56c3a247e..f58e33b3c019 100644
+index 2ca56c3a247e674ee15b0a0ee30e6c2941aa93d3..f58e33b3c0198e4333f98cd1928c8f6d9be45738 100644
 --- a/chrome/browser/speech/tts_controller_impl.cc
 +++ b/chrome/browser/speech/tts_controller_impl.cc
 @@ -624,12 +624,14 @@ const PrefService* TtsControllerImpl::GetPrefService(
@@ -16,9 +22,9 @@ index 2ca56c3a247e..f58e33b3c019 100644
 +#endif
    return prefs;
  }
-
+ 
 diff --git a/chrome/browser/speech/tts_mac.mm b/chrome/browser/speech/tts_mac.mm
-index 74996d854df3..d3bf665c2963 100644
+index 74996d854df318de0e01873f27f6662bf4998cf8..d3bf665c2963560a2bf35afaca56ec5b57d0890b 100644
 --- a/chrome/browser/speech/tts_mac.mm
 +++ b/chrome/browser/speech/tts_mac.mm
 @@ -11,7 +11,6 @@
@@ -26,11 +32,11 @@ index 74996d854df3..d3bf665c2963 100644
  #include "chrome/browser/speech/tts_controller.h"
  #include "chrome/browser/speech/tts_platform.h"
 -#include "extensions/browser/extension_function.h"
-
+ 
  #import <Cocoa/Cocoa.h>
-
+ 
 diff --git a/chrome/browser/speech/tts_message_filter.cc b/chrome/browser/speech/tts_message_filter.cc
-index 013c7a9c60f9..73a244a726e3 100644
+index 013c7a9c60f95475d63701c4f6848cb00dac19d9..73a244a726e3e1a1b5b52ca0e8e3b209aaf432ff 100644
 --- a/chrome/browser/speech/tts_message_filter.cc
 +++ b/chrome/browser/speech/tts_message_filter.cc
 @@ -9,14 +9,40 @@
@@ -45,9 +51,9 @@ index 013c7a9c60f9..73a244a726e3 100644
  #include "content/public/browser/browser_context.h"
  #include "content/public/browser/notification_service.h"
  #include "content/public/browser/render_process_host.h"
-
+ 
  using content::BrowserThread;
-
+ 
 +namespace {
 +
 +class TtsMessageFilterShutdownNotifierFactory
@@ -77,7 +83,7 @@ index 013c7a9c60f9..73a244a726e3 100644
 @@ -24,28 +50,27 @@ TtsMessageFilter::TtsMessageFilter(content::BrowserContext* browser_context)
    CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
    TtsController::GetInstance()->AddVoicesChangedDelegate(this);
-
+ 
 -  // TODO(dmazzoni): make it so that we can listen for a BrowserContext
 -  // being destroyed rather than a Profile.  http://crbug.com/444668
 -  Profile* profile = Profile::FromBrowserContext(browser_context);
@@ -89,12 +95,12 @@ index 013c7a9c60f9..73a244a726e3 100644
 +          ->Get(browser_context)
 +          ->Subscribe(base::Bind(&TtsMessageFilter::BrowserContextDestroyed,
 +                                 base::RetainedRef(this)));
-
+ 
    // Balanced in OnChannelClosingInUIThread() to keep the ref-count be non-zero
    // until all pointers to this class are invalidated.
    AddRef();
  }
-
+ 
 -void TtsMessageFilter::OverrideThreadForMessage(
 -    const IPC::Message& message, BrowserThread::ID* thread) {
 +void TtsMessageFilter::OverrideThreadForMessage(const IPC::Message& message,
@@ -116,11 +122,11 @@ index 013c7a9c60f9..73a244a726e3 100644
 +      break;
    }
  }
-
+ 
 @@ -207,10 +232,8 @@ void TtsMessageFilter::Cleanup() {
    TtsController::GetInstance()->RemoveUtteranceEventDelegate(this);
  }
-
+ 
 -void TtsMessageFilter::Observe(
 -    int type,
 -    const content::NotificationSource& source,
@@ -132,7 +138,7 @@ index 013c7a9c60f9..73a244a726e3 100644
 +  browser_context_shutdown_notifier_.reset();
  }
 diff --git a/chrome/browser/speech/tts_message_filter.h b/chrome/browser/speech/tts_message_filter.h
-index cc9e2806b5c3..d21fb42f1aca 100644
+index cc9e2806b5c3942472785bf3a3a32e23d859971d..d21fb42f1aca2906b8d8968bd1a46721fbc55edb 100644
 --- a/chrome/browser/speech/tts_message_filter.h
 +++ b/chrome/browser/speech/tts_message_filter.h
 @@ -9,10 +9,9 @@
@@ -144,11 +150,11 @@ index cc9e2806b5c3..d21fb42f1aca 100644
  #include "content/public/browser/browser_thread.h"
 -#include "content/public/browser/notification_observer.h"
 -#include "content/public/browser/notification_registrar.h"
-
+ 
  namespace content {
  class BrowserContext;
 @@ -22,7 +21,6 @@ struct TtsUtteranceRequest;
-
+ 
  class TtsMessageFilter
      : public content::BrowserMessageFilter,
 -      public content::NotificationObserver,
@@ -158,19 +164,19 @@ index cc9e2806b5c3..d21fb42f1aca 100644
 @@ -64,15 +62,13 @@ class TtsMessageFilter
    // about to be deleted.
    bool Valid();
-
+ 
 -  // content::NotificationObserver implementation.
 -  void Observe(int type,
 -               const content::NotificationSource& source,
 -               const content::NotificationDetails& details) override;
 +  void BrowserContextDestroyed();
-
+ 
 +  std::unique_ptr<KeyedServiceShutdownNotifier::Subscription>
 +      browser_context_shutdown_notifier_;
    content::BrowserContext* browser_context_;
    mutable base::Lock mutex_;
    mutable bool valid_;
 -  content::NotificationRegistrar notification_registrar_;
-
+ 
    DISALLOW_COPY_AND_ASSIGN(TtsMessageFilter);
  };

--- a/patches/common/chromium/webui_in_subframes.patch
+++ b/patches/common/chromium/webui_in_subframes.patch
@@ -5,7 +5,7 @@ Subject: webui_in_subframes.patch
 
 
 diff --git a/content/browser/frame_host/render_frame_host_delegate.cc b/content/browser/frame_host/render_frame_host_delegate.cc
-index 26b8eec2bb76..fb3843168f14 100644
+index 26b8eec2bb763c6a1e29309abe34c4c068eee609..fb3843168f14fa7b584e2ec52f1c1495aa7dd070 100644
 --- a/content/browser/frame_host/render_frame_host_delegate.cc
 +++ b/content/browser/frame_host/render_frame_host_delegate.cc
 @@ -99,7 +99,9 @@ RenderFrameHostDelegate::GetFocusedFrameIncludingInnerWebContents() {
@@ -20,7 +20,7 @@ index 26b8eec2bb76..fb3843168f14 100644
  }
  
 diff --git a/content/browser/frame_host/render_frame_host_delegate.h b/content/browser/frame_host/render_frame_host_delegate.h
-index 7919ac1e5795..03f331915213 100644
+index 7919ac1e579592815fa96e88f30537c51b110fa9..03f33191521354031357a4886fe7ef3417ba17b6 100644
 --- a/content/browser/frame_host/render_frame_host_delegate.h
 +++ b/content/browser/frame_host/render_frame_host_delegate.h
 @@ -278,7 +278,8 @@ class CONTENT_EXPORT RenderFrameHostDelegate {
@@ -34,7 +34,7 @@ index 7919ac1e5795..03f331915213 100644
    // Called by |frame| to notify that it has received an update on focused
    // element. |bounds_in_root_view| is the rectangle containing the element that
 diff --git a/content/browser/frame_host/render_frame_host_impl.cc b/content/browser/frame_host/render_frame_host_impl.cc
-index 783dc705f748..9fa14c824032 100644
+index 783dc705f748bc6c9d3b8630ce12ad39ff2fd7d2..9fa14c824032463cedbbf5db41f1dbe3490c4a69 100644
 --- a/content/browser/frame_host/render_frame_host_impl.cc
 +++ b/content/browser/frame_host/render_frame_host_impl.cc
 @@ -26,6 +26,7 @@
@@ -71,7 +71,7 @@ index 783dc705f748..9fa14c824032 100644
        pending_web_ui_type_ = new_web_ui_type;
  
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
-index 64ad6ca91d93..88211169a7d7 100644
+index 64ad6ca91d9331a09d09f7e29b7c24a0c12852a2..88211169a7d731cb805f34c48ae4caf2fdcd1c84 100644
 --- a/content/browser/web_contents/web_contents_impl.cc
 +++ b/content/browser/web_contents/web_contents_impl.cc
 @@ -788,6 +788,25 @@ RenderFrameHostManager* WebContentsImpl::GetRenderManagerForTesting() {
@@ -127,7 +127,7 @@ index 64ad6ca91d93..88211169a7d7 100644
  
  NavigationEntry*
 diff --git a/content/browser/web_contents/web_contents_impl.h b/content/browser/web_contents/web_contents_impl.h
-index d16a99122772..907738e0bf80 100644
+index d16a99122772385e6fcdb13a8080c82ee0695232..907738e0bf80e4a34c5f068e67a6ba15d5d8338d 100644
 --- a/content/browser/web_contents/web_contents_impl.h
 +++ b/content/browser/web_contents/web_contents_impl.h
 @@ -542,7 +542,8 @@ class CONTENT_EXPORT WebContentsImpl : public WebContents,

--- a/patches/common/chromium/webview_reattach.patch
+++ b/patches/common/chromium/webview_reattach.patch
@@ -7,7 +7,7 @@ Backports https://chromium-review.googlesource.com/c/chromium/src/+/1161391
 Fixes webview not working after renderer process restarted.
 
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
-index 64ad6ca91d9331a09d09f7e29b7c24a0c12852a2..ec3d1ccbad7e3e4184205f87b6b3fb7dcd4c07f2 100644
+index 88211169a7d731cb805f34c48ae4caf2fdcd1c84..7b2715aea2afb9e939a6d5cf7fa7ec23f330194a 100644
 --- a/content/browser/web_contents/web_contents_impl.cc
 +++ b/content/browser/web_contents/web_contents_impl.cc
 @@ -4906,6 +4906,12 @@ void WebContentsImpl::NotifyViewSwapped(RenderViewHost* old_host,

--- a/patches/common/chromium/windows_cc_wrapper.patch
+++ b/patches/common/chromium/windows_cc_wrapper.patch
@@ -6,7 +6,7 @@ Subject: windows_cc_wrapper.patch
 Allow use of cc_wrapper (eg sccache).
 
 diff --git a/build/toolchain/win/BUILD.gn b/build/toolchain/win/BUILD.gn
-index eb3e2b2b377dde31e062be46837bf509ecab0325..5c014b190e121619056aa2eb7301887d47490d57 100644
+index fdffcdbdbbfe1280f50c5b8401b117e24ea5267f..0b7487e1d288a65a94cace8795c90c880649eef7 100644
 --- a/build/toolchain/win/BUILD.gn
 +++ b/build/toolchain/win/BUILD.gn
 @@ -6,6 +6,7 @@ import("//build/config/clang/clang.gni")


### PR DESCRIPTION
#### Description of Change
This backports a change from Chromium that fixes a rare renderer hang in the `BeginMainFrame` method. The bug in Chromium is view-restricted, but enne@ indicated that this is the change that should fix the issue: https://chromium-review.googlesource.com/c/chromium/src/+/1419132

It's already present in m72 so 5-0-x should be fine. https://chromium-review.googlesource.com/c/chromium/src/+/1427521

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fixed a rare renderer hang in cc::ProxyMain::BeginMainFrame.
