### PR TITLE
chore: remove superfluous ScopedAllowBaseSync in desktopCapturer

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -87,10 +87,6 @@ void DesktopCapturer::StartHandling(bool capture_window,
   capture_screen_ = capture_screen;
 
   {
-    // Remove this once
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=795340 is fixed.
-    base::ScopedAllowBaseSyncPrimitivesForTesting
-        scoped_allow_base_sync_primitives;
     // Initialize the source list.
     // Apply the new thumbnail size and restart capture.
     if (capture_window) {


### PR DESCRIPTION
#### Description of Change

[#796889](https://bugs.chromium.org/p/chromium/issues/detail?id=796889) has been fixed and so this is no longer necessary.

cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
