### PR TITLE
[WIP] chore: add missing capabilities to run cypress tests in Electron

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -309,6 +309,13 @@ const assertChromeExtension = function (contents, api) {
   }
 }
 
+ipcMainUtils.handle('CHROME_TABS_QUERY', function (event, requestId) {
+  return BrowserWindow.getAllWindows().map(w => ({
+    id: w.webContents.id,
+    url: w.webContents.getURL()
+  }))
+})
+
 ipcMainUtils.handle('CHROME_TABS_EXECUTE_SCRIPT', async function (event, tabId, extensionId, details) {
   assertChromeExtension(event.sender, 'chrome.tabs.executeScript()')
 

--- a/lib/renderer/chrome-api.ts
+++ b/lib/renderer/chrome-api.ts
@@ -7,9 +7,16 @@ const Event = require('@electron/internal/renderer/extensions/event')
 
 class Tab {
   public id: number
+  public url: string = ''
 
   constructor (tabId: number) {
     this.id = tabId
+  }
+
+  static fromURL = (opts: { id: number, url: string }) => {
+    const t = new Tab(opts.id)
+    t.url = opts.url
+    return t
   }
 }
 
@@ -163,6 +170,14 @@ export function injectTo (extensionId: string, context: any) {
   }
 
   chrome.tabs = {
+    // https://developer.chrome.com/extensions/tabs#method-query
+    query (
+      _options: any,
+      resultCallback: Function
+    ) {
+      ipcRendererUtils.invoke('CHROME_TABS_QUERY')
+        .then((result: any) => resultCallback(result.map(Tab.fromURL)))
+    },
     // https://developer.chrome.com/extensions/tabs#method-executeScript
     executeScript (
       tabId: number,


### PR DESCRIPTION
#### What?

This does two things

1. Adds `ELECTRON_UNSAFELY_ALLOW_NODE_IN_CHILD_WINDOWS` as an undocumented environment variable to override the memory leak protection when opening child windows with `node` enabled.  For testing purposes we **need** to be able to do that.  It is deliberately left undocumented as using it causes memory leaks.
2. Adds support for `chrome.tabs.query` as the Cypress helper extension requires this API to function correctly.

#### Why?

We are currently working towards running Cypress powered browser tests in a wrapping Electron application.  These two changes allow us to do so with minimal architectural changes to either the app or Cypress.

Notes: no-notes