### PR TITLE
chore: make util::Promise a move-only type

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -136,29 +136,29 @@ inline net::CookieStore* GetCookieStore(
   return getter->GetURLRequestContext()->cookie_store();
 }
 
-void ResolvePromiseWithCookies(scoped_refptr<util::Promise> promise,
-                               net::CookieList cookieList) {
-  promise->Resolve(cookieList);
+void ResolvePromiseWithCookies(util::Promise promise,
+                               const net::CookieList& cookie_list) {
+  promise.Resolve(cookie_list);
 }
 
-void ResolvePromise(scoped_refptr<util::Promise> promise) {
-  promise->Resolve();
+void ResolvePromise(util::Promise promise) {
+  promise.Resolve();
 }
 
 // Resolve |promise| in UI thread.
-void ResolvePromiseInUI(scoped_refptr<util::Promise> promise) {
+void ResolvePromiseInUI(util::Promise promise) {
   base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI},
                            base::BindOnce(ResolvePromise, std::move(promise)));
 }
 
 // Run |callback| on UI thread.
-void RunCallbackInUI(const base::Closure& callback) {
-  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI}, callback);
+void RunCallbackInUI(base::OnceClosure callback) {
+  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI}, std::move(callback));
 }
 
 // Remove cookies from |list| not matching |filter|, and pass it to |callback|.
 void FilterCookies(std::unique_ptr<base::DictionaryValue> filter,
-                   scoped_refptr<util::Promise> promise,
+                   util::Promise promise,
                    const net::CookieList& list) {
   net::CookieList result;
   for (const auto& cookie : list) {
@@ -174,50 +174,50 @@ void FilterCookies(std::unique_ptr<base::DictionaryValue> filter,
 // Receives cookies matching |filter| in IO thread.
 void GetCookiesOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                     std::unique_ptr<base::DictionaryValue> filter,
-                    scoped_refptr<util::Promise> promise) {
+                    util::Promise promise) {
   std::string url;
   filter->GetString("url", &url);
 
   auto filtered_callback =
-      base::Bind(FilterCookies, base::Passed(&filter), std::move(promise));
+      base::BindOnce(FilterCookies, std::move(filter), std::move(promise));
 
   // Empty url will match all url cookies.
   if (url.empty())
-    GetCookieStore(getter)->GetAllCookiesAsync(filtered_callback);
+    GetCookieStore(getter)->GetAllCookiesAsync(std::move(filtered_callback));
   else
-    GetCookieStore(getter)->GetAllCookiesForURLAsync(GURL(url),
-                                                     filtered_callback);
+    GetCookieStore(getter)->GetAllCookiesForURLAsync(
+        GURL(url), std::move(filtered_callback));
 }
 
 // Removes cookie with |url| and |name| in IO thread.
 void RemoveCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                       const GURL& url,
                       const std::string& name,
-                      scoped_refptr<util::Promise> promise) {
+                      util::Promise promise) {
   GetCookieStore(getter)->DeleteCookieAsync(
       url, name, base::BindOnce(ResolvePromiseInUI, std::move(promise)));
 }
 
 // Resolves/rejects the |promise| in UI thread.
-void SettlePromiseInUI(scoped_refptr<util::Promise> promise,
-                       const std::string& errmsg) {
+void SettlePromiseInUI(util::Promise promise, const std::string& errmsg) {
   if (errmsg.empty()) {
-    promise->Resolve();
+    promise.Resolve();
   } else {
-    promise->RejectWithErrorMessage(errmsg);
+    promise.RejectWithErrorMessage(errmsg);
   }
 }
 
 // Callback of SetCookie.
-void OnSetCookie(scoped_refptr<util::Promise> promise, bool success) {
+void OnSetCookie(util::Promise promise, bool success) {
   const std::string errmsg = success ? "" : "Setting cookie failed";
-  RunCallbackInUI(base::Bind(SettlePromiseInUI, std::move(promise), errmsg));
+  RunCallbackInUI(
+      base::BindOnce(SettlePromiseInUI, std::move(promise), errmsg));
 }
 
 // Flushes cookie store in IO thread.
 void FlushCookieStoreOnIOThread(
     scoped_refptr<net::URLRequestContextGetter> getter,
-    scoped_refptr<util::Promise> promise) {
+    util::Promise promise) {
   GetCookieStore(getter)->FlushStore(
       base::BindOnce(ResolvePromiseInUI, std::move(promise)));
 }
@@ -225,7 +225,7 @@ void FlushCookieStoreOnIOThread(
 // Sets cookie with |details| in IO thread.
 void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                    std::unique_ptr<base::DictionaryValue> details,
-                   scoped_refptr<util::Promise> promise) {
+                   util::Promise promise) {
   std::string url, name, value, domain, path;
   bool secure = false;
   bool http_only = false;
@@ -297,7 +297,8 @@ Cookies::Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context)
 Cookies::~Cookies() {}
 
 v8::Local<v8::Promise> Cookies::Get(const base::DictionaryValue& filter) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto copy = base::DictionaryValue::From(
       base::Value::ToUniquePtrValue(filter.Clone()));
@@ -305,26 +306,28 @@ v8::Local<v8::Promise> Cookies::Get(const base::DictionaryValue& filter) {
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
       base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter), std::move(copy),
-                     promise));
+                     std::move(promise)));
 
-  return promise->GetHandle();
+  return handle;
 }
 
 v8::Local<v8::Promise> Cookies::Remove(const GURL& url,
                                        const std::string& name) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto* getter = browser_context_->GetRequestContext();
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
       base::BindOnce(RemoveCookieOnIO, base::RetainedRef(getter), url, name,
-                     promise));
+                     std::move(promise)));
 
-  return promise->GetHandle();
+  return handle;
 }
 
 v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto copy = base::DictionaryValue::From(
       base::Value::ToUniquePtrValue(details.Clone()));
@@ -332,20 +335,22 @@ v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
       base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), std::move(copy),
-                     promise));
+                     std::move(promise)));
 
-  return promise->GetHandle();
+  return handle;
 }
 
 v8::Local<v8::Promise> Cookies::FlushStore() {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto* getter = browser_context_->GetRequestContext();
-  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::IO},
-                           base::BindOnce(FlushCookieStoreOnIOThread,
-                                          base::RetainedRef(getter), promise));
+  base::PostTaskWithTraits(
+      FROM_HERE, {BrowserThread::IO},
+      base::BindOnce(FlushCookieStoreOnIOThread, base::RetainedRef(getter),
+                     std::move(promise)));
 
-  return promise->GetHandle();
+  return handle;
 }
 
 void Cookies::OnCookieChanged(const CookieDetails* details) {

--- a/atom/browser/api/atom_api_debugger.h
+++ b/atom/browser/api/atom_api_debugger.h
@@ -54,7 +54,7 @@ class Debugger : public mate::TrackableObject<Debugger>,
                               content::RenderFrameHost* new_rfh) override;
 
  private:
-  using PendingRequestMap = std::map<int, scoped_refptr<atom::util::Promise>>;
+  using PendingRequestMap = std::map<int, atom::util::Promise>;
 
   void Attach(mate::Arguments* args);
   bool IsAttached();

--- a/atom/browser/api/atom_api_net_log.h
+++ b/atom/browser/api/atom_api_net_log.h
@@ -47,7 +47,7 @@ class NetLog : public mate::TrackableObject<NetLog>,
  private:
   AtomBrowserContext* browser_context_;
   net_log::NetExportFileWriter* net_log_writer_;
-  std::list<scoped_refptr<atom::util::Promise>> stop_callback_queue_;
+  std::list<atom::util::Promise> stop_callback_queue_;
   std::unique_ptr<base::DictionaryValue> net_log_state_;
 
   DISALLOW_COPY_AND_ASSIGN(NetLog);

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -177,21 +177,22 @@ bool IsProtocolHandledInIO(
   return is_handled;
 }
 
-void PromiseCallback(scoped_refptr<util::Promise> promise, bool handled) {
-  promise->Resolve(handled);
+void PromiseCallback(util::Promise promise, bool handled) {
+  promise.Resolve(handled);
 }
 
 v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
   auto* getter = static_cast<URLRequestContextGetter*>(
       browser_context_->GetRequestContext());
 
   base::PostTaskWithTraitsAndReplyWithResult(
       FROM_HERE, {content::BrowserThread::IO},
-      base::Bind(&IsProtocolHandledInIO, base::RetainedRef(getter), scheme),
-      base::Bind(&PromiseCallback, promise));
+      base::BindOnce(&IsProtocolHandledInIO, base::RetainedRef(getter), scheme),
+      base::BindOnce(&PromiseCallback, std::move(promise)));
 
-  return promise->GetHandle();
+  return handle;
 }
 
 void Protocol::UninterceptProtocol(const std::string& scheme,

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -241,12 +241,11 @@ namespace api {
 namespace {
 
 // Called when CapturePage is done.
-void OnCapturePageDone(scoped_refptr<util::Promise> promise,
-                       const SkBitmap& bitmap) {
+void OnCapturePageDone(util::Promise promise, const SkBitmap& bitmap) {
   // Hack to enable transparency in captured image
   // TODO(nitsakh) Remove hack once fixed in chromium
   const_cast<SkBitmap&>(bitmap).setAlphaType(kPremul_SkAlphaType);
-  promise->Resolve(gfx::Image::CreateFrom1xBitmap(bitmap));
+  promise.Resolve(gfx::Image::CreateFrom1xBitmap(bitmap));
 }
 
 }  // namespace
@@ -1302,14 +1301,12 @@ std::string WebContents::GetUserAgent() {
 v8::Local<v8::Promise> WebContents::SavePage(
     const base::FilePath& full_file_path,
     const content::SavePageType& save_type) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
-  auto* handler = new SavePageHandler(web_contents(), promise);
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> ret = promise.GetHandle();
 
-  const bool saveStarted = handler->Handle(full_file_path, save_type);
-  if (!saveStarted)
-    promise->RejectWithErrorMessage("Failed to save the page");
-
-  return promise->GetHandle();
+  auto* handler = new SavePageHandler(web_contents(), std::move(promise));
+  handler->Handle(full_file_path, save_type);
+  return ret;
 }
 
 void WebContents::OpenDevTools(mate::Arguments* args) {
@@ -1506,10 +1503,11 @@ std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {
 
 v8::Local<v8::Promise> WebContents::PrintToPDF(
     const base::DictionaryValue& settings) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
   PrintPreviewMessageHandler::FromWebContents(web_contents())
-      ->PrintToPDF(settings, promise);
-  return promise->GetHandle();
+      ->PrintToPDF(settings, std::move(promise));
+  return handle;
 }
 #endif
 
@@ -1780,15 +1778,16 @@ void WebContents::StartDrag(const mate::Dictionary& item,
 
 v8::Local<v8::Promise> WebContents::CapturePage(mate::Arguments* args) {
   gfx::Rect rect;
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate());
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   // get rect arguments if they exist
   args->GetNext(&rect);
 
   auto* const view = web_contents()->GetRenderWidgetHostView();
   if (!view) {
-    promise->Resolve(gfx::Image());
-    return promise->GetHandle();
+    promise.Resolve(gfx::Image());
+    return handle;
   }
 
   // Capture full page if user doesn't specify a |rect|.
@@ -1807,8 +1806,8 @@ v8::Local<v8::Promise> WebContents::CapturePage(mate::Arguments* args) {
     bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
 
   view->CopyFromSurface(gfx::Rect(rect.origin(), view_size), bitmap_size,
-                        base::BindOnce(&OnCapturePageDone, promise));
-  return promise->GetHandle();
+                        base::BindOnce(&OnCapturePageDone, std::move(promise)));
+  return handle;
 }
 
 void WebContents::OnCursorChange(const content::WebCursor& cursor) {

--- a/atom/browser/api/gpuinfo_manager.h
+++ b/atom/browser/api/gpuinfo_manager.h
@@ -25,8 +25,8 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
   GPUInfoManager();
   ~GPUInfoManager() override;
   bool NeedsCompleteGpuInfoCollection() const;
-  void FetchCompleteInfo(scoped_refptr<util::Promise> promise);
-  void FetchBasicInfo(scoped_refptr<util::Promise> promise);
+  void FetchCompleteInfo(util::Promise promise);
+  void FetchBasicInfo(util::Promise promise);
   void OnGpuInfoUpdate() override;
 
  private:
@@ -34,12 +34,12 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
       gpu::GPUInfo gpu_info) const;
 
   // These should be posted to the task queue
-  void CompleteInfoFetcher(scoped_refptr<util::Promise> promise);
+  void CompleteInfoFetcher(util::Promise promise);
   void ProcessCompleteInfo();
 
   // This set maintains all the promises that should be fulfilled
   // once we have the complete information data
-  std::vector<scoped_refptr<util::Promise>> complete_info_promise_set_;
+  std::vector<util::Promise> complete_info_promise_set_;
   content::GpuDataManager* gpu_data_manager_;
 
   DISALLOW_COPY_AND_ASSIGN(GPUInfoManager);

--- a/atom/browser/api/save_page_handler.h
+++ b/atom/browser/api/save_page_handler.h
@@ -30,7 +30,7 @@ class SavePageHandler : public content::DownloadManager::Observer,
                         public download::DownloadItem::Observer {
  public:
   SavePageHandler(content::WebContents* web_contents,
-                  scoped_refptr<atom::util::Promise> promise);
+                  atom::util::Promise promise);
   ~SavePageHandler() override;
 
   bool Handle(const base::FilePath& full_path,
@@ -47,7 +47,7 @@ class SavePageHandler : public content::DownloadManager::Observer,
   void OnDownloadUpdated(download::DownloadItem* item) override;
 
   content::WebContents* web_contents_;  // weak
-  scoped_refptr<atom::util::Promise> promise_;
+  atom::util::Promise promise_;
 };
 
 }  // namespace api

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -165,14 +165,14 @@ void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
     observer.OnFinishLaunching(launch_info);
 }
 
-util::Promise* Browser::WhenReady(v8::Isolate* isolate) {
+const util::Promise& Browser::WhenReady(v8::Isolate* isolate) {
   if (!ready_promise_) {
-    ready_promise_ = new util::Promise(isolate);
+    ready_promise_.reset(new util::Promise(isolate));
     if (is_ready()) {
       ready_promise_->Resolve();
     }
   }
-  return ready_promise_;
+  return *ready_promise_;
 }
 
 void Browser::OnAccessibilitySupportChanged() {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -253,7 +253,7 @@ class Browser : public WindowListObserver {
   bool is_shutting_down() const { return is_shutdown_; }
   bool is_quiting() const { return is_quiting_; }
   bool is_ready() const { return is_ready_; }
-  util::Promise* WhenReady(v8::Isolate* isolate);
+  const util::Promise& WhenReady(v8::Isolate* isolate);
 
  protected:
   // Returns the version of application bundle or executable file.
@@ -292,7 +292,7 @@ class Browser : public WindowListObserver {
 
   int badge_count_ = 0;
 
-  util::Promise* ready_promise_ = nullptr;
+  std::unique_ptr<util::Promise> ready_promise_;
 
 #if defined(OS_LINUX) || defined(OS_MACOSX)
   base::DictionaryValue about_panel_options_;

--- a/atom/browser/printing/print_preview_message_handler.h
+++ b/atom/browser/printing/print_preview_message_handler.h
@@ -31,8 +31,7 @@ class PrintPreviewMessageHandler
  public:
   ~PrintPreviewMessageHandler() override;
 
-  void PrintToPDF(const base::DictionaryValue& options,
-                  scoped_refptr<atom::util::Promise> promise);
+  void PrintToPDF(const base::DictionaryValue& options, util::Promise promise);
 
  protected:
   // content::WebContentsObserver implementation.
@@ -56,13 +55,13 @@ class PrintPreviewMessageHandler
   void OnPrintPreviewCancelled(int document_cookie,
                                const PrintHostMsg_PreviewIds& ids);
 
-  scoped_refptr<atom::util::Promise> GetPromise(int request_id);
+  util::Promise GetPromise(int request_id);
 
   void ResolvePromise(int request_id,
                       scoped_refptr<base::RefCountedMemory> data_bytes);
   void RejectPromise(int request_id);
 
-  using PromiseMap = std::map<int, scoped_refptr<atom::util::Promise>>;
+  using PromiseMap = std::map<int, atom::util::Promise>;
   PromiseMap promise_map_;
 
   base::WeakPtrFactory<PrintPreviewMessageHandler> weak_ptr_factory_;

--- a/atom/common/api/atom_api_shell.cc
+++ b/atom/common/api/atom_api_shell.cc
@@ -44,12 +44,12 @@ struct Converter<base::win::ShortcutOperation> {
 
 namespace {
 
-void OnOpenExternalFinished(scoped_refptr<atom::util::Promise> promise,
+void OnOpenExternalFinished(atom::util::Promise promise,
                             const std::string& error) {
   if (error.empty())
-    promise->Resolve();
+    promise.Resolve();
   else
-    promise->RejectWithErrorMessage(error.c_str());
+    promise.RejectWithErrorMessage(error.c_str());
 }
 
 bool OpenExternalSync(
@@ -78,8 +78,7 @@ v8::Local<v8::Promise> OpenExternal(
     const GURL& url,
 #endif
     mate::Arguments* args) {
-  scoped_refptr<atom::util::Promise> promise =
-      new atom::util::Promise(args->isolate());
+  atom::util::Promise promise(args->isolate());
 
   platform_util::OpenExternalOptions options;
   if (args->Length() >= 2) {
@@ -90,10 +89,11 @@ v8::Local<v8::Promise> OpenExternal(
     }
   }
 
-  platform_util::OpenExternal(url, options,
-                              base::Bind(&OnOpenExternalFinished, promise));
-
-  return promise->GetHandle();
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+  platform_util::OpenExternal(
+      url, options,
+      base::BindOnce(&OnOpenExternalFinished, std::move(promise)));
+  return handle;
 }
 
 #if defined(OS_WIN)

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -17,7 +17,6 @@
 #include "atom/common/heap_snapshot.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
-#include "atom/common/promise_util.h"
 #include "base/logging.h"
 #include "base/process/process.h"
 #include "base/process/process_handle.h"
@@ -233,30 +232,31 @@ v8::Local<v8::Value> AtomBindings::GetSystemMemoryInfo(v8::Isolate* isolate,
 // static
 v8::Local<v8::Promise> AtomBindings::GetProcessMemoryInfo(
     v8::Isolate* isolate) {
-  scoped_refptr<util::Promise> promise = new util::Promise(isolate);
+  util::Promise promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (mate::Locker::IsBrowserProcess() && !Browser::Get()->is_ready()) {
-    promise->RejectWithErrorMessage(
+    promise.RejectWithErrorMessage(
         "Memory Info is available only after app ready");
-    return promise->GetHandle();
+    return handle;
   }
 
   v8::Global<v8::Context> context(isolate, isolate->GetCurrentContext());
   memory_instrumentation::MemoryInstrumentation::GetInstance()
-      ->RequestGlobalDumpForPid(base::GetCurrentProcId(),
-                                std::vector<std::string>(),
-                                base::Bind(&AtomBindings::DidReceiveMemoryDump,
-                                           std::move(context), promise));
-  return promise->GetHandle();
+      ->RequestGlobalDumpForPid(
+          base::GetCurrentProcId(), std::vector<std::string>(),
+          base::BindOnce(&AtomBindings::DidReceiveMemoryDump,
+                         std::move(context), std::move(promise)));
+  return handle;
 }
 
 // static
 void AtomBindings::DidReceiveMemoryDump(
-    const v8::Global<v8::Context>& context,
-    scoped_refptr<util::Promise> promise,
+    v8::Global<v8::Context> context,
+    util::Promise promise,
     bool success,
     std::unique_ptr<memory_instrumentation::GlobalMemoryDump> global_dump) {
-  v8::Isolate* isolate = promise->isolate();
+  v8::Isolate* isolate = promise.isolate();
   mate::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::MicrotasksScope script_scope(isolate,
@@ -265,7 +265,7 @@ void AtomBindings::DidReceiveMemoryDump(
       v8::Local<v8::Context>::New(isolate, context));
 
   if (!success) {
-    promise->RejectWithErrorMessage("Failed to create memory dump");
+    promise.RejectWithErrorMessage("Failed to create memory dump");
     return;
   }
 
@@ -280,13 +280,13 @@ void AtomBindings::DidReceiveMemoryDump(
 #endif
       dict.Set("private", osdump.private_footprint_kb);
       dict.Set("shared", osdump.shared_footprint_kb);
-      promise->Resolve(dict.GetHandle());
+      promise.Resolve(dict.GetHandle());
       resolved = true;
       break;
     }
   }
   if (!resolved) {
-    promise->RejectWithErrorMessage(
+    promise.RejectWithErrorMessage(
         R"(Failed to find current process memory details in memory dump)");
   }
 }

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -8,6 +8,7 @@
 #include <list>
 #include <memory>
 
+#include "atom/common/promise_util.h"
 #include "base/files/file_path.h"
 #include "base/macros.h"
 #include "base/memory/scoped_refptr.h"
@@ -30,10 +31,6 @@ class Environment;
 }
 
 namespace atom {
-
-namespace util {
-class Promise;
-}
 
 class AtomBindings {
  public:
@@ -72,8 +69,8 @@ class AtomBindings {
   static void OnCallNextTick(uv_async_t* handle);
 
   static void DidReceiveMemoryDump(
-      const v8::Global<v8::Context>& context,
-      scoped_refptr<util::Promise> promise,
+      v8::Global<v8::Context> context,
+      util::Promise promise,
       bool success,
       std::unique_ptr<memory_instrumentation::GlobalMemoryDump> dump);
 

--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -19,7 +19,7 @@ class GURL;
 
 namespace platform_util {
 
-typedef base::Callback<void(const std::string&)> OpenExternalCallback;
+typedef base::OnceCallback<void(const std::string&)> OpenExternalCallback;
 
 // Show the given file in a file manager. If possible, select the file.
 // Must be called from the UI thread.
@@ -52,7 +52,7 @@ void OpenExternal(
     const GURL& url,
 #endif
     const OpenExternalOptions& options,
-    const OpenExternalCallback& callback);
+    OpenExternalCallback callback);
 
 // Move a file to trash.
 bool MoveItemToTrash(const base::FilePath& full_path);

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -92,9 +92,9 @@ bool OpenExternal(const GURL& url, const OpenExternalOptions& options) {
 
 void OpenExternal(const GURL& url,
                   const OpenExternalOptions& options,
-                  const OpenExternalCallback& callback) {
+                  OpenExternalCallback callback) {
   // TODO(gabriel): Implement async open if callback is specified
-  callback.Run(OpenExternal(url, options) ? "" : "Failed to open");
+  std::move(callback).Run(OpenExternal(url, options) ? "" : "Failed to open");
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path) {

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -106,19 +106,19 @@ bool OpenExternal(const GURL& url, const OpenExternalOptions& options) {
 
 void OpenExternal(const GURL& url,
                   const OpenExternalOptions& options,
-                  const OpenExternalCallback& callback) {
+                  OpenExternalCallback callback) {
   NSURL* ns_url = net::NSURLWithGURL(url);
   if (!ns_url) {
-    callback.Run("Invalid URL");
+    std::move(callback).Run("Invalid URL");
     return;
   }
 
-  __block OpenExternalCallback c = callback;
+  __block OpenExternalCallback c = std::move(callback);
   dispatch_async(
       dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         __block std::string error = OpenURL(ns_url, options.activate);
         dispatch_async(dispatch_get_main_queue(), ^{
-          c.Run(error);
+          std::move(c).Run(error);
         });
       });
 }

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -317,9 +317,9 @@ bool OpenExternal(const base::string16& url,
 
 void OpenExternal(const base::string16& url,
                   const OpenExternalOptions& options,
-                  const OpenExternalCallback& callback) {
+                  OpenExternalCallback callback) {
   // TODO(gabriel): Implement async open if callback is specified
-  callback.Run(OpenExternal(url, options) ? "" : "Failed to open");
+  std::move(callback).Run(OpenExternal(url, options) ? "" : "Failed to open");
 }
 
 bool MoveItemToTrash(const base::FilePath& path) {

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -16,16 +16,30 @@ namespace atom {
 
 namespace util {
 
-class Promise : public base::RefCounted<Promise> {
+// A wrapper around the v8::Promise.
+//
+// This is a move-only type that should always be `std::move`d when passed to
+// callbacks, and it should be destroyed on the same thread of creation.
+class Promise {
  public:
+  // Create a new promise.
   explicit Promise(v8::Isolate* isolate);
+
+  // Wrap an existing v8 promise.
+  Promise(v8::Isolate* isolate, v8::Local<v8::Promise::Resolver> handle);
+
+  ~Promise();
+
+  // Support moving.
+  Promise(Promise&&);
+  Promise& operator=(Promise&&);
 
   v8::Isolate* isolate() const { return isolate_; }
   v8::Local<v8::Context> GetContext() {
     return v8::Local<v8::Context>::New(isolate_, context_);
   }
 
-  virtual v8::Local<v8::Promise> GetHandle() const;
+  v8::Local<v8::Promise> GetHandle() const;
 
   v8::Maybe<bool> Resolve() {
     v8::HandleScope handle_scope(isolate());
@@ -87,20 +101,38 @@ class Promise : public base::RefCounted<Promise> {
 
   v8::Maybe<bool> RejectWithErrorMessage(const std::string& error);
 
- protected:
-  virtual ~Promise();
-  friend class base::RefCounted<Promise>;
-  v8::Isolate* isolate_;
-  v8::Global<v8::Context> context_;
-
  private:
+  friend class CopyablePromise;
+
   v8::Local<v8::Promise::Resolver> GetInner() const {
     return resolver_.Get(isolate());
   }
 
+  v8::Isolate* isolate_;
+  v8::Global<v8::Context> context_;
   v8::Global<v8::Promise::Resolver> resolver_;
 
   DISALLOW_COPY_AND_ASSIGN(Promise);
+};
+
+// A wrapper of Promise that can be copied.
+//
+// This class should only be used when we have to pass Promise to a Chromium API
+// that does not take OnceCallback.
+class CopyablePromise {
+ public:
+  explicit CopyablePromise(const Promise& promise);
+  CopyablePromise(const CopyablePromise&);
+  ~CopyablePromise();
+
+  Promise GetPromise() const;
+
+ private:
+  using CopyablePersistent =
+      v8::CopyablePersistentTraits<v8::Promise::Resolver>::CopyablePersistent;
+
+  v8::Isolate* isolate_;
+  CopyablePersistent handle_;
 };
 
 }  // namespace util
@@ -110,9 +142,9 @@ class Promise : public base::RefCounted<Promise> {
 namespace mate {
 
 template <>
-struct Converter<atom::util::Promise*> {
+struct Converter<atom::util::Promise> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   atom::util::Promise* val);
+                                   const atom::util::Promise& val);
   // TODO(MarshallOfSound): Implement FromV8 to allow promise chaining
   //                        in native land
   // static bool FromV8(v8::Isolate* isolate,

--- a/native_mate/native_mate/arguments.h
+++ b/native_mate/native_mate/arguments.h
@@ -75,7 +75,7 @@ class Arguments {
   }
 
   template<typename T>
-  void Return(T val) {
+  void Return(const T& val) {
     info_->GetReturnValue().Set(ConvertToV8(isolate_, val));
   }
 


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/16799, close #16788, close #17037.

By making `util::Promise` a move-only type, we can:
* Eliminate the `CalledOnValidSequence` error when passing promise between threads as explained in #16799;
* Make the code easier to understand since Promise is no longer ref-counted;
* Have slight performance gain.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes