### PR TITLE
fix: remove label/image from segment if they are mutated to null

### DIFF
--- a/atom/browser/ui/cocoa/atom_touch_bar.mm
+++ b/atom/browser/ui/cocoa/atom_touch_bar.mm
@@ -623,9 +623,14 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     segments[i].Get("enabled", &enabled);
     if (segments[i].Get("label", &label)) {
       [control setLabel:base::SysUTF8ToNSString(label) forSegment:i];
-    } else if (segments[i].Get("icon", &image)) {
+    } else {
+      [control setLabel:@"" forSegment:i];
+    }
+    if (segments[i].Get("icon", &image)) {
       [control setImage:image.AsNSImage() forSegment:i];
       [control setImageScaling:NSImageScaleProportionallyUpOrDown forSegment:i];
+    } else {
+      [control setImage:nil forSegment:i];
     }
     [control setEnabled:enabled forSegment:i];
   }


### PR DESCRIPTION
#### Description of Change
The way we manage segmented controls is mutating them in place to match the new properties.  This had issues when "label" or "image" wasn't just changed, rather completely removed / reset to `null`.

This PR updates the logic to handle the null/undefined cases.

Fixes #17322

Notes: TouchBarSegmentedControl instances now correctly update when you update the `segments` array and remove `label` or `image` dynamically.
