### PR TITLE
build: revert disabling Vulkan support (5-0-x)

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -10,7 +10,6 @@ v8_typed_array_max_size_in_heap = 0
 v8_embedder_string = "-electron.0"
 
 enable_cdm_host_verification = false
-enable_vulkan = false
 proprietary_codecs = true
 ffmpeg_branding = "Chrome"
 


### PR DESCRIPTION
#### Description of Change
Reverts #17788, the correct way to fix the issue is #17985.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes