### PR TITLE
chore: replace usage of deprecated beginSheetModalForWindow API

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -171,7 +171,7 @@ It returns the index of the clicked button.
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
-If a `callback` is passed, the dialog will not block the process. The API call
+If the `callback` and `browserWindow` arguments are passed, the dialog will not block the process. The API call
 will be asynchronous and the result will be passed via `callback(response)`.
 
 ### `dialog.showErrorBox(title, content)`


### PR DESCRIPTION
#### Description of Change
Replaces usages of deprecated APIs that required some hax in the C73 upgrade

Fixes #16984 

This also updates the docs for a subtlety I noted in the `dialog.showMessageBox` API (validated against v3/v4 to ensure it wasn't a regression rather "always behavior")

#### Release Notes

Notes: no-notes
