### PR TITLE
chore: add deprecation helper for fnToProperty

### DIFF
--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -56,14 +56,24 @@ const deprecate: ElectronInternal.DeprecationUtil = {
   },
 
   // deprecate a getter/setter function in favor of a property
-  fnToProperty: (fn, propName) => {
-    const fnName = fn.name || 'function'
-    const warn = warnOnce(`${fnName} function`, `${propName} property `)
+  fnToProperty: <A extends Function, B extends Function>(propName: string, getterFn: A, setterFn: B) => {
+    const getterName = getterFn.name || 'function'
+    const setterName = setterFn.name || 'function'
 
-    return function (this: any) {
-      warn()
-      fn.apply(this, arguments)
+    const warnGetter = warnOnce(`${getterName} function`, `${propName} property `)
+    const warnSetter = warnOnce(`${setterName} function`, `${propName} property `)
+
+    const deprecatedGetter: unknown = function (this: any) {
+      warnGetter()
+      getterFn.apply(this, arguments)
     }
+
+    const deprecatedSetter: unknown = function (this: any) {
+      warnSetter()
+      setterFn.apply(this, arguments)
+    }
+
+    return [deprecatedGetter as A, deprecatedSetter as B]
   },
 
   // remove a property with no replacement

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -33,6 +33,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     }
   },
 
+  // change the name of a function
   function: (fn, newName) => {
     const warn = warnOnce(fn.name, newName)
     return function (this: any) {
@@ -41,6 +42,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     }
   },
 
+  // change the name of an event
   event: (emitter, oldName, newName) => {
     const warn = newName.startsWith('-') /* internal event */
       ? warnOnce(`${oldName} event`)
@@ -53,6 +55,18 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     })
   },
 
+  // deprecate a getter/setter function in favor of a property
+  fnToProperty: (fn, propName) => {
+    const fnName = fn.name || 'function'
+    const warn = warnOnce(`${fnName} function`, `${propName} property `)
+
+    return function (this: any) {
+      warn()
+      fn.apply(this, arguments)
+    }
+  },
+
+  // remove a property with no replacement
   removeProperty: (o, removedName) => {
     // if the property's already been removed, warn about it
     if (!(removedName in o)) {
@@ -75,6 +89,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     })
   },
 
+  // deprecate a callback-based function in favor of one returning a Promise
   promisify: <T extends (...args: any[]) => any>(fn: T): T => {
     const fnName = fn.name || 'function'
     const oldName = `${fnName} with callbacks`
@@ -103,6 +118,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
   },
 
   // convertPromiseValue: Temporarily disabled until it's used
+  // deprecate a callback-based function in favor of one returning a Promise
   promisifyMultiArg: <T extends (...args: any[]) => any>(fn: T /* convertPromiseValue: (v: any) => any */): T => {
     const fnName = fn.name || 'function'
     const oldName = `${fnName} with callbacks`
@@ -129,6 +145,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     } as T
   },
 
+  // change the name of a property
   renameProperty: (o, oldName, newName) => {
     const warn = warnOnce(oldName, newName)
 

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -144,6 +144,32 @@ describe('deprecations', () => {
     }).to.throw(/this is deprecated/)
   })
 
+  it('warns when a function is deprecated in favor of a property', () => {
+    const warnings = []
+    deprecations.setHandler(warning => warnings.push(warning))
+
+    function oldGetterFn () { return 'getter' }
+    function oldSetterFn () { return 'setter' }
+
+    const newProp = 'myRadProp'
+
+    const [
+      deprecatedGetter,
+      deprecatedSetter
+    ] = deprecate.fnToProperty(newProp, oldGetterFn, oldSetterFn)
+
+    deprecatedGetter()
+    deprecatedSetter()
+
+    expect(warnings).to.have.lengthOf(2)
+
+    expect(warnings[0]).to.include('oldGetterFn')
+    expect(warnings[0]).to.include(newProp)
+
+    expect(warnings[1]).to.include('oldSetterFn')
+    expect(warnings[1]).to.include(newProp)
+  })
+
   describe('promisify', () => {
     const expected = 'Hello, world!'
     let promiseFunc

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -67,7 +67,7 @@ declare namespace ElectronInternal {
     log(message: string): void;
     function(fn: Function, newName: string): Function;
     event(emitter: NodeJS.EventEmitter, oldName: string, newName: string): void;
-    fnToProperty(fn: Function, propName: string): Function;
+    fnToProperty<A extends Function, B extends Function>(propName: string, getterFn: A, setterFn: B): [A, B];
     removeProperty<T, K extends (keyof T & string)>(object: T, propertyName: K): T;
     renameProperty<T, K extends (keyof T & string)>(object: T, oldName: string, newName: K): T;
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -67,6 +67,7 @@ declare namespace ElectronInternal {
     log(message: string): void;
     function(fn: Function, newName: string): Function;
     event(emitter: NodeJS.EventEmitter, oldName: string, newName: string): void;
+    fnToProperty(fn: Function, propName: string): Function;
     removeProperty<T, K extends (keyof T & string)>(object: T, propertyName: K): T;
     renameProperty<T, K extends (keyof T & string)>(object: T, oldName: string, newName: K): T;
 


### PR DESCRIPTION
#### Description of Change

Add a helper for deprecating a getter/setter function in favor of a bespoke property as part of the modernization initiative.

cc @MarshallOfSound @ckerr @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
