### PR TITLE
docs: update sandbox-option.md

### DIFF
--- a/docs/api/sandbox-option.md
+++ b/docs/api/sandbox-option.md
@@ -113,8 +113,8 @@ window.open = customWindowOpen
 Important things to notice in the preload script:
 
 - Even though the sandboxed renderer doesn't have Node.js running, it still has
-  access to a limited node-like environment: `Buffer`, `process`, `setImmediate`
-  and `require` are available.
+  access to a limited node-like environment: `Buffer`, `process`, `setImmediate`,
+  `clearImmediate` and `require` are available.
 - The preload script can indirectly access all APIs from the main process through the
   `remote` and `ipcRenderer` modules.
 - The preload script must be contained in a single script, but it is possible to have
@@ -162,16 +162,17 @@ feature. We are still not aware of the security implications of exposing some
 Electron renderer APIs to the preload script, but here are some things to
 consider before rendering untrusted content:
 
-- A preload script can accidentally leak privileged APIs to untrusted code.
+- A preload script can accidentally leak privileged APIs to untrusted code,
+  unless [`contextIsolation`](../tutorial/security.md#3-enable-context-isolation-for-remote-content)
+  is also enabled.
 - Some bug in V8 engine may allow malicious code to access the renderer preload
   APIs, effectively granting full access to the system through the `remote`
-  module.
+  module. Therefore, it is highly recommented to
+  [disable the `remote` module](../tutorial/security.md#15-disable-the-remote-module).
+  If disabling is not feasible, you should selectively
+  [filter the `remote` module](../tutorial/security.md#16-filter-the-remote-module).
 
 Since rendering untrusted content in Electron is still uncharted territory,
 the APIs exposed to the sandbox preload script should be considered more
 unstable than the rest of Electron APIs, and may have breaking changes to fix
 security issues.
-
-One planned enhancement that should greatly increase security is to block IPC
-messages from sandboxed renderers by default, allowing the main process to
-explicitly define a set of messages the renderer is allowed to send.

--- a/docs/api/sandbox-option.md
+++ b/docs/api/sandbox-option.md
@@ -167,7 +167,7 @@ consider before rendering untrusted content:
   is also enabled.
 - Some bug in V8 engine may allow malicious code to access the renderer preload
   APIs, effectively granting full access to the system through the `remote`
-  module. Therefore, it is highly recommented to
+  module. Therefore, it is highly recommended to
   [disable the `remote` module](../tutorial/security.md#15-disable-the-remote-module).
   If disabling is not feasible, you should selectively
   [filter the `remote` module](../tutorial/security.md#16-filter-the-remote-module).


### PR DESCRIPTION
#### Description of Change
- add missing `clearImmediate` to APIs available in sandboxed renderers
- mention `remote` module disabling / filtering
- remove section about planned blocking of IPCs. This has been addressed by IPC channel separation (https://github.com/electron/electron/pull/13940) and continuous effort to validate all internal IPC messages in the main process.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes