### PR TITLE
fix: validate sender for replies in ipcMainInternalUtils.invokeInWebContents()

### DIFF
--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -29,9 +29,17 @@ let nextId = 0
 export function invokeInWebContents<T> (sender: Electron.WebContentsInternal, command: string, ...args: any[]) {
   return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId
-    ipcMainInternal.once(`${command}_RESPONSE_${requestId}`, (
-      _event, error: Electron.SerializedError, result: any
-    ) => {
+    const channel = `${command}_RESPONSE_${requestId}`
+    ipcMainInternal.on(channel, function handler (
+      event, error: Electron.SerializedError, result: any
+    ) {
+      if (event.sender !== sender) {
+        console.error(`Reply to ${command} sent by unexpected WebContents (${event.sender.id})`)
+        return
+      }
+
+      ipcMainInternal.removeListener(channel, handler)
+
       if (error) {
         reject(errorUtils.deserialize(error))
       } else {


### PR DESCRIPTION
#### Description of Change
This prevents malicious webContents from replying to IPCs addressed to another webContents.
Follow up to [refactor: add ipcMainUtils.invokeInWebContents / ipcRendererUtils.handle helpers](https://github.com/electron/electron/pull/17313)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes