### PR TITLE
fix: skip media-started-playing media-paused events test when media is not supported

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1061,6 +1061,12 @@ describe('<webview> tag', function () {
   })
 
   describe('media-started-playing media-paused events', () => {
+    before(function () {
+      if (!document.createElement('audio').canPlayType('audio/wav')) {
+        this.skip()
+      }
+    })
+
     it('emits when audio starts and stops playing', async () => {
       await loadWebView(webview, { src: `file://${fixtures}/pages/base-page.html` })
 


### PR DESCRIPTION
#### Description of Change
Skip a test requiring the `<audio>` element to support playing WAV file when the format is not supported (internal VSCode Electron build has special FFMpeg configuration without codecs, where this test would fail with "Failed to load because no supported source was found.")

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes