### PR TITLE
feat: expose colorSpace to display object

### DIFF
--- a/atom/common/native_mate_converters/gfx_converter.cc
+++ b/atom/common/native_mate_converters/gfx_converter.cc
@@ -147,6 +147,7 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
   dict.Set("accelerometerSupport", val.accelerometer_support());
   dict.Set("monochrome", val.is_monochrome());
   dict.Set("colorDepth", val.color_depth());
+  dict.Set("colorSpace", val.color_space().ToString());
   dict.Set("depthPerComponent", val.depth_per_component());
   dict.Set("size", val.size());
   dict.Set("workAreaSize", val.work_area_size());

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -7,7 +7,7 @@
 * `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
 * `monochrome` Boolean - Whether or not the display is a monochrome display.
 * `accelerometerSupport` String - Can be `available`, `unavailable`, `unknown`.
-* `colorSpace` String - fixme
+* `colorSpace` String -  represent a color space (three-dimensional object which contains all realizable color combinations) for the purpose of color conversions
 * `colorDepth` Number - The number of bits per pixel.
 * `depthPerComponent` Number - The number of bits per color component.
 * `bounds` [Rectangle](rectangle.md)

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -7,6 +7,7 @@
 * `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
 * `monochrome` Boolean - Whether or not the display is a monochrome display.
 * `accelerometerSupport` String - Can be `available`, `unavailable`, `unknown`.
+* `colorSpace` String - fixme
 * `colorDepth` Number - The number of bits per pixel.
 * `depthPerComponent` Number - The number of bits per color component.
 * `bounds` [Rectangle](rectangle.md)

--- a/spec/api-screen-spec.js
+++ b/spec/api-screen-spec.js
@@ -29,6 +29,7 @@ describe('screen module', () => {
       expect(display).to.have.a.property('monochrome').that.is.a('boolean')
       expect(display).to.have.a.property('depthPerComponent').that.is.a('number')
       expect(display).to.have.a.property('colorDepth').that.is.a('number')
+      expect(display).to.have.a.property('colorSpace').that.is.a('string')
     })
 
     it('has a size object property', function () {


### PR DESCRIPTION
#### Description of Change

Exposes `colorSpace` to the display object from chromium. I did some digging into how we could potentially expose this as an object instead of a string, but there's no way to access the private member variables we'd need to do so without patching chromium, and i'd like to avoid that.

cc @miniak 

Example output:
```
  colorSpace:
   '{primaries_d50_referred: [[0.6587, 0.3332],  [0.3206, 0.6135],  [0.1508, 0.0527]], transfer:0.0777*x + 0.0000 if x < 0.0450 else (0.9478*x + 0.0521)**2.4000 + 0.0002, matrix:RGB, range:FULL}',
```
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Exposed `colorSpace` to the `Display` object
