### PR TITLE
fix: permission handler regression in default app

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -81,7 +81,7 @@ async function createWindow () {
       cancelId: 1
     }
 
-    dialog.showMessageBox(mainWindow!, options).then(response => {
+    dialog.showMessageBox(mainWindow!, options).then(({ response }) => {
       done(response === 0)
     })
   })


### PR DESCRIPTION
#### Description of Change
- The code wasn't fixed properly in #17357 after `dialog.showMessageBox()` promisification.
- Tested using `electron https://webrtc.github.io/samples/src/content/getusermedia/gum/`
- No release notes as the bug hasn't been "released" anywhere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes

/cc @codebytere