### PR TITLE
feat: implement win.setAspectRatio() on Windows

### DIFF
--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -184,6 +184,7 @@ class NativeWindowViews : public NativeWindow,
                     LPARAM l_param,
                     LRESULT* result) override;
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
+  void HandleSizingEvent(WPARAM w_param, LPARAM l_param);
   void SetForwardMouseMessages(bool forward);
   static LRESULT CALLBACK SubclassProc(HWND hwnd,
                                        UINT msg,

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -307,7 +307,7 @@ void NativeWindowViews::HandleSizingEvent(WPARAM w_param, LPARAM l_param) {
     return;
   }
   RECT* window_rect;
-  window_rect = (RECT*)l_param;
+  window_rect = reinterpret_cast<RECT*> l_param;
   int width = window_rect->right - window_rect->left;
   int height = window_rect->bottom - window_rect->top;
 
@@ -318,18 +318,18 @@ void NativeWindowViews::HandleSizingEvent(WPARAM w_param, LPARAM l_param) {
     case WMSZ_LEFT:
     case WMSZ_RIGHT:
       result_width = width;
-      result_height = (double)width / aspect_ratio;
+      result_height = static_cast<double> width / aspect_ratio;
       break;
     case WMSZ_TOP:
     case WMSZ_BOTTOM:
-      result_width = (double)height * aspect_ratio;
+      result_width = static_cast<double> height * aspect_ratio;
       result_height = height;
       break;
     case WMSZ_TOPLEFT:
     case WMSZ_TOPRIGHT:
     case WMSZ_BOTTOMLEFT:
     case WMSZ_BOTTOMRIGHT:
-      result_width = (double)height * aspect_ratio;
+      result_width = static_cast<double> height * aspect_ratio;
       result_height = height;
       break;
     default:

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -307,7 +307,7 @@ void NativeWindowViews::HandleSizingEvent(WPARAM w_param, LPARAM l_param) {
     return;
   }
   RECT* window_rect;
-  window_rect = reinterpret_cast<RECT*> l_param;
+  window_rect = reinterpret_cast<RECT*>(l_param);
   int width = window_rect->right - window_rect->left;
   int height = window_rect->bottom - window_rect->top;
 
@@ -318,18 +318,18 @@ void NativeWindowViews::HandleSizingEvent(WPARAM w_param, LPARAM l_param) {
     case WMSZ_LEFT:
     case WMSZ_RIGHT:
       result_width = width;
-      result_height = static_cast<double> width / aspect_ratio;
+      result_height = static_cast<double>(width) / aspect_ratio;
       break;
     case WMSZ_TOP:
     case WMSZ_BOTTOM:
-      result_width = static_cast<double> height * aspect_ratio;
+      result_width = static_cast<double>(height) * aspect_ratio;
       result_height = height;
       break;
     case WMSZ_TOPLEFT:
     case WMSZ_TOPRIGHT:
     case WMSZ_BOTTOMLEFT:
     case WMSZ_BOTTOMRIGHT:
-      result_width = static_cast<double> height * aspect_ratio;
+      result_width = static_cast<double>(height) * aspect_ratio;
       result_height = height;
       break;
     default:

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -859,7 +859,7 @@ Returns `Boolean` - Whether the window is in normal state (not maximized, not mi
 * `aspectRatio` Float - The aspect ratio to maintain for some portion of the
 content view.
 * `extraSize` [Size](structures/size.md) - The extra size not to be included while,
-maintaining the aspect ratio. this pamameter is not worked on _Windows_ OS
+maintaining the aspect ratio. _macOS_
 
 This will make a window maintain an aspect ratio. The extra size allows a
 developer to have space, specified in pixels, not included within the aspect

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -854,12 +854,12 @@ Returns `Boolean` - Whether the window is in simple (pre-Lion) fullscreen mode.
 
 Returns `Boolean` - Whether the window is in normal state (not maximized, not minimized, not in fullscreen mode).
 
-#### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_
+#### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_ _Windows_
 
 * `aspectRatio` Float - The aspect ratio to maintain for some portion of the
 content view.
-* `extraSize` [Size](structures/size.md) - The extra size not to be included while
-maintaining the aspect ratio.
+* `extraSize` [Size](structures/size.md) - The extra size not to be included while,
+maintaining the aspect ratio. this pamameter is not worked on _Windows_ OS
 
 This will make a window maintain an aspect ratio. The extra size allows a
 developer to have space, specified in pixels, not included within the aspect


### PR DESCRIPTION
#### Description of Change
Implemented `win.setAspectRatio()` on Windows by handling the `WM_SIZING` message.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Implemented `win.setAspectRatio()` on Windows.