### PR TITLE
fix: docs/api/browser-window.md: fix typo

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -592,7 +592,7 @@ win.on('app-command', (e, cmd) => {
 })
 ```
 
-The following app commands are explictly supported on Linux:
+The following app commands are explicitly supported on Linux:
 
 * `browser-backward`
 * `browser-forward`


### PR DESCRIPTION
notes: no-notes