### PR TITLE
fix: update patch to make Windows key work with global shortcuts (backport: 5-0-x)

### DIFF
--- a/patches/common/chromium/command-ismediakey.patch
+++ b/patches/common/chromium/command-ismediakey.patch
@@ -46,7 +46,7 @@ index befe726af9c10b1563a7fc0bb77cc55f65943d5c..46c6fe08bab8471007f78d3ef227e519
  GlobalShortcutListener* GlobalShortcutListener::GetInstance() {
    CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
 diff --git a/chrome/browser/extensions/global_shortcut_listener_win.cc b/chrome/browser/extensions/global_shortcut_listener_win.cc
-index eb58c51eb768bb013e293649e0308786c5482e21..e469e5115fce12fe5d382bd75d9c6f41fa24293e 100644
+index f5d0ac4ba826ee4f023224ce90c6d8b6614c2912..380682029d20cab485bb8b52bd5c7d9cdc424c7d 100644
 --- a/chrome/browser/extensions/global_shortcut_listener_win.cc
 +++ b/chrome/browser/extensions/global_shortcut_listener_win.cc
 @@ -62,6 +62,8 @@ void GlobalShortcutListenerWin::OnWndProc(HWND hwnd,
@@ -58,6 +58,14 @@ index eb58c51eb768bb013e293649e0308786c5482e21..e469e5115fce12fe5d382bd75d9c6f41
    ui::Accelerator accelerator(
        ui::KeyboardCodeForWindowsKeyCode(key_code), modifiers);
  
+@@ -98,6 +100,7 @@ bool GlobalShortcutListenerWin::RegisterAcceleratorImpl(
+   modifiers |= accelerator.IsShiftDown() ? MOD_SHIFT : 0;
+   modifiers |= accelerator.IsCtrlDown() ? MOD_CONTROL : 0;
+   modifiers |= accelerator.IsAltDown() ? MOD_ALT : 0;
++  modifiers |= accelerator.IsCmdDown() ? MOD_WIN : 0;
+ 
+   // Create an observer that registers a hot key for |accelerator|.
+   std::unique_ptr<gfx::SingletonHwndHotKeyObserver> observer =
 diff --git a/chrome/browser/extensions/global_shortcut_listener_x11.cc b/chrome/browser/extensions/global_shortcut_listener_x11.cc
 index 392cf3d58c64c088596e8d321a2ce37b0ec60b6e..43e30f47240dc10a3a9b950255d4e48792cc4159 100644
 --- a/chrome/browser/extensions/global_shortcut_listener_x11.cc


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Backport of #17565.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a bug which caused global shortcuts with the Windows key not to work properly on Windows.<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
