### PR TITLE
build: use https to download from GitHub for external binaries

### DIFF
--- a/script/external-binaries.json
+++ b/script/external-binaries.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://github.com/electron/electron-frameworks/releases/download",
+  "baseUrl": "https://github.com/electron/electron-frameworks/releases/download",
   "version": "v1.4.0",
   "binaries": [
     {


### PR DESCRIPTION
When we download external binaries we are using http instead of https to download but the http link redirects to https, so we should just use the https link

related #17926

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
