### PR TITLE
fix: load node even if frame has opener

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -75,8 +75,7 @@ void AtomRendererClient::DidCreateScriptContext(
 
   // Do not load node if we're aren't a main frame or a devtools extension
   // unless node support has been explicitly enabled for sub frames
-  bool is_main_frame =
-      render_frame->IsMainFrame() && !render_frame->GetWebFrame()->Opener();
+  bool is_main_frame = render_frame->IsMainFrame();
   bool is_devtools = IsDevToolsExtension(render_frame);
   bool allow_node_in_subframes =
       base::CommandLine::ForCurrentProcess()->HasSwitch(


### PR DESCRIPTION
#### Description of Change
Fixes #18070
Load Node in renderer frame even if it has an opener.

####  Test instructions
```
$ git clone git@github.com:jeremyspiegel/electron-quick-start.git -b preload-not-run-on-window-open
$ cd electron-quick-start
$ npm install
$ /path/to/out/out/Debug/Electron.app/Contents/MacOS/Electron .
```
Verify that an alert `'preload'` is shown in opened window.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed preload script not executed in a window created after `window.open`

cc @jeremyspiegel 