### PR TITLE
build: save HEAD when git-import-patches runs

### DIFF
--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -9,14 +9,35 @@ import sys
 
 def guess_base_commit(repo):
   """Guess which commit the patches might be based on"""
-  args = [
-    'git',
-    '-C',
-    repo,
-    'describe',
-    '--tags',
-  ]
-  return subprocess.check_output(args).rsplit('-', 2)[0:2]
+  try:
+    args = [
+      'git',
+      '-C',
+      repo,
+      'rev-parse',
+      '--verify',
+      'refs/patches/upstream-head',
+    ]
+    upstream_head = subprocess.check_output(args).strip()
+    args = [
+      'git',
+      '-C',
+      repo,
+      'rev-list',
+      '--count',
+      upstream_head + '..',
+    ]
+    num_commits = subprocess.check_output(args).strip()
+    return [upstream_head, num_commits]
+  except subprocess.CalledProcessError:
+    args = [
+      'git',
+      '-C',
+      repo,
+      'describe',
+      '--tags',
+    ]
+    return subprocess.check_output(args).rsplit('-', 2)[0:2]
 
 
 def format_patch(repo, since):

--- a/script/git-import-patches
+++ b/script/git-import-patches
@@ -17,6 +17,12 @@ def main(argv):
       help="use 3-way merge to resolve conflicts")
   args = parser.parse_args(argv)
 
+  # save the upstream HEAD so we can refer to it when we later export patches
+  git.update_ref(
+      repo='.',
+      ref='refs/patches/upstream-head',
+      newvalue='HEAD'
+  )
   git.am(
       repo='.',
       patch_data=patch_from_dir(args.patch_dir),

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -102,6 +102,12 @@ def get_head_commit(repo):
   return subprocess.check_output(args).strip()
 
 
+def update_ref(repo, ref, newvalue):
+  args = ['git', '-C', repo, 'update-ref', ref, newvalue]
+
+  return subprocess.check_call(args)
+
+
 def reset(repo):
   args = ['git', '-C', repo, 'reset']
 


### PR DESCRIPTION
#### Description of Change
This saves what HEAD is when `git-import-patches` runs so that when we later run `git-export-patches` we can remember what base to use. Should be faster & more reliable, and will work for repos that don't always have a tag/branch at HEAD when we clone them (notably: boringssl, ffmpeg, and lkgr chromium itself).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes