### PR TITLE
fix: correctly parse default_app path on windows

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -30,7 +30,11 @@ function isTrustedSender (webContents: Electron.WebContents) {
   }
 
   const parsedUrl = new URL(webContents.getURL())
-  return parsedUrl.protocol === 'file:' && parsedUrl.pathname === indexPath
+  const urlPath = process.platform === 'win32'
+    // Strip the prefixed "/" that occurs on windows
+    ? path.resolve(parsedUrl.pathname.substr(1))
+    : parsedUrl.pathname
+  return parsedUrl.protocol === 'file:' && urlPath === indexPath
 }
 
 ipcMain.on('bootstrap', (event) => {


### PR DESCRIPTION
Noticed this on my Windows machine while verifying the `6.0.0-beta.1` release.  On windows, `pathname` looks like `/c:/a/b/c` (that preceding `/` breaks things).  No notes as it's a `default_app` UI change, app devs don't need to know.

This is the bug -->
![image](https://user-images.githubusercontent.com/6634592/57009051-27a0b780-6ba9-11e9-9a24-ead12bf71600.png)

Notes: no-notes