### PR TITLE
fix: correctly return properties on the netLog module

### DIFF
--- a/lib/browser/api/net-log.js
+++ b/lib/browser/api/net-log.js
@@ -10,7 +10,11 @@ Object.setPrototypeOf(module.exports, new Proxy({}, {
     if (!app.isReady()) return
 
     const netLog = session.defaultSession.netLog
+
     if (!Object.getPrototypeOf(netLog).hasOwnProperty(property)) return
+
+    // check for properties on the prototype chain  that aren't functions
+    if (typeof netLog[property] !== 'function') return netLog[property]
 
     // Returning a native function directly would throw error.
     return (...args) => netLog[property](...args)


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/17519.

We were unconditionally assuming all properties on the prototype chain were functions, which wouldn't be true in the case of `currentlyLogging` and `currentlyLoggingPath`. This adds a check to return non-function properties correctly.

cc @MarshallOfSound @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with netLog module properties not being returned correctly.
