### PR TITLE
refactor: make shell.ShowItemInFolder asynchronous

### DIFF
--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -23,7 +23,7 @@ typedef base::OnceCallback<void(const std::string&)> OpenExternalCallback;
 
 // Show the given file in a file manager. If possible, select the file.
 // Must be called from the UI thread.
-bool ShowItemInFolder(const base::FilePath& full_path);
+void ShowItemInFolder(const base::FilePath& full_path);
 
 // Open the given file in the desktop's default manner.
 // Must be called from the UI thread.

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -69,12 +69,12 @@ namespace platform_util {
 // TODO(estade): It would be nice to be able to select the file in the file
 // manager, but that probably requires extending xdg-open. For now just
 // show the folder.
-bool ShowItemInFolder(const base::FilePath& full_path) {
+void ShowItemInFolder(const base::FilePath& full_path) {
   base::FilePath dir = full_path.DirName();
   if (!base::DirectoryExists(dir))
-    return false;
+    return;
 
-  return XDGOpen(dir.value(), false);
+  XDGOpen(dir.value(), false);
 }
 
 bool OpenItem(const base::FilePath& full_path) {

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -62,7 +62,7 @@ NSString* GetLoginHelperBundleIdentifier() {
 
 namespace platform_util {
 
-bool ShowItemInFolder(const base::FilePath& path) {
+void ShowItemInFolder(const base::FilePath& path) {
   // The API only takes absolute path.
   base::FilePath full_path =
       path.IsAbsolute() ? path : base::MakeAbsoluteFilePath(path);
@@ -72,9 +72,7 @@ bool ShowItemInFolder(const base::FilePath& path) {
   if (!path_string || ![[NSWorkspace sharedWorkspace] selectFile:path_string
                                         inFileViewerRootedAtPath:@""]) {
     LOG(WARNING) << "NSWorkspace failed to select file " << full_path.value();
-    return false;
   }
-  return true;
 }
 
 bool OpenItem(const base::FilePath& full_path) {

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -28,6 +28,7 @@
 #include "base/win/scoped_co_mem.h"
 #include "base/win/scoped_com_initializer.h"
 #include "base/win/windows_version.h"
+#include "content/public/browser/browser_task_traits.h"
 #include "ui/base/win/shell.h"
 #include "url/gurl.h"
 
@@ -228,10 +229,6 @@ HRESULT DeleteFileProgressSink::ResumeTimer() {
   return S_OK;
 }
 
-}  // namespace
-
-namespace platform_util {
-
 void ShowItemInFolderOnWorkerThread(const base::FilePath& full_path) {
   base::ScopedBlockingCall scoped_blocking_call(base::BlockingType::MAY_BLOCK);
   base::win::ScopedCOMInitializer com_initializer;
@@ -283,6 +280,10 @@ void ShowItemInFolderOnWorkerThread(const base::FilePath& full_path) {
     }
   }
 }
+
+}  // namespace
+
+namespace platform_util {
 
 void ShowItemInFolder(const base::FilePath& full_path) {
   base::CreateCOMSTATaskRunnerWithTraits(

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -23,6 +23,7 @@
 #include "base/stl_util.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/task/post_task.h"
 #include "base/threading/scoped_blocking_call.h"
 #include "base/win/registry.h"
 #include "base/win/scoped_co_mem.h"

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -23,6 +23,7 @@
 #include "base/stl_util.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/threading/scoped_blocking_call.h"
 #include "base/win/registry.h"
 #include "base/win/scoped_co_mem.h"
 #include "base/win/scoped_com_initializer.h"
@@ -232,6 +233,7 @@ HRESULT DeleteFileProgressSink::ResumeTimer() {
 namespace platform_util {
 
 bool ShowItemInFolder(const base::FilePath& full_path) {
+  base::ScopedBlockingCall scoped_blocking_call(base::BlockingType::MAY_BLOCK);
   base::win::ScopedCOMInitializer com_initializer;
   if (!com_initializer.Succeeded())
     return false;
@@ -297,6 +299,7 @@ bool OpenItem(const base::FilePath& full_path) {
 
 bool OpenExternal(const base::string16& url,
                   const OpenExternalOptions& options) {
+  base::ScopedBlockingCall scoped_blocking_call(base::BlockingType::MAY_BLOCK);
   // Quote the input scheme to be sure that the command does not have
   // parameters unexpected by the external program. This url should already
   // have been escaped.

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -22,8 +22,6 @@ The `shell` module has the following methods:
 
 * `fullPath` String
 
-Returns `Boolean` - Whether the item was successfully shown.
-
 Show the given file in a file manager. If possible, select the file.
 
 ### `shell.openItem(fullPath)`


### PR DESCRIPTION
#### Description of Change

BREAKING CHANGE: change return type of `ShowItemInFolder` to `void` from `bool` and offload task to new thread.

cc @nornagon @deepak1556

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Made `ShowItemInFolder` asynchronous with no return value.
