### PR TITLE
fix: set default_id and cancel_id correctly on confirm dialogs

### DIFF
--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -52,9 +52,16 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
     return;
   }
 
+  // No default button
+  int default_id = -1;
+  int cancel_id = 0;
+
   std::vector<std::string> buttons = {"OK"};
   if (dialog_type == JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_CONFIRM) {
     buttons.push_back("Cancel");
+    // First button is default, second button is cancel
+    default_id = 0;
+    cancel_id = 1;
   }
 
   origin_counts_[origin]++;
@@ -76,8 +83,8 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
   }
 
   atom::ShowMessageBox(
-      window, atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, -1, 0,
-      atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
+      window, atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, default_id,
+      cancel_id, atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
       base::UTF16ToUTF8(message_text), "", checkbox, false, gfx::ImageSkia(),
       base::Bind(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
                  base::Unretained(this), base::Passed(std::move(callback)),


### PR DESCRIPTION
#### Description of Change
Sets `cancel_id` to the Cancel button and `default_id` to the OK button in CONFIRM type dialogs. (`window.confirm`)

Fixes #17502

#### Release Notes

Notes: Fixed the handling of the escape key in dialogs created by `window.confirm`. The "Cancel" button is now triggered by the escape key, and the "OK" button is now triggered by the return key.
