### PR TITLE
chore: convert base::Bind instances across some files

### DIFF
--- a/atom/browser/atom_blob_reader.cc
+++ b/atom/browser/atom_blob_reader.cc
@@ -81,8 +81,8 @@ void AtomBlobReader::BlobReadHelper::Read() {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   storage::BlobReader::Status size_status = blob_reader_->CalculateSize(
-      base::Bind(&AtomBlobReader::BlobReadHelper::DidCalculateSize,
-                 base::Unretained(this)));
+      base::BindOnce(&AtomBlobReader::BlobReadHelper::DidCalculateSize,
+                     base::Unretained(this)));
   if (size_status != storage::BlobReader::Status::IO_PENDING)
     DidCalculateSize(net::OK);
 }
@@ -100,8 +100,8 @@ void AtomBlobReader::BlobReadHelper::DidCalculateSize(int result) {
   scoped_refptr<net::IOBuffer> blob_data =
       new net::IOBuffer(static_cast<size_t>(total_size));
   auto callback =
-      base::Bind(&AtomBlobReader::BlobReadHelper::DidReadBlobData,
-                 base::Unretained(this), base::RetainedRef(blob_data));
+      base::BindRepeating(&AtomBlobReader::BlobReadHelper::DidReadBlobData,
+                          base::Unretained(this), base::RetainedRef(blob_data));
   storage::BlobReader::Status read_status =
       blob_reader_->Read(blob_data.get(), total_size, &bytes_read, callback);
   if (read_status != storage::BlobReader::Status::IO_PENDING)

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -124,11 +124,11 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
     atom::util::Promise dialog_promise(isolate);
     auto dialog_callback =
-        base::Bind(&AtomDownloadManagerDelegate::OnDownloadSaveDialogDone,
-                   base::Unretained(this), download_id, callback);
+        base::BindOnce(&AtomDownloadManagerDelegate::OnDownloadSaveDialogDone,
+                       base::Unretained(this), download_id, callback);
 
     file_dialog::ShowSaveDialog(settings, std::move(dialog_promise));
-    ignore_result(dialog_promise.Then(dialog_callback));
+    ignore_result(dialog_promise.Then(std::move(dialog_callback)));
   } else {
     callback.Run(path, download::DownloadItem::TARGET_DISPOSITION_PROMPT,
                  download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS, path,

--- a/atom/browser/lib/bluetooth_chooser.cc
+++ b/atom/browser/lib/bluetooth_chooser.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include "atom/browser/lib/bluetooth_chooser.h"
-#include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/native_mate_converters/once_callback.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "native_mate/dictionary.h"
 
@@ -70,7 +70,7 @@ void BluetoothChooser::ShowDiscoveryState(DiscoveryState state) {
       } else {
         bool prevent_default = api_web_contents_->Emit(
             "select-bluetooth-device", GetDeviceList(),
-            base::Bind(&OnDeviceChosen, event_handler_));
+            base::BindOnce(&OnDeviceChosen, event_handler_));
         if (!prevent_default) {
           auto it = device_map_.begin();
           auto device_id = it->first;
@@ -102,9 +102,9 @@ void BluetoothChooser::AddOrUpdateDevice(const std::string& device_id,
   if (changed) {
     // Emit a select-bluetooth-device handler to allow for user to listen for
     // bluetooth device found.
-    bool prevent_default =
-        api_web_contents_->Emit("select-bluetooth-device", GetDeviceList(),
-                                base::Bind(&OnDeviceChosen, event_handler_));
+    bool prevent_default = api_web_contents_->Emit(
+        "select-bluetooth-device", GetDeviceList(),
+        base::BindOnce(&OnDeviceChosen, event_handler_));
 
     // If emit not implimented select first device that matches the filters
     //  provided.

--- a/atom/browser/net/asar/url_request_asar_job.cc
+++ b/atom/browser/net/asar/url_request_asar_job.cc
@@ -131,8 +131,8 @@ int URLRequestAsarJob::ReadRawData(net::IOBuffer* dest, int dest_size) {
 
   int rv = stream_->Read(
       dest, dest_size,
-      base::Bind(&URLRequestAsarJob::DidRead, weak_ptr_factory_.GetWeakPtr(),
-                 WrapRefCounted(dest)));
+      base::BindOnce(&URLRequestAsarJob::DidRead,
+                     weak_ptr_factory_.GetWeakPtr(), WrapRefCounted(dest)));
   if (rv >= 0) {
     remaining_bytes_ -= rv;
     DCHECK_GE(remaining_bytes_, 0);
@@ -257,9 +257,9 @@ void URLRequestAsarJob::DidFetchMetaInfo(const FileMetaInfo* meta_info) {
 
   int flags =
       base::File::FLAG_OPEN | base::File::FLAG_READ | base::File::FLAG_ASYNC;
-  int rv = stream_->Open(
-      meta_info_.file_path, flags,
-      base::Bind(&URLRequestAsarJob::DidOpen, weak_ptr_factory_.GetWeakPtr()));
+  int rv = stream_->Open(meta_info_.file_path, flags,
+                         base::BindOnce(&URLRequestAsarJob::DidOpen,
+                                        weak_ptr_factory_.GetWeakPtr()));
   if (rv != net::ERR_IO_PENDING)
     DidOpen(rv);
 }
@@ -297,9 +297,9 @@ void URLRequestAsarJob::DidOpen(int result) {
   seek_offset_ = byte_range_.first_byte_position() + read_offset;
 
   if (remaining_bytes_ > 0 && seek_offset_ != 0) {
-    int rv =
-        stream_->Seek(seek_offset_, base::Bind(&URLRequestAsarJob::DidSeek,
-                                               weak_ptr_factory_.GetWeakPtr()));
+    int rv = stream_->Seek(seek_offset_,
+                           base::BindOnce(&URLRequestAsarJob::DidSeek,
+                                          weak_ptr_factory_.GetWeakPtr()));
     if (rv != net::ERR_IO_PENDING) {
       // stream_->Seek() failed, so pass an intentionally erroneous value
       // into DidSeek().

--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -66,7 +66,7 @@ WebContentsPermissionHelper::~WebContentsPermissionHelper() {}
 
 void WebContentsPermissionHelper::RequestPermission(
     content::PermissionType permission,
-    const base::Callback<void(bool)>& callback,
+    const base::RepeatingCallback<void(bool)>& callback,
     bool user_gesture,
     const base::DictionaryValue* details) {
   auto* rfh = web_contents_->GetMainFrame();
@@ -75,7 +75,7 @@ void WebContentsPermissionHelper::RequestPermission(
   auto origin = web_contents_->GetLastCommittedURL();
   permission_manager->RequestPermissionWithDetails(
       permission, rfh, origin, false, details,
-      base::Bind(&OnPermissionResponse, std::move(callback)));
+      base::BindRepeating(&OnPermissionResponse, callback));
 }
 
 bool WebContentsPermissionHelper::CheckPermission(
@@ -121,7 +121,7 @@ void WebContentsPermissionHelper::RequestMediaAccessPermission(
 }
 
 void WebContentsPermissionHelper::RequestWebNotificationPermission(
-    const base::Callback<void(bool)>& callback) {
+    const base::RepeatingCallback<void(bool)>& callback) {
   RequestPermission(content::PermissionType::NOTIFICATIONS, callback);
 }
 
@@ -129,11 +129,11 @@ void WebContentsPermissionHelper::RequestPointerLockPermission(
     bool user_gesture) {
   RequestPermission(
       static_cast<content::PermissionType>(PermissionType::POINTER_LOCK),
-      base::Bind(&OnPointerLockResponse, web_contents_), user_gesture);
+      base::BindRepeating(&OnPointerLockResponse, web_contents_), user_gesture);
 }
 
 void WebContentsPermissionHelper::RequestOpenExternalPermission(
-    const base::Callback<void(bool)>& callback,
+    const base::RepeatingCallback<void(bool)>& callback,
     bool user_gesture,
     const GURL& url) {
   base::DictionaryValue details;

--- a/atom/browser/web_contents_permission_helper.h
+++ b/atom/browser/web_contents_permission_helper.h
@@ -25,15 +25,17 @@ class WebContentsPermissionHelper
   };
 
   // Asynchronous Requests
-  void RequestFullscreenPermission(const base::Callback<void(bool)>& callback);
+  void RequestFullscreenPermission(
+      const base::RepeatingCallback<void(bool)>& callback);
   void RequestMediaAccessPermission(const content::MediaStreamRequest& request,
                                     content::MediaResponseCallback callback);
   void RequestWebNotificationPermission(
-      const base::Callback<void(bool)>& callback);
+      const base::RepeatingCallback<void(bool)>& callback);
   void RequestPointerLockPermission(bool user_gesture);
-  void RequestOpenExternalPermission(const base::Callback<void(bool)>& callback,
-                                     bool user_gesture,
-                                     const GURL& url);
+  void RequestOpenExternalPermission(
+      const base::RepeatingCallback<void(bool)>& callback,
+      bool user_gesture,
+      const GURL& url);
 
   // Synchronous Checks
   bool CheckMediaAccessPermission(const GURL& security_origin,
@@ -44,7 +46,7 @@ class WebContentsPermissionHelper
   friend class content::WebContentsUserData<WebContentsPermissionHelper>;
 
   void RequestPermission(content::PermissionType permission,
-                         const base::Callback<void(bool)>& callback,
+                         const base::RepeatingCallback<void(bool)>& callback,
                          bool user_gesture = false,
                          const base::DictionaryValue* details = nullptr);
 

--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -52,8 +52,8 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
     atom::util::Promise promise(isolate);
 
     file_dialog::ShowOpenDialog(settings, std::move(promise));
-    auto callback = base::Bind(&FileSelectHelper::OnOpenDialogDone, this);
-    ignore_result(promise.Then(callback));
+    auto callback = base::BindOnce(&FileSelectHelper::OnOpenDialogDone, this);
+    ignore_result(promise.Then(std::move(callback)));
   }
 
   void ShowSaveDialog(const file_dialog::DialogSettings& settings) {

--- a/atom/common/promise_util.h
+++ b/atom/common/promise_util.h
@@ -10,6 +10,7 @@
 
 #include "atom/common/api/locker.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/native_mate_converters/once_callback.h"
 #include "base/task/post_task.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -104,7 +105,8 @@ class Promise {
   }
 
   template <typename ReturnType, typename... ArgTypes>
-  v8::MaybeLocal<v8::Promise> Then(base::Callback<ReturnType(ArgTypes...)> cb) {
+  v8::MaybeLocal<v8::Promise> Then(
+      base::OnceCallback<ReturnType(ArgTypes...)> cb) {
     v8::HandleScope handle_scope(isolate());
     v8::Context::Scope context_scope(
         v8::Local<v8::Context>::New(isolate(), GetContext()));


### PR DESCRIPTION
#### Description of Change

More progressive `base::Bind` conversion.

cc @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
