### PR TITLE
docs: add upstream doc links to default window

### DIFF
--- a/default_app/renderer.ts
+++ b/default_app/renderer.ts
@@ -27,7 +27,7 @@ function initialize () {
   }
 
   document.querySelector<HTMLAnchorElement>('.electron-version')!.innerText = `Electron v${process.versions.electron}`
-  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText =`<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>``
+  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText =`<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>`
   document.querySelector<HTMLAnchorElement>('.node-version')!.innerText = `<a href="https://nodejs.org/docs/v${process.versions.node}">Node v${process.versions.node}</a>`
   document.querySelector<HTMLAnchorElement>('.v8-version')!.innerText = `v8 v${process.versions.v8}`
   document.querySelector<HTMLAnchorElement>('.command-example')!.innerText = `${electronPath} path-to-app`

--- a/default_app/renderer.ts
+++ b/default_app/renderer.ts
@@ -27,7 +27,7 @@ function initialize () {
   }
 
   document.querySelector<HTMLAnchorElement>('.electron-version')!.innerText = `Electron v${process.versions.electron}`
-  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText =`<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>`
+  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText = `<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>`
   document.querySelector<HTMLAnchorElement>('.node-version')!.innerText = `<a href="https://nodejs.org/docs/v${process.versions.node}">Node v${process.versions.node}</a>`
   document.querySelector<HTMLAnchorElement>('.v8-version')!.innerText = `v8 v${process.versions.v8}`
   document.querySelector<HTMLAnchorElement>('.command-example')!.innerText = `${electronPath} path-to-app`

--- a/default_app/renderer.ts
+++ b/default_app/renderer.ts
@@ -28,7 +28,7 @@ function initialize () {
 
   document.querySelector<HTMLAnchorElement>('.electron-version')!.innerText = `Electron v${process.versions.electron}`
   document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText = `<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>`
-  document.querySelector<HTMLAnchorElement>('.node-version')!.innerText = `<a href="https://nodejs.org/docs/v${process.versions.node}">Node v${process.versions.node}</a>`
+  document.querySelector<HTMLAnchorElement>('.node-version')!.innerHTML = `<a href="https://nodejs.org/docs/v${process.versions.node}/api">Node v${process.versions.node}</a>`
   document.querySelector<HTMLAnchorElement>('.v8-version')!.innerText = `v8 v${process.versions.v8}`
   document.querySelector<HTMLAnchorElement>('.command-example')!.innerText = `${electronPath} path-to-app`
 

--- a/default_app/renderer.ts
+++ b/default_app/renderer.ts
@@ -28,7 +28,7 @@ function initialize () {
 
   document.querySelector<HTMLAnchorElement>('.electron-version')!.innerText = `Electron v${process.versions.electron}`
   document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText =`<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>``
-  document.querySelector<HTMLAnchorElement>('.node-version')!.innerText = `<a href="https://nodejs.org/docs/v${process.versions.node}">Node v${process.versions.node}</a>``
+  document.querySelector<HTMLAnchorElement>('.node-version')!.innerText = `<a href="https://nodejs.org/docs/v${process.versions.node}">Node v${process.versions.node}</a>`
   document.querySelector<HTMLAnchorElement>('.v8-version')!.innerText = `v8 v${process.versions.v8}`
   document.querySelector<HTMLAnchorElement>('.command-example')!.innerText = `${electronPath} path-to-app`
 

--- a/default_app/renderer.ts
+++ b/default_app/renderer.ts
@@ -27,7 +27,7 @@ function initialize () {
   }
 
   document.querySelector<HTMLAnchorElement>('.electron-version')!.innerText = `Electron v${process.versions.electron}`
-  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText = `<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>`
+  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerHTML = `<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>`
   document.querySelector<HTMLAnchorElement>('.node-version')!.innerHTML = `<a href="https://nodejs.org/docs/v${process.versions.node}/api">Node v${process.versions.node}</a>`
   document.querySelector<HTMLAnchorElement>('.v8-version')!.innerText = `v8 v${process.versions.v8}`
   document.querySelector<HTMLAnchorElement>('.command-example')!.innerText = `${electronPath} path-to-app`

--- a/default_app/renderer.ts
+++ b/default_app/renderer.ts
@@ -27,8 +27,8 @@ function initialize () {
   }
 
   document.querySelector<HTMLAnchorElement>('.electron-version')!.innerText = `Electron v${process.versions.electron}`
-  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText = `Chromium v${process.versions.chrome}`
-  document.querySelector<HTMLAnchorElement>('.node-version')!.innerText = `Node v${process.versions.node}`
+  document.querySelector<HTMLAnchorElement>('.chrome-version')!.innerText =`<a href="https://www.chromium.org/v${process.versions.chrome}">Chromium v${process.versions.chrome}</a>``
+  document.querySelector<HTMLAnchorElement>('.node-version')!.innerText = `<a href="https://nodejs.org/docs/v${process.versions.node}">Node v${process.versions.node}</a>``
   document.querySelector<HTMLAnchorElement>('.v8-version')!.innerText = `v8 v${process.versions.v8}`
   document.querySelector<HTMLAnchorElement>('.command-example')!.innerText = `${electronPath} path-to-app`
 


### PR DESCRIPTION
#### Description of Change
Added the link to the Node docs and Chromium docs to the default window (not sure if I linked the chromium docs correctly, please let me know/feel free to suggest changes if you know the correct way to do so)
Fixes #14728.

#### Checklist
(I'm new, so I apologize, but I have no clue what the first item means)
- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
notes: no-notes
