### PR TITLE
refactor: Port chrome-api to TypeScript

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -63,7 +63,7 @@ filenames = {
     "lib/common/reset-search-paths.ts",
     "lib/common/web-view-methods.js",
     "lib/renderer/callbacks-registry.js",
-    "lib/renderer/chrome-api.js",
+    "lib/renderer/chrome-api.ts",
     "lib/renderer/content-scripts-injector.ts",
     "lib/renderer/init.js",
     "lib/renderer/inspector.js",

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -79,3 +79,27 @@ declare namespace ElectronInternal {
     once(channel: string, listener: (event: IpcMainInternalEvent, ...args: any[]) => void): this;
   }
 }
+
+declare namespace Chrome {
+  namespace Tabs {
+    // https://developer.chrome.com/extensions/tabs#method-executeScript
+    interface ExecuteScriptDetails {
+      code?: string;
+      file?: string;
+      allFrames?: boolean;
+      frameId?: number;
+      matchAboutBlank?: boolean;
+      runAt?: 'document-start' | 'document-end' | 'document_idle';
+      cssOrigin: 'author' | 'user';
+    }
+
+    type ExecuteScriptCallback = (result: Array<any>) => void;
+
+    // https://developer.chrome.com/extensions/tabs#method-sendMessage
+    interface SendMessageDetails {
+      frameId?: number;
+    }
+
+    type SendMessageCallback = (result: any) => void;
+  }
+}


### PR DESCRIPTION
Another chunk of TypeScript conversion, this time around for `chrome-api`.

Notes: no-notes