### PR TITLE
fix: compile error in netlog

### DIFF
--- a/atom/browser/api/atom_api_net_log.cc
+++ b/atom/browser/api/atom_api_net_log.cc
@@ -92,7 +92,7 @@ v8::Local<v8::Promise> NetLog::StartLogging(mate::Arguments* args) {
 
   // TODO(deepak1556): Provide more flexibility to this module
   // by allowing customizations on the capturing options.
-  auto capture_mode = network::mojom::NetLogCaptureMode::DEFAULT;
+  auto capture_mode = net::NetLogCaptureMode::Default();
   auto max_file_size = network::mojom::NetLogExporter::kUnlimitedFileSize;
 
   base::PostTaskAndReplyWithResult(
@@ -105,11 +105,10 @@ v8::Local<v8::Promise> NetLog::StartLogging(mate::Arguments* args) {
   return handle;
 }
 
-void NetLog::StartNetLogAfterCreateFile(
-    network::mojom::NetLogCaptureMode capture_mode,
-    uint64_t max_file_size,
-    base::Value custom_constants,
-    base::File output_file) {
+void NetLog::StartNetLogAfterCreateFile(net::NetLogCaptureMode capture_mode,
+                                        uint64_t max_file_size,
+                                        base::Value custom_constants,
+                                        base::File output_file) {
   if (!net_log_exporter_) {
     // Theoretically the mojo pipe could have been closed by the time we get
     // here via the connection error handler. If so, the promise has already

--- a/atom/browser/api/atom_api_net_log.h
+++ b/atom/browser/api/atom_api_net_log.h
@@ -41,11 +41,10 @@ class NetLog : public mate::TrackableObject<NetLog> {
 
   void OnConnectionError();
 
-  void StartNetLogAfterCreateFile(
-      network::mojom::NetLogCaptureMode capture_mode,
-      uint64_t max_file_size,
-      base::Value custom_constants,
-      base::File output_file);
+  void StartNetLogAfterCreateFile(net::NetLogCaptureMode capture_mode,
+                                  uint64_t max_file_size,
+                                  base::Value custom_constants,
+                                  base::File output_file);
   void NetLogStarted(int32_t error);
 
  private:


### PR DESCRIPTION
#### Description of Change
Fixes a compile error introduced by a bad interaction between #18289 and https://chromium-review.googlesource.com/c/chromium/src/+/1613936

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
