### PR TITLE
build: Fix windows test hang

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_version':
     '63.0.3239.150',
   'libchromiumcontent_revision':
-    'cd7a2326b0668f24b83d568eccab16ee9ba8dc9a',
+    'b4d2be246ca4c44c839b8f23ee2fd27bb1071082',
   'node_version':
     'v9.7.0-33-g538a5023af',
   'native_mate_revision':

--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_version':
     '63.0.3239.150',
   'libchromiumcontent_revision':
-    'b4d2be246ca4c44c839b8f23ee2fd27bb1071082',
+    'cd7a2326b0668f24b83d568eccab16ee9ba8dc9a',
   'node_version':
     'v9.7.0-33-g538a5023af',
   'native_mate_revision':

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ build_script:
     echo "Build worker image $env:APPVEYOR_BUILD_WORKER_IMAGE"
 
     &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
-    
+
     if($env:SKIP_GYP_BUILD -eq "true") {
       Write-warning "Skipping debug build for older branch"; Exit-AppveyorBuild
     } elseif(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
@@ -44,7 +44,7 @@ test_script:
       Write-Output "Skipping tests for release build"
     } else {
       Write-Output "Running tests for debug build"
-      python script\test.py --ci --rebuild_native_modules
+      python script\test.py --ci --rebuild_native_modules -v
       if ($LASTEXITCODE -ne '0') {
         throw "Tests failed with exit code $LASTEXITCODE"
       } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ test_script:
       $env:RUN_TESTS="true"
       Write-Output "Running tests for debug build"
     }
-- if "%RUN_TESTS%"=="true" ( echo Running test suite & python script\test.py --ci --rebuild_native_modules -v)
+- if "%RUN_TESTS%"=="true" ( echo Running test suite & python script\test.py --ci --rebuild_native_modules)
 - if "%RUN_TESTS%"=="true" ( echo Running verify ffmpeg & python script\verify-ffmpeg.py)
 artifacts:
 - path: test-results.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,20 +43,11 @@ test_script:
     if (Test-Path Env:\ELECTRON_RELEASE) {
       Write-Output "Skipping tests for release build"
     } else {
+      $env:RUN_TESTS="true"
       Write-Output "Running tests for debug build"
-      python script\test.py --ci --rebuild_native_modules -v
-      if ($LASTEXITCODE -ne '0') {
-        throw "Tests failed with exit code $LASTEXITCODE"
-      } else {
-        Write-Output "Tests succeeded."
-      }
-      python script\verify-ffmpeg.py
-      if ($LASTEXITCODE -ne '0') {
-        throw "Verify ffmpeg failed with exit code $LASTEXITCODE"
-      } else {
-        "Verify ffmpeg succeeded."
-      }
     }
+- if "%RUN_TESTS%"=="true" ( echo Running test suite & python script\test.py --ci --rebuild_native_modules -v)
+- if "%RUN_TESTS%"=="true" ( echo Running verify ffmpeg & python script\verify-ffmpeg.py)
 artifacts:
 - path: test-results.xml
   name: test-results.xml

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2791,9 +2791,11 @@ describe('BrowserWindow module', () => {
   })
 
   describe('window.getNativeWindowHandle()', () => {
-    if (!nativeModulesEnabled) {
-      this.skip()
-    }
+    before(function () {
+      if (!nativeModulesEnabled) {
+        this.skip()
+      }
+    })
 
     it('returns valid handle', () => {
       // The module's source code is hosted at


### PR DESCRIPTION
#### Description of Change
Windows testing was hanging because of a bad test where `this.skip()` was incorrectly being called.  This PR fixes that test and updates Appveyor to better output the test results.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
