### PR TITLE
fix: improve focused menu bar item visibility

### DIFF
--- a/atom/browser/ui/views/submenu_button.cc
+++ b/atom/browser/ui/views/submenu_button.cc
@@ -37,7 +37,7 @@ SubmenuButton::SubmenuButton(const base::string16& title,
 
   SetInkDropMode(InkDropMode::ON);
   set_ink_drop_base_color(
-      color_utils::BlendTowardMaxContrast(background_color_, 0x61));
+      color_utils::BlendTowardMaxContrast(background_color_, 0x81));
 }
 
 SubmenuButton::~SubmenuButton() {}
@@ -55,6 +55,7 @@ std::unique_ptr<views::InkDrop> SubmenuButton::CreateInkDrop() {
   std::unique_ptr<views::InkDropImpl> ink_drop =
       views::Button::CreateDefaultInkDropImpl();
   ink_drop->SetShowHighlightOnHover(false);
+  ink_drop->SetShowHighlightOnFocus(true);
   return std::move(ink_drop);
 }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

It looks like during the C73 upgrade we lost the highlight on the focused menu bar items (there was a small dotted border around the text of the focused item). This is bad because you can now navigate the menu with just the keyboard, and you can't tell which top level item you are currently on.

This PR enables the background highlighting of the `InkDrop` for the focused item, giving some visual feedback to the user when navigating with the keyboard. Also, I made the highlight a tiny bit darker to make it easier to see.

This is what we had before the C73 upgrade:
![electron-acc-4](https://user-images.githubusercontent.com/1690458/54058388-fb466b80-41f5-11e9-9601-2caf24b0e8e0.gif)
After the upgrade:
![electron-acc-2](https://user-images.githubusercontent.com/1690458/54058396-039ea680-41f6-11e9-87fb-1a3dad39fdc6.gif)
With this PR:
![electron-acc-3](https://user-images.githubusercontent.com/1690458/54058414-0bf6e180-41f6-11e9-9689-f98104cda44b.gif)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Improved the visibility of the focused item on the menu bar. <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
