### PR TITLE
fix: reset the NSUserNotication handle on dismiss

### DIFF
--- a/atom/browser/notifications/mac/cocoa_notification.mm
+++ b/atom/browser/notifications/mac/cocoa_notification.mm
@@ -109,6 +109,8 @@ void CocoaNotification::Dismiss() {
   NotificationDismissed();
 
   this->LogAction("dismissed");
+
+  notification_.reset(nil);
 }
 
 void CocoaNotification::NotificationDisplayed() {


### PR DESCRIPTION
Fixes #17758 

The destructor and `Dismiss` both attempt to `removeDeliveredNotification` which you can only do once.

Notes: Fix crash when manually dismissing notifications before quit on macOS