### PR TITLE
chore: augment promisifyMultiArg deprecation

### DIFF
--- a/lib/browser/api/content-tracing.js
+++ b/lib/browser/api/content-tracing.js
@@ -5,6 +5,9 @@ const contentTracing = process.atomBinding('content_tracing')
 contentTracing.getCategories = deprecate.promisify(contentTracing.getCategories)
 contentTracing.startRecording = deprecate.promisify(contentTracing.startRecording)
 contentTracing.stopRecording = deprecate.promisify(contentTracing.stopRecording)
-contentTracing.getTraceBufferUsage = deprecate.promisifyMultiArg(contentTracing.getTraceBufferUsage)
+contentTracing.getTraceBufferUsage = deprecate.promisifyMultiArg(
+  contentTracing.getTraceBufferUsage,
+  (value) => [value.paths, value.bookmarks]
+)
 
 module.exports = contentTracing

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -102,7 +102,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     } as T
   },
 
-  promisifyMultiArg: <T extends (...args: any[]) => any>(fn: T): T => {
+  promisifyMultiArg: <T extends (...args: any[]) => any>(fn: T, convertPromiseValue: (v: any) => any): T => {
     const fnName = fn.name || 'function'
     const oldName = `${fnName} with callbacks`
     const newName = `${fnName} with Promises`

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -66,7 +66,7 @@ declare namespace ElectronInternal {
     renameProperty<T, K extends (keyof T & string)>(object: T, oldName: string, newName: K): T;
 
     promisify<T extends (...args: any[]) => any>(fn: T): T;
-    promisifyMultiArg<T extends (...args: any[]) => any>(fn: T): T;
+    promisifyMultiArg<T extends (...args: any[]) => any>(fn: T, convertPromiseValue: (v: any) => any): T;
   }
 
   // Internal IPC has _replyInternal and NO reply method


### PR DESCRIPTION
#### Description of Change

Add custom deprecation function to  `promisifyMultiArg` to allow custom callback deprecation in a more extensible way.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
