### PR TITLE
chore: update codeowners for release scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,17 +4,27 @@
 # https://git-scm.com/docs/gitignore
 
 # Most stuff in here is owned by the Community & Safety WG...
-/.github/* @electron/wg-community
+/.github/*                              @electron/wg-community
 
 # ...except the Admin WG maintains this file.
-/.github/CODEOWNERS @electron/wg-admin
+/.github/CODEOWNERS                     @electron/wg-admin
 
 # Upgrades WG
-/patches/ @electron/wg-upgrades
+/patches/                               @electron/wg-upgrades
 
 # Docs & Tooling WG
 /default_app/ @electron/wg-docs-tools
-/docs/ @electron/wg-docs-tools
+/docs/                                  @electron/wg-docs-tools
 
 # Releases WG
-/npm/ @electron/wg-releases
+/npm/                                   @electron/wg-releases
+/script/release-notes                   @electron/wg-releases
+/script/prepare-release.js              @electron/wg-releases
+/script/bump-version.js                 @electron/wg-releases
+/script/ci-release-build.js             @electron/wg-releases
+/script/release.js                      @electron/wg-releases
+/script/upload-to-github.js             @electron/wg-releases
+/script/release-artifact-cleanup.js     @electron/wg-releases
+/script/get-last-major-for-master.js    @electron/wg-releases
+/script/find-release.js                 @electron/wg-releases
+/script/download-circleci-artifacts.js  @electron/wg-releases


### PR DESCRIPTION
#### Description of Change

Adds release scripts to codeownership of @electron/wg-releases. Also streamlines formatting.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
