### PR TITLE
fix: don't package mojom{,-lite}.js files in dist.zip

### DIFF
--- a/build/zip.py
+++ b/build/zip.py
@@ -5,7 +5,9 @@ import sys
 import zipfile
 
 EXTENSIONS_TO_SKIP = [
-  '.pdb'
+  '.pdb',
+  '.mojom.js',
+  '.mojom-lite.js',
 ]
 
 PATHS_TO_SKIP = [


### PR DESCRIPTION
#### Description of Change
These files aren't needed for Electron to run. I believe the dependency on them is in error in Chromium, but I'm not sure what the right upstream fix is for now so just masking them out in zip.py.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed inadvertently included mojom.js files from distribution bundle.