### PR TITLE
test: add spec for contentTracing.stopRecording with empty path

### DIFF
--- a/spec/api-content-tracing-spec.js
+++ b/spec/api-content-tracing-spec.js
@@ -15,10 +15,6 @@ const timeout = async (milliseconds) => {
   })
 }
 
-const getPathInATempFolder = (filename) => {
-  return path.join(app.getPath('temp'), filename)
-}
-
 describe('contentTracing', () => {
   beforeEach(function () {
     // FIXME: The tests are skipped on arm/arm64.
@@ -38,7 +34,7 @@ describe('contentTracing', () => {
     return resultFilePath
   }
 
-  const outputFilePath = getPathInATempFolder('trace.json')
+  const outputFilePath = path.join(app.getPath('temp'), 'trace.json')
   beforeEach(() => {
     if (fs.existsSync(outputFilePath)) {
       fs.unlinkSync(outputFilePath)
@@ -114,6 +110,18 @@ describe('contentTracing', () => {
 
   describe('stopRecording', function () {
     this.timeout(5e3)
+
+    it('does not crash on empty string', async () => {
+      const options = {
+        categoryFilter: '*',
+        traceOptions: 'record-until-full,enable-sampling'
+      }
+
+      await contentTracing.startRecording(options)
+      const path = await contentTracing.stopRecording('')
+      expect(path).to.be.a('string').that.is.not.empty()
+      expect(fs.statSync(path).isFile()).to.be.true()
+    })
 
     it('calls its callback with a result file path', async () => {
       const resultFilePath = await record(/* options */ {}, outputFilePath)


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/16019.

The crash raised in the issue has been verified to be fixed in `master` locally, so this PR adds a test to prevent future regressions with the `''` argument to `contentTracing.stopRecording`.

cc @miniak @alexeykuzmin @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
