### PR TITLE
fix: emit process 'loaded' event in sandboxed renderers

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -191,6 +191,8 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   // Execute the function with proper arguments
   ignore_result(
       func->Call(context, v8::Null(isolate), node::arraysize(args), args));
+
+  InvokeIpcCallback(context, "onLoaded", std::vector<v8::Local<v8::Value>>());
 }
 
 void AtomSandboxedRendererClient::WillReleaseScriptContext(

--- a/lib/sandboxed_renderer/api/ipc-renderer.js
+++ b/lib/sandboxed_renderer/api/ipc-renderer.js
@@ -13,6 +13,10 @@ ipcNative.onMessage = function (channel, args) {
   ipcRenderer.emit(channel, {sender: ipcRenderer}, ...args)
 }
 
+ipcNative.onLoaded = function () {
+  process.emit('loaded')
+}
+
 ipcNative.onExit = function () {
   process.emit('exit')
 }

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -62,6 +62,7 @@ preloadProcess.execPath = process.execPath = binding.getExecPath()
 preloadProcess.platform = process.platform = platform
 preloadProcess.env = process.env = env
 
+process.on('loaded', () => preloadProcess.emit('loaded'))
 process.on('exit', () => preloadProcess.emit('exit'))
 
 // This is the `require` function that will be visible to the preload script

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1259,6 +1259,19 @@ describe('BrowserWindow module', () => {
         w.loadURL('file://' + path.join(fixtures, 'api', 'preload.html'))
       })
 
+      it('exposes "loaded" event to preload script', function (done) {
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: true,
+            preload
+          }
+        })
+        ipcMain.once('process-loaded', () => done())
+        w.loadURL('about:blank')
+      })
+
       it('exposes "exit" event to preload script', function (done) {
         w.destroy()
         w = new BrowserWindow({

--- a/spec/fixtures/module/preload-sandbox.js
+++ b/spec/fixtures/module/preload-sandbox.js
@@ -4,6 +4,11 @@
   window.ipcRenderer = ipcRenderer
   window.setImmediate = setImmediate
   window.require = require
+
+  process.once('loaded', () => {
+    ipcRenderer.send('process-loaded')
+  })
+
   if (location.protocol === 'file:') {
     window.test = 'preload'
     window.process = process


### PR DESCRIPTION
#### Description of Change
Backport https://github.com/electron/electron/pull/17680

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `'loaded'` event not being emitted in sandboxed renderers.