### PR TITLE
feat: add webContents 'zoom-changed' event

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -235,6 +235,27 @@ struct Converter<atom::api::WebContents::Type> {
   }
 };
 
+template <>
+struct Converter<atom::WebContentsZoomController::ZoomDirection> {
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      atom::WebContentsZoomController::ZoomDirection val) {
+    using ZoomDirection = atom::WebContentsZoomController::ZoomDirection;
+    std::string direction = "";
+    switch (val) {
+      case ZoomDirection::kIn:
+        direction = "in";
+        break;
+      case ZoomDirection::kOut:
+        direction = "out";
+        break;
+      default:
+        break;
+    }
+    return mate::ConvertToV8(isolate, direction);
+  }
+};
+
 }  // namespace mate
 
 namespace atom {
@@ -634,7 +655,11 @@ content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
 }
 
 void WebContents::ContentsZoomChange(bool zoom_in) {
-  Emit("zoom-changed", zoom_in);
+  const atom::WebContentsZoomController::ZoomDirection zoom_direction =
+      zoom_in ? atom::WebContentsZoomController::ZoomDirection::kIn
+              : atom::WebContentsZoomController::ZoomDirection::kOut;
+
+  Emit("zoom-changed", zoom_direction);
 }
 
 void WebContents::EnterFullscreenModeForTab(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -235,27 +235,6 @@ struct Converter<atom::api::WebContents::Type> {
   }
 };
 
-template <>
-struct Converter<atom::WebContentsZoomController::ZoomDirection> {
-  static v8::Local<v8::Value> ToV8(
-      v8::Isolate* isolate,
-      atom::WebContentsZoomController::ZoomDirection val) {
-    using ZoomDirection = atom::WebContentsZoomController::ZoomDirection;
-    std::string direction = "";
-    switch (val) {
-      case ZoomDirection::kIn:
-        direction = "in";
-        break;
-      case ZoomDirection::kOut:
-        direction = "out";
-        break;
-      default:
-        break;
-    }
-    return mate::ConvertToV8(isolate, direction);
-  }
-};
-
 }  // namespace mate
 
 namespace atom {
@@ -655,11 +634,7 @@ content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
 }
 
 void WebContents::ContentsZoomChange(bool zoom_in) {
-  const atom::WebContentsZoomController::ZoomDirection zoom_direction =
-      zoom_in ? atom::WebContentsZoomController::ZoomDirection::kIn
-              : atom::WebContentsZoomController::ZoomDirection::kOut;
-
-  Emit("zoom-changed", zoom_direction);
+  Emit("zoom-changed", zoom_in ? "in" : "out");
 }
 
 void WebContents::EnterFullscreenModeForTab(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -633,6 +633,10 @@ content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
   return content::KeyboardEventProcessingResult::NOT_HANDLED;
 }
 
+void WebContents::ContentsZoomChange(bool zoom_in) {
+  Emit("zoom-changed", zoom_in);
+}
+
 void WebContents::EnterFullscreenModeForTab(
     content::WebContents* source,
     const GURL& origin,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -369,6 +369,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   content::KeyboardEventProcessingResult PreHandleKeyboardEvent(
       content::WebContents* source,
       const content::NativeWebKeyboardEvent& event) override;
+  void ContentsZoomChange(bool zoom_in) override;
   void EnterFullscreenModeForTab(
       content::WebContents* source,
       const GURL& origin,

--- a/atom/browser/web_contents_zoom_controller.h
+++ b/atom/browser/web_contents_zoom_controller.h
@@ -51,6 +51,15 @@ class WebContentsZoomController
     ZOOM_MODE_DISABLED,
   };
 
+  enum class ZoomDirection {
+    // Represents a change in zoom where the zoom level is increasing (zooming
+    // in).
+    kIn,
+    // Represents a change in zoom where the zoom level is decreasing (zooming
+    // out).
+    kOut
+  };
+
   explicit WebContentsZoomController(content::WebContents* web_contents);
   ~WebContentsZoomController() override;
 

--- a/atom/browser/web_contents_zoom_controller.h
+++ b/atom/browser/web_contents_zoom_controller.h
@@ -51,15 +51,6 @@ class WebContentsZoomController
     ZOOM_MODE_DISABLED,
   };
 
-  enum class ZoomDirection {
-    // Represents a change in zoom where the zoom level is increasing (zooming
-    // in).
-    kIn,
-    // Represents a change in zoom where the zoom level is decreasing (zooming
-    // out).
-    kOut
-  };
-
   explicit WebContentsZoomController(content::WebContents* web_contents);
   ~WebContentsZoomController() override;
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -378,7 +378,7 @@ Emitted when the window leaves a full-screen state triggered by HTML API.
 
 Returns:
 * `event` Event
-* `zoomedIn` Boolean - true if the user is trying to zoom in, false if the user is trying to zoom out
+* `zoomDirection` String - Can be `in` or `out`.
 
 Emitted when the user is requesting to change the zoom level using the mouse wheel.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -374,6 +374,14 @@ Emitted when the window enters a full-screen state triggered by HTML API.
 
 Emitted when the window leaves a full-screen state triggered by HTML API.
 
+#### Event: 'zoom-changed'
+
+Returns:
+* `event` Event
+* `zoomedIn` Boolean - true if the user is trying to zoom in, false if the user is trying to zoom out
+
+Emitted when the user is requesting to change the zoom level using the mouse wheel.
+
 #### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -358,8 +358,8 @@ describe('webContents module', () => {
       w.webContents.once('did-finish-load', () => {
         const testZoomChanged = (opts) => {
           return new Promise((resolve, reject) => {
-            w.webContents.once('zoom-changed', (event, zoomingIn) => {
-              assert.strictEqual(zoomingIn, opts.zoomingIn)
+            w.webContents.once('zoom-changed', (event, zoomDirection) => {
+              assert.strictEqual(zoomDirection, opts.zoomingIn ? 'in' : 'out')
               resolve()
             })
 


### PR DESCRIPTION
#### Description of Change
Emit `zoom-changed` event when the user is trying to zoom in / out using the mouse wheel on Windows. This is the only way the Electron app will be able to handle these events when the focus is inside a (x-origin) iframe.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `zoom-changed` event to `webContents`, which is emitted when the user is trying to zoom in / out using the mouse wheel on Windows, even if the focus is inside an (x-origin) iframe.