### PR TITLE
chore: remove unused arg parsing code in dialog

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -15,32 +15,6 @@ const fileDialogProperties = {
   treatPackageAsDirectory: 1 << 7
 }
 
-const messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']
-
-const messageBoxOptions = {
-  noLink: 1 << 0
-}
-
-const parseArgs = function (window, options, callback, ...args) {
-  if (window != null && window.constructor !== BrowserWindow) {
-    // Shift.
-    [callback, options, window] = [options, window, null]
-  }
-
-  if ((callback == null) && typeof options === 'function') {
-    // Shift.
-    [callback, options] = [options, null]
-  }
-
-  // Fallback to using very last argument as the callback function
-  const lastArgument = args[args.length - 1]
-  if ((callback == null) && typeof lastArgument === 'function') {
-    callback = lastArgument
-  }
-
-  return [window, options, callback]
-}
-
 const normalizeAccessKey = (text) => {
   if (typeof text !== 'string') return text
 
@@ -143,6 +117,9 @@ const messageBox = (sync, window, options) => {
 
   if (window && window.constructor !== BrowserWindow) options = window
   if (options == null) options = { type: 'none' }
+
+  const messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']
+  const messageBoxOptions = { noLink: 1 << 0 }
 
   let {
     buttons = [],


### PR DESCRIPTION
#### Description of Change

After cleanup and promisification of the dialog module, we no longer need to parse arguments for a callback the way we previously did. This thus removes that dead `parseArgs` helper and moves a few variables into the `showMessageBox` method for cleanliness.

cc @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
