### PR TITLE
docs: fully document MenuItem instance properties

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -122,6 +122,46 @@ Lowercase `role`, e.g. `toggledevtools`, is still supported.
 
 The following properties are available on instances of `MenuItem`:
 
+#### `menuItem.id`
+
+A `String` indicating the item's unique id, this property can be
+dynamically changed.
+
+#### `menuItem.label`
+
+A `String` indicating the item's visible label, this property can be
+dynamically changed.
+
+#### `menuItem.click`
+
+A `Function` that is fired when the MenuItem receives a click event.
+
+#### `menuItem.submenu`
+
+A `MenuItemConstructorOptions[] | Menu` (optional) containing the menu
+item's submenu, if present.
+
+#### `menuItem.type`
+
+A `String` indicating the type of the item.
+
+#### `menuItem.role`
+
+A `String` (optional) indicating the item's role, if set.
+
+#### `menuItem.accelerator`
+
+A `String` (optional) indicating the item's accelerator, if set.
+
+#### `menuItem.icon`
+
+A `[NativeImage](native-image.md) | String` (optional) indicating the
+item's icon, if set.
+
+#### `menuItem.sublabel`
+
+A `String` indicating the item's sublabel, this property can be dynamically changed.
+
 #### `menuItem.enabled`
 
 A `Boolean` indicating whether the item is enabled, this property can be
@@ -145,10 +185,15 @@ will turn off that property for all adjacent items in the same menu.
 
 You can add a `click` function for additional behavior.
 
-#### `menuItem.label`
+#### `menuItem.registerAccelerator`
 
-A `String` representing the menu items visible label.
+A `Boolean` indicating if the accelerator should be registered with the
+system or just displayed, this property can be dynamically changed.
 
-#### `menuItem.click`
+#### `menuItem.commandId`
 
-A `Function` that is fired when the MenuItem receives a click event.
+A `Number` indicating an item's sequential unique id.
+
+#### `menuItem.menu`
+
+A `[Menu](#menu.md))` that the item is a part of.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -135,6 +135,10 @@ dynamically changed.
 #### `menuItem.click`
 
 A `Function` that is fired when the MenuItem receives a click event.
+It can be called with `menuItem.click(event, focusedWindow, focusedWebContents)`.
+* `event` [KeyboardEvent](structures/keyboard-event.md)
+* `focusedWindow` [BrowserWindow](browser-window.md)
+* `focusedWebContents` [WebContents](web-contents.md)
 
 #### `menuItem.submenu`
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -138,7 +138,7 @@ A `Function` that is fired when the MenuItem receives a click event.
 
 #### `menuItem.submenu`
 
-A `MenuItemConstructorOptions[] | Menu` (optional) containing the menu
+A `Menu` (optional) containing the menu
 item's submenu, if present.
 
 #### `menuItem.type`
@@ -155,7 +155,7 @@ A `String` (optional) indicating the item's accelerator, if set.
 
 #### `menuItem.icon`
 
-A `[NativeImage](native-image.md) | String` (optional) indicating the
+A `NativeImage | String` (optional) indicating the
 item's icon, if set.
 
 #### `menuItem.sublabel`
@@ -196,4 +196,4 @@ A `Number` indicating an item's sequential unique id.
 
 #### `menuItem.menu`
 
-A `[Menu](#menu.md))` that the item is a part of.
+A `Menu` that the item is a part of.


### PR DESCRIPTION
#### Description of Change

Closes #15000.

I've documented the instance properties of MenuItem so that typescript typings will work as intended.

#### Checklist
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes

However, I think I need to iterate on it. I am not sure if properties have the correct `| null` and `readonly` typings right now.
I'm requesting the assistance of someone familiar with the automatic typing system to tell me how to specify that correctly.