### PR TITLE
chore: run protocol tests in separate WebContents

### DIFF
--- a/spec/fixtures/pages/jquery.html
+++ b/spec/fixtures/pages/jquery.html
@@ -3,5 +3,20 @@
   <script src="../../static/jquery-2.0.3.min.js"></script>
 </head>
 <body>
+<script>
+  window.ajax = (url, options) => {
+    return new Promise((resolve, reject) => {
+      options.url = url
+      options.cache = false
+      options.success = (data, status, request) => {
+        resolve({data, status: request.status, headers: request.getAllResponseHeaders()})
+      }
+      options.error = (xhr, errorType, error) => {
+        reject(error ? error : xhr.status)
+      }
+      $.ajax(options)
+    })
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Refs #15791.

After migrating protocol module to NetworkService, there is a behavior change that, after registering a new protocol, it is impossible to access the new-registered protocol via ajax requests immediately in the opened WebContents, all WebContents have to do navigations to be able to access the new-registered protocol.

However our tests for protocol module rely on this behavior, so in order to make the tests pass with NetworkService enabled, I have to refactor the tests to do ajax requests in a separate WebContents instead of current WebContents.

I have also simplified the tests with async/await, and if in future we found a way to work around this limitation of NetworkService, it is very easy to revert back to the old way by changing a few lines.

I'll document the behavior changes of protocol module in other PRs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes