### PR TITLE
fix: crash when passing empty string to recording

### DIFF
--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -12,6 +12,7 @@
 #include "atom/common/promise_util.h"
 #include "base/bind.h"
 #include "base/files/file_util.h"
+#include "base/threading/thread_restrictions.h"
 #include "content/public/browser/tracing_controller.h"
 #include "native_mate/dictionary.h"
 
@@ -58,6 +59,11 @@ scoped_refptr<TracingController::TraceDataEndpoint> GetTraceDataEndpoint(
     const base::FilePath& path,
     const CompletionCallback& callback) {
   base::FilePath result_file_path = path;
+
+  // base::CreateTemporaryFile prevents blocking so we need to allow it
+  // for now since offloading this to a different sequence would require
+  // changing the api shape
+  base::ThreadRestrictions::ScopedAllowIO allow_io;
   if (result_file_path.empty() && !base::CreateTemporaryFile(&result_file_path))
     LOG(ERROR) << "Creating temporary file failed";
 

--- a/spec/api-content-tracing-spec.js
+++ b/spec/api-content-tracing-spec.js
@@ -214,8 +214,7 @@ describe('contentTracing', () => {
       expect(resultFilePath).to.be.a('string').and.be.equal(outputFilePath)
     })
 
-    // FIXME(alexeykuzmin): https://github.com/electron/electron/issues/16019
-    xit('creates a temporary file when an empty string is passed', async function () {
+    it('creates a temporary file when an empty string is passed', async function () {
       const resultFilePath = await record(/* options */ {}, /* outputFilePath */ '')
       expect(resultFilePath).to.be.a('string').that.is.not.empty()
     })


### PR DESCRIPTION
#### Description of Change

Fixes a crash in the `contentTracing` API occurring when empty strings were passed to `record`. `base::CreateTemporaryFile` is a blocking call called on the main thread which disallows blocking, and of two ways to fix this one would require changing the API shape and offloading to a diff thread so the most efficient solution in this case was just to manually bypass threading restrictions.

cc @alexeykuzmin @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash when passing empty strings to recording in the `contentTracing` module.
