### PR TITLE
build: optionally exclude some parts of patches from being applied

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -40,13 +40,17 @@ def get_repo_root(path):
   return get_repo_root(parent_path)
 
 
-def am(repo, patch_data, threeway=False, directory=None,
+def am(repo, patch_data, threeway=False, directory=None, exclude=None,
     committer_name=None, committer_email=None):
   args = []
   if threeway:
     args += ['--3way']
   if directory is not None:
     args += ['--directory', directory]
+  if exclude is not None:
+    for path_pattern in exclude:
+      args += ['--exclude', path_pattern]
+
   root_args = ['-C', repo]
   if committer_name is not None:
     root_args += ['-c', 'user.name=' + committer_name]


### PR DESCRIPTION
#### Description of Change
The change targets Electron consumers who build Electron themselves.
Sometimes not all patch contents are needed, and it's not possible to apply it,
because some parts of the dependencies are missing.

The change is not supposed to affect Electron itself.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes