### PR TITLE
refactor: make applicationMenu a property on app

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1332,6 +1332,11 @@ Sets the `image` associated with this dock icon.
 
 ## Properties
 
+### `app.applicationMenu`
+
+A `Menu` property that return [`Menu`](menu.md) if one has been set and `null` otherwise.
+Users can pass a [Menu](menu.md) to set this property.
+
 ### `app.isPackaged`
 
 A `Boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -19,9 +19,11 @@ Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 EventEmitter.call(app as any)
 
 Object.assign(app, {
+  // TODO(codebytere): remove in 7.0
   setApplicationMenu (menu: Electron.Menu | null) {
     return Menu.setApplicationMenu(menu)
   },
+  // TODO(codebytere): remove in 7.0
   getApplicationMenu () {
     return Menu.getApplicationMenu()
   },
@@ -37,6 +39,17 @@ Object.assign(app, {
 })
 
 app.getFileIcon = deprecate.promisify(app.getFileIcon)
+
+// we define this here because it'd be overly complicated to
+// do in native land
+Object.defineProperty(app, 'applicationMenu', {
+  get () {
+    return Menu.getApplicationMenu()
+  },
+  set (menu: Electron.Menu | null) {
+    return Menu.setApplicationMenu(menu)
+  }
+})
 
 app.isPackaged = (() => {
   const execFile = path.basename(process.execPath).toLowerCase()

--- a/lib/browser/api/top-level-window.js
+++ b/lib/browser/api/top-level-window.js
@@ -12,7 +12,7 @@ TopLevelWindow.prototype._init = function () {
 
   // Simulate the application menu on platforms other than macOS.
   if (process.platform !== 'darwin') {
-    const menu = app.getApplicationMenu()
+    const menu = app.applicationMenu
     if (menu) this.setMenu(menu)
   }
 }

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1232,6 +1232,12 @@ describe('app module', () => {
     })
   })
 
+  describe('app.applicationMenu', () => {
+    it('has the applicationMenu property', () => {
+      expect(app).to.have.property('applicationMenu')
+    })
+  })
+
   describe('commandLine.hasSwitch', () => {
     it('returns true when present', () => {
       app.commandLine.appendSwitch('foobar1')


### PR DESCRIPTION
#### Description of Change

This PR converts `applicationMenu` to a proper JS property on `app`, so that users can use `get` and `set` on properties instead of using `getApplicationMenu` and `setApplicationMenu`.

cc @MarshallOfSound @nornagon @miniak  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `applicationMenu` to a proper JS property on the `app` module.
