### PR TITLE
docs: note session.clearAuthCache planned change for 7.0

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -6,6 +6,19 @@ Breaking changes will be documented here, and deprecation warnings added to JS c
 
 The `FIXME` string is used in code comments to denote things that should be fixed for future releases. See https://github.com/electron/electron/search?q=fixme
 
+## Planned Breaking API Changes (7.0)
+
+### `session.clearAuthCache(options)`
+
+The `session.clearAuthCache` API no longer accepts options for what to clear, and instead unconditionally clears the whole cache.
+
+```
+// Deprecated
+session.clearAuthCache({ type: 'password' })
+// Replace with
+session.clearAuthCache()
+```
+
 ## Planned Breaking API Changes (6.0)
 
 ### `win.setMenu(null)`
@@ -81,7 +94,7 @@ powerMonitor.querySystemIdleTime(callback)
 const idleTime = getSystemIdleTime()
 ```
 
-## `app.enableMixedSandbox`
+### `app.enableMixedSandbox`
 
 ```js
 // Deprecated

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -12,7 +12,7 @@ The `FIXME` string is used in code comments to denote things that should be fixe
 
 The `session.clearAuthCache` API no longer accepts options for what to clear, and instead unconditionally clears the whole cache.
 
-```
+```js
 // Deprecated
 session.clearAuthCache({ type: 'password' })
 // Replace with


### PR DESCRIPTION
#### Description of Change
session.clearAuthCache options was deprecated in #18131 and removed in #17970. This adds a note about the change to the planned breaking changes document.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes