### PR TITLE
feat: emit process 'loaded' event in sandboxed renderers

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -226,6 +226,10 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   node::per_process::native_module_loader.CompileAndCall(
       isolate->GetCurrentContext(), "electron/js2c/preload_bundle",
       &preload_bundle_params, &preload_bundle_args, nullptr);
+
+  v8::HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(context);
+  InvokeHiddenCallback(context, kLifecycleKey, "onLoaded");
 }
 
 void AtomSandboxedRendererClient::SetupMainWorldOverrides(

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -56,6 +56,9 @@ v8Util.setHiddenValue(global, 'ipcNative', {
 
 // AtomSandboxedRendererClient will look for the "lifecycle" hidden object when
 v8Util.setHiddenValue(global, 'lifecycle', {
+  onLoaded () {
+    process.emit('loaded')
+  },
   onExit () {
     process.emit('exit')
   },
@@ -89,6 +92,7 @@ Object.defineProperty(preloadProcess, 'noDeprecation', {
   }
 })
 
+process.on('loaded', () => preloadProcess.emit('loaded'))
 process.on('exit', () => preloadProcess.emit('exit'))
 
 // This is the `require` function that will be visible to the preload script

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1568,7 +1568,6 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload
           }
@@ -1586,7 +1585,6 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload: preloadSpecialChars
           }
@@ -1594,12 +1592,24 @@ describe('BrowserWindow module', () => {
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
 
+      it('exposes "loaded" event to preload script', function (done) {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true,
+            preload
+          }
+        })
+        ipcMain.once('process-loaded', () => done())
+        w.loadURL('about:blank')
+      })
+
       it('exposes "exit" event to preload script', function (done) {
         w.destroy()
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload
           }
@@ -1622,7 +1632,6 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload
           }

--- a/spec/fixtures/module/preload-sandbox.js
+++ b/spec/fixtures/module/preload-sandbox.js
@@ -13,6 +13,10 @@
     }
   }
 
+  process.once('loaded', () => {
+    ipcRenderer.send('process-loaded')
+  })
+
   if (location.protocol === 'file:') {
     window.test = 'preload'
     window.process = process


### PR DESCRIPTION
#### Description of Change
Makes it consistent with non-sandboxed renderer behavior.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Process now emits 'loaded' event in sandboxed renderers.