### PR TITLE
fix: use file path as key for safeDialogs on filesystem

### DIFF
--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -41,7 +41,16 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     DialogClosedCallback callback,
     bool* did_suppress_message) {
   auto origin_url = rfh->GetLastCommittedURL();
-  const std::string& origin = origin_url.GetOrigin().spec();
+
+  std::string origin;
+  // For file:// URLs we do the alert filtering by the
+  // file path currently loaded
+  if (origin_url.SchemeIsFile()) {
+    origin = origin_url.path();
+  } else {
+    origin = origin_url.GetOrigin().spec();
+  }
+
   if (origin_counts_[origin] == kUserWantsNoMoreDialogs) {
     return std::move(callback).Run(false, base::string16());
   }


### PR DESCRIPTION
#### Description of Change
`file://` protocol URLs weren't getting valid keys for the count store.

Notes: The `safeDialogs` webPreferences option now actually works on `file://` URLs