### PR TITLE
build: disable Vulkan support by default (4-1-x)

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -8,6 +8,7 @@ v8_embedder_string = "-electron.0"
 
 enable_cdm_host_verification = false
 enable_extensions = false
+enable_vulkan = false
 proprietary_codecs = true
 ffmpeg_branding = "Chrome"
 


### PR DESCRIPTION
#### Description of Change
Is was enabled in
https://chromium.googlesource.com/chromium/src.git/+/327326656f2c8c45ecb0ff4675e5c577e7c275ef
which landed in 69.0.3460.0

Vulkan support would require a command line parameter "--enable-vulkan"
to be passes to a binary to be enabled anyway,
so this change doesn't actual alter the current behaviour of Electron.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed unused Vulkan libraries from bundle.
