### PR TITLE
refactor: add emitCustomEvent() helper

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -350,22 +350,6 @@ WebContents.prototype._init = function () {
     })
   })
 
-  const forwardedEvents = [
-    'desktop-capturer-get-sources',
-    'remote-require',
-    'remote-get-global',
-    'remote-get-builtin',
-    'remote-get-current-window',
-    'remote-get-current-web-contents',
-    'remote-get-guest-web-contents'
-  ]
-
-  for (const eventName of forwardedEvents) {
-    this.on(eventName, (event, ...args) => {
-      app.emit(eventName, event, this, ...args)
-    })
-  }
-
   this.on('crashed', (event, ...args) => {
     app.emit('renderer-process-crashed', event, this, ...args)
   })

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -1,22 +1,12 @@
 'use strict'
 
-const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
-
 const { createDesktopCapturer } = process.electronBinding('desktop_capturer')
-const eventBinding = process.electronBinding('event')
 
 const deepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b)
 
 let currentlyRunning = []
 
-ipcMainUtils.handle('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', (event, captureWindow, captureScreen, thumbnailSize, fetchWindowIcons) => {
-  const customEvent = eventBinding.createWithSender(event.sender)
-  event.sender.emit('desktop-capturer-get-sources', customEvent)
-
-  if (customEvent.defaultPrevented) {
-    return []
-  }
-
+exports.getSources = (event, captureWindow, captureScreen, thumbnailSize, fetchWindowIcons) => {
   const options = {
     captureWindow,
     captureScreen,
@@ -69,7 +59,7 @@ ipcMainUtils.handle('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', (event, cap
   })
 
   return getSources
-})
+}
 
 const createCapturerEmitHandler = (capturer, request) => {
   return function handlEmitOnCapturer (event, name, sources, fetchWindowIcons) {

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -44,7 +44,7 @@ if (process.platform === 'win32') {
 // Don't quit on fatal error.
 process.on('uncaughtException', function (error) {
   // Do nothing if the user has a custom uncaught exception handler.
-  if (process.listeners('uncaughtException').length > 1) {
+  if (process.listenerCount('uncaughtException') > 1) {
     return
   }
 
@@ -158,12 +158,6 @@ require('@electron/internal/browser/chrome-devtools')
 
 // Load the chrome extension support.
 require('@electron/internal/browser/chrome-extension')
-
-const features = process.electronBinding('features')
-if (features.isDesktopCapturerEnabled()) {
-  // Load internal desktop-capturer module.
-  require('@electron/internal/browser/desktop-capturer')
-}
 
 // Load protocol module to ensure it is populated on app ready
 require('@electron/internal/browser/api/protocol')

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -8,6 +8,7 @@ const path = require('path')
 const v8Util = process.electronBinding('v8_util')
 const eventBinding = process.electronBinding('event')
 const clipboard = process.electronBinding('clipboard')
+const features = process.electronBinding('features')
 
 const { isPromise } = electron
 
@@ -273,6 +274,15 @@ const handleRemoteCommand = function (channel, handler) {
   })
 }
 
+const emitCustomEvent = function (contents, eventName, ...args) {
+  const event = eventBinding.createWithSender(contents)
+
+  electron.app.emit(eventName, event, contents, ...args)
+  contents.emit(eventName, event, ...args)
+
+  return event
+}
+
 handleRemoteCommand('ELECTRON_BROWSER_WRONG_CONTEXT_ERROR', function (event, contextId, passedContextId, id) {
   const objectId = [passedContextId, id]
   if (!rendererFunctions.has(objectId)) {
@@ -283,8 +293,7 @@ handleRemoteCommand('ELECTRON_BROWSER_WRONG_CONTEXT_ERROR', function (event, con
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_REQUIRE', function (event, contextId, moduleName) {
-  const customEvent = eventBinding.createWithSender(event.sender)
-  event.sender.emit('remote-require', customEvent, moduleName)
+  const customEvent = emitCustomEvent(event.sender, 'remote-require', moduleName)
 
   if (customEvent.returnValue === undefined) {
     if (customEvent.defaultPrevented) {
@@ -298,8 +307,7 @@ handleRemoteCommand('ELECTRON_BROWSER_REQUIRE', function (event, contextId, modu
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_GET_BUILTIN', function (event, contextId, moduleName) {
-  const customEvent = eventBinding.createWithSender(event.sender)
-  event.sender.emit('remote-get-builtin', customEvent, moduleName)
+  const customEvent = emitCustomEvent(event.sender, 'remote-get-builtin', moduleName)
 
   if (customEvent.returnValue === undefined) {
     if (customEvent.defaultPrevented) {
@@ -313,8 +321,7 @@ handleRemoteCommand('ELECTRON_BROWSER_GET_BUILTIN', function (event, contextId, 
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_GLOBAL', function (event, contextId, globalName) {
-  const customEvent = eventBinding.createWithSender(event.sender)
-  event.sender.emit('remote-get-global', customEvent, globalName)
+  const customEvent = emitCustomEvent(event.sender, 'remote-get-global', globalName)
 
   if (customEvent.returnValue === undefined) {
     if (customEvent.defaultPrevented) {
@@ -328,8 +335,7 @@ handleRemoteCommand('ELECTRON_BROWSER_GLOBAL', function (event, contextId, globa
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_CURRENT_WINDOW', function (event, contextId) {
-  const customEvent = eventBinding.createWithSender(event.sender)
-  event.sender.emit('remote-get-current-window', customEvent)
+  const customEvent = emitCustomEvent(event.sender, 'remote-get-current-window')
 
   if (customEvent.returnValue === undefined) {
     if (customEvent.defaultPrevented) {
@@ -343,8 +349,7 @@ handleRemoteCommand('ELECTRON_BROWSER_CURRENT_WINDOW', function (event, contextI
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_CURRENT_WEB_CONTENTS', function (event, contextId) {
-  const customEvent = eventBinding.createWithSender(event.sender)
-  event.sender.emit('remote-get-current-web-contents', customEvent)
+  const customEvent = emitCustomEvent(event.sender, 'remote-get-current-web-contents')
 
   if (customEvent.returnValue === undefined) {
     if (customEvent.defaultPrevented) {
@@ -447,8 +452,7 @@ handleRemoteCommand('ELECTRON_BROWSER_CONTEXT_RELEASE', (event, contextId) => {
 handleRemoteCommand('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, contextId, guestInstanceId) {
   const guest = guestViewManager.getGuestForWebContents(guestInstanceId, event.sender)
 
-  const customEvent = eventBinding.createWithSender(event.sender)
-  event.sender.emit('remote-get-guest-web-contents', customEvent, guest)
+  const customEvent = emitCustomEvent(event.sender, 'remote-get-guest-web-contents', guest)
 
   if (customEvent.returnValue === undefined) {
     if (customEvent.defaultPrevented) {
@@ -497,6 +501,21 @@ ipcMainUtils.handle('ELECTRON_BROWSER_CLIPBOARD', function (event, method, ...ar
 
   return clipboardUtils.serialize(electron.clipboard[method](...clipboardUtils.deserialize(args)))
 })
+
+if (features.isDesktopCapturerEnabled()) {
+  const desktopCapturer = require('@electron/internal/browser/desktop-capturer')
+
+  ipcMainUtils.handle('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function (event, ...args) {
+    const customEvent = emitCustomEvent(event.sender, 'desktop-capturer-get-sources')
+
+    if (customEvent.defaultPrevented) {
+      console.error('Blocked desktopCapturer.getSources()')
+      return []
+    }
+
+    return desktopCapturer.getSources(event, ...args)
+  })
+}
 
 let absoluteAppPath
 const getAppPath = async function () {

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -166,7 +166,7 @@ if (nodeIntegration) {
 
   // Redirect window.onerror to uncaughtException.
   window.onerror = function (_message, _filename, _lineno, _colno, error) {
-    if (global.process.listeners('uncaughtException').length > 0) {
+    if (global.process.listenerCount('uncaughtException') > 0) {
       // We do not want to add `uncaughtException` to our definitions
       // because we don't want anyone else (anywhere) to throw that kind
       // of error.


### PR DESCRIPTION
#### Description of Change
Simplifies #17902 by moving duplicate code emitting filtering events into a helper function.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
