### PR TITLE
test: remove non-applicable processMemoryInfo specs

### DIFF
--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1828,29 +1828,6 @@ describe('BrowserWindow module', () => {
         w.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
       })
 
-      // TODO(alexeykuzmin): `GetProcessMemoryInfo()` is not available starting Ch67.
-      xit('releases memory after popup is closed', (done) => {
-        w.destroy()
-        w = new BrowserWindow({
-          show: false,
-          webPreferences: {
-            preload,
-            sandbox: true
-          }
-        })
-        w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), { search: 'allocate-memory' })
-        ipcMain.once('answer', function (event, { bytesBeforeOpen, bytesAfterOpen, bytesAfterClose }) {
-          const memoryIncreaseByOpen = bytesAfterOpen - bytesBeforeOpen
-          const memoryDecreaseByClose = bytesAfterOpen - bytesAfterClose
-          // decreased memory should be less than increased due to factors we
-          // can't control, but given the amount of memory allocated in the
-          // fixture, we can reasonably expect decrease to be at least 70% of
-          // increase
-          assert(memoryDecreaseByClose > memoryIncreaseByOpen * 0.7)
-          done()
-        })
-      })
-
       // see #9387
       it('properly manages remote object references after page reload', (done) => {
         w.destroy()

--- a/spec/fixtures/api/sandbox.html
+++ b/spec/fixtures/api/sandbox.html
@@ -35,21 +35,6 @@
         await invokeGc()
         ipcRenderer.send('answer', new Hello().say())
       },
-      // FIXME: Chromium 67 - getProcessMemoryInfo has been removed
-      // 'allocate-memory': async () => {
-      //   await invokeGc()
-      //   const {privateBytes: bytesBeforeOpen} = process.getProcessMemoryInfo()
-      //   let w = open('./allocate-memory.html')
-      //   await invokeGc()
-      //   const {privateBytes: bytesAfterOpen} = process.getProcessMemoryInfo()
-      //   w.close()
-      //   w = null
-      //   await invokeGc()
-      //   const {privateBytes: bytesAfterClose} = process.getProcessMemoryInfo()
-      //   ipcRenderer.send('answer', {
-      //     bytesBeforeOpen, bytesAfterOpen, bytesAfterClose
-      //   })
-      // },
       'window-events': () => {
         document.title = 'changed'
       },


### PR DESCRIPTION
#### Description of Change

`process.getProcessMemoryInfo` changed implementations after M67, and new tests were added to account for this new behavior. Some of the older tests were commented out but never replaced; this PR removes them.

cc @alexeykuzmin @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
