### PR TITLE
feat: add safer nativeImage.createFromBitmap(), which does not decode PNG/JPEG

### DIFF
--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -51,6 +51,10 @@ class NativeImage : public mate::Wrappable<NativeImage> {
                                                   size_t length);
   static mate::Handle<NativeImage> CreateFromPath(v8::Isolate* isolate,
                                                   const base::FilePath& path);
+  static mate::Handle<NativeImage> CreateFromBitmap(
+      mate::Arguments* args,
+      v8::Local<v8::Value> buffer,
+      const mate::Dictionary& options);
   static mate::Handle<NativeImage> CreateFromBuffer(
       mate::Arguments* args,
       v8::Local<v8::Value> buffer);

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -137,6 +137,19 @@ let image = nativeImage.createFromPath('/Users/somebody/images/icon.png')
 console.log(image)
 ```
 
+### `nativeImage.createFromBitmap(buffer, options)`
+
+* `buffer` [Buffer][buffer]
+* `options` Object
+  * `width` Integer
+  * `height` Integer
+  * `scaleFactor` Double (optional) - Defaults to 1.0.
+
+Returns `NativeImage`
+
+Creates a new `NativeImage` instance from `buffer` that contains the raw bitmap
+pixel data returned by `toBitmap()`. The specific format is platform-dependent.
+
 ### `nativeImage.createFromBuffer(buffer[, options])`
 
 * `buffer` [Buffer][buffer]
@@ -147,7 +160,7 @@ console.log(image)
 
 Returns `NativeImage`
 
-Creates a new `NativeImage` instance from `buffer`.
+Creates a new `NativeImage` instance from `buffer`. Tries to decode as PNG or JPEG first.
 
 ### `nativeImage.createFromDataURL(dataURL)`
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -127,6 +127,30 @@ describe('nativeImage module', () => {
     })
   })
 
+  describe('createFromBitmap(buffer, options)', () => {
+    it('returns an empty image when the buffer is empty', () => {
+      expect(nativeImage.createFromBitmap(Buffer.from([]), { width: 0, height: 0 }).isEmpty())
+    })
+
+    it('returns an image created from the given buffer', () => {
+      const imageA = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
+
+      const imageB = nativeImage.createFromBitmap(imageA.toBitmap(), imageA.getSize())
+      expect(imageB.getSize()).to.deep.equal({ width: 538, height: 190 })
+
+      const imageC = nativeImage.createFromBuffer(imageA.toBitmap(), { ...imageA.getSize(), scaleFactor: 2.0 })
+      expect(imageC.getSize()).to.deep.equal({ width: 269, height: 95 })
+    })
+
+    it('throws on invalid arguments', () => {
+      expect(() => nativeImage.createFromBitmap(null, {})).to.throw('buffer must be a node Buffer')
+      expect(() => nativeImage.createFromBitmap([12, 14, 124, 12], {})).to.throw('buffer must be a node Buffer')
+      expect(() => nativeImage.createFromBitmap(Buffer.from([]), {})).to.throw('width is required')
+      expect(() => nativeImage.createFromBitmap(Buffer.from([]), { width: 1 })).to.throw('height is required')
+      expect(() => nativeImage.createFromBitmap(Buffer.from([]), { width: 1, height: 1 })).to.throw('invalid buffer size')
+    })
+  })
+
   describe('createFromBuffer(buffer, options)', () => {
     it('returns an empty image when the buffer is empty', () => {
       expect(nativeImage.createFromBuffer(Buffer.from([])).isEmpty())


### PR DESCRIPTION
#### Description of Change
Required to safely serialize/deserialize `NativeImage` instances to be sent over IPC in https://github.com/electron/electron/pull/17200

/cc @nornagon

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added safer `nativeImage.createFromBitmap()`, which does not decode PNG/JPEG.