### PR TITLE
feat: migrate protocol module to NetworkService (Part 9)

### DIFF
--- a/atom/browser/api/atom_api_protocol_ns.cc
+++ b/atom/browser/api/atom_api_protocol_ns.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/api/atom_api_protocol_ns.h"
 
 #include <memory>
+#include <utility>
 
 #include "atom/browser/atom_browser_context.h"
 #include "atom/common/native_mate_converters/net_converter.h"

--- a/atom/browser/api/atom_api_protocol_ns.cc
+++ b/atom/browser/api/atom_api_protocol_ns.cc
@@ -37,8 +37,6 @@ std::string ErrorCodeToString(ProtocolError error) {
   }
 }
 
-void Noop() {}
-
 }  // namespace
 
 ProtocolNS::ProtocolNS(v8::Isolate* isolate,
@@ -82,15 +80,36 @@ bool ProtocolNS::IsProtocolRegistered(const std::string& scheme) {
   return base::ContainsKey(handlers_, scheme);
 }
 
+ProtocolError ProtocolNS::InterceptProtocol(ProtocolType type,
+                                            const std::string& scheme,
+                                            const ProtocolHandler& handler) {
+  ProtocolError error = ProtocolError::OK;
+  if (!base::ContainsKey(intercept_handlers_, scheme))
+    intercept_handlers_[scheme] = std::make_pair(type, handler);
+  else
+    error = ProtocolError::INTERCEPTED;
+  return error;
+}
+
 void ProtocolNS::UninterceptProtocol(const std::string& scheme,
                                      mate::Arguments* args) {
-  HandleOptionalCallback(args, ProtocolError::NOT_INTERCEPTED);
+  ProtocolError error = ProtocolError::OK;
+  if (base::ContainsKey(intercept_handlers_, scheme))
+    intercept_handlers_.erase(scheme);
+  else
+    error = ProtocolError::NOT_INTERCEPTED;
+  HandleOptionalCallback(args, error);
+}
+
+bool ProtocolNS::IsProtocolIntercepted(const std::string& scheme) {
+  return base::ContainsKey(intercept_handlers_, scheme);
 }
 
 v8::Local<v8::Promise> ProtocolNS::IsProtocolHandled(
     const std::string& scheme) {
   util::Promise promise(isolate());
   promise.Resolve(IsProtocolRegistered(scheme) ||
+                  IsProtocolIntercepted(scheme) ||
                   // The |isProtocolHandled| should return true for builtin
                   // schemes, however with NetworkService it is impossible to
                   // know which schemes are registered until a real network
@@ -141,12 +160,20 @@ void ProtocolNS::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("unregisterProtocol", &ProtocolNS::UnregisterProtocol)
       .SetMethod("isProtocolRegistered", &ProtocolNS::IsProtocolRegistered)
       .SetMethod("isProtocolHandled", &ProtocolNS::IsProtocolHandled)
-      .SetMethod("interceptStringProtocol", &Noop)
-      .SetMethod("interceptBufferProtocol", &Noop)
-      .SetMethod("interceptFileProtocol", &Noop)
-      .SetMethod("interceptHttpProtocol", &Noop)
-      .SetMethod("interceptStreamProtocol", &Noop)
-      .SetMethod("uninterceptProtocol", &ProtocolNS::UninterceptProtocol);
+      .SetMethod("interceptStringProtocol",
+                 &ProtocolNS::InterceptProtocolFor<ProtocolType::kString>)
+      .SetMethod("interceptBufferProtocol",
+                 &ProtocolNS::InterceptProtocolFor<ProtocolType::kBuffer>)
+      .SetMethod("interceptFileProtocol",
+                 &ProtocolNS::InterceptProtocolFor<ProtocolType::kFile>)
+      .SetMethod("interceptHttpProtocol",
+                 &ProtocolNS::InterceptProtocolFor<ProtocolType::kHttp>)
+      .SetMethod("interceptStreamProtocol",
+                 &ProtocolNS::InterceptProtocolFor<ProtocolType::kStream>)
+      .SetMethod("interceptProtocol",
+                 &ProtocolNS::InterceptProtocolFor<ProtocolType::kFree>)
+      .SetMethod("uninterceptProtocol", &ProtocolNS::UninterceptProtocol)
+      .SetMethod("isProtocolIntercepted", &ProtocolNS::IsProtocolIntercepted);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_protocol_ns.h
+++ b/atom/browser/api/atom_api_protocol_ns.h
@@ -5,9 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_PROTOCOL_NS_H_
 #define ATOM_BROWSER_API_ATOM_API_PROTOCOL_NS_H_
 
-#include <map>
 #include <string>
-#include <utility>
 
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/net/atom_url_loader_factory.h"
@@ -43,9 +41,6 @@ class ProtocolNS : public mate::TrackableObject<ProtocolNS> {
   void RegisterURLLoaderFactories(
       content::ContentBrowserClient::NonNetworkURLLoaderFactoryMap* factories);
 
-  // scheme => (type, handler).
-  using HandlersMap =
-      std::map<std::string, std::pair<ProtocolType, ProtocolHandler>>;
   const HandlersMap& intercept_handlers() const { return intercept_handlers_; }
 
  private:

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -971,13 +971,15 @@ bool AtomBrowserClient::WillCreateURLLoaderFactory(
     bool* bypass_redirect_checks) {
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(frame_host);
-  if (!web_contents)
+  api::ProtocolNS* protocol = api::ProtocolNS::FromWrappedClass(
+      v8::Isolate::GetCurrent(), web_contents->GetBrowserContext());
+  if (!protocol)
     return false;
 
   auto proxied_request = std::move(*factory_request);
   network::mojom::URLLoaderFactoryPtrInfo target_factory_info;
   *factory_request = mojo::MakeRequest(&target_factory_info);
-  new ProxyingURLLoaderFactory(std::move(proxied_request),
+  new ProxyingURLLoaderFactory(protocol, std::move(proxied_request),
                                std::move(target_factory_info));
   return true;
 }

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -979,7 +979,8 @@ bool AtomBrowserClient::WillCreateURLLoaderFactory(
   auto proxied_request = std::move(*factory_request);
   network::mojom::URLLoaderFactoryPtrInfo target_factory_info;
   *factory_request = mojo::MakeRequest(&target_factory_info);
-  new ProxyingURLLoaderFactory(protocol, std::move(proxied_request),
+  new ProxyingURLLoaderFactory(protocol->intercept_handlers(),
+                               std::move(proxied_request),
                                std::move(target_factory_info));
   return true;
 }

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -24,8 +24,7 @@ enum class ProtocolType {
   kFree,  // special type for returning arbitrary type of response.
 };
 
-using StartLoadingCallback =
-    base::OnceCallback<void(v8::Local<v8::Value>, mate::Arguments*)>;
+using StartLoadingCallback = base::OnceCallback<void(mate::Arguments*)>;
 using ProtocolHandler =
     base::Callback<void(const network::ResourceRequest&, StartLoadingCallback)>;
 
@@ -56,7 +55,6 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       network::mojom::URLLoaderClientPtr client,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       ProtocolType type,
-      v8::Local<v8::Value> response,
       mate::Arguments* args);
   static void StartLoadingBuffer(network::mojom::URLLoaderClientPtr client,
                                  const mate::Dictionary& dict);

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -5,7 +5,9 @@
 #ifndef ATOM_BROWSER_NET_ATOM_URL_LOADER_FACTORY_H_
 #define ATOM_BROWSER_NET_ATOM_URL_LOADER_FACTORY_H_
 
+#include <map>
 #include <string>
+#include <utility>
 
 #include "mojo/public/cpp/bindings/binding_set.h"
 #include "native_mate/dictionary.h"
@@ -27,6 +29,10 @@ enum class ProtocolType {
 using StartLoadingCallback = base::OnceCallback<void(mate::Arguments*)>;
 using ProtocolHandler =
     base::Callback<void(const network::ResourceRequest&, StartLoadingCallback)>;
+
+// scheme => (type, handler).
+using HandlersMap =
+    std::map<std::string, std::pair<ProtocolType, ProtocolHandler>>;
 
 // Implementation of URLLoaderFactory.
 class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {

--- a/atom/browser/net/atom_url_loader_factory.h
+++ b/atom/browser/net/atom_url_loader_factory.h
@@ -51,7 +51,6 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
                                 traffic_annotation) override;
   void Clone(network::mojom::URLLoaderFactoryRequest request) override;
 
- private:
   static void StartLoading(
       network::mojom::URLLoaderRequest loader,
       int32_t routing_id,
@@ -62,6 +61,8 @@ class AtomURLLoaderFactory : public network::mojom::URLLoaderFactory {
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       ProtocolType type,
       mate::Arguments* args);
+
+ private:
   static void StartLoadingBuffer(network::mojom::URLLoaderClientPtr client,
                                  const mate::Dictionary& dict);
   static void StartLoadingString(network::mojom::URLLoaderClientPtr client,

--- a/atom/browser/net/proxying_url_loader_factory.cc
+++ b/atom/browser/net/proxying_url_loader_factory.cc
@@ -38,10 +38,12 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
   // Check if user has intercepted this scheme.
   auto it = handlers_.find(request.url.scheme());
   if (it != handlers_.end()) {
-    AtomURLLoaderFactory(it->second.first, it->second.second)
-        .CreateLoaderAndStart(std::move(loader), routing_id, request_id,
-                              options, request, std::move(client),
-                              traffic_annotation);
+    // <scheme, <type, handler>>
+    it->second.second.Run(
+        request, base::BindOnce(&AtomURLLoaderFactory::StartLoading,
+                                std::move(loader), routing_id, request_id,
+                                options, request, std::move(client),
+                                traffic_annotation, it->second.first));
     return;
   }
 

--- a/atom/browser/net/proxying_url_loader_factory.cc
+++ b/atom/browser/net/proxying_url_loader_factory.cc
@@ -16,7 +16,7 @@ ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
     const HandlersMap& handlers,
     network::mojom::URLLoaderFactoryRequest loader_request,
     network::mojom::URLLoaderFactoryPtrInfo target_factory_info)
-    : handlers_(handlers), weak_factory_(this) {
+    : handlers_(handlers) {
   target_factory_.Bind(std::move(target_factory_info));
   target_factory_.set_connection_error_handler(base::BindOnce(
       &ProxyingURLLoaderFactory::OnTargetFactoryError, base::Unretained(this)));

--- a/atom/browser/net/proxying_url_loader_factory.h
+++ b/atom/browser/net/proxying_url_loader_factory.h
@@ -44,8 +44,6 @@ class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
   mojo::BindingSet<network::mojom::URLLoaderFactory> proxy_bindings_;
   network::mojom::URLLoaderFactoryPtr target_factory_;
 
-  base::WeakPtrFactory<ProxyingURLLoaderFactory> weak_factory_;
-
   DISALLOW_COPY_AND_ASSIGN(ProxyingURLLoaderFactory);
 };
 

--- a/atom/browser/net/proxying_url_loader_factory.h
+++ b/atom/browser/net/proxying_url_loader_factory.h
@@ -5,21 +5,14 @@
 #ifndef ATOM_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
 #define ATOM_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
 
-#include "mojo/public/cpp/bindings/binding.h"
-#include "mojo/public/cpp/bindings/binding_set.h"
-#include "services/network/public/mojom/url_loader.mojom.h"
-#include "services/network/public/mojom/url_loader_factory.mojom.h"
+#include "atom/browser/net/atom_url_loader_factory.h"
 
 namespace atom {
-
-namespace api {
-class ProtocolNS;
-}
 
 class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
  public:
   ProxyingURLLoaderFactory(
-      api::ProtocolNS* protocol,
+      const HandlersMap& handlers,
       network::mojom::URLLoaderFactoryRequest loader_request,
       network::mojom::URLLoaderFactoryPtrInfo target_factory_info);
   ~ProxyingURLLoaderFactory() override;
@@ -39,7 +32,15 @@ class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
   void OnTargetFactoryError();
   void OnProxyBindingError();
 
-  api::ProtocolNS* protocol_;
+  // This is passed from api::ProtocolNS.
+  //
+  // The ProtocolNS instance lives through the lifetime of BrowserContenxt,
+  // which is guarenteed to cover the lifetime of URLLoaderFactory, so the
+  // reference is guarenteed to be valid.
+  //
+  // In this way we can avoid using code from api namespace in this file.
+  const HandlersMap& handlers_;
+
   mojo::BindingSet<network::mojom::URLLoaderFactory> proxy_bindings_;
   network::mojom::URLLoaderFactoryPtr target_factory_;
 

--- a/atom/browser/net/proxying_url_loader_factory.h
+++ b/atom/browser/net/proxying_url_loader_factory.h
@@ -12,9 +12,14 @@
 
 namespace atom {
 
+namespace api {
+class ProtocolNS;
+}
+
 class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
  public:
   ProxyingURLLoaderFactory(
+      api::ProtocolNS* protocol,
       network::mojom::URLLoaderFactoryRequest loader_request,
       network::mojom::URLLoaderFactoryPtrInfo target_factory_info);
   ~ProxyingURLLoaderFactory() override;
@@ -34,6 +39,7 @@ class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
   void OnTargetFactoryError();
   void OnProxyBindingError();
 
+  api::ProtocolNS* protocol_;
   mojo::BindingSet<network::mojom::URLLoaderFactory> proxy_bindings_;
   network::mojom::URLLoaderFactoryPtr target_factory_;
 

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -310,8 +310,8 @@ describe('protocol module', () => {
       const handler = (request, callback) => callback({ url: redirectURL })
       await registerHttpProtocol(protocolName, handler)
 
-      await contents.loadURL(url)
-      expect(contents.getURL()).to.equal(url)
+      const r = await ajax(url)
+      expect(r.data).to.equal(text)
     })
 
     it('can access request headers', (done) => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This PR implements the `protocol.interceptXXXProtocol` APIs with NetworkService, also fixes a few related tests.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes