### PR TITLE
fix: crash when failed to get devices in desktopCapturer

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -165,8 +165,14 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
       std::vector<std::string> device_names;
       // Crucially, this list of device names will be in the same order as
       // |media_list_sources|.
-      webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
-          &device_names);
+      bool success =
+          webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
+              &device_names);
+
+      if (!success)
+        Emit("finished",
+             "Failed to get device names of all screens on the system.");
+
       int device_name_index = 0;
       for (auto& source : screen_sources) {
         const auto& device_name = device_names[device_name_index++];

--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -165,13 +165,11 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
       std::vector<std::string> device_names;
       // Crucially, this list of device names will be in the same order as
       // |media_list_sources|.
-      bool success =
-          webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
-              &device_names);
-
-      if (!success)
-        Emit("finished",
-             "Failed to get device names of all screens on the system.");
+      if (!webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
+              &device_names)) {
+        Emit("error", "Failed to get sources.");
+        return;
+      }
 
       int device_name_index = 0;
       for (auto& source : screen_sources) {

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -26,7 +26,8 @@ ipcMainUtils.handle('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', (event, cap
         thumbnailSize,
         fetchWindowIcons
       },
-      resolve
+      resolve,
+      reject
     }
     requestsQueue.push(request)
     if (requestsQueue.length === 1) {
@@ -45,6 +46,12 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   // Receiving sources result from main process, now send them back to renderer.
   const handledRequest = requestsQueue.shift()
   const unhandledRequestsQueue = []
+
+  if (name === 'error') {
+    const error = sources
+    handledRequest.reject(error)
+    return
+  }
 
   const result = sources.map(source => {
     return {


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/17551.

`GetDeviceNames` returns a boolean on success, which we previously weren't checking and just assuming would succeed. On failure, the devices list would be empty, which caused the crash experience by a user in the above issue.

This PR changes that `DxgiDuplicatorController` call and checks the boolean so that a descriptive error is now emitted instead of a crash on failure.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when failed to get devices in desktopCapturer on Windows.
