### PR TITLE
backport: Fix network service not working when running as a remote app before Windows 8

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -99,3 +99,4 @@ keyboard-lock-service-impl.patch
 make_--explicitly-allowed-ports_work_with_networkservice.patch
 fix_crashes_in_renderframeimpl_onselectpopupmenuitem_s.patch
 fix_re-entracy_problem_with_invalidateframesinkid.patch
+fix_network_service_not_working_when_running_as_a_remote_app_before.patch

--- a/patches/common/chromium/fix_network_service_not_working_when_running_as_a_remote_app_before.patch
+++ b/patches/common/chromium/fix_network_service_not_working_when_running_as_a_remote_app_before.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Abd-El-Malek <jam@chromium.org>
+Date: Wed, 28 Nov 2018 20:37:49 +0000
+Subject: Fix network service not working when running as a remote app before
+ Windows 8.
+
+r562058 made the network process always run in a job object to try to avoid it outliving the browser process. This was added to make the network process quit sooner if there was a lot of pending I/O, which happened with layout tests. Windows before version 8 doesn't support nested job objects though, so we need to stop this mitigation for those old versions.
+
+Bug: 904361
+Change-Id: If75fc933052b1b7d4ef3d3e90664f777624c04d7
+Reviewed-on: https://chromium-review.googlesource.com/c/1350977
+Commit-Queue: John Abd-El-Malek <jam@chromium.org>
+Reviewed-by: Julian Pastarmov <pastarmovj@chromium.org>
+Reviewed-by: James Forshaw <forshaw@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#611856}
+
+diff --git a/services/service_manager/sandbox/win/sandbox_win.cc b/services/service_manager/sandbox/win/sandbox_win.cc
+index 7beb41460e7d1a7340cca8ebc98a114ec41b3e44..474035f8612816d1be000e5f7d4796005943b158 100644
+--- a/services/service_manager/sandbox/win/sandbox_win.cc
++++ b/services/service_manager/sandbox/win/sandbox_win.cc
+@@ -831,7 +831,12 @@ sandbox::ResultCode SandboxWin::StartSandboxedProcess(
+           service_manager::switches::kNoSandbox)) {
+     base::LaunchOptions options;
+     options.handles_to_inherit = handles_to_inherit;
+-    if (sandbox_type == SANDBOX_TYPE_NETWORK) {
++    BOOL in_job = true;
++    // Prior to Windows 8 nested jobs aren't possible.
++    if (sandbox_type == SANDBOX_TYPE_NETWORK &&
++        (base::win::GetVersion() >= base::win::VERSION_WIN8 ||
++         (::IsProcessInJob(::GetCurrentProcess(), nullptr, &in_job) &&
++          !in_job))) {
+       // Launch the process in a job to ensure that the network process doesn't
+       // outlive the browser. This could happen if there is a lot of I/O on
+       // process shutdown, in which case TerminateProcess would fail.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
