### PR TITLE
chore: add mate converter for long

### DIFF
--- a/native_mate/native_mate/converter.cc
+++ b/native_mate/native_mate/converter.cc
@@ -139,6 +139,17 @@ bool Converter<double>::FromV8(Isolate* isolate,
   return true;
 }
 
+Local<Value> Converter<long>::ToV8(Isolate* isolate, long val) {
+  return ToV8(isolate, (long long)val);
+}
+
+bool Converter<long>::FromV8(Isolate* isolate, Local<Value> val, long* out) {
+  if (!val->IsNumber())
+    return false;
+  *out = static_cast<long>(val.As<Number>()->Value());
+  return true;
+}
+
 Local<Value> Converter<const char*>::ToV8(Isolate* isolate, const char* val) {
   return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal)
       .ToLocalChecked();

--- a/native_mate/native_mate/converter.h
+++ b/native_mate/native_mate/converter.h
@@ -114,6 +114,12 @@ struct Converter<double> {
 };
 
 template <>
+struct Converter<long> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, long val);
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val, long* out);
+};
+
+template <>
 struct Converter<const char*> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val);
 };


### PR DESCRIPTION
#### Description of Change

Adds a `native_mate` convert to marshall the `long` type. Prompted by https://github.com/electron/electron/pull/17298.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
