### PR TITLE
docs: explanation on using protocols with partitions

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -35,16 +35,16 @@ const { session, app, protocol } = require('electron')
 const path = require('path')
 
 app.on('ready', () => {
-  const partition = "persist:example"
+  const partition = 'persist:example'
   const ses = session.fromPartition(partition)
-  
+
   ses.protocol.registerFileProtocol('atom', (request, callback) => {
     const url = request.url.substr(7)
     callback({ path: path.normalize(`${__dirname}/${url}`) })
   }, (error) => {
     if (error) console.error('Failed to register protocol')
-  });
-  
+  })
+
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -24,7 +24,7 @@ app.on('ready', () => {
 **Note:** All methods unless specified can only be used after the `ready` event
 of the `app` module gets emitted.
 
-## Using `protocol` with a `partition` in `webPreferences`
+## Using `protocol` with a custom `partition` or `session`
 
 A protocol is registered to the default Electron session. If you define a `partition` on your `browserWindow`'s `webPreferences`, then that partition will use a different session and your custom protocol will not work.
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -26,7 +26,7 @@ of the `app` module gets emitted.
 
 ## Using `protocol` with a custom `partition` or `session`
 
-A protocol is registered to a specific Electron [`session`](./session.md) object. If you define a `partition` or `session` on your `browserWindow`'s `webPreferences`, then that window will use a different session and your custom protocol will not work if you just use `electron.protocol.XXX`.
+A protocol is registered to a specific Electron [`session`](./session.md) object. If you don't specify a session, then your `protocol` will be applied to the default session that Electron uses. However, if you define a `partition` or `session` on your `browserWindow`'s `webPreferences`, then that window will use a different session and your custom protocol will not work if you just use `electron.protocol.XXX`.
 
 To have your custom protocol work in combination with a custom session, you need to register it to that session explicitly.
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -28,7 +28,7 @@ of the `app` module gets emitted.
 
 A protocol is registered to the default Electron session. If you define a `partition` on your `browserWindow`'s `webPreferences`, then that partition will use a different session and your custom protocol will not work.
 
-To have your custom protocol work in combination with a partition, you need to register it to the session of that partition:
+To have your custom protocol work in combination with a custom session, you need to register it to that session explicitly.
 
 ```javascript
 const { session, app, protocol } = require('electron')

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -26,7 +26,7 @@ of the `app` module gets emitted.
 
 ## Using `protocol` with a custom `partition` or `session`
 
-A protocol is registered to the default Electron session. If you define a `partition` on your `browserWindow`'s `webPreferences`, then that partition will use a different session and your custom protocol will not work.
+A protocol is registered to a specific Electron [`session`](./session.md) object. If you define a `partition` or `session` on your `browserWindow`'s `webPreferences`, then that window will use a different session and your custom protocol will not work if you just use `electron.protocol.XXX`.
 
 To have your custom protocol work in combination with a custom session, you need to register it to that session explicitly.
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -24,6 +24,38 @@ app.on('ready', () => {
 **Note:** All methods unless specified can only be used after the `ready` event
 of the `app` module gets emitted.
 
+## Using `protocol` with a `partition` in `webPreferences`
+
+A protocol is registered to the default Electron session. If you define a `partition` on your `browserWindow`'s `webPreferences`, then that partition will use a different session and your custom protocol will not work.
+
+To have your custom protocol work in combination with a partition, you need to register it to the session of that partition:
+
+```javascript
+const { session, app, protocol } = require('electron')
+const path = require('path')
+
+app.on('ready', () => {
+  const partition = "persist:example"
+  const ses = session.fromPartition(partition)
+  
+  ses.protocol.registerFileProtocol('atom', (request, callback) => {
+    const url = request.url.substr(7)
+    callback({ path: path.normalize(`${__dirname}/${url}`) })
+  }, (error) => {
+    if (error) console.error('Failed to register protocol')
+  });
+  
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      partition: partition
+    }
+  })
+})
+```
+Using `protocol.registerStandardSchemes` without the session will still register your custom protocol as a standard scheme.
+
 ## Methods
 
 The `protocol` module has the following methods:


### PR DESCRIPTION
#### Description of Change
I just spent the past two days debugging and figuring out why a custom protocol didn't work. Turns out it was the partition on my browserwindow's webPreferences. That's not documented anywhere, so I added it.

#### Release Notes

Notes: no-notes