### PR TITLE
fix: lagging when using tabbed window （4-2-x)

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -100,3 +100,4 @@ make_--explicitly-allowed-ports_work_with_networkservice.patch
 fix_crashes_in_renderframeimpl_onselectpopupmenuitem_s.patch
 fix_re-entracy_problem_with_invalidateframesinkid.patch
 chore_expose_getcontentclient_to_embedders.patch
+tabbed_window_lagging.patch

--- a/patches/common/chromium/tabbed_window_lagging.patch
+++ b/patches/common/chromium/tabbed_window_lagging.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu May 16 13:52:12 JST 2019
+Subject: tabbed_window_lagging.patch
+
+Fix lagging when using tabbed windows.
+
+Later Chromium has some enhancements on graphics code that fix the lagging
+problem, but the changes are split in multiple commits on multiple files and
+we can not just cherry-pick them.
+
+Instead I'm just using the dummy fix and it does not seem to have side effects.
+
+diff --git a/ui/views/cocoa/bridged_native_widget.mm b/ui/views/cocoa/bridged_native_widget.mm
+index 69c5f1f44d7e..45aba19b2390 100644
+--- a/ui/views/cocoa/bridged_native_widget.mm
++++ b/ui/views/cocoa/bridged_native_widget.mm
+@@ -1037,6 +1037,12 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
+ // BridgedNativeWidget, ui::CATransactionObserver
+ 
+ bool BridgedNativeWidget::ShouldWaitInPreCommit() {
++  // Fix lagging when using tabbed windows, see the issue for more:
++  // https://github.com/electron/electron/issues/16925
++  if (@available(macOS 10.12, *)) {
++    if ([[window_ tabbedWindows] count] > 0)
++      return false;
++  }
+   if (!window_visible_)
+     return false;
+   if (ca_transaction_sync_suppressed_)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fix lagging when using tabbed windows, close https://github.com/electron/electron/issues/16925.

This problem only happens for 4.x so I'm only patching `4-2-x` branch. 

Later Chromium has some enhancements on graphics code that fix the lagging problem, but the changes are split in multiple commits on multiple files and we can not just cherry-pick them.

Instead I'm just using the dummy fix and it does not seem to have side effects.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix lagging when using tabbed window.