### PR TITLE
docs: Fix incorrect dialog docs

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -155,6 +155,30 @@ dialog.showOpenDialog(mainWindow, {
 })
 ```
 
+### `dialog.showSaveDialogSync([browserWindow, ]options)`
+
+* `browserWindow` [BrowserWindow](browser-window.md) (optional)
+* `options` Object
+  * `title` String (optional)
+  * `defaultPath` String (optional) - Absolute directory path, absolute file
+    path, or file name to use by default.
+  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
+    left empty the default label will be used.
+  * `filters` [FileFilter[]](structures/file-filter.md) (optional)
+  * `message` String (optional) _macOS_ - Message to display above text fields.
+  * `nameFieldLabel` String (optional) _macOS_ - Custom label for the text
+    displayed in front of the filename text field.
+  * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
+    defaults to `true`.
+  * `securityScopedBookmarks` Boolean (optional) _macOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
+
+Returns `String | undefined`, the path of the file chosen by the user; if the dialog is cancelled it returns `undefined`.
+
+The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+
+The `filters` specifies an array of file types that can be displayed, see
+`dialog.showOpenDialog` for an example.
+
 ### `dialog.showSaveDialog([browserWindow, ]options)`
 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -172,30 +172,6 @@ dialog.showOpenDialog(mainWindow, {
     defaults to `true`.
   * `securityScopedBookmarks` Boolean (optional) _macOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
 
-Returns `String | undefined`, the path of the file chosen by the user; if the dialog is cancelled it returns `undefined`.
-
-The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
-
-The `filters` specifies an array of file types that can be displayed, see
-`dialog.showOpenDialog` for an example.
-
-### `dialog.showSaveDialog([browserWindow, ]options)`
-
-* `browserWindow` [BrowserWindow](browser-window.md) (optional)
-* `options` Object
-  * `title` String (optional)
-  * `defaultPath` String (optional) - Absolute directory path, absolute file
-    path, or file name to use by default.
-  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
-    left empty the default label will be used.
-  * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `message` String (optional) _macOS_ - Message to display above text fields.
-  * `nameFieldLabel` String (optional) _macOS_ - Custom label for the text
-    displayed in front of the filename text field.
-  * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
-    defaults to `true`.
-  * `securityScopedBookmarks` Boolean (optional) _macOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
-
 Returns `Promise<Object>` - Resolve with an object containing the following:
   * `canceled` Boolean - whether or not the dialog was canceled.
   * `filePath` String (optional) - If the dialog is canceled, this will be `undefined`.


### PR DESCRIPTION
#### Description of Change
We had multiple definitions for `showSaveDialog`. This removes the old ones.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
notes: Fixed incorrect definition and documentation for `dialog.showSaveDialog()`