### PR TITLE
fix: 'page-title-updated' event forwarding + documentation

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -416,9 +416,11 @@ Returns:
 
 * `event` Event
 * `title` String
+* `explicitSet` Boolean
 
 Emitted when the document changed its title, calling `event.preventDefault()`
 will prevent the native window's title from changing.
+`explicitSet` is false when title is synthesized from file url.
 
 #### Event: 'close'
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -101,6 +101,17 @@ Returns:
 
 Emitted when the document in the given frame is loaded.
 
+#### Event: 'page-title-updated'
+
+Returns:
+
+* `event` Event
+* `title` String
+* `explicitSet` Boolean
+
+Fired when page title is set during navigation. `explicitSet` is false when
+title is synthesized from file url.
+
 #### Event: 'page-favicon-updated'
 
 Returns:

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -39,9 +39,9 @@ BrowserWindow.prototype._init = function () {
   })
 
   // Change window title to page title.
-  this.webContents.on('page-title-updated', (event, title) => {
+  this.webContents.on('page-title-updated', (event, title, ...args) => {
     // Route the event to BrowserWindow.
-    this.emit('page-title-updated', event, title)
+    this.emit('page-title-updated', event, title, ...args)
     if (!this.isDestroyed() && !event.defaultPrevented) this.setTitle(title)
   })
 


### PR DESCRIPTION
#### Description of Change
Address https://github.com/electron/electron/issues/18210.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added missing `'page-title-updated'` event on `webContents` to documentation. Also fixed forwarding of the `explicitSet` argument when emitted on `BrowserWindow`.