### PR TITLE
feat: add 'gpu-info-update' event to app

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -770,6 +770,10 @@ void App::SelectClientCertificate(
   }
 }
 
+void App::OnGpuInfoUpdate() {
+  Emit("gpu-info-update");
+}
+
 void App::OnGpuProcessCrashed(base::TerminationStatus status) {
   Emit("gpu-process-crashed",
        status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -157,6 +157,7 @@ class App : public AtomBrowserClient::Delegate,
                        bool* no_javascript_access) override;
 
   // content::GpuDataManagerObserver:
+  void OnGpuInfoUpdate() override;
   void OnGpuProcessCrashed(base::TerminationStatus status) override;
 
   // content::BrowserChildProcessObserver:

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -343,6 +343,10 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
 })
 ```
 
+### Event: 'gpu-info-update'
+
+Emitted whenever there is a GPU info update.
+
 ### Event: 'gpu-process-crashed'
 
 Returns:
@@ -1011,6 +1015,8 @@ Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetr
 ### `app.getGPUFeatureStatus()`
 
 Returns [`GPUFeatureStatus`](structures/gpu-feature-status.md) - The Graphics Feature Status from `chrome://gpu/`.
+
+**Note:** This information is only usable after the `gpu-info-update` event is emitted.
 
 ### `app.getGPUInfo(infoType)`
 


### PR DESCRIPTION
#### Description of Change
Added `gpu-info-update` event to `app`, which is emitted whenever there is a GPU info update.
Reported by [`GpuDataManagerObserver::OnGpuInfoUpdate`](https://cs.chromium.org/chromium/src/content/public/browser/gpu_data_manager_observer.h?type=cs&q=OnGpuInfoUpdate&sq=package:chromium&g=0&l=18)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `gpu-info-update` event to `app`, which is emitted whenever there is a GPU info update.