### PR TITLE
build: remove deprecated octokit auth calls

### DIFF
--- a/script/find-release.js
+++ b/script/find-release.js
@@ -1,6 +1,8 @@
 if (!process.env.CI) require('dotenv-safe').load()
 
-const octokit = require('@octokit/rest')()
+const octokit = require('@octokit/rest')({
+  auth: process.env.ELECTRON_GITHUB_TOKEN
+})
 
 if (process.argv.length < 3) {
   console.log('Usage: find-release version')
@@ -10,8 +12,6 @@ if (process.argv.length < 3) {
 const version = process.argv[2]
 
 async function findRelease () {
-  octokit.authenticate({ type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN })
-
   const releases = await octokit.repos.listReleases({
     owner: 'electron',
     repo: version.indexOf('nightly') > 0 ? 'nightlies' : 'electron'

--- a/script/prepare-release.js
+++ b/script/prepare-release.js
@@ -5,7 +5,9 @@ const args = require('minimist')(process.argv.slice(2), {
   boolean: ['automaticRelease', 'notesOnly', 'stable']
 })
 const ciReleaseBuild = require('./ci-release-build')
-const octokit = require('@octokit/rest')()
+const octokit = require('@octokit/rest')({
+  auth: process.env.ELECTRON_GITHUB_TOKEN
+})
 const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
 
@@ -27,8 +29,6 @@ if (!bumpType && !args.notesOnly) {
 }
 
 const gitDir = path.resolve(__dirname, '..')
-octokit.authenticate({ type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN })
-
 async function getNewVersion (dryRun) {
   if (!dryRun) {
     console.log(`Bumping for new "${bumpType}" version.`)

--- a/script/release-artifact-cleanup.js
+++ b/script/release-artifact-cleanup.js
@@ -12,15 +12,12 @@ const { execSync } = require('child_process')
 const { GitProcess } = require('dugite')
 const { getCurrentBranch } = require('./lib/utils.js')
 
-const octokit = require('@octokit/rest')()
-const path = require('path')
-
-const gitDir = path.resolve(__dirname, '..')
-
-octokit.authenticate({
-  type: 'token',
-  token: process.env.ELECTRON_GITHUB_TOKEN
+const octokit = require('@octokit/rest')({
+  auth: process.env.ELECTRON_GITHUB_TOKEN
 })
+
+const path = require('path')
+const gitDir = path.resolve(__dirname, '..')
 
 function getLastBumpCommit (tag) {
   const data = execSync(`git log -n1 --grep "Bump ${tag}" --format='format:{"hash": "%H", "message": "%s"}'`).toString()

--- a/script/release-notes/notes.js
+++ b/script/release-notes/notes.js
@@ -6,7 +6,9 @@ const os = require('os')
 const path = require('path')
 
 const { GitProcess } = require('dugite')
-const octokit = require('@octokit/rest')()
+const octokit = require('@octokit/rest')({
+  auth: process.env.ELECTRON_GITHUB_TOKEN
+})
 const semver = require('semver')
 
 const MAX_FAIL_COUNT = 3
@@ -16,8 +18,6 @@ const CACHE_DIR = path.resolve(__dirname, '.cache')
 const NO_NOTES = 'No notes'
 const FOLLOW_REPOS = [ 'electron/electron', 'electron/libchromiumcontent', 'electron/node' ]
 const gitDir = path.resolve(__dirname, '..', '..')
-
-octokit.authenticate({ type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN })
 
 const breakTypes = new Set(['breaking-change'])
 const docTypes = new Set(['doc', 'docs'])

--- a/script/release.js
+++ b/script/release.js
@@ -24,10 +24,8 @@ const sumchecker = require('sumchecker')
 const temp = require('temp').track()
 const { URL } = require('url')
 
-const octokit = require('@octokit/rest')()
-octokit.authenticate({
-  type: 'token',
-  token: process.env.ELECTRON_GITHUB_TOKEN
+const octokit = require('@octokit/rest')({
+  auth: process.env.ELECTRON_GITHUB_TOKEN
 })
 
 const targetRepo = pkgVersion.indexOf('nightly') > 0 ? 'nightlies' : 'electron'

--- a/script/upload-to-github.js
+++ b/script/upload-to-github.js
@@ -2,8 +2,9 @@ if (!process.env.CI) require('dotenv-safe').load()
 
 const fs = require('fs')
 
-const octokit = require('@octokit/rest')()
-octokit.authenticate({ type: 'token', token: process.env.ELECTRON_GITHUB_TOKEN })
+const octokit = require('@octokit/rest')({
+  auth: process.env.ELECTRON_GITHUB_TOKEN
+})
 
 if (process.argv.length < 6) {
   console.log('Usage: upload-to-github filePath fileName releaseId')


### PR DESCRIPTION
#### Description of Change

`octokit.authenticate` is deprecated and its notices caused release failures. This fixes that.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
