### PR TITLE
docs: add FAQ entry about subpixel anti-aliased text

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -168,6 +168,24 @@ is very likely you are using the module in the wrong process. For example
 `electron.app` can only be used in the main process, while `electron.webFrame`
 is only available in renderer processes.
 
+## The font looks blurry, what is this and what can i do?
+
+If [sub-pixel anti-aliasing](http://alienryderflex.com/sub_pixel/) is deactivated, then fonts on LCD screens can look blurry. Example:
+
+![subpixel rendering example](images/subpixel-rendering-screenshot.gif)
+
+Sub-pixel anti-aliasing needs a non-transparent background of the layer containing the font glyphs. (See [this issue](https://github.com/electron/electron/issues/6344#issuecomment-420371918) for more info).
+
+To achieve this goal, set the background in the constructor for [BrowserWindow][browser-window]:
+
+```javascript
+new BrowserWindow({backgroundColor: '#fff'});
+```
+
+The effect is visible only on (some?) LCD screens. Even if you dont see a difference, some of your users may. It is best to always set the background this way, unless you have reasons not to do so.
+
+Notice that just setting the background in the CSS does not have the desired effect.
+
 [memory-management]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_Management
 [variable-scope]: https://msdn.microsoft.com/library/bzt2dkta(v=vs.94).aspx
 [electron-module]: https://www.npmjs.com/package/electron
@@ -175,3 +193,4 @@ is only available in renderer processes.
 [local-storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
 [session-storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
 [indexed-db]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
+[browser-window]: api/browser-window.md

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -172,7 +172,7 @@ is only available in renderer processes.
 
 If [sub-pixel anti-aliasing](http://alienryderflex.com/sub_pixel/) is deactivated, then fonts on LCD screens can look blurry. Example:
 
-![subpixel rendering example](images/subpixel-rendering-screenshot.gif)
+![subpixel rendering example]
 
 Sub-pixel anti-aliasing needs a non-transparent background of the layer containing the font glyphs. (See [this issue](https://github.com/electron/electron/issues/6344#issuecomment-420371918) for more info).
 
@@ -197,3 +197,4 @@ Notice that just setting the background in the CSS does not have the desired eff
 [session-storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
 [indexed-db]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [browser-window]: api/browser-window.md
+[subpixel rendering example]: images/code_coverage_infra_diagram.png

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -179,7 +179,10 @@ Sub-pixel anti-aliasing needs a non-transparent background of the layer containi
 To achieve this goal, set the background in the constructor for [BrowserWindow][browser-window]:
 
 ```javascript
-new BrowserWindow({backgroundColor: '#fff'});
+const { BrowserWindow } = require('electron')
+let win = new BrowserWindow({
+  backgroundColor: '#fff'
+})
 ```
 
 The effect is visible only on (some?) LCD screens. Even if you dont see a difference, some of your users may. It is best to always set the background this way, unless you have reasons not to do so.


### PR DESCRIPTION
This is a redo of  #16459, which was authored by @heronils.  I closed that PR because I was trying to trigger lint by closing and reopening the PR, but the source repo had disappeared, thus the new PR:

#### docs: Add FAQ entry about subpixel anti-aliased text

Added an entry to docs/faq.md, which explains the reason for blurry looking fonts: A transparent font layer. It further explains how to fix it: By setting `backgroundColor` to a non-transparent color in the constructor of BrowserWindow. This will enable subpixel anti-aliased text and the font will stop looking blurry on LCD screens.

Resolves: #10955

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
