### PR TITLE
build: ensure the sccache server is running before we build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,9 @@ step-setup-env-for-build: &step-setup-env-for-build
       if [ "$USE_SCCACHE" == "true" ]; then
         # https://github.com/mozilla/sccache
         SCCACHE_PATH="$PWD/src/electron/external_binaries/sccache"
+        $SCCACHE_PATH --start-server
+        $SCCACHE_PATH --show-stats
+
         echo 'export SCCACHE_PATH="'"$SCCACHE_PATH"'"' >> $BASH_ENV
         if [ "$CIRCLE_PR_NUMBER" != "" ]; then
           #if building a fork set readonly access to sccache


### PR DESCRIPTION
This fixes a flake seen locally a lot and on CI here --> https://circleci.com/gh/electron/electron/166604 where the sccache build times out because there server did not start in time.  `--start-server` does not time out 👍

Notes: no-notes