### PR TITLE
refactor: add ipcMainUtils.invokeInWebContents / ipcRendererUtils.handle helpers

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -9,6 +9,7 @@ const { app, ipcMain, session, deprecate } = electron
 
 const NavigationController = require('@electron/internal/browser/navigation-controller')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
+const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
 
 // session is not used here, the purpose is to make sure session is initalized
@@ -193,7 +194,7 @@ const asyncWebFrameMethods = function (requestId, method, callback, ...args) {
 
 for (const method of webFrameMethods) {
   WebContents.prototype[method] = function (...args) {
-    this._sendInternal('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, args)
+    ipcMainUtils.invokeInWebContents(this, 'ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, ...args)
   }
 }
 

--- a/lib/renderer/ipc-renderer-internal-utils.ts
+++ b/lib/renderer/ipc-renderer-internal-utils.ts
@@ -1,6 +1,21 @@
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal'
 import * as errorUtils from '@electron/internal/common/error-utils'
 
+type IPCHandler = (event: Electron.IpcRendererEvent, ...args: any[]) => any
+
+export const handle = function <T extends IPCHandler> (channel: string, handler: T) {
+  ipcRendererInternal.on(channel, (event, requestId, ...args) => {
+    new Promise(resolve => resolve(handler(event, ...args))
+    ).then(result => {
+      return [null, result]
+    }, error => {
+      return [errorUtils.serialize(error)]
+    }).then(responseArgs => {
+      event.sender.send(`${channel}_RESPONSE_${requestId}`, ...responseArgs)
+    })
+  })
+}
+
 let nextId = 0
 
 export function invoke<T> (command: string, ...args: any[]) {

--- a/lib/renderer/web-frame-init.ts
+++ b/lib/renderer/web-frame-init.ts
@@ -1,5 +1,6 @@
 import { webFrame, WebFrame } from 'electron'
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal'
+import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils'
 import * as errorUtils from '@electron/internal/common/error-utils'
 
 // All keys of WebFrame that extend Function
@@ -10,13 +11,13 @@ type WebFrameMethod = {
 
 export const webFrameInit = () => {
   // Call webFrame method
-  ipcRendererInternal.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (
-    _event, method: keyof WebFrameMethod, args: any[]
+  ipcRendererUtils.handle('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (
+    event, method: keyof WebFrameMethod, ...args: any[]
   ) => {
     // The TypeScript compiler cannot handle the sheer number of
     // call signatures here and simply gives up. Incorrect invocations
     // will be caught by "keyof WebFrameMethod" though.
-    (webFrame[method] as any)(...args)
+    return (webFrame[method] as any)(...args)
   })
 
   ipcRendererInternal.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -55,6 +55,10 @@ declare namespace Electron {
     sendToAll(webContentsId: number, channel: string, ...args: any[]): void
   }
 
+  interface WebContentsInternal extends Electron.WebContents {
+    _sendInternal(channel: string, ...args: any[]): void;
+  }
+
   const deprecate: ElectronInternal.DeprecationUtil;
 }
 


### PR DESCRIPTION
#### Description of Change
Allows invoking handlers easily in renderers from main via IPC, handling errors and promises.
Simplifies https://github.com/electron/electron/pull/17312 (feat: promisify executeJavaScript)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes

/cc @nornagon, @MarshallOfSound