### PR TITLE
refactor: make ELECTRON_INSPECTOR_CONTEXT_MENU handler async

### DIFF
--- a/lib/browser/chrome-devtools.js
+++ b/lib/browser/chrome-devtools.js
@@ -9,13 +9,13 @@ const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils
 
 const readFile = util.promisify(fs.readFile)
 
-const convertToMenuTemplate = function (event, items) {
+const convertToMenuTemplate = function (items, handler) {
   return items.map(function (item) {
     const transformed = item.type === 'subMenu' ? {
       type: 'submenu',
       label: item.label,
       enabled: item.enabled,
-      submenu: convertToMenuTemplate(event, item.subItems)
+      submenu: convertToMenuTemplate(item.subItems, handler)
     } : item.type === 'separator' ? {
       type: 'separator'
     } : item.type === 'checkbox' ? {
@@ -30,9 +30,7 @@ const convertToMenuTemplate = function (event, items) {
     }
 
     if (item.id != null) {
-      transformed.click = function () {
-        event._replyInternal('ELECTRON_INSPECTOR_CONTEXT_MENU_CLICK', item.id)
-      }
+      transformed.click = () => handler(item.id)
     }
 
     return transformed
@@ -67,22 +65,22 @@ const assertChromeDevTools = function (contents, api) {
 }
 
 ipcMainUtils.handle('ELECTRON_INSPECTOR_CONTEXT_MENU', function (event, items, isEditMenu) {
-  assertChromeDevTools(event.sender, 'window.InspectorFrontendHost.showContextMenuAtPoint()')
+  return new Promise(resolve => {
+    assertChromeDevTools(event.sender, 'window.InspectorFrontendHost.showContextMenuAtPoint()')
 
-  const template = isEditMenu ? getEditMenuItems() : convertToMenuTemplate(event, items)
-  const menu = Menu.buildFromTemplate(template)
-  const window = event.sender.getOwnerBrowserWindow()
+    const template = isEditMenu ? getEditMenuItems() : convertToMenuTemplate(items, resolve)
+    const menu = Menu.buildFromTemplate(template)
+    const window = event.sender.getOwnerBrowserWindow()
 
-  menu.once('menu-will-close', () => {
-    // menu-will-close is emitted before the click handler, but needs to be sent after.
-    // otherwise, DevToolsAPI.contextMenuCleared() would be called before
-    // DevToolsAPI.contextMenuItemSelected(id) and the menu will not work properly.
-    setTimeout(() => {
-      event._replyInternal('ELECTRON_INSPECTOR_CONTEXT_MENU_CLOSE')
+    menu.once('menu-will-close', () => {
+      // menu-will-close is emitted before the click handler, but needs to be sent after.
+      // otherwise, DevToolsAPI.contextMenuCleared() would be called before
+      // DevToolsAPI.contextMenuItemSelected(id) and the menu will not work properly.
+      setTimeout(() => resolve())
     })
-  })
 
-  menu.popup({ window })
+    menu.popup({ window })
+  })
 })
 
 ipcMainUtils.handle('ELECTRON_INSPECTOR_SELECT_FILE', async function (event) {


### PR DESCRIPTION
#### Description of Change
Simplifies the flow of handling the context menu

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes