### PR TITLE
feat: Add content script world isolation

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -137,6 +137,26 @@ npm_action("atom_browserify_isolated") {
   ]
 }
 
+npm_action("atom_browserify_content_script") {
+  script = "browserify"
+
+  inputs = [
+    "lib/content_script/init.js",
+  ]
+
+  outputs = [
+    "$target_gen_dir/js2c/content_script_bundle.js",
+  ]
+
+  args = [
+    "lib/content_script/init.js",
+    "-t",
+    "aliasify",
+    "-o",
+    rebase_path(outputs[0]),
+  ]
+}
+
 copy("atom_js2c_copy") {
   sources = [
     "lib/common/asar.js",
@@ -149,12 +169,14 @@ copy("atom_js2c_copy") {
 
 action("atom_js2c") {
   deps = [
+    ":atom_browserify_content_script",
     ":atom_browserify_isolated",
     ":atom_browserify_sandbox",
     ":atom_js2c_copy",
   ]
 
   browserify_sources = [
+    "$target_gen_dir/js2c/content_script_bundle.js",
     "$target_gen_dir/js2c/isolated_bundle.js",
     "$target_gen_dir/js2c/preload_bundle.js",
   ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -139,9 +139,14 @@ npm_action("atom_browserify_isolated") {
 
 npm_action("atom_browserify_content_script") {
   script = "browserify"
+  deps = [
+    ":build_electron_definitions",
+  ]
 
   inputs = [
     "lib/content_script/init.js",
+    "tsconfig.electron.json",
+    "tsconfig.json",
   ]
 
   outputs = [
@@ -152,6 +157,12 @@ npm_action("atom_browserify_content_script") {
     "lib/content_script/init.js",
     "-t",
     "aliasify",
+    "-p",
+    "[",
+    "tsify",
+    "-p",
+    "tsconfig.electron.json",
+    "]",
     "-o",
     rebase_path(outputs[0]),
   ]

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -113,6 +113,11 @@ void AtomRenderFrameObserver::DidCreateScriptContext(
     CreateIsolatedWorldContext();
     renderer_client_->SetupMainWorldOverrides(context, render_frame_);
   }
+
+  if (world_id >= World::ISOLATED_WORLD_EXTENSIONS) {
+    LOG(INFO) << "Init extension world id=" << world_id;
+    renderer_client_->SetupExtensionWorldOverrides(context, render_frame_);
+  }
 }
 
 void AtomRenderFrameObserver::DraggableRegionsChanged() {

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -114,8 +114,8 @@ void AtomRenderFrameObserver::DidCreateScriptContext(
     renderer_client_->SetupMainWorldOverrides(context, render_frame_);
   }
 
-  if (world_id >= World::ISOLATED_WORLD_EXTENSIONS) {
-    LOG(INFO) << "Init extension world id=" << world_id;
+  if (world_id >= World::ISOLATED_WORLD_EXTENSIONS &&
+      world_id <= World::ISOLATED_WORLD_EXTENSIONS_END) {
     renderer_client_->SetupExtensionWorldOverrides(context, render_frame_);
   }
 }

--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -116,7 +116,8 @@ void AtomRenderFrameObserver::DidCreateScriptContext(
 
   if (world_id >= World::ISOLATED_WORLD_EXTENSIONS &&
       world_id <= World::ISOLATED_WORLD_EXTENSIONS_END) {
-    renderer_client_->SetupExtensionWorldOverrides(context, render_frame_);
+    renderer_client_->SetupExtensionWorldOverrides(context, render_frame_,
+                                                   world_id);
   }
 }
 

--- a/atom/renderer/atom_render_frame_observer.h
+++ b/atom/renderer/atom_render_frame_observer.h
@@ -11,6 +11,7 @@
 #include "base/strings/string16.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "ipc/ipc_platform_file.h"
+#include "third_party/blink/public/platform/web_isolated_world_ids.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 namespace base {
@@ -27,9 +28,13 @@ enum World {
   ISOLATED_WORLD = 999,
 
   // Numbers for isolated worlds for extensions are set in
-  // lib/renderer/content-script-injector.js, and are greater than or equal to
-  // this number.
-  ISOLATED_WORLD_EXTENSIONS = 1000,
+  // lib/renderer/content-script-injector.ts, and are greater than or equal to
+  // this number, up to ISOLATED_WORLD_EXTENSIONS_END.
+  ISOLATED_WORLD_EXTENSIONS = 1 << 20,
+
+  // Last valid isolated world ID.
+  ISOLATED_WORLD_EXTENSIONS_END =
+      blink::IsolatedWorldId::kEmbedderWorldIdLimit - 1
 };
 
 // Helper class to forward the messages to the client.

--- a/atom/renderer/atom_render_frame_observer.h
+++ b/atom/renderer/atom_render_frame_observer.h
@@ -21,9 +21,15 @@ namespace atom {
 
 enum World {
   MAIN_WORLD = 0,
+
   // Use a high number far away from 0 to not collide with any other world
   // IDs created internally by Chrome.
-  ISOLATED_WORLD = 999
+  ISOLATED_WORLD = 999,
+
+  // Numbers for isolated worlds for extensions are set in
+  // lib/renderer/content-script-injector.js, and are greater than or equal to
+  // this number.
+  ISOLATED_WORLD_EXTENSIONS = 1000,
 };
 
 // Helper class to forward the messages to the client.

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -212,8 +212,23 @@ void AtomRendererClient::SetupMainWorldOverrides(
 
 void AtomRendererClient::SetupExtensionWorldOverrides(
     v8::Handle<v8::Context> context,
-    content::RenderFrame* render_frame) {
-  // TODO(samuelmaddock): inject script
+    content::RenderFrame* render_frame,
+    int world_id) {
+  auto* isolate = context->GetIsolate();
+
+  std::vector<v8::Local<v8::String>> isolated_bundle_params = {
+      node::FIXED_ONE_BYTE_STRING(isolate, "nodeProcess"),
+      node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld"),
+      node::FIXED_ONE_BYTE_STRING(isolate, "worldId")};
+
+  std::vector<v8::Local<v8::Value>> isolated_bundle_args = {
+      GetEnvironment(render_frame)->process_object(),
+      GetContext(render_frame->GetWebFrame(), isolate)->Global(),
+      v8::Integer::New(isolate, world_id)};
+
+  node::per_process::native_module_loader.CompileAndCall(
+      context, "electron/js2c/content_script_bundle", &isolated_bundle_params,
+      &isolated_bundle_args, nullptr);
 }
 
 node::Environment* AtomRendererClient::GetEnvironment(

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -210,6 +210,12 @@ void AtomRendererClient::SetupMainWorldOverrides(
       &isolated_bundle_args, nullptr);
 }
 
+void AtomRendererClient::SetupExtensionWorldOverrides(
+    v8::Handle<v8::Context> context,
+    content::RenderFrame* render_frame) {
+  // TODO(samuelmaddock): inject script
+}
+
 node::Environment* AtomRendererClient::GetEnvironment(
     content::RenderFrame* render_frame) const {
   if (injected_frames_.find(render_frame) == injected_frames_.end())

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -33,6 +33,9 @@ class AtomRendererClient : public RendererClientBase {
                                 content::RenderFrame* render_frame) override;
   void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                content::RenderFrame* render_frame) override;
+  void SetupExtensionWorldOverrides(
+      v8::Handle<v8::Context> context,
+      content::RenderFrame* render_frame) override;
 
  private:
   // content::ContentRendererClient:

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -33,9 +33,9 @@ class AtomRendererClient : public RendererClientBase {
                                 content::RenderFrame* render_frame) override;
   void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                content::RenderFrame* render_frame) override;
-  void SetupExtensionWorldOverrides(
-      v8::Handle<v8::Context> context,
-      content::RenderFrame* render_frame) override;
+  void SetupExtensionWorldOverrides(v8::Handle<v8::Context> context,
+                                    content::RenderFrame* render_frame,
+                                    int world_id) override;
 
  private:
   // content::ContentRendererClient:

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -270,6 +270,28 @@ void AtomSandboxedRendererClient::SetupMainWorldOverrides(
       &isolated_bundle_args, nullptr);
 }
 
+void AtomSandboxedRendererClient::SetupExtensionWorldOverrides(
+    v8::Handle<v8::Context> context,
+    content::RenderFrame* render_frame) {
+  auto* isolate = context->GetIsolate();
+
+  mate::Dictionary process = mate::Dictionary::CreateEmpty(isolate);
+  process.SetMethod("binding", GetBinding);
+
+  std::vector<v8::Local<v8::String>> isolated_bundle_params = {
+      node::FIXED_ONE_BYTE_STRING(isolate, "nodeProcess"),
+      node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld")};
+
+  std::vector<v8::Local<v8::Value>> isolated_bundle_args = {
+      process.GetHandle(),
+      GetContext(render_frame->GetWebFrame(), isolate)->Global()};
+
+  // TODO(samuelmaddock): inject content script bundle
+  node::per_process::native_module_loader.CompileAndCall(
+      context, "electron/js2c/isolated_bundle", &isolated_bundle_params,
+      &isolated_bundle_args, nullptr);
+}
+
 void AtomSandboxedRendererClient::WillReleaseScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -272,7 +272,8 @@ void AtomSandboxedRendererClient::SetupMainWorldOverrides(
 
 void AtomSandboxedRendererClient::SetupExtensionWorldOverrides(
     v8::Handle<v8::Context> context,
-    content::RenderFrame* render_frame) {
+    content::RenderFrame* render_frame,
+    int world_id) {
   auto* isolate = context->GetIsolate();
 
   mate::Dictionary process = mate::Dictionary::CreateEmpty(isolate);
@@ -280,13 +281,14 @@ void AtomSandboxedRendererClient::SetupExtensionWorldOverrides(
 
   std::vector<v8::Local<v8::String>> isolated_bundle_params = {
       node::FIXED_ONE_BYTE_STRING(isolate, "nodeProcess"),
-      node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld")};
+      node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld"),
+      node::FIXED_ONE_BYTE_STRING(isolate, "worldId")};
 
   std::vector<v8::Local<v8::Value>> isolated_bundle_args = {
       process.GetHandle(),
-      GetContext(render_frame->GetWebFrame(), isolate)->Global()};
+      GetContext(render_frame->GetWebFrame(), isolate)->Global(),
+      v8::Integer::New(isolate, world_id)};
 
-  // TODO(samuelmaddock): inject content script bundle
   node::per_process::native_module_loader.CompileAndCall(
       context, "electron/js2c/content_script_bundle", &isolated_bundle_params,
       &isolated_bundle_args, nullptr);

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -288,7 +288,7 @@ void AtomSandboxedRendererClient::SetupExtensionWorldOverrides(
 
   // TODO(samuelmaddock): inject content script bundle
   node::per_process::native_module_loader.CompileAndCall(
-      context, "electron/js2c/isolated_bundle", &isolated_bundle_params,
+      context, "electron/js2c/content_script_bundle", &isolated_bundle_params,
       &isolated_bundle_args, nullptr);
 }
 

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -32,9 +32,9 @@ class AtomSandboxedRendererClient : public RendererClientBase {
                                 content::RenderFrame* render_frame) override;
   void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                content::RenderFrame* render_frame) override;
-  void SetupExtensionWorldOverrides(
-      v8::Handle<v8::Context> context,
-      content::RenderFrame* render_frame) override;
+  void SetupExtensionWorldOverrides(v8::Handle<v8::Context> context,
+                                    content::RenderFrame* render_frame,
+                                    int world_id) override;
   // content::ContentRendererClient:
   void RenderFrameCreated(content::RenderFrame*) override;
   void RenderViewCreated(content::RenderView*) override;

--- a/atom/renderer/atom_sandboxed_renderer_client.h
+++ b/atom/renderer/atom_sandboxed_renderer_client.h
@@ -32,6 +32,9 @@ class AtomSandboxedRendererClient : public RendererClientBase {
                                 content::RenderFrame* render_frame) override;
   void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                content::RenderFrame* render_frame) override;
+  void SetupExtensionWorldOverrides(
+      v8::Handle<v8::Context> context,
+      content::RenderFrame* render_frame) override;
   // content::ContentRendererClient:
   void RenderFrameCreated(content::RenderFrame*) override;
   void RenderViewCreated(content::RenderView*) override;

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -34,9 +34,9 @@ class RendererClientBase : public content::ContentRendererClient {
   virtual void DidClearWindowObject(content::RenderFrame* render_frame);
   virtual void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                        content::RenderFrame* render_frame) = 0;
-  virtual void SetupExtensionWorldOverrides(
-      v8::Handle<v8::Context> context,
-      content::RenderFrame* render_frame) = 0;
+  virtual void SetupExtensionWorldOverrides(v8::Handle<v8::Context> context,
+                                            content::RenderFrame* render_frame,
+                                            int world_id) = 0;
 
   bool isolated_world() const { return isolated_world_; }
 

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -34,6 +34,9 @@ class RendererClientBase : public content::ContentRendererClient {
   virtual void DidClearWindowObject(content::RenderFrame* render_frame);
   virtual void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                        content::RenderFrame* render_frame) = 0;
+  virtual void SetupExtensionWorldOverrides(
+      v8::Handle<v8::Context> context,
+      content::RenderFrame* render_frame) = 0;
 
   bool isolated_world() const { return isolated_world_; }
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -119,7 +119,7 @@ this limitation.
 
 ### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])`
 
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `scripts` [WebSource[]](structures/web-source.md)
 * `userGesture` Boolean (optional) - Default is `false`.
 * `callback` Function (optional) - Called after script has been executed.
@@ -129,27 +129,27 @@ Work like `executeJavaScript` but evaluates `scripts` in an isolated context.
 
 ### `webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp)` _(Deprecated)_
 
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `csp` String
 
 Set the content security policy of the isolated world.
 
 ### `webFrame.setIsolatedWorldHumanReadableName(worldId, name)` _(Deprecated)_
 
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `name` String
 
 Set the name of the isolated world. Useful in devtools.
 
 ### `webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin)` _(Deprecated)_
 
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `securityOrigin` String
 
 Set the security origin of the isolated world.
 
 ### `webFrame.setIsolatedWorldInfo(worldId, info)`
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `info` Object
   * `securityOrigin` String (optional) - Security origin for the isolated world.
   * `csp` String (optional) - Content Security Policy for the isolated world.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -95,6 +95,12 @@ webFrame.setSpellCheckProvider('en-US', {
 })
 ```
 
+### `webFrame.insertCSS(css)`
+
+* `css` String - CSS source code.
+
+Inserts `css` as a style sheet in the document.
+
 ### `webFrame.insertText(text)`
 
 * `text` String

--- a/lib/content_script/init.js
+++ b/lib/content_script/init.js
@@ -2,11 +2,23 @@
 
 /* global nodeProcess, isolatedWorld */
 
-console.log('content script bundle')
+const events = require('events')
+const { EventEmitter } = events
 
-const atomBinding = require('@electron/internal/common/atom-binding-setup')(nodeProcess.binding, 'renderer')
+process.atomBinding = require('@electron/internal/common/atom-binding-setup')(nodeProcess.binding, 'renderer')
 
-const v8Util = atomBinding('v8_util')
+const v8Util = process.atomBinding('v8_util')
+// The `lib/renderer/ipc-renderer-internal.js` module looks for the ipc object in the
+// "ipc-internal" hidden value
+v8Util.setHiddenValue(global, 'ipc-internal', new EventEmitter())
+// The process object created by browserify is not an event emitter, fix it so
+// the API is more compatible with non-sandboxed renderers.
+for (const prop of Object.keys(EventEmitter.prototype)) {
+  if (process.hasOwnProperty(prop)) {
+    delete process[prop]
+  }
+}
+Object.setPrototypeOf(process, EventEmitter.prototype)
 
 const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
 
@@ -15,4 +27,15 @@ if (isolatedWorldArgs) {
   require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 }
 
-// require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, false, window)
+const chromeAPI = require('@electron/internal/renderer/chrome-api')
+
+// Await initialization with extension ID
+window.__init = (extensionId) => {
+  try {
+    chromeAPI.injectTo(extensionId, false, window)
+  } catch (e) {
+    // Stack trace crashes so we can only log the message
+    console.error(e.message)
+  }
+  delete window.__init
+}

--- a/lib/content_script/init.js
+++ b/lib/content_script/init.js
@@ -1,0 +1,18 @@
+'use strict'
+
+/* global nodeProcess, isolatedWorld */
+
+console.log('content script bundle')
+
+const atomBinding = require('@electron/internal/common/atom-binding-setup')(nodeProcess.binding, 'renderer')
+
+const v8Util = atomBinding('v8_util')
+
+const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
+
+if (isolatedWorldArgs) {
+  const { ipcRenderer, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+  require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+}
+
+// require('@electron/internal/renderer/chrome-api').injectTo(window.location.hostname, false, window)

--- a/lib/content_script/init.js
+++ b/lib/content_script/init.js
@@ -1,11 +1,10 @@
 'use strict'
 
-/* global nodeProcess, isolatedWorld */
+/* global nodeProcess, isolatedWorld, worldId */
 
-const events = require('events')
-const { EventEmitter } = events
+const { EventEmitter } = require('events')
 
-process.atomBinding = require('@electron/internal/common/atom-binding-setup')(nodeProcess.binding, 'renderer')
+process.atomBinding = require('@electron/internal/common/atom-binding-setup').atomBindingSetup(nodeProcess.binding, 'renderer')
 
 const v8Util = process.atomBinding('v8_util')
 // The `lib/renderer/ipc-renderer-internal.js` module looks for the ipc object in the
@@ -23,19 +22,14 @@ Object.setPrototypeOf(process, EventEmitter.prototype)
 const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
 
 if (isolatedWorldArgs) {
-  const { ipcRenderer, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
-  require('@electron/internal/renderer/window-setup')(ipcRenderer, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+  const { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+  const { windowSetup } = require('@electron/internal/renderer/window-setup')
+  windowSetup(ipcRendererInternal, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 }
 
-const chromeAPI = require('@electron/internal/renderer/chrome-api')
+const extensionId = v8Util.getHiddenValue(isolatedWorld, `extension-${worldId}`)
 
-// Await initialization with extension ID
-window.__init = (extensionId) => {
-  try {
-    chromeAPI.injectTo(extensionId, false, window)
-  } catch (e) {
-    // Stack trace crashes so we can only log the message
-    console.error(e.message)
-  }
-  delete window.__init
+if (extensionId) {
+  const chromeAPI = require('@electron/internal/renderer/chrome-api')
+  chromeAPI.injectTo(extensionId, false, window)
 }

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -56,27 +56,7 @@ const runAllContentScript = function (scripts: Array<Electron.InjectionBase>, ex
 }
 
 const runStylesheet = function (this: any, url: string, code: string) {
-  // const wrapper = `((code) => {
-  //   function init() {
-  //     const styleElement = document.createElement('style');
-  //     styleElement.textContent = code;
-  //     document.head.append(styleElement);
-  //   }
-  //   document.addEventListener('DOMContentLoaded', init);
-  // })`
-
-  // try {
-  //   const compiledWrapper = runInThisContext(wrapper, {
-  //     filename: url,
-  //     lineOffset: 1,
-  //     displayErrors: true
-  //   })
-  //   return compiledWrapper.call(this, code)
-  // } catch (error) {
-  //   // TODO(samuelmaddock): Insert stylesheet directly into document, see chromium script_injection.cc
-  //   console.error(`Error inserting content script stylesheet ${url}`)
-  //   console.error(error)
-  // }
+  webFrame.insertCSS(code)
 }
 
 const runAllStylesheet = function (css: Array<Electron.InjectionBase>) {

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -27,14 +27,10 @@ const matchesPattern = function (pattern: string) {
 
 // Run the code with chrome API integrated.
 const runContentScript = function (this: any, extensionId: string, url: string, code: string) {
-  // TODO(samuelmaddock): how should we inject chrome API into isolated world?
-  // const context = {}
-  // require('@electron/internal/renderer/chrome-api').injectTo(extensionId, false, context)
   const sources = [
-    {
-      code,
-      url
-    }
+    // initialize Chrome API in isolated world
+    { code: `typeof __init === 'function' && __init('${extensionId}')` },
+    { code, url }
   ]
 
   // Assign unique world ID to each extension

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -3,12 +3,15 @@ import { runInThisContext } from 'vm'
 import { webFrame } from 'electron'
 
 const IsolatedWorldIDs = {
-  // atom_render_frame_observer.h
-  ISOLATED_WORLD_EXTENSIONS: 1000
+  /**
+   * Start of extension isolated world IDs, as defined in
+   * atom_render_frame_observer.h
+   */
+  ISOLATED_WORLD_EXTENSIONS: 1 << 20
 }
 
 let isolatedWorldIds = IsolatedWorldIDs.ISOLATED_WORLD_EXTENSIONS
-const extensionWorldId = {}
+const extensionWorldId: {[key: string]: number | undefined} = {}
 
 // https://cs.chromium.org/chromium/src/extensions/renderer/script_injection.cc?type=cs&sq=package:chromium&g=0&l=52
 const getIsolatedWorldIdForInstance = () => {
@@ -37,10 +40,11 @@ const runContentScript = function (this: any, extensionId: string, url: string, 
   const worldId = extensionWorldId[extensionId] ||
     (extensionWorldId[extensionId] = getIsolatedWorldIdForInstance())
 
-  webFrame.setIsolatedWorldHumanReadableName(worldId, `${extensionId} [${worldId}]`)
-
-  // TODO(samuelmaddock): read `content_security_policy` from extension manifest
-  // webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp)
+  webFrame.setIsolatedWorldInfo(worldId, {
+    name: `${extensionId} [${worldId}]`
+    // TODO(samuelmaddock): read `content_security_policy` from extension manifest
+    // csp: manifest.content_security_policy,
+  })
 
   webFrame.executeJavaScriptInIsolatedWorld(worldId, sources)
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Executes Chrome extension content scripts in an isolated world.

When an isolated world script context is created for a content script, `content_script_bundle` is injected. The bundle contains code to initialize Chrome APIs and Electron setup.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Added world isolation to Chrome extension content scripts.
