### PR TITLE
docs: update 6.0.0 release dates per Upgrades WG

### DIFF
--- a/docs/electron-timelines.md
+++ b/docs/electron-timelines.md
@@ -1,15 +1,12 @@
 # Electron Release Timelines
+### Notes:
+* The `-beta.1` and `stable` dates are our *concrete* release dates.
+* We strive for weekly beta releases, however we often release more betas than scheduled.
+* All dates are our goals but there may be reasons for adjusting the stable deadline, such as security bugs.
 
 ## 5.0.0 Release Schedule
+*Includes: Chromium M73 and Node v12.0*
 
-Take a look at 5.0.0 Timeline [blog post](https://electronjs.org/blog/electron-5-0-timeline) for info about publicizing our release dates.
-
-### Notes
-
-- These dates are our goals but there may be reasons for adjusting the stable deadline, such as security bugs.
-- These are our scheduled beta releases, however we often release more betas than scheduled.
-
-## 5.0.0 Release Schedule
 Take a look at 5.0.0 Timeline [blog post](https://electronjs.org/blog/electron-5-0-timeline) for info about publicizing our release dates.
 
 | Date/Week Of    | Release      | Comments       |
@@ -29,29 +26,25 @@ Take a look at 5.0.0 Timeline [blog post](https://electronjs.org/blog/electron-5
 | Tue, 2019-Apr-16 | none | quiet period - stable prep |
 | Tue, 2019-Apr-23 | 5.0.0 |✨stable ✨|
 
-*Includes: Chromium M73 and Node v12.0*
-
 ## 6.0.0 Release Schedule
-
-### Notes
-
-- These dates are our goals but there may be reasons for adjusting the stable deadline, such as security bugs.
-- These are our scheduled beta releases, however we often release more betas than scheduled.
+*Includes: Chromium M76 and Node v12.0*
 
 | Date/Week Of    | Release      | Comments       |
 | --------------- | ------------ | -------------- |
-| Thu, 2019-Apr-25 | 6.0.0-beta.1 | 🔥 |
-| Tue, 2019-Apr-30 | 6.0.0-beta.x | |
+| Tue, 2019-Apr-30 | 6.0.0-beta.1 | 🔥 |
 | Tue, 2019-May-07 | 6.0.0-beta.x | |
 | Tue, 2019-May-14 | 6.0.0-beta.x | |
 | Tue, 2019-May-21 | 6.0.0-beta.x | |
 | Tue, 2019-May-28 | 6.0.0-beta.x | |
-| Tue, 2019-Jun-04 | 6.0.0-beta.x | halfway mark |
-| Tue, 2019-Jun-11 | 6.0.0-beta.x | |
+| Tue, 2019-Jun-04 | 6.0.0-beta.x | |
+| Tue, 2019-Jun-11 | 6.0.0-beta.x | halfway mark |
 | Tue, 2019-Jun-18 | 6.0.0-beta.x | |
 | Tue, 2019-Jun-25 | 6.0.0-beta.x | |
 | Tue, 2019-Jul-02 | 6.0.0-beta.x | |
-| Tue, 2019-Jul-09 | 6.0.0-beta.x | 🚧 quiet period - stable prep 🚧 |
-| Thu, 2019-Jul-18 | 6.0.0 | ✨ stable ✨ |
+| Tue, 2019-Jul-09 | 6.0.0-beta.x | |
+| Tue, 2019-Jul-16 | 6.0.0-beta.x | |
+| Tue, 2019-Jul-23 | 6.0.0-beta.x | 🚧 quiet period - stable prep 🚧 |
+| Tue, 2019-Jul-30 | 6.0.0 | ✨ stable ✨ |
 
-*Includes: Chromium M75 and Node v12.0*
+## 7.0.0 Release Schedule
+TBD


### PR DESCRIPTION
#### Description of Change
Updating 6.0.0 release schedule according to @electron/wg-upgrades decision to upgrade to M76 in electron v6. Electron v6 and M76 will both release stable on July 30.


#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
