### PR TITLE
fix: populate phase of WebMouseWheelEvents in webContents.sendInputEvent

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1804,6 +1804,19 @@ void WebContents::SendInputEvent(v8::Isolate* isolate,
             mouse_wheel_event);
 #endif
       } else {
+        // Chromium expects phase info in wheel events (and applies a
+        // DCHECK to verify it). See: https://crbug.com/756524.
+        mouse_wheel_event.phase = blink::WebMouseWheelEvent::kPhaseBegan;
+        mouse_wheel_event.dispatch_type = blink::WebInputEvent::kBlocking;
+        rwh->ForwardWheelEvent(mouse_wheel_event);
+
+        // Send a synthetic wheel event with phaseEnded to finish scrolling.
+        mouse_wheel_event.has_synthetic_phase = true;
+        mouse_wheel_event.delta_x = 0;
+        mouse_wheel_event.delta_y = 0;
+        mouse_wheel_event.phase = blink::WebMouseWheelEvent::kPhaseEnded;
+        mouse_wheel_event.dispatch_type =
+            blink::WebInputEvent::kEventNonBlocking;
         rwh->ForwardWheelEvent(mouse_wheel_event);
       }
       return;


### PR DESCRIPTION
When wheel scroll latching and async wheel events are enabled, phase information gets added to `WebMouseWheelEvents` when they are generated from native events. Chromium expects this information to be available and asserts that expectation with a `DCHECK`. Phase information must be synthesized and set to a `WebMouseWheelEvent` that is generated with `webContents.sendInputEvent` or a `DCHECK` will fail in Chromium.

The very same problem was found and fixed in Chromium for the simulation of mouse wheel events from the devtools. See [ticket](https://bugs.chromium.org/p/chromium/issues/detail?id=756524) and [fix commit](https://chromium.googlesource.com/chromium/src.git/+/2abac3742f431d44ebad70c8c052d55432bfbd9d). This is basically a port of that fix to `webContents.sendInputEvent`.

This makes it possible to run the test in [this PR](https://github.com/electron/electron/pull/17747).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Using `webContents.sendInputEvent` to send a `WebMouseWheelEvent` now has the expected effect.
