### PR TITLE
chore: deprecate the 'options' argument to clearAuthCache

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -548,9 +548,13 @@ Clears the session’s HTTP authentication cache.
 
 **[Deprecated Soon](modernization/promisification.md)**
 
-#### `ses.clearAuthCache(options)`
+#### `ses.clearAuthCache(options)` _(deprecated)_
 
 * `options` ([RemovePassword](structures/remove-password.md) | [RemoveClientCertificate](structures/remove-client-certificate.md))
+
+Returns `Promise<void>` - resolves when the session’s HTTP authentication cache has been cleared.
+
+#### `ses.clearAuthCache()`
 
 Returns `Promise<void>` - resolves when the session’s HTTP authentication cache has been cleared.
 

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -31,11 +31,11 @@ Session.prototype.getCacheSize = deprecate.promisify(Session.prototype.getCacheS
 Session.prototype.clearCache = deprecate.promisify(Session.prototype.clearCache)
 Session.prototype.clearAuthCache = deprecate.promisify(Session.prototype.clearAuthCache)
 Session.prototype.getBlobData = deprecate.promisifyMultiArg(Session.prototype.getBlobData)
-Session.prototype.clearAuthCache = ((clearAuthCache) => function (options) {
-  if (arguments.length > 0) {
+Session.prototype.clearAuthCache = ((clearAuthCache) => function (...args) {
+  if (args.length > 0) {
     deprecate.log(`The 'options' argument to 'clearAuthCache' is deprecated. Beginning with Electron 7, clearAuthCache will clear the entire auth cache unconditionally.`)
   }
-  return clearAuthCache.call(this, options)
+  return clearAuthCache.apply(this, args)
 })(Session.prototype.clearAuthCache)
 
 Cookies.prototype.flushStore = deprecate.promisify(Cookies.prototype.flushStore)

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -35,7 +35,7 @@ Session.prototype.clearAuthCache = ((clearAuthCache) => function (options) {
   if (arguments.length > 0) {
     deprecate.log(`The 'options' argument to 'clearAuthCache' is deprecated. Beginning with Electron 7, clearAuthCache will clear the entire auth cache unconditionally.`)
   }
-  clearAuthCache.call(this, options)
+  return clearAuthCache.call(this, options)
 })(Session.prototype.clearAuthCache)
 
 Cookies.prototype.flushStore = deprecate.promisify(Cookies.prototype.flushStore)

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -31,6 +31,12 @@ Session.prototype.getCacheSize = deprecate.promisify(Session.prototype.getCacheS
 Session.prototype.clearCache = deprecate.promisify(Session.prototype.clearCache)
 Session.prototype.clearAuthCache = deprecate.promisify(Session.prototype.clearAuthCache)
 Session.prototype.getBlobData = deprecate.promisifyMultiArg(Session.prototype.getBlobData)
+Session.prototype.clearAuthCache = ((clearAuthCache) => function (options) {
+  if (arguments.length > 0) {
+    deprecate.log(`The 'options' argument to 'clearAuthCache' is deprecated. Beginning with Electron 7, clearAuthCache will clear the entire auth cache unconditionally.`)
+  }
+  clearAuthCache.call(this, options)
+})(Session.prototype.clearAuthCache)
 
 Cookies.prototype.flushStore = deprecate.promisify(Cookies.prototype.flushStore)
 Cookies.prototype.get = deprecate.promisify(Cookies.prototype.get)


### PR DESCRIPTION
#### Description of Change
The network service APIs do not support the fine-grained clearing of the auth cache. In preparation for switching to the network service in 7.x, log a warning that the options argument is deprecated. Ref #17970.

This might not be quite right as we could also potentially expose the new options that are available: namely, start and end time. #17970 does not expose those options, but it would in theory be possible to support them with the existing network service APIs. The current options object does not offer time-based cache clearing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Deprecated the options argument to session.clearAuthCache.
