### PR TITLE
chore: node_includes header no longer needs to be at the end of the list

### DIFF
--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -15,6 +15,7 @@
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/node_bindings.h"
+#include "atom/common/node_includes.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/task/task_scheduler/task_scheduler.h"
@@ -23,8 +24,6 @@
 #include "gin/public/isolate_holder.h"
 #include "gin/v8_initializer.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -24,6 +24,7 @@
 #include "atom/common/native_mate_converters/net_converter.h"
 #include "atom/common/native_mate_converters/network_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
 #include "base/environment.h"
@@ -50,12 +51,6 @@
 #include "services/service_manager/sandbox/switches.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/gfx/image/image.h"
-
-// clang-format off
-// This header should be declared at the end to avoid
-// redefinition errors.
-#include "atom/common/node_includes.h"  // NOLINT(build/include_alpha)
-// clang-format on
 
 #if defined(OS_WIN)
 #include "atom/browser/ui/win/jump_list.h"

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -15,6 +15,7 @@
 #include "atom/common/color_util.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
@@ -24,8 +25,6 @@
 #include "gin/converter.h"
 #include "native_mate/dictionary.h"
 #include "ui/gl/gpu_switching_manager.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -8,13 +8,12 @@
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/promise_util.h"
 #include "base/bind.h"
 #include "base/files/file_util.h"
 #include "content/public/browser/tracing_controller.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 using content::TracingController;
 

--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -10,13 +10,12 @@
 
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/web_contents.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 using content::DevToolsAgentHost;
 

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -10,6 +10,7 @@
 
 #include "atom/common/api/atom_api_native_image.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_restrictions.h"
@@ -25,8 +26,6 @@
 #include "third_party/webrtc/modules/desktop_capture/win/screen_capturer_win_directx.h"
 #include "ui/display/win/display_info.h"
 #endif  // defined(OS_WIN)
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/browser/api/atom_api_dialog.cc
+++ b/atom/browser/api/atom_api_dialog.cc
@@ -16,10 +16,9 @@
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/net_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/promise_util.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 namespace {
 

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -11,12 +11,11 @@
 #include "atom/common/native_mate_converters/file_dialog_converter.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "native_mate/dictionary.h"
 #include "net/base/filename_util.h"
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -10,11 +10,10 @@
 #include "atom/browser/api/atom_api_system_preferences.h"
 #include "atom/common/native_mate_converters/accelerator_converter.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/node_includes.h"
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 #if defined(OS_MACOSX)
 #include "base/mac/mac_util.h"

--- a/atom/browser/api/atom_api_in_app_purchase.cc
+++ b/atom/browser/api/atom_api_in_app_purchase.cc
@@ -9,9 +9,8 @@
 #include <vector>
 
 #include "atom/common/native_mate_converters/callback.h"
-#include "native_mate/dictionary.h"
-
 #include "atom/common/node_includes.h"
+#include "native_mate/dictionary.h"
 
 namespace mate {
 

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -9,11 +9,10 @@
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/node_includes.h"
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -6,6 +6,7 @@
 
 #include "atom/browser/native_window.h"
 #include "atom/browser/unresponsive_suppressor.h"
+#include "atom/common/node_includes.h"
 #include "base/mac/scoped_sending_event.h"
 #include "base/message_loop/message_loop.h"
 #include "base/strings/sys_string_conversions.h"
@@ -13,8 +14,6 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_contents.h"
-
-#include "atom/common/node_includes.h"
 
 using content::BrowserThread;
 

--- a/atom/browser/api/atom_api_net_log.cc
+++ b/atom/browser/api/atom_api_net_log.cc
@@ -10,6 +10,7 @@
 #include "atom/browser/net/system_network_context_manager.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/command_line.h"
 #include "chrome/browser/browser_process.h"
 #include "components/net_log/chrome_net_log.h"
@@ -17,8 +18,6 @@
 #include "native_mate/dictionary.h"
 #include "native_mate/handle.h"
 #include "net/url_request/url_request_context_getter.h"
-
-#include "atom/common/node_includes.h"
 
 namespace {
 

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -10,15 +10,13 @@
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/guid.h"
 #include "base/strings/utf_string_conversions.h"
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "url/gurl.h"
-// Must be the last in the includes list.
-// See https://github.com/electron/electron/issues/10363
-#include "atom/common/node_includes.h"
 
 namespace mate {
 template <>

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -6,11 +6,10 @@
 
 #include "atom/browser/browser.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/node_includes.h"
 #include "base/power_monitor/power_monitor.h"
 #include "base/power_monitor/power_monitor_device_source.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 template <>

--- a/atom/browser/api/atom_api_power_save_blocker.cc
+++ b/atom/browser/api/atom_api_power_save_blocker.cc
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "atom/common/node_includes.h"
 #include "base/task/post_task.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "content/public/common/service_manager_connection.h"
@@ -13,8 +14,6 @@
 #include "services/device/public/mojom/constants.mojom.h"
 #include "services/device/public/mojom/wake_lock_provider.mojom.h"
 #include "services/service_manager/public/cpp/connector.h"
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -7,11 +7,10 @@
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/atom_browser_client.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "content/public/browser/render_process_host.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -10,6 +10,7 @@
 #include "atom/browser/api/atom_api_browser_window.h"
 #include "atom/browser/browser.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/bind.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
@@ -20,8 +21,6 @@
 #if defined(OS_WIN)
 #include "ui/display/win/screen_win.h"
 #endif
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -28,6 +28,7 @@
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/net_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/files/file_path.h"
 #include "base/guid.h"
 #include "base/strings/string_number_conversions.h"
@@ -58,8 +59,6 @@
 #include "net/url_request/url_request_context.h"
 #include "net/url_request/url_request_context_getter.h"
 #include "ui/base/l10n/l10n_util.h"
-
-#include "atom/common/node_includes.h"
 
 using content::BrowserThread;
 using content::StoragePartition;

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -18,6 +18,7 @@
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
 #include "electron/buildflags/buildflags.h"
 #include "gin/converter.h"
@@ -32,8 +33,6 @@
 #include "atom/browser/ui/win/taskbar_host.h"
 #include "ui/base/win/shell.h"
 #endif
-
-#include "atom/common/node_includes.h"
 
 #if defined(OS_WIN)
 namespace mate {

--- a/atom/browser/api/atom_api_view.cc
+++ b/atom/browser/api/atom_api_view.cc
@@ -4,9 +4,8 @@
 
 #include "atom/browser/api/atom_api_view.h"
 
-#include "native_mate/dictionary.h"
-
 #include "atom/common/node_includes.h"
+#include "native_mate/dictionary.h"
 
 namespace atom {
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -45,6 +45,7 @@
 #include "atom/common/native_mate_converters/network_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
 #include "base/message_loop/message_loop.h"
 #include "base/no_destructor.h"
@@ -105,8 +106,6 @@
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "components/printing/common/print_messages.h"
 #endif
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/browser/api/atom_api_web_contents_view.cc
+++ b/atom/browser/api/atom_api_web_contents_view.cc
@@ -8,14 +8,13 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/ui/inspectable_web_contents_view.h"
 #include "atom/common/api/constructor.h"
+#include "atom/common/node_includes.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "native_mate/dictionary.h"
 
 #if defined(OS_MACOSX)
 #include "atom/browser/ui/cocoa/delayed_native_view_host.h"
 #endif
-
-#include "atom/common/node_includes.h"
 
 namespace {
 

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -7,13 +7,10 @@
 #include "atom/browser/web_view_manager.h"
 #include "atom/common/native_mate_converters/content_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
 #include "content/public/browser/browser_context.h"
 #include "native_mate/dictionary.h"
-
-// Must be the last in the includes list.
-// See https://github.com/electron/electron/issues/10363
-#include "atom/common/node_includes.h"
 
 using atom::WebContentsPreferences;
 

--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -5,13 +5,12 @@
 #include "atom/browser/api/event_emitter.h"
 
 #include "atom/browser/api/event.h"
+#include "atom/common/node_includes.h"
 #include "content/public/browser/render_frame_host.h"
 #include "native_mate/arguments.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "ui/events/event_constants.h"
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/browser/api/frame_subscriber.cc
+++ b/atom/browser/api/frame_subscriber.cc
@@ -7,12 +7,11 @@
 #include <utility>
 
 #include "atom/common/native_mate_converters/gfx_converter.h"
+#include "atom/common/node_includes.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/render_widget_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "ui/gfx/skbitmap_operations.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/stream_subscriber.cc
+++ b/atom/browser/api/stream_subscriber.cc
@@ -9,10 +9,9 @@
 #include "atom/browser/net/url_request_stream_job.h"
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/node_includes.h"
 #include "base/task/post_task.h"
 #include "content/public/browser/browser_task_traits.h"
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/browser/api/views/atom_api_box_layout.cc
+++ b/atom/browser/api/views/atom_api_box_layout.cc
@@ -8,9 +8,8 @@
 
 #include "atom/browser/api/atom_api_view.h"
 #include "atom/common/api/constructor.h"
-#include "native_mate/dictionary.h"
-
 #include "atom/common/node_includes.h"
+#include "native_mate/dictionary.h"
 
 namespace mate {
 

--- a/atom/browser/api/views/atom_api_button.cc
+++ b/atom/browser/api/views/atom_api_button.cc
@@ -5,9 +5,8 @@
 #include "atom/browser/api/views/atom_api_button.h"
 
 #include "atom/common/api/constructor.h"
-#include "native_mate/dictionary.h"
-
 #include "atom/common/node_includes.h"
+#include "native_mate/dictionary.h"
 
 namespace atom {
 

--- a/atom/browser/api/views/atom_api_label_button.cc
+++ b/atom/browser/api/views/atom_api_label_button.cc
@@ -5,10 +5,9 @@
 #include "atom/browser/api/views/atom_api_label_button.h"
 
 #include "atom/common/api/constructor.h"
+#include "atom/common/node_includes.h"
 #include "base/strings/utf_string_conversions.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/views/atom_api_layout_manager.cc
+++ b/atom/browser/api/views/atom_api_layout_manager.cc
@@ -5,9 +5,8 @@
 #include "atom/browser/api/views/atom_api_layout_manager.h"
 
 #include "atom/common/api/constructor.h"
-#include "native_mate/dictionary.h"
-
 #include "atom/common/node_includes.h"
+#include "native_mate/dictionary.h"
 
 namespace atom {
 

--- a/atom/browser/api/views/atom_api_md_text_button.cc
+++ b/atom/browser/api/views/atom_api_md_text_button.cc
@@ -5,10 +5,9 @@
 #include "atom/browser/api/views/atom_api_md_text_button.h"
 
 #include "atom/common/api/constructor.h"
+#include "atom/common/node_includes.h"
 #include "base/strings/utf_string_conversions.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/api/views/atom_api_resize_area.cc
+++ b/atom/browser/api/views/atom_api_resize_area.cc
@@ -5,9 +5,8 @@
 #include "atom/browser/api/views/atom_api_resize_area.h"
 
 #include "atom/common/api/constructor.h"
-#include "native_mate/dictionary.h"
-
 #include "atom/common/node_includes.h"
+#include "native_mate/dictionary.h"
 
 namespace atom {
 

--- a/atom/browser/api/views/atom_api_text_field.cc
+++ b/atom/browser/api/views/atom_api_text_field.cc
@@ -5,9 +5,8 @@
 #include "atom/browser/api/views/atom_api_text_field.h"
 
 #include "atom/common/api/constructor.h"
-#include "native_mate/dictionary.h"
-
 #include "atom/common/node_includes.h"
+#include "native_mate/dictionary.h"
 
 namespace atom {
 

--- a/atom/browser/atom_blob_reader.cc
+++ b/atom/browser/atom_blob_reader.cc
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "atom/common/node_includes.h"
 #include "base/task/post_task.h"
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"  // nogncheck
 #include "content/public/browser/browser_task_traits.h"
@@ -15,8 +16,6 @@
 #include "storage/browser/blob/blob_data_handle.h"
 #include "storage/browser/blob/blob_reader.h"
 #include "storage/browser/blob/blob_storage_context.h"
-
-#include "atom/common/node_includes.h"
 
 using content::BrowserThread;
 

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -27,6 +27,7 @@
 #include "atom/common/application_info.h"
 #include "atom/common/asar/asar_util.h"
 #include "atom/common/node_bindings.h"
+#include "atom/common/node_includes.h"
 #include "base/base_switches.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
@@ -88,9 +89,6 @@
 #include "device/bluetooth/bluetooth_adapter_factory.h"
 #include "device/bluetooth/dbus/dbus_bluez_manager_wrapper_linux.h"
 #endif
-
-// Must be included after all other headers.
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "atom/browser/microtasks_runner.h"
+#include "atom/common/node_includes.h"
 #include "base/command_line.h"
 #include "base/message_loop/message_loop.h"
 #include "base/task/task_scheduler/initialization_util.h"
@@ -14,8 +15,6 @@
 #include "content/public/common/content_switches.h"
 #include "gin/array_buffer.h"
 #include "gin/v8_initializer.h"
-
-#include "atom/common/node_includes.h"
 #include "tracing/trace_event.h"
 
 namespace atom {

--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -8,14 +8,13 @@
 #include <string>
 #include <vector>
 
+#include "atom/common/node_includes.h"
 #include "base/command_line.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "libplatform/libplatform.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/browser/printing/print_preview_message_handler.cc
+++ b/atom/browser/printing/print_preview_message_handler.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <utility>
 
+#include "atom/common/node_includes.h"
 #include "base/bind.h"
 #include "base/memory/read_only_shared_memory_region.h"
 #include "base/memory/ref_counted.h"
@@ -23,8 +24,6 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
-
-#include "atom/common/node_includes.h"
 
 using content::BrowserThread;
 

--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -9,12 +9,11 @@
 #include "atom/common/asar/archive.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
+#include "atom/common/node_includes.h"
 #include "native_mate/arguments.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "native_mate/wrappable.h"
-
-#include "atom/common/node_includes.h"
 #include "third_party/electron_node/src/node_native_module.h"
 
 namespace {

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -6,14 +6,13 @@
 
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/strings/utf_string_conversions.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPixmap.h"
 #include "ui/base/clipboard/clipboard_format_type.h"
 #include "ui/base/clipboard/scoped_clipboard_writer.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/common/api/atom_api_command_line.cc
+++ b/atom/common/api/atom_api_command_line.cc
@@ -4,14 +4,13 @@
 
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/strings/string_util.h"
 #include "native_mate/converter.h"
 #include "native_mate/dictionary.h"
 #include "services/network/public/cpp/network_switches.h"
-
-#include "atom/common/node_includes.h"
 
 namespace {
 

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -14,6 +14,7 @@
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/files/file_util.h"
 #include "base/strings/pattern.h"
 #include "base/strings/string_util.h"
@@ -37,8 +38,6 @@
 #include "base/win/scoped_gdi_object.h"
 #include "ui/gfx/icon_util.h"
 #endif
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -17,6 +17,8 @@
 #include "atom/common/heap_snapshot.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/node_includes.h"
+#include "atom/common/promise_util.h"
 #include "base/logging.h"
 #include "base/process/process.h"
 #include "base/process/process_handle.h"
@@ -27,10 +29,6 @@
 #include "native_mate/dictionary.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/global_memory_dump.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
-
-// Must be the last in the includes list, otherwise the definition of chromium
-// macros conflicts with node macros.
-#include "atom/common/node_includes.h"
 
 namespace atom {
 

--- a/atom/common/api/features.cc
+++ b/atom/common/api/features.cc
@@ -2,12 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "atom/common/node_includes.h"
 #include "electron/buildflags/buildflags.h"
 #include "native_mate/dictionary.h"
 #include "printing/buildflags/buildflags.h"
-// clang-format off
-#include "atom/common/node_includes.h"  // NOLINT(build/include_alpha)
-// clang-format on
 
 namespace {
 

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -11,6 +11,7 @@
 
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/values.h"
@@ -24,8 +25,6 @@
 #include "net/http/http_response_headers.h"
 #include "net/url_request/url_request.h"
 #include "storage/browser/blob/upload_blob_element_reader.h"
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -14,6 +14,7 @@
 #include "atom/common/api/locker.h"
 #include "atom/common/atom_command_line.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
+#include "atom/common/node_includes.h"
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/environment.h"
@@ -27,8 +28,6 @@
 #include "content/public/common/content_paths.h"
 #include "electron/buildflags/buildflags.h"
 #include "native_mate/dictionary.h"
-
-#include "atom/common/node_includes.h"
 
 #define ELECTRON_BUILTIN_MODULES(V)          \
   V(atom_browser_app)                        \

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -13,6 +13,7 @@
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/node_includes.h"
 #include "atom/renderer/api/atom_api_spell_check_client.h"
 #include "base/memory/memory_pressure_listener.h"
 #include "content/public/renderer/render_frame.h"
@@ -34,8 +35,6 @@
 #include "third_party/blink/public/web/web_script_source.h"
 #include "third_party/blink/public/web/web_view.h"
 #include "url/url_util.h"
-
-#include "atom/common/node_includes.h"
 
 namespace mate {
 

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -11,6 +11,7 @@
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/asar/asar_util.h"
 #include "atom/common/node_bindings.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
 #include "atom/renderer/atom_render_frame_observer.h"
 #include "atom/renderer/web_worker_observer.h"
@@ -19,8 +20,6 @@
 #include "native_mate/dictionary.h"
 #include "third_party/blink/public/web/web_document.h"
 #include "third_party/blink/public/web/web_local_frame.h"
-
-#include "atom/common/node_includes.h"
 #include "third_party/electron_node/src/node_native_module.h"
 
 namespace atom {

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -10,6 +10,7 @@
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_bindings.h"
+#include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
 #include "atom/renderer/atom_render_frame_observer.h"
 #include "base/base_paths.h"
@@ -22,8 +23,6 @@
 #include "native_mate/dictionary.h"
 #include "third_party/blink/public/web/blink.h"
 #include "third_party/blink/public/web/web_document.h"
-
-#include "atom/common/node_includes.h"
 #include "third_party/electron_node/src/node_binding.h"
 #include "third_party/electron_node/src/node_native_module.h"
 

--- a/atom/renderer/web_worker_observer.cc
+++ b/atom/renderer/web_worker_observer.cc
@@ -8,10 +8,9 @@
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/asar/asar_util.h"
 #include "atom/common/node_bindings.h"
+#include "atom/common/node_includes.h"
 #include "base/lazy_instance.h"
 #include "base/threading/thread_local.h"
-
-#include "atom/common/node_includes.h"
 
 namespace atom {
 


### PR DESCRIPTION
Until one of the latest version of node, the definition of the DISALLOW_COPY_AND_ASSIGN macro in node was different than in chromium. That is no longer the case, so just undefining the macro in node_includes.h works.
Related to https://github.com/electron/electron/issues/10363.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes
