### PR TITLE
fix: Patch download architecture for ARM (fixes ARM broken install)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -28,7 +28,7 @@ download({
   cache: process.env.electron_config_cache,
   version: version,
   platform: process.env.npm_config_platform,
-  arch: process.env.npm_config_arch,
+  arch: ( process.env.npm_config_arch == 'arm' ? 'armv7l' : process.env.npm_config_arch ),
   strictSSL: process.env.npm_config_strict_ssl === 'true',
   force: process.env.force_no_cache === 'true',
   quiet: process.env.npm_config_loglevel === 'silent' || process.env.CI


### PR DESCRIPTION
Electron no longer produces an 'arm' build, and now labels it 'armv7l'.  As NPM still uses 'arm', we need to patch the variable name here or the download fails with a 404 error like so:

 Error: GET https://github.com/electron/electron/releases/download/v3.1.3/electron-v3.1.3-linux-arm.zip returned 404

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
