### PR TITLE
feat: allow setting working directory in app.setUserTasks() / app.setJumpList()

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -85,6 +85,7 @@ struct Converter<Browser::UserTask> {
       return false;
     dict.Get("arguments", &(out->arguments));
     dict.Get("description", &(out->description));
+    dict.Get("workingDirectory", &(out->working_dir));
     return true;
   }
 };
@@ -158,6 +159,7 @@ struct Converter<JumpListItem> {
 
         dict.Get("args", &(out->arguments));
         dict.Get("description", &(out->description));
+        dict.Get("workingDirectory", &(out->working_dir));
         return true;
 
       case JumpListItem::Type::SEPARATOR:
@@ -184,6 +186,7 @@ struct Converter<JumpListItem> {
         dict.Set("iconPath", val.icon_path);
         dict.Set("iconIndex", val.icon_index);
         dict.Set("description", val.description);
+        dict.Set("workingDirectory", val.working_dir);
         break;
 
       case JumpListItem::Type::SEPARATOR:

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -197,6 +197,7 @@ class Browser : public WindowListObserver {
     base::string16 arguments;
     base::string16 title;
     base::string16 description;
+    base::FilePath working_dir;
     base::FilePath icon_path;
     int icon_index;
 

--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -141,6 +141,7 @@ bool Browser::SetUserTasks(const std::vector<UserTask>& tasks) {
     item.icon_path = task.icon_path;
     item.icon_index = task.icon_index;
     item.description = task.description;
+    item.working_dir = task.working_dir;
     category.items.push_back(item);
   }
 

--- a/atom/browser/ui/win/jump_list.cc
+++ b/atom/browser/ui/win/jump_list.cc
@@ -23,6 +23,7 @@ bool AppendTask(const JumpListItem& item, IObjectCollection* collection) {
   if (FAILED(link.CoCreateInstance(CLSID_ShellLink)) ||
       FAILED(link->SetPath(item.path.value().c_str())) ||
       FAILED(link->SetArguments(item.arguments.c_str())) ||
+      FAILED(link->SetWorkingDirectory(item.working_dir.value().c_str())) ||
       FAILED(link->SetDescription(item.description.c_str())))
     return false;
 
@@ -86,6 +87,8 @@ bool ConvertShellLinkToJumpListItem(IShellLink* shell_link,
   if (FAILED(shell_link->GetPath(path, MAX_PATH, nullptr, 0)))
     return false;
 
+  item->path = base::FilePath(path);
+
   CComQIPtr<IPropertyStore> property_store = shell_link;
   base::win::ScopedPropVariant prop;
   if (SUCCEEDED(
@@ -98,6 +101,9 @@ bool ConvertShellLinkToJumpListItem(IShellLink* shell_link,
       (prop.get().vt == VT_LPWSTR)) {
     item->title = prop.get().pwszVal;
   }
+
+  if (SUCCEEDED(shell_link->GetWorkingDirectory(path, base::size(path))))
+    item->working_dir = base::FilePath(path);
 
   int icon_index;
   if (SUCCEEDED(shell_link->GetIconLocation(path, MAX_PATH, &icon_index))) {

--- a/atom/browser/ui/win/jump_list.h
+++ b/atom/browser/ui/win/jump_list.h
@@ -49,6 +49,7 @@ struct JumpListItem {
   base::string16 arguments;
   base::string16 title;
   base::string16 description;
+  base::FilePath working_dir;
   base::FilePath icon_path;
   int icon_index = 0;
 

--- a/docs/api/structures/jump-list-item.md
+++ b/docs/api/structures/jump-list-item.md
@@ -26,3 +26,4 @@
   resource file contains multiple icons this value can be used to specify the
   zero-based index of the icon that should be displayed for this task. If a
   resource file contains only one icon, this property should be set to zero.
+* `workingDirectory` String (optional) - The working directory. Default is empty.

--- a/docs/api/structures/task.md
+++ b/docs/api/structures/task.md
@@ -12,3 +12,4 @@
 * `iconIndex` Number - The icon index in the icon file. If an icon file
   consists of two or more icons, set this value to identify the icon. If an
   icon file consists of one icon, this value is 0.
+* `workingDirectory` String (optional) - The working directory. Default is empty.

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -241,7 +241,8 @@ app.setUserTasks([
     iconPath: process.execPath,
     iconIndex: 0,
     title: 'New Window',
-    description: 'Create a new window'
+    description: 'Create a new window',
+    workingDirectory: path.dirname(process.execPath)
   }
 ])
 app.setUserTasks([])
@@ -265,7 +266,8 @@ app.setJumpList([
         args: '--run-tool-a',
         iconPath: process.execPath,
         iconIndex: 0,
-        description: 'Runs Tool A'
+        description: 'Runs Tool A',
+        workingDirectory: path.dirname(process.execPath)
       },
       {
         type: 'task',
@@ -274,7 +276,8 @@ app.setJumpList([
         args: '--run-tool-b',
         iconPath: process.execPath,
         iconIndex: 0,
-        description: 'Runs Tool B'
+        description: 'Runs Tool B',
+        workingDirectory: path.dirname(process.execPath)
       }]
   },
   {


### PR DESCRIPTION
#### Description of Change
Allow setting working directory in `app.setUserTasks()` / `app.setJumpList()`.
Fixes https://github.com/electron/electron/issues/17697

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Allowed setting working directory in `app.setUserTasks()` / `app.setJumpList()`.