### PR TITLE
fix: crash when alt key pressed with falsy menu bar visiblity

### DIFF
--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -145,9 +145,11 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
 
     View* focused_view = GetFocusManager()->GetFocusedView();
     last_focused_view_tracker_->SetView(focused_view);
-    menu_bar_->RequestFocus();
-    // Show accelerators when menu bar is focused
-    menu_bar_->SetAcceleratorVisibility(true);
+    if (menu_bar_visible_) {
+      menu_bar_->RequestFocus();
+      // Show accelerators when menu bar is focused
+      menu_bar_->SetAcceleratorVisibility(true);
+    }
   } else {
     // When any other keys except single Alt have been pressed/released:
     menu_bar_alt_pressed_ = false;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixed crash when pressing `Alt` key with `setMenuBarVisibility` to false, by adding if statement for check if menu visible to give focus.

Fixes #17652 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash when pressing `Alt` key with `setMenuBarVisibility` to false.
