### PR TITLE
feat: migrate protocol module to NetworkService (Part 2)

### DIFF
--- a/atom/browser/api/atom_api_protocol_ns.cc
+++ b/atom/browser/api/atom_api_protocol_ns.cc
@@ -7,8 +7,8 @@
 #include <memory>
 
 #include "atom/browser/atom_browser_context.h"
-#include "atom/common/native_mate_converters/callback.h"
-#include "atom/common/native_mate_converters/value_converter.h"
+#include "atom/common/native_mate_converters/net_converter.h"
+#include "atom/common/native_mate_converters/once_callback.h"
 #include "atom/common/promise_util.h"
 #include "base/stl_util.h"
 

--- a/atom/browser/api/atom_api_protocol_ns.h
+++ b/atom/browser/api/atom_api_protocol_ns.h
@@ -7,8 +7,10 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 #include "atom/browser/api/trackable_object.h"
+#include "atom/browser/net/atom_url_loader_factory.h"
 #include "content/public/browser/content_browser_client.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/handle.h"
@@ -46,25 +48,31 @@ class ProtocolNS : public mate::TrackableObject<ProtocolNS> {
   ~ProtocolNS() override;
 
   // Callback types.
-  using Handler =
-      base::Callback<void(const base::DictionaryValue&, v8::Local<v8::Value>)>;
   using CompletionCallback = base::Callback<void(v8::Local<v8::Value>)>;
 
   // JS APIs.
-  int RegisterProtocol(const std::string& scheme,
-                       const Handler& handler,
-                       mate::Arguments* args);
+  ProtocolError RegisterProtocol(ProtocolType type,
+                                 const std::string& scheme,
+                                 const ProtocolHandler& handler);
   void UnregisterProtocol(const std::string& scheme, mate::Arguments* args);
   bool IsProtocolRegistered(const std::string& scheme);
 
   // Old async version of IsProtocolRegistered.
   v8::Local<v8::Promise> IsProtocolHandled(const std::string& scheme);
 
+  // Helper for converting old registration APIs to new RegisterProtocol API.
+  template <ProtocolType type>
+  void RegisterProtocolFor(const std::string& scheme,
+                           const ProtocolHandler& handler,
+                           mate::Arguments* args) {
+    HandleOptionalCallback(args, RegisterProtocol(type, scheme, handler));
+  }
+
   // Be compatible with old interface, which accepts optional callback.
   void HandleOptionalCallback(mate::Arguments* args, ProtocolError error);
 
-  // scheme => handler.
-  std::map<std::string, Handler> handlers_;
+  // scheme => (type, handler).
+  std::map<std::string, std::pair<ProtocolType, ProtocolHandler>> handlers_;
 };
 
 }  // namespace api

--- a/atom/browser/net/atom_url_loader_factory.cc
+++ b/atom/browser/net/atom_url_loader_factory.cc
@@ -15,7 +15,9 @@ using content::BrowserThread;
 
 namespace atom {
 
-AtomURLLoaderFactory::AtomURLLoaderFactory() {}
+AtomURLLoaderFactory::AtomURLLoaderFactory(ProtocolType type,
+                                           const ProtocolHandler& handler)
+    : type_(type), handler_(handler) {}
 
 AtomURLLoaderFactory::~AtomURLLoaderFactory() = default;
 

--- a/atom/browser/net/atom_url_loader_factory.cc
+++ b/atom/browser/net/atom_url_loader_factory.cc
@@ -7,9 +7,13 @@
 #include <string>
 #include <utility>
 
+#include "atom/common/native_mate_converters/net_converter.h"
 #include "content/public/browser/browser_thread.h"
+#include "gin/dictionary.h"
 #include "services/network/public/cpp/url_loader_completion_status.h"
 #include "services/network/public/mojom/url_loader.mojom.h"
+
+#include "atom/common/node_includes.h"
 
 using content::BrowserThread;
 
@@ -17,7 +21,7 @@ namespace atom {
 
 AtomURLLoaderFactory::AtomURLLoaderFactory(ProtocolType type,
                                            const ProtocolHandler& handler)
-    : type_(type), handler_(handler) {}
+    : type_(type), handler_(handler), weak_factory_(this) {}
 
 AtomURLLoaderFactory::~AtomURLLoaderFactory() = default;
 
@@ -29,28 +33,130 @@ void AtomURLLoaderFactory::CreateLoaderAndStart(
     const network::ResourceRequest& request,
     network::mojom::URLLoaderClientPtr client,
     const net::MutableNetworkTrafficAnnotationTag& traffic_annotation) {
-  std::string contents = "Not Implemented";
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  uint32_t size = base::saturated_cast<uint32_t>(contents.size());
-  mojo::DataPipe pipe(size);
-  MojoResult result = pipe.producer_handle->WriteData(
-      contents.data(), &size, MOJO_WRITE_DATA_FLAG_NONE);
-  if (result != MOJO_RESULT_OK || size < contents.size()) {
-    client->OnComplete(network::URLLoaderCompletionStatus(net::ERR_FAILED));
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Context::Scope context_scope(context);
+  if (HandleError(&client, isolate, response))
     return;
-  }
 
-  network::ResourceResponseHead head;
-  head.mime_type = "text/html";
-  head.charset = "utf-8";
-  client->OnReceiveResponse(head);
-  client->OnStartLoadingResponseBody(std::move(pipe.consumer_handle));
-  client->OnComplete(network::URLLoaderCompletionStatus(net::OK));
+  switch (type_) {
+    case ProtocolType::kBuffer:
+      handler_.Run(request,
+                   base::BindOnce(&AtomURLLoaderFactory::SendResponseBuffer,
+                                  weak_factory_.GetWeakPtr(), std::move(client),
+                                  isolate));
+      break;
+    case ProtocolType::kString:
+      handler_.Run(request,
+                   base::BindOnce(&AtomURLLoaderFactory::SendResponseString,
+                                  weak_factory_.GetWeakPtr(), std::move(client),
+                                  isolate));
+      break;
+    default: {
+      std::string contents = "Not Implemented";
+      SendContents(std::move(client), "text/html", "utf-8", contents.data(),
+                   contents.size());
+    }
+  }
 }
 
 void AtomURLLoaderFactory::Clone(
     network::mojom::URLLoaderFactoryRequest request) {
   bindings_.AddBinding(this, std::move(request));
+}
+
+void AtomURLLoaderFactory::SendResponseBuffer(
+    network::mojom::URLLoaderClientPtr client,
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> response) {
+  std::string mime_type = "text/html";
+  std::string charset = "utf-8";
+  v8::Local<v8::Value> buffer;
+  if (node::Buffer::HasInstance(response)) {
+    buffer = response;
+  } else if (response->IsObject()) {
+    gin::Dictionary dict(
+        isolate,
+        response->ToObject(isolate->GetCurrentContext()).ToLocalChecked());
+    dict.Get("mimeType", &mime_type);
+    dict.Get("charset", &charset);
+    dict.Get("data", &buffer);
+    if (!node::Buffer::HasInstance(response))
+      buffer = v8::Local<v8::Value>();
+  }
+
+  if (buffer.IsEmpty()) {
+    network::URLLoaderCompletionStatus status;
+    status.error_code = net::ERR_NOT_IMPLEMENTED;
+    client->OnComplete(status);
+    return;
+  }
+
+  SendContents(std::move(client), std::move(mime_type), std::move(charset),
+               node::Buffer::Data(buffer), node::Buffer::Length(buffer));
+}
+
+void AtomURLLoaderFactory::SendResponseString(
+    network::mojom::URLLoaderClientPtr client,
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> response) {
+  std::string mime_type = "text/html";
+  std::string charset = "utf-8";
+  std::string contents;
+  if (response->IsString()) {
+    contents = gin::V8ToString(isolate, response);
+  } else if (response->IsObject()) {
+    gin::Dictionary dict(
+        isolate,
+        response->ToObject(isolate->GetCurrentContext()).ToLocalChecked());
+    dict.Get("mimeType", &mime_type);
+    dict.Get("charset", &charset);
+    dict.Get("data", &contents);
+  }
+  SendContents(std::move(client), std::move(mime_type), std::move(charset),
+               contents.data(), contents.size());
+}
+
+bool AtomURLLoaderFactory::HandleError(
+    network::mojom::URLLoaderClientPtr* client,
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> response) {
+  if (!response->IsObject())
+    return false;
+  v8::Local<v8::Object> obj =
+      response->ToObject(isolate->GetCurrentContext()).ToLocalChecked();
+  network::URLLoaderCompletionStatus status;
+  if (!gin::Dictionary(isolate, obj).Get("error", &status.error_code))
+    return false;
+  std::move(*client)->OnComplete(status);
+  return true;
+}
+
+void AtomURLLoaderFactory::SendContents(
+    network::mojom::URLLoaderClientPtr client,
+    std::string mime_type,
+    std::string charset,
+    const char* data,
+    size_t ssize) {
+  uint32_t size = base::saturated_cast<uint32_t>(ssize);
+  mojo::DataPipe pipe(size);
+  MojoResult result =
+      pipe.producer_handle->WriteData(data, &size, MOJO_WRITE_DATA_FLAG_NONE);
+  if (result != MOJO_RESULT_OK || size < ssize) {
+    client->OnComplete(network::URLLoaderCompletionStatus(net::ERR_FAILED));
+    return;
+  }
+
+  network::ResourceResponseHead head;
+  head.mime_type = std::move(mime_type);
+  head.charset = std::move(charset);
+  client->OnReceiveResponse(head);
+  client->OnStartLoadingResponseBody(std::move(pipe.consumer_handle));
+  client->OnComplete(network::URLLoaderCompletionStatus(net::OK));
 }
 
 }  // namespace atom

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -53,6 +53,11 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
   void SendResponseString(network::mojom::URLLoaderClientPtr client,
                           v8::Isolate* isolate,
                           v8::Local<v8::Value> response);
+  void SendResponseFile(network::mojom::URLLoaderRequest loader,
+                        network::ResourceRequest request,
+                        network::mojom::URLLoaderClientPtr client,
+                        v8::Isolate* isolate,
+                        v8::Local<v8::Value> response);
 
   bool HandleError(network::mojom::URLLoaderClientPtr* client,
                    v8::Isolate* isolate,

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -24,6 +24,7 @@
 #include "net/cert/x509_util.h"
 #include "net/http/http_response_headers.h"
 #include "net/url_request/url_request.h"
+#include "services/network/public/cpp/resource_request.h"
 #include "storage/browser/blob/upload_blob_element_reader.h"
 
 namespace mate {
@@ -221,6 +222,22 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
     }
   }
   return true;
+}
+
+// static
+v8::Local<v8::Value> Converter<network::ResourceRequest>::ToV8(
+    v8::Isolate* isolate,
+    const network::ResourceRequest& val) {
+  mate::Dictionary dict(isolate, v8::Object::New(isolate));
+  dict.Set("method", val.method);
+  dict.Set("url", val.url.spec());
+  dict.Set("referrer", val.referrer.spec());
+  mate::Dictionary headers(isolate, v8::Object::New(isolate));
+  for (net::HttpRequestHeaders::Iterator it(val.headers); it.GetNext();)
+    headers.Set(it.name(), it.value());
+  dict.Set("headers", headers);
+  // FIXME(zcbenz): Figure out how to support uploadData.
+  return dict.GetHandle();
 }
 
 }  // namespace mate

--- a/atom/common/native_mate_converters/net_converter.h
+++ b/atom/common/native_mate_converters/net_converter.h
@@ -21,6 +21,10 @@ class HttpResponseHeaders;
 struct CertPrincipal;
 }  // namespace net
 
+namespace network {
+struct ResourceRequest;
+}
+
 namespace mate {
 
 template <>
@@ -53,6 +57,12 @@ struct Converter<net::HttpResponseHeaders*> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      net::HttpResponseHeaders* out);
+};
+
+template <>
+struct Converter<network::ResourceRequest> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const network::ResourceRequest& val);
 };
 
 }  // namespace mate


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Refs https://github.com/electron/electron/issues/15791.

This is part of the changes to reimplement the protocol module with NetworkService API, the new implementation lives in parallel with current implementation and only gets used when `--enable-features=NetworkService` is passed.

This PR implements the `protocol.registerFileProtocol/registerBufferProtocol/registerStringProtocol` with NetworkService APIs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes