### PR TITLE
chore: remove use of base::GetProcId

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -777,38 +777,39 @@ void App::OnGpuProcessCrashed(base::TerminationStatus status) {
 
 void App::BrowserChildProcessLaunchedAndConnected(
     const content::ChildProcessData& data) {
-  ChildProcessLaunched(data.process_type, data.GetProcess().Handle());
+  ChildProcessLaunched(data.process_type, data.GetProcess().Handle(),
+                       data.GetProcess().Pid());
 }
 
 void App::BrowserChildProcessHostDisconnected(
     const content::ChildProcessData& data) {
-  ChildProcessDisconnected(base::GetProcId(data.GetProcess().Handle()));
+  ChildProcessDisconnected(data.GetProcess().Pid());
 }
 
 void App::BrowserChildProcessCrashed(
     const content::ChildProcessData& data,
     const content::ChildProcessTerminationInfo& info) {
-  ChildProcessDisconnected(base::GetProcId(data.GetProcess().Handle()));
+  ChildProcessDisconnected(data.GetProcess().Pid());
 }
 
 void App::BrowserChildProcessKilled(
     const content::ChildProcessData& data,
     const content::ChildProcessTerminationInfo& info) {
-  ChildProcessDisconnected(base::GetProcId(data.GetProcess().Handle()));
+  ChildProcessDisconnected(data.GetProcess().Pid());
 }
 
 void App::RenderProcessReady(content::RenderProcessHost* host) {
   ChildProcessLaunched(content::PROCESS_TYPE_RENDERER,
-                       host->GetProcess().Handle());
+                       host->GetProcess().Handle(), host->GetProcess().Pid());
 }
 
 void App::RenderProcessDisconnected(base::ProcessId host_pid) {
   ChildProcessDisconnected(host_pid);
 }
 
-void App::ChildProcessLaunched(int process_type, base::ProcessHandle handle) {
-  auto pid = base::GetProcId(handle);
-
+void App::ChildProcessLaunched(int process_type,
+                               base::ProcessHandle handle,
+                               base::ProcessId pid) {
 #if defined(OS_MACOSX)
   std::unique_ptr<base::ProcessMetrics> metrics(
       base::ProcessMetrics::CreateProcessMetrics(

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -173,7 +173,9 @@ class App : public AtomBrowserClient::Delegate,
 
  private:
   void SetAppPath(const base::FilePath& app_path);
-  void ChildProcessLaunched(int process_type, base::ProcessHandle handle);
+  void ChildProcessLaunched(int process_type,
+                            base::ProcessHandle handle,
+                            base::ProcessId pid);
   void ChildProcessDisconnected(base::ProcessId pid);
 
   void SetAppLogsPath(mate::Arguments* args);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/13218.

Removes use of `base::GetProcId` in favor of `Process::Pid()`.

cc @deepak1556 @miniak @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none