### PR TITLE
chore: remove last instances of base::Bind

### DIFF
--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -100,16 +100,17 @@ class Menu : public mate::TrackableObject<Menu>,
   bool WorksWhenHiddenAt(int index) const;
 
   // Stored delegate methods.
-  base::Callback<bool(v8::Local<v8::Value>, int)> is_checked_;
-  base::Callback<bool(v8::Local<v8::Value>, int)> is_enabled_;
-  base::Callback<bool(v8::Local<v8::Value>, int)> is_visible_;
-  base::Callback<bool(v8::Local<v8::Value>, int)> works_when_hidden_;
-  base::Callback<v8::Local<v8::Value>(v8::Local<v8::Value>, int, bool)>
+  base::RepeatingCallback<bool(v8::Local<v8::Value>, int)> is_checked_;
+  base::RepeatingCallback<bool(v8::Local<v8::Value>, int)> is_enabled_;
+  base::RepeatingCallback<bool(v8::Local<v8::Value>, int)> is_visible_;
+  base::RepeatingCallback<bool(v8::Local<v8::Value>, int)> works_when_hidden_;
+  base::RepeatingCallback<v8::Local<v8::Value>(v8::Local<v8::Value>, int, bool)>
       get_accelerator_;
-  base::Callback<bool(v8::Local<v8::Value>, int)> should_register_accelerator_;
-  base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>, int)>
+  base::RepeatingCallback<bool(v8::Local<v8::Value>, int)>
+      should_register_accelerator_;
+  base::RepeatingCallback<void(v8::Local<v8::Value>, v8::Local<v8::Value>, int)>
       execute_command_;
-  base::Callback<void(v8::Local<v8::Value>)> menu_will_show_;
+  base::RepeatingCallback<void(v8::Local<v8::Value>)> menu_will_show_;
 
   DISALLOW_COPY_AND_ASSIGN(Menu);
 };

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -40,9 +40,10 @@ void RegisterSchemesAsPrivileged(v8::Local<v8::Value> val,
 
 class Protocol : public mate::TrackableObject<Protocol> {
  public:
-  using Handler =
-      base::Callback<void(const base::DictionaryValue&, v8::Local<v8::Value>)>;
-  using CompletionCallback = base::Callback<void(v8::Local<v8::Value>)>;
+  using Handler = base::RepeatingCallback<void(const base::DictionaryValue&,
+                                               v8::Local<v8::Value>)>;
+  using CompletionCallback =
+      base::RepeatingCallback<void(v8::Local<v8::Value>)>;
 
   static mate::Handle<Protocol> Create(v8::Isolate* isolate,
                                        AtomBrowserContext* browser_context);

--- a/atom/browser/api/atom_api_protocol_ns.h
+++ b/atom/browser/api/atom_api_protocol_ns.h
@@ -48,7 +48,8 @@ class ProtocolNS : public mate::TrackableObject<ProtocolNS> {
   ~ProtocolNS() override;
 
   // Callback types.
-  using CompletionCallback = base::Callback<void(v8::Local<v8::Value>)>;
+  using CompletionCallback =
+      base::RepeatingCallback<void(v8::Local<v8::Value>)>;
 
   // JS APIs.
   ProtocolError RegisterProtocol(ProtocolType type,

--- a/atom/browser/api/atom_api_system_preferences.h
+++ b/atom/browser/api/atom_api_system_preferences.h
@@ -66,7 +66,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
 #elif defined(OS_MACOSX)
   using NotificationCallback =
-      base::Callback<void(const std::string&, const base::DictionaryValue&)>;
+      base::RepeatingCallback<void(const std::string&,
+                                   const base::DictionaryValue&)>;
 
   void PostNotification(const std::string& name,
                         const base::DictionaryValue& user_info,

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -211,7 +211,8 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void SetIcon(mate::Handle<NativeImage> icon);
 #endif
 #if defined(OS_WIN)
-  typedef base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>)>
+  typedef base::RepeatingCallback<void(v8::Local<v8::Value>,
+                                       v8::Local<v8::Value>)>
       MessageCallback;
   bool HookWindowMessage(UINT message, const MessageCallback& callback);
   bool IsWindowMessageHooked(UINT message);

--- a/atom/browser/api/atom_api_web_request.cc
+++ b/atom/browser/api/atom_api_web_request.cc
@@ -9,8 +9,8 @@
 
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/net/atom_network_delegate.h"
-#include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/net_converter.h"
+#include "atom/common/native_mate_converters/once_callback.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "base/task/post_task.h"
 #include "content/public/browser/browser_task_traits.h"

--- a/atom/browser/api/frame_subscriber.h
+++ b/atom/browser/api/frame_subscriber.h
@@ -28,7 +28,7 @@ class FrameSubscriber : public content::WebContentsObserver,
                         public viz::mojom::FrameSinkVideoConsumer {
  public:
   using FrameCaptureCallback =
-      base::Callback<void(const gfx::Image&, const gfx::Rect&)>;
+      base::RepeatingCallback<void(const gfx::Image&, const gfx::Rect&)>;
 
   FrameSubscriber(content::WebContents* web_contents,
                   const FrameCaptureCallback& callback,

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -561,7 +561,7 @@ void AtomBrowserClient::AllowCertificateError(
     bool is_main_frame_request,
     bool strict_enforcement,
     bool expired_previous_decision,
-    const base::Callback<void(content::CertificateRequestResultType)>&
+    const base::RepeatingCallback<void(content::CertificateRequestResultType)>&
         callback) {
   if (delegate_) {
     delegate_->AllowCertificateError(
@@ -758,7 +758,7 @@ void AtomBrowserClient::WebNotificationAllowed(
     return;
   }
   permission_helper->RequestWebNotificationPermission(
-      base::Bind(callback, web_contents->IsAudioMuted()));
+      base::BindRepeating(callback, web_contents->IsAudioMuted()));
 }
 
 void AtomBrowserClient::RenderProcessHostDestroyed(
@@ -810,7 +810,7 @@ void HandleExternalProtocolInUI(
     return;
 
   GURL escaped_url(net::EscapeExternalHandlerValue(url.spec()));
-  auto callback = base::Bind(&OnOpenExternal, escaped_url);
+  auto callback = base::BindRepeating(&OnOpenExternal, escaped_url);
   permission_helper->RequestOpenExternalPermission(callback, has_user_gesture,
                                                    url);
 }

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -52,7 +52,7 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   NotificationPresenter* GetNotificationPresenter();
 
   void WebNotificationAllowed(int render_process_id,
-                              const base::Callback<void(bool, bool)>& callback);
+                              base::OnceCallback<void(bool, bool)> callback);
 
   // content::NavigatorDelegate
   std::vector<std::unique_ptr<content::NavigationThrottle>>

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -95,9 +95,9 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
       window, atom::MessageBoxType::kNone, buttons, default_id, cancel_id,
       atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
       base::UTF16ToUTF8(message_text), "", checkbox, false, gfx::ImageSkia(),
-      base::Bind(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
-                 base::Unretained(this), base::Passed(std::move(callback)),
-                 origin));
+      base::BindRepeating(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
+                          base::Unretained(this),
+                          base::Passed(std::move(callback)), origin));
 }
 
 void AtomJavaScriptDialogManager::RunBeforeUnloadDialog(

--- a/atom/browser/atom_javascript_dialog_manager.cc
+++ b/atom/browser/atom_javascript_dialog_manager.cc
@@ -95,9 +95,9 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
       window, atom::MessageBoxType::kNone, buttons, default_id, cancel_id,
       atom::MessageBoxOptions::MESSAGE_BOX_NONE, "",
       base::UTF16ToUTF8(message_text), "", checkbox, false, gfx::ImageSkia(),
-      base::BindRepeating(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
-                          base::Unretained(this),
-                          base::Passed(std::move(callback)), origin));
+      base::BindOnce(&AtomJavaScriptDialogManager::OnMessageBoxCallback,
+                     base::Unretained(this), base::Passed(std::move(callback)),
+                     origin));
 }
 
 void AtomJavaScriptDialogManager::RunBeforeUnloadDialog(

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -523,15 +523,15 @@ void CommonWebContentsDelegate::DevToolsIndexPath(
       scoped_refptr<DevToolsFileSystemIndexer::FileSystemIndexingJob>(
           devtools_file_system_indexer_->IndexPath(
               file_system_path, excluded_folders,
-              base::Bind(
+              base::BindRepeating(
                   &CommonWebContentsDelegate::OnDevToolsIndexingWorkCalculated,
                   weak_factory_.GetWeakPtr(), request_id, file_system_path),
-              base::Bind(&CommonWebContentsDelegate::OnDevToolsIndexingWorked,
-                         weak_factory_.GetWeakPtr(), request_id,
-                         file_system_path),
-              base::Bind(&CommonWebContentsDelegate::OnDevToolsIndexingDone,
-                         weak_factory_.GetWeakPtr(), request_id,
-                         file_system_path)));
+              base::BindRepeating(
+                  &CommonWebContentsDelegate::OnDevToolsIndexingWorked,
+                  weak_factory_.GetWeakPtr(), request_id, file_system_path),
+              base::BindRepeating(
+                  &CommonWebContentsDelegate::OnDevToolsIndexingDone,
+                  weak_factory_.GetWeakPtr(), request_id, file_system_path)));
 }
 
 void CommonWebContentsDelegate::DevToolsStopIndexing(int request_id) {
@@ -553,8 +553,9 @@ void CommonWebContentsDelegate::DevToolsSearchInPath(
   }
   devtools_file_system_indexer_->SearchInPath(
       file_system_path, query,
-      base::Bind(&CommonWebContentsDelegate::OnDevToolsSearchCompleted,
-                 weak_factory_.GetWeakPtr(), request_id, file_system_path));
+      base::BindRepeating(&CommonWebContentsDelegate::OnDevToolsSearchCompleted,
+                          weak_factory_.GetWeakPtr(), request_id,
+                          file_system_path));
 }
 
 void CommonWebContentsDelegate::OnDevToolsIndexingWorkCalculated(

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -484,8 +484,8 @@ int AtomNetworkDelegate::HandleResponseEvent(
   callbacks_[request->identifier()] = std::move(callback);
 
   ResponseCallback response =
-      base::Bind(&AtomNetworkDelegate::OnListenerResultInUI<Out>,
-                 base::Unretained(this), request->identifier(), out);
+      base::BindRepeating(&AtomNetworkDelegate::OnListenerResultInUI<Out>,
+                          base::Unretained(this), request->identifier(), out);
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::UI},
       base::BindOnce(RunResponseListener, info.listener, std::move(details),

--- a/atom/browser/net/atom_network_delegate.h
+++ b/atom/browser/net/atom_network_delegate.h
@@ -32,10 +32,13 @@ class LoginHandler;
 
 class AtomNetworkDelegate : public net::NetworkDelegate {
  public:
-  using ResponseCallback = base::Callback<void(const base::DictionaryValue&)>;
-  using SimpleListener = base::Callback<void(const base::DictionaryValue&)>;
-  using ResponseListener = base::Callback<void(const base::DictionaryValue&,
-                                               const ResponseCallback&)>;
+  using ResponseCallback =
+      base::OnceCallback<void(const base::DictionaryValue&)>;
+  using SimpleListener =
+      base::RepeatingCallback<void(const base::DictionaryValue&)>;
+  using ResponseListener =
+      base::RepeatingCallback<void(const base::DictionaryValue&,
+                                   ResponseCallback)>;
 
   enum SimpleEvent {
     kOnSendHeaders,

--- a/atom/browser/osr/osr_render_widget_host_view.cc
+++ b/atom/browser/osr/osr_render_widget_host_view.cc
@@ -265,8 +265,8 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
 
   if (content::GpuDataManager::GetInstance()->HardwareAccelerationEnabled()) {
     video_consumer_.reset(new OffScreenVideoConsumer(
-        this, base::Bind(&OffScreenRenderWidgetHostView::OnPaint,
-                         weak_ptr_factory_.GetWeakPtr())));
+        this, base::BindRepeating(&OffScreenRenderWidgetHostView::OnPaint,
+                                  weak_ptr_factory_.GetWeakPtr())));
     video_consumer_->SetActive(IsPainting());
     video_consumer_->SetFrameRate(GetFrameRate());
   }
@@ -503,8 +503,8 @@ void OffScreenRenderWidgetHostView::InitAsPopup(
 
   parent_host_view_->set_popup_host_view(this);
   parent_callback_ =
-      base::Bind(&OffScreenRenderWidgetHostView::OnPopupPaint,
-                 parent_host_view_->weak_ptr_factory_.GetWeakPtr());
+      base::BindRepeating(&OffScreenRenderWidgetHostView::OnPopupPaint,
+                          parent_host_view_->weak_ptr_factory_.GetWeakPtr());
 
   popup_position_ = pos;
 
@@ -741,8 +741,8 @@ OffScreenRenderWidgetHostView::CreateHostDisplayClient(
     ui::Compositor* compositor) {
   host_display_client_ = new OffScreenHostDisplayClient(
       gfx::kNullAcceleratedWidget,
-      base::Bind(&OffScreenRenderWidgetHostView::OnPaint,
-                 weak_ptr_factory_.GetWeakPtr()));
+      base::BindRepeating(&OffScreenRenderWidgetHostView::OnPaint,
+                          weak_ptr_factory_.GetWeakPtr()));
   host_display_client_->SetActive(IsPainting());
   return base::WrapUnique(host_display_client_);
 }
@@ -1084,8 +1084,9 @@ void OffScreenRenderWidgetHostView::SetupFrameRate(bool force) {
   } else {
     begin_frame_timer_.reset(new AtomBeginFrameTimer(
         frame_rate_threshold_us_,
-        base::Bind(&OffScreenRenderWidgetHostView::OnBeginFrameTimerTick,
-                   weak_ptr_factory_.GetWeakPtr())));
+        base::BindRepeating(
+            &OffScreenRenderWidgetHostView::OnBeginFrameTimerTick,
+            weak_ptr_factory_.GetWeakPtr())));
   }
 }
 

--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -48,12 +48,12 @@ void OnPointerLockResponse(content::WebContents* web_contents, bool allowed) {
     web_contents->GotResponseToLockMouseRequest(allowed);
 }
 
-void OnPermissionResponse(base::Callback<void(bool)> callback,
+void OnPermissionResponse(base::OnceCallback<void(bool)> callback,
                           blink::mojom::PermissionStatus status) {
   if (status == blink::mojom::PermissionStatus::GRANTED)
-    callback.Run(true);
+    std::move(callback).Run(true);
   else
-    callback.Run(false);
+    std::move(callback).Run(false);
 }
 
 }  // namespace
@@ -66,7 +66,7 @@ WebContentsPermissionHelper::~WebContentsPermissionHelper() {}
 
 void WebContentsPermissionHelper::RequestPermission(
     content::PermissionType permission,
-    const base::RepeatingCallback<void(bool)>& callback,
+    base::OnceCallback<void(bool)> callback,
     bool user_gesture,
     const base::DictionaryValue* details) {
   auto* rfh = web_contents_->GetMainFrame();
@@ -75,7 +75,7 @@ void WebContentsPermissionHelper::RequestPermission(
   auto origin = web_contents_->GetLastCommittedURL();
   permission_manager->RequestPermissionWithDetails(
       permission, rfh, origin, false, details,
-      base::BindRepeating(&OnPermissionResponse, callback));
+      base::BindOnce(&OnPermissionResponse, std::move(callback)));
 }
 
 bool WebContentsPermissionHelper::CheckPermission(
@@ -90,10 +90,10 @@ bool WebContentsPermissionHelper::CheckPermission(
 }
 
 void WebContentsPermissionHelper::RequestFullscreenPermission(
-    const base::Callback<void(bool)>& callback) {
+    base::OnceCallback<void(bool)> callback) {
   RequestPermission(
       static_cast<content::PermissionType>(PermissionType::FULLSCREEN),
-      callback);
+      std::move(callback));
 }
 
 void WebContentsPermissionHelper::RequestMediaAccessPermission(
@@ -121,26 +121,27 @@ void WebContentsPermissionHelper::RequestMediaAccessPermission(
 }
 
 void WebContentsPermissionHelper::RequestWebNotificationPermission(
-    const base::RepeatingCallback<void(bool)>& callback) {
-  RequestPermission(content::PermissionType::NOTIFICATIONS, callback);
+    base::OnceCallback<void(bool)> callback) {
+  RequestPermission(content::PermissionType::NOTIFICATIONS,
+                    std::move(callback));
 }
 
 void WebContentsPermissionHelper::RequestPointerLockPermission(
     bool user_gesture) {
   RequestPermission(
       static_cast<content::PermissionType>(PermissionType::POINTER_LOCK),
-      base::BindRepeating(&OnPointerLockResponse, web_contents_), user_gesture);
+      base::BindOnce(&OnPointerLockResponse, web_contents_), user_gesture);
 }
 
 void WebContentsPermissionHelper::RequestOpenExternalPermission(
-    const base::RepeatingCallback<void(bool)>& callback,
+    base::OnceCallback<void(bool)> callback,
     bool user_gesture,
     const GURL& url) {
   base::DictionaryValue details;
   details.SetString("externalURL", url.spec());
   RequestPermission(
       static_cast<content::PermissionType>(PermissionType::OPEN_EXTERNAL),
-      callback, user_gesture, &details);
+      std::move(callback), user_gesture, &details);
 }
 
 bool WebContentsPermissionHelper::CheckMediaAccessPermission(

--- a/atom/browser/web_contents_permission_helper.h
+++ b/atom/browser/web_contents_permission_helper.h
@@ -25,17 +25,15 @@ class WebContentsPermissionHelper
   };
 
   // Asynchronous Requests
-  void RequestFullscreenPermission(
-      const base::RepeatingCallback<void(bool)>& callback);
+  void RequestFullscreenPermission(base::OnceCallback<void(bool)> callback);
   void RequestMediaAccessPermission(const content::MediaStreamRequest& request,
                                     content::MediaResponseCallback callback);
   void RequestWebNotificationPermission(
-      const base::RepeatingCallback<void(bool)>& callback);
+      base::OnceCallback<void(bool)> callback);
   void RequestPointerLockPermission(bool user_gesture);
-  void RequestOpenExternalPermission(
-      const base::RepeatingCallback<void(bool)>& callback,
-      bool user_gesture,
-      const GURL& url);
+  void RequestOpenExternalPermission(base::OnceCallback<void(bool)> callback,
+                                     bool user_gesture,
+                                     const GURL& url);
 
   // Synchronous Checks
   bool CheckMediaAccessPermission(const GURL& security_origin,
@@ -46,7 +44,7 @@ class WebContentsPermissionHelper
   friend class content::WebContentsUserData<WebContentsPermissionHelper>;
 
   void RequestPermission(content::PermissionType permission,
-                         const base::RepeatingCallback<void(bool)>& callback,
+                         base::OnceCallback<void(bool)> callback,
                          bool user_gesture = false,
                          const base::DictionaryValue* details = nullptr);
 

--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -11,7 +11,7 @@
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/ui/file_dialog.h"
-#include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/native_mate_converters/once_callback.h"
 #include "base/bind.h"
 #include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
@@ -69,7 +69,8 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
     ignore_result(handle->Then(
         context,
         v8::Local<v8::Function>::Cast(mate::ConvertToV8(
-            isolate, base::Bind(&FileSelectHelper::OnSaveDialogDone, this)))));
+            isolate,
+            base::BindOnce(&FileSelectHelper::OnSaveDialogDone, this)))));
   }
 
   void OnDirectoryListerDone(std::vector<FileChooserFileInfoPtr> file_info,

--- a/atom/common/api/constructor.h
+++ b/atom/common/api/constructor.h
@@ -14,8 +14,9 @@ namespace mate {
 // only ONCE in the program's whole lifetime, otherwise we would have memory
 // leak.
 template <typename T, typename Sig>
-v8::Local<v8::Function> CreateConstructor(v8::Isolate* isolate,
-                                          const base::Callback<Sig>& func) {
+v8::Local<v8::Function> CreateConstructor(
+    v8::Isolate* isolate,
+    const base::RepeatingCallback<Sig>& func) {
 #ifndef NDEBUG
   static bool called = false;
   CHECK(!called) << "CreateConstructor can only be called for one type once";

--- a/atom/common/native_mate_converters/callback.cc
+++ b/atom/common/native_mate_converters/callback.cc
@@ -124,8 +124,9 @@ v8::Local<v8::Value> CreateFunctionFromTranslater(v8::Isolate* isolate,
                                                   bool one_time) {
   // The FunctionTemplate is cached.
   if (g_call_translater.IsEmpty())
-    g_call_translater.Reset(isolate, mate::CreateFunctionTemplate(
-                                         isolate, base::Bind(&CallTranslater)));
+    g_call_translater.Reset(isolate,
+                            mate::CreateFunctionTemplate(
+                                isolate, base::BindRepeating(&CallTranslater)));
 
   v8::Local<v8::FunctionTemplate> call_translater =
       v8::Local<v8::FunctionTemplate>::New(isolate, g_call_translater);

--- a/atom/common/native_mate_converters/content_converter.cc
+++ b/atom/common/native_mate_converters/content_converter.cc
@@ -56,8 +56,8 @@ v8::Local<v8::Value> MenuItemToV8(
     v8_item.Set("submenu",
                 MenuToV8(isolate, web_contents, context, item.submenu));
   else if (item.action > 0)
-    v8_item.Set("click",
-                base::Bind(ExecuteCommand, web_contents, item.action, context));
+    v8_item.Set("click", base::BindRepeating(ExecuteCommand, web_contents,
+                                             item.action, context));
   return v8_item.GetHandle();
 }
 

--- a/chromium_src/chrome/browser/process_singleton.h
+++ b/chromium_src/chrome/browser/process_singleton.h
@@ -58,9 +58,9 @@ class ProcessSingleton {
   // Chrome process was launched. Return true if the command line will be
   // handled within the current browser instance or false if the remote process
   // should handle it (i.e., because the current process is shutting down).
-  using NotificationCallback =
-      base::Callback<bool(const base::CommandLine::StringVector& command_line,
-                          const base::FilePath& current_directory)>;
+  using NotificationCallback = base::RepeatingCallback<bool(
+      const base::CommandLine::StringVector& command_line,
+      const base::FilePath& current_directory)>;
 
   ProcessSingleton(const base::FilePath& user_data_dir,
                    const NotificationCallback& notification_callback);
@@ -94,7 +94,7 @@ class ProcessSingleton {
 #if defined(OS_WIN)
   // Called to query whether to kill a hung browser process that has visible
   // windows. Return true to allow killing the hung process.
-  using ShouldKillRemoteProcessCallback = base::Callback<bool()>;
+  using ShouldKillRemoteProcessCallback = base::RepeatingCallback<bool()>;
   void OverrideShouldKillRemoteProcessCallbackForTesting(
       const ShouldKillRemoteProcessCallback& display_dialog_callback);
 #endif
@@ -120,7 +120,7 @@ class ProcessSingleton {
       const base::TimeDelta& timeout);
   void OverrideCurrentPidForTesting(base::ProcessId pid);
   void OverrideKillCallbackForTesting(
-      const base::Callback<void(int)>& callback);
+      const base::RepeatingCallback<void(int)>& callback);
 #endif
 
  private:

--- a/chromium_src/chrome/browser/process_singleton_posix.cc
+++ b/chromium_src/chrome/browser/process_singleton_posix.cc
@@ -482,8 +482,8 @@ class ProcessSingleton::LinuxWatcher
       DCHECK_CURRENTLY_ON(BrowserThread::IO);
       // Wait for reads.
       fd_watch_controller_ = base::FileDescriptorWatcher::WatchReadable(
-          fd, base::Bind(&SocketReader::OnSocketCanReadWithoutBlocking,
-                         base::Unretained(this)));
+          fd, base::BindRepeating(&SocketReader::OnSocketCanReadWithoutBlocking,
+                                  base::Unretained(this)));
       // If we haven't completed in a reasonable amount of time, give up.
       timer_.Start(FROM_HERE, base::TimeDelta::FromSeconds(kTimeoutInSeconds),
                    this, &SocketReader::CleanupAndDeleteSelf);
@@ -592,8 +592,8 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
   // Watch for client connections on this socket.
   socket_watcher_ = base::FileDescriptorWatcher::WatchReadable(
-      socket, base::Bind(&LinuxWatcher::OnSocketCanReadWithoutBlocking,
-                         base::Unretained(this), socket));
+      socket, base::BindRepeating(&LinuxWatcher::OnSocketCanReadWithoutBlocking,
+                                  base::Unretained(this), socket));
 }
 
 void ProcessSingleton::LinuxWatcher::HandleMessage(
@@ -686,8 +686,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
 
   // Return to the UI thread to handle opening a new browser tab.
   ui_task_runner_->PostTask(
-      FROM_HERE, base::Bind(&ProcessSingleton::LinuxWatcher::HandleMessage,
-                            parent_, current_dir, tokens, this));
+      FROM_HERE, base::BindOnce(&ProcessSingleton::LinuxWatcher::HandleMessage,
+                                parent_, current_dir, tokens, this));
   fd_watch_controller_.reset();
 
   // LinuxWatcher::HandleMessage() is in charge of destroying this SocketReader
@@ -707,8 +707,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
 
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
-      base::Bind(&ProcessSingleton::LinuxWatcher::RemoveSocketReader, parent_,
-                 this));
+      base::BindOnce(&ProcessSingleton::LinuxWatcher::RemoveSocketReader,
+                     parent_, this));
   // We will be deleted once the posted RemoveSocketReader task runs.
 }
 
@@ -728,8 +728,8 @@ ProcessSingleton::ProcessSingleton(
   lock_path_ = user_data_dir.Append(kSingletonLockFilename);
   cookie_path_ = user_data_dir.Append(kSingletonCookieFilename);
 
-  kill_callback_ =
-      base::Bind(&ProcessSingleton::KillProcess, base::Unretained(this));
+  kill_callback_ = base::BindRepeating(&ProcessSingleton::KillProcess,
+                                       base::Unretained(this));
 }
 
 ProcessSingleton::~ProcessSingleton() {
@@ -887,8 +887,8 @@ void ProcessSingleton::StartListeningOnSocket() {
   watcher_ = new LinuxWatcher(this);
   base::PostTaskWithTraits(
       FROM_HERE, {BrowserThread::IO},
-      base::Bind(&ProcessSingleton::LinuxWatcher::StartListening, watcher_,
-                 sock_));
+      base::BindOnce(&ProcessSingleton::LinuxWatcher::StartListening, watcher_,
+                     sock_));
 }
 
 void ProcessSingleton::OnBrowserReady() {
@@ -950,7 +950,7 @@ void ProcessSingleton::OverrideCurrentPidForTesting(base::ProcessId pid) {
 }
 
 void ProcessSingleton::OverrideKillCallbackForTesting(
-    const base::Callback<void(int)>& callback) {
+    const base::RepeatingCallback<void(int)>& callback) {
   kill_callback_ = callback;
 }
 

--- a/chromium_src/chrome/browser/process_singleton_win.cc
+++ b/chromium_src/chrome/browser/process_singleton_win.cc
@@ -176,7 +176,8 @@ ProcessSingleton::ProcessSingleton(
       is_virtualized_(false),
       lock_file_(INVALID_HANDLE_VALUE),
       user_data_dir_(user_data_dir),
-      should_kill_remote_process_callback_(base::Bind(&TerminateAppWithError)) {
+      should_kill_remote_process_callback_(
+          base::BindRepeating(&TerminateAppWithError)) {
   // The user_data_dir may have not been created yet.
   base::CreateDirectoryAndGetError(user_data_dir, nullptr);
 }
@@ -290,9 +291,10 @@ bool ProcessSingleton::Create() {
       if (lock_file_ != INVALID_HANDLE_VALUE) {
         // Set the window's title to the path of our user data directory so
         // other Chrome instances can decide if they should forward to us.
-        bool result = window_.CreateNamed(
-            base::Bind(&ProcessLaunchNotification, notification_callback_),
-            user_data_dir_.value());
+        bool result =
+            window_.CreateNamed(base::BindRepeating(&ProcessLaunchNotification,
+                                                    notification_callback_),
+                                user_data_dir_.value());
 
         // NB: Ensure that if the primary app gets started as elevated
         // admin inadvertently, secondary windows running not as elevated


### PR DESCRIPTION
#### Description of Change

Remove last instances of `base::Bind` in favor of `base::BindOnce` and `base::BindRepeating`.

cc @zcbenz @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
