### PR TITLE
build: revert disabling Vulkan support (4-1-x)

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -8,7 +8,6 @@ v8_embedder_string = "-electron.0"
 
 enable_cdm_host_verification = false
 enable_extensions = false
-enable_vulkan = false
 proprietary_codecs = true
 ffmpeg_branding = "Chrome"
 


### PR DESCRIPTION
#### Description of Change
Reverts #17789, the correct way to fix the issue is #17985.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes