### PR TITLE
refactor: Port callbacks-registry to TypeScript

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -62,7 +62,7 @@ filenames = {
     "lib/common/parse-features-string.js",
     "lib/common/reset-search-paths.ts",
     "lib/common/web-view-methods.js",
-    "lib/renderer/callbacks-registry.js",
+    "lib/renderer/callbacks-registry.ts",
     "lib/renderer/chrome-api.js",
     "lib/renderer/content-scripts-injector.ts",
     "lib/renderer/init.js",

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -4,7 +4,7 @@ const v8Util = process.atomBinding('v8_util')
 const { isPromise } = require('electron')
 const resolvePromise = Promise.resolve.bind(Promise)
 
-const CallbacksRegistry = require('@electron/internal/renderer/callbacks-registry')
+const { CallbacksRegistry } = require('@electron/internal/renderer/callbacks-registry')
 const bufferUtils = require('@electron/internal/common/buffer-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
 const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal')

--- a/lib/renderer/callbacks-registry.ts
+++ b/lib/renderer/callbacks-registry.ts
@@ -1,16 +1,12 @@
-'use strict'
-
 const v8Util = process.atomBinding('v8_util')
 
-class CallbacksRegistry {
-  constructor () {
-    this.nextId = 0
-    this.callbacks = {}
-  }
+export class CallbacksRegistry {
+  public nextId = 0
+  public callbacks: Record<number, any> = {}
 
-  add (callback) {
+  public add (callback: (...args: Array<any>) => any) {
     // The callback is already added.
-    let id = v8Util.getHiddenValue(callback, 'callbackId')
+    let id: number | null = v8Util.getHiddenValue(callback, 'callbackId')
     if (id != null) return id
 
     id = this.nextId += 1
@@ -23,31 +19,35 @@ class CallbacksRegistry {
     let filenameAndLine
     let match
 
-    while ((match = regexp.exec(stackString)) !== null) {
+    while ((match = regexp.exec(stackString || '')) !== null) {
       const location = match[1]
       if (location.includes('(native)')) continue
       if (location.includes('(<anonymous>)')) continue
       if (location.includes('electron.asar')) continue
 
       const ref = /([^/^)]*)\)?$/gi.exec(location)
+
+      if (!ref) continue
       filenameAndLine = ref[1]
       break
     }
+
     this.callbacks[id] = callback
     v8Util.setHiddenValue(callback, 'callbackId', id)
     v8Util.setHiddenValue(callback, 'location', filenameAndLine)
+
     return id
   }
 
-  get (id) {
+  get (id: number) {
     return this.callbacks[id] || function () {}
   }
 
-  apply (id, ...args) {
+  apply (id: number, ...args: Array<any>) {
     return this.get(id).apply(global, ...args)
   }
 
-  remove (id) {
+  remove (id: number) {
     const callback = this.callbacks[id]
     if (callback) {
       v8Util.deleteHiddenValue(callback, 'callbackId')
@@ -55,5 +55,3 @@ class CallbacksRegistry {
     }
   }
 }
-
-module.exports = CallbacksRegistry

--- a/spec/api-callbacks-registry-spec.js
+++ b/spec/api-callbacks-registry-spec.js
@@ -4,7 +4,7 @@ const dirtyChai = require('dirty-chai')
 const { expect } = chai
 chai.use(dirtyChai)
 
-const CallbacksRegistry = require('../lib/renderer/callbacks-registry')
+const { CallbacksRegistry } = require('../lib/renderer/callbacks-registry')
 
 describe('CallbacksRegistry module', () => {
   let registry = null

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -13,6 +13,7 @@ declare namespace NodeJS {
   interface V8UtilBinding {
     getHiddenValue<T>(obj: any, key: string): T;
     setHiddenValue<T>(obj: any, key: string, value: T): void;
+    deleteHiddenValue(obj: any, key: string): boolean;
   }
   interface Process {
     /**


### PR DESCRIPTION
Another chunk of TypeScript conversion, this time around for `callbacks-registry`.

Notes: no-notes