### PR TITLE
refactor: make ELECTRON_INSPECTOR_CONFIRM handler async

### DIFF
--- a/lib/browser/chrome-devtools.js
+++ b/lib/browser/chrome-devtools.js
@@ -97,22 +97,16 @@ ipcMainUtils.handle('ELECTRON_INSPECTOR_SELECT_FILE', async function (event) {
   return [path, data]
 })
 
-ipcMainUtils.handle('ELECTRON_INSPECTOR_CONFIRM', function (event, message, title) {
-  return new Promise((resolve, reject) => {
-    assertChromeDevTools(event.sender, 'window.confirm()')
+ipcMainUtils.handle('ELECTRON_INSPECTOR_CONFIRM', async function (event, message = '', title = '') {
+  assertChromeDevTools(event.sender, 'window.confirm()')
 
-    if (message == null) message = ''
-    if (title == null) title = ''
-
-    const options = {
-      message: `${message}`,
-      title: `${title}`,
-      buttons: ['OK', 'Cancel'],
-      cancelId: 1
-    }
-    const window = event.sender.getOwnerBrowserWindow()
-    dialog.showMessageBox(window, options, (response) => {
-      resolve(response === 0)
-    })
-  })
+  const options = {
+    message: String(message),
+    title: String(title),
+    buttons: ['OK', 'Cancel'],
+    cancelId: 1
+  }
+  const window = event.sender.getOwnerBrowserWindow()
+  const { response } = await dialog.showMessageBox(window, options)
+  return response === 0
 })


### PR DESCRIPTION
#### Description of Change
Follow up to "feat: promisify dialog.showMessageBox()" https://github.com/electron/electron/pull/17298

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

/cc @codebytere

#### Release Notes
Notes: no-notes