### PR TITLE
chore: convert session base::Bind instances

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -350,9 +350,9 @@ v8::Local<v8::Promise> Session::ResolveProxy(mate::Arguments* args) {
   args->GetNext(&url);
 
   browser_context_->GetResolveProxyHelper()->ResolveProxy(
-      url,
-      base::Bind(util::CopyablePromise::ResolveCopyablePromise<std::string>,
-                 util::CopyablePromise(promise)));
+      url, base::BindRepeating(
+               util::CopyablePromise::ResolveCopyablePromise<std::string>,
+               util::CopyablePromise(promise)));
 
   return handle;
 }
@@ -413,8 +413,7 @@ v8::Local<v8::Promise> Session::ClearStorageData(mate::Arguments* args) {
   storage_partition->ClearData(
       options.storage_types, options.quota_types, options.origin, base::Time(),
       base::Time::Max(),
-      base::Bind(util::CopyablePromise::ResolveEmptyCopyablePromise,
-                 util::CopyablePromise(promise)));
+      base::BindOnce(util::Promise::ResolveEmptyPromise, std::move(promise)));
   return handle;
 }
 
@@ -496,17 +495,18 @@ void Session::DisableNetworkEmulation() {
       network_emulation_token_, network::mojom::NetworkConditions::New());
 }
 
-void WrapVerifyProc(base::Callback<void(const VerifyRequestParams& request,
-                                        base::Callback<void(int)>)> proc,
-                    const VerifyRequestParams& request,
-                    base::OnceCallback<void(int)> cb) {
-  proc.Run(request, base::AdaptCallbackForRepeating(std::move(cb)));
+void WrapVerifyProc(
+    base::OnceCallback<void(const VerifyRequestParams& request,
+                            base::RepeatingCallback<void(int)>)> proc,
+    const VerifyRequestParams& request,
+    base::OnceCallback<void(int)> cb) {
+  std::move(proc).Run(request, base::AdaptCallbackForRepeating(std::move(cb)));
 }
 
 void Session::SetCertVerifyProc(v8::Local<v8::Value> val,
                                 mate::Arguments* args) {
-  base::Callback<void(const VerifyRequestParams& request,
-                      base::Callback<void(int)>)>
+  base::RepeatingCallback<void(const VerifyRequestParams& request,
+                               base::RepeatingCallback<void(int)>)>
       proc;
   if (!(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &proc))) {
     args->ThrowError("Must pass null or function");
@@ -517,7 +517,7 @@ void Session::SetCertVerifyProc(v8::Local<v8::Value> val,
       FROM_HERE, {BrowserThread::IO},
       base::BindOnce(&SetCertVerifyProcInIO,
                      WrapRefCounted(browser_context_->GetRequestContext()),
-                     base::Bind(&WrapVerifyProc, proc)));
+                     base::BindRepeating(&WrapVerifyProc, proc)));
 }
 
 void Session::SetPermissionRequestHandler(v8::Local<v8::Value> val,
@@ -645,7 +645,7 @@ void Session::CreateInterruptedDownload(const mate::Dictionary& options) {
   }
   auto* download_manager =
       content::BrowserContext::GetDownloadManager(browser_context());
-  download_manager->GetDelegate()->GetNextId(base::Bind(
+  download_manager->GetDelegate()->GetNextId(base::BindRepeating(
       &DownloadIdCallback, download_manager, path, url_chain, mime_type, offset,
       length, last_modified, etag, base::Time::FromDoubleT(start_time)));
 }

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -350,9 +350,8 @@ v8::Local<v8::Promise> Session::ResolveProxy(mate::Arguments* args) {
   args->GetNext(&url);
 
   browser_context_->GetResolveProxyHelper()->ResolveProxy(
-      url, base::BindRepeating(
-               util::CopyablePromise::ResolveCopyablePromise<std::string>,
-               util::CopyablePromise(promise)));
+      url, base::BindOnce(util::Promise::ResolvePromise<std::string>,
+                          std::move(promise)));
 
   return handle;
 }
@@ -496,11 +495,11 @@ void Session::DisableNetworkEmulation() {
 }
 
 void WrapVerifyProc(
-    base::OnceCallback<void(const VerifyRequestParams& request,
-                            base::RepeatingCallback<void(int)>)> proc,
+    base::RepeatingCallback<void(const VerifyRequestParams& request,
+                                 base::RepeatingCallback<void(int)>)> proc,
     const VerifyRequestParams& request,
     base::OnceCallback<void(int)> cb) {
-  std::move(proc).Run(request, base::AdaptCallbackForRepeating(std::move(cb)));
+  proc.Run(request, base::AdaptCallbackForRepeating(std::move(cb)));
 }
 
 void Session::SetCertVerifyProc(v8::Local<v8::Value> val,

--- a/atom/browser/net/resolve_proxy_helper.cc
+++ b/atom/browser/net/resolve_proxy_helper.cc
@@ -30,10 +30,10 @@ ResolveProxyHelper::~ResolveProxyHelper() {
 }
 
 void ResolveProxyHelper::ResolveProxy(const GURL& url,
-                                      const ResolveProxyCallback& callback) {
+                                      ResolveProxyCallback callback) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   // Enqueue the pending request.
-  pending_requests_.push_back(PendingRequest(url, callback));
+  pending_requests_.push_back(PendingRequest(url, std::move(callback)));
 
   // If nothing is in progress, start.
   if (!binding_.is_bound()) {
@@ -76,7 +76,7 @@ void ResolveProxyHelper::OnProxyLookupComplete(
     proxy = proxy_info->ToPacString();
 
   if (!completed_request.callback.is_null())
-    completed_request.callback.Run(proxy);
+    std::move(completed_request.callback).Run(proxy);
 
   // Start the next request.
   if (!pending_requests_.empty())
@@ -85,8 +85,8 @@ void ResolveProxyHelper::OnProxyLookupComplete(
 
 ResolveProxyHelper::PendingRequest::PendingRequest(
     const GURL& url,
-    const ResolveProxyCallback& callback)
-    : url(url), callback(callback) {}
+    ResolveProxyCallback callback)
+    : url(url), callback(std::move(callback)) {}
 
 ResolveProxyHelper::PendingRequest::PendingRequest(
     ResolveProxyHelper::PendingRequest&& pending_request) = default;

--- a/atom/browser/net/resolve_proxy_helper.h
+++ b/atom/browser/net/resolve_proxy_helper.h
@@ -22,11 +22,11 @@ class ResolveProxyHelper
     : public base::RefCountedThreadSafe<ResolveProxyHelper>,
       network::mojom::ProxyLookupClient {
  public:
-  using ResolveProxyCallback = base::Callback<void(std::string)>;
+  using ResolveProxyCallback = base::OnceCallback<void(std::string)>;
 
   explicit ResolveProxyHelper(AtomBrowserContext* browser_context);
 
-  void ResolveProxy(const GURL& url, const ResolveProxyCallback& callback);
+  void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
 
  protected:
   ~ResolveProxyHelper() override;
@@ -36,7 +36,7 @@ class ResolveProxyHelper
   // A PendingRequest is a resolve request that is in progress, or queued.
   struct PendingRequest {
    public:
-    PendingRequest(const GURL& url, const ResolveProxyCallback& callback);
+    PendingRequest(const GURL& url, ResolveProxyCallback callback);
     PendingRequest(PendingRequest&& pending_request) noexcept;
     ~PendingRequest();
 

--- a/atom/browser/ui/views/autofill_popup_view.cc
+++ b/atom/browser/ui/views/autofill_popup_view.cc
@@ -93,8 +93,8 @@ void AutofillPopupView::Show() {
   if (initialize_widget)
     views::WidgetFocusManager::GetInstance()->AddFocusChangeListener(this);
 
-  keypress_callback_ = base::Bind(&AutofillPopupView::HandleKeyPressEvent,
-                                  base::Unretained(this));
+  keypress_callback_ = base::BindRepeating(
+      &AutofillPopupView::HandleKeyPressEvent, base::Unretained(this));
   auto* host = popup_->frame_host_->GetRenderViewHost()->GetWidget();
   host->AddKeyPressEventCallback(keypress_callback_);
 
@@ -294,8 +294,8 @@ void AutofillPopupView::OnMouseExited(const ui::MouseEvent& event) {
   // OnMouseExited event. Pressing return should activate the current selection
   // via AcceleratorPressed, so we need to let that run first.
   base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, base::Bind(&AutofillPopupView::ClearSelection,
-                            weak_ptr_factory_.GetWeakPtr()));
+      FROM_HERE, base::BindOnce(&AutofillPopupView::ClearSelection,
+                                weak_ptr_factory_.GetWeakPtr()));
 }
 
 void AutofillPopupView::OnMouseMoved(const ui::MouseEvent& event) {


### PR DESCRIPTION
#### Description of Change

Convert instances of `base::Bind` to `base::BindOnce` and `base::BindRepeating` as applicable in the session module as well as in Autofill popups.

cc @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
