### PR TITLE
refactor: convert powerSaveBlocker to gin

### DIFF
--- a/atom/browser/api/atom_api_power_save_blocker.h
+++ b/atom/browser/api/atom_api_power_save_blocker.h
@@ -8,24 +8,24 @@
 #include <map>
 #include <memory>
 
-#include "atom/browser/api/trackable_object.h"
-#include "native_mate/handle.h"
+#include "gin/handle.h"
+#include "gin/object_template_builder.h"
+#include "gin/wrappable.h"
 #include "services/device/public/mojom/wake_lock.mojom.h"
-
-namespace mate {
-class Dictionary;
-}
 
 namespace atom {
 
 namespace api {
 
-class PowerSaveBlocker : public mate::TrackableObject<PowerSaveBlocker> {
+class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
  public:
-  static mate::Handle<PowerSaveBlocker> Create(v8::Isolate* isolate);
+  static gin::Handle<PowerSaveBlocker> Create(v8::Isolate* isolate);
 
-  static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::FunctionTemplate> prototype);
+  // gin::Wrappable
+  gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
+      v8::Isolate* isolate) override;
+
+  static gin::WrapperInfo kWrapperInfo;
 
  protected:
   explicit PowerSaveBlocker(v8::Isolate* isolate);


### PR DESCRIPTION
#### Description of Change
Converts PowerSaveBlocker to gin. I didn't see any particular reason for this to use `TrackableObject` rather than just straight `gin::Wrappable`, though I may be missing something.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes