### PR TITLE
feat: support ELECTRON_DEFAULT_ERROR_MODE in the GPU process

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -436,6 +436,7 @@ static_library("electron_lib") {
     "//content/public/browser",
     "//content/public/child",
     "//content/public/common:service_names",
+    "//content/public/gpu",
     "//content/public/renderer",
     "//content/public/utility",
     "//device/bluetooth",

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -14,6 +14,7 @@
 
 #include "atom/app/atom_content_client.h"
 #include "atom/browser/atom_browser_client.h"
+#include "atom/browser/atom_gpu_client.h"
 #include "atom/browser/feature_list.h"
 #include "atom/browser/relauncher.h"
 #include "atom/common/options_switches.h"
@@ -260,6 +261,11 @@ void AtomMainDelegate::PreCreateMainMessageLoop() {
 content::ContentBrowserClient* AtomMainDelegate::CreateContentBrowserClient() {
   browser_client_.reset(new AtomBrowserClient);
   return browser_client_.get();
+}
+
+content::ContentGpuClient* AtomMainDelegate::CreateContentGpuClient() {
+  gpu_client_.reset(new AtomGpuClient);
+  return gpu_client_.get();
 }
 
 content::ContentRendererClient*

--- a/atom/app/atom_main_delegate.h
+++ b/atom/app/atom_main_delegate.h
@@ -27,6 +27,7 @@ class AtomMainDelegate : public content::ContentMainDelegate {
   void PreCreateMainMessageLoop() override;
   void PostEarlyInitialization(bool is_running_tests) override;
   content::ContentBrowserClient* CreateContentBrowserClient() override;
+  content::ContentGpuClient* CreateContentGpuClient() override;
   content::ContentRendererClient* CreateContentRendererClient() override;
   content::ContentUtilityClient* CreateContentUtilityClient() override;
   int RunProcess(
@@ -48,6 +49,7 @@ class AtomMainDelegate : public content::ContentMainDelegate {
 
   std::unique_ptr<content::ContentBrowserClient> browser_client_;
   std::unique_ptr<content::ContentClient> content_client_;
+  std::unique_ptr<content::ContentGpuClient> gpu_client_;
   std::unique_ptr<content::ContentRendererClient> renderer_client_;
   std::unique_ptr<content::ContentUtilityClient> utility_client_;
 

--- a/atom/browser/atom_gpu_client.cc
+++ b/atom/browser/atom_gpu_client.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/atom_gpu_client.h"
+
+#include "base/environment.h"
+
+#if defined(OS_WIN)
+#include <windows.h>
+#endif
+
+namespace atom {
+
+AtomGpuClient::AtomGpuClient() = default;
+
+void AtomGpuClient::PreCreateMessageLoop() {
+#if defined(OS_WIN)
+  auto env = base::Environment::Create();
+  if (env->HasVar("ELECTRON_DEFAULT_ERROR_MODE"))
+    SetErrorMode(GetErrorMode() & ~SEM_NOGPFAULTERRORBOX);
+#endif
+}
+
+}  // namespace atom

--- a/atom/browser/atom_gpu_client.h
+++ b/atom/browser/atom_gpu_client.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_ATOM_GPU_CLIENT_H_
+#define ATOM_BROWSER_ATOM_GPU_CLIENT_H_
+
+#include "content/public/gpu/content_gpu_client.h"
+
+namespace atom {
+
+class AtomGpuClient : public content::ContentGpuClient {
+ public:
+  AtomGpuClient();
+
+  // content::ContentGpuClient:
+  void PreCreateMessageLoop() override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(AtomGpuClient);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_ATOM_GPU_CLIENT_H_

--- a/filenames.gni
+++ b/filenames.gni
@@ -231,6 +231,8 @@ filenames = {
     "atom/browser/atom_browser_context.h",
     "atom/browser/atom_download_manager_delegate.cc",
     "atom/browser/atom_download_manager_delegate.h",
+    "atom/browser/atom_gpu_client.cc",
+    "atom/browser/atom_gpu_client.h",
     "atom/browser/atom_browser_main_parts.cc",
     "atom/browser/atom_browser_main_parts.h",
     "atom/browser/atom_browser_main_parts_mac.mm",

--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -76,3 +76,4 @@ viz_osr.patch
 patch_the_ensure_gn_version_py_script_to_work_on_mac_ci.patch
 revert_roll_clang_356356_357569.patch
 build_add_electron_tracing_category.patch
+add_contentgpuclient_precreatemessageloop_callback.patch

--- a/patches/common/chromium/add_contentgpuclient_precreatemessageloop_callback.patch
+++ b/patches/common/chromium/add_contentgpuclient_precreatemessageloop_callback.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Milan Burda <milan.burda@gmail.com>
+Date: Thu, 11 Apr 2019 14:49:20 +0200
+Subject: Add ContentGpuClient::PreCreateMessageLoop() callback
+
+Invoke in GpuMain after SetErrorMode, before starting the message loop.
+Allows Electron to restore WER when ELECTRON_DEFAULT_ERROR_MODE is set.
+
+This should be upstreamed
+
+diff --git a/content/gpu/gpu_main.cc b/content/gpu/gpu_main.cc
+index 39e87967360a9c7a2856ce4df9c182c782efb2a5..ade3e7905d01b25128f477c68c10edd0f96626c3 100644
+--- a/content/gpu/gpu_main.cc
++++ b/content/gpu/gpu_main.cc
+@@ -234,6 +234,10 @@ int GpuMain(const MainFunctionParams& parameters) {
+ 
+   logging::SetLogMessageHandler(GpuProcessLogMessageHandler);
+ 
++  auto* client = GetContentClient()->gpu();
++  if (client)
++    client->PreCreateMessageLoop();
++
+   // We are experiencing what appear to be memory-stomp issues in the GPU
+   // process. These issues seem to be impacting the message loop and listeners
+   // registered to it. Create the message loop on the heap to guard against
+@@ -329,7 +333,6 @@ int GpuMain(const MainFunctionParams& parameters) {
+ 
+   GpuProcess gpu_process(io_thread_priority);
+ 
+-  auto* client = GetContentClient()->gpu();
+   if (client)
+     client->PostIOThreadCreated(gpu_process.io_task_runner());
+ 
+diff --git a/content/public/gpu/content_gpu_client.h b/content/public/gpu/content_gpu_client.h
+index 20e31e1bd96395cb4350aa6ae84cc16c4ca2116b..d89af81ef9426c197a62027b514011afd10ea3ce 100644
+--- a/content/public/gpu/content_gpu_client.h
++++ b/content/public/gpu/content_gpu_client.h
+@@ -35,6 +35,10 @@ class CONTENT_EXPORT ContentGpuClient {
+  public:
+   virtual ~ContentGpuClient() {}
+ 
++  // Allows the embedder to perform platform-specific initialization before
++  // creating the message loop.
++  virtual void PreCreateMessageLoop() {}
++
+   // Initializes the registry. |registry| will be passed to a ConnectionFilter
+   // (which lives on the IO thread). Unlike other childthreads, the client must
+   // register additional interfaces on this registry rather than just creating


### PR DESCRIPTION
#### Description of Change
It should be possible to enable Windows Error Reporting for the GPU process as well.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added missing support for `ELECTRON_DEFAULT_ERROR_MODE` in the GPU process