### PR TITLE
refactor: let mate converters do their job, don't call GetHandle manually

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1123,10 +1123,9 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
 }
 #endif  // defined(OS_WIN)
 
-v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
-                                        mate::Arguments* args) {
+util::Promise App::GetFileIcon(const base::FilePath& path,
+                               mate::Arguments* args) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
   base::FilePath normalized_path = path.NormalizePathSeparators();
 
   IconLoader::IconSize icon_size;
@@ -1150,7 +1149,7 @@ v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
         base::BindOnce(&OnIconDataAvailable, std::move(promise)),
         &cancelable_task_tracker_);
   }
-  return handle;
+  return promise;
 }
 
 std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
@@ -1196,20 +1195,19 @@ v8::Local<v8::Value> App::GetGPUFeatureStatus(v8::Isolate* isolate) {
   return mate::ConvertToV8(isolate, status ? *status : temp);
 }
 
-v8::Local<v8::Promise> App::GetGPUInfo(v8::Isolate* isolate,
-                                       const std::string& info_type) {
+util::Promise App::GetGPUInfo(v8::Isolate* isolate,
+                              const std::string& info_type) {
   auto* const gpu_data_manager = content::GpuDataManagerImpl::GetInstance();
   util::Promise promise(isolate);
-  v8::Local<v8::Promise> handle = promise.GetHandle();
   if (info_type != "basic" && info_type != "complete") {
     promise.RejectWithErrorMessage(
         "Invalid info type. Use 'basic' or 'complete'");
-    return handle;
+    return promise;
   }
   std::string reason;
   if (!gpu_data_manager->GpuAccessAllowed(&reason)) {
     promise.RejectWithErrorMessage("GPU access not allowed. Reason: " + reason);
-    return handle;
+    return promise;
   }
 
   auto* const info_mgr = GPUInfoManager::GetInstance();
@@ -1222,7 +1220,7 @@ v8::Local<v8::Promise> App::GetGPUInfo(v8::Isolate* isolate,
   } else /* (info_type == "basic") */ {
     info_mgr->FetchBasicInfo(std::move(promise));
   }
-  return handle;
+  return promise;
 }
 
 static void RemoveNoSandboxSwitch(base::CommandLine* command_line) {

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -198,13 +198,11 @@ class App : public AtomBrowserClient::Delegate,
   void ImportCertificate(const base::DictionaryValue& options,
                          const net::CompletionCallback& callback);
 #endif
-  v8::Local<v8::Promise> GetFileIcon(const base::FilePath& path,
-                                     mate::Arguments* args);
+  util::Promise GetFileIcon(const base::FilePath& path, mate::Arguments* args);
 
   std::vector<mate::Dictionary> GetAppMetrics(v8::Isolate* isolate);
   v8::Local<v8::Value> GetGPUFeatureStatus(v8::Isolate* isolate);
-  v8::Local<v8::Promise> GetGPUInfo(v8::Isolate* isolate,
-                                    const std::string& info_type);
+  util::Promise GetGPUInfo(v8::Isolate* isolate, const std::string& info_type);
   void EnableSandbox(mate::Arguments* args);
 
 #if defined(OS_MACOSX)

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -296,9 +296,8 @@ Cookies::Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context)
 
 Cookies::~Cookies() {}
 
-v8::Local<v8::Promise> Cookies::Get(const base::DictionaryValue& filter) {
+util::Promise Cookies::Get(const base::DictionaryValue& filter) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto copy = base::DictionaryValue::From(
       base::Value::ToUniquePtrValue(filter.Clone()));
@@ -308,13 +307,11 @@ v8::Local<v8::Promise> Cookies::Get(const base::DictionaryValue& filter) {
       base::BindOnce(GetCookiesOnIO, base::RetainedRef(getter), std::move(copy),
                      std::move(promise)));
 
-  return handle;
+  return promise;
 }
 
-v8::Local<v8::Promise> Cookies::Remove(const GURL& url,
-                                       const std::string& name) {
+util::Promise Cookies::Remove(const GURL& url, const std::string& name) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto* getter = browser_context_->GetRequestContext();
   base::PostTaskWithTraits(
@@ -322,12 +319,11 @@ v8::Local<v8::Promise> Cookies::Remove(const GURL& url,
       base::BindOnce(RemoveCookieOnIO, base::RetainedRef(getter), url, name,
                      std::move(promise)));
 
-  return handle;
+  return promise;
 }
 
-v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
+util::Promise Cookies::Set(const base::DictionaryValue& details) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto copy = base::DictionaryValue::From(
       base::Value::ToUniquePtrValue(details.Clone()));
@@ -337,12 +333,11 @@ v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
       base::BindOnce(SetCookieOnIO, base::RetainedRef(getter), std::move(copy),
                      std::move(promise)));
 
-  return handle;
+  return promise;
 }
 
-v8::Local<v8::Promise> Cookies::FlushStore() {
+util::Promise Cookies::FlushStore() {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto* getter = browser_context_->GetRequestContext();
   base::PostTaskWithTraits(
@@ -350,7 +345,7 @@ v8::Local<v8::Promise> Cookies::FlushStore() {
       base::BindOnce(FlushCookieStoreOnIOThread, base::RetainedRef(getter),
                      std::move(promise)));
 
-  return handle;
+  return promise;
 }
 
 void Cookies::OnCookieChanged(const CookieDetails* details) {

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -47,10 +47,10 @@ class Cookies : public mate::TrackableObject<Cookies> {
   Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context);
   ~Cookies() override;
 
-  v8::Local<v8::Promise> Get(const base::DictionaryValue& filter);
-  v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
-  v8::Local<v8::Promise> Remove(const GURL& url, const std::string& name);
-  v8::Local<v8::Promise> FlushStore();
+  util::Promise Get(const base::DictionaryValue& filter);
+  util::Promise Set(const base::DictionaryValue& details);
+  util::Promise Remove(const GURL& url, const std::string& name);
+  util::Promise FlushStore();
 
   // CookieChangeNotifier subscription:
   void OnCookieChanged(const CookieDetails*);

--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -128,19 +128,18 @@ void Debugger::Detach() {
   AgentHostClosed(agent_host_.get());
 }
 
-v8::Local<v8::Promise> Debugger::SendCommand(mate::Arguments* args) {
+util::Promise Debugger::SendCommand(mate::Arguments* args) {
   atom::util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (!agent_host_) {
     promise.RejectWithErrorMessage("No target available");
-    return handle;
+    return promise;
   }
 
   std::string method;
   if (!args->GetNext(&method)) {
     promise.RejectWithErrorMessage("Invalid method");
-    return handle;
+    return promise;
   }
 
   base::DictionaryValue command_params;
@@ -159,7 +158,7 @@ v8::Local<v8::Promise> Debugger::SendCommand(mate::Arguments* args) {
   base::JSONWriter::Write(request, &json_args);
   agent_host_->DispatchProtocolMessage(this, json_args);
 
-  return handle;
+  return promise;
 }
 
 void Debugger::ClearPendingRequests() {

--- a/atom/browser/api/atom_api_debugger.h
+++ b/atom/browser/api/atom_api_debugger.h
@@ -59,7 +59,7 @@ class Debugger : public mate::TrackableObject<Debugger>,
   void Attach(mate::Arguments* args);
   bool IsAttached();
   void Detach();
-  v8::Local<v8::Promise> SendCommand(mate::Arguments* args);
+  util::Promise SendCommand(mate::Arguments* args);
   void ClearPendingRequests();
 
   content::WebContents* web_contents_;  // Weak Reference.

--- a/atom/browser/api/atom_api_net_log.cc
+++ b/atom/browser/api/atom_api_net_log.cc
@@ -96,9 +96,8 @@ std::string NetLog::GetCurrentlyLoggingPath() const {
   return std::string();
 }
 
-v8::Local<v8::Promise> NetLog::StopLogging(mate::Arguments* args) {
+util::Promise NetLog::StopLogging(mate::Arguments* args) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (IsCurrentlyLogging()) {
     stop_callback_queue_.emplace_back(std::move(promise));
@@ -107,7 +106,7 @@ v8::Local<v8::Promise> NetLog::StopLogging(mate::Arguments* args) {
     promise.Resolve(base::FilePath());
   }
 
-  return handle;
+  return promise;
 }
 
 void NetLog::OnNewState(const base::DictionaryValue& state) {

--- a/atom/browser/api/atom_api_net_log.h
+++ b/atom/browser/api/atom_api_net_log.h
@@ -35,7 +35,7 @@ class NetLog : public mate::TrackableObject<NetLog>,
   std::string GetLoggingState() const;
   bool IsCurrentlyLogging() const;
   std::string GetCurrentlyLoggingPath() const;
-  v8::Local<v8::Promise> StopLogging(mate::Arguments* args);
+  util::Promise StopLogging(mate::Arguments* args);
 
  protected:
   explicit NetLog(v8::Isolate* isolate, AtomBrowserContext* browser_context);

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -181,9 +181,8 @@ void PromiseCallback(util::Promise promise, bool handled) {
   promise.Resolve(handled);
 }
 
-v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme) {
+util::Promise Protocol::IsProtocolHandled(const std::string& scheme) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
   auto* getter = static_cast<URLRequestContextGetter*>(
       browser_context_->GetRequestContext());
 
@@ -192,7 +191,7 @@ v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme) {
       base::BindOnce(&IsProtocolHandledInIO, base::RetainedRef(getter), scheme),
       base::BindOnce(&PromiseCallback, std::move(promise)));
 
-  return handle;
+  return promise;
 }
 
 void Protocol::UninterceptProtocol(const std::string& scheme,

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -134,7 +134,7 @@ class Protocol : public mate::TrackableObject<Protocol> {
       const std::string& scheme);
 
   // Whether the protocol has handler registered.
-  v8::Local<v8::Promise> IsProtocolHandled(const std::string& scheme);
+  util::Promise IsProtocolHandled(const std::string& scheme);
 
   // Replace the protocol handler with a new one.
   template <typename RequestJob>

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -96,8 +96,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   std::string GetSystemColor(const std::string& color, mate::Arguments* args);
 
   bool CanPromptTouchID();
-  v8::Local<v8::Promise> PromptTouchID(v8::Isolate* isolate,
-                                       const std::string& reason);
+  util::Promise PromptTouchID(v8::Isolate* isolate, const std::string& reason);
 
   static bool IsTrustedAccessibilityClient(bool prompt);
 
@@ -105,8 +104,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   // are running tests on a Mojave machine
   std::string GetMediaAccessStatus(const std::string& media_type,
                                    mate::Arguments* args);
-  v8::Local<v8::Promise> AskForMediaAccess(v8::Isolate* isolate,
-                                           const std::string& media_type);
+  util::Promise AskForMediaAccess(v8::Isolate* isolate,
+                                  const std::string& media_type);
 
   // TODO(MarshallOfSound): Write tests for these methods once we
   // are running tests on a Mojave machine

--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -465,11 +465,9 @@ void OnTouchIDFailed(util::Promise promise, const std::string& reason) {
   promise.RejectWithErrorMessage(reason);
 }
 
-v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
-    v8::Isolate* isolate,
-    const std::string& reason) {
+util::Promise SystemPreferences::PromptTouchID(v8::Isolate* isolate,
+                                               const std::string& reason) {
   util::Promise promise(isolate);
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (@available(macOS 10.12.2, *)) {
     base::scoped_nsobject<LAContext> context([[LAContext alloc] init]);
@@ -508,7 +506,7 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
     promise.RejectWithErrorMessage(
         "This API is not available on macOS versions older than 10.12.2");
   }
-  return handle;
+  return promise;
 }
 
 // static
@@ -624,11 +622,10 @@ std::string SystemPreferences::GetMediaAccessStatus(
   }
 }
 
-v8::Local<v8::Promise> SystemPreferences::AskForMediaAccess(
+util::Promise SystemPreferences::AskForMediaAccess(
     v8::Isolate* isolate,
     const std::string& media_type) {
   util::Promise promise(isolate);
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (auto type = ParseMediaType(media_type)) {
     if (@available(macOS 10.14, *)) {
@@ -647,7 +644,7 @@ v8::Local<v8::Promise> SystemPreferences::AskForMediaAccess(
     promise.RejectWithErrorMessage("Invalid media type");
   }
 
-  return handle;
+  return promise;
 }
 
 void SystemPreferences::RemoveUserDefault(const std::string& name) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1298,15 +1298,13 @@ std::string WebContents::GetUserAgent() {
   return web_contents()->GetUserAgentOverride();
 }
 
-v8::Local<v8::Promise> WebContents::SavePage(
-    const base::FilePath& full_file_path,
-    const content::SavePageType& save_type) {
+util::Promise WebContents::SavePage(const base::FilePath& full_file_path,
+                                    const content::SavePageType& save_type) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> ret = promise.GetHandle();
 
   auto* handler = new SavePageHandler(web_contents(), std::move(promise));
   handler->Handle(full_file_path, save_type);
-  return ret;
+  return promise;
 }
 
 void WebContents::OpenDevTools(mate::Arguments* args) {
@@ -1501,13 +1499,11 @@ std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {
   return printers;
 }
 
-v8::Local<v8::Promise> WebContents::PrintToPDF(
-    const base::DictionaryValue& settings) {
+util::Promise WebContents::PrintToPDF(const base::DictionaryValue& settings) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
   PrintPreviewMessageHandler::FromWebContents(web_contents())
       ->PrintToPDF(settings, std::move(promise));
-  return handle;
+  return promise;
 }
 #endif
 
@@ -1776,10 +1772,9 @@ void WebContents::StartDrag(const mate::Dictionary& item,
   }
 }
 
-v8::Local<v8::Promise> WebContents::CapturePage(mate::Arguments* args) {
+util::Promise WebContents::CapturePage(mate::Arguments* args) {
   gfx::Rect rect;
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   // get rect arguments if they exist
   args->GetNext(&rect);
@@ -1787,7 +1782,7 @@ v8::Local<v8::Promise> WebContents::CapturePage(mate::Arguments* args) {
   auto* const view = web_contents()->GetRenderWidgetHostView();
   if (!view) {
     promise.Resolve(gfx::Image());
-    return handle;
+    return promise;
   }
 
   // Capture full page if user doesn't specify a |rect|.
@@ -1807,7 +1802,7 @@ v8::Local<v8::Promise> WebContents::CapturePage(mate::Arguments* args) {
 
   view->CopyFromSurface(gfx::Rect(rect.origin(), view_size), bitmap_size,
                         base::BindOnce(&OnCapturePageDone, std::move(promise)));
-  return handle;
+  return promise;
 }
 
 void WebContents::OnCursorChange(const content::WebCursor& cursor) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -149,8 +149,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetUserAgent(const std::string& user_agent, mate::Arguments* args);
   std::string GetUserAgent();
   void InsertCSS(const std::string& css);
-  v8::Local<v8::Promise> SavePage(const base::FilePath& full_file_path,
-                                  const content::SavePageType& save_type);
+  util::Promise SavePage(const base::FilePath& full_file_path,
+                         const content::SavePageType& save_type);
   void OpenDevTools(mate::Arguments* args);
   void CloseDevTools();
   bool IsDevToolsOpened();
@@ -173,7 +173,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   // Print current page as PDF.
-  v8::Local<v8::Promise> PrintToPDF(const base::DictionaryValue& settings);
+  util::Promise PrintToPDF(const base::DictionaryValue& settings);
 #endif
 
   // DevTools workspace api.
@@ -232,7 +232,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Captures the page with |rect|, |callback| would be called when capturing is
   // done.
-  v8::Local<v8::Promise> CapturePage(mate::Arguments* args);
+  util::Promise CapturePage(mate::Arguments* args);
 
   // Methods for creating <webview>.
   bool IsGuest() const;

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -171,7 +171,7 @@ class Browser : public WindowListObserver {
 
   // Hide/Show dock.
   void DockHide();
-  v8::Local<v8::Promise> DockShow(v8::Isolate* isolate);
+  util::Promise DockShow(v8::Isolate* isolate);
   bool DockIsVisible();
 
   // Set docks' menu.

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -341,9 +341,8 @@ bool Browser::DockIsVisible() {
           NSApplicationActivationPolicyRegular);
 }
 
-v8::Local<v8::Promise> Browser::DockShow(v8::Isolate* isolate) {
+util::Promise Browser::DockShow(v8::Isolate* isolate) {
   util::Promise promise(isolate);
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   BOOL active = [[NSRunningApplication currentApplication] isActive];
   ProcessSerialNumber psn = {0, kCurrentProcess};
@@ -371,7 +370,7 @@ v8::Local<v8::Promise> Browser::DockShow(v8::Isolate* isolate) {
     TransformProcessType(&psn, kProcessTransformToForegroundApplication);
     promise.Resolve();
   }
-  return handle;
+  return promise;
 }
 
 void Browser::DockSetMenu(AtomMenuModel* model) {

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -230,15 +230,13 @@ v8::Local<v8::Value> AtomBindings::GetSystemMemoryInfo(v8::Isolate* isolate,
 }
 
 // static
-v8::Local<v8::Promise> AtomBindings::GetProcessMemoryInfo(
-    v8::Isolate* isolate) {
+util::Promise AtomBindings::GetProcessMemoryInfo(v8::Isolate* isolate) {
   util::Promise promise(isolate);
-  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (mate::Locker::IsBrowserProcess() && !Browser::Get()->is_ready()) {
     promise.RejectWithErrorMessage(
         "Memory Info is available only after app ready");
-    return handle;
+    return promise;
   }
 
   v8::Global<v8::Context> context(isolate, isolate->GetCurrentContext());
@@ -247,7 +245,7 @@ v8::Local<v8::Promise> AtomBindings::GetProcessMemoryInfo(
           base::GetCurrentProcId(), std::vector<std::string>(),
           base::BindOnce(&AtomBindings::DidReceiveMemoryDump,
                          std::move(context), std::move(promise)));
-  return handle;
+  return promise;
 }
 
 // static

--- a/atom/common/api/atom_bindings.h
+++ b/atom/common/api/atom_bindings.h
@@ -57,7 +57,7 @@ class AtomBindings {
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,
                                                   mate::Arguments* args);
-  static v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
+  static util::Promise GetProcessMemoryInfo(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,
                                           v8::Isolate* isolate);
   static v8::Local<v8::Value> GetIOCounters(v8::Isolate* isolate);

--- a/atom/common/promise_util.cc
+++ b/atom/common/promise_util.cc
@@ -70,4 +70,10 @@ v8::Local<v8::Value> mate::Converter<atom::util::Promise>::ToV8(
   return val.GetHandle();
 }
 
+v8::Local<v8::Value> mate::Converter<atom::util::CopyablePromise>::ToV8(
+    v8::Isolate* isolate,
+    const atom::util::CopyablePromise& val) {
+  return mate::ConvertToV8(isolate, val.GetPromise());
+}
+
 }  // namespace mate

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -152,6 +152,12 @@ struct Converter<atom::util::Promise> {
   //                    Promise* out);
 };
 
+template <>
+struct Converter<atom::util::CopyablePromise> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const atom::util::CopyablePromise& val);
+};
+
 }  // namespace mate
 
 #endif  // ATOM_COMMON_PROMISE_UTIL_H_


### PR DESCRIPTION
We have mate converters for `util::Promise`, there is no need to convert to `v8::Local<T>` manually, in fact this will allow us to more easily change how `util::Promise` works in the future.

Notes: no-notes