### PR TITLE
build: add env var to allow easily triggering a 3way patch

### DIFF
--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import os
 import sys
 
 from lib import git
@@ -9,8 +10,10 @@ from lib.patches import patch_from_dir
 
 
 def apply_patches(dirs):
+  threeway = os.environ.get("ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES")
   for patch_dir, repo in dirs.iteritems():
     git.import_patches(repo=repo, patch_data=patch_from_dir(patch_dir),
+      threeway=threeway is not None,
       committer_name="Electron Scripts", committer_email="scripts@electron")
 
 


### PR DESCRIPTION
I find myself manually adding `threeway=True` in this script every now and again to deal with patch rebases / conflicts.  This would allow us to do `ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=true e sync` to deal with these conflicts.

Notes: no-notes