### PR TITLE
fix: close context menu before popup

### DIFF
--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -142,6 +142,10 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
   if (!SetForegroundWindow(window_))
     return;
 
+  // Cancel current menu if there is one.
+  if (menu_runner_ && menu_runner_->IsRunning())
+    menu_runner_->Cancel();
+
   // Show menu at mouse's position by default.
   gfx::Rect rect(pos, gfx::Size());
   if (pos.IsOrigin())

--- a/spec/api-tray-spec.js
+++ b/spec/api-tray-spec.js
@@ -24,6 +24,23 @@ describe('tray module', () => {
     })
   })
 
+  describe('tray.popUpContextMenu', () => {
+    before(function () {
+      if (process.platform !== 'win32') {
+        this.skip()
+      }
+    })
+
+    it('can be called when menu is showing', (done) => {
+      tray.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
+      setTimeout(() => {
+        tray.popUpContextMenu()
+        done()
+      })
+      tray.popUpContextMenu()
+    })
+  })
+
   describe('tray.setImage', () => {
     it('accepts empty image', () => {
       tray.setImage(nativeImage.createEmpty())


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Close https://github.com/electron/electron/issues/17353.

Fix crash when showing a tray menu while one is already shown.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix crash when showing a tray menu while one is already shown.
