### PR TITLE
chore: properly template the Then promise helper

### DIFF
--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -47,7 +47,8 @@ class Promise : public base::RefCounted<Promise> {
     return GetInner()->Reject(GetContext(), v8::Undefined(isolate()));
   }
 
-  v8::MaybeLocal<v8::Promise> Then(base::Closure cb) {
+  template <typename ReturnType, typename... ArgTypes>
+  v8::MaybeLocal<v8::Promise> Then(base::Callback<ReturnType(ArgTypes...)> cb) {
     v8::HandleScope handle_scope(isolate());
     v8::Context::Scope context_scope(
         v8::Local<v8::Context>::New(isolate(), GetContext()));


### PR DESCRIPTION
#### Description of Change

We can't pass a `base::Closure` into the Promise util `Then` helper because that assumes a callback with no parameters or no unbound parameters, and more often than not the passed callback will have several unbound parameters. We thus need to template this helper with the `ReturnType` and `ArgTypes`.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
