### PR TITLE
refactor: make ELECTRON_BROWSER_SANDBOX_LOAD handler async

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -3,6 +3,7 @@
 const electron = require('electron')
 const { EventEmitter } = require('events')
 const fs = require('fs')
+const util = require('util')
 const v8Util = process.atomBinding('v8_util')
 const eventBinding = process.atomBinding('event')
 
@@ -495,12 +496,14 @@ ipcMainUtils.handle('ELECTRON_BROWSER_CLIPBOARD_WRITE_FIND_TEXT', function (even
   return electron.clipboard.writeFindText(text)
 })
 
-const getPreloadScript = function (preloadPath) {
+const readFile = util.promisify(fs.readFile)
+
+const getPreloadScript = async function (preloadPath) {
   let preloadSrc = null
   let preloadError = null
   if (preloadPath) {
     try {
-      preloadSrc = fs.readFileSync(preloadPath).toString()
+      preloadSrc = (await readFile(preloadPath)).toString()
     } catch (err) {
       preloadError = errorUtils.serialize(err)
     }
@@ -508,14 +511,14 @@ const getPreloadScript = function (preloadPath) {
   return { preloadPath, preloadSrc, preloadError }
 }
 
-ipcMainInternal.on('ELECTRON_BROWSER_SANDBOX_LOAD', function (event) {
+ipcMainUtils.handle('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) {
   const preloadPaths = [
     ...(event.sender.session ? event.sender.session.getPreloads() : []),
     event.sender._getPreloadPath()
   ]
 
-  event.returnValue = {
-    preloadScripts: preloadPaths.map(path => getPreloadScript(path)),
+  return {
+    preloadScripts: await Promise.all(preloadPaths.map(path => getPreloadScript(path))),
     isRemoteModuleEnabled: isRemoteModuleEnabled(event.sender),
     isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),
     process: {

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -27,10 +27,11 @@ for (const prop of Object.keys(EventEmitter.prototype)) {
 Object.setPrototypeOf(process, EventEmitter.prototype)
 
 const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal')
+const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
 const {
   preloadScripts, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
-} = ipcRendererInternal.sendSync('ELECTRON_BROWSER_SANDBOX_LOAD')
+} = ipcRendererUtils.invokeSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 process.isRemoteModuleEnabled = isRemoteModuleEnabled
 


### PR DESCRIPTION
#### Description of Change
Load all preload scripts in parallel asynchronously without blocking the main thread.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes