### PR TITLE
fix: do not crash when async id check fails (6-0-x)

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -329,6 +329,14 @@ node::Environment* NodeBindings::CreateEnvironment(
       node::CreateIsolateData(context->GetIsolate(), uv_loop_, platform),
       context, args.size(), c_argv.get(), 0, nullptr);
 
+  // Do not crash when async id check fails in Node.
+  //
+  // Due to the way node integration works in Electron, the async hooks can not
+  // correctly track the execution of async calls. We should eventually find out
+  // how to make async hooks work correctly in Electron, but for now we just
+  // disable the check to avoid hard crashes.
+  env->async_hooks()->no_force_checks();
+
   if (browser_env_ == BROWSER) {
     // SetAutorunMicrotasks is no longer called in node::CreateEnvironment
     // so instead call it here to match expected node behavior

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -393,6 +393,21 @@ describe('node feature', () => {
           setImmediate(() => setImmediate(done))
         })
       })
+
+      it('does not crash with exception in it', (done) => {
+        setImmediate(() => {
+          expect(() => { throw new Error() }).to.throw(Error)
+          done()
+        })
+      })
+    })
+
+    describe('async hooks', () => {
+      it('does not crash', () => {
+        const asyncHooks = require('async_hooks')
+        const hook = asyncHooks.createHook({ init: function () {} })
+        hook.enable()
+      })
     })
   })
 


### PR DESCRIPTION
Backport of #18452.

Notes: Fix crash when throwing Error in setImmediate.