### PR TITLE
refactor: make ELECTRON_INSPECTOR_SELECT_FILE handler async

### DIFF
--- a/lib/browser/chrome-devtools.js
+++ b/lib/browser/chrome-devtools.js
@@ -3,8 +3,11 @@
 const { dialog, Menu } = require('electron')
 const fs = require('fs')
 const url = require('url')
+const util = require('util')
 
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
+
+const readFile = util.promisify(fs.readFile)
 
 const convertToMenuTemplate = function (event, items) {
   return items.map(function (item) {
@@ -82,25 +85,16 @@ ipcMainUtils.handle('ELECTRON_INSPECTOR_CONTEXT_MENU', function (event, items, i
   menu.popup({ window })
 })
 
-ipcMainUtils.handle('ELECTRON_INSPECTOR_SELECT_FILE', function (event) {
-  return new Promise((resolve, reject) => {
-    assertChromeDevTools(event.sender, 'window.UI.createFileSelectorElement()')
+ipcMainUtils.handle('ELECTRON_INSPECTOR_SELECT_FILE', async function (event) {
+  assertChromeDevTools(event.sender, 'window.UI.createFileSelectorElement()')
 
-    dialog.showOpenDialog({}, function (result) {
-      if (!result.canceled) {
-        const path = result.filePaths[0]
-        fs.readFile(path, (error, data) => {
-          if (error) {
-            reject(error)
-          } else {
-            resolve([path, data])
-          }
-        })
-      } else {
-        resolve([])
-      }
-    })
-  })
+  const result = await dialog.showOpenDialog({})
+  if (result.canceled) return []
+
+  const path = result.filePaths[0]
+  const data = await readFile(path)
+
+  return [path, data]
 })
 
 ipcMainUtils.handle('ELECTRON_INSPECTOR_CONFIRM', function (event, message, title) {


### PR DESCRIPTION
#### Description of Change
Follow up to "feat: promisify dialog.showOpenDialog()" https://github.com/electron/electron/pull/16973

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

/cc @codebytere

#### Release Notes
Notes: no-notes