### PR TITLE
fix: launch child processes in a job to ensure that they don't outlive the browser

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -77,3 +77,4 @@ viz_osr.patch
 video_capturer_dirty_rect.patch
 unsandboxed_ppapi_processes_skip_zygote.patch
 autofill_size_calculation.patch
+launch_child_unsandboxed_processes_in_kill_on_job_close_job.patch

--- a/patches/common/chromium/launch_child_unsandboxed_processes_in_kill_on_job_close_job.patch
+++ b/patches/common/chromium/launch_child_unsandboxed_processes_in_kill_on_job_close_job.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Francois Doray <fdoray@chromium.org>
+Date: Mon, 8 Apr 2019 15:44:07 +0000
+Subject: Launch child unsandboxed processes in "Kill on Job Close" job.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When the --no-sandbox flag is used, hanging child processes can outlive
+a browser process that gets killed. This results in leftover processes
+on bots when the process launcher sequence is made CONTINUE_ON_SHUTDOWN
+(see https://crbug.com/830954#c18).
+
+With this CL, all child processes are part of a "Kill on Job Close" job
+and are guaranteed not to outlive the browser process.
+
+This is a prerequisite to make the process launcher sequence
+CONTINUE_ON_SHUTDOWN, which will fix ~12% of shutdown hangs on Windows.
+
+Bug: 830954
+Change-Id: Ieec2b0a4cfc7db93dfffde947cae9fdb46fedb02
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1548839
+Reviewed-by: Will Harris <wfh@chromium.org>
+Commit-Queue: François Doray <fdoray@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#648686}
+
+diff --git a/services/service_manager/sandbox/win/sandbox_win.cc b/services/service_manager/sandbox/win/sandbox_win.cc
+index f4c3eeda228573ce92b71d3e4e4090e8e26d8bfd..7127a6f2a138fa97e29571e6469a4c97973c38dc 100644
+--- a/services/service_manager/sandbox/win/sandbox_win.cc
++++ b/services/service_manager/sandbox/win/sandbox_win.cc
+@@ -862,13 +862,12 @@ sandbox::ResultCode SandboxWin::StartSandboxedProcess(
+     options.handles_to_inherit = handles_to_inherit;
+     BOOL in_job = true;
+     // Prior to Windows 8 nested jobs aren't possible.
+-    if (sandbox_type == SANDBOX_TYPE_NETWORK &&
+-        (base::win::GetVersion() >= base::win::VERSION_WIN8 ||
+-         (::IsProcessInJob(::GetCurrentProcess(), nullptr, &in_job) &&
+-          !in_job))) {
+-      // Launch the process in a job to ensure that the network process doesn't
+-      // outlive the browser. This could happen if there is a lot of I/O on
+-      // process shutdown, in which case TerminateProcess would fail.
++    if (base::win::GetVersion() >= base::win::VERSION_WIN8 ||
++        (::IsProcessInJob(::GetCurrentProcess(), nullptr, &in_job) &&
++         !in_job)) {
++      // Launch the process in a job to ensure that it doesn't outlive the
++      // browser. This could happen if there is a lot of I/O on process
++      // shutdown, in which case TerminateProcess would fail.
+       // https://crbug.com/820996
+       if (!g_job_object_handle) {
+         sandbox::Job job_obj;


### PR DESCRIPTION
#### Description of Change
Backport https://chromium-review.googlesource.com/c/chromium/src/+/1548839
> Launch child unsandboxed processes in "Kill on Job Close" job.
> 
> When the --no-sandbox flag is used, hanging child processes can outlive
> a browser process that gets killed. This results in leftover processes
> on bots when the process launcher sequence is made CONTINUE_ON_SHUTDOWN
> (see https://crbug.com/830954#c18).
> 
> With this CL, all child processes are part of a "Kill on Job Close" job
> and are guaranteed not to outlive the browser process.
> 
> This is a prerequisite to make the process launcher sequence
> CONTINUE_ON_SHUTDOWN, which will fix ~12% of shutdown hangs on Windows.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed non-sandboxed renderer processes on Windows not terminating in all cases (JS thread stuck in infinite loop for example) when the main process is killed.