### PR TITLE
refactor: load electron builtin modules with process._linkedBinding

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '73.0.3683.68',
   'node_version':
-    '70a78f07b1c4d53f3da462b08cef42a4ff8f949f',
+    '5e32b02e3c180c9997d60fe85042d335b6d9a588',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1425,4 +1425,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_app, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_app, Initialize)

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -154,4 +154,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_auto_updater, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_auto_updater, Initialize)

--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -180,4 +180,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_browser_view, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_browser_view, Initialize)

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -481,4 +481,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_window, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_window, Initialize)

--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -148,4 +148,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_content_tracing, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_content_tracing, Initialize)

--- a/atom/browser/api/atom_api_debugger.cc
+++ b/atom/browser/api/atom_api_debugger.cc
@@ -205,4 +205,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_debugger, Initialize);
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_debugger, Initialize);

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -232,4 +232,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_desktop_capturer, Initialize);
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_desktop_capturer, Initialize);

--- a/atom/browser/api/atom_api_dialog.cc
+++ b/atom/browser/api/atom_api_dialog.cc
@@ -104,4 +104,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_dialog, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_dialog, Initialize)

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -251,4 +251,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_download_item, Initialize);
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_download_item, Initialize);

--- a/atom/browser/api/atom_api_event.cc
+++ b/atom/browser/api/atom_api_event.cc
@@ -23,4 +23,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_event, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_event, Initialize)

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -166,4 +166,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_global_shortcut, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_global_shortcut, Initialize)

--- a/atom/browser/api/atom_api_in_app_purchase.cc
+++ b/atom/browser/api/atom_api_in_app_purchase.cc
@@ -140,4 +140,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_in_app_purchase, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_in_app_purchase, Initialize)

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -257,4 +257,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_menu, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_menu, Initialize)

--- a/atom/browser/api/atom_api_net.cc
+++ b/atom/browser/api/atom_api_net.cc
@@ -61,4 +61,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_net, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_net, Initialize)

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -272,4 +272,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_notification, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_notification, Initialize)

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -148,4 +148,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_power_monitor, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_power_monitor, Initialize)

--- a/atom/browser/api/atom_api_power_save_blocker.cc
+++ b/atom/browser/api/atom_api_power_save_blocker.cc
@@ -151,4 +151,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_power_save_blocker, Initialize);
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_power_save_blocker, Initialize);

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -317,4 +317,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_protocol, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_protocol, Initialize)

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -87,5 +87,5 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_render_process_preferences,
-                                  Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_render_process_preferences,
+                                 Initialize)

--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -171,4 +171,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_screen, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_screen, Initialize)

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -823,4 +823,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_session, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_session, Initialize)

--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -130,4 +130,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_system_preferences, Initialize);
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_system_preferences, Initialize);

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -1195,4 +1195,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_top_level_window, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_top_level_window, Initialize)

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -261,4 +261,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_tray, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_tray, Initialize)

--- a/atom/browser/api/atom_api_view.cc
+++ b/atom/browser/api/atom_api_view.cc
@@ -86,4 +86,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_view, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_view, Initialize)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -2283,4 +2283,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_web_contents, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_web_contents, Initialize)

--- a/atom/browser/api/atom_api_web_contents_view.cc
+++ b/atom/browser/api/atom_api_web_contents_view.cc
@@ -131,4 +131,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_web_contents_view, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_web_contents_view, Initialize)

--- a/atom/browser/api/atom_api_web_view_manager.cc
+++ b/atom/browser/api/atom_api_web_view_manager.cc
@@ -55,4 +55,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_web_view_manager, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_web_view_manager, Initialize)

--- a/atom/browser/api/views/atom_api_box_layout.cc
+++ b/atom/browser/api/views/atom_api_box_layout.cc
@@ -84,4 +84,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_box_layout, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_box_layout, Initialize)

--- a/atom/browser/api/views/atom_api_button.cc
+++ b/atom/browser/api/views/atom_api_button.cc
@@ -57,4 +57,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_button, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_button, Initialize)

--- a/atom/browser/api/views/atom_api_label_button.cc
+++ b/atom/browser/api/views/atom_api_label_button.cc
@@ -77,4 +77,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_label_button, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_label_button, Initialize)

--- a/atom/browser/api/views/atom_api_layout_manager.cc
+++ b/atom/browser/api/views/atom_api_layout_manager.cc
@@ -60,4 +60,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_layout_manager, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_layout_manager, Initialize)

--- a/atom/browser/api/views/atom_api_md_text_button.cc
+++ b/atom/browser/api/views/atom_api_md_text_button.cc
@@ -54,4 +54,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_md_text_button, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_md_text_button, Initialize)

--- a/atom/browser/api/views/atom_api_resize_area.cc
+++ b/atom/browser/api/views/atom_api_resize_area.cc
@@ -57,4 +57,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_resize_area, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_resize_area, Initialize)

--- a/atom/browser/api/views/atom_api_text_field.cc
+++ b/atom/browser/api/views/atom_api_text_field.cc
@@ -64,4 +64,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_browser_text_field, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_browser_text_field, Initialize)

--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -144,4 +144,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_asar, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_asar, Initialize)

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -227,4 +227,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_clipboard, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_clipboard, Initialize)

--- a/atom/common/api/atom_api_command_line.cc
+++ b/atom/common/api/atom_api_command_line.cc
@@ -58,4 +58,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_command_line, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_command_line, Initialize)

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -66,4 +66,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_crash_reporter, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_crash_reporter, Initialize)

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -623,4 +623,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_native_image, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_native_image, Initialize)

--- a/atom/common/api/atom_api_shell.cc
+++ b/atom/common/api/atom_api_shell.cc
@@ -170,4 +170,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_shell, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_shell, Initialize)

--- a/atom/common/api/atom_api_v8_util.cc
+++ b/atom/common/api/atom_api_v8_util.cc
@@ -126,4 +126,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_v8_util, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_v8_util, Initialize)

--- a/atom/common/api/features.cc
+++ b/atom/common/api/features.cc
@@ -61,4 +61,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_common_features, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_features, Initialize)

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -84,7 +84,7 @@
 // __attribute__((constructor)), we call the _register_<modname>
 // function for each built-in modules explicitly. This is only
 // forward declaration. The definitions are in each module's
-// implementation when calling the NODE_BUILTIN_MODULE_CONTEXT_AWARE.
+// implementation when calling the NODE_LINKED_MODULE_CONTEXT_AWARE.
 #define V(modname) void _register_##modname();
 ELECTRON_BUILTIN_MODULES(V)
 #if BUILDFLAG(ENABLE_VIEW_API)

--- a/atom/common/node_includes.h
+++ b/atom/common/node_includes.h
@@ -53,6 +53,12 @@
 #include "node_options.h"
 #include "node_platform.h"
 
+// Alternative to NODE_MODULE_CONTEXT_AWARE_X.
+// Allows to explicitly register builtin modules instead of using
+// __attribute__((constructor)).
+#define NODE_LINKED_MODULE_CONTEXT_AWARE(modname, regfunc) \
+  NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_LINKED)
+
 #pragma pop_macro("ASSERT")
 #pragma pop_macro("CHECK")
 #pragma pop_macro("CHECK_EQ")

--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -107,4 +107,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_renderer_ipc, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_renderer_ipc, Initialize)

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -548,4 +548,4 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(atom_renderer_web_frame, Initialize)
+NODE_LINKED_MODULE_CONTEXT_AWARE(atom_renderer_web_frame, Initialize)

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -68,7 +68,7 @@ v8::Local<v8::Value> GetBinding(v8::Isolate* isolate,
     return exports;
   }
 
-  auto* mod = node::binding::get_builtin_module(module_key.c_str());
+  auto* mod = node::binding::get_linked_module(module_key.c_str());
 
   if (!mod) {
     char errmsg[1024];

--- a/lib/common/atom-binding-setup.ts
+++ b/lib/common/atom-binding-setup.ts
@@ -1,4 +1,4 @@
-export function atomBindingSetup (binding: typeof process['binding'], processType: typeof process['type']): typeof process['atomBinding'] {
+export function atomBindingSetup (binding: typeof process['_linkedBinding'], processType: typeof process['type']): typeof process['atomBinding'] {
   return function atomBinding (name: string) {
     try {
       return binding(`atom_${processType}_${name}`)

--- a/lib/common/init.ts
+++ b/lib/common/init.ts
@@ -3,7 +3,7 @@ import * as util from 'util'
 
 import { atomBindingSetup } from '@electron/internal/common/atom-binding-setup'
 
-process.atomBinding = atomBindingSetup(process.binding, process.type)
+process.atomBinding = atomBindingSetup(process._linkedBinding, process.type)
 
 type AnyFn = (...args: any[]) => any
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -18,7 +18,7 @@ declare namespace NodeJS {
     /**
      * DO NOT USE DIRECTLY, USE process.atomBinding
      */
-    binding(name: string): any;
+    _linkedBinding(name: string): any;
     atomBinding(name: string): any;
     atomBinding(name: 'features'): FeaturesBinding;
     atomBinding(name: 'v8_util'): V8UtilBinding;


### PR DESCRIPTION
#### Description of Change

`NODE_BUILTIN_MODULE_CONTEXT_AWARE` and `process.binding` are removed in nodejs/node#25829. This change adopts the alternative available without any functionality change.

Relevant electron/node PR: https://github.com/electron/node/pull/95

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
