### PR TITLE
refactor: expose ipcRendererInternal to the main world for window-setup using the content script world pattern

### DIFF
--- a/lib/content_script/init.js
+++ b/lib/content_script/init.js
@@ -24,9 +24,9 @@ Object.setPrototypeOf(process, EventEmitter.prototype)
 const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
 
 if (isolatedWorldArgs) {
-  const { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+  const { guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
   const { windowSetup } = require('@electron/internal/renderer/window-setup')
-  windowSetup(ipcRendererInternal, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+  windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 }
 
 const extensionId = v8Util.getHiddenValue(isolatedWorld, `extension-${worldId}`)

--- a/lib/isolated_renderer/init.js
+++ b/lib/isolated_renderer/init.js
@@ -2,9 +2,13 @@
 
 /* global nodeProcess, isolatedWorld */
 
-const electronBinding = require('@electron/internal/common/atom-binding-setup').electronBindingSetup(nodeProcess.binding, 'renderer')
+process.electronBinding = require('@electron/internal/common/atom-binding-setup').electronBindingSetup(nodeProcess.binding, 'renderer')
 
-const v8Util = electronBinding('v8_util')
+const v8Util = process.electronBinding('v8_util')
+
+// The `lib/renderer/ipc-renderer-internal.js` module looks for the ipc object in the
+// "ipc-internal" hidden value
+v8Util.setHiddenValue(global, 'ipc-internal', v8Util.getHiddenValue(isolatedWorld, 'ipc-internal'))
 
 const webViewImpl = v8Util.getHiddenValue(isolatedWorld, 'web-view-impl')
 
@@ -17,7 +21,7 @@ if (webViewImpl) {
 const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
 
 if (isolatedWorldArgs) {
-  const { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+  const { guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
   const { windowSetup } = require('@electron/internal/renderer/window-setup')
-  windowSetup(ipcRendererInternal, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+  windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 }

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -82,7 +82,7 @@ switch (window.location.protocol) {
   default: {
     // Override default web functions.
     const { windowSetup } = require('@electron/internal/renderer/window-setup')
-    windowSetup(ipcRendererInternal, guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 
     // Inject content scripts.
     require('@electron/internal/renderer/content-scripts-injector')(process.getRenderProcessPreferences)


### PR DESCRIPTION
#### Description of Change
This allows using the `ipc-renderer-internal-utils` module easily, without having to pass it from the outside as well. Inspired by https://github.com/electron/electron/pull/17032 (which got fixed in https://github.com/electron/electron/pull/17422)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes