### PR TITLE
chore: convert some more modules from base::Bind

### DIFF
--- a/atom/browser/api/atom_api_browser_window.cc
+++ b/atom/browser/api/atom_api_browser_window.cc
@@ -392,8 +392,8 @@ void BrowserWindow::ScheduleUnresponsiveEvent(int ms) {
   if (!window_unresponsive_closure_.IsCancelled())
     return;
 
-  window_unresponsive_closure_.Reset(
-      base::Bind(&BrowserWindow::NotifyWindowUnresponsive, GetWeakPtr()));
+  window_unresponsive_closure_.Reset(base::BindRepeating(
+      &BrowserWindow::NotifyWindowUnresponsive, GetWeakPtr()));
   base::ThreadTaskRunnerHandle::Get()->PostDelayedTask(
       FROM_HERE, window_unresponsive_closure_.callback(),
       base::TimeDelta::FromMilliseconds(ms));
@@ -474,8 +474,9 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("BrowserWindow", mate::CreateConstructor<BrowserWindow>(
-                                isolate, base::Bind(&BrowserWindow::New)));
+  dict.Set("BrowserWindow",
+           mate::CreateConstructor<BrowserWindow>(
+               isolate, base::BindRepeating(&BrowserWindow::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_content_tracing.cc
+++ b/atom/browser/api/atom_api_content_tracing.cc
@@ -53,7 +53,7 @@ struct Converter<base::trace_event::TraceConfig> {
 
 namespace {
 
-using CompletionCallback = base::Callback<void(const base::FilePath&)>;
+using CompletionCallback = base::RepeatingCallback<void(const base::FilePath&)>;
 
 scoped_refptr<TracingController::TraceDataEndpoint> GetTraceDataEndpoint(
     const base::FilePath& path,
@@ -68,7 +68,7 @@ scoped_refptr<TracingController::TraceDataEndpoint> GetTraceDataEndpoint(
     LOG(ERROR) << "Creating temporary file failed";
 
   return TracingController::CreateFileEndpoint(
-      result_file_path, base::Bind(callback, result_file_path));
+      result_file_path, base::BindRepeating(callback, result_file_path));
 }
 
 v8::Local<v8::Promise> StopRecording(v8::Isolate* isolate,
@@ -79,9 +79,10 @@ v8::Local<v8::Promise> StopRecording(v8::Isolate* isolate,
   // TODO(zcbenz): Remove the use of CopyablePromise when the
   // CreateFileEndpoint API accepts OnceCallback.
   TracingController::GetInstance()->StopTracing(GetTraceDataEndpoint(
-      path, base::Bind(atom::util::CopyablePromise::ResolveCopyablePromise<
-                           const base::FilePath&>,
-                       atom::util::CopyablePromise(promise))));
+      path,
+      base::BindRepeating(atom::util::CopyablePromise::ResolveCopyablePromise<
+                              const base::FilePath&>,
+                          atom::util::CopyablePromise(promise))));
   return handle;
 }
 

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -176,7 +176,8 @@ Cookies::Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context)
   Init(isolate);
   cookie_change_subscription_ =
       browser_context_->cookie_change_notifier()->RegisterCookieChangeCallback(
-          base::Bind(&Cookies::OnCookieChanged, base::Unretained(this)));
+          base::BindRepeating(&Cookies::OnCookieChanged,
+                              base::Unretained(this)));
 }
 
 Cookies::~Cookies() {}

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -41,10 +41,11 @@ void MenuMac::PopupAt(TopLevelWindow* window,
   if (!native_window)
     return;
 
-  auto popup = base::Bind(&MenuMac::PopupOnUI, weak_factory_.GetWeakPtr(),
-                          native_window->GetWeakPtr(), window->weak_map_id(), x,
-                          y, positioning_item, callback);
-  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI}, popup);
+  auto popup =
+      base::BindOnce(&MenuMac::PopupOnUI, weak_factory_.GetWeakPtr(),
+                     native_window->GetWeakPtr(), window->weak_map_id(), x, y,
+                     positioning_item, callback);
+  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI}, std::move(popup));
 }
 
 void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
@@ -57,7 +58,7 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
     return;
   NSWindow* nswindow = native_window->GetNativeWindow().GetNativeNSWindow();
 
-  auto close_callback = base::Bind(
+  auto close_callback = base::BindRepeating(
       &MenuMac::OnClosed, weak_factory_.GetWeakPtr(), window_id, callback);
   popup_controllers_[window_id] = base::scoped_nsobject<AtomMenuController>([
       [AtomMenuController alloc] initWithModel:model()

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -46,7 +46,7 @@ void MenuViews::PopupAt(TopLevelWindow* window,
 
   // Show the menu.
   int32_t window_id = window->weak_map_id();
-  auto close_callback = base::Bind(
+  auto close_callback = base::BindRepeating(
       &MenuViews::OnClosed, weak_factory_.GetWeakPtr(), window_id, callback);
   menu_runners_[window_id] =
       std::make_unique<MenuRunner>(model(), flags, close_callback);


### PR DESCRIPTION
#### Description of Change

Converts instances of `base:Bind` to base::BindOnce and `base::BindRepeating` where applicable in the following modules:

- `Menu`
- `Cookies`
- `BrowserWindow`
- `contentTracing`

cc @MarshallOfSound @zcbenz @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
