### PR TITLE
test: fix race condition in debugger spec

### DIFF
--- a/spec/api-debugger-spec.js
+++ b/spec/api-debugger-spec.js
@@ -142,8 +142,9 @@ describe('debugger module', () => {
       w.webContents.loadURL('about:blank')
       w.webContents.debugger.attach()
 
+      const opened = emittedOnce(w.webContents, 'devtools-opened')
       w.webContents.openDevTools()
-      await emittedOnce(w.webContents, 'devtools-opened')
+      await opened
 
       const params = { 'expression': '4+2' }
       const res = await w.webContents.debugger.sendCommand('Runtime.evaluate', params)


### PR DESCRIPTION
#### Description of Change
the `webContents` here is a remote object, so event listeners must be attached before the event they're listening for could be generated.

cc @jkleinsc https://github.com/electron/electron/pull/16861#discussion_r257039199

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes