### PR TITLE
[wip] feat: allow optional activation of app windows on show

### DIFF
--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -118,7 +118,7 @@ class Browser : public WindowListObserver {
   void Hide();
 
   // Show the application.
-  void Show();
+  void Show(mate::Arguments* args);
 
   // Creates an activity and sets it as the one currently in use.
   void SetUserActivity(const std::string& type,

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -36,8 +36,15 @@ void Browser::Hide() {
   [[AtomApplication sharedApplication] hide:nil];
 }
 
-void Browser::Show() {
-  [[AtomApplication sharedApplication] unhide:nil];
+void Browser::Show(mate::Arguments* args) {
+  bool should_activate;
+  args->GetNext(&should_activate);
+
+  if (should_activate) {
+    [[AtomApplication sharedApplication] unhide:nil];
+  } else {
+    [[AtomApplication sharedApplication] unhideWithoutActivation:nil];
+  }
 }
 
 void Browser::AddRecentDocument(const base::FilePath& path) {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -565,9 +565,12 @@ the active app. On Windows, focuses on the application's first window.
 
 Hides all application windows without minimizing them.
 
-### `app.show()` _macOS_
+### `app.show(options)` _macOS_
 
-Shows application windows after they were hidden. Does not automatically focus
+* `options` Object
+  * `shouldActivate` String - whether or not app should activate windows after restoring them.
+
+Shows application windows after they were hidden. If `noActivate` is `true`, the app does not automatically focus
 them.
 
 ### `app.getAppPath()`


### PR DESCRIPTION
#### Description of Change

Previously, our implementation of `app.show()` used [`unhide`](https://developer.apple.com/documentation/appkit/nsapplication/1428761-unhide?language=objc) unconditionally, which meant that hidden windows would be restored to the screen and automatically activated. There are many scenarios where a developer may not want that specific show behavior, and may instead want to show windows without automatically activating them.

This PR this uses [`unhideWithoutActivation`](https://developer.apple.com/documentation/appkit/nsapplication/1428566-unhidewithoutactivation?language=objc) to allow users to pass a boolean to `app.show()` for more granular control over this behavior.

cc @MarshallOfSound @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Allow optional activation of app windows on `app.show()`.
