### PR TITLE
chore: retry octokit calls several times on fail

### DIFF
--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -9,6 +9,9 @@ const { GitProcess } = require('dugite')
 const octokit = require('@octokit/rest')()
 const semver = require('semver')
 
+const MAX_FAIL_COUNT = 3
+const CHECK_INTERVAL = 5000
+
 const CACHE_DIR = path.resolve(__dirname, '.cache')
 const NO_NOTES = 'No notes'
 const FOLLOW_REPOS = [ 'electron/electron', 'electron/libchromiumcontent', 'electron/node' ]
@@ -298,35 +301,41 @@ const checkCache = async (name, operation) => {
   return response
 }
 
+// helper function to add some resiliency to volatile GH api endpoints
+async function runRetryable (fn, maxRetries) {
+  let lastError
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      return await fn()
+    } catch (error) {
+      await new Promise((resolve, reject) => setTimeout(resolve, CHECK_INTERVAL))
+      lastError = error
+    }
+  }
+  // Silently eat 404s.
+  if (lastError.status !== 404) throw lastError
+}
+
 const getPullRequest = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}`
   return checkCache(name, async () => {
-    try {
-      return await octokit.pulls.get({ number, owner, repo })
-    } catch (error) {
-      // Silently eat 404s.
-      // We can get a bad pull number if someone manually lists
-      // an issue number in PR number notation, e.g. 'fix: foo (#123)'
-      if (error.code !== 404) {
-        throw error
-      }
-    }
+    return runRetryable(octokit.pulls.get({
+      number,
+      owner,
+      repo
+    }), MAX_FAIL_COUNT)
   })
 }
 
 const getComments = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}-comments`
   return checkCache(name, async () => {
-    try {
-      return await octokit.issues.listComments({ number, owner, repo, per_page: 100 })
-    } catch (error) {
-      // Silently eat 404s.
-      // We can get a bad pull number if someone manually lists
-      // an issue number in PR number notation, e.g. 'fix: foo (#123)'
-      if (error.code !== 404) {
-        throw error
-      }
-    }
+    return runRetryable(octokit.issues.listComments({
+      number,
+      owner,
+      repo,
+      per_page: 100
+    }), MAX_FAIL_COUNT)
   })
 }
 


### PR DESCRIPTION
#### Description of Change

Retry any of the octokit requests in the notes generator 3 times before actually failing the script.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
