### PR TITLE
fix: ensure value of atom::PATH_END is valid

### DIFF
--- a/atom/browser/atom_paths.h
+++ b/atom/browser/atom_paths.h
@@ -28,18 +28,22 @@ enum {
 
 #if defined(OS_LINUX)
   DIR_APP_DATA,  // Application Data directory under the user profile.
-#else
+#endif
+
+  PATH_END,  // End of new paths. Those that follow redirect to base::DIR_*
+
+#if !defined(OS_LINUX)
   DIR_APP_DATA = base::DIR_APP_DATA,
 #endif
 
 #if defined(OS_POSIX)
-  DIR_CACHE = base::DIR_CACHE,  // Directory where to put cache data.
+  DIR_CACHE = base::DIR_CACHE  // Directory where to put cache data.
 #else
-  DIR_CACHE = base::DIR_APP_DATA,
+  DIR_CACHE = base::DIR_APP_DATA
 #endif
-
-  PATH_END
 };
+
+static_assert(PATH_START < PATH_END, "invalid PATH boundaries");
 
 }  // namespace atom
 


### PR DESCRIPTION
#### Description of Change

The last entries in the `atom::PATH_*` enum copy their values from `base::PATH_*` entries, so the final item in the enum -- `atom::PATH_END` -- accidentally picked up a value somewhere between `base::PATH_START` and `base::PATH_END`.

This a minor correctness patch. `atom::PATH_END` was the only enum bitten by this and it doesn't appear to be used anywhere.

Kind of a random PR. I spotted this while reading for an unrelated issue.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes