### PR TITLE
chore: Remove transparency hack

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -243,8 +243,6 @@ namespace {
 // Called when CapturePage is done.
 void OnCapturePageDone(util::Promise promise, const SkBitmap& bitmap) {
   // Hack to enable transparency in captured image
-  // TODO(nitsakh) Remove hack once fixed in chromium
-  const_cast<SkBitmap&>(bitmap).setAlphaType(kPremul_SkAlphaType);
   promise.Resolve(gfx::Image::CreateFrom1xBitmap(bitmap));
 }
 


### PR DESCRIPTION
This change undoes the hack that was put in because of a bug in chromium. That has since been fixed in chromium, so this is no longer need, hence removing.
The 'BrowserWindow' > 'preserves transparency' test, validates this working.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: no-notes
