### PR TITLE
fix: handle a race condition between preload scripts executing and navigations

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1200,6 +1200,9 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   params.transition_type = ui::PAGE_TRANSITION_TYPED;
   params.should_clear_history_list = true;
   params.override_user_agent = content::NavigationController::UA_OVERRIDE_TRUE;
+  // Discord non-committed entries to ensure that we don't re-use a pending
+  // entry
+  web_contents()->GetController().DiscardNonCommittedEntries();
   web_contents()->GetController().LoadURLWithParams(params);
 
   // Set the background color of RenderWidgetHostView.


### PR DESCRIPTION
There is a race condition between DidCreateScriptContext and another navigation occuring in the main process. If the navigation occurs while the preload script is running, the same process is re-used.  This ensures that any pending navigations are completely removed / ignored when we trigger a new navigation.

Refs #17576

Please note that although this refs #17576 it does not completely fix that issue, it makes it way harder to occur but it could still occur.  This is the quick fix, I'll be following up with another patch later to fix this / patch over this in the NavigationController impl in Chromium.

#### Release Notes

Notes:  Fixed issue where preload scripts would sometimes run twice in the same process in different contexts resulting in broken native node module loading.
