### PR TITLE
build: disable Vulkan validation layers

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -14,5 +14,6 @@ proprietary_codecs = true
 ffmpeg_branding = "Chrome"
 
 enable_basic_printing = true
+angle_enable_vulkan_validation_layers = false
 
 is_cfi = false


### PR DESCRIPTION
#### Description of Change
Removes the following DLLs from the build, which are only meant to be used for Chromium development:
- VkLayer_core_validation.dll
- VkLayer_object_tracker.dll
- VkLayer_parameter_validation.dll
- VkLayer_threading.dll
- VkLayer_unique_objects.dll

[angle.gni](https://cs.chromium.org/chromium/src/third_party/angle/gni/angle.gni?type=cs&q=angle_enable_vulkan_validation_layers&g=0&l=78) for more details

Follow up to https://github.com/electron/electron/pull/17694

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed Vulkan validation layers DLLs from electron.zip, which are only meant to be used for Chromium development.