### PR TITLE
build: ensure runner is defined inside the spec callback

### DIFF
--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -75,16 +75,19 @@ app.whenReady().then(() => {
 
   walker.on('end', () => {
     const runner = mocha.run(() => {
-      if (isCi && runner.hasOnly) {
-        try {
-          throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
-        } catch (error) {
-          console.error(error.stack || error)
+      // Ensure the callback is called after runner is defined
+      process.nextTick(() => {
+        if (isCi && runner.hasOnly) {
+          try {
+            throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
+          } catch (error) {
+            console.error(error.stack || error)
+          }
+          process.exit(1)
         }
-        process.exit(1)
-      }
 
-      process.exit(runner.failures)
+        process.exit(runner.failures)
+      })
     })
   })
 })

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -94,21 +94,24 @@
     }
 
     const runner = mocha.run(() => {
-      if (isCi && runner.hasOnly) {
-        try {
-          throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
-        } catch (error) {
-          console.error(error.stack || error)
+      // Ensure the callback is called after runner is defined
+      setTimeout(() => {
+        if (isCi && runner.hasOnly) {
+          try {
+            throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
+          } catch (error) {
+            console.error(error.stack || error)
+          }
+          ipcRenderer.send('process.exit', 1)
+          return
         }
-        ipcRenderer.send('process.exit', 1)
-        return
-      }
 
-      Mocha.utils.highlightTags('code')
+        Mocha.utils.highlightTags('code')
 
-      if (isCi) {
-        ipcRenderer.send('process.exit', runner.failures)
-      }
+        if (isCi) {
+          ipcRenderer.send('process.exit', runner.failures)
+        }
+      }, 0)
     })
   })
 })()


### PR DESCRIPTION
Fixes #17648 

Turns out if there are no tests the callback in `run` gets called synchronously before `runner` is defined 👍 

Notes: no-notes