### PR TITLE
docs: remove outdated refs to protocol.registerStandardSchemes

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -54,7 +54,6 @@ app.on('ready', () => {
   })
 })
 ```
-Using `protocol.registerStandardSchemes` without the session will still register your custom protocol as a standard scheme.
 
 ## Methods
 
@@ -158,9 +157,7 @@ specified. For the available error numbers you can use, please see the
 [net error list][net-error].
 
 By default the `scheme` is treated like `http:`, which is parsed differently
-than protocols that follow the "generic URI syntax" like `file:`, so you
-probably want to call `protocol.registerStandardSchemes` to have your scheme
-treated as a standard scheme.
+than protocols that follow the "generic URI syntax" like `file:`.
 
 ### `protocol.registerBufferProtocol(scheme, handler[, completion])`
 


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/17956.

Removes outdated refs to `protocol.registerStandardSchemes()`.

cc @electron/wg-docs-tools 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
