### PR TITLE
feat: add 'disableHtmlFullscreenWindowResize' option to webPreferences 

### DIFF
--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -616,7 +616,17 @@ void CommonWebContentsDelegate::SetHtmlApiFullscreen(bool enter_fullscreen) {
     return;
   }
 
-  owner_window_->SetFullScreen(enter_fullscreen);
+  // Set fullscreen on window if allowed.
+  auto* web_preferences = WebContentsPreferences::From(GetWebContents());
+  bool html_fullscreenable =
+      web_preferences ? !web_preferences->IsEnabled(
+                            options::kDisableHtmlFullscreenWindowResize)
+                      : true;
+
+  if (html_fullscreenable) {
+    owner_window_->SetFullScreen(enter_fullscreen);
+  }
+
   html_fullscreen_ = enter_fullscreen;
   native_fullscreen_ = false;
 }

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -122,6 +122,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kNodeIntegration, false);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInSubFrames, false);
   SetDefaultBoolIfUndefined(options::kNodeIntegrationInWorker, false);
+  SetDefaultBoolIfUndefined(options::kDisableHtmlFullscreenWindowResize, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
   SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
@@ -370,6 +371,9 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
   if (IsEnabled(options::kNodeIntegrationInSubFrames))
     command_line->AppendSwitch(switches::kNodeIntegrationInSubFrames);
+
+  if (IsEnabled(options::kDisableHtmlFullscreenWindowResize))
+    command_line->AppendSwitch(switches::kDisableHtmlFullscreenWindowResize);
 
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -156,6 +156,10 @@ const char kOffscreen[] = "offscreen";
 
 const char kNodeIntegrationInSubFrames[] = "nodeIntegrationInSubFrames";
 
+// Disable window resizing when HTML Fullscreen API is activated.
+const char kDisableHtmlFullscreenWindowResize[] =
+    "disableHtmlFullscreenWindowResize";
+
 }  // namespace options
 
 namespace switches {
@@ -219,6 +223,10 @@ const char kNodeIntegrationInWorker[] = "node-integration-in-worker";
 // Command switch passed to renderer process to control whether node
 // environments will be created in sub-frames.
 const char kNodeIntegrationInSubFrames[] = "node-integration-in-subframes";
+
+// Disable window resizing when HTML Fullscreen API is activated.
+const char kDisableHtmlFullscreenWindowResize[] =
+    "disable-html-fullscreen-window-resize";
 
 // Widevine options
 // Path to Widevine CDM binaries.

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -76,6 +76,7 @@ extern const char kWebSecurity[];
 extern const char kAllowRunningInsecureContent[];
 extern const char kOffscreen[];
 extern const char kNodeIntegrationInSubFrames[];
+extern const char kDisableHtmlFullscreenWindowResize[];
 
 }  // namespace options
 
@@ -111,6 +112,7 @@ extern const char kNativeWindowOpen[];
 extern const char kNodeIntegrationInWorker[];
 extern const char kWebviewTag[];
 extern const char kNodeIntegrationInSubFrames[];
+extern const char kDisableHtmlFullscreenWindowResize[];
 
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -379,6 +379,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       content in the window, can be `no-user-gesture-required`,
       `user-gesture-required`, `document-user-activation-required`. Defaults to
       `no-user-gesture-required`.
+    * `disableHtmlFullscreenWindowResize` Boolean (optional) - Whether to
+      prevent the window from resizing when entering HTML Fullscreen. Default
+      is `false`.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -361,6 +361,14 @@ win.webContents.on('before-input-event', (event, input) => {
 })
 ```
 
+#### Event: 'enter-html-full-screen'
+
+Emitted when the window enters a full-screen state triggered by HTML API.
+
+#### Event: 'leave-html-full-screen'
+
+Emitted when the window leaves a full-screen state triggered by HTML API.
+
 #### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2097,6 +2097,28 @@ describe('BrowserWindow module', () => {
         expect(typeofProcess).to.eql('undefined')
       })
     })
+
+    describe('"disableHtmlFullscreenWindowResize" option', () => {
+      it('prevents window from resizing when set', (done) => {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            disableHtmlFullscreenWindowResize: true
+          }
+        })
+        w.webContents.once('did-finish-load', () => {
+          const size = w.getSize()
+          w.webContents.once('enter-html-full-screen', () => {
+            const newSize = w.getSize()
+            expect(newSize).to.deep.equal(size)
+            done()
+          })
+          w.webContents.executeJavaScript('document.body.webkitRequestFullscreen()', true)
+        })
+        w.loadURL('about:blank')
+      })
+    })
   })
 
   describe('nativeWindowOpen + contextIsolation options', () => {


### PR DESCRIPTION
#### Description of Change
Adds an option to `webPreferences` named `disableHtmlFullscreenWindowResize`. If set to `true`, the window will retain its size when using the HTML5 Fullscreen API. The requested HTML element will still fullscreen within the viewport though.

This is a fairly specialized use case for my application, [Metastream](https://github.com/samuelmaddock/metastream). I'd like to be able to trigger HTML5 fullscreen without causing the window to resize. An example can be seen in the following GIF.

![html5-fullscreen](https://user-images.githubusercontent.com/1656324/53691261-eb3b1180-3d47-11e9-94b0-f29a25eeda3a.gif)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `disableHtmlFullscreenWindowResize` option to `webPreferences` to allow preventing window from resizing when entering HTML5 fullscreen.
