### PR TITLE
fix: don't crash when nativeImage.createFromBuffer() is called with invalid buffer

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -509,6 +509,11 @@ mate::Handle<NativeImage> NativeImage::CreateFromPath(
 mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
     mate::Arguments* args,
     v8::Local<v8::Value> buffer) {
+  if (!node::Buffer::HasInstance(buffer)) {
+    args->ThrowError("buffer must be a node Buffer");
+    return mate::Handle<NativeImage>();
+  }
+
   int width = 0;
   int height = 0;
   double scale_factor = 1.;

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -127,7 +127,7 @@ describe('nativeImage module', () => {
     })
   })
 
-  describe('createFromBuffer(buffer, scaleFactor)', () => {
+  describe('createFromBuffer(buffer, options)', () => {
     it('returns an empty image when the buffer is empty', () => {
       expect(nativeImage.createFromBuffer(Buffer.from([])).isEmpty())
     })
@@ -164,6 +164,11 @@ describe('nativeImage module', () => {
       const imageI = nativeImage.createFromBuffer(imageA.toBitmap(),
         { width: 538, height: 190, scaleFactor: 2.0 })
       expect(imageI.getSize()).to.deep.equal({ width: 269, height: 95 })
+    })
+
+    it('throws on invalid arguments', () => {
+      expect(() => nativeImage.createFromBuffer(null)).to.throw('buffer must be a node Buffer')
+      expect(() => nativeImage.createFromBuffer([12, 14, 124, 12])).to.throw('buffer must be a node Buffer')
     })
   })
 


### PR DESCRIPTION
#### Description of Change
Adds missing `node::Buffer::HasInstance(buffer)` check before using the `buffer`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed crash when `nativeImage.createFromBuffer()` is called with invalid `buffer`.