### PR TITLE
build: allow pulling in a later version of Clang

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -7,6 +7,7 @@ blink_local_frame.patch
 blink_world_context.patch
 browser_compositor_mac.patch
 can_create_window.patch
+clang_fetch_env.patch
 disable_hidden.patch
 dom_storage_limits.patch
 frame_host_manager.patch

--- a/patches/common/chromium/clang_fetch_env.patch
+++ b/patches/common/chromium/clang_fetch_env.patch
@@ -1,0 +1,31 @@
+From 4eab1744c164013657091bcd424be06988f55ad8 Mon Sep 17 00:00:00 2001
+From: Richard Townsend <richard.townsend@arm.com>
+Date: Wed, 24 Apr 2019 14:19:27 +0100
+Subject: [PATCH] fix: support getting a clang version from the environment
+
+Due to an MSVC interoperability defect in the version of Clang used for
+Chromium 74-76, it's necessary to build with a later version of Clang.
+This change allows the correct version to be specified via the
+environment during a gclient sync. This is only intended to be a
+temporary workaround and will be removed when Electron's Chromium
+updates to a new version.
+---
+ tools/clang/scripts/update.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tools/clang/scripts/update.py b/tools/clang/scripts/update.py
+index c284aff1e3b7..145232ac6a27 100755
+--- a/tools/clang/scripts/update.py
++++ b/tools/clang/scripts/update.py
+@@ -37,6 +37,8 @@ import zipfile
+ # Reverting problematic clang rolls is safe, though.
+ CLANG_REVISION = '357692'
+ 
++CLANG_REVISION = os.environ.get('LLVM_FORCE_REVISION', CLANG_REVISION).strip()
++
+ use_head_revision = bool(os.environ.get('LLVM_FORCE_HEAD_REVISION', '0')
+                          in ('1', 'YES'))
+ if use_head_revision:
+-- 
+2.19.1.windows.1
+

--- a/patches/common/chromium/revert_roll_clang_356356_357569.patch
+++ b/patches/common/chromium/revert_roll_clang_356356_357569.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 8a1f8c959995b08241a32f30e1a3fd9928efa31d Mon Sep 17 00:00:00 2001
 From: Jeremy Apthorp <nornagon@nornagon.net>
 Date: Thu, 18 Apr 2019 11:07:51 -0700
 Subject: Revert "Roll clang 356356:357569."
@@ -7,8 +7,13 @@ This reverts commit a50f2f33843d26fd7c0d1f1a2331aa45a392c6cd.
 
 This roll broke ARM builds. Tracking bug: crbug.com/953815
 
+Patch-Filename: revert_roll_clang_356356_357569.patch
+---
+ tools/clang/scripts/update.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
 diff --git a/tools/clang/scripts/update.py b/tools/clang/scripts/update.py
-index c284aff1e3b73977050dcc9ee0608aae6c650f5c..39a4c86ee5fbfbd8f9f8d5b2b08d12af3be078ee 100755
+index 145232ac6a27..8bbf3d6f85a8 100755
 --- a/tools/clang/scripts/update.py
 +++ b/tools/clang/scripts/update.py
 @@ -35,7 +35,7 @@ import zipfile
@@ -17,15 +22,18 @@ index c284aff1e3b73977050dcc9ee0608aae6c650f5c..39a4c86ee5fbfbd8f9f8d5b2b08d12af
  # Reverting problematic clang rolls is safe, though.
 -CLANG_REVISION = '357692'
 +CLANG_REVISION = '356356'
- 
- use_head_revision = bool(os.environ.get('LLVM_FORCE_HEAD_REVISION', '0')
-                          in ('1', 'YES'))
-@@ -43,7 +43,7 @@ if use_head_revision:
+
+ CLANG_REVISION = os.environ.get('LLVM_FORCE_REVISION', CLANG_REVISION).strip()
+
+@@ -45,7 +45,7 @@ if use_head_revision:
    CLANG_REVISION = 'HEAD'
- 
+
  # This is incremented when pushing a new build of Clang at the same revision.
 -CLANG_SUB_REVISION=1
 +CLANG_SUB_REVISION=3
- 
+
  PACKAGE_VERSION = "%s-%s" % (CLANG_REVISION, CLANG_SUB_REVISION)
- 
+
+--
+2.19.1.windows.1
+


### PR DESCRIPTION
Due to an MSVC interoperability defect in the version of Clang used for
Chromium 75, it's necessary to build with a later version of Clang. This
change allows the correct version to be specified by setting
`LLVM_FORCE_REVISION=version` in the environment during a `gclient sync`.
We will provide a documentation update when a fixed version of Clang is
available. This PR is only intended to be a temporary workaround and
will be removed when Electron's Chromium updates to a new version.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
