### PR TITLE
build: notify MC of failures to allow easy reruns

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,16 @@ environment:
   DISABLE_CRASH_REPORTER_TESTS: true
   ELECTRON_OUT_DIR: Default
   ELECTRON_ENABLE_STACK_DUMPING: 1
+notifications:
+  - provider: Webhook
+    url: https://electron-mission-control.herokuapp.com/rest/appveyor-hook
+    method: POST
+    headers:
+      x-mission-control-secret:
+        secure: 90BLVPcqhJPG7d24v0q/RRray6W3wDQ8uVQlQjOHaBWkw1i8FoA1lsjr2C/v1dVok+tS2Pi6KxDctPUkwIb4T27u4RhvmcPzQhVpfwVJAG9oNtq+yKN7vzHfg7k/pojEzVdJpQLzeJGcSrZu7VY39Q==
+    on_build_success: false
+    on_build_failure: true
+    on_build_status_changed: false
 build_script:
   - ps: >-
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {


### PR DESCRIPTION
This posts failed build notifications to Mission Control so that it can then forward failed build notifications to the appropriate Slack users who can then click "re-run" from within slack.

This is part 1 of a "let people rerun builds from slack" wave of things.  Screenshots included below.

**Notification**
![image](https://user-images.githubusercontent.com/6634592/56795491-6f000000-67c5-11e9-9d8c-a080e75d2511.png)

**After ReRun**
![image](https://user-images.githubusercontent.com/6634592/56795409-4d067d80-67c5-11e9-98e8-26c3d843e347.png)

Notes: no-notes