### PR TITLE
build: enable gn check for //electron:electron_lib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,7 @@ step-gn-check: &step-gn-check
     command: |
       cd src
       gn check out/Default //electron:electron_lib
+      gn check out/Default //electron:electron_app
 
 step-electron-build: &step-electron-build
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,6 +579,7 @@ steps-electron-gn-check: &steps-electron-gn-check
   steps:
     - attach_workspace:
         at: .
+    - *step-depot-tools-add-to-path
     - *step-setup-env-for-build
     - *step-gn-gen-default
     - *step-gn-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,13 @@ step-gn-gen-default: &step-gn-gen-default
       cd src
       gn gen out/Default --args='import("'$GN_CONFIG'") cc_wrapper="'"$SCCACHE_PATH"'"'" $GN_EXTRA_ARGS"
 
+step-gn-check: &step-gn-check
+  run:
+    name: GN check
+    command: |
+      cd src
+      gn check out/Default //electron:electron_lib
+
 step-electron-build: &step-electron-build
   run:
     name: Electron build
@@ -568,6 +575,14 @@ steps-checkout: &steps-checkout
           - depot_tools
           - src
 
+steps-electron-gn-check: &steps-electron-gn-check
+  steps:
+    - attach_workspace:
+        at: .
+    - *step-setup-env-for-build
+    - *step-gn-gen-default
+    - *step-gn-check
+
 steps-electron-build: &steps-electron-build
   steps:
     - attach_workspace:
@@ -857,6 +872,13 @@ jobs:
       <<: *env-enable-sccache
     <<: *steps-electron-build
 
+  linux-x64-debug-gn-check:
+    <<: *machine-linux-medium
+    environment:
+      <<: *env-linux-medium
+      <<: *env-debug-build
+    <<: *steps-electron-gn-check
+
   linux-x64-testing:
     <<: *machine-linux-2xlarge
     environment:
@@ -864,6 +886,13 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
     <<: *steps-electron-build-for-tests
+
+  linux-x64-testing-gn-check:
+    <<: *machine-linux-medium
+    environment:
+      <<: *env-linux-medium
+      <<: *env-testing-build
+    <<: *steps-electron-gn-check
 
   linux-x64-chromedriver:
     <<: *machine-linux-medium
@@ -1005,6 +1034,14 @@ jobs:
       <<: *env-enable-sccache
     <<: *steps-electron-build
 
+  linux-arm64-debug-gn-check:
+    <<: *machine-linux-medium
+    environment:
+      <<: *env-linux-medium
+      <<: *env-arm64
+      <<: *env-debug-build
+    <<: *steps-electron-gn-check
+
   linux-arm64-testing:
     <<: *machine-linux-2xlarge
     environment:
@@ -1014,6 +1051,14 @@ jobs:
       <<: *env-enable-sccache
       TRIGGER_ARM_TEST: true
     <<: *steps-electron-build-for-tests
+
+  linux-arm64-testing-gn-check:
+    <<: *machine-linux-medium
+    environment:
+      <<: *env-linux-medium
+      <<: *env-arm64
+      <<: *env-testing-build
+    <<: *steps-electron-gn-check
 
   linux-arm64-chromedriver:
     <<: *machine-linux-medium
@@ -1062,6 +1107,20 @@ jobs:
       <<: *env-enable-sccache
     <<: *steps-electron-build-for-tests
 
+  osx-debug-gn-check:
+    <<: *machine-mac
+    environment:
+      <<: *env-machine-mac
+      <<: *env-debug-build
+    <<: *steps-electron-gn-check
+
+  osx-testing-gn-check:
+    <<: *machine-mac
+    environment:
+      <<: *env-machine-mac
+      <<: *env-testing-build
+    <<: *steps-electron-gn-check
+
   osx-chromedriver:
     <<: *machine-mac
     environment:
@@ -1095,6 +1154,22 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
     <<: *steps-electron-build-for-tests
+
+  mas-debug-gn-check:
+    <<: *machine-mac
+    environment:
+      <<: *env-machine-mac
+      <<: *env-mas
+      <<: *env-debug-build
+    <<: *steps-electron-gn-check
+
+  mas-testing-gn-check:
+    <<: *machine-mac
+    environment:
+      <<: *env-machine-mac
+      <<: *env-mas
+      <<: *env-testing-build
+    <<: *steps-electron-gn-check
 
   mas-chromedriver:
     <<: *machine-mac
@@ -1353,7 +1428,13 @@ workflows:
       - linux-x64-debug:
           requires:
             - linux-checkout
+      - linux-x64-debug-gn-check:
+          requires:
+            - linux-checkout
       - linux-x64-testing:
+          requires:
+            - linux-checkout
+      - linux-x64-testing-gn-check:
           requires:
             - linux-checkout
       - linux-x64-testing-tests:
@@ -1380,7 +1461,13 @@ workflows:
       - linux-arm64-debug:
           requires:
             - linux-checkout
+      - linux-arm64-debug-gn-check:
+          requires:
+            - linux-checkout
       - linux-arm64-testing:
+          requires:
+            - linux-checkout
+      - linux-arm64-testing-gn-check:
           requires:
             - linux-checkout
 
@@ -1391,11 +1478,25 @@ workflows:
           requires:
             - mac-checkout
 
+      - osx-debug-gn-check:
+          requires:
+            - mac-checkout
+      - osx-testing-gn-check:
+          requires:
+            - mac-checkout
+
       - osx-testing-tests:
           requires:
             - osx-testing
 
       - mas-testing:
+          requires:
+            - mac-checkout
+
+      - mas-debug-gn-check:
+          requires:
+            - mac-checkout
+      - mas-testing-gn-check:
           requires:
             - mac-checkout
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -326,6 +326,7 @@ static_library("electron_lib") {
 
   deps = [
     ":atom_js2c",
+    ":resources",
     "buildflags",
     "chromium_src:chrome",
     "manifests",
@@ -333,6 +334,7 @@ static_library("electron_lib") {
     "//base",
     "//base:base_static",
     "//base:i18n",
+    "//base/allocator:buildflags",
     "//chrome/app/resources:platform_locale_settings",
     "//components/certificate_transparency",
     "//components/net_log",
@@ -345,6 +347,9 @@ static_library("electron_lib") {
     "//content/public/browser",
     "//content/public/child",
     "//content/public/common:service_names",
+    "//content/public/renderer",
+    "//content/public/utility",
+    "//device/bluetooth",
     "//gin",
     "//media/capture/mojom:video_capture",
     "//media/mojo/interfaces",
@@ -354,6 +359,7 @@ static_library("electron_lib") {
     "//ppapi/host",
     "//ppapi/proxy",
     "//ppapi/shared_impl",
+    "//printing/buildflags",
     "//services/audio/public/mojom:constants",
     "//services/device/public/mojom",
     "//services/proxy_resolver:lib",
@@ -369,8 +375,11 @@ static_library("electron_lib") {
     "//third_party/widevine/cdm:headers",
     "//ui/events:dom_keycode_converter",
     "//ui/gl",
+    "//ui/native_theme",
+    "//ui/shell_dialogs:shell_dialogs",
     "//ui/views",
     "//v8",
+    "//v8:v8_libplatform",
   ]
 
   include_dirs = [
@@ -435,6 +444,7 @@ static_library("electron_lib") {
       "atom/browser/fake_location_provider.cc",
       "atom/browser/fake_location_provider.h",
     ]
+    deps += [ "//services/device/public/cpp/geolocation" ]
   }
 
   if (is_mac) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -331,9 +331,7 @@ static_library("electron_lib") {
     "chromium_src:chrome",
     "manifests",
     "native_mate",
-    "//base",
     "//base:base_static",
-    "//base:i18n",
     "//base/allocator:buildflags",
     "//chrome/app/resources:platform_locale_settings",
     "//components/certificate_transparency",
@@ -343,7 +341,6 @@ static_library("electron_lib") {
     "//components/spellcheck/renderer",
     "//components/viz/host",
     "//components/viz/service",
-    "//content/public/app:both",
     "//content/public/browser",
     "//content/public/child",
     "//content/public/common:service_names",
@@ -376,10 +373,16 @@ static_library("electron_lib") {
     "//ui/events:dom_keycode_converter",
     "//ui/gl",
     "//ui/native_theme",
-    "//ui/shell_dialogs:shell_dialogs",
+    "//ui/shell_dialogs",
     "//ui/views",
     "//v8",
     "//v8:v8_libplatform",
+  ]
+
+  public_deps = [
+    "//base",
+    "//base:i18n",
+    "//content/public/app:both",
   ]
 
   include_dirs = [
@@ -495,9 +498,6 @@ static_library("electron_lib") {
       "//device/bluetooth",
       "//ui/events/devices/x11",
       "//ui/events/platform/x11",
-      "//ui/native_theme",
-      "//ui/views/controls/webview",
-      "//ui/wm",
     ]
     configs += [ ":gio_unix" ]
     defines += [
@@ -509,9 +509,20 @@ static_library("electron_lib") {
   }
   if (is_win) {
     libs += [ "dwmapi.lib" ]
+    deps += [
+      "//third_party/breakpad:breakpad_handler",
+      "//third_party/breakpad:breakpad_sender",
+      "//ui/native_theme:native_theme_browser",
+      "//ui/wm/public",
+    ]
+    public_deps += [ "//sandbox/win:sandbox" ]
   }
   if (is_linux || is_win) {
-    deps += [ "//third_party/breakpad:client" ]
+    deps += [
+      "//third_party/breakpad:client",
+      "//ui/views/controls/webview",
+      "//ui/wm",
+    ]
     include_dirs += [ "//third_party/breakpad" ]
   }
 
@@ -876,6 +887,7 @@ if (is_mac) {
       ":electron_lib",
       ":packed_resources",
       "//content:sandbox_helper_win",
+      "//electron/buildflags",
       "//ui/strings",
     ]
 
@@ -904,17 +916,7 @@ if (is_mac) {
         # TODO: we should be generating our .rc files more like how chrome does
         "atom/browser/resources/win/atom.ico",
         "atom/browser/resources/win/atom.rc",
-        "atom/browser/resources/win/resources.h",
-      ]
-
-      deps += [
-        "//third_party/breakpad:breakpad_handler",
-        "//third_party/breakpad:breakpad_sender",
-        "//ui/native_theme:native_theme_browser",
-        "//ui/shell_dialogs",
-        "//ui/views/controls/webview",
-        "//ui/wm",
-        "//ui/wm/public",
+        "atom/browser/resources/win/resource.h",
       ]
 
       libs = [

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ build_script:
   - cd src
   - ps: $env:BUILD_CONFIG_PATH="//electron/build/args/%GN_CONFIG%.gn"
   - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") %GN_EXTRA_ARGS%"
+  - gn check out/Default //electron:electron_lib
   - ninja -C out/Default electron:electron_app
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/ffmpeg electron:electron_ffmpeg_zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,7 @@ build_script:
   - ps: $env:BUILD_CONFIG_PATH="//electron/build/args/%GN_CONFIG%.gn"
   - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") %GN_EXTRA_ARGS%"
   - gn check out/Default //electron:electron_lib
+  - gn check out/Default //electron:electron_app
   - ninja -C out/Default electron:electron_app
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/ffmpeg electron:electron_ffmpeg_zip

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -34,8 +34,8 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/common/chrome_paths.h"
-#include "content/browser/gpu/compositor_util.h"
-#include "content/browser/gpu/gpu_data_manager_impl.h"
+#include "content/browser/gpu/compositor_util.h"        // nogncheck
+#include "content/browser/gpu/gpu_data_manager_impl.h"  // nogncheck
 #include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/browser/browser_child_process_host.h"
 #include "content/public/browser/child_process_data.h"

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -17,8 +17,8 @@
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/options_switches.h"
 #include "base/threading/thread_task_runner_handle.h"
-#include "content/browser/renderer_host/render_widget_host_impl.h"
-#include "content/browser/renderer_host/render_widget_host_owner_delegate.h"
+#include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
+#include "content/browser/renderer_host/render_widget_host_owner_delegate.h"  // nogncheck
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "gin/converter.h"

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -49,7 +49,7 @@
 #include "native_mate/object_template_builder.h"
 #include "net/base/load_flags.h"
 #include "net/disk_cache/disk_cache.h"
-#include "net/dns/host_cache.h"
+#include "net/dns/host_cache.h"  // nogncheck
 #include "net/http/http_auth_handler_factory.h"
 #include "net/http/http_auth_preferences.h"
 #include "net/http/http_cache.h"

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -54,10 +54,10 @@
 #include "base/values.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/ssl/security_state_tab_helper.h"
-#include "content/browser/frame_host/frame_tree_node.h"
-#include "content/browser/frame_host/render_frame_host_manager.h"
-#include "content/browser/renderer_host/render_widget_host_impl.h"
-#include "content/browser/renderer_host/render_widget_host_view_base.h"
+#include "content/browser/frame_host/frame_tree_node.h"             // nogncheck
+#include "content/browser/frame_host/render_frame_host_manager.h"   // nogncheck
+#include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
+#include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
 #include "content/common/widget_messages.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/download_request_utils.h"

--- a/atom/browser/api/atom_api_web_contents_impl.cc
+++ b/atom/browser/api/atom_api_web_contents_impl.cc
@@ -4,9 +4,9 @@
 
 #include "atom/browser/api/atom_api_web_contents.h"
 
-#include "content/browser/frame_host/frame_tree.h"
-#include "content/browser/frame_host/frame_tree_node.h"
-#include "content/browser/web_contents/web_contents_impl.h"
+#include "content/browser/frame_host/frame_tree.h"           // nogncheck
+#include "content/browser/frame_host/frame_tree_node.h"      // nogncheck
+#include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
 #include "content/public/browser/guest_mode.h"
 
 #if BUILDFLAG(ENABLE_OSR)

--- a/atom/browser/api/gpuinfo_manager.h
+++ b/atom/browser/api/gpuinfo_manager.h
@@ -11,7 +11,7 @@
 
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/promise_util.h"
-#include "content/browser/gpu/gpu_data_manager_impl.h"
+#include "content/browser/gpu/gpu_data_manager_impl.h"  // nogncheck
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/gpu_data_manager_observer.h"
 

--- a/atom/browser/atom_blob_reader.cc
+++ b/atom/browser/atom_blob_reader.cc
@@ -7,7 +7,7 @@
 #include <utility>
 
 #include "base/task/post_task.h"
-#include "content/browser/blob_storage/chrome_blob_storage_context.h"
+#include "content/browser/blob_storage/chrome_blob_storage_context.h"  // nogncheck
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "net/base/io_buffer.h"

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -36,7 +36,7 @@
 #include "components/prefs/value_map_pref_store.h"
 #include "components/proxy_config/pref_proxy_config_tracker_impl.h"
 #include "components/proxy_config/proxy_config_pref_names.h"
-#include "content/browser/blob_storage/chrome_blob_storage_context.h"
+#include "content/browser/blob_storage/chrome_blob_storage_context.h"  // nogncheck
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"
 #include "net/base/escape.h"

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -24,13 +24,12 @@
 #include "base/threading/scoped_blocking_call.h"
 #include "base/threading/sequenced_task_runner_handle.h"
 #include "chrome/browser/ssl/security_state_tab_helper.h"
-#include "chrome/browser/ui/color_chooser.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
 #include "components/security_state/content/content_utils.h"
 #include "components/security_state/core/security_state.h"
-#include "content/browser/renderer_host/render_widget_host_view_base.h"
+#include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/file_select_listener.h"
@@ -41,6 +40,10 @@
 #include "content/public/browser/security_style_explanations.h"
 #include "printing/buildflags/buildflags.h"
 #include "storage/browser/fileapi/isolated_context.h"
+
+#if BUILDFLAG(ENABLE_COLOR_CHOOSER)
+#include "chrome/browser/ui/color_chooser.h"
+#endif
 
 #if BUILDFLAG(ENABLE_OSR)
 #include "atom/browser/osr/osr_web_contents_view.h"

--- a/atom/browser/loader/layered_resource_handler.h
+++ b/atom/browser/loader/layered_resource_handler.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include "content/browser/loader/layered_resource_handler.h"
+#include "content/browser/loader/layered_resource_handler.h"  // nogncheck
 #include "services/network/public/cpp/resource_response.h"
 
 namespace atom {

--- a/atom/browser/net/url_request_context_getter.cc
+++ b/atom/browser/net/url_request_context_getter.cc
@@ -35,7 +35,7 @@
 #include "net/base/host_mapping_rules.h"
 #include "net/cert/multi_log_ct_verifier.h"
 #include "net/cookies/cookie_monster.h"
-#include "net/dns/mapped_host_resolver.h"
+#include "net/dns/mapped_host_resolver.h"  // nogncheck
 #include "net/http/http_auth_handler_factory.h"
 #include "net/http/http_auth_preferences.h"
 #include "net/http/http_auth_scheme.h"

--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.h
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.h
@@ -7,7 +7,7 @@
 
 #include <Quartz/Quartz.h>
 
-#include "ui/views_bridge_mac/views_nswindow_delegate.h"
+#include "ui/views_bridge_mac/views_nswindow_delegate.h"  // nogncheck
 
 namespace atom {
 class NativeWindowMac;

--- a/atom/browser/web_view_guest_delegate.cc
+++ b/atom/browser/web_view_guest_delegate.cc
@@ -8,7 +8,7 @@
 
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
-#include "content/browser/web_contents/web_contents_impl.h"
+#include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -33,7 +33,7 @@
 #include "third_party/blink/public/web/web_script_source.h"
 #include "third_party/blink/public/web/web_security_policy.h"
 #include "third_party/blink/public/web/web_view.h"
-#include "third_party/blink/renderer/platform/weborigin/scheme_registry.h"
+#include "third_party/blink/renderer/platform/weborigin/scheme_registry.h"  // nogncheck
 
 #if defined(OS_MACOSX)
 #include "base/strings/sys_string_conversions.h"

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -15,7 +15,7 @@
 #include "widevine_cdm_version.h"  // NOLINT(build/include)
 
 #if defined(WIDEVINE_CDM_AVAILABLE)
-#include "chrome/renderer/media/chrome_key_systems_provider.h"
+#include "chrome/renderer/media/chrome_key_systems_provider.h"  // nogncheck
 #endif
 
 namespace atom {

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -49,14 +49,15 @@ static_library("chrome") {
     "//extensions/browser/app_window/size_constraints.h",
   ]
   public_deps = [
-    "//content/public/browser",
-  ]
-  deps = [
     "//chrome/common",
-    "//components/feature_engagement:buildflags",
+    "//chrome/common:version_header",
     "//components/keyed_service/content",
     "//components/proxy_config",
     "//components/security_state/content",
+    "//content/public/browser",
+  ]
+  deps = [
+    "//components/feature_engagement:buildflags",
   ]
 
   if (is_linux) {
@@ -85,6 +86,7 @@ static_library("chrome") {
       "//chrome/browser/platform_util.cc",
       "//chrome/browser/platform_util.h",
       "//chrome/browser/ui/browser_dialogs.h",
+      "//chrome/browser/ui/color_chooser.h",
     ]
 
     if (use_aura) {
@@ -156,14 +158,16 @@ static_library("chrome") {
       "//chrome/browser/printing/printing_message_filter.cc",
       "//chrome/browser/printing/printing_message_filter.h",
     ]
-    deps += [
+    public_deps += [
       "//chrome/services/printing:lib",
       "//components/printing/browser",
-      "//components/printing/common",
       "//components/printing/renderer",
-      "//components/services/pdf_compositor",
       "//components/services/pdf_compositor/public/cpp:factory",
       "//components/services/pdf_compositor/public/interfaces",
+    ]
+    deps += [
+      "//components/printing/common",
+      "//components/services/pdf_compositor",
       "//printing",
     ]
 


### PR DESCRIPTION
#### Description of Change

- [x] Fix gn check errors for `//electron`
- [x] Add --gn-check lint option
- [x] Add check to ci

The headers included from some private targets have been suffixed with `nogncheck`, these targets are known to be built as a transitive dep, so lets avoid a visibility patch in chromium. Also this gives a good idea of private headers we depend on, lets try to minimize them. 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes
