### PR TITLE
build: fix issues for stable release we fixed in 5-0-x

### DIFF
--- a/script/bump-version.js
+++ b/script/bump-version.js
@@ -144,7 +144,7 @@ async function updateVersionH (components) {
   const filePath = path.resolve(__dirname, '..', 'atom', 'common', 'atom_version.h')
   const data = await readFile(filePath, 'utf8')
   const arr = data.split('\n')
-  const pre = components.pre != null ? `-${components.pre[0]}.${components.pre[1]}` : null
+  const pre = components.pre && components.pre.length >= 2 ? `-${components.pre[0]}.${components.pre[1]}` : null
 
   arr.forEach((item, idx) => {
     if (item.includes('#define ATOM_MAJOR_VERSION')) {

--- a/script/lib/version-utils.js
+++ b/script/lib/version-utils.js
@@ -32,7 +32,7 @@ const isStable = v => {
 const makeVersion = (components, delim, pre = preType.NONE) => {
   let version = [components.major, components.minor, components.patch].join(delim)
   if (pre === preType.PARTIAL) {
-    version += `${delim}${components.pre[1]}`
+    version += `${delim}${components.pre[1] || 0}`
   } else if (pre === preType.FULL) {
     version += `-${components.pre[0]}${delim}${components.pre[1]}`
   }

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -100,7 +100,7 @@ async function createRelease (branchToTarget, isBeta) {
     }
     releaseIsPrelease = true
   } else {
-    releaseBody = releaseNotes
+    releaseBody = releaseNotes.text
   }
 
   const release = await octokit.repos.createRelease({


### PR DESCRIPTION
During the `5-0-x` stable release we found a few issues in our release scripts (bumping and release notes).  These were fixed in `5-0-x` to unblock the release, this PR just cherry picks them onto master.

Notes: no-notes