### PR TITLE
fix: only listen to sender replies in ipcMainInternalUtils.invokeInWebContents()

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -359,10 +359,13 @@ WebContents.prototype._init = function () {
   // render-view-deleted event, so ignore the listeners warning.
   this.setMaxListeners(0)
 
+  this._ipcInternal = new EventEmitter()
+
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message', function (event, internal, channel, args) {
     if (internal) {
       addReplyInternalToEvent(event)
+      this._ipcInternal.emit(channel, event, ...args)
       ipcMainInternal.emit(channel, event, ...args)
     } else {
       addReplyToEvent(event)
@@ -375,6 +378,7 @@ WebContents.prototype._init = function () {
     addReturnValueToEvent(event)
     if (internal) {
       addReplyInternalToEvent(event)
+      this._ipcInternal.emit(channel, event, ...args)
       ipcMainInternal.emit(channel, event, ...args)
     } else {
       addReplyToEvent(event)

--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -29,7 +29,7 @@ let nextId = 0
 export function invokeInWebContents<T> (sender: Electron.WebContentsInternal, command: string, ...args: any[]) {
   return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId
-    ipcMainInternal.once(`${command}_RESPONSE_${requestId}`, (
+    sender._ipcInternal.once(`${command}_RESPONSE_${requestId}`, (
       _event, error: Electron.SerializedError, result: any
     ) => {
       if (error) {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -60,6 +60,7 @@ declare namespace Electron {
   }
 
   interface WebContentsInternal extends Electron.WebContents {
+    readonly _ipcInternal: ElectronInternal.IpcMainInternal;
     _sendInternal(channel: string, ...args: any[]): void;
   }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
