### PR TITLE
feat: enable setuid sandbox on linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1026,6 +1026,9 @@ dist_zip("electron_dist_zip") {
     ":licenses",
     ":electron_version",
   ]
+  if (is_linux) {
+    data_deps += [ "//sandbox/linux:chrome_sandbox" ]
+  }
   outputs = [
     "$root_build_dir/dist.zip",
   ]

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -237,10 +237,6 @@ void AtomMainDelegate::PreSandboxStartup() {
   if (!IsBrowserProcess(command_line))
     return;
 
-  // Disable setuid sandbox since it is not longer required on
-  // linux (namespace sandbox is available on most distros).
-  command_line->AppendSwitch(service_manager::switches::kDisableSetuidSandbox);
-
   // Allow file:// URIs to read other file:// URIs by default.
   command_line->AppendSwitch(::switches::kAllowFileAccessFromFiles);
 

--- a/build/zip.py
+++ b/build/zip.py
@@ -61,7 +61,10 @@ def main(argv):
             for file in files:
               z.write(os.path.join(root, file))
         else:
-          z.write(dep)
+          basename = os.path.basename(dep)
+          dirname = os.path.dirname(dep)
+          arcname = os.path.join(dirname, 'chrome-sandbox') if basename == 'chrome_sandbox' else dep
+          z.write(dep, arcname)
 
 if __name__ == '__main__':
   sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
#### Description of Change
This change enables the [setuid sandbox](https://chromium.googlesource.com/chromium/src/+/73.0.3683.65/docs/linux_suid_sandbox.md) on Linux. This allows Electron to run sandboxed in environments that disable CLONE_NEWUSER for unprivileged users (e.g. docker without `CAP_SYS_ADMIN`, and Arch Linux).

Closes #16631.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enabled the setuid sandbox on Linux, allowing Electron to launch sandboxed processes in environments that disable CLONE_NEWUSER for unprivileged users.
