### PR TITLE
chore: clean up promise resolution with helpers

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -149,7 +149,7 @@ void FilterCookies(std::unique_ptr<base::DictionaryValue> filter,
 
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::UI},
-      base::BindOnce(util::Promise::ResolvePromise<net::CookieList>,
+      base::BindOnce(util::Promise::ResolvePromise<const net::CookieList&>,
                      std::move(promise), std::move(result)));
 }
 

--- a/atom/browser/api/atom_api_net_log.cc
+++ b/atom/browser/api/atom_api_net_log.cc
@@ -19,15 +19,6 @@
 #include "native_mate/handle.h"
 #include "net/url_request/url_request_context_getter.h"
 
-namespace {
-
-void OnGetFilePathToCompletedLog(const atom::util::CopyablePromise& promise,
-                                 const base::FilePath& file_path) {
-  promise.GetPromise().Resolve(file_path);
-}
-
-}  // namespace
-
 namespace atom {
 
 namespace api {
@@ -120,7 +111,8 @@ void NetLog::OnNewState(const base::DictionaryValue& state) {
       // TODO(zcbenz): Remove the use of CopyablePromise when the
       // GetFilePathToCompletedLog API accepts OnceCallback.
       net_log_writer_->GetFilePathToCompletedLog(base::Bind(
-          &OnGetFilePathToCompletedLog, util::CopyablePromise(promise)));
+          util::CopyablePromise::ResolveCopyablePromise<const base::FilePath&>,
+          util::CopyablePromise(promise)));
     }
     stop_callback_queue_.clear();
   }

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -177,10 +177,6 @@ bool IsProtocolHandledInIO(
   return is_handled;
 }
 
-void PromiseCallback(util::Promise promise, bool handled) {
-  promise.Resolve(handled);
-}
-
 v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme) {
   util::Promise promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
@@ -190,7 +186,7 @@ v8::Local<v8::Promise> Protocol::IsProtocolHandled(const std::string& scheme) {
   base::PostTaskWithTraitsAndReplyWithResult(
       FROM_HERE, {content::BrowserThread::IO},
       base::BindOnce(&IsProtocolHandledInIO, base::RetainedRef(getter), scheme),
-      base::BindOnce(&PromiseCallback, std::move(promise)));
+      base::BindOnce(util::Promise::ResolvePromise<bool>, std::move(promise)));
 
   return handle;
 }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1300,11 +1300,12 @@ v8::Local<v8::Promise> WebContents::SavePage(
     const base::FilePath& full_file_path,
     const content::SavePageType& save_type) {
   util::Promise promise(isolate());
-  v8::Local<v8::Promise> ret = promise.GetHandle();
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto* handler = new SavePageHandler(web_contents(), std::move(promise));
   handler->Handle(full_file_path, save_type);
-  return ret;
+
+  return handle;
 }
 
 void WebContents::OpenDevTools(mate::Arguments* args) {


### PR DESCRIPTION
#### Description of Change

Cleans up old promise resolution code with static helpers introduced in https://github.com/electron/electron/pull/17223.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
