### PR TITLE
build: copy generated electron.d.ts file in a cross-platform way

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -59,24 +59,14 @@ config("branding") {
 # The one in $target_gen_dir is used for the actual TSC build later one
 # and the one in //electron/electron.d.ts is used by your IDE (vscode)
 # for typescript prompting
-if (is_win) {
-  npm_action("build_electron_definitions") {
-    script = "gn-typescript-definitions-win"
-    args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
-    inputs = auto_filenames.api_docs + [ "package-lock.json" ]
-    outputs = [
-      "$target_gen_dir/tsc/typings/electron.d.ts",
-    ]
-  }
-} else {
-  npm_action("build_electron_definitions") {
-    script = "gn-typescript-definitions"
-    args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
-    inputs = auto_filenames.api_docs + [ "package-lock.json" ]
-    outputs = [
-      "$target_gen_dir/tsc/typings/electron.d.ts",
-    ]
-  }
+npm_action("build_electron_definitions") {
+  script = "gn-typescript-definitions"
+  args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
+  inputs = auto_filenames.api_docs + [ "package-lock.json" ]
+
+  outputs = [
+    "$target_gen_dir/tsc/typings/electron.d.ts",
+  ]
 }
 
 npm_action("atom_browserify_sandbox") {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -59,14 +59,24 @@ config("branding") {
 # The one in $target_gen_dir is used for the actual TSC build later one
 # and the one in //electron/electron.d.ts is used by your IDE (vscode)
 # for typescript prompting
-npm_action("build_electron_definitions") {
-  script = "gn-typescript-definitions"
-  args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
-  inputs = auto_filenames.api_docs + [ "package-lock.json" ]
-
-  outputs = [
-    "$target_gen_dir/tsc/typings/electron.d.ts",
-  ]
+if (is_win) {
+  npm_action("build_electron_definitions") {
+    script = "gn-typescript-definitions-win"
+    args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
+    inputs = auto_filenames.api_docs + [ "package-lock.json" ]
+    outputs = [
+      "$target_gen_dir/tsc/typings/electron.d.ts",
+    ]
+  }
+} else {
+  npm_action("build_electron_definitions") {
+    script = "gn-typescript-definitions"
+    args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
+    inputs = auto_filenames.api_docs + [ "package-lock.json" ]
+    outputs = [
+      "$target_gen_dir/tsc/typings/electron.d.ts",
+    ]
+  }
 }
 
 npm_action("atom_browserify_sandbox") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4622,8 +4622,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4647,15 +4646,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4672,22 +4669,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4818,8 +4812,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4833,7 +4826,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4850,7 +4842,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4859,15 +4850,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4888,7 +4877,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4977,8 +4965,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4992,7 +4979,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5088,8 +5074,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5131,7 +5116,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5153,7 +5137,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5202,15 +5185,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lint:js-in-markdown": "standard-markdown docs",
     "create-api-json": "electron-docs-linter docs --outfile=electron-api.json",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=electron-api.json --out=electron.d.ts && node spec/ts-smoke/runner.js",
+    "gn-typescript-definitions-win": "npm run create-typescript-definitions && copy electron.d.ts",
     "gn-typescript-definitions": "npm run create-typescript-definitions && cp electron.d.ts",
     "pre-flight": "pre-flight",
     "preinstall": "node -e 'process.exit(0)'",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "lint:js-in-markdown": "standard-markdown docs",
     "create-api-json": "electron-docs-linter docs --outfile=electron-api.json",
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --in=electron-api.json --out=electron.d.ts && node spec/ts-smoke/runner.js",
-    "gn-typescript-definitions-win": "npm run create-typescript-definitions && copy electron.d.ts",
     "gn-typescript-definitions": "npm run create-typescript-definitions && cp electron.d.ts",
     "pre-flight": "pre-flight",
     "preinstall": "node -e 'process.exit(0)'",


### PR DESCRIPTION
#### Description of Change
 in window os, electron.d.ts copy method is not working. because script in package.json use 'cp' command. so i add new script "gn-typescript-definitions-win": "npm run create-typescript-definitions && copy electron.d.ts" and BUILD.gn modify for window build

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes