### PR TITLE
docs: Lead with packaging tools on distribution page

### DIFF
--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -1,5 +1,16 @@
 # Application Distribution
 
+To distribute your app with Electron, you need to package and rebrand it. The easiest way to do this is to use one of the following third party packaging tools:
+
+* [electron-forge](https://github.com/electron-userland/electron-forge)
+* [electron-builder](https://github.com/electron-userland/electron-builder)
+* [electron-packager](https://github.com/electron-userland/electron-packager)
+
+These tools will take care of all the steps you need to take to end up with a distributable Electron applications, such as packaging your application, rebranding the executable, setting the right icons and optionally creating installers. 
+
+## Manual distribution
+You can also choose to manually get your app ready for distribution. The steps needed to do this are outlined below. 
+
 To distribute your app with Electron, you need to download Electron's [prebuilt
 binaries](https://github.com/electron/electron/releases). Next, the folder
 containing your app should be named `app` and placed in Electron's resources
@@ -95,15 +106,6 @@ MyApp.app/Contents
 ### Linux
 
 You can rename the `electron` executable to any name you like.
-
-## Packaging Tools
-
-Apart from packaging your app manually, you can also choose to use third party
-packaging tools to do the work for you:
-
-* [electron-forge](https://github.com/electron-userland/electron-forge)
-* [electron-builder](https://github.com/electron-userland/electron-builder)
-* [electron-packager](https://github.com/electron-userland/electron-packager)
 
 ## Rebranding by Rebuilding Electron from Source
 

--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -6,10 +6,10 @@ To distribute your app with Electron, you need to package and rebrand it. The ea
 * [electron-builder](https://github.com/electron-userland/electron-builder)
 * [electron-packager](https://github.com/electron-userland/electron-packager)
 
-These tools will take care of all the steps you need to take to end up with a distributable Electron applications, such as packaging your application, rebranding the executable, setting the right icons and optionally creating installers. 
+These tools will take care of all the steps you need to take to end up with a distributable Electron applications, such as packaging your application, rebranding the executable, setting the right icons and optionally creating installers.
 
 ## Manual distribution
-You can also choose to manually get your app ready for distribution. The steps needed to do this are outlined below. 
+You can also choose to manually get your app ready for distribution. The steps needed to do this are outlined below.
 
 To distribute your app with Electron, you need to download Electron's [prebuilt
 binaries](https://github.com/electron/electron/releases). Next, the folder


### PR DESCRIPTION
#### Description of Change
Per discussion in the docs and tools workgroup, I updated the application distribution page to lead with automated packaging tools. They're friendlier and less likely to result in errors, so we want to guide users to them. Leading with the automated packaging tools makes them the "first choice". 

#### Release Notes
notes: no-notes