### PR TITLE
docs: added 'nodeIntegration: true' to the first-app.md tutorial

### DIFF
--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -109,7 +109,13 @@ const { app, BrowserWindow } = require('electron')
 
 function createWindow () {
   // Create the browser window.
-  let win = new BrowserWindow({ width: 800, height: 600 })
+  let win = new BrowserWindow({ 
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true
+    }
+   })
 
   // and load the index.html of the app.
   win.loadFile('index.html')


### PR DESCRIPTION
#### Description of Change
Added "webPreferences: {nodeIntegration: true}" to the code in the example at first-app.md. Without this change when an user runs the code in the example the app doesnt shows the node, chrome and electron versions. Also the edit complies with the code that appears in the electron-quick-start repo.

#### Checklist

- [X] PR description included and stakeholders cc'd
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no notes