### PR TITLE
feat: add a tabbingIdentifier property on windows

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -1022,6 +1022,16 @@ void TopLevelWindow::RemoveFromParentChildWindows() {
   parent->child_windows_.Remove(weak_map_id());
 }
 
+v8::Local<v8::Value> TopLevelWindow::GetTabbingIdentifier() {
+#if defined(OS_MACOSX)
+  std::string identifier = window_->GetTabbingIdentifier();
+  if (!identifier.empty()) {
+    return mate::ConvertToV8(isolate(), identifier);
+  }
+#endif
+  return v8::Undefined(isolate());
+}
+
 // static
 mate::WrappableBase* TopLevelWindow::New(mate::Arguments* args) {
   mate::Dictionary options;
@@ -1174,7 +1184,8 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setThumbnailToolTip", &TopLevelWindow::SetThumbnailToolTip)
       .SetMethod("setAppDetails", &TopLevelWindow::SetAppDetails)
 #endif
-      .SetProperty("id", &TopLevelWindow::GetID);
+      .SetProperty("id", &TopLevelWindow::GetID)
+      .SetProperty("tabbingIdentifier", &TopLevelWindow::GetTabbingIdentifier);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -197,6 +197,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
   void PreviewFile(const std::string& path, mate::Arguments* args);
   void CloseFilePreview();
+  v8::Local<v8::Value> GetTabbingIdentifier();
 
   // Public getters of NativeWindow.
   v8::Local<v8::Value> GetContentView() const;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -235,6 +235,10 @@ class NativeWindow : public base::SupportsUserData,
       content::WebContents*,
       const content::NativeWebKeyboardEvent& event) {}
 
+#if defined(OS_MACOSX)
+  virtual const std::string GetTabbingIdentifier() const = 0;
+#endif
+
   // Public API used by platform-dependent delegates and observers to send UI
   // related notifications.
   void NotifyWindowRequestPreferredWith(int* width);

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -127,6 +127,7 @@ class NativeWindowMac : public NativeWindow {
   void MoveTabToNewWindow() override;
   void ToggleTabBar() override;
   bool AddTabbedWindow(NativeWindow* window) override;
+  const std::string GetTabbingIdentifier() const override;
 
   bool SetWindowButtonVisibility(bool visible) override;
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -151,7 +151,7 @@
 
 #if !defined(AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER)
 
-enum { NSWindowTabbingModeDisallowed = 2 };
+enum { NSWindowTabbingModeAutomatic = 0, NSWindowTabbingModeDisallowed = 2 };
 
 @interface NSWindow (SierraSDK)
 - (void)setTabbingMode:(NSInteger)mode;
@@ -1509,6 +1509,20 @@ void NativeWindowMac::SetCollectionBehavior(bool on, NSUInteger flag) {
   // Change collectionBehavior will make the zoom button revert to default,
   // probably a bug of Cocoa or macOS.
   SetMaximizable(was_maximizable);
+}
+
+const std::string NativeWindowMac::GetTabbingIdentifier() const {
+  if (@available(macOS 10.12, *)) {
+    NSString* current_identifier = [window_ tabbingIdentifier];
+    // If tabbing is disabled even though macOS has a default tabbingIdentifier
+    // we should return undefined here
+    if (current_identifier == nil ||
+        [window_ tabbingMode] == NSWindowTabbingModeDisallowed)
+      return "";
+
+    return base::SysNSStringToUTF8(current_identifier);
+  }
+  return "";
 }
 
 // static

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -728,29 +728,6 @@ console.log(installed)
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-### Instance Properties
-
-Objects created with `new BrowserWindow` have the following properties:
-
-```javascript
-const { BrowserWindow } = require('electron')
-// In this example `win` is our instance
-let win = new BrowserWindow({ width: 800, height: 600 })
-win.loadURL('https://github.com')
-```
-
-#### `win.webContents`
-
-A `WebContents` object this window owns. All web page related events and
-operations will be done via it.
-
-See the [`webContents` documentation](web-contents.md) for its methods and
-events.
-
-#### `win.id`
-
-A `Integer` representing the unique ID of the window.
-
 ### Instance Methods
 
 Objects created with `new BrowserWindow` have the following instance methods:
@@ -1638,7 +1615,33 @@ removed in future Electron releases.
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment
 
-### Properties
+### Instance Properties
+
+Objects created with `new BrowserWindow` have the following properties:
+
+```javascript
+const { BrowserWindow } = require('electron')
+// In this example `win` is our instance
+let win = new BrowserWindow({ width: 800, height: 600 })
+win.loadURL('https://github.com')
+```
+
+#### `win.webContents`
+
+A `WebContents` object this window owns. All web page related events and
+operations will be done via it.
+
+See the [`webContents` documentation](web-contents.md) for its methods and
+events.
+
+#### `win.id`
+
+A `Integer` representing the unique ID of the window.
+
+#### `win.tabbingIdentififer` _macOS_ _readonly_
+
+A `String` (optional) property that is equal to the `tabbingIdentifier` you
+provided in the constructor.
 
 #### `win.excludedFromShownWindowsMenu` _macOS_
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1314,6 +1314,32 @@ describe('BrowserWindow module', () => {
         frame: false
       })
     })
+
+    it('can be read off a window', () => {
+      expect(w.tabbingIdentifier).to.equal(undefined)
+      w.destroy()
+      w = new BrowserWindow({
+        tabbingIdentifier: 'group1',
+        show: false
+      })
+      expect(w.tabbingIdentifier).to.equal('group1')
+      w.destroy()
+      w = new BrowserWindow({
+        tabbingIdentifier: 'group2',
+        show: false
+      })
+      expect(w.tabbingIdentifier).to.equal('group2')
+    })
+
+    it('is ignored is the window is frameless', () => {
+      w.destroy()
+      w = new BrowserWindow({
+        tabbingIdentifier: 'group1',
+        show: false,
+        frame: false
+      })
+      expect(w.tabbingIdentifier).to.equal(undefined)
+    })
   })
 
   describe('"webPreferences" option', () => {


### PR DESCRIPTION
Closes #18138

Notes: Added a new `tabbingIdentifier` property on `BrowserWindow`'s to allow reading the current identifier at runtime.