### PR TITLE
fix: remove non-existent gpu-crashed event on <webview> (5-0-x)

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -887,10 +887,6 @@ ipcRenderer.on('ping', () => {
 
 Fired when the renderer process is crashed.
 
-### Event: 'gpu-crashed'
-
-Fired when the gpu process is crashed.
-
 ### Event: 'plugin-crashed'
 
 Returns:

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -36,7 +36,6 @@ const supportedWebViewEvents = [
   'focus-change',
   'close',
   'crashed',
-  'gpu-crashed',
   'plugin-crashed',
   'destroyed',
   'page-title-updated',

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -28,7 +28,6 @@ const WEB_VIEW_EVENTS = {
   'focus-change': ['focus', 'guestInstanceId'],
   'close': [],
   'crashed': [],
-  'gpu-crashed': [],
   'plugin-crashed': ['name', 'version'],
   'destroyed': [],
   'page-title-updated': ['title', 'explicitSet'],


### PR DESCRIPTION
#### Description of Change
Backport of #17317

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed non-existent `gpu-crashed` event on `<webview>`.