### PR TITLE
fix: process.getProcessMemoryInfo not being exposed to sandbox renderers

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -158,6 +158,8 @@ void AtomSandboxedRendererClient::InitializeBindings(
   process.SetMethod("hang", AtomBindings::Hang);
   process.SetMethod("getHeapStatistics", &AtomBindings::GetHeapStatistics);
   process.SetMethod("getSystemMemoryInfo", &AtomBindings::GetSystemMemoryInfo);
+  process.SetMethod("getProcessMemoryInfo",
+                    &AtomBindings::GetProcessMemoryInfo);
   process.SetMethod(
       "getCPUUsage",
       base::Bind(&AtomBindings::GetCPUUsage, base::Unretained(metrics_.get())));


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/17661.

Exposes `process.getProcessMemoryInfo` to sandbox renderers.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `process.getProcessMemoryInfo` not being exposed to sandbox renderers.