### PR TITLE
build: ensure we use objc regexps for export-patches

### DIFF
--- a/patches/common/chromium/can_create_window.patch
+++ b/patches/common/chromium/can_create_window.patch
@@ -5,7 +5,7 @@ Subject: can_create_window.patch
 
 
 diff --git a/content/browser/frame_host/render_frame_host_impl.cc b/content/browser/frame_host/render_frame_host_impl.cc
-index a50837cb5b78b72ca5271940e13685885b947e0b..3d4862d257a8758d69b778c807499032be000e50 100644
+index ff75eeab521bf92d0ea40ef6372b229b0233f4f0..6b037a3bd5ace397e1b357498ae3c562084d38af 100644
 --- a/content/browser/frame_host/render_frame_host_impl.cc
 +++ b/content/browser/frame_host/render_frame_host_impl.cc
 @@ -3694,6 +3694,7 @@ void RenderFrameHostImpl::CreateNewWindow(
@@ -32,7 +32,7 @@ index 16a30995a0e20b1a32a418be5a44f1e3c2305cee..637ed8e1ee82cf1cacfedaf142fccc7d
  
  // Operation result when the renderer asks the browser to create a new window.
 diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
-index f60a65efffe1dbf7850063b0c8f236bc94841dfd..798a62cbb030514ce2373f898d9680ceda7b9062 100644
+index 9cd2333fe0270a36e4fdc67231adec3324f2f814..4665bd481c452ff790f3626b2f5dc2ab621ebfdf 100644
 --- a/content/public/browser/content_browser_client.cc
 +++ b/content/public/browser/content_browser_client.cc
 @@ -506,6 +506,8 @@ bool ContentBrowserClient::CanCreateWindow(
@@ -45,7 +45,7 @@ index f60a65efffe1dbf7850063b0c8f236bc94841dfd..798a62cbb030514ce2373f898d9680ce
      bool opener_suppressed,
      bool* no_javascript_access) {
 diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
-index 9ed297dba6d9005e2183c9d7ec35f0389ea1ec70..5a6d3cbf0a913f56a789ac1166d850eb29332a78 100644
+index 009991aa57e8f543d2fdb7095b2fe2c863373d71..ef7385a2d8619b1264e4aa77629d16948bd3669a 100644
 --- a/content/public/browser/content_browser_client.h
 +++ b/content/public/browser/content_browser_client.h
 @@ -175,6 +175,7 @@ class RenderFrameHost;

--- a/patches/common/chromium/command-ismediakey.patch
+++ b/patches/common/chromium/command-ismediakey.patch
@@ -18,7 +18,7 @@ diff --git a/chrome/browser/extensions/global_shortcut_listener_mac.mm b/chrome/
 index befe726af9c10b1563a7fc0bb77cc55f65943d5c..46c6fe08bab8471007f78d3ef227e5195bfdf0e1 100644
 --- a/chrome/browser/extensions/global_shortcut_listener_mac.mm
 +++ b/chrome/browser/extensions/global_shortcut_listener_mac.mm
-@@ -21,6 +21,26 @@ using extensions::GlobalShortcutListenerMac;
+@@ -21,6 +21,26 @@
  
  namespace extensions {
  
@@ -104,7 +104,7 @@ index 71b417ee8b64aa2ff7f1b2390851668ec1dcd7cf..1768af408d4cc3075e5bae046649e495
    }
    return VKEY_UNKNOWN;
  }
-@@ -192,7 +198,10 @@ CGEventRef MediaKeysListenerImpl::EventTapCallback(CGEventTapProxy proxy,
+@@ -192,7 +198,10 @@ static CGEventRef EventTapCallback(CGEventTapProxy proxy,
    int key_code = (data1 & 0xFFFF0000) >> 16;
    if (key_code != NX_KEYTYPE_PLAY && key_code != NX_KEYTYPE_NEXT &&
        key_code != NX_KEYTYPE_PREVIOUS && key_code != NX_KEYTYPE_FAST &&

--- a/patches/common/chromium/cross_site_document_resource_handler.patch
+++ b/patches/common/chromium/cross_site_document_resource_handler.patch
@@ -22,7 +22,7 @@ index f86a9167ac1ec5e7b082e474eb4b5f217d06df92..47df32ecb078a8f18e474f5c38faf2c7
  }
  
 diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
-index 337bb0ed74b3efe7ae0bcb6ea8ef662becb0cabd..a3dcd9c097254fa7b9f7278f6e960be27cfbd133 100644
+index 08fd583f43c15505fa7b8fa4947db429bb3cc595..a841e5c00e2fcc52481ffffcd62fa55892ab8109 100644
 --- a/content/public/browser/content_browser_client.cc
 +++ b/content/public/browser/content_browser_client.cc
 @@ -61,6 +61,10 @@ ContentBrowserClient::SiteInstanceForNavigationType ContentBrowserClient::Should
@@ -37,7 +37,7 @@ index 337bb0ed74b3efe7ae0bcb6ea8ef662becb0cabd..a3dcd9c097254fa7b9f7278f6e960be2
      const MainFunctionParams& parameters) {
    return nullptr;
 diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
-index 3dfe4abcc76b88580d818ea1bd61a0e32c0af882..924d9da7d9f6bd6b1adc1aa2d286f3cc998efdce 100644
+index 53aeab691ae012401008162e71415e64fa204177..9161d0055ad26bd95de7f8fcad3c1587db1e54e9 100644
 --- a/content/public/browser/content_browser_client.h
 +++ b/content/public/browser/content_browser_client.h
 @@ -241,6 +241,9 @@ class CONTENT_EXPORT ContentBrowserClient {

--- a/patches/common/chromium/disable_color_correct_rendering.patch
+++ b/patches/common/chromium/disable_color_correct_rendering.patch
@@ -215,7 +215,7 @@ index e43e5f6bb667a62e7e1205e8da6073de6179e79f..027a552cfbfce3f4f8fe5670bec7db45
      service_manager::switches::kGpuSandboxAllowSysVShm,
      service_manager::switches::kGpuSandboxFailuresFatal,
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index 2588bbfa0f90f7e2204e9d544c8cc562396ae9ad..d21a7911db396682640e0ce9a5d8961f82a7b69f 100644
+index b5a8bc48d92a6b2f7fc031ca7ee662db26941008..7805ce82b11be1eaed59aae1fe76f6fd13e901a5 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -220,6 +220,7 @@
@@ -235,7 +235,7 @@ index 2588bbfa0f90f7e2204e9d544c8cc562396ae9ad..d21a7911db396682640e0ce9a5d8961f
      network::switches::kExplicitlyAllowedPorts,
      service_manager::switches::kDisableInProcessStackTraces,
 diff --git a/content/renderer/render_widget.cc b/content/renderer/render_widget.cc
-index fc68491562ad7a4d3c9d81942740ccf6a4ad1453..21ef29b70f47e65b8d1136c6578b9e15a1665743 100644
+index e4e8117be4b425e82b58e7e58ce0008a353e4fba..ede9225f944796d4375a704b944b79c47750f8f2 100644
 --- a/content/renderer/render_widget.cc
 +++ b/content/renderer/render_widget.cc
 @@ -2771,6 +2771,9 @@ cc::LayerTreeSettings RenderWidget::GenerateLayerTreeSettings(

--- a/patches/common/chromium/disable_hidden.patch
+++ b/patches/common/chromium/disable_hidden.patch
@@ -5,7 +5,7 @@ Subject: disable_hidden.patch
 
 
 diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
-index 2e7577d87f0ae54f7390c4dc6ceb874367c41758..c716ef9a9f0f4bcaa080cd4af2702c3c2e406795 100644
+index 5be3603a8100f731e70dd1ea47205c3e213af413..bf9dc541d3e8889f512fe287e48b67210bc5c2b8 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc
 +++ b/content/browser/renderer_host/render_widget_host_impl.cc
 @@ -765,6 +765,9 @@ void RenderWidgetHostImpl::WasHidden() {

--- a/patches/common/chromium/disable_user_gesture_requirement_for_beforeunload_dialogs.patch
+++ b/patches/common/chromium/disable_user_gesture_requirement_for_beforeunload_dialogs.patch
@@ -6,7 +6,7 @@ Subject: disable_user_gesture_requirement_for_beforeunload_dialogs.patch
 See https://github.com/electron/electron/issues/10754
 
 diff --git a/third_party/blink/renderer/core/dom/document.cc b/third_party/blink/renderer/core/dom/document.cc
-index 6925a13ceab4265016a5c22a25cb9476bbcf95dd..8c8937b4b203a1e0fa400bc9840bc51949ae2b30 100644
+index 02e6831f00c14a9aab6ba6d4218a94ec133c6076..5746b1207c4ecd6c2d252be79a7e97bd82cc8d0a 100644
 --- a/third_party/blink/renderer/core/dom/document.cc
 +++ b/third_party/blink/renderer/core/dom/document.cc
 @@ -3682,7 +3682,9 @@ bool Document::DispatchBeforeUnloadEvent(ChromeClient* chrome_client,

--- a/patches/common/chromium/frame_host_manager.patch
+++ b/patches/common/chromium/frame_host_manager.patch
@@ -108,7 +108,7 @@ index cc7c7b4ffab5377fa71016e233fbfaae87d50329..81a351569528e74fa44e68a804de968b
  }
  
 diff --git a/content/public/browser/content_browser_client.cc b/content/public/browser/content_browser_client.cc
-index 798a62cbb030514ce2373f898d9680ceda7b9062..337bb0ed74b3efe7ae0bcb6ea8ef662becb0cabd 100644
+index 4665bd481c452ff790f3626b2f5dc2ab621ebfdf..08fd583f43c15505fa7b8fa4947db429bb3cc595 100644
 --- a/content/public/browser/content_browser_client.cc
 +++ b/content/public/browser/content_browser_client.cc
 @@ -51,6 +51,16 @@ void OverrideOnBindInterface(const service_manager::BindSourceInfo& remote_info,
@@ -129,7 +129,7 @@ index 798a62cbb030514ce2373f898d9680ceda7b9062..337bb0ed74b3efe7ae0bcb6ea8ef662b
      const MainFunctionParams& parameters) {
    return nullptr;
 diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
-index 5a6d3cbf0a913f56a789ac1166d850eb29332a78..3dfe4abcc76b88580d818ea1bd61a0e32c0af882 100644
+index ef7385a2d8619b1264e4aa77629d16948bd3669a..53aeab691ae012401008162e71415e64fa204177 100644
 --- a/content/public/browser/content_browser_client.h
 +++ b/content/public/browser/content_browser_client.h
 @@ -210,8 +210,37 @@ CONTENT_EXPORT void OverrideOnBindInterface(

--- a/patches/common/chromium/mas_no_private_api.patch
+++ b/patches/common/chromium/mas_no_private_api.patch
@@ -181,10 +181,10 @@ index 9b8e15866a325faee845a97f0e5a2f14e343d2f6..148d5fdd3f11ab318f6a0d0add23bd45
    return nil;
  }
 diff --git a/content/browser/accessibility/browser_accessibility_manager_mac.mm b/content/browser/accessibility/browser_accessibility_manager_mac.mm
-index 2a1ad6a78e90ea8b84630bcefeacab7cf9ec7a05..fced3606ea1a3746554ee7bfbf80fec3dad46c37 100644
+index 47525323f56ca591ac5551c45dbdfed5208ac674..d559e05afb73c73e37d0c11ee5dc1597699ab562 100644
 --- a/content/browser/accessibility/browser_accessibility_manager_mac.mm
 +++ b/content/browser/accessibility/browser_accessibility_manager_mac.mm
-@@ -460,6 +460,7 @@ void PostAnnouncementNotification(NSString* announcement) {
+@@ -461,6 +461,7 @@ void PostAnnouncementNotification(NSString* announcement) {
        [user_info setObject:native_focus_object
                      forKey:NSAccessibilityTextChangeElement];
  
@@ -192,7 +192,7 @@ index 2a1ad6a78e90ea8b84630bcefeacab7cf9ec7a05..fced3606ea1a3746554ee7bfbf80fec3
        id selected_text = [native_focus_object selectedTextMarkerRange];
        if (selected_text) {
          NSString* const NSAccessibilitySelectedTextMarkerRangeAttribute =
-@@ -467,6 +468,7 @@ void PostAnnouncementNotification(NSString* announcement) {
+@@ -468,6 +469,7 @@ void PostAnnouncementNotification(NSString* announcement) {
          [user_info setObject:selected_text
                        forKey:NSAccessibilitySelectedTextMarkerRangeAttribute];
        }

--- a/patches/common/chromium/notification_provenance.patch
+++ b/patches/common/chromium/notification_provenance.patch
@@ -106,7 +106,7 @@ index c7c9bc8fb304697bb1802d04e26038c65b8facdc..e73d2b0a276d4a0a7d1a484d11d5ac43
  
    // Removes |service| from the list of owned services, for example because the
 diff --git a/content/browser/renderer_interface_binders.cc b/content/browser/renderer_interface_binders.cc
-index 8e4df0b15aebc30c517a8c99f20201d8148777e0..ad49782df16c92a6ed0f736a5980263de908c137 100644
+index b317a37b4fa12be4e737a91948110fd16308c221..b3968f52c478ce051370e543b2fb904360d7892c 100644
 --- a/content/browser/renderer_interface_binders.cc
 +++ b/content/browser/renderer_interface_binders.cc
 @@ -189,7 +189,7 @@ void RendererInterfaceBinders::InitializeParameterizedBinderRegistry() {

--- a/patches/common/chromium/scroll_bounce_flag.patch
+++ b/patches/common/chromium/scroll_bounce_flag.patch
@@ -6,7 +6,7 @@ Subject: scroll_bounce_flag.patch
 Patch to make scrollBounce option work.
 
 diff --git a/content/renderer/render_thread_impl.cc b/content/renderer/render_thread_impl.cc
-index 9d029d4ee65b3246b3cca4c338e53c43731a6e5d..b4ad334e00bcbaa5ad4d96a3f34b2372027a35f0 100644
+index 44d963793f143530704a0a06273e51d7c68766cc..5cea319fea51e27f6bd5be7221bafb186b2a3973 100644
 --- a/content/renderer/render_thread_impl.cc
 +++ b/content/renderer/render_thread_impl.cc
 @@ -1535,7 +1535,7 @@ bool RenderThreadImpl::IsGpuMemoryBufferCompositorResourcesEnabled() {

--- a/patches/common/chromium/support_mixed_sandbox_with_zygote.patch
+++ b/patches/common/chromium/support_mixed_sandbox_with_zygote.patch
@@ -22,7 +22,7 @@ However, the patch would need to be reviewed by the security team, as it
 does touch a security-sensitive class.
 
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index 92a6bcde3867a8d0f7a36e5b892de67b9d777f60..2588bbfa0f90f7e2204e9d544c8cc562396ae9ad 100644
+index d2cf83659d91d0439c341d8b9fe40d36f616a9d3..b5a8bc48d92a6b2f7fc031ca7ee662db26941008 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -423,6 +423,10 @@ class RendererSandboxedProcessLauncherDelegate

--- a/patches/common/chromium/web_contents.patch
+++ b/patches/common/chromium/web_contents.patch
@@ -5,10 +5,10 @@ Subject: web_contents.patch
 
 
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
-index 9ad76884fa8cff7e9940a478a50df0260dda366a..d6590498e9f188a829440e61a169fb57221a3b5f 100644
+index c7ea2789c7d8cb28df9f270340c201cf73a03e7e..34578d40d4505d7bb134650686c2cc61af2c7c3a 100644
 --- a/content/browser/web_contents/web_contents_impl.cc
 +++ b/content/browser/web_contents/web_contents_impl.cc
-@@ -2068,6 +2068,12 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params) {
+@@ -2069,6 +2069,12 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params) {
    std::string unique_name;
    frame_tree_.root()->SetFrameName(params.main_frame_name, unique_name);
  
@@ -21,7 +21,7 @@ index 9ad76884fa8cff7e9940a478a50df0260dda366a..d6590498e9f188a829440e61a169fb57
    WebContentsViewDelegate* delegate =
        GetContentClient()->browser()->GetWebContentsViewDelegate(this);
  
-@@ -2083,6 +2089,7 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params) {
+@@ -2084,6 +2090,7 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params) {
            &render_view_host_delegate_view_);
      }
    }

--- a/script/.electron.attributes
+++ b/script/.electron.attributes
@@ -1,1 +1,2 @@
 *.mm diff=objc
+*.m diff=objc

--- a/script/.electron.attributes
+++ b/script/.electron.attributes
@@ -1,0 +1,1 @@
+*.mm diff=objc

--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -24,6 +24,12 @@ def format_patch(repo, since):
     'git',
     '-C',
     repo,
+    '-c',
+    'core.attributesfile=' + os.path.join(os.path.dirname(os.path.realpath(__file__)), '.electron.attributes'),
+    # Ensure it is not possible to match anything
+    # Disabled for now as we have consistent chunk headers
+    # '-c',
+    # 'diff.electron.xfuncname=$^',
     'format-patch',
     '--keep-subject',
     '--no-stat',


### PR DESCRIPTION
This will minimize the churn when folks with different versions of git export/import patches 👍 

Notes: no-notes