### PR TITLE
fix: reverse showSaveDialog cancellation bool

### DIFF
--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -117,7 +117,7 @@ void RunSaveDialogInNewThread(const RunState& run_state,
   bool result = ShowSaveDialogSync(settings, &path);
   run_state.ui_task_runner->PostTask(
       FROM_HERE,
-      base::BindOnce(&OnSaveDialogDone, std::move(promise), result, path));
+      base::BindOnce(&OnSaveDialogDone, std::move(promise), !result, path));
   run_state.ui_task_runner->DeleteSoon(FROM_HERE, run_state.dialog_thread);
 }
 
@@ -321,7 +321,7 @@ void ShowSaveDialog(const DialogSettings& settings,
   RunState run_state;
   if (!CreateDialogThread(&run_state)) {
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
-    dict.Set("canceled", false);
+    dict.Set("canceled", true);
     dict.Set("filePath", base::FilePath());
     promise.Resolve(dict.GetHandle());
   } else {


### PR DESCRIPTION
#### Description of Change

Addresses the issue raised in [this comment](https://github.com/electron/electron/pull/17054#issuecomment-493633762).

The cancellation boolean values were reversed, in that `ShowSaveDialogSync` returned `true` if the dialog was _not_ cancelled and we were unilaterally passing it to the completion callback as the _canceled_ value. We also should be returning `canceled` as `true` if `CreateDialogThread` returned `false.`

This PR thus corrects that error. 

cc @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Corrected a reversal of cancellation values in `showSaveDialog` on the Windows platform.
