### PR TITLE
fix: callback values for printing cancellation and success

### DIFF
--- a/patches/chromium/blink-worker-enable-csp-in-file-scheme.patch
+++ b/patches/chromium/blink-worker-enable-csp-in-file-scheme.patch
@@ -5,10 +5,10 @@ Subject: blink-worker-enable-csp-in-file-scheme.patch
 
 
 diff --git a/third_party/blink/renderer/core/workers/worker_classic_script_loader.cc b/third_party/blink/renderer/core/workers/worker_classic_script_loader.cc
-index eeeaa47777df0cab00e1c14f60a0d1e26432c538..608ba10174a9c313bb17ab6d5f68053ce37a0435 100644
+index c51ae1141e62ec69a3d3da8e285d89c3b0e04722..57bfcd4c22347f0f4bb9a59598414d50410666a2 100644
 --- a/third_party/blink/renderer/core/workers/worker_classic_script_loader.cc
 +++ b/third_party/blink/renderer/core/workers/worker_classic_script_loader.cc
-@@ -307,7 +307,6 @@ void WorkerClassicScriptLoader::ProcessContentSecurityPolicy(
+@@ -308,7 +308,6 @@ void WorkerClassicScriptLoader::ProcessContentSecurityPolicy(
    // document (which is implemented in WorkerMessagingProxy, and
    // m_contentSecurityPolicy should be left as nullptr to inherit the policy).
    if (!response.CurrentRequestUrl().ProtocolIs("blob") &&

--- a/patches/chromium/blink_local_frame.patch
+++ b/patches/chromium/blink_local_frame.patch
@@ -14,7 +14,7 @@ when there is code doing that.
 This patch reverts the change to fix the crash in Electron.
 
 diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/blink/renderer/core/frame/local_frame.cc
-index 06f9c9f62dc94bd093942d9ee523a4279203a177..3ee1caa9ad92cfedd326b364817ce9b5e8db800e 100644
+index d1922a486fb0143d688a26f954462e3a915af2b5..b1e800f51e44a7a5d3fabd66563d5bdb6a7aa280 100644
 --- a/third_party/blink/renderer/core/frame/local_frame.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame.cc
 @@ -393,10 +393,6 @@ void LocalFrame::DetachImpl(FrameDetachType type) {

--- a/patches/chromium/blink_world_context.patch
+++ b/patches/chromium/blink_world_context.patch
@@ -19,7 +19,7 @@ index 82fb3fdfe6bfa8c8d885ee133270b6f2564325a8..f3bad71eab608d3b9ac0e08446c9e520
    // that the script evaluated to with callback. Script execution can be
    // suspend.
 diff --git a/third_party/blink/renderer/core/frame/web_local_frame_impl.cc b/third_party/blink/renderer/core/frame/web_local_frame_impl.cc
-index ce93c3ba0fc4255999fed2bb01dfbb4161faa0dd..305ed843db5dd095a4cd9e8784e3025a1370a491 100644
+index e12642b4703474840a490f426b90c61141f9881e..2610245d88af53e116faa825df264fd9d9babc05 100644
 --- a/third_party/blink/renderer/core/frame/web_local_frame_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_local_frame_impl.cc
 @@ -873,6 +873,13 @@ v8::Local<v8::Object> WebLocalFrameImpl::GlobalProxy() const {

--- a/patches/chromium/build_add_electron_tracing_category.patch
+++ b/patches/chromium/build_add_electron_tracing_category.patch
@@ -8,7 +8,7 @@ categories in use are known / declared.  This patch is required for us
 to introduce a new Electron category.
 
 diff --git a/base/trace_event/builtin_categories.h b/base/trace_event/builtin_categories.h
-index 97055b4bdaf0dc38b8d248fefddfcf8c68c123b9..6dbe407151dfc5a9168df77f42932e51b802377f 100644
+index 2225bfcbb9a2bf8ee0082304adf6528522964e65..151f7fe91fc53b3069ce892607e4e6f9c91b40f7 100644
 --- a/base/trace_event/builtin_categories.h
 +++ b/base/trace_event/builtin_categories.h
 @@ -61,6 +61,7 @@

--- a/patches/chromium/can_create_window.patch
+++ b/patches/chromium/can_create_window.patch
@@ -5,10 +5,10 @@ Subject: can_create_window.patch
 
 
 diff --git a/content/browser/frame_host/render_frame_host_impl.cc b/content/browser/frame_host/render_frame_host_impl.cc
-index 387831a4615746339f4fe16b2b1bf405f7364b54..37d8be6076b9e98ca68acb5f7dc024b0d018879e 100644
+index 0334ac0cfb75a9d99f841aea388c9a3fc960141b..c341ea17c13ec6f63936c1b4d4faba9bc40362d1 100644
 --- a/content/browser/frame_host/render_frame_host_impl.cc
 +++ b/content/browser/frame_host/render_frame_host_impl.cc
-@@ -3719,6 +3719,7 @@ void RenderFrameHostImpl::CreateNewWindow(
+@@ -3722,6 +3722,7 @@ void RenderFrameHostImpl::CreateNewWindow(
            last_committed_origin_, params->window_container_type,
            params->target_url, params->referrer.To<Referrer>(),
            params->frame_name, params->disposition, *params->features,
@@ -32,7 +32,7 @@ index 82882159b0bac6d47d678c485de0aacc7db06c2d..dd2299094b79d82da7ec1cd8f559050b
  
  // Operation result when the renderer asks the browser to create a new window.
 diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
-index f4c61acba134daf907a1b9afaaf0327a183287e4..d15061de5254fd4f248fed92f47a1b1fcf34cd68 100644
+index 53e67715469ce47147b66393ecc6a20d0d657977..2dd31166cc52ccb528b338b63fde7d2fb4bbf63d 100644
 --- a/content/public/browser/content_browser_client.cc
 +++ b/content/public/browser/content_browser_client.cc
 @@ -519,6 +519,8 @@ bool ContentBrowserClient::CanCreateWindow(
@@ -45,7 +45,7 @@ index f4c61acba134daf907a1b9afaaf0327a183287e4..d15061de5254fd4f248fed92f47a1b1f
      bool opener_suppressed,
      bool* no_javascript_access) {
 diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
-index 6ab15079fe2e1234aca140dfebd5287d8701c147..8ceccd96c4e143921ace8db69685a9631e168dd2 100644
+index 2b4c2c1004fb98da76eb244db4c35dba84085f45..04bfc1a4a804d1f5aa28f894e2feb816bbe80ffc 100644
 --- a/content/public/browser/content_browser_client.h
 +++ b/content/public/browser/content_browser_client.h
 @@ -177,6 +177,7 @@ class RenderFrameHost;

--- a/patches/chromium/cross_site_document_resource_handler.patch
+++ b/patches/chromium/cross_site_document_resource_handler.patch
@@ -22,7 +22,7 @@ index d514c10160dd12f225c42e927977660cacbc9c43..49345f1d4d75c8b96efe485202d89774
  }
  
 diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
-index 62d5e17f0599a78d679495d6fa674939d237602e..f40a4ff5f08e906e62dd838eb5af63ade92037d2 100644
+index ce64276225d5b0acf684e9e70c600a64a56fe96e..2a9661d877fbc09904eb469191523b5cd59eaeda 100644
 --- a/content/public/browser/content_browser_client.cc
 +++ b/content/public/browser/content_browser_client.cc
 @@ -71,6 +71,10 @@ std::unique_ptr<BrowserMainParts> ContentBrowserClient::CreateBrowserMainParts(
@@ -37,7 +37,7 @@ index 62d5e17f0599a78d679495d6fa674939d237602e..f40a4ff5f08e906e62dd838eb5af63ad
      const base::Location& from_here,
      const scoped_refptr<base::TaskRunner>& task_runner,
 diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
-index 136df7edaaaaaa1eb121ef7cf80aebc47969dc8d..5b889fec05ee9017f5f149fab70c4feab39c86dc 100644
+index 5bf7340b106bd3ce826ff3322106ef94cbe19d29..ba27455e1c0934f77ed2871ee585361807ab701a 100644
 --- a/content/public/browser/content_browser_client.h
 +++ b/content/public/browser/content_browser_client.h
 @@ -252,6 +252,9 @@ class CONTENT_EXPORT ContentBrowserClient {

--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -133,7 +133,7 @@ index 47401abc984e6fe26c7f4c5399aa565c687060b0..ca6a527ffac877c27aac94337ec5a7b5
   protected:
    virtual ~DesktopMediaListObserver() {}
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index b060eb31d194e44c6c89e2cbf990323802c1aa5f..514325c3d6cb11b69b0d43e72d851c49f0ef6824 100644
+index e8f454aa3ae7f5646a2158b84c2281f5bbfdca4a..01ffcc13ff0bdc626e7518aeb4993f0403ab41e8 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 @@ -7,14 +7,15 @@

--- a/patches/chromium/disable_user_gesture_requirement_for_beforeunload_dialogs.patch
+++ b/patches/chromium/disable_user_gesture_requirement_for_beforeunload_dialogs.patch
@@ -6,7 +6,7 @@ Subject: disable_user_gesture_requirement_for_beforeunload_dialogs.patch
 See https://github.com/electron/electron/issues/10754
 
 diff --git a/third_party/blink/renderer/core/dom/document.cc b/third_party/blink/renderer/core/dom/document.cc
-index 7be135720a40d819bf19afddce77670d721cfe59..1ceaf378636e16d5e93f5acc6ff42019fc87f680 100644
+index b29cd849621a012e06955fdef4970f8d85976002..39ab0f7988c3b8aa16fbc747f0a5b3200fcbb227 100644
 --- a/third_party/blink/renderer/core/dom/document.cc
 +++ b/third_party/blink/renderer/core/dom/document.cc
 @@ -3653,7 +3653,9 @@ bool Document::DispatchBeforeUnloadEvent(ChromeClient* chrome_client,

--- a/patches/chromium/exclude-a-few-test-files-from-build.patch
+++ b/patches/chromium/exclude-a-few-test-files-from-build.patch
@@ -7,10 +7,10 @@ Compilation of those files fails with the Chromium 68.
 Remove the patch during the Chromium 69 upgrade.
 
 diff --git a/third_party/blink/renderer/platform/BUILD.gn b/third_party/blink/renderer/platform/BUILD.gn
-index 070fd58b25aee470a861bd79c27f66470e80a271..ae07383907664394544bf4643044b2b43171a029 100644
+index 64ae02a700342c446aec62756180e25434eea46d..b1da69c1810fc502334dfc26130afec02a1c85db 100644
 --- a/third_party/blink/renderer/platform/BUILD.gn
 +++ b/third_party/blink/renderer/platform/BUILD.gn
-@@ -1713,7 +1713,7 @@ jumbo_source_set("blink_platform_unittests_sources") {
+@@ -1715,7 +1715,7 @@ jumbo_source_set("blink_platform_unittests_sources") {
      "graphics/paint/drawing_display_item_test.cc",
      "graphics/paint/drawing_recorder_test.cc",
      "graphics/paint/float_clip_rect_test.cc",

--- a/patches/chromium/frame_host_manager.patch
+++ b/patches/chromium/frame_host_manager.patch
@@ -179,7 +179,7 @@ index a46901055bdf17b6b0dab14edf753b234dc04a12..113660b6eeff81d56a0415b0fa16211e
    size_t GetRelatedActiveContentsCount() override;
    bool RequiresDedicatedProcess() override;
 diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
-index d15061de5254fd4f248fed92f47a1b1fcf34cd68..62d5e17f0599a78d679495d6fa674939d237602e 100644
+index 2dd31166cc52ccb528b338b63fde7d2fb4bbf63d..ce64276225d5b0acf684e9e70c600a64a56fe96e 100644
 --- a/content/public/browser/content_browser_client.cc
 +++ b/content/public/browser/content_browser_client.cc
 @@ -52,6 +52,20 @@ void OverrideOnBindInterface(const service_manager::BindSourceInfo& remote_info,
@@ -204,7 +204,7 @@ index d15061de5254fd4f248fed92f47a1b1fcf34cd68..62d5e17f0599a78d679495d6fa674939
      const MainFunctionParams& parameters) {
    return nullptr;
 diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
-index 8ceccd96c4e143921ace8db69685a9631e168dd2..136df7edaaaaaa1eb121ef7cf80aebc47969dc8d 100644
+index 04bfc1a4a804d1f5aa28f894e2feb816bbe80ffc..5bf7340b106bd3ce826ff3322106ef94cbe19d29 100644
 --- a/content/public/browser/content_browser_client.h
 +++ b/content/public/browser/content_browser_client.h
 @@ -211,8 +211,41 @@ CONTENT_EXPORT void OverrideOnBindInterface(

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -1,15 +1,17 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Heilig Benedek <benecene@gmail.com>
-Date: Thu, 18 Oct 2018 17:08:18 -0700
-Subject: printing.patch
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Fri, 7 Jun 2019 13:59:37 -0700
+Subject: fix: printing
 
 Add changeset that was previously applied to sources in chromium_src. The
 majority of changes originally come from these PRs:
   * https://github.com/electron/electron/pull/1835
   * https://github.com/electron/electron/pull/8596
 
+This patch also fixes callback for manual user cancellation and success.
+
 diff --git a/chrome/browser/printing/print_job_worker.cc b/chrome/browser/printing/print_job_worker.cc
-index 88a6142eea4c7a219c08fe3463c44711f5c9fada..a1ec557f54cea6e976d357032328f2e10cc30054 100644
+index 88a6142eea4c7a219c08fe3463c44711f5c9fada..81db315a0036a123658697aa677e2356d1e56dfb 100644
 --- a/chrome/browser/printing/print_job_worker.cc
 +++ b/chrome/browser/printing/print_job_worker.cc
 @@ -21,12 +21,12 @@
@@ -26,14 +28,11 @@ index 88a6142eea4c7a219c08fe3463c44711f5c9fada..a1ec557f54cea6e976d357032328f2e1
  #include "printing/print_job_constants.h"
  #include "printing/printed_document.h"
  #include "printing/printing_utils.h"
-@@ -267,10 +267,18 @@ void PrintJobWorker::GetSettingsDone(PrintingContext::Result result) {
-   // We can't use OnFailure() here since query_ does not support notifications.
+@@ -225,7 +225,15 @@ void PrintJobWorker::UpdatePrintSettingsFromPOD(
  
-   DCHECK(query_);
--  query_->PostTask(FROM_HERE,
--                   base::BindOnce(&PrinterQuery::GetSettingsDone,
--                                  base::WrapRefCounted(query_),
--                                  printing_context_->settings(), result));
+ void PrintJobWorker::GetSettingsDone(SettingsCallback callback,
+                                      PrintingContext::Result result) {
+-  std::move(callback).Run(printing_context_->settings(), result);
 +  if (result == PrintingContext::CANCEL) {
 +    print_job_->PostTask(
 +      FROM_HERE,
@@ -41,16 +40,13 @@ index 88a6142eea4c7a219c08fe3463c44711f5c9fada..a1ec557f54cea6e976d357032328f2e1
 +                    JobEventDetails::USER_INIT_CANCELED, 0,
 +                    base::RetainedRef(document_)));
 +  } else {
-+    query_->PostTask(FROM_HERE,
-+                  base::BindOnce(&PrinterQuery::GetSettingsDone,
-+                                base::WrapRefCounted(query_),
-+                                printing_context_->settings(), result));
++    std::move(callback).Run(printing_context_->settings(), result);
 +  }
  }
  
- void PrintJobWorker::GetSettingsWithUI(
+ void PrintJobWorker::GetSettingsWithUI(int document_page_count,
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25db1e7537 100644
+index 7ba43aada1ac44827cca264d6f37814e4a91f458..c41b0c24974147e847baa21b9b48926158311aa0 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -85,7 +81,7 @@ index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25
    base::AutoReset<bool> auto_reset(&is_dialog_shown, true);
  
    chrome::ShowWarningMessageBox(nullptr, base::string16(), message);
-+#endif
++  #endif
  }
  
  #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
@@ -93,14 +89,14 @@ index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25
        queue_(g_browser_process->print_job_manager()->queue()),
        weak_ptr_factory_(this) {
    DCHECK(queue_);
-+#if 0
++  #if 0
    Profile* profile =
        Profile::FromBrowserContext(web_contents->GetBrowserContext());
    printing_enabled_.Init(
        prefs::kPrintingEnabled, profile->GetPrefs(),
        base::Bind(&PrintViewManagerBase::UpdatePrintingEnabled,
                   weak_ptr_factory_.GetWeakPtr()));
-+#endif
++  #endif
  }
  
  PrintViewManagerBase::~PrintViewManagerBase() {
@@ -197,7 +193,7 @@ index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25
    // Don't close the worker thread.
    print_job_ = nullptr;
  }
-@@ -678,6 +684,9 @@ bool PrintViewManagerBase::PrintNowInternal(
+@@ -674,6 +680,9 @@ bool PrintViewManagerBase::PrintNowInternal(
    // Don't print / print preview interstitials or crashed tabs.
    if (web_contents()->ShowingInterstitialPage() || web_contents()->IsCrashed())
      return false;
@@ -208,7 +204,7 @@ index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25
  }
  
 diff --git a/chrome/browser/printing/print_view_manager_base.h b/chrome/browser/printing/print_view_manager_base.h
-index cf074791d0e2e17bbf8cf0b000b8d63e235b7deb..0838041cfe45d26dca65b549452535820191ae44 100644
+index cf074791d0e2e17bbf8cf0b000b8d63e235b7deb..c12107d0af1291c113e05bc1a9cc87e2466c8610 100644
 --- a/chrome/browser/printing/print_view_manager_base.h
 +++ b/chrome/browser/printing/print_view_manager_base.h
 @@ -39,6 +39,8 @@ class PrintJob;
@@ -235,14 +231,14 @@ index cf074791d0e2e17bbf8cf0b000b8d63e235b7deb..0838041cfe45d26dca65b54945253582
    // The current RFH that is printing with a system printing dialog.
    content::RenderFrameHost* printing_rfh_;
  
-+  // Responded with success of the print job.
++  // Respond with success of the print job.
 +  CompletionCallback callback_;
 +
    // Indication of success of the print job.
    bool printing_succeeded_;
  
 diff --git a/chrome/browser/printing/printing_message_filter.cc b/chrome/browser/printing/printing_message_filter.cc
-index 1f79e7b127f35e2eaef923af5c4a5f0a7e5250a5..b93d8f59850b59f74271233440d1a3b2d0aded46 100644
+index 1f79e7b127f35e2eaef923af5c4a5f0a7e5250a5..327b37dfbb84c60d7f0e339c3c4cb8ca3b3c9b26 100644
 --- a/chrome/browser/printing/printing_message_filter.cc
 +++ b/chrome/browser/printing/printing_message_filter.cc
 @@ -21,6 +21,7 @@
@@ -272,11 +268,11 @@ index 1f79e7b127f35e2eaef923af5c4a5f0a7e5250a5..b93d8f59850b59f74271233440d1a3b2
 +          ->Get(browser_context)
            ->Subscribe(base::Bind(&PrintingMessageFilter::ShutdownOnUIThread,
                                   base::Unretained(this)));
-+#if 0
++  #if 0
    is_printing_enabled_.Init(prefs::kPrintingEnabled, profile->GetPrefs());
    is_printing_enabled_.MoveToThread(
        base::CreateSingleThreadTaskRunnerWithTraits({BrowserThread::IO}));
-+#endif
++  #endif
  }
  
  PrintingMessageFilter::~PrintingMessageFilter() {
@@ -284,13 +280,13 @@ index 1f79e7b127f35e2eaef923af5c4a5f0a7e5250a5..b93d8f59850b59f74271233440d1a3b2
  void PrintingMessageFilter::OnGetDefaultPrintSettings(IPC::Message* reply_msg) {
    DCHECK_CURRENTLY_ON(BrowserThread::IO);
    scoped_refptr<PrinterQuery> printer_query;
-+#if 0
++  #if 0
    if (!is_printing_enabled_.GetValue()) {
      // Reply with NULL query.
      OnGetDefaultPrintSettingsReply(printer_query, reply_msg);
      return;
    }
-+#endif
++  #endif
    printer_query = queue_->PopPrinterQuery(0);
    if (!printer_query.get()) {
      printer_query =
@@ -298,13 +294,13 @@ index 1f79e7b127f35e2eaef923af5c4a5f0a7e5250a5..b93d8f59850b59f74271233440d1a3b2
                                                    base::Value job_settings,
                                                    IPC::Message* reply_msg) {
    scoped_refptr<PrinterQuery> printer_query;
-+#if 0
++  #if 0
    if (!is_printing_enabled_.GetValue()) {
      // Reply with NULL query.
      OnUpdatePrintSettingsReply(printer_query, reply_msg);
      return;
    }
-+#endif
++  #endif
    printer_query = queue_->PopPrinterQuery(document_cookie);
    if (!printer_query.get()) {
      printer_query = queue_->CreatePrinterQuery(
@@ -359,7 +355,7 @@ index 1802034a6e15a6ad8b0d9591cfb79ba5873dc982..a827091facdb4f6b1d74ce826c3492ce
  // Like PrintMsg_PrintPages, but using the print preview document's frame/node.
  IPC_MESSAGE_ROUTED0(PrintMsg_PrintForSystemDialog)
 diff --git a/components/printing/renderer/print_render_frame_helper.cc b/components/printing/renderer/print_render_frame_helper.cc
-index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..5c54aad4e874d723dd4b9e5733449d2af6d9e047 100644
+index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1abdb0ddd 100644
 --- a/components/printing/renderer/print_render_frame_helper.cc
 +++ b/components/printing/renderer/print_render_frame_helper.cc
 @@ -1115,7 +1115,9 @@ void PrintRenderFrameHelper::ScriptedPrint(bool user_initiated) {
@@ -413,19 +409,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..5c54aad4e874d723dd4b9e5733449d2a
    print_preview_context_.OnPrintPreview();
  
    UMA_HISTOGRAM_ENUMERATION("PrintPreview.PreviewEvent",
-@@ -1621,7 +1629,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
- 
-     auto self = weak_ptr_factory_.GetWeakPtr();
-     Print(duplicate_node.GetDocument().GetFrame(), duplicate_node,
--          PrintRequestType::kRegular);
-+          PrintRequestType::kRegular,
-+          false /* silent */,
-+          false /* print_background */,
-+          base::DictionaryValue() /* new_settings */);
-     // Check if |this| is still valid.
-     if (!self)
-       return;
-@@ -1632,7 +1643,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
+@@ -1632,7 +1640,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
  
  void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
                                     const blink::WebNode& node,
@@ -437,7 +421,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..5c54aad4e874d723dd4b9e5733449d2a
    // If still not finished with earlier print request simply ignore.
    if (prep_frame_view_)
      return;
-@@ -1640,7 +1654,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1640,7 +1651,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
    FrameReference frame_ref(frame);
  
    int expected_page_count = 0;
@@ -446,7 +430,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..5c54aad4e874d723dd4b9e5733449d2a
      DidFinishPrinting(FAIL_PRINT_INIT);
      return;  // Failed to init print page settings.
    }
-@@ -1660,8 +1674,9 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1660,8 +1671,9 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
  
      PrintMsg_PrintPages_Params print_settings;
      auto self = weak_ptr_factory_.GetWeakPtr();
@@ -454,11 +438,11 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..5c54aad4e874d723dd4b9e5733449d2a
 -                             print_request_type, &print_settings);
 +    if (!silent)
 +      GetPrintSettingsFromUser(frame_ref.GetFrame(), node, expected_page_count,
-+                               print_request_type, &print_settings);
++                              print_request_type, &print_settings);
      // Check if |this| is still valid.
      if (!self)
        return;
-@@ -1671,6 +1686,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1671,6 +1683,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
              ? blink::kWebPrintScalingOptionSourceSize
              : scaling_option;
      SetPrintPagesParams(print_settings);
@@ -466,7 +450,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..5c54aad4e874d723dd4b9e5733449d2a
      if (print_settings.params.dpi.IsEmpty() ||
          !print_settings.params.document_cookie) {
        DidFinishPrinting(OK);  // Release resources and fail silently on failure.
-@@ -1859,10 +1875,24 @@ std::vector<int> PrintRenderFrameHelper::GetPrintedPages(
+@@ -1859,10 +1872,24 @@ std::vector<int> PrintRenderFrameHelper::GetPrintedPages(
    return printed_pages;
  }
  
@@ -494,7 +478,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..5c54aad4e874d723dd4b9e5733449d2a
    // Check if the printer returned any settings, if the settings is empty, we
    // can safely assume there are no printer drivers configured. So we safely
    // terminate.
-@@ -1882,12 +1912,14 @@ bool PrintRenderFrameHelper::InitPrintSettings(bool fit_to_paper_size) {
+@@ -1882,12 +1909,14 @@ bool PrintRenderFrameHelper::InitPrintSettings(bool fit_to_paper_size) {
    return result;
  }
  

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -27,7 +27,7 @@ index 88a6142eea4c7a219c08fe3463c44711f5c9fada..a1ec557f54cea6e976d357032328f2e1
  #include "printing/printed_document.h"
  #include "printing/printing_utils.h"
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25db1e7537 100644
+index 007b003dd58d44acd6e1351c237fca6463d90602..89e0c1f5ba961b6d885cd212d62011ec8a39b90f 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -121,7 +121,31 @@ index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25
  #endif
  
    ReleasePrinterQuery();
-@@ -594,6 +599,9 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -436,9 +441,12 @@ void PrintViewManagerBase::OnNotifyPrintJobEvent(
+           content::NotificationService::NoDetails());
+       break;
+     }
+-    case JobEventDetails::USER_INIT_DONE:
+-    case JobEventDetails::DEFAULT_INIT_DONE:
+     case JobEventDetails::USER_INIT_CANCELED: {
++      ReleasePrintJob();
++      break;
++    }
++    case JobEventDetails::USER_INIT_DONE:
++    case JobEventDetails::DEFAULT_INIT_DONE: {
+       NOTREACHED();
+       break;
+     }
+@@ -544,8 +552,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(PrinterQuery* query) {
+   DCHECK(!print_job_);
+   print_job_ = base::MakeRefCounted<PrintJob>();
+   print_job_->Initialize(query, RenderSourceName(), number_pages_);
+-  registrar_.Add(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
+-                 content::Source<PrintJob>(print_job_.get()));
+   printing_succeeded_ = false;
+   return true;
+ }
+@@ -594,6 +600,9 @@ void PrintViewManagerBase::ReleasePrintJob() {
    content::RenderFrameHost* rfh = printing_rfh_;
    printing_rfh_ = nullptr;
  
@@ -130,6 +154,25 @@ index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25
 +
    if (!print_job_)
      return;
+ 
+@@ -604,7 +613,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
+   }
+ 
+   registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
+-                    content::Source<PrintJob>(print_job_.get()));
++                    content::NotificationService::AllSources());
+   // Don't close the worker thread.
+   print_job_ = nullptr;
+ }
+@@ -678,6 +687,9 @@ bool PrintViewManagerBase::PrintNowInternal(
+   // Don't print / print preview interstitials or crashed tabs.
+   if (web_contents()->ShowingInterstitialPage() || web_contents()->IsCrashed())
+     return false;
++
++  registrar_.Add(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
++                content::NotificationService::AllSources());
+   return rfh->Send(message.release());
+ }
  
 diff --git a/chrome/browser/printing/print_view_manager_base.h b/chrome/browser/printing/print_view_manager_base.h
 index cf074791d0e2e17bbf8cf0b000b8d63e235b7deb..0838041cfe45d26dca65b549452535820191ae44 100644

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -355,7 +355,7 @@ index 1802034a6e15a6ad8b0d9591cfb79ba5873dc982..a827091facdb4f6b1d74ce826c3492ce
  // Like PrintMsg_PrintPages, but using the print preview document's frame/node.
  IPC_MESSAGE_ROUTED0(PrintMsg_PrintForSystemDialog)
 diff --git a/components/printing/renderer/print_render_frame_helper.cc b/components/printing/renderer/print_render_frame_helper.cc
-index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1abdb0ddd 100644
+index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c199df80be 100644
 --- a/components/printing/renderer/print_render_frame_helper.cc
 +++ b/components/printing/renderer/print_render_frame_helper.cc
 @@ -1115,7 +1115,9 @@ void PrintRenderFrameHelper::ScriptedPrint(bool user_initiated) {
@@ -409,7 +409,19 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1
    print_preview_context_.OnPrintPreview();
  
    UMA_HISTOGRAM_ENUMERATION("PrintPreview.PreviewEvent",
-@@ -1632,7 +1640,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
+@@ -1621,7 +1629,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
+ 
+     auto self = weak_ptr_factory_.GetWeakPtr();
+     Print(duplicate_node.GetDocument().GetFrame(), duplicate_node,
+-          PrintRequestType::kRegular);
++          PrintRequestType::kRegular,
++          false /* silent */,
++          false /* print_background */,
++          base::DictionaryValue() /* new_settings */);
+     // Check if |this| is still valid.
+     if (!self)
+       return;
+@@ -1632,7 +1643,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
  
  void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
                                     const blink::WebNode& node,
@@ -421,7 +433,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1
    // If still not finished with earlier print request simply ignore.
    if (prep_frame_view_)
      return;
-@@ -1640,7 +1651,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1640,7 +1654,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
    FrameReference frame_ref(frame);
  
    int expected_page_count = 0;
@@ -430,7 +442,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1
      DidFinishPrinting(FAIL_PRINT_INIT);
      return;  // Failed to init print page settings.
    }
-@@ -1660,8 +1671,9 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1660,8 +1674,9 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
  
      PrintMsg_PrintPages_Params print_settings;
      auto self = weak_ptr_factory_.GetWeakPtr();
@@ -442,7 +454,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1
      // Check if |this| is still valid.
      if (!self)
        return;
-@@ -1671,6 +1683,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1671,6 +1686,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
              ? blink::kWebPrintScalingOptionSourceSize
              : scaling_option;
      SetPrintPagesParams(print_settings);
@@ -450,7 +462,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1
      if (print_settings.params.dpi.IsEmpty() ||
          !print_settings.params.document_cookie) {
        DidFinishPrinting(OK);  // Release resources and fail silently on failure.
-@@ -1859,10 +1872,24 @@ std::vector<int> PrintRenderFrameHelper::GetPrintedPages(
+@@ -1859,10 +1875,24 @@ std::vector<int> PrintRenderFrameHelper::GetPrintedPages(
    return printed_pages;
  }
  
@@ -478,7 +490,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..f80f8f7de20e4f81f8368e418ff72ea1
    // Check if the printer returned any settings, if the settings is empty, we
    // can safely assume there are no printer drivers configured. So we safely
    // terminate.
-@@ -1882,12 +1909,14 @@ bool PrintRenderFrameHelper::InitPrintSettings(bool fit_to_paper_size) {
+@@ -1882,12 +1912,14 @@ bool PrintRenderFrameHelper::InitPrintSettings(bool fit_to_paper_size) {
    return result;
  }
  

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -50,7 +50,7 @@ index 88a6142eea4c7a219c08fe3463c44711f5c9fada..a1ec557f54cea6e976d357032328f2e1
  
  void PrintJobWorker::GetSettingsWithUI(
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 007b003dd58d44acd6e1351c237fca6463d90602..89e0c1f5ba961b6d885cd212d62011ec8a39b90f 100644
+index 7ba43aada1ac44827cca264d6f37814e4a91f458..db011ba8370423723ff9d21be30cbf25db1e7537 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -159,7 +159,17 @@ index 007b003dd58d44acd6e1351c237fca6463d90602..89e0c1f5ba961b6d885cd212d62011ec
        NOTREACHED();
        break;
      }
-@@ -544,8 +552,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(PrinterQuery* query) {
+@@ -532,9 +540,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(PrinterQuery* query) {
+   DCHECK(!quit_inner_loop_);
+   DCHECK(query);
+ 
+-  // Disconnect the current |print_job_|.
+-  DisconnectFromCurrentPrintJob();
+-
+   // We can't print if there is no renderer.
+   if (!web_contents()->GetRenderViewHost() ||
+       !web_contents()->GetRenderViewHost()->IsRenderViewLive()) {
+@@ -544,8 +549,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(PrinterQuery* query) {
    DCHECK(!print_job_);
    print_job_ = base::MakeRefCounted<PrintJob>();
    print_job_->Initialize(query, RenderSourceName(), number_pages_);
@@ -168,7 +178,7 @@ index 007b003dd58d44acd6e1351c237fca6463d90602..89e0c1f5ba961b6d885cd212d62011ec
    printing_succeeded_ = false;
    return true;
  }
-@@ -594,6 +600,9 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -594,6 +597,9 @@ void PrintViewManagerBase::ReleasePrintJob() {
    content::RenderFrameHost* rfh = printing_rfh_;
    printing_rfh_ = nullptr;
  
@@ -178,7 +188,7 @@ index 007b003dd58d44acd6e1351c237fca6463d90602..89e0c1f5ba961b6d885cd212d62011ec
    if (!print_job_)
      return;
  
-@@ -604,7 +613,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -604,7 +610,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
    }
  
    registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
@@ -187,7 +197,7 @@ index 007b003dd58d44acd6e1351c237fca6463d90602..89e0c1f5ba961b6d885cd212d62011ec
    // Don't close the worker thread.
    print_job_ = nullptr;
  }
-@@ -678,6 +687,9 @@ bool PrintViewManagerBase::PrintNowInternal(
+@@ -678,6 +684,9 @@ bool PrintViewManagerBase::PrintNowInternal(
    // Don't print / print preview interstitials or crashed tabs.
    if (web_contents()->ShowingInterstitialPage() || web_contents()->IsCrashed())
      return false;

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -26,6 +26,29 @@ index 88a6142eea4c7a219c08fe3463c44711f5c9fada..a1ec557f54cea6e976d357032328f2e1
  #include "printing/print_job_constants.h"
  #include "printing/printed_document.h"
  #include "printing/printing_utils.h"
+@@ -267,10 +267,18 @@ void PrintJobWorker::GetSettingsDone(PrintingContext::Result result) {
+   // We can't use OnFailure() here since query_ does not support notifications.
+ 
+   DCHECK(query_);
+-  query_->PostTask(FROM_HERE,
+-                   base::BindOnce(&PrinterQuery::GetSettingsDone,
+-                                  base::WrapRefCounted(query_),
+-                                  printing_context_->settings(), result));
++  if (result == PrintingContext::CANCEL) {
++    print_job_->PostTask(
++      FROM_HERE,
++      base::BindOnce(&NotificationCallback, base::RetainedRef(print_job_),
++                    JobEventDetails::USER_INIT_CANCELED, 0,
++                    base::RetainedRef(document_)));
++  } else {
++    query_->PostTask(FROM_HERE,
++                  base::BindOnce(&PrinterQuery::GetSettingsDone,
++                                base::WrapRefCounted(query_),
++                                printing_context_->settings(), result));
++  }
+ }
+ 
+ void PrintJobWorker::GetSettingsWithUI(
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
 index 007b003dd58d44acd6e1351c237fca6463d90602..89e0c1f5ba961b6d885cd212d62011ec8a39b90f 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/17265.
Resolves https://github.com/electron/electron/issues/16085.

Callback `false` when disconnecting from the print job if the current printing job has not completed, and `true` if printing is triggered successfully.

cc @deepak1556 @jkleinsc

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `webContents.print()` callback not returning boolean correctly in all cases.
