### PR TITLE
fix: update patch to make Windows key work with global shortcuts

### DIFF
--- a/patches/common/chromium/command-ismediakey.patch
+++ b/patches/common/chromium/command-ismediakey.patch
@@ -18,7 +18,7 @@ diff --git a/chrome/browser/extensions/global_shortcut_listener_mac.mm b/chrome/
 index befe726af9c10b1563a7fc0bb77cc55f65943d5c..46c6fe08bab8471007f78d3ef227e5195bfdf0e1 100644
 --- a/chrome/browser/extensions/global_shortcut_listener_mac.mm
 +++ b/chrome/browser/extensions/global_shortcut_listener_mac.mm
-@@ -21,6 +21,26 @@
+@@ -21,6 +21,26 @@ using extensions::GlobalShortcutListenerMac;
  
  namespace extensions {
  
@@ -46,7 +46,7 @@ index befe726af9c10b1563a7fc0bb77cc55f65943d5c..46c6fe08bab8471007f78d3ef227e519
  GlobalShortcutListener* GlobalShortcutListener::GetInstance() {
    CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
 diff --git a/chrome/browser/extensions/global_shortcut_listener_win.cc b/chrome/browser/extensions/global_shortcut_listener_win.cc
-index f5d0ac4ba826ee4f023224ce90c6d8b6614c2912..2dac08bf9fb46beed57484636c9304ceaea347fc 100644
+index f5d0ac4ba826ee4f023224ce90c6d8b6614c2912..380682029d20cab485bb8b52bd5c7d9cdc424c7d 100644
 --- a/chrome/browser/extensions/global_shortcut_listener_win.cc
 +++ b/chrome/browser/extensions/global_shortcut_listener_win.cc
 @@ -62,6 +62,8 @@ void GlobalShortcutListenerWin::OnWndProc(HWND hwnd,
@@ -58,6 +58,14 @@ index f5d0ac4ba826ee4f023224ce90c6d8b6614c2912..2dac08bf9fb46beed57484636c9304ce
    ui::Accelerator accelerator(
        ui::KeyboardCodeForWindowsKeyCode(key_code), modifiers);
  
+@@ -98,6 +100,7 @@ bool GlobalShortcutListenerWin::RegisterAcceleratorImpl(
+   modifiers |= accelerator.IsShiftDown() ? MOD_SHIFT : 0;
+   modifiers |= accelerator.IsCtrlDown() ? MOD_CONTROL : 0;
+   modifiers |= accelerator.IsAltDown() ? MOD_ALT : 0;
++  modifiers |= accelerator.IsCmdDown() ? MOD_WIN : 0;
+ 
+   // Create an observer that registers a hot key for |accelerator|.
+   std::unique_ptr<gfx::SingletonHwndHotKeyObserver> observer =
 diff --git a/chrome/browser/extensions/global_shortcut_listener_x11.cc b/chrome/browser/extensions/global_shortcut_listener_x11.cc
 index 392cf3d58c64c088596e8d321a2ce37b0ec60b6e..43e30f47240dc10a3a9b950255d4e48792cc4159 100644
 --- a/chrome/browser/extensions/global_shortcut_listener_x11.cc
@@ -96,7 +104,7 @@ index 71b417ee8b64aa2ff7f1b2390851668ec1dcd7cf..1768af408d4cc3075e5bae046649e495
    }
    return VKEY_UNKNOWN;
  }
-@@ -192,7 +198,10 @@ static CGEventRef EventTapCallback(CGEventTapProxy proxy,
+@@ -192,7 +198,10 @@ CGEventRef MediaKeysListenerImpl::EventTapCallback(CGEventTapProxy proxy,
    int key_code = (data1 & 0xFFFF0000) >> 16;
    if (key_code != NX_KEYTYPE_PLAY && key_code != NX_KEYTYPE_NEXT &&
        key_code != NX_KEYTYPE_PREVIOUS && key_code != NX_KEYTYPE_FAST &&


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes #17246.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a bug which caused global shortcuts with the Windows key not to work properly on Windows.<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
