### PR TITLE
fix: respect minimizable/closable for customButtonsOnHover

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -167,7 +167,7 @@ class NativeWindowMac : public NativeWindow {
 
  private:
   // Add custom layers to the content view.
-  void AddContentViewLayers();
+  void AddContentViewLayers(bool minimizable, bool closable);
 
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void SetForwardMouseMessages(bool forward);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -74,9 +74,11 @@
   NSButton* close_button =
       [NSWindow standardWindowButton:NSWindowCloseButton
                         forStyleMask:NSWindowStyleMaskTitled];
+  [close_button setTag:1];
   NSButton* miniaturize_button =
       [NSWindow standardWindowButton:NSWindowMiniaturizeButton
                         forStyleMask:NSWindowStyleMaskTitled];
+  [miniaturize_button setTag:2];
 
   CGFloat x = 0;
   const CGFloat space_between = 20;
@@ -320,26 +322,23 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
   }
 
   NSUInteger styleMask = NSWindowStyleMaskTitled;
-  if (title_bar_style_ == TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER &&
-      (!useStandardWindow || transparent() || !has_frame())) {
+  bool customOnHover =
+      title_bar_style_ == TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER;
+  if (customOnHover && (!useStandardWindow || transparent() || !has_frame()))
     styleMask = NSWindowStyleMaskFullSizeContentView;
-  }
-  if (minimizable) {
+
+  if (minimizable)
     styleMask |= NSMiniaturizableWindowMask;
-  }
-  if (closable) {
+  if (closable)
     styleMask |= NSWindowStyleMaskClosable;
-  }
-  if (title_bar_style_ != TitleBarStyle::NORMAL) {
-    // The window without titlebar is treated the same with frameless window.
-    set_has_frame(false);
-  }
-  if (!useStandardWindow || transparent() || !has_frame()) {
-    styleMask |= NSTexturedBackgroundWindowMask;
-  }
-  if (resizable_) {
+  if (resizable_)
     styleMask |= NSResizableWindowMask;
-  }
+
+  // The window without titlebar is treated the same with frameless window.
+  if (title_bar_style_ != TitleBarStyle::NORMAL)
+    set_has_frame(false);
+  if (!useStandardWindow || transparent() || !has_frame())
+    styleMask |= NSTexturedBackgroundWindowMask;
 
   // Create views::Widget and assign window_ with it.
   // TODO(zcbenz): Get rid of the window_ in future.
@@ -461,7 +460,7 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
 
   // Default content view.
   SetContentView(new views::View());
-  AddContentViewLayers();
+  AddContentViewLayers(minimizable, closable);
 
   original_frame_ = [window_ frame];
   original_level_ = [window_ level];
@@ -1386,7 +1385,7 @@ views::View* NativeWindowMac::GetContentsView() {
   return root_view_.get();
 }
 
-void NativeWindowMac::AddContentViewLayers() {
+void NativeWindowMac::AddContentViewLayers(bool minimizable, bool closable) {
   // Make sure the bottom corner is rounded for non-modal windows:
   // http://crbug.com/396264.
   if (!is_modal()) {
@@ -1424,8 +1423,15 @@ void NativeWindowMac::AddContentViewLayers() {
     if (title_bar_style_ == TitleBarStyle::CUSTOM_BUTTONS_ON_HOVER) {
       buttons_view_.reset(
           [[CustomWindowButtonView alloc] initWithFrame:NSZeroRect]);
+
       // NSWindowStyleMaskFullSizeContentView does not work with zoom button
       SetFullScreenable(false);
+
+      if (!minimizable)
+        [[buttons_view_ viewWithTag:2] removeFromSuperview];
+      if (!closable)
+        [[buttons_view_ viewWithTag:1] removeFromSuperview];
+
       [[window_ contentView] addSubview:buttons_view_];
     } else {
       if (title_bar_style_ != TitleBarStyle::NORMAL)
@@ -1482,7 +1488,7 @@ void NativeWindowMac::OverrideNSWindowContentView() {
       setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
   [container_view_ setFrame:[[[window_ contentView] superview] bounds]];
   [window_ setContentView:container_view_];
-  AddContentViewLayers();
+  AddContentViewLayers(IsMinimizable(), IsClosable());
 }
 
 void NativeWindowMac::SetStyleMask(bool on, NSUInteger flag) {


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/18364.

This PR ameliorates an issue whereby `minimizable` and `closable` weren't respected in `customButtonsOnHover` mode. `maximizable` isn't addressable here, since it's been blanket disabled in newer versions of macOS owing to an issue with the `NSWindowStyleMaskFullSizeContentView` style mask. That will, however, be addressed in the relevant backport pull request.

This can be backported to 6 as-is but will need to be manually backported to 5 & 4 to account for the `maximizable` consideration.

cc @pronebird @MarshallOfSound @nornagon @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue whereby `minimizable` and `closable` weren't respected in `customButtonsOnHover` mode.
