### PR TITLE
feat: allow pages to override window.history.length

### DIFF
--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -233,7 +233,8 @@ export const windowSetup = (
   defineProperty(window.history, 'length', {
     get: function () {
       return ipcRendererInternal.sendSync('ELECTRON_NAVIGATION_CONTROLLER_LENGTH')
-    }
+    },
+    configurable: true
   })
 
   if (guestInstanceId != null) {

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -234,7 +234,7 @@ export const windowSetup = (
     get: function () {
       return ipcRendererInternal.sendSync('ELECTRON_NAVIGATION_CONTROLLER_LENGTH')
     },
-    set() {}
+    set () {}
   })
 
   if (guestInstanceId != null) {

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -234,7 +234,7 @@ export const windowSetup = (
     get: function () {
       return ipcRendererInternal.sendSync('ELECTRON_NAVIGATION_CONTROLLER_LENGTH')
     },
-    configurable: true
+    set() {}
   })
 
   if (guestInstanceId != null) {


### PR DESCRIPTION
#### Description of Change
If a page tries to override `window.history.length`, an error is thrown.
![image](https://user-images.githubusercontent.com/1098371/55870892-d2fdb400-5b89-11e9-8d35-3e3da733e175.png)

Example: Login to [Wunderlist](https://www.wunderlist.com/webapp) inside a webview or BrowserWindow, the above error will be thrown.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
notes: Fixed Wunderlist app not loading
