### PR TITLE
fix: set cancelId to 1 when defaultId == 0 and no 'cancel' button

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -263,7 +263,8 @@ module.exports = {
 
     // Choose a default button to get selected when dialog is cancelled.
     if (cancelId == null) {
-      cancelId = 0
+      // If the defaultId is set to 0, ensure the cancel button is a different index (1)
+      cancelId = (defaultId === 0 && buttons.length > 1) ? 1 : 0
       for (let i = 0; i < buttons.length; i++) {
         const text = buttons[i].toLowerCase()
         if (text === 'cancel' || text === 'no') {


### PR DESCRIPTION
#### Description of Change
Previously when no `cancelId` was provided and it couldn't be detected based on "cancel" or "no" values `cancelId` defaulted to `0` which **overrode** the default style applied to the button on macOS if `defaultId` was set to `0` as well.

This change ensures that the dialog defaults can never collide like that when it matters

Fixes #17101

#### Release Notes

Notes: Fixed `defaultId` not taking affect when set to `0` and no "cancel" button was present on macOS