### PR TITLE
refactor: use base::size() for array sizes

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -368,7 +368,7 @@ void AtomBrowserMainParts::ToolkitInitialized() {
   gfx::win::SetGetMinimumFontSizeCallback(&GetMinimumFontSize);
 
   wchar_t module_name[MAX_PATH] = {0};
-  if (GetModuleFileName(NULL, module_name, MAX_PATH))
+  if (GetModuleFileName(NULL, module_name, base::size(module_name)))
     ui::CursorLoaderWin::SetCursorResourceModule(module_name);
 #endif
 

--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -259,7 +259,8 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
       return false;
 
     wchar_t file_name[MAX_PATH];
-    hr = GetFileNameFromShellItem(item, SIGDN_FILESYSPATH, file_name, MAX_PATH);
+    hr = GetFileNameFromShellItem(item, SIGDN_FILESYSPATH, file_name,
+                                  base::size(file_name));
 
     if (FAILED(hr))
       return false;

--- a/atom/browser/ui/win/jump_list.cc
+++ b/atom/browser/ui/win/jump_list.cc
@@ -83,7 +83,7 @@ bool ConvertShellLinkToJumpListItem(IShellLink* shell_link,
 
   item->type = JumpListItem::Type::TASK;
   wchar_t path[MAX_PATH];
-  if (FAILED(shell_link->GetPath(path, MAX_PATH, nullptr, 0)))
+  if (FAILED(shell_link->GetPath(path, base::size(path), nullptr, 0)))
     return false;
 
   CComQIPtr<IPropertyStore> property_store = shell_link;
@@ -100,13 +100,14 @@ bool ConvertShellLinkToJumpListItem(IShellLink* shell_link,
   }
 
   int icon_index;
-  if (SUCCEEDED(shell_link->GetIconLocation(path, MAX_PATH, &icon_index))) {
+  if (SUCCEEDED(
+          shell_link->GetIconLocation(path, base::size(path), &icon_index))) {
     item->icon_path = base::FilePath(path);
     item->icon_index = icon_index;
   }
 
   wchar_t item_desc[INFOTIPSIZE];
-  if (SUCCEEDED(shell_link->GetDescription(item_desc, INFOTIPSIZE)))
+  if (SUCCEEDED(shell_link->GetDescription(item_desc, base::size(item_desc))))
     item->description = item_desc;
 
   return true;


### PR DESCRIPTION
#### Description of Change
Use `base::size()` when passing buffer sizes instead of hardcoding the size. Eliminates duplicate values and makes the code more robust.

```diff
   wchar_t module_name[MAX_PATH] = {};
-  if (GetModuleFileName(NULL, module_name, MAX_PATH))
+  if (GetModuleFileName(NULL, module_name, base::size(module_name)))
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes