### PR TITLE
fix: explicitly focus window on win.show()

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -380,6 +380,9 @@ void NativeWindowViews::Show() {
 
   widget()->native_widget_private()->Show(GetRestoredState(), gfx::Rect());
 
+  // explicitly focus the window
+  widget()->Activate();
+
   NotifyWindowShow();
 
 #if defined(USE_X11)


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/18034.

Our documentation for [`win.show`](https://github.com/electron/electron/blob/f901170a4feba092d20d12d85261059af74d5f24/docs/api/browser-window.md#L789) says that this explicitly gives the window focus, and on macOS we implement `Show` with [`unhide`](https://developer.apple.com/documentation/appkit/nsapplication/1428761-unhide?language=objc) and so this rings true.

However, this is not true on Windows, which is implemented in [`NativeWindowViews`](https://github.com/electron/electron/blob/141fb9e7582572d7c5f61b59a9bd2684d86159ee/atom/browser/native_window_views.cc#L376). This PR fixes that issue by explicitly focusing the window with `widget()->Activate()`.

cc @MarshallOfSound @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue on Windows where calling `.show()` on a BrowserWindow did not focus the window.
