### PR TITLE
build: remove strip_debug_info gn arg declaration

### DIFF
--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -1,7 +1,6 @@
 import("all.gn")
 is_component_build = false
 is_official_build = true
-strip_debug_info = true
 
 # This may be guarded behind is_chrome_branded alongside
 # proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,


### PR DESCRIPTION
It is [android only](https://cs.chromium.org/chromium/src/build/config/compiler/BUILD.gn) and causing release build failures on windows

This is currently causing release build failures on Windows with C74

Notes: no-notes
