### PR TITLE
docs: update community Slack URL to point to Discourse invite thread

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -12,7 +12,7 @@ you can interact with the community in these locations:
 - [`electron`](https://discuss.atom.io/c/electron) category on the Atom
 forums
 - `#atom-shell` channel on Freenode
-- ~~[`Electron`](https://atom-slack.herokuapp.com) channel on Atom's Slack~~ (currently offline for maintenance)
+- `#electron` channel on [Atom's Slack](https://discuss.atom.io/t/join-us-on-slack/16638?source_topic_id=25406)
 - [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*
 - [`electron-br`](https://electron-br.slack.com) *(Brazilian Portuguese)*
 - [`electron-kr`](https://electron-kr.github.io/electron-kr) *(Korean)*

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -12,7 +12,7 @@ you can interact with the community in these locations:
 - [`electron`](https://discuss.atom.io/c/electron) category on the Atom
 forums
 - `#atom-shell` channel on Freenode
-- [`Electron`](https://atom-slack.herokuapp.com) channel on Atom's Slack
+- ~~[`Electron`](https://atom-slack.herokuapp.com) channel on Atom's Slack~~ (currently offline for maintenance)
 - [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*
 - [`electron-br`](https://electron-br.slack.com) *(Brazilian Portuguese)*
 - [`electron-kr`](https://electron-kr.github.io/electron-kr) *(Korean)*


### PR DESCRIPTION
#### Description of Change
Update link to community Slack to point at the Discourse thread

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes