### PR TITLE
fix: honor extensionId arg in chrome.runtime.connect

### DIFF
--- a/lib/renderer/chrome-api.ts
+++ b/lib/renderer/chrome-api.ts
@@ -117,7 +117,7 @@ export function injectTo (extensionId: string, context: any) {
       let targetExtensionId = extensionId
       let connectInfo = { name: '' }
       if (args.length === 1) {
-        connectInfo = args[0]
+        targetExtensionId = args[0]
       } else if (args.length === 2) {
         [targetExtensionId, connectInfo] = args
       }


### PR DESCRIPTION
Fixes: #16997. The first argument to chrome.runtime.connect is extensionId, not connectInfo.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes