### PR TITLE
refactor: mojofy MessageTo and MessageHost

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -934,6 +934,13 @@ void WebContents::MessageTo(bool internal,
   }
 }
 
+void WebContents::MessageHost(const std::string& channel,
+                              base::Value arguments) {
+  // webContents.emit('ipc-message-host', new Event(), channel, args);
+  EmitWithSender("ipc-message-host", bindings_.dispatch_context(),
+                 base::nullopt, channel, std::move(arguments));
+}
+
 void WebContents::RenderFrameDeleted(
     content::RenderFrameHost* render_frame_host) {
   // A RenderFrameHost can be destroyed before the related Mojo binding is
@@ -1112,7 +1119,6 @@ bool WebContents::OnMessageReceived(const IPC::Message& message,
   bool handled = true;
   FrameDispatchHelper helper = {this, frame_host};
   IPC_BEGIN_MESSAGE_MAP_WITH_PARAM(WebContents, message, frame_host)
-    IPC_MESSAGE_HANDLER(AtomFrameHostMsg_Message_Host, OnRendererMessageHost)
     IPC_MESSAGE_FORWARD_DELAY_REPLY(
         AtomFrameHostMsg_SetTemporaryZoomLevel, &helper,
         FrameDispatchHelper::OnSetTemporaryZoomLevel)
@@ -2270,13 +2276,6 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
 
 AtomBrowserContext* WebContents::GetBrowserContext() const {
   return static_cast<AtomBrowserContext*>(web_contents()->GetBrowserContext());
-}
-
-void WebContents::OnRendererMessageHost(content::RenderFrameHost* frame_host,
-                                        const std::string& channel,
-                                        const base::ListValue& args) {
-  // webContents.emit('ipc-message-host', new Event(), channel, args);
-  EmitWithSender("ipc-message-host", frame_host, base::nullopt, channel, args);
 }
 
 // static

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -479,6 +479,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // RenderFrameHost is destroyed, all related bindings will be removed.
   void BindElectronBrowser(mojom::ElectronBrowserRequest request,
                            content::RenderFrameHost* render_frame_host);
+  void OnElectronBrowserConnectionError();
 
   uint32_t GetNextRequestId() { return ++request_id_; }
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -500,14 +500,10 @@ class WebContents : public mate::TrackableObject<WebContents>,
                  int32_t web_contents_id,
                  const std::string& channel,
                  base::Value arguments) override;
+  void MessageHost(const std::string& channel, base::Value arguments) override;
 
   // Called when we receive a CursorChange message from chromium.
   void OnCursorChange(const content::WebCursor& cursor);
-
-  // Called when received a message from renderer to host.
-  void OnRendererMessageHost(content::RenderFrameHost* frame_host,
-                             const std::string& channel,
-                             const base::ListValue& args);
 
   // Called when received a synchronous message from renderer to
   // set temporary zoom level.

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -495,17 +495,14 @@ class WebContents : public mate::TrackableObject<WebContents>,
                    const std::string& channel,
                    base::Value arguments,
                    MessageSyncCallback callback) override;
+  void MessageTo(bool internal,
+                 bool send_to_all,
+                 int32_t web_contents_id,
+                 const std::string& channel,
+                 base::Value arguments) override;
 
   // Called when we receive a CursorChange message from chromium.
   void OnCursorChange(const content::WebCursor& cursor);
-
-  // Called when received a message from renderer to be forwarded.
-  void OnRendererMessageTo(content::RenderFrameHost* frame_host,
-                           bool internal,
-                           bool send_to_all,
-                           int32_t web_contents_id,
-                           const std::string& channel,
-                           const base::ListValue& args);
 
   // Called when received a message from renderer to host.
   void OnRendererMessageHost(content::RenderFrameHost* frame_host,

--- a/atom/browser/ui/webui/pdf_viewer_ui.cc
+++ b/atom/browser/ui/webui/pdf_viewer_ui.cc
@@ -222,7 +222,6 @@ bool PdfViewerUI::OnMessageReceived(
     content::RenderFrameHost* render_frame_host) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(PdfViewerUI, message)
-    IPC_MESSAGE_HANDLER(AtomFrameHostMsg_PDFSaveURLAs, OnSaveURLAs)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;

--- a/atom/common/api/api.mojom
+++ b/atom/common/api/api.mojom
@@ -14,11 +14,16 @@ interface ElectronRenderer {
 };
 
 interface ElectronBrowser {
+  // Emits an event on |channel| from the ipcMain JavaScript object in the main
+  // process.
   Message(
       bool internal,
       string channel,
       mojo_base.mojom.ListValue arguments);
 
+  // Emits an event on |channel| from the ipcMain JavaScript object in the main
+  // process, and waits synchronously for a response.
+  //
   // NB. this is not marked [Sync] because mojo synchronous methods can be
   // reordered with respect to asynchronous methods on the same channel.
   // Instead, callers can manually block on the response to this method.
@@ -26,4 +31,13 @@ interface ElectronBrowser {
     bool internal,
     string channel,
     mojo_base.mojom.ListValue arguments) => (mojo_base.mojom.Value result);
+
+  // Emits an event from the |ipcRenderer| JavaScript object in the target
+  // WebContents's main frame, specified by |web_contents_id|.
+  MessageTo(
+    bool internal,
+    bool send_to_all,
+    int32 web_contents_id,
+    string channel,
+    mojo_base.mojom.ListValue arguments);
 };

--- a/atom/common/api/api.mojom
+++ b/atom/common/api/api.mojom
@@ -40,4 +40,8 @@ interface ElectronBrowser {
     int32 web_contents_id,
     string channel,
     mojo_base.mojom.ListValue arguments);
+
+  MessageHost(
+    string channel,
+    mojo_base.mojom.ListValue arguments);
 };

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -25,10 +25,6 @@ IPC_STRUCT_TRAITS_BEGIN(atom::DraggableRegion)
   IPC_STRUCT_TRAITS_MEMBER(bounds)
 IPC_STRUCT_TRAITS_END()
 
-IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_Message_Host,
-                    std::string /* channel */,
-                    base::ListValue /* arguments */)
-
 IPC_MESSAGE_ROUTED0(AtomViewMsg_Offscreen)
 
 IPC_MESSAGE_ROUTED3(AtomAutofillFrameHostMsg_ShowPopup,

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -51,8 +51,3 @@ IPC_SYNC_MESSAGE_ROUTED1_1(AtomFrameHostMsg_SetTemporaryZoomLevel,
 
 // Sent by renderer to get the zoom level.
 IPC_SYNC_MESSAGE_ROUTED0_1(AtomFrameHostMsg_GetZoomLevel, double /* result */)
-
-// Brings up SaveAs... dialog to save specified URL.
-IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_PDFSaveURLAs,
-                    GURL /* url */,
-                    content::Referrer /* referrer */)

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -25,13 +25,6 @@ IPC_STRUCT_TRAITS_BEGIN(atom::DraggableRegion)
   IPC_STRUCT_TRAITS_MEMBER(bounds)
 IPC_STRUCT_TRAITS_END()
 
-IPC_MESSAGE_ROUTED5(AtomFrameHostMsg_Message_To,
-                    bool /* internal */,
-                    bool /* send_to_all */,
-                    int32_t /* web_contents_id */,
-                    std::string /* channel */,
-                    base::ListValue /* arguments */)
-
 IPC_MESSAGE_ROUTED2(AtomFrameHostMsg_Message_Host,
                     std::string /* channel */,
                     base::ListValue /* arguments */)

--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -48,7 +48,8 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
     mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
         .SetMethod("send", &IPCRenderer::Send)
         .SetMethod("sendSync", &IPCRenderer::SendSync)
-        .SetMethod("sendTo", &IPCRenderer::SendTo);
+        .SetMethod("sendTo", &IPCRenderer::SendTo)
+        .SetMethod("sendToHost", &IPCRenderer::SendToHost);
   }
   static mate::Handle<IPCRenderer> Create(v8::Isolate* isolate) {
     return mate::CreateHandle(isolate, new IPCRenderer(isolate));
@@ -69,6 +70,12 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
               const base::ListValue& arguments) {
     electron_browser_ptr_->MessageTo(internal, send_to_all, web_contents_id,
                                      channel, arguments.Clone());
+  }
+
+  void SendToHost(mate::Arguments* args,
+                  const std::string& channel,
+                  const base::ListValue& arguments) {
+    electron_browser_ptr_->MessageHost(channel, arguments.Clone());
   }
 
   base::Value SendSync(mate::Arguments* args,
@@ -130,27 +137,12 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
   atom::mojom::ElectronBrowserPtr electron_browser_ptr_;
 };
 
-void SendToHost(mate::Arguments* args,
-                const std::string& channel,
-                const base::ListValue& arguments) {
-  RenderFrame* render_frame = GetCurrentRenderFrame();
-  if (render_frame == nullptr)
-    return;
-
-  bool success = render_frame->Send(new AtomFrameHostMsg_Message_Host(
-      render_frame->GetRoutingID(), channel, arguments));
-
-  if (!success)
-    args->ThrowError("Unable to send AtomFrameHostMsg_Message_Host");
-}
-
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
   dict.Set("ipc", IPCRenderer::Create(context->GetIsolate()));
-  dict.SetMethod("sendToHost", &SendToHost);
 }
 
 }  // namespace

--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -47,7 +47,8 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
     prototype->SetClassName(mate::StringToV8(isolate, "IPCRenderer"));
     mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
         .SetMethod("send", &IPCRenderer::Send)
-        .SetMethod("sendSync", &IPCRenderer::SendSync);
+        .SetMethod("sendSync", &IPCRenderer::SendSync)
+        .SetMethod("sendTo", &IPCRenderer::SendTo);
   }
   static mate::Handle<IPCRenderer> Create(v8::Isolate* isolate) {
     return mate::CreateHandle(isolate, new IPCRenderer(isolate));
@@ -58,6 +59,16 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
             const std::string& channel,
             const base::ListValue& arguments) {
     electron_browser_ptr_->Message(internal, channel, arguments.Clone());
+  }
+
+  void SendTo(mate::Arguments* args,
+              bool internal,
+              bool send_to_all,
+              int32_t web_contents_id,
+              const std::string& channel,
+              const base::ListValue& arguments) {
+    electron_browser_ptr_->MessageTo(internal, send_to_all, web_contents_id,
+                                     channel, arguments.Clone());
   }
 
   base::Value SendSync(mate::Arguments* args,
@@ -119,24 +130,6 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
   atom::mojom::ElectronBrowserPtr electron_browser_ptr_;
 };
 
-void SendTo(mate::Arguments* args,
-            bool internal,
-            bool send_to_all,
-            int32_t web_contents_id,
-            const std::string& channel,
-            const base::ListValue& arguments) {
-  RenderFrame* render_frame = GetCurrentRenderFrame();
-  if (render_frame == nullptr)
-    return;
-
-  bool success = render_frame->Send(new AtomFrameHostMsg_Message_To(
-      render_frame->GetRoutingID(), internal, send_to_all, web_contents_id,
-      channel, arguments));
-
-  if (!success)
-    args->ThrowError("Unable to send AtomFrameHostMsg_Message_To");
-}
-
 void SendToHost(mate::Arguments* args,
                 const std::string& channel,
                 const base::ListValue& arguments) {
@@ -157,7 +150,6 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
   dict.Set("ipc", IPCRenderer::Create(context->GetIsolate()));
-  dict.SetMethod("sendTo", &SendTo);
   dict.SetMethod("sendToHost", &SendToHost);
 }
 

--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const binding = process.electronBinding('ipc')
+const { ipc } = process.electronBinding('ipc')
 const v8Util = process.electronBinding('v8_util')
 
 // Created by init.js.
@@ -8,23 +8,23 @@ const ipcRenderer = v8Util.getHiddenValue(global, 'ipc')
 const internal = false
 
 ipcRenderer.send = function (channel, ...args) {
-  return binding.ipc.send(internal, channel, args)
+  return ipc.send(internal, channel, args)
 }
 
 ipcRenderer.sendSync = function (channel, ...args) {
-  return binding.ipc.sendSync(internal, channel, args)[0]
+  return ipc.sendSync(internal, channel, args)[0]
 }
 
 ipcRenderer.sendToHost = function (channel, ...args) {
-  return binding.sendToHost(channel, args)
+  return ipc.sendToHost(channel, args)
 }
 
 ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
-  return binding.ipc.sendTo(internal, false, webContentsId, channel, args)
+  return ipc.sendTo(internal, false, webContentsId, channel, args)
 }
 
 ipcRenderer.sendToAll = function (webContentsId, channel, ...args) {
-  return binding.ipc.sendTo(internal, true, webContentsId, channel, args)
+  return ipc.sendTo(internal, true, webContentsId, channel, args)
 }
 
 module.exports = ipcRenderer

--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -20,11 +20,11 @@ ipcRenderer.sendToHost = function (channel, ...args) {
 }
 
 ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
-  return binding.sendTo(internal, false, webContentsId, channel, args)
+  return binding.ipc.sendTo(internal, false, webContentsId, channel, args)
 }
 
 ipcRenderer.sendToAll = function (webContentsId, channel, ...args) {
-  return binding.sendTo(internal, true, webContentsId, channel, args)
+  return binding.ipc.sendTo(internal, true, webContentsId, channel, args)
 }
 
 module.exports = ipcRenderer

--- a/spec/chrome-api-spec.js
+++ b/spec/chrome-api-spec.js
@@ -73,13 +73,8 @@ describe('chrome api', () => {
     w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`)
 
     const [,, responseString] = await promise
-    try {
-      const response = JSON.parse(responseString)
+    const response = JSON.parse(responseString)
 
-      expect(response).to.equal(3)
-    } catch (e) {
-      console.log(responseString)
-      throw e
-    }
+    expect(response).to.equal(3)
   })
 })

--- a/spec/chrome-api-spec.js
+++ b/spec/chrome-api-spec.js
@@ -73,8 +73,13 @@ describe('chrome api', () => {
     w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`)
 
     const [,, responseString] = await promise
-    const response = JSON.parse(responseString)
+    try {
+      const response = JSON.parse(responseString)
 
-    expect(response).to.equal(3)
+      expect(response).to.equal(3)
+    } catch (e) {
+      console.log(responseString)
+      throw e
+    }
   })
 })


### PR DESCRIPTION
#### Description of Change
Based on #17406

This ports the `MessageTo` and `MessageHost` IPC calls to Mojo.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
