### PR TITLE
fix: explicitly don't create missing directories with app.setPath

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -580,7 +580,7 @@ them.
 
 * `path` String (optional) - A custom path for your logs. Must be absolute.
 
-Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(newPath)`.
+Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(pathName, newPath)`.
 
 On _macOS_, this directory will be set by deafault to `/Library/Logs/YourAppName`, and on _Linux_ and _Windows_ it will be placed inside your `userData` directory.
 
@@ -641,9 +641,9 @@ On _Linux_ and _macOS_, icons depend on the application associated with file mim
 * `name` String
 * `path` String
 
-Overrides the `path` to a special directory or file associated with `name`. If
-the path specifies a directory that does not exist, the directory will be
-created by this method. On failure an `Error` is thrown.
+Overrides the `path` to a special directory or file associated with `name`.
+If the path specifies a directory that does not exist, an `Error` is thrown.
+In that case, the directory should be created with `fs.mkdirSync` or similar.
 
 You can only override paths of a `name` defined in `app.getPath`.
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -667,6 +667,18 @@ describe('app module', () => {
     })
   })
 
+  describe('setPath(name, path)', () => {
+    it('does not create a new directory by default', () => {
+      const badPath = path.join(__dirname, 'music')
+
+      expect(fs.existsSync(badPath)).to.be.false
+      app.setPath('music', badPath)
+      expect(fs.existsSync(badPath)).to.be.false
+
+      expect(() => { app.getPath(badPath) }).to.throw()
+    })
+  })
+
   describe('select-client-certificate event', () => {
     let w: BrowserWindow
 


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/18242.

Our [documentation](https://github.com/electron/electron/blob/master/docs/api/app.md#appsetpathname-path) specifies that nonexistent directories should be created when `app.setPath` is called if they don't already exist. We do this with [`base::PathService::OverrideAndCreateIfNeeded`](https://cs.chromium.org/chromium/src/base/path_service.h?sq=package:chromium&pv=1&g=0&l=58), which uses the last parameter to specify whether the path should be created.

This has potential for side effects should it be enabled, and so this PR corrects documentation to reflect implementation reality.

cc @nornagon @inukshuk @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
