### PR TITLE
build: Update TypeScript, use @typescript-eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "standard",
-  "parser": "typescript-eslint-parser",
-  "plugins": ["typescript"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
   "env": {
     "browser": true
   },
@@ -9,7 +9,11 @@
     "no-var": "error",
     "no-unused-vars": 0,
     "no-global-assign": 0,
-    "typescript/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": ["error", {
+      "vars": "all",
+      "args": "after-used",
+      "ignoreRestSiblings": false
+    }],
     "prefer-const": ["error", {
       "destructuring": "all"
     }]
@@ -17,5 +21,13 @@
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"
-  }
+  },
+  "overrides": [
+    {
+      "files": "*.js",
+      "rules": {
+          "@typescript-eslint/no-unused-vars": "off"
+      }
+    }
+  ]
 }

--- a/default_app/.eslintrc
+++ b/default_app/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "parserOptions": {
-    "sourceType": "script"
-  },
-  "rules": {
-    "strict": ["error", "global"]
-  }
-}

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "parserOptions": {
-    "sourceType": "script"
-  },
-  "rules": {
-    "strict": ["error", "global"]
-  }
-}

--- a/lib/browser/api/content-tracing.js
+++ b/lib/browser/api/content-tracing.js
@@ -6,8 +6,9 @@ contentTracing.getCategories = deprecate.promisify(contentTracing.getCategories)
 contentTracing.startRecording = deprecate.promisify(contentTracing.startRecording)
 contentTracing.stopRecording = deprecate.promisify(contentTracing.stopRecording)
 contentTracing.getTraceBufferUsage = deprecate.promisifyMultiArg(
-  contentTracing.getTraceBufferUsage,
-  (value) => [value.paths, value.bookmarks]
+  contentTracing.getTraceBufferUsage
+  // convertPromiseValue: Temporarily disabled until it's used
+  /* (value) => [value.paths, value.bookmarks] */
 )
 
 module.exports = contentTracing

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -5,7 +5,7 @@ const protocol = process.atomBinding('protocol')
 
 // Fallback protocol APIs of default session.
 Object.setPrototypeOf(protocol, new Proxy({}, {
-  get (target, property) {
+  get (_target, property) {
     if (!app.isReady()) return
 
     const protocol = session.defaultSession!.protocol
@@ -21,7 +21,7 @@ Object.setPrototypeOf(protocol, new Proxy({}, {
     return Object.getOwnPropertyNames(Object.getPrototypeOf(session.defaultSession!.protocol))
   },
 
-  getOwnPropertyDescriptor (target) {
+  getOwnPropertyDescriptor () {
     return { configurable: true, enumerable: true }
   }
 }))

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -102,7 +102,8 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     } as T
   },
 
-  promisifyMultiArg: <T extends (...args: any[]) => any>(fn: T, convertPromiseValue: (v: any) => any): T => {
+  // convertPromiseValue: Temporarily disabled until it's used
+  promisifyMultiArg: <T extends (...args: any[]) => any>(fn: T /* convertPromiseValue: (v: any) => any */): T => {
     const fnName = fn.name || 'function'
     const oldName = `${fnName} with callbacks`
     const newName = `${fnName} with Promises`

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,64 @@
       "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.4.2.tgz",
+      "integrity": "sha512-6WInypy/cK4rM1dirKbD5p7iFW28DbSRKT/+PGn+DYzBWEvHq5KnZAqQ5cX25JBc0qMkFxJNxNfBbFXJyyzVcw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "1.4.2",
+        "@typescript-eslint/typescript-estree": "1.4.2",
+        "requireindex": "^1.2.0",
+        "tsutils": "^3.7.0"
+      },
+      "dependencies": {
+        "requireindex": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+          "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.8.0.tgz",
+          "integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.4.2.tgz",
+      "integrity": "sha512-OqLkY9295DXXaWToItUv3olO2//rmzh6Th6Sc7YjFFEpEuennsm5zhygLLvHZjPxPlzrQgE8UDaOPurDylaUuw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.4.2",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.2.tgz",
+      "integrity": "sha512-wKgi/w6k1v3R4b6oDc20cRWro2gBzp0wn6CAeYC8ExJMfvXMfiaXzw2tT9ilxdONaVWMCk7B9fMdjos7bF/CWw==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -12593,35 +12651,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
       "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-22.0.0.tgz",
-      "integrity": "sha512-pD8D7oTeRwWvFVxK3PaY6FYAiZsuRXFkIc2+1xkwCT3NduySgCgjeAkR5/dnIWecOiFVcEHf4ypXurF02Q6Z3Q==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "18.0.0"
-      }
-    },
-    "typescript-estree": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-18.0.0.tgz",
-      "integrity": "sha512-HxTWrzFyYOPWA91Ij7xL9mNUVpGTKLH2KiaBn28CMbYgX2zgWdJqU9hO7Are+pAPAqY91NxAYoaAyDDZ3rLj2A==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
-      }
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4622,8 +4622,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4647,15 +4646,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4672,22 +4669,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4818,8 +4812,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4833,7 +4826,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4850,7 +4842,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4859,15 +4850,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4888,7 +4877,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4977,8 +4965,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4992,7 +4979,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5088,8 +5074,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5131,7 +5116,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5153,7 +5137,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5202,15 +5185,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12608,26 +12589,26 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz",
-      "integrity": "sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-22.0.0.tgz",
+      "integrity": "sha512-pD8D7oTeRwWvFVxK3PaY6FYAiZsuRXFkIc2+1xkwCT3NduySgCgjeAkR5/dnIWecOiFVcEHf4ypXurF02Q6Z3Q==",
       "dev": true,
       "requires": {
         "eslint-scope": "^4.0.0",
         "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "5.3.0"
+        "typescript-estree": "18.0.0"
       }
     },
     "typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-18.0.0.tgz",
+      "integrity": "sha512-HxTWrzFyYOPWA91Ij7xL9mNUVpGTKLH2KiaBn28CMbYgX2zgWdJqU9hO7Are+pAPAqY91NxAYoaAyDDZ3rLj2A==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "devDependencies": {
     "@octokit/rest": "^16.3.2",
     "@types/node": "^10.12.21",
+    "@typescript-eslint/eslint-plugin": "^1.4.2",
+    "@typescript-eslint/parser": "^1.4.2",
     "aliasify": "^2.1.0",
     "asar": "^1.0.0",
     "browserify": "^16.2.3",
@@ -40,8 +42,7 @@
     "sumchecker": "^2.0.2",
     "temp": "^0.8.3",
     "tsify": "^4.0.1",
-    "typescript": "~3.3.3333",
-    "typescript-eslint-parser": "^22.0.0"
+    "typescript": "~3.3.3333"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "sumchecker": "^2.0.2",
     "temp": "^0.8.3",
     "tsify": "^4.0.1",
-    "typescript": "~3.1.1",
-    "typescript-eslint-parser": "^21.0.0"
+    "typescript": "~3.3.3333",
+    "typescript-eslint-parser": "^22.0.0"
   },
   "private": true,
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "baseUrl": ".",
     "allowJs": true,
+    "noUnusedLocals": true,
     "outDir": "ts-gen",
     "paths": {
       "@electron/internal/*": ["lib/*"]

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -66,7 +66,9 @@ declare namespace ElectronInternal {
     renameProperty<T, K extends (keyof T & string)>(object: T, oldName: string, newName: K): T;
 
     promisify<T extends (...args: any[]) => any>(fn: T): T;
-    promisifyMultiArg<T extends (...args: any[]) => any>(fn: T, convertPromiseValue: (v: any) => any): T;
+
+    // convertPromiseValue: Temporarily disabled until it's used
+    promisifyMultiArg<T extends (...args: any[]) => any>(fn: T, /*convertPromiseValue: (v: any) => any*/): T;
   }
 
   // Internal IPC has _replyInternal and NO reply method


### PR DESCRIPTION
#### Description of Change
This PR updates our TypeScript version to 3.3.3333 (don't ask), which is an all-around _better_ version of TypeScript without breaking any code we have today. 

That upgrade surfaced an issue with [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser), which is deprecated and archived. The new kid on the block is [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint), which is _better_ and actually found some issues in our code.

The only change that requires explanation is the removal of `.eslintrc` files that are overriding our `module` definition with `script` definitions. That declaration is incorrect as soon as TypeScript rolls around, which compiles in module mode (outputting a script, but that's none of ESLint's concern).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
