### PR TITLE
chore: remove special handling for dialog methods in remote module

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -244,8 +244,3 @@ module.exports.showMessageBox = deprecate.promisify(module.exports.showMessageBo
 module.exports.showOpenDialog = deprecate.promisify(module.exports.showOpenDialog)
 module.exports.showSaveDialog = deprecate.promisify(module.exports.showSaveDialog)
 module.exports.showCertificateTrustDialog = deprecate.promisify(module.exports.showCertificateTrustDialog)
-
-// Mark standard asynchronous functions.
-v8Util.setHiddenValue(module.exports.showMessageBox, 'asynchronous', true)
-v8Util.setHiddenValue(module.exports.showOpenDialog, 'asynchronous', true)
-v8Util.setHiddenValue(module.exports.showSaveDialog, 'asynchronous', true)

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -242,20 +242,6 @@ const unwrapArgs = function (sender, frameId, contextId, args) {
   return args.map(metaToValue)
 }
 
-const callFunction = function (func, caller, args) {
-  try {
-    return func.apply(caller, args)
-  } catch (error) {
-    // Catch functions thrown further down in function invocation and wrap
-    // them with the function name so it's easier to trace things like
-    // `Error processing argument -1.`
-    const funcName = func.name || 'anonymous'
-    const err = new Error(`Could not call remote function '${funcName}'. Check that the function signature is correct. Underlying error: ${error.message}`)
-    err.cause = error
-    throw err
-  }
-}
-
 const isRemoteModuleEnabledCache = new WeakMap()
 
 const isRemoteModuleEnabled = function (contents) {
@@ -389,7 +375,13 @@ handleRemoteCommand('ELECTRON_BROWSER_FUNCTION_CALL', function (event, contextId
     throwRPCError(`Cannot call function on missing remote object ${id}`)
   }
 
-  return valueToMeta(event.sender, contextId, callFunction(func, global, args), true)
+  try {
+    return valueToMeta(event.sender, contextId, func(...args), true)
+  } catch (error) {
+    const err = new Error(`Could not call remote function '${func.name || 'anonymous'}'. Check that the function signature is correct. Underlying error: ${error.message}`)
+    err.cause = error
+    throw err
+  }
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', function (event, contextId, id, method, args) {
@@ -405,13 +397,19 @@ handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', function (event, cont
 
 handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CALL', function (event, contextId, id, method, args) {
   args = unwrapArgs(event.sender, event.frameId, contextId, args)
-  const obj = objectsRegistry.get(id)
+  const object = objectsRegistry.get(id)
 
-  if (obj == null) {
-    throwRPCError(`Cannot call function '${method}' on missing remote object ${id}`)
+  if (object == null) {
+    throwRPCError(`Cannot call method '${method}' on missing remote object ${id}`)
   }
 
-  return valueToMeta(event.sender, contextId, callFunction(obj[method], obj, args), true)
+  try {
+    return valueToMeta(event.sender, contextId, object[method](...args), true)
+  } catch (error) {
+    const err = new Error(`Could not call remote method '${method}'. Check that the method signature is correct. Underlying error: ${error.message}`)
+    err.cause = error
+    throw err
+  }
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_MEMBER_SET', function (event, contextId, id, name, args) {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -242,21 +242,9 @@ const unwrapArgs = function (sender, frameId, contextId, args) {
   return args.map(metaToValue)
 }
 
-// Call a function and send reply asynchronously if it's a an asynchronous
-// style function and the caller didn't pass a callback.
-const callFunction = function (event, contextId, func, caller, args) {
-  const funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous')
-  const funcPassedCallback = typeof args[args.length - 1] === 'function'
+const callFunction = function (func, caller, args) {
   try {
-    if (funcMarkedAsync && !funcPassedCallback) {
-      args.push(function (ret) {
-        event.returnValue = valueToMeta(event.sender, contextId, ret, true)
-      })
-      func.apply(caller, args)
-    } else {
-      const ret = func.apply(caller, args)
-      return valueToMeta(event.sender, contextId, ret, true)
-    }
+    return func.apply(caller, args)
   } catch (error) {
     // Catch functions thrown further down in function invocation and wrap
     // them with the function name so it's easier to trace things like
@@ -401,7 +389,7 @@ handleRemoteCommand('ELECTRON_BROWSER_FUNCTION_CALL', function (event, contextId
     throwRPCError(`Cannot call function on missing remote object ${id}`)
   }
 
-  return callFunction(event, contextId, func, global, args)
+  return valueToMeta(event.sender, contextId, callFunction(func, global, args), true)
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CONSTRUCTOR', function (event, contextId, id, method, args) {
@@ -423,7 +411,7 @@ handleRemoteCommand('ELECTRON_BROWSER_MEMBER_CALL', function (event, contextId, 
     throwRPCError(`Cannot call function '${method}' on missing remote object ${id}`)
   }
 
-  return callFunction(event, contextId, obj[method], obj, args)
+  return valueToMeta(event.sender, contextId, callFunction(obj[method], obj, args), true)
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_MEMBER_SET', function (event, contextId, id, name, args) {

--- a/spec/api-ipc-main-spec.js
+++ b/spec/api-ipc-main-spec.js
@@ -77,7 +77,7 @@ describe('ipc main module', () => {
       })
 
       ipcMain.once('error-message', (event, message) => {
-        const correctMsgStart = message.startsWith('Cannot call function \'getURL\' on missing remote object')
+        const correctMsgStart = message.startsWith('Cannot call method \'getURL\' on missing remote object')
         expect(correctMsgStart).to.be.true()
         done()
       })


### PR DESCRIPTION
#### Description of Change
This workaround is no longer applicable after the dialog methods have been promisified and separate synchronous versions have been added.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Removed special handling that forced `dialog` methods called over the `remote` module to return their result synchronously but not block the main process.

/cc @codebytere