### PR TITLE
chore: remove deprecated app.enableMixedSandbox()

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -81,6 +81,15 @@ powerMonitor.querySystemIdleTime(callback)
 const idleTime = getSystemIdleTime()
 ```
 
+## `app.enableMixedSandbox`
+
+```js
+// Deprecated
+app.enableMixedSandbox()
+```
+
+Mixed-sandbox mode is now enabled by default.
+
 ## Preload scripts outside of app path are not allowed
 
 For security reasons, preload scripts can only be loaded from a subpath of the [app path](app.md#appgetapppath).

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -181,6 +181,11 @@ logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
 
+## --no-sandbox
+
+Disables Chromium sandbox, which is now enabled by default.
+Should only be used for testing.
+
 [app]: app.md
 [append-switch]: app.md#appcommandlineappendswitchswitch-value
 [ready]: app.md#event-ready

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -32,10 +32,7 @@ Object.assign(app, {
     getSwitchValue: (theSwitch: string) => commandLine.getSwitchValue(String(theSwitch)),
     appendSwitch: (theSwitch: string, value?: string) => commandLine.appendSwitch(String(theSwitch), typeof value === 'undefined' ? value : String(value)),
     appendArgument: (arg: string) => commandLine.appendArgument(String(arg))
-  } as Electron.CommandLine,
-  enableMixedSandbox () {
-    deprecate.log(`'enableMixedSandbox' is deprecated. Mixed-sandbox mode is now enabled by default. You can safely remove the call to enableMixedSandbox().`)
-  }
+  } as Electron.CommandLine
 })
 
 // we define this here because it'd be overly complicated to


### PR DESCRIPTION
#### Description of Change
Follow up to https://github.com/electron/electron/pull/15894

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed deprecated `app.enableMixedSandbox()` API.

/cc @nornagon 