### PR TITLE
fix: emit process 'loaded' event in sandboxed renderers

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -209,6 +209,10 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   node::per_process::native_module_loader.CompileAndCall(
       isolate->GetCurrentContext(), "electron/js2c/preload_bundle",
       &preload_bundle_params, &preload_bundle_args, nullptr);
+
+  v8::HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(context);
+  InvokeIpcCallback(context, "onLoaded", std::vector<v8::Local<v8::Value>>());
 }
 
 void AtomSandboxedRendererClient::SetupMainWorldOverrides(

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -64,6 +64,10 @@ ipcNative.onMessage = function (channel, args, senderId) {
   electron.ipcRenderer.emit(channel, { sender: electron.ipcRenderer, senderId }, ...args)
 }
 
+ipcNative.onLoaded = function () {
+  process.emit('loaded')
+}
+
 ipcNative.onExit = function () {
   process.emit('exit')
 }
@@ -89,6 +93,7 @@ Object.defineProperty(preloadProcess, 'noDeprecation', {
   }
 })
 
+process.on('loaded', () => preloadProcess.emit('loaded'))
 process.on('exit', () => preloadProcess.emit('exit'))
 
 const { remoteRequire } = require('@electron/internal/renderer/remote')

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1526,7 +1526,6 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload
           }
@@ -1544,7 +1543,6 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload: preloadSpecialChars
           }
@@ -1552,12 +1550,24 @@ describe('BrowserWindow module', () => {
         w.loadFile(path.join(fixtures, 'api', 'preload.html'))
       })
 
+      it('exposes "loaded" event to preload script', function (done) {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true,
+            preload
+          }
+        })
+        ipcMain.once('process-loaded', () => done())
+        w.loadURL('about:blank')
+      })
+
       it('exposes "exit" event to preload script', function (done) {
         w.destroy()
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload
           }
@@ -1580,7 +1590,6 @@ describe('BrowserWindow module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true,
             sandbox: true,
             preload
           }

--- a/spec/fixtures/module/preload-sandbox.js
+++ b/spec/fixtures/module/preload-sandbox.js
@@ -4,6 +4,11 @@
   window.ipcRenderer = ipcRenderer
   window.setImmediate = setImmediate
   window.require = require
+
+  process.once('loaded', () => {
+    ipcRenderer.send('process-loaded')
+  })
+
   if (location.protocol === 'file:') {
     window.test = 'preload'
     window.process = process


### PR DESCRIPTION
#### Description of Change
Backport https://github.com/electron/electron/pull/17680

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `'loaded'` event not being emitted in sandboxed renderers.