### PR TITLE
docs: add sample code for contents.insertCSS()

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -943,6 +943,12 @@ Returns `String` - The user agent for this web page.
 
 Injects CSS into the current web page.
 
+```js
+contents.on('did-finish-load', function () {
+  contents.insertCSS('html, body { background-color: #f00; }')
+})
+```
+
 #### `contents.executeJavaScript(code[, userGesture, callback])`
 
 * `code` String


### PR DESCRIPTION
#### Description of Change

`contents.insertCSS()` does not work before Event: 'did-finish-load', so add this sample code to show it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Added documentation example code for `contents.insertCSS()`