### PR TITLE
fix: match net module headers & http.IncomingMessage headers

### DIFF
--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -21,13 +21,10 @@ module instead of the native Node.js modules:
 * Support for traffic monitoring proxies: Fiddler-like proxies used for access
   control and monitoring.
 
-The `net` module API has been specifically designed to mimic, as closely as
-possible, the familiar Node.js API. The API components including classes,
-methods, properties and event names are similar to those commonly used in
+The API components (including classes, methods, properties and event names) are similar to those used in
 Node.js.
 
-For instance, the following example quickly shows how the `net` API might be
-used:
+Example usage:
 
 ```javascript
 const { app } = require('electron')
@@ -47,10 +44,6 @@ app.on('ready', () => {
   request.end()
 })
 ```
-
-By the way, it is almost identical to how you would normally use the
-[HTTP](https://nodejs.org/api/http.html)/[HTTPS](https://nodejs.org/api/https.html)
-modules of Node.js
 
 The `net` API can be used only after the application emits the `ready` event.
 Trying to use the module before the `ready` event will throw an error.

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -75,7 +75,7 @@ class IncomingMessage extends Readable {
           // see https://nodejs.org/api/http.html#http_message_headers
           filteredHeaders[header] = rawHeaders[header]
         } else {
-          // for all other headers, the values are joined together with ', '
+          // for non-cookie headers, the values are joined together with ', '
           filteredHeaders[header] = rawHeaders[header].join(', ')
         }
       }

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -41,7 +41,46 @@ class IncomingMessage extends Readable {
   }
 
   get headers () {
-    return this.urlRequest.rawResponseHeaders
+    // list of headers that Node.js discards duplicates for
+    // see https://nodejs.org/api/http.html#http_message_headers
+    const discardableDuplicateHeaders = [
+      'content-type',
+      'content-length',
+      'user-agent',
+      'referer',
+      'host',
+      'authorization',
+      'proxy-authorization',
+      'if-modified-since',
+      'if-unmodified-since',
+      'from',
+      'location',
+      'max-forwards',
+      'retry-after',
+      'etag',
+      'last-modified',
+      'server',
+      'age',
+      'expires'
+    ]
+
+    const filteredHeaders = {}
+    const rawHeaders = this.urlRequest.rawResponseHeaders
+    Object.keys(rawHeaders).forEach(header => {
+      if (header in filteredHeaders && discardableDuplicateHeaders.includes(header)) {
+        // do nothing with discardable duplicate headers
+      } else {
+        if (header === 'set-cookie') {
+          // keep set-cookie as an array per Node.js rules
+          // see https://nodejs.org/api/http.html#http_message_headers
+          filteredHeaders[header] = rawHeaders[header]
+        } else {
+          // a header is present iff it has a value, and there will only be 1 value
+          filteredHeaders[header] = rawHeaders[header][0]
+        }
+      }
+    })
+    return filteredHeaders
   }
 
   get httpVersion () {

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -16,6 +16,29 @@ Object.setPrototypeOf(URLRequest.prototype, EventEmitter.prototype)
 
 const kSupportedProtocols = new Set(['http:', 'https:'])
 
+// set of headers that Node.js discards duplicates for
+// see https://nodejs.org/api/http.html#http_message_headers
+const discardableDuplicateHeaders = new Set([
+  'content-type',
+  'content-length',
+  'user-agent',
+  'referer',
+  'host',
+  'authorization',
+  'proxy-authorization',
+  'if-modified-since',
+  'if-unmodified-since',
+  'from',
+  'location',
+  'max-forwards',
+  'retry-after',
+  'etag',
+  'last-modified',
+  'server',
+  'age',
+  'expires'
+])
+
 class IncomingMessage extends Readable {
   constructor (urlRequest) {
     super()
@@ -41,33 +64,10 @@ class IncomingMessage extends Readable {
   }
 
   get headers () {
-    // list of headers that Node.js discards duplicates for
-    // see https://nodejs.org/api/http.html#http_message_headers
-    const discardableDuplicateHeaders = [
-      'content-type',
-      'content-length',
-      'user-agent',
-      'referer',
-      'host',
-      'authorization',
-      'proxy-authorization',
-      'if-modified-since',
-      'if-unmodified-since',
-      'from',
-      'location',
-      'max-forwards',
-      'retry-after',
-      'etag',
-      'last-modified',
-      'server',
-      'age',
-      'expires'
-    ]
-
     const filteredHeaders = {}
     const rawHeaders = this.urlRequest.rawResponseHeaders
     Object.keys(rawHeaders).forEach(header => {
-      if (header in filteredHeaders && discardableDuplicateHeaders.includes(header)) {
+      if (header in filteredHeaders && discardableDuplicateHeaders.has(header)) {
         // do nothing with discardable duplicate headers
       } else {
         if (header === 'set-cookie') {
@@ -75,8 +75,8 @@ class IncomingMessage extends Readable {
           // see https://nodejs.org/api/http.html#http_message_headers
           filteredHeaders[header] = rawHeaders[header]
         } else {
-          // a header is present iff it has a value, and there will only be 1 value
-          filteredHeaders[header] = rawHeaders[header][0]
+          // for all other headers, the values are joined together with ', '
+          filteredHeaders[header] = rawHeaders[header].join(', ')
         }
       }
     })

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const { expect } = require('chai')
 const { remote } = require('electron')
 const { ipcRenderer } = require('electron')
 const http = require('http')
@@ -1363,6 +1364,7 @@ describe('net module', () => {
       const requestUrl = '/requestUrl'
       const customHeaderName = 'Some-Custom-Header-Name'
       const customHeaderValue = 'Some-Customer-Header-Value'
+
       server.on('request', (request, response) => {
         switch (request.url) {
           case requestUrl:
@@ -1375,31 +1377,115 @@ describe('net module', () => {
             handleUnexpectedURL(request, response)
         }
       })
+
       const urlRequest = net.request({
         method: 'GET',
         url: `${server.url}${requestUrl}`
       })
+
       urlRequest.on('response', (response) => {
-        const statusCode = response.statusCode
-        assert(typeof statusCode === 'number')
-        assert.strictEqual(statusCode, 200)
-        const statusMessage = response.statusMessage
-        assert(typeof statusMessage === 'string')
-        assert.strictEqual(statusMessage, 'OK')
+        expect(response.statusCode).to.equal(200)
+        expect(response.statusMessage).to.equal('OK')
+
         const headers = response.headers
-        assert(typeof headers === 'object')
-        assert.deepStrictEqual(headers[customHeaderName.toLowerCase()], customHeaderValue)
+        expect(headers).to.be.an('object')
+        const headerValue = headers[customHeaderName.toLowerCase()]
+        expect(headerValue).to.equal(customHeaderValue)
+
         const httpVersion = response.httpVersion
-        assert(typeof httpVersion === 'string')
-        assert(httpVersion.length > 0)
+        expect(httpVersion).to.be.a('string').and.to.have.lengthOf.at.least(1)
+
         const httpVersionMajor = response.httpVersionMajor
-        assert(typeof httpVersionMajor === 'number')
-        assert(httpVersionMajor >= 1)
+        expect(httpVersionMajor).to.be.a('number').and.to.be.at.least(1)
+
         const httpVersionMinor = response.httpVersionMinor
-        assert(typeof httpVersionMinor === 'number')
-        assert(httpVersionMinor >= 0)
+        expect(httpVersionMinor).to.be.a('number').and.to.be.at.least(0)
+
         response.pause()
-        response.on('data', (chunk) => {})
+        response.on('data', chunk => {})
+        response.on('end', () => { done() })
+        response.resume()
+      })
+      urlRequest.end()
+    })
+
+    it('should discard duplicate headers', (done) => {
+      const requestUrl = '/duplicateRequestUrl'
+      const includedHeader = 'max-forwards'
+      const discardableHeader = 'Max-Forwards'
+
+      const includedHeaderValue = 'max-fwds-val'
+      const discardableHeaderValue = 'max-fwds-val-two'
+
+      server.on('request', (request, response) => {
+        switch (request.url) {
+          case requestUrl:
+            response.statusCode = 200
+            response.statusMessage = 'OK'
+            response.setHeader(includedHeader, includedHeaderValue)
+            response.setHeader(discardableHeader, discardableHeaderValue)
+            response.end()
+            break
+          default:
+            handleUnexpectedURL(request, response)
+        }
+      })
+
+      const urlRequest = net.request({
+        method: 'GET',
+        url: `${server.url}${requestUrl}`
+      })
+
+      urlRequest.on('response', response => {
+        expect(response.statusCode).to.equal(200)
+        expect(response.statusMessage).to.equal('OK')
+
+        const headers = response.headers
+        expect(headers).to.be.an('object')
+
+        expect(headers).to.have.property(includedHeader)
+        expect(headers).to.not.have.property(discardableHeader)
+
+        response.pause()
+        response.on('data', chunk => {})
+        response.on('end', () => { done() })
+        response.resume()
+      })
+      urlRequest.end()
+    })
+
+    it('should join repeated non-discardable value with ,', (done) => {
+      const requestUrl = '/requestUrl'
+
+      server.on('request', (request, response) => {
+        switch (request.url) {
+          case requestUrl:
+            response.statusCode = 200
+            response.statusMessage = 'OK'
+            response.setHeader('referrer-policy', ['first-text', 'second-text'])
+            response.end()
+            break
+          default:
+            handleUnexpectedURL(request, response)
+        }
+      })
+
+      const urlRequest = net.request({
+        method: 'GET',
+        url: `${server.url}${requestUrl}`
+      })
+
+      urlRequest.on('response', response => {
+        expect(response.statusCode).to.equal(200)
+        expect(response.statusMessage).to.equal('OK')
+
+        const headers = response.headers
+        expect(headers).to.be.an('object')
+        expect(headers).to.have.a.property('referrer-policy')
+        expect(headers['referrer-policy']).to.equal('first-text, second-text')
+
+        response.pause()
+        response.on('data', chunk => {})
         response.on('end', () => { done() })
         response.resume()
       })

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -1422,8 +1422,8 @@ describe('net module', () => {
           case requestUrl:
             response.statusCode = 200
             response.statusMessage = 'OK'
-            response.setHeader(includedHeader, includedHeaderValue)
             response.setHeader(discardableHeader, discardableHeaderValue)
+            response.setHeader(includedHeader, includedHeaderValue)
             response.end()
             break
           default:

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -1445,6 +1445,7 @@ describe('net module', () => {
 
         expect(headers).to.have.property(includedHeader)
         expect(headers).to.not.have.property(discardableHeader)
+        expect(headers[includedHeader]).to.equal(includedHeaderValue)
 
         response.pause()
         response.on('data', chunk => {})

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -1388,8 +1388,7 @@ describe('net module', () => {
         assert.strictEqual(statusMessage, 'OK')
         const headers = response.headers
         assert(typeof headers === 'object')
-        assert.deepStrictEqual(headers[customHeaderName.toLowerCase()],
-          [customHeaderValue])
+        assert.deepStrictEqual(headers[customHeaderName.toLowerCase()], customHeaderValue)
         const httpVersion = response.httpVersion
         assert(typeof httpVersion === 'string')
         assert(httpVersion.length > 0)
@@ -1400,11 +1399,8 @@ describe('net module', () => {
         assert(typeof httpVersionMinor === 'number')
         assert(httpVersionMinor >= 0)
         response.pause()
-        response.on('data', (chunk) => {
-        })
-        response.on('end', () => {
-          done()
-        })
+        response.on('data', (chunk) => {})
+        response.on('end', () => { done() })
         response.resume()
       })
       urlRequest.end()


### PR DESCRIPTION
#### Description of Change

BREAKING CHANGE

Fixes https://github.com/electron/electron/issues/8117.

Filters net module incoming headers to more accurately match those returned in [`http.IncomingMessage`](https://nodejs.org/api/http.html#http_message_headers).

cc @nornagon @MarshallOfSound 

More specifically, after this change: 
* Duplicates of `age`, `authorization`, `content-length`, `content-type`, `etag`, `expires`, `from`, `host`, `if-modified-since`, `if-unmodified-since`, `last-modified`, `location`, `max-forwards`, `proxy-authorization`, `referer`, `retry-after`, or `user-agent` are discarded.
* `set-cookie` is always an array. Duplicates are added to the array.
* For duplicate cookie headers, the values are joined together with '; '.
* For all other headers, the values are joined together with ', '.

Tested with:
```js
const { app } = require('electron')

app.on('ready', () => {
  const { net } = require('electron')
  const request = net.request('https://github.com')
  request.on('response', response => {
    console.log('HEADERS: ', response.headers)
  })
  request.end()
})
```
to ensure that headers conform to the new rules appropriately


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are added or changed
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed disparity between `net` module headers and Node.js'  `http.IncomingMessage` headers
