### PR TITLE
refactor: merge ipcMainUtils.handle / handleSync

### DIFF
--- a/lib/browser/chrome-devtools.js
+++ b/lib/browser/chrome-devtools.js
@@ -103,7 +103,7 @@ ipcMainUtils.handle('ELECTRON_INSPECTOR_SELECT_FILE', function (event) {
   })
 })
 
-ipcMainUtils.handleSync('ELECTRON_INSPECTOR_CONFIRM', function (event, message, title) {
+ipcMainUtils.handle('ELECTRON_INSPECTOR_CONFIRM', function (event, message, title) {
   return new Promise((resolve, reject) => {
     assertChromeDevTools(event.sender, 'window.confirm()')
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -170,7 +170,7 @@ ipcMainInternal.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, conne
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONCONNECT_${extensionId}`, event.sender.id, portId, connectInfo)
 })
 
-ipcMainUtils.handleSync('CHROME_EXTENSION_MANIFEST', function (event, extensionId) {
+ipcMainUtils.handle('CHROME_EXTENSION_MANIFEST', function (event, extensionId) {
   const manifest = manifestMap[extensionId]
   if (!manifest) {
     throw new Error(`Invalid extensionId: ${extensionId}`)
@@ -232,7 +232,7 @@ const getMessagesPath = (extensionId) => {
   }
 }
 
-ipcMainUtils.handleSync('CHROME_GET_MESSAGES', function (event, extensionId) {
+ipcMainUtils.handle('CHROME_GET_MESSAGES', function (event, extensionId) {
   const messagesPath = getMessagesPath(extensionId)
   return fs.readFileSync(messagesPath)
 })

--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -15,15 +15,11 @@ const callHandler = async function (handler: IPCHandler, event: ElectronInternal
 export const handle = function <T extends IPCHandler> (channel: string, handler: T) {
   ipcMainInternal.on(channel, (event, requestId, ...args) => {
     callHandler(handler, event, args, responseArgs => {
-      event._replyInternal(`${channel}_RESPONSE_${requestId}`, ...responseArgs)
-    })
-  })
-}
-
-export const handleSync = function <T extends IPCHandler> (channel: string, handler: T) {
-  ipcMainInternal.on(channel, (event, ...args) => {
-    callHandler(handler, event, args, responseArgs => {
-      event.returnValue = responseArgs
+      if (requestId) {
+        event._replyInternal(`${channel}_RESPONSE_${requestId}`, ...responseArgs)
+      } else {
+        event.returnValue = responseArgs
+      }
     })
   })
 }

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -479,19 +479,19 @@ ipcMainInternal.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
   event.returnValue = null
 })
 
-ipcMainUtils.handleSync('ELECTRON_CRASH_REPORTER_INIT', function (event, options) {
+ipcMainUtils.handle('ELECTRON_CRASH_REPORTER_INIT', function (event, options) {
   return crashReporterInit(options)
 })
 
-ipcMainUtils.handleSync('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES', function (event) {
+ipcMainUtils.handle('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES', function (event) {
   return event.sender.getLastWebPreferences()
 })
 
-ipcMainUtils.handleSync('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', function (event) {
+ipcMainUtils.handle('ELECTRON_BROWSER_CLIPBOARD_READ_FIND_TEXT', function (event) {
   return electron.clipboard.readFindText()
 })
 
-ipcMainUtils.handleSync('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (event, text) {
+ipcMainUtils.handle('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (event, text) {
   return electron.clipboard.writeFindText(text)
 })
 

--- a/lib/renderer/ipc-renderer-internal-utils.ts
+++ b/lib/renderer/ipc-renderer-internal-utils.ts
@@ -20,7 +20,7 @@ export function invoke<T> (command: string, ...args: any[]) {
 }
 
 export function invokeSync<T> (command: string, ...args: any[]): T {
-  const [ error, result ] = ipcRendererInternal.sendSync(command, ...args)
+  const [ error, result ] = ipcRendererInternal.sendSync(command, null, ...args)
 
   if (error) {
     throw errorUtils.deserialize(error)


### PR DESCRIPTION
#### Description of Change
There is no need for a separate `handleSync` method, we can tell whether the request is sync or async by the presence of the `requestId`.

/cc @MarshallOfSound

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
