### PR TITLE
fix: copy pixels in NativeImage::CreateFromBitmap

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -568,7 +568,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
 
   SkBitmap bitmap;
   bitmap.allocN32Pixels(width, height, false);
-  bitmap.setPixels(node::Buffer::Data(buffer));
+  bitmap.writePixels({info, node::Buffer::Data(buffer), bitmap.rowBytes()});
 
   gfx::ImageSkia image_skia;
   image_skia.AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));


### PR DESCRIPTION
#### Description of Change
Follow up to https://github.com/electron/electron/pull/17843

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes