### PR TITLE
test: move beforeunload tests to main runner and fix flake

### DIFF
--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -9,7 +9,7 @@ const { expect } = chai
 
 chai.use(chaiAsPromised)
 
-const fixturesPath = path.resolve(__dirname, '../spec/fixtures')
+const fixturesPath = path.resolve(__dirname, '..', 'spec', 'fixtures')
 
 describe('webContents module', () => {
   let w: BrowserWindow = (null as unknown as BrowserWindow)
@@ -50,6 +50,27 @@ describe('webContents module', () => {
       expect(all[0].getType()).to.equal('window')
       expect(all[all.length - 2].getType()).to.equal('webview')
       expect(all[all.length - 1].getType()).to.equal('remote')
+    })
+  })
+
+  describe('will-prevent-unload event', () => {
+    it('does not emit if beforeunload returns undefined', (done) => {
+      w.once('closed', () => done())
+      w.webContents.once('will-prevent-unload', (e) => {
+        expect.fail('should not have fired')
+      })
+      w.loadFile(path.join(fixturesPath, 'api', 'close-beforeunload-undefined.html'))
+    })
+
+    it('emits if beforeunload returns false', (done) => {
+      w.webContents.once('will-prevent-unload', () => done())
+      w.loadFile(path.join(fixturesPath, 'api', 'close-beforeunload-false.html'))
+    })
+
+    it('supports calling preventDefault on will-prevent-unload events', (done) => {
+      w.webContents.once('will-prevent-unload', event => event.preventDefault())
+      w.once('closed', () => done())
+      w.loadFile(path.join(fixturesPath, 'api', 'close-beforeunload-false.html'))
     })
   })
 })

--- a/spec-main/window-helpers.ts
+++ b/spec-main/window-helpers.ts
@@ -2,26 +2,37 @@ import { expect } from 'chai'
 import { BrowserWindow, WebContents } from 'electron'
 import { emittedOnce } from './events-helpers';
 
+async function ensureWindowIsClosed(window) {
+  if (window && !window.isDestroyed()) {
+    if (window.webContents && !window.webContents.isDestroyed()) {
+      // If a window isn't destroyed already, and it has non-destroyed WebContents,
+      // then calling destroy() won't immediately destroy it, as it may have
+      // <webview> children which need to be destroyed first. In that case, we
+      // await the 'closed' event which signals the complete shutdown of the
+      // window.
+      const isClosed = emittedOnce(window, 'closed')
+      window.destroy()
+      await isClosed()
+    } else {
+      // If there's no WebContents or if the WebContents is already destroyed,
+      // then the 'closed' event has already been emitted so there's nothing to
+      // wait for.
+      window.destroy()
+    }
+  }
+}
+
 export const closeWindow = async (
   window: BrowserWindow | null = null,
   { assertNotWindows } = { assertNotWindows: true }
 ) => {
-  if (window && !window.isDestroyed()) {
-    window.destroy()
-  }
+  await ensureWindowIsClosed(window)
 
   if (assertNotWindows) {
     const windows = BrowserWindow.getAllWindows()
     for (const win of windows) {
-      win.destroy()
+      await ensureWindowIsClosed(win)
     }
     expect(windows).to.have.lengthOf(0)
-  }
-}
-
-exports.waitForWebContentsToLoad = async (webContents: WebContents) => {
-  const didFinishLoadPromise = emittedOnce(webContents, 'did-finish-load')
-  if (webContents.isLoadingMainFrame()) {
-    await didFinishLoadPromise
   }
 }

--- a/spec-main/window-helpers.ts
+++ b/spec-main/window-helpers.ts
@@ -7,18 +7,13 @@ export const closeWindow = async (
   { assertNotWindows } = { assertNotWindows: true }
 ) => {
   if (window && !window.isDestroyed()) {
-    const isClosed = emittedOnce(window, 'closed')
-    window.setClosable(true)
-    window.close()
-    await isClosed
+    window.destroy()
   }
 
   if (assertNotWindows) {
     const windows = BrowserWindow.getAllWindows()
     for (const win of windows) {
-      const closePromise = emittedOnce(win, 'closed')
-      win.close()
-      await closePromise
+      win.destroy()
     }
     expect(windows).to.have.lengthOf(0)
   }

--- a/spec-main/window-helpers.ts
+++ b/spec-main/window-helpers.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
-import { BrowserWindow, WebContents } from 'electron'
+import { BrowserWindow } from 'electron'
 import { emittedOnce } from './events-helpers';
 
-async function ensureWindowIsClosed(window) {
+async function ensureWindowIsClosed(window: BrowserWindow | null) {
   if (window && !window.isDestroyed()) {
     if (window.webContents && !window.webContents.isDestroyed()) {
       // If a window isn't destroyed already, and it has non-destroyed WebContents,
@@ -12,7 +12,7 @@ async function ensureWindowIsClosed(window) {
       // window.
       const isClosed = emittedOnce(window, 'closed')
       window.destroy()
-      await isClosed()
+      await isClosed
     } else {
       // If there's no WebContents or if the WebContents is already destroyed,
       // then the 'closed' event has already been emitted so there's nothing to

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -779,31 +779,6 @@ describe('webContents module', () => {
     })
   })
 
-  describe('will-prevent-unload event', () => {
-    it('does not emit if beforeunload returns undefined', (done) => {
-      w.once('closed', () => {
-        done()
-      })
-      w.webContents.on('will-prevent-unload', (e) => {
-        expect.fail('should not have fired')
-      })
-      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-undefined.html'))
-    })
-
-    it('emits if beforeunload returns false', (done) => {
-      w.webContents.on('will-prevent-unload', () => {
-        done()
-      })
-      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-false.html'))
-    })
-
-    it('supports calling preventDefault on will-prevent-unload events', (done) => {
-      ipcRenderer.send('prevent-next-will-prevent-unload', w.webContents.id)
-      w.once('closed', () => done())
-      w.loadFile(path.join(fixtures, 'api', 'close-beforeunload-false.html'))
-    })
-  })
-
   describe('render view deleted events', () => {
     let server = null
 

--- a/spec/window-helpers.js
+++ b/spec/window-helpers.js
@@ -4,15 +4,29 @@ const { BrowserWindow } = remote
 
 const { emittedOnce } = require('./events-helpers')
 
+async function ensureWindowIsClosed (window) {
+  if (window && !window.isDestroyed()) {
+    if (window.webContents && !window.webContents.isDestroyed()) {
+      // If a window isn't destroyed already, and it has non-destroyed WebContents,
+      // then calling destroy() won't immediately destroy it, as it may have
+      // <webview> children which need to be destroyed first. In that case, we
+      // await the 'closed' event which signals the complete shutdown of the
+      // window.
+      const isClosed = emittedOnce(window, 'closed')
+      window.destroy()
+      await isClosed
+    } else {
+      // If there's no WebContents or if the WebContents is already destroyed,
+      // then the 'closed' event has already been emitted so there's nothing to
+      // wait for.
+      window.destroy()
+    }
+  }
+}
+
 exports.closeWindow = async (window = null,
   { assertSingleWindow } = { assertSingleWindow: true }) => {
-  const windowExists = (window !== null) && !window.isDestroyed()
-  if (windowExists) {
-    const isClosed = emittedOnce(window, 'closed')
-    window.setClosable(true)
-    window.close()
-    await isClosed
-  }
+  await ensureWindowIsClosed(window)
 
   if (assertSingleWindow) {
     // Although we want to assert that no windows were left handing around
@@ -22,9 +36,7 @@ exports.closeWindow = async (window = null,
     const windows = BrowserWindow.getAllWindows()
     for (const win of windows) {
       if (win.id !== currentId) {
-        const closePromise = emittedOnce(win, 'closed')
-        win.close()
-        await closePromise
+        await ensureWindowIsClosed(win)
       }
     }
     expect(windows).to.have.lengthOf(1)


### PR DESCRIPTION
#### Description of Change
This fixes a flaky test where a race in window closing could cause the `'closed'` event to never be emitted when cleaning up in the `afterEach` of the webContents spec.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
