### PR TITLE
chore: add Then helper for native promises

### DIFF
--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "atom/common/api/locker.h"
+#include "atom/common/native_mate_converters/callback.h"
 #include "content/public/browser/browser_thread.h"
 #include "native_mate/converter.h"
 
@@ -44,6 +45,17 @@ class Promise : public base::RefCounted<Promise> {
         v8::Local<v8::Context>::New(isolate(), GetContext()));
 
     return GetInner()->Reject(GetContext(), v8::Undefined(isolate()));
+  }
+
+  v8::MaybeLocal<v8::Promise> Then(base::Closure cb) {
+    v8::HandleScope handle_scope(isolate());
+    v8::Context::Scope context_scope(
+        v8::Local<v8::Context>::New(isolate(), GetContext()));
+
+    v8::Local<v8::Value> value = mate::ConvertToV8(isolate(), cb);
+    v8::Local<v8::Function> handler = v8::Local<v8::Function>::Cast(value);
+
+    return GetHandle()->Then(GetContext(), handler);
   }
 
   // Promise resolution is a microtask


### PR DESCRIPTION
#### Description of Change

Adds a native `Then` helper for our promise wrapper utility to prevent truly terrible workarounds [like this](https://github.com/electron/electron/pull/16973/files#diff-1723fc06542f55eca6f1abc2a3988822R49).

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
