### PR TITLE
build: speed up windows download of external binaries

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -68,7 +68,7 @@ def download(text, url, path):
     web_file = urllib2.urlopen(url)
     file_size = int(web_file.info().getheaders("Content-Length")[0])
     downloaded_size = 0
-    block_size = 128
+    block_size = 4096
 
     ci = os.environ.get('CI') is not None
 


### PR DESCRIPTION
So turns out Windows so _so bad_ at printing stuff on stdout that this script literally makes my computer take 5 minutes to download a 300kb zip file.

This makes it finish in a few seconds 👍 

Notes: no-notes