### PR TITLE
docs: correct doc for registerFileProtocol

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -148,8 +148,8 @@ going to be created with `scheme`. `completion` will be called with
 To handle the `request`, the `callback` should be called with either the file's
 path or an object that has a `path` property, e.g. `callback(filePath)` or
 `callback({ path: filePath })`. The object may also have a `headers` property
-which gives a list of strings for the response headers, e.g.
-`callback({ path: filePath, headers: ["Content-Security-Policy: default-src 'none'"]})`.
+which gives a map of headers to values for the response headers, e.g.
+`callback({ path: filePath, headers: {"Content-Security-Policy": "default-src 'none'"]})`.
 
 When `callback` is called with nothing, a number, or an object that has an
 `error` property, the `request` will fail with the `error` number you


### PR DESCRIPTION


#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
In the registerFileProtocol docs the "headers" argument of the callback was described as being a list.
In fact is has to be an object mapping header-entries to values. This can be seen in Line 326 of [`/spec/api-protocol-spec.js`](https://github.com/electron/electron/blob/fe618631f1e6858077874226682fa299d1700b36/spec/api-protocol-spec.js#L326).
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: no-notes<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
