### PR TITLE
fix: skip zygote for unsandboxed ppapi processes (backport: 5-0-x)

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -75,3 +75,4 @@ fix_disable_usage_of_pthread_fchdir_np_and_pthread_chdir_np_in_mas.patch
 fix_disable_usage_of_setapplicationisdaemon_and.patch
 viz_osr.patch
 video_capturer_dirty_rect.patch
+unsandboxed_ppapi_processes_skip_zygote.patch

--- a/patches/common/chromium/unsandboxed_ppapi_processes_skip_zygote.patch
+++ b/patches/common/chromium/unsandboxed_ppapi_processes_skip_zygote.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Tue, 16 Apr 2019 11:25:08 -0700
+Subject: unsandboxed ppapi processes skip zygote
+
+
+diff --git a/content/browser/ppapi_plugin_process_host.cc b/content/browser/ppapi_plugin_process_host.cc
+index 2d57937dfffb4ea85739f27780e53c04ef087f58..39a21171b4584cc6f45e2407a02dee2609603249 100644
+--- a/content/browser/ppapi_plugin_process_host.cc
++++ b/content/browser/ppapi_plugin_process_host.cc
+@@ -106,6 +106,9 @@ class PpapiPluginSandboxedProcessLauncherDelegate
+   service_manager::ZygoteHandle GetZygote() override {
+     const base::CommandLine& browser_command_line =
+         *base::CommandLine::ForCurrentProcess();
++    if (browser_command_line.HasSwitch(service_manager::switches::kNoSandbox)) {
++      return nullptr;
++    }
+     base::CommandLine::StringType plugin_launcher = browser_command_line
+         .GetSwitchValueNative(switches::kPpapiPluginLauncher);
+     if (is_broker_ || !plugin_launcher.empty())


### PR DESCRIPTION
Backport of #17823

See that PR for details.

Notes: Fixed an issue preventing the Flash plugin from loading on Linux.