### PR TITLE
build: ensure macos updater specs do not fail on fork PRs

### DIFF
--- a/spec-main/api-autoupdater-darwin-spec.ts
+++ b/spec-main/api-autoupdater-darwin-spec.ts
@@ -22,9 +22,10 @@ describeFn('autoUpdater behavior', function () {
   beforeEach(function () {
     const result = cp.spawnSync(path.resolve(__dirname, '../script/codesign/get-trusted-identity.sh'))
     if (result.status !== 0 || result.stdout.toString().trim().length === 0)  {
-      if (isCI) {
-        throw new Error('No valid signing identity available to run autoUpdater specs')
-      }
+// .     TODO(MarshallOfSOund): Figure out how to run these tests without a protected certificate
+//       if (isCI) {
+//         throw new Error('No valid signing identity available to run autoUpdater specs')
+//       }
       this.skip()
     } else {
       identity = result.stdout.toString().trim()


### PR DESCRIPTION
Fixes #17649

For now if there is no way to safely share this var with fork PRs so we'll allow the build to be skipped.

Notes: no-notes