### PR TITLE
chore: convert more module and helper files from base::Bind

### DIFF
--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -140,7 +140,8 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("createPowerMonitor", base::Bind(&PowerMonitor::Create, isolate));
+  dict.Set("createPowerMonitor",
+           base::BindRepeating(&PowerMonitor::Create, isolate));
   dict.Set("PowerMonitor", PowerMonitor::GetConstructor(isolate)
                                ->GetFunction(context)
                                .ToLocalChecked());

--- a/atom/browser/api/atom_api_render_process_preferences.cc
+++ b/atom/browser/api/atom_api_render_process_preferences.cc
@@ -64,9 +64,9 @@ void RenderProcessPreferences::BuildPrototype(
 // static
 mate::Handle<RenderProcessPreferences>
 RenderProcessPreferences::ForAllWebContents(v8::Isolate* isolate) {
-  return mate::CreateHandle(isolate,
-                            new RenderProcessPreferences(
-                                isolate, base::Bind(&IsWebContents, isolate)));
+  return mate::CreateHandle(
+      isolate, new RenderProcessPreferences(
+                   isolate, base::BindRepeating(&IsWebContents, isolate)));
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -163,7 +163,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("createScreen", base::Bind(&Screen::Create, isolate));
+  dict.Set("createScreen", base::BindRepeating(&Screen::Create, isolate));
   dict.Set(
       "Screen",
       Screen::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());

--- a/atom/browser/api/stream_subscriber.cc
+++ b/atom/browser/api/stream_subscriber.cc
@@ -28,9 +28,9 @@ StreamSubscriber::StreamSubscriber(
   DCHECK(ui_task_runner->RunsTasksInCurrentSequence());
 
   auto weak_self = weak_factory_.GetWeakPtr();
-  On("data", base::Bind(&StreamSubscriber::OnData, weak_self));
-  On("end", base::Bind(&StreamSubscriber::OnEnd, weak_self));
-  On("error", base::Bind(&StreamSubscriber::OnError, weak_self));
+  On("data", base::BindRepeating(&StreamSubscriber::OnData, weak_self));
+  On("end", base::BindRepeating(&StreamSubscriber::OnEnd, weak_self));
+  On("error", base::BindRepeating(&StreamSubscriber::OnError, weak_self));
 }
 
 StreamSubscriber::~StreamSubscriber() {
@@ -80,20 +80,20 @@ void StreamSubscriber::OnData(mate::Arguments* args) {
   // Pass the data to the URLJob in IO thread.
   std::vector<char> buffer(data, data + length);
   base::PostTaskWithTraits(FROM_HERE, {content::BrowserThread::IO},
-                           base::Bind(&atom::URLRequestStreamJob::OnData,
-                                      url_job_, base::Passed(&buffer)));
+                           base::BindOnce(&atom::URLRequestStreamJob::OnData,
+                                          url_job_, base::Passed(&buffer)));
 }
 
 void StreamSubscriber::OnEnd(mate::Arguments* args) {
   base::PostTaskWithTraits(
       FROM_HERE, {content::BrowserThread::IO},
-      base::Bind(&atom::URLRequestStreamJob::OnEnd, url_job_));
+      base::BindOnce(&atom::URLRequestStreamJob::OnEnd, url_job_));
 }
 
 void StreamSubscriber::OnError(mate::Arguments* args) {
   base::PostTaskWithTraits(FROM_HERE, {content::BrowserThread::IO},
-                           base::Bind(&atom::URLRequestStreamJob::OnError,
-                                      url_job_, net::ERR_FAILED));
+                           base::BindOnce(&atom::URLRequestStreamJob::OnError,
+                                          url_job_, net::ERR_FAILED));
 }
 
 void StreamSubscriber::RemoveAllListeners() {

--- a/atom/browser/api/stream_subscriber.h
+++ b/atom/browser/api/stream_subscriber.h
@@ -40,7 +40,7 @@ class StreamSubscriber
   friend class base::RefCountedDeleteOnSequence<StreamSubscriber>;
 
   using JSHandlersMap = std::map<std::string, v8::Global<v8::Value>>;
-  using EventCallback = base::Callback<void(mate::Arguments* args)>;
+  using EventCallback = base::RepeatingCallback<void(mate::Arguments* args)>;
 
   ~StreamSubscriber();
 

--- a/atom/browser/atom_blob_reader.cc
+++ b/atom/browser/atom_blob_reader.cc
@@ -81,8 +81,8 @@ void AtomBlobReader::BlobReadHelper::Read() {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   storage::BlobReader::Status size_status = blob_reader_->CalculateSize(
-      base::Bind(&AtomBlobReader::BlobReadHelper::DidCalculateSize,
-                 base::Unretained(this)));
+      base::BindOnce(&AtomBlobReader::BlobReadHelper::DidCalculateSize,
+                     base::Unretained(this)));
   if (size_status != storage::BlobReader::Status::IO_PENDING)
     DidCalculateSize(net::OK);
 }
@@ -100,8 +100,8 @@ void AtomBlobReader::BlobReadHelper::DidCalculateSize(int result) {
   scoped_refptr<net::IOBuffer> blob_data =
       new net::IOBuffer(static_cast<size_t>(total_size));
   auto callback =
-      base::Bind(&AtomBlobReader::BlobReadHelper::DidReadBlobData,
-                 base::Unretained(this), base::RetainedRef(blob_data));
+      base::BindRepeating(&AtomBlobReader::BlobReadHelper::DidReadBlobData,
+                          base::Unretained(this), base::RetainedRef(blob_data));
   storage::BlobReader::Status read_status =
       blob_reader_->Read(blob_data.get(), total_size, &bytes_read, callback);
   if (read_status != storage::BlobReader::Status::IO_PENDING)

--- a/atom/browser/atom_browser_main_parts_posix.cc
+++ b/atom/browser/atom_browser_main_parts_posix.cc
@@ -136,10 +136,10 @@ void ShutdownDetector::ThreadMain() {
     bytes_read += ret;
   } while (bytes_read < sizeof(signal));
   VLOG(1) << "Handling shutdown for signal " << signal << ".";
-  base::Closure task =
-      base::Bind(&Browser::Quit, base::Unretained(Browser::Get()));
 
-  if (!base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI}, task)) {
+  if (!base::PostTaskWithTraits(
+          FROM_HERE, {BrowserThread::UI},
+          base::BindOnce(&Browser::Quit, base::Unretained(Browser::Get())))) {
     // Without a UI thread to post the exit task to, there aren't many
     // options.  Raise the signal again.  The default handler will pick it up
     // and cause an ungraceful exit.

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -94,9 +94,9 @@ bool AtomResourceDispatcherHostDelegate::ShouldInterceptResourceAsStream(
     *origin = GURL(kPdfViewerUIOrigin);
     base::PostTaskWithTraits(
         FROM_HERE, {BrowserThread::UI},
-        base::Bind(&OnPdfResourceIntercepted, request->url(),
-                   render_process_host_id, render_frame_id,
-                   info->GetWebContentsGetterForRequest()));
+        base::BindOnce(&OnPdfResourceIntercepted, request->url(),
+                       render_process_host_id, render_frame_id,
+                       info->GetWebContentsGetterForRequest()));
     return true;
   }
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)

--- a/atom/browser/ui/webui/pdf_viewer_handler.cc
+++ b/atom/browser/ui/webui/pdf_viewer_handler.cc
@@ -76,22 +76,23 @@ void PdfViewerHandler::SetPdfResourceStream(content::StreamInfo* stream) {
 
 void PdfViewerHandler::RegisterMessages() {
   web_ui()->RegisterMessageCallback(
-      "initialize",
-      base::Bind(&PdfViewerHandler::Initialize, base::Unretained(this)));
+      "initialize", base::BindRepeating(&PdfViewerHandler::Initialize,
+                                        base::Unretained(this)));
   web_ui()->RegisterMessageCallback(
-      "getDefaultZoom",
-      base::Bind(&PdfViewerHandler::GetInitialZoom, base::Unretained(this)));
+      "getDefaultZoom", base::BindRepeating(&PdfViewerHandler::GetInitialZoom,
+                                            base::Unretained(this)));
   web_ui()->RegisterMessageCallback(
-      "getInitialZoom",
-      base::Bind(&PdfViewerHandler::GetInitialZoom, base::Unretained(this)));
+      "getInitialZoom", base::BindRepeating(&PdfViewerHandler::GetInitialZoom,
+                                            base::Unretained(this)));
   web_ui()->RegisterMessageCallback(
       "setZoom",
-      base::Bind(&PdfViewerHandler::SetZoom, base::Unretained(this)));
+      base::BindRepeating(&PdfViewerHandler::SetZoom, base::Unretained(this)));
   web_ui()->RegisterMessageCallback(
-      "getStrings",
-      base::Bind(&PdfViewerHandler::GetStrings, base::Unretained(this)));
+      "getStrings", base::BindRepeating(&PdfViewerHandler::GetStrings,
+                                        base::Unretained(this)));
   web_ui()->RegisterMessageCallback(
-      "reload", base::Bind(&PdfViewerHandler::Reload, base::Unretained(this)));
+      "reload",
+      base::BindRepeating(&PdfViewerHandler::Reload, base::Unretained(this)));
 }
 
 void PdfViewerHandler::OnJavascriptAllowed() {

--- a/atom/browser/ui/webui/pdf_viewer_ui.cc
+++ b/atom/browser/ui/webui/pdf_viewer_ui.cc
@@ -187,9 +187,9 @@ class PdfViewerUI::ResourceRequester
 
     base::PostTaskWithTraits(
         FROM_HERE, {BrowserThread::UI},
-        base::Bind(&CallMigrationCallback<StreamResponseCallback>,
-                   base::Passed(&stream_response_cb_),
-                   base::Passed(&stream_info_)));
+        base::BindOnce(&CallMigrationCallback<StreamResponseCallback>,
+                       base::Passed(&stream_response_cb_),
+                       base::Passed(&stream_info_)));
   }
 
  private:
@@ -246,9 +246,9 @@ void PdfViewerUI::RenderFrameCreated(content::RenderFrameHost* rfh) {
   resource_requester_ = new ResourceRequester(std::move(callback));
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
-      base::Bind(&ResourceRequester::StartRequest, resource_requester_,
-                 GURL(src_), GURL(kPdfViewerUIOrigin), render_process_id,
-                 render_view_id, render_frame_id, resource_context));
+      base::BindOnce(&ResourceRequester::StartRequest, resource_requester_,
+                     GURL(src_), GURL(kPdfViewerUIOrigin), render_process_id,
+                     render_view_id, render_frame_id, resource_context));
 }
 
 void PdfViewerUI::OnSaveURLAs(const GURL& url,


### PR DESCRIPTION
#### Description of Change

This PR continues to update instances of `base::Bind` to `base::BindRepeating` and `base::BindOnce` as applicable. The following files are affected by this PR:

```
        atom/browser/api/atom_api_power_monitor.cc
        atom/browser/api/atom_api_render_process_preferences.cc
        atom/browser/api/atom_api_screen.cc
        atom/browser/api/stream_subscriber.cc
        atom/browser/api/stream_subscriber.h
        atom/browser/atom_blob_reader.cc
        atom/browser/atom_browser_main_parts_posix.cc
        atom/browser/atom_resource_dispatcher_host_delegate.cc
        atom/browser/ui/webui/pdf_viewer_handler.cc
        atom/browser/ui/webui/pdf_viewer_ui.cc
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
