### PR TITLE
feat: make badgeCount a property on app

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1350,13 +1350,15 @@ void App::BuildPrototype(v8::Isolate* isolate,
                  base::Bind(&Browser::SetAsDefaultProtocolClient, browser))
       .SetMethod("removeAsDefaultProtocolClient",
                  base::Bind(&Browser::RemoveAsDefaultProtocolClient, browser))
-      .SetMethod("setBadgeCount", base::Bind(&Browser::SetBadgeCount, browser))
-      .SetMethod("getBadgeCount", base::Bind(&Browser::GetBadgeCount, browser))
+      .SetMethod("_setBadgeCount", base::Bind(&Browser::SetBadgeCount, browser))
+      .SetMethod("_getBadgeCount", base::Bind(&Browser::GetBadgeCount, browser))
       .SetMethod("getLoginItemSettings", &App::GetLoginItemSettings)
       .SetMethod("setLoginItemSettings",
                  base::Bind(&Browser::SetLoginItemSettings, browser))
       .SetMethod("isEmojiPanelSupported",
                  base::Bind(&Browser::IsEmojiPanelSupported, browser))
+      .SetProperty("badgeCount", base::Bind(&Browser::GetBadgeCount, browser),
+                   base::Bind(&Browser::SetBadgeCount, browser))
 #if defined(OS_MACOSX)
       .SetMethod("hide", base::Bind(&Browser::Hide, browser))
       .SetMethod("show", base::Bind(&Browser::Show, browser))

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1064,6 +1064,7 @@ gpuDevice:
 machineModelName: 'MacBookPro',
 machineModelVersion: '11.5' }
 ```
+
 Using `basic` should be preferred if only basic information like `vendorId` or `driverId` is needed.
 
 ### `app.setBadgeCount(count)` _Linux_ _macOS_
@@ -1080,9 +1081,13 @@ On macOS, it shows on the dock icon. On Linux, it only works for Unity launcher.
 **Note:** Unity launcher requires the existence of a `.desktop` file to work,
 for more information please read [Desktop Environment Integration][unity-requirement].
 
+**[Deprecated Soon](modernization/property-updates.md)**
+
 ### `app.getBadgeCount()` _Linux_ _macOS_
 
 Returns `Integer` - The current value displayed in the counter badge.
+
+**[Deprecated Soon](modernization/property-updates.md)**
 
 ### `app.isUnityRunning()` _Linux_
 
@@ -1344,11 +1349,6 @@ Sets the `image` associated with this dock icon.
 
 ## Properties
 
-### `app.applicationMenu`
-
-A `Menu` property that return [`Menu`](menu.md) if one has been set and `null` otherwise.
-Users can pass a [Menu](menu.md) to set this property.
-
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_
 
 A `Boolean` property that's `true` if Chrome's accessibility support is enabled, `false` otherwise. This property will be `true` if the use of assistive technologies, such as screen readers, has been detected. Setting this property to `true` manually enables Chrome's accessibility support, allowing developers to expose accessibility switch to users in application settings.
@@ -1358,6 +1358,20 @@ See [Chromium's accessibility docs](https://www.chromium.org/developers/design-d
 This API must be called after the `ready` event is emitted.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
+
+### `app.applicationMenu`
+
+A `Menu` property that return [`Menu`](menu.md) if one has been set and `null` otherwise.
+Users can pass a [Menu](menu.md) to set this property.
+
+### `app.badgeCount` _Linux_ _macOS_
+
+An `Integer` property that returns the badge count for current app. Setting the count to `0` will hide the badge.
+
+On macOS, setting this with any nonzero integer shows on the dock icon. On Linux, this property only works for Unity launcher.
+
+**Note:** Unity launcher requires the existence of a `.desktop` file to work,
+for more information please read [Desktop Environment Integration][unity-requirement].
 
 ### `app.isPackaged`
 

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -5,7 +5,6 @@ The Electron team is currently undergoing an initiative to convert separate gett
 ## Candidates
 
 * `app` module
-  * `badgeCount`
   * `name`
   * `dock`
     * `badge`
@@ -58,3 +57,4 @@ The Electron team is currently undergoing an initiative to convert separate gett
 * `app` module
   * `accessibilitySupport`
   * `applicationMenu`
+  * `badgeCount`

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -91,6 +91,7 @@ app.getFileIcon = deprecate.promisify(app.getFileIcon)
 
 // Property Deprecations
 deprecate.fnToProperty(app, 'accessibilitySupportEnabled', '_isAccessibilitySupportEnabled', '_setAccessibilitySupportEnabled')
+deprecate.fnToProperty(app, 'badgeCount', '_getBadgeCount', '_setBadgeCount')
 
 // Wrappers for native classes.
 const { DownloadItem } = process.electronBinding('download_item')

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -502,51 +502,31 @@ describe('app module', () => {
     })
   })
 
-  describe('app.setBadgeCount', () => {
+  describe('app.badgeCount', () => {
     const platformIsNotSupported =
         (process.platform === 'win32') ||
         (process.platform === 'linux' && !app.isUnityRunning())
     const platformIsSupported = !platformIsNotSupported
 
     const expectedBadgeCount = 42
-    let returnValue: boolean | null = null
 
-    beforeEach(() => { returnValue = app.setBadgeCount(expectedBadgeCount) })
-
-    after(() => {
-      // Remove the badge.
-      app.setBadgeCount(0)
-    })
+    after(() => { app.badgeCount = 0 })
 
     describe('on supported platform', () => {
-      before(function () {
-        if (platformIsNotSupported) {
-          this.skip()
-        }
-      })
+      it('sets a badge count', function () {
+        if (platformIsNotSupported) return this.skip()
 
-      it('returns true', () => {
-        expect(returnValue).to.equal(true)
-      })
-
-      it('sets a badge count', () => {
-        expect(app.getBadgeCount()).to.equal(expectedBadgeCount)
+        app.badgeCount = expectedBadgeCount
+        expect(app.badgeCount).to.equal(expectedBadgeCount)
       })
     })
 
     describe('on unsupported platform', () => {
-      before(function () {
-        if (platformIsSupported) {
-          this.skip()
-        }
-      })
+      it('does not set a badge count', function () {
+        if (platformIsSupported) return this.skip()
 
-      it('returns false', () => {
-        expect(returnValue).to.equal(false)
-      })
-
-      it('does not set a badge count', () => {
-        expect(app.getBadgeCount()).to.equal(0)
+        app.badgeCount = 9999
+        expect(app.badgeCount).to.equal(0)
       })
     })
   })


### PR DESCRIPTION
#### Description of Change

This PR converts `badgeCount` to a proper JS property on `app`, so that users can use get and set on properties instead of using `app.getBadgeCount()` and `app.setbadgeCount(count)`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `badgeCount` to an actual property on the `app` module.
