### PR TITLE
docs: add electron-crash-report-server

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -23,6 +23,7 @@ following projects:
 
 * [socorro](https://github.com/mozilla/socorro)
 * [mini-breakpad-server](https://github.com/electron/mini-breakpad-server)
+* [electron-crash-report-server](https://github.com/johnmuhl/electron-crash-report-server)
 
 Or use a 3rd party hosted solution:
 


### PR DESCRIPTION
#### Description of Change

Add [electron-crash-report-server](/johnmuhl/electron-crash-report-server) to the list of self-installable crash report server options.

#### Checklist

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
