### PR TITLE
test: narrow scope of afterEach in remote to tests that need it

### DIFF
--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -23,10 +23,6 @@ const comparePaths = (path1, path2) => {
 describe('remote module', () => {
   const fixtures = path.join(__dirname, 'fixtures')
 
-  let w = null
-
-  afterEach(() => closeWindow(w).then(() => { w = null }))
-
   describe('remote.getGlobal filtering', () => {
     it('can return custom values', () => {
       ipcRenderer.send('handle-next-remote-get-global', { test: 'Hello World!' })
@@ -552,6 +548,9 @@ describe('remote module', () => {
   })
 
   describe('remote function in renderer', () => {
+    let w = null
+
+    afterEach(() => closeWindow(w).then(() => { w = null }))
     afterEach(() => {
       ipcMain.removeAllListeners('done')
     })


### PR DESCRIPTION
#### Description of Change
See example failure: https://circleci.com/gh/electron/electron/206549

This doesn't address the cause of the flake, but it should hopefully make flake less likely by calling `closeWindow` less often.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes