### PR TITLE
refactor: prevent node macros from overriding base

### DIFF
--- a/atom/common/node_includes.h
+++ b/atom/common/node_includes.h
@@ -17,18 +17,32 @@
 // again. But we still need the tracing functions, so declaring them.
 #define SRC_TRACING_TRACE_EVENT_H_
 
+#pragma push_macro("ASSERT")
+#pragma push_macro("CHECK")
+#pragma push_macro("CHECK_EQ")
+#pragma push_macro("CHECK_GE")
+#pragma push_macro("CHECK_GT")
+#pragma push_macro("CHECK_LE")
+#pragma push_macro("CHECK_LT")
+#pragma push_macro("CHECK_NE")
+#pragma push_macro("DISALLOW_COPY_AND_ASSIGN")
+#pragma push_macro("LIKELY")
+#pragma push_macro("NO_RETURN")
+#pragma push_macro("UNLIKELY")
+
 #undef ASSERT
 #undef CHECK
 #undef CHECK_EQ
-#undef CHECK_NE
 #undef CHECK_GE
 #undef CHECK_GT
 #undef CHECK_LE
 #undef CHECK_LT
-#undef UNLIKELY
+#undef CHECK_NE
 #undef DISALLOW_COPY_AND_ASSIGN
-#undef NO_RETURN
 #undef LIKELY
+#undef NO_RETURN
+#undef UNLIKELY
+
 #undef debug_string    // This is defined in macOS SDK in AssertMacros.h.
 #undef require_string  // This is defined in macOS SDK in AssertMacros.h.
 #include "env-inl.h"
@@ -38,6 +52,19 @@
 #include "node_internals.h"
 #include "node_options.h"
 #include "node_platform.h"
+
+#pragma pop_macro("ASSERT")
+#pragma pop_macro("CHECK")
+#pragma pop_macro("CHECK_EQ")
+#pragma pop_macro("CHECK_GE")
+#pragma pop_macro("CHECK_GT")
+#pragma pop_macro("CHECK_LE")
+#pragma pop_macro("CHECK_LT")
+#pragma pop_macro("CHECK_NE")
+#pragma pop_macro("DISALLOW_COPY_AND_ASSIGN")
+#pragma pop_macro("LIKELY")
+#pragma pop_macro("NO_RETURN")
+#pragma pop_macro("UNLIKELY")
 
 namespace node {
 namespace tracing {


### PR DESCRIPTION
#### Description of Change
These redefinitions meant that any Electron file that had `#include "node_includes.h"` would be unable to use `CHECK`, `DCHECK`, etc. from `base/`. This change makes it so that Electron code will use Chromium's logging macros, instead of Node's, but keep Node using Node's logging macros.

`push_macro` and `pop_macro` are non-standard C++, but [are used by Chromium](https://chromium.googlesource.com/chromium/src/+/72.0.3626.84/ui/gl/init/gl_initializer_android.cc#29) occasionally.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes