### PR TITLE
docs: replace the atom.io headers URL with electronjs.org

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -8,6 +8,16 @@ The `FIXME` string is used in code comments to denote things that should be fixe
 
 ## Planned Breaking API Changes (7.0)
 
+### Node Headers URL
+
+This is the URL specified as `disturl` in a `.npmrc` file or as the `--dist-url`
+command line flag when building native Node modules.  Both will be supported for
+the forseeable future but it is reccomened that you switch.
+
+Deprecated: https://atom.io/download/electron
+
+Replace with: https://electronjs.org/headers
+
 ### `session.clearAuthCache(options)`
 
 The `session.clearAuthCache` API no longer accepts options for what to clear, and instead unconditionally clears the whole cache.

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -55,7 +55,7 @@ export npm_config_target=1.2.3
 export npm_config_arch=x64
 export npm_config_target_arch=x64
 # Download headers for Electron.
-export npm_config_disturl=https://atom.io/download/electron
+export npm_config_disturl=https://electronjs.org/headers
 # Tell node-pre-gyp that we are building for Electron.
 export npm_config_runtime=electron
 # Tell node-pre-gyp to build module from source code.
@@ -72,7 +72,7 @@ use `node-gyp` directly to build for Electron:
 
 ```sh
 cd /path-to-module/
-HOME=~/.electron-gyp node-gyp rebuild --target=1.2.3 --arch=x64 --dist-url=https://atom.io/download/electron
+HOME=~/.electron-gyp node-gyp rebuild --target=1.2.3 --arch=x64 --dist-url=https://electronjs.org/headers
 ```
 
 * `HOME=~/.electron-gyp` changes where to find development headers.

--- a/native_mate/README.md
+++ b/native_mate/README.md
@@ -53,4 +53,4 @@ void Initialize(v8::Handle<v8::Object> exports) {
 
 
 [chromium-gin-lib]: https://code.google.com/p/chromium/codesearch#chromium/src/gin/README.md&sq=package:chromium
-[electron]: http://electron.atom.io/
+[electron]: https://electronjs.org/

--- a/script/upload-node-checksums.py
+++ b/script/upload-node-checksums.py
@@ -10,7 +10,7 @@ import tempfile
 from lib.config import s3_config
 from lib.util import download, rm_rf, s3put, safe_mkdir
 
-DIST_URL = 'https://atom.io/download/electron/'
+DIST_URL = 'https://electronjs.org/headers/'
 
 
 def main():

--- a/tools/dump-version-info.js
+++ b/tools/dump-version-info.js
@@ -2,7 +2,7 @@ var app = require('electron').app
 var fs = require('fs')
 var request = require('request')
 
-var TARGET_URL = 'https://atom.io/download/electron/index.json'
+var TARGET_URL = 'https://electronjs.org/headers/index.json'
 
 function getDate () {
   var today = new Date()


### PR DESCRIPTION
Pairs with: https://github.com/electron/electron-rebuild/pull/299

We shouldn't be depending on an `atom.io` URL / service to provide Electron users with our headers.  We added the same redirect to the electron website.

Notes: Deprecate support for the old `atom.io/download/electron` URL in favor of `electronjs.org/headers` for download headers for native module compilation