### PR TITLE
fix: run subframe preload bundles in isolated context

### DIFF
--- a/spec/api-subframe-spec.js
+++ b/spec/api-subframe-spec.js
@@ -83,26 +83,28 @@ describe('renderer nodeIntegrationInSubFrames', () => {
         expect(details[1]).to.equal(event3[0].frameId)
       })
 
-      if (webPreferences.contextIsolation) {
-        it('should not expose globals in main world', async () => {
-          const detailsPromise = emittedNTimes(remote.ipcMain, 'preload-ran', 2)
-          w.loadFile(path.resolve(__dirname, 'fixtures/sub-frames/frame-container.html'))
-          const details = await detailsPromise
-          const senders = details.map(event => event[0].sender)
-          await new Promise((resolve) => {
-            let resultCount = 0
-            senders.forEach(sender => {
-              sender.webContents.executeJavaScript('window.isolatedGlobal', result => {
+      it('should not expose globals in main world', async () => {
+        const detailsPromise = emittedNTimes(remote.ipcMain, 'preload-ran', 2)
+        w.loadFile(path.resolve(__dirname, 'fixtures/sub-frames/frame-container.html'))
+        const details = await detailsPromise
+        const senders = details.map(event => event[0].sender)
+        await new Promise((resolve) => {
+          let resultCount = 0
+          senders.forEach(sender => {
+            sender.webContents.executeJavaScript('window.isolatedGlobal', result => {
+              if (webPreferences.contextIsolation) {
                 expect(result).to.be.null()
-                resultCount++
-                if (resultCount === senders.length) {
-                  resolve()
-                }
-              })
+              } else {
+                expect(result).to.equal(true)
+              }
+              resultCount++
+              if (resultCount === senders.length) {
+                resolve()
+              }
             })
           })
         })
-      }
+      })
     })
   }
 

--- a/spec/fixtures/sub-frames/preload.js
+++ b/spec/fixtures/sub-frames/preload.js
@@ -1,5 +1,7 @@
 const { ipcRenderer, webFrame } = require('electron')
 
+window.isolatedGlobal = true
+
 ipcRenderer.send('preload-ran', window.location.href, webFrame.routingId)
 
 ipcRenderer.on('preload-ping', () => {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
fixes #16804

The isolated context was only being created for the main frame. This creates an isolated context for subframes when `nodeIntegrationInSubFrames` is true.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
