### PR TITLE
feat: add support for relative preload script paths (resolved against app.getAppPath())

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -218,12 +218,8 @@ bool WebContentsPreferences::GetPreloadPath(
   DCHECK(path);
   base::FilePath::StringType preload;
   if (GetAsString(&preference_, options::kPreloadScript, &preload)) {
-    if (base::FilePath(preload).IsAbsolute()) {
-      *path = std::move(preload);
-      return true;
-    } else {
-      LOG(ERROR) << "preload script must have absolute path.";
-    }
+    *path = std::move(preload);
+    return true;
   } else if (GetAsString(&preference_, options::kPreloadURL, &preload)) {
     // Translate to file path if there is "preload-url" option.
     base::FilePath preload_path;

--- a/docs/api/sandbox-option.md
+++ b/docs/api/sandbox-option.md
@@ -77,7 +77,7 @@ app.on('ready', () => {
   win = new BrowserWindow({
     webPreferences: {
       sandbox: true,
-      preload: path.join(app.getAppPath(), 'preload.js')
+      preload: 'preload.js'
     }
   })
   win.loadURL('http://google.com')

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -195,7 +195,7 @@ const mainWindow = new BrowserWindow({
   webPreferences: {
     nodeIntegration: false,
     nodeIntegrationInWorker: false,
-    preload: path.join(app.getAppPath(), 'preload.js')
+    preload: 'preload.js'
   }
 })
 
@@ -262,7 +262,7 @@ very small investment.
 const mainWindow = new BrowserWindow({
   webPreferences: {
     contextIsolation: true,
-    preload: path.join(app.getAppPath(), 'preload.js')
+    preload: 'preload.js'
   }
 })
 ```

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -514,10 +514,11 @@ const getPreloadScript = async function (preloadPath) {
   let preloadSrc = null
   let preloadError = null
   try {
-    if (!isParentDir(await getAppPath(), await realpath(preloadPath))) {
+    const resolvedPath = path.resolve(electron.app.getAppPath(), preloadPath)
+    if (!isParentDir(await getAppPath(), await realpath(resolvedPath))) {
       throw new Error('Preload scripts outside of app path are not allowed')
     }
-    preloadSrc = (await readFile(preloadPath)).toString()
+    preloadSrc = (await readFile(resolvedPath)).toString()
   } catch (err) {
     preloadError = errorUtils.serialize(err)
   }

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -513,23 +513,22 @@ const getAppPath = async function () {
 const getPreloadScript = async function (preloadPath) {
   let preloadSrc = null
   let preloadError = null
-  if (preloadPath) {
-    try {
-      if (!isParentDir(await getAppPath(), await realpath(preloadPath))) {
-        throw new Error('Preload scripts outside of app path are not allowed')
-      }
-      preloadSrc = (await readFile(preloadPath)).toString()
-    } catch (err) {
-      preloadError = errorUtils.serialize(err)
+  try {
+    if (!isParentDir(await getAppPath(), await realpath(preloadPath))) {
+      throw new Error('Preload scripts outside of app path are not allowed')
     }
+    preloadSrc = (await readFile(preloadPath)).toString()
+  } catch (err) {
+    preloadError = errorUtils.serialize(err)
   }
   return { preloadPath, preloadSrc, preloadError }
 }
 
 ipcMainUtils.handle('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) {
+  const preloadPath = event.sender._getPreloadPath()
   const preloadPaths = [
     ...(event.sender.session ? event.sender.session.getPreloads() : []),
-    event.sender._getPreloadPath()
+    ...(preloadPath ? [preloadPath] : [])
   ]
 
   return {

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -183,10 +183,11 @@ const getAppPath = function () {
 // Load the preload scripts.
 for (const preloadScript of preloadScripts) {
   try {
-    if (!isParentDir(getAppPath(), fs.realpathSync(preloadScript))) {
+    const resolvedPath = path.resolve(appPath!, preloadScript)
+    if (!isParentDir(getAppPath(), fs.realpathSync(resolvedPath))) {
       throw new Error('Preload scripts outside of app path are not allowed')
     }
-    require(preloadScript)
+    require(resolvedPath)
   } catch (error) {
     console.error(`Unable to load preload script: ${preloadScript}`)
     console.error(`${error}`)

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -1086,6 +1086,24 @@ describe('webContents module', () => {
     })
   })
 
+  describe('relative preload path', () => {
+    it('is resolved against app.getAppPath()', async () => {
+      const appPath = path.join(fixtures, 'api', 'relative-preload')
+      const electronPath = remote.getGlobal('process').execPath
+      const appProcess = ChildProcess.spawn(electronPath, [appPath])
+      const [code] = await emittedOnce(appProcess, 'close')
+      expect(code).to.equal(0)
+    })
+
+    it('is resolved against app.getAppPath() when sandboxed', async () => {
+      const appPath = path.join(fixtures, 'api', 'relative-preload')
+      const electronPath = remote.getGlobal('process').execPath
+      const appProcess = ChildProcess.spawn(electronPath, [appPath, '--sandbox-window'])
+      const [code] = await emittedOnce(appProcess, 'close')
+      expect(code).to.equal(0)
+    })
+  })
+
   describe('preload-error event', () => {
     const generateSpecs = (description, sandbox) => {
       describe(description, () => {

--- a/spec/fixtures/api/relative-preload/main.js
+++ b/spec/fixtures/api/relative-preload/main.js
@@ -1,0 +1,13 @@
+const { app, BrowserWindow } = require('electron')
+
+app.once('ready', async () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      preload: 'preload.js',
+      sandbox: app.commandLine.hasSwitch('sandbox-window')
+    }
+  })
+  await mainWindow.loadURL('about:blank')
+  app.exit(1)
+})

--- a/spec/fixtures/api/relative-preload/package.json
+++ b/spec/fixtures/api/relative-preload/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "relative-preload",
+  "main": "main.js"
+}

--- a/spec/fixtures/api/relative-preload/preload.js
+++ b/spec/fixtures/api/relative-preload/preload.js
@@ -1,0 +1,2 @@
+const { remote } = require('electron')
+remote.app.exit(0)


### PR DESCRIPTION
#### Description of Change
Allow relative preload script paths, resolved against `app.getAppPath()` similar to `WebContents.prototype.loadFile()`.

Previously, only the main preload script was enforced to be an absolute path, while the session preload scripts could be relative (with potentially inconsistent behavior between sandboxed and non-sandboxed renderers).

Follow up to #17308.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added support for relative preload script paths (resolved against `app.getAppPath()`).