### PR TITLE
fix: correctly support the webkitdirectory input attr

### DIFF
--- a/atom/browser/web_dialog_helper.h
+++ b/atom/browser/web_dialog_helper.h
@@ -6,8 +6,10 @@
 #define ATOM_BROWSER_WEB_DIALOG_HELPER_H_
 
 #include <memory>
+#include <vector>
 
 #include "base/memory/weak_ptr.h"
+#include "net/base/directory_lister.h"
 #include "third_party/blink/public/mojom/choosers/file_chooser.mojom.h"
 
 namespace base {
@@ -21,6 +23,32 @@ class WebContents;
 }  // namespace content
 
 namespace atom {
+
+class DirectoryListerHelperDelegate {
+ public:
+  virtual void OnDirectoryListerDone(
+      std::vector<blink::mojom::FileChooserFileInfoPtr> file_info,
+      base::FilePath base_dir) = 0;
+};
+
+class DirectoryListerHelper
+    : public net::DirectoryLister::DirectoryListerDelegate {
+ public:
+  DirectoryListerHelper(base::FilePath base,
+                        DirectoryListerHelperDelegate* helper);
+  ~DirectoryListerHelper() override;
+
+ private:
+  void OnListFile(
+      const net::DirectoryLister::DirectoryListerData& data) override;
+  void OnListDone(int error) override;
+
+  base::FilePath base_dir_;
+  DirectoryListerHelperDelegate* delegate_;
+  std::vector<base::FilePath> paths_;
+
+  DISALLOW_COPY_AND_ASSIGN(DirectoryListerHelper);
+};
 
 class NativeWindow;
 


### PR DESCRIPTION
Fixes #839

The implementation here was loosely inspired by the implementation in
`//chrome` found in their FileSelectHelper.  I.e. That's where the usage
of `net::DirectoryList` comes from.

Refs: https://cs.chromium.org/chromium/src/chrome/browser/file_select_helper.cc

Notes: Fixed support for the `webkitdirectory` attribute on `input[type=file]` elements