### PR TITLE
fix: take foreground visibility into account for win.isVisible() on macOS

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -576,7 +576,12 @@ void NativeWindowMac::Hide() {
 }
 
 bool NativeWindowMac::IsVisible() {
-  return [window_ isVisible];
+  bool occluded = [window_ occlusionState] == NSWindowOcclusionStateVisible;
+
+  // For a window to be visible, it must be visible to the user in the
+  // foreground of the app, which means that it should not be minimized or
+  // occluded
+  return [window_ isVisible] && !occluded && !IsMinimized();
 }
 
 bool NativeWindowMac::IsEnabled() {


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16776.

Right now, our documentation says that for `isVisible` to return `true` for a given BrowserWindow, it must be "visible to the user." As @nickfujita pointed out, this should take into account whether or not a window is minimized, as well as whether or not a window is in the foreground (i.e. not obscured by other apps).

This PR therefore updates our `win.isVisible()` implementation on macOS to take occlusion and minimization into explicit account.

cc @MarshallOfSound  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue whereby foreground visibility of a window was not correctly taken into account for `win.isVisible()` on macOS
