### PR TITLE
fix: remove non-existent gpu-crashed event on <webview>

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -885,10 +885,6 @@ ipcRenderer.on('ping', () => {
 
 Fired when the renderer process is crashed.
 
-### Event: 'gpu-crashed'
-
-Fired when the gpu process is crashed.
-
 ### Event: 'plugin-crashed'
 
 Returns:

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -36,7 +36,6 @@ const supportedWebViewEvents = [
   'focus-change',
   'close',
   'crashed',
-  'gpu-crashed',
   'plugin-crashed',
   'destroyed',
   'page-title-updated',

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -27,7 +27,6 @@ const WEB_VIEW_EVENTS: Record<string, Array<string>> = {
   'focus-change': ['focus', 'guestInstanceId'],
   'close': [],
   'crashed': [],
-  'gpu-crashed': [],
   'plugin-crashed': ['name', 'version'],
   'destroyed': [],
   'page-title-updated': ['title', 'explicitSet'],


### PR DESCRIPTION
#### Description of Change
There is no such event implemented. `WebContents` would have to emit `gpu-crashed` (similar to `crashed` and `plugin-crashed`).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Remove non-existent `gpu-crashed` event on `<webview>`.