### PR TITLE
build: fix linux release builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,8 +186,11 @@ step-get-more-space-on-mac: &step-get-more-space-on-mac
 
 step-delete-git-directories: &step-delete-git-directories
   run:
-    name: Delete src/.git directory
-    command: sudo rm -rf src/.git
+    name: Delete src/.git directory on MacOS to free space
+    command: |
+      if [ "`uname`" == "Darwin" ]; then
+        sudo rm -rf src/.git
+      fi
 
 # On macOS the npm install command during gclient sync was run on a linux
 # machine and therefore installed a slightly different set of dependencies


### PR DESCRIPTION
#### Description of Change
#18099 added a step to use sudo to delete the `.git` directory, but unfortunately our docker container on Linux doesn't currently support passwordless sudo, so the command fails.  This deletion is really only needed on Mac, so this PR changes that step to only run on Mac.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
