### PR TITLE
test: un-disable 60 chromium-spec tests

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -275,7 +275,7 @@ describe('chromium feature', () => {
   })
 
   describe('navigator.geolocation', () => {
-    before(function () {
+    beforeEach(function () {
       if (!features.isFakeLocationProviderEnabled()) {
         return this.skip()
       }


### PR DESCRIPTION
the skip() was unexpectedly applying to all following tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
