### PR TITLE
[wip] fix: destroy WebContents synchronously on shutdown (3-1-x)

### DIFF
--- a/atom/browser/api/atom_api_browser_view.h
+++ b/atom/browser/api/atom_api_browser_view.h
@@ -10,6 +10,7 @@
 
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/native_browser_view.h"
+#include "content/public/browser/web_contents_observer.h"
 #include "native_mate/handle.h"
 
 namespace gfx {
@@ -29,7 +30,8 @@ namespace api {
 
 class WebContents;
 
-class BrowserView : public mate::TrackableObject<BrowserView> {
+class BrowserView : public mate::TrackableObject<BrowserView>,
+                    public content::WebContentsObserver {
  public:
   static mate::WrappableBase* New(mate::Arguments* args);
 
@@ -46,6 +48,9 @@ class BrowserView : public mate::TrackableObject<BrowserView> {
               v8::Local<v8::Object> wrapper,
               const mate::Dictionary& options);
   ~BrowserView() override;
+
+  // content::WebContentsObserver:
+  void WebContentsDestroyed() override;
 
  private:
   void Init(v8::Isolate* isolate,

--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -390,7 +390,9 @@ void BrowserWindow::Cleanup() {
   if (host)
     host->GetWidget()->RemoveInputEventObserver(this);
 
-  api_web_contents_->DestroyWebContents(true /* async */);
+  // Destroy WebContents asynchronously unless app is shutting down,
+  // because destroy() might be called inside WebContents's event handler.
+  api_web_contents_->DestroyWebContents(!Browser::Get()->is_shutting_down());
   Observe(nullptr);
 }
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -99,7 +99,19 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   static int64_t GetIDForContents(content::WebContents* web_contents);
 
-  // Notifies to destroy any guest web contents before destroying self.
+  // Destroy the managed content::WebContents instance.
+  //
+  // Note: The |async| should only be |true| when users are expecting to use the
+  // webContents immediately after the call. Always pass |false| if you are not
+  // sure.
+  // See https://github.com/electron/electron/issues/8930.
+  //
+  // Note: When destroying a webContents member inside a destructor, the |async|
+  // should always be |false|, otherwise the destroy task might be delayed after
+  // normal shutdown procedure, resulting in an assertion.
+  // The normal pattern for calling this method in destructor is:
+  // api_web_contents_->DestroyWebContents(!Browser::Get()->is_shutting_down())
+  // See https://github.com/electron/electron/issues/15133.
   void DestroyWebContents(bool async);
 
   int64_t GetID() const;

--- a/atom/browser/api/atom_api_web_contents_view.cc
+++ b/atom/browser/api/atom_api_web_contents_view.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/api/atom_api_web_contents_view.h"
 
 #include "atom/browser/api/atom_api_web_contents.h"
+#include "atom/browser/browser.h"
 #include "atom/common/api/constructor.h"
 #include "brightray/browser/inspectable_web_contents_view.h"
 #include "content/public/browser/web_contents_user_data.h"
@@ -64,8 +65,11 @@ WebContentsView::WebContentsView(v8::Isolate* isolate,
 }
 
 WebContentsView::~WebContentsView() {
-  if (api_web_contents_)
-    api_web_contents_->DestroyWebContents(false /* async */);
+  if (api_web_contents_) {  // destroy() is called
+    // Destroy WebContents asynchronously unless app is shutting down,
+    // because destroy() might be called inside WebContents's event handler.
+    api_web_contents_->DestroyWebContents(!Browser::Get()->is_shutting_down());
+  }
 }
 
 void WebContentsView::WebContentsDestroyed() {

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -1,7 +1,10 @@
 'use strict'
 
 const chai = require('chai')
+const ChildProcess = require('child_process')
 const dirtyChai = require('dirty-chai')
+const path = require('path')
+const {emittedOnce} = require('./events-helpers')
 const {closeWindow} = require('./window-helpers')
 
 const {remote} = require('electron')
@@ -170,6 +173,16 @@ describe('BrowserView module', () => {
       const views = BrowserView.getAllViews()
       expect(views).to.be.an('array').that.has.lengthOf(1)
       expect(views[0].webContents.id).to.equal(view.webContents.id)
+    })
+  })
+
+  describe('new BrowserView()', () => {
+    it('does not crash on exit', async () => {
+      const appPath = path.join(__dirname, 'fixtures', 'api', 'leak-exit-browserview.js')
+      const electronPath = remote.getGlobal('process').execPath
+      const appProcess = ChildProcess.spawn(electronPath, [appPath])
+      const [code] = await emittedOnce(appProcess, 'close')
+      expect(code).to.equal(0)
     })
   })
 })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const ChildProcess = require('child_process')
 const http = require('http')
 const path = require('path')
 const {closeWindow} = require('./window-helpers')
@@ -664,6 +665,16 @@ describe('webContents module', () => {
     it('does not throw', () => {
       assert.equal(w.webContents.setIgnoreMenuShortcuts(true), undefined)
       assert.equal(w.webContents.setIgnoreMenuShortcuts(false), undefined)
+    })
+  })
+
+  describe('create()', () => {
+    it('does not crash on exit', async () => {
+      const appPath = path.join(__dirname, 'fixtures', 'api', 'leak-exit-webcontents.js')
+      const electronPath = remote.getGlobal('process').execPath
+      const appProcess = ChildProcess.spawn(electronPath, [appPath])
+      const [code] = await emittedOnce(appProcess, 'close')
+      assert.equal(code, 0)
     })
   })
 

--- a/spec/fixtures/api/leak-exit-browserview.js
+++ b/spec/fixtures/api/leak-exit-browserview.js
@@ -1,0 +1,6 @@
+const { BrowserView, app } = require('electron')
+app.on('ready', function () {
+  new BrowserView({})  // eslint-disable-line
+
+  process.nextTick(() => app.quit())
+})

--- a/spec/fixtures/api/leak-exit-webcontents.js
+++ b/spec/fixtures/api/leak-exit-webcontents.js
@@ -1,0 +1,6 @@
+const { app, webContents } = require('electron')
+app.on('ready', function () {
+  webContents.create({})
+
+  process.nextTick(() => app.quit())
+})

--- a/spec/fixtures/api/leak-exit-webcontentsview.js
+++ b/spec/fixtures/api/leak-exit-webcontentsview.js
@@ -1,0 +1,7 @@
+const { WebContentsView, app, webContents } = require('electron')
+app.on('ready', function () {
+  const web = webContents.create({})
+  new WebContentsView(web)  // eslint-disable-line
+
+  process.nextTick(() => app.quit())
+})


### PR DESCRIPTION
Backport  https://github.com/electron/electron/pull/15541 to 3-1-x.

Notes: Fix crash on exit when using BrowserView.