### PR TITLE
refactor: address TODO for WebContents type parsing

### DIFF
--- a/atom/browser/api/atom_api_browser_view.cc
+++ b/atom/browser/api/atom_api_browser_view.cc
@@ -68,7 +68,7 @@ void BrowserView::Init(v8::Isolate* isolate,
                        const mate::Dictionary& options) {
   mate::Dictionary web_preferences = mate::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
-  web_preferences.Set("isBrowserView", true);
+  web_preferences.Set("type", "browserView");
   mate::Handle<class WebContents> web_contents =
       WebContents::Create(isolate, web_preferences);
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -297,20 +297,12 @@ WebContents::WebContents(v8::Isolate* isolate,
   // Read options.
   options.Get("backgroundThrottling", &background_throttling_);
 
-  // FIXME(zcbenz): We should read "type" parameter for better design, but
-  // on Windows we have encountered a compiler bug that if we read "type"
-  // from |options| and then set |type_|, a memory corruption will happen
-  // and Electron will soon crash.
-  // Remvoe this after we upgraded to use VS 2015 Update 3.
+  // Get type
+  options.Get("type", &type_);
+
   bool b = false;
-  if (options.Get("isGuest", &b) && b)
-    type_ = Type::WEB_VIEW;
-  else if (options.Get("isBackgroundPage", &b) && b)
-    type_ = Type::BACKGROUND_PAGE;
-  else if (options.Get("isBrowserView", &b) && b)
-    type_ = Type::BROWSER_VIEW;
 #if BUILDFLAG(ENABLE_OSR)
-  else if (options.Get(options::kOffscreen, &b) && b)
+  if (options.Get(options::kOffscreen, &b) && b)
     type_ = Type::OFF_SCREEN;
 #endif
 
@@ -2266,7 +2258,6 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("beginFrameSubscription", &WebContents::BeginFrameSubscription)
       .SetMethod("endFrameSubscription", &WebContents::EndFrameSubscription)
       .SetMethod("startDrag", &WebContents::StartDrag)
-      .SetMethod("isGuest", &WebContents::IsGuest)
       .SetMethod("attachToIframe", &WebContents::AttachToIframe)
       .SetMethod("detachFromOuterFrame", &WebContents::DetachFromOuterFrame)
       .SetMethod("isOffscreen", &WebContents::IsOffScreen)

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -108,8 +108,8 @@ WebContentsPreferences::WebContentsPreferences(
   mate::Dictionary copied(isolate, web_preferences.GetHandle()->Clone());
   // Following fields should not be stored.
   copied.Delete("embedder");
-  copied.Delete("isGuest");
   copied.Delete("session");
+  copied.Delete("type");
 
   mate::ConvertFromV8(isolate, copied.GetHandle(), &preference_);
   web_contents->SetUserData(UserDataKey(), base::WrapUnique(this));

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -93,7 +93,7 @@ const startBackgroundPages = function (manifest) {
 
   const contents = webContents.create({
     partition: 'persist:__chrome_extension',
-    isBackgroundPage: true,
+    type: 'backgroundPage',
     sandbox: true,
     enableRemoteModule: false
   })

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -59,7 +59,7 @@ const createGuest = function (embedder, params) {
   }
 
   const guest = webContents.create({
-    isGuest: true,
+    type: 'webview',
     partition: params.partition,
     embedder: embedder
   })

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -28,7 +28,7 @@ const mergeOptions = function (child, parent, visited) {
 
   visited.add(parent)
   for (const key in parent) {
-    if (key === 'isBrowserView') continue
+    if (key === 'type') continue
     if (!hasProp.call(parent, key)) continue
     if (key in child && key !== 'webPreferences') continue
 
@@ -244,7 +244,7 @@ ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', functio
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer)
   const { newGuest } = event
-  if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {
+  if ((event.sender.getType() === 'webview' && !event.sender.allowPopups) || event.defaultPrevented) {
     if (newGuest != null) {
       if (options.webContents === newGuest.webContents) {
         // the webContents is not changed, so set defaultPrevented to false to


### PR DESCRIPTION
#### Description of Change
Address:
> // FIXME(zcbenz): We should read "type" parameter for better design, but
  // on Windows we have encountered a compiler bug that if we read "type"
  // from |options| and then set |type_|, a memory corruption will happen
  // and Electron will soon crash.
  // Remove this after we upgraded to use VS 2015 Update 3

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes

/cc @zcbenz