### PR TITLE
fix: use a more unique identifier for NSUserNotification instances

### DIFF
--- a/atom/browser/notifications/mac/cocoa_notification.mm
+++ b/atom/browser/notifications/mac/cocoa_notification.mm
@@ -13,8 +13,6 @@
 
 namespace atom {
 
-int g_identifier_ = 1;
-
 CocoaNotification::CocoaNotification(NotificationDelegate* delegate,
                                      NotificationPresenter* presenter)
     : Notification(delegate, presenter) {}
@@ -29,7 +27,9 @@ void CocoaNotification::Show(const NotificationOptions& options) {
   notification_.reset([[NSUserNotification alloc] init]);
 
   NSString* identifier =
-      [NSString stringWithFormat:@"ElectronNotification%d", g_identifier_++];
+      [NSString stringWithFormat:@"%@:notification:%@",
+                                 [[NSBundle mainBundle] bundleIdentifier],
+                                 [[[NSUUID alloc] init] UUIDString]];
 
   [notification_ setTitle:base::SysUTF16ToNSString(options.title)];
   [notification_ setSubtitle:base::SysUTF16ToNSString(options.subtitle)];


### PR DESCRIPTION
#### Description of Change

So although apple has it documented that notifications with duplicate identifiers in the same session won't be presented.  They apparently forgot to mention that macOS also non-deterministically and without any errors, logs or warnings will also not present some notifications in future sessions if they have a previously used identifier.

As such, we're going to truly randomize these identifiers so they are unique between apps and sessions.  The identifier now consists of a randomly generated UUID and the app bundle id.

#### Release Notes

Notes: Fixed an issue where `Notification` objects constructed in the main process would randomly not be shown to the user.
