### PR TITLE
fix: correct crash reporter for Windows on Arm

### DIFF
--- a/atom/common/crash_reporter/crash_reporter_win.cc
+++ b/atom/common/crash_reporter/crash_reporter_win.cc
@@ -93,8 +93,13 @@ bool RegisterNonABICompliantCodeRange(void* start, size_t size_in_bytes) {
 
   // All addresses are 32bit relative offsets to start.
   record->runtime_function.BeginAddress = 0;
+#if defined(_M_ARM64)
+  record->runtime_function.FunctionLength =
+      base::checked_cast<DWORD>(size_in_bytes);
+#else
   record->runtime_function.EndAddress =
       base::checked_cast<DWORD>(size_in_bytes);
+#endif
   record->runtime_function.UnwindData =
       offsetof(ExceptionHandlerRecord, unwind_info);
 


### PR DESCRIPTION
#### Description of Change
Windows for Arm64's header files clean up and move around `RUNTIME_FUNCTION` structure fields. With this PR applied, electron now builds cleanly for Windows on Arm.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes