### PR TITLE
chore: auto add filenames.auto.gni when md files are changed

### DIFF
--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -71,6 +71,7 @@ auto_filenames = {
     "docs/api/structures/custom-scheme.md",
     "docs/api/structures/desktop-capturer-source.md",
     "docs/api/structures/display.md",
+    "docs/api/structures/event.md",
     "docs/api/structures/file-filter.md",
     "docs/api/structures/gpu-feature-status.md",
     "docs/api/structures/io-counters.md",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     ],
     "docs/api/*.md": [
       "node script/gen-filenames.js",
-      "git add"
+      "git add filenames.auto.gni"
     ]
   }
 }


### PR DESCRIPTION
`lint-staged` by default only "git add"'s the files that were changed (the markdown files) not the generated file.  This updates the lint-staged config to add "filenames.auto.gni" for the generate step 👍 

Notes: no-notes