### PR TITLE
refactor: remove textured BrowserWindow type option

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -311,17 +311,9 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   std::string windowType;
   options.Get(options::kType, &windowType);
 
-  bool useStandardWindow = true;
-  // eventually deprecate separate "standardWindow" option in favor of
-  // standard / textured window types
-  options.Get(options::kStandardWindow, &useStandardWindow);
-  if (windowType == "textured") {
-    useStandardWindow = false;
-  }
-
   NSUInteger styleMask = NSWindowStyleMaskTitled;
   if (title_bar_style_ == TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER &&
-      (!useStandardWindow || transparent() || !has_frame())) {
+      (transparent() || !has_frame())) {
     styleMask = NSWindowStyleMaskFullSizeContentView;
   }
   if (minimizable) {
@@ -333,9 +325,6 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   if (title_bar_style_ != TitleBarStyle::NORMAL) {
     // The window without titlebar is treated the same with frameless window.
     set_has_frame(false);
-  }
-  if (!useStandardWindow || transparent() || !has_frame()) {
-    styleMask |= NSTexturedBackgroundWindowMask;
   }
   if (resizable_) {
     styleMask |= NSResizableWindowMask;

--- a/atom/browser/ui/cocoa/atom_inspectable_web_contents_view.mm
+++ b/atom/browser/ui/cocoa/atom_inspectable_web_contents_view.mm
@@ -138,7 +138,6 @@
 
     auto styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                      NSMiniaturizableWindowMask | NSWindowStyleMaskResizable |
-                     NSTexturedBackgroundWindowMask |
                      NSWindowStyleMaskUnifiedTitleAndToolbar;
     devtools_window_.reset([[EventDispatchingWindow alloc]
         initWithContentRect:NSMakeRect(0, 0, 800, 600)

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -77,9 +77,6 @@ const char kType[] = "type";
 // Disable auto-hiding cursor.
 const char kDisableAutoHideCursor[] = "disableAutoHideCursor";
 
-// Use the macOS' standard window instead of the textured window.
-const char kStandardWindow[] = "standardWindow";
-
 // Default browser window background color.
 const char kBackgroundColor[] = "backgroundColor";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -45,7 +45,6 @@ extern const char kDarkTheme[];
 extern const char kTransparent[];
 extern const char kType[];
 extern const char kDisableAutoHideCursor[];
-extern const char kStandardWindow[];
 extern const char kBackgroundColor[];
 extern const char kHasShadow[];
 extern const char kOpacity[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -394,9 +394,7 @@ Possible values are:
 
 * On Linux, possible types are `desktop`, `dock`, `toolbar`, `splash`,
   `notification`.
-* On macOS, possible types are `desktop`, `textured`.
-  * The `textured` type adds metal gradient appearance
-    (`NSTexturedBackgroundWindowMask`).
+* On macOS, possible type is `desktop`.
   * The `desktop` type places the window at the desktop background window level
     (`kCGDesktopWindowLevel - 1`). Note that desktop window will not receive
     focus, keyboard or mouse events, but you can use `globalShortcut` to receive


### PR DESCRIPTION
#### Description of Change

Both [`NSTexturedWindowMask`](https://developer.apple.com/documentation/appkit/nstexturedbackgroundwindowmask?language=objc) and [`NSWindowStyleMaskTexturedBackground`](https://developer.apple.com/documentation/appkit/nswindowstylemask/nswindowstylemasktexturedbackground?language=objc) have been deprecated with no replacements in macOS. This therefore removes that option from the `type` options for new BrowserWindows on macOS.

Since there is no longer a textured window option, there will no longer be a case where `standardWindow` will be false and this we can remove it as well.

A paired deprecation PR will be opened against `6-0-x` once this has been merged.

cc @nornagon @deepak1556 @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed `textured` from the `type` options for new BrowserWindows on macOS.
