### PR TITLE
feat: show user gesture type in click event

### DIFF
--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -79,6 +79,7 @@ v8::Local<v8::Object> CreateEventFromFlags(v8::Isolate* isolate, int flags) {
   obj.Set("ctrlKey", static_cast<bool>(flags & ui::EF_CONTROL_DOWN));
   obj.Set("altKey", static_cast<bool>(flags & ui::EF_ALT_DOWN));
   obj.Set("metaKey", static_cast<bool>(flags & ui::EF_COMMAND_DOWN));
+  obj.Set("triggeredByAccelerator", static_cast<bool>(flags));
   return obj.GetHandle();
 }
 

--- a/docs/api/structures/keyboard-event.md
+++ b/docs/api/structures/keyboard-event.md
@@ -4,3 +4,4 @@
 * `metaKey` Boolean (optional) - whether a meta key was used in an accelerator to trigger the Event
 * `shiftKey` Boolean (optional) - whether a Shift key was used in an accelerator to trigger the Event
 * `altKey` Boolean (optional) - whether an Alt key was used in an accelerator to trigger the Event
+* `triggeredByAccelerator` Boolean (optional) - whether an accelerator was used to trigger the event as opposed to another user gesture like mouse click

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -31,7 +31,7 @@ const delegate = {
     command.click(event, TopLevelWindow.getFocusedWindow(), webContents.getFocusedWebContents())
   },
   menuWillShow: (menu) => {
-    // Ensure radio groups have at least one menu item seleted
+    // Ensure radio groups have at least one menu item selected
     for (const id in menu.groupsMap) {
       const found = menu.groupsMap[id].find(item => item.checked) || null
       if (!found) v8Util.setHiddenValue(menu.groupsMap[id][0], 'checked', true)


### PR DESCRIPTION
#### Description of Change

Resolves: https://github.com/electron/electron/issues/16947

Adds a new Event property `triggeredByAccelerator`, which is called back in custom `click` events on `MenuItems`.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added a new Event property `triggeredByAccelerator`, which is called back in custom `click` events on `MenuItems`.
