### PR TITLE
fix: pass the correct HostPort into the node inspector

### DIFF
--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -59,7 +59,8 @@ void NodeDebugger::Start() {
   }
 
   const char* path = "";
-  if (inspector->Start(path, options, env_->inspector_host_port(),
+  if (inspector->Start(path, options,
+                       std::make_shared<node::HostPort>(options.host_port),
                        true /* is_main */))
     DCHECK(env_->inspector_agent()->IsListening());
 }

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -269,6 +269,34 @@ describe('node feature', () => {
       child.stdout.on('data', outDataHandler)
     })
 
+    it('supports starting the v8 inspector with --inspect and a provided port', (done) => {
+      child = ChildProcess.spawn(process.execPath, ['--inspect=17364', path.join(__dirname, 'fixtures', 'module', 'run-as-node.js')], {
+        env: {
+          ELECTRON_RUN_AS_NODE: true
+        }
+      })
+
+      let output = ''
+      function cleanup () {
+        child.stderr.removeListener('data', errorDataListener)
+        child.stdout.removeListener('data', outDataHandler)
+      }
+      function errorDataListener (data) {
+        output += data
+        if (output.trim().startsWith('Debugger listening on ws://')) {
+          expect(output.trim()).to.contain(':17364', 'should be listening on port 17364')
+          cleanup()
+          done()
+        }
+      }
+      function outDataHandler (data) {
+        cleanup()
+        done(new Error(`Unexpected output: ${data.toString()}`))
+      }
+      child.stderr.on('data', errorDataListener)
+      child.stdout.on('data', outDataHandler)
+    })
+
     it('does not start the v8 inspector when --inspect is after a -- argument', (done) => {
       child = ChildProcess.spawn(remote.process.execPath, [path.join(__dirname, 'fixtures', 'module', 'noop.js'), '--', '--inspect'])
 


### PR DESCRIPTION
Fixes #17348

#### Description of Change
We were passing the incorrect `HostPort` instance into the inspector start call.  This passes the correct one in.

#### Release Notes

Notes: launching the node inspector through `--inspect` now listens on the correct port when one is provided
