### PR TITLE
fix: crashReporter.getParameters() takes no params

### DIFF
--- a/lib/common/crash-reporter.js
+++ b/lib/common/crash-reporter.js
@@ -15,29 +15,17 @@ class CrashReporter {
   start (options) {
     if (options == null) options = {}
 
-    let {
+    const {
       productName,
       companyName,
-      extra,
-      ignoreSystemCrashHandler,
+      extra = {},
+      ignoreSystemCrashHandler = false,
       submitURL,
-      uploadToServer
+      uploadToServer = true
     } = options
 
-    if (uploadToServer == null) {
-      uploadToServer = true
-    }
-
-    if (ignoreSystemCrashHandler == null) {
-      ignoreSystemCrashHandler = false
-    }
-
-    if (companyName == null) {
-      throw new Error('companyName is a required option to crashReporter.start')
-    }
-    if (submitURL == null) {
-      throw new Error('submitURL is a required option to crashReporter.start')
-    }
+    if (companyName == null) throw new Error('companyName is a required option to crashReporter.start')
+    if (submitURL == null) throw new Error('submitURL is a required option to crashReporter.start')
 
     const ret = this.init({
       submitURL,
@@ -48,7 +36,6 @@ class CrashReporter {
     this.crashesDirectory = ret.crashesDirectory
     this.crashServicePid = ret.crashServicePid
 
-    if (extra == null) extra = {}
     if (extra._productName == null) extra._productName = ret.productName
     if (extra._companyName == null) extra._companyName = companyName
     if (extra._version == null) extra._version = ret.appVersion
@@ -103,7 +90,7 @@ class CrashReporter {
     binding.removeExtraParameter(key)
   }
 
-  getParameters (key, value) {
+  getParameters () {
     return binding.getParameters()
   }
 }


### PR DESCRIPTION
#### Description of Change

Fixes an issue in `crashReporter` whereby `getParameters` took `key` and `val` as parameters and should take none. Also cleans up `crashReporter.start(options)` with default parameters.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
