### PR TITLE
fix: default enable_negotiate_port to false

### DIFF
--- a/atom/browser/net/system_network_context_manager.cc
+++ b/atom/browser/net/system_network_context_manager.cc
@@ -51,6 +51,8 @@ network::mojom::HttpAuthDynamicParamsPtr CreateHttpAuthDynamicParams() {
       command_line->GetSwitchValueASCII(atom::switches::kAuthServerWhitelist);
   auth_dynamic_params->delegate_whitelist = command_line->GetSwitchValueASCII(
       atom::switches::kAuthNegotiateDelegateWhitelist);
+  auth_dynamic_params->enable_negotiate_port =
+      command_line->HasSwitch(atom::switches::kEnableAuthNegotiatePort);
 
   return auth_dynamic_params;
 }

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -263,6 +263,9 @@ const char kAuthServerWhitelist[] = "auth-server-whitelist";
 const char kAuthNegotiateDelegateWhitelist[] =
     "auth-negotiate-delegate-whitelist";
 
+// If set, include the port in generated Kerberos SPNs.
+const char kEnableAuthNegotiatePort[] = "enable-auth-negotiate-port";
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -126,6 +126,7 @@ extern const char kDiskCacheSize[];
 extern const char kIgnoreConnectionsLimit[];
 extern const char kAuthServerWhitelist[];
 extern const char kAuthNegotiateDelegateWhitelist[];
+extern const char kEnableAuthNegotiatePort[];
 
 }  // namespace switches
 


### PR DESCRIPTION
#### Description of Change
The default value of this was switched from false to true in [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/1089661), which we inherited as part of the M69 upgrade. I'm unsure, but I think this might be responsible for #17111 and similar Kerberos-related issues. In any case, it makes sense to keep the default the same as before (and the same as Chrome, which forces this option to false, despite the interface defaulting it to true).

See https://chromium.googlesource.com/chromium/src/+/69.0.3497.128/net/http/http_auth_handler_negotiate.cc#142 for some context about what this feature does.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a regression in Kerberos SPN generation. In the M69 upgrade, the default for the `enable_negotiate_port` option was inadvertently changed from false to true; this restores the former behavior and aligns with Chromium.