### PR TITLE
docs: add BugSplat to list of hosted solutions

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -28,6 +28,7 @@ Or use a 3rd party hosted solution:
 
 * [Backtrace I/O](https://backtrace.io/electron/)
 * [Sentry](https://docs.sentry.io/clients/electron)
+* [BugSplat](https://www.bugsplat.com/docs/platforms/electron)
 
 Crash reports are saved locally in an application-specific temp directory folder.
 For a `productName` of `YourName`, crash reports will be stored in a folder


### PR DESCRIPTION
#### Description of Change

Added [BugSplat](https://www.bugsplat.com/) to the crashReporter docs. BugSplat offers a hosted crash reporting solution with a [free tier](https://www.bugsplat.com/docs/payments/free-plan) available to individuals and small teams. More information can be found in our [docs](url).

#### Checklist

- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

notes: no-notes
