### PR TITLE
test: fix isEmpty() checks in nativeImage tests

### DIFF
--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -108,7 +108,7 @@ describe('nativeImage module', () => {
   describe('createEmpty()', () => {
     it('returns an empty image', () => {
       const empty = nativeImage.createEmpty()
-      expect(empty.isEmpty())
+      expect(empty.isEmpty()).to.be.true()
       expect(empty.getAspectRatio()).to.equal(1)
       expect(empty.toDataURL()).to.equal('data:image/png;base64,')
       expect(empty.toDataURL({ scaleFactor: 2.0 })).to.equal('data:image/png;base64,')
@@ -129,7 +129,7 @@ describe('nativeImage module', () => {
 
   describe('createFromBitmap(buffer, options)', () => {
     it('returns an empty image when the buffer is empty', () => {
-      expect(nativeImage.createFromBitmap(Buffer.from([]), { width: 0, height: 0 }).isEmpty())
+      expect(nativeImage.createFromBitmap(Buffer.from([]), { width: 0, height: 0 }).isEmpty()).to.be.true()
     })
 
     it('returns an image created from the given buffer', () => {
@@ -153,7 +153,7 @@ describe('nativeImage module', () => {
 
   describe('createFromBuffer(buffer, options)', () => {
     it('returns an empty image when the buffer is empty', () => {
-      expect(nativeImage.createFromBuffer(Buffer.from([])).isEmpty())
+      expect(nativeImage.createFromBuffer(Buffer.from([])).isEmpty()).to.be.true()
     })
 
     it('returns an image created from the given buffer', () => {
@@ -175,7 +175,7 @@ describe('nativeImage module', () => {
       expect(imageE.getSize()).to.deep.equal({ width: 100, height: 200 })
 
       const imageF = nativeImage.createFromBuffer(imageA.toBitmap())
-      expect(imageF.isEmpty())
+      expect(imageF.isEmpty()).to.be.true()
 
       const imageG = nativeImage.createFromBuffer(imageA.toPNG(),
         { width: 100, height: 200 })
@@ -198,7 +198,7 @@ describe('nativeImage module', () => {
 
   describe('createFromDataURL(dataURL)', () => {
     it('returns an empty image from the empty string', () => {
-      expect(nativeImage.createFromDataURL('').isEmpty())
+      expect(nativeImage.createFromDataURL('').isEmpty()).to.be.true()
     })
 
     it('returns an image created from the given string', () => {
@@ -207,7 +207,7 @@ describe('nativeImage module', () => {
         const imageFromPath = nativeImage.createFromPath(imageData.path)
         const imageFromDataUrl = nativeImage.createFromDataURL(imageData.dataUrl)
 
-        expect(imageFromDataUrl.isEmpty())
+        expect(imageFromDataUrl.isEmpty()).to.be.false()
         expect(imageFromDataUrl.getSize()).to.deep.equal(imageFromPath.getSize())
         expect(imageFromDataUrl.toBitmap()).to.satisfy(
           bitmap => imageFromPath.toBitmap().equals(bitmap))
@@ -301,11 +301,11 @@ describe('nativeImage module', () => {
 
   describe('createFromPath(path)', () => {
     it('returns an empty image for invalid paths', () => {
-      expect(nativeImage.createFromPath('').isEmpty())
-      expect(nativeImage.createFromPath('does-not-exist.png').isEmpty())
-      expect(nativeImage.createFromPath('does-not-exist.ico').isEmpty())
-      expect(nativeImage.createFromPath(__dirname).isEmpty())
-      expect(nativeImage.createFromPath(__filename).isEmpty())
+      expect(nativeImage.createFromPath('').isEmpty()).to.be.true()
+      expect(nativeImage.createFromPath('does-not-exist.png').isEmpty()).to.be.true()
+      expect(nativeImage.createFromPath('does-not-exist.ico').isEmpty()).to.be.true()
+      expect(nativeImage.createFromPath(__dirname).isEmpty()).to.be.true()
+      expect(nativeImage.createFromPath(__filename).isEmpty()).to.be.true()
     })
 
     it('loads images from paths relative to the current working directory', () => {
@@ -364,7 +364,7 @@ describe('nativeImage module', () => {
   describe('createFromNamedImage(name)', () => {
     it('returns empty for invalid options', () => {
       const image = nativeImage.createFromNamedImage('totally_not_real')
-      expect(image.isEmpty())
+      expect(image.isEmpty()).to.be.true()
     })
 
     it('returns empty on non-darwin platforms', function () {
@@ -375,7 +375,7 @@ describe('nativeImage module', () => {
       }
 
       const image = nativeImage.createFromNamedImage('NSActionTemplate')
-      expect(image.isEmpty())
+      expect(image.isEmpty()).to.be.true()
     })
 
     it('returns a valid image on darwin', function () {
@@ -421,8 +421,8 @@ describe('nativeImage module', () => {
     })
 
     it('returns an empty image when called on an empty image', () => {
-      expect(nativeImage.createEmpty().resize({ width: 1, height: 1 }).isEmpty())
-      expect(nativeImage.createEmpty().resize({ width: 0, height: 0 }).isEmpty())
+      expect(nativeImage.createEmpty().resize({ width: 1, height: 1 }).isEmpty()).to.be.true()
+      expect(nativeImage.createEmpty().resize({ width: 0, height: 0 }).isEmpty()).to.be.true()
     })
 
     it('supports a quality option', () => {
@@ -438,16 +438,16 @@ describe('nativeImage module', () => {
 
   describe('crop(bounds)', () => {
     it('returns an empty image when called on an empty image', () => {
-      expect(nativeImage.createEmpty().crop({ width: 1, height: 2, x: 0, y: 0 }).isEmpty())
-      expect(nativeImage.createEmpty().crop({ width: 0, height: 0, x: 0, y: 0 }).isEmpty())
+      expect(nativeImage.createEmpty().crop({ width: 1, height: 2, x: 0, y: 0 }).isEmpty()).to.be.true()
+      expect(nativeImage.createEmpty().crop({ width: 0, height: 0, x: 0, y: 0 }).isEmpty()).to.be.true()
     })
 
     it('returns an empty image when the bounds are invalid', () => {
       const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
-      expect(image.crop({ width: 0, height: 0, x: 0, y: 0 }).isEmpty())
-      expect(image.crop({ width: -1, height: 10, x: 0, y: 0 }).isEmpty())
-      expect(image.crop({ width: 10, height: -35, x: 0, y: 0 }).isEmpty())
-      expect(image.crop({ width: 100, height: 100, x: 1000, y: 1000 }).isEmpty())
+      expect(image.crop({ width: 0, height: 0, x: 0, y: 0 }).isEmpty()).to.be.true()
+      expect(image.crop({ width: -1, height: 10, x: 0, y: 0 }).isEmpty()).to.be.true()
+      expect(image.crop({ width: 10, height: -35, x: 0, y: 0 }).isEmpty()).to.be.true()
+      expect(image.crop({ width: 100, height: 100, x: 1000, y: 1000 }).isEmpty()).to.be.true()
     })
 
     it('returns a cropped image', () => {


### PR DESCRIPTION
#### Description of Change
Fix tests regressed in https://github.com/electron/electron/pull/11139. 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes

/cc @alexeykuzmin