### PR TITLE
chore: update @types/node version for 3-1-x

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,7 @@
   "main": "index.js",
   "types": "electron.d.ts",
   "dependencies": {
-    "@types/node": "^8.0.24",
+    "@types/node": "^10.1.4",
     "electron-download": "^4.1.0",
     "extract-zip": "^1.0.3"
   },


### PR DESCRIPTION
Backport of #16174

A direct copy of #18239 just running on first-party CI instead of external-contrib CI

Notes: Update @types/node dependency to a version compatible with Node 10.2.0