### PR TITLE
feat: add app.enableSecureMode() API

### DIFF
--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -210,6 +210,8 @@ class App : public AtomBrowserClient::Delegate,
   v8::Local<v8::Promise> GetGPUInfo(v8::Isolate* isolate,
                                     const std::string& info_type);
   void EnableSandbox(mate::Arguments* args);
+  void EnableSecureMode(mate::Arguments* args);
+  bool GetSecureModeEnabled();
   void SetUserAgentFallback(const std::string& user_agent);
   std::string GetUserAgentFallback();
 

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -100,6 +100,9 @@ class TrackableObject : public TrackableObjectBase,
       return std::vector<v8::Local<v8::Object>>();
   }
 
+  // Returns the number of objects in this class's weak map.
+  static size_t GetCount() { return weak_map_ ? weak_map_->Size() : 0; }
+
   // Removes this instance from the weak map.
   void RemoveFromWeakMap() {
     if (weak_map_ && weak_map_->Has(weak_map_id()))

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -249,4 +249,8 @@ void Browser::NewWindowForTab() {
 }
 #endif
 
+void Browser::EnableSecureMode(const SecureModeOptions& options) {
+  secure_mode_ = options;
+}
+
 }  // namespace atom

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -15,6 +15,7 @@
 #include "base/compiler_specific.h"
 #include "base/macros.h"
 #include "base/observer_list.h"
+#include "base/optional.h"
 #include "base/strings/string16.h"
 #include "base/values.h"
 #include "native_mate/arguments.h"
@@ -262,6 +263,16 @@ class Browser : public WindowListObserver {
   bool is_ready() const { return is_ready_; }
   const util::Promise& WhenReady(v8::Isolate* isolate);
 
+  struct SecureModeOptions {
+    bool configurable_sandbox = false;
+    bool configurable_context_isolation = false;
+    bool configurable_native_window_open = false;
+    bool configurable_remote_module = false;
+  };
+
+  base::Optional<SecureModeOptions> secure_mode() const { return secure_mode_; }
+  void EnableSecureMode(const SecureModeOptions& options);
+
  protected:
   // Returns the version of application bundle or executable file.
   std::string GetExecutableFileVersion() const;
@@ -293,6 +304,9 @@ class Browser : public WindowListObserver {
 
   // The browser is being shutdown.
   bool is_shutdown_ = false;
+
+  // Secure mode options.
+  base::Optional<SecureModeOptions> secure_mode_;
 
   // Null until/unless the default main message loop is running.
   base::OnceClosure quit_main_message_loop_;

--- a/atom/browser/lib/bluetooth_chooser.cc
+++ b/atom/browser/lib/bluetooth_chooser.cc
@@ -69,7 +69,7 @@ void BluetoothChooser::ShowDiscoveryState(DiscoveryState state) {
         event_handler_.Run(event, "");
       } else {
         bool prevent_default = api_web_contents_->Emit(
-            "select-bluetooth-device", GetDeviceList(),
+            "-select-bluetooth-device", GetDeviceList(),
             base::BindOnce(&OnDeviceChosen, event_handler_));
         if (!prevent_default) {
           auto it = device_map_.begin();
@@ -103,7 +103,7 @@ void BluetoothChooser::AddOrUpdateDevice(const std::string& device_id,
     // Emit a select-bluetooth-device handler to allow for user to listen for
     // bluetooth device found.
     bool prevent_default = api_web_contents_->Emit(
-        "select-bluetooth-device", GetDeviceList(),
+        "-select-bluetooth-device", GetDeviceList(),
         base::BindOnce(&OnDeviceChosen, event_handler_));
 
     // If emit not implimented select first device that matches the filters

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -75,6 +75,11 @@ class WebContentsPreferences
   // Set preference value to given bool if user did not provide value
   bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);
 
+  void SetBool(const base::StringPiece& key, bool value);
+  void SetBoolConfigurable(const base::StringPiece& key,
+                           bool value,
+                           bool configurable);
+
   static std::vector<WebContentsPreferences*> instances_;
 
   content::WebContents* web_contents_;

--- a/atom/common/key_weak_map.h
+++ b/atom/common/key_weak_map.h
@@ -50,6 +50,9 @@ class KeyWeakMap {
   // Whethere there is an object with |key| in this WeakMap.
   bool Has(const K& key) const { return map_.find(key) != map_.end(); }
 
+  // The number of entries
+  size_t Size() const { return map_.size(); }
+
   // Returns all objects.
   std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) const {
     std::vector<v8::Local<v8::Object>> keys;

--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -3,6 +3,8 @@ import * as path from 'path'
 
 let mainWindow: BrowserWindow | null = null
 
+app.enableSecureMode()
+
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   app.quit()
@@ -54,10 +56,7 @@ async function createWindow () {
     autoHideMenuBar: true,
     backgroundColor: '#FFFFFF',
     webPreferences: {
-      preload: path.resolve(__dirname, 'preload.js'),
-      contextIsolation: true,
-      sandbox: true,
-      enableRemoteModule: false
+      preload: path.resolve(__dirname, 'preload.js')
     },
     useContentSize: true,
     show: false

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1202,6 +1202,18 @@ stopAccessingSecurityScopedResource()
 
 Start accessing a security scoped resource. With this method Electron applications that are packaged for the Mac App Store may reach outside their sandbox to access files chosen by the user. See [Apple's documentation](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) for a description of how this system works.
 
+### `app.enableSecureMode([options])` _Experimental_
+
+* `options` Object (optional)
+  * `configurableSandbox` Boolean (optional)
+  * `configurableContextIsolation` Boolean (optional)
+  * `configurableNativeWindowOpen` Boolean (optional)
+  * `configurableRemoteModule` Boolean (optional)
+
+Enables [secure mode](secure-mode.md).
+
+This method can only be called before WebContents are created.
+
 ### `app.enableSandbox()` _Experimental_
 
 Enables full sandbox mode on the app.
@@ -1267,6 +1279,10 @@ dock on macOS.
 ### `app.isPackaged`
 
 A `Boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.
+
+### `app.secureModeEnabled`
+
+A `Boolean` property that returns `true` if [secure mode](secure-mode.md) is enabled, `false` otherwise.
 
 [dock-menu]:https://developer.apple.com/macos/human-interface-guidelines/menus/dock-menus/
 [tasks]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks

--- a/docs/api/secure-mode.md
+++ b/docs/api/secure-mode.md
@@ -1,0 +1,73 @@
+# Secure Mode
+
+This is an opt-in locked down mode designed for apps loading remote content.
+
+## Default values
+
+Changes the default values of the following `webPreferences`:
+- `sandbox: true`
+- `contextIsolation: true`
+- `nativeWindowOpen: true`
+- `enableRemoteModule: false`
+
+Potentially unsafe options must be overriden explicitly:
+```js
+let win = new BrowserWindow({
+  webPreferences: {
+    sandbox: false,
+    contextIsolation: false,
+    nativeWindowOpen: false,
+    enableRemoteModule: true // filtering events need to be handled
+  }
+})
+```
+
+## Disabled features
+
+Removes the ability to use the following `webPreferences`:
+- `nodeIntegration`
+- `nodeIntegrationInWorker`
+
+Preload scripts must be used to explicitly expose native APIs safely.
+
+## Event handling
+
+When the following events are unhandled, `event.preventDefault()` is called implicitly:
+
+`webContents`:
+- `new-window`
+- `will-attach-webview`
+- `select-bluetooth-device`
+
+`webContents` / `app`:
+- `desktop-capturer-get-sources`
+- `remote-require`
+- `remote-get-builtin`
+- `remote-get-global`
+- `remote-get-current-window`
+- `remote-get-current-web-contents`
+- `remote-get-guest-web-contents`
+
+These events must be handled (with potential filtering / argument sanitization) explicitly:
+```js
+app.on('desktop-capturer-get-sources', (event) => {
+  // suppress event.preventDefault()
+})
+```
+
+## Permission handling
+
+When no handlers are set using the following APIs, permissions are denied implicitly:
+- `session.setPermissionCheckHandler()`
+- `session.setPermissionRequestHandler()`
+
+Request handlers must be used to explicitly grant the permissions (potentially asking the user for consent):
+```js
+session.setPermissionCheckHandler((webContents, permission) => {
+  return true
+})
+
+session.setPermissionRequestHandler((webContents, permission, callback) => {
+  callback(true)
+})
+```

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -43,6 +43,7 @@ auto_filenames = {
     "docs/api/remote.md",
     "docs/api/sandbox-option.md",
     "docs/api/screen.md",
+    "docs/api/secure-mode.md",
     "docs/api/session.md",
     "docs/api/shell.md",
     "docs/api/structures",

--- a/filenames.gni
+++ b/filenames.gni
@@ -46,6 +46,7 @@ filenames = {
     "lib/browser/navigation-controller.js",
     "lib/browser/objects-registry.js",
     "lib/browser/rpc-server.js",
+    "lib/browser/secure-mode.ts",
     "lib/browser/utils.ts",
     "lib/common/api/clipboard.js",
     "lib/common/api/deprecate.ts",

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -11,6 +11,7 @@ const NavigationController = require('@electron/internal/browser/navigation-cont
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
+const { preventDefaultInSecureMode } = require('@electron/internal/browser/secure-mode')
 
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
@@ -401,6 +402,11 @@ WebContents.prototype._init = function () {
         event, url, referrer, frameName, disposition, options)
     })
   }
+
+  this.on('-select-bluetooth-device', (event, ...args) => {
+    preventDefaultInSecureMode(this, event, 'select-bluetooth-device')
+    this.emit('select-bluetooth-device', event, ...args)
+  })
 
   app.emit('web-contents-created', {}, this)
 }

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -4,6 +4,8 @@ const { webContents } = require('electron')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 const parseFeaturesString = require('@electron/internal/common/parse-features-string')
+const { preventDefaultInSecureMode } = require('@electron/internal/browser/secure-mode')
+
 const {
   syncMethods,
   asyncCallbackMethods,
@@ -251,6 +253,8 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
       webPreferences[name] = value
     }
   }
+
+  preventDefaultInSecureMode(embedder, event, 'will-attach-webview')
 
   embedder.emit('will-attach-webview', event, webPreferences, params)
   if (event.defaultPrevented) {

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -4,6 +4,7 @@ const { BrowserWindow, webContents } = require('electron')
 const { isSameOrigin } = process.electronBinding('v8_util')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const parseFeaturesString = require('@electron/internal/common/parse-features-string')
+const { preventDefaultInSecureMode } = require('@electron/internal/browser/secure-mode')
 
 const hasProp = {}.hasOwnProperty
 const frameToGuest = new Map()
@@ -242,6 +243,9 @@ ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', functio
   frameName, disposition, options,
   additionalFeatures, postData) {
   options = mergeBrowserWindowOptions(event.sender, options)
+
+  preventDefaultInSecureMode(event.sender, event, 'new-window')
+
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer)
   const { newGuest } = event
   if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -21,6 +21,7 @@ const bufferUtils = require('@electron/internal/common/buffer-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
 const clipboardUtils = require('@electron/internal/common/clipboard-utils')
 const { isParentDir } = require('@electron/internal/common/path-utils')
+const { preventDefaultInSecureMode } = require('@electron/internal/browser/secure-mode')
 
 const hasProp = {}.hasOwnProperty
 
@@ -276,6 +277,8 @@ const handleRemoteCommand = function (channel, handler) {
 
 const emitCustomEvent = function (contents, eventName, ...args) {
   const event = eventBinding.createWithSender(contents)
+
+  preventDefaultInSecureMode([contents, electron.app], event, eventName)
 
   electron.app.emit(eventName, event, contents, ...args)
   contents.emit(eventName, event, ...args)

--- a/lib/browser/secure-mode.ts
+++ b/lib/browser/secure-mode.ts
@@ -1,0 +1,16 @@
+import { app } from 'electron'
+
+function hasListeners (emitter: Electron.EventEmitter | Electron.EventEmitter[], eventName: string) {
+  if (Array.isArray(emitter)) {
+    return (emitter as Electron.EventEmitter[]).some(item => item.listenerCount(eventName) > 0)
+  } else {
+    return emitter.listenerCount(eventName) > 0
+  }
+}
+
+export function preventDefaultInSecureMode (emitter: Electron.EventEmitter | Electron.EventEmitter[], event: Electron.IpcMainEvent, eventName: string) {
+  if (app.secureModeEnabled && !hasListeners(emitter, eventName)) {
+    console.warn(`Secure mode: preventing default for '${eventName}' event`)
+    event.preventDefault()
+  }
+}

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1099,6 +1099,44 @@ describe('app module', () => {
     })
   })
 
+  describe('app.enableSecureMode', () => {
+    it('works', async () => {
+      const result = await runTestApp('secure-mode', '--enable-secure-mode')
+      expect(result.enablesSandbox).to.equal(true)
+      expect(result.enablesContextIsolation).to.equal(true)
+      expect(result.enablesNativeWindowOpen).to.equal(true)
+      expect(result.disablesRemoteModule).to.equal(true)
+      expect(result.disablesNodeIntegration).to.equal(true)
+      expect(result.disablesNodeIntegrationInWorker).to.equal(true)
+      expect(result.blocksNewWindow).to.equal(true)
+      expect(result.blocksWillAttachWebView).to.equal(true)
+      expect(result.blocksGetSources).to.equal(true)
+      expect(result.blocksRemoteRequire).to.equal(true)
+      expect(result.blocksRemoteGetGlobal).to.equal(true)
+      expect(result.blocksRemoteGetBuiltin).to.equal(true)
+      expect(result.blocksRemoteGetCurrentWindow).to.equal(true)
+      expect(result.blocksRemoteGetCurrentWebContents).to.equal(true)
+    })
+
+    it('does not have side-effects when not used', async () => {
+      const result = await runTestApp('secure-mode')
+      expect(result.enablesSandbox).to.equal(false)
+      expect(result.enablesContextIsolation).to.equal(false)
+      expect(result.enablesNativeWindowOpen).to.equal(false)
+      expect(result.disablesRemoteModule).to.equal(false)
+      expect(result.disablesNodeIntegration).to.equal(false)
+      expect(result.disablesNodeIntegrationInWorker).to.equal(false)
+      expect(result.blocksNewWindow).to.equal(false)
+      expect(result.blocksWillAttachWebView).to.equal(false)
+      expect(result.blocksGetSources).to.equal(false)
+      expect(result.blocksRemoteRequire).to.equal(false)
+      expect(result.blocksRemoteGetGlobal).to.equal(false)
+      expect(result.blocksRemoteGetBuiltin).to.equal(false)
+      expect(result.blocksRemoteGetCurrentWindow).to.equal(false)
+      expect(result.blocksRemoteGetCurrentWebContents).to.equal(false)
+    })
+  })
+
   describe('disableDomainBlockingFor3DAPIs() API', () => {
     it('throws when called after app is ready', () => {
       expect(() => {

--- a/spec/fixtures/api/secure-mode/main.js
+++ b/spec/fixtures/api/secure-mode/main.js
@@ -1,0 +1,72 @@
+const { app, BrowserWindow, webContents, ipcMain, session } = require('electron')
+const path = require('path')
+const { emittedOnce } = require('../../../events-helpers')
+
+if (app.commandLine.hasSwitch('enable-secure-mode')) {
+  app.enableSecureMode({
+    configurableSandbox: true,
+    configurableContextIsolation: true,
+    configurableNativeWindowOpen: true,
+    configurableRemoteModule: true
+  })
+}
+
+process.on('uncaughtException', (error) => {
+  console.error(error)
+  app.exit(1)
+})
+
+app.once('ready', async () => {
+  session.defaultSession.setPreloads([
+    path.join(__dirname, 'preload-base.js')
+  ])
+
+  let win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      enableRemoteModule: true,
+      webviewTag: true
+    }
+  })
+
+  win.webContents.once('preload-error', (event, preloadPath, error) => {
+    console.error(error)
+    app.exit(1)
+  })
+
+  const promise = emittedOnce(ipcMain, 'result')
+  win.loadURL('about:blank')
+
+  const [, result] = await promise
+
+  await win.webContents.executeJavaScript(`window.open()`)
+  const blocksNewWindow = BrowserWindow.getAllWindows().length === 1
+
+  await win.webContents.executeJavaScript(`document.createElement('webview').src = 'about:blank'`)
+  const blocksWillAttachWebView = webContents.getAllWebContents().length === 1
+
+  Object.assign(result, {
+    blocksNewWindow,
+    blocksWillAttachWebView
+  })
+
+  win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      sandbox: false,
+      contextIsolation: false,
+      nodeIntegration: true,
+      nodeIntegrationInWorker: true
+    }
+  })
+
+  const promise2 = emittedOnce(ipcMain, 'result')
+  win.loadFile('worker.html')
+
+  const [, moreResult] = await promise2
+  Object.assign(result, moreResult)
+
+  console.log(JSON.stringify(result))
+  app.exit(0)
+})

--- a/spec/fixtures/api/secure-mode/package.json
+++ b/spec/fixtures/api/secure-mode/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "secure-mode",
+  "main": "main.js"
+}

--- a/spec/fixtures/api/secure-mode/preload-base.js
+++ b/spec/fixtures/api/secure-mode/preload-base.js
@@ -1,0 +1,2 @@
+window.electron = require('electron')
+window.process = process

--- a/spec/fixtures/api/secure-mode/preload.js
+++ b/spec/fixtures/api/secure-mode/preload.js
@@ -1,0 +1,37 @@
+const { desktopCapturer, ipcRenderer, remote, webFrame } = require('electron')
+
+process.once('loaded', async () => {
+  let sources = []
+  try {
+    sources = await desktopCapturer.getSources({ types: ['window', 'screen'] })
+  } catch {
+    // ignore
+  }
+
+  function doesThrow (code) {
+    try {
+      code()
+      return false
+    } catch {
+      return true
+    }
+  }
+
+  let enablesContextIsolation
+  try {
+    enablesContextIsolation = await webFrame.executeJavaScript(`typeof electron === 'undefined'`)
+  } catch {
+    // ignore
+  }
+
+  ipcRenderer.send('result', {
+    enablesSandbox: !!process.sandboxed,
+    enablesContextIsolation,
+    blocksGetSources: sources.length === 0,
+    blocksRemoteRequire: doesThrow(() => remote.require('electron')),
+    blocksRemoteGetGlobal: doesThrow(() => remote.process),
+    blocksRemoteGetBuiltin: doesThrow(() => remote.app),
+    blocksRemoteGetCurrentWindow: doesThrow(() => remote.getCurrentWindow()),
+    blocksRemoteGetCurrentWebContents: doesThrow(() => remote.getCurrentWebContents())
+  })
+})

--- a/spec/fixtures/api/secure-mode/worker.html
+++ b/spec/fixtures/api/secure-mode/worker.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <meta http-equiv="content-security-policy" content="script-src 'self' 'unsafe-inline'" />
+  </head>
+  <body>
+    <script>
+      const worker = new Worker('worker.js')
+      worker.onmessage = function (event) {
+        electron.ipcRenderer.send('result', {
+          enablesNativeWindowOpen: String(window.open).includes('[native code]'),
+          disablesRemoteModule: typeof electron.remote === 'undefined',
+          disablesNodeIntegration: typeof require === 'undefined',
+          disablesNodeIntegrationInWorker: event.data.require === 'undefined'
+        })
+        worker.terminate()
+      }
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/api/secure-mode/worker.js
+++ b/spec/fixtures/api/secure-mode/worker.js
@@ -1,0 +1,3 @@
+self.postMessage({
+  require: typeof require
+})


### PR DESCRIPTION
#### Description of Change
This is an opt-in locked down mode designed for apps loading remote content.

Check [docs/api/secure-mode.md](https://github.com/electron/electron/blob/miniak/secure-mode/docs/api/secure-mode.md) for details.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `app.enableSecureMode()` API to opt-in into more secure mode designed for apps running remote content.

/cc @electron/wg-security