### PR TITLE
[wip] test: workaround for nested describe skips

### DIFF
--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -3,21 +3,15 @@ const { ipcRenderer } = require('electron')
 const { expect } = require('chai')
 
 describe('autoUpdater module', function () {
-  // XXX(alexeykuzmin): Calling `.skip()` in a 'before' hook
-  // doesn't affect nested 'describe's
   beforeEach(function () {
-    // Skip autoUpdater tests in MAS build.
-    if (process.mas) {
-      this.skip()
-    }
+    if (process.mas) this.skip()
   })
 
   describe('checkForUpdates', function () {
     it('emits an error on Windows when called the feed URL is not set', function (done) {
       if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
+        this.test.parent.pending = true
+        this.skip()
       }
 
       ipcRenderer.once('auto-updater-error', (event, message) => {
@@ -36,9 +30,8 @@ describe('autoUpdater module', function () {
 
     it('correctly fetches the previously set FeedURL', function (done) {
       if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const updateURL = 'https://fake-update.electron.io'
@@ -55,9 +48,7 @@ describe('autoUpdater module', function () {
       }
 
       before(function () {
-        if (process.platform !== 'win32' && process.platform !== 'darwin') {
-          this.skip()
-        }
+        if (process.platform === 'linux') this.skip()
       })
 
       it('sets url successfully using old (url, headers) syntax', () => {
@@ -89,9 +80,7 @@ describe('autoUpdater module', function () {
       const isServerTypeError = (err) => err.message.includes('Expected serverType to be \'default\' or \'json\'')
 
       before(function () {
-        if (process.platform !== 'darwin') {
-          this.skip()
-        }
+        if (process.platform !== 'darwin') this.skip()
       })
 
       it('emits an error when the application is unsigned', done => {
@@ -125,9 +114,8 @@ describe('autoUpdater module', function () {
   describe('quitAndInstall', () => {
     it('emits an error on Windows when no update is available', function (done) {
       if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
+        this.test.parent.pending = true
+        this.skip()
       }
 
       ipcRenderer.once('auto-updater-error', (event, message) => {
@@ -141,9 +129,8 @@ describe('autoUpdater module', function () {
   describe('error event', () => {
     it('serializes correctly over the remote module', function (done) {
       if (process.platform === 'linux') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
+        this.test.parent.pending = true
+        this.skip()
       }
 
       autoUpdater.once('error', error => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2761,15 +2761,9 @@ describe('BrowserWindow module', () => {
   })
 
   describe('window states (excluding Linux)', () => {
-    // FIXME(alexeykuzmin): Skip the tests instead of using the `return` here.
-    // Why it cannot be done now:
-    // - `.skip()` called in the 'before' hook doesn't affect
-    //     nested `describe`s.
-    // - `.skip()` called in the 'beforeEach' hook prevents 'afterEach'
-    //     hook from being called.
-    // Not implemented on Linux.
     if (process.platform === 'linux') {
-      return
+      this.test.parent.pending = true
+      this.skip()
     }
 
     describe('movable state', () => {

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -106,9 +106,8 @@ describe('clipboard module', () => {
   describe('clipboard.writeBuffer(format, buffer)', () => {
     it('writes a Buffer for the specified format', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const buffer = Buffer.from('writeBuffer', 'utf8')

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -57,8 +57,10 @@ describe('crashReporter module', () => {
       })
 
       it('should send minidump when renderer crashes', function (done) {
-        // TODO(alexeykuzmin): Skip the test instead of marking it as passed.
-        if (process.env.APPVEYOR === 'True') return done()
+        if (process.env.APPVEYOR === 'True') {
+          this.test.parent.pending = true
+          this.skip()
+        }
 
         this.timeout(180000)
 
@@ -72,8 +74,10 @@ describe('crashReporter module', () => {
       })
 
       it('should send minidump when node processes crash', function (done) {
-        // TODO(alexeykuzmin): Skip the test instead of marking it as passed.
-        if (process.env.APPVEYOR === 'True') return done()
+        if (process.env.APPVEYOR === 'True') {
+          this.test.parent.pending = true
+          this.skip()
+        }
 
         this.timeout(180000)
 
@@ -167,8 +171,10 @@ describe('crashReporter module', () => {
       })
 
       it('should send minidump with updated extra parameters', function (done) {
-        // TODO(alexeykuzmin): Skip the test instead of marking it as passed.
-        if (process.env.APPVEYOR === 'True') return done()
+        if (process.env.APPVEYOR === 'True') {
+          this.test.parent.pending = true
+          this.skip()
+        }
 
         this.timeout(180000)
 
@@ -290,11 +296,11 @@ describe('crashReporter module', () => {
     it('throws an error when called from the renderer process', () => {
       assert.throws(() => require('electron').crashReporter.getUploadToServer())
     })
+
     it('returns true when uploadToServer is set to true', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       crashReporter.start({
@@ -304,11 +310,11 @@ describe('crashReporter module', () => {
       })
       assert.strictEqual(crashReporter.getUploadToServer(), true)
     })
+
     it('returns false when uploadToServer is set to false', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       crashReporter.start({
@@ -325,11 +331,11 @@ describe('crashReporter module', () => {
     it('throws an error when called from the renderer process', () => {
       assert.throws(() => require('electron').crashReporter.setUploadToServer('arg'))
     })
+
     it('sets uploadToServer false when called with false', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       crashReporter.start({
@@ -340,11 +346,11 @@ describe('crashReporter module', () => {
       crashReporter.setUploadToServer(false)
       assert.strictEqual(crashReporter.getUploadToServer(), false)
     })
+
     it('sets uploadToServer true when called with true', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       crashReporter.start({
@@ -367,11 +373,11 @@ describe('crashReporter module', () => {
       const parameters = crashReporter.getParameters()
       assert(typeof parameters === 'object')
     })
+
     it('adds a parameter to current parameters', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       crashReporter.start({
@@ -382,11 +388,11 @@ describe('crashReporter module', () => {
       crashReporter.addExtraParameter('hello', 'world')
       assert('hello' in crashReporter.getParameters())
     })
+
     it('removes a parameter from current parameters', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       crashReporter.start({

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -336,9 +336,8 @@ describe('nativeImage module', () => {
 
     it('Gets an NSImage pointer on macOS', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const imagePath = `${path.join(__dirname, 'fixtures', 'api')}${path.sep}..${path.sep}${path.join('assets', 'logo.png')}`
@@ -354,9 +353,8 @@ describe('nativeImage module', () => {
 
     it('loads images from .ico files on Windows', function () {
       if (process.platform !== 'win32') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const imagePath = path.join(__dirname, 'fixtures', 'assets', 'icon.ico')
@@ -374,9 +372,8 @@ describe('nativeImage module', () => {
 
     it('returns empty on non-darwin platforms', function () {
       if (process.platform === 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const image = nativeImage.createFromNamedImage('NSActionTemplate')
@@ -385,9 +382,8 @@ describe('nativeImage module', () => {
 
     it('returns a valid image on darwin', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const image = nativeImage.createFromNamedImage('NSActionTemplate')
@@ -396,9 +392,8 @@ describe('nativeImage module', () => {
 
     it('returns allows an HSL shift for a valid image on darwin', function () {
       if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const image = nativeImage.createFromNamedImage('NSActionTemplate', [0.5, 0.2, 0.8])

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -525,9 +525,8 @@ describe('session module', () => {
 
     it('can generate a default filename', function (done) {
       if (process.env.APPVEYOR === 'True') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return done()
+        this.test.parent.pending = true
+        this.skip()
       }
 
       downloadServer.listen(0, '127.0.0.1', () => {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -850,9 +850,8 @@ describe('chromium feature', () => {
 
     it('can be get as context in canvas', () => {
       if (process.platform === 'linux') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return
+        this.test.parent.pending = true
+        this.skip()
       }
 
       const webgl = document.createElement('canvas').getContext('webgl')


### PR DESCRIPTION
#### Description of Change

Corrects some tests that we were incorrectly marking as passed when they should be explicitly skipped instead.

cc @alexeykuzmin 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
