### PR TITLE
build: fix a symbol linkage error for WoA

### DIFF
--- a/patches/common/v8/.patches
+++ b/patches/common/v8/.patches
@@ -6,3 +6,4 @@ dcheck.patch
 fixme_revert_heap_api_remove_deprecated_apis.patch
 revert_cctest_add_v8_export_private_to_arm_arm64_ports.patch
 export_symbols_needed_for_windows_build.patch
+woa_symbol_workaround.patch

--- a/patches/common/v8/woa_symbol_workaround.patch
+++ b/patches/common/v8/woa_symbol_workaround.patch
@@ -1,0 +1,82 @@
+From 93a2903b1392fe70bccd32db67649487d88985bd Mon Sep 17 00:00:00 2001
+From: Richard Townsend <richard.townsend@arm.com>
+Date: Wed, 24 Apr 2019 13:57:36 +0100
+Subject: [PATCH] Workaround an undefined symbol error
+
+Previously, builds configured with dcheck_always_on=true would error
+with messages like this in the log:
+ lld-link: error: undefined symbol: public: bool __cdecl
+  v8::internal::CPURegister::IsZero(void) const
+
+By moving some functions out of the the arm64-assembler header file,
+this error no longer seems to happen.
+---
+ src/arm64/assembler-arm64.cc | 16 ++++++++++++++++
+ src/arm64/assembler-arm64.h  | 17 +++--------------
+ 2 files changed, 19 insertions(+), 14 deletions(-)
+
+diff --git a/src/arm64/assembler-arm64.cc b/src/arm64/assembler-arm64.cc
+index 2763a647c7..7d19be5de8 100644
+--- a/src/arm64/assembler-arm64.cc
++++ b/src/arm64/assembler-arm64.cc
+@@ -4001,6 +4001,22 @@ void Assembler::MoveWide(const Register& rd, uint64_t imm, int shift,
+        ImmMoveWide(static_cast<int>(imm)) | ShiftMoveWide(shift));
+ }
+
++Instr Assembler::RmNot31(CPURegister rm) {
++  DCHECK_NE(rm.code(), kSPRegInternalCode);
++  DCHECK(!rm.IsZero());
++  return Rm(rm);
++}
++
++Instr Assembler::RdSP(Register rd) {
++  DCHECK(!rd.IsZero());
++  return (rd.code() & kRegCodeMask) << Rd_offset;
++}
++
++Instr Assembler::RnSP(Register rn) {
++  DCHECK(!rn.IsZero());
++  return (rn.code() & kRegCodeMask) << Rn_offset;
++}
++
+ void Assembler::AddSub(const Register& rd, const Register& rn,
+                        const Operand& operand, FlagsUpdate S, AddSubOp op) {
+   DCHECK_EQ(rd.SizeInBits(), rn.SizeInBits());
+diff --git a/src/arm64/assembler-arm64.h b/src/arm64/assembler-arm64.h
+index 586eff1241..30b8586f69 100644
+--- a/src/arm64/assembler-arm64.h
++++ b/src/arm64/assembler-arm64.h
+@@ -2232,11 +2232,7 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
+     return rm.code() << Rm_offset;
+   }
+
+-  static Instr RmNot31(CPURegister rm) {
+-    DCHECK_NE(rm.code(), kSPRegInternalCode);
+-    DCHECK(!rm.IsZero());
+-    return Rm(rm);
+-  }
++  static Instr RmNot31(CPURegister rm);
+
+   static Instr Ra(CPURegister ra) {
+     DCHECK_NE(ra.code(), kSPRegInternalCode);
+@@ -2260,15 +2256,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
+
+   // These encoding functions allow the stack pointer to be encoded, and
+   // disallow the zero register.
+-  static Instr RdSP(Register rd) {
+-    DCHECK(!rd.IsZero());
+-    return (rd.code() & kRegCodeMask) << Rd_offset;
+-  }
+-
+-  static Instr RnSP(Register rn) {
+-    DCHECK(!rn.IsZero());
+-    return (rn.code() & kRegCodeMask) << Rn_offset;
+-  }
++  static Instr RdSP(Register rd);
++  static Instr RnSP(Register rn);
+
+   // Flags encoding.
+   inline static Instr Flags(FlagsUpdate S);
+--
+2.19.1.windows.1
+


### PR DESCRIPTION
#### Description of Change
When `dcheck_always_on=true`, electron's unusual component-build-but-not configuration creates some linking problems in V8, which this patch works around. This should enable the CI to build for Windows on Arm in testing mode.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
