### PR TITLE
chore: update the npm package to use @electron/get

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -13,6 +13,6 @@
     "extract-zip": "^1.0.3"
   },
   "engines": {
-    "node": ">= 6.0"
+    "node": ">= 8.6"
   }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,29 +1,18 @@
 {
-  "scripts": {
-    "cache-clean": "rm -rf ~/.electron && rm -rf dist",
-    "postinstall": "node install.js",
-    "pretest": "npm run cache-clean",
-    "test": "standard"
-  },
+  "main": "index.js",
+  "types": "electron.d.ts",
   "bin": {
     "electron": "cli.js"
   },
-  "main": "index.js",
-  "types": "electron.d.ts",
+  "scripts": {
+    "postinstall": "node install.js"
+  },
   "dependencies": {
+    "@electron/get": "^1.0.1",
     "@types/node": "^10.12.18",
-    "electron-download": "^4.1.0",
     "extract-zip": "^1.0.3"
   },
-  "devDependencies": {
-    "home-path": "^0.1.1",
-    "path-exists": "^2.0.0",
-    "standard": "^5.4.1"
-  },
-  "directories": {
-    "test": "test"
-  },
   "engines": {
-    "node": ">= 4.0"
+    "node": ">= 6.0"
   }
 }


### PR DESCRIPTION
This updates our npm package to use `@electron/get` the new and shiny version of `electron-download`.  Tested locally and appears to work 👍 

Notes: Updated the `electron` module to use `@electron/get`.  The minimum supported node version is now Node 8.