### PR TITLE
fix: handle remote-debugging-port=0 correctly

### DIFF
--- a/atom/browser/ui/devtools_manager_delegate.cc
+++ b/atom/browser/ui/devtools_manager_delegate.cc
@@ -8,9 +8,11 @@
 #include <utility>
 #include <vector>
 
+#include "atom/browser/atom_paths.h"
 #include "base/bind.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
+#include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
@@ -67,7 +69,7 @@ std::unique_ptr<content::DevToolsSocketFactory> CreateSocketFactory() {
     int temp_port;
     std::string port_str =
         command_line.GetSwitchValueASCII(switches::kRemoteDebuggingPort);
-    if (base::StringToInt(port_str, &temp_port) && temp_port > 0 &&
+    if (base::StringToInt(port_str, &temp_port) && temp_port >= 0 &&
         temp_port < 65535) {
       port = temp_port;
     } else {
@@ -84,8 +86,10 @@ std::unique_ptr<content::DevToolsSocketFactory> CreateSocketFactory() {
 
 // static
 void DevToolsManagerDelegate::StartHttpHandler() {
+  base::FilePath user_dir;
+  base::PathService::Get(DIR_USER_DATA, &user_dir);
   content::DevToolsAgentHost::StartRemoteDebuggingServer(
-      CreateSocketFactory(), base::FilePath(), base::FilePath());
+      CreateSocketFactory(), user_dir, base::FilePath());
 }
 
 DevToolsManagerDelegate::DevToolsManagerDelegate() {}

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -91,9 +91,7 @@ function loadApplicationPackage (packagePath) {
       } else if (packageJson.name) {
         app.setName(packageJson.name)
       }
-      app.setPath('userData', path.join(app.getPath('appData'), app.getName()))
-      app.setPath('userCache', path.join(app.getPath('cache'), app.getName()))
-      app.setAppPath(packagePath)
+      app._setDefaultAppPaths(packagePath)
     }
 
     try {

--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -58,6 +58,21 @@ app.isPackaged = (() => {
   return execFile !== 'electron'
 })()
 
+app._setDefaultAppPaths = (packagePath) => {
+  // Set the user path according to application's name.
+  app.setPath('userData', path.join(app.getPath('appData'), app.getName()))
+  app.setPath('userCache', path.join(app.getPath('cache'), app.getName()))
+  app.setAppPath(packagePath)
+
+  // Add support for --user-data-dir=
+  const userDataDirFlag = '--user-data-dir='
+  const userDataArg = process.argv.find(arg => arg.startsWith(userDataDirFlag))
+  if (userDataArg) {
+    const userDataDir = userDataArg.substr(userDataDirFlag.length)
+    if (path.isAbsolute(userDataDir)) app.setPath('userData', userDataDir)
+  }
+}
+
 if (process.platform === 'darwin') {
   app.dock = {
     bounce (type = 'informational') {

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -144,10 +144,7 @@ if (packageJson.v8Flags != null) {
   v8.setFlagsFromString(packageJson.v8Flags)
 }
 
-// Set the user path according to application's name.
-app.setPath('userData', path.join(app.getPath('appData'), app.getName()))
-app.setPath('userCache', path.join(app.getPath('cache'), app.getName()))
-app.setAppPath(packagePath)
+app._setDefaultAppPaths(packagePath)
 
 // Load the chrome extension support.
 require('@electron/internal/browser/chrome-extension')


### PR DESCRIPTION
Backport of #17800 

See that PR for details.

Notes: Fixed issue where `chromedriver` would not connect correctly if you didn't provide a custom `remote-debugging-port`