### PR TITLE
fix: make parseFeaturesString support all webPreferences option

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -216,7 +216,7 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
   // this uses the same parsing rules as window.open uses for its features
   if (typeof params.webpreferences === 'string') {
     parseFeaturesString(params.webpreferences, function (key, value) {
-      if (value === undefined) {
+      if (value === '') {
         // no value was specified, default it to true
         value = true
       }

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -189,7 +189,7 @@ ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, fra
 
   // Parse the features
   parseFeaturesString(features, function (key, value) {
-    if (value === undefined) {
+    if (value === '') {
       additionalFeatures.push(key)
     } else {
       // Don't allow webPreferences to be set since it must be an object

--- a/lib/common/parse-features-string.js
+++ b/lib/common/parse-features-string.js
@@ -1,21 +1,62 @@
 'use strict'
 
+// interpret the value as a boolean, if possible
+function interpretValue (value) {
+  return (value === 'yes' || value === '1') ? true
+    : (value === 'no' || value === '0') ? false : value
+}
+
 // parses a feature string that has the format used in window.open()
 // - `features` input string
 // - `emit` function(key, value) - called for each parsed KV
 module.exports = function parseFeaturesString (features, emit) {
   features = `${features}`.trim()
-  // split the string by ','
-  features.split(/\s*,\s*/).forEach((feature) => {
-    // expected form is either a key by itself or a key/value pair in the form of
-    // 'key=value'
-    let [key, value] = feature.split(/\s*=\s*/)
-    if (!key) return
 
-    // interpret the value as a boolean, if possible
-    value = (value === 'yes' || value === '1') ? true : (value === 'no' || value === '0') ? false : value
+  if (!features) return
 
-    // emit the parsed pair
-    emit(key, value)
-  })
+  let inArrayValue = false // mark whether in []
+  let value = ''
+  let arrayValue = []
+  let key = ''
+  let inGetKey = true // mark whether get key now
+
+  const { length } = features
+  for (let i = 0; i < length; i++) {
+    const char = features[i]
+    if (char === ' ' && !inArrayValue) {
+      continue
+    } else if (char === ',') {
+      if (!inArrayValue) {
+        inGetKey = true
+        if (arrayValue.length) {
+          emit(key, arrayValue)
+          arrayValue = []
+        } else {
+          emit(key, interpretValue(value))
+        }
+        key = ''
+      } else {
+        arrayValue.push(value)
+      }
+      value = ''
+    } else if (char === '=' && !inArrayValue) {
+      inGetKey = false
+      value = ''
+    } else if (char === '[') {
+      inArrayValue = true
+      arrayValue = []
+    } else if (char === ']') {
+      inArrayValue = false
+      arrayValue.push(value)
+      value = ''
+    } else if (inGetKey) {
+      key += char
+    } else {
+      value += char
+    }
+  }
+
+  if (key) {
+    emit(key, arrayValue.length ? arrayValue : interpretValue(value))
+  }
 }

--- a/spec/internal-spec.js
+++ b/spec/internal-spec.js
@@ -9,6 +9,7 @@ describe('feature-string parsing', () => {
       parseFeaturesString(string, (k, v) => { features[k] = v })
       expect(features).to.deep.equal(parsed)
     }
+
     checkParse('a=yes,c=d', { a: true, c: 'd' })
     checkParse('a=yes ,c=d', { a: true, c: 'd' })
     checkParse('a=yes, c=d', { a: true, c: 'd' })
@@ -19,5 +20,13 @@ describe('feature-string parsing', () => {
     checkParse(' a = yes , c =d', { a: true, c: 'd' })
     checkParse(' a = yes , c = d', { a: true, c: 'd' })
     checkParse(' a = yes , c = d ', { a: true, c: 'd' })
+    checkParse('a=1, c=d, additionalArguments=[--name=name test,--title=title]', {
+      additionalArguments: ['--name=name test', '--title=title'],
+      a: true,
+      c: 'd'
+    })
+    checkParse(' additionalArguments = [--title=title] ', {
+      additionalArguments: ['--title=title']
+    })
   })
 })


### PR DESCRIPTION
#### Description of Change
before change, webview not support webpreferences options like:
- expected additionalArguments is support
```html
<webview src="https://github.com" webpreferences="additionalArguments=[--test=test, --name=name]"></webview>
```
webpreferences object will like:
```js
// before change
{
  additionalArguments: '[--test', 
  '--name': 'name' 
}
// now
{ 
  additionalArguments: ['--test=test', '--name=name'] 
}
```
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed parseFeaturesString support all webPreferences option
