### PR TITLE
fix: event leak when reusing TouchBarItems

### DIFF
--- a/lib/browser/api/touch-bar.js
+++ b/lib/browser/api/touch-bar.js
@@ -46,7 +46,6 @@ class TouchBar extends EventEmitter {
 
     const registerItem = (item) => {
       this.items[item.id] = item
-      item.on('change', this.changeListener)
       if (item.child instanceof TouchBar) {
         item.child.ordereredItems.forEach(registerItem)
       }
@@ -85,6 +84,16 @@ class TouchBar extends EventEmitter {
     if (this.windowListeners.hasOwnProperty(id)) return
 
     window._touchBar = this
+
+    const registerItems = (items) => {
+      for (const item of items) {
+        item.on('change', this.changeListener)
+        if (item.child instanceof TouchBar) {
+          registerItems(item.child.ordereredItems)
+        }
+      }
+    }
+    registerItems(this.ordereredItems)
 
     const changeListener = (itemID) => {
       window._refreshTouchBarItem(itemID)


### PR DESCRIPTION
#### Description of Change
When reusing a `TouchBarItem` in more than 10 instances of `TouchBar` the following warning will show up:
```
(node:14027) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 change listeners added. Use emitter.setMaxListeners() to increase limit
```

Here's a code example of this issue ([fiddle](https://gist.github.com/e86b3054fe72f9a47c645737f0ea874e)):
```javascript
const {TouchBar} = require('electron')
const {TouchBarSpacer} = TouchBar

const flexSpace = new TouchBarSpacer({ size: 'flexible' })
for(let i = 0; i < 11; i++){
  new TouchBar([
    flexSpace
  ]);
}
```

This warning will still appear if reusing a `TouchBarItem` over 11 different windows with different `TouchBar`s but in that case it won't be a leak.

Related issue: https://github.com/electron/electron/issues/12508 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed event leak when creating many TouchBar instances that reuse TouchBarItems.