### PR TITLE
feat: add <webview>.getWebContentsId()

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -672,6 +672,10 @@ this `webview`.
 It depends on the [`remote`](remote.md) module,
 it is therefore not available when this module is disabled.
 
+### `<webview>.getWebContentsId()`
+
+Returns `Number` - The WebContents ID of this `webview`.
+
 ## DOM events
 
 The following DOM events are available to the `webview` tag:

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -49,14 +49,8 @@ const supportedWebViewEvents = [
   'update-target-url'
 ]
 
-let nextGuestInstanceId = 0
 const guestInstances = {}
 const embedderElementsMap = {}
-
-// Generate guestInstanceId.
-const getNextGuestInstanceId = function () {
-  return ++nextGuestInstanceId
-}
 
 // Create a new guest instance.
 const createGuest = function (embedder, params) {
@@ -64,12 +58,12 @@ const createGuest = function (embedder, params) {
     webViewManager = process.electronBinding('web_view_manager')
   }
 
-  const guestInstanceId = getNextGuestInstanceId(embedder)
   const guest = webContents.create({
     isGuest: true,
     partition: params.partition,
     embedder: embedder
   })
+  const guestInstanceId = guest.id
   guestInstances[guestInstanceId] = {
     guest: guest,
     embedder: embedder

--- a/spec/fixtures/pages/webview-did-attach-event.html
+++ b/spec/fixtures/pages/webview-did-attach-event.html
@@ -9,7 +9,7 @@
       var {ipcRenderer} = require('electron')
       var wv = document.querySelector('webview')
       wv.addEventListener('dom-ready', () => {
-        ipcRenderer.send('webview-dom-ready', wv.getWebContents().id)
+        ipcRenderer.send('webview-dom-ready', wv.getWebContentsId())
       })
     </script>
   </body>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1124,7 +1124,7 @@ describe('<webview> tag', function () {
       assert.ok(webview.partition)
 
       const listener = function (webContents, permission, callback) {
-        if (webContents.id === webview.getWebContents().id) {
+        if (webContents.id === webview.getWebContentsId()) {
           // requestMIDIAccess with sysex requests both midi and midiSysex so
           // grant the first midi one and then reject the midiSysex one
           if (requestedPermission === 'midiSysex' && permission === 'midi') {
@@ -1210,12 +1210,21 @@ describe('<webview> tag', function () {
       webview.partition = 'permissionTest'
       webview.setAttribute('nodeintegration', 'on')
       session.fromPartition(webview.partition).setPermissionRequestHandler((webContents, permission, callback) => {
-        if (webContents.id === webview.getWebContents().id) {
+        if (webContents.id === webview.getWebContentsId()) {
           assert.strictEqual(permission, 'notifications')
           setTimeout(() => { callback(true) }, 10)
         }
       })
       document.body.appendChild(webview)
+    })
+  })
+
+  describe('<webview>.getWebContentsId', () => {
+    it('can return the WebContents ID', async () => {
+      const src = 'about:blank'
+      await loadWebView(webview, { src })
+
+      expect(webview.getWebContentsId()).to.be.equal(webview.getWebContents().id)
     })
   })
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -121,6 +121,7 @@ declare namespace ElectronInternal {
 
     // Created in web-view-impl
     public getWebContents(): Electron.WebContents;
+    public getWebContentsId(): number;
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Allows getting the WebContents ID of `<webview>`s when the `remote` module is disabled.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `<webview>.getWebContentsId()`, which does not depend of the `remote` module.