### PR TITLE
chore: add a script to check if patches changed post-checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "precommit": "lint-staged",
     "prepack": "check-for-leaks",
     "prepush": "check-for-leaks",
+    "postcheckout": "python ./script/check-patches.py -c ./patches/common/config.json",
     "repl": "node ./script/start.js --interactive",
     "start": "node ./script/start.js",
     "test": "node ./script/spec-runner.js",

--- a/script/check-patches.py
+++ b/script/check-patches.py
@@ -99,7 +99,7 @@ def compare_diffs(a, b):
       for i in range(0, len(a[diff])):
         if a[diff][i].strip() != b[diff][i].strip():
           return False
-  except:
+  except Exception:
     return False
 
   return True

--- a/script/check-patches.py
+++ b/script/check-patches.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+import os
+import argparse
+import json
+import sys
+
+from lib import git
+from lib.util import index_of_first
+from lib.patches import patch_filenames_for_dir, guess_base_commit, format_patch, split_patches, get_file_name
+
+def print_in_a_frame(message, padding = 2):
+  size = len(message)
+  padding_str = ' ' * padding * 2
+
+  print('#' * (size + 2 + padding * 2 * 2))
+  for i in range(padding):
+    print('#{}{}{}#'.format(padding_str, ' ' * size, padding_str))
+  print('#{}{}{}#'.format(padding_str, message, padding_str))
+  for i in range(padding):
+    print('#{}{}{}#'.format(padding_str, ' ' * size, padding_str))
+  print('#' * (size + 2 + padding * 2 * 2))
+
+def strip_atat_lines(line):
+  """Strip @@ ... @@ lines to make them easier to compare"""
+  if line.startswith('@@'):
+    return line.split('@@', 2)[1].strip()
+  return line
+
+def filter_patch_line(l):
+  """Filter out lines from the patches that contain the hashes. These can not be
+  reliably used to compare two patches (the same changes might cause different
+  hashes if the original patch is older and did not apply 100% cleanly)"""
+  return not l.startswith('index ') and not len(l) == 0
+
+def map_diffs(patch_lines):
+  """Turns the lines of the patchfiles into a map, where the keys are the files
+  that are changed by the patch (the entire diff --... line) and the associated
+  values are the actual changes"""
+  diffs = {}
+
+  key = patch_lines[0].strip()
+  diffs[key] = []
+  for line in patch_lines[1:]:
+    if line.startswith('diff -'):
+      key = line.strip()
+      diffs[key] = []
+    else:
+      diffs[key].append(line)
+
+  return diffs
+
+def get_patch_diffs(patch):
+  """Filter out the beginning of the file, until the first diff -- line, do some
+  additional filtering and then turn the file into a map of diffs"""
+  start = index_of_first(patch, lambda l: l.startswith('diff -'))
+  meaningful_patch = patch[start:]
+  patch_lines = filter(filter_patch_line, meaningful_patch)
+  patch_lines = map(strip_atat_lines, patch_lines)
+
+  return map_diffs(patch_lines)
+
+def get_patches_from_git(root, dirs):
+  """Get the patches that are applied currently to the various repos. Very
+  similar to how git-export-patches works, but does some processing with
+  get_patch_diffs() to make things easier to compare"""
+  patch_map = {}
+
+  for patch, repo in dirs.iteritems():
+    patch_dir = os.path.normpath(os.path.join(root, patch))
+    repo_dir = os.path.normpath(os.path.join(root, repo))
+
+    patch_range, num_patches = guess_base_commit(repo_dir)
+    patch_data = format_patch(repo_dir, patch_range)
+    patches = split_patches(patch_data)
+
+    for patch in patches:
+      patch_name = os.path.join(repo, get_file_name(patch))
+      patch_map[patch_name] = get_patch_diffs(patch)
+
+  return patch_map
+
+def compare_diffs(a, b):
+  """Compares two patches, checking the diffs (changes of one file in a patch).
+  This expects the patches to be in the diff map form mentioned above"""
+  if len(a) != len(b):
+    return False
+
+  try:
+    for diff in a:
+      if len(a[diff]) != len(b[diff]):
+        return False
+
+      for i in range(0, len(a[diff])):
+        if a[diff][i].strip() != b[diff][i].strip():
+          return False
+  except Exception as e:
+    return False
+
+  return True
+
+def check_patches(root, dirs, inputs):
+  """Iterates over the patch files it gets as input, and checks if they are
+  equivalent to the ones already applied"""
+  patches_from_git = get_patches_from_git(root, dirs)
+
+  for input in inputs:
+    patch_relative_path = os.path.relpath(input, root)
+    patch_dir = os.path.dirname(patch_relative_path).replace('\\', '/')
+
+    patch_name = os.path.join(dirs[patch_dir], os.path.basename(input))
+
+    with open(input) as f:
+      patch_from_file = get_patch_diffs(f.readlines())
+      if not compare_diffs(patch_from_file, patches_from_git[patch_name]):
+        return False
+
+  return True
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Apply Electron patches')
+  parser.add_argument('-c', '--config',
+                      type=argparse.FileType('r'),
+                      help='patches\' config(s) in the JSON format',
+                      required=True)
+  return parser.parse_args()
+
+def main():
+  args = parse_args()
+
+  root_dir = os.path.normpath(os.path.join(os.getcwd(), "../.."))
+  patchfiles = []
+  for root, dirs, files in os.walk(os.path.join(os.getcwd(), "patches/common")):
+    for file in files:
+      if file.endswith('.patches'):
+        with open(os.path.join(root, file)) as f:
+          for line in f.readlines():
+            patchfiles.append(os.path.join(root, line.strip()))
+
+  if not check_patches(root_dir, json.load(args.config), patchfiles):
+    print_in_a_frame('Patches have changed, run `gclient sync` again.')
+    sys.exit(1)
+
+if __name__ == '__main__':
+  main()

--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -2,98 +2,9 @@
 
 import argparse
 import os
-import re
-import subprocess
 import sys
 
-
-def guess_base_commit(repo):
-  """Guess which commit the patches might be based on"""
-  args = [
-    'git',
-    '-C',
-    repo,
-    'describe',
-    '--tags',
-  ]
-  return subprocess.check_output(args).rsplit('-', 2)[0:2]
-
-
-def format_patch(repo, since):
-  args = [
-    'git',
-    '-C',
-    repo,
-    '-c',
-    'core.attributesfile=' + os.path.join(os.path.dirname(os.path.realpath(__file__)), '.electron.attributes'),
-    # Ensure it is not possible to match anything
-    # Disabled for now as we have consistent chunk headers
-    # '-c',
-    # 'diff.electron.xfuncname=$^',
-    'format-patch',
-    '--keep-subject',
-    '--no-stat',
-    '--stdout',
-
-    # Per RFC 3676 the signature is separated from the body by a line with
-    # '-- ' on it. If the signature option is omitted the signature defaults
-    # to the Git version number.
-    '--no-signature',
-
-    # The name of the parent commit object isn't useful information in this
-    # context, so zero it out to avoid needless patch-file churn.
-    '--zero-commit',
-
-    # Some versions of git print out different numbers of characters in the
-    # 'index' line of patches, so pass --full-index to get consistent
-    # behaviour.
-    '--full-index',
-    since
-  ]
-  return subprocess.check_output(args)
-
-
-def split_patches(patch_data):
-  """Split a concatenated series of patches into N separate patches"""
-  patches = []
-  patch_start = re.compile('^From [0-9a-f]+ ')
-  for line in patch_data.splitlines():
-    if patch_start.match(line):
-      patches.append([])
-    patches[-1].append(line)
-  return patches
-
-
-def munge_subject_to_filename(subject):
-  """Derive a suitable filename from a commit's subject"""
-  if subject.endswith('.patch'):
-    subject = subject[:-6]
-  return re.sub(r'[^A-Za-z0-9-]+', '_', subject).strip('_').lower() + '.patch'
-
-
-def get_file_name(patch):
-  """Return the name of the file to which the patch should be written"""
-  for line in patch:
-    if line.startswith('Patch-Filename: '):
-      return line[len('Patch-Filename: '):]
-  # If no patch-filename header, munge the subject.
-  for line in patch:
-    if line.startswith('Subject: '):
-      return munge_subject_to_filename(line[len('Subject: '):])
-
-
-def remove_patch_filename(patch):
-  """Strip out the Patch-Filename trailer from a patch's message body"""
-  force_keep_next_line = False
-  for i, l in enumerate(patch):
-    is_patchfilename = l.startswith('Patch-Filename: ')
-    next_is_patchfilename = i < len(patch) - 1 and patch[i+1].startswith('Patch-Filename: ')
-    if not force_keep_next_line and (is_patchfilename or (next_is_patchfilename and len(l.rstrip()) == 0)):
-      pass # drop this line
-    else:
-      yield l
-    force_keep_next_line = l.startswith('Subject: ')
-
+from lib.patches import guess_base_commit, format_patch, split_patches, get_file_name, remove_patch_filename
 
 def main(argv):
   parser = argparse.ArgumentParser()

--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import os
+import re
+import subprocess
 
 
 def read_patch(patch_dir, patch_filename):
@@ -15,13 +17,111 @@ def read_patch(patch_dir, patch_filename):
   return ''.join(ret)
 
 
+def patch_filenames_for_dir(patch_dir):
+  """Read a directory of patches and return the list of patch filenames"""
+  with open(os.path.join(patch_dir, ".patches")) as f:
+    return [l.rstrip('\n') for l in f.readlines()]
+
 def patch_from_dir(patch_dir):
   """Read a directory of patches into a format suitable for passing to
   'git am'"""
-  with open(os.path.join(patch_dir, ".patches")) as f:
-    patch_list = [l.rstrip('\n') for l in f.readlines()]
+  patch_list = patch_filenames_for_dir(patch_dir)
 
   return ''.join([
     read_patch(patch_dir, patch_filename)
     for patch_filename in patch_list
   ])
+
+
+def guess_base_commit(repo):
+  """Guess which commit the patches might be based on"""
+  args = [
+    'git',
+    '-C',
+    repo,
+    'reflog',
+    'show',
+    '--grep-reflog',
+    'checkout:',
+    '-1',
+    '--no-abbrev',
+  ]
+  output = subprocess.check_output(args)
+  m = re.search('HEAD@\{([0-9]+)\}', output)
+  return [output[0:40], m.group(1)]
+
+
+def format_patch(repo, since):
+  args = [
+    'git',
+    '-C',
+    repo,
+    '-c',
+    'core.attributesfile=' + os.path.join(os.path.dirname(os.path.realpath(__file__)), '.electron.attributes'),
+    # Ensure it is not possible to match anything
+    # Disabled for now as we have consistent chunk headers
+    # '-c',
+    # 'diff.electron.xfuncname=$^',
+    'format-patch',
+    '--keep-subject',
+    '--no-stat',
+    '--stdout',
+
+    # Per RFC 3676 the signature is separated from the body by a line with
+    # '-- ' on it. If the signature option is omitted the signature defaults
+    # to the Git version number.
+    '--no-signature',
+
+    # The name of the parent commit object isn't useful information in this
+    # context, so zero it out to avoid needless patch-file churn.
+    '--zero-commit',
+
+    # Some versions of git print out different numbers of characters in the
+    # 'index' line of patches, so pass --full-index to get consistent
+    # behaviour.
+    '--full-index',
+    since
+  ]
+  return subprocess.check_output(args)
+
+
+def split_patches(patch_data):
+  """Split a concatenated series of patches into N separate patches"""
+  patches = []
+  patch_start = re.compile('^From [0-9a-f]+ ')
+  for line in patch_data.splitlines():
+    if patch_start.match(line):
+      patches.append([])
+    patches[-1].append(line)
+  return patches
+
+
+def munge_subject_to_filename(subject):
+  """Derive a suitable filename from a commit's subject"""
+  if subject.endswith('.patch'):
+    subject = subject[:-6]
+  return re.sub(r'[^A-Za-z0-9-]+', '_', subject).strip('_').lower() + '.patch'
+
+
+def get_file_name(patch):
+  """Return the name of the file to which the patch should be written"""
+  for line in patch:
+    if line.startswith('Patch-Filename: '):
+      return line[len('Patch-Filename: '):]
+  # If no patch-filename header, munge the subject.
+  for line in patch:
+    if line.startswith('Subject: '):
+      return munge_subject_to_filename(line[len('Subject: '):])
+
+
+def remove_patch_filename(patch):
+  """Strip out the Patch-Filename trailer from a patch's message body"""
+  force_keep_next_line = False
+  for i, l in enumerate(patch):
+    is_patchfilename = l.startswith('Patch-Filename: ')
+    next_is_patchfilename = i < len(patch) - 1 and patch[i+1].startswith('Patch-Filename: ')
+    if not force_keep_next_line and (is_patchfilename or (next_is_patchfilename and len(l.rstrip()) == 0)):
+      pass # drop this line
+    else:
+      yield l
+    force_keep_next_line = l.startswith('Subject: ')

--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -57,7 +57,8 @@ def format_patch(repo, since):
     '-C',
     repo,
     '-c',
-    'core.attributesfile=' + os.path.join(os.path.dirname(os.path.realpath(__file__)), '.electron.attributes'),
+    'core.attributesfile=' + os.path.join(os.path.dirname( \
+                          os.path.realpath(__file__)), '.electron.attributes'),
     # Ensure it is not possible to match anything
     # Disabled for now as we have consistent chunk headers
     # '-c',
@@ -119,8 +120,10 @@ def remove_patch_filename(patch):
   force_keep_next_line = False
   for i, l in enumerate(patch):
     is_patchfilename = l.startswith('Patch-Filename: ')
-    next_is_patchfilename = i < len(patch) - 1 and patch[i+1].startswith('Patch-Filename: ')
-    if not force_keep_next_line and (is_patchfilename or (next_is_patchfilename and len(l.rstrip()) == 0)):
+    next_is_patchfilename = i < len(patch) - 1 and \
+                            patch[i+1].startswith('Patch-Filename: ')
+    if not force_keep_next_line and \
+       (is_patchfilename or (next_is_patchfilename and len(l.rstrip()) == 0)):
       pass # drop this line
     else:
       yield l

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -241,3 +241,9 @@ def get_electron_exec():
 
   raise Exception(
       "get_electron_exec: unexpected platform '{0}'".format(sys.platform))
+
+def index_of_first(lst, pred):
+  for i,v in enumerate(lst):
+    if pred(v):
+      return i
+  return None


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Sometimes I find myself forgetting to run `gclient sync` when patches change, which can lead to things not building (properly). This PR adds a script to check the patches against the applied patchsets to indicate if you should run `gclient sync` after you checked out the code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
