### PR TITLE
fix: skip zygote for unsandboxed ppapi processes

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -73,3 +73,4 @@ fix_disable_usage_of_setapplicationisdaemon_and.patch
 disable_custom_libcxx_on_windows.patch
 fix_retain_compatibility_with_msvc.patch
 disable_network_services_by_default.patch
+unsandboxed_ppapi_processes_skip_zygote.patch

--- a/patches/common/chromium/unsandboxed_ppapi_processes_skip_zygote.patch
+++ b/patches/common/chromium/unsandboxed_ppapi_processes_skip_zygote.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Tue, 16 Apr 2019 11:25:08 -0700
+Subject: unsandboxed ppapi processes skip zygote
+
+
+diff --git a/content/browser/ppapi_plugin_process_host.cc b/content/browser/ppapi_plugin_process_host.cc
+index 2d57937dfffb4ea85739f27780e53c04ef087f58..39a21171b4584cc6f45e2407a02dee2609603249 100644
+--- a/content/browser/ppapi_plugin_process_host.cc
++++ b/content/browser/ppapi_plugin_process_host.cc
+@@ -106,6 +106,9 @@ class PpapiPluginSandboxedProcessLauncherDelegate
+   service_manager::ZygoteHandle GetZygote() override {
+     const base::CommandLine& browser_command_line =
+         *base::CommandLine::ForCurrentProcess();
++    if (browser_command_line.HasSwitch(service_manager::switches::kNoSandbox)) {
++      return nullptr;
++    }
+     base::CommandLine::StringType plugin_launcher = browser_command_line
+         .GetSwitchValueNative(switches::kPpapiPluginLauncher);
+     if (is_broker_ || !plugin_launcher.empty())


### PR DESCRIPTION
#### Description of Change
Fixes #17034.

The sequence of events here was:

1. The main process starts
2. Early in the initialization sequence, before `main.js` is run, content spawns a zygote and initializes the sandbox
3. `main.js` runs, and adds `--no-sandbox` to the command-line flags
4. The renderer boots and requests a ppapi process
5. The ppapi process is forked from the zygote, which already has the sandbox pre-initialized, since it was warmed up before the `--no-sandbox` flag was added.

With this patch, we intervene before (5) and re-check the command-line flags. If `--no-sandbox` is present, we do not launch from the zygote, and instead spawn a fresh process without the sandbox.

This patch is similar to [the one that supports mixed-sandbox mode](https://github.com/electron/electron/blob/a34c47b54234237696a6630718ff74609ab7cd00/patches/common/chromium/support_mixed_sandbox_with_zygote.patch#L66).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue preventing the Flash plugin from loading on Linux.