### PR TITLE
build: actually run import-patches on gclient sync

### DIFF
--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -10,7 +10,7 @@ from lib.patches import patch_from_dir
 
 def apply_patches(dirs):
   for patch_dir, repo in dirs.iteritems():
-    git.am(repo=repo, patch_data=patch_from_dir(patch_dir),
+    git.import_patches(repo=repo, patch_data=patch_from_dir(patch_dir),
       committer_name="Electron Scripts", committer_email="scripts@electron")
 
 

--- a/script/git-import-patches
+++ b/script/git-import-patches
@@ -17,13 +17,7 @@ def main(argv):
       help="use 3-way merge to resolve conflicts")
   args = parser.parse_args(argv)
 
-  # save the upstream HEAD so we can refer to it when we later export patches
-  git.update_ref(
-      repo='.',
-      ref='refs/patches/upstream-head',
-      newvalue='HEAD'
-  )
-  git.am(
+  git.import_patches(
       repo='.',
       patch_data=patch_from_dir(args.patch_dir),
       threeway=args.threeway

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -86,6 +86,17 @@ def apply_patch(repo, patch_path, directory=None, index=False, reverse=False):
   return applied_successfully
 
 
+def import_patches(repo, **kwargs):
+  """same as am(), but we save the upstream HEAD so we can refer to it when we
+  later export patches"""
+  update_ref(
+      repo=repo,
+      ref='refs/patches/upstream-head',
+      newvalue='HEAD'
+  )
+  am(repo=repo, **kwargs)
+
+
 def get_patch(repo, commit_hash):
   args = ['git', '-C', repo, 'diff-tree',
           '-p',


### PR DESCRIPTION
#### Description of Change
Follow-up to #17824 that makes it actually run on `gclient sync` :)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes