### PR TITLE
feat: enable reporting api

### DIFF
--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -435,7 +435,7 @@ bool AtomNetworkDelegate::OnCancelURLRequestWithPolicyViolatingReferrerHeader(
 // https://crbug.com/704259
 bool AtomNetworkDelegate::OnCanQueueReportingReport(
     const url::Origin& origin) const {
-  return false;
+  return true;
 }
 
 void AtomNetworkDelegate::OnCanSendReportingReports(

--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -431,8 +431,6 @@ bool AtomNetworkDelegate::OnCancelURLRequestWithPolicyViolatingReferrerHeader(
   return false;
 }
 
-// TODO(deepak1556) : Enable after hooking into the reporting service
-// https://crbug.com/704259
 bool AtomNetworkDelegate::OnCanQueueReportingReport(
     const url::Origin& origin) const {
   return true;
@@ -440,16 +438,18 @@ bool AtomNetworkDelegate::OnCanQueueReportingReport(
 
 void AtomNetworkDelegate::OnCanSendReportingReports(
     std::set<url::Origin> origins,
-    base::OnceCallback<void(std::set<url::Origin>)> result_callback) const {}
+    base::OnceCallback<void(std::set<url::Origin>)> result_callback) const {
+  std::move(result_callback).Run(std::move(origins));
+}
 
 bool AtomNetworkDelegate::OnCanSetReportingClient(const url::Origin& origin,
                                                   const GURL& endpoint) const {
-  return false;
+  return true;
 }
 
 bool AtomNetworkDelegate::OnCanUseReportingClient(const url::Origin& origin,
                                                   const GURL& endpoint) const {
-  return false;
+  return true;
 }
 
 void AtomNetworkDelegate::OnErrorOccurred(net::URLRequest* request,

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1,0 +1,72 @@
+import * as chai from 'chai'
+import * as chaiAsPromised from 'chai-as-promised'
+import { BrowserWindow, session } from 'electron'
+import { emittedOnce } from './events-helpers';
+import * as https from 'https';
+import * as path from 'path';
+import * as fs from 'fs';
+import { EventEmitter } from 'events';
+
+const { expect } = chai
+
+chai.use(chaiAsPromised)
+const fixturesPath = path.resolve(__dirname, '..', 'spec', 'fixtures')
+
+describe('reporting api', () => {
+  it('sends a report for a deprecation', async () => {
+    const reports = new EventEmitter
+
+    // The Reporting API only works on https with valid certs. To dodge having
+    // to set up a trusted certificate, hack the validator.
+    session.defaultSession.setCertificateVerifyProc((req, cb) => {
+      cb(0)
+    })
+    const certPath = path.join(fixturesPath, 'certificates')
+    const options = {
+      key: fs.readFileSync(path.join(certPath, 'server.key')),
+      cert: fs.readFileSync(path.join(certPath, 'server.pem')),
+      ca: [
+        fs.readFileSync(path.join(certPath, 'rootCA.pem')),
+        fs.readFileSync(path.join(certPath, 'intermediateCA.pem'))
+      ],
+      requestCert: true,
+      rejectUnauthorized: false
+    }
+
+    const server = https.createServer(options, (req, res) => {
+      if (req.url === '/report') {
+        let data = ''
+        req.on('data', (d) => data += d.toString('utf-8'))
+        req.on('end', () => {
+          reports.emit('report', JSON.parse(data))
+        })
+      }
+      res.setHeader('Report-To', JSON.stringify({
+        group: 'default',
+        max_age: 120,
+        endpoints: [ {url: `https://localhost:${(server.address() as any).port}/report`} ],
+      }))
+      res.setHeader('Content-Type', 'text/html')
+      // using the deprecated `webkitRequestAnimationFrame` will trigger a
+      // "deprecation" report.
+      res.end('<script>webkitRequestAnimationFrame(() => {})</script>')
+    })
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const bw = new BrowserWindow({
+      show: false,
+    })
+    try {
+      const reportGenerated = emittedOnce(reports, 'report')
+      const url = `https://localhost:${(server.address() as any).port}/a`
+      await bw.loadURL(url)
+      const [report] = await reportGenerated
+      expect(report).to.be.an('array')
+      expect(report[0].type).to.equal('deprecation')
+      expect(report[0].url).to.equal(url)
+      expect(report[0].body.id).to.equal('PrefixedRequestAnimationFrame')
+    } finally {
+      bw.destroy()
+      server.close()
+    }
+  })
+})


### PR DESCRIPTION
#### Description of Change
Fixes #18252.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enabled the W3C [Reporting API](https://w3c.github.io/reporting/).
