### PR TITLE
docs: update guide on MAS entitlements and export compliance

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -72,7 +72,9 @@ Then, you need to prepare three entitlements files.
     <key>com.apple.security.app-sandbox</key>
     <true/>
     <key>com.apple.security.application-groups</key>
-    <string>TEAM_ID.your.bundle.id</string>
+    <array>
+      <string>TEAM_ID.your.bundle.id</string>
+    </array>
   </dict>
 </plist>
 ```

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -229,9 +229,10 @@ more details.
 
 ## Cryptographic Algorithms Used by Electron
 
-Depending on the country and region you are located, Mac App Store may require
-documenting the cryptographic algorithms used in your app, and even ask you to
-submit a copy of U.S. Encryption Registration (ERN) approval.
+Depending on the countries in which you are releasing your app, you may be
+required to provide information on the cryptographic algorithms used in your
+software. See the [encryption export compliance docs][export-compliance] for
+more information.
 
 Electron uses following cryptographic algorithms:
 
@@ -259,10 +260,6 @@ Electron uses following cryptographic algorithms:
 * RC5 - http://people.csail.mit.edu/rivest/Rivest-rc5rev.pdf
 * RIPEMD - [ISO/IEC 10118-3](https://webstore.ansi.org/RecordDetail.aspx?sku=ISO%2FIEC%2010118-3:2004)
 
-On how to get the ERN approval, you can reference the article: [How to legally
-submit an app to Apple’s App Store when it uses encryption (or how to obtain an
-ERN)][ern-tutorial].
-
 [developer-program]: https://developer.apple.com/support/compare-memberships/
 [submitting-your-app]: https://developer.apple.com/library/mac/documentation/IDEs/Conceptual/AppDistributionGuide/SubmittingYourApp/SubmittingYourApp.html
 [nwjs-guide]: https://github.com/nwjs/nw.js/wiki/Mac-App-Store-%28MAS%29-Submission-Guideline#first-steps
@@ -272,7 +269,7 @@ ERN)][ern-tutorial].
 [electron-packager]: https://github.com/electron-userland/electron-packager
 [submit-for-review]: https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html
 [app-sandboxing]: https://developer.apple.com/app-sandboxing/
-[ern-tutorial]: https://carouselapps.com/2015/12/15/legally-submit-app-apples-app-store-uses-encryption-obtain-ern/
+[export-compliance]: https://help.apple.com/app-store-connect/#/devc3f64248f
 [temporary-exception]: https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/AppSandboxTemporaryExceptionEntitlements.html
 [user-selected]: https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW6
 [network-access]: https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW9


### PR DESCRIPTION
#### Description of Change

I updated the following information in the Mac App Store Submission Guide:

* Fixed the value of the app groups entitlement in the `parent.plist` snippet – needs to be a string array instead of a string (see [Apple's docs](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups))
* Updated the information on encryption export compliance: An ERN is apparently no longer required (see [App Store Connect Help](https://help.apple.com/app-store-connect/#/devc3f64248f)) and therefore the provided blog link is no longer relevant

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes