### PR TITLE
fix: bad assertion in crypto functions that use BN_bn2bin_padded

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '73.0.3683.61',
   'node_version':
-    'fac6d766c143db8db05bb3b0c0871df8f032363c',
+    '70a78f07b1c4d53f3da462b08cef42a4ff8f949f',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -472,6 +472,24 @@ describe('node feature', () => {
       const iv = Buffer.from('fedcba9876543210', 'hex')
       require('crypto').createCipheriv('des-ede-cbc', key, iv)
     })
+
+    it('should not crash when getting an ECDH key', () => {
+      const ecdh = require('crypto').createECDH('prime256v1')
+      expect(ecdh.getPrivateKey()).to.be.a(Buffer)
+    })
+
+    it('should not crash when generating DH keys', () => {
+      const dh = require('crypto').createDiffieHellman('modp15')
+      expect(dh.generateKeys()).to.be.a(Buffer)
+    })
+
+    it('should not crash when fetching DH parameters', () => {
+      const dh = require('crypto').createDiffieHellman('modp15')
+      expect(dh.getPrime()).to.be.a(Buffer)
+      expect(dh.getGenerator()).to.be.a(Buffer)
+      expect(dh.getPublicKey()).to.be.a(Buffer)
+      expect(dh.getPrivateKey()).to.be.a(Buffer)
+    })
   })
 
   it('includes the electron version in process.versions', () => {

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -475,20 +475,17 @@ describe('node feature', () => {
 
     it('should not crash when getting an ECDH key', () => {
       const ecdh = require('crypto').createECDH('prime256v1')
-      expect(ecdh.getPrivateKey()).to.be.a(Buffer)
+      expect(ecdh.generateKeys()).to.be.an.instanceof(Buffer)
+      expect(ecdh.getPrivateKey()).to.be.an.instanceof(Buffer)
     })
 
-    it('should not crash when generating DH keys', () => {
+    it('should not crash when generating DH keys or fetching DH fields', () => {
       const dh = require('crypto').createDiffieHellman('modp15')
-      expect(dh.generateKeys()).to.be.a(Buffer)
-    })
-
-    it('should not crash when fetching DH parameters', () => {
-      const dh = require('crypto').createDiffieHellman('modp15')
-      expect(dh.getPrime()).to.be.a(Buffer)
-      expect(dh.getGenerator()).to.be.a(Buffer)
-      expect(dh.getPublicKey()).to.be.a(Buffer)
-      expect(dh.getPrivateKey()).to.be.a(Buffer)
+      expect(dh.generateKeys()).to.be.an.instanceof(Buffer)
+      expect(dh.getPublicKey()).to.be.an.instanceof(Buffer)
+      expect(dh.getPrivateKey()).to.be.an.instanceof(Buffer)
+      expect(dh.getPrime()).to.be.an.instanceof(Buffer)
+      expect(dh.getGenerator()).to.be.an.instanceof(Buffer)
     })
   })
 


### PR DESCRIPTION
in particular, this picks up electron/node#70a78f07b, which fixes an issue with incorrect usage of the BN_bn2bin_padded API in boringssl. This also adds tests to make sure those functions are fixed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an assertion when calling `ECDH.getPrivateKey()`, `diffieHellman.generateKeys()` or `diffieHellman.get*()`.