### PR TITLE
build: make torque patch more specific for native arm builds

### DIFF
--- a/patches/common/v8/build-torque-with-x64-toolchain-on-arm.patch
+++ b/patches/common/v8/build-torque-with-x64-toolchain-on-arm.patch
@@ -6,34 +6,26 @@ Subject: build-torque-with-x64-toolchain-on-arm.patch
 torque binary has to be run during the build.
 
 diff --git a/BUILD.gn b/BUILD.gn
-index b70c09aa34aa7547e7d26d9e35795904a17c092f..0fa207082101165ec5d888cd21e4ca916ee458a9 100644
+index 9251b1cab957249be15e05beeabd9f20c841c348..465247a682cc1012d77c28c731fe1553565f128f 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -184,7 +184,8 @@ declare_args() {
+@@ -184,7 +184,9 @@ declare_args() {
  
  v8_generator_toolchain = v8_snapshot_toolchain
  if (host_cpu == "x64" &&
 -    (v8_current_cpu == "mips" || v8_current_cpu == "mips64")) {
 +    (v8_current_cpu == "mips" || v8_current_cpu == "mips64" ||
-+     v8_current_cpu == "arm" || v8_current_cpu == "arm64")) {
++     v8_snapshot_toolchain == "//build/toolchain/linux:clang_arm" ||
++     v8_snapshot_toolchain == "//build/toolchain/linux:clang_arm64")) {
    v8_generator_toolchain = "//build/toolchain/linux:clang_x64"
  }
  
-@@ -3352,7 +3353,7 @@ if (v8_monolithic) {
- # Executables
- #
- 
--if (current_toolchain == v8_generator_toolchain) {
-+if (current_toolchain == current_toolchain) {
-   v8_executable("bytecode_builtins_list_generator") {
-     visibility = [ ":*" ]  # Only targets in this file can depend on this.
- 
-@@ -3402,7 +3403,7 @@ if (v8_use_snapshot && current_toolchain == v8_snapshot_toolchain) {
+@@ -3412,7 +3414,7 @@ if (v8_use_snapshot && current_toolchain == v8_snapshot_toolchain) {
    }
  }
  
 -if (current_toolchain == v8_snapshot_toolchain) {
-+if (current_toolchain == current_toolchain) {
++if (current_toolchain == v8_generator_toolchain) {
    v8_executable("torque") {
      visibility = [ ":*" ]  # Only targets in this file can depend on this.
  

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -88,6 +88,7 @@ steps:
   timeoutInMinutes: 5
   env:
     ELECTRON_DISABLE_SANDBOX: 1
+  condition: and(succeeded(), eq(variables['RUN_NATIVE_MKSNAPSHOT'], 'true'))
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -2,13 +2,13 @@ resources:
   containers:
   - container: arm64v8-test-container
     image: electronbuilds/arm64v8:0.0.4
+    env:
+      RUN_NATIVE_MKSNAPSHOT: true
 
 jobs:
 - job: Test_Arm64
   container: arm64v8-test-container
   displayName: Test Arm64 on Arm64 hardware
   timeoutInMinutes: 30
-  env:
-    RUN_NATIVE_MKSNAPSHOT: true
   steps:
   - template: vsts-arm-test-steps.yml

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -8,5 +8,7 @@ jobs:
   container: arm64v8-test-container
   displayName: Test Arm64 on Arm64 hardware
   timeoutInMinutes: 30
+  env:
+    RUN_NATIVE_MKSNAPSHOT: true
   steps:
   - template: vsts-arm-test-steps.yml


### PR DESCRIPTION
Fixes #16985 

The v8_generator_toolchain should only be overridden if the snapshot toolchain is a native arm or arm64 toolchain.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
