### PR TITLE
fix: check for pane focus before removing it.

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -119,7 +119,9 @@ bool MenuBar::GetMenuButtonFromScreenPoint(const gfx::Point& screenPoint,
 }
 
 void MenuBar::OnBeforeExecuteCommand() {
-  RemovePaneFocus();
+  if (GetPaneFocusTraversable() != nullptr) {
+    RemovePaneFocus();
+  }
   window_->RestoreFocus();
 }
 


### PR DESCRIPTION
Fixes #16883. This bug seems to have been introduced as a side-effect of #15302's menu a11y refactor and is new in 5-0-x.

#### Description of Change

The a11y refactor introduced code that tries to remove pane focus in `atom::MenuBar::OnBeforeExecuteCommand()` whether it has focus or not, and calling `AccessiblePaneView::RemovePaneFocus()` when it doesn't have focus results in a nullptr dereference.

This PR adds a test to check for pane focus before removing it.

CC @brenca 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed 5.0.0-beta.1 menuitem crash on Windows and Linux