### PR TITLE
refactor: remove ServiceWorker APIs from WebContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1430,40 +1430,6 @@ void WebContents::InspectServiceWorker() {
   }
 }
 
-void WebContents::HasServiceWorker(const base::Callback<void(bool)>& callback) {
-  auto* context = GetServiceWorkerContext(web_contents());
-  if (!context)
-    return;
-
-  struct WrappedCallback {
-    base::Callback<void(bool)> callback_;
-    explicit WrappedCallback(const base::Callback<void(bool)>& callback)
-        : callback_(callback) {}
-    void Run(content::ServiceWorkerCapability capability) {
-      callback_.Run(capability !=
-                    content::ServiceWorkerCapability::NO_SERVICE_WORKER);
-      delete this;
-    }
-  };
-
-  auto* wrapped_callback = new WrappedCallback(callback);
-
-  context->CheckHasServiceWorker(
-      web_contents()->GetLastCommittedURL(), GURL::EmptyGURL(),
-      base::BindOnce(&WrappedCallback::Run,
-                     base::Unretained(wrapped_callback)));
-}
-
-void WebContents::UnregisterServiceWorker(
-    const base::Callback<void(bool)>& callback) {
-  auto* context = GetServiceWorkerContext(web_contents());
-  if (!context)
-    return;
-
-  context->UnregisterServiceWorker(web_contents()->GetLastCommittedURL(),
-                                   callback);
-}
-
 void WebContents::SetIgnoreMenuShortcuts(bool ignore) {
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   DCHECK(web_preferences);
@@ -2170,9 +2136,6 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getLastWebPreferences", &WebContents::GetLastWebPreferences)
       .SetMethod("_isRemoteModuleEnabled", &WebContents::IsRemoteModuleEnabled)
       .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
-      .SetMethod("hasServiceWorker", &WebContents::HasServiceWorker)
-      .SetMethod("unregisterServiceWorker",
-                 &WebContents::UnregisterServiceWorker)
       .SetMethod("inspectServiceWorker", &WebContents::InspectServiceWorker)
 #if BUILDFLAG(ENABLE_PRINTING)
       .SetMethod("_print", &WebContents::Print)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -161,8 +161,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DisableDeviceEmulation();
   void InspectElement(int x, int y);
   void InspectServiceWorker();
-  void HasServiceWorker(const base::Callback<void(bool)>&);
-  void UnregisterServiceWorker(const base::Callback<void(bool)>&);
   void SetIgnoreMenuShortcuts(bool ignore);
   void SetAudioMuted(bool muted);
   bool IsAudioMuted();

--- a/docs/api/promisification.md
+++ b/docs/api/promisification.md
@@ -27,8 +27,6 @@ When a majority of affected functions are migrated, this flag will be enabled by
 - [ses.getBlobData(identifier, callback)](https://github.com/electron/electron/blob/master/docs/api/session.md#getBlobData)
 - [ses.clearAuthCache(options[, callback])](https://github.com/electron/electron/blob/master/docs/api/session.md#clearAuthCache)
 - [contents.executeJavaScript(code[, userGesture, callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#executeJavaScript)
-- [contents.hasServiceWorker(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#hasServiceWorker)
-- [contents.unregisterServiceWorker(callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#unregisterServiceWorker)
 - [contents.print([options], [callback])](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#print)
 - [contents.printToPDF(options, callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#printToPDF)
 - [contents.savePage(fullPath, saveType, callback)](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#savePage)

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1156,23 +1156,6 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
-#### `contents.hasServiceWorker(callback)`
-
-* `callback` Function
-  * `hasWorker` Boolean
-
-Checks if any ServiceWorker is registered and returns a boolean as
-response to `callback`.
-
-#### `contents.unregisterServiceWorker(callback)`
-
-* `callback` Function
-  * `success` Boolean
-
-Unregisters any ServiceWorker if present and returns a boolean as
-response to `callback` when the JS promise is fulfilled or false
-when the JS promise is rejected.
-
 #### `contents.getPrinters()`
 
 Get the system printer list.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -379,8 +379,6 @@ WebContents.prototype._init = function () {
   this.setMaxListeners(0)
 
   this.capturePage = deprecate.promisify(this.capturePage)
-  this.hasServiceWorker = deprecate.function(this.hasServiceWorker)
-  this.unregisterServiceWorker = deprecate.function(this.unregisterServiceWorker)
 
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, [channel, ...args]) {


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/16717.

Remove ServiceWorker APIs (`hasServiceWorker` and `unregisterServiceWorker`) from `WebContents`. They haven't worked properly in some time and were not originally intended to exist on `WebContents`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed `hasServiceWorker` and `unregisterServiceWorker` APIs from the WebContents modules.

