### PR TITLE
refactor: session.clearAuthCache nws13n

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -74,15 +74,6 @@ struct ClearStorageDataOptions {
   uint32_t quota_types = StoragePartition::QUOTA_MANAGED_STORAGE_MASK_ALL;
 };
 
-struct ClearAuthCacheOptions {
-  std::string type;
-  GURL origin;
-  std::string realm;
-  base::string16 username;
-  base::string16 password;
-  net::HttpAuth::Scheme auth_scheme;
-};
-
 uint32_t GetStorageMask(const std::vector<std::string>& storage_types) {
   uint32_t storage_mask = 0;
   for (const auto& it : storage_types) {
@@ -123,18 +114,6 @@ uint32_t GetQuotaMask(const std::vector<std::string>& quota_types) {
   return quota_mask;
 }
 
-net::HttpAuth::Scheme GetAuthSchemeFromString(const std::string& scheme) {
-  if (scheme == "basic")
-    return net::HttpAuth::AUTH_SCHEME_BASIC;
-  if (scheme == "digest")
-    return net::HttpAuth::AUTH_SCHEME_DIGEST;
-  if (scheme == "ntlm")
-    return net::HttpAuth::AUTH_SCHEME_NTLM;
-  if (scheme == "negotiate")
-    return net::HttpAuth::AUTH_SCHEME_NEGOTIATE;
-  return net::HttpAuth::AUTH_SCHEME_MAX;
-}
-
 void SetUserAgentInIO(scoped_refptr<net::URLRequestContextGetter> getter,
                       const std::string& accept_lang,
                       const std::string& user_agent) {
@@ -162,26 +141,6 @@ struct Converter<ClearStorageDataOptions> {
       out->storage_types = GetStorageMask(types);
     if (options.Get("quotas", &types))
       out->quota_types = GetQuotaMask(types);
-    return true;
-  }
-};
-
-template <>
-struct Converter<ClearAuthCacheOptions> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     ClearAuthCacheOptions* out) {
-    mate::Dictionary options;
-    if (!ConvertFromV8(isolate, val, &options))
-      return false;
-    options.Get("type", &out->type);
-    options.Get("origin", &out->origin);
-    options.Get("realm", &out->realm);
-    options.Get("username", &out->username);
-    options.Get("password", &out->password);
-    std::string scheme;
-    if (options.Get("scheme", &scheme))
-      out->auth_scheme = GetAuthSchemeFromString(scheme);
     return true;
   }
 };
@@ -285,34 +244,6 @@ void SetCertVerifyProcInIO(
   auto* request_context = context_getter->GetURLRequestContext();
   static_cast<AtomCertVerifier*>(request_context->cert_verifier())
       ->SetVerifyProc(proc);
-}
-
-void ClearAuthCacheInIO(
-    const scoped_refptr<net::URLRequestContextGetter>& context_getter,
-    const ClearAuthCacheOptions& options,
-    util::Promise promise) {
-  auto* request_context = context_getter->GetURLRequestContext();
-  auto* network_session =
-      request_context->http_transaction_factory()->GetSession();
-  if (network_session) {
-    if (options.type == "password") {
-      auto* auth_cache = network_session->http_auth_cache();
-      if (!options.origin.is_empty()) {
-        auth_cache->Remove(
-            options.origin, options.realm, options.auth_scheme,
-            net::AuthCredentials(options.username, options.password));
-      } else {
-        auth_cache->ClearAllEntries();
-      }
-    } else if (options.type == "clientCertificate") {
-      auto* client_auth_cache = network_session->ssl_client_auth_cache();
-      client_auth_cache->Remove(net::HostPortPair::FromURL(options.origin));
-    }
-    network_session->CloseAllConnections();
-  }
-  base::PostTaskWithTraits(
-      FROM_HERE, {BrowserThread::UI},
-      base::BindOnce(util::Promise::ResolveEmptyPromise, std::move(promise)));
 }
 
 void AllowNTLMCredentialsForDomainsInIO(
@@ -598,32 +529,24 @@ v8::Local<v8::Promise> Session::ClearHostResolverCache(mate::Arguments* args) {
 
   content::BrowserContext::GetDefaultStoragePartition(browser_context_.get())
       ->GetNetworkContext()
-      ->ClearHostCache(
-          nullptr, base::BindOnce(
-                       [](util::Promise promise) {
-                         util::Promise::ResolveEmptyPromise(std::move(promise));
-                       },
-                       std::move(promise)));
+      ->ClearHostCache(nullptr,
+                       base::BindOnce(util::Promise::ResolveEmptyPromise,
+                                      std::move(promise)));
 
   return handle;
 }
 
-v8::Local<v8::Promise> Session::ClearAuthCache(mate::Arguments* args) {
-  v8::Isolate* isolate = args->isolate();
+v8::Local<v8::Promise> Session::ClearAuthCache() {
+  auto* isolate = v8::Isolate::GetCurrent();
   util::Promise promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
-  ClearAuthCacheOptions options;
-  if (!args->GetNext(&options)) {
-    promise.RejectWithErrorMessage("Must specify options object");
-    return handle;
-  }
+  content::BrowserContext::GetDefaultStoragePartition(browser_context_.get())
+      ->GetNetworkContext()
+      ->ClearHttpAuthCache(base::Time(),
+                           base::BindOnce(util::Promise::ResolveEmptyPromise,
+                                          std::move(promise)));
 
-  base::PostTaskWithTraits(
-      FROM_HERE, {BrowserThread::IO},
-      base::BindOnce(&ClearAuthCacheInIO,
-                     WrapRefCounted(browser_context_->GetRequestContext()),
-                     options, std::move(promise)));
   return handle;
 }
 

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -77,7 +77,7 @@ class Session : public mate::TrackableObject<Session>,
   void SetPermissionCheckHandler(v8::Local<v8::Value> val,
                                  mate::Arguments* args);
   v8::Local<v8::Promise> ClearHostResolverCache(mate::Arguments* args);
-  v8::Local<v8::Promise> ClearAuthCache(mate::Arguments* args);
+  v8::Local<v8::Promise> ClearAuthCache();
   void AllowNTLMCredentialsForDomains(const std::string& domains);
   void SetUserAgent(const std::string& user_agent, mate::Arguments* args);
   std::string GetUserAgent();


### PR DESCRIPTION
#### Description of Change
Refactor session.clearAuthCache to use the network service. This results in losing the ability to filter what is cleared; we should deprecate this in 6-0-x.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: session.clearAuthCache no longer allows filtering the cleared cache entries.