### PR TITLE
build: minor fixes to git-export-patches

### DIFF
--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -16,7 +16,7 @@ def guess_base_commit(repo):
     'describe',
     '--tags',
   ]
-  return subprocess.check_output(args).split('-')[0:2]
+  return subprocess.check_output(args).rsplit('-', 2)[0:2]
 
 
 def format_patch(repo, since):

--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -92,7 +92,8 @@ def remove_patch_filename(patch):
 def main(argv):
   parser = argparse.ArgumentParser()
   parser.add_argument("-o", "--output",
-      help="directory into which exported patches will be written")
+      help="directory into which exported patches will be written",
+      required=True)
   parser.add_argument("patch_range",
       nargs='?',
       help="range of patches to export. Defaults to all commits since the "


### PR DESCRIPTION
#### Description of Change
Multiple people have been confused when export-patches gave them an error like:
```
Exporting nightly.20190307
 patches since v6.0.0
fatal: ambiguous argument 'v6.0.0': unknown revision or path not in the working tree.
```

which is a result of mis-parsing the output of `git describe --tags`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes