### PR TITLE
fix: FrameSubscriber should not scale frame down

### DIFF
--- a/atom/browser/api/frame_subscriber.h
+++ b/atom/browser/api/frame_subscriber.h
@@ -54,6 +54,9 @@ class FrameSubscriber : public content::WebContentsObserver,
 
   void Done(const gfx::Rect& damage, const SkBitmap& frame);
 
+  // Get the pixel size of render view.
+  gfx::Size GetRenderViewSize() const;
+
   FrameCaptureCallback callback_;
   bool only_dirty_;
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

The `beginFrameSubscription` currently passes the DIP size to Chromium, which would then scale the frame down and return blurred image on HiDPI displays.

This PR changes the code to pass pixel size, so the API works correctly on HiDPI displays.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `beginFrameSubscription` returning blurred images on HiDPI displays.