### PR TITLE
fix: crash on systemPreferences.getAccentColor()

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -16,6 +16,7 @@
 
 #include "atom/browser/mac/atom_application.h"
 #include "atom/browser/mac/dict_util.h"
+#include "atom/browser/ui/cocoa/NSColor+Hex.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "base/mac/scoped_cftyperef.h"
@@ -112,21 +113,6 @@ std::string ConvertAuthorizationStatus(AVAuthorizationStatusMac status) {
     default:
       return "unknown";
   }
-}
-
-// Convert color to RGBA value like "aabbccdd"
-std::string ToRGBA(NSColor* color) {
-  return base::StringPrintf(
-      "%02X%02X%02X%02X", (int)(color.redComponent * 0xFF),
-      (int)(color.greenComponent * 0xFF), (int)(color.blueComponent * 0xFF),
-      (int)(color.alphaComponent * 0xFF));
-}
-
-// Convert color to RGB hex value like "#ABCDEF"
-std::string ToRGBHex(NSColor* color) {
-  return base::StringPrintf("#%02X%02X%02X", (int)(color.redComponent * 0xFF),
-                            (int)(color.greenComponent * 0xFF),
-                            (int)(color.blueComponent * 0xFF));
 }
 
 }  // namespace
@@ -408,7 +394,7 @@ std::string SystemPreferences::GetAccentColor() {
   if (@available(macOS 10.14, *))
     sysColor = [NSColor controlAccentColor];
 
-  return ToRGBA(sysColor);
+  return base::SysNSStringToUTF8([sysColor RGBAValue]);
 }
 
 std::string SystemPreferences::GetSystemColor(const std::string& color,
@@ -437,7 +423,7 @@ std::string SystemPreferences::GetSystemColor(const std::string& color,
     return "";
   }
 
-  return ToRGBHex(sysColor);
+  return base::SysNSStringToUTF8([sysColor hexadecimalValue]);
 }
 
 bool SystemPreferences::CanPromptTouchID() {
@@ -590,7 +576,7 @@ std::string SystemPreferences::GetColor(const std::string& color,
     return "";
   }
 
-  return ToRGBHex(sysColor);
+  return base::SysNSStringToUTF8([sysColor hexadecimalValue]);
 }
 
 std::string SystemPreferences::GetMediaAccessStatus(

--- a/atom/browser/ui/cocoa/NSColor+Hex.h
+++ b/atom/browser/ui/cocoa/NSColor+Hex.h
@@ -10,6 +10,8 @@
 #import <Cocoa/Cocoa.h>
 
 @interface NSColor (Hex)
+- (NSString*)hexadecimalValue;
+- (NSString*)RGBAValue;
 + (NSColor*)colorWithHexColorString:(NSString*)hex;
 @end
 

--- a/atom/browser/ui/cocoa/NSColor+Hex.mm
+++ b/atom/browser/ui/cocoa/NSColor+Hex.mm
@@ -8,17 +8,65 @@
 
 @implementation NSColor (Hex)
 
+- (NSString*)RGBAValue {
+  double redFloatValue, greenFloatValue, blueFloatValue, alphaFloatValue;
+
+  NSColor* convertedColor =
+      [self colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+
+  if (convertedColor) {
+    [convertedColor getRed:&redFloatValue
+                     green:&greenFloatValue
+                      blue:&blueFloatValue
+                     alpha:&alphaFloatValue];
+
+    int redIntValue = redFloatValue * 255.99999f;
+    int greenIntValue = greenFloatValue * 255.99999f;
+    int blueIntValue = blueFloatValue * 255.99999f;
+    int alphaIntValue = alphaFloatValue * 255.99999f;
+
+    return
+        [NSString stringWithFormat:@"%02x%02x%02x%02x", redIntValue,
+                                   greenIntValue, blueIntValue, alphaIntValue];
+  }
+
+  return nil;
+}
+
+- (NSString*)hexadecimalValue {
+  double redFloatValue, greenFloatValue, blueFloatValue;
+
+  NSColor* convertedColor =
+      [self colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+
+  if (convertedColor) {
+    [convertedColor getRed:&redFloatValue
+                     green:&greenFloatValue
+                      blue:&blueFloatValue
+                     alpha:NULL];
+
+    int redIntValue = redFloatValue * 255.99999f;
+    int greenIntValue = greenFloatValue * 255.99999f;
+    int blueIntValue = blueFloatValue * 255.99999f;
+
+    return [NSString stringWithFormat:@"#%02x%02x%02x", redIntValue,
+                                      greenIntValue, blueIntValue];
+  }
+
+  return nil;
+}
+
 + (NSColor*)colorWithHexColorString:(NSString*)inColorString {
   unsigned colorCode = 0;
-  unsigned char redByte, greenByte, blueByte;
 
   if (inColorString) {
     NSScanner* scanner = [NSScanner scannerWithString:inColorString];
     (void)[scanner scanHexInt:&colorCode];  // ignore error
   }
-  redByte = (unsigned char)(colorCode >> 16);
-  greenByte = (unsigned char)(colorCode >> 8);
-  blueByte = (unsigned char)(colorCode);  // masks off high bits
+
+  unsigned char redByte = (unsigned char)(colorCode >> 16);
+  unsigned char greenByte = (unsigned char)(colorCode >> 8);
+  unsigned char blueByte = (unsigned char)(colorCode);  // masks off high bits
 
   return [NSColor colorWithCalibratedRed:(CGFloat)redByte / 0xff
                                    green:(CGFloat)greenByte / 0xff


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/18140.

Fixes a crash in `systemPreferences.getAccentColor()` by properly implementing `hexadecimalValue` on `NSColor` instead of using a helper that doesn't account for potential nullptrs.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in `systemPreferences.getAccentColor()`.
