### PR TITLE
feat: migrate protocol module to NetworkService (Part 8)

### DIFF
--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -167,6 +167,16 @@ class AtomBrowserClient : public content::ContentBrowserClient,
       int render_process_id,
       int render_frame_id,
       NonNetworkURLLoaderFactoryMap* factories) override;
+  bool WillCreateURLLoaderFactory(
+      content::BrowserContext* browser_context,
+      content::RenderFrameHost* frame,
+      int render_process_id,
+      bool is_navigation,
+      bool is_download,
+      const url::Origin& request_initiator,
+      network::mojom::URLLoaderFactoryRequest* factory_request,
+      network::mojom::TrustedURLLoaderHeaderClientPtrInfo* header_client,
+      bool* bypass_redirect_checks) override;
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;

--- a/atom/browser/net/proxying_url_loader_factory.cc
+++ b/atom/browser/net/proxying_url_loader_factory.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/net/proxying_url_loader_factory.h"
+
+namespace atom {
+
+ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
+    network::mojom::URLLoaderFactoryRequest loader_request,
+    network::mojom::URLLoaderFactoryPtrInfo target_factory_info)
+    : weak_factory_(this) {
+  target_factory_.Bind(std::move(target_factory_info));
+  target_factory_.set_connection_error_handler(base::BindOnce(
+      &ProxyingURLLoaderFactory::OnTargetFactoryError, base::Unretained(this)));
+  proxy_bindings_.AddBinding(this, std::move(loader_request));
+  proxy_bindings_.set_connection_error_handler(base::BindRepeating(
+      &ProxyingURLLoaderFactory::OnProxyBindingError, base::Unretained(this)));
+}
+
+ProxyingURLLoaderFactory::~ProxyingURLLoaderFactory() = default;
+
+void ProxyingURLLoaderFactory::CreateLoaderAndStart(
+    network::mojom::URLLoaderRequest loader,
+    int32_t routing_id,
+    int32_t request_id,
+    uint32_t options,
+    const network::ResourceRequest& request,
+    network::mojom::URLLoaderClientPtr client,
+    const net::MutableNetworkTrafficAnnotationTag& traffic_annotation) {
+  target_factory_->CreateLoaderAndStart(std::move(loader), routing_id,
+                                        request_id, options, request,
+                                        std::move(client), traffic_annotation);
+}
+
+void ProxyingURLLoaderFactory::Clone(
+    network::mojom::URLLoaderFactoryRequest loader_request) {
+  proxy_bindings_.AddBinding(this, std::move(loader_request));
+}
+
+void ProxyingURLLoaderFactory::OnTargetFactoryError() {
+  delete this;
+}
+
+void ProxyingURLLoaderFactory::OnProxyBindingError() {
+  if (proxy_bindings_.empty())
+    delete this;
+}
+
+}  // namespace atom

--- a/atom/browser/net/proxying_url_loader_factory.h
+++ b/atom/browser/net/proxying_url_loader_factory.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
+#define ATOM_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
+
+#include "mojo/public/cpp/bindings/binding.h"
+#include "mojo/public/cpp/bindings/binding_set.h"
+#include "services/network/public/mojom/url_loader.mojom.h"
+#include "services/network/public/mojom/url_loader_factory.mojom.h"
+
+namespace atom {
+
+class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
+ public:
+  ProxyingURLLoaderFactory(
+      network::mojom::URLLoaderFactoryRequest loader_request,
+      network::mojom::URLLoaderFactoryPtrInfo target_factory_info);
+  ~ProxyingURLLoaderFactory() override;
+
+  // network::mojom::URLLoaderFactory:
+  void CreateLoaderAndStart(network::mojom::URLLoaderRequest loader,
+                            int32_t routing_id,
+                            int32_t request_id,
+                            uint32_t options,
+                            const network::ResourceRequest& request,
+                            network::mojom::URLLoaderClientPtr client,
+                            const net::MutableNetworkTrafficAnnotationTag&
+                                traffic_annotation) override;
+  void Clone(network::mojom::URLLoaderFactoryRequest request) override;
+
+ private:
+  void OnTargetFactoryError();
+  void OnProxyBindingError();
+
+  mojo::BindingSet<network::mojom::URLLoaderFactory> proxy_bindings_;
+  network::mojom::URLLoaderFactoryPtr target_factory_;
+
+  base::WeakPtrFactory<ProxyingURLLoaderFactory> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(ProxyingURLLoaderFactory);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_

--- a/filenames.gni
+++ b/filenames.gni
@@ -336,6 +336,8 @@ filenames = {
     "atom/browser/net/atom_url_request_job_factory.h",
     "atom/browser/net/http_protocol_handler.cc",
     "atom/browser/net/http_protocol_handler.h",
+    "atom/browser/net/proxying_url_loader_factory.cc",
+    "atom/browser/net/proxying_url_loader_factory.h",
     "atom/browser/net/js_asker.cc",
     "atom/browser/net/js_asker.h",
     "atom/browser/net/network_context_service_factory.cc",


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This PR makes the `file://` protocol support asar files when using NetworkService.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes