### PR TITLE
docs: clarify that 'second-instance' is only emitted when the second instance calls `app.requestSingleInstanceLock()`

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -404,8 +404,10 @@ Returns:
 * `workingDirectory` String - The second instance's working directory
 
 This event will be emitted inside the primary instance of your application
-when a second instance has been executed. `argv` is an Array of the second instance's
-command line arguments, and `workingDirectory` is its current working directory. Usually
+when a second instance has been executed and calls `app.requestSingleInstanceLock()`.
+
+`argv` is an Array of the second instance's command line arguments,
+and `workingDirectory` is its current working directory. Usually
 applications respond to this by making their primary window focused and
 non-minimized.
 


### PR DESCRIPTION
#### Description of Change
Address https://github.com/electron/electron/issues/17604

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes