### PR TITLE
chore: Bind=>BindRepeating for constructors

### DIFF
--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -219,7 +219,7 @@ class App : public AtomBrowserClient::Delegate,
 #endif
 
 #if defined(MAS_BUILD)
-  base::Callback<void()> StartAccessingSecurityScopedResource(
+  base::RepeatingCallback<void()> StartAccessingSecurityScopedResource(
       mate::Arguments* args);
 #endif
 

--- a/atom/browser/api/atom_api_app_mas.mm
+++ b/atom/browser/api/atom_api_app_mas.mm
@@ -19,7 +19,7 @@ void OnStopAccessingSecurityScopedResource(NSURL* bookmarkUrl) {
 }
 
 // Get base64 encoded NSData, create a bookmark for it and start accessing it.
-base::Callback<void()> App::StartAccessingSecurityScopedResource(
+base::RepeatingCallback<void()> App::StartAccessingSecurityScopedResource(
     mate::Arguments* args) {
   std::string data;
   args->GetNext(&data);
@@ -55,7 +55,8 @@ base::Callback<void()> App::StartAccessingSecurityScopedResource(
   [bookmarkUrl retain];
 
   // Return a js callback which will close the bookmark.
-  return base::Bind(&OnStopAccessingSecurityScopedResource, bookmarkUrl);
+  return base::BindRepeating(&OnStopAccessingSecurityScopedResource,
+                             bookmarkUrl);
 }
 
 }  // namespace atom

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -91,7 +91,8 @@ void AutoUpdater::OnUpdateDownloaded(const std::string& release_notes,
                                      const std::string& url) {
   Emit("update-downloaded", release_notes, release_name, release_date, url,
        // Keep compatibility with old APIs.
-       base::Bind(&AutoUpdater::QuitAndInstall, base::Unretained(this)));
+       base::BindRepeating(&AutoUpdater::QuitAndInstall,
+                           base::Unretained(this)));
 }
 
 void AutoUpdater::OnWindowAllClosed() {

--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -165,7 +165,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  BrowserView::SetConstructor(isolate, base::Bind(&BrowserView::New));
+  BrowserView::SetConstructor(isolate, base::BindRepeating(&BrowserView::New));
 
   mate::Dictionary browser_view(isolate, BrowserView::GetConstructor(isolate)
                                              ->GetFunction(context)

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -241,7 +241,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Menu::SetConstructor(isolate, base::Bind(&Menu::New));
+  Menu::SetConstructor(isolate, base::BindRepeating(&Menu::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set(

--- a/atom/browser/api/atom_api_net.cc
+++ b/atom/browser/api/atom_api_net.cc
@@ -51,7 +51,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
 
-  URLRequest::SetConstructor(isolate, base::Bind(URLRequest::New));
+  URLRequest::SetConstructor(isolate, base::BindRepeating(URLRequest::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("net", Net::Create(isolate));

--- a/atom/browser/api/atom_api_notification.cc
+++ b/atom/browser/api/atom_api_notification.cc
@@ -258,7 +258,8 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Notification::SetConstructor(isolate, base::Bind(&Notification::New));
+  Notification::SetConstructor(isolate,
+                               base::BindRepeating(&Notification::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("Notification", Notification::GetConstructor(isolate)

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -1190,7 +1190,8 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  TopLevelWindow::SetConstructor(isolate, base::Bind(&TopLevelWindow::New));
+  TopLevelWindow::SetConstructor(isolate,
+                                 base::BindRepeating(&TopLevelWindow::New));
 
   mate::Dictionary constructor(isolate, TopLevelWindow::GetConstructor(isolate)
                                             ->GetFunction(context)

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -262,7 +262,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  Tray::SetConstructor(isolate, base::Bind(&Tray::New));
+  Tray::SetConstructor(isolate, base::BindRepeating(&Tray::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set(

--- a/atom/browser/api/atom_api_view.cc
+++ b/atom/browser/api/atom_api_view.cc
@@ -73,7 +73,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  View::SetConstructor(isolate, base::Bind(&View::New));
+  View::SetConstructor(isolate, base::BindRepeating(&View::New));
 
   mate::Dictionary constructor(
       isolate,


### PR DESCRIPTION
#### Description of Change

This PR converts `base::Bind` to `base::BindRepeating` for native module constructors. Also converts 
`App::StartAccessingSecurityScopedResources`.

cc @deepak1556 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
