### PR TITLE
feat: enable macOS apps to receive push notifications from APNs

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -496,6 +496,7 @@ source_set("electron_lib") {
         "Squirrel.framework",
         "ReactiveObjC.framework",
         "Mantle.framework",
+        "UserNotifications.framework",
       ]
 
       deps += [

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1396,6 +1396,16 @@ details.
 
 **Note:** Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
 
+### `app.registerForRemoteNotifications()` _macOS_
+
+Registers this app with Apple Push Notification service (APNS) to receive [Badge, Sound, and Alert](https://developer.apple.com/documentation/appkit/sremotenotificationtype?language=objc) notifications. If registration is successful, the BrowserWindow event `registered-for-remote-notifications` will be emitted with the APNS device token. Otherwise, the event `failed-to-register-for-remote-notifications` will be emitted.
+See: https://developer.apple.com/documentation/appkit/nsapplication/1428476-registerforremotenotificationtyp?language=objc
+
+### `app.unregisterForRemoteNotifications()` _macOS_
+
+Unregisters the app for notifications received from APNS.
+See: https://developer.apple.com/documentation/appkit/nsapplication/1428747-unregisterforremotenotifications?language=objc
+
 ## Properties
 
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -666,6 +666,33 @@ Emitted when the window has closed a sheet.
 
 Emitted when the native new tab button is clicked.
 
+#### Event: 'registered-for-remote-notifications' _macOS_
+
+Returns:
+
+* `token` String - A token that identifies the device to Apple Push Notification Service (APNS)
+
+Emitted when the app successfully registers to receive remote notifications from APNS.
+See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428766-application?language=objc
+
+#### Event: 'failed-to-register-for-remote-notifications' _macOS_
+
+Returns:
+
+* `error` String
+
+Emitted when the app fails to register to receive remote notifications from APNS.
+See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428554-application?language=objc
+
+#### Event: 'received-remote-notification' _macOS_
+
+Returns:
+
+* `user_info` Object
+
+Emitted when the app receives a remote notification while running.
+See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428430-application?language=objc
+
 ### Static Methods
 
 The `BrowserWindow` class has the following static methods:

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -688,7 +688,7 @@ See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428
 
 Returns:
 
-* `user_info` Object
+* `userInfo` Record<String, any>
 
 Emitted when the app receives a remote notification while running.
 See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428430-application?language=objc

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -731,6 +731,21 @@ void App::OnNewWindowForTab() {
 void App::OnDidBecomeActive() {
   Emit("did-become-active");
 }
+
+void App::OnDidRegisterForRemoteNotificationsWithDeviceToken(
+    const std::string& token) {
+  Emit("registered-for-remote-notifications", token);
+}
+
+void App::OnDidFailToRegisterForRemoteNotificationsWithError(
+    const std::string& error) {
+  Emit("failed-to-register-for-remote-notifications", error);
+}
+
+void App::OnDidReceiveRemoteNotification(
+    const base::DictionaryValue& user_info) {
+  Emit("received-remote-notification", user_info);
+}
 #endif
 
 bool App::CanCreateWindow(
@@ -1598,6 +1613,12 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
       .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
       .SetMethod("setActivationPolicy", &App::SetActivationPolicy)
+      .SetMethod("registerForRemoteNotifications",
+                 base::BindRepeating(&Browser::RegisterForRemoteNotifications,
+                                     browser))
+      .SetMethod("unregisterForRemoteNotifications",
+                 base::BindRepeating(&Browser::UnregisterForRemoteNotifications,
+                                     browser))
 #endif
       .SetMethod("setAboutPanelOptions",
                  base::BindRepeating(&Browser::SetAboutPanelOptions, browser))

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -111,6 +111,12 @@ class App : public ElectronBrowserClient::Delegate,
       const base::DictionaryValue& user_info) override;
   void OnNewWindowForTab() override;
   void OnDidBecomeActive() override;
+  void OnDidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token) override;
+  void OnDidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error) override;
+  void OnDidReceiveRemoteNotification(
+      const base::DictionaryValue& user_info) override;
 #endif
 
   // content::ContentBrowserClient:

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -225,6 +225,22 @@ class Browser : public WindowListObserver {
   // Set docks' icon.
   void DockSetIcon(const gfx::Image& image);
 
+  // Register with APNS
+  void RegisterForRemoteNotifications();
+  void UnregisterForRemoteNotifications();
+
+  // Indicates that APNS registration succeeded, the token can be used to send
+  // notifications.
+  void DidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token);
+
+  // Indicates a failure to register for APNS
+  void DidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error);
+
+  // Indicates that a new remote notification has been received while the app is
+  // running.
+  void DidReceiveRemoteNotification(const base::DictionaryValue& user_info);
 #endif  // defined(OS_MACOSX)
 
   void ShowAboutPanel();

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -497,4 +497,33 @@ void Browser::SetSecureKeyboardEntryEnabled(bool enabled) {
   }
 }
 
+void Browser::RegisterForRemoteNotifications() {
+  [[AtomApplication sharedApplication]
+      registerForRemoteNotificationTypes:NSRemoteNotificationTypeBadge |
+                                         NSRemoteNotificationTypeAlert |
+                                         NSRemoteNotificationTypeSound];
+}
+
+void Browser::UnregisterForRemoteNotifications() {
+  [[AtomApplication sharedApplication] unregisterForRemoteNotifications];
+}
+
+void Browser::DidRegisterForRemoteNotificationsWithDeviceToken(
+    const std::string& token) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidRegisterForRemoteNotificationsWithDeviceToken(token);
+}
+
+void Browser::DidFailToRegisterForRemoteNotificationsWithError(
+    const std::string& error) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidFailToRegisterForRemoteNotificationsWithError(error);
+}
+
+void Browser::DidReceiveRemoteNotification(
+    const base::DictionaryValue& user_info) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidReceiveRemoteNotification(user_info);
+}
+
 }  // namespace electron

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -85,6 +85,18 @@ class BrowserObserver : public base::CheckedObserver {
 
   // Browser did become active.
   virtual void OnDidBecomeActive() {}
+
+  // The browser successfully registered for APNS. (macOS only)
+  virtual void OnDidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token) {}
+
+  // The browser failed to register for APNS. (macOS only)
+  virtual void OnDidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error) {}
+
+  // The browser received a remote notification from APNS (macOS only)
+  virtual void OnDidReceiveRemoteNotification(
+      const base::DictionaryValue& user_info) {}
 #endif
 
  protected:

--- a/shell/browser/mac/dict_util.h
+++ b/shell/browser/mac/dict_util.h
@@ -19,10 +19,6 @@ NSArray* ListValueToNSArray(const base::ListValue& value);
 base::ListValue NSArrayToListValue(NSArray* arr);
 NSDictionary* DictionaryValueToNSDictionary(const base::DictionaryValue& value);
 base::DictionaryValue NSDictionaryToDictionaryValue(NSDictionary* dict);
-
-std::unique_ptr<base::DictionaryValue> NSDictionaryToDictionaryValue(
-    NSDictionary* dict);
-
 NSDictionary* UNNotificationResponseToNSDictionary(
     UNNotificationResponse* response) API_AVAILABLE(macosx(10.14));
 

--- a/shell/browser/mac/dict_util.h
+++ b/shell/browser/mac/dict_util.h
@@ -6,6 +6,7 @@
 #define SHELL_BROWSER_MAC_DICT_UTIL_H_
 
 #import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
 
 namespace base {
 class ListValue;
@@ -18,6 +19,12 @@ NSArray* ListValueToNSArray(const base::ListValue& value);
 base::ListValue NSArrayToListValue(NSArray* arr);
 NSDictionary* DictionaryValueToNSDictionary(const base::DictionaryValue& value);
 base::DictionaryValue NSDictionaryToDictionaryValue(NSDictionary* dict);
+
+std::unique_ptr<base::DictionaryValue> NSDictionaryToDictionaryValue(
+    NSDictionary* dict);
+
+NSDictionary* UNNotificationResponseToNSDictionary(
+    UNNotificationResponse* response) API_AVAILABLE(macosx(10.14));
 
 }  // namespace electron
 

--- a/shell/browser/mac/dict_util.mm
+++ b/shell/browser/mac/dict_util.mm
@@ -111,9 +111,9 @@ NSDictionary* UNNotificationResponseToNSDictionary(
   }
 
   NSMutableDictionary* notification_response_dictionary =
-    [NSMutableDictionary new];
+      [NSMutableDictionary new];
   notification_response_dictionary[@"actionIdentifier"] =
-    [response actionIdentifier];
+      [response actionIdentifier];
 
   UNNotification* notification = [response notification];
   if (notification) {
@@ -132,7 +132,7 @@ NSDictionary* UNNotificationResponseToNSDictionary(
 
   if ([response isKindOfClass:[UNTextInputNotificationResponse class]]) {
     notification_response_dictionary[@"userTextInput"] =
-      [(UNTextInputNotificationResponse *)response userText];
+        [static_cast<UNTextInputNotificationResponse*>(response) userText];
   }
 
   return notification_response_dictionary;

--- a/shell/browser/mac/dict_util.mm
+++ b/shell/browser/mac/dict_util.mm
@@ -104,4 +104,38 @@ base::DictionaryValue NSDictionaryToDictionaryValue(NSDictionary* dict) {
   return result;
 }
 
+NSDictionary* UNNotificationResponseToNSDictionary(
+    UNNotificationResponse* response) {
+  if (!response) {
+    return nil;
+  }
+
+  NSMutableDictionary* notification_response_dictionary =
+    [NSMutableDictionary new];
+  notification_response_dictionary[@"actionIdentifier"] =
+    [response actionIdentifier];
+
+  UNNotification* notification = [response notification];
+  if (notification) {
+    NSMutableDictionary* request_info = [NSMutableDictionary new];
+    UNNotificationRequest* request = [notification request];
+    if (request) {
+      request_info[@"identifier"] = [request identifier] ?: @"";
+      request_info[@"content"] = [[request content] userInfo] ?: @{};
+    }
+
+    NSMutableDictionary* notification_info = [NSMutableDictionary new];
+    notification_info[@"date"] = [notification date] ?: @"";
+    notification_info[@"request"] = request_info;
+    notification_response_dictionary[@"notification"] = notification_info;
+  }
+
+  if ([response isKindOfClass:[UNTextInputNotificationResponse class]]) {
+    notification_response_dictionary[@"userTextInput"] =
+      [(UNTextInputNotificationResponse *)response userText];
+  }
+
+  return notification_response_dictionary;
+}
+
 }  // namespace electron

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -156,4 +156,36 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
   electron::Browser::Get()->NewWindowForTab();
 }
 
+- (void)application:(NSApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
+  // https://stackoverflow.com/a/16411517
+  const char *tokenData = (const char *)[deviceToken bytes];
+  NSMutableString *tokenString = [NSMutableString string];
+  for (NSUInteger i = 0; i < [deviceToken length]; i++) {
+    [tokenString appendFormat:@"%02.2hhX", tokenData[i]];
+  }
+  atom::Browser* browser = atom::Browser::Get();
+  browser->DidRegisterForRemoteNotificationsWithDeviceToken(
+    base::SysNSStringToUTF8(tokenString));
+}
+
+- (void)application:(NSApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
+  std::string error_message(base::SysNSStringToUTF8(
+    [NSString stringWithFormat:@"%ld %@ %@",
+      [error code],
+      [error domain],
+      [error userInfo]]));
+  atom::Browser* browser = atom::Browser::Get();
+  browser->DidFailToRegisterForRemoteNotificationsWithError(error_message);
+}
+
+- (void)application:(NSApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo {
+  std::unique_ptr<base::DictionaryValue> user_info =
+      atom::NSDictionaryToDictionaryValue(userInfo);
+  atom::Browser* browser = atom::Browser::Get();
+  browser->DidReceiveRemoteNotification(*user_info);
+}
+
 @end

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -71,25 +71,24 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 
 - (void)applicationDidFinishLaunching:(NSNotification*)notify {
   NSObject* user_notification =
-    [notify userInfo][(id) @"NSApplicationLaunchUserNotificationKey"];
+      [notify userInfo][(id) @"NSApplicationLaunchUserNotificationKey"];
   NSDictionary* notification_info = nil;
 
   if (user_notification) {
     if ([user_notification isKindOfClass:[NSUserNotification class]]) {
       notification_info =
-        [(NSUserNotification *)user_notification userInfo];
+          [static_cast<NSUserNotification*>(user_notification) userInfo];
     } else if (@available(macOS 10.14, *)) {
       if ([user_notification isKindOfClass:[UNNotificationResponse class]]) {
-        notification_info = atom::UNNotificationResponseToNSDictionary(
-          (UNNotificationResponse *)user_notification);
+        notification_info = electron::UNNotificationResponseToNSDictionary(
+            static_cast<UNNotificationResponse*>(user_notification));
       }
     }
   }
 
   if (notification_info) {
-    std::unique_ptr<base::DictionaryValue> launch_info =
-        atom::NSDictionaryToDictionaryValue(notification_info);
-    electron::Browser::Get()->DidFinishLaunching(*launch_info);
+    electron::Browser::Get()->DidFinishLaunching(
+        electron::NSDictionaryToDictionaryValue(notification_info));
   } else {
     electron::Browser::Get()->DidFinishLaunching(base::DictionaryValue());
   }
@@ -175,33 +174,28 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 - (void)application:(NSApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
   // https://stackoverflow.com/a/16411517
-  const char *tokenData = (const char *)[deviceToken bytes];
-  NSMutableString *tokenString = [NSMutableString string];
+  const char* tokenData = static_cast<const char*>([deviceToken bytes]);
+  NSMutableString* tokenString = [NSMutableString string];
   for (NSUInteger i = 0; i < [deviceToken length]; i++) {
     [tokenString appendFormat:@"%02.2hhX", tokenData[i]];
   }
-  atom::Browser* browser = atom::Browser::Get();
-  browser->DidRegisterForRemoteNotificationsWithDeviceToken(
-    base::SysNSStringToUTF8(tokenString));
+  electron::Browser::Get()->DidRegisterForRemoteNotificationsWithDeviceToken(
+      base::SysNSStringToUTF8(tokenString));
 }
 
 - (void)application:(NSApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
   std::string error_message(base::SysNSStringToUTF8(
-    [NSString stringWithFormat:@"%ld %@ %@",
-      [error code],
-      [error domain],
-      [error userInfo]]));
-  atom::Browser* browser = atom::Browser::Get();
-  browser->DidFailToRegisterForRemoteNotificationsWithError(error_message);
+      [NSString stringWithFormat:@"%ld %@ %@", [error code], [error domain],
+                                 [error userInfo]]));
+  electron::Browser::Get()->DidFailToRegisterForRemoteNotificationsWithError(
+      error_message);
 }
 
 - (void)application:(NSApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo {
-  std::unique_ptr<base::DictionaryValue> user_info =
-      atom::NSDictionaryToDictionaryValue(userInfo);
-  atom::Browser* browser = atom::Browser::Get();
-  browser->DidReceiveRemoteNotification(*user_info);
+  electron::Browser::Get()->DidReceiveRemoteNotification(
+      electron::NSDictionaryToDictionaryValue(userInfo));
 }
 
 @end

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -17,6 +17,8 @@
 #include "shell/browser/mac/dict_util.h"
 #import "shell/browser/mac/electron_application.h"
 
+#import <UserNotifications/UserNotifications.h>
+
 #if BUILDFLAG(USE_ALLOCATOR_SHIM)
 // On macOS 10.12, the IME system attempts to allocate a 2^64 size buffer,
 // which would typically cause an OOM crash. To avoid this, the problematic
@@ -68,12 +70,26 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification*)notify {
-  NSUserNotification* user_notification =
-      [notify userInfo][(id) @"NSApplicationLaunchUserNotificationKey"];
+  NSObject* user_notification =
+    [notify userInfo][(id) @"NSApplicationLaunchUserNotificationKey"];
+  NSDictionary* notification_info = nil;
 
-  if (user_notification.userInfo) {
-    electron::Browser::Get()->DidFinishLaunching(
-        electron::NSDictionaryToDictionaryValue(user_notification.userInfo));
+  if (user_notification) {
+    if ([user_notification isKindOfClass:[NSUserNotification class]]) {
+      notification_info =
+        [(NSUserNotification *)user_notification userInfo];
+    } else if (@available(macOS 10.14, *)) {
+      if ([user_notification isKindOfClass:[UNNotificationResponse class]]) {
+        notification_info = atom::UNNotificationResponseToNSDictionary(
+          (UNNotificationResponse *)user_notification);
+      }
+    }
+  }
+
+  if (notification_info) {
+    std::unique_ptr<base::DictionaryValue> launch_info =
+        atom::NSDictionaryToDictionaryValue(notification_info);
+    electron::Browser::Get()->DidFinishLaunching(*launch_info);
   } else {
     electron::Browser::Get()->DidFinishLaunching(base::DictionaryValue());
   }

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -545,6 +545,17 @@ describe('app module', () => {
         expect(webContents).to.equal(w.webContents);
       });
     });
+
+    it('should emit failed-to-register-for-remote-notifications event when app.registerForRemoteNotifications() is invoked and APNS registration fails', async function() {
+      if (process.platform !== 'darwin') {
+        this.skip();
+      }
+
+      const promise = emittedOnce(app, 'failed-to-register-for-remote-notifications');
+      app.registerForRemoteNotifications();
+      const [, error] = await promise;
+      expect(error).to.be.a('string');
+    });
   });
 
   describe('app.badgeCount', () => {

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -546,7 +546,7 @@ describe('app module', () => {
       });
     });
 
-    it('should emit failed-to-register-for-remote-notifications event when app.registerForRemoteNotifications() is invoked and APNS registration fails', async function() {
+    it('should emit failed-to-register-for-remote-notifications event when app.registerForRemoteNotifications() is invoked and APNS registration fails', async function () {
       if (process.platform !== 'darwin') {
         this.skip();
       }


### PR DESCRIPTION
#### Description of Change
I'm picking up where @frantic left off in https://github.com/electron/electron/pull/13777 :)

This exposes some API for registering for [Apple Push Notification service](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns?language=objc) to let macOS apps receive push notifications even when the app is not running. Here is an [example of electron-quick-start](https://github.com/kevinhu88/electron-quick-start) that uses the stuff in this PR to register for APNS, receive a remote notification, launch the app from a user action, and displays the notification contents:
<img width="357" alt="Screen Shot 2019-05-13 at 11 33 09 AM" src="https://user-images.githubusercontent.com/44754661/57645384-02ca1e00-7573-11e9-8a6c-88bda36fa495.png">
<img width="359" alt="Screen Shot 2019-05-13 at 11 33 23 AM" src="https://user-images.githubusercontent.com/44754661/57645385-02ca1e00-7573-11e9-890c-24e4904c8616.png">
<img width="815" alt="Screen Shot 2019-05-13 at 11 33 37 AM" src="https://user-images.githubusercontent.com/44754661/57645387-0362b480-7573-11e9-85dc-122f2d5fce24.png">


This PR uses the [UserNotifications Framework](https://developer.apple.com/documentation/usernotifications?language=objc), which allows us to launch apps from custom user actions in the push notification, optionally with text input, on macOS mojave. **This requires building Electron with the macOS SDK 10.14+.** Launching the app from a notification on mojave results in a `UNNotificationResponse` mapped to `[notify userInfo][NSApplicationLaunchUserNotificationKey]` in `applicationDidFinishLaunching`, instead of `NSUserNotification`. This PR accounts for this and adds a function `UNNotificationResponseToNSDictionary` to convert the `UNNotificationResponse` to send as the `launch_info` dictionary with the `did-finish-launching` event so the Electron app can handle the notification payload.

As with any other macOS app, enabling push notifications requires setting up a provisioning profile with the APS Environment (macOS) Entitlement enabled in your Apple developer account. See [this doc](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns?language=objc) for more info about setup. Because of this requirement, I'm not sure what other test cases I could add besides testing failed registration.

I'm looking forward to feedback on this and really hope we can get this feature into the official Electron release!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for push notifications from APNs for macOS apps.
<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
