### PR TITLE
chore: finalize dropping support for OS X Mavericks (version 10.9)

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -410,37 +410,31 @@ std::string SystemPreferences::GetAccentColor() {
 
 std::string SystemPreferences::GetSystemColor(const std::string& color,
                                               mate::Arguments* args) {
-  if (@available(macOS 10.10, *)) {
-    NSColor* sysColor;
-    if (color == "blue") {
-      sysColor = [NSColor systemBlueColor];
-    } else if (color == "brown") {
-      sysColor = [NSColor systemBrownColor];
-    } else if (color == "gray") {
-      sysColor = [NSColor systemGrayColor];
-    } else if (color == "green") {
-      sysColor = [NSColor systemGreenColor];
-    } else if (color == "orange") {
-      sysColor = [NSColor systemOrangeColor];
-    } else if (color == "pink") {
-      sysColor = [NSColor systemPinkColor];
-    } else if (color == "purple") {
-      sysColor = [NSColor systemPurpleColor];
-    } else if (color == "red") {
-      sysColor = [NSColor systemRedColor];
-    } else if (color == "yellow") {
-      sysColor = [NSColor systemYellowColor];
-    } else {
-      args->ThrowError("Unknown system color: " + color);
-      return "";
-    }
-
-    return ToRGBHex(sysColor);
+  NSColor* sysColor = nil;
+  if (color == "blue") {
+    sysColor = [NSColor systemBlueColor];
+  } else if (color == "brown") {
+    sysColor = [NSColor systemBrownColor];
+  } else if (color == "gray") {
+    sysColor = [NSColor systemGrayColor];
+  } else if (color == "green") {
+    sysColor = [NSColor systemGreenColor];
+  } else if (color == "orange") {
+    sysColor = [NSColor systemOrangeColor];
+  } else if (color == "pink") {
+    sysColor = [NSColor systemPinkColor];
+  } else if (color == "purple") {
+    sysColor = [NSColor systemPurpleColor];
+  } else if (color == "red") {
+    sysColor = [NSColor systemRedColor];
+  } else if (color == "yellow") {
+    sysColor = [NSColor systemYellowColor];
   } else {
-    args->ThrowError(
-        "This api is not available on MacOS version 10.9 or lower.");
+    args->ThrowError("Unknown system color: " + color);
     return "";
   }
+
+  return ToRGBHex(sysColor);
 }
 
 bool SystemPreferences::CanPromptTouchID() {
@@ -542,23 +536,18 @@ std::string SystemPreferences::GetColor(const std::string& color,
   } else if (color == "keyboard-focus-indicator") {
     sysColor = [NSColor keyboardFocusIndicatorColor];
   } else if (color == "label") {
-    if (@available(macOS 10.10, *))
-      sysColor = [NSColor labelColor];
+    sysColor = [NSColor labelColor];
   } else if (color == "link") {
-    if (@available(macOS 10.10, *))
-      sysColor = [NSColor linkColor];
+    sysColor = [NSColor linkColor];
   } else if (color == "placeholder-text") {
-    if (@available(macOS 10.10, *))
-      sysColor = [NSColor placeholderTextColor];
+    sysColor = [NSColor placeholderTextColor];
   } else if (color == "quaternary-label") {
-    if (@available(macOS 10.10, *))
-      sysColor = [NSColor quaternaryLabelColor];
+    sysColor = [NSColor quaternaryLabelColor];
   } else if (color == "scrubber-textured-background") {
     if (@available(macOS 10.12.2, *))
       sysColor = [NSColor scrubberTexturedBackgroundColor];
   } else if (color == "secondary-label") {
-    if (@available(macOS 10.10, *))
-      sysColor = [NSColor secondaryLabelColor];
+    sysColor = [NSColor secondaryLabelColor];
   } else if (color == "selected-content-background") {
     if (@available(macOS 10.14, *))
       sysColor = [NSColor selectedContentBackgroundColor];
@@ -578,8 +567,7 @@ std::string SystemPreferences::GetColor(const std::string& color,
   } else if (color == "shadow") {
     sysColor = [NSColor shadowColor];
   } else if (color == "tertiary-label") {
-    if (@available(macOS 10.10, *))
-      sysColor = [NSColor tertiaryLabelColor];
+    sysColor = [NSColor tertiaryLabelColor];
   } else if (color == "text-background") {
     sysColor = [NSColor textBackgroundColor];
   } else if (color == "text") {

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -148,13 +148,9 @@ void Browser::SetUserActivity(const std::string& type,
 }
 
 std::string Browser::GetCurrentActivityType() {
-  if (@available(macOS 10.10, *)) {
-    NSUserActivity* userActivity =
-        [[AtomApplication sharedApplication] getCurrentActivity];
-    return base::SysNSStringToUTF8(userActivity.activityType);
-  } else {
-    return std::string();
-  }
+  NSUserActivity* userActivity =
+      [[AtomApplication sharedApplication] getCurrentActivity];
+  return base::SysNSStringToUTF8(userActivity.activityType);
 }
 
 void Browser::InvalidateCurrentActivity() {

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -104,8 +104,7 @@ typedef NS_ENUM(NSInteger, AVAuthorizationStatusMac) {
                                             NSUserActivityDelegate> {
  @private
   BOOL handlingSendEvent_;
-  base::scoped_nsobject<NSUserActivity> currentActivity_
-      API_AVAILABLE(macosx(10.10));
+  base::scoped_nsobject<NSUserActivity> currentActivity_;
   NSCondition* handoffLock_;
   BOOL updateReceived_;
   base::Callback<bool()> shouldShutdown_;
@@ -121,7 +120,7 @@ typedef NS_ENUM(NSInteger, AVAuthorizationStatusMac) {
 // CrAppControlProtocol:
 - (void)setHandlingSendEvent:(BOOL)handlingSendEvent;
 
-- (NSUserActivity*)getCurrentActivity API_AVAILABLE(macosx(10.10));
+- (NSUserActivity*)getCurrentActivity;
 - (void)setCurrentActivity:(NSString*)type
               withUserInfo:(NSDictionary*)userInfo
             withWebpageURL:(NSURL*)webpageURL;

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -69,15 +69,13 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 - (void)setCurrentActivity:(NSString*)type
               withUserInfo:(NSDictionary*)userInfo
             withWebpageURL:(NSURL*)webpageURL {
-  if (@available(macOS 10.10, *)) {
-    currentActivity_ = base::scoped_nsobject<NSUserActivity>(
-        [[NSUserActivity alloc] initWithActivityType:type]);
-    [currentActivity_ setUserInfo:userInfo];
-    [currentActivity_ setWebpageURL:webpageURL];
-    [currentActivity_ setDelegate:self];
-    [currentActivity_ becomeCurrent];
-    [currentActivity_ setNeedsSave:YES];
-  }
+  currentActivity_ = base::scoped_nsobject<NSUserActivity>(
+      [[NSUserActivity alloc] initWithActivityType:type]);
+  [currentActivity_ setUserInfo:userInfo];
+  [currentActivity_ setWebpageURL:webpageURL];
+  [currentActivity_ setDelegate:self];
+  [currentActivity_ becomeCurrent];
+  [currentActivity_ setNeedsSave:YES];
 }
 
 - (NSUserActivity*)getCurrentActivity {
@@ -103,8 +101,7 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   [handoffLock_ unlock];
 }
 
-- (void)userActivityWillSave:(NSUserActivity*)userActivity
-    API_AVAILABLE(macosx(10.10)) {
+- (void)userActivityWillSave:(NSUserActivity*)userActivity {
   __block BOOL shouldWait = NO;
   dispatch_sync_main(^{
     std::string activity_type(
@@ -132,8 +129,7 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   [userActivity setNeedsSave:YES];
 }
 
-- (void)userActivityWasContinued:(NSUserActivity*)userActivity
-    API_AVAILABLE(macosx(10.10)) {
+- (void)userActivityWasContinued:(NSUserActivity*)userActivity {
   dispatch_async(dispatch_get_main_queue(), ^{
     std::string activity_type(
         base::SysNSStringToUTF8(userActivity.activityType));

--- a/atom/browser/mac/atom_application_delegate.mm
+++ b/atom/browser/mac/atom_application_delegate.mm
@@ -103,7 +103,7 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 #else
           (void (^)(NSArray* restorableObjects))
 #endif
-              restorationHandler API_AVAILABLE(macosx(10.10)) {
+              restorationHandler {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
   std::unique_ptr<base::DictionaryValue> user_info =
       atom::NSDictionaryToDictionaryValue(userActivity.userInfo);

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -168,8 +168,6 @@ class NativeWindowMac : public NativeWindow {
   void AddContentViewLayers();
 
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
-  void ShowWindowButton(NSWindowButton button);
-
   void SetForwardMouseMessages(bool forward);
 
   AtomNSWindow* window_;  // Weak ref, managed by widget_.

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -315,11 +315,9 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   }
 
   NSUInteger styleMask = NSWindowStyleMaskTitled;
-  if (@available(macOS 10.10, *)) {
-    if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER &&
-        (!useStandardWindow || transparent() || !has_frame())) {
-      styleMask = NSWindowStyleMaskFullSizeContentView;
-    }
+  if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER &&
+      (!useStandardWindow || transparent() || !has_frame())) {
+    styleMask = NSWindowStyleMaskFullSizeContentView;
   }
   if (minimizable) {
     styleMask |= NSMiniaturizableWindowMask;
@@ -378,11 +376,9 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
     [window_ setDisableKeyOrMainWindow:YES];
 
   if (transparent() || !has_frame()) {
-    if (@available(macOS 10.10, *)) {
-      // Don't show title bar.
-      [window_ setTitlebarAppearsTransparent:YES];
-      [window_ setTitleVisibility:NSWindowTitleHidden];
-    }
+    // Don't show title bar.
+    [window_ setTitlebarAppearsTransparent:YES];
+    [window_ setTitleVisibility:NSWindowTitleHidden];
     // Remove non-transparent corners, see http://git.io/vfonD.
     [window_ setOpaque:NO];
   }
@@ -401,22 +397,15 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
 
   // Hide the title bar background
   if (title_bar_style_ != NORMAL) {
-    if (@available(macOS 10.10, *)) {
-      [window_ setTitlebarAppearsTransparent:YES];
-    }
+    [window_ setTitlebarAppearsTransparent:YES];
   }
 
   // Hide the title bar.
   if (title_bar_style_ == HIDDEN_INSET) {
-    if (@available(macOS 10.10, *)) {
-      base::scoped_nsobject<NSToolbar> toolbar(
-          [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
-      [toolbar setShowsBaselineSeparator:NO];
-      [window_ setToolbar:toolbar];
-    } else {
-      [window_ enableWindowButtonsOffset];
-      [window_ setWindowButtonsOffset:NSMakePoint(12, 10)];
-    }
+    base::scoped_nsobject<NSToolbar> toolbar(
+        [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
+    [toolbar setShowsBaselineSeparator:NO];
+    [window_ setToolbar:toolbar];
   }
 
   // Resize to content bounds.
@@ -874,17 +863,11 @@ void NativeWindowMac::Invalidate() {
 }
 
 void NativeWindowMac::SetTitle(const std::string& title) {
-  // For macOS <= 10.9, the setTitleVisibility API is not available, we have
-  // to avoid calling setTitle for frameless window.
-  if (!base::mac::IsAtLeastOS10_10() && (transparent() || !has_frame()))
-    return;
-
   [window_ setTitle:base::SysUTF8ToNSString(title)];
 }
 
 std::string NativeWindowMac::GetTitle() {
   return base::SysNSStringToUTF8([window_ title]);
-  ;
 }
 
 void NativeWindowMac::FlashFrame(bool flash) {
@@ -1246,84 +1229,81 @@ bool NativeWindowMac::SetWindowButtonVisibility(bool visible) {
 }
 
 void NativeWindowMac::SetVibrancy(const std::string& type) {
-  if (@available(macOS 10.10, *)) {
-    NSView* vibrant_view = [window_ vibrantView];
+  NSView* vibrant_view = [window_ vibrantView];
 
-    if (type.empty()) {
-      if (background_color_before_vibrancy_) {
-        [window_ setBackgroundColor:background_color_before_vibrancy_];
-        [window_ setTitlebarAppearsTransparent:transparency_before_vibrancy_];
-      }
-      if (vibrant_view == nil)
-        return;
-
-      [vibrant_view removeFromSuperview];
-      [window_ setVibrantView:nil];
-
+  if (type.empty()) {
+    if (background_color_before_vibrancy_) {
+      [window_ setBackgroundColor:background_color_before_vibrancy_];
+      [window_ setTitlebarAppearsTransparent:transparency_before_vibrancy_];
+    }
+    if (vibrant_view == nil)
       return;
-    }
 
-    background_color_before_vibrancy_.reset([[window_ backgroundColor] retain]);
-    transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
+    [vibrant_view removeFromSuperview];
+    [window_ setVibrantView:nil];
 
-    if (title_bar_style_ != NORMAL) {
-      [window_ setTitlebarAppearsTransparent:YES];
-      [window_ setBackgroundColor:[NSColor clearColor]];
-    }
-
-    NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
-    if (effect_view == nil) {
-      effect_view = [[[NSVisualEffectView alloc]
-          initWithFrame:[[window_ contentView] bounds]] autorelease];
-      [window_ setVibrantView:(NSView*)effect_view];
-
-      [effect_view
-          setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-      [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
-      [effect_view setState:NSVisualEffectStateActive];
-      [[window_ contentView] addSubview:effect_view
-                             positioned:NSWindowBelow
-                             relativeTo:nil];
-    }
-
-    NSVisualEffectMaterial vibrancyType = NSVisualEffectMaterialLight;
-
-    if (type == "appearance-based") {
-      vibrancyType = NSVisualEffectMaterialAppearanceBased;
-    } else if (type == "light") {
-      vibrancyType = NSVisualEffectMaterialLight;
-    } else if (type == "dark") {
-      vibrancyType = NSVisualEffectMaterialDark;
-    } else if (type == "titlebar") {
-      vibrancyType = NSVisualEffectMaterialTitlebar;
-    }
-
-    if (@available(macOS 10.11, *)) {
-      // TODO(kevinsawicki): Use NSVisualEffectMaterial* constants directly once
-      // they are available in the minimum SDK version
-      if (type == "selection") {
-        // NSVisualEffectMaterialSelection
-        vibrancyType = static_cast<NSVisualEffectMaterial>(4);
-      } else if (type == "menu") {
-        // NSVisualEffectMaterialMenu
-        vibrancyType = static_cast<NSVisualEffectMaterial>(5);
-      } else if (type == "popover") {
-        // NSVisualEffectMaterialPopover
-        vibrancyType = static_cast<NSVisualEffectMaterial>(6);
-      } else if (type == "sidebar") {
-        // NSVisualEffectMaterialSidebar
-        vibrancyType = static_cast<NSVisualEffectMaterial>(7);
-      } else if (type == "medium-light") {
-        // NSVisualEffectMaterialMediumLight
-        vibrancyType = static_cast<NSVisualEffectMaterial>(8);
-      } else if (type == "ultra-dark") {
-        // NSVisualEffectMaterialUltraDark
-        vibrancyType = static_cast<NSVisualEffectMaterial>(9);
-      }
-    }
-
-    [effect_view setMaterial:vibrancyType];
+    return;
   }
+
+  background_color_before_vibrancy_.reset([[window_ backgroundColor] retain]);
+  transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
+
+  if (title_bar_style_ != NORMAL) {
+    [window_ setTitlebarAppearsTransparent:YES];
+    [window_ setBackgroundColor:[NSColor clearColor]];
+  }
+
+  NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
+  if (effect_view == nil) {
+    effect_view = [[[NSVisualEffectView alloc]
+        initWithFrame:[[window_ contentView] bounds]] autorelease];
+    [window_ setVibrantView:(NSView*)effect_view];
+
+    [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+    [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
+    [effect_view setState:NSVisualEffectStateActive];
+    [[window_ contentView] addSubview:effect_view
+                           positioned:NSWindowBelow
+                           relativeTo:nil];
+  }
+
+  NSVisualEffectMaterial vibrancyType = NSVisualEffectMaterialLight;
+
+  if (type == "appearance-based") {
+    vibrancyType = NSVisualEffectMaterialAppearanceBased;
+  } else if (type == "light") {
+    vibrancyType = NSVisualEffectMaterialLight;
+  } else if (type == "dark") {
+    vibrancyType = NSVisualEffectMaterialDark;
+  } else if (type == "titlebar") {
+    vibrancyType = NSVisualEffectMaterialTitlebar;
+  }
+
+  if (@available(macOS 10.11, *)) {
+    // TODO(kevinsawicki): Use NSVisualEffectMaterial* constants directly once
+    // they are available in the minimum SDK version
+    if (type == "selection") {
+      // NSVisualEffectMaterialSelection
+      vibrancyType = static_cast<NSVisualEffectMaterial>(4);
+    } else if (type == "menu") {
+      // NSVisualEffectMaterialMenu
+      vibrancyType = static_cast<NSVisualEffectMaterial>(5);
+    } else if (type == "popover") {
+      // NSVisualEffectMaterialPopover
+      vibrancyType = static_cast<NSVisualEffectMaterial>(6);
+    } else if (type == "sidebar") {
+      // NSVisualEffectMaterialSidebar
+      vibrancyType = static_cast<NSVisualEffectMaterial>(7);
+    } else if (type == "medium-light") {
+      // NSVisualEffectMaterialMediumLight
+      vibrancyType = static_cast<NSVisualEffectMaterial>(8);
+    } else if (type == "ultra-dark") {
+      // NSVisualEffectMaterialUltraDark
+      vibrancyType = static_cast<NSVisualEffectMaterial>(9);
+    }
+  }
+
+  [effect_view setMaterial:vibrancyType];
 }
 
 void NativeWindowMac::SetTouchBar(
@@ -1466,11 +1446,6 @@ void NativeWindowMac::InternalSetParentWindow(NativeWindow* parent,
     [parent->GetNativeWindow().GetNativeNSWindow()
         addChildWindow:window_
                ordered:NSWindowAbove];
-}
-
-void NativeWindowMac::ShowWindowButton(NSWindowButton button) {
-  auto view = [window_ standardWindowButton:button];
-  [view.superview addSubview:view positioned:NSWindowAbove relativeTo:nil];
 }
 
 void NativeWindowMac::SetForwardMouseMessages(bool forward) {

--- a/atom/browser/notifications/mac/cocoa_notification.h
+++ b/atom/browser/notifications/mac/cocoa_notification.h
@@ -29,8 +29,7 @@ class CocoaNotification : public Notification {
   void NotificationDisplayed();
   void NotificationReplied(const std::string& reply);
   void NotificationActivated();
-  void NotificationActivated(NSUserNotificationAction* action)
-      API_AVAILABLE(macosx(10.10));
+  void NotificationActivated(NSUserNotificationAction* action);
   void NotificationDismissed();
 
   NSUserNotification* notification() const { return notification_; }

--- a/atom/browser/notifications/mac/cocoa_notification.mm
+++ b/atom/browser/notifications/mac/cocoa_notification.mm
@@ -72,24 +72,18 @@ void CocoaNotification::Show(const NotificationOptions& options) {
         // All of the rest are appended to the list of additional actions
         NSString* actionIdentifier =
             [NSString stringWithFormat:@"%@Action%d", identifier, i];
-        if (@available(macOS 10.10, *)) {
-          NSUserNotificationAction* notificationAction =
-              [NSUserNotificationAction
-                  actionWithIdentifier:actionIdentifier
-                                 title:base::SysUTF16ToNSString(action.text)];
-          [additionalActions addObject:notificationAction];
-          additional_action_indices_.insert(
-              std::make_pair(base::SysNSStringToUTF8(actionIdentifier), i));
-        }
+        NSUserNotificationAction* notificationAction = [NSUserNotificationAction
+            actionWithIdentifier:actionIdentifier
+                           title:base::SysUTF16ToNSString(action.text)];
+        [additionalActions addObject:notificationAction];
+        additional_action_indices_.insert(
+            std::make_pair(base::SysNSStringToUTF8(actionIdentifier), i));
       }
     }
     i++;
   }
-  if ([additionalActions count] > 0 &&
-      [notification_ respondsToSelector:@selector(setAdditionalActions:)]) {
-    if (@available(macOS 10.10, *)) {
-      [notification_ setAdditionalActions:additionalActions];
-    }
+  if ([additionalActions count] > 0) {
+    [notification_ setAdditionalActions:additionalActions];
   }
 
   if (options.has_reply) {

--- a/atom/browser/notifications/mac/notification_center_delegate.mm
+++ b/atom/browser/notifications/mac/notification_center_delegate.mm
@@ -47,12 +47,9 @@
                NSUserNotificationActivationTypeReplied) {
       notification->NotificationReplied([notif.response.string UTF8String]);
     } else {
-      if (@available(macOS 10.10, *)) {
-        if (notif.activationType ==
-            NSUserNotificationActivationTypeAdditionalActionClicked) {
-          notification->NotificationActivated(
-              [notif additionalActivationAction]);
-        }
+      if (notif.activationType ==
+          NSUserNotificationActivationTypeAdditionalActionClicked) {
+        notification->NotificationActivated([notif additionalActivationAction]);
       }
     }
   }

--- a/atom/browser/ui/cocoa/atom_ns_window.h
+++ b/atom/browser/ui/cocoa/atom_ns_window.h
@@ -30,20 +30,17 @@ class ScopedDisableResize {
 @interface AtomNSWindow : NativeWidgetMacNSWindow {
  @private
   atom::NativeWindowMac* shell_;
-  CGFloat windowButtonsInterButtonSpacing_;
 }
 @property BOOL acceptsFirstMouse;
 @property BOOL enableLargerThanScreen;
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
-@property NSPoint windowButtonsOffset;
 @property(nonatomic, retain) NSView* vibrantView;
 - (id)initWithShell:(atom::NativeWindowMac*)shell
           styleMask:(NSUInteger)styleMask;
 - (atom::NativeWindowMac*)shell;
 - (id)accessibilityFocusedUIElement;
 - (NSRect)originalContentRectForFrameRect:(NSRect)frameRect;
-- (void)enableWindowButtonsOffset;
 - (void)toggleFullScreenMode:(id)sender;
 @end
 

--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -179,62 +179,56 @@
   shell_->SetResizable(true);
   // Hide the native toolbar before entering fullscreen, so there is no visual
   // artifacts.
-  if (@available(macOS 10.10, *)) {
-    if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
-      NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
-      [window setToolbar:nil];
-    }
+  if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+    NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
+    [window setToolbar:nil];
   }
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
   shell_->NotifyWindowEnterFullScreen();
 
-  if (@available(macOS 10.10, *)) {
-    // For frameless window we don't show set title for normal mode since the
-    // titlebar is expected to be empty, but after entering fullscreen mode we
-    // have to set one, because title bar is visible here.
-    NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
-    if ((shell_->transparent() || !shell_->has_frame()) &&
-        // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
-        // fullscreen mode.
-        // Show title if fullscreen_window_title flag is set
-        (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
-         shell_->fullscreen_window_title())) {
-      [window setTitleVisibility:NSWindowTitleVisible];
-    }
+  // For frameless window we don't show set title for normal mode since the
+  // titlebar is expected to be empty, but after entering fullscreen mode we
+  // have to set one, because title bar is visible here.
+  NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
+  if ((shell_->transparent() || !shell_->has_frame()) &&
+      // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
+      // fullscreen mode.
+      // Show title if fullscreen_window_title flag is set
+      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+       shell_->fullscreen_window_title())) {
+    [window setTitleVisibility:NSWindowTitleVisible];
+  }
 
-    // Restore the native toolbar immediately after entering fullscreen, if we
-    // do this before leaving fullscreen, traffic light buttons will be jumping.
-    if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
-      base::scoped_nsobject<NSToolbar> toolbar(
-          [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
-      [toolbar setShowsBaselineSeparator:NO];
-      [window setToolbar:toolbar];
+  // Restore the native toolbar immediately after entering fullscreen, if we
+  // do this before leaving fullscreen, traffic light buttons will be jumping.
+  if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+    base::scoped_nsobject<NSToolbar> toolbar(
+        [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
+    [toolbar setShowsBaselineSeparator:NO];
+    [window setToolbar:toolbar];
 
-      // Set window style to hide the toolbar, otherwise the toolbar will show
-      // in fullscreen mode.
-      [window setTitlebarAppearsTransparent:NO];
-      shell_->SetStyleMask(true, NSWindowStyleMaskFullSizeContentView);
-    }
+    // Set window style to hide the toolbar, otherwise the toolbar will show
+    // in fullscreen mode.
+    [window setTitlebarAppearsTransparent:NO];
+    shell_->SetStyleMask(true, NSWindowStyleMaskFullSizeContentView);
   }
 }
 
 - (void)windowWillExitFullScreen:(NSNotification*)notification {
-  if (@available(macOS 10.10, *)) {
-    // Restore the titlebar visibility.
-    NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
-    if ((shell_->transparent() || !shell_->has_frame()) &&
-        (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
-         shell_->fullscreen_window_title())) {
-      [window setTitleVisibility:NSWindowTitleHidden];
-    }
+  // Restore the titlebar visibility.
+  NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
+  if ((shell_->transparent() || !shell_->has_frame()) &&
+      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+       shell_->fullscreen_window_title())) {
+    [window setTitleVisibility:NSWindowTitleHidden];
+  }
 
-    // Turn off the style for toolbar.
-    if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
-      shell_->SetStyleMask(false, NSWindowStyleMaskFullSizeContentView);
-      [window setTitlebarAppearsTransparent:YES];
-    }
+  // Turn off the style for toolbar.
+  if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+    shell_->SetStyleMask(false, NSWindowStyleMaskFullSizeContentView);
+    [window setTitlebarAppearsTransparent:YES];
   }
 }
 

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -26,11 +26,8 @@ namespace {
 // thread safe, including LSGetApplicationForURL (> 10.2) and
 // NSWorkspace#openURLs.
 std::string OpenURL(NSURL* ns_url, bool activate) {
-  CFURLRef ref = nil;
-  if (@available(macOS 10.10, *)) {
-    ref = LSCopyDefaultApplicationURLForURL(base::mac::NSToCFCast(ns_url),
-                                            kLSRolesAll, nullptr);
-  }
+  CFURLRef ref = LSCopyDefaultApplicationURLForURL(
+      base::mac::NSToCFCast(ns_url), kLSRolesAll, nullptr);
 
   // If no application could be found, NULL is returned and outError
   // (if not NULL) is populated with kLSApplicationNotFoundErr.


### PR DESCRIPTION
#### Description of Change
Re-apply https://github.com/electron/electron/pull/13296 after [mac: bump deployment target to 10.10](https://chromium.googlesource.com/chromium/src/+/bd6d39d548edd2afa4f00d7aed33ce92e8adf13a)
Mostly removes obsolete `@available(macOS 10.10, *)` checks in the code
Follow up to https://github.com/electron/electron/pull/15357

/cc @nornagon, @codebytere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes