### PR TITLE
fix: crash in ECDH.setPrivateKey (backport: 4-0-x)

### DIFF
--- a/patches/common/boringssl/.patches
+++ b/patches/common/boringssl/.patches
@@ -2,3 +2,4 @@ implement_ssl_get_tlsext_status_type.patch
 expose_ripemd160.patch
 expose_aes-cfb.patch
 sync_sorted_ciphers.patch
+handle_pub_key_null_in_ec_key_set_public_key.patch

--- a/patches/common/boringssl/handle_pub_key_null_in_ec_key_set_public_key.patch
+++ b/patches/common/boringssl/handle_pub_key_null_in_ec_key_set_public_key.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Mon, 4 Mar 2019 10:59:35 -0800
+Subject: handle pub_key == null in EC_KEY_set_public_key
+
+
+diff --git a/crypto/fipsmodule/ec/ec_key.c b/crypto/fipsmodule/ec/ec_key.c
+index 4bc12a073650f66f5ae8ba2beabb9a6fb2b21878..7e86ccb0d76c66f32fc05c7093c870d5da7b9994 100644
+--- a/crypto/fipsmodule/ec/ec_key.c
++++ b/crypto/fipsmodule/ec/ec_key.c
+@@ -267,7 +267,7 @@ int EC_KEY_set_public_key(EC_KEY *key, const EC_POINT *pub_key) {
+     return 0;
+   }
+ 
+-  if (EC_GROUP_cmp(key->group, pub_key->group, NULL) != 0) {
++  if (pub_key != NULL && EC_GROUP_cmp(key->group, pub_key->group, NULL) != 0) {
+     OPENSSL_PUT_ERROR(EC, EC_R_GROUP_MISMATCH);
+     return 0;
+   }

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -452,6 +452,28 @@ describe('node feature', () => {
       const iv = Buffer.from('fedcba9876543210', 'hex')
       require('crypto').createCipheriv('des-ede-cbc', key, iv)
     })
+
+    it('should not crash when getting an ECDH key', () => {
+      const ecdh = require('crypto').createECDH('prime256v1')
+      expect(ecdh.generateKeys()).to.be.an.instanceof(Buffer)
+      expect(ecdh.getPrivateKey()).to.be.an.instanceof(Buffer)
+    })
+
+    it('should not crash when generating DH keys or fetching DH fields', () => {
+      const dh = require('crypto').createDiffieHellman('modp15')
+      expect(dh.generateKeys()).to.be.an.instanceof(Buffer)
+      expect(dh.getPublicKey()).to.be.an.instanceof(Buffer)
+      expect(dh.getPrivateKey()).to.be.an.instanceof(Buffer)
+      expect(dh.getPrime()).to.be.an.instanceof(Buffer)
+      expect(dh.getGenerator()).to.be.an.instanceof(Buffer)
+    })
+
+    it('should not crash when creating an ECDH cipher', () => {
+      const crypto = require('crypto')
+      const dh = crypto.createECDH('prime256v1')
+      dh.generateKeys()
+      dh.setPrivateKey(dh.getPrivateKey())
+    })
   })
 
   it('includes the electron version in process.versions', () => {


### PR DESCRIPTION
Backport of #17219

See that PR for details.


Notes: Fixed a crash when calling ECDH.setPrivateKey().