### PR TITLE
[wip] feat: make remote.getGuestWebContents() public

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -487,7 +487,7 @@ Returns:
 * `webContents` [WebContents](web-contents.md)
 * `guestWebContents` [WebContents](web-contents.md)
 
-Emitted when `<webview>.getWebContents()` is called in the renderer process of `webContents`.
+Emitted when `remote.getGuestWebContents()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the object from being returned.
 Custom value can be returned by setting `event.returnValue`.
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -188,7 +188,13 @@ consequences.
 
 ### `remote.getCurrentWebContents()`
 
-Returns [`WebContents`](web-contents.md) - The web contents of this web page.
+Returns [`WebContents`](web-contents.md) - The WebContents of this web page.
+
+### `remote.getGuestWebContents(guestInstanceId)`
+
+* `guestInstanceId` Number
+
+Returns [`WebContents`](web-contents.md) - The guest WebContents from guestInstanceId.
 
 ### `remote.getGlobal(name)`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -770,7 +770,7 @@ Returns:
 * `event` Event
 * `guestWebContents` [WebContents](web-contents.md)
 
-Emitted when `<webview>.getWebContents()` is called in the renderer process.
+Emitted when `remote.getGuestWebContents()` is called in the renderer process.
 Calling `event.preventDefault()` will prevent the object from being returned.
 Custom value can be returned by setting `event.returnValue`.
 
@@ -1344,11 +1344,13 @@ An example of showing devtools in a `<webview>` tag:
   <webview id="browser" src="https://github.com"></webview>
   <webview id="devtools"></webview>
   <script>
+    const { remote } = require('electron')
     const browserView = document.getElementById('browser')
     const devtoolsView = document.getElementById('devtools')
     browserView.addEventListener('dom-ready', () => {
-      const browser = browserView.getWebContents()
-      browser.setDevToolsWebContents(devtoolsView.getWebContents())
+      const browser = remote.getGuestWebContents(browserView.getWebContentsId())
+      const devtools = remote.getGuestWebContents(devtoolsView.getWebContentsId())
+      browser.setDevToolsWebContents(devtools)
       browser.openDevTools()
     })
   </script>

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -672,6 +672,10 @@ this `webview`.
 It depends on the [`remote`](remote.md) module,
 it is therefore not available when this module is disabled.
 
+### `<webview>.getWebContentsId()`
+
+Returns `Number` - The WebContents ID of this `webview`.
+
 ## DOM events
 
 The following DOM events are available to the `webview` tag:

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -664,9 +664,9 @@ Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 Shows pop-up dictionary that searches the selected word on the page.
 
-### `<webview>.getWebContents()`
+### `<webview>.getWebContents()` _(Deprecated)_
 
-Returns [`WebContents`](web-contents.md) - The web contents associated with
+Returns [`WebContents`](web-contents.md) - The WebContents associated with
 this `webview`.
 
 It depends on the [`remote`](remote.md) module,

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -49,14 +49,8 @@ const supportedWebViewEvents = [
   'update-target-url'
 ]
 
-let nextGuestInstanceId = 0
 const guestInstances = {}
 const embedderElementsMap = {}
-
-// Generate guestInstanceId.
-const getNextGuestInstanceId = function () {
-  return ++nextGuestInstanceId
-}
 
 // Create a new guest instance.
 const createGuest = function (embedder, params) {
@@ -64,12 +58,12 @@ const createGuest = function (embedder, params) {
     webViewManager = process.atomBinding('web_view_manager')
   }
 
-  const guestInstanceId = getNextGuestInstanceId(embedder)
   const guest = webContents.create({
     isGuest: true,
     partition: params.partition,
     embedder: embedder
   })
+  const guestInstanceId = guest.id
   guestInstances[guestInstanceId] = {
     guest: guest,
     embedder: embedder

--- a/spec/fixtures/pages/webview-devtools.html
+++ b/spec/fixtures/pages/webview-devtools.html
@@ -6,9 +6,10 @@
   <body>
     <webview nodeintegration src="./a.html"></webview>
     <script>
+        const { remote } = require('electron')
         var wv = document.querySelector('webview')
         wv.addEventListener('dom-ready', () => {
-          const webContents = wv.getWebContents()
+          const webContents = remote.getGuestWebContents(wv.getWebContentsId())
           webContents.on('devtools-opened', function () {
             var showPanelIntevalId = setInterval(function () {
               if (webContents.devToolsWebContents) {

--- a/spec/fixtures/pages/webview-did-attach-event.html
+++ b/spec/fixtures/pages/webview-did-attach-event.html
@@ -9,7 +9,7 @@
       var {ipcRenderer} = require('electron')
       var wv = document.querySelector('webview')
       wv.addEventListener('dom-ready', () => {
-        ipcRenderer.send('webview-dom-ready', wv.getWebContents().id)
+        ipcRenderer.send('webview-dom-ready', wv.getWebContentsId())
       })
     </script>
   </body>

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -5,7 +5,6 @@ import {
   webFrame,
   clipboard,
   crashReporter,
-  nativeImage,
   screen,
   shell
 } from 'electron'
@@ -256,9 +255,10 @@ webview.send('ping')
 webview.capturePage((image) => { console.log(image) })
 
 {
+  const contents = remote.getGuestWebContents(webview.getWebContentsId())
   const opened: boolean = webview.isDevToolsOpened()
   const focused: boolean = webview.isDevToolsFocused()
-  const focused2: boolean = webview.getWebContents().isFocused()
+  const focused2: boolean = contents.isFocused()
 }
 
 // In guest page.

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1124,7 +1124,7 @@ describe('<webview> tag', function () {
       assert.ok(webview.partition)
 
       const listener = function (webContents, permission, callback) {
-        if (webContents.id === webview.getWebContents().id) {
+        if (webContents.id === webview.getWebContentsId()) {
           // requestMIDIAccess with sysex requests both midi and midiSysex so
           // grant the first midi one and then reject the midiSysex one
           if (requestedPermission === 'midiSysex' && permission === 'midi') {
@@ -1210,12 +1210,21 @@ describe('<webview> tag', function () {
       webview.partition = 'permissionTest'
       webview.setAttribute('nodeintegration', 'on')
       session.fromPartition(webview.partition).setPermissionRequestHandler((webContents, permission, callback) => {
-        if (webContents.id === webview.getWebContents().id) {
+        if (webContents.id === webview.getWebContentsId()) {
           assert.strictEqual(permission, 'notifications')
           setTimeout(() => { callback(true) }, 10)
         }
       })
       document.body.appendChild(webview)
+    })
+  })
+
+  describe('<webview>.getWebContentsId', () => {
+    it('can return the WebContents ID', async () => {
+      const src = 'about:blank'
+      await loadWebView(webview, { src })
+
+      expect(webview.getWebContentsId()).to.be.a('number').above(0)
     })
   })
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -121,6 +121,7 @@ declare namespace ElectronInternal {
 
     // Created in web-view-impl
     public getWebContents(): Electron.WebContents;
+    public getWebContentsId(): number;
   }
 }
 


### PR DESCRIPTION
#### Description of Change
- makes `remote.getGuestWebContents()` public to make the usage of the `remote` module explicit
- adds `<webview>.getGuestInstanceId()` to get the `guestInstanceId`
- deprecates the original `<webview>.getWebContents()`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

/cc @nornagon, @MarshallOfSound, @deepak1556 

#### Release Notes

Notes: Added `remote.getGuestWebContents()` / `<webview>.getGuestInstanceId()` to replace deprecated `<webview>.getWebContents()`.