### PR TITLE
refactor: initialize feature list earlier

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -14,6 +14,7 @@
 
 #include "atom/app/atom_content_client.h"
 #include "atom/browser/atom_browser_client.h"
+#include "atom/browser/feature_list.h"
 #include "atom/browser/relauncher.h"
 #include "atom/common/options_switches.h"
 #include "atom/renderer/atom_renderer_client.h"
@@ -247,6 +248,10 @@ void AtomMainDelegate::PreSandboxStartup() {
 }
 
 void AtomMainDelegate::PreCreateMainMessageLoop() {
+  // This is initialized early because the service manager reads some feature
+  // flags and we need to make sure the feature list is initialized before the
+  // service manager reads the features.
+  InitializeFeatureList();
 #if defined(OS_MACOSX)
   RegisterAtomCrApp();
 #endif

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -255,6 +255,7 @@ void AtomBrowserMainParts::RegisterDestructionCallback(
 }
 
 int AtomBrowserMainParts::PreEarlyInitialization() {
+  field_trial_list_ = std::make_unique<base::FieldTrialList>(nullptr);
 #if defined(USE_X11)
   views::LinuxUI::SetInstance(BuildGtkUi());
   OverrideLinuxAppDataPath();

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -19,6 +19,7 @@
 #include "atom/browser/atom_web_ui_controller_factory.h"
 #include "atom/browser/browser.h"
 #include "atom/browser/browser_process_impl.h"
+#include "atom/browser/feature_list.h"
 #include "atom/browser/javascript_environment.h"
 #include "atom/browser/media/media_capture_devices_dispatcher.h"
 #include "atom/browser/node_debugger.h"
@@ -197,23 +198,6 @@ int X11EmptyIOErrorHandler(Display* d) {
 
 }  // namespace
 
-void AtomBrowserMainParts::InitializeFeatureList() {
-  auto* cmd_line = base::CommandLine::ForCurrentProcess();
-  auto enable_features =
-      cmd_line->GetSwitchValueASCII(::switches::kEnableFeatures);
-  auto disable_features =
-      cmd_line->GetSwitchValueASCII(::switches::kDisableFeatures);
-  // Disable creation of spare renderer process with site-per-process mode,
-  // it interferes with our process preference tracking for non sandboxed mode.
-  // Can be reenabled when our site instance policy is aligned with chromium
-  // when node integration is enabled.
-  disable_features +=
-      std::string(",") + features::kSpareRendererForSitePerProcess.name;
-  auto feature_list = std::make_unique<base::FeatureList>();
-  feature_list->InitializeFromCommandLine(enable_features, disable_features);
-  base::FeatureList::SetInstance(std::move(feature_list));
-}
-
 // static
 AtomBrowserMainParts* AtomBrowserMainParts::self_ = nullptr;
 
@@ -271,8 +255,6 @@ void AtomBrowserMainParts::RegisterDestructionCallback(
 }
 
 int AtomBrowserMainParts::PreEarlyInitialization() {
-  InitializeFeatureList();
-  field_trial_list_ = std::make_unique<base::FieldTrialList>(nullptr);
 #if defined(USE_X11)
   views::LinuxUI::SetInstance(BuildGtkUi());
   OverrideLinuxAppDataPath();

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -125,6 +125,7 @@ class AtomBrowserMainParts : public content::BrowserMainParts {
   std::unique_ptr<NodeEnvironment> node_env_;
   std::unique_ptr<NodeDebugger> node_debugger_;
   std::unique_ptr<IconManager> icon_manager_;
+  std::unique_ptr<base::FieldTrialList> field_trial_list_;
 
   base::RepeatingTimer gc_timer_;
 

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -87,7 +87,6 @@ class AtomBrowserMainParts : public content::BrowserMainParts {
   void PostDestroyThreads() override;
 
  private:
-  void InitializeFeatureList();
   void PreMainMessageLoopStartCommon();
 
 #if defined(OS_POSIX)
@@ -126,7 +125,6 @@ class AtomBrowserMainParts : public content::BrowserMainParts {
   std::unique_ptr<NodeEnvironment> node_env_;
   std::unique_ptr<NodeDebugger> node_debugger_;
   std::unique_ptr<IconManager> icon_manager_;
-  std::unique_ptr<base::FieldTrialList> field_trial_list_;
 
   base::RepeatingTimer gc_timer_;
 

--- a/atom/browser/feature_list.cc
+++ b/atom/browser/feature_list.cc
@@ -4,6 +4,8 @@
 
 #include "electron/atom/browser/feature_list.h"
 
+#include <string>
+
 #include "base/base_switches.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"

--- a/atom/browser/feature_list.cc
+++ b/atom/browser/feature_list.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "electron/atom/browser/feature_list.h"
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+#include "base/feature_list.h"
+#include "content/public/common/content_features.h"
+
+namespace atom {
+
+void InitializeFeatureList() {
+  auto* cmd_line = base::CommandLine::ForCurrentProcess();
+  auto enable_features =
+      cmd_line->GetSwitchValueASCII(::switches::kEnableFeatures);
+  auto disable_features =
+      cmd_line->GetSwitchValueASCII(::switches::kDisableFeatures);
+  // Disable creation of spare renderer process with site-per-process mode,
+  // it interferes with our process preference tracking for non sandboxed mode.
+  // Can be reenabled when our site instance policy is aligned with chromium
+  // when node integration is enabled.
+  disable_features +=
+      std::string(",") + features::kSpareRendererForSitePerProcess.name;
+  base::FeatureList::InitializeInstance(enable_features, disable_features);
+}
+
+}  // namespace atom

--- a/atom/browser/feature_list.h
+++ b/atom/browser/feature_list.h
@@ -2,11 +2,11 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#ifndef ELECTRON_ATOM_BROWSER_FEATURE_LIST_H_
-#define ELECTRON_ATOM_BROWSER_FEATURE_LIST_H_
+#ifndef ATOM_BROWSER_FEATURE_LIST_H_
+#define ATOM_BROWSER_FEATURE_LIST_H_
 
 namespace atom {
 void InitializeFeatureList();
 }
 
-#endif  // ELECTRON_ATOM_BROWSER_FEATURE_LIST_H_
+#endif  // ATOM_BROWSER_FEATURE_LIST_H_

--- a/atom/browser/feature_list.h
+++ b/atom/browser/feature_list.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_ATOM_BROWSER_FEATURE_LIST_H_
+#define ELECTRON_ATOM_BROWSER_FEATURE_LIST_H_
+
+namespace atom {
+void InitializeFeatureList();
+}
+
+#endif  // ELECTRON_ATOM_BROWSER_FEATURE_LIST_H_

--- a/filenames.gni
+++ b/filenames.gni
@@ -131,6 +131,8 @@ filenames = {
     "atom/browser/api/atom_api_app.cc",
     "atom/browser/font_defaults.cc",
     "atom/browser/font_defaults.h",
+    "atom/browser/feature_list.cc",
+    "atom/browser/feature_list.h",
     "atom/browser/api/atom_api_app.h",
     "atom/browser/api/atom_api_auto_updater.cc",
     "atom/browser/api/atom_api_auto_updater.h",


### PR DESCRIPTION
#### Description of Change
This makes it so that `--enable-features=NetworkService` will actually start the network service. Currently, the feature list is initialized too late, so passing `--enable-features=NetworkService` on the command-line won't actually enable the network service.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes