### PR TITLE
build: disable gpg signing in git-import-patches

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -52,6 +52,7 @@ def am(repo, patch_data, threeway=False, directory=None,
     root_args += ['-c', 'user.name=' + committer_name]
   if committer_email is not None:
     root_args += ['-c', 'user.email=' + committer_email]
+  root_args += ['-c', 'commit.gpgsign=false']
   command = ['git'] + root_args + ['am'] + args
   proc = subprocess.Popen(
       command,


### PR DESCRIPTION
#### Description of Change

Ensure that gpg signing is turned off during patch application. This guards against the case where the user has `commit.gpgsign=true` in their `.gitconfig`, which can cause the sync to fail due to gpg requesting a passphrase.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
