### PR TITLE
fix: drain tasks before shutting down isolate (5-0-x)

### DIFF
--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -74,6 +74,7 @@ void JavascriptEnvironment::OnMessageLoopCreated() {
 void JavascriptEnvironment::OnMessageLoopDestroying() {
   DCHECK(microtasks_runner_);
   base::MessageLoopCurrent::Get()->RemoveTaskObserver(microtasks_runner_.get());
+  platform_->DrainTasks(isolate_);
   platform_->UnregisterIsolate(isolate_);
 }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Close https://github.com/electron/electron/issues/17845.

According to the crash trace, it happened because there are pending tasks in queue when shutting down, so draining tasks before shutdown can fix it.

I'm not sure why it only happened for x86 Windows, and why it does not happen in https://github.com/electron/electron/pull/17838 on master branch which also has Node 12.

Anyway this fixes the problem without bad side effect as I see, and we can also put it in master branch if needed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes