### PR TITLE
feat: allow windows to be excluded from the windows menu

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -567,6 +567,14 @@ void TopLevelWindow::SetSkipTaskbar(bool skip) {
   window_->SetSkipTaskbar(skip);
 }
 
+void TopLevelWindow::SetExcludedFromWindowsMenu(bool excluded) {
+  window_->SetExcludedFromWindowsMenu(excluded);
+}
+
+bool TopLevelWindow::IsExcludedFromWindowsMenu() {
+  return window_->IsExcludedFromWindowsMenu();
+}
+
 void TopLevelWindow::SetSimpleFullScreen(bool simple_fullscreen) {
   window_->SetSimpleFullScreen(simple_fullscreen);
 }
@@ -1133,6 +1141,9 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("addTabbedWindow", &TopLevelWindow::AddTabbedWindow)
       .SetMethod("setWindowButtonVisibility",
                  &TopLevelWindow::SetWindowButtonVisibility)
+      .SetProperty("excludedFromWindowsMenu",
+                   &TopLevelWindow::IsExcludedFromWindowsMenu,
+                   &TopLevelWindow::SetExcludedFromWindowsMenu)
 #endif
       .SetMethod("setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
       .SetMethod("isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -567,12 +567,12 @@ void TopLevelWindow::SetSkipTaskbar(bool skip) {
   window_->SetSkipTaskbar(skip);
 }
 
-void TopLevelWindow::SetExcludedFromWindowsMenu(bool excluded) {
-  window_->SetExcludedFromWindowsMenu(excluded);
+void TopLevelWindow::SetExcludedFromShownWindowsMenu(bool excluded) {
+  window_->SetExcludedFromShownWindowsMenu(excluded);
 }
 
-bool TopLevelWindow::IsExcludedFromWindowsMenu() {
-  return window_->IsExcludedFromWindowsMenu();
+bool TopLevelWindow::IsExcludedFromShownWindowsMenu() {
+  return window_->IsExcludedFromShownWindowsMenu();
 }
 
 void TopLevelWindow::SetSimpleFullScreen(bool simple_fullscreen) {
@@ -1141,9 +1141,9 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("addTabbedWindow", &TopLevelWindow::AddTabbedWindow)
       .SetMethod("setWindowButtonVisibility",
                  &TopLevelWindow::SetWindowButtonVisibility)
-      .SetProperty("excludedFromWindowsMenu",
-                   &TopLevelWindow::IsExcludedFromWindowsMenu,
-                   &TopLevelWindow::SetExcludedFromWindowsMenu)
+      .SetProperty("excludedFromShownWindowsMenu",
+                   &TopLevelWindow::IsExcludedFromShownWindowsMenu,
+                   &TopLevelWindow::SetExcludedFromShownWindowsMenu)
 #endif
       .SetMethod("setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
       .SetMethod("isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -145,8 +145,8 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   std::string GetTitle();
   void FlashFrame(bool flash);
   void SetSkipTaskbar(bool skip);
-  void SetExcludedFromWindowsMenu(bool excluded);
-  bool IsExcludedFromWindowsMenu();
+  void SetExcludedFromShownWindowsMenu(bool excluded);
+  bool IsExcludedFromShownWindowsMenu();
   void SetSimpleFullScreen(bool simple_fullscreen);
   bool IsSimpleFullScreen();
   void SetKiosk(bool kiosk);

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -145,6 +145,8 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   std::string GetTitle();
   void FlashFrame(bool flash);
   void SetSkipTaskbar(bool skip);
+  void SetExcludedFromWindowsMenu(bool excluded);
+  bool IsExcludedFromWindowsMenu();
   void SetSimpleFullScreen(bool simple_fullscreen);
   bool IsSimpleFullScreen();
   void SetKiosk(bool kiosk);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -136,8 +136,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetTitle() = 0;
   virtual void FlashFrame(bool flash) = 0;
   virtual void SetSkipTaskbar(bool skip) = 0;
-  virtual void SetExcludedFromWindowsMenu(bool excluded) = 0;
-  virtual bool IsExcludedFromWindowsMenu() = 0;
+  virtual void SetExcludedFromShownWindowsMenu(bool excluded) = 0;
+  virtual bool IsExcludedFromShownWindowsMenu() = 0;
   virtual void SetSimpleFullScreen(bool simple_fullscreen) = 0;
   virtual bool IsSimpleFullScreen() = 0;
   virtual void SetKiosk(bool kiosk) = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -136,6 +136,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetTitle() = 0;
   virtual void FlashFrame(bool flash) = 0;
   virtual void SetSkipTaskbar(bool skip) = 0;
+  virtual void SetExcludedFromWindowsMenu(bool excluded) = 0;
+  virtual bool IsExcludedFromWindowsMenu() = 0;
   virtual void SetSimpleFullScreen(bool simple_fullscreen) = 0;
   virtual bool IsSimpleFullScreen() = 0;
   virtual void SetKiosk(bool kiosk) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -87,6 +87,8 @@ class NativeWindowMac : public NativeWindow {
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;
   void SetSkipTaskbar(bool skip) override;
+  void SetExcludedFromWindowsMenu(bool excluded) override;
+  bool IsExcludedFromWindowsMenu() override;
   void SetSimpleFullScreen(bool simple_fullscreen) override;
   bool IsSimpleFullScreen() override;
   void SetKiosk(bool kiosk) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -87,8 +87,8 @@ class NativeWindowMac : public NativeWindow {
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;
   void SetSkipTaskbar(bool skip) override;
-  void SetExcludedFromWindowsMenu(bool excluded) override;
-  bool IsExcludedFromWindowsMenu() override;
+  void SetExcludedFromShownWindowsMenu(bool excluded) override;
+  bool IsExcludedFromShownWindowsMenu() override;
   void SetSimpleFullScreen(bool simple_fullscreen) override;
   bool IsSimpleFullScreen() override;
   void SetKiosk(bool kiosk) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -886,12 +886,12 @@ void NativeWindowMac::FlashFrame(bool flash) {
 
 void NativeWindowMac::SetSkipTaskbar(bool skip) {}
 
-bool NativeWindowMac::IsExcludedFromWindowsMenu() {
+bool NativeWindowMac::IsExcludedFromShownWindowsMenu() {
   NSWindow* window = GetNativeWindow().GetNativeNSWindow();
   return [window isExcludedFromWindowsMenu];
 }
 
-void NativeWindowMac::SetExcludedFromWindowsMenu(bool excluded) {
+void NativeWindowMac::SetExcludedFromShownWindowsMenu(bool excluded) {
   NSWindow* window = GetNativeWindow().GetNativeNSWindow();
   [window setExcludedFromWindowsMenu:excluded];
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -886,6 +886,16 @@ void NativeWindowMac::FlashFrame(bool flash) {
 
 void NativeWindowMac::SetSkipTaskbar(bool skip) {}
 
+bool NativeWindowMac::IsExcludedFromWindowsMenu() {
+  NSWindow* window = GetNativeWindow().GetNativeNSWindow();
+  return [window isExcludedFromWindowsMenu];
+}
+
+void NativeWindowMac::SetExcludedFromWindowsMenu(bool excluded) {
+  NSWindow* window = GetNativeWindow().GetNativeNSWindow();
+  [window setExcludedFromWindowsMenu:excluded];
+}
+
 void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
   NSWindow* window = GetNativeWindow().GetNativeNSWindow();
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -721,6 +721,13 @@ bool NativeWindowViews::IsMaximizable() {
 #endif
 }
 
+void NativeWindowViews::SetExcludedFromShownWindowsMenu(bool excluded) {}
+
+bool NativeWindowViews::IsExcludedFromShownWindowsMenu() {
+  // return false on unsupported platforms
+  return false;
+}
+
 void NativeWindowViews::SetFullScreenable(bool fullscreenable) {
   fullscreenable_ = fullscreenable;
 }

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -97,6 +97,8 @@ class NativeWindowViews : public NativeWindow,
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;
   void SetSkipTaskbar(bool skip) override;
+  void SetExcludedFromShownWindowsMenu(bool excluded) override;
+  bool IsExcludedFromShownWindowsMenu() override;
   void SetSimpleFullScreen(bool simple_fullscreen) override;
   bool IsSimpleFullScreen() override;
   void SetKiosk(bool kiosk) override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1648,3 +1648,24 @@ removed in future Electron releases.
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment
+
+### Properties
+
+#### `win.excludedFromWindowsMenu` _macOS_
+
+A `Boolean` property that determines whether the window is excluded from the application’s Windows menu. `false` by default.
+
+```js
+const win = new BrowserWindow({ height: 600, width: 600 })
+
+const template = [
+  {
+    role: 'windowmenu'
+  }
+]
+
+win.excludedFromWindowsMenu = true
+
+const menu = Menu.buildFromTemplate(template)
+Menu.setApplicationMenu(menu)
+```

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1651,7 +1651,7 @@ removed in future Electron releases.
 
 ### Properties
 
-#### `win.excludedFromWindowsMenu` _macOS_
+#### `win.excludedFromShownWindowsMenu` _macOS_
 
 A `Boolean` property that determines whether the window is excluded from the application’s Windows menu. `false` by default.
 
@@ -1664,7 +1664,7 @@ const template = [
   }
 ]
 
-win.excludedFromWindowsMenu = true
+win.excludedFromShownWindowsMenu = true
 
 const menu = Menu.buildFromTemplate(template)
 Menu.setApplicationMenu(menu)


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/17193.

Allows for windows to be excluded from the windows menu so that they don't appear in either the dock or the primary application menu.

Before:
![Screen Shot 2019-03-15 at 2 13 11 PM](https://user-images.githubusercontent.com/2036040/54462453-18ff5d80-472d-11e9-9a4b-3ced69465457.png)

After:
![Screen Shot 2019-03-15 at 2 17 28 PM](https://user-images.githubusercontent.com/2036040/54462464-1ef53e80-472d-11e9-827c-ae0d5b84090e.png)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `excludedFromShownWindowsMenu` property to allow for windows to be excluded from the windows menu.
