### PR TITLE
refactor: add invoke helpers to window-setup

### DIFF
--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -81,9 +81,7 @@ class LocationProxy {
           // It's right, that's bad, but we're doing it anway.
           (guestURL as any)[propertyKey] = newVal
 
-          return this.ipcRenderer.sendSync(
-            'ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC',
-            this.guestId, 'loadURL', guestURL.toString())
+          return this._invokeWebContentsMethodSync('loadURL', guestURL.toString())
         }
       }
     })
@@ -102,7 +100,7 @@ class LocationProxy {
   }
 
   private getGuestURL (): URL | null {
-    const urlString = ipcRendererInternal.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', this.guestId, 'getURL')
+    const urlString = this._invokeWebContentsMethodSync('getURL') as string
     try {
       return new URL(urlString)
     } catch (e) {
@@ -110,6 +108,10 @@ class LocationProxy {
     }
 
     return null
+  }
+
+  private _invokeWebContentsMethodSync (method: string, ...args: any[]) {
+    return ipcRendererInternal.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', this.guestId, method, ...args)
   }
 }
 
@@ -127,7 +129,7 @@ class BrowserWindowProxy {
   }
   public set location (url: string | any) {
     url = resolveURL(url)
-    ipcRendererInternal.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', this.guestId, 'loadURL', url)
+    this._invokeWebContentsMethodSync('loadURL', url)
   }
 
   constructor (guestId: number) {
@@ -145,23 +147,35 @@ class BrowserWindowProxy {
   }
 
   public focus () {
-    ipcRendererInternal.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'focus')
+    this._invokeWindowMethod('focus')
   }
 
   public blur () {
-    ipcRendererInternal.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'blur')
+    this._invokeWindowMethod('blur')
   }
 
   public print () {
-    ipcRendererInternal.send('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, 'print')
+    this._invokeWebContentsMethod('print')
   }
 
   public postMessage (message: any, targetOrigin: any) {
     ipcRendererInternal.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', this.guestId, message, toString(targetOrigin), window.location.origin)
   }
 
-  public eval (...args: any[]) {
-    ipcRendererInternal.send('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, 'executeJavaScript', ...args)
+  public eval (code: string) {
+    this._invokeWebContentsMethod('executeJavaScript', code)
+  }
+
+  private _invokeWindowMethod (method: string, ...args: any[]) {
+    return ipcRendererInternal.send('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, method, ...args)
+  }
+
+  private _invokeWebContentsMethod (method: string, ...args: any[]) {
+    return ipcRendererInternal.send('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', this.guestId, method, ...args)
+  }
+
+  private _invokeWebContentsMethodSync (method: string, ...args: any[]) {
+    return ipcRendererInternal.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC', this.guestId, method, ...args)
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Eliminate duplicate code sending IPCs (to invoke window / webContents methods).
Simplifies further changes (#17948).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes