### PR TITLE
feat: add tray.getTitle()

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -159,7 +159,17 @@ void Tray::SetToolTip(const std::string& tool_tip) {
 }
 
 void Tray::SetTitle(const std::string& title) {
+#if defined(OS_MACOSX)
   tray_icon_->SetTitle(title);
+#endif
+}
+
+std::string Tray::GetTitle() {
+#if defined(OS_MACOSX)
+  return tray_icon_->GetTitle();
+#else
+  return "";
+#endif
 }
 
 void Tray::SetHighlightMode(TrayIcon::HighlightMode mode) {
@@ -227,6 +237,7 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setPressedImage", &Tray::SetPressedImage)
       .SetMethod("setToolTip", &Tray::SetToolTip)
       .SetMethod("setTitle", &Tray::SetTitle)
+      .SetMethod("getTitle", &Tray::GetTitle)
       .SetMethod("setHighlightMode", &Tray::SetHighlightMode)
       .SetMethod("setIgnoreDoubleClickEvents",
                  &Tray::SetIgnoreDoubleClickEvents)

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -69,6 +69,7 @@ class Tray : public mate::TrackableObject<Tray>, public TrayIconObserver {
   void SetPressedImage(v8::Isolate* isolate, mate::Handle<NativeImage> image);
   void SetToolTip(const std::string& tool_tip);
   void SetTitle(const std::string& title);
+  std::string GetTitle();
   void SetHighlightMode(TrayIcon::HighlightMode mode);
   void SetIgnoreDoubleClickEvents(bool ignore);
   bool GetIgnoreDoubleClickEvents();

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -12,8 +12,6 @@ TrayIcon::~TrayIcon() {}
 
 void TrayIcon::SetPressedImage(ImageType image) {}
 
-void TrayIcon::SetTitle(const std::string& title) {}
-
 void TrayIcon::SetHighlightMode(TrayIcon::HighlightMode mode) {}
 
 void TrayIcon::DisplayBalloon(ImageType icon,

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -39,10 +39,6 @@ class TrayIcon {
   // status icon (e.g. Ubuntu Unity).
   virtual void SetToolTip(const std::string& tool_tip) = 0;
 
-  // Sets the title displayed aside of the status icon in the status bar. This
-  // only works on macOS.
-  virtual void SetTitle(const std::string& title);
-
   // Sets the status icon highlight mode. This only works on macOS.
   enum HighlightMode {
     ALWAYS,    // Always highlight the tray icon
@@ -51,11 +47,14 @@ class TrayIcon {
   };
   virtual void SetHighlightMode(HighlightMode mode);
 
-  // Setter and getter for the flag which determines whether to ignore double
-  // click events. These only work on macOS.
 #if defined(OS_MACOSX)
+  // Set/Get flag determining whether to ignore double click events.
   virtual void SetIgnoreDoubleClickEvents(bool ignore) = 0;
   virtual bool GetIgnoreDoubleClickEvents() = 0;
+
+  // Set/Get title displayed next to status icon in the status bar.
+  virtual void SetTitle(const std::string& title) = 0;
+  virtual std::string GetTitle() = 0;
 #endif
 
   // Displays a notification balloon with the specified contents.

--- a/atom/browser/ui/tray_icon_cocoa.h
+++ b/atom/browser/ui/tray_icon_cocoa.h
@@ -26,6 +26,7 @@ class TrayIconCocoa : public TrayIcon, public AtomMenuModel::Observer {
   void SetPressedImage(const gfx::Image& image) override;
   void SetToolTip(const std::string& tool_tip) override;
   void SetTitle(const std::string& title) override;
+  std::string GetTitle() override;
   void SetHighlightMode(TrayIcon::HighlightMode mode) override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -235,6 +235,10 @@ const CGFloat kVerticalTitleMargin = 2;
   [self updateDimensions];
 }
 
+- (NSString*)title {
+  return title_;
+}
+
 - (void)updateAttributedTitle {
   NSDictionary* attributes =
       @{NSFontAttributeName : [NSFont menuBarFontOfSize:0]};
@@ -457,6 +461,10 @@ void TrayIconCocoa::SetToolTip(const std::string& tool_tip) {
 
 void TrayIconCocoa::SetTitle(const std::string& title) {
   [status_item_view_ setTitle:base::SysUTF8ToNSString(title)];
+}
+
+std::string TrayIconCocoa::GetTitle() {
+  return base::SysNSStringToUTF8([status_item_view_ title]);
 }
 
 void TrayIconCocoa::SetHighlightMode(TrayIcon::HighlightMode mode) {

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -184,7 +184,13 @@ Sets the hover text for this tray icon.
 
 * `title` String
 
-Sets the title displayed aside of the tray icon in the status bar (Support ANSI colors).
+Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
+
+#### `tray.getTitle()` _macOS_
+
+* `title` String
+
+Returns `String` - the title displayed next to the tray icon in the status bar
 
 #### `tray.setHighlightMode(mode)` _macOS_
 

--- a/spec/api-tray-spec.js
+++ b/spec/api-tray-spec.js
@@ -37,6 +37,12 @@ describe('tray module', () => {
   })
 
   describe('tray title get/set', () => {
+    before(function () {
+      if (process.platform !== 'darwin') {
+        this.skip()
+      }
+    })
+
     it('sets/gets non-empty title', () => {
       const title = 'Hello World!'
       tray.setTitle(title)

--- a/spec/api-tray-spec.js
+++ b/spec/api-tray-spec.js
@@ -1,4 +1,5 @@
 const { remote } = require('electron')
+const { expect } = require('chai')
 const { Menu, Tray, nativeImage } = remote
 
 describe('tray module', () => {
@@ -35,13 +36,21 @@ describe('tray module', () => {
     })
   })
 
-  describe('tray.setTitle', () => {
-    it('accepts non-empty string', () => {
-      tray.setTitle('Hello World!')
+  describe('tray title get/set', () => {
+    it('sets/gets non-empty title', () => {
+      const title = 'Hello World!'
+      tray.setTitle(title)
+      const newTitle = tray.getTitle()
+
+      expect(newTitle).to.equal(title)
     })
 
-    it('accepts empty string', () => {
-      tray.setTitle('')
+    it('sets/gets empty title', () => {
+      const title = ''
+      tray.setTitle(title)
+      const newTitle = tray.getTitle()
+
+      expect(newTitle).to.equal(title)
     })
   })
 })


### PR DESCRIPTION
#### Description of Change

This PR adds a getter for the tray title on macOS. This allows a user to programmatically ensure that `setTitle` took effect as well as acting as a precursor for making `title` a property on the Tray module, which would necessitate both a getter and setter where only a setter existed before.

Also cleans up methods within defines so that the title setter and getter don't have to be implemented cross-platform emptily.

cc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `tray.getTitle()` to allows users to see the title set next to the status bar icon on macOS.
