### PR TITLE
fix: make devtools extensions load correctly

### DIFF
--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -213,6 +213,7 @@ void AtomRenderFrameObserver::OnBrowserMessage(bool internal,
   EmitIPCEvent(frame, internal, channel, args, sender_id);
 
   // Also send the message to all sub-frames.
+  // TODO(MarshallOfSound): Completely move this logic to the main process
   if (send_to_all) {
     for (blink::WebFrame* child = frame->FirstChild(); child;
          child = child->NextSibling())

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -397,7 +397,7 @@ const loadDevToolsExtensions = function (win, manifests) {
   extensionInfoArray.forEach((extension) => {
     win.devToolsWebContents._grantOriginAccess(extension.startPage)
   })
-  win.devToolsWebContents.executeJavaScript(`DevToolsAPI.addExtensions(${JSON.stringify(extensionInfoArray)})`)
+  win.devToolsWebContents.executeJavaScript(`InspectorFrontendAPI.addExtensions(${JSON.stringify(extensionInfoArray)})`)
 }
 
 app.on('web-contents-created', function (event, webContents) {

--- a/lib/renderer/chrome-api.ts
+++ b/lib/renderer/chrome-api.ts
@@ -122,7 +122,7 @@ export function injectTo (extensionId: string, context: any) {
         [targetExtensionId, connectInfo] = args
       }
 
-      const { tabId, portId } = ipcRendererInternal.sendSync('CHROME_RUNTIME_CONNECT', targetExtensionId, connectInfo)
+      const { tabId, portId } = ipcRendererUtils.invokeSync('CHROME_RUNTIME_CONNECT', targetExtensionId, connectInfo)
       return new Port(tabId, portId, extensionId, connectInfo.name)
     },
 
@@ -210,4 +210,10 @@ export function injectTo (extensionId: string, context: any) {
 
   chrome.i18n = require('@electron/internal/renderer/extensions/i18n').setup(extensionId)
   chrome.webNavigation = require('@electron/internal/renderer/extensions/web-navigation').setup()
+
+  // Electron has no concept of a browserAction but we should stub these APIs for compatibility
+  chrome.browserAction = {
+    setIcon () {},
+    setPopup () {}
+  }
 }


### PR DESCRIPTION
This is a multi-part fix as each fix revealed a new bug, so, yay I guess 😄 

Fixes #17586

#### `send_to_all` now works better'er

First off, we should remove this API, it's private and bad and we can remove it as soon as extension support lands for real in #17440 

Previously `send_to_all` was handled on the render_frame side  and messages were dispatched to the main frame which then proxied the event to all `WebLocalFrame`'s.  This missed out on all `WebRemoteFrame`'s which only became a problem recently.

This PR changes our `send_to_all` logic where it matters to send to all frames from the browser process.  There is a TODO to completely move our `send_to_all` logic and then remove it 👍 

#### Legacy DevToolsAPI

We were still using the legacy `DevToolsAPI` attach point, updated to use the `InspectorFrontendAPI` API

#### `chrome.browserAction` stubs

Newer versions of React Dev Tools require those APIs to exist or it throws 👍 

#### Fixing `chrome.runtime.connect`

The ipc utils refactor made these APIs stop working so now we use `invoke` on the renderer side correctly

Notes: DevTools Extensions now load correctly