### PR TITLE
fix: throw error when inserting menu items out-of-range

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -110,7 +110,9 @@ Menu.prototype.insert = function (pos, item) {
     throw new TypeError('Invalid item')
   }
 
-  if (pos > this.getItemCount()) {
+  if (pos < 0) {
+    throw new RangeError(`Position ${pos} cannot be less than 0`)
+  } else if (pos > this.getItemCount()) {
     throw new RangeError(`Position ${pos} cannot be greater than the total MenuItem count`)
   }
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -110,6 +110,10 @@ Menu.prototype.insert = function (pos, item) {
     throw new TypeError('Invalid item')
   }
 
+  if (pos > this.getItemCount()) {
+    throw new RangeError(`Position ${pos} cannot be greater than the total MenuItem count`)
+  }
+
   // insert item depending on its type
   insertItemByType.call(this, item, pos)
 

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -700,6 +700,10 @@ describe('Menu module', () => {
       expect(() => {
         menu.insert(9999, item)
       }).to.throw(/Position 9999 cannot be greater than the total MenuItem count/)
+
+      expect(() => {
+        menu.insert(-9999, item)
+      }).to.throw(/Position -9999 cannot be less than 0/)
     })
 
     it('should store item in @items by its index', () => {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -688,6 +688,20 @@ describe('Menu module', () => {
   })
 
   describe('Menu.insert', () => {
+    it('should throw when attempting to insert at out-of-range indices', () => {
+      const menu = Menu.buildFromTemplate([
+        { label: '1' },
+        { label: '2' },
+        { label: '3' }
+      ])
+
+      const item = new MenuItem({ label: 'badInsert' })
+
+      expect(() => {
+        menu.insert(9999, item)
+      }).to.throw(/Position 9999 cannot be greater than the total MenuItem count/)
+    })
+
     it('should store item in @items by its index', () => {
       const menu = Menu.buildFromTemplate([
         { label: '1' },


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/17225.

Adds a check for invalid menu index and throws an appropriate `RangeError`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added a check for invalid menu index to prevent out-of-range crashes on insertion.
