### PR TITLE
fix: default enable_negotiate_port to false (4-2-x)

### DIFF
--- a/atom/browser/io_thread.cc
+++ b/atom/browser/io_thread.cc
@@ -49,7 +49,7 @@ network::mojom::HttpAuthDynamicParamsPtr CreateHttpAuthDynamicParams(
   auth_dynamic_params->delegate_whitelist = command_line.GetSwitchValueASCII(
       switches::kAuthNegotiateDelegateWhitelist);
   auth_dynamic_params->enable_negotiate_port =
-      command_line->HasSwitch(atom::switches::kEnableAuthNegotiatePort);
+      command_line.HasSwitch(atom::switches::kEnableAuthNegotiatePort);
 
   return auth_dynamic_params;
 }

--- a/atom/browser/io_thread.cc
+++ b/atom/browser/io_thread.cc
@@ -48,6 +48,8 @@ network::mojom::HttpAuthDynamicParamsPtr CreateHttpAuthDynamicParams(
       command_line.GetSwitchValueASCII(switches::kAuthServerWhitelist);
   auth_dynamic_params->delegate_whitelist = command_line.GetSwitchValueASCII(
       switches::kAuthNegotiateDelegateWhitelist);
+  auth_dynamic_params->enable_negotiate_port =
+      command_line->HasSwitch(atom::switches::kEnableAuthNegotiatePort);
 
   return auth_dynamic_params;
 }

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -247,6 +247,9 @@ const char kAuthServerWhitelist[] = "auth-server-whitelist";
 const char kAuthNegotiateDelegateWhitelist[] =
     "auth-negotiate-delegate-whitelist";
 
+// If set, include the port in generated Kerberos SPNs.
+const char kEnableAuthNegotiatePort[] = "enable-auth-negotiate-port";
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -118,6 +118,7 @@ extern const char kDiskCacheSize[];
 extern const char kIgnoreConnectionsLimit[];
 extern const char kAuthServerWhitelist[];
 extern const char kAuthNegotiateDelegateWhitelist[];
+extern const char kEnableAuthNegotiatePort[];
 
 }  // namespace switches
 


### PR DESCRIPTION
Backport of #18251

See that PR for details.


Notes: Fixed a regression in Kerberos SPN generation. In the M69 upgrade, the default for the `enable_negotiate_port` option was inadvertently changed from false to true; this restores the former behavior and aligns with Chromium.