### PR TITLE
refactor: nws13n: session.allowNTLMCredentialsForDomains

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -22,6 +22,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/media/media_device_id_salt.h"
 #include "atom/browser/net/atom_cert_verifier.h"
+#include "atom/browser/net/system_network_context_manager.h"
 #include "atom/browser/session_preferences.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/content_converter.h"
@@ -492,12 +493,8 @@ v8::Local<v8::Promise> Session::ClearAuthCache() {
 }
 
 void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
-  auto* command_line = base::CommandLine::ForCurrentProcess();
-
-  auto auth_params = ::network::mojom::HttpAuthDynamicParams::New();
+  auto auth_params = CreateHttpAuthDynamicParams();
   auth_params->server_whitelist = domains;
-  auth_params->delegate_whitelist = command_line->GetSwitchValueASCII(
-      atom::switches::kAuthNegotiateDelegateWhitelist);
   content::GetNetworkService()->ConfigureHttpAuthPrefs(std::move(auth_params));
 }
 

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -30,6 +30,7 @@
 #include "atom/common/native_mate_converters/net_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
+#include "atom/common/options_switches.h"
 #include "base/files/file_path.h"
 #include "base/guid.h"
 #include "base/strings/string_number_conversions.h"
@@ -46,6 +47,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/download_item_utils.h"
 #include "content/public/browser/download_manager_delegate.h"
+#include "content/public/browser/network_service_instance.h"
 #include "content/public/browser/storage_partition.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
@@ -177,17 +179,6 @@ void SetCertVerifyProcInIO(
       ->SetVerifyProc(proc);
 }
 
-void AllowNTLMCredentialsForDomainsInIO(
-    const scoped_refptr<net::URLRequestContextGetter>& context_getter,
-    const std::string& domains) {
-  auto* request_context = context_getter->GetURLRequestContext();
-  auto* auth_handler = request_context->http_auth_handler_factory();
-  if (auth_handler) {
-    auto* auth_preferences = const_cast<net::HttpAuthPreferences*>(
-        auth_handler->http_auth_preferences());
-    if (auth_preferences)
-      auth_preferences->SetServerWhitelist(domains);
-  }
 }
 
 void DownloadIdCallback(content::DownloadManager* download_manager,
@@ -503,11 +494,13 @@ v8::Local<v8::Promise> Session::ClearAuthCache() {
 }
 
 void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
-  base::PostTaskWithTraits(
-      FROM_HERE, {BrowserThread::IO},
-      base::BindOnce(&AllowNTLMCredentialsForDomainsInIO,
-                     WrapRefCounted(browser_context_->GetRequestContext()),
-                     domains));
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+
+  auto auth_params = ::network::mojom::HttpAuthDynamicParams::New();
+  auth_params->server_whitelist = domains;
+  auth_params->delegate_whitelist = command_line->GetSwitchValueASCII(
+      atom::switches::kAuthNegotiateDelegateWhitelist);
+  content::GetNetworkService()->ConfigureHttpAuthPrefs(std::move(auth_params));
 }
 
 void Session::SetUserAgent(const std::string& user_agent,

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -179,8 +179,6 @@ void SetCertVerifyProcInIO(
       ->SetVerifyProc(proc);
 }
 
-}
-
 void DownloadIdCallback(content::DownloadManager* download_manager,
                         const base::FilePath& path,
                         const std::vector<GURL>& url_chain,

--- a/atom/browser/net/system_network_context_manager.cc
+++ b/atom/browser/net/system_network_context_manager.cc
@@ -42,6 +42,10 @@ network::mojom::HttpAuthStaticParamsPtr CreateHttpAuthStaticParams() {
   return auth_static_params;
 }
 
+}  // namespace
+
+namespace atom {
+
 network::mojom::HttpAuthDynamicParamsPtr CreateHttpAuthDynamicParams() {
   auto* command_line = base::CommandLine::ForCurrentProcess();
   network::mojom::HttpAuthDynamicParamsPtr auth_dynamic_params =
@@ -57,7 +61,7 @@ network::mojom::HttpAuthDynamicParamsPtr CreateHttpAuthDynamicParams() {
   return auth_dynamic_params;
 }
 
-}  // namespace
+}  // namespace atom
 
 // SharedURLLoaderFactory backed by a SystemNetworkContextManager and its
 // network context. Transparently handles crashes.
@@ -192,7 +196,7 @@ void SystemNetworkContextManager::SetUp(
     *network_context_params = CreateDefaultNetworkContextParams();
   }
   *http_auth_static_params = CreateHttpAuthStaticParams();
-  *http_auth_dynamic_params = CreateHttpAuthDynamicParams();
+  *http_auth_dynamic_params = atom::CreateHttpAuthDynamicParams();
 }
 
 // static
@@ -231,7 +235,7 @@ void SystemNetworkContextManager::OnNetworkServiceCreated(
     return;
 
   network_service->SetUpHttpAuth(CreateHttpAuthStaticParams());
-  network_service->ConfigureHttpAuthPrefs(CreateHttpAuthDynamicParams());
+  network_service->ConfigureHttpAuthPrefs(atom::CreateHttpAuthDynamicParams());
 
   // The system NetworkContext must be created first, since it sets
   // |primary_network_context| to true.

--- a/atom/browser/net/system_network_context_manager.h
+++ b/atom/browser/net/system_network_context_manager.h
@@ -27,6 +27,10 @@ namespace net_log {
 class NetExportFileWriter;
 }
 
+namespace atom {
+network::mojom::HttpAuthDynamicParamsPtr CreateHttpAuthDynamicParams();
+}
+
 // Responsible for creating and managing access to the system NetworkContext.
 // Lives on the UI thread. The NetworkContext this owns is intended for requests
 // not associated with a session. It stores no data on disk, and has no HTTP


### PR DESCRIPTION
#### Description of Change
Refactors `session.allowNTLMCredentialsForDomains` to use the network service.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes