### PR TITLE
feat: migrate protocol module to NetworkService (Part 6)

### DIFF
--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -41,28 +41,82 @@ NodeStreamLoader::~NodeStreamLoader() {
     node::MakeCallback(isolate_, emitter_.Get(isolate_), "removeListener",
                        node::arraysize(args), args, {0, 0});
   }
+
+  // Release references.
+  emitter_.Reset();
+  buffer_.Reset();
 }
 
 void NodeStreamLoader::Start(network::ResourceResponseHead head) {
+  mojo::ScopedDataPipeProducerHandle producer;
   mojo::ScopedDataPipeConsumerHandle consumer;
-  MojoResult rv = mojo::CreateDataPipe(nullptr, &producer_, &consumer);
+  MojoResult rv = mojo::CreateDataPipe(nullptr, &producer, &consumer);
   if (rv != MOJO_RESULT_OK) {
-    client_->OnComplete(
-        network::URLLoaderCompletionStatus(net::ERR_INSUFFICIENT_RESOURCES));
-    delete this;
+    NotifyComplete(net::ERR_INSUFFICIENT_RESOURCES);
     return;
   }
+
+  producer_ =
+      std::make_unique<mojo::StringDataPipeProducer>(std::move(producer));
 
   client_->OnReceiveResponse(head);
   client_->OnStartLoadingResponseBody(std::move(consumer));
 
   auto weak = weak_factory_.GetWeakPtr();
-  On("end", base::BindRepeating(&NodeStreamLoader::OnEnd, weak));
-  On("error", base::BindRepeating(&NodeStreamLoader::OnError, weak));
-  // Since every node::MakeCallback call has a micro scope itself, we have to
-  // subscribe |data| at last otherwise |end|'s listener won't be called when
-  // it is emitted in the same tick.
-  On("data", base::BindRepeating(&NodeStreamLoader::OnData, weak));
+  On("end",
+     base::BindRepeating(&NodeStreamLoader::NotifyComplete, weak, net::OK));
+  On("error", base::BindRepeating(&NodeStreamLoader::NotifyComplete, weak,
+                                  net::ERR_FAILED));
+  On("readable", base::BindRepeating(&NodeStreamLoader::ReadMore, weak));
+}
+
+void NodeStreamLoader::NotifyComplete(int result) {
+  // Wait until write finishes or fails.
+  if (is_writing_) {
+    ended_ = true;
+    result_ = result;
+    return;
+  }
+
+  client_->OnComplete(network::URLLoaderCompletionStatus(result));
+  delete this;
+}
+
+void NodeStreamLoader::ReadMore() {
+  // buffer = emitter.read()
+  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(
+      isolate_, emitter_.Get(isolate_), "read", 0, nullptr, {0, 0});
+
+  // If there is no buffer read, wait until |readable| is emitted again.
+  v8::Local<v8::Value> buffer;
+  if (!ret.ToLocal(&buffer) || !node::Buffer::HasInstance(buffer))
+    return;
+
+  // Hold the buffer until the write is done.
+  buffer_.Reset(isolate_, buffer);
+
+  // Write buffer to mojo pipe asyncronously.
+  is_writing_ = true;
+  producer_->Write(
+      base::StringPiece(node::Buffer::Data(buffer),
+                        node::Buffer::Length(buffer)),
+      mojo::StringDataPipeProducer::AsyncWritingMode::
+          STRING_STAYS_VALID_UNTIL_COMPLETION,
+      base::BindOnce(&NodeStreamLoader::DidWrite, weak_factory_.GetWeakPtr()));
+}
+
+void NodeStreamLoader::DidWrite(MojoResult result) {
+  is_writing_ = false;
+  // We were told to end streaming.
+  if (ended_) {
+    NotifyComplete(result_);
+    return;
+  }
+
+  if (result == MOJO_RESULT_OK)
+    ReadMore();
+  else
+    NotifyComplete(net::ERR_FAILED);
 }
 
 void NodeStreamLoader::On(const char* event, EventCallback callback) {
@@ -78,34 +132,7 @@ void NodeStreamLoader::On(const char* event, EventCallback callback) {
   handlers_[event].Reset(isolate_, args[1]);
   node::MakeCallback(isolate_, emitter_.Get(isolate_), "on",
                      node::arraysize(args), args, {0, 0});
-}
-
-void NodeStreamLoader::OnData(mate::Arguments* args) {
-  v8::Local<v8::Value> buffer;
-  args->GetNext(&buffer);
-  if (!node::Buffer::HasInstance(buffer)) {
-    args->ThrowError("data must be Buffer");
-    return;
-  }
-
-  size_t ssize = node::Buffer::Length(buffer);
-  uint32_t size = base::saturated_cast<uint32_t>(ssize);
-  MojoResult result = producer_->WriteData(node::Buffer::Data(buffer), &size,
-                                           MOJO_WRITE_DATA_FLAG_NONE);
-  if (result != MOJO_RESULT_OK || size < ssize) {
-    OnError(nullptr);
-    return;
-  }
-}
-
-void NodeStreamLoader::OnEnd(mate::Arguments* args) {
-  client_->OnComplete(network::URLLoaderCompletionStatus(net::OK));
-  delete this;
-}
-
-void NodeStreamLoader::OnError(mate::Arguments* args) {
-  client_->OnComplete(network::URLLoaderCompletionStatus(net::ERR_FAILED));
-  delete this;
+  // No more code bellow, as this class may destruct when subscribing.
 }
 
 }  // namespace atom

--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -23,6 +23,10 @@ NodeStreamLoader::NodeStreamLoader(network::ResourceResponseHead head,
       isolate_(isolate),
       emitter_(isolate, emitter),
       weak_factory_(this) {
+  binding_.set_connection_error_handler(
+      base::BindOnce(&NodeStreamLoader::NotifyComplete,
+                     weak_factory_.GetWeakPtr(), net::ERR_FAILED));
+
   // PostTask since it might destruct.
   base::SequencedTaskRunnerHandle::Get()->PostTask(
       FROM_HERE, base::BindOnce(&NodeStreamLoader::Start,

--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -47,7 +47,9 @@ void NodeStreamLoader::Start(network::ResourceResponseHead head) {
   mojo::ScopedDataPipeConsumerHandle consumer;
   MojoResult rv = mojo::CreateDataPipe(nullptr, &producer_, &consumer);
   if (rv != MOJO_RESULT_OK) {
-    OnError(nullptr);
+    client_->OnComplete(
+        network::URLLoaderCompletionStatus(net::ERR_INSUFFICIENT_RESOURCES));
+    delete this;
     return;
   }
 

--- a/atom/browser/net/node_stream_loader.cc
+++ b/atom/browser/net/node_stream_loader.cc
@@ -73,10 +73,9 @@ void NodeStreamLoader::On(const char* event, EventCallback callback) {
       mate::StringToV8(isolate_, event),
       mate::CallbackToV8(isolate_, std::move(callback)),
   };
+  handlers_[event].Reset(isolate_, args[1]);
   node::MakeCallback(isolate_, emitter_.Get(isolate_), "on",
                      node::arraysize(args), args, {0, 0});
-
-  handlers_[event].Reset(isolate_, args[1]);
 }
 
 void NodeStreamLoader::OnData(mate::Arguments* args) {

--- a/atom/browser/net/node_stream_loader.h
+++ b/atom/browser/net/node_stream_loader.h
@@ -32,6 +32,8 @@ class NodeStreamLoader : public network::mojom::URLLoader {
 
   using EventCallback = base::RepeatingCallback<void(mate::Arguments* args)>;
 
+  void Start(network::ResourceResponseHead head);
+
   // URLLoader:
   void FollowRedirect(const std::vector<std::string>& removed_headers,
                       const net::HttpRequestHeaders& modified_headers,

--- a/atom/browser/net/node_stream_loader.h
+++ b/atom/browser/net/node_stream_loader.h
@@ -10,12 +10,9 @@
 #include <vector>
 
 #include "mojo/public/cpp/bindings/strong_binding.h"
+#include "mojo/public/cpp/system/string_data_pipe_producer.h"
 #include "services/network/public/mojom/url_loader.mojom.h"
 #include "v8/include/v8.h"
-
-namespace mate {
-class Arguments;
-}
 
 namespace atom {
 
@@ -24,7 +21,9 @@ namespace atom {
 // This class manages its own lifetime and should delete itself when the
 // connection is lost or finished.
 //
-// The code is updated with `BlobURLLoader`.
+// We use |paused mode| to read data from |Readable| stream, so we don't need to
+// copy data from buffer and hold it in memory, and we only need to make sure
+// the passed |Buffer| is alive while writing data to pipe.
 class NodeStreamLoader : public network::mojom::URLLoader {
  public:
   NodeStreamLoader(network::ResourceResponseHead head,
@@ -36,9 +35,15 @@ class NodeStreamLoader : public network::mojom::URLLoader {
  private:
   ~NodeStreamLoader() override;
 
-  using EventCallback = base::RepeatingCallback<void(mate::Arguments* args)>;
+  using EventCallback = base::RepeatingCallback<void()>;
 
   void Start(network::ResourceResponseHead head);
+  void NotifyComplete(int result);
+  void ReadMore();
+  void DidWrite(MojoResult result);
+
+  // Subscribe to events of |emitter|.
+  void On(const char* event, EventCallback callback);
 
   // URLLoader:
   void FollowRedirect(const std::vector<std::string>& removed_headers,
@@ -50,20 +55,23 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   void PauseReadingBodyFromNet() override {}
   void ResumeReadingBodyFromNet() override {}
 
-  // JS bindings.
-  void On(const char* event, EventCallback callback);
-  void OnData(mate::Arguments* args);
-  void OnEnd(mate::Arguments* args);
-  void OnError(mate::Arguments* args);
-
   mojo::Binding<network::mojom::URLLoader> binding_;
   network::mojom::URLLoaderClientPtr client_;
 
   v8::Isolate* isolate_;
   v8::Global<v8::Object> emitter_;
+  v8::Global<v8::Value> buffer_;
 
-  // Pipes for communicating between Node and NetworkService.
-  mojo::ScopedDataPipeProducerHandle producer_;
+  // Mojo data pipe where the data that is being read is written to.
+  std::unique_ptr<mojo::StringDataPipeProducer> producer_;
+
+  // Whether we are in the middle of write.
+  bool is_writing_ = false;
+
+  // When NotifyComplete is called while writing, we will save the result and
+  // quit with it after the write is done.
+  bool ended_ = false;
+  int result_ = net::OK;
 
   // Store the V8 callbacks to unsubscribe them later.
   std::map<std::string, v8::Global<v8::Value>> handlers_;

--- a/atom/browser/net/node_stream_loader.h
+++ b/atom/browser/net/node_stream_loader.h
@@ -19,6 +19,12 @@ class Arguments;
 
 namespace atom {
 
+// Read data from node Stream and feed it to NetworkService.
+//
+// This class manages its own lifetime and should delete itself when the
+// connection is lost or finished.
+//
+// The code is updated with `BlobURLLoader`.
 class NodeStreamLoader : public network::mojom::URLLoader {
  public:
   NodeStreamLoader(network::ResourceResponseHead head,
@@ -49,13 +55,6 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   void OnData(mate::Arguments* args);
   void OnEnd(mate::Arguments* args);
   void OnError(mate::Arguments* args);
-
-  // This class manages its own lifetime and should delete itself when the
-  // connection is lost or finished.
-  //
-  // The code is updated with `content::FileURLLoader`.
-  void OnConnectionError();
-  void MaybeDeleteSelf();
 
   mojo::Binding<network::mojom::URLLoader> binding_;
   network::mojom::URLLoaderClientPtr client_;

--- a/atom/browser/net/node_stream_loader.h
+++ b/atom/browser/net/node_stream_loader.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_NET_NODE_STREAM_LOADER_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This PR fixes large file handling when using `registerStreamProtocol` API with NetworkService enabled, all `registerStreamProtocol` tests are passing now.

The `NodeStreamLoader` is also refactored to use [`paused mode`](https://nodejs.org/api/stream.html#stream_two_reading_modes) to read data from `Readable` stream, so we don't need to copy data from buffer and hold it in memory, and we only need to make sure the passed `Buffer` is alive while writing data to pipe.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes