### PR TITLE
build: use npm ci instead of npm install to ensure no lock file changes

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -107,7 +107,7 @@ hooks = [
     'action': [
       'python',
       '-c',
-      'import os, subprocess; os.chdir(os.path.join("src", "electron")); subprocess.check_call(["python", "script/lib/npm.py", "install"]);',
+      'import os, subprocess; os.chdir(os.path.join("src", "electron")); subprocess.check_call(["python", "script/lib/npm.py", "install", "--no-package-lock"]);',
     ],
   },
   {

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -60,7 +60,7 @@ async function installSpecModules () {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017'
   })
-  const { status } = childProcess.spawnSync(NPM_CMD, ['install'], {
+  const { status } = childProcess.spawnSync(NPM_CMD, ['install', '--no-package-lock'], {
     env,
     cwd: path.resolve(__dirname, '../spec'),
     stdio: 'inherit'


### PR DESCRIPTION
Every damm time you sync or run the tests the `package-lock` changes, because, Reasons ™️ 

Well...

![nomore](https://user-images.githubusercontent.com/6634592/54166681-8c4e5a00-4423-11e9-8be1-694f0d16eb24.jpg)

The `package-lock` shouldn't change now 🎉 

Notes: no-notes