### PR TITLE
chore: update @types/node to match with version embedded in Electron 3.x

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,7 @@
   "main": "index.js",
   "types": "electron.d.ts",
   "dependencies": {
-    "@types/node": "^8.0.24",
+    "@types/node": "^10.1.4",
     "electron-download": "^4.1.0",
     "extract-zip": "^1.0.3"
   },


### PR DESCRIPTION
#### Description of Change

Backport of #16174

Electron 3 embeds Node `10.2.0`, but the corresponding `@types/node` declaration is still on `8.something`.

It looks like the original PR #16174 was backported to v4 in #16177 but there wasn't a backport to v3, so here's me trying to do this.

I thought I'd be able to hack around this using yarn's `resolutions` trick:

```
  "resolutions": {
    "**/@types/node": "10.1.4"
  }
```

 But even that is not happy with me:

<img width="765" src="https://user-images.githubusercontent.com/359239/57483502-5db2fb00-727d-11e9-892d-0bdb38ede18d.png">

Maybe it works anyway? 

Not sure what other checks I need to do while I'm in here to catch any potential regressions, but I'll see what CI does first.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- ~~[ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)~~
- ~~[ ] relevant documentation is changed or added~~
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Update @types/node dependency to version compatible with Node 10.2.0
