### PR TITLE
chore: remove dead code

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -354,9 +354,6 @@ WebContents.prototype._init = function () {
     app.emit('renderer-process-crashed', event, this, ...args)
   })
 
-  deprecate.event(this, 'did-get-response-details', '-did-get-response-details')
-  deprecate.event(this, 'did-get-redirect-request', '-did-get-redirect-request')
-
   // The devtools requests the webContents to reload.
   this.on('devtools-reload-page', function () {
     this.reload()


### PR DESCRIPTION
#### Description of Change
Follow up to https://github.com/electron/electron/commit/7b47d69efe6fec355778c1ea7e1c9c29a2cc3599#diff-faaead3da8a3aa51eff1331507a67934
The `did-get-response-details` and `did-get-redirect-request` events have been long gone now.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes