### PR TITLE
refactor: native_mate => gin (cookies API)

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -18,8 +18,8 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"
-#include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "gin/dictionary.h"
+#include "gin/object_template_builder.h"
 #include "net/cookies/canonical_cookie.h"
 #include "net/cookies/cookie_store.h"
 #include "net/cookies/cookie_util.h"
@@ -28,7 +28,7 @@
 
 using content::BrowserThread;
 
-namespace mate {
+namespace gin {
 
 template <>
 struct Converter<atom::api::Cookies::Error> {
@@ -45,7 +45,7 @@ template <>
 struct Converter<net::CanonicalCookie> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const net::CanonicalCookie& val) {
-    mate::Dictionary dict(isolate, v8::Object::New(isolate));
+    gin::Dictionary dict(isolate, v8::Object::New(isolate));
     dict.Set("name", val.Name());
     dict.Set("value", val.Value());
     dict.Set("domain", val.Domain());
@@ -56,7 +56,7 @@ struct Converter<net::CanonicalCookie> {
     dict.Set("session", !val.IsPersistent());
     if (val.IsPersistent())
       dict.Set("expirationDate", val.ExpiryDate().ToDoubleT());
-    return dict.GetHandle();
+    return ConvertToV8(isolate, dict).As<v8::Object>();
   }
 };
 
@@ -68,22 +68,22 @@ struct Converter<network::mojom::CookieChangeCause> {
     switch (val) {
       case network::mojom::CookieChangeCause::INSERTED:
       case network::mojom::CookieChangeCause::EXPLICIT:
-        return mate::StringToV8(isolate, "explicit");
+        return gin::StringToV8(isolate, "explicit");
       case network::mojom::CookieChangeCause::OVERWRITE:
-        return mate::StringToV8(isolate, "overwrite");
+        return gin::StringToV8(isolate, "overwrite");
       case network::mojom::CookieChangeCause::EXPIRED:
-        return mate::StringToV8(isolate, "expired");
+        return gin::StringToV8(isolate, "expired");
       case network::mojom::CookieChangeCause::EVICTED:
-        return mate::StringToV8(isolate, "evicted");
+        return gin::StringToV8(isolate, "evicted");
       case network::mojom::CookieChangeCause::EXPIRED_OVERWRITE:
-        return mate::StringToV8(isolate, "expired-overwrite");
+        return gin::StringToV8(isolate, "expired-overwrite");
       default:
-        return mate::StringToV8(isolate, "unknown");
+        return gin::StringToV8(isolate, "unknown");
     }
   }
 };
 
-}  // namespace mate
+}  // namespace gin
 
 namespace atom {
 
@@ -143,7 +143,7 @@ void FilterCookies(const base::Value& filter,
       result.push_back(cookie);
   }
 
-  promise.Resolve(result);
+  promise.Resolve(gin::ConvertToV8(promise.isolate(), result));
 }
 
 std::string InclusionStatusToString(
@@ -330,19 +330,21 @@ v8::Local<v8::Promise> Cookies::FlushStore() {
 }
 
 void Cookies::OnCookieChanged(const CookieDetails* details) {
-  Emit("changed", *(details->cookie), details->cause, details->removed);
+  Emit("changed", gin::ConvertToV8(isolate(), *(details->cookie)),
+       gin::ConvertToV8(isolate(), details->cause),
+       gin::ConvertToV8(isolate(), details->removed));
 }
 
 // static
-mate::Handle<Cookies> Cookies::Create(v8::Isolate* isolate,
-                                      AtomBrowserContext* browser_context) {
-  return mate::CreateHandle(isolate, new Cookies(isolate, browser_context));
+gin::Handle<Cookies> Cookies::Create(v8::Isolate* isolate,
+                                     AtomBrowserContext* browser_context) {
+  return gin::CreateHandle(isolate, new Cookies(isolate, browser_context));
 }
 
 // static
 void Cookies::BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(mate::StringToV8(isolate, "Cookies"));
+  prototype->SetClassName(gin::StringToV8(isolate, "Cookies"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("get", &Cookies::Get)
       .SetMethod("remove", &Cookies::Remove)

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -12,7 +12,7 @@
 #include "atom/browser/net/cookie_details.h"
 #include "atom/common/promise_util.h"
 #include "base/callback_list.h"
-#include "native_mate/handle.h"
+#include "gin/handle.h"
 #include "net/cookies/canonical_cookie.h"
 
 namespace base {
@@ -36,8 +36,8 @@ class Cookies : public mate::TrackableObject<Cookies> {
     FAILED,
   };
 
-  static mate::Handle<Cookies> Create(v8::Isolate* isolate,
-                                      AtomBrowserContext* browser_context);
+  static gin::Handle<Cookies> Create(v8::Isolate* isolate,
+                                     AtomBrowserContext* browser_context);
 
   // mate::TrackableObject:
   static void BuildPrototype(v8::Isolate* isolate,

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -46,6 +46,9 @@ class EventEmitter : public Wrappable<T> {
   v8::Local<v8::Object> GetWrapper() const {
     return Wrappable<T>::GetWrapper();
   }
+  v8::MaybeLocal<v8::Object> GetWrapper(v8::Isolate* isolate) const {
+    return Wrappable<T>::GetWrapper(isolate);
+  }
 
   // this.emit(name, event, args...);
   template <typename... Args>

--- a/native_mate/native_mate/wrappable.cc
+++ b/native_mate/native_mate/wrappable.cc
@@ -28,6 +28,15 @@ v8::Local<v8::Object> WrappableBase::GetWrapper() const {
     return v8::Local<v8::Object>();
 }
 
+v8::MaybeLocal<v8::Object> WrappableBase::GetWrapper(
+    v8::Isolate* isolate) const {
+  if (!wrapper_.IsEmpty())
+    return v8::MaybeLocal<v8::Object>(
+        v8::Local<v8::Object>::New(isolate, wrapper_));
+  else
+    return v8::MaybeLocal<v8::Object>();
+}
+
 void WrappableBase::InitWith(v8::Isolate* isolate,
                              v8::Local<v8::Object> wrapper) {
   CHECK(wrapper_.IsEmpty());

--- a/native_mate/native_mate/wrappable_base.h
+++ b/native_mate/native_mate/wrappable_base.h
@@ -30,6 +30,7 @@ class WrappableBase {
 
   // Retrieve the v8 wrapper object cooresponding to this object.
   v8::Local<v8::Object> GetWrapper() const;
+  v8::MaybeLocal<v8::Object> GetWrapper(v8::Isolate* isolate) const;
 
   // Returns the Isolate this object is created in.
   v8::Isolate* isolate() const { return isolate_; }


### PR DESCRIPTION
#### Description of Change
Refactors the Cookies API to use gin instead of native_mate.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes