### PR TITLE
refactor: change autoUpdater to use feedURL property

### DIFF
--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -105,8 +105,12 @@ void AutoUpdater::OnWindowAllClosed() {
   QuitAndInstall();
 }
 
-void AutoUpdater::SetFeedURL(mate::Arguments* args) {
-  auto_updater::AutoUpdater::SetFeedURL(args);
+void AutoUpdater::SetFeedURL(const std::string& feedURL) {
+  auto_updater::AutoUpdater::SetFeedURL(feedURL);
+}
+
+void AutoUpdater::Initialize(mate::Arguments* args) {
+  auto_updater::AutoUpdater::Initialize(args);
 }
 
 void AutoUpdater::QuitAndInstall() {
@@ -134,8 +138,11 @@ void AutoUpdater::BuildPrototype(v8::Isolate* isolate,
   prototype->SetClassName(mate::StringToV8(isolate, "AutoUpdater"));
   mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("checkForUpdates", &auto_updater::AutoUpdater::CheckForUpdates)
-      .SetMethod("getFeedURL", &auto_updater::AutoUpdater::GetFeedURL)
-      .SetMethod("setFeedURL", &AutoUpdater::SetFeedURL)
+      .SetMethod("initialize", &AutoUpdater::Initialize)
+      .SetProperty("feedURL", &auto_updater::AutoUpdater::GetFeedURL,
+                   &AutoUpdater::SetFeedURL)
+      .SetMethod("_getFeedURL", &auto_updater::AutoUpdater::GetFeedURL)
+      .SetMethod("_setFeedURL", &AutoUpdater::SetFeedURL)
       .SetMethod("quitAndInstall", &AutoUpdater::QuitAndInstall);
 }
 

--- a/atom/browser/api/atom_api_auto_updater.h
+++ b/atom/browser/api/atom_api_auto_updater.h
@@ -48,7 +48,8 @@ class AutoUpdater : public mate::EventEmitter<AutoUpdater>,
 
  private:
   std::string GetFeedURL();
-  void SetFeedURL(mate::Arguments* args);
+  void Initialize(mate::Arguments* args);
+  void SetFeedURL(const std::string& feedURL);
   void QuitAndInstall();
 
   DISALLOW_COPY_AND_ASSIGN(AutoUpdater);

--- a/atom/browser/auto_updater.cc
+++ b/atom/browser/auto_updater.cc
@@ -21,7 +21,9 @@ std::string AutoUpdater::GetFeedURL() {
   return "";
 }
 
-void AutoUpdater::SetFeedURL(mate::Arguments* args) {}
+void AutoUpdater::SetFeedURL(std::string feedURL) {}
+
+void AutoUpdater::Initialize(mate::Arguments* args) {}
 
 void AutoUpdater::CheckForUpdates() {}
 

--- a/atom/browser/auto_updater.h
+++ b/atom/browser/auto_updater.h
@@ -53,9 +53,12 @@ class AutoUpdater {
   // Gets/Sets the delegate.
   static Delegate* GetDelegate();
   static void SetDelegate(Delegate* delegate);
-
   static std::string GetFeedURL();
-  static void SetFeedURL(mate::Arguments* args);
+  static void SetFeedURL(std::string);
+  static void Initialize(mate::Arguments* args);
+  static void SetFeedOptions(std::string serverType,
+                             std::string feed,
+                             HeaderMap requestHeaders);
   static void CheckForUpdates();
   static void QuitAndInstall();
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -97,6 +97,18 @@ When this API is called, the `before-quit` event is not emitted before all windo
 
 The `autoUpdater` object has the following methods:
 
+### `autoUpdater.initialize(options)`
+
+* `options` Object
+  * `url` String
+  * `headers` Record<string, string> (optional) _macOS_ - HTTP request headers.
+  * `serverType` String (optional) _macOS_ - Either `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
+    README for more information.
+
+Sets the `url` and initializes the auto updater.
+
+**[Deprecated](modernization/property-updates.md)**
+
 ### `autoUpdater.setFeedURL(options)`
 
 * `options` Object
@@ -105,7 +117,9 @@ The `autoUpdater` object has the following methods:
   * `serverType` String (optional) _macOS_ - Either `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
     README for more information.
 
-Sets the `url` and initialize the auto updater.
+Sets the `url` and initializes the auto updater.
+
+**[Deprecated](modernization/property-updates.md)**
 
 ### `autoUpdater.getFeedURL()`
 
@@ -113,7 +127,7 @@ Returns `String` - The current update feed URL.
 
 ### `autoUpdater.checkForUpdates()`
 
-Asks the server whether there is an update. You must call `setFeedURL` before
+Asks the server whether there is an update. You must call `initialize` or set the `feedURL` property before
 using this API.
 
 ### `autoUpdater.quitAndInstall()`
@@ -128,6 +142,14 @@ closed.
 **Note:** It is not strictly necessary to call this function to apply an update,
 as a successfully downloaded update will always be applied the next time the
 application starts.
+
+## Properties
+
+### `autoUpdater.feedURL`
+
+A `String` property containing the auto updater feed URL.  This value can be set via `autoUpdater.initialize(options)`
+or directly through the property accessor.
+
 
 [squirrel-mac]: https://github.com/Squirrel/Squirrel.Mac
 [server-support]: https://github.com/Squirrel/Squirrel.Mac#server-support

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -6,6 +6,19 @@ Breaking changes will be documented here, and deprecation warnings added to JS c
 
 The `FIXME` string is used in code comments to denote things that should be fixed for future releases. See https://github.com/electron/electron/search?q=fixme
 
+## Planned Breaking API Changes (8.0)
+
+### `autoUpdater.setFeedURL`
+
+```js
+// Removed in Electron 8.0
+autoUpdater.setFeedURL(options)
+// Replace with initialize
+autoUpdate.initialize(options)
+// OR set property directly
+autoUpdate.feedURL = feedURL
+```
+
 ## Planned Breaking API Changes (7.0)
 
 ### Node Headers URL
@@ -50,7 +63,7 @@ const idleTime = getSystemIdleTime()
 ### webFrame Isolated World APIs
 
 ```js
-// Removed in Elecron 7.0
+// Removed in Electron 7.0
 webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp)
 webFrame.setIsolatedWorldHumanReadableName(worldId, name)
 webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin)

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -7,8 +7,6 @@ The Electron team is currently undergoing an initiative to convert separate gett
 * `app` module
   * `dock`
     * `badge`
-* `autoUpdater` module
-  * `feedUrl`
 * `BrowserWindow`
   * `fullscreen`
   * `simpleFullscreen`
@@ -47,6 +45,8 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `applicationMenu`
   * `badgeCount`
   * `name`
+* `autoUpdater` module
+  * `feedUrl`
 * `BrowserWindow` module
   * `autohideMenuBar`
   * `resizable`

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -90,7 +90,7 @@ Next, construct the URL of the update server and tell
 const server = 'https://your-deployment-url.com'
 const feed = `${server}/update/${process.platform}/${app.getVersion()}`
 
-autoUpdater.setFeedURL(feed)
+autoUpdater.feedURL = feed
 ```
 
 As the final step, check for updates. The example below will check every minute:

--- a/lib/browser/api/auto-updater/auto-updater-native.js
+++ b/lib/browser/api/auto-updater/auto-updater-native.js
@@ -1,10 +1,13 @@
 'use strict'
-
 const EventEmitter = require('events').EventEmitter
 const { autoUpdater, AutoUpdater } = process.electronBinding('auto_updater')
+const { deprecate } = require('electron')
 
 // AutoUpdater is an EventEmitter.
 Object.setPrototypeOf(AutoUpdater.prototype, EventEmitter.prototype)
 EventEmitter.call(autoUpdater)
+
+deprecate.renameFunction(autoUpdater, 'setFeedURL', 'initialize')
+deprecate.fnToProperty(autoUpdater, 'feedURL', '_getFeedURL')
 
 module.exports = autoUpdater

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -1,10 +1,15 @@
 'use strict'
 
-const { app } = require('electron')
+const { app, deprecate } = require('electron')
 const { EventEmitter } = require('events')
 const squirrelUpdate = require('@electron/internal/browser/api/auto-updater/squirrel-update-win')
 
 class AutoUpdater extends EventEmitter {
+  constructor () {
+    super()
+    this.feedURL = ''
+  }
+
   quitAndInstall () {
     if (!this.updateAvailable) {
       return this.emitError('No update available, can\'t quit and install')
@@ -13,35 +18,35 @@ class AutoUpdater extends EventEmitter {
     app.quit()
   }
 
-  getFeedURL () {
-    return this.updateURL
+  _getFeedURL () {
+    return this.feedURL
   }
 
-  setFeedURL (options) {
+  initialize (options) {
     let updateURL
     if (typeof options === 'object') {
       if (typeof options.url === 'string') {
         updateURL = options.url
       } else {
-        throw new Error('Expected options object to contain a \'url\' string property in setFeedUrl call')
+        throw new Error('Expected options object to contain a \'url\' string property in initialize call')
       }
     } else if (typeof options === 'string') {
       updateURL = options
     } else {
       throw new Error('Expected an options object with a \'url\' property to be provided')
     }
-    this.updateURL = updateURL
+    this.feedURL = updateURL
   }
 
   checkForUpdates () {
-    if (!this.updateURL) {
+    if (!this.feedURL) {
       return this.emitError('Update URL is not set')
     }
     if (!squirrelUpdate.supported()) {
       return this.emitError('Can not find Squirrel')
     }
     this.emit('checking-for-update')
-    squirrelUpdate.checkForUpdate(this.updateURL, (error, update) => {
+    squirrelUpdate.checkForUpdate(this.feedURL, (error, update) => {
       if (error != null) {
         return this.emitError(error)
       }
@@ -50,14 +55,14 @@ class AutoUpdater extends EventEmitter {
       }
       this.updateAvailable = true
       this.emit('update-available')
-      squirrelUpdate.update(this.updateURL, (error) => {
+      squirrelUpdate.update(this.feedURL, (error) => {
         if (error != null) {
           return this.emitError(error)
         }
         const { releaseNotes, version } = update
         // Date is not available on Windows, so fake it.
         const date = new Date()
-        this.emit('update-downloaded', {}, releaseNotes, version, date, this.updateURL, () => {
+        this.emit('update-downloaded', {}, releaseNotes, version, date, this.feedURL, () => {
           this.quitAndInstall()
         })
       })
@@ -71,4 +76,8 @@ class AutoUpdater extends EventEmitter {
   }
 }
 
-module.exports = new AutoUpdater()
+const autoUpdater = new AutoUpdater()
+deprecate.renameFunction(autoUpdater, 'setFeedURL', 'initialize')
+deprecate.fnToProperty(autoUpdater, 'feedURL', '_getFeedURL')
+
+module.exports = autoUpdater

--- a/spec/api-deprecate-spec.js
+++ b/spec/api-deprecate-spec.js
@@ -82,6 +82,33 @@ describe('deprecate', () => {
     expect(msg).to.include(prop)
   })
 
+  it('renames a function', () => {
+    let msg
+    deprecate.setHandler(m => { msg = m })
+
+    const oldFunction = 'dingyOldFunction'
+    const newFunction = 'shinyNewFunction'
+
+    const value = 'hi'
+    const o = {
+      shinyNewFunction: function () {
+        return value
+      }
+    }
+    expect(o).to.not.have.a.property(oldFunction)
+    expect(o).to.have.a.property(newFunction).that.is.a('function')
+
+    deprecate.renameFunction(o, oldFunction, newFunction)
+    expect(o.shinyNewFunction()).to.equal(value)
+    expect(o.dingyOldFunction()).to.equal(value)
+
+    expect(msg).to.be.a('string')
+    expect(msg).to.include(oldFunction)
+    expect(msg).to.include(newFunction)
+
+    expect(o).to.have.a.property(oldFunction).that.is.a('function')
+  })
+
   it('warns exactly once when a function is deprecated with no replacement', () => {
     let msg
     deprecate.setHandler(m => { msg = m })

--- a/spec/fixtures/auto-update/check/index.js
+++ b/spec/fixtures/auto-update/check/index.js
@@ -12,7 +12,7 @@ autoUpdater.on('error', (err) => {
 
 const feedUrl = process.argv[1]
 
-autoUpdater.setFeedURL({
+autoUpdater.initialize({
   url: feedUrl
 })
 

--- a/spec/fixtures/auto-update/initial/index.js
+++ b/spec/fixtures/auto-update/initial/index.js
@@ -9,7 +9,7 @@ const feedUrl = process.argv[1]
 
 console.log('Setting Feed URL')
 
-autoUpdater.setFeedURL({
+autoUpdater.initialize({
   url: feedUrl
 })
 

--- a/spec/fixtures/auto-update/update/index.js
+++ b/spec/fixtures/auto-update/update/index.js
@@ -21,7 +21,7 @@ if (!feedUrl || !feedUrl.startsWith('http')) {
   fs.writeFileSync(urlPath, `${feedUrl}/updated`)
 }
 
-autoUpdater.setFeedURL({
+autoUpdater.initialize({
   url: feedUrl
 })
 

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -428,7 +428,7 @@ app.exit(0)
 // auto-updater
 // https://github.com/atom/electron/blob/master/docs/api/auto-updater.md
 
-autoUpdater.setFeedURL({
+autoUpdater.initialize({
   url: 'http://mycompany.com/myapp/latest?version=' + app.getVersion(),
   headers: {
     key: 'value'

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -78,7 +78,8 @@ declare namespace ElectronInternal {
     log(message: string): void;
     function(fn: Function, newName: string): Function;
     event(emitter: NodeJS.EventEmitter, oldName: string, newName: string): void;
-    fnToProperty(module: any, prop: string, getter: string, setter: string): void;
+    fnToProperty(module: any, prop: string, getter: string, setter?: string): void;
+    renameFunction(module: any, oldName: string, newName: string): void;
     removeProperty<T, K extends (keyof T & string)>(object: T, propertyName: K): T;
     renameProperty<T, K extends (keyof T & string)>(object: T, oldName: string, newName: K): T;
 


### PR DESCRIPTION

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR is part of the[ API modernization initiative](https://github.com/electron/electron/blob/master/docs/api/modernization/property-updates.md).  This PR changes the `autoUpdater` API to use a `feedURL` property instead of `getFeedURL` and `setFeedURL`.  Additionally, what was the `setFeedURL` function has been refactored as the `initialize` function because it was an overloaded function that was no longer properly named.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->changed autoUpdater to use feedURL property instead of getFeedURL/setFeedURL.
