### PR TITLE
docs: Fix types and missing property in WebRequest APIs

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -45,7 +45,7 @@ The following methods are available on instances of `WebRequest`:
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String
@@ -72,7 +72,7 @@ The `callback` has to be called with an `response` object.
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String
@@ -98,7 +98,7 @@ The `callback` has to be called with an `response` object.
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String
@@ -117,7 +117,7 @@ response are visible by the time this listener is fired.
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String
@@ -147,7 +147,7 @@ The `callback` has to be called with an `response` object.
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String
@@ -170,7 +170,7 @@ and response headers are available.
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String
@@ -193,7 +193,7 @@ redirect is about to occur.
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String
@@ -215,7 +215,7 @@ completed.
 * `filter` Object (optional)
   * `urls` String[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
-* `listener` Function
+* `listener` Function | null
   * `details` Object
     * `id` Integer
     * `url` String

--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -52,6 +52,7 @@ The following methods are available on instances of `WebRequest`:
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `uploadData` [UploadData[]](structures/upload-data.md)
   * `callback` Function

--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -80,6 +80,7 @@ The `callback` has to be called with an `response` object.
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `requestHeaders` Object
   * `callback` Function
@@ -106,6 +107,7 @@ The `callback` has to be called with an `response` object.
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `requestHeaders` Object
 
@@ -125,6 +127,7 @@ response are visible by the time this listener is fired.
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `statusLine` String
     * `statusCode` Integer
@@ -155,6 +158,7 @@ The `callback` has to be called with an `response` object.
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `responseHeaders` Object
     * `fromCache` Boolean - Indicates whether the response was fetched from disk
@@ -178,6 +182,7 @@ and response headers are available.
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `redirectURL` String
     * `statusCode` Integer
@@ -223,6 +228,7 @@ completed.
     * `method` String
     * `webContentsId` Integer (optional)
     * `resourceType` String
+    * `referrer` String
     * `timestamp` Double
     * `fromCache` Boolean
     * `error` String - The error description.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

I found that some types in `electron.d.ts` are wrong related to `WebRequest` API. I believe that it is generated from docs so I fixed the docs.

- Hook methods of `WebRequest` should accept `null` as listener parameter for removing the listener. This is documented in [doc](https://electronjs.org/docs/api/web-request)
- `referrer` prop is missing in `OnBoeforeRequestDetails` object

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
