### PR TITLE
fix: ensure dots in content script patterns aren't used as wildcards

### DIFF
--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -21,11 +21,15 @@ const getIsolatedWorldIdForInstance = () => {
   return isolatedWorldIds++
 }
 
+const escapePattern = function (pattern: string) {
+  return pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')
+}
+
 // Check whether pattern matches.
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern: string) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')}$`)
+  const regexp = new RegExp(`^${escapePattern(pattern)}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -22,14 +22,14 @@ const getIsolatedWorldIdForInstance = () => {
 }
 
 const escapePattern = function (pattern: string) {
-  return pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')
+  return pattern.replace(/[\\^$+?.()|[\]{}]/g, '\\$&')
 }
 
 // Check whether pattern matches.
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern: string) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${escapePattern(pattern)}$`)
+  const regexp = new RegExp(`^${pattern.split('*').map(escapePattern).join('.*')}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -25,7 +25,7 @@ const getIsolatedWorldIdForInstance = () => {
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern: string) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${pattern.replace(/\*/g, '.*')}$`)
+  const regexp = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -25,7 +25,7 @@ const getIsolatedWorldIdForInstance = () => {
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern: string) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`)
+  const regexp = new RegExp(`^${pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }


### PR DESCRIPTION
Notes: Injected chrome extensions that have content scripts with a `.` in the `pattern` field now treat it as a raw `.` instead of a wildcard