### PR TITLE
docs: fix MenuItem `windowMenu` role description

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -85,7 +85,7 @@ The `role` property can have following values:
 * `fileMenu` - Whole default "File" menu (Close / Quit)
 * `editMenu` - Whole default "Edit" menu (Undo, Copy, etc.).
 * `viewMenu` - Whole default "View" menu (Reload, Toggle Developer Tools, etc.)
-* `windowMenu` - Whole default "Window" menu (Minimize, Close, etc.).
+* `windowMenu` - Whole default "Window" menu (Minimize, Zoom, etc.).
 
 The following additional roles are available on _macOS_:
 


### PR DESCRIPTION
The behavior was changed in https://github.com/electron/electron/pull/15930

Notes: Fixed MenuItem `windowMenu` role description to account for changing of `Close` to `Zoom`.