### PR TITLE
fix: ensure the sandboxed preloads globals do not leak

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -9,6 +9,7 @@ import("//tools/grit/repack.gni")
 import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
 import("//v8/snapshot_toolchain.gni")
 import("build/asar.gni")
+import("build/js_wrap.gni")
 import("build/npm.gni")
 import("buildflags/buildflags.gni")
 import("electron_paks.gni")
@@ -52,7 +53,7 @@ config("branding") {
   ]
 }
 
-npm_action("atom_browserify_sandbox") {
+npm_action("atom_browserify_sandbox_unwrapped") {
   script = "browserify"
 
   inputs = [
@@ -64,7 +65,7 @@ npm_action("atom_browserify_sandbox") {
   ]
 
   outputs = [
-    "$target_gen_dir/js2c/preload_bundle.js",
+    "$target_gen_dir/js2c/preload_bundle_unwrapped.js",
   ]
 
   args = [
@@ -73,12 +74,14 @@ npm_action("atom_browserify_sandbox") {
     "./lib/sandboxed_renderer/api/exports/electron.js:electron",
     "-t",
     "aliasify",
+    "--standalone",
+    "sandboxed_preload",
     "-o",
     rebase_path(outputs[0]),
   ]
 }
 
-npm_action("atom_browserify_isolated") {
+npm_action("atom_browserify_isolated_unwrapped") {
   script = "browserify"
 
   inputs = [
@@ -86,15 +89,45 @@ npm_action("atom_browserify_isolated") {
   ]
 
   outputs = [
-    "$target_gen_dir/js2c/isolated_bundle.js",
+    "$target_gen_dir/js2c/isolated_bundle_unwrapped.js",
   ]
 
   args = [
     "lib/isolated_renderer/init.js",
     "-t",
     "aliasify",
+    "--standalone",
+    "isolated_preload",
     "-o",
     rebase_path(outputs[0]),
+  ]
+}
+
+js_wrap("atom_browserify_isolated") {
+  deps = [
+    ":atom_browserify_isolated_unwrapped",
+  ]
+
+  inputs = [
+    "$target_gen_dir/js2c/isolated_bundle_unwrapped.js",
+  ]
+
+  outputs = [
+    "$target_gen_dir/js2c/isolated_bundle.js",
+  ]
+}
+
+js_wrap("atom_browserify_sandbox") {
+  deps = [
+    ":atom_browserify_sandbox_unwrapped",
+  ]
+
+  inputs = [
+    "$target_gen_dir/js2c/preload_bundle_unwrapped.js",
+  ]
+
+  outputs = [
+    "$target_gen_dir/js2c/preload_bundle.js",
   ]
 }
 

--- a/build/js_wrap.gni
+++ b/build/js_wrap.gni
@@ -1,0 +1,19 @@
+template("js_wrap") {
+  assert(defined(invoker.inputs), "Need input JS script")
+  assert(defined(invoker.outputs), "Need output JS script")
+
+  action(target_name) {
+    forward_variables_from(invoker,
+                           [
+                             "deps",
+                             "public_deps",
+                             "sources",
+                             "inputs",
+                             "outputs",
+                           ])
+
+    script = "//electron/build/js_wrap.py"
+    args = [ "--in" ] + rebase_path(invoker.inputs) + [ "--out" ] +
+           rebase_path(invoker.outputs)
+  }
+}

--- a/build/js_wrap.py
+++ b/build/js_wrap.py
@@ -1,0 +1,19 @@
+import sys
+
+in_start = sys.argv.index("--in") + 1
+out_start = sys.argv.index("--out") + 1
+
+in_bundles = sys.argv[in_start:out_start - 1]
+out_bundles = sys.argv[out_start:]
+
+if len(in_bundles) is not len(out_bundles):
+  print("--out and --in must provide the same number of arguments")
+  sys.exit(1)
+
+for i in range(len(in_bundles)):
+  in_bundle = in_bundles[i]
+  out_path = out_bundles[i]
+  with open(in_bundle, 'r') as f:
+    lines = ["(function(){var exports={},module={exports};"] + f.readlines() + ["})();"]
+    with open(out_path, 'w') as out_f:
+      out_f.writelines(lines)

--- a/spec/fixtures/api/no-leak.html
+++ b/spec/fixtures/api/no-leak.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+</head>
+<body>
+  <script>
+  window.postMessage({
+    require: typeof require,
+    exports: typeof exports,
+    windowRequire: typeof window.require,
+    windowExports: typeof window.exports,
+    windowPreload: typeof window.sandboxed_preload,
+  })
+  </script>
+</body>
+</html>

--- a/spec/fixtures/module/empty.js
+++ b/spec/fixtures/module/empty.js
@@ -1,0 +1,5 @@
+const { ipcRenderer } = require('electron')
+
+window.addEventListener('message', (event) => {
+  ipcRenderer.send('leak-result', event.data)
+})


### PR DESCRIPTION
Backport of #17712 

See that PR for details.

Notes:  Fixed issue where sandboxed renderers could sometimes leak globals outside of the preload script