### PR TITLE
refactor: eliminate duplicate code in asar.js

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -308,107 +308,67 @@
 
     fs.promises.stat = util.promisify(fs.stat)
 
-    const { realpathSync } = fs
-    fs.realpathSync = function (pathArgument, options) {
-      const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return realpathSync.apply(this, arguments)
+    const wrapRealpathSync = function (realpathSync) {
+      return function (pathArgument, options) {
+        const { isAsar, asarPath, filePath } = splitPath(pathArgument)
+        if (!isAsar) return realpathSync.apply(this, arguments)
 
-      const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        throw createError(AsarError.INVALID_ARCHIVE, { asarPath })
+        const archive = getOrCreateArchive(asarPath)
+        if (!archive) {
+          throw createError(AsarError.INVALID_ARCHIVE, { asarPath })
+        }
+
+        const fileRealPath = archive.realpath(filePath)
+        if (fileRealPath === false) {
+          throw createError(AsarError.NOT_FOUND, { asarPath, filePath })
+        }
+
+        return path.join(realpathSync(asarPath, options), fileRealPath)
       }
-
-      const fileRealPath = archive.realpath(filePath)
-      if (fileRealPath === false) {
-        throw createError(AsarError.NOT_FOUND, { asarPath, filePath })
-      }
-
-      return path.join(realpathSync(asarPath, options), fileRealPath)
     }
 
-    fs.realpathSync.native = function (pathArgument, options) {
-      const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return realpathSync.native.apply(this, arguments)
+    const { realpathSync } = fs
+    fs.realpathSync = wrapRealpathSync(realpathSync)
+    fs.realpathSync.native = wrapRealpathSync(realpathSync.native)
 
-      const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        throw createError(AsarError.INVALID_ARCHIVE, { asarPath })
+    const wrapRealpath = function (realpath) {
+      return function (pathArgument, options, callback) {
+        const { isAsar, asarPath, filePath } = splitPath(pathArgument)
+        if (!isAsar) return realpath.apply(this, arguments)
+
+        if (arguments.length < 3) {
+          callback = options
+          options = {}
+        }
+
+        const archive = getOrCreateArchive(asarPath)
+        if (!archive) {
+          const error = createError(AsarError.INVALID_ARCHIVE, { asarPath })
+          nextTick(callback, [error])
+          return
+        }
+
+        const fileRealPath = archive.realpath(filePath)
+        if (fileRealPath === false) {
+          const error = createError(AsarError.NOT_FOUND, { asarPath, filePath })
+          nextTick(callback, [error])
+          return
+        }
+
+        realpath(asarPath, options, (error, archiveRealPath) => {
+          if (error === null) {
+            const fullPath = path.join(archiveRealPath, fileRealPath)
+            callback(null, fullPath)
+          } else {
+            callback(error)
+          }
+        })
       }
-
-      const fileRealPath = archive.realpath(filePath)
-      if (fileRealPath === false) {
-        throw createError(AsarError.NOT_FOUND, { asarPath, filePath })
-      }
-
-      return path.join(realpathSync.native(asarPath, options), fileRealPath)
     }
 
     const { realpath } = fs
-    fs.realpath = function (pathArgument, options, callback) {
-      const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return realpath.apply(this, arguments)
-
-      if (arguments.length < 3) {
-        callback = options
-        options = {}
-      }
-
-      const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        const error = createError(AsarError.INVALID_ARCHIVE, { asarPath })
-        nextTick(callback, [error])
-        return
-      }
-
-      const fileRealPath = archive.realpath(filePath)
-      if (fileRealPath === false) {
-        const error = createError(AsarError.NOT_FOUND, { asarPath, filePath })
-        nextTick(callback, [error])
-        return
-      }
-
-      realpath(asarPath, options, (error, archiveRealPath) => {
-        if (error === null) {
-          const fullPath = path.join(archiveRealPath, fileRealPath)
-          callback(null, fullPath)
-        } else {
-          callback(error)
-        }
-      })
-    }
-
-    fs.realpath.native = function (pathArgument, options, callback) {
-      const { isAsar, asarPath, filePath } = splitPath(pathArgument)
-      if (!isAsar) return realpath.native.apply(this, arguments)
-
-      if (arguments.length < 3) {
-        callback = options
-        options = {}
-      }
-
-      const archive = getOrCreateArchive(asarPath)
-      if (!archive) {
-        const error = createError(AsarError.INVALID_ARCHIVE, { asarPath })
-        nextTick(callback, [error])
-        return
-      }
-
-      const fileRealPath = archive.realpath(filePath)
-      if (fileRealPath === false) {
-        const error = createError(AsarError.NOT_FOUND, { asarPath, filePath })
-        nextTick(callback, [error])
-        return
-      }
-
-      realpath.native(asarPath, options, (error, archiveRealPath) => {
-        if (error === null) {
-          const fullPath = path.join(archiveRealPath, fileRealPath)
-          callback(null, fullPath)
-        } else {
-          callback(error)
-        }
-      })
-    }
+    fs.realpath = wrapRealpath(realpath)
+    fs.realpath.native = wrapRealpath(realpath.native)
 
     fs.promises.realpath = util.promisify(fs.realpath.native)
 


### PR DESCRIPTION
#### Description of Change
Merge identical implementations of:
- `fs.realpath` / `fs.realpath.native`
- `fs.realpathSync` / `fs.realpathSync.native`

Pass the original function as argument to the wrapper creator.
Use "Hide whitespace changes" when reviewing.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes