### PR TITLE
fix: Windows logger path

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -138,7 +138,10 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 #if defined(DEBUG)
   // Print logging to debug.log on Windows
   settings.logging_dest = logging::LOG_TO_ALL;
-  settings.log_file = L"debug.log";
+  base::FilePath log_filename;
+  base::PathService::Get(base::DIR_EXE, &log_filename);
+  log_filename = log_filename.AppendASCII("debug.log");
+  settings.log_file = log_filename.value().c_str();
   settings.lock_log = logging::LOCK_LOG_FILE;
   settings.delete_old = logging::DELETE_OLD_LOG_FILE;
 #else


### PR DESCRIPTION
#### Description of Change
Windows debug isn't logging because of a DCHECK failure during startup. This changes the logger initialization to use the absolute path, so that logging works again.
Fixes https://github.com/electron/electron/issues/13770#issuecomment-412199748

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed windows debug logging
