### PR TITLE
feat: add process.getBlinkMemoryInfo()

### DIFF
--- a/atom/common/api/electron_bindings.h
+++ b/atom/common/api/electron_bindings.h
@@ -58,6 +58,7 @@ class ElectronBindings {
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,
                                                   mate::Arguments* args);
   static v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
+  static v8::Local<v8::Value> GetBlinkMemoryInfo(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,
                                           v8::Isolate* isolate);
   static v8::Local<v8::Value> GetIOCounters(v8::Isolate* isolate);

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -15,6 +15,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 - `hang()`
 - `getCreationTime()`
 - `getHeapStatistics()`
+- `getBlinkMemoryInfo()`
 - `getProcessMemoryInfo()`
 - `getSystemMemoryInfo()`
 - `getSystemVersion()`
@@ -169,6 +170,18 @@ Returns `Object`:
 * `doesZapGarbage` Boolean
 
 Returns an object with V8 heap statistics. Note that all statistics are reported in Kilobytes.
+
+### `process.getBlinkMemoryInfo()`
+
+Returns `Object`:
+
+* `allocated` Integer - Total allocated object size in Kilobytes.
+* `marked` Integer - Total marked object size in Kilobytes.
+* `total` Integer - Total allocated space in Kilobytes.
+
+Returns an object with Blink memory information.
+It can be useful for debugging rendering / DOM related memory issues.
+Note that all values are reported in Kilobytes.
 
 ### `process.getProcessMemoryInfo()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -175,8 +175,8 @@ Returns an object with V8 heap statistics. Note that all statistics are reported
 
 Returns `Object`:
 
-* `allocated` Integer - Total allocated object size in Kilobytes.
-* `marked` Integer - Total marked object size in Kilobytes.
+* `allocated` Integer - Size of all allocated objects in Kilobytes.
+* `marked` Integer - Size of all marked objects in Kilobytes.
 * `total` Integer - Total allocated space in Kilobytes.
 
 Returns an object with Blink memory information.

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1915,6 +1915,7 @@ describe('BrowserWindow module', () => {
           expect(test.hasCrash).to.be.true()
           expect(test.hasHang).to.be.true()
           expect(test.heapStatistics).to.be.an('object')
+          expect(test.blinkMemoryInfo).to.be.an('object')
           expect(test.processMemoryInfo).to.be.an('object')
           expect(test.systemVersion).to.be.a('string')
           expect(test.cpuUsage).to.be.an('object')

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -38,6 +38,15 @@ describe('process module', () => {
     })
   })
 
+  describe('process.getBlinkMemoryInfo()', () => {
+    it('returns blink memory information object', () => {
+      const heapStats = process.getBlinkMemoryInfo()
+      expect(heapStats.allocated).to.be.a('number')
+      expect(heapStats.marked).to.be.a('number')
+      expect(heapStats.total).to.be.a('number')
+    })
+  })
+
   describe('process.getProcessMemoryInfo()', async () => {
     it('resolves promise successfully with valid data', async () => {
       const memoryInfo = await process.getProcessMemoryInfo()

--- a/spec/fixtures/module/preload-sandbox.js
+++ b/spec/fixtures/module/preload-sandbox.js
@@ -27,6 +27,7 @@
         hasHang: typeof process.hang === 'function',
         creationTime: invoke(() => process.getCreationTime()),
         heapStatistics: invoke(() => process.getHeapStatistics()),
+        blinkMemoryInfo: invoke(() => process.getBlinkMemoryInfo()),
         processMemoryInfo: invoke(() => process.getProcessMemoryInfo()),
         systemMemoryInfo: invoke(() => process.getSystemMemoryInfo()),
         systemVersion: invoke(() => process.getSystemVersion()),


### PR DESCRIPTION
#### Description of Change
Expose blink memory information provided by https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/heap/process_heap.h

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `process.getBlinkMemoryInfo()`.
