### PR TITLE
feat: add renderer-process-crashed event to app

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -352,6 +352,16 @@ Returns:
 
 Emitted when the gpu process crashes or is killed.
 
+### Event: 'renderer-process-crashed'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+* `killed` Boolean
+
+Emitted when the renderer process of `webContents` crashes or is killed.
+
 ### Event: 'accessibility-support-changed' _macOS_ _Windows_
 
 Returns:

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -431,6 +431,10 @@ WebContents.prototype._init = function () {
     })
   }
 
+  this.on('crashed', (event, ...args) => {
+    app.emit('renderer-process-crashed', event, this, ...args)
+  })
+
   deprecate.event(this, 'did-get-response-details', '-did-get-response-details')
   deprecate.event(this, 'did-get-redirect-request', '-did-get-redirect-request')
 

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -379,6 +379,22 @@ describe('app module', () => {
       w = new BrowserWindow({ show: false })
     })
 
+    it('should emit renderer-process-crashed event when renderer crashes', async () => {
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
+      await w.loadURL('about:blank')
+
+      const promise = emittedOnce(app, 'renderer-process-crashed')
+      w.webContents.executeJavaScript('process.crash()')
+
+      const [, webContents] = await promise
+      expect(webContents).to.equal(w.webContents)
+    })
+
     it('should emit desktop-capturer-get-sources event when desktopCapturer.getSources() is invoked', async () => {
       w = new BrowserWindow({
         show: false,

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -110,10 +110,12 @@ app.on('window-all-closed', function () {
   app.quit()
 })
 
-app.on('web-contents-created', (event, contents) => {
-  contents.on('crashed', (event, killed) => {
-    console.log(`webContents ${contents.id} crashed: ${contents.getURL()} (killed=${killed})`)
-  })
+app.on('gpu-process-crashed', (event, killed) => {
+  console.log(`GPU process crashed (killed=${killed})`)
+})
+
+app.on('renderer-process-crashed', (event, contents, killed) => {
+  console.log(`webContents ${contents.id} crashed: ${contents.getURL()} (killed=${killed})`)
 })
 
 app.on('ready', function () {


### PR DESCRIPTION
#### Description of Change
Allows handling crashes for all renderer processes (including devtools and chrome extension background script hosts) in a single place.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `renderer-process-crashed` event to `app`, which is emitted when any renderer process crashes.