### PR TITLE
refactor: add missing constants for options

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -128,10 +128,10 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
   SetDefaultBoolIfUndefined(options::kEnableRemoteModule, true);
   SetDefaultBoolIfUndefined(options::kContextIsolation, false);
-  SetDefaultBoolIfUndefined("javascript", true);
-  SetDefaultBoolIfUndefined("images", true);
-  SetDefaultBoolIfUndefined("textAreasAreResizable", true);
-  SetDefaultBoolIfUndefined("webgl", true);
+  SetDefaultBoolIfUndefined(options::kJavaScript, true);
+  SetDefaultBoolIfUndefined(options::kImages, true);
+  SetDefaultBoolIfUndefined(options::kTextAreasAreResizable, true);
+  SetDefaultBoolIfUndefined(options::kWebGL, true);
   bool webSecurity = true;
   SetDefaultBoolIfUndefined(options::kWebSecurity, webSecurity);
   // If webSecurity was explicity set to false, let's inherit that into
@@ -405,19 +405,20 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
 void WebContentsPreferences::OverrideWebkitPrefs(
     content::WebPreferences* prefs) {
-  prefs->javascript_enabled = IsEnabled("javascript", true /* default_value */);
-  prefs->images_enabled = IsEnabled("images", true /* default_value */);
+  prefs->javascript_enabled =
+      IsEnabled(options::kJavaScript, true /* default_value */);
+  prefs->images_enabled = IsEnabled(options::kImages, true /* default_value */);
   prefs->text_areas_are_resizable =
-      IsEnabled("textAreasAreResizable", true /* default_value */);
+      IsEnabled(options::kTextAreasAreResizable, true /* default_value */);
   prefs->navigate_on_drag_drop =
-      IsEnabled("navigateOnDragDrop", false /* default_value */);
+      IsEnabled(options::kNavigateOnDragDrop, false /* default_value */);
   if (!GetAsAutoplayPolicy(&preference_, "autoplayPolicy",
                            &prefs->autoplay_policy)) {
     prefs->autoplay_policy = content::AutoplayPolicy::kNoUserGestureRequired;
   }
 
   // Check if webgl should be enabled.
-  bool is_webgl_enabled = IsEnabled("webgl", true /* default_value */);
+  bool is_webgl_enabled = IsEnabled(options::kWebGL, true /* default_value */);
   prefs->webgl1_enabled = is_webgl_enabled;
   prefs->webgl2_enabled = is_webgl_enabled;
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -160,6 +160,22 @@ const char kNodeIntegrationInSubFrames[] = "nodeIntegrationInSubFrames";
 const char kDisableHtmlFullscreenWindowResize[] =
     "disableHtmlFullscreenWindowResize";
 
+// Enables JavaScript support.
+const char kJavaScript[] = "javascript";
+
+// Enables image support.
+const char kImages[] = "images";
+
+// Make TextArea elements resizable.
+const char kTextAreasAreResizable[] = "textAreasAreResizable";
+
+// Enables WebGL support.
+const char kWebGL[] = "webgl";
+
+// Whether dragging and dropping a file or link onto the page causes a
+// navigation.
+const char kNavigateOnDragDrop[] = "navigateOnDragDrop";
+
 }  // namespace options
 
 namespace switches {

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -77,6 +77,11 @@ extern const char kAllowRunningInsecureContent[];
 extern const char kOffscreen[];
 extern const char kNodeIntegrationInSubFrames[];
 extern const char kDisableHtmlFullscreenWindowResize[];
+extern const char kJavaScript[];
+extern const char kImages[];
+extern const char kTextAreasAreResizable[];
+extern const char kWebGL[];
+extern const char kNavigateOnDragDrop[];
 
 }  // namespace options
 


### PR DESCRIPTION
#### Description of Change
Add missing constants for options.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes