### PR TITLE
fix: incorrect default path setting for dl items

### DIFF
--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -113,7 +113,7 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
       settings.parent_window = window;
     if (settings.title.size() == 0)
       settings.title = item->GetURL().spec();
-    if (!settings.default_path.empty())
+    if (settings.default_path.empty())
       settings.default_path = default_path;
 
     auto* web_preferences = WebContentsPreferences::From(web_contents);


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/17754.

The conditional to set this was reversed: we were setting the default path when `!settings.default_path.empty()` but in fact we wanted to be setting a default path when it _was_ empty.

cc @brenca 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with default filenames not showing in download items on macOS.
