### PR TITLE
docs: correct reference chrome://plugins to components

### DIFF
--- a/docs/tutorial/testing-widevine-cdm.md
+++ b/docs/tutorial/testing-widevine-cdm.md
@@ -75,7 +75,7 @@ const { app, BrowserWindow } = require('electron')
 // * `libwidevinecdm.dylib` on macOS,
 // * `widevinecdm.dll` on Windows.
 app.commandLine.appendSwitch('widevine-cdm-path', '/path/to/widevine_library')
-// The version of plugin can be got from `chrome://plugins` page in Chrome.
+// The version of plugin can be got from `chrome://components` page in Chrome.
 app.commandLine.appendSwitch('widevine-cdm-version', '1.4.8.866')
 
 let win = null


### PR DESCRIPTION
chrome://plugins was removed in Chrome 57 but still has one reference here

notes: none