### PR TITLE
build: rename sandbox bundle

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -80,7 +80,7 @@ npm_action("atom_browserify_sandbox_unwrapped") {
   inputs = auto_filenames.sandbox_browserify_deps
 
   outputs = [
-    "$target_gen_dir/js2c/preload_bundle_unwrapped.js",
+    "$target_gen_dir/js2c/sandbox_bundle_unwrapped.js",
   ]
 
   args = [
@@ -194,11 +194,11 @@ js_wrap("atom_browserify_sandbox") {
   ]
 
   inputs = [
-    "$target_gen_dir/js2c/preload_bundle_unwrapped.js",
+    "$target_gen_dir/js2c/sandbox_bundle_unwrapped.js",
   ]
 
   outputs = [
-    "$target_gen_dir/js2c/preload_bundle.js",
+    "$target_gen_dir/js2c/sandbox_bundle.js",
   ]
 }
 
@@ -223,7 +223,7 @@ action("atom_js2c") {
   browserify_sources = [
     "$target_gen_dir/js2c/content_script_bundle.js",
     "$target_gen_dir/js2c/isolated_bundle.js",
-    "$target_gen_dir/js2c/preload_bundle.js",
+    "$target_gen_dir/js2c/sandbox_bundle.js",
   ]
 
   sources = browserify_sources + [

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -218,14 +218,14 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
   InitializeBindings(binding, context, render_frame->IsMainFrame());
   AddRenderBindings(isolate, binding);
 
-  std::vector<v8::Local<v8::String>> preload_bundle_params = {
+  std::vector<v8::Local<v8::String>> sandbox_preload_bundle_params = {
       node::FIXED_ONE_BYTE_STRING(isolate, "binding")};
 
-  std::vector<v8::Local<v8::Value>> preload_bundle_args = {binding};
+  std::vector<v8::Local<v8::Value>> sandbox_preload_bundle_args = {binding};
 
   node::per_process::native_module_loader.CompileAndCall(
-      isolate->GetCurrentContext(), "electron/js2c/preload_bundle",
-      &preload_bundle_params, &preload_bundle_args, nullptr);
+      isolate->GetCurrentContext(), "electron/js2c/sandbox_bundle",
+      &sandbox_preload_bundle_params, &sandbox_preload_bundle_args, nullptr);
 
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(context);


### PR DESCRIPTION
The other bundles are appropriately named (content_script, isolated).  `preload` isn't exactly helpful when you want to figure out what it does 😄 Now we have multiple bundles it makes sense to name them usefully 👍 

Notes: no-notes