### PR TITLE
feat: migrate protocol module to NetworkService (Part 3)

### DIFF
--- a/atom/browser/net/atom_url_loader_factory.cc
+++ b/atom/browser/net/atom_url_loader_factory.cc
@@ -194,7 +194,7 @@ void AtomURLLoaderFactory::SendResponseHttp(
     int32_t routing_id,
     int32_t request_id,
     uint32_t options,
-    network::ResourceRequest request,
+    const network::ResourceRequest& original_request,
     network::mojom::URLLoaderClientPtr client,
     const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
     v8::Isolate* isolate,
@@ -229,9 +229,13 @@ void AtomURLLoaderFactory::SendResponseHttp(
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory =
       content::BrowserContext::GetDefaultStoragePartition(browser_context.get())
           ->GetURLLoaderFactoryForBrowserProcess();
+  network::ResourceRequest request;
+  request.headers = original_request.headers;
+  request.cors_exempt_headers = original_request.cors_exempt_headers;
   dict.Get("url", &request.url);
   dict.Get("referrer", &request.referrer);
-  dict.Get("method", &request.method);
+  if (!dict.Get("method", &request.method))
+    request.method = original_request.method;
   url_loader_factory->CreateLoaderAndStart(
       std::move(loader), routing_id, request_id, options, std::move(request),
       std::move(client), traffic_annotation);

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -63,7 +63,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       int32_t routing_id,
       int32_t request_id,
       uint32_t options,
-      network::ResourceRequest request,
+      const network::ResourceRequest& original_request,
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       v8::Isolate* isolate,

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -54,6 +54,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
                           v8::Isolate* isolate,
                           v8::Local<v8::Value> response);
   void SendResponseFile(network::mojom::URLLoaderRequest loader,
+                        network::ResourceRequest request,
                         network::mojom::URLLoaderClientPtr client,
                         v8::Isolate* isolate,
                         v8::Local<v8::Value> response);

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -60,6 +60,10 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
                         v8::Local<v8::Value> response);
   void SendResponseHttp(
       network::mojom::URLLoaderRequest loader,
+      int32_t routing_id,
+      int32_t request_id,
+      uint32_t options,
+      network::ResourceRequest request,
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       v8::Isolate* isolate,

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -54,10 +54,15 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
                           v8::Isolate* isolate,
                           v8::Local<v8::Value> response);
   void SendResponseFile(network::mojom::URLLoaderRequest loader,
-                        network::ResourceRequest request,
                         network::mojom::URLLoaderClientPtr client,
                         v8::Isolate* isolate,
                         v8::Local<v8::Value> response);
+  void SendResponseHttp(
+      network::mojom::URLLoaderRequest loader,
+      network::mojom::URLLoaderClientPtr client,
+      const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+      v8::Isolate* isolate,
+      v8::Local<v8::Value> response);
 
   bool HandleError(network::mojom::URLLoaderClientPtr* client,
                    v8::Isolate* isolate,


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This is part of the changes to reimplement the protocol module with NetworkService API, the new implementation lives in parallel with current implementation and only gets used when `--enable-features=NetworkService` is passed.

This PR implements the `protocol.registerHttpProtocol` with NetworkService APIs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes