### PR TITLE
fix: remove disable NSWindowZoomButton in frameless window

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -1431,11 +1431,6 @@ void NativeWindowMac::AddContentViewLayers() {
       [[window_ standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
       [[window_ standardWindowButton:NSWindowCloseButton] setHidden:YES];
     }
-
-    // Some third-party macOS utilities check the zoom button's enabled state to
-    // determine whether to show custom UI on hover, so we disable it here to
-    // prevent them from doing so in a frameless app window.
-    [[window_ standardWindowButton:NSWindowZoomButton] setEnabled:NO];
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Fixes [16091](https://github.com/electron/electron/issues/16091)

electron `1-3-x ~ 2-1-x` [achieve](https://github.com/electron/electron/blob/2-0-x/atom/browser/native_window_mac.mm#L1047):
```objective-c
// see in NativeWindowMac constructor
{
  // ...
  InstallView();

  SetMaximizable(maximizable);
}
// InstallView set like this 
[[window_ standardWindowButton:NSWindowZoomButton] setEnabled:NO];
// then quickly SetMaximizable reset
[[window_ standardWindowButton:NSWindowZoomButton] setEnabled:maximizable];
```

Can remove disable zoom-button? If remove will support some tools like [Magnet](https://magnet.crowdcafe.com/)
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Remove disable NSWindowZoomButton in frameless window
