### PR TITLE
fix: do not mark navigations interupted with same-document navigations as aborted

### DIFF
--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -86,10 +86,16 @@ const NavigationController = (function () {
       let navigationStarted = false
       const navigationListener = (event, url, isSameDocument, isMainFrame, frameProcessId, frameRoutingId, navigationId) => {
         if (isMainFrame) {
-          if (navigationStarted) {
+          if (navigationStarted && !isSameDocument) {
             // the webcontents has started another unrelated navigation in the
             // main frame (probably from the app calling `loadURL` again); reject
             // the promise
+            // We should only consider the request aborted if the "navigation" is
+            // actually navigating and not simply transitioning URL state in the
+            // current context.  E.g. pushState and `location.hash` changes are
+            // considered navigation events but are triggered with isSameDocument.
+            // We can ignore these to allow virtual routing on page load as long
+            // as the routing does not leave the document
             return rejectAndCleanup(-3, 'ERR_ABORTED', url)
           }
           navigationStarted = true

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -289,6 +289,27 @@ describe('BrowserWindow module', () => {
       w.loadURL(`data:image/png;base64,${data}`)
     })
 
+    it('should return a promise', () => {
+      const p = w.loadURL('about:blank')
+      expect(p).to.have.property('then')
+    })
+
+    it('should return a promise that resolves', async () => {
+      expect(w.loadURL('about:blank')).to.eventually.be.fulfilled()
+    })
+
+    it('should return a promise that rejects on a load failure', async () => {
+      const data = Buffer.alloc(2 * 1024 * 1024).toString('base64')
+      const p = w.loadURL(`data:image/png;base64,${data}`)
+      await expect(p).to.eventually.be.rejected()
+    })
+
+    it('should return a promise that resolves even if pushState occurs during navigation', async () => {
+      const data = Buffer.alloc(2 * 1024 * 1024).toString('base64')
+      const p = w.loadURL('data:text/html,<script>window.history.pushState({}, "/foo")</script>')
+      await expect(p).to.eventually.be.fulfilled()
+    })
+
     describe('POST navigations', () => {
       afterEach(() => { w.webContents.session.webRequest.onBeforeSendHeaders(null) })
 


### PR DESCRIPTION
Fixes #17526 

This is probably the closest thing we can get to something that makes everyone happy.  Virtual navigations are now ignored, actually interrupting the `loadURL` call with another `loadURL` call still correctly rejects the first promise.

Notes: Fixed case where the promise returned by `loadURL` and `loadFile` would be rejected with `ERR_ABORTED` if you triggered a virtual navigation before the page had finished loading.  E.g. Used `history.pushState` or set `location.hash`