### PR TITLE
refactor: use fs.promises API, which is stable since Node 12

### DIFF
--- a/lib/browser/chrome-devtools.js
+++ b/lib/browser/chrome-devtools.js
@@ -3,11 +3,8 @@
 const { dialog, Menu } = require('electron')
 const fs = require('fs')
 const url = require('url')
-const util = require('util')
 
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
-
-const readFile = util.promisify(fs.readFile)
 
 const convertToMenuTemplate = function (items, handler) {
   return items.map(function (item) {
@@ -90,7 +87,7 @@ ipcMainUtils.handle('ELECTRON_INSPECTOR_SELECT_FILE', async function (event) {
   if (result.canceled) return []
 
   const path = result.filePaths[0]
-  const data = await readFile(path)
+  const data = await fs.promises.readFile(path)
 
   return [path, data]
 })

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -11,9 +11,6 @@ const path = require('path')
 const url = require('url')
 const util = require('util')
 
-const readFile = util.promisify(fs.readFile)
-const writeFile = util.promisify(fs.writeFile)
-
 // Mapping between extensionId(hostname) and manifest.
 const manifestMap = {} // extensionId => manifest
 const manifestNameMap = {} // name => manifest
@@ -237,7 +234,7 @@ const getMessagesPath = (extensionId) => {
 
 ipcMainUtils.handle('CHROME_GET_MESSAGES', async function (event, extensionId) {
   const messagesPath = getMessagesPath(extensionId)
-  return readFile(messagesPath)
+  return fs.promises.readFile(messagesPath)
 })
 
 const validStorageTypes = new Set(['sync', 'local'])
@@ -254,27 +251,11 @@ const getChromeStoragePath = (storageType, extensionId) => {
   return path.join(app.getPath('userData'), `/Chrome Storage/${extensionId}-${storageType}.json`)
 }
 
-const mkdirp = util.promisify((dir, callback) => {
-  fs.mkdir(dir, (error) => {
-    if (error && error.code === 'ENOENT') {
-      mkdirp(path.dirname(dir), (error) => {
-        if (!error) {
-          mkdirp(dir, callback)
-        }
-      })
-    } else if (error && error.code === 'EEXIST') {
-      callback(null)
-    } else {
-      callback(error)
-    }
-  })
-})
-
 ipcMainUtils.handle('CHROME_STORAGE_READ', async function (event, storageType, extensionId) {
   const filePath = getChromeStoragePath(storageType, extensionId)
 
   try {
-    return await readFile(filePath, 'utf8')
+    return await fs.promises.readFile(filePath, 'utf8')
   } catch (error) {
     if (error.code === 'ENOENT') {
       return null
@@ -288,12 +269,12 @@ ipcMainUtils.handle('CHROME_STORAGE_WRITE', async function (event, storageType, 
   const filePath = getChromeStoragePath(storageType, extensionId)
 
   try {
-    await mkdirp(path.dirname(filePath))
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
   } catch {
-    // we just ignore the errors of mkdir or mkdirp
+    // we just ignore the errors of mkdir
   }
 
-  return writeFile(filePath, data, 'utf8')
+  return fs.promises.writeFile(filePath, data, 'utf8')
 })
 
 const isChromeExtension = function (pageURL) {

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -4,7 +4,6 @@ const electron = require('electron')
 const { EventEmitter } = require('events')
 const fs = require('fs')
 const path = require('path')
-const util = require('util')
 
 const v8Util = process.electronBinding('v8_util')
 const eventBinding = process.electronBinding('event')
@@ -499,13 +498,10 @@ ipcMainUtils.handle('ELECTRON_BROWSER_CLIPBOARD', function (event, method, ...ar
   return clipboardUtils.serialize(electron.clipboard[method](...clipboardUtils.deserialize(args)))
 })
 
-const readFile = util.promisify(fs.readFile)
-const realpath = util.promisify(fs.realpath)
-
 let absoluteAppPath
 const getAppPath = async function () {
   if (absoluteAppPath === undefined) {
-    absoluteAppPath = await realpath(electron.app.getAppPath())
+    absoluteAppPath = await fs.promises.realpath(electron.app.getAppPath())
   }
   return absoluteAppPath
 }
@@ -515,10 +511,10 @@ const getPreloadScript = async function (preloadPath) {
   let preloadError = null
   if (preloadPath) {
     try {
-      if (!isParentDir(await getAppPath(), await realpath(preloadPath))) {
+      if (!isParentDir(await getAppPath(), await fs.promises.realpath(preloadPath))) {
         throw new Error('Preload scripts outside of app path are not allowed')
       }
-      preloadSrc = (await readFile(preloadPath)).toString()
+      preloadSrc = (await fs.promises.readFile(preloadPath)).toString()
     } catch (err) {
       preloadError = errorUtils.serialize(err)
     }


### PR DESCRIPTION
#### Description of Change
Simplifies the code by using https://nodejs.org/api/fs.html#fs_fs_promises_api
Custom `mkdirp` is no longer needed, as `fs.mkdir` supports the `recursive` option now.
Follow up to #17838

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
