### PR TITLE
fix: set window to null when no window is passed

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -47,7 +47,11 @@ const checkAppInitialized = function () {
 const saveDialog = (sync, window, options) => {
   checkAppInitialized()
 
-  if (window && window.constructor !== BrowserWindow) options = window
+  if (window && window.constructor !== BrowserWindow) {
+    options = window
+    window = null
+  }
+
   if (options == null) options = { title: 'Save' }
 
   const {
@@ -74,7 +78,11 @@ const saveDialog = (sync, window, options) => {
 const openDialog = (sync, window, options) => {
   checkAppInitialized()
 
-  if (window && window.constructor !== BrowserWindow) options = window
+  if (window && window.constructor !== BrowserWindow) {
+    options = window
+    window = null
+  }
+
   if (options == null) {
     options = {
       title: 'Open',
@@ -115,7 +123,11 @@ const openDialog = (sync, window, options) => {
 const messageBox = (sync, window, options) => {
   checkAppInitialized()
 
-  if (window && window.constructor !== BrowserWindow) options = window
+  if (window && window.constructor !== BrowserWindow) {
+    options = window
+    window = null
+  }
+
   if (options == null) options = { type: 'none' }
 
   const messageBoxTypes = ['none', 'info', 'warning', 'error', 'question']

--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -1,8 +1,24 @@
 const { expect } = require('chai')
-const { dialog } = require('electron').remote
+const { closeWindow } = require('./window-helpers')
+const { BrowserWindow, dialog } = require('electron').remote
 
 describe('dialog module', () => {
   describe('showOpenDialog', () => {
+    it('should not throw for valid cases', () => {
+      let w
+
+      expect(() => {
+        dialog.showOpenDialog({ title: 'i am title' })
+      }).to.not.throw()
+
+      expect(() => {
+        w = new BrowserWindow()
+        dialog.showOpenDialog(w, { title: 'i am title' })
+      }).to.not.throw()
+
+      closeWindow(w).then(() => { w = null })
+    })
+
     it('throws errors when the options are invalid', () => {
       expect(() => {
         dialog.showOpenDialog({ properties: false })
@@ -27,6 +43,21 @@ describe('dialog module', () => {
   })
 
   describe('showSaveDialog', () => {
+    it('should not throw for valid cases', () => {
+      let w
+
+      expect(() => {
+        dialog.showSaveDialog({ title: 'i am title' })
+      }).to.not.throw()
+
+      expect(() => {
+        w = new BrowserWindow()
+        dialog.showSaveDialog(w, { title: 'i am title' })
+      }).to.not.throw()
+
+      closeWindow(w).then(() => { w = null })
+    })
+
     it('throws errors when the options are invalid', () => {
       expect(() => {
         dialog.showSaveDialog({ title: 300 })
@@ -51,6 +82,21 @@ describe('dialog module', () => {
   })
 
   describe('showMessageBox', () => {
+    it('should not throw for valid cases', () => {
+      let w
+
+      expect(() => {
+        dialog.showMessageBox({ title: 'i am title' })
+      }).to.not.throw()
+
+      expect(() => {
+        w = new BrowserWindow()
+        dialog.showMessageBox(w, { title: 'i am title' })
+      }).to.not.throw()
+
+      closeWindow(w).then(() => { w = null })
+    })
+
     it('throws errors when the options are invalid', () => {
       expect(() => {
         dialog.showMessageBox(undefined, { type: 'not-a-valid-type' })

--- a/spec/api-dialog-spec.js
+++ b/spec/api-dialog-spec.js
@@ -1,10 +1,15 @@
 const { expect } = require('chai')
 const { closeWindow } = require('./window-helpers')
-const { BrowserWindow, dialog } = require('electron').remote
+const { remote } = require('electron')
+const { BrowserWindow, dialog } = remote
+const isCI = remote.getGlobal('isCi')
 
 describe('dialog module', () => {
   describe('showOpenDialog', () => {
     it('should not throw for valid cases', () => {
+      // Blocks the main process and can't be run in CI
+      if (isCI) return
+
       let w
 
       expect(() => {
@@ -44,6 +49,9 @@ describe('dialog module', () => {
 
   describe('showSaveDialog', () => {
     it('should not throw for valid cases', () => {
+      // Blocks the main process and can't be run in CI
+      if (isCI) return
+
       let w
 
       expect(() => {
@@ -83,6 +91,9 @@ describe('dialog module', () => {
 
   describe('showMessageBox', () => {
     it('should not throw for valid cases', () => {
+      // Blocks the main process and can't be run in CI
+      if (isCI) return
+
       let w
 
       expect(() => {


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/18236.

Our options parsing for dialogs correctly set `options` if no `window` was passed, but then did not correctly set the `window` back to null and it was then left as an object equal to options. This caused a crash when passed to native code as there is no valid circumstance where the `window` would be an object.

This same issue would have affected `showSaveDialog` and `showOpenDialog` and as such it is also fixed in those methods.

cc @adill @sofianguy @MarshallOfSound @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a dialog crash when no BrowserWindow was passed.
