### PR TITLE
fix: gn check errors in release build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -358,6 +358,7 @@ static_library("electron_lib") {
     "//ppapi/shared_impl",
     "//printing/buildflags",
     "//services/audio/public/mojom:constants",
+    "//services/device/public/cpp/geolocation",
     "//services/device/public/mojom",
     "//services/proxy_resolver:lib",
     "//services/video_capture/public/mojom:constants",
@@ -447,7 +448,6 @@ static_library("electron_lib") {
       "atom/browser/fake_location_provider.cc",
       "atom/browser/fake_location_provider.h",
     ]
-    deps += [ "//services/device/public/cpp/geolocation" ]
   }
 
   if (is_mac) {


### PR DESCRIPTION
#### Description of Change

```
ERROR at //electron/atom/browser/atom_browser_client.cc:74:11: Can't include this header from here.
#include "services/device/public/cpp/geolocation/location_provider.h"
          ^---------------------------------------------------------
The target:
  //electron:electron_lib
is including a file from the target:
  //services/device/public/cpp/geolocation:geolocation
It's usually best to depend directly on the destination target.
In some cases, the destination target is considered a subcomponent
of an intermediate target. In this case, the intermediate target
should depend publicly on the destination to forward the ability
to include headers.
Dependency chain (there may also be others):
  //electron:electron_lib -->
  //content/public/browser:browser -->
  //content/public/browser:browser_sources --[private]-->
  //services/device/public/cpp/geolocation:geolocation

```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
