### PR TITLE
docs: remove dead link to chromiumdev slack

### DIFF
--- a/docs/development/chromium-development.md
+++ b/docs/development/chromium-development.md
@@ -2,7 +2,7 @@
 
 > A collection of resources for learning about Chromium and tracking its development
 
-- [chromiumdev](https://chromiumdev-slack.herokuapp.com) on Slack
+- [#chromium](irc://irc.freenode.net/chromium) on Freenode IRC
 - [@ChromiumDev](https://twitter.com/ChromiumDev) on Twitter
 - [@googlechrome](https://twitter.com/googlechrome) on Twitter
 - [Blog](https://blog.chromium.org)

--- a/docs/development/chromium-development.md
+++ b/docs/development/chromium-development.md
@@ -2,7 +2,6 @@
 
 > A collection of resources for learning about Chromium and tracking its development
 
-- [#chromium](irc://irc.freenode.net/chromium) on Freenode IRC
 - [@ChromiumDev](https://twitter.com/ChromiumDev) on Twitter
 - [@googlechrome](https://twitter.com/googlechrome) on Twitter
 - [Blog](https://blog.chromium.org)


### PR DESCRIPTION
The link seems to be showing something unrelated to chromium-dev slack.

Closes #17154 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes