### PR TITLE
fix: Comparison using is when operands support __eq__

### DIFF
--- a/build/js_wrap.py
+++ b/build/js_wrap.py
@@ -6,7 +6,7 @@ out_start = sys.argv.index("--out") + 1
 in_bundles = sys.argv[in_start:out_start - 1]
 out_bundles = sys.argv[out_start:]
 
-if len(in_bundles) is not len(out_bundles):
+if len(in_bundles) != len(out_bundles):
   print("--out and --in must provide the same number of arguments")
   sys.exit(1)
 


### PR DESCRIPTION
Comparison using 'is' when equivalence is not the same as identity

When you compare two values using the is or is not operator, it is the object identities of the two values that is tested rather than their equality. If the class of either of the values in the comparison redefines equality then the is operator may return False even though the objects compare as equal. Equality is defined by the __eq__ or, in Python2, __cmp__ method. To compare two objects for equality, use the == or != operator instead.

Recommendation
When you want to compare the value of two literals, use the comparison operator == or != in place of is or is not.

If the uniqueness property or performance are important then use an object that does not redefine equality.

Notes: none