### PR TITLE
fix: carry through arguments in webContents.print()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1461,7 +1461,7 @@ bool WebContents::IsCurrentlyAudible() {
 
 #if BUILDFLAG(ENABLE_PRINTING)
 void WebContents::Print(mate::Arguments* args) {
-  bool silent, print_background = false;
+  bool silent = false, print_background = false;
   base::string16 device_name;
   mate::Dictionary options = mate::Dictionary::CreateEmpty(args->isolate());
   base::DictionaryValue settings;

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -313,7 +313,7 @@ WebContents.prototype.printToPDF = function (options) {
 
 WebContents.prototype.print = function (...args) {
   if (features.isPrintingEnabled()) {
-    this._print(args)
+    this._print(...args)
   } else {
     console.error('Error: Printing feature is disabled.')
   }


### PR DESCRIPTION
#### Description of Change

Fix for https://github.com/electron/electron/issues/16792

`webContents.print()` doesn't deserialize arguments correctly, and doesn't initialize the `silent` argument correctly. This had the side-effect of `webContents.print()` only sometimes working and always ignoring passed arguments.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fix `webContents.print()` not working correctly
