### PR TITLE
build: add support for Electron trace events

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -205,6 +205,7 @@ base::FilePath::StringType NodeBindings::GetHelperResourcesPath() {
 }
 
 void NodeBindings::Initialize() {
+  TRACE_EVENT0("electron", "NodeBindings::Initialize");
   // Open node's error reporting system for browser process.
   node::g_standalone_mode = browser_env_ == BROWSER;
   node::g_upstream_node_mode = false;

--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -75,3 +75,4 @@ unsandboxed_ppapi_processes_skip_zygote.patch
 viz_osr.patch
 patch_the_ensure_gn_version_py_script_to_work_on_mac_ci.patch
 revert_roll_clang_356356_357569.patch
+build_add_electron_tracing_category.patch

--- a/patches/common/chromium/build_add_electron_tracing_category.patch
+++ b/patches/common/chromium/build_add_electron_tracing_category.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <sattard@slack-corp.com>
+Date: Tue, 23 Apr 2019 09:51:43 -0700
+Subject: build: add electron tracing category
+
+All TRACE events in Chromium use a static assert to ensure that the
+categories in use are known / declared.  This patch is required for us
+to introduce a new Electron category.
+
+diff --git a/base/trace_event/builtin_categories.h b/base/trace_event/builtin_categories.h
+index 0a0fb37798bdf596fef33c148ee0d9d358559286..ea0775c7edca664f9e1ba981b4a512f6fa5f3c29 100644
+--- a/base/trace_event/builtin_categories.h
++++ b/base/trace_event/builtin_categories.h
+@@ -61,6 +61,7 @@
+   X("dwrite")                                                            \
+   X("DXVA Decoding")                                                     \
+   X("EarlyJava")                                                         \
++  X("electron")                                                          \
+   X("evdev")                                                             \
+   X("event")                                                             \
+   X("exo")                                                               \


### PR DESCRIPTION
Adds support for us to add Electron tracing events in `contentTracing` output through the `electron` category.

Notes: no-notes