### PR TITLE
build: fix incorrect reference to this.skip

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -3181,9 +3181,11 @@ describe('BrowserWindow module', () => {
   })
 
   describe('window.getNativeWindowHandle()', () => {
-    if (!nativeModulesEnabled) {
-      this.skip()
-    }
+    before(function () {
+      if (!nativeModulesEnabled) {
+        this.skip()
+      }
+    })
 
     it('returns valid handle', () => {
       // The module's source code is hosted at


### PR DESCRIPTION
#### Description of Change
I discovered in #17271 in 3-1-x  that there was a test that was incorrectly trying to use this.skip.  The same issue exists in master, so this PR fixes it there.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes