### PR TITLE
test: robustify some webview tests

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -73,8 +73,9 @@ describe('<webview> tag', function () {
         nodeIntegration: true
       }
     })
+    const pong = emittedOnce(ipcMain, 'pong')
     w.loadFile(path.join(fixtures, 'pages', 'webview-no-script.html'))
-    await emittedOnce(ipcMain, 'pong')
+    await pong
   })
 
   it('works with sandbox', async () => {
@@ -86,8 +87,9 @@ describe('<webview> tag', function () {
         sandbox: true
       }
     })
+    const pong = emittedOnce(ipcMain, 'pong')
     w.loadFile(path.join(fixtures, 'pages', 'webview-isolated.html'))
-    await emittedOnce(ipcMain, 'pong')
+    await pong
   })
 
   it('works with contextIsolation', async () => {
@@ -99,8 +101,9 @@ describe('<webview> tag', function () {
         contextIsolation: true
       }
     })
+    const pong = emittedOnce(ipcMain, 'pong')
     w.loadFile(path.join(fixtures, 'pages', 'webview-isolated.html'))
-    await emittedOnce(ipcMain, 'pong')
+    await pong
   })
 
   it('works with contextIsolation + sandbox', async () => {
@@ -113,8 +116,9 @@ describe('<webview> tag', function () {
         sandbox: true
       }
     })
+    const pong = emittedOnce(ipcMain, 'pong')
     w.loadFile(path.join(fixtures, 'pages', 'webview-isolated.html'))
-    await emittedOnce(ipcMain, 'pong')
+    await pong
   })
 
   it('is disabled by default', async () => {
@@ -126,8 +130,9 @@ describe('<webview> tag', function () {
       }
     })
 
+    const webview = emittedOnce(ipcMain, 'webview')
     w.loadFile(path.join(fixtures, 'pages', 'webview-no-script.html'))
-    const [, type] = await emittedOnce(ipcMain, 'webview')
+    const [, type] = await webview
 
     expect(type).to.equal('undefined', 'WebView still exists')
   })


### PR DESCRIPTION
#### Description of Change
Example flake: https://circleci.com/gh/electron/electron/149521

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes