### PR TITLE
fix: ensure dots in content script patterns aren't used as wildcards

### DIFF
--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -7,7 +7,7 @@ const { runInThisContext } = require('vm')
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`)
+  const regexp = new RegExp(`^${pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -3,11 +3,15 @@
 const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
 const { runInThisContext } = require('vm')
 
+const escapePattern = function (pattern) {
+  return pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')
+}
+
 // Check whether pattern matches.
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')}$`)
+  const regexp = new RegExp(`^${escapePattern(pattern)}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -4,14 +4,14 @@ const ipcRenderer = require('@electron/internal/renderer/ipc-renderer-internal')
 const { runInThisContext } = require('vm')
 
 const escapePattern = function (pattern) {
-  return pattern.split('*').map(x => x.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))).join('.*')
+  return pattern.replace(/[\\^$+?.()|[\]{}]/g, '\\$&')
 }
 
 // Check whether pattern matches.
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${escapePattern(pattern)}$`)
+  const regexp = new RegExp(`^${pattern.split('*').map(escapePattern).join('.*')}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }

--- a/lib/renderer/content-scripts-injector.js
+++ b/lib/renderer/content-scripts-injector.js
@@ -7,7 +7,7 @@ const { runInThisContext } = require('vm')
 // https://developer.chrome.com/extensions/match_patterns
 const matchesPattern = function (pattern) {
   if (pattern === '<all_urls>') return true
-  const regexp = new RegExp(`^${pattern.replace(/\*/g, '.*')}$`)
+  const regexp = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`)
   const url = `${location.protocol}//${location.host}${location.pathname}`
   return url.match(regexp)
 }


### PR DESCRIPTION
Backport of #17593

Notes: Injected chrome extensions that have content scripts with a `.` in the `pattern` field now treat it as a raw `.` instead of a wildcard