### PR TITLE
test: de-flake getAllWebContents test by moving it to spec-main

### DIFF
--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1,0 +1,55 @@
+import * as chai from 'chai'
+import * as chaiAsPromised from 'chai-as-promised'
+import * as path from 'path'
+import { BrowserWindow, webContents } from 'electron'
+import { emittedOnce } from './events-helpers';
+import { closeWindow } from './window-helpers';
+
+const { expect } = chai
+
+chai.use(chaiAsPromised)
+
+const fixturesPath = path.resolve(__dirname, '../spec/fixtures')
+
+describe('webContents module', () => {
+  let w: BrowserWindow = (null as unknown as BrowserWindow)
+
+  beforeEach(() => {
+    w = new BrowserWindow({
+      show: false,
+      width: 400,
+      height: 400,
+      webPreferences: {
+        backgroundThrottling: false,
+        nodeIntegration: true,
+        webviewTag: true
+      }
+    })
+  })
+
+  afterEach(async () => {
+    await closeWindow(w)
+    w = (null as unknown as BrowserWindow)
+  })
+
+  describe('getAllWebContents() API', () => {
+    it('returns an array of web contents', async () => {
+      w.loadFile(path.join(fixturesPath, 'pages', 'webview-zoom-factor.html'))
+
+      await emittedOnce(w.webContents, 'did-attach-webview')
+
+      w.webContents.openDevTools()
+
+      await emittedOnce(w.webContents, 'devtools-opened')
+
+      const all = webContents.getAllWebContents().sort((a, b) => {
+        return a.id - b.id
+      })
+
+      expect(all).to.have.length(3)
+      expect(all[0].getType()).to.equal('window')
+      expect(all[all.length - 2].getType()).to.equal('webview')
+      expect(all[all.length - 1].getType()).to.equal('remote')
+    })
+  })
+})

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -141,28 +141,6 @@ describe('webContents module', () => {
     })
   })
 
-  describe('getAllWebContents() API', () => {
-    it('returns an array of web contents', (done) => {
-      w.webContents.on('devtools-opened', () => {
-        const all = webContents.getAllWebContents().sort((a, b) => {
-          return a.id - b.id
-        })
-
-        assert.ok(all.length >= 4)
-        assert.strictEqual(all[0].getType(), 'window')
-        assert.strictEqual(all[all.length - 2].getType(), 'webview')
-        assert.strictEqual(all[all.length - 1].getType(), 'remote')
-
-        done()
-      })
-
-      w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-factor.html'))
-      w.webContents.on('did-attach-webview', () => {
-        w.webContents.openDevTools()
-      })
-    })
-  })
-
   describe('getFocusedWebContents() API', () => {
     it('returns the focused web contents', (done) => {
       if (isCi) return done()


### PR DESCRIPTION
#### Description of Change
Test was flaky because `did-attach-webview` could be emitted before the listener was attached.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes