### PR TITLE
fix: add a compatibility EVP_CIPH_OCB_MODE value (#16214).

### DIFF
--- a/patches/common/boringssl/.patches
+++ b/patches/common/boringssl/.patches
@@ -1,3 +1,4 @@
+compatibility_evp_ciph_ocb_mode.patch
 implement_ssl_get_tlsext_status_type.patch
 expose_ripemd160.patch
 expose_aes-cfb.patch

--- a/patches/common/boringssl/compatibility_evp_ciph_ocb_mode.patch
+++ b/patches/common/boringssl/compatibility_evp_ciph_ocb_mode.patch
@@ -1,0 +1,16 @@
+diff --git a/include/openssl/cipher.h b/include/openssl/cipher.h
+index 5963413..e9545c8 100644
+--- a/include/openssl/cipher.h
++++ b/include/openssl/cipher.h
+@@ -424,8 +424,9 @@
+ 
+ // The following flags do nothing and are included only to make it easier to
+ // compile code with BoringSSL.
+-#define EVP_CIPH_CCM_MODE 0
+-#define EVP_CIPH_WRAP_MODE 0
++#define EVP_CIPH_CCM_MODE (-1)
++#define EVP_CIPH_OCB_MODE (-2)
++#define EVP_CIPH_WRAP_MODE (-3)
+ #define EVP_CIPHER_CTX_FLAG_WRAP_ALLOW 0
+ 
+ // EVP_CIPHER_CTX_set_flags does nothing.


### PR DESCRIPTION
Backported [google/boringssl@4b9683](https://boringssl.googlesource.com/boringssl/+/4b968339e3ced2d498f4182cd725243bb6cca81b) to 4.1.x branch. This patch
replaces the no-op modes with negative numbers rather than zero.
Stream ciphers like RC4 report a "mode" of zero, so code comparing
the mode to a dummy value will get confused.

This patch fixed issue #16214.

#### Release Notes

Notes: Fixed the "rc4" cipher (#16214) (4.1.x).
