### PR TITLE
chore: add static promise resolution helpers

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -141,21 +141,6 @@ void ResolvePromiseWithCookies(util::Promise promise,
   promise.Resolve(cookie_list);
 }
 
-void ResolvePromise(util::Promise promise) {
-  promise.Resolve();
-}
-
-// Resolve |promise| in UI thread.
-void ResolvePromiseInUI(util::Promise promise) {
-  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI},
-                           base::BindOnce(ResolvePromise, std::move(promise)));
-}
-
-// Run |callback| on UI thread.
-void RunCallbackInUI(base::OnceClosure callback) {
-  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI}, std::move(callback));
-}
-
 // Remove cookies from |list| not matching |filter|, and pass it to |callback|.
 void FilterCookies(std::unique_ptr<base::DictionaryValue> filter,
                    util::Promise promise,
@@ -195,23 +180,21 @@ void RemoveCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                       const std::string& name,
                       util::Promise promise) {
   GetCookieStore(getter)->DeleteCookieAsync(
-      url, name, base::BindOnce(ResolvePromiseInUI, std::move(promise)));
-}
-
-// Resolves/rejects the |promise| in UI thread.
-void SettlePromiseInUI(util::Promise promise, const std::string& errmsg) {
-  if (errmsg.empty()) {
-    promise.Resolve();
-  } else {
-    promise.RejectWithErrorMessage(errmsg);
-  }
+      url, name,
+      base::BindOnce(util::Promise::ResolveEmptyPromise, std::move(promise)));
 }
 
 // Callback of SetCookie.
 void OnSetCookie(util::Promise promise, bool success) {
-  const std::string errmsg = success ? "" : "Setting cookie failed";
-  RunCallbackInUI(
-      base::BindOnce(SettlePromiseInUI, std::move(promise), errmsg));
+  if (success)
+    base::PostTaskWithTraits(
+        FROM_HERE, {BrowserThread::UI},
+        base::BindOnce(util::Promise::ResolveEmptyPromise, std::move(promise)));
+  else
+    base::PostTaskWithTraits(
+        FROM_HERE, {BrowserThread::UI},
+        base::BindOnce(util::Promise::RejectPromise, std::move(promise),
+                       "Setting cookie failed"));
 }
 
 // Flushes cookie store in IO thread.
@@ -219,7 +202,7 @@ void FlushCookieStoreOnIOThread(
     scoped_refptr<net::URLRequestContextGetter> getter,
     util::Promise promise) {
   GetCookieStore(getter)->FlushStore(
-      base::BindOnce(ResolvePromiseInUI, std::move(promise)));
+      base::BindOnce(util::Promise::ResolveEmptyPromise, std::move(promise)));
 }
 
 // Sets cookie with |details| in IO thread.

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -172,9 +172,8 @@ class CopyablePromise {
     if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
       base::PostTaskWithTraits(
           FROM_HERE, {content::BrowserThread::UI},
-          base::Bind([](const CopyablePromise& promise,
-                        T result) { promise.GetPromise().Resolve(result); },
-                     promise, result));
+          base::BindOnce(Promise::ResolvePromise, promise.GetPromise(),
+                         std::move(result)));
     } else {
       promise.GetPromise().Resolve(result);
     }
@@ -182,12 +181,9 @@ class CopyablePromise {
 
   static void ResolveEmptyCopyablePromise(const CopyablePromise& promise) {
     if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
-      base::PostTaskWithTraits(FROM_HERE, {content::BrowserThread::UI},
-                               base::Bind(
-                                   [](const CopyablePromise& promise) {
-                                     promise.GetPromise().Resolve();
-                                   },
-                                   promise));
+      base::PostTaskWithTraits(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::BindOnce(Promise::ResolveEmptyPromise, promise.GetPromise()));
     } else {
       promise.GetPromise().Resolve();
     }
@@ -198,11 +194,8 @@ class CopyablePromise {
     if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
       base::PostTaskWithTraits(
           FROM_HERE, {content::BrowserThread::UI},
-          base::BindOnce(
-              [](const CopyablePromise& promise, std::string errmsg) {
-                promise.GetPromise().RejectWithErrorMessage(errmsg);
-              },
-              promise, errmsg));
+          base::BindOnce(Promise::RejectPromise, promise.GetPromise(),
+                         std::move(errmsg)));
     } else {
       promise.GetPromise().RejectWithErrorMessage(errmsg);
     }

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -6,9 +6,12 @@
 #define ATOM_COMMON_PROMISE_UTIL_H_
 
 #include <string>
+#include <utility>
 
 #include "atom/common/api/locker.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "base/task/post_task.h"
+#include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "native_mate/converter.h"
 
@@ -37,6 +40,45 @@ class Promise {
   v8::Isolate* isolate() const { return isolate_; }
   v8::Local<v8::Context> GetContext() {
     return v8::Local<v8::Context>::New(isolate_, context_);
+  }
+
+  // helpers for promise resolution and rejection
+
+  template <typename T>
+  static void ResolvePromise(Promise promise, T result) {
+    if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
+      base::PostTaskWithTraits(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::BindOnce(
+              [](Promise promise, T result) { promise.Resolve(result); },
+              std::move(promise), result));
+    } else {
+      promise.Resolve(result);
+    }
+  }
+
+  static void ResolveEmptyPromise(Promise promise) {
+    if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
+      base::PostTaskWithTraits(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::BindOnce([](Promise promise) { promise.Resolve(); },
+                         std::move(promise)));
+    } else {
+      promise.Resolve();
+    }
+  }
+
+  static void RejectPromise(Promise promise, std::string errmsg) {
+    if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
+      base::PostTaskWithTraits(FROM_HERE, {content::BrowserThread::UI},
+                               base::BindOnce(
+                                   [](Promise promise, std::string errmsg) {
+                                     promise.RejectWithErrorMessage(errmsg);
+                                   },
+                                   std::move(promise), errmsg));
+    } else {
+      promise.RejectWithErrorMessage(errmsg);
+    }
   }
 
   v8::Local<v8::Promise> GetHandle() const;
@@ -124,6 +166,47 @@ class CopyablePromise {
   explicit CopyablePromise(const Promise& promise);
   CopyablePromise(const CopyablePromise&);
   ~CopyablePromise();
+
+  template <typename T>
+  static void ResolveCopyablePromise(const CopyablePromise& promise, T result) {
+    if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
+      base::PostTaskWithTraits(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::Bind([](const CopyablePromise& promise,
+                        T result) { promise.GetPromise().Resolve(result); },
+                     promise, result));
+    } else {
+      promise.GetPromise().Resolve(result);
+    }
+  }
+
+  static void ResolveEmptyCopyablePromise(const CopyablePromise& promise) {
+    if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
+      base::PostTaskWithTraits(FROM_HERE, {content::BrowserThread::UI},
+                               base::Bind(
+                                   [](const CopyablePromise& promise) {
+                                     promise.GetPromise().Resolve();
+                                   },
+                                   promise));
+    } else {
+      promise.GetPromise().Resolve();
+    }
+  }
+
+  static void RejectCopyablePromise(const CopyablePromise& promise,
+                                    std::string errmsg) {
+    if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
+      base::PostTaskWithTraits(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::BindOnce(
+              [](const CopyablePromise& promise, std::string errmsg) {
+                promise.GetPromise().RejectWithErrorMessage(errmsg);
+              },
+              promise, errmsg));
+    } else {
+      promise.GetPromise().RejectWithErrorMessage(errmsg);
+    }
+  }
 
   Promise GetPromise() const;
 

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -51,7 +51,7 @@ class Promise {
           FROM_HERE, {content::BrowserThread::UI},
           base::BindOnce(
               [](Promise promise, T result) { promise.Resolve(result); },
-              std::move(promise), result));
+              std::move(promise), std::move(result)));
     } else {
       promise.Resolve(result);
     }
@@ -75,7 +75,7 @@ class Promise {
                                    [](Promise promise, std::string errmsg) {
                                      promise.RejectWithErrorMessage(errmsg);
                                    },
-                                   std::move(promise), errmsg));
+                                   std::move(promise), std::move(errmsg)));
     } else {
       promise.RejectWithErrorMessage(errmsg);
     }


### PR DESCRIPTION
#### Description of Change

Add static helpers for commonly recycled promise resolution functions.

cc @deepak1556 @miniak

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
