### PR TITLE
fix: ensure the webContents is not destroyed before communicating

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -115,7 +115,9 @@ const removeBackgroundPages = function (manifest) {
 
 const sendToBackgroundPages = function (...args) {
   for (const page of Object.values(backgroundPages)) {
-    page.webContents._sendInternalToAll(...args)
+    if (!page.webContents.isDestroyed()) {
+      page.webContents._sendInternalToAll(...args)
+    }
   }
 }
 
@@ -161,7 +163,7 @@ ipcMainUtils.handle('CHROME_RUNTIME_CONNECT', function (event, extensionId, conn
   }
 
   const page = backgroundPages[extensionId]
-  if (!page) {
+  if (!page || page.webContents.isDestroyed()) {
     throw new Error(`Connect to unknown extension ${extensionId}`)
   }
 
@@ -191,7 +193,7 @@ ipcMainUtils.handle('CHROME_RUNTIME_SEND_MESSAGE', async function (event, extens
   }
 
   const page = backgroundPages[extensionId]
-  if (!page) {
+  if (!page || page.webContents.isDestroyed()) {
     throw new Error(`Connect to unknown extension ${extensionId}`)
   }
 


### PR DESCRIPTION
Noticed this while running a Fiddle, sometimes it seems a `webContents` can exist in a destroyed state in this object.

`no-notes` because I think it only happens when the background page crashes and I'm not sure how to explain that to users in a way that is useful for them

Notes: no-notes