### PR TITLE
fix: check the result when calling js function

### DIFF
--- a/atom/common/native_mate_converters/callback.h
+++ b/atom/common/native_mate_converters/callback.h
@@ -55,11 +55,12 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args{ConvertToV8(isolate, raw)...};
-    v8::Local<v8::Value> ret(holder
-                                 ->Call(context, holder, args.size(),
-                                        args.empty() ? nullptr : &args.front())
-                                 .ToLocalChecked());
-    return handle_scope.Escape(ret);
+    v8::MaybeLocal<v8::Value> ret = holder->Call(
+        context, holder, args.size(), args.empty() ? nullptr : &args.front());
+    if (ret.IsEmpty())
+      return v8::Undefined(isolate);
+    else
+      return handle_scope.Escape(ret.ToLocalChecked());
   }
 };
 
@@ -81,7 +82,7 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
     holder
         ->Call(context, holder, args.size(),
                args.empty() ? nullptr : &args.front())
-        .ToLocalChecked();
+        .IsEmpty();
   }
 };
 

--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -334,11 +334,10 @@ std::unique_ptr<base::Value> V8ValueConverter::FromV8ValueImpl(
                                           v8::NewStringType::kNormal)
                       .ToLocalChecked());
     if (toISOString->IsFunction()) {
-      v8::Local<v8::Value> result = toISOString.As<v8::Function>()
-                                        ->Call(context, val, 0, nullptr)
-                                        .ToLocalChecked();
+      v8::MaybeLocal<v8::Value> result =
+          toISOString.As<v8::Function>()->Call(context, val, 0, nullptr);
       if (!result.IsEmpty()) {
-        v8::String::Utf8Value utf8(isolate, result);
+        v8::String::Utf8Value utf8(isolate, result.ToLocalChecked());
         return std::make_unique<base::Value>(std::string(*utf8, utf8.length()));
       }
     }

--- a/atom/renderer/api/atom_api_spell_check_client.cc
+++ b/atom/renderer/api/atom_api_spell_check_client.cc
@@ -221,7 +221,7 @@ void SpellCheckClient::SpellCheckWords(
   v8::Local<v8::Value> args[] = {mate::ConvertToV8(isolate_, words),
                                  templ->GetFunction(context).ToLocalChecked()};
   // Call javascript with the words and the callback function
-  scope.spell_check_->Call(context, scope.provider_, 2, args).ToLocalChecked();
+  scope.spell_check_->Call(context, scope.provider_, 2, args).IsEmpty();
 }
 
 // Returns whether or not the given string is a contraction.

--- a/native_mate/native_mate/wrappable.cc
+++ b/native_mate/native_mate/wrappable.cc
@@ -39,8 +39,7 @@ void WrappableBase::InitWith(v8::Isolate* isolate,
   // Call object._init if we have one.
   v8::Local<v8::Function> init;
   if (Dictionary(isolate, wrapper).Get("_init", &init))
-    init->Call(isolate->GetCurrentContext(), wrapper, 0, nullptr)
-        .ToLocalChecked();
+    init->Call(isolate->GetCurrentContext(), wrapper, 0, nullptr).IsEmpty();
 
   AfterInit(isolate);
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2525,15 +2525,24 @@ describe('BrowserWindow module', () => {
 
   describe('beginFrameSubscription method', () => {
     before(function () {
-      // This test is too slow, only test it on CI.
-      if (!isCI) {
-        this.skip()
-      }
-
       // FIXME These specs crash on Linux when run in a docker container
       if (isCI && process.platform === 'linux') {
         this.skip()
       }
+    })
+
+    it('does not crash when callback returns nothing', (done) => {
+      w.loadFile(path.join(fixtures, 'api', 'frame-subscriber.html'))
+      w.webContents.on('dom-ready', () => {
+        w.webContents.beginFrameSubscription(function (data) {
+          // Pending endFrameSubscription to next tick can reliably reproduce
+          // a crash which happens when nothing is returned in the callback.
+          setTimeout(() => {
+            w.webContents.endFrameSubscription()
+            done()
+          })
+        })
+      })
     })
 
     it('subscribes to frame updates', (done) => {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

When a JS function returns `undefined`, the returned `v8::MaybeLocal` in C++ would be empty, and calling `ToLocalChecked()` without checking would crash immediately.

This PR does 2 things:
1. Check whether `MaybeLocal` is empty before using it;
2. Replace `ToLocalChecked` with `IsEmpty` where the only purpose is to suppress compiler warning.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix crash when passing callbacks which return `undefined` to some APIs.