### PR TITLE
build: override the NMV for Electron 5

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '73.0.3683.116',
   'node_version':
-    '61d92b0bd93b013a81f0fc96eaf7334d462b97bc',
+    '696d8fb66d6f65fc82869d390e0d2078970b1eb4',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '73.0.3683.116',
   'node_version':
-    '08480a494f3349223764c7c534e1ee5f57cee28a',
+    '9f1c9beb645d472e7411b8054e75412750c3d4da',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '73.0.3683.116',
   'node_version':
-    '9f1c9beb645d472e7411b8054e75412750c3d4da',
+    '61d92b0bd93b013a81f0fc96eaf7334d462b97bc',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '73.0.3683.116',
   'node_version':
-    'de2f087468244d2a86e4400803f743c42fa9345a',
+    '08480a494f3349223764c7c534e1ee5f57cee28a',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,6 +2,7 @@ is_electron_build = true
 use_jumbo_build = true
 root_extra_deps = [ "//electron" ]
 
+# Registry of NMVs --> https://github.com/nodejs/node/pull/24114/files
 node_module_version = 70
 
 v8_promise_internal_field_count = 1

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,6 +2,8 @@ is_electron_build = true
 use_jumbo_build = true
 root_extra_deps = [ "//electron" ]
 
+node_module_version = 70
+
 v8_promise_internal_field_count = 1
 v8_typed_array_max_size_in_heap = 0
 v8_embedder_string = "-electron.0"

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,7 +2,7 @@ is_electron_build = true
 use_jumbo_build = true
 root_extra_deps = [ "//electron" ]
 
-# Registry of NMVs --> https://github.com/nodejs/node/pull/24114/files
+# Registry of NMVs --> https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json
 node_module_version = 70
 
 v8_promise_internal_field_count = 1


### PR DESCRIPTION
This corrects the NMV for Electron 5 now that we are updated to node 12

Notes: no-notes