### PR TITLE
build: add a pre-flight check to all NPM steps in GN to ensure that we have the right NPM deps installed

### DIFF
--- a/build/npm.gni
+++ b/build/npm.gni
@@ -3,6 +3,26 @@ template("npm_action") {
          "Need script name to run (must be defined in package.json)")
   assert(defined(invoker.args), "Need script argumets")
 
+  action("npm_pre_flight_" + target_name) {
+    inputs = [
+      "package.json",
+      "package-lock.json",
+    ]
+    script = "//electron/build/npm-run.py"
+
+    outputs = [
+      "$target_gen_dir/npm_pre_stamps/" + target_name + ".stamp",
+    ]
+
+    args = [
+      "--silent",
+      "pre-flight",
+      "--",
+      "--stamp",
+      rebase_path(outputs[0]),
+    ]
+  }
+
   action(target_name) {
     forward_variables_from(invoker,
                            [
@@ -12,6 +32,11 @@ template("npm_action") {
                              "inputs",
                              "outputs",
                            ])
+    if (!defined(deps)) {
+      deps = []
+    }
+    deps += [ ":npm_pre_flight_" + target_name ]
+
     script = "//electron/build/npm-run.py"
     args = [
              "--silent",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2977,9 +2977,9 @@
       }
     },
     "electron-typescript-definitions": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/electron-typescript-definitions/-/electron-typescript-definitions-6.0.0.tgz",
-      "integrity": "sha512-W2CHJ1bUtbDXXzIAEbQ+s2XewpSdUUqNECJmhniV0GbPoIhwjAg90++BkMxH6wPBxHWOxesvUMipUEeJN9+wlQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/electron-typescript-definitions/-/electron-typescript-definitions-7.0.0.tgz",
+      "integrity": "sha512-9/BkCl/sJdVn09fn42+bihGsYymBKxzaFM2VY/LYoPe4/7B+3TPhgQyunOgWRaPT1Kx+ZJBgJbYj+rQYEUFR2w==",
       "dev": true,
       "requires": {
         "@types/node": "^7.0.18",
@@ -2995,9 +2995,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.2.tgz",
-          "integrity": "sha512-RO4ig5taKmcrU4Rex8ojG1gpwFkjddzug9iPQSDvbewHN9vDpcFewevkaOK+KT+w1LeZnxbgOyfXwV4pxsQ4GQ==",
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.3.tgz",
+          "integrity": "sha512-HeyK+csRk7Khhg9krpMGJeT9pLzjsmiJFHYRzYpPv/dQ5tPclQsbvceiX/HKynRt/9lMLorWUYTbBHC3hRI4sg==",
           "dev": true
         },
         "lodash": {
@@ -4455,8 +4455,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4480,15 +4479,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4505,22 +4502,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4651,8 +4645,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4666,7 +4659,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4683,7 +4675,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4692,15 +4683,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4721,7 +4710,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4810,8 +4798,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4825,7 +4812,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4921,8 +4907,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4964,7 +4949,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4986,7 +4970,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5035,15 +5018,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9024,6 +9005,17 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "pre-flight": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pre-flight/-/pre-flight-1.1.0.tgz",
+      "integrity": "sha512-4kb2Ht/scZIxx6bxBe63+Ul5i3KK0v9wu4xh5E9+z2n0QgTL2dBiGMZ0JR2Ncn3yckTgaGY12ISw9t7udLbGxw==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "commander": "^2.9.0",
+        "semver": "^5.1.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "nugget": "^2.0.1",
     "octicons": "^7.3.0",
     "plist": "^3.0.1",
+    "pre-flight": "^1.1.0",
     "remark-cli": "^4.0.0",
     "remark-preset-lint-markdown-style-guide": "^2.1.1",
     "request": "^2.88.0",
@@ -59,6 +60,7 @@
     "create-api-json": "electron-docs-linter docs --outfile=electron-api.json",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=electron-api.json --out=electron.d.ts && node spec/ts-smoke/runner.js",
     "gn-typescript-definitions": "npm run create-typescript-definitions && cp electron.d.ts",
+    "pre-flight": "pre-flight",
     "preinstall": "node -e 'process.exit(0)'",
     "precommit": "lint-staged",
     "prepack": "check-for-leaks",
@@ -78,7 +80,10 @@
       "@electron/internal/(.+)": "./lib/$1"
     },
     "appliesTo": {
-      "includeExtensions": [".js", ".ts"]
+      "includeExtensions": [
+        ".js",
+        ".ts"
+      ]
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Sometimes when we bump npm dependencies the build fails when people rebase / pull master because they haven't run `sync` / `npm install`.  Normally these errors aren't super obvious that that is what the issue is.

This adjusts our `npm_action` template to check that npm has all the deps installed it needs

Notes: no-notes