### PR TITLE
docs: clarify documentation for getLastCrashReport

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -96,7 +96,7 @@ them will get reported without `companyName`, `productName` or any of the `extra
 Returns [`CrashReport`](structures/crash-report.md):
 
 Returns the date and ID of the last crash report. If no crash reports have been
-sent or the crash reporter has not been started, `null` is returned.
+sent (i.e a crash was triggered with `process.crash()` and crash reports are present in the `crashDirectory`, but have not been explicitly uploaded) or the crash reporter has not been started, `null` is returned.
 
 ### `crashReporter.getUploadedReports()`
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -95,8 +95,7 @@ them will get reported without `companyName`, `productName` or any of the `extra
 
 Returns [`CrashReport`](structures/crash-report.md):
 
-Returns the date and ID of the last crash report. If no crash reports have been
-sent (i.e a crash was triggered with `process.crash()` and crash reports are present in the `crashDirectory`, but have not been explicitly uploaded) or the crash reporter has not been started, `null` is returned.
+Returns the date and ID of the last crash report. Only crash reports that have been uploaded will be returned; even if a crash report is present on disk it will not be returned until it is uploaded. In the case that there are no uploaded reports, `null` is returned.
 
 ### `crashReporter.getUploadedReports()`
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/17399.

At present, it's not clear that `getLastCrashReport` _only_ returns crash reports that have been uploaded, and so this PR add clarifying information to documentation.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Clarified usage of `crashReporter.getLastCrashReport()` in documentation.
