### PR TITLE
build: pass through value of unknown flag as well as the flag to make --grep work again

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -5,12 +5,21 @@ const crypto = require('crypto')
 const fs = require('fs')
 const { hashElement } = require('folder-hash')
 const path = require('path')
-const unknownArgs = []
+const unknownFlags = []
 
 const args = require('minimist')(process.argv, {
   string: ['runners'],
-  unknown: arg => unknownArgs.push(arg)
+  unknown: arg => unknownFlags.push(arg)
 })
+
+const unknownArgs = []
+for (const flag of unknownFlags) {
+  unknownArgs.push(flag)
+  const onlyFlag = flag.replace(/^-+/, '')
+  if (args[onlyFlag]) {
+    unknownArgs.push(args[onlyFlag])
+  }
+}
 
 const utils = require('./lib/utils')
 


### PR DESCRIPTION
`unknown` appears to only be called with flags, not their values.  This updates the spec-runner to pull all of the values of the flags into the `unknownArgs` array for passthrough to the actual test runners.

Notes: no-notes