### PR TITLE
fix: remove crashReporterRenderer.sendSync() workaround (4-0-x)

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -41,6 +41,7 @@ filenames = {
     "lib/browser/api/web-contents.js",
     "lib/browser/api/web-contents-view.js",
     "lib/browser/chrome-extension.js",
+    "lib/browser/crash-reporter-init.js",
     "lib/browser/guest-view-manager.js",
     "lib/browser/guest-window-manager.js",
     "lib/browser/init.js",

--- a/lib/browser/api/crash-reporter.js
+++ b/lib/browser/api/crash-reporter.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const CrashReporter = require('@electron/internal/common/crash-reporter')
-const ipcMain = require('@electron/internal/browser/ipc-main-internal')
+const { crashReporterInit } = require('@electron/internal/browser/crash-reporter-init')
 
 class CrashReporterMain extends CrashReporter {
-  sendSync (channel, ...args) {
-    const event = {}
-    ipcMain.emit(channel, event, ...args)
-    return event.returnValue
+  init (options) {
+    return crashReporterInit(options)
   }
 }
 

--- a/lib/browser/crash-reporter-init.js
+++ b/lib/browser/crash-reporter-init.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { app } = require('electron')
+const cp = require('child_process')
+const os = require('os')
+const path = require('path')
+
+const getTempDirectory = function () {
+  try {
+    return app.getPath('temp')
+  } catch (error) {
+    return os.tmpdir()
+  }
+}
+
+exports.crashReporterInit = function (options) {
+  const productName = options.productName || app.getName()
+  const crashesDirectory = path.join(getTempDirectory(), `${productName} Crashes`)
+  let crashServicePid
+
+  if (process.platform === 'win32') {
+    const env = {
+      ELECTRON_INTERNAL_CRASH_SERVICE: 1
+    }
+    const args = [
+      '--reporter-url=' + options.submitURL,
+      '--application-name=' + productName,
+      '--crashes-directory=' + crashesDirectory,
+      '--v=1'
+    ]
+
+    const crashServiceProcess = cp.spawn(process.helperExecPath, args, {
+      env,
+      detached: true
+    })
+
+    crashServicePid = crashServiceProcess.pid
+  }
+
+  return {
+    productName,
+    crashesDirectory,
+    crashServicePid,
+    appVersion: app.getVersion()
+  }
+}

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -1,16 +1,14 @@
 'use strict'
 
-const { spawn } = require('child_process')
 const electron = require('electron')
 const { EventEmitter } = require('events')
 const fs = require('fs')
-const os = require('os')
-const path = require('path')
 const v8Util = process.atomBinding('v8_util')
 const eventBinding = process.atomBinding('event')
 
 const { isPromise } = electron
 
+const { crashReporterInit } = require('@electron/internal/browser/crash-reporter-init')
 const ipcMain = require('@electron/internal/browser/ipc-main-internal')
 const objectsRegistry = require('@electron/internal/browser/objects-registry')
 const guestViewManager = require('@electron/internal/browser/guest-view-manager')
@@ -467,46 +465,6 @@ ipcMain.on('ELECTRON_BROWSER_WINDOW_CLOSE', function (event) {
   }
   event.returnValue = null
 })
-
-const getTempDirectory = function () {
-  try {
-    return electron.app.getPath('temp')
-  } catch (error) {
-    return os.tmpdir()
-  }
-}
-
-const crashReporterInit = function (options) {
-  const productName = options.productName || electron.app.getName()
-  const crashesDirectory = path.join(getTempDirectory(), `${productName} Crashes`)
-  let crashServicePid
-
-  if (process.platform === 'win32') {
-    const env = {
-      ELECTRON_INTERNAL_CRASH_SERVICE: 1
-    }
-    const args = [
-      '--reporter-url=' + options.submitURL,
-      '--application-name=' + productName,
-      '--crashes-directory=' + crashesDirectory,
-      '--v=1'
-    ]
-
-    const crashServiceProcess = spawn(process.helperExecPath, args, {
-      env,
-      detached: true
-    })
-
-    crashServicePid = crashServiceProcess.pid
-  }
-
-  return {
-    productName,
-    crashesDirectory,
-    crashServicePid,
-    appVersion: electron.app.getVersion()
-  }
-}
 
 const setReturnValue = function (event, getValue) {
   try {

--- a/lib/common/crash-reporter.js
+++ b/lib/common/crash-reporter.js
@@ -2,26 +2,14 @@
 
 const binding = process.atomBinding('crash_reporter')
 
-const errorUtils = require('@electron/internal/common/error-utils')
-
 class CrashReporter {
   contructor () {
     this.productName = null
     this.crashesDirectory = null
   }
 
-  sendSync (channel, ...args) {
+  init (options) {
     throw new Error('Not implemented')
-  }
-
-  invoke (command, ...args) {
-    const [ error, result ] = this.sendSync(command, ...args)
-
-    if (error) {
-      throw errorUtils.deserialize(error)
-    }
-
-    return result
   }
 
   start (options) {
@@ -51,7 +39,7 @@ class CrashReporter {
       throw new Error('submitURL is a required option to crashReporter.start')
     }
 
-    const ret = this.invoke('ELECTRON_CRASH_REPORTER_INIT', {
+    const ret = this.init({
       submitURL,
       productName
     })

--- a/lib/renderer/api/crash-reporter.js
+++ b/lib/renderer/api/crash-reporter.js
@@ -2,10 +2,21 @@
 
 const CrashReporter = require('@electron/internal/common/crash-reporter')
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
+const errorUtils = require('@electron/internal/common/error-utils')
+
+const invoke = function (command, ...args) {
+  const [ error, result ] = ipcRenderer.sendSync(command, ...args)
+
+  if (error) {
+    throw errorUtils.deserialize(error)
+  }
+
+  return result
+}
 
 class CrashReporterRenderer extends CrashReporter {
-  sendSync (channel, ...args) {
-    return ipcRenderer.sendSync(channel, ...args)
+  init (options) {
+    return invoke('ELECTRON_CRASH_REPORTER_INIT', options)
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Remove `crashReporterRenderer.sendSync()`, allows sending internal IPCs. This should not be exposed to application code. Based on https://github.com/electron/electron/pull/16729.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes