### PR TITLE
fix: report module name when require fails in sandboxed renderers

### DIFF
--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -102,7 +102,7 @@ function preloadRequire (module) {
     electron.deprecate.warn(`require('${module}')`, `remote.require('${module}')`)
     return remoteRequire(module)
   }
-  throw new Error('module not found')
+  throw new Error(`module not found: ${module}`)
 }
 
 // Process command line arguments.


### PR DESCRIPTION
#### Description of Change
Backport https://github.com/electron/electron/pull/17413

> Added missing module name to the exception message thrown when `require` fails in sandboxed renderers. Follow up to [chore: remove deprecated modules internally using remote.require in sandboxed renderer context](https://github.com/electron/electron/pull/15957)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added missing module name to the exception message thrown when `require` fails in sandboxed renderers.

/cc @electron/wg-releases 