### PR TITLE
refactor: Port content-scripts-injector to TypeScript

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -64,7 +64,7 @@ filenames = {
     "lib/common/web-view-methods.js",
     "lib/renderer/callbacks-registry.js",
     "lib/renderer/chrome-api.js",
-    "lib/renderer/content-scripts-injector.js",
+    "lib/renderer/content-scripts-injector.ts",
     "lib/renderer/init.js",
     "lib/renderer/inspector.js",
     "lib/renderer/ipc-renderer-internal-utils.ts",

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -26,6 +26,13 @@ declare namespace NodeJS {
     atomBinding(name: 'command_line'): Electron.CommandLine;
     log: NodeJS.WriteStream['write'];
     activateUvLoop(): void;
+
+    // Additional methods
+    getRenderProcessPreferences(): Array<Electron.RendererProcessPreference> | null;
+
+    // Additional events
+    once(event: 'document-start', listener: () => any): this;
+    once(event: 'document-end', listener: () => any): this;
   }
 }
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -27,6 +27,25 @@ declare namespace Electron {
     __ELECTRON_SERIALIZED_ERROR__: true
   }
 
+  interface InjectionBase {
+    url: string;
+    code: string
+  }
+
+  interface ContentScript {
+    js: Array<InjectionBase>;
+    css: Array<InjectionBase>;
+    runAt: string;
+    matches: {
+      some: (input: (pattern: string) => boolean | RegExpMatchArray | null) => boolean;
+    }
+  }
+
+  interface RendererProcessPreference {
+    contentScripts: Array<ContentScript>
+    extensionId: string;
+  }
+
   interface IpcRendererInternal extends Electron.IpcRenderer {
     sendToAll(webContentsId: number, channel: string, ...args: any[]): void
   }


### PR DESCRIPTION
Another chunk of TypeScript conversion, this time around for `content-scripts-injector`.

Notes: no-notes