### PR TITLE
fix: do not crash when async id check fails

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -332,6 +332,14 @@ node::Environment* NodeBindings::CreateEnvironment(
       node::CreateIsolateData(context->GetIsolate(), uv_loop_, platform),
       context, args.size(), c_argv.get(), 0, nullptr);
 
+  // Do not crash when async id check fails in Node.
+  //
+  // Due to the way node integration works in Electron, the async hooks can not
+  // correctly track the execution of async calls. We should eventually find out
+  // how to make async hooks work correctly in Electron, but for now we just
+  // disable the check to avoid hard crashes.
+  env->async_hooks()->no_force_checks();
+
   if (browser_env_ == BrowserEnvironment::BROWSER) {
     // SetAutorunMicrotasks is no longer called in node::CreateEnvironment
     // so instead call it here to match expected node behavior

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -393,6 +393,22 @@ describe('node feature', () => {
           setImmediate(() => setImmediate(done))
         })
       })
+
+      it('does not crash with exception in it', (done) => {
+        setImmediate(() => {
+          expect(() => { throw new Error() }).to.throw(Error)
+          done()
+        })
+      })
+    })
+
+    describe('async hooks', () => {
+      it('does not crash', () => {
+        const asyncHooks = require('async_hooks')
+        const hook = asyncHooks.createHook({ init: function () {} })
+        after(() => hook.disable())
+        hook.enable()
+      })
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Close #12798.

Due to the way node integration works in Electron, the async hooks can not correctly track the execution of async calls under certain cases. We should eventually find out how to make async hooks work correctly in Electron, but for now we just disable the check to avoid hard crashes.

The async hooks will not be able to track those executions which crashed before, but there are no other side effects.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix crash when throwing Error in `setImmediate`