### PR TITLE
feat: enable NodeIntegrationInSubFrames for webview (5-0-x)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '73.0.3683.79',
   'node_version':
-    '70a78f07b1c4d53f3da462b08cef42a4ff8f949f',
+    'f807d72614d4b8973d71548328be213532b46b1b',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -126,6 +126,17 @@ integration and can use node APIs like `require` and `process` to access low
 level system resources. Node integration is disabled by default in the guest
 page.
 
+### `nodeintegrationinsubframes`
+
+```html
+<webview src="http://www.google.com/" nodeintegrationinsubframes></webview>
+```
+
+Experimental option for enabling NodeJS support in sub-frames such as iframes
+inside the `webview`. All your preloads will load for every iframe, you can
+use `process.isMainFrame` to determine if you are in the main frame or not.
+This option is disabled by default in the guest page.
+
 ### `enableremotemodule`
 
 ```html

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -210,6 +210,7 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
   const webPreferences = {
     guestInstanceId: guestInstanceId,
     nodeIntegration: params.nodeintegration != null ? params.nodeintegration : false,
+    nodeIntegrationInSubFrames: params.nodeintegrationinsubframes != null ? params.nodeintegrationinsubframes : false,
     enableRemoteModule: params.enableremotemodule,
     plugins: params.plugins,
     zoomFactor: embedder.getZoomFactor(),

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -270,6 +270,7 @@ WebViewImpl.prototype.setupWebViewAttributes = function () {
   this.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER] = new HttpReferrerAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_USERAGENT] = new UserAgentAttribute(this)
   this.attributes[webViewConstants.ATTRIBUTE_NODEINTEGRATION] = new BooleanAttribute(webViewConstants.ATTRIBUTE_NODEINTEGRATION, this)
+  this.attributes[webViewConstants.ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES] = new BooleanAttribute(webViewConstants.ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES, this)
   this.attributes[webViewConstants.ATTRIBUTE_PLUGINS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_PLUGINS, this)
   this.attributes[webViewConstants.ATTRIBUTE_DISABLEWEBSECURITY] = new BooleanAttribute(webViewConstants.ATTRIBUTE_DISABLEWEBSECURITY, this)
   this.attributes[webViewConstants.ATTRIBUTE_ALLOWPOPUPS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_ALLOWPOPUPS, this)

--- a/lib/renderer/web-view/web-view-constants.js
+++ b/lib/renderer/web-view/web-view-constants.js
@@ -7,6 +7,7 @@ module.exports = {
   ATTRIBUTE_SRC: 'src',
   ATTRIBUTE_HTTPREFERRER: 'httpreferrer',
   ATTRIBUTE_NODEINTEGRATION: 'nodeintegration',
+  ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES: 'nodeintegrationinsubframes',
   ATTRIBUTE_ENABLEREMOTEMODULE: 'enableremotemodule',
   ATTRIBUTE_PLUGINS: 'plugins',
   ATTRIBUTE_DISABLEWEBSECURITY: 'disablewebsecurity',

--- a/lib/renderer/web-view/web-view-element.js
+++ b/lib/renderer/web-view/web-view-element.js
@@ -23,6 +23,7 @@ const defineWebViewElement = (v8Util, webViewImpl) => {
         webViewConstants.ATTRIBUTE_HTTPREFERRER,
         webViewConstants.ATTRIBUTE_USERAGENT,
         webViewConstants.ATTRIBUTE_NODEINTEGRATION,
+        webViewConstants.ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES,
         webViewConstants.ATTRIBUTE_PLUGINS,
         webViewConstants.ATTRIBUTE_DISABLEWEBSECURITY,
         webViewConstants.ATTRIBUTE_ALLOWPOPUPS,

--- a/spec/api-subframe-spec.js
+++ b/spec/api-subframe-spec.js
@@ -112,7 +112,7 @@ describe('renderer nodeIntegrationInSubFrames', () => {
       for (let j = 0; j < length; j++) {
         const newConfig = Object.assign({}, configs[j])
         newConfig.webPreferences = Object.assign({},
-            newConfig.webPreferences, permutations[i].webPreferences)
+          newConfig.webPreferences, permutations[i].webPreferences)
         newConfig.names = newConfig.names.slice(0)
         newConfig.names.push(permutations[i].name)
         configs.push(newConfig)

--- a/spec/fixtures/sub-frames/frame-container-webview.html
+++ b/spec/fixtures/sub-frames/frame-container-webview.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  This is the root page with a webview
+  <webview src="./frame-container.html" sandbox nodeIntegrationInSubFrames preload="./preload.js"></webview>
+</body>
+</html>

--- a/spec/fixtures/sub-frames/frame-with-frame-container-webview.html
+++ b/spec/fixtures/sub-frames/frame-with-frame-container-webview.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  This is the root page with a webview
+  <webview src="./frame-with-frame-container.html" sandbox nodeIntegrationInSubFrames preload="./preload.js"></webview>
+</body>
+</html>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Manual backport of #17226.
Depends on #17396 for the node backport to land in `5-0-x`.

This was previously not done because of a crash. electron/node#94 fixes that crash, and allow us to enable this option for the `webview`. The node PR also fixes #16733.

Fixes #16780.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enabled `NodeIntegrationInSubFrames` option usage for `webview` tags.
