### PR TITLE
feat: migrate protocol module to NetworkService (Part 4)

### DIFF
--- a/atom/browser/api/atom_api_protocol_ns.cc
+++ b/atom/browser/api/atom_api_protocol_ns.cc
@@ -119,6 +119,8 @@ void ProtocolNS::BuildPrototype(v8::Isolate* isolate,
                  &ProtocolNS::RegisterProtocolFor<ProtocolType::kHttp>)
       .SetMethod("registerStreamProtocol",
                  &ProtocolNS::RegisterProtocolFor<ProtocolType::kStream>)
+      .SetMethod("registerProtocol",
+                 &ProtocolNS::RegisterProtocolFor<ProtocolType::kFree>)
       .SetMethod("unregisterProtocol", &ProtocolNS::UnregisterProtocol)
       .SetMethod("isProtocolRegistered", &ProtocolNS::IsProtocolRegistered)
       .SetMethod("isProtocolHandled", &ProtocolNS::IsProtocolHandled)

--- a/atom/browser/net/atom_url_loader_factory.cc
+++ b/atom/browser/net/atom_url_loader_factory.cc
@@ -186,7 +186,7 @@ void AtomURLLoaderFactory::StartLoading(
                        request, std::move(client), traffic_annotation, dict);
       break;
     case ProtocolType::kStream:
-      StartLoadingStream(std::move(client), dict);
+      StartLoadingStream(std::move(loader), std::move(client), dict);
       break;
     case ProtocolType::kFree:
       ProtocolType type;
@@ -306,6 +306,7 @@ void AtomURLLoaderFactory::StartLoadingHttp(
 
 // static
 void AtomURLLoaderFactory::StartLoadingStream(
+    network::mojom::URLLoaderRequest loader,
     network::mojom::URLLoaderClientPtr client,
     const mate::Dictionary& dict) {
   network::ResourceResponseHead head = ToResponseHead(dict);
@@ -332,8 +333,8 @@ void AtomURLLoaderFactory::StartLoadingStream(
     return;
   }
 
-  new NodeStreamLoader(std::move(head), std::move(client), data.isolate(),
-                       data.GetHandle());
+  new NodeStreamLoader(std::move(head), std::move(loader), std::move(client),
+                       data.isolate(), data.GetHandle());
 }
 
 // static

--- a/atom/browser/net/atom_url_loader_factory.cc
+++ b/atom/browser/net/atom_url_loader_factory.cc
@@ -132,7 +132,7 @@ void AtomURLLoaderFactory::CreateLoaderAndStart(
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   handler_.Run(
       request,
-      base::BindOnce(&AtomURLLoaderFactory::SendResponse, std::move(loader),
+      base::BindOnce(&AtomURLLoaderFactory::StartLoading, std::move(loader),
                      routing_id, request_id, options, request,
                      std::move(client), traffic_annotation, type_));
 }
@@ -143,7 +143,7 @@ void AtomURLLoaderFactory::Clone(
 }
 
 // static
-void AtomURLLoaderFactory::SendResponse(
+void AtomURLLoaderFactory::StartLoading(
     network::mojom::URLLoaderRequest loader,
     int32_t routing_id,
     int32_t request_id,
@@ -172,21 +172,21 @@ void AtomURLLoaderFactory::SendResponse(
 
   switch (type) {
     case ProtocolType::kBuffer:
-      SendResponseBuffer(std::move(client), dict);
+      StartLoadingBuffer(std::move(client), dict);
       break;
     case ProtocolType::kString:
-      SendResponseString(std::move(client), dict, args->isolate(), response);
+      StartLoadingString(std::move(client), dict, args->isolate(), response);
       break;
     case ProtocolType::kFile:
-      SendResponseFile(std::move(loader), request, std::move(client), dict,
+      StartLoadingFile(std::move(loader), request, std::move(client), dict,
                        args->isolate(), response);
       break;
     case ProtocolType::kHttp:
-      SendResponseHttp(std::move(loader), routing_id, request_id, options,
+      StartLoadingHttp(std::move(loader), routing_id, request_id, options,
                        request, std::move(client), traffic_annotation, dict);
       break;
     case ProtocolType::kStream:
-      SendResponseStream(std::move(client), dict);
+      StartLoadingStream(std::move(client), dict);
       break;
     case ProtocolType::kFree:
       ProtocolType type;
@@ -197,7 +197,7 @@ void AtomURLLoaderFactory::SendResponse(
         args->ThrowError("Invalid args, must pass (type, options)");
         return;
       }
-      SendResponse(std::move(loader), routing_id, request_id, options, request,
+      StartLoading(std::move(loader), routing_id, request_id, options, request,
                    std::move(client), traffic_annotation, type, extra_arg,
                    args);
       break;
@@ -205,7 +205,7 @@ void AtomURLLoaderFactory::SendResponse(
 }
 
 // static
-void AtomURLLoaderFactory::SendResponseBuffer(
+void AtomURLLoaderFactory::StartLoadingBuffer(
     network::mojom::URLLoaderClientPtr client,
     const mate::Dictionary& dict) {
   v8::Local<v8::Value> buffer = dict.GetHandle();
@@ -220,7 +220,7 @@ void AtomURLLoaderFactory::SendResponseBuffer(
 }
 
 // static
-void AtomURLLoaderFactory::SendResponseString(
+void AtomURLLoaderFactory::StartLoadingString(
     network::mojom::URLLoaderClientPtr client,
     const mate::Dictionary& dict,
     v8::Isolate* isolate,
@@ -236,7 +236,7 @@ void AtomURLLoaderFactory::SendResponseString(
 }
 
 // static
-void AtomURLLoaderFactory::SendResponseFile(
+void AtomURLLoaderFactory::StartLoadingFile(
     network::mojom::URLLoaderRequest loader,
     network::ResourceRequest request,
     network::mojom::URLLoaderClientPtr client,
@@ -263,7 +263,7 @@ void AtomURLLoaderFactory::SendResponseFile(
 }
 
 // static
-void AtomURLLoaderFactory::SendResponseHttp(
+void AtomURLLoaderFactory::StartLoadingHttp(
     network::mojom::URLLoaderRequest loader,
     int32_t routing_id,
     int32_t request_id,
@@ -305,7 +305,7 @@ void AtomURLLoaderFactory::SendResponseHttp(
 }
 
 // static
-void AtomURLLoaderFactory::SendResponseStream(
+void AtomURLLoaderFactory::StartLoadingStream(
     network::mojom::URLLoaderClientPtr client,
     const mate::Dictionary& dict) {
   network::ResourceResponseHead head = ToResponseHead(dict);

--- a/atom/browser/net/atom_url_loader_factory.cc
+++ b/atom/browser/net/atom_url_loader_factory.cc
@@ -60,6 +60,7 @@ namespace atom {
 
 namespace {
 
+// Determine whether a protocol type can accept non-object response.
 bool ResponseMustBeObject(ProtocolType type) {
   switch (type) {
     case ProtocolType::kString:
@@ -71,6 +72,7 @@ bool ResponseMustBeObject(ProtocolType type) {
   }
 }
 
+// Helper to convert value to Dictionary.
 mate::Dictionary ToDict(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   if (value->IsObject())
     return mate::Dictionary(
@@ -80,6 +82,7 @@ mate::Dictionary ToDict(v8::Isolate* isolate, v8::Local<v8::Value> value) {
     return mate::Dictionary();
 }
 
+// Parse headers from response object.
 network::ResourceResponseHead ToResponseHead(const mate::Dictionary& dict) {
   network::ResourceResponseHead head;
   head.mime_type = "text/html";
@@ -114,7 +117,7 @@ network::ResourceResponseHead ToResponseHead(const mate::Dictionary& dict) {
 
 AtomURLLoaderFactory::AtomURLLoaderFactory(ProtocolType type,
                                            const ProtocolHandler& handler)
-    : type_(type), handler_(handler), weak_factory_(this) {}
+    : type_(type), handler_(handler) {}
 
 AtomURLLoaderFactory::~AtomURLLoaderFactory() = default;
 
@@ -127,11 +130,11 @@ void AtomURLLoaderFactory::CreateLoaderAndStart(
     network::mojom::URLLoaderClientPtr client,
     const net::MutableNetworkTrafficAnnotationTag& traffic_annotation) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  handler_.Run(request,
-               base::BindOnce(&AtomURLLoaderFactory::SendResponse,
-                              weak_factory_.GetWeakPtr(), std::move(loader),
-                              routing_id, request_id, options, request,
-                              std::move(client), traffic_annotation, type_));
+  handler_.Run(
+      request,
+      base::BindOnce(&AtomURLLoaderFactory::SendResponse, std::move(loader),
+                     routing_id, request_id, options, request,
+                     std::move(client), traffic_annotation, type_));
 }
 
 void AtomURLLoaderFactory::Clone(
@@ -139,6 +142,7 @@ void AtomURLLoaderFactory::Clone(
   bindings_.AddBinding(this, std::move(request));
 }
 
+// static
 void AtomURLLoaderFactory::SendResponse(
     network::mojom::URLLoaderRequest loader,
     int32_t routing_id,
@@ -195,6 +199,7 @@ void AtomURLLoaderFactory::SendResponse(
   }
 }
 
+// static
 void AtomURLLoaderFactory::SendResponseBuffer(
     network::mojom::URLLoaderClientPtr client,
     const mate::Dictionary& dict) {
@@ -209,6 +214,7 @@ void AtomURLLoaderFactory::SendResponseBuffer(
                node::Buffer::Data(buffer), node::Buffer::Length(buffer));
 }
 
+// static
 void AtomURLLoaderFactory::SendResponseString(
     network::mojom::URLLoaderClientPtr client,
     const mate::Dictionary& dict,
@@ -223,6 +229,7 @@ void AtomURLLoaderFactory::SendResponseString(
                contents.size());
 }
 
+// static
 void AtomURLLoaderFactory::SendResponseFile(
     network::mojom::URLLoaderRequest loader,
     network::ResourceRequest request,
@@ -249,6 +256,7 @@ void AtomURLLoaderFactory::SendResponseFile(
                                nullptr, false, head.headers);
 }
 
+// static
 void AtomURLLoaderFactory::SendResponseHttp(
     network::mojom::URLLoaderRequest loader,
     int32_t routing_id,
@@ -290,6 +298,7 @@ void AtomURLLoaderFactory::SendResponseHttp(
       std::move(client), traffic_annotation);
 }
 
+// static
 void AtomURLLoaderFactory::SendResponseStream(
     network::mojom::URLLoaderClientPtr client,
     const mate::Dictionary& dict) {
@@ -321,6 +330,7 @@ void AtomURLLoaderFactory::SendResponseStream(
                        data.GetHandle());
 }
 
+// static
 bool AtomURLLoaderFactory::HandleError(
     network::mojom::URLLoaderClientPtr* client,
     const mate::Dictionary& dict) {
@@ -333,6 +343,7 @@ bool AtomURLLoaderFactory::HandleError(
   return true;
 }
 
+// static
 void AtomURLLoaderFactory::SendContents(
     network::mojom::URLLoaderClientPtr client,
     network::ResourceResponseHead head,

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -79,7 +79,8 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       const mate::Dictionary& dict);
-  static void StartLoadingStream(network::mojom::URLLoaderClientPtr client,
+  static void StartLoadingStream(network::mojom::URLLoaderRequest loader,
+                                 network::mojom::URLLoaderClientPtr client,
                                  const mate::Dictionary& dict);
 
   // Helper to send string as response.

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -25,7 +25,8 @@ enum class ProtocolType {
   kFree,  // special type for returning arbitrary type of response.
 };
 
-using SendResponseCallback = base::OnceCallback<void(v8::Local<v8::Value>)>;
+using SendResponseCallback =
+    base::OnceCallback<void(v8::Local<v8::Value>, mate::Arguments*)>;
 using ProtocolHandler =
     base::Callback<void(const network::ResourceRequest&, SendResponseCallback)>;
 
@@ -56,8 +57,8 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       ProtocolType type,
-      v8::Isolate* isolate,
-      v8::Local<v8::Value> response);
+      v8::Local<v8::Value> response,
+      mate::Arguments* args);
   void SendResponseBuffer(network::mojom::URLLoaderClientPtr client,
                           const mate::Dictionary& dict);
   void SendResponseString(network::mojom::URLLoaderClientPtr client,

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -24,10 +24,10 @@ enum class ProtocolType {
   kFree,  // special type for returning arbitrary type of response.
 };
 
-using SendResponseCallback =
+using StartLoadingCallback =
     base::OnceCallback<void(v8::Local<v8::Value>, mate::Arguments*)>;
 using ProtocolHandler =
-    base::Callback<void(const network::ResourceRequest&, SendResponseCallback)>;
+    base::Callback<void(const network::ResourceRequest&, StartLoadingCallback)>;
 
 // Implementation of URLLoaderFactory.
 class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
@@ -47,7 +47,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
   void Clone(network::mojom::URLLoaderFactoryRequest request) override;
 
  private:
-  static void SendResponse(
+  static void StartLoading(
       network::mojom::URLLoaderRequest loader,
       int32_t routing_id,
       int32_t request_id,
@@ -58,19 +58,19 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       ProtocolType type,
       v8::Local<v8::Value> response,
       mate::Arguments* args);
-  static void SendResponseBuffer(network::mojom::URLLoaderClientPtr client,
+  static void StartLoadingBuffer(network::mojom::URLLoaderClientPtr client,
                                  const mate::Dictionary& dict);
-  static void SendResponseString(network::mojom::URLLoaderClientPtr client,
+  static void StartLoadingString(network::mojom::URLLoaderClientPtr client,
                                  const mate::Dictionary& dict,
                                  v8::Isolate* isolate,
                                  v8::Local<v8::Value> response);
-  static void SendResponseFile(network::mojom::URLLoaderRequest loader,
+  static void StartLoadingFile(network::mojom::URLLoaderRequest loader,
                                network::ResourceRequest request,
                                network::mojom::URLLoaderClientPtr client,
                                const mate::Dictionary& dict,
                                v8::Isolate* isolate,
                                v8::Local<v8::Value> response);
-  static void SendResponseHttp(
+  static void StartLoadingHttp(
       network::mojom::URLLoaderRequest loader,
       int32_t routing_id,
       int32_t request_id,
@@ -79,7 +79,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       const mate::Dictionary& dict);
-  static void SendResponseStream(network::mojom::URLLoaderClientPtr client,
+  static void StartLoadingStream(network::mojom::URLLoaderClientPtr client,
                                  const mate::Dictionary& dict);
 
   // Helper to send string as response.

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -68,6 +68,9 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       v8::Isolate* isolate,
       v8::Local<v8::Value> response);
+  void SendResponseStream(network::mojom::URLLoaderClientPtr client,
+                          v8::Isolate* isolate,
+                          v8::Local<v8::Value> response);
 
   bool HandleError(network::mojom::URLLoaderClientPtr* client,
                    v8::Isolate* isolate,

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -47,15 +47,27 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
   void Clone(network::mojom::URLLoaderFactoryRequest request) override;
 
  private:
+  void SendResponse(
+      network::mojom::URLLoaderRequest loader,
+      int32_t routing_id,
+      int32_t request_id,
+      uint32_t options,
+      const network::ResourceRequest& request,
+      network::mojom::URLLoaderClientPtr client,
+      const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+      ProtocolType type,
+      v8::Isolate* isolate,
+      v8::Local<v8::Value> response);
   void SendResponseBuffer(network::mojom::URLLoaderClientPtr client,
-                          v8::Isolate* isolate,
-                          v8::Local<v8::Value> response);
+                          const mate::Dictionary& dict);
   void SendResponseString(network::mojom::URLLoaderClientPtr client,
+                          const mate::Dictionary& dict,
                           v8::Isolate* isolate,
                           v8::Local<v8::Value> response);
   void SendResponseFile(network::mojom::URLLoaderRequest loader,
                         network::ResourceRequest request,
                         network::mojom::URLLoaderClientPtr client,
+                        const mate::Dictionary& dict,
                         v8::Isolate* isolate,
                         v8::Local<v8::Value> response);
   void SendResponseHttp(
@@ -66,11 +78,9 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       const network::ResourceRequest& original_request,
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
-      v8::Isolate* isolate,
-      v8::Local<v8::Value> response);
+      const mate::Dictionary& dict);
   void SendResponseStream(network::mojom::URLLoaderClientPtr client,
-                          v8::Isolate* isolate,
-                          v8::Local<v8::Value> response);
+                          const mate::Dictionary& dict);
 
   bool HandleError(network::mojom::URLLoaderClientPtr* client,
                    const mate::Dictionary& dict);

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -9,9 +9,9 @@
 
 #include "base/memory/weak_ptr.h"
 #include "mojo/public/cpp/bindings/binding_set.h"
+#include "native_mate/dictionary.h"
 #include "net/url_request/url_request_job_factory.h"
 #include "services/network/public/mojom/url_loader_factory.mojom.h"
-#include "v8/include/v8.h"
 
 namespace atom {
 
@@ -73,8 +73,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
                           v8::Local<v8::Value> response);
 
   bool HandleError(network::mojom::URLLoaderClientPtr* client,
-                   v8::Isolate* isolate,
-                   v8::Local<v8::Value> response);
+                   const mate::Dictionary& dict);
   void SendContents(network::mojom::URLLoaderClientPtr client,
                     network::ResourceResponseHead head,
                     const char* data,

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -76,8 +76,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
                    v8::Isolate* isolate,
                    v8::Local<v8::Value> response);
   void SendContents(network::mojom::URLLoaderClientPtr client,
-                    std::string mime_type,
-                    std::string charset,
+                    network::ResourceResponseHead head,
                     const char* data,
                     size_t size);
 

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -82,8 +82,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
   static void SendResponseStream(network::mojom::URLLoaderClientPtr client,
                                  const mate::Dictionary& dict);
 
-  static bool HandleError(network::mojom::URLLoaderClientPtr* client,
-                          const mate::Dictionary& dict);
+  // Helper to send string as response.
   static void SendContents(network::mojom::URLLoaderClientPtr client,
                            network::ResourceResponseHead head,
                            const char* data,

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/memory/weak_ptr.h"
 #include "mojo/public/cpp/bindings/binding_set.h"
 #include "native_mate/dictionary.h"
 #include "net/url_request/url_request_job_factory.h"
@@ -48,7 +47,7 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
   void Clone(network::mojom::URLLoaderFactoryRequest request) override;
 
  private:
-  void SendResponse(
+  static void SendResponse(
       network::mojom::URLLoaderRequest loader,
       int32_t routing_id,
       int32_t request_id,
@@ -59,19 +58,19 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       ProtocolType type,
       v8::Local<v8::Value> response,
       mate::Arguments* args);
-  void SendResponseBuffer(network::mojom::URLLoaderClientPtr client,
-                          const mate::Dictionary& dict);
-  void SendResponseString(network::mojom::URLLoaderClientPtr client,
-                          const mate::Dictionary& dict,
-                          v8::Isolate* isolate,
-                          v8::Local<v8::Value> response);
-  void SendResponseFile(network::mojom::URLLoaderRequest loader,
-                        network::ResourceRequest request,
-                        network::mojom::URLLoaderClientPtr client,
-                        const mate::Dictionary& dict,
-                        v8::Isolate* isolate,
-                        v8::Local<v8::Value> response);
-  void SendResponseHttp(
+  static void SendResponseBuffer(network::mojom::URLLoaderClientPtr client,
+                                 const mate::Dictionary& dict);
+  static void SendResponseString(network::mojom::URLLoaderClientPtr client,
+                                 const mate::Dictionary& dict,
+                                 v8::Isolate* isolate,
+                                 v8::Local<v8::Value> response);
+  static void SendResponseFile(network::mojom::URLLoaderRequest loader,
+                               network::ResourceRequest request,
+                               network::mojom::URLLoaderClientPtr client,
+                               const mate::Dictionary& dict,
+                               v8::Isolate* isolate,
+                               v8::Local<v8::Value> response);
+  static void SendResponseHttp(
       network::mojom::URLLoaderRequest loader,
       int32_t routing_id,
       int32_t request_id,
@@ -80,15 +79,15 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       const mate::Dictionary& dict);
-  void SendResponseStream(network::mojom::URLLoaderClientPtr client,
-                          const mate::Dictionary& dict);
+  static void SendResponseStream(network::mojom::URLLoaderClientPtr client,
+                                 const mate::Dictionary& dict);
 
-  bool HandleError(network::mojom::URLLoaderClientPtr* client,
-                   const mate::Dictionary& dict);
-  void SendContents(network::mojom::URLLoaderClientPtr client,
-                    network::ResourceResponseHead head,
-                    const char* data,
-                    size_t size);
+  static bool HandleError(network::mojom::URLLoaderClientPtr* client,
+                          const mate::Dictionary& dict);
+  static void SendContents(network::mojom::URLLoaderClientPtr client,
+                           network::ResourceResponseHead head,
+                           const char* data,
+                           size_t size);
 
   // TODO(zcbenz): This comes from extensions/browser/extension_protocols.cc
   // but I don't know what it actually does, find out the meanings of |Clone|
@@ -97,8 +96,6 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
 
   ProtocolType type_;
   ProtocolHandler handler_;
-
-  base::WeakPtrFactory<AtomURLLoaderFactory> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomURLLoaderFactory);
 };

--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -1,0 +1,7 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/net/node_stream_loader.h"
+
+namespace atom {}  // namespace atom

--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -4,4 +4,89 @@
 
 #include "atom/browser/net/node_stream_loader.h"
 
-namespace atom {}  // namespace atom
+#include "atom/common/api/event_emitter_caller.h"
+#include "atom/common/native_mate_converters/callback.h"
+
+#include "atom/common/node_includes.h"
+
+namespace atom {
+
+NodeStreamLoader::NodeStreamLoader(network::ResourceResponseHead head,
+                                   network::mojom::URLLoaderClientPtr client,
+                                   v8::Isolate* isolate,
+                                   v8::Local<v8::Object> emitter)
+    : client_(std::move(client)),
+      isolate_(isolate),
+      emitter_(isolate, emitter),
+      weak_factory_(this) {
+  mojo::ScopedDataPipeConsumerHandle consumer;
+  MojoResult rv = mojo::CreateDataPipe(nullptr, &producer_, &consumer);
+  if (rv != MOJO_RESULT_OK) {
+    OnError(nullptr);
+    return;
+  }
+
+  client_->OnReceiveResponse(head);
+  client_->OnStartLoadingResponseBody(std::move(consumer));
+
+  auto weak = weak_factory_.GetWeakPtr();
+  On("data", base::BindRepeating(&NodeStreamLoader::OnData, weak));
+  On("end", base::BindRepeating(&NodeStreamLoader::OnEnd, weak));
+  On("error", base::BindRepeating(&NodeStreamLoader::OnError, weak));
+}
+
+NodeStreamLoader::~NodeStreamLoader() {
+  v8::Locker locker(isolate_);
+  v8::Isolate::Scope isolate_scope(isolate_);
+  v8::HandleScope handle_scope(isolate_);
+
+  // Unsubscribe all handlers.
+  for (const auto& it : handlers_) {
+    v8::Local<v8::Value> args[] = {mate::StringToV8(isolate_, it.first),
+                                   it.second.Get(isolate_)};
+    node::MakeCallback(isolate_, emitter_.Get(isolate_), "removeListener",
+                       node::arraysize(args), args, {0, 0});
+  }
+}
+
+void NodeStreamLoader::On(const char* event, EventCallback callback) {
+  v8::Locker locker(isolate_);
+  v8::Isolate::Scope isolate_scope(isolate_);
+  v8::HandleScope handle_scope(isolate_);
+
+  // emitter.on(event, callback)
+  auto fn = mate::CallbackToV8(isolate_, std::move(callback));
+  mate::EmitEvent(isolate_, emitter_.Get(isolate_), "on", event, fn);
+
+  handlers_[event].Reset(isolate_, fn);
+}
+
+void NodeStreamLoader::OnData(mate::Arguments* args) {
+  v8::Local<v8::Value> buffer;
+  args->GetNext(&buffer);
+  if (!node::Buffer::HasInstance(buffer)) {
+    args->ThrowError("data must be Buffer");
+    return;
+  }
+
+  size_t ssize = node::Buffer::Length(buffer);
+  uint32_t size = base::saturated_cast<uint32_t>(ssize);
+  MojoResult result = producer_->WriteData(node::Buffer::Data(buffer), &size,
+                                           MOJO_WRITE_DATA_FLAG_NONE);
+  if (result != MOJO_RESULT_OK || size < ssize) {
+    OnError(nullptr);
+    return;
+  }
+}
+
+void NodeStreamLoader::OnEnd(mate::Arguments* args) {
+  client_->OnComplete(network::URLLoaderCompletionStatus(net::OK));
+  delete this;
+}
+
+void NodeStreamLoader::OnError(mate::Arguments* args) {
+  client_->OnComplete(network::URLLoaderCompletionStatus(net::ERR_FAILED));
+  delete this;
+}
+
+}  // namespace atom

--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -57,10 +57,14 @@ void NodeStreamLoader::On(const char* event, EventCallback callback) {
   v8::HandleScope handle_scope(isolate_);
 
   // emitter.on(event, callback)
-  auto fn = mate::CallbackToV8(isolate_, std::move(callback));
-  mate::EmitEvent(isolate_, emitter_.Get(isolate_), "on", event, fn);
+  v8::Local<v8::Value> args[] = {
+      mate::StringToV8(isolate_, event),
+      mate::CallbackToV8(isolate_, std::move(callback)),
+  };
+  node::MakeCallback(isolate_, emitter_.Get(isolate_), "on",
+                     node::arraysize(args), args, {0, 0});
 
-  handlers_[event].Reset(isolate_, fn);
+  handlers_[event].Reset(isolate_, args[1]);
 }
 
 void NodeStreamLoader::OnData(mate::Arguments* args) {

--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -4,6 +4,8 @@
 
 #include "atom/browser/net/node_stream_loader.h"
 
+#include <utility>
+
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/callback.h"
 

--- a/atom/browser/net/node_stream_loader.h
+++ b/atom/browser/net/node_stream_loader.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "services/network/public/mojom/url_loader.mojom.h"

--- a/atom/browser/net/node_stream_loader.h
+++ b/atom/browser/net/node_stream_loader.h
@@ -5,19 +5,49 @@
 #ifndef ATOM_BROWSER_NET_NODE_STREAM_LOADER_H_
 #define ATOM_BROWSER_NET_NODE_STREAM_LOADER_H_
 
-#include "services/network/public/mojom/url_loader_factory.mojom.h"
+#include <map>
+#include <string>
+
+#include "services/network/public/mojom/url_loader.mojom.h"
 #include "v8/include/v8.h"
+
+namespace mate {
+class Arguments;
+}
 
 namespace atom {
 
 class NodeStreamLoader {
  public:
-  NodeStreamLoader(network::mojom::URLLoaderClientPtr client,
+  NodeStreamLoader(network::ResourceResponseHead head,
+                   network::mojom::URLLoaderClientPtr client,
                    v8::Isolate* isolate,
-                   v8::Local<v8::Value> response);
-  ~NodeStreamLoader();
+                   v8::Local<v8::Object> emitter);
 
  private:
+  ~NodeStreamLoader();
+
+  using EventCallback = base::RepeatingCallback<void(mate::Arguments* args)>;
+
+  void On(const char* event, EventCallback callback);
+
+  void OnData(mate::Arguments* args);
+  void OnEnd(mate::Arguments* args);
+  void OnError(mate::Arguments* args);
+
+  network::mojom::URLLoaderClientPtr client_;
+
+  v8::Isolate* isolate_;
+  v8::Global<v8::Object> emitter_;
+
+  // Pipes for communicating between Node and NetworkService.
+  mojo::ScopedDataPipeProducerHandle producer_;
+
+  // Store the V8 callbacks to unsubscribe them later.
+  std::map<std::string, v8::Global<v8::Value>> handlers_;
+
+  base::WeakPtrFactory<NodeStreamLoader> weak_factory_;
+
   DISALLOW_COPY_AND_ASSIGN(NodeStreamLoader);
 };
 

--- a/atom/browser/net/node_stream_loader.h
+++ b/atom/browser/net/node_stream_loader.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_NET_NODE_STREAM_LOADER_H_
+#define ATOM_BROWSER_NET_NODE_STREAM_LOADER_H_
+
+#include "services/network/public/mojom/url_loader_factory.mojom.h"
+#include "v8/include/v8.h"
+
+namespace atom {
+
+class NodeStreamLoader {
+ public:
+  NodeStreamLoader(network::mojom::URLLoaderClientPtr client,
+                   v8::Isolate* isolate,
+                   v8::Local<v8::Value> response);
+  ~NodeStreamLoader();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(NodeStreamLoader);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_NET_NODE_STREAM_LOADER_H_

--- a/filenames.gni
+++ b/filenames.gni
@@ -340,6 +340,8 @@ filenames = {
     "atom/browser/net/network_context_service_factory.h",
     "atom/browser/net/network_context_service.cc",
     "atom/browser/net/network_context_service.h",
+    "atom/browser/net/node_stream_loader.cc",
+    "atom/browser/net/node_stream_loader.h",
     "atom/browser/net/require_ct_delegate.cc",
     "atom/browser/net/require_ct_delegate.h",
     "atom/browser/net/resolve_proxy_helper.cc",


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This is part of the changes to reimplement the protocol module with NetworkService API, the new implementation lives in parallel with current implementation and only gets used when `--enable-features=NetworkService` is passed.

This PR implements the `protocol.registerStreamProtocol` with NetworkService APIs, and also refactors the code of `AtomURLLoaderFactory`.

Due to the migration of NetworkService APIs, it is now possible to return different types of responses in one protocol handler, I have added an experimental `protocol.registerProtocol` API to demonstrate the possibility:

```js
protocol.registerProtocol('test', (request, callback) => {
  if (/* stream */) {
    callback('stream', {
      statusCode: 200,
      headers: {
        'content-type': 'text/html'
      },
      data: createStream('<h5>Response</h5>')
    })
  } else if (/* file */) {
    callback('file', '/path/to/file')
  }
})
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes