### PR TITLE
chore: remove deprecated APIs

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -19,6 +19,41 @@ session.clearAuthCache({ type: 'password' })
 session.clearAuthCache()
 ```
 
+### `powerMonitor.querySystemIdleState`
+
+```js
+// Removed in Electron 7.0
+powerMonitor.querySystemIdleState(threshold, callback)
+// Replace with synchronous API
+const idleState = getSystemIdleState(threshold)
+```
+
+### `powerMonitor.querySystemIdleTime`
+
+```js
+// Removed in Electron 7.0
+powerMonitor.querySystemIdleTime(callback)
+// Replace with synchronous API
+const idleTime = getSystemIdleTime()
+```
+
+### webFrame Isolated World APIs
+
+```js
+// Removed in Elecron 7.0
+webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp)
+webFrame.setIsolatedWorldHumanReadableName(worldId, name)
+webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin)
+// Replace with
+webFrame.setIsolatedWorldInfo(
+  worldId,
+  {
+    securityOrigin: 'some_origin',
+    name: 'human_readable_name',
+    csp: 'content_security_policy'
+  })
+```
+
 ## Planned Breaking API Changes (6.0)
 
 ### `win.setMenu(null)`

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -59,24 +59,6 @@ Emitted as soon as the systems screen is unlocked.
 
 The `powerMonitor` module has the following methods:
 
-### `powerMonitor.querySystemIdleState(idleThreshold, callback)` _(Deprecated)_
-
-* `idleThreshold` Integer
-* `callback` Function
-  * `idleState` String - Can be `active`, `idle`, `locked` or `unknown`
-
-Calculate the system idle state. `idleThreshold` is the amount of time (in seconds)
-before considered idle. `callback` will be called synchronously on some systems
-and with an `idleState` argument that describes the system's state. `locked` is
-available on supported systems only.
-
-### `powerMonitor.querySystemIdleTime(callback)` _(Deprecated)_
-
-* `callback` Function
-  * `idleTime` Integer - Idle time in seconds
-
-Calculate system idle time in seconds.
-
 ### `powerMonitor.getSystemIdleState(idleThreshold)`
 
 * `idleThreshold` Integer

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -132,27 +132,6 @@ or is rejected if the result of the code is a rejected promise.
 
 Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
 
-### `webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp)` _(Deprecated)_
-
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
-* `csp` String
-
-Set the content security policy of the isolated world.
-
-### `webFrame.setIsolatedWorldHumanReadableName(worldId, name)` _(Deprecated)_
-
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
-* `name` String
-
-Set the name of the isolated world. Useful in devtools.
-
-### `webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin)` _(Deprecated)_
-
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
-* `securityOrigin` String
-
-Set the security origin of the isolated world.
-
 ### `webFrame.setIsolatedWorldInfo(worldId, info)`
 * `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `info` Object

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -19,14 +19,6 @@ Object.setPrototypeOf(App.prototype, EventEmitter.prototype)
 EventEmitter.call(app as any)
 
 Object.assign(app, {
-  // TODO(codebytere): remove in 7.0
-  setApplicationMenu (menu: Electron.Menu | null) {
-    return Menu.setApplicationMenu(menu)
-  },
-  // TODO(codebytere): remove in 7.0
-  getApplicationMenu () {
-    return Menu.getApplicationMenu()
-  },
   commandLine: {
     hasSwitch: (theSwitch: string) => commandLine.hasSwitch(String(theSwitch)),
     getSwitchValue: (theSwitch: string) => commandLine.getSwitchValue(String(theSwitch)),

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -4,7 +4,6 @@ import { createLazyInstance } from '../utils'
 
 const { EventEmitter } = require('events')
 const { createPowerMonitor, PowerMonitor } = process.electronBinding('power_monitor')
-const { deprecate } = require('electron')
 
 // PowerMonitor is an EventEmitter.
 Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
@@ -24,25 +23,6 @@ if (process.platform === 'linux') {
       powerMonitor.unblockShutdown()
     }
   })
-}
-
-// TODO(nitsakh): Remove in 7.0
-powerMonitor.querySystemIdleState = function (threshold: number, callback: Function) {
-  deprecate.warn('powerMonitor.querySystemIdleState', 'powerMonitor.getSystemIdleState')
-  if (typeof threshold !== 'number') throw new Error('Must pass threshold as a number')
-  if (typeof callback !== 'function') throw new Error('Must pass callback as a function argument')
-
-  const idleState = this.getSystemIdleState(threshold)
-  process.nextTick(() => callback(idleState))
-}
-
-// TODO(nitsakh): Remove in 7.0
-powerMonitor.querySystemIdleTime = function (callback: Function) {
-  deprecate.warn('powerMonitor.querySystemIdleTime', 'powerMonitor.getSystemIdleTime')
-  if (typeof callback !== 'function') throw new Error('Must pass function as an argument')
-
-  const idleTime = this.getSystemIdleTime()
-  process.nextTick(() => callback(idleTime))
 }
 
 module.exports = powerMonitor

--- a/lib/renderer/api/web-frame.ts
+++ b/lib/renderer/api/web-frame.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events'
-import { deprecate } from 'electron'
 
 const binding = process.electronBinding('web_frame')
 
@@ -45,26 +44,6 @@ class WebFrame extends EventEmitter {
 
   get routingId () {
     return binding._getRoutingId(this.context)
-  }
-
-  // Deprecations
-  // TODO(nitsakh): Remove in 6.0
-  setIsolatedWorldSecurityOrigin (worldId: number, securityOrigin: string) {
-    deprecate.warn('webFrame.setIsolatedWorldSecurityOrigin', 'webFrame.setIsolatedWorldInfo')
-    binding.setIsolatedWorldInfo(this.context, worldId, { securityOrigin })
-  }
-
-  setIsolatedWorldContentSecurityPolicy (worldId: number, csp: string) {
-    deprecate.warn('webFrame.setIsolatedWorldContentSecurityPolicy', 'webFrame.setIsolatedWorldInfo')
-    binding.setIsolatedWorldInfo(this.context, worldId, {
-      securityOrigin: window.location.origin,
-      csp
-    })
-  }
-
-  setIsolatedWorldHumanReadableName (worldId: number, name: string) {
-    deprecate.warn('webFrame.setIsolatedWorldHumanReadableName', 'webFrame.setIsolatedWorldInfo')
-    binding.setIsolatedWorldInfo(this.context, worldId, { name })
   }
 }
 

--- a/spec/api-power-monitor-spec.js
+++ b/spec/api-power-monitor-spec.js
@@ -128,44 +128,6 @@ describe('powerMonitor', () => {
       powerMonitor = require('electron').remote.powerMonitor
     })
 
-    // TODO(nitsakh): Remove in 7.0
-    describe('powerMonitor.querySystemIdleState', () => {
-      it('notify current system idle state', done => {
-        // this function is not mocked out, so we can test the result's
-        // form and type but not its value.
-        powerMonitor.querySystemIdleState(1, idleState => {
-          expect(idleState).to.be.a('string')
-          const validIdleStates = [ 'active', 'idle', 'locked', 'unknown' ]
-          expect(validIdleStates).to.include(idleState)
-          done()
-        })
-      })
-
-      it('does not accept non positive integer threshold', () => {
-        expect(() => {
-          powerMonitor.querySystemIdleState(-1, (idleState) => {})
-        }).to.throw()
-
-        expect(() => {
-          powerMonitor.querySystemIdleState(NaN, (idleState) => {})
-        }).to.throw()
-
-        expect(() => {
-          powerMonitor.querySystemIdleState('a', (idleState) => {})
-        }).to.throw()
-      })
-    })
-
-    // TODO(nitsakh): Remove in 7.0
-    describe('powerMonitor.querySystemIdleTime', () => {
-      it('notify current system idle time', done => {
-        powerMonitor.querySystemIdleTime(idleTime => {
-          expect(idleTime).to.be.at.least(0)
-          done()
-        })
-      })
-    })
-
     describe('powerMonitor.getSystemIdleState', () => {
       it('gets current system idle state', () => {
         // this function is not mocked out, so we can test the result's


### PR DESCRIPTION
#### Description of Change
BREAKING CHANGE

The following deprecated APIs are supposed to be removed in Electron 7:
- `powerMonitor.querySystemIdleState()`
- `powerMonitor.querySystemIdleTime()`
- `webFrame.setIsolatedWorldContentSecurityPolicy()`
- `webFrame.setIsolatedWorldHumanReadableName()`
- `webFrame.setIsolatedWorldSecurityOrigin()`
- `app.getApplicationMenu()`
- `app.setApplicationMenu()`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed deprecated APIs: `powerMonitor.querySystemIdleState()`, `powerMonitor.querySystemIdleTime()`, `webFrame.setIsolatedWorldContentSecurityPolicy()`, `webFrame.setIsolatedWorldHumanReadableName()`, `webFrame.setIsolatedWorldSecurityOrigin()`, `app.getApplicationMenu()` and `app.setApplicationMenu()`.