### PR TITLE
fix: allow creating service for temporary partitions (nws13n)

### DIFF
--- a/atom/browser/net/network_context_service_factory.cc
+++ b/atom/browser/net/network_context_service_factory.cc
@@ -31,4 +31,10 @@ KeyedService* NetworkContextServiceFactory::BuildServiceInstanceFor(
   return new NetworkContextService(static_cast<AtomBrowserContext*>(context));
 }
 
+content::BrowserContext* NetworkContextServiceFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  // Create separate service for temporary sessions.
+  return context;
+}
+
 }  // namespace atom

--- a/atom/browser/net/network_context_service_factory.h
+++ b/atom/browser/net/network_context_service_factory.h
@@ -41,6 +41,8 @@ class NetworkContextServiceFactory : public BrowserContextKeyedServiceFactory {
   // BrowserContextKeyedServiceFactory implementation:
   KeyedService* BuildServiceInstanceFor(
       content::BrowserContext* context) const override;
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
 };
 
 }  // namespace atom


### PR DESCRIPTION
#### Description of Change

Fixes crash when starting app with `--enable-features=NetworkService` that uses temporary sessions.

Ref https://github.com/electron/electron/issues/15791

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
