### PR TITLE
refactor: natively promisify WebContents.prototype.takeHeapSnapshot

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -2153,21 +2153,23 @@ void WebContents::GrantOriginAccess(const GURL& url) {
       url::Origin::Create(url));
 }
 
-void WebContents::TakeHeapSnapshot(const base::FilePath& file_path,
-                                   base::Callback<void(bool)> callback) {
-  base::ThreadRestrictions::ScopedAllowIO allow_io;
+v8::Local<v8::Promise> WebContents::TakeHeapSnapshot(
+    const base::FilePath& file_path) {
+  util::Promise promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
+  base::ThreadRestrictions::ScopedAllowIO allow_io;
   base::File file(file_path,
                   base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE);
   if (!file.IsValid()) {
-    std::move(callback).Run(false);
-    return;
+    promise.RejectWithErrorMessage("takeHeapSnapshot failed");
+    return handle;
   }
 
   auto* frame_host = web_contents()->GetMainFrame();
   if (!frame_host) {
-    std::move(callback).Run(false);
-    return;
+    promise.RejectWithErrorMessage("takeHeapSnapshot failed");
+    return handle;
   }
 
   // This dance with `base::Owned` is to ensure that the interface stays alive
@@ -2179,10 +2181,17 @@ void WebContents::TakeHeapSnapshot(const base::FilePath& file_path,
   auto* raw_ptr = electron_ptr.get();
   (*raw_ptr)->TakeHeapSnapshot(
       mojo::WrapPlatformFile(file.TakePlatformFile()),
-      base::BindOnce([](mojom::ElectronRendererAssociatedPtr* ep,
-                        base::Callback<void(bool)> callback,
-                        bool success) { callback.Run(success); },
-                     base::Owned(std::move(electron_ptr)), callback));
+      base::BindOnce(
+          [](mojom::ElectronRendererAssociatedPtr* ep, util::Promise promise,
+             bool success) {
+            if (success) {
+              promise.Resolve();
+            } else {
+              promise.RejectWithErrorMessage("takeHeapSnapshot failed");
+            }
+          },
+          base::Owned(std::move(electron_ptr)), std::move(promise)));
+  return handle;
 }
 
 // static
@@ -2288,7 +2297,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getWebRTCIPHandlingPolicy",
                  &WebContents::GetWebRTCIPHandlingPolicy)
       .SetMethod("_grantOriginAccess", &WebContents::GrantOriginAccess)
-      .SetMethod("_takeHeapSnapshot", &WebContents::TakeHeapSnapshot)
+      .SetMethod("takeHeapSnapshot", &WebContents::TakeHeapSnapshot)
       .SetProperty("id", &WebContents::ID)
       .SetProperty("session", &WebContents::Session)
       .SetProperty("hostWebContents", &WebContents::HostWebContents)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -294,8 +294,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // the specified URL.
   void GrantOriginAccess(const GURL& url);
 
-  void TakeHeapSnapshot(const base::FilePath& file_path,
-                        base::Callback<void(bool)>);
+  v8::Local<v8::Promise> TakeHeapSnapshot(const base::FilePath& file_path);
 
   // Properties.
   int32_t ID() const;

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -226,18 +226,6 @@ WebContents.prototype.getZoomFactor = function (callback) {
   }
 }
 
-WebContents.prototype.takeHeapSnapshot = function (filePath) {
-  return new Promise((resolve, reject) => {
-    this._takeHeapSnapshot(filePath, (success) => {
-      if (success) {
-        resolve()
-      } else {
-        reject(new Error('takeHeapSnapshot failed'))
-      }
-    })
-  })
-}
-
 // Translate the options of printToPDF.
 WebContents.prototype.printToPDF = function (options) {
   const printingSetting = Object.assign({}, defaultPrintingSetting)


### PR DESCRIPTION
#### Description of Change
Follow up to #17406

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes

/cc @nornagon