### PR TITLE
refactor: convert C++ enums to C++11 enum classes

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1291,9 +1291,9 @@ bool App::IsInApplicationsFolder() {
 int DockBounce(const std::string& type) {
   int request_id = -1;
   if (type == "critical")
-    request_id = Browser::Get()->DockBounce(Browser::BOUNCE_CRITICAL);
+    request_id = Browser::Get()->DockBounce(Browser::BounceType::CRITICAL);
   else if (type == "informational")
-    request_id = Browser::Get()->DockBounce(Browser::BOUNCE_INFORMATIONAL);
+    request_id = Browser::Get()->DockBounce(Browser::BounceType::INFORMATIONAL);
   return request_id;
 }
 

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -31,17 +31,6 @@ using content::BrowserThread;
 namespace gin {
 
 template <>
-struct Converter<atom::api::Cookies::Error> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   atom::api::Cookies::Error val) {
-    if (val == atom::api::Cookies::SUCCESS)
-      return v8::Null(isolate);
-    else
-      return v8::Exception::Error(StringToV8(isolate, "Setting cookie failed"));
-  }
-};
-
-template <>
 struct Converter<net::CanonicalCookie> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const net::CanonicalCookie& val) {

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -31,11 +31,6 @@ namespace api {
 
 class Cookies : public mate::TrackableObject<Cookies> {
  public:
-  enum Error {
-    SUCCESS,
-    FAILED,
-  };
-
   static gin::Handle<Cookies> Create(v8::Isolate* isolate,
                                      AtomBrowserContext* browser_context);
 

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -164,9 +164,9 @@ Protocol::ProtocolError Protocol::UnregisterProtocolInIO(
     const std::string& scheme) {
   auto* job_factory = request_context_getter->job_factory();
   if (!job_factory->HasProtocolHandler(scheme))
-    return PROTOCOL_NOT_REGISTERED;
+    return ProtocolError::NOT_REGISTERED;
   job_factory->SetProtocolHandler(scheme, nullptr);
-  return PROTOCOL_OK;
+  return ProtocolError::OK;
 }
 
 bool IsProtocolHandledInIO(
@@ -209,8 +209,8 @@ Protocol::ProtocolError Protocol::UninterceptProtocolInIO(
     scoped_refptr<URLRequestContextGetter> request_context_getter,
     const std::string& scheme) {
   return request_context_getter->job_factory()->UninterceptProtocol(scheme)
-             ? PROTOCOL_OK
-             : PROTOCOL_NOT_INTERCEPTED;
+             ? ProtocolError::OK
+             : ProtocolError::NOT_INTERCEPTED;
 }
 
 void Protocol::OnIOCompleted(const CompletionCallback& callback,
@@ -222,7 +222,7 @@ void Protocol::OnIOCompleted(const CompletionCallback& callback,
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
 
-  if (error == PROTOCOL_OK) {
+  if (error == ProtocolError::OK) {
     callback.Run(v8::Null(isolate()));
   } else {
     std::string str = ErrorCodeToString(error);
@@ -232,15 +232,15 @@ void Protocol::OnIOCompleted(const CompletionCallback& callback,
 
 std::string Protocol::ErrorCodeToString(ProtocolError error) {
   switch (error) {
-    case PROTOCOL_FAIL:
+    case ProtocolError::FAIL:
       return "Failed to manipulate protocol factory";
-    case PROTOCOL_REGISTERED:
+    case ProtocolError::REGISTERED:
       return "The scheme has been registered";
-    case PROTOCOL_NOT_REGISTERED:
+    case ProtocolError::NOT_REGISTERED:
       return "The scheme has not been registered";
-    case PROTOCOL_INTERCEPTED:
+    case ProtocolError::INTERCEPTED:
       return "The scheme has been intercepted";
-    case PROTOCOL_NOT_INTERCEPTED:
+    case ProtocolError::NOT_INTERCEPTED:
       return "The scheme has not been intercepted";
     default:
       return "Unexpected error";

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -56,13 +56,13 @@ class Protocol : public mate::TrackableObject<Protocol> {
 
  private:
   // Possible errors.
-  enum ProtocolError {
-    PROTOCOL_OK,    // no error
-    PROTOCOL_FAIL,  // operation failed, should never occur
-    PROTOCOL_REGISTERED,
-    PROTOCOL_NOT_REGISTERED,
-    PROTOCOL_INTERCEPTED,
-    PROTOCOL_NOT_INTERCEPTED,
+  enum class ProtocolError {
+    OK,    // no error
+    FAIL,  // operation failed, should never occur
+    REGISTERED,
+    NOT_REGISTERED,
+    INTERCEPTED,
+    NOT_INTERCEPTED,
   };
 
   // The protocol handler that will create a protocol handler for certain
@@ -118,13 +118,13 @@ class Protocol : public mate::TrackableObject<Protocol> {
       const Handler& handler) {
     auto* job_factory = request_context_getter->job_factory();
     if (job_factory->IsHandledProtocol(scheme))
-      return PROTOCOL_REGISTERED;
+      return ProtocolError::REGISTERED;
     auto protocol_handler = std::make_unique<CustomProtocolHandler<RequestJob>>(
         isolate, request_context_getter.get(), handler);
     if (job_factory->SetProtocolHandler(scheme, std::move(protocol_handler)))
-      return PROTOCOL_OK;
+      return ProtocolError::OK;
     else
-      return PROTOCOL_FAIL;
+      return ProtocolError::FAIL;
   }
 
   // Unregister the protocol handler that handles |scheme|.
@@ -159,15 +159,15 @@ class Protocol : public mate::TrackableObject<Protocol> {
       const Handler& handler) {
     auto* job_factory = request_context_getter->job_factory();
     if (!job_factory->IsHandledProtocol(scheme))
-      return PROTOCOL_NOT_REGISTERED;
+      return ProtocolError::NOT_REGISTERED;
     // It is possible a protocol is handled but can not be intercepted.
     if (!job_factory->HasProtocolHandler(scheme))
-      return PROTOCOL_FAIL;
+      return ProtocolError::FAIL;
     auto protocol_handler = std::make_unique<CustomProtocolHandler<RequestJob>>(
         isolate, request_context_getter.get(), handler);
     if (!job_factory->InterceptProtocol(scheme, std::move(protocol_handler)))
-      return PROTOCOL_INTERCEPTED;
-    return PROTOCOL_OK;
+      return ProtocolError::INTERCEPTED;
+    return ProtocolError::OK;
   }
 
   // Restore the |scheme| to its original protocol handler.

--- a/atom/browser/api/atom_api_protocol_ns.cc
+++ b/atom/browser/api/atom_api_protocol_ns.cc
@@ -20,13 +20,13 @@ namespace {
 // Convert error code to string.
 std::string ErrorCodeToString(ProtocolError error) {
   switch (error) {
-    case PROTOCOL_REGISTERED:
+    case ProtocolError::REGISTERED:
       return "The scheme has been registered";
-    case PROTOCOL_NOT_REGISTERED:
+    case ProtocolError::NOT_REGISTERED:
       return "The scheme has not been registered";
-    case PROTOCOL_INTERCEPTED:
+    case ProtocolError::INTERCEPTED:
       return "The scheme has been intercepted";
-    case PROTOCOL_NOT_INTERCEPTED:
+    case ProtocolError::NOT_INTERCEPTED:
       return "The scheme has not been intercepted";
     default:
       return "Unexpected error";
@@ -56,21 +56,21 @@ void ProtocolNS::RegisterURLLoaderFactories(
 ProtocolError ProtocolNS::RegisterProtocol(ProtocolType type,
                                            const std::string& scheme,
                                            const ProtocolHandler& handler) {
-  ProtocolError error = PROTOCOL_OK;
+  ProtocolError error = ProtocolError::OK;
   if (!base::ContainsKey(handlers_, scheme))
     handlers_[scheme] = std::make_pair(type, handler);
   else
-    error = PROTOCOL_REGISTERED;
+    error = ProtocolError::REGISTERED;
   return error;
 }
 
 void ProtocolNS::UnregisterProtocol(const std::string& scheme,
                                     mate::Arguments* args) {
-  ProtocolError error = PROTOCOL_OK;
+  ProtocolError error = ProtocolError::OK;
   if (base::ContainsKey(handlers_, scheme))
     handlers_.erase(scheme);
   else
-    error = PROTOCOL_NOT_REGISTERED;
+    error = ProtocolError::NOT_REGISTERED;
   HandleOptionalCallback(args, error);
 }
 
@@ -89,7 +89,7 @@ void ProtocolNS::HandleOptionalCallback(mate::Arguments* args,
                                         ProtocolError error) {
   CompletionCallback callback;
   if (args->GetNext(&callback)) {
-    if (error == PROTOCOL_OK)
+    if (error == ProtocolError::OK)
       callback.Run(v8::Null(args->isolate()));
     else
       callback.Run(v8::Exception::Error(

--- a/atom/browser/api/atom_api_protocol_ns.h
+++ b/atom/browser/api/atom_api_protocol_ns.h
@@ -22,12 +22,12 @@ class AtomBrowserContext;
 namespace api {
 
 // Possible errors.
-enum ProtocolError {
-  PROTOCOL_OK,  // no error
-  PROTOCOL_REGISTERED,
-  PROTOCOL_NOT_REGISTERED,
-  PROTOCOL_INTERCEPTED,
-  PROTOCOL_NOT_INTERCEPTED,
+enum class ProtocolError {
+  OK,  // no error
+  REGISTERED,
+  NOT_REGISTERED,
+  INTERCEPTED,
+  NOT_INTERCEPTED,
 };
 
 // Protocol implementation based on network services.

--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -737,15 +737,15 @@ void TopLevelWindow::SetProgressBar(double progress, mate::Arguments* args) {
   std::string mode;
   args->GetNext(&options) && options.Get("mode", &mode);
 
-  NativeWindow::ProgressState state = NativeWindow::PROGRESS_NORMAL;
+  NativeWindow::ProgressState state = NativeWindow::ProgressState::kNormal;
   if (mode == "error")
-    state = NativeWindow::PROGRESS_ERROR;
+    state = NativeWindow::ProgressState::kError;
   else if (mode == "paused")
-    state = NativeWindow::PROGRESS_PAUSED;
+    state = NativeWindow::ProgressState::kPaused;
   else if (mode == "indeterminate")
-    state = NativeWindow::PROGRESS_INDETERMINATE;
+    state = NativeWindow::ProgressState::kIndeterminate;
   else if (mode == "none")
-    state = NativeWindow::PROGRESS_NONE;
+    state = NativeWindow::ProgressState::kNone;
 
   window_->SetProgressBar(progress, state);
 }

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -25,18 +25,19 @@ struct Converter<atom::TrayIcon::HighlightMode> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      atom::TrayIcon::HighlightMode* out) {
+    using HighlightMode = atom::TrayIcon::HighlightMode;
     std::string mode;
     if (ConvertFromV8(isolate, val, &mode)) {
       if (mode == "always") {
-        *out = atom::TrayIcon::HighlightMode::ALWAYS;
+        *out = HighlightMode::ALWAYS;
         return true;
       }
       if (mode == "selection") {
-        *out = atom::TrayIcon::HighlightMode::SELECTION;
+        *out = HighlightMode::SELECTION;
         return true;
       }
       if (mode == "never") {
-        *out = atom::TrayIcon::HighlightMode::NEVER;
+        *out = HighlightMode::NEVER;
         return true;
       }
     }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -80,7 +80,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
                     public content::WebContentsObserver,
                     public mojom::ElectronBrowser {
  public:
-  enum Type {
+  enum class Type {
     BACKGROUND_PAGE,  // A DevTools extension background page.
     BROWSER_WINDOW,   // Used by BrowserWindow.
     BROWSER_VIEW,     // Used by BrowserView.
@@ -534,7 +534,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   WebContentsZoomController* zoom_controller_ = nullptr;
 
   // The type of current WebContents.
-  Type type_ = BROWSER_WINDOW;
+  Type type_ = Type::BROWSER_WINDOW;
 
   // Request id used for findInPage request.
   uint32_t request_id_ = 0;

--- a/atom/browser/api/atom_api_web_contents_mac.mm
+++ b/atom/browser/api/atom_api_web_contents_mac.mm
@@ -16,7 +16,7 @@ bool WebContents::IsFocused() const {
   if (!view)
     return false;
 
-  if (GetType() != BACKGROUND_PAGE) {
+  if (GetType() != Type::BACKGROUND_PAGE) {
     auto window = [web_contents()->GetNativeView().GetNativeNSView() window];
     // On Mac the render widget host view does not lose focus when the window
     // loses focus so check if the top level window is the key window.

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -205,7 +205,8 @@ AtomBrowserMainParts::AtomBrowserMainParts(
     const content::MainFunctionParams& params)
     : fake_browser_process_(new BrowserProcessImpl),
       browser_(new Browser),
-      node_bindings_(NodeBindings::Create(NodeBindings::BROWSER)),
+      node_bindings_(
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::BROWSER)),
       electron_bindings_(new ElectronBindings(uv_default_loop())),
       main_function_params_(params) {
   DCHECK(!self_) << "Cannot have two AtomBrowserMainParts";

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -92,8 +92,8 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
   }
 
   atom::ShowMessageBox(
-      window, atom::MessageBoxType::MESSAGE_BOX_TYPE_NONE, buttons, default_id,
-      cancel_id, atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
+      window, atom::MessageBoxType::kNone, buttons, default_id, cancel_id,
+      atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
       base::UTF16ToUTF8(message_text), "", checkbox, false, gfx::ImageSkia(),
       base::Bind(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
                  base::Unretained(this), base::Passed(std::move(callback)),

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -155,9 +155,9 @@ class Browser : public WindowListObserver {
                                const base::DictionaryValue& user_info);
 
   // Bounce the dock icon.
-  enum BounceType {
-    BOUNCE_CRITICAL = 0,
-    BOUNCE_INFORMATIONAL = 10,
+  enum class BounceType {
+    CRITICAL = 0,        // NSCriticalRequest
+    INFORMATIONAL = 10,  // NSInformationalRequest
   };
   int DockBounce(BounceType type);
   void DockCancelBounce(int request_id);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -164,12 +164,12 @@ class NativeWindow : public base::SupportsUserData,
   virtual NativeWindowHandle GetNativeWindowHandle() const = 0;
 
   // Taskbar/Dock APIs.
-  enum ProgressState {
-    PROGRESS_NONE,           // no progress, no marking
-    PROGRESS_INDETERMINATE,  // progress, indeterminate
-    PROGRESS_ERROR,          // progress, errored (red)
-    PROGRESS_PAUSED,         // progress, paused (yellow)
-    PROGRESS_NORMAL,         // progress, not marked (green)
+  enum class ProgressState {
+    kNone,           // no progress, no marking
+    kIndeterminate,  // progress, indeterminate
+    kError,          // progress, errored (red)
+    kPaused,         // progress, paused (yellow)
+    kNormal,         // progress, not marked (green)
   };
 
   virtual void SetProgressBar(double progress, const ProgressState state) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -146,7 +146,7 @@ class NativeWindowMac : public NativeWindow {
   void SetStyleMask(bool on, NSUInteger flag);
   void SetCollectionBehavior(bool on, NSUInteger flag);
 
-  enum TitleBarStyle {
+  enum class TitleBarStyle {
     NORMAL,
     HIDDEN,
     HIDDEN_INSET,
@@ -200,7 +200,7 @@ class NativeWindowMac : public NativeWindow {
   NSApplicationPresentationOptions kiosk_options_;
 
   // The "titleBarStyle" option.
-  TitleBarStyle title_bar_style_ = NORMAL;
+  TitleBarStyle title_bar_style_ = TitleBarStyle::NORMAL;
 
   // The visibility mode of window button controls when explicitly set through
   // setWindowButtonVisibility().

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -211,15 +211,16 @@ struct Converter<atom::NativeWindowMac::TitleBarStyle> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Handle<v8::Value> val,
                      atom::NativeWindowMac::TitleBarStyle* out) {
+    using TitleBarStyle = atom::NativeWindowMac::TitleBarStyle;
     std::string title_bar_style;
     if (!ConvertFromV8(isolate, val, &title_bar_style))
       return false;
     if (title_bar_style == "hidden") {
-      *out = atom::NativeWindowMac::HIDDEN;
+      *out = TitleBarStyle::HIDDEN;
     } else if (title_bar_style == "hiddenInset") {
-      *out = atom::NativeWindowMac::HIDDEN_INSET;
+      *out = TitleBarStyle::HIDDEN_INSET;
     } else if (title_bar_style == "customButtonsOnHover") {
-      *out = atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER;
+      *out = TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER;
     } else {
       return false;
     }
@@ -319,7 +320,7 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   }
 
   NSUInteger styleMask = NSWindowStyleMaskTitled;
-  if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER &&
+  if (title_bar_style_ == TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER &&
       (!useStandardWindow || transparent() || !has_frame())) {
     styleMask = NSWindowStyleMaskFullSizeContentView;
   }
@@ -329,7 +330,7 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   if (closable) {
     styleMask |= NSWindowStyleMaskClosable;
   }
-  if (title_bar_style_ != NORMAL) {
+  if (title_bar_style_ != TitleBarStyle::NORMAL) {
     // The window without titlebar is treated the same with frameless window.
     set_has_frame(false);
   }
@@ -400,12 +401,12 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   }
 
   // Hide the title bar background
-  if (title_bar_style_ != NORMAL) {
+  if (title_bar_style_ != TitleBarStyle::NORMAL) {
     [window_ setTitlebarAppearsTransparent:YES];
   }
 
   // Hide the title bar.
-  if (title_bar_style_ == HIDDEN_INSET) {
+  if (title_bar_style_ == TitleBarStyle::HIDDEN_INSET) {
     base::scoped_nsobject<NSToolbar> toolbar(
         [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
     [toolbar setShowsBaselineSeparator:NO];
@@ -1235,7 +1236,7 @@ bool NativeWindowMac::AddTabbedWindow(NativeWindow* window) {
 }
 
 bool NativeWindowMac::SetWindowButtonVisibility(bool visible) {
-  if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER) {
+  if (title_bar_style_ == TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER) {
     return false;
   }
 
@@ -1267,7 +1268,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
   background_color_before_vibrancy_.reset([[window_ backgroundColor] retain]);
   transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
 
-  if (title_bar_style_ != NORMAL) {
+  if (title_bar_style_ != TitleBarStyle::NORMAL) {
     [window_ setTitlebarAppearsTransparent:YES];
     [window_ setBackgroundColor:[NSColor clearColor]];
   }
@@ -1420,14 +1421,14 @@ void NativeWindowMac::AddContentViewLayers() {
     // The fullscreen button should always be hidden for frameless window.
     [[window_ standardWindowButton:NSWindowFullScreenButton] setHidden:YES];
 
-    if (title_bar_style_ == CUSTOM_BUTTONS_ON_HOVER) {
+    if (title_bar_style_ == TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER) {
       buttons_view_.reset(
           [[CustomWindowButtonView alloc] initWithFrame:NSZeroRect]);
       // NSWindowStyleMaskFullSizeContentView does not work with zoom button
       SetFullScreenable(false);
       [[window_ contentView] addSubview:buttons_view_];
     } else {
-      if (title_bar_style_ != NORMAL)
+      if (title_bar_style_ != TitleBarStyle::NORMAL)
         return;
 
       // Hide the window buttons.

--- a/atom/browser/net/asar/url_request_asar_job.cc
+++ b/atom/browser/net/asar/url_request_asar_job.cc
@@ -54,7 +54,7 @@ void URLRequestAsarJob::Initialize(
   std::shared_ptr<Archive> archive = GetOrCreateAsarArchive(asar_path);
   Archive::FileInfo file_info;
   if (!archive || !archive->GetFileInfo(relative_path, &file_info)) {
-    type_ = TYPE_ERROR;
+    type_ = JobType::kError;
     return;
   }
 
@@ -73,7 +73,7 @@ void URLRequestAsarJob::InitializeAsarJob(
     std::shared_ptr<Archive> archive,
     const base::FilePath& file_path,
     const Archive::FileInfo& file_info) {
-  type_ = TYPE_ASAR;
+  type_ = JobType::kAsar;
   file_task_runner_ = file_task_runner;
   stream_.reset(new net::FileStream(file_task_runner_));
   archive_ = archive;
@@ -84,16 +84,16 @@ void URLRequestAsarJob::InitializeAsarJob(
 void URLRequestAsarJob::InitializeFileJob(
     const scoped_refptr<base::TaskRunner> file_task_runner,
     const base::FilePath& file_path) {
-  type_ = TYPE_FILE;
+  type_ = JobType::kFile;
   file_task_runner_ = file_task_runner;
   stream_.reset(new net::FileStream(file_task_runner_));
   file_path_ = file_path;
 }
 
 void URLRequestAsarJob::Start() {
-  if (type_ == TYPE_ASAR || type_ == TYPE_FILE) {
+  if (type_ == JobType::kAsar || type_ == JobType::kFile) {
     auto* meta_info = new FileMetaInfo();
-    if (type_ == TYPE_ASAR) {
+    if (type_ == JobType::kAsar) {
       meta_info->file_path = archive_->path();
       meta_info->file_exists = true;
       meta_info->is_directory = false;
@@ -144,7 +144,7 @@ int URLRequestAsarJob::ReadRawData(net::IOBuffer* dest, int dest_size) {
 bool URLRequestAsarJob::IsRedirectResponse(GURL* location,
                                            int* http_status_code,
                                            bool* insecure_scheme_was_upgraded) {
-  if (type_ != TYPE_FILE)
+  if (type_ != JobType::kFile)
     return false;
 #if defined(OS_WIN)
   // Follow a Windows shortcut.
@@ -222,7 +222,7 @@ void URLRequestAsarJob::GetResponseInfo(net::HttpResponseInfo* info) {
 void URLRequestAsarJob::FetchMetaInfo(const base::FilePath& file_path,
                                       JobType type,
                                       FileMetaInfo* meta_info) {
-  if (type == TYPE_FILE) {
+  if (type == JobType::kFile) {
     base::File::Info file_info;
     meta_info->file_exists = base::GetFileInfo(file_path, &file_info);
     if (meta_info->file_exists) {
@@ -278,7 +278,7 @@ void URLRequestAsarJob::DidOpen(int result) {
   }
 
   int64_t file_size, read_offset;
-  if (type_ == TYPE_ASAR) {
+  if (type_ == JobType::kAsar) {
     file_size = file_info_.size;
     read_offset = file_info_.offset;
   } else {

--- a/atom/browser/net/asar/url_request_asar_job.h
+++ b/atom/browser/net/asar/url_request_asar_job.h
@@ -66,10 +66,10 @@ class URLRequestAsarJob : public net::URLRequestJob {
 
  private:
   // The type of this job.
-  enum JobType {
-    TYPE_ERROR,
-    TYPE_ASAR,
-    TYPE_FILE,
+  enum class JobType {
+    kError,
+    kAsar,
+    kFile,
   };
 
   // Meta information about the file. It's used as a member in the
@@ -111,7 +111,7 @@ class URLRequestAsarJob : public net::URLRequestJob {
   // Callback after data is asynchronously read from the file into |buf|.
   void DidRead(scoped_refptr<net::IOBuffer> buf, int result);
 
-  JobType type_ = TYPE_ERROR;
+  JobType type_ = JobType::kError;
 
   std::shared_ptr<Archive> archive_;
   base::FilePath file_path_;

--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -157,7 +157,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (void)performClose:(id)sender {
   if (shell_->title_bar_style() ==
-      atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER) {
+      atom::NativeWindowMac::TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER) {
     [[self delegate] windowShouldClose:self];
   } else if (shell_->IsSimpleFullScreen()) {
     if ([[self delegate] respondsToSelector:@selector(windowShouldClose:)]) {
@@ -182,7 +182,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (void)performMiniaturize:(id)sender {
   if (shell_->title_bar_style() ==
-      atom::NativeWindowMac::CUSTOM_BUTTONS_ON_HOVER)
+      atom::NativeWindowMac::TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER)
     [self miniaturize:self];
   else
     [super performMiniaturize:sender];

--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -15,6 +15,8 @@
 #include "ui/views/widget/native_widget_mac.h"
 #include "ui/views_bridge_mac/bridged_native_widget_impl.h"
 
+using TitleBarStyle = atom::NativeWindowMac::TitleBarStyle;
+
 @implementation AtomNSWindowDelegate
 
 - (id)initWithShell:(atom::NativeWindowMac*)shell {
@@ -181,7 +183,7 @@
   shell_->SetResizable(true);
   // Hide the native toolbar before entering fullscreen, so there is no visual
   // artifacts.
-  if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+  if (shell_->title_bar_style() == TitleBarStyle::HIDDEN_INSET) {
     NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
     [window setToolbar:nil];
   }
@@ -198,14 +200,14 @@
       // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
       // fullscreen mode.
       // Show title if fullscreen_window_title flag is set
-      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+      (shell_->title_bar_style() != TitleBarStyle::HIDDEN_INSET ||
        shell_->fullscreen_window_title())) {
     [window setTitleVisibility:NSWindowTitleVisible];
   }
 
   // Restore the native toolbar immediately after entering fullscreen, if we
   // do this before leaving fullscreen, traffic light buttons will be jumping.
-  if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+  if (shell_->title_bar_style() == TitleBarStyle::HIDDEN_INSET) {
     base::scoped_nsobject<NSToolbar> toolbar(
         [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
     [toolbar setShowsBaselineSeparator:NO];
@@ -222,13 +224,13 @@
   // Restore the titlebar visibility.
   NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
   if ((shell_->transparent() || !shell_->has_frame()) &&
-      (shell_->title_bar_style() != atom::NativeWindowMac::HIDDEN_INSET ||
+      (shell_->title_bar_style() != TitleBarStyle::HIDDEN_INSET ||
        shell_->fullscreen_window_title())) {
     [window setTitleVisibility:NSWindowTitleHidden];
   }
 
   // Turn off the style for toolbar.
-  if (shell_->title_bar_style() == atom::NativeWindowMac::HIDDEN_INSET) {
+  if (shell_->title_bar_style() == TitleBarStyle::HIDDEN_INSET) {
     shell_->SetStyleMask(false, NSWindowStyleMaskFullSizeContentView);
     [window setTitlebarAppearsTransparent:YES];
   }

--- a/atom/browser/ui/message_box.h
+++ b/atom/browser/ui/message_box.h
@@ -19,12 +19,12 @@ namespace atom {
 
 class NativeWindow;
 
-enum MessageBoxType {
-  MESSAGE_BOX_TYPE_NONE = 0,
-  MESSAGE_BOX_TYPE_INFORMATION,
-  MESSAGE_BOX_TYPE_WARNING,
-  MESSAGE_BOX_TYPE_ERROR,
-  MESSAGE_BOX_TYPE_QUESTION,
+enum class MessageBoxType {
+  kNone = 0,
+  kInformation,
+  kWarning,
+  kError,
+  kQuestion,
 };
 
 enum MessageBoxOptions {

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -111,13 +111,13 @@ class GtkMessageBox : public NativeWindowObserver {
 
   GtkMessageType GetMessageType(MessageBoxType type) {
     switch (type) {
-      case MESSAGE_BOX_TYPE_INFORMATION:
+      case MessageBoxType::kInformation:
         return GTK_MESSAGE_INFO;
-      case MESSAGE_BOX_TYPE_WARNING:
+      case MessageBoxType::kWarning:
         return GTK_MESSAGE_WARNING;
-      case MESSAGE_BOX_TYPE_QUESTION:
+      case MessageBoxType::kQuestion:
         return GTK_MESSAGE_QUESTION;
-      case MESSAGE_BOX_TYPE_ERROR:
+      case MessageBoxType::kError:
         return GTK_MESSAGE_ERROR;
       default:
         return GTK_MESSAGE_OTHER;
@@ -235,7 +235,7 @@ void ShowMessageBox(NativeWindow* parent,
 
 void ShowErrorBox(const base::string16& title, const base::string16& content) {
   if (Browser::Get()->is_ready()) {
-    GtkMessageBox(nullptr, MESSAGE_BOX_TYPE_ERROR, {"OK"}, -1, 0, "Error",
+    GtkMessageBox(nullptr, MessageBoxType::kError, {"OK"}, -1, 0, "Error",
                   base::UTF16ToUTF8(title).c_str(),
                   base::UTF16ToUTF8(content).c_str(), "", false,
                   gfx::ImageSkia())

--- a/atom/browser/ui/message_box_mac.mm
+++ b/atom/browser/ui/message_box_mac.mm
@@ -38,11 +38,11 @@ NSAlert* CreateNSAlert(NativeWindow* parent_window,
   [alert setInformativeText:base::SysUTF8ToNSString(detail)];
 
   switch (type) {
-    case MESSAGE_BOX_TYPE_INFORMATION:
+    case MessageBoxType::kInformation:
       alert.alertStyle = NSInformationalAlertStyle;
       break;
-    case MESSAGE_BOX_TYPE_WARNING:
-    case MESSAGE_BOX_TYPE_ERROR:
+    case MessageBoxType::kWarning:
+    case MessageBoxType::kError:
       // NSWarningAlertStyle shows the app icon while NSCriticalAlertStyle
       // shows a warning icon with an app icon badge. Since there is no
       // error variant, lets just use NSCriticalAlertStyle.

--- a/atom/browser/ui/message_box_win.cc
+++ b/atom/browser/ui/message_box_win.cc
@@ -119,17 +119,17 @@ int ShowTaskDialogUTF16(NativeWindow* parent,
   } else {
     // Show icon according to dialog's type.
     switch (type) {
-      case MESSAGE_BOX_TYPE_INFORMATION:
-      case MESSAGE_BOX_TYPE_QUESTION:
+      case MessageBoxType::kInformation:
+      case MessageBoxType::kQuestion:
         config.pszMainIcon = TD_INFORMATION_ICON;
         break;
-      case MESSAGE_BOX_TYPE_WARNING:
+      case MessageBoxType::kWarning:
         config.pszMainIcon = TD_WARNING_ICON;
         break;
-      case MESSAGE_BOX_TYPE_ERROR:
+      case MessageBoxType::kError:
         config.pszMainIcon = TD_ERROR_ICON;
         break;
-      case MESSAGE_BOX_TYPE_NONE:
+      case MessageBoxType::kNone:
         break;
     }
   }
@@ -279,7 +279,7 @@ void ShowMessageBox(NativeWindow* parent,
 
 void ShowErrorBox(const base::string16& title, const base::string16& content) {
   atom::UnresponsiveSuppressor suppressor;
-  ShowTaskDialogUTF16(nullptr, MESSAGE_BOX_TYPE_ERROR, {}, -1, 0, 0, L"Error",
+  ShowTaskDialogUTF16(nullptr, MessageBoxType::kError, {}, -1, 0, 0, L"Error",
                       title, content, L"", nullptr, gfx::ImageSkia());
 }
 

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -40,7 +40,7 @@ class TrayIcon {
   virtual void SetToolTip(const std::string& tool_tip) = 0;
 
   // Sets the status icon highlight mode. This only works on macOS.
-  enum HighlightMode {
+  enum class HighlightMode {
     ALWAYS,    // Always highlight the tray icon
     NEVER,     // Never highlight the tray icon
     SELECTION  // Highlight the tray icon when clicked or the menu is opened

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -425,12 +425,13 @@ const CGFloat kVerticalTitleMargin = 2;
 }
 
 - (BOOL)shouldHighlight {
+  using HighlightMode = atom::TrayIcon::HighlightMode;
   switch (highlight_mode_) {
-    case atom::TrayIcon::HighlightMode::ALWAYS:
+    case HighlightMode::ALWAYS:
       return true;
-    case atom::TrayIcon::HighlightMode::NEVER:
+    case HighlightMode::NEVER:
       return false;
-    case atom::TrayIcon::HighlightMode::SELECTION:
+    case HighlightMode::SELECTION:
       BOOL isMenuOpen = menuController_ && [menuController_ isMenuOpen];
       return forceHighlight_ || inMouseEventSequence_ || isMenuOpen;
   }

--- a/atom/browser/ui/webui/pdf_viewer_handler.cc
+++ b/atom/browser/ui/webui/pdf_viewer_handler.cc
@@ -122,7 +122,7 @@ void PdfViewerHandler::Initialize(const base::ListValue* args) {
 
   auto zoom_controller =
       WebContentsZoomController::FromWebContents(web_ui()->GetWebContents());
-  zoom_controller->SetZoomMode(WebContentsZoomController::ZOOM_MODE_MANUAL);
+  zoom_controller->SetZoomMode(WebContentsZoomController::ZoomMode::MANUAL);
   zoom_controller->SetZoomLevel(0);
 }
 

--- a/atom/browser/ui/win/taskbar_host.cc
+++ b/atom/browser/ui/win/taskbar_host.cc
@@ -139,18 +139,18 @@ bool TaskbarHost::SetProgressBar(HWND window,
     return false;
 
   bool success;
-  if (value > 1.0 || state == NativeWindow::PROGRESS_INDETERMINATE) {
+  if (value > 1.0 || state == NativeWindow::ProgressState::kIndeterminate) {
     success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_INDETERMINATE));
-  } else if (value < 0 || state == NativeWindow::PROGRESS_NONE) {
+  } else if (value < 0 || state == NativeWindow::ProgressState::kNone) {
     success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_NOPROGRESS));
   } else {
     // Unless SetProgressState set a blocking state (TBPF_ERROR, TBPF_PAUSED)
     // for the window, a call to SetProgressValue assumes the TBPF_NORMAL
     // state even if it is not explicitly set.
     // SetProgressValue overrides and clears the TBPF_INDETERMINATE state.
-    if (state == NativeWindow::PROGRESS_ERROR) {
+    if (state == NativeWindow::ProgressState::kError) {
       success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_ERROR));
-    } else if (state == NativeWindow::PROGRESS_PAUSED) {
+    } else if (state == NativeWindow::ProgressState::kPaused) {
       success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_PAUSED));
     } else {
       success = SUCCEEDED(taskbar_->SetProgressState(window, TBPF_NORMAL));

--- a/atom/browser/web_contents_zoom_controller.h
+++ b/atom/browser/web_contents_zoom_controller.h
@@ -32,23 +32,23 @@ class WebContentsZoomController
   };
 
   // Defines how zoom changes are handled.
-  enum ZoomMode {
+  enum class ZoomMode {
     // Results in default zoom behavior, i.e. zoom changes are handled
     // automatically and on a per-origin basis, meaning that other tabs
     // navigated to the same origin will also zoom.
-    ZOOM_MODE_DEFAULT,
+    DEFAULT,
     // Results in zoom changes being handled automatically, but on a per-tab
     // basis. Tabs in this zoom mode will not be affected by zoom changes in
     // other tabs, and vice versa.
-    ZOOM_MODE_ISOLATED,
+    ISOLATED,
     // Overrides the automatic handling of zoom changes. The |onZoomChange|
     // event will still be dispatched, but the page will not actually be zoomed.
     // These zoom changes can be handled manually by listening for the
     // |onZoomChange| event. Zooming in this mode is also on a per-tab basis.
-    ZOOM_MODE_MANUAL,
+    MANUAL,
     // Disables all zooming in this tab. The tab will revert to the default
     // zoom level, and all attempted zoom changes will be ignored.
-    ZOOM_MODE_DISABLED,
+    DISABLED,
   };
 
   explicit WebContentsZoomController(content::WebContents* web_contents);
@@ -95,7 +95,7 @@ class WebContentsZoomController
   void SetZoomFactorOnNavigationIfNeeded(const GURL& url);
 
   // The current zoom mode.
-  ZoomMode zoom_mode_ = ZOOM_MODE_DEFAULT;
+  ZoomMode zoom_mode_ = ZoomMode::DEFAULT;
 
   // Current zoom level.
   double zoom_level_ = 1.0;

--- a/atom/common/node_bindings.h
+++ b/atom/common/node_bindings.h
@@ -77,7 +77,7 @@ class NodeBindings {
   void WakeupEmbedThread();
 
   // Which environment we are running.
-  BrowserEnvironment browser_env_;
+  const BrowserEnvironment browser_env_;
 
   // Current thread's MessageLoop.
   scoped_refptr<base::SingleThreadTaskRunner> task_runner_;

--- a/atom/common/node_bindings.h
+++ b/atom/common/node_bindings.h
@@ -25,7 +25,7 @@ namespace atom {
 
 class NodeBindings {
  public:
-  enum BrowserEnvironment {
+  enum class BrowserEnvironment {
     BROWSER,
     RENDERER,
     WORKER,

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -34,7 +34,8 @@ bool IsDevToolsExtension(content::RenderFrame* render_frame) {
 }  // namespace
 
 AtomRendererClient::AtomRendererClient()
-    : node_bindings_(NodeBindings::Create(NodeBindings::RENDERER)),
+    : node_bindings_(
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::RENDERER)),
       electron_bindings_(new ElectronBindings(uv_default_loop())) {}
 
 AtomRendererClient::~AtomRendererClient() {

--- a/atom/renderer/web_worker_observer.cc
+++ b/atom/renderer/web_worker_observer.cc
@@ -29,7 +29,8 @@ WebWorkerObserver* WebWorkerObserver::GetCurrent() {
 }
 
 WebWorkerObserver::WebWorkerObserver()
-    : node_bindings_(NodeBindings::Create(NodeBindings::WORKER)),
+    : node_bindings_(
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::WORKER)),
       electron_bindings_(new ElectronBindings(node_bindings_->uv_loop())) {
   lazy_tls.Pointer()->Set(this);
 }


### PR DESCRIPTION
#### Description of Change
Use C++11 enum classes for better type safety.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes