### PR TITLE
chore: convert some apis incl. View APIs from base::Bind

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1353,7 +1353,7 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("clearRecentDocuments",
                  base::BindRepeating(&Browser::ClearRecentDocuments, browser))
       .SetMethod("setAppUserModelId",
-                 base::Bind(&Browser::SetAppUserModelID, browser))
+                 base::BindRepeating(&Browser::SetAppUserModelID, browser))
       .SetMethod(
           "isDefaultProtocolClient",
           base::BindRepeating(&Browser::IsDefaultProtocolClient, browser))

--- a/atom/browser/api/atom_api_net_log.cc
+++ b/atom/browser/api/atom_api_net_log.cc
@@ -110,7 +110,7 @@ void NetLog::OnNewState(const base::DictionaryValue& state) {
     for (auto& promise : stop_callback_queue_) {
       // TODO(zcbenz): Remove the use of CopyablePromise when the
       // GetFilePathToCompletedLog API accepts OnceCallback.
-      net_log_writer_->GetFilePathToCompletedLog(base::Bind(
+      net_log_writer_->GetFilePathToCompletedLog(base::BindRepeating(
           util::CopyablePromise::ResolveCopyablePromise<const base::FilePath&>,
           util::CopyablePromise(promise)));
     }

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -37,11 +37,11 @@ namespace api {
 
 PowerMonitor::PowerMonitor(v8::Isolate* isolate) {
 #if defined(OS_LINUX)
-  SetShutdownHandler(
-      base::Bind(&PowerMonitor::ShouldShutdown, base::Unretained(this)));
+  SetShutdownHandler(base::BindRepeating(&PowerMonitor::ShouldShutdown,
+                                         base::Unretained(this)));
 #elif defined(OS_MACOSX)
-  Browser::Get()->SetShutdownHandler(
-      base::Bind(&PowerMonitor::ShouldShutdown, base::Unretained(this)));
+  Browser::Get()->SetShutdownHandler(base::BindRepeating(
+      &PowerMonitor::ShouldShutdown, base::Unretained(this)));
 #endif
   base::PowerMonitor::Get()->AddObserver(this);
   Init(isolate);

--- a/atom/browser/api/atom_api_web_contents_view.cc
+++ b/atom/browser/api/atom_api_web_contents_view.cc
@@ -124,8 +124,9 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("WebContentsView", mate::CreateConstructor<WebContentsView>(
-                                  isolate, base::Bind(&WebContentsView::New)));
+  dict.Set("WebContentsView",
+           mate::CreateConstructor<WebContentsView>(
+               isolate, base::BindRepeating(&WebContentsView::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/views/atom_api_box_layout.cc
+++ b/atom/browser/api/views/atom_api_box_layout.cc
@@ -78,7 +78,7 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("BoxLayout", mate::CreateConstructor<BoxLayout>(
-                            isolate, base::Bind(&BoxLayout::New)));
+                            isolate, base::BindRepeating(&BoxLayout::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/views/atom_api_button.cc
+++ b/atom/browser/api/views/atom_api_button.cc
@@ -50,8 +50,8 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("Button",
-           mate::CreateConstructor<Button>(isolate, base::Bind(&Button::New)));
+  dict.Set("Button", mate::CreateConstructor<Button>(
+                         isolate, base::BindRepeating(&Button::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/views/atom_api_label_button.cc
+++ b/atom/browser/api/views/atom_api_label_button.cc
@@ -71,7 +71,7 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("LabelButton", mate::CreateConstructor<LabelButton>(
-                              isolate, base::Bind(&LabelButton::New)));
+                              isolate, base::BindRepeating(&LabelButton::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/views/atom_api_layout_manager.cc
+++ b/atom/browser/api/views/atom_api_layout_manager.cc
@@ -53,8 +53,9 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("LayoutManager", mate::CreateConstructor<LayoutManager>(
-                                isolate, base::Bind(&LayoutManager::New)));
+  dict.Set("LayoutManager",
+           mate::CreateConstructor<LayoutManager>(
+               isolate, base::BindRepeating(&LayoutManager::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/views/atom_api_md_text_button.cc
+++ b/atom/browser/api/views/atom_api_md_text_button.cc
@@ -47,8 +47,9 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("MdTextButton", mate::CreateConstructor<MdTextButton>(
-                               isolate, base::Bind(&MdTextButton::New)));
+  dict.Set("MdTextButton",
+           mate::CreateConstructor<MdTextButton>(
+               isolate, base::BindRepeating(&MdTextButton::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/views/atom_api_resize_area.cc
+++ b/atom/browser/api/views/atom_api_resize_area.cc
@@ -51,7 +51,7 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("ResizeArea", mate::CreateConstructor<ResizeArea>(
-                             isolate, base::Bind(&ResizeArea::New)));
+                             isolate, base::BindRepeating(&ResizeArea::New)));
 }
 
 }  // namespace

--- a/atom/browser/api/views/atom_api_text_field.cc
+++ b/atom/browser/api/views/atom_api_text_field.cc
@@ -58,7 +58,7 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
   dict.Set("TextField", mate::CreateConstructor<TextField>(
-                            isolate, base::Bind(&TextField::New)));
+                            isolate, base::BindRepeating(&TextField::New)));
 }
 
 }  // namespace

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -52,16 +52,19 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
   auto reporter = base::Unretained(CrashReporter::GetInstance());
-  dict.SetMethod("start", base::Bind(&CrashReporter::Start, reporter));
+  dict.SetMethod("start", base::BindRepeating(&CrashReporter::Start, reporter));
   dict.SetMethod("addExtraParameter", &AddExtraParameter);
   dict.SetMethod("removeExtraParameter", &RemoveExtraParameter);
   dict.SetMethod("getParameters", &GetParameters);
-  dict.SetMethod("getUploadedReports",
-                 base::Bind(&CrashReporter::GetUploadedReports, reporter));
-  dict.SetMethod("setUploadToServer",
-                 base::Bind(&CrashReporter::SetUploadToServer, reporter));
-  dict.SetMethod("getUploadToServer",
-                 base::Bind(&CrashReporter::GetUploadToServer, reporter));
+  dict.SetMethod(
+      "getUploadedReports",
+      base::BindRepeating(&CrashReporter::GetUploadedReports, reporter));
+  dict.SetMethod(
+      "setUploadToServer",
+      base::BindRepeating(&CrashReporter::SetUploadToServer, reporter));
+  dict.SetMethod(
+      "getUploadToServer",
+      base::BindRepeating(&CrashReporter::GetUploadToServer, reporter));
 }
 
 }  // namespace

--- a/atom/common/api/electron_bindings.cc
+++ b/atom/common/api/electron_bindings.cc
@@ -73,8 +73,9 @@ void ElectronBindings::BindProcess(v8::Isolate* isolate,
   process->SetMethod("getSystemVersion",
                      &base::SysInfo::OperatingSystemVersion);
   process->SetMethod("getIOCounters", &GetIOCounters);
-  process->SetMethod("getCPUUsage", base::Bind(&ElectronBindings::GetCPUUsage,
-                                               base::Unretained(metrics)));
+  process->SetMethod("getCPUUsage",
+                     base::BindRepeating(&ElectronBindings::GetCPUUsage,
+                                         base::Unretained(metrics)));
 
 #if defined(MAS_BUILD)
   process->SetReadOnly("mas", true);
@@ -97,8 +98,9 @@ void ElectronBindings::BindTo(v8::Isolate* isolate,
 #if defined(OS_POSIX)
   dict.SetMethod("setFdLimit", &base::IncreaseFdLimitTo);
 #endif
-  dict.SetMethod("activateUvLoop", base::Bind(&ElectronBindings::ActivateUVLoop,
-                                              base::Unretained(this)));
+  dict.SetMethod("activateUvLoop",
+                 base::BindRepeating(&ElectronBindings::ActivateUVLoop,
+                                     base::Unretained(this)));
 
   mate::Dictionary versions;
   if (dict.Get("versions", &versions)) {

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -134,9 +134,9 @@ void RendererClientBase::AddRenderBindings(
     v8::Isolate* isolate,
     v8::Local<v8::Object> binding_object) {
   mate::Dictionary dict(isolate, binding_object);
-  dict.SetMethod(
-      "getRenderProcessPreferences",
-      base::Bind(GetRenderProcessPreferences, preferences_manager_.get()));
+  dict.SetMethod("getRenderProcessPreferences",
+                 base::BindRepeating(GetRenderProcessPreferences,
+                                     preferences_manager_.get()));
 }
 
 void RendererClientBase::RenderThreadStarted() {


### PR DESCRIPTION
#### Description of Change

Continuation of `base::Bind` migration for the Views API & a few other classes. These instances are called in the class `Initialize` methods, so they should all need to be `RepeatingCallbacks` and thus created with `base::BindRepeating`.

cc @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
