### PR TITLE
docs: fix doc linter warnings

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1237,7 +1237,7 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 
-* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
+Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -205,9 +205,12 @@ that all statistics are reported in Kilobytes.
 Returns `String` - The version of the host operating system.
 
 Examples:
-- macOS: `10.13.6`
-- Windows: `10.0.17763`
-- Linux: `4.15.0-45-generic`
+
+| Platform | Version |
+|----------|---------|
+| macOS | `10.13.6` |
+| Windows | `10.0.17763` |
+| Linux | `4.15.0-45-generic` |
 
 **Note:** It returns the actual operating system version instead of kernel version on macOS unlike `os.release()`.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1185,7 +1185,7 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
-* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
+Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
@@ -1249,7 +1249,7 @@ The `callback` will be called with `callback(error, data)` on completion. The
   * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
   * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
 
-* Returns `Promise<Buffer>` - Resolves with the generated PDF data.
+Returns `Promise<Buffer>` - Resolves with the generated PDF data.
 
 Prints window's web page as PDF with Chromium's preview printing custom
 settings.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -580,7 +580,7 @@ Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, cal
   * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
   * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
 
-* Returns `Promise<Buffer>` - Resolves with the generated PDF data.
+Returns `Promise<Buffer>` - Resolves with the generated PDF data.
 
 Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options)`.
 
@@ -600,7 +600,7 @@ that stores data of the snapshot. Omitting `rect` will capture the whole visible
 
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
-* Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
+Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 


### PR DESCRIPTION
This gets rid of those _really_ annoying docs linter warnings, turns out a few of them were legit issues 👍 

Notes: no-notes