### PR TITLE
chore: remove some bot config options

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,13 +1,3 @@
-# Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
-
-# Comment to be posted to on first time issues
-newIssueWelcomeComment: |
-  👋 Thanks for opening your first issue here! If you're reporting a 🐞 bug, please make sure you include steps to reproduce it. We get a lot of issues on this repo, so please be patient and we will get back to you as soon as we can.
-
-  To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md).
-
-# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
-
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
@@ -35,11 +25,6 @@ newPRWelcomeComment: |
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
   Congrats on merging your first pull request! 🎉🎉🎉
-
-# Configuration for trop - https://github.com/electron/trop
-
-watchedProject:
-  name: Backports
 
 # Users authorized to run manual trop backports
 authorizedUsers:


### PR DESCRIPTION
#### Description of Change

The information conveyed by the first-issue bot is essentially subsumed by https://github.com/electron/electron/pull/17505 and should be shown on every issue in the template comments. 

`watchedProject` is not applicable anymore, that functionality is gone.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
