### PR TITLE
feat: add systemPreferences.getAnimationSettings()

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -8,6 +8,7 @@
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
 #include "native_mate/dictionary.h"
+#include "ui/gfx/animation/animation.h"
 #include "ui/gfx/color_utils.h"
 
 namespace atom {
@@ -42,6 +43,19 @@ bool SystemPreferences::IsHighContrastColorScheme() {
   return false;
 }
 #endif  // !defined(OS_WIN)
+
+v8::Local<v8::Value> SystemPreferences::GetAnimationSettings(
+    v8::Isolate* isolate) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
+  dict.Set("shouldRenderRichAnimation",
+           gfx::Animation::ShouldRenderRichAnimation());
+  dict.Set("scrollAnimationsEnabledBySystem",
+           gfx::Animation::ScrollAnimationsEnabledBySystem());
+  dict.Set("prefersReducedMotion", gfx::Animation::PrefersReducedMotion());
+
+  return dict.GetHandle();
+}
 
 // static
 mate::Handle<SystemPreferences> SystemPreferences::Create(
@@ -105,7 +119,9 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::IsInvertedColorScheme)
       .SetMethod("isHighContrastColorScheme",
                  &SystemPreferences::IsHighContrastColorScheme)
-      .SetMethod("isDarkMode", &SystemPreferences::IsDarkMode);
+      .SetMethod("isDarkMode", &SystemPreferences::IsDarkMode)
+      .SetMethod("getAnimationSettings",
+                 &SystemPreferences::GetAnimationSettings);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -117,6 +117,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   bool IsDarkMode();
   bool IsInvertedColorScheme();
   bool IsHighContrastColorScheme();
+  v8::Local<v8::Value> GetAnimationSettings(v8::Isolate* isolate);
 
  protected:
   explicit SystemPreferences(v8::Isolate* isolate);

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -429,3 +429,13 @@ Returns `Promise<Boolean>` - A promise that resolves with `true` if consent was 
 **Important:** In order to properly leverage this API, you [must set](https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos?language=objc) the `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings in your app's `Info.plist` file. The values for these keys will be used to populate the permission dialogs so that the user will be properly informed as to the purpose of the permission request. See [Electron Application Distribution](https://electronjs.org/docs/tutorial/application-distribution#macos) for more information about how to set these in the context of Electron.
 
 This user consent was not required until macOS 10.14 Mojave, so this method will always return `true` if your system is running 10.13 High Sierra or lower.
+
+### `systemPreferences.getAnimationSettings()`
+
+Returns `Object`:
+
+* `shouldRenderRichAnimation` Boolean - Returns true if rich animations should be rendered. Looks at session type (e.g. remote desktop) and accessibility settings to give guidance for heavy animations.
+* `scrollAnimationsEnabledBySystem` Boolean - Determines on a per-platform basis whether scroll animations (e.g. produced by home/end key) should be enabled.
+* `prefersReducedMotion` Boolean - Determines whether the user desires reduced motion based on platform APIs.
+
+Returns an object with system animation settings.

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -173,4 +173,14 @@ describe('systemPreferences module', () => {
       assert.strictEqual(typeof systemPreferences.isInvertedColorScheme(), 'boolean')
     })
   })
+
+  describe('systemPreferences.getAnimationSettings()', () => {
+    it('returns an object with all properties', () => {
+      const settings = systemPreferences.getAnimationSettings()
+      assert.strictEqual(typeof settings, 'object')
+      assert.strictEqual(typeof settings.shouldRenderRichAnimation, 'boolean')
+      assert.strictEqual(typeof settings.scrollAnimationsEnabledBySystem, 'boolean')
+      assert.strictEqual(typeof settings.prefersReducedMotion, 'boolean')
+    })
+  })
 })


### PR DESCRIPTION
#### Description of Change
Expose system animation settings provided by https://cs.chromium.org/chromium/src/ui/gfx/animation/animation.h

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `systemPreferences.getAnimationSettings()` returning system animation settings provided by Chromium.