### PR TITLE
feat: Add new powerMonitor synchronous API

### DIFF
--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -84,8 +84,8 @@ void PowerMonitor::OnResume() {
   Emit("resume");
 }
 
-ui::IdleState PowerMonitor::QuerySystemIdleState(v8::Isolate* isolate,
-                                                 int idle_threshold) {
+ui::IdleState PowerMonitor::GetSystemIdleState(v8::Isolate* isolate,
+                                               int idle_threshold) {
   if (idle_threshold > 0) {
     return ui::CalculateIdleState(idle_threshold);
   } else {
@@ -95,7 +95,7 @@ ui::IdleState PowerMonitor::QuerySystemIdleState(v8::Isolate* isolate,
   }
 }
 
-int PowerMonitor::QuerySystemIdleTime() {
+int PowerMonitor::GetSystemIdleTime() {
   return ui::CalculateIdleTime();
 }
 
@@ -122,8 +122,8 @@ void PowerMonitor::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("blockShutdown", &PowerMonitor::BlockShutdown)
       .SetMethod("unblockShutdown", &PowerMonitor::UnblockShutdown)
 #endif
-      .SetMethod("_querySystemIdleState", &PowerMonitor::QuerySystemIdleState)
-      .SetMethod("_querySystemIdleTime", &PowerMonitor::QuerySystemIdleTime);
+      .SetMethod("getSystemIdleState", &PowerMonitor::GetSystemIdleState)
+      .SetMethod("getSystemIdleTime", &PowerMonitor::GetSystemIdleTime);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -46,8 +46,8 @@ class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
   void OnResume() override;
 
  private:
-  ui::IdleState QuerySystemIdleState(v8::Isolate* isolate, int idle_threshold);
-  int QuerySystemIdleTime();
+  ui::IdleState GetSystemIdleState(v8::Isolate* isolate, int idle_threshold);
+  int GetSystemIdleTime();
 
 #if defined(OS_WIN)
   // Static callback invoked when a message comes in to our messaging window.

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -63,6 +63,24 @@ require('path')
 require('electron').remote.require('path')
 ```
 
+## `powerMonitor.querySystemIdleState`
+
+```js
+// Deprecated
+powerMonitor.querySystemIdleState(threshold, callback)
+// Replace with synchronous API
+const idleState = getSystemIdleState(threshold)
+```
+
+## `powerMonitor.querySystemIdleTime`
+
+```js
+// Deprecated
+powerMonitor.querySystemIdleTime(callback)
+// Replace with synchronous API
+const idleTime = getSystemIdleTime()
+```
+
 # Planned Breaking API Changes (5.0)
 
 ## `new BrowserWindow({ webPreferences })`

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -59,7 +59,7 @@ Emitted as soon as the systems screen is unlocked.
 
 The `powerMonitor` module has the following methods:
 
-#### `powerMonitor.querySystemIdleState(idleThreshold, callback)`
+#### `powerMonitor.querySystemIdleState(idleThreshold, callback)` _(Deprecated)_
 
 * `idleThreshold` Integer
 * `callback` Function
@@ -70,9 +70,25 @@ before considered idle. `callback` will be called synchronously on some systems
 and with an `idleState` argument that describes the system's state. `locked` is
 available on supported systems only.
 
-#### `powerMonitor.querySystemIdleTime(callback)`
+#### `powerMonitor.querySystemIdleTime(callback)` _(Deprecated)_
 
 * `callback` Function
   * `idleTime` Integer - Idle time in seconds
 
 Calculate system idle time in seconds.
+
+#### `powerMonitor.getSystemIdleState(idleThreshold)`
+
+* `idleThreshold` Integer
+
+Returns `String` - The system's current state. Can be `active`, `idle`, `locked` or `unknown`.
+
+Calculate the system idle state. `idleThreshold` is the amount of time (in seconds)
+before considered idle.  `locked` is available on supported systems only.
+
+#### `powerMonitor.getSystemIdleTime()`
+
+Returns `Integer` - Idle time in seconds
+
+Calculate system idle time in seconds.
+

--- a/lib/browser/api/power-monitor.js
+++ b/lib/browser/api/power-monitor.js
@@ -2,6 +2,7 @@
 
 const { EventEmitter } = require('events')
 const { powerMonitor, PowerMonitor } = process.atomBinding('power_monitor')
+const { deprecate } = require('electron')
 
 // PowerMonitor is an EventEmitter.
 Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
@@ -22,8 +23,9 @@ if (process.platform === 'linux') {
   })
 }
 
-// TODO(deepak1556): Deprecate async api in favor of sync version in 5.0
+// TODO(nitsakh): Remove in 7.0
 powerMonitor.querySystemIdleState = function (threshold, callback) {
+  deprecate.warn('powerMonitor.querySystemIdleState', 'powerMonitor.getSystemIdleState')
   if (typeof threshold !== 'number') {
     throw new Error('Must pass threshold as a number')
   }
@@ -32,18 +34,19 @@ powerMonitor.querySystemIdleState = function (threshold, callback) {
     throw new Error('Must pass callback as a function argument')
   }
 
-  const idleState = this._querySystemIdleState(threshold)
+  const idleState = this.getSystemIdleState(threshold)
 
   process.nextTick(() => callback(idleState))
 }
 
-// TODO(deepak1556): Deprecate async api in favor of sync version in 5.0
+// TODO(nitsakh): Remove in 7.0
 powerMonitor.querySystemIdleTime = function (callback) {
+  deprecate.warn('powerMonitor.querySystemIdleTime', 'powerMonitor.getSystemIdleTime')
   if (typeof callback !== 'function') {
     throw new Error('Must pass function as an argument')
   }
 
-  const idleTime = this._querySystemIdleTime()
+  const idleTime = this.getSystemIdleTime()
 
   process.nextTick(() => callback(idleTime))
 }

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -128,6 +128,7 @@ describe('powerMonitor', () => {
       powerMonitor = require('electron').remote.powerMonitor
     })
 
+    // TODO(nitsakh): Remove in 7.0
     describe('powerMonitor.querySystemIdleState', () => {
       it('notify current system idle state', done => {
         // this function is not mocked out, so we can test the result's
@@ -155,12 +156,45 @@ describe('powerMonitor', () => {
       })
     })
 
+    // TODO(nitsakh): Remove in 7.0
     describe('powerMonitor.querySystemIdleTime', () => {
       it('notify current system idle time', done => {
         powerMonitor.querySystemIdleTime(idleTime => {
           expect(idleTime).to.be.at.least(0)
           done()
         })
+      })
+    })
+
+    describe('powerMonitor.getSystemIdleState', () => {
+      it('gets current system idle state', () => {
+        // this function is not mocked out, so we can test the result's
+        // form and type but not its value.
+        const idleState = powerMonitor.getSystemIdleState(1)
+        expect(idleState).to.be.a('string')
+        const validIdleStates = [ 'active', 'idle', 'locked', 'unknown' ]
+        expect(validIdleStates).to.include(idleState)
+      })
+
+      it('does not accept non positive integer threshold', () => {
+        expect(() => {
+          powerMonitor.getSystemIdleState(-1)
+        }).to.throw(/must be greater than 0/)
+
+        expect(() => {
+          powerMonitor.getSystemIdleState(NaN)
+        }).to.throw(/conversion failure/)
+
+        expect(() => {
+          powerMonitor.getSystemIdleState('a')
+        }).to.throw(/conversion failure/)
+      })
+    })
+
+    describe('powerMonitor.getSystemIdleTime', () => {
+      it('notify current system idle time', () => {
+        const idleTime = powerMonitor.getSystemIdleTime()
+        expect(idleTime).to.be.at.least(0)
       })
     })
   })

--- a/spec/package-lock.json
+++ b/spec/package-lock.json
@@ -75,7 +75,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "optional": true,
       "requires": {
@@ -231,7 +231,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -363,7 +363,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -781,7 +781,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -789,7 +789,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -975,7 +975,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "optional": true
     },
@@ -1040,7 +1040,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1058,7 +1058,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -1357,7 +1357,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1373,7 +1373,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -1442,7 +1442,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -1537,7 +1537,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
`powerMonitor.querySystemIdleState` and `powerMonitor.querySystemIdleTime` had async backing APIs in chromium (https://chromium-review.googlesource.com/c/chromium/src/+/1379183). However, that has changed in ch73. So, this PR deprecates the old async APIs and adds new sync APIs.
Refer [this comment](https://github.com/electron/electron/pull/16823#issuecomment-461864274).
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Replaced `powerMonitor` `querySystemIdleState` and `querySystemIdleTime` with synchronous APIs.
