### PR TITLE
test: contentTracing.stopRecording with empty path

### DIFF
--- a/spec/api-content-tracing-spec.js
+++ b/spec/api-content-tracing-spec.js
@@ -203,6 +203,18 @@ describe('contentTracing', () => {
   describe('stopRecording', function () {
     this.timeout(5e3)
 
+    it('does not crash on empty string', async () => {
+      const options = {
+        categoryFilter: '*',
+        traceOptions: 'record-until-full,enable-sampling'
+      }
+
+      await contentTracing.startRecording(options)
+      const path = await contentTracing.stopRecording('')
+      expect(path).to.be.a('string').that.is.not.empty()
+      expect(fs.statSync(path).isFile()).to.be.true()
+    })
+
     it('calls its callback with a result file path', async () => {
       const resultFilePath = await record(/* options */ {}, outputFilePath)
       expect(resultFilePath).to.be.a('string').and.be.equal(outputFilePath)


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/18391.

See that PR for more details.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
