### PR TITLE
fix: remove lingering data when notifications autodismiss on Windows 7

### DIFF
--- a/atom/browser/notifications/win/win32_desktop_notifications/toast.cc
+++ b/atom/browser/notifications/win/win32_desktop_notifications/toast.cc
@@ -270,10 +270,16 @@ LRESULT DesktopNotificationController::Toast::WndProc(HWND hwnd,
     case WM_MOUSEACTIVATE:
       return MA_NOACTIVATE;
 
-    case WM_TIMER:
+    case WM_TIMER: {
       if (wparam == TimerID_AutoDismiss) {
-        Get(hwnd)->AutoDismiss();
+        auto* inst = Get(hwnd);
+
+        Notification notification(inst->data_);
+        inst->data_->controller->OnNotificationDismissed(notification);
+
+        inst->AutoDismiss();
       }
+    }
       return 0;
 
     case WM_LBUTTONDOWN: {

--- a/atom/browser/notifications/win/win32_notification.cc
+++ b/atom/browser/notifications/win/win32_notification.cc
@@ -47,8 +47,12 @@ void Win32Notification::Show(const NotificationOptions& options) {
 
   if (existing) {
     existing->tag_.clear();
+
     this->notification_ref_ = std::move(existing->notification_ref_);
     this->notification_ref_.Set(options.title, options.msg, image);
+    // Need to remove the entry in the notifications set that
+    // NotificationPresenter is holding
+    existing->Destroy();
   } else {
     this->notification_ref_ =
         presenter->AddNotification(options.title, options.msg, image);


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

I Windows 7 notifications that gets auto dismissed (notifications that closes after 4 seconds due to no interaction) won't remove the reference to the notification object which means following notifications that uses the same tag won't be shown.

To solve this issue we need to remove the old reference to the notification within the presenter when a new notification with the same tag is created. Also when a notification is auto dismissed the calls for a manual dismiss is called to remove the notification objets.

Fixes: https://github.com/electron/electron/issues/11189

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug where notifications with same tag wouldn't show more than once when first notification was auto dismissed in Windows 7. <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
