### PR TITLE
fix: copy pixels in AddImageSkiaRepFromBuffer (3-1-x)

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -135,7 +135,7 @@ bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
 
   SkBitmap bitmap;
   bitmap.allocN32Pixels(width, height, false);
-  bitmap.setPixels(const_cast<void*>(reinterpret_cast<const void*>(data)));
+  bitmap.writePixels({info, data, bitmap.rowBytes()});
 
   image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
   return true;


### PR DESCRIPTION
#### Description of Change
Backport of #17843

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed inconsistent behavior where modifying the buffer would change `nativeImage` pixels, while decoded PNG / JPEG data is a copy.